### PR TITLE
refactor(compiler): support external runtime component styles for file-based stylesheets

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/common/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/src/api.ts
@@ -87,4 +87,20 @@ export interface ResourceLoaderContext {
    * The absolute path to the file that contains the resource or reference to the resource.
    */
   containingFile: string;
+
+  /**
+   * For style resources, the placement of the style within the containing file with lower numbers
+   * being before higher numbers.
+   * The value is primarily used by the Angular CLI to create a deterministic identifier for each
+   * style in HMR scenarios.
+   * This is undefined for templates.
+   */
+  order?: number;
+
+  /**
+   * The name of the class that defines the component using the resource.
+   * This allows identifying the source usage of a resource in cases where multiple components are
+   * contained in a single source file.
+   */
+  className: string;
 }

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/resources.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/resources.ts
@@ -429,6 +429,7 @@ export function preloadAndParseTemplate(
       const templatePromise = resourceLoader.preload(resourceUrl, {
         type: 'template',
         containingFile,
+        className: node.name.text,
       });
 
       // If the preload worked, then actually load and parse the template, and wait for any

--- a/packages/compiler-cli/src/ngtsc/core/api/src/interfaces.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/interfaces.ts
@@ -92,6 +92,22 @@ export interface ResourceHostContext {
    * The absolute path to the file that contains the resource or reference to the resource.
    */
   readonly containingFile: string;
+
+  /**
+   * For style resources, the placement of the style within the containing file with lower numbers
+   * being before higher numbers.
+   * The value is primarily used by the Angular CLI to create a deterministic identifier for each
+   * style in HMR scenarios.
+   * This is undefined for templates.
+   */
+  readonly order?: number;
+
+  /**
+   * The name of the class that defines the component using the resource.
+   * This allows identifying the source usage of a resource in cases where multiple components are
+   * contained in a single source file.
+   */
+  className: string;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
@@ -97,6 +97,16 @@ export interface InternalOptions {
   _enableLetSyntax?: boolean;
 
   /**
+   * Enables the use of `<link>` elements for component styleUrls instead of inlining the file
+   * content.
+   * This option is intended to be used with a development server that processes and serves
+   * the files on-demand for an application.
+   *
+   * @internal
+   */
+  externalRuntimeStyles?: boolean;
+
+  /**
    * Detected version of `@angular/core` in the workspace. Used by the
    * compiler to adjust the output depending on the available symbols.
    *

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -1392,6 +1392,7 @@ export class NgCompiler {
     const strictCtorDeps = this.options.strictInjectionParameters || false;
     const supportJitMode = this.options['supportJitMode'] ?? true;
     const supportTestBed = this.options['supportTestBed'] ?? true;
+    const externalRuntimeStyles = this.options['externalRuntimeStyles'] ?? false;
 
     // Libraries compiled in partial mode could potentially be used with TestBed within an
     // application. Since this is not known at library compilation time, support is required to
@@ -1457,6 +1458,7 @@ export class NgCompiler {
         !!this.options.forbidOrphanComponents,
         this.enableBlockSyntax,
         this.enableLetSyntax,
+        externalRuntimeStyles,
         localCompilationExtraImportsTracker,
         jitDeclarationRegistry,
         this.options.i18nPreserveWhitespaceForLegacyExtraction ?? true,

--- a/packages/compiler-cli/src/ngtsc/resource/src/loader.ts
+++ b/packages/compiler-cli/src/ngtsc/resource/src/loader.ts
@@ -98,6 +98,7 @@ export class AdapterResourceLoader implements ResourceLoader {
         type: 'style',
         containingFile: context.containingFile,
         resourceFile: resolvedUrl,
+        className: context.className,
       };
       result = Promise.resolve(result).then(async (str) => {
         const transformResult = await this.adapter.transformResource!(str, resourceContext);
@@ -135,6 +136,8 @@ export class AdapterResourceLoader implements ResourceLoader {
       type: 'style',
       containingFile: context.containingFile,
       resourceFile: null,
+      order: context.order,
+      className: context.className,
     });
     if (transformResult === null) {
       return data;

--- a/packages/compiler-cli/test/compliance/partial/partial_compliance_goldens.bzl
+++ b/packages/compiler-cli/test/compliance/partial/partial_compliance_goldens.bzl
@@ -12,7 +12,7 @@ def partial_compliance_golden(filePath):
         "//packages/compiler-cli/test/compliance/partial:generate_golden_partial_lib",
         "//packages/core:npm_package",
         filePath,
-    ] + native.glob(["%s/*.ts" % path, "%s/**/*.html" % path])
+    ] + native.glob(["%s/*.ts" % path, "%s/**/*.html" % path, "%s/**/*.css" % path])
 
     nodejs_binary(
         name = generate_partial_name,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_styles/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_styles/GOLDEN_PARTIAL.js
@@ -36,6 +36,43 @@ export declare class MyModule {
 }
 
 /****************************************************************************************************
+ * PARTIAL FILE: encapsulation_emulated.js
+ ****************************************************************************************************/
+import { Component, NgModule, ViewEncapsulation } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyComponent {
+}
+MyComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent, selector: "my-component", ngImport: i0, template: '...', isInline: true, styles: ["div.bar { color: blue; }\n", "div.baz { color: purple; }\n", "div.foo { color: red; }", ":host p:nth-child(even) { --webkit-transition: 1s linear all; }"] });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, decorators: [{
+            type: Component,
+            args: [{ selector: 'my-component', encapsulation: ViewEncapsulation.Emulated, template: '...', styles: ["div.bar { color: blue; }\n", "div.baz { color: purple; }\n", "div.foo { color: red; }", ":host p:nth-child(even) { --webkit-transition: 1s linear all; }"] }]
+        }] });
+export class MyModule {
+}
+MyModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
+MyModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, declarations: [MyComponent] });
+MyModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, decorators: [{
+            type: NgModule,
+            args: [{ declarations: [MyComponent] }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: encapsulation_emulated.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyComponent {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyComponent, "my-component", never, {}, {}, never, never, false, never>;
+}
+export declare class MyModule {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyModule, never>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MyModule, [typeof MyComponent], never, never>;
+    static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
+}
+
+/****************************************************************************************************
  * PARTIAL FILE: encapsulation_none.js
  ****************************************************************************************************/
 import { Component, NgModule, ViewEncapsulation } from '@angular/core';
@@ -97,6 +134,43 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 
 /****************************************************************************************************
  * PARTIAL FILE: encapsulation_shadow_dom.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyComponent {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyComponent, "my-component", never, {}, {}, never, never, false, never>;
+}
+export declare class MyModule {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyModule, never>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MyModule, [typeof MyComponent], never, never>;
+    static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: external_runtime_files.js
+ ****************************************************************************************************/
+import { Component, NgModule, ViewEncapsulation } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyComponent {
+}
+MyComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent, selector: "my-component", ngImport: i0, template: '...', isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, decorators: [{
+            type: Component,
+            args: [{ selector: 'my-component', encapsulation: ViewEncapsulation.Emulated, template: '...' }]
+        }] });
+export class MyModule {
+}
+MyModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
+MyModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, declarations: [MyComponent] });
+MyModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, decorators: [{
+            type: NgModule,
+            args: [{ declarations: [MyComponent] }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: external_runtime_files.d.ts
  ****************************************************************************************************/
 import * as i0 from "@angular/core";
 export declare class MyComponent {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_styles/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_styles/TEST_CASES.json
@@ -16,6 +16,20 @@
       ]
     },
     {
+      "description": "should pass in the component metadata styles into the component definition and shim them using style encapsulation",
+      "inputFiles": [
+        "encapsulation_emulated.ts"
+      ],
+      "expectations": [
+        {
+          "failureMessage": "Incorrect template",
+          "files": [
+            "encapsulation_emulated.js"
+          ]
+        }
+      ]
+    },
+    {
       "description": "should pass in styles, but skip shimming the styles if the view encapsulation signals not to",
       "inputFiles": [
         "encapsulation_none.ts"
@@ -39,6 +53,26 @@
           "failureMessage": "Incorrect template",
           "files": [
             "encapsulation_shadow_dom.js"
+          ]
+        }
+      ]
+    },
+    {
+      "description": "should emit external runtime styles component feature for file-based styles when 'externalRuntimeStyles' option is enabled",
+      "inputFiles": [
+        "external_runtime_files.ts"
+      ],
+      "angularCompilerOptions": {
+        "externalRuntimeStyles": true
+      },
+      "compilationModeFilter": [
+        "full compile"
+      ],
+      "expectations": [
+        {
+          "failureMessage": "Incorrect template",
+          "files": [
+            "external_runtime_files.js"
           ]
         }
       ]

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_styles/encapsulation_emulated.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_styles/encapsulation_emulated.js
@@ -1,0 +1,1 @@
+["div.bar { color: blue; }\n", "div.baz { color: purple; }\n", "div.foo { color: red; }", ":host p:nth-child(even) { --webkit-transition: 1s linear all; }"]

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_styles/encapsulation_emulated.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_styles/encapsulation_emulated.ts
@@ -1,0 +1,17 @@
+import {Component, NgModule, ViewEncapsulation} from '@angular/core';
+
+@Component({
+  selector: 'my-component',
+  encapsulation: ViewEncapsulation.Emulated,
+  styles: [
+    'div.foo { color: red; }', ':host p:nth-child(even) { --webkit-transition: 1s linear all; }'
+  ],
+  styleUrls: ['./style-A.css', './style-B.css'],
+  template: '...'
+})
+export class MyComponent {
+}
+
+@NgModule({declarations: [MyComponent]})
+export class MyModule {
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_styles/external_runtime_files.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_styles/external_runtime_files.js
@@ -1,0 +1,1 @@
+ɵɵExternalStylesFeature(["/style-A.css", "/style-B.css"])

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_styles/external_runtime_files.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_styles/external_runtime_files.ts
@@ -1,0 +1,14 @@
+import {Component, NgModule, ViewEncapsulation} from '@angular/core';
+
+@Component({
+  selector: 'my-component',
+  encapsulation: ViewEncapsulation.Emulated,
+  styleUrls: ['./style-A.css', './style-B.css'],
+  template: '...'
+})
+export class MyComponent {
+}
+
+@NgModule({declarations: [MyComponent]})
+export class MyModule {
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_styles/style-A.css
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_styles/style-A.css
@@ -1,0 +1,1 @@
+div.bar { color: blue; }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_styles/style-B.css
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_styles/style-B.css
@@ -1,0 +1,1 @@
+div.baz { color: purple; }

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -553,6 +553,11 @@ export class Identifiers {
     moduleName: CORE,
   };
 
+  static ExternalStylesFeature: o.ExternalReference = {
+    name: 'ɵɵExternalStylesFeature',
+    moduleName: CORE,
+  };
+
   static listener: o.ExternalReference = {name: 'ɵɵlistener', moduleName: CORE};
 
   static getInheritedFactory: o.ExternalReference = {

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -237,6 +237,11 @@ export interface R3ComponentMetadata<DeclarationT extends R3TemplateDependency>
   styles: string[];
 
   /**
+   * A collection of style paths for external stylesheets that will be applied and scoped to the component.
+   */
+  externalStyles?: string[];
+
+  /**
    * An encapsulation policy for the component's styling.
    * Possible values:
    * - `ViewEncapsulation.Emulated`: Apply modified component styles in order to emulate

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -152,6 +152,12 @@ function addFeatures(
   if (meta.hasOwnProperty('template') && meta.isStandalone) {
     features.push(o.importExpr(R3.StandaloneFeature));
   }
+  if ('externalStyles' in meta && meta.externalStyles?.length) {
+    const externalStyleNodes = meta.externalStyles.map((externalStyle) => o.literal(externalStyle));
+    features.push(
+      o.importExpr(R3.ExternalStylesFeature).callFn([o.literalArr(externalStyleNodes)]),
+    );
+  }
   if (features.length) {
     definitionMap.set('features', o.literalArr(features));
   }
@@ -281,8 +287,10 @@ export function compileComponentFromMetadata(
     meta.encapsulation = core.ViewEncapsulation.Emulated;
   }
 
+  let hasStyles = !!meta.externalStyles?.length;
   // e.g. `styles: [str1, str2]`
   if (meta.styles && meta.styles.length) {
+    hasStyles = true;
     const styleValues =
       meta.encapsulation == core.ViewEncapsulation.Emulated
         ? compileStyles(meta.styles, CONTENT_ATTR, HOST_ATTR)
@@ -297,7 +305,9 @@ export function compileComponentFromMetadata(
     if (styleNodes.length > 0) {
       definitionMap.set('styles', o.literalArr(styleNodes));
     }
-  } else if (meta.encapsulation === core.ViewEncapsulation.Emulated) {
+  }
+
+  if (!hasStyles && meta.encapsulation === core.ViewEncapsulation.Emulated) {
     // If there is no style, don't generate css selectors on elements
     meta.encapsulation = core.ViewEncapsulation.None;
   }


### PR DESCRIPTION
The AOT compiler now has the capability to handle component stylesheet files as external runtime files. External runtime files are stylesheets that are not embedded within the component code at build time. Instead a URL path is emitted within a component's metadata. When combined with separate updates to the shared style host and DOM renderer, this will allow these stylesheet files to be fetched and processed by a development server on-demand. This behavior is controlled by an internal compiler option `externalRuntimeStyles`. The Angular CLI development server will also be updated to provide the serving functionality once this capability is enabled. This capability enables upcoming features such as automatic component style hot module replacement (HMR) and development server deferred stylesheet processing.

To provide support for HMR of inline component styles (`styles` decorator field), the AOT compiler will now use the resource host transformation API with the Angular CLI to provide external runtime stylesheet URLs when the `externalRuntimeStyles` compiler option is enabled. This allows both a component's file-based and inline styles to be available for HMR when used with a compatible development server such as with the Angular CLI. No behavioral change is present if the `externalRuntimeStyles` option is not enabled or the resource host transformation API is not used. An `order` numeric field is also added to the transformation API which allows consumers such as the Angular CLI to create identifiers for each inline style in a specific containing file.

Runtime: https://github.com/angular/angular/pull/57922