### PR TITLE
fix(core): removing a pending task delays stability until the next tick

### DIFF
--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling.ts
@@ -47,6 +47,9 @@ export const enum NotificationSource {
   ViewDetachedFromDOM,
   // Applying animations might result in new DOM state and should rerun render hooks
   AsyncAnimationsLoaded,
+  // The scheduler is notified when a pending task is removed via the public API.
+  // This allows us to make stability async, delayed until the next application tick.
+  PendingTaskRemoved,
 }
 
 /**

--- a/packages/core/test/acceptance/pending_tasks_spec.ts
+++ b/packages/core/test/acceptance/pending_tasks_spec.ts
@@ -72,9 +72,12 @@ describe('public ExperimentalPendingTasks', () => {
     const appRef = TestBed.inject(ApplicationRef);
     const pendingTasks = TestBed.inject(ExperimentalPendingTasks);
 
-    const taskA = pendingTasks.add();
+    const removeTaskA = pendingTasks.add();
     await expectAsync(applicationRefIsStable(appRef)).toBeResolvedTo(false);
-    taskA();
+    removeTaskA();
+    // stability is delayed until a tick happens
+    await expectAsync(applicationRefIsStable(appRef)).toBeResolvedTo(false);
+    TestBed.inject(ApplicationRef).tick();
     await expectAsync(applicationRefIsStable(appRef)).toBeResolvedTo(true);
   });
 });


### PR DESCRIPTION
This commit updates the public API for pending tasks to schedule an application tick, effectively making the stability async when the last task is removed.
