### PR TITLE
ci: fix fw-testing group triggering for schematics testing changes

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -372,7 +372,7 @@ groups:
     <<: *defaults
     conditions:
       - >
-        contains_any_globs(files.exclude('packages/compiler-cli/*').exclude('packages/language-service/*').exclude('packages/service-worker/*'), [
+        contains_any_globs(files.exclude('packages/compiler-cli/*').exclude('packages/language-service/*').exclude('packages/service-worker/*').exclude('packages/core/schematics/*'), [
           'packages/**/testing/**/{*,.*}',
           ])
     reviewers:


### PR DESCRIPTION
The `fw-testing` group should not trigger for schematic changes.
