### PR TITLE
fix(devtools): ignore DOM Nodes from other frames when performing render tree detection

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.ts
@@ -19,6 +19,11 @@ const extractViewTree = (
   getComponent: (element: Element) => {} | null,
   getDirectives: (node: Node) => {}[],
 ): ComponentTreeNode[] => {
+  // Ignore DOM Node if it came from a different frame. Use instanceof Node to check this.
+  if (!(domNode instanceof Node)) {
+    return result;
+  }
+
   const directives = getDirectives(domNode);
   if (!directives.length && !(domNode instanceof Element)) {
     return result;


### PR DESCRIPTION
Previously, if an application had DOM Nodes injected into it from other frames, DevTools would fail to parse component trees with the render tree strategy properly because of an instanceof Node check that the framework performs.

Now we check for instanceof Node before even calling framework debug APIs on DOM nodes so that we can skip nodes that come from other frames entirely.

Closes https://github.com/angular/angular/issues/47357