### PR TITLE
docs: fix image src in feature modules

### DIFF
--- a/adev/src/content/guide/ngmodules/feature-modules.md
+++ b/adev/src/content/guide/ngmodules/feature-modules.md
@@ -147,7 +147,7 @@ Next, in the `AppComponent`, `app.component.html`, add the tag `<app-customer-da
 
 Now, in addition to the title that renders by default, the `CustomerDashboardComponent` template renders too:
 
-<img alt="feature module component" src="assets/images/guide/ngmodules/feature-module.png">
+<img alt="feature module component" src="assets/images/guide/modules/feature-module.png">
 
 ## More on NgModules
 


### PR DESCRIPTION
fix image src in feature modules at https://angular.dev/guide/ngmodules/feature-modules

Before
<img width="789" alt="Screenshot 2024-08-30 at 7 46 49 PM" src="https://github.com/user-attachments/assets/87dfd3e1-9a11-4086-903d-1fc49e1bcb28">

After
<img width="767" alt="Screenshot 2024-08-30 at 7 47 18 PM" src="https://github.com/user-attachments/assets/b03df377-cc72-41ac-8643-66f04a1806da">