### PR TITLE
fix(core): Schedulers run in zone above Angular rather than root

### DIFF
--- a/packages/core/src/change_detection/scheduling/flags.ts
+++ b/packages/core/src/change_detection/scheduling/flags.ts
@@ -6,4 +6,4 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export const SCHEDULE_IN_ROOT_ZONE_DEFAULT = true;
+export const SCHEDULE_IN_ROOT_ZONE_DEFAULT = false;


### PR DESCRIPTION
This change updates the timers used in the coalescing and hybrid mode schedulers to run in the zone above Angular rather than the root zone. Running the timers in the root zone makes them impossible to flush when using `fakeAsync` and also may make them invisible to other zones in the hierarchy that might have desirable behaviors such as task/perf tracking.

fixes #56767

BREAKING CHANGE: The timers that are used for zone coalescing and hybrid mode scheduling (which schedules an application state synchronization when changes happen outside the Angular zone) will now run in the zone above Angular rather than the root zone. This will mostly affect tests which use `fakeAsync`: these timers will now be visible to `fakeAsync` and can be affected by `tick` or `flush`.