### PR TITLE
docs: adding provider information for DefaultValueAccessor

### DIFF
--- a/packages/forms/src/directives/default_value_accessor.ts
+++ b/packages/forms/src/directives/default_value_accessor.ts
@@ -52,7 +52,7 @@ export const COMPOSITION_BUFFER_MODE = new InjectionToken<boolean>(
 /**
  * The default `ControlValueAccessor` for writing a value and listening to changes on input
  * elements. The accessor is used by the `FormControlDirective`, `FormControlName`, and
- * `NgModel` directives.
+ * `NgModel` directives. This is provided by `FormsModule` and `ReactiveFormsModule`.
  *
  * {@searchKeywords ngDefaultControl}
  *

--- a/packages/forms/src/directives/default_value_accessor.ts
+++ b/packages/forms/src/directives/default_value_accessor.ts
@@ -52,7 +52,8 @@ export const COMPOSITION_BUFFER_MODE = new InjectionToken<boolean>(
 /**
  * The default `ControlValueAccessor` for writing a value and listening to changes on input
  * elements. The accessor is used by the `FormControlDirective`, `FormControlName`, and
- * `NgModel` directives. This is provided by `FormsModule` and `ReactiveFormsModule`.
+ * `NgModel` directives. This directive is included automatically when the `FormsModule`
+ * or `ReactiveFormsModule` are imported into a component.
  *
  * {@searchKeywords ngDefaultControl}
  *


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Each default providers in angular framework should have scope of where it is provided. I think DefaultValueAccessor has not.

Issue Number: N/A


## What is the new behavior?
Description of the where the DefaultValueAccessor is provided.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
