### PR TITLE
docs(docs-infra): add status filter to api reference overview

### DIFF
--- a/adev/shared-docs/styles/_colors.scss
+++ b/adev/shared-docs/styles/_colors.scss
@@ -263,24 +263,36 @@
   }
 }
 
-@mixin mdc-definitions() {
-  @include mat.snack-bar-overrides(
-    (
-      container-shape: 0.25rem,
-      container-color: var(--page-background),
-      supporting-text-color: var(--primary-contrast),
-    )
-  );
-}
+@include mat.snack-bar-overrides(
+  (
+    container-shape: 0.25rem,
+    container-color: var(--page-background),
+    supporting-text-color: var(--primary-contrast),
+  )
+);
+
+@include mat.chips-overrides(
+  (
+    outline-color: var(--quinary-contrast),
+    disabled-outline-color: var(--quinary-contrast),
+    flat-selected-outline-width: 1px,
+    label-text-color: var(--tertiary-contrast),
+    label-text-size: 14px,
+    label-text-line-height: 20px,
+
+    with-icon-icon-color: var(--french-violet),
+    with-icon-selected-icon-color: var(--french-violet),
+    selected-label-text-color: var(--french-violet),
+    focus-outline-color: var(--french-violet),
+  )
+);
 
 // LIGHT MODE (Explicit)
 .docs-light-mode {
   background-color: #ffffff;
   @include root-definitions();
-  @include mdc-definitions();
   .docs-invert-mode {
     @include dark-mode-definitions();
-    @include mdc-definitions();
   }
 }
 
@@ -289,9 +301,7 @@
   background-color: oklch(16.93% 0.004 285.95);
   @include root-definitions();
   @include dark-mode-definitions();
-  @include mdc-definitions();
   .docs-invert-mode {
     @include root-definitions();
-    @include mdc-definitions();
   }
 }

--- a/adev/src/app/features/references/api-items-section/api-items-section.component.html
+++ b/adev/src/app/features/references/api-items-section/api-items-section.component.html
@@ -29,7 +29,13 @@
         <span class="adev-item-title" [attr.title]="apiItem.title">{{ apiItem.title }}</span>
       </a>
       @if (apiItem.isDeprecated) {
-        <span class="adev-deprecated"> &lt;!&gt; </span>
+        <span class="adev-item-attribute" matTooltip="Deprecated"> &lt;!&gt; </span>
+      }
+      @if(apiItem.isExperimental) {
+        <span class="adev-item-attribute" matTooltip="Experimental"> 🧪 </span>
+      }
+      @if(apiItem.isDeveloperPreview) {
+        <span class="adev-item-attribute" matTooltip="Developer Preview"> 🚧 </span>
       }
     </li>
   }

--- a/adev/src/app/features/references/api-items-section/api-items-section.component.scss
+++ b/adev/src/app/features/references/api-items-section/api-items-section.component.scss
@@ -79,11 +79,12 @@
   gap: 1em;
 }
 
