### PR TITLE
refactor(migrations): replacements in tsurge are always serializable

### DIFF
--- a/packages/core/schematics/utils/tsurge/migration.ts
+++ b/packages/core/schematics/utils/tsurge/migration.ts
@@ -89,7 +89,7 @@ export abstract class TsurgeFunnelMigration<
    *
    * @returns All replacements for the whole project.
    */
-  abstract migrate(globalData: CombinedGlobalMetadata): Promise<Serializable<Replacement[]>>;
+  abstract migrate(globalData: CombinedGlobalMetadata): Promise<Replacement[]>;
 }
 
 /**


### PR DESCRIPTION
This removes an unnecessary type wrapping that can be removed because `Replacements` is
expected to be serializable by default.

Similar to how it's done in `TsurgeComplexMigration`.