### PR TITLE
refactor(migrations): pass project-relative paths for tsurge replacements

### DIFF
--- a/packages/core/schematics/migrations/signal-migration/src/batch/test_bin.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/batch/test_bin.ts
@@ -41,12 +41,12 @@ async function main() {
 
     process.stdout.write(JSON.stringify(mergedResult));
   } else if (mode === 'migrate') {
-    const replacements = await executeMigratePhase(
+    const {replacements, projectDirAbsPath} = await executeMigratePhase(
       migration,
       JSON.parse(fs.readFileSync(path.resolve(args[1]), 'utf8')) as CompilationUnitData,
       path.resolve(args[0]),
     );
 
-    writeMigrationReplacements(replacements);
+    writeMigrationReplacements(replacements, projectDirAbsPath);
   }
 }

--- a/packages/core/schematics/migrations/signal-migration/src/index.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/index.ts
@@ -36,6 +36,8 @@ export async function main(absoluteTsconfigPath: string, bestEffortMode: boolean
     'Expected upgraded analysis phase results; batch mode is disabled.',
   );
 
+  const {replacements, projectAbsDirPath} = migration.upgradedAnalysisPhaseResults;
+
   // Apply replacements
-  writeMigrationReplacements(migration.upgradedAnalysisPhaseResults);
+  writeMigrationReplacements(replacements, projectAbsDirPath);
 }

