### PR TITLE
perf(core): simplify injector scopes

### DIFF
--- a/packages/core/src/di/create_injector.ts
+++ b/packages/core/src/di/create_injector.ts
@@ -44,7 +44,7 @@ export function createInjectorWithoutInjectorInstances(
   parent: Injector | null = null,
   additionalProviders: Array<Provider | StaticProvider> | null = null,
   name?: string,
-  scopes = new Set<InjectorScope>(),
+  scopes = InjectorScope.None,
 ): R3Injector {
   const providers = [additionalProviders || EMPTY_ARRAY, importProvidersFrom(defType)];
   name = name || (typeof defType === 'object' ? undefined : stringify(defType));

--- a/packages/core/src/di/scope.ts
+++ b/packages/core/src/di/scope.ts
@@ -8,7 +8,12 @@
 
 import {InjectionToken} from './injection_token';
 
-export type InjectorScope = 'root' | 'platform' | 'environment';
+export const enum InjectorScope {
+  None = 0,
+  Root = 1 << 0,
+  Platform = 1 << 1,
+  Environment = 1 << 2,
+}
 
 /**
  * An internal token whose presence in an injector indicates that the injector should treat itself

--- a/packages/core/src/platform/platform.ts
+++ b/packages/core/src/platform/platform.ts
@@ -12,7 +12,7 @@ import {
 } from '../application/application_ref';
 import {PLATFORM_INITIALIZER} from '../application/application_tokens';
 import {InjectionToken, Injector, StaticProvider} from '../di';
-import {INJECTOR_SCOPE} from '../di/scope';
+import {INJECTOR_SCOPE, InjectorScope} from '../di/scope';
 import {RuntimeError, RuntimeErrorCode} from '../errors';
 
 import {PlatformRef} from './platform_ref';
@@ -93,7 +93,7 @@ function createPlatformInjector(providers: StaticProvider[] = [], name?: string)
   return Injector.create({
     name,
     providers: [
-      {provide: INJECTOR_SCOPE, useValue: 'platform'},
+      {provide: INJECTOR_SCOPE, useValue: InjectorScope.Platform},
       {provide: PLATFORM_DESTROY_LISTENERS, useValue: new Set([() => (_platformInjector = null)])},
       ...providers,
     ],

--- a/packages/core/src/render3/ng_module_ref.ts
+++ b/packages/core/src/render3/ng_module_ref.ts
@@ -10,6 +10,7 @@ import {createInjectorWithoutInjectorInstances} from '../di/create_injector';
 import {Injector} from '../di/injector';
 import {EnvironmentProviders, Provider, StaticProvider} from '../di/interface/provider';
 import {EnvironmentInjector, getNullInjector, R3Injector} from '../di/r3_injector';
+import {InjectorScope} from '../di/scope';
 import {Type} from '../interface/type';
 import {ComponentFactoryResolver as viewEngine_ComponentFactoryResolver} from '../linker/component_factory_resolver';
 import {
@@ -92,7 +93,7 @@ export class NgModuleRef<T> extends viewEngine_NgModuleRef<T> implements Interna
         ...additionalProviders,
       ],
       stringify(ngModuleType),
-      new Set(['environment']),
+      InjectorScope.Environment,
     ) as R3Injector;
 
     // We need to resolve the injector types separately from the injector creation, because
@@ -164,7 +165,7 @@ export class EnvironmentNgModuleRefAdapter extends viewEngine_NgModuleRef<null> 
       ],
       config.parent || getNullInjector(),
       config.debugName,
-      new Set(['environment']),
+      InjectorScope.Environment,
     );
     this.injector = injector;
     if (config.runEnvironmentInitializers) {

--- a/packages/core/src/render3/util/injector_discovery_utils.ts
+++ b/packages/core/src/render3/util/injector_discovery_utils.ts
@@ -16,6 +16,7 @@ import {INJECTOR_DEF_TYPES} from '../../di/internal_tokens';
 import {NullInjector} from '../../di/null_injector';
 import {SingleProvider, walkProviderTree} from '../../di/provider_collection';
 import {EnvironmentInjector, R3Injector} from '../../di/r3_injector';
+import {InjectorScope} from '../../di/scope';
 import {Type} from '../../interface/type';
 import {NgModuleRef as viewEngine_NgModuleRef} from '../../linker/ng_module_factory';
 import {deepForEach} from '../../util/array_utils';
@@ -462,8 +463,8 @@ function getEnvironmentInjectorProviders(injector: EnvironmentInjector): Provide
   return providerRecords;
 }
 
-function isPlatformInjector(injector: Injector) {
-  return injector instanceof R3Injector && injector.scopes.has('platform');
+function isPlatformInjector(injector: Injector): boolean {
+  return injector instanceof R3Injector && (injector.scopes & InjectorScope.Platform) !== 0;
 }
 
 /**

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -61,6 +61,7 @@ import {
   ɵINJECTOR_SCOPE,
   ɵInternalEnvironmentProviders as InternalEnvironmentProviders,
 } from '@angular/core';
+import {InjectorScope} from '@angular/core/src/di/scope';
 import {RuntimeError, RuntimeErrorCode} from '@angular/core/src/errors';
 import {ViewRef as ViewRefInternal} from '@angular/core/src/render3/view_ref';
 import {TestBed} from '@angular/core/testing';
@@ -2500,10 +2501,10 @@ describe('di', () => {
       expect(anyService.injector).toBe(childInjector);
 
       const rootService = childInjector.get(RootService);
-      expect(rootService.injector.get(ɵINJECTOR_SCOPE)).toBe('root');
+      expect(rootService.injector.get(ɵINJECTOR_SCOPE)).toBe(InjectorScope.Root);
 
       const platformService = childInjector.get(PlatformService);
-      expect(platformService.injector.get(ɵINJECTOR_SCOPE)).toBe('platform');
+      expect(platformService.injector.get(ɵINJECTOR_SCOPE)).toBe(InjectorScope.Platform);
     });
 
     it('should create a provider that uses `forwardRef` inside `providedIn`', () => {

--- a/packages/core/test/acceptance/injector_profiler_spec.ts
+++ b/packages/core/test/acceptance/injector_profiler_spec.ts
@@ -33,6 +33,7 @@ import {
   isValueProvider,
 } from '@angular/core/src/di/provider_collection';
 import {EnvironmentInjector, R3Injector} from '@angular/core/src/di/r3_injector';
+import {InjectorScope} from '@angular/core/src/di/scope';
 import {setupFrameworkInjectorProfiler} from '@angular/core/src/render3/debug/framework_injector_profiler';
 import {
   getInjectorProfilerContext,
@@ -311,7 +312,9 @@ describe('setProfiler', () => {
     expect(rootServiceProviderConfiguredEvent!.context).toBeTruthy();
     expect(rootServiceProviderConfiguredEvent!.context!.injector).toBeInstanceOf(R3Injector);
     expect(
-      (rootServiceProviderConfiguredEvent!.context!.injector as R3Injector).scopes.has('root'),
+      ((rootServiceProviderConfiguredEvent!.context!.injector as R3Injector).scopes &
+        InjectorScope.Root) !==
+        0,
     ).toBeTrue();
 
     const platformServiceProviderConfiguredEvent = searchForProfilerEvent<ProviderConfiguredEvent>(
@@ -322,9 +325,9 @@ describe('setProfiler', () => {
     expect(platformServiceProviderConfiguredEvent!.context).toBeTruthy();
     expect(platformServiceProviderConfiguredEvent!.context!.injector).toBeInstanceOf(R3Injector);
     expect(
-      (platformServiceProviderConfiguredEvent!.context!.injector as R3Injector).scopes.has(
-        'platform',
-      ),
+      ((platformServiceProviderConfiguredEvent!.context!.injector as R3Injector).scopes &
+        InjectorScope.Platform) !==
+        0,
     ).toBeTrue();
 
     const providedInRootInjectionTokenProviderConfiguredEvent =
@@ -338,9 +341,10 @@ describe('setProfiler', () => {
       R3Injector,
     );
     expect(
-      (
-        providedInRootInjectionTokenProviderConfiguredEvent!.context!.injector as R3Injector
-      ).scopes.has('root'),
+      ((providedInRootInjectionTokenProviderConfiguredEvent!.context!.injector as R3Injector)
+        .scopes &
+        InjectorScope.Root) !==
+        0,
     ).toBeTrue();
     expect(providedInRootInjectionTokenProviderConfiguredEvent!.providerRecord.token).toBe(
       providedInRootInjectionToken,
@@ -357,9 +361,9 @@ describe('setProfiler', () => {
       R3Injector,
     );
     expect(
-      (providedInPlatformTokenProviderConfiguredEvent!.context!.injector as R3Injector).scopes.has(
-        'platform',
-      ),
+      ((providedInPlatformTokenProviderConfiguredEvent!.context!.injector as R3Injector).scopes &
+        InjectorScope.Platform) !==
+        0,
     ).toBeTrue();
     expect(providedInPlatformTokenProviderConfiguredEvent!.providerRecord.token).toBe(
       providedInPlatformToken,
@@ -464,7 +468,7 @@ describe('getInjectorMetadata', () => {
   });
 
   it('should return null as the source for an R3Injector with no source.', () => {
-    const emptyR3Injector = new R3Injector([], new NullInjector(), null, new Set());
+    const emptyR3Injector = new R3Injector([], new NullInjector(), null, InjectorScope.None);
     const r3InjectorMetadata = getInjectorMetadata(emptyR3Injector);
     expect(r3InjectorMetadata).toBeDefined();
     expect(r3InjectorMetadata!.source).toBeNull();
@@ -1367,16 +1371,16 @@ describe('getInjectorResolutionPath', () => {
 
       expect(path[3]).toBeInstanceOf(R3Injector);
       expect(path[3]).toBe(lazyComponentEnvironmentInjector);
-      expect((path[3] as R3Injector).scopes.has('environment')).toBeTrue();
+      expect(((path[3] as R3Injector).scopes & InjectorScope.Environment) !== 0).toBeTrue();
       expect((path[3] as R3Injector).source).toBe('Standalone[LazyComponent]');
 
       expect(path[4]).toBeInstanceOf(R3Injector);
-      expect((path[4] as R3Injector).scopes.has('environment')).toBeTrue();
+      expect(((path[4] as R3Injector).scopes & InjectorScope.Environment) !== 0).toBeTrue();
       expect((path[4] as R3Injector).source).toBe('DynamicTestModule');
-      expect((path[4] as R3Injector).scopes.has('root')).toBeTrue();
+      expect(((path[4] as R3Injector).scopes & InjectorScope.Root) !== 0).toBeTrue();
 
       expect(path[5]).toBeInstanceOf(R3Injector);
-      expect((path[5] as R3Injector).scopes.has('platform')).toBeTrue();
+      expect(((path[5] as R3Injector).scopes & InjectorScope.Platform) !== 0).toBeTrue();
 
       expect(path[6]).toBeInstanceOf(NullInjector);
     }

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -54,6 +54,7 @@ import {EVENT_MANAGER_PLUGINS, EventManager} from './dom/events/event_manager';
 import {KeyEventsPlugin} from './dom/events/key_events';
 import {SharedStylesHost} from './dom/shared_styles_host';
 import {RuntimeErrorCode} from './errors';
+import {InjectorScope} from '@angular/core/src/di/scope';
 
 /**
  * Set of config options available during the application bootstrap operation.
@@ -232,7 +233,8 @@ const TESTABILITY_PROVIDERS = [
 ];
 
 const BROWSER_MODULE_PROVIDERS: Provider[] = [
-  {provide: INJECTOR_SCOPE, useValue: 'root'},
+  // tslint:disable-next-line: no-toplevel-property-access
+  {provide: INJECTOR_SCOPE, useValue: InjectorScope.Root},
   {provide: ErrorHandler, useFactory: errorHandler, deps: []},
   {
     provide: EVENT_MANAGER_PLUGINS,


### PR DESCRIPTION
Currently when we create a `R3Injector`, we have to pass a `Set` of scopes. This is a bit wasteful, because the scopes are a pre-defined set of 3 (`root`, `platform` and `environment`).

These changes switch to storing them as a bit map which should be quicker to instantiate and consume less memory.