### PR TITLE
docs: revert changes on API entries urls

### DIFF
--- a/adev/src/app/features/references/helpers/manifest.helper.ts
+++ b/adev/src/app/features/references/helpers/manifest.helper.ts
@@ -58,7 +58,8 @@ export function getApiNavigationItems(): NavigationItem[] {
 }
 
 export function getApiUrl(packageEntry: ApiManifestPackage, apiName: string): string {
-  return `${PagePrefix.API}/${packageEntry.normalizedModuleName}/${apiName}`;
+  const packageName = packageEntry.normalizedModuleName.replace('angular_', '');
+  return `${PagePrefix.API}/${packageName}/${apiName}`;
 }
 
 function getNormalizedFilename(


### PR DESCRIPTION
The name `angular_` shouldn't be included in the URL.

fixes #57587
