### PR TITLE
docs: remove `@searchKeywords`

### DIFF
--- a/packages/forms/src/directives/default_value_accessor.ts
+++ b/packages/forms/src/directives/default_value_accessor.ts
@@ -54,7 +54,6 @@ export const COMPOSITION_BUFFER_MODE = new InjectionToken<boolean>(
  * elements. The accessor is used by the `FormControlDirective`, `FormControlName`, and
  * `NgModel` directives.
  *
- * {@searchKeywords ngDefaultControl}
  *
  * @usageNotes
  *


### PR DESCRIPTION
This tag is not supported.

fixes #57540