### PR TITLE
feat(core): introduce `afterRenderEffect`

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -50,6 +50,17 @@ export function afterRender<E = never, W = never, M = never>(spec: {
 export function afterRender(callback: VoidFunction, options?: AfterRenderOptions): AfterRenderRef;
 
 // @public
+export function afterRenderEffect(callback: (onCleanup: EffectCleanupRegisterFn) => void, options?: Omit<AfterRenderOptions, 'phase'>): AfterRenderRef;
+
+// @public
+export function afterRenderEffect<E = never, W = never, M = never>(spec: {
+    earlyRead?: (onCleanup: EffectCleanupRegisterFn) => E;
+    write?: (...args: [...ɵFirstAvailableSignal<[E]>, EffectCleanupRegisterFn]) => W;
+    mixedReadWrite?: (...args: [...ɵFirstAvailableSignal<[W, E]>, EffectCleanupRegisterFn]) => M;
+    read?: (...args: [...ɵFirstAvailableSignal<[M, W, E]>, EffectCleanupRegisterFn]) => void;
+}, options?: Omit<AfterRenderOptions, 'phase'>): AfterRenderRef;
+
+// @public
 export interface AfterRenderOptions {
     injector?: Injector;
     // @deprecated

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -7,8 +7,8 @@
   },
   "cli-hello-world-ivy-i18n": {
     "uncompressed": {
-      "main": 130590,
-      "polyfills": 34676
+      "main": 135813,
+      "polyfills": 35883
     }
   },
   "cli-hello-world-lazy": {

--- a/packages/core/src/core_reactivity_export_internal.ts
+++ b/packages/core/src/core_reactivity_export_internal.ts
@@ -23,4 +23,5 @@ export {
   EffectCleanupRegisterFn,
   EffectScheduler as ɵEffectScheduler,
 } from './render3/reactivity/effect';
+export {afterRenderEffect, ɵFirstAvailableSignal} from './render3/reactivity/after_render_effect';
 export {assertNotInReactiveContext} from './render3/reactivity/asserts';

--- a/packages/core/src/render3/after_render/hooks.ts
+++ b/packages/core/src/render3/after_render/hooks.ts
@@ -459,6 +459,6 @@ function afterRenderImpl(
 }
 
 /** `AfterRenderRef` that does nothing. */
-const NOOP_AFTER_RENDER_REF: AfterRenderRef = {
+export const NOOP_AFTER_RENDER_REF: AfterRenderRef = {
   destroy() {},
 };

--- a/packages/core/src/render3/reactivity/after_render_effect.ts
+++ b/packages/core/src/render3/reactivity/after_render_effect.ts
@@ -1,0 +1,381 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {
+  consumerAfterComputation,
+  consumerBeforeComputation,
+  consumerPollProducersForChange,
+  producerAccessed,
+  SIGNAL,
+  SIGNAL_NODE,
+  type SignalNode,
+} from '@angular/core/primitives/signals';
+
+import {type Signal} from '../reactivity/api';
+import {type EffectCleanupFn, type EffectCleanupRegisterFn} from './effect';
+
+import {
+  ChangeDetectionScheduler,
+  NotificationSource,
+} from '../../change_detection/scheduling/zoneless_scheduling';
+import {Injector} from '../../di/injector';
+import {inject} from '../../di/injector_compatibility';
+import {AfterRenderImpl, AfterRenderManager, AfterRenderSequence} from '../after_render/manager';
+import {AfterRenderPhase, type AfterRenderRef} from '../after_render/api';
+import {NOOP_AFTER_RENDER_REF, type AfterRenderOptions} from '../after_render/hooks';
+import {DestroyRef} from '../../linker/destroy_ref';
+import {assertNotInReactiveContext} from './asserts';
+import {assertInInjectionContext} from '../../di/contextual';
+import {isPlatformBrowser} from '../util/misc_utils';
+
+const NOT_SET = Symbol('NOT_SET');
+const EMPTY_CLEANUP_SET = new Set<() => void>();
+
+/** Callback type for an `afterRenderEffect` phase effect */
+type AfterRenderPhaseEffectHook = (
+  // Either a cleanup function or a pipelined value and a cleanup function
+  ...args:
+    | [onCleanup: EffectCleanupRegisterFn]
+    | [previousPhaseValue: unknown, onCleanup: EffectCleanupRegisterFn]
+) => unknown;
+
+/**
+ * Reactive node in the graph for this `afterRenderEffect` phase effect.
+ *
+ * This node type extends `SignalNode` because `afterRenderEffect` phases effects produce a value
+ * which is consumed as a `Signal` by subsequent phases.
+ */
+interface AfterRenderPhaseEffectNode extends SignalNode<unknown> {
+  /** The phase of the effect implemented by this node */
+  phase: AfterRenderPhase;
+  /** The sequence of phases to which this node belongs, used for state of the whole sequence */
+  sequence: AfterRenderEffectSequence;
+  /** The user's callback function */
+  userFn: AfterRenderPhaseEffectHook;
+  /** Signal function that retrieves the value of this node, used as the value for the next phase */
+  signal: Signal<unknown>;
+  /** Registered cleanup functions, or `null` if none have ever been registered */
+  cleanup: Set<() => void> | null;
+  /** Pre-bound helper function passed to the user's callback which writes to `this.cleanup` */
+  registerCleanupFn: EffectCleanupRegisterFn;
+  /** Entrypoint to running this effect that's given to the `afterRender` machinery */
+  phaseFn(previousValue?: unknown): unknown;
+}
+
+const AFTER_RENDER_PHASE_EFFECT_NODE = {
+  ...SIGNAL_NODE,
+  consumerIsAlwaysLive: true,
+  consumerAllowSignalWrites: true,
+  value: NOT_SET,
+  cleanup: null,
+  /** Called when the effect becomes dirty */
+  consumerMarkedDirty(this: AfterRenderPhaseEffectNode): void {
+    if (this.sequence.impl.executing) {
+      // If hooks are in the middle of executing, then it matters whether this node has yet been
+      // executed within its sequence. If not, then we don't want to notify the scheduler since
+      // this node will be reached naturally.
+      if (this.sequence.lastPhase === null || this.sequence.lastPhase < this.phase) {
+        return;
+      }
+
+      // If during the execution of a later phase an earlier phase became dirty, then we should not
+      // run any further phases until the earlier one reruns.
+      this.sequence.erroredOrDestroyed = true;
+    }
+
+    // Either hooks are not running, or we're marking a node dirty that has already run within its
+    // sequence.
+    this.sequence.scheduler.notify(NotificationSource.RenderHook);
+  },
+  phaseFn(this: AfterRenderPhaseEffectNode, previousValue?: unknown): unknown {
+    this.sequence.lastPhase = this.phase;
+
+    if (!this.dirty) {
+      return this.signal;
+    }
+
+    this.dirty = false;
+    if (this.value !== NOT_SET && !consumerPollProducersForChange(this)) {
+      // None of our producers report a change since the last time they were read, so no
+      // recomputation of our value is necessary.
+      return this.signal;
+    }
+
+    // Run any needed cleanup functions.
+    try {
+      for (const cleanupFn of this.cleanup ?? EMPTY_CLEANUP_SET) {
+        cleanupFn();
+      }
+    } finally {
+      // Even if a cleanup function errors, ensure it's cleared.
+      this.cleanup?.clear();
+    }
+
+    // Prepare to call the user's effect callback. If there was a previous phase, then it gave us
+    // its value as a `Signal`, otherwise `previousValue` will be `undefined`.
+    const args: unknown[] = [];
+    if (previousValue !== undefined) {
+      args.push(previousValue);
+    }
+    args.push(this.registerCleanupFn);
+
+    // Call the user's callback in our reactive context.
+    const prevConsumer = consumerBeforeComputation(this);
+    let newValue;
+    try {
+      newValue = this.userFn.apply(null, args as any);
+    } finally {
+      consumerAfterComputation(this, prevConsumer);
+    }
+
+    if (this.value === NOT_SET || !this.equal(this.value, newValue)) {
+      this.value = newValue;
+      this.version++;
+    }
+
+    return this.signal;
+  },
+};
+
+/**
+ * An `AfterRenderSequence` that manages an `afterRenderEffect`'s phase effects.
+ */
+class AfterRenderEffectSequence extends AfterRenderSequence {
+  /**
+   * While this sequence is executing, this tracks the last phase which was called by the
+   * `afterRender` machinery.
+   *
+   * When a phase effect is marked dirty, this is used to determine whether it's already run or not.
+   */
+  lastPhase: AfterRenderPhase | null = null;
+
+  /**
+   * The reactive nodes for each phase, if a phase effect is defined for that phase.
+   *
+   * These are initialized to `undefined` but set in the constructor.
+   */
+  private readonly nodes: [
+    AfterRenderPhaseEffectNode | undefined,
+    AfterRenderPhaseEffectNode | undefined,
+    AfterRenderPhaseEffectNode | undefined,
+    AfterRenderPhaseEffectNode | undefined,
+  ] = [undefined, undefined, undefined, undefined];
+
+  constructor(
+    impl: AfterRenderImpl,
+    effectHooks: Array<AfterRenderPhaseEffectHook | undefined>,
+    readonly scheduler: ChangeDetectionScheduler,
+    destroyRef: DestroyRef,
+  ) {
+    // Note that we also initialize the underlying `AfterRenderSequence` hooks to `undefined` and
+    // populate them as we create reactive nodes below.
+    super(impl, [undefined, undefined, undefined, undefined], false, destroyRef);
+
+    // Setup a reactive node for each phase.
+    for (const phase of AfterRenderImpl.PHASES) {
+      const effectHook = effectHooks[phase];
+      if (effectHook === undefined) {
+        continue;
+      }
+
+      const node = Object.create(AFTER_RENDER_PHASE_EFFECT_NODE) as AfterRenderPhaseEffectNode;
+      node.sequence = this;
+      node.phase = phase;
+      node.userFn = effectHook;
+      node.dirty = true;
+      node.signal = (() => {
+        producerAccessed(node);
+        return node.value;
+      }) as Signal<unknown>;
+      node.signal[SIGNAL] = node;
+      node.registerCleanupFn = (fn: EffectCleanupFn) =>
+        (node.cleanup ??= new Set<() => void>()).add(fn);
+
+      this.nodes[phase] = node;
+
+      // Install the upstream hook which runs the `phaseFn` for this phase.
+      this.hooks[phase] = (value) => node.phaseFn(value);
+    }
+  }
+
+  override afterRun(): void {
+    super.afterRun();
+    // We're done running this sequence, so reset `lastPhase`.
+    this.lastPhase = null;
+  }
+
+  override destroy(): void {
+    super.destroy();
+
+    // Run the cleanup functions for each node.
+    for (const node of this.nodes) {
+      for (const fn of node?.cleanup ?? EMPTY_CLEANUP_SET) {
+        fn();
+      }
+    }
+  }
+}
+
+/**
+ * An argument list containing the first non-never type in the given type array, or an empty
+ * argument list if there are no non-never types in the type array.
+ */
+export type ɵFirstAvailableSignal<T extends unknown[]> = T extends [infer H, ...infer R]
+  ? [H] extends [never]
+    ? ɵFirstAvailableSignal<R>
+    : [Signal<H>]
+  : [];
+
+/**
+ * Register an effect that, when triggered, is invoked when the application finishes rendering, during the
+ * `mixedReadWrite` phase.
+ *
+ * <div class="alert is-critical">
+ *
+ * You should prefer specifying an explicit phase for the effect instead, or you risk significant
+ * performance degradation.
+ *
+ * </div>
+ *
+ * Note that callback-based `afterRenderEffect`s will run
+ * - in the order it they are registered
+ * - only when dirty
+ * - on browser platforms only
+ * - during the `mixedReadWrite` phase
+ *
+ * <div class="alert is-important">
+ *
+ * Components are not guaranteed to be [hydrated](guide/hydration) before the callback runs.
+ * You must use caution when directly reading or writing the DOM and layout.
+ *
+ * </div>
+ *
+ * @param callback An effect callback function to register
+ * @param options Options to control the behavior of the callback
+ *
+ * @experimental
+ */
+export function afterRenderEffect(
+  callback: (onCleanup: EffectCleanupRegisterFn) => void,
+  options?: Omit<AfterRenderOptions, 'phase'>,
+): AfterRenderRef;
+/**
+ * Register effects that, when triggered, are invoked when the application finishes rendering,
+ * during the specified phases. The available phases are:
+ * - `earlyRead`
+ *   Use this phase to **read** from the DOM before a subsequent `write` callback, for example to
+ *   perform custom layout that the browser doesn't natively support. Prefer the `read` phase if
+ *   reading can wait until after the write phase. **Never** write to the DOM in this phase.
+ * - `write`
+ *    Use this phase to **write** to the DOM. **Never** read from the DOM in this phase.
+ * - `mixedReadWrite`
+ *    Use this phase to read from and write to the DOM simultaneously. **Never** use this phase if
+ *    it is possible to divide the work among the other phases instead.
+ * - `read`
+ *    Use this phase to **read** from the DOM. **Never** write to the DOM in this phase.
+ *
+ * <div class="alert is-critical">
+ *
+ * You should prefer using the `read` and `write` phases over the `earlyRead` and `mixedReadWrite`
+ * phases when possible, to avoid performance degradation.
+ *
+ * </div>
+ *
+ * Note that:
+ * - Effects run in the following phase order, only when dirty through signal dependencies:
+ *   1. `earlyRead`
+ *   2. `write`
+ *   3. `mixedReadWrite`
+ *   4. `read`
+ * - `afterRenderEffect`s in the same phase run in the order they are registered.
+ * - `afterRenderEffect`s run on browser platforms only, they will not run on the server.
+ * - `afterRenderEffect`s will run at least once.
+ *
+ * The first phase callback to run as part of this spec will receive no parameters. Each
+ * subsequent phase callback in this spec will receive the return value of the previously run
+ * phase callback as a `Signal`. This can be used to coordinate work across multiple phases.
+ *
+ * Angular is unable to verify or enforce that phases are used correctly, and instead
+ * relies on each developer to follow the guidelines documented for each value and
+ * carefully choose the appropriate one, refactoring their code if necessary. By doing
+ * so, Angular is better able to minimize the performance degradation associated with
+ * manual DOM access, ensuring the best experience for the end users of your application
+ * or library.
+ *
+ * <div class="alert is-important">
+ *
+ * Components are not guaranteed to be [hydrated](guide/hydration) before the callback runs.
+ * You must use caution when directly reading or writing the DOM and layout.
+ *
+ * </div>
+ *
+ * @param spec The effect functions to register
+ * @param options Options to control the behavior of the effects
+ *
+ * @usageNotes
+ *
+ * Use `afterRenderEffect` to create effects that will read or write from the DOM and thus should
+ * run after rendering.
+ *
+ * @experimental
+ */
+export function afterRenderEffect<E = never, W = never, M = never>(
+  spec: {
+    earlyRead?: (onCleanup: EffectCleanupRegisterFn) => E;
+    write?: (...args: [...ɵFirstAvailableSignal<[E]>, EffectCleanupRegisterFn]) => W;
+    mixedReadWrite?: (...args: [...ɵFirstAvailableSignal<[W, E]>, EffectCleanupRegisterFn]) => M;
+    read?: (...args: [...ɵFirstAvailableSignal<[M, W, E]>, EffectCleanupRegisterFn]) => void;
+  },
+  options?: Omit<AfterRenderOptions, 'phase'>,
+): AfterRenderRef;
+
+export function afterRenderEffect<E = never, W = never, M = never>(
+  callbackOrSpec:
+    | ((onCleanup: EffectCleanupRegisterFn) => void)
+    | {
+        earlyRead?: (onCleanup: EffectCleanupRegisterFn) => E;
+        write?: (...args: [...ɵFirstAvailableSignal<[E]>, EffectCleanupRegisterFn]) => W;
+        mixedReadWrite?: (
+          ...args: [...ɵFirstAvailableSignal<[W, E]>, EffectCleanupRegisterFn]
+        ) => M;
+        read?: (...args: [...ɵFirstAvailableSignal<[M, W, E]>, EffectCleanupRegisterFn]) => void;
+      },
+  options?: Omit<AfterRenderOptions, 'phase'>,
+): AfterRenderRef {
+  ngDevMode &&
+    assertNotInReactiveContext(
+      afterRenderEffect,
+      'Call `afterRenderEffect` outside of a reactive context. For example, create the render ' +
+        'effect inside the component constructor`.',
+    );
+
+  !options?.injector && assertInInjectionContext(afterRenderEffect);
+  const injector = options?.injector ?? inject(Injector);
+
+  if (!isPlatformBrowser(injector)) {
+    return NOOP_AFTER_RENDER_REF;
+  }
+
+  const scheduler = injector.get(ChangeDetectionScheduler);
+  const manager = injector.get(AfterRenderManager);
+  manager.impl ??= injector.get(AfterRenderImpl);
+
+  let spec = callbackOrSpec;
+  if (typeof spec === 'function') {
+    spec = {mixedReadWrite: callbackOrSpec as any};
+  }
+
+  const sequence = new AfterRenderEffectSequence(
+    manager.impl,
+    [spec.earlyRead, spec.write, spec.mixedReadWrite, spec.read] as AfterRenderPhaseEffectHook[],
+    scheduler,
+    injector.get(DestroyRef),
+  );
+  manager.impl.register(sequence);
+  return sequence;
+}

--- a/packages/core/test/acceptance/after_render_effect_spec.ts
+++ b/packages/core/test/acceptance/after_render_effect_spec.ts
@@ -1,0 +1,336 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {
+  afterNextRender,
+  ApplicationRef,
+  computed,
+  PLATFORM_ID,
+  provideExperimentalZonelessChangeDetection,
+  signal,
+} from '@angular/core';
+import {afterRenderEffect} from '@angular/core/src/render3/reactivity/after_render_effect';
+import {TestBed} from '@angular/core/testing';
+
+describe('afterRenderEffect', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({providers: [{provide: PLATFORM_ID, useValue: 'browser'}]});
+  });
+
+  it('should support a single callback in the mixedReadWrite phase', () => {
+    const log: string[] = [];
+    const appRef = TestBed.inject(ApplicationRef);
+    afterNextRender(() => log.push('before'), {injector: appRef.injector});
+    afterRenderEffect(() => log.push('mixedReadWrite'), {injector: appRef.injector});
+    afterNextRender(() => log.push('after'), {injector: appRef.injector});
+    appRef.tick();
+    expect(log).toEqual(['before', 'mixedReadWrite', 'after']);
+  });
+
+  it('should run once', () => {
+    const log: string[] = [];
+    const appRef = TestBed.inject(ApplicationRef);
+    afterRenderEffect(
+      {
+        earlyRead: () => log.push('earlyRead'),
+        write: () => log.push('write'),
+        mixedReadWrite: () => log.push('mixedReadWrite'),
+        read: () => log.push('read'),
+      },
+      {injector: appRef.injector},
+    );
+    appRef.tick();
+    expect(log).toEqual(['earlyRead', 'write', 'mixedReadWrite', 'read']);
+  });
+
+  it('should not run when not dirty', () => {
+    const log: string[] = [];
+    const appRef = TestBed.inject(ApplicationRef);
+
+    afterRenderEffect(
+      {
+        earlyRead: () => log.push('earlyRead'),
+        write: () => log.push('write'),
+        mixedReadWrite: () => log.push('mixedReadWrite'),
+        read: () => log.push('read'),
+      },
+      {injector: appRef.injector},
+    );
+
+    // We expect an initial run, and clear the log.
+    appRef.tick();
+    log.length = 0;
+
+    // The second tick() should not re-run the effects as they're not dirty.
+    appRef.tick();
+    expect(log.length).toBe(0);
+  });
+
+  it('should run when made dirty via signal', () => {
+    const log: string[] = [];
+    const appRef = TestBed.inject(ApplicationRef);
+    const counter = signal(0);
+
+    afterRenderEffect(
+      {
+        // `earlyRead` depends on `counter`
+        earlyRead: () => log.push(`earlyRead: ${counter()}`),
+        // `write` does not
+        write: () => log.push('write'),
+      },
+      {injector: appRef.injector},
+    );
+    appRef.tick();
+    log.length = 0;
+
+    counter.set(1);
+    appRef.tick();
+
+    expect(log).toEqual(['earlyRead: 1']);
+  });
+
+  it('should not run when not actually dirty from signals', () => {
+    const log: string[] = [];
+    const appRef = TestBed.inject(ApplicationRef);
+    const counter = signal(0);
+    const isEven = computed(() => counter() % 2 === 0);
+
+    afterRenderEffect(
+      {
+        earlyRead: () => log.push(`earlyRead: ${isEven()}`),
+      },
+      {injector: appRef.injector},
+    );
+    appRef.tick();
+    log.length = 0;
+
+    counter.set(2);
+    appRef.tick();
+
+    // Should not have run since `isEven()` didn't actually change despite becoming dirty.
+    expect(log.length).toBe(0);
+  });
+
+  it('should pass data from one phase to the next via signal', () => {
+    const log: string[] = [];
+    const appRef = TestBed.inject(ApplicationRef);
+    const counter = signal(0);
+
+    afterRenderEffect(
+      {
+        // `earlyRead` calculates `isEven`
+        earlyRead: () => counter() % 2 === 0,
+        write: (isEven) => log.push(`isEven: ${isEven()}`),
+      },
+      {injector: appRef.injector},
+    );
+    appRef.tick();
+    log.length = 0;
+
+    // isEven: false
+    counter.set(1);
+    appRef.tick();
+
+    // isEven: true
+    counter.set(2);
+    appRef.tick();
+
+    // No change (no log).
+    counter.set(4);
+    appRef.tick();
+
+    expect(log).toEqual(['isEven: false', 'isEven: true']);
+  });
+
+  it('should run cleanup functions before re-running phase effects', () => {
+    const log: string[] = [];
+    const appRef = TestBed.inject(ApplicationRef);
+    const counter = signal(0);
+
+    afterRenderEffect(
+      {
+        earlyRead: (onCleanup) => {
+          onCleanup(() => log.push('cleanup earlyRead'));
+          log.push(`earlyRead: ${counter()}`);
+          // Calculate isEven:
+          return counter() % 2 === 0;
+        },
+        write: (isEven, onCleanup) => {
+          onCleanup(() => log.push('cleanup write'));
+          log.push(`write: ${isEven()}`);
+        },
+      },
+      {injector: appRef.injector},
+    );
+
+    // Initial run should run both effects with no cleanup
+    appRef.tick();
+    expect(log).toEqual(['earlyRead: 0', 'write: true']);
+    log.length = 0;
+
+    // A counter of 1 will clean up and rerun both effects.
+    counter.set(1);
+    appRef.tick();
+    expect(log).toEqual(['cleanup earlyRead', 'earlyRead: 1', 'cleanup write', 'write: false']);
+    log.length = 0;
+
+    // A counter of 3 will clean up and rerun the earlyRead phase only.
+    counter.set(3);
+    appRef.tick();
+    expect(log).toEqual(['cleanup earlyRead', 'earlyRead: 3']);
+    log.length = 0;
+
+    // A counter of 4 will then clean up and rerun both effects.
+    counter.set(4);
+    appRef.tick();
+    expect(log).toEqual(['cleanup earlyRead', 'earlyRead: 4', 'cleanup write', 'write: true']);
+  });
+
+  it('should run cleanup functions when destroyed', () => {
+    const log: string[] = [];
+    const appRef = TestBed.inject(ApplicationRef);
+
+    const ref = afterRenderEffect(
+      {
+        earlyRead: (onCleanup) => {
+          onCleanup(() => log.push('cleanup earlyRead'));
+        },
+        write: (_, onCleanup) => {
+          onCleanup(() => log.push('cleanup write'));
+        },
+        mixedReadWrite: (_, onCleanup) => {
+          onCleanup(() => log.push('cleanup mixedReadWrite'));
+        },
+        read: (_, onCleanup) => {
+          onCleanup(() => log.push('cleanup read'));
+        },
+      },
+      {injector: appRef.injector},
+    );
+
+    appRef.tick();
+    expect(log.length).toBe(0);
+
+    ref.destroy();
+    expect(log).toEqual([
+      'cleanup earlyRead',
+      'cleanup write',
+      'cleanup mixedReadWrite',
+      'cleanup read',
+    ]);
+  });
+
+  it('should schedule CD when dirty', async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideExperimentalZonelessChangeDetection(),
+        {provide: PLATFORM_ID, useValue: 'browser'},
+      ],
+    });
+
+    const log: string[] = [];
+    const appRef = TestBed.inject(ApplicationRef);
+    const counter = signal(0);
+
+    afterRenderEffect(
+      {earlyRead: () => log.push(`earlyRead: ${counter()}`)},
+      {injector: appRef.injector},
+    );
+    await appRef.whenStable();
+    expect(log).toEqual(['earlyRead: 0']);
+
+    counter.set(1);
+    await appRef.whenStable();
+    expect(log).toEqual(['earlyRead: 0', 'earlyRead: 1']);
+  });
+
+  it('should cause a re-run for hooks that re-dirty themselves', () => {
+    const log: string[] = [];
+    const appRef = TestBed.inject(ApplicationRef);
+    const counter = signal(0);
+
+    afterRenderEffect(
+      {
+        earlyRead: () => {
+          log.push(`counter: ${counter()}`);
+
+          // Cause a re-execution when counter is 1.
+          if (counter() === 1) {
+            counter.set(0);
+          }
+        },
+      },
+      {injector: appRef.injector},
+    );
+
+    appRef.tick();
+    log.length = 0;
+
+    counter.set(1);
+    appRef.tick();
+    expect(log).toEqual(['counter: 1', 'counter: 0']);
+  });
+
+  it('should cause a re-run for hooks that re-dirty earlier hooks', () => {
+    const log: string[] = [];
+    const appRef = TestBed.inject(ApplicationRef);
+    const counter = signal(0);
+
+    afterRenderEffect(
+      {
+        earlyRead: () => {
+          log.push(`earlyRead: ${counter()}`);
+          return counter();
+        },
+        write: (value) => {
+          log.push(`write: ${value()}`);
+          // Cause a re-execution when value from earlyRead is 1.
+          if (value() === 1) {
+            counter.set(0);
+          }
+        },
+      },
+      {injector: appRef.injector},
+    );
+
+    appRef.tick();
+    log.length = 0;
+
+    counter.set(1);
+    appRef.tick();
+    expect(log).toEqual(['earlyRead: 1', 'write: 1', 'earlyRead: 0', 'write: 0']);
+  });
+
+  it('should not run later hooks when an earlier hook is re-dirtied', () => {
+    const log: string[] = [];
+    const appRef = TestBed.inject(ApplicationRef);
+    const counter = signal(0);
+
+    afterRenderEffect(
+      {
+        earlyRead: () => {
+          const value = counter();
+          log.push(`earlyRead: ${value}`);
+          if (value === 1) {
+            counter.set(0);
+          }
+          return value;
+        },
+        write: (value) => log.push(`write: ${value()}`),
+      },
+      {injector: appRef.injector},
+    );
+
+    appRef.tick();
+    log.length = 0;
+
+    counter.set(1);
+    appRef.tick();
+    expect(log).toEqual(['earlyRead: 1', 'earlyRead: 0', 'write: 0']);
+  });
+});

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -699,6 +699,9 @@
     "name": "configureViewWithDirective"
   },
   {
+    "name": "consumerAfterComputation"
+  },
+  {
     "name": "consumerBeforeComputation"
   },
   {
@@ -760,6 +763,9 @@
   },
   {
     "name": "deepForEachProvider"
+  },
+  {
+    "name": "defaultEquals"
   },
   {
     "name": "defaultErrorHandler"
@@ -1063,6 +1069,9 @@
   },
   {
     "name": "init_advance"
+  },
+  {
+    "name": "init_after_render_effect"
   },
   {
     "name": "init_all"


### PR DESCRIPTION
Implement the `afterRenderEffect` primitive, which creates effect(s) that run as part of Angular's `afterRender` sequence. `afterRenderEffect` is a useful primitive for expressing DOM operations in a declarative, reactive way.

The API itself mirrors `afterRender` and `afterNextRender` with one big difference: values are propagated from phase to phase as signals instead of as plain values. As a result, later phases may not need to execute if the values returned by earlier phases do not change.
