### PR TITLE
docs: api sub-entries should have `/` in urls.

### DIFF
--- a/adev/src/app/features/references/helpers/manifest.helper.spec.ts
+++ b/adev/src/app/features/references/helpers/manifest.helper.spec.ts
@@ -1,0 +1,35 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {ApiManifestPackage} from '../interfaces/api-manifest';
+import {getApiUrl} from './manifest.helper';
+
+describe('ManiferHelper', () => {
+  describe('getApiUrl', () => {
+    it('should return the correct URL for a given package and API name', () => {
+      const packageEntry: ApiManifestPackage = {
+        moduleName: '@angular/common',
+        moduleLabel: 'common',
+        normalizedModuleName: 'angular_common',
+        entries: [],
+      };
+      const apiName = 'DatePipe';
+      const result = getApiUrl(packageEntry, apiName);
+      expect(result).toBe('api/common/DatePipe');
+
+      const packageEntry2: ApiManifestPackage = {
+        moduleName: '@angular/animations/browser',
+        moduleLabel: 'animations/browser',
+        normalizedModuleName: 'angular_animations_browser',
+        entries: [],
+      };
+      const result2 = getApiUrl(packageEntry2, apiName);
+      expect(result2).toBe('api/animations/browser/DatePipe');
+    });
+  });
+});

--- a/adev/src/app/features/references/helpers/manifest.helper.ts
+++ b/adev/src/app/features/references/helpers/manifest.helper.ts
@@ -58,7 +58,11 @@ export function getApiNavigationItems(): NavigationItem[] {
 }
 
 export function getApiUrl(packageEntry: ApiManifestPackage, apiName: string): string {
-  const packageName = packageEntry.normalizedModuleName.replace('angular_', '');
+  const packageName = packageEntry.normalizedModuleName
+    // packages like `angular_core` should be `core`
+    // packages like `angular_animation_browser` should be `animation/browser`
+    .replace('angular_', '')
+    .replace('_', '/');
   return `${PagePrefix.API}/${packageName}/${apiName}`;
 }
 


### PR DESCRIPTION
`@angular/animations/browser` => `api/animations/browser/xyz`
