### PR TITLE
refactor(compiler-cli): exclude private computed properties from clas…

### DIFF
--- a/packages/compiler-cli/src/ngtsc/docs/src/class_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/class_extractor.ts
@@ -108,7 +108,10 @@ class ClassExtractor {
   protected extractClassMember(memberDeclaration: MemberElement): MemberEntry | undefined {
     if (this.isMethod(memberDeclaration)) {
       return this.extractMethod(memberDeclaration);
-    } else if (this.isProperty(memberDeclaration)) {
+    } else if (
+      this.isProperty(memberDeclaration) &&
+      !this.hasPrivateComputedProperty(memberDeclaration)
+    ) {
       return this.extractClassProperty(memberDeclaration);
     } else if (ts.isAccessor(memberDeclaration)) {
       return this.extractGetterSetter(memberDeclaration);
@@ -342,6 +345,17 @@ class ClassExtractor {
   private isAbstract(): boolean {
     const modifiers = this.declaration.modifiers ?? [];
     return modifiers.some((mod) => mod.kind === ts.SyntaxKind.AbstractKeyword);
+  }
+
+  /**
+   * Check wether a member has a private computed property name like [ɵWRITABLE_SIGNAL]
+   *
+   * This will prevent exposing private computed properties in the docs.
+   */
+  private hasPrivateComputedProperty(property: PropertyLike) {
+    return (
+      ts.isComputedPropertyName(property.name) && property.name.expression.getText().startsWith('ɵ')
+    );
   }
 }
 


### PR DESCRIPTION
…s member extractions

This will exclude properties like `[ɵWRITABLE_SIGNAL]` from the `WritableSignal` interface.