-.adev-deprecated {
+.adev-item-attribute {
+  width: 24px;
+  text-align: center;
   font-family: var(--code-font);
   background-color: var(--senary-contrast);
   color: var(--tertiary-contrast);
-  width: max-content;
   border-radius: 0.25rem;
   padding: 0.001rem 0.2rem 0.005rem;
   margin-inline-start: 0.5rem;

--- a/adev/src/app/features/references/api-items-section/api-items-section.component.spec.ts
+++ b/adev/src/app/features/references/api-items-section/api-items-section.component.spec.ts
@@ -59,7 +59,7 @@ describe('ApiItemsSection', () => {
     fixture.detectChanges();
 
     const deprecatedApiIcons = fixture.debugElement.queryAll(
-      By.css('.adev-api-items-section-grid li .adev-deprecated'),
+      By.css('.adev-api-items-section-grid li .adev-item-attribute'),
     );
     const deprecatedApiTitle = deprecatedApiIcons[0].parent?.query(By.css('.adev-item-title'));
 

--- a/adev/src/app/features/references/api-items-section/api-items-section.component.ts
+++ b/adev/src/app/features/references/api-items-section/api-items-section.component.ts
@@ -10,10 +10,11 @@ import {ChangeDetectionStrategy, Component, input} from '@angular/core';
 import {RouterLink} from '@angular/router';
 import {ApiItemsGroup} from '../interfaces/api-items-group';
 import ApiItemLabel from '../api-item-label/api-item-label.component';
+import {MatTooltipModule} from '@angular/material/tooltip';
 
 @Component({
   selector: 'adev-api-items-section',
-  imports: [ApiItemLabel, RouterLink],
+  imports: [ApiItemLabel, RouterLink, MatTooltipModule],
   templateUrl: './api-items-section.component.html',
   styleUrls: ['./api-items-section.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.ts
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.ts
@@ -18,7 +18,6 @@ const HIGHLIGHTED_CARD_CLASS = 'docs-highlighted-card';
 
 @Component({
   selector: 'adev-reference-page',
-  standalone: true,
   imports: [DocViewer],
   templateUrl: './api-reference-details-page.component.html',
   styleUrls: ['./api-reference-details-page.component.scss'],

--- a/adev/src/app/features/references/api-reference-list/api-reference-list.component.html
+++ b/adev/src/app/features/references/api-reference-list/api-reference-list.component.html
@@ -4,19 +4,18 @@
 
 <div class="adev-reference-list-filter">
   <div class="adev-reference-list-query-filter">
-    <docs-text-field
-      name="query"
-      placeholder="Filter"
-      [(ngModel)]="query"
-      (ngModelChange)="syncUrlWithFilters()"
-    />
+    <docs-text-field name="query" placeholder="Filter" [(ngModel)]="query" />
+  </div>
 
-    <docs-slide-toggle
-      buttonId="includeDeprecated"
-      label="Show @deprecated"
-      name="includeDeprecated"
-      [(ngModel)]="includeDeprecated"
-    />
+  <div class="adev-reference-list-status">
+    <mat-chip-listbox multiple="true" aria-label="Status selection">
+      <!-- null indicates to not re-order the object keys -->
+      @for (stat of statuses | keyvalue:null; track $index) {
+        <mat-chip-option [selected]="isStatusSelected(stat.value)" (click)="setStatus(stat.value)">
+          {{statusLabels[stat.value]}}
+        </mat-chip-option>
+      }
+    </mat-chip-listbox>
   </div>
 
   <p class="adev-reference-list-type-filter-label">Filter by Identifier type</p>
@@ -25,7 +24,7 @@
       <li
         class="adev-reference-list-type-filter-item"
         [class.adev-reference-list-type-filter-item-active]="type() === itemType"
-        (click)="filterByItemType(itemType)"
+        (click)="setItemType(itemType)"
       >
         <docs-api-item-label [type]="itemType" mode="short" class="docs-api-item-label" />
         <span class="docs-api-item-label-full">{{ itemType | adevApiLabel : 'full' }}</span>

--- a/adev/src/app/features/references/api-reference-list/api-reference-list.component.scss
+++ b/adev/src/app/features/references/api-reference-list/api-reference-list.component.scss
@@ -108,3 +108,28 @@
     width: 100%;
   }
 }
+
+.adev-reference-list-empty {
+  flex-basis: 100%;
+  p {
+    font-size: 1rem;
+  }
+}
+
+.docs-api-item-label-full {
+  white-space: nowrap;
+}
+
+.map-chip-option {
+  min-width: 190px;
+}
+
+.adev-reference-list-status {
+  display: flex;
+  align-items: center;
+  margin-top: 12px;
+
+  label {
+    margin-right: 8px;
+  }
+}

--- a/adev/src/app/features/references/api-reference-list/api-reference-list.component.spec.ts
+++ b/adev/src/app/features/references/api-reference-list/api-reference-list.component.spec.ts
@@ -8,7 +8,11 @@
 
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
-import ApiReferenceList, {ALL_TYPES_KEY} from './api-reference-list.component';
+import ApiReferenceList, {
+  ALL_TYPES_KEY,
+  DEFAULT_STATUS,
+  STATUSES,
+} from './api-reference-list.component';
 import {ApiReferenceManager} from './api-reference-manager.service';
 import {signal} from '@angular/core';
 import {ApiItemType} from '../interfaces/api-item-type';
@@ -26,24 +30,52 @@ describe('ApiReferenceList', () => {
     'url': 'api/animations/fakeItem1',
     'itemType': ApiItemType.FUNCTION,
     'isDeprecated': false,
+    'isDeveloperPreview': false,
+    'isExperimental': false,
   };
   let fakeItem2 = {
     'title': 'fakeItem2',
     'url': 'api/animations/fakeItem2',
     'itemType': ApiItemType.CLASS,
     'isDeprecated': false,
+    'isDeveloperPreview': false,
+    'isExperimental': false,
   };
   let fakeDeprecatedFeaturedItem = {
     'title': 'fakeItemDeprecated',
     'url': 'api/animations/fakeItemDeprecated',
     'itemType': ApiItemType.INTERFACE,
     'isDeprecated': true,
+    'isDeveloperPreview': false,
+    'isExperimental': false,
+  };
+  let fakeDeveloperPreviewItem = {
+    'title': 'fakeItemDeveloperPreview',
+    'url': 'api/animations/fakeItemDeveloperPreview',
+    'itemType': ApiItemType.INTERFACE,
+    'isDeprecated': false,
+    'isDeveloperPreview': true,
+    'isExperimental': false,
+  };
+  let fakeExperimentalItem = {
+    'title': 'fakeItemExperimental',
+    'url': 'api/animations/fakeItemExperimental',
+    'itemType': ApiItemType.INTERFACE,
+    'isDeprecated': false,
+    'isDeveloperPreview': false,
+    'isExperimental': true,
   };
   const fakeApiReferenceManager = {
     apiGroups: signal([
       {
         title: 'Fake Group',
-        items: [fakeItem1, fakeItem2, fakeDeprecatedFeaturedItem],
+        items: [
+          fakeItem1,
+          fakeItem2,
+          fakeDeprecatedFeaturedItem,
+          fakeDeveloperPreviewItem,
+          fakeExperimentalItem,
+        ],
         isFeatured: false,
       },
     ]),
@@ -71,33 +103,15 @@ describe('ApiReferenceList', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should display both Deprecated and Non-deprecated APIs when includeDeprecated toggle is set to true', () => {
-    component.includeDeprecated.set(true);
-    fixture.detectChanges();
-
-    expect(component.filteredGroups()![0].items).toEqual([
-      fakeItem1,
-      fakeItem2,
-      fakeDeprecatedFeaturedItem,
-    ]);
-  });
-
-  it('should display both Non-deprecated APIs when includeDeprecated toggle is set to false', () => {
-    component.includeDeprecated.set(false);
-    fixture.detectChanges();
-
-    expect(component.filteredGroups()![0].items).toEqual([fakeItem1, fakeItem2]);
-  });
-
   it('should display only items which contains provided query when query is not empty', () => {
-    component.query.set('Item1');
+    fixture.componentRef.setInput('query', 'Item1');
     fixture.detectChanges();
 
     expect(component.filteredGroups()![0].items).toEqual([fakeItem1]);
   });
 
   it('should display only class items when user selects Class in the Type select', () => {
-    fixture.componentInstance.type.set(ApiItemType.CLASS);
+    fixture.componentRef.setInput('type', ApiItemType.CLASS);
     fixture.detectChanges();
 
     expect(component.type()).toEqual(ApiItemType.CLASS);
@@ -106,17 +120,17 @@ describe('ApiReferenceList', () => {
 
   it('should set selected type when provided type is different than selected', async () => {
     expect(component.type()).toBe(ALL_TYPES_KEY);
-    component.filterByItemType(ApiItemType.BLOCK);
+    component.setItemType(ApiItemType.BLOCK);
     await RouterTestingHarness.create(`/api?type=${ApiItemType.BLOCK}`);
     expect(component.type()).toBe(ApiItemType.BLOCK);
   });
 
   it('should reset selected type when provided type is equal to selected', async () => {
-    component.filterByItemType(ApiItemType.BLOCK);
+    component.setItemType(ApiItemType.BLOCK);
     const harness = await RouterTestingHarness.create(`/api?type=${ApiItemType.BLOCK}`);
     expect(component.type()).toBe(ApiItemType.BLOCK);
 
-    component.filterByItemType(ApiItemType.BLOCK);
+    component.setItemType(ApiItemType.BLOCK);
     harness.navigateByUrl(`/api`);
     expect(component.type()).toBe(ALL_TYPES_KEY);
   });
@@ -126,28 +140,67 @@ describe('ApiReferenceList', () => {
 
     const textField = fixture.debugElement.query(By.directive(TextField));
     (textField.componentInstance as TextField).setValue('item1');
-
     await fixture.whenStable();
-    expect(location.path()).toBe(`?query=item1&type=All`);
+    expect(location.path()).toBe(`?query=item1`);
   });
 
-  it('should keep the values of existing queryParams and set new queryParam equal to the type', async () => {
+  it('should keep the values of existing queryParams and set new queryParam equal to given value', async () => {
     const location = TestBed.inject(Location);
 
     const textField = fixture.debugElement.query(By.directive(TextField));
     (textField.componentInstance as TextField).setValue('item1');
     await fixture.whenStable();
-    expect(location.path()).toBe(`?query=item1&type=All`);
+    expect(location.path()).toBe(`?query=item1`);
 
-    component.filterByItemType(ApiItemType.BLOCK);
+    component.setItemType(ApiItemType.BLOCK);
     await fixture.whenStable();
     expect(location.path()).toBe(`?query=item1&type=${ApiItemType.BLOCK}`);
+
+    fixture.componentRef.setInput('status', STATUSES.experimental);
+    await fixture.whenStable();
+    expect(location.path()).toBe(
+      `?query=item1&type=${ApiItemType.BLOCK}&status=${STATUSES.experimental}`,
+    );
   });
 
-  it('should display all items when query and type are undefined', async () => {
-    component.query.set(undefined);
-    component.type.set(undefined);
+  it('should display all items when query and type and status are undefined', async () => {
+    fixture.componentRef.setInput('query', undefined);
+    fixture.componentRef.setInput('type', undefined);
+    fixture.componentRef.setInput('status', undefined);
     await fixture.whenStable();
+    expect(component.filteredGroups()![0].items).toEqual([
+      fakeItem1,
+      fakeItem2,
+      fakeDeveloperPreviewItem,
+      fakeExperimentalItem,
+    ]);
+  });
+
+  it('should not display deprecated and developer-preview and experimental items when status is set to stable', () => {
+    fixture.componentRef.setInput('status', STATUSES.stable);
+    fixture.detectChanges();
+
     expect(component.filteredGroups()![0].items).toEqual([fakeItem1, fakeItem2]);
+  });
+
+  it('should only display deprecated items when status is set to deprecated', () => {
+    fixture.componentRef.setInput('status', STATUSES.deprecated);
+    fixture.detectChanges();
+
+    expect(component.filteredGroups()![0].items).toEqual([fakeDeprecatedFeaturedItem]);
+  });
+
+  it('should only display developer-preview items when status is set to developer-preview', () => {
+    fixture.componentRef.setInput('status', STATUSES.developerPreview);
+    fixture.detectChanges();
+
+    expect(component.filteredGroups()![0].items).toEqual([fakeDeveloperPreviewItem]);
+  });
+
+  it('should only display experimental items when status is set to experimental', () => {
+    fixture.componentRef.setInput('status', STATUSES.experimental);
+    fixture.detectChanges();
+
+    expect(component.filteredGroups()![0].items).toEqual([fakeExperimentalItem]);
   });
 });

--- a/adev/src/app/features/references/api-reference-list/api-reference-manager.service.ts
+++ b/adev/src/app/features/references/api-reference-list/api-reference-manager.service.ts
@@ -30,12 +30,16 @@ export class ApiReferenceManager {
         id: module.normalizedModuleName,
         items: module.entries.map((api) => {
           const url = getApiUrl(module, api.name);
-          return {
+          const apiItem = {
             itemType: api.type,
             title: api.name,
             isDeprecated: !!api.isDeprecated,
+            isDeveloperPreview: !!api.isDeveloperPreview,
+            isExperimental: !!api.isExperimental,
             url,
           };
+
+          return apiItem;
         }),
       });
     }

--- a/adev/src/app/features/references/interfaces/api-item.ts
+++ b/adev/src/app/features/references/interfaces/api-item.ts
@@ -12,7 +12,8 @@ export interface ApiItem {
   title: string;
   itemType: ApiItemType;
   url: string;
-  isFeatured?: boolean;
   isDeprecated?: boolean;
+  isDeveloperPreview?: boolean;
+  isExperimental?: boolean;
   groupName?: string;
 }

--- a/adev/src/app/features/references/interfaces/api-manifest.ts
+++ b/adev/src/app/features/references/interfaces/api-manifest.ts
@@ -11,7 +11,9 @@ import {ApiItemType} from './api-item-type';
 export interface ApiManifestEntry {
   name: string;
   type: ApiItemType;
-  isDeprecated?: boolean;
+  isDeprecated: boolean;
+  isDeveloperPreview: boolean;
+  isExperimental: boolean;
 }
 
 export interface ApiManifestPackage {

--- a/adev/src/app/router_providers.ts
+++ b/adev/src/app/router_providers.ts
@@ -127,7 +127,8 @@ const initializeNavigationAdapter = () => {
     // Skip this for popstate/traversals that are already committed.
     // The rollback is problematic so we only do it for navigations that
     // defer the actual update (pushState) on the browser.
-    if (router.getCurrentNavigation()?.trigger === 'popstate') {
+    const currentNavigation = router.getCurrentNavigation();
+    if (currentNavigation?.trigger === 'popstate' || currentNavigation?.extras.replaceUrl) {
       return;
     }
     if (e instanceof NavigationStart) {


### PR DESCRIPTION
add a status filter on the api reference overview page to filter on status (all|stable|deprecated|developer-preview|experimental)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently it's not possible to filter the API references on status, except for showing deprecated items in the list of references.

Issue Number: https://github.com/angular/angular/issues/57119


## What is the new behavior?
Replaced the 'show deprecated' toggle with a button dropdown that allows you to select `All | Stable | Deprecated | Developer-preview | Experimental` allowing to quickly get an overview of  which items are safe to use in production and which are currently in developer preview/experimental

The status is also accessible via a `queryParam`: `https://angular.dev/api?status=developer-preview` which can be used to link to from an external source or from within the docs (e.g. https://angular.dev/reference/releases#developer-preview can be updated with a direct link to a list of developer-preview references)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
