### PR TITLE
refactor(migrations): simplify signal input migration language-service integration

### DIFF
--- a/packages/core/schematics/migrations/signal-migration/src/best_effort_mode.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/best_effort_mode.ts
@@ -6,18 +6,25 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {nonIgnorableIncompatibilities} from './input_detection/incompatibility';
+import {InputIncompatibilityReason} from './input_detection/incompatibility';
 import {KnownInputs} from './input_detection/known_inputs';
+
+/** Input reasons that cannot be ignored. */
+const nonIgnorableInputIncompatibilities: InputIncompatibilityReason[] = [
+  // There is no good output for accessor inputs.
+  InputIncompatibilityReason.Accessor,
+  // There is no good output for such inputs. We can't perform "conversion".
+  InputIncompatibilityReason.RequiredInputButNoGoodExplicitTypeExtractable,
+];
 
 /** Filters ignorable input incompatibilities when best effort mode is enabled. */
 export function filterIncompatibilitiesForBestEffortMode(knownInputs: KnownInputs) {
-  // Remove all "ignorable" incompatibilities of inputs, if best effort mode is requested.
   knownInputs.knownInputIds.forEach(({container: c}) => {
-    if (c.incompatible !== null && !nonIgnorableIncompatibilities.includes(c.incompatible)) {
-      c.incompatible = null;
-    }
+    // All class incompatibilities are "filterable" right now.
+    c.incompatible = null;
+
     for (const [key, i] of c.memberIncompatibility.entries()) {
-      if (!nonIgnorableIncompatibilities.includes(i.reason)) {
+      if (!nonIgnorableInputIncompatibilities.includes(i.reason)) {
         c.memberIncompatibility.delete(key);
       }
     }

--- a/packages/core/schematics/migrations/signal-migration/src/index.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/index.ts
@@ -21,11 +21,10 @@ main(path.resolve(process.argv[2]), process.argv.includes('--best-effort-mode'))
  * Runs the signal input migration for the given TypeScript project.
  */
 export async function main(absoluteTsconfigPath: string, bestEffortMode: boolean) {
-  const migration = new SignalInputMigration();
-
-  migration.bestEffortMode = bestEffortMode;
-  migration.upgradeAnalysisPhaseToAvoidBatch = true;
-
+  const migration = new SignalInputMigration({
+    bestEffortMode,
+    upgradeAnalysisPhaseToAvoidBatch: true,
+  });
   const baseInfo = migration.createProgram(absoluteTsconfigPath);
   const info = migration.prepareProgram(baseInfo);
 

--- a/packages/core/schematics/migrations/signal-migration/src/input_detection/directive_info.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/input_detection/directive_info.ts
@@ -24,21 +24,23 @@ export class DirectiveInfo {
   /** Map of input IDs and their incompatibilities. */
   memberIncompatibility = new Map<InputUniqueKey, InputMemberIncompatibility>();
 
-  /** Whether the whole class is incompatible. */
+  /**
+   * Whether the whole class is incompatible.
+   *
+   * Class incompatibility precedes individual member incompatibility.
+   * All members in the class are considered incompatible.
+   */
   incompatible: ClassIncompatibilityReason | null = null;
 
   constructor(public clazz: ts.ClassDeclaration) {}
 
   /**
-   * Checks whether the class is skipped for migration because all of
-   * the inputs are marked as incompatible, or the class itself.
+   * Checks whether there are any incompatible inputs for the
+   * given class.
    */
-  isClassSkippedForMigration(): boolean {
-    return (
-      this.incompatible !== null ||
-      Array.from(this.inputFields.values()).every(({descriptor}) =>
-        this.isInputMemberIncompatible(descriptor),
-      )
+  hasIncompatibleMembers(): boolean {
+    return Array.from(this.inputFields.values()).some(({descriptor}) =>
+      this.isInputMemberIncompatible(descriptor),
     );
   }
 

--- a/packages/core/schematics/migrations/signal-migration/src/input_detection/incompatibility.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/input_detection/incompatibility.ts
@@ -10,6 +10,7 @@ import ts from 'typescript';
 
 /** Reasons why an input cannot be migrated. */
 export enum InputIncompatibilityReason {
+  SkippedViaConfigFilter,
   Accessor,
   WriteAssignment,
   OverriddenByDerivedClass,
@@ -18,7 +19,6 @@ export enum InputIncompatibilityReason {
   ParentIsIncompatible,
   SpyOnThatOverwritesField,
   PotentiallyNarrowedInTemplateButNoSupportYet,
-  IgnoredBecauseOfLanguageServiceRefactoringRange,
   RequiredInputButNoGoodExplicitTypeExtractable,
 }
 
@@ -33,16 +33,6 @@ export interface InputMemberIncompatibility {
   reason: InputIncompatibilityReason;
   context: ts.Node | null;
 }
-
-/** Reasons that cannot be ignored. */
-export const nonIgnorableIncompatibilities: Array<
-  InputIncompatibilityReason | ClassIncompatibilityReason
-> = [
-  // There is no good output for accessor inputs.
-  InputIncompatibilityReason.Accessor,
-  // There is no good output for such inputs. We can't perform "conversion".
-  InputIncompatibilityReason.RequiredInputButNoGoodExplicitTypeExtractable,
-];
 
 /** Whether the given value refers to an input member incompatibility. */
 export function isInputMemberIncompatibility(value: unknown): value is InputMemberIncompatibility {

--- a/packages/core/schematics/migrations/signal-migration/src/passes/9_migrate_ts_type_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/9_migrate_ts_type_references.ts
@@ -34,8 +34,8 @@ export function pass9__migrateTypeScriptTypeReferences(
     if (!isTsInputClassTypeReference(reference)) {
       continue;
     }
-    // Skip references to classes that are not migrated.
-    if (knownInputs.getDirectiveInfoForClass(reference.target)!.isClassSkippedForMigration()) {
+    // Skip references to classes that are not fully migrated.
+    if (knownInputs.getDirectiveInfoForClass(reference.target)?.hasIncompatibleMembers()) {
       continue;
     }
     // Skip duplicate references. E.g. in batching.

--- a/packages/core/schematics/migrations/signal-migration/src/phase_analysis.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/phase_analysis.ts
@@ -16,7 +16,6 @@ import {pass2_IdentifySourceFileReferences} from './passes/2_find_source_file_re
 import {MigrationResult} from './result';
 import {InheritanceGraph} from './utils/inheritance_graph';
 import {GroupedTsAstVisitor} from './utils/grouped_ts_ast_visitor';
-import {nonIgnorableIncompatibilities} from './input_detection/incompatibility';
 
 /**
  * Executes the analysis phase of the migration.

--- a/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
@@ -647,11 +647,11 @@ new ManualInstantiation();
 
 // tslint:disable
 
-import {Component, Input} from '@angular/core';
+import { Component, input } from '@angular/core';
 
 @Component({})
 export class ManualInstantiation {
-  @Input() bla: string = '';
+  readonly bla = input<string>('');
 }
 @@@@@@ modifier_tests.ts @@@@@@
 
@@ -917,10 +917,10 @@ export class ScopeMismatchTest {
 
 // tslint:disable
 
-import {Input} from '@angular/core';
+import { input } from '@angular/core';
 
 class MyComp {
-  @Input() myInput = () => {};
+  readonly myInput = input(() => { });
 }
 
 spyOn<MyComp>(new MyComp(), 'myInput').and.returnValue();


### PR DESCRIPTION
Instead of some special hook that relies on mutation to filter inputs in the signal input migration, we are now introducing a new configuration interface where the language-service can pass a filter method.

This makes the code more readable. We also need the filter method to support filtering based on directories. E.g. when the migration runs against sub-folders, all inputs outside of the folder should be considered incompatible; to not migrate incorrectly.