### PR TITLE
refactor(platform-browser): support adding component styles as external link elements

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -41,13 +41,13 @@
   },
   "standalone-bootstrap": {
     "uncompressed": {
-      "main": 89354,
+      "main": 94681,
       "polyfills": 33802
     }
   },
   "defer": {
     "uncompressed": {
-      "main": 12148,
+      "main": 13449,
       "polyfills": 33807,
       "defer.component": 371
     }

--- a/packages/platform-browser/test/dom/shared_styles_host_spec.ts
+++ b/packages/platform-browser/test/dom/shared_styles_host_spec.ts
@@ -21,43 +21,98 @@ describe('SharedStylesHost', () => {
     someHost = getDOM().createElement('div');
   });
 
-  it('should add existing styles to new hosts', () => {
-    ssh.addStyles(['a {};']);
-    ssh.addHost(someHost);
-    expect(someHost.innerHTML).toEqual('<style>a {};</style>');
+  describe('embedded', () => {
+    it('should add existing styles to new hosts', () => {
+      ssh.addStyles(['a {};']);
+      ssh.addHost(someHost);
+      expect(someHost.innerHTML).toEqual('<style>a {};</style>');
+    });
+
+    it('should add new styles to hosts', () => {
+      ssh.addHost(someHost);
+      ssh.addStyles(['a {};']);
+      expect(someHost.innerHTML).toEqual('<style>a {};</style>');
+    });
+
+    it('should add styles only once to hosts', () => {
+      ssh.addStyles(['a {};']);
+      ssh.addHost(someHost);
+      ssh.addStyles(['a {};']);
+      expect(someHost.innerHTML).toEqual('<style>a {};</style>');
+    });
+
+    it('should use the document head as default host', () => {
+      ssh.addStyles(['a {};', 'b {};']);
+      expect(doc.head).toHaveText('a {};b {};');
+    });
+
+    it('should remove style nodes on destroy', () => {
+      ssh.addStyles(['a {};']);
+      ssh.addHost(someHost);
+      expect(someHost.innerHTML).toEqual('<style>a {};</style>');
+
+      ssh.ngOnDestroy();
+      expect(someHost.innerHTML).toEqual('');
+    });
+
+    it(`should add 'nonce' attribute when a nonce value is provided`, () => {
+      ssh = new SharedStylesHost(doc, 'app-id', '{% nonce %}');
+      ssh.addStyles(['a {};']);
+      ssh.addHost(someHost);
+      expect(someHost.innerHTML).toEqual('<style nonce="{% nonce %}">a {};</style>');
+    });
   });
 
-  it('should add new styles to hosts', () => {
-    ssh.addHost(someHost);
-    ssh.addStyles(['a {};']);
-    expect(someHost.innerHTML).toEqual('<style>a {};</style>');
-  });
+  describe('external', () => {
+    it('should add existing styles to new hosts', () => {
+      ssh.addExternalStyles(['component-1.css']);
+      ssh.addHost(someHost);
+      expect(someHost.innerHTML).toEqual('<link rel="stylesheet" href="component-1.css">');
+    });
 
-  it('should add styles only once to hosts', () => {
-    ssh.addStyles(['a {};']);
-    ssh.addHost(someHost);
-    ssh.addStyles(['a {};']);
-    expect(someHost.innerHTML).toEqual('<style>a {};</style>');
-  });
+    it('should add new styles to hosts', () => {
+      ssh.addHost(someHost);
+      ssh.addExternalStyles(['component-1.css']);
+      expect(someHost.innerHTML).toEqual('<link rel="stylesheet" href="component-1.css">');
+    });
 
-  it('should use the document head as default host', () => {
-    ssh.addStyles(['a {};', 'b {};']);
-    expect(doc.head).toHaveText('a {};b {};');
-  });
+    it('should add styles only once to hosts', () => {
+      ssh.addExternalStyles(['component-1.css']);
+      ssh.addHost(someHost);
+      ssh.addExternalStyles(['component-1.css']);
+      expect(someHost.innerHTML).toEqual('<link rel="stylesheet" href="component-1.css">');
+    });
 
-  it('should remove style nodes on destroy', () => {
-    ssh.addStyles(['a {};']);
-    ssh.addHost(someHost);
-    expect(someHost.innerHTML).toEqual('<style>a {};</style>');
+    it('should use the document head as default host', () => {
+      ssh.addExternalStyles(['component-1.css', 'component-2.css']);
+      expect(doc.head.innerHTML).toContain('<link rel="stylesheet" href="component-1.css">');
+      expect(doc.head.innerHTML).toContain('<link rel="stylesheet" href="component-2.css">');
+    });
 
-    ssh.ngOnDestroy();
-    expect(someHost.innerHTML).toEqual('');
-  });
+    it('should remove style nodes on destroy', () => {
+      ssh.addExternalStyles(['component-1.css']);
+      ssh.addHost(someHost);
+      expect(someHost.innerHTML).toEqual('<link rel="stylesheet" href="component-1.css">');
 
-  it(`should add 'nonce' attribute when a nonce value is provided`, () => {
-    ssh = new SharedStylesHost(doc, 'app-id', '{% nonce %}');
-    ssh.addStyles(['a {};']);
-    ssh.addHost(someHost);
-    expect(someHost.innerHTML).toEqual('<style nonce="{% nonce %}">a {};</style>');
+      ssh.ngOnDestroy();
+      expect(someHost.innerHTML).toEqual('');
+    });
+
+    it(`should add 'nonce' attribute when a nonce value is provided`, () => {
+      ssh = new SharedStylesHost(doc, 'app-id', '{% nonce %}');
+      ssh.addExternalStyles(['component-1.css']);
+      ssh.addHost(someHost);
+      expect(someHost.innerHTML).toEqual(
+        '<link rel="stylesheet" href="component-1.css" nonce="{% nonce %}">',
+      );
+    });
+
+    it('should keep search parameters of urls', () => {
+      ssh.addHost(someHost);
+      ssh.addExternalStyles(['component-1.css?ngcomp=ng-app-c123456789']);
+      expect(someHost.innerHTML).toEqual(
+        '<link rel="stylesheet" href="component-1.css?ngcomp=ng-app-c123456789">',
+      );
+    });
   });
 });


### PR DESCRIPTION
The shared style host now has the capability to add component styles as link elements with external style references. This is currently unused within the runtime but is an enabling feature for upcoming features such as automatic component style HMR and development server deferred stylesheet processing. Instead of inline style content that is then added to a `style` element for each host node, a `link` element with a stylesheet `rel` attribute and a `href` attribute can now be created. The development server must be configured to provide the relevant component stylesheet upon request. The Angular CLI development server will provide this functionality once this capability is enabled.
Since the primary use of this capability is development mode and will not be used for production code, server (SSR) style reuse is currently not yet implemented but may be implemented in the future.
A component feature is used to provide the DOM renderer access to any external styles that were emitted at compile time. When external styles are present, the `getExternalStyles` function will be present on the runtime component metadata object. The DOM render will use this function to access and encapsulate the external style URLs as required by the component.

Related PRs:
* Compiler: https://github.com/angular/angular/pull/57613