### PR TITLE
refactor(compiler): extend directive mock to avoid failing at matching logic

### DIFF
--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -94,6 +94,7 @@ export function findMatchingDirectivesAndPipes(template: string, directiveSelect
     // function internally).
     const fakeDirective = {
       selector,
+      exportAs: null,
       inputs: {
         hasBindingPropertyName() {
           return false;

--- a/packages/compiler/test/render3/view/binding_spec.ts
+++ b/packages/compiler/test/render3/view/binding_spec.ts
@@ -206,6 +206,35 @@ describe('findMatchingDirectivesAndPipes', () => {
       },
     });
   });
+
+  it('should handle directives on elements with local refs', () => {
+    const template = `
+        <input [(ngModel)]="name" #ctrl="ngModel" required />
+        @defer {
+          <my-defer-cmp [label]="abc | lowercase" [title]="abc | uppercase" />
+          <input [(ngModel)]="name" #ctrl="ngModel" required />
+        } @placeholder {}
+      `;
+    const directiveSelectors = [
+      '[ngModel]:not([formControlName]):not([formControl])',
+      '[title]',
+      'my-defer-cmp',
+      'not-matching',
+    ];
+    const result = findMatchingDirectivesAndPipes(template, directiveSelectors);
+    expect(result).toEqual({
+      directives: {
+        // `ngModel` is used both eagerly and in a defer block, thus it's located
+        // in the "regular" (eager) bucket.
+        regular: ['[ngModel]:not([formControlName]):not([formControl])'],
+        deferCandidates: ['my-defer-cmp', '[title]'],
+      },
+      pipes: {
+        regular: [],
+        deferCandidates: ['lowercase', 'uppercase'],
+      },
+    });
+  });
 });
 
 describe('t2 binding', () => {


### PR DESCRIPTION
This commit updates a directive mock instance to include an extra field that a compiler code was expecting, which caused issues while processing elements with local refs and exported directives.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No