### PR TITLE
refactor(migrations): switch from esbuild to Rollup for schematics bundling

### DIFF
--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "pkg_npm")
+load("@npm//@bazel/rollup:index.bzl", "rollup_bundle")
 
 exports_files([
     "tsconfig.json",
@@ -20,9 +21,33 @@ pkg_npm(
     validate = False,
     visibility = ["//packages/core:__pkg__"],
     deps = [
-        "//packages/core/schematics/ng-generate/control-flow-migration:bundle",
-        "//packages/core/schematics/ng-generate/inject-migration:bundle",
-        "//packages/core/schematics/ng-generate/route-lazy-loading:bundle",
-        "//packages/core/schematics/ng-generate/standalone-migration:bundle",
+        ":bundles",
+    ],
+)
+
+rollup_bundle(
+    name = "bundles",
+    config_file = ":rollup.config.js",
+    entry_points = {
+        "//packages/core/schematics/ng-generate/control-flow-migration:index.ts": "control-flow-migration",
+        "//packages/core/schematics/ng-generate/inject-migration:index.ts": "inject-migration",
+        "//packages/core/schematics/ng-generate/route-lazy-loading:index.ts": "route-lazy-loading",
+        "//packages/core/schematics/ng-generate/standalone-migration:index.ts": "standalone-migration",
+    },
+    format = "cjs",
+    link_workspace_root = True,
+    output_dir = True,
+    sourcemap = "false",
+    visibility = [
+        "//packages/core/schematics/test:__pkg__",
+    ],
+    deps = [
+        "//packages/core/schematics/ng-generate/control-flow-migration",
+        "//packages/core/schematics/ng-generate/inject-migration",
+        "//packages/core/schematics/ng-generate/route-lazy-loading",
+        "//packages/core/schematics/ng-generate/standalone-migration",
+        "@npm//@rollup/plugin-commonjs",
+        "@npm//@rollup/plugin-node-resolve",
+        "@npm//magic-string",
     ],
 )

--- a/packages/core/schematics/collection.json
+++ b/packages/core/schematics/collection.json
@@ -2,34 +2,27 @@
   "schematics": {
     "standalone-migration": {
       "description": "Converts the entire application or a part of it to standalone",
-      "factory": "./ng-generate/standalone-migration/bundle",
+      "factory": "./bundles/standalone-migration#migrate",
       "schema": "./ng-generate/standalone-migration/schema.json",
-      "aliases": [
-        "standalone"
-      ]
+      "aliases": ["standalone"]
     },
     "control-flow-migration": {
       "description": "Converts the entire application to block control flow syntax",
-      "factory": "./ng-generate/control-flow-migration/bundle",
+      "factory": "./bundles/control-flow-migration#migrate",
       "schema": "./ng-generate/control-flow-migration/schema.json",
-      "aliases": [
-        "control-flow"
-      ]
+      "aliases": ["control-flow"]
     },
     "inject-migration": {
       "description": "Converts usages of constructor-based injection to the inject() function",
-      "factory": "./ng-generate/inject-migration/bundle",
+      "factory": "./bundles/inject-migration#migrate",
       "schema": "./ng-generate/inject-migration/schema.json",
-      "aliases": [
-        "inject"
-      ]
+      "aliases": ["inject"]
     },
     "route-lazy-loading-migration": {
       "description": "Updates route definitions to use lazy-loading of components instead of eagerly referencing them",
-      "factory": "./ng-generate/route-lazy-loading/bundle",
+      "factory": "./bundles/route-lazy-loading#migrate",
       "schema": "./ng-generate/route-lazy-loading/schema.json",
       "aliases": ["route-lazy-loading"]
     }
   }
 }
-

--- a/packages/core/schematics/ng-generate/control-flow-migration/BUILD.bazel
+++ b/packages/core/schematics/ng-generate/control-flow-migration/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "esbuild_no_sourcemaps", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 package(
     default_visibility = [
@@ -24,16 +24,4 @@ ts_library(
         "@npm//@types/node",
         "@npm//typescript",
     ],
-)
-
-esbuild_no_sourcemaps(
-    name = "bundle",
-    entry_point = ":index.ts",
-    external = [
-        "@angular-devkit/*",
-        "typescript",
-    ],
-    format = "cjs",
-    platform = "node",
-    deps = [":control-flow-migration"],
 )

--- a/packages/core/schematics/ng-generate/control-flow-migration/ifs.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/ifs.ts
@@ -23,7 +23,6 @@ import {
   getPlaceholder,
   hasLineBreaks,
   parseTemplate,
-  PlaceholderKind,
   reduceNestingOffset,
 } from './util';
 

--- a/packages/core/schematics/ng-generate/control-flow-migration/index.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/index.ts
@@ -21,7 +21,7 @@ interface Options {
   format: boolean;
 }
 
-export default function (options: Options): Rule {
+export function migrate(options: Options): Rule {
   return async (tree: Tree, context: SchematicContext) => {
     const basePath = process.cwd();
     const pathToMigrate = normalizePath(join(basePath, options.path));

--- a/packages/core/schematics/ng-generate/control-flow-migration/migration.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/migration.ts
@@ -23,10 +23,8 @@ import {
 import {
   canRemoveCommonModule,
   formatTemplate,
-  parseTemplate,
   processNgTemplates,
   removeImports,
-  validateI18nStructure,
   validateMigratedTemplate,
 } from './util';
 

--- a/packages/core/schematics/ng-generate/inject-migration/BUILD.bazel
+++ b/packages/core/schematics/ng-generate/inject-migration/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "esbuild_no_sourcemaps", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 package(
     default_visibility = [
@@ -23,16 +23,4 @@ ts_library(
         "@npm//@types/node",
         "@npm//typescript",
     ],
-)
-
-esbuild_no_sourcemaps(
-    name = "bundle",
-    entry_point = ":index.ts",
-    external = [
-        "@angular-devkit/*",
-        "typescript",
-    ],
-    format = "cjs",
-    platform = "node",
-    deps = [":inject-migration"],
 )

--- a/packages/core/schematics/ng-generate/inject-migration/index.ts
+++ b/packages/core/schematics/ng-generate/inject-migration/index.ts
@@ -18,7 +18,7 @@ interface Options extends MigrationOptions {
   path: string;
 }
 
-export default function (options: Options): Rule {
+export function migrate(options: Options): Rule {
   return async (tree: Tree) => {
     const basePath = process.cwd();
     const pathToMigrate = normalizePath(join(basePath, options.path));

--- a/packages/core/schematics/ng-generate/route-lazy-loading/BUILD.bazel
+++ b/packages/core/schematics/ng-generate/route-lazy-loading/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "esbuild_no_sourcemaps", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 package(
     default_visibility = [
@@ -25,16 +25,4 @@ ts_library(
         "@npm//@types/node",
         "@npm//typescript",
     ],
-)
-
-esbuild_no_sourcemaps(
-    name = "bundle",
-    entry_point = ":index.ts",
-    external = [
-        "@angular-devkit/*",
-        "typescript",
-    ],
-    format = "cjs",
-    platform = "node",
-    deps = [":route-lazy-loading"],
 )

--- a/packages/core/schematics/ng-generate/route-lazy-loading/index.ts
+++ b/packages/core/schematics/ng-generate/route-lazy-loading/index.ts
@@ -20,7 +20,7 @@ interface Options {
   path: string;
 }
 
-export default function (options: Options): Rule {
+export function migrate(options: Options): Rule {
   return async (tree, context) => {
     const {buildPaths} = await getProjectTsConfigPaths(tree);
     const basePath = process.cwd();

--- a/packages/core/schematics/ng-generate/standalone-migration/BUILD.bazel
+++ b/packages/core/schematics/ng-generate/standalone-migration/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "esbuild_no_sourcemaps", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 package(
     default_visibility = [
@@ -25,16 +25,4 @@ ts_library(
         "@npm//@types/node",
         "@npm//typescript",
     ],
-)
-
-esbuild_no_sourcemaps(
-    name = "bundle",
-    entry_point = ":index.ts",
-    external = [
-        "@angular-devkit/*",
-        "typescript",
-    ],
-    format = "cjs",
-    platform = "node",
-    deps = [":standalone-migration"],
 )

--- a/packages/core/schematics/ng-generate/standalone-migration/index.ts
+++ b/packages/core/schematics/ng-generate/standalone-migration/index.ts
@@ -32,7 +32,7 @@ interface Options {
   mode: MigrationMode;
 }
 
-export default function (options: Options): Rule {
+export function migrate(options: Options): Rule {
   return async (tree, context) => {
     const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
     const basePath = process.cwd();

--- a/packages/core/schematics/rollup.config.js
+++ b/packages/core/schematics/rollup.config.js
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+const {nodeResolve} = require('@rollup/plugin-node-resolve');
+const commonjs = require('@rollup/plugin-commonjs');
+const MagicString = require('magic-string');
+
+/** Removed license banners from input files. */
+const stripBannerPlugin = {
+  name: 'strip-license-banner',
+  transform(code, _filePath) {
+    const banner = /(\/\**\s+\*\s@license.*?\*\/)/s.exec(code);
+    if (!banner) {
+      return;
+    }
+
+    const [bannerContent] = banner;
+    const magicString = new MagicString(code);
+    const pos = code.indexOf(bannerContent);
+    magicString.remove(pos, pos + bannerContent.length).trimStart();
+
+    return {
+      code: magicString.toString(),
+      map: magicString.generateMap({
+        hires: true,
+      }),
+    };
+  },
+};
+
+const banner = `'use strict';
+/**
+ * @license Angular v0.0.0-PLACEHOLDER
+ * (c) 2010-2024 Google LLC. https://angular.io/
+ * License: MIT
+ */`;
+
+const plugins = [
+  nodeResolve({
+    jail: process.cwd(),
+  }),
+  stripBannerPlugin,
+  commonjs(),
+];
+
+const config = {
+  plugins,
+  external: ['typescript', 'tslib', /@angular-devkit\/.+/],
+  output: {
+    exports: 'auto',
+    banner,
+  },
+};
+
+module.exports = config;

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -3,7 +3,7 @@ load("//tools:defaults.bzl", "jasmine_node_test", "ts_library")
 ts_library(
     name = "test_lib",
     testonly = True,
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(["*.ts"]),
     deps = [
         "//packages/core/schematics/utils",
         "@npm//@angular-devkit/core",
@@ -17,22 +17,14 @@ ts_library(
 jasmine_node_test(
     name = "test",
     data = [
+        "//packages/core/schematics:bundles",
         "//packages/core/schematics:collection.json",
         "//packages/core/schematics:migrations.json",
-        "//packages/core/schematics/ng-generate/control-flow-migration",
-        "//packages/core/schematics/ng-generate/control-flow-migration:bundle",
         "//packages/core/schematics/ng-generate/control-flow-migration:static_files",
-        "//packages/core/schematics/ng-generate/inject-migration",
-        "//packages/core/schematics/ng-generate/inject-migration:bundle",
         "//packages/core/schematics/ng-generate/inject-migration:static_files",
-        "//packages/core/schematics/ng-generate/route-lazy-loading",
-        "//packages/core/schematics/ng-generate/route-lazy-loading:bundle",
         "//packages/core/schematics/ng-generate/route-lazy-loading:static_files",
-        "//packages/core/schematics/ng-generate/standalone-migration",
-        "//packages/core/schematics/ng-generate/standalone-migration:bundle",
         "//packages/core/schematics/ng-generate/standalone-migration:static_files",
     ],
-    templated_args = ["--nobazel_run_linker"],
     deps = [
         ":test_lib",
         "@npm//shelljs",

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -10,7 +10,6 @@ load("@npm//@bazel/protractor:index.bzl", _protractor_web_test_suite = "protract
 load("@npm//typescript:index.bzl", "tsc")
 load("@npm//@angular/build-tooling/bazel/app-bundling:index.bzl", _app_bundle = "app_bundle")
 load("@npm//@angular/build-tooling/bazel/http-server:index.bzl", _http_server = "http_server")
-load("@npm//@angular/build-tooling/bazel:filter_outputs.bzl", "filter_outputs")
 load("@npm//@angular/build-tooling/bazel/karma:index.bzl", _karma_web_test = "karma_web_test", _karma_web_test_suite = "karma_web_test_suite")
 load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", _api_golden_test = "api_golden_test", _api_golden_test_npm_package = "api_golden_test_npm_package")
 load("@npm//@angular/build-tooling/bazel:extract_js_module_output.bzl", "extract_js_module_output")
@@ -649,24 +648,6 @@ def esbuild(args = None, **kwargs):
             "resolveExtensions": [".mjs", ".js", ".json"],
         },
         **kwargs
-    )
-
-def esbuild_no_sourcemaps(name, **kwargs):
-    esbuild_target_name = "%s.with-sourcemap" % name
-
-    # Unlike linked, when using external the .js output file does not contain a //# sourceMappingURL= comment.
-    # See: https://esbuild.github.io/api/#sourcemap
-    esbuild(
-        name = esbuild_target_name,
-        sourcemap = "external",
-        output = "%s.js" % name,
-        **kwargs
-    )
-
-    filter_outputs(
-        name = name,
-        target = esbuild_target_name,
-        filters = ["%s.js" % name],
     )
 
 def esbuild_checked_in(name, **kwargs):


### PR DESCRIPTION

Replaces esbuild with Rollup for bundling schematics to support code splitting, as esbuild does not handle code splitting when targeting CommonJS modules.

**Before:**
```
du -sh dist/bin/packages/core/npm_package/schematics
7.7M    dist/bin/packages/core/npm_package/schematics
```

**After:**
```
du -sh dist/bin/packages/core/npm_package/schematics
3.1M    dist/bin/packages/core/npm_package/schematics
```

