### PR TITLE
docs(docs-infra): add search via queryparam on all adev routes

### DIFF
--- a/adev/src/app/main.component.ts
+++ b/adev/src/app/main.component.ts
@@ -1,0 +1,28 @@
+import {Component, effect, inject, model, WritableSignal} from '@angular/core';
+import {IS_SEARCH_DIALOG_OPEN, Search} from '@angular/docs';
+import {RouterOutlet} from '@angular/router';
+
+@Component({
+  standalone: true,
+  selector: 'adev-main',
+  imports: [RouterOutlet],
+  template: `<router-outlet />`,
+})
+export default class MainComponent {
+  private readonly displaySearchDialog: WritableSignal<boolean> = inject(IS_SEARCH_DIALOG_OPEN);
+  private readonly searchService = inject(Search);
+  search = model<string | undefined>('');
+
+  constructor() {
+    effect(
+      () => {
+        const search = this.search();
+        if (search !== undefined) {
+          this.displaySearchDialog.set(true);
+          this.searchService.updateSearchQuery(search);
+        }
+      },
+      {allowSignalWrites: true},
+    );
+  }
+}

--- a/adev/src/app/routes.ts
+++ b/adev/src/app/routes.ts
@@ -12,6 +12,7 @@ import {Route} from '@angular/router';
 import {DefaultPage, PagePrefix} from './core/enums/pages';
 import {SUB_NAVIGATION_DATA} from './sub-navigation-data';
 import {mapApiManifestToRoutes} from './features/references/helpers/manifest.helper';
+import MainComponent from './main.component';
 
 // Docs navigation data contains routes which navigates to /tutorials pages, in
 // that case we should load Tutorial component
@@ -124,6 +125,7 @@ const API_REFERENCE_ROUTES: Route[] = mapApiManifestToRoutes();
 export const routes: Route[] = [
   {
     path: '',
+    component: MainComponent,
     children: [
       {
         path: '',


### PR DESCRIPTION
add search via a queryparam (?search=query) on all adev routes

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Search is only accessible from the search button in the side nav.

Issue Number: N/A


## What is the new behavior?
Allows search via a queryParam, to link directly to search results for a given query. e.g. `https://angular.dev/?search=inject` will show the same results as manually searching for `inject`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
