### PR TITLE
fix(common): set HttpResponseBase.statusText to an empty string by default

### DIFF
--- a/packages/common/http/src/response.ts
+++ b/packages/common/http/src/response.ts
@@ -164,7 +164,7 @@ export abstract class HttpResponseBase {
   readonly status: number;
 
   /**
-   * Textual description of response status code, defaults to OK.
+   * Textual description of response status code, defaults to an empty string.
    *
    * Do not depend on this.
    */
@@ -200,7 +200,7 @@ export abstract class HttpResponseBase {
       url?: string;
     },
     defaultStatus: number = 200,
-    defaultStatusText: string = 'OK',
+    defaultStatusText: string = '',
   ) {
     // If the hash has values passed, use them to initialize the response.
     // Otherwise use the default values.
@@ -363,9 +363,10 @@ export class HttpErrorResponse extends HttpResponseBase implements Error {
     if (this.status >= 200 && this.status < 300) {
       this.message = `Http failure during parsing for ${init.url || '(unknown url)'}`;
     } else {
-      this.message = `Http failure response for ${init.url || '(unknown url)'}: ${init.status} ${
-        init.statusText
-      }`;
+      const statusErrorText = [undefined, ''].includes(init.statusText)
+        ? ''
+        : ` ${init.statusText}`;
+      this.message = `Http failure response for ${init.url || '(unknown url)'}: ${init.status}${statusErrorText}`;
     }
     this.error = init.error || null;
   }

--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -138,7 +138,7 @@ export class HttpXhrBackend implements HttpBackend {
               return headerResponse;
             }
 
-            const statusText = xhr.statusText || 'OK';
+            const statusText = xhr.statusText || '';
 
             // Parse headers from XMLHttpRequest - this step is lazy.
             const headers = new HttpHeaders(xhr.getAllResponseHeaders());

--- a/packages/common/http/testing/src/request.ts
+++ b/packages/common/http/testing/src/request.ts
@@ -93,9 +93,6 @@ export class TestRequest {
         statusText ||= 'OK';
       }
     }
-    if (statusText === undefined) {
-      throw new Error('statusText is required when setting a custom status.');
-    }
     if (status >= 200 && status < 300) {
       this.observer.next(new HttpResponse<any>({body, headers, status, statusText, url}));
       this.observer.complete();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Issue Number: #23334

## What is the new behavior?
The new behaviour


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
The statusText on HttpResponseBase no longer defaults to 'OK'.

Any code that depends on statusText being 'OK' in situations where there is none set needs to be updated to expect an empty string. Note that this may apply to use-cases like displaying and logging HTTP response errors.


## Other information
