### PR TITLE
docs: Add extended/implemented classes/interfaces to the API docs

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/entities.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/entities.ts
@@ -101,6 +101,8 @@ export interface ClassEntry extends DocEntry {
   isAbstract: boolean;
   members: MemberEntry[];
   generics: GenericEntry[];
+  extends?: string;
+  implements: string[];
 }
 
 // From an API doc perspective, class and interfaces are identical.

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/code-transforms.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/code-transforms.ts
@@ -422,9 +422,28 @@ function appendPrefixAndSuffix(entry: DocEntry, codeTocData: CodeTableOfContents
     data.contents = `${firstLine}\n${data.contents}${lastLine}`;
   };
 
-  if (isClassEntry(entry)) {
-    const abstractPrefix = entry.isAbstract ? 'abstract ' : '';
-    appendFirstAndLastLines(codeTocData, `${abstractPrefix}class ${entry.name} {`, `}`);
+  if (isClassEntry(entry) || isInterfaceEntry(entry)) {
+    const generics =
+      entry.generics?.length > 0
+        ? `<${entry.generics
+            .map((g) => (g.constraint ? `${g.name} extends ${g.constraint}` : g.name))
+            .join(', ')}>`
+        : '';
+
+    const extendsStr = entry.extends ? ` extends ${entry.extends}` : '';
+    // TODO: remove the ? when we distinguish Class & Decorator entries
+    const implementsStr =
+      entry.implements?.length > 0 ? ` implements ${entry.implements.join(' ,')}` : '';
+
+    const signature = `${entry.name}${generics}${extendsStr}${implementsStr}`;
+    if (isClassEntry(entry)) {
+      const abstractPrefix = entry.isAbstract ? 'abstract ' : '';
+      appendFirstAndLastLines(codeTocData, `${abstractPrefix}class ${signature} {`, `}`);
+    }
+
+    if (isInterfaceEntry(entry)) {
+      appendFirstAndLastLines(codeTocData, `interface ${signature} {`, `}`);
+    }
   }
 
   if (isEnumEntry(entry)) {

--- a/packages/compiler-cli/src/ngtsc/docs/src/entities.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/entities.ts
@@ -107,6 +107,8 @@ export interface ClassEntry extends DocEntry {
   isAbstract: boolean;
   members: MemberEntry[];
   generics: GenericEntry[];
+  extends?: string;
+  implements: string[];
 }
 
 // From an API doc perspective, class and interfaces are identical.

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/class_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/class_doc_extraction_spec.ts
@@ -461,6 +461,27 @@ runInEachFileSystem(() => {
       expect(genericEntry.default).toBeUndefined();
     });
 
+    it('should extract inheritence/interface conformance', () => {
+      env.write(
+        'index.ts',
+        `
+          interface Foo {}
+          interface Bar {}
+
+          class Parent extends Ancestor {}
+
+          export class Child extends Parent implements Foo, Bar {}
+        `,
+      );
+
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
+      expect(docs.length).toBe(1);
+
+      const classEntry = docs[0] as ClassEntry;
+      expect(classEntry.extends).toBe('Parent');
+      expect(classEntry.implements).toEqual(['Foo', 'Bar']);
+    });
+
     it('should extract inherited members', () => {
       env.write(
         'index.ts',


### PR DESCRIPTION
See individual commits 

Worthy example: https://ng-dev-previews-fw--pr-angular-angular-57588-adev-prev-u5qbiak5.web.app/api/common/HashLocationStrategy 