### PR TITLE
docs: Add fallback content for <ng-content> in content projection guide

### DIFF
--- a/adev/src/content/guide/components/content-projection.md
+++ b/adev/src/content/guide/components/content-projection.md
@@ -148,6 +148,38 @@ did not match a `select` attribute:
 If a component does not include an `<ng-content>` placeholder without a `select` attribute, any
 elements that don't match one of the component's placeholders do not render into the DOM.
 
+## Fallback content
+
+Angular can show *fallback content* for a component's `<ng-content>` placeholder if that component doesn't have any matching child content. You can specify fallback content by adding child content to the `<ng-content>` element itself.
+
+```angular-html
+<!-- Component template -->
+<div class="card-shadow">
+  <ng-content select="card-title">Default Title</ng-content>
+  <div class="card-divider"></div>
+  <ng-content select="card-body">Default Body</ng-content>
+</div>
+```
+
+```angular-html
+<!-- Using the component -->
+<custom-card>
+  <card-title>Hello</card-title>
+  <!-- No card-body provided -->
+</custom-card>
+```
+
+```angular-html
+<!-- Rendered DOM -->
+<custom-card>
+  <div class="card-shadow">
+    Hello
+    <div class="card-divider"></div>
+    Default Body
+  </div>
+</custom-card>
+```
+
 ## Aliasing content for projection
 
 Angular supports a special attribute, `ngProjectAs`, that allows you to specify a CSS selector on


### PR DESCRIPTION
Angular 18 introduced fallback content for ng-content. This commit updates the docs of content projection guide to contain fallback content.

PR Close angular#57083

<img width="1060" alt="Screenshot 2024-08-27 at 3 41 41 PM" src="https://github.com/user-attachments/assets/637b51e3-70b9-4b01-8dc0-c8242d7956f5">