--- a/packages/core/schematics/migrations/signal-migration/src/migration.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/migration.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {FileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {AbsoluteFsPath, FileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {confirmAsSerializable, Serializable} from '../../../utils/tsurge/helpers/serializable';
 import {BaseProgramInfo, ProgramInfo} from '../../../utils/tsurge/program_info';
 import {TsurgeComplexMigration} from '../../../utils/tsurge/migration';
@@ -36,7 +36,10 @@ export class SignalInputMigration extends TsurgeComplexMigration<
   CompilationUnitData
 > {
   upgradeAnalysisPhaseToAvoidBatch = false;
-  upgradedAnalysisPhaseResults: Replacement[] | null = null;
+  upgradedAnalysisPhaseResults: {
+    replacements: Replacement[];
+    projectAbsDirPath: AbsoluteFsPath;
+  } | null = null;
 
   // Necessary for language service configuration.
   reportProgressFn: ((percentage: number, updateMessage: string) => void) | null = null;
@@ -102,7 +105,7 @@ export class SignalInputMigration extends TsurgeComplexMigration<
       this.reportProgressFn?.(100, 'Completed migration.');
 
       // Expose the upgraded analysis stage results.
-      this.upgradedAnalysisPhaseResults = replacements;
+      this.upgradedAnalysisPhaseResults = {replacements, projectAbsDirPath: info.projectDirAbsPath};
     }
 
     return confirmAsSerializable(unitData);

--- a/packages/core/schematics/migrations/signal-migration/src/passes/10_apply_import_manager.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/10_apply_import_manager.ts
@@ -10,6 +10,7 @@ import {ImportManager} from '@angular/compiler-cli/src/ngtsc/translator';
 import ts from 'typescript';
 import {applyImportManagerChanges} from '../../../../utils/tsurge/helpers/apply_import_manager';
 import {MigrationResult} from '../result';
+import {AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
 
 /**
  * Phase that applies all changes recorded by the import manager in
@@ -19,6 +20,7 @@ export function pass10_applyImportManager(
   importManager: ImportManager,
   result: MigrationResult,
   sourceFiles: readonly ts.SourceFile[],
+  projectAbsPath: AbsoluteFsPath,
 ) {
-  applyImportManagerChanges(importManager, result.replacements, sourceFiles);
+  applyImportManagerChanges(importManager, result.replacements, sourceFiles, projectAbsPath);
 }

--- a/packages/core/schematics/migrations/signal-migration/src/passes/5_migrate_ts_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/5_migrate_ts_references.ts
@@ -9,13 +9,13 @@
 import ts from 'typescript';
 import {MigrationResult} from '../result';
 import {analyzeControlFlow} from '../flow_analysis';
-import {Replacement, TextUpdate} from '../../../../utils/tsurge/replacement';
+import {projectRelativePath, Replacement, TextUpdate} from '../../../../utils/tsurge/replacement';
 import {InputUniqueKey} from '../utils/input_id';
 import {isTsInputReference} from '../utils/input_reference';
 import {traverseAccess} from '../utils/traverse_access';
 import {KnownInputs} from '../input_detection/known_inputs';
 import {UniqueNamesGenerator} from '../utils/unique_names';
-import {absoluteFromSourceFile} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
 
 /**
  * Phase that migrates TypeScript input references to be signal compatible.
@@ -46,6 +46,7 @@ export function pass5__migrateTypeScriptReferences(
   result: MigrationResult,
   checker: ts.TypeChecker,
   knownInputs: KnownInputs,
+  projectDirAbsPath: AbsoluteFsPath,
 ) {
   const tsReferences = new Map<InputUniqueKey, {accesses: ts.Identifier[]}>();
   const seenIdentifiers = new WeakSet<ts.Identifier>();
@@ -95,7 +96,7 @@ export function pass5__migrateTypeScriptReferences(
         // Append `()` to unwrap the signal.
         result.replacements.push(
           new Replacement(
-            absoluteFromSourceFile(sf),
+            projectRelativePath(sf, projectDirAbsPath),
             new TextUpdate({
               position: originalNode.getEnd(),
               end: originalNode.getEnd(),
@@ -112,7 +113,7 @@ export function pass5__migrateTypeScriptReferences(
         const replaceNode = traverseAccess(originalNode);
         result.replacements.push(
           new Replacement(
-            absoluteFromSourceFile(sf),
+            projectRelativePath(sf, projectDirAbsPath),
             new TextUpdate({
               position: replaceNode.getStart(),
               end: replaceNode.getEnd(),
@@ -147,7 +148,7 @@ export function pass5__migrateTypeScriptReferences(
 
       result.replacements.push(
         new Replacement(
-          absoluteFromSourceFile(sf),
+          projectRelativePath(sf, projectDirAbsPath),
           new TextUpdate({
             position: previous.getStart(),
             end: previous.getStart(),
@@ -158,7 +159,7 @@ export function pass5__migrateTypeScriptReferences(
 
       result.replacements.push(
         new Replacement(
-          absoluteFromSourceFile(sf),
+          projectRelativePath(sf, projectDirAbsPath),
           new TextUpdate({
             position: replaceNode.getStart(),
             end: replaceNode.getEnd(),

--- a/packages/core/schematics/migrations/signal-migration/src/passes/6_migrate_input_declarations.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/6_migrate_input_declarations.ts
@@ -12,8 +12,8 @@ import {convertToSignalInput} from '../convert-input/convert_to_signal';
 import assert from 'assert';
 import {KnownInputs} from '../input_detection/known_inputs';
 import {ImportManager} from '@angular/compiler-cli/src/ngtsc/translator';
-import {Replacement, TextUpdate} from '../../../../utils/tsurge/replacement';
-import {absoluteFromSourceFile} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {projectRelativePath, Replacement, TextUpdate} from '../../../../utils/tsurge/replacement';
+import {AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
 
 /**
  * Phase that migrates `@Input()` declarations to signal inputs and
@@ -24,6 +24,7 @@ export function pass6__migrateInputDeclarations(
   result: MigrationResult,
   knownInputs: KnownInputs,
   importManager: ImportManager,
+  projectDirAbsPath: AbsoluteFsPath,
 ) {
   let filesWithMigratedInputs = new Set<ts.SourceFile>();
   let filesWithIncompatibleInputs = new WeakSet<ts.SourceFile>();
@@ -42,7 +43,7 @@ export function pass6__migrateInputDeclarations(
     filesWithMigratedInputs.add(sf);
     result.replacements.push(
       new Replacement(
-        absoluteFromSourceFile(sf),
+        projectRelativePath(sf, projectDirAbsPath),
         new TextUpdate({
           position: input.node.getStart(),
           end: input.node.getEnd(),

--- a/packages/core/schematics/migrations/signal-migration/src/passes/7_migrate_template_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/7_migrate_template_references.ts
@@ -7,11 +7,11 @@
  */
 
 import {MigrationHost} from '../migration_host';
-import {absoluteFrom} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {MigrationResult} from '../result';
 import {isTemplateInputReference} from '../utils/input_reference';
 import {KnownInputs} from '../input_detection/known_inputs';
-import {Replacement, TextUpdate} from '../../../../utils/tsurge/replacement';
+import {projectRelativePath, Replacement, TextUpdate} from '../../../../utils/tsurge/replacement';
 
 /**
  * Phase that migrates Angular template references to
@@ -21,6 +21,7 @@ export function pass7__migrateTemplateReferences(
   host: MigrationHost,
   result: MigrationResult,
   knownInputs: KnownInputs,
+  projectDirAbsPath: AbsoluteFsPath,
 ) {
   const seenFileReferences = new Set<string>();
 
@@ -48,7 +49,7 @@ export function pass7__migrateTemplateReferences(
 
     result.replacements.push(
       new Replacement(
-        absoluteFrom(host.idToFilePath(reference.from.templateFileId)),
+        projectRelativePath(host.idToFilePath(reference.from.templateFileId), projectDirAbsPath),
         new TextUpdate({
           position: reference.from.read.sourceSpan.end,
           end: reference.from.read.sourceSpan.end,

--- a/packages/core/schematics/migrations/signal-migration/src/passes/8_migrate_host_bindings.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/8_migrate_host_bindings.ts
@@ -7,8 +7,8 @@
  */
 
 import ts from 'typescript';
-import {absoluteFromSourceFile} from '@angular/compiler-cli/src/ngtsc/file_system';
-import {Replacement, TextUpdate} from '../../../../utils/tsurge/replacement';
+import {AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {projectRelativePath, Replacement, TextUpdate} from '../../../../utils/tsurge/replacement';
 import {MigrationResult} from '../result';
 import {isHostBindingInputReference} from '../utils/input_reference';
 import {KnownInputs} from '../input_detection/known_inputs';
@@ -17,7 +17,11 @@ import {KnownInputs} from '../input_detection/known_inputs';
  * Phase that migrates Angular host binding references to
  * unwrap signals.
  */
-export function pass8__migrateHostBindings(result: MigrationResult, knownInputs: KnownInputs) {
+export function pass8__migrateHostBindings(
+  result: MigrationResult,
+  knownInputs: KnownInputs,
+  projectDirAbsPath: AbsoluteFsPath,
+) {
   const seenReferences = new WeakMap<ts.Node, Set<number>>();
 
   for (const reference of result.references) {
@@ -51,7 +55,7 @@ export function pass8__migrateHostBindings(result: MigrationResult, knownInputs:
 
     result.replacements.push(
       new Replacement(
-        absoluteFromSourceFile(bindingField.getSourceFile()),
+        projectRelativePath(bindingField.getSourceFile(), projectDirAbsPath),
         new TextUpdate({position: readEndPos, end: readEndPos, toInsert: appendText}),
       ),
     );

--- a/packages/core/schematics/migrations/signal-migration/src/passes/9_migrate_ts_type_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/9_migrate_ts_type_references.ts
@@ -10,8 +10,8 @@ import ts from 'typescript';
 import {KnownInputs} from '../input_detection/known_inputs';
 import {MigrationResult} from '../result';
 import {isTsInputClassTypeReference} from '../utils/input_reference';
-import {absoluteFromSourceFile} from '@angular/compiler-cli/src/ngtsc/file_system';
-import {Replacement, TextUpdate} from '../../../../utils/tsurge/replacement';
+import {AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {projectRelativePath, Replacement, TextUpdate} from '../../../../utils/tsurge/replacement';
 import assert from 'assert';
 import {ImportManager} from '@angular/compiler-cli/src/ngtsc/translator';
 
@@ -25,6 +25,7 @@ export function pass9__migrateTypeScriptTypeReferences(
   result: MigrationResult,
   knownInputs: KnownInputs,
   importManager: ImportManager,
+  projectDirAbsPath: AbsoluteFsPath,
 ) {
   const seenTypeNodes = new WeakSet<ts.TypeReferenceNode>();
 
@@ -58,7 +59,7 @@ export function pass9__migrateTypeScriptTypeReferences(
 
       result.replacements.push(
         new Replacement(
-          absoluteFromSourceFile(sf),
+          projectRelativePath(sf, projectDirAbsPath),
           new TextUpdate({
             position: firstArg.getStart(),
             end: firstArg.getStart(),
@@ -68,7 +69,7 @@ export function pass9__migrateTypeScriptTypeReferences(
       );
       result.replacements.push(
         new Replacement(
-          absoluteFromSourceFile(sf),
+          projectRelativePath(sf, projectDirAbsPath),
           new TextUpdate({position: firstArg.getEnd(), end: firstArg.getEnd(), toInsert: '>'}),
         ),
       );

--- a/packages/core/schematics/migrations/signal-migration/src/phase_migrate.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/phase_migrate.ts
@@ -31,7 +31,7 @@ export function executeMigrationPhase(
   host: MigrationHost,
   knownInputs: KnownInputs,
   result: MigrationResult,
-  {typeChecker, sourceFiles}: AnalysisProgramInfo,
+  {typeChecker, sourceFiles, projectDirAbsPath}: AnalysisProgramInfo,
 ) {
   const importManager = new ImportManager({
     // For the purpose of this migration, we always use `input` and don't alias
@@ -40,10 +40,16 @@ export function executeMigrationPhase(
   });
 
   // Migrate passes.
-  pass5__migrateTypeScriptReferences(result, typeChecker, knownInputs);
-  pass6__migrateInputDeclarations(typeChecker, result, knownInputs, importManager);
-  pass7__migrateTemplateReferences(host, result, knownInputs);
-  pass8__migrateHostBindings(result, knownInputs);
-  pass9__migrateTypeScriptTypeReferences(result, knownInputs, importManager);
-  pass10_applyImportManager(importManager, result, sourceFiles);
+  pass5__migrateTypeScriptReferences(result, typeChecker, knownInputs, projectDirAbsPath);
+  pass6__migrateInputDeclarations(
+    typeChecker,
+    result,
+    knownInputs,
+    importManager,
+    projectDirAbsPath,
+  );
+  pass7__migrateTemplateReferences(host, result, knownInputs, projectDirAbsPath);
+  pass8__migrateHostBindings(result, knownInputs, projectDirAbsPath);
+  pass9__migrateTypeScriptTypeReferences(result, knownInputs, importManager, projectDirAbsPath);
+  pass10_applyImportManager(importManager, result, sourceFiles, projectDirAbsPath);
 }

--- a/packages/core/schematics/migrations/signal-migration/src/write_replacements.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/write_replacements.ts
@@ -6,16 +6,22 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import fs from 'fs';
 import {applyTextUpdates, Replacement} from '../../../utils/tsurge/replacement';
 import {groupReplacementsByFile} from '../../../utils/tsurge/helpers/group_replacements';
+import {AbsoluteFsPath, getFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 
 /** Applies the migration result and applies it to the file system. */
-export function writeMigrationReplacements(replacements: Replacement[]) {
-  for (const [filePath, updates] of groupReplacementsByFile(replacements)) {
-    const fileText = fs.readFileSync(filePath, 'utf8')!;
+export function writeMigrationReplacements(
+  replacements: Replacement[],
+  projectDirAbsPath: AbsoluteFsPath,
+) {
+  const fs = getFileSystem();
+
+  for (const [projectRelativePath, updates] of groupReplacementsByFile(replacements)) {
+    const filePath = fs.join(projectDirAbsPath, projectRelativePath);
+    const fileText = fs.readFile(filePath);
     const newText = applyTextUpdates(fileText, updates);
 
-    fs.writeFileSync(filePath, newText, 'utf8');
+    fs.writeFile(filePath, newText);
   }
 }

--- a/packages/core/schematics/migrations/signal-queries-migration/BUILD.bazel
+++ b/packages/core/schematics/migrations/signal-queries-migration/BUILD.bazel
@@ -12,6 +12,7 @@ ts_library(
         "//packages/compiler-cli/private",
         "//packages/compiler-cli/src/ngtsc/annotations",
         "//packages/compiler-cli/src/ngtsc/annotations/directive",
+        "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler-cli/src/ngtsc/reflection",
         "//packages/core/schematics/migrations/signal-migration/src",
         "//packages/core/schematics/utils/tsurge",

--- a/packages/core/schematics/migrations/signal-queries-migration/convert_query_property.ts
+++ b/packages/core/schematics/migrations/signal-queries-migration/convert_query_property.ts
@@ -8,8 +8,8 @@
 
 import ts from 'typescript';
 import {ExtractedQuery} from './identify_queries';
-import {Replacement, TextUpdate} from '../../utils/tsurge';
-import {absoluteFromSourceFile} from '../../../../compiler-cli';
+import {projectRelativePath, Replacement, TextUpdate} from '../../utils/tsurge';
+import {AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {ImportManager} from '@angular/compiler-cli/private/migrations';
 import assert from 'assert';
 import {WrappedNodeExpr} from '@angular/compiler';
@@ -43,6 +43,7 @@ export function computeReplacementsToMigrateQuery(
   node: ts.PropertyDeclaration,
   metadata: ExtractedQuery,
   importManager: ImportManager,
+  projectDirAbsPath: AbsoluteFsPath,
 ): Replacement[] {
   const sf = node.getSourceFile();
   let newQueryFn = importManager.addImport({
@@ -133,7 +134,7 @@ export function computeReplacementsToMigrateQuery(
 
   return [
     new Replacement(
-      absoluteFromSourceFile(node.getSourceFile()),
+      projectRelativePath(node.getSourceFile(), projectDirAbsPath),
       new TextUpdate({
         position: node.getStart(),
         end: node.getEnd(),

--- a/packages/core/schematics/migrations/signal-queries-migration/migration.ts
+++ b/packages/core/schematics/migrations/signal-queries-migration/migration.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {absoluteFromSourceFile} from '@angular/compiler-cli';
 import {TypeScriptReflectionHost} from '@angular/compiler-cli/src/ngtsc/reflection';
 import ts from 'typescript';
 import {
   confirmAsSerializable,
   ProgramInfo,
+  projectRelativePath,
   Replacement,
   Serializable,
   TextUpdate,
@@ -140,6 +140,7 @@ export class SignalQueriesMigration extends TsurgeComplexMigration<
             node as ts.PropertyDeclaration,
             extractedQuery,
             importManager,
+            projectDirAbsPath,
           ),
         );
         return;
@@ -151,7 +152,7 @@ export class SignalQueriesMigration extends TsurgeComplexMigration<
         if (targetId !== null && isMigratedQuery(targetId)) {
           replacements.push(
             new Replacement(
-              absoluteFromSourceFile(node.getSourceFile()),
+              projectRelativePath(node.getSourceFile(), projectDirAbsPath),
               new TextUpdate({position: node.getEnd(), end: node.getEnd(), toInsert: '()'}),
             ),
           );
@@ -173,7 +174,7 @@ export class SignalQueriesMigration extends TsurgeComplexMigration<
       }
     }
 
-    applyImportManagerChanges(importManager, replacements, sourceFiles);
+    applyImportManagerChanges(importManager, replacements, sourceFiles, projectDirAbsPath);
 
     return replacements;
   }

--- a/packages/core/schematics/utils/tsurge/base_migration.ts
+++ b/packages/core/schematics/utils/tsurge/base_migration.ts
@@ -7,7 +7,7 @@
  */
 
 import path from 'path';
-import {FileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {absoluteFrom, FileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {isShim} from '@angular/compiler-cli/src/ngtsc/shims';
 import {createNgtscProgram} from './helpers/ngtsc_program';
 import {BaseProgramInfo, ProgramInfo} from './program_info';
@@ -37,7 +37,7 @@ export abstract class TsurgeBaseMigration {
     );
 
     const basePath = path.dirname(info.tsconfigAbsolutePath);
-    const projectDirAbsPath = info.userOptions.rootDir ?? basePath;
+    const projectDirAbsPath = absoluteFrom(info.userOptions.rootDir ?? basePath);
 
     return {
       ...info,

--- a/packages/core/schematics/utils/tsurge/executors/migrate_exec.ts
+++ b/packages/core/schematics/utils/tsurge/executors/migrate_exec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {TsurgeMigration} from '../migration';
 import {Replacement} from '../replacement';
 
@@ -16,15 +17,19 @@ import {Replacement} from '../replacement';
  * This requires the global migration data, computed by the
  * analysis and merge phases of the migration.
  *
- * @returns a list of text replacements to apply to disk.
+ * @returns a list of text replacements to apply to disk and the
+ *   absolute project directory path (to allow for applying).
  */
 export async function executeMigratePhase<UnitData, GlobalData>(
   migration: TsurgeMigration<UnitData, GlobalData>,
   globalMetadata: GlobalData,
   tsconfigAbsolutePath: string,
-): Promise<Replacement[]> {
+): Promise<{replacements: Replacement[]; projectDirAbsPath: AbsoluteFsPath}> {
   const baseInfo = migration.createProgram(tsconfigAbsolutePath);
   const info = migration.prepareProgram(baseInfo);
 
-  return await migration.migrate(globalMetadata, info);
+  return {
+    replacements: await migration.migrate(globalMetadata, info),
+    projectDirAbsPath: info.projectDirAbsPath,
+  };
 }

--- a/packages/core/schematics/utils/tsurge/helpers/apply_import_manager.ts
+++ b/packages/core/schematics/utils/tsurge/helpers/apply_import_manager.ts
@@ -8,8 +8,12 @@
 
 import ts from 'typescript';
 import {ImportManager} from '@angular/compiler-cli/src/ngtsc/translator';
-import {absoluteFrom, absoluteFromSourceFile} from '@angular/compiler-cli/src/ngtsc/file_system';
-import {Replacement, TextUpdate} from '../replacement';
+import {
+  absoluteFrom,
+  absoluteFromSourceFile,
+  AbsoluteFsPath,
+} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {projectRelativePath, Replacement, TextUpdate} from '../replacement';
 
 /**
  * Applies import manager changes, and writes them as replacements the
@@ -19,6 +23,7 @@ export function applyImportManagerChanges(
   importManager: ImportManager,
   replacements: Replacement[],
   sourceFiles: readonly ts.SourceFile[],
+  projectAbsPath: AbsoluteFsPath,
 ) {
   const {newImports, updatedImports, deletedImports} = importManager.finalize();
   const printer = ts.createPrinter({});
@@ -34,7 +39,7 @@ export function applyImportManagerChanges(
       );
       replacements.push(
         new Replacement(
-          absoluteFrom(fileName),
+          projectRelativePath(fileName, projectAbsPath),
           new TextUpdate({position: 0, end: 0, toInsert: `${printedImport}\n`}),
         ),
       );
@@ -50,7 +55,7 @@ export function applyImportManagerChanges(
     );
     replacements.push(
       new Replacement(
-        absoluteFromSourceFile(oldBindings.getSourceFile()),
+        projectRelativePath(oldBindings.getSourceFile(), projectAbsPath),
         new TextUpdate({
           position: oldBindings.getStart(),
           end: oldBindings.getEnd(),
@@ -64,7 +69,7 @@ export function applyImportManagerChanges(
   for (const removedImport of deletedImports) {
     replacements.push(
       new Replacement(
-        absoluteFromSourceFile(removedImport.getSourceFile()),
+        projectRelativePath(removedImport.getSourceFile(), projectAbsPath),
         new TextUpdate({
           position: removedImport.getStart(),
           end: removedImport.getEnd(),

--- a/packages/core/schematics/utils/tsurge/helpers/group_replacements.ts
+++ b/packages/core/schematics/utils/tsurge/helpers/group_replacements.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
-import {Replacement, TextUpdate} from '../replacement';
+import {ProjectRelativePath, Replacement, TextUpdate} from '../replacement';
 
 /**
  * Groups the given replacements per file path.
@@ -17,13 +16,13 @@ import {Replacement, TextUpdate} from '../replacement';
  */
 export function groupReplacementsByFile(
   replacements: Replacement[],
-): Map<AbsoluteFsPath, TextUpdate[]> {
-  const result = new Map<AbsoluteFsPath, TextUpdate[]>();
-  for (const {absoluteFilePath, update} of replacements) {
-    if (!result.has(absoluteFilePath)) {
-      result.set(absoluteFilePath, []);
+): Map<ProjectRelativePath, TextUpdate[]> {
+  const result = new Map<ProjectRelativePath, TextUpdate[]>();
+  for (const {projectRelativePath, update} of replacements) {
+    if (!result.has(projectRelativePath)) {
+      result.set(projectRelativePath, []);
     }
-    result.get(absoluteFilePath)!.push(update);
+    result.get(projectRelativePath)!.push(update);
   }
   return result;
 }

--- a/packages/core/schematics/utils/tsurge/program_info.ts
+++ b/packages/core/schematics/utils/tsurge/program_info.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgtscProgram} from '@angular/compiler-cli/src/ngtsc/program';
 import {NgCompilerOptions} from '@angular/compiler-cli/src/ngtsc/core/api';
+import {AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
 
 import ts from 'typescript';
 import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
@@ -35,5 +35,5 @@ export interface BaseProgramInfo {
 export interface ProgramInfo extends BaseProgramInfo {
   sourceFiles: ts.SourceFile[];
   fullProgramSourceFiles: readonly ts.SourceFile[];
-  projectDirAbsPath: string;
+  projectDirAbsPath: AbsoluteFsPath;
 }

--- a/packages/core/schematics/utils/tsurge/replacement.ts
+++ b/packages/core/schematics/utils/tsurge/replacement.ts
@@ -6,14 +6,29 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
-
+import {
+  absoluteFrom,
+  AbsoluteFsPath,
+  getFileSystem,
+} from '@angular/compiler-cli/src/ngtsc/file_system';
 import MagicString from 'magic-string';
+import ts from 'typescript';
+
+/**
+ * Branded type representing a project-relative path.
+ *
+ * This is important to enforce as replacements should be relative
+ * to the project root, so that they can be serialized between phases.
+ *
+ * E.g. Tsunami may have different project roots in different stages, or
+ * we can't reliably relativize paths after Tsunami completed.
+ */
+export type ProjectRelativePath = string & {__projectRelativePath: true};
 
 /** A text replacement for the given file. */
 export class Replacement {
   constructor(
-    public absoluteFilePath: AbsoluteFsPath,
+    public projectRelativePath: ProjectRelativePath,
     public update: TextUpdate,
   ) {}
 }
@@ -27,6 +42,17 @@ export class TextUpdate {
       toInsert: string;
     },
   ) {}
+}
+
+/** Gets a project-relative relative for the given source file. */
+export function projectRelativePath(
+  file: ts.SourceFile | string,
+  projectAbsPath: AbsoluteFsPath,
+): ProjectRelativePath {
+  return getFileSystem().relative(
+    projectAbsPath,
+    typeof file === 'string' ? file : file.fileName,
+  ) as string as ProjectRelativePath;
 }
 
 /** Helper that applies updates to the given text. */

--- a/packages/core/schematics/utils/tsurge/test/output_migration.ts
+++ b/packages/core/schematics/utils/tsurge/test/output_migration.ts
@@ -12,7 +12,7 @@ import {TypeScriptReflectionHost} from '@angular/compiler-cli/src/ngtsc/reflecti
 import {DtsMetadataReader} from '@angular/compiler-cli/src/ngtsc/metadata';
 import {confirmAsSerializable} from '../helpers/serializable';
 import {TsurgeComplexMigration} from '../migration';
-import {Replacement, TextUpdate} from '../replacement';
+import {projectRelativePath, Replacement, TextUpdate} from '../replacement';
 import {findOutputDeclarationsAndReferences, OutputID} from './output_helpers';
 import {ProgramInfo} from '../program_info';
 
@@ -96,7 +96,7 @@ export class OutputMigration extends TsurgeComplexMigration<AnalysisUnit, Global
 
       replacements.push(
         new Replacement(
-          absoluteFromSourceFile(node.getSourceFile()),
+          projectRelativePath(node.getSourceFile(), info.projectDirAbsPath),
           new TextUpdate({
             position: node.getStart(),
             end: node.getStart(),

--- a/packages/core/schematics/utils/tsurge/testing/index.ts
+++ b/packages/core/schematics/utils/tsurge/testing/index.ts
@@ -64,8 +64,9 @@ export async function runTsurgeMigration<UnitData, GlobalData>(
       : await migration.migrate(merged, info);
 
   const updates = groupReplacementsByFile(replacements);
-  for (const [filePath, changes] of updates.entries()) {
-    mockFs.writeFile(filePath, applyTextUpdates(mockFs.readFile(filePath), changes));
+  for (const [projectRelativePath, changes] of updates.entries()) {
+    const absolutePath = mockFs.resolve('/', projectRelativePath);
+    mockFs.writeFile(absolutePath, applyTextUpdates(mockFs.readFile(absolutePath), changes));
   }
 
   return mockFs;

--- a/packages/language-service/src/refactorings/convert_to_signal_input.ts
+++ b/packages/language-service/src/refactorings/convert_to_signal_input.ts
@@ -162,7 +162,7 @@ export class ConvertToSignalInputRefactoring implements Refactoring {
     }
 
     const edits: ts.FileTextChanges[] = Array.from(
-      groupReplacementsByFile(this.migration.upgradedAnalysisPhaseResults).entries(),
+      groupReplacementsByFile(this.migration.upgradedAnalysisPhaseResults.replacements).entries(),
     ).map(([fileName, changes]) => {
       return {
         fileName,

--- a/packages/language-service/test/signal_input_refactoring_action_spec.ts
+++ b/packages/language-service/test/signal_input_refactoring_action_spec.ts
@@ -107,7 +107,7 @@ describe('Signal input refactoring action', () => {
     expect(edits?.notApplicableReason).toBeUndefined();
     expect(edits?.edits).toEqual([
       {
-        fileName: '/test/app.ts',
+        fileName: 'app.ts',
         textChanges: [
           // Input declaration.
           {


### PR DESCRIPTION
This allows for the replacements to be conveniently passed between migration stages. This is especially relevant in 1P where stages may have different root directories.

Tsunami attempts to relativize paths in general, similar to how we do here, but this doesn't work with e.g. Funnel-based migrations where replacements are serialized in between stages; and where the migration stage at the end doesn't know about the previous root directory anymore.