### PR TITLE
docs: update common-router-tasks to include sample dynamic fragment

### DIFF
--- a/adev/src/content/guide/routing/common-router-tasks.md
+++ b/adev/src/content/guide/routing/common-router-tasks.md
@@ -392,8 +392,21 @@ The `goToItems()` method interprets the destination URI as relative to the activ
 ## Accessing query parameters and fragments
 
 Sometimes, a feature of your application requires accessing a part of a route, such as a query parameter or a fragment.
-The Tour of Heroes application at this stage in the tutorial uses a list view in which you can click on a hero to see details.
-The router uses an `id` to show the correct hero's details.
+In this example, the route contains an `id` parameter we can use to target a specific hero page.
+
+```ts
+import {ApplicationConfig} from "@angular/core";
+import {Routes} from '@angular/router';
+import {HeroListComponent} from './hero-list.component';
+
+export const routes: Routes = [
+  {path: 'hero/:id', component: HeroDetailComponent}
+];
+
+export const appConfig: ApplicationConfig = {
+  providers: [provideRouter(routes)],
+};
+```
 
 First, import the following members in the component you want to navigate from.
 


### PR DESCRIPTION
Remove specific reference to "Tour of Heroes" tutorial and add sample route for use in the example for reference.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The "common routing tasks" documentation refers to the old "Tour of Heroes" tutorial which doesn't appear on "angular.dev". This old tutorial was a useful reference for remembering the specific syntax for dynamic route parameters in a url (:id). Because it is now missing on "angular.dev", it becomes difficult to find documentation to define dynamic url fragments in the route.  

Issue Number: N/A


## What is the new behavior?

This new documentation pulls in that sample route definition from tour of hero's and introduces it as an example. The specific mention of "Tour of Heroes" is also removed. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
