### PR TITLE
docs: ensure the all `_` are replaced by slash for API entry urls.

### DIFF
--- a/adev/src/app/features/references/helpers/manifest.helper.spec.ts
+++ b/adev/src/app/features/references/helpers/manifest.helper.spec.ts
@@ -30,6 +30,15 @@ describe('ManiferHelper', () => {
       };
       const result2 = getApiUrl(packageEntry2, apiName);
       expect(result2).toBe('api/animations/browser/DatePipe');
+
+      const packageEntry3: ApiManifestPackage = {
+        moduleName: '@angular/common/http/testing',
+        moduleLabel: 'common/http/testing',
+        normalizedModuleName: 'angular_common_http_testing',
+        entries: [],
+      };
+      const result3 = getApiUrl(packageEntry3, apiName);
+      expect(result3).toBe('api/common/http/testing/DatePipe');
     });
   });
 });

--- a/adev/src/app/features/references/helpers/manifest.helper.ts
+++ b/adev/src/app/features/references/helpers/manifest.helper.ts
@@ -62,7 +62,7 @@ export function getApiUrl(packageEntry: ApiManifestPackage, apiName: string): st
     // packages like `angular_core` should be `core`
     // packages like `angular_animation_browser` should be `animation/browser`
     .replace('angular_', '')
-    .replace('_', '/');
+    .replaceAll('_', '/');
   return `${PagePrefix.API}/${packageName}/${apiName}`;
 }
 


### PR DESCRIPTION
fixes #57599
