### PR TITLE
fix(docs-infra): Fix scrolling in application

### DIFF
--- a/adev/src/app/app-scroller.ts
+++ b/adev/src/app/app-scroller.ts
@@ -64,7 +64,7 @@ export class AppScroller {
     const {anchor, position} = this._lastScrollEvent;
 
     // Don't scroll during rendering
-    this.cancelScroll = afterNextRender(
+    const ref = afterNextRender(
       {
         write: () => {
           if (position) {
@@ -77,6 +77,9 @@ export class AppScroller {
         },
       },
       {injector: this.injector},
-    ).destroy;
+    );
+    this.cancelScroll = () => {
+      ref.destroy();
+    };
   }
 }


### PR DESCRIPTION
Since the change to the after render hooks, the "this" context must be correct for the destroy to work.

fixes #57552
