### PR TITLE
ci: use version 13.15.1 of firebase-tools for deployment of doc sites

### DIFF
--- a/.github/actions/deploy-docs-site/lib/deploy.ts
+++ b/.github/actions/deploy-docs-site/lib/deploy.ts
@@ -103,7 +103,7 @@ export async function setupRedirect(deployment: Deployment) {
 }
 
 function firebase(cmd: string, cwd?: string) {
-  spawnSync('npx', `-y firebase-tools@latest ${cmd}`.split(' '), {
+  spawnSync('npx', `-y firebase-tools@13.15.1 ${cmd}`.split(' '), {
     cwd,
     encoding: 'utf-8',
     shell: true,

--- a/.github/actions/deploy-docs-site/main.js
+++ b/.github/actions/deploy-docs-site/main.js
@@ -11415,7 +11415,7 @@ async function setupRedirect(deployment) {
   await rm(tmpRedirectDir, { recursive: true });
 }
 function firebase(cmd, cwd) {
-  spawnSync("npx", `-y firebase-tools@latest ${cmd}`.split(" "), {
+  spawnSync("npx", `-y firebase-tools@13.15.1 ${cmd}`.split(" "), {
     cwd,
     encoding: "utf-8",
     shell: true,


### PR DESCRIPTION
Use 13.15.1 instead of tracking to latest to prevent unexpected and unbisectable changes.
