### PR TITLE
Revert "fix(http): Dynamicaly call the global fetch implementation (#…

### DIFF
--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -52,11 +52,9 @@ function getResponseUrl(response: Response): string | null {
  */
 @Injectable()
 export class FetchBackend implements HttpBackend {
-  // Note: binding fetch directly causes an "illegal invocation" error
-  // We use an arrow function to always reference the current global implementation of fetch
-  // In case it has been (monkey)patched after the FetchBackend has been created
+  // We need to bind the native fetch to its context or it will throw an "illegal invocation"
   private readonly fetchImpl =
-    inject(FetchFactory, {optional: true})?.fetch ?? ((...args) => globalThis.fetch(...args));
+    inject(FetchFactory, {optional: true})?.fetch ?? fetch.bind(globalThis);
   private readonly ngZone = inject(NgZone);
 
   handle(request: HttpRequest<any>): Observable<HttpEvent<any>> {

--- a/packages/common/http/test/fetch_spec.ts
+++ b/packages/common/http/test/fetch_spec.ts
@@ -12,14 +12,11 @@ import {Observable, of, Subject} from 'rxjs';
 import {catchError, retry, scan, skip, take, toArray} from 'rxjs/operators';
 
 import {
-  HttpClient,
   HttpDownloadProgressEvent,
   HttpErrorResponse,
   HttpHeaderResponse,
   HttpParams,
   HttpStatusCode,
-  provideHttpClient,
-  withFetch,
 } from '../public_api';
 import {FetchBackend, FetchFactory} from '../src/fetch';
 
@@ -417,36 +414,6 @@ describe('FetchBackend', async () => {
           },
         });
       fetchMock.mockFlush(0, 'CORS 0 status');
-    });
-  });
-
-  describe('dynamic global fetch', () => {
-    beforeEach(() => {
-      TestBed.resetTestingModule();
-      TestBed.configureTestingModule({
-        providers: [provideHttpClient(withFetch())],
-      });
-    });
-
-    it('should use the current implementation of the global fetch', async () => {
-      const fakeFetch = jasmine
-        .createSpy('', () => Promise.resolve(new Response(JSON.stringify({foo: 'bar'}))))
-        .and.callThrough();
-      globalThis.fetch = fakeFetch;
-
-      const client = TestBed.inject(HttpClient);
-      expect(fakeFetch).not.toHaveBeenCalled();
-      let response = await client.get<unknown>('').toPromise();
-      expect(fakeFetch).toHaveBeenCalled();
-      expect(response).toEqual({foo: 'bar'});
-
-      // We dynamicaly change the implementation of fetch
-      const fakeFetch2 = jasmine
-        .createSpy('', () => Promise.resolve(new Response(JSON.stringify({foo: 'baz'}))))
-        .and.callThrough();
-      globalThis.fetch = fakeFetch2;
-      response = await client.get<unknown>('').toPromise();
-      expect(response).toEqual({foo: 'baz'});
     });
   });
 });


### PR DESCRIPTION
…57531)"

This reverts commit 21445a29322d12fadfb2decaea56f14e95878886.

Reason: failing test
