### PR TITLE
docs(docs-infra): Add dedicated support for decorators.

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/entities/categorization.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/entities/categorization.ts
@@ -1,6 +1,7 @@
 import {
   ClassEntry,
   ConstantEntry,
+  DecoratorEntry,
   DocEntry,
   EntryType,
   EnumEntry,
@@ -20,6 +21,7 @@ import {
   ClassEntryRenderable,
   CliCommandRenderable,
   ConstantEntryRenderable,
+  DecoratorEntryRenderable,
   DocEntryRenderable,
   EnumEntryRenderable,
   FunctionEntryRenderable,
@@ -42,9 +44,14 @@ export function isClassEntry(entry: DocEntry): entry is ClassEntry {
     entry.entryType === EntryType.Component ||
     entry.entryType === EntryType.Pipe ||
     entry.entryType === EntryType.NgModule ||
-    entry.entryType === EntryType.Directive ||
-    entry.entryType === EntryType.Decorator
+    entry.entryType === EntryType.Directive
   );
+}
+
+export function isDecoratorEntry(entry: DocEntryRenderable): entry is DecoratorEntryRenderable;
+export function isDecoratorEntry(entry: DocEntry): entry is DecoratorEntry;
+export function isDecoratorEntry(entry: DocEntry): entry is DecoratorEntry {
+  return entry.entryType === EntryType.Decorator;
 }
 
 /** Gets whether the given entry represents a constant */

--- a/adev/shared-docs/pipeline/api-gen/rendering/entities/renderables.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/entities/renderables.ts
@@ -9,6 +9,7 @@
 import {
   ClassEntry,
   ConstantEntry,
+  DecoratorEntry,
   DocEntry,
   EnumEntry,
   FunctionEntry,
@@ -54,6 +55,12 @@ export type TypeAliasEntryRenderable = TypeAliasEntry & DocEntryRenderable & Has
 
 /** Documentation entity for a TypeScript class augmented transformed content for rendering. */
 export type ClassEntryRenderable = ClassEntry &
+  DocEntryRenderable &
+  HasRenderableToc & {
+    members: MemberEntryRenderable[];
+  };
+
+export type DecoratorEntryRenderable = DecoratorEntry &
   DocEntryRenderable &
   HasRenderableToc & {
     members: MemberEntryRenderable[];

--- a/adev/shared-docs/pipeline/api-gen/rendering/processing.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/processing.ts
@@ -12,6 +12,7 @@ import {
   isClassEntry,
   isCliEntry,
   isConstantEntry,
+  isDecoratorEntry,
   isEnumEntry,
   isFunctionEntry,
   isInitializerApiFunctionEntry,
@@ -20,6 +21,7 @@ import {
 } from './entities/categorization';
 import {CliCommandRenderable, DocEntryRenderable} from './entities/renderables';
 import {getClassRenderable} from './transforms/class-transforms';
+import {getDecoratorRenderable} from './transforms/decorator-transforms';
 import {getCliRenderable} from './transforms/cli-transforms';
 import {getConstantRenderable} from './transforms/constant-transforms';
 import {getEnumRenderable} from './transforms/enum-transforms';
@@ -42,6 +44,9 @@ export function getRenderable(
 ): DocEntryRenderable | CliCommandRenderable {
   if (isClassEntry(entry)) {
     return getClassRenderable(entry, moduleName);
+  }
+  if (isDecoratorEntry(entry)) {
+    return getDecoratorRenderable(entry, moduleName);
   }
   if (isConstantEntry(entry)) {
     return getConstantRenderable(entry, moduleName);

--- a/adev/shared-docs/pipeline/api-gen/rendering/rendering.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/rendering.ts
@@ -12,6 +12,7 @@ import {
   isClassEntry,
   isCliEntry,
   isConstantEntry,
+  isDecoratorEntry,
   isEnumEntry,
   isFunctionEntry,
   isInitializerApiFunctionEntry,
@@ -34,7 +35,7 @@ export function renderEntry(renderable: DocEntryRenderable | CliCommandRenderabl
     return render(CliCommandReference(renderable));
   }
 
-  if (isClassEntry(renderable) || isInterfaceEntry(renderable)) {
+  if (isClassEntry(renderable) || isInterfaceEntry(renderable) || isDecoratorEntry(renderable)) {
     return render(ClassReference(renderable));
   }
   if (isConstantEntry(renderable)) {

--- a/adev/shared-docs/pipeline/api-gen/rendering/shiki/shiki.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/shiki/shiki.ts
@@ -37,18 +37,22 @@ export function codeToHtml(
   });
 
   if (options?.removeFunctionKeyword) {
-    return removeFunctionKeywordFromShikiHtml(html);
+    return replaceKeywordFromShikiHtml('function', html);
   }
   return html;
 }
 
-export function removeFunctionKeywordFromShikiHtml(shikiHtml: string): string {
+export function replaceKeywordFromShikiHtml(
+  keyword: string,
+  shikiHtml: string,
+  replaceWith = '',
+): string {
   return (
     shikiHtml
       // remove the leading space of the element after the "function" element
-      .replace(/(<[^>]*>function<\/\w+><[^>]*>)(\s)(\w+<\/\w+>)/g, '$1$3')
+      .replace(new RegExp(`(<[^>]*>${keyword}<\\/\\w+><[^>]*>)(\\s)(\\w+<\\/\\w+>)`, 'g'), '$1$3')
       // Shiki requires the keyword function for highlighting functions signatures
       // We don't want to display it so we remove elements with the keyword
-      .replace(/<[^>]*>function<\/\w+>/g, '')
+      .replace(new RegExp(`<[^>]*>${keyword}<\\/\\w+>`, 'g'), replaceWith)
   );
 }

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/class-reference.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/class-reference.tsx
@@ -7,7 +7,7 @@
  */
 
 import {Fragment, h} from 'preact';
-import {ClassEntryRenderable} from '../entities/renderables';
+import {ClassEntryRenderable, DecoratorEntryRenderable} from '../entities/renderables';
 import {ClassMemberList} from './class-member-list';
 import {HeaderApi} from './header-api';
 import {REFERENCE_MEMBERS_CONTAINER} from '../styling/css-classes';
@@ -16,20 +16,20 @@ import {TabUsageNotes} from './tab-usage-notes';
 import {TabApi} from './tab-api';
 
 /** Component to render a class API reference document. */
-export function ClassReference(entry: ClassEntryRenderable) {
+export function ClassReference(entry: ClassEntryRenderable | DecoratorEntryRenderable) {
   return (
     <div class="api">
       <HeaderApi entry={entry} />
       <TabApi entry={entry} />
       <TabDescription entry={entry} />
       <TabUsageNotes entry={entry} />
-      {
-        entry.members.length > 0
-          ? (<div class={REFERENCE_MEMBERS_CONTAINER}>
-              <ClassMemberList members={entry.members} />
-            </div>)
-          : (<></>)
-      }
+      {entry.members.length > 0 ? (
+        <div class={REFERENCE_MEMBERS_CONTAINER}>
+          <ClassMemberList members={entry.members} />
+        </div>
+      ) : (
+        <></>
+      )}
     </div>
   );
 }

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/decorator-transforms.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/decorator-transforms.ts
@@ -1,0 +1,38 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {DecoratorEntry} from '../entities';
+import {DecoratorEntryRenderable} from '../entities/renderables';
+import {addRenderableCodeToc} from './code-transforms';
+import {
+  addHtmlAdditionalLinks,
+  addHtmlDescription,
+  addHtmlJsDocTagComments,
+  addHtmlUsageNotes,
+  setEntryFlags,
+} from './jsdoc-transforms';
+import {addRenderableMembers} from './member-transforms';
+import {addModuleName} from './module-name';
+
+/** Given an unprocessed class entry, get the fully renderable class entry. */
+export function getDecoratorRenderable(
+  classEntry: DecoratorEntry,
+  moduleName: string,
+): DecoratorEntryRenderable {
+  return setEntryFlags(
+    addRenderableCodeToc(
+      addRenderableMembers(
+        addHtmlAdditionalLinks(
+          addHtmlUsageNotes(
+            addHtmlJsDocTagComments(addHtmlDescription(addModuleName(classEntry, moduleName))),
+          ),
+        ),
+      ),
+    ),
+  ) as DecoratorEntryRenderable;
+}


### PR DESCRIPTION
This commit adds dedicated behavior for decorators

Demo: https://ng-dev-previews-fw--pr-angular-angular-57595-adev-prev-hyy8izqv.web.app/api/core/Component

Fixes #57595