### PR TITLE
feat(core): allow passing `undefined` without needing to include it i…

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -974,7 +974,9 @@ export interface InputDecorator {
 export interface InputFunction {
     <T>(): InputSignal<T | undefined>;
     <T>(initialValue: T, opts?: InputOptionsWithoutTransform<T>): InputSignal<T>;
+    <T>(initialValue: undefined, opts: InputOptionsWithoutTransform<T>): InputSignal<T | undefined>;
     <T, TransformT>(initialValue: T, opts: InputOptionsWithTransform<T, TransformT>): InputSignalWithTransform<T, TransformT>;
+    <T, TransformT>(initialValue: undefined, opts: InputOptionsWithTransform<T | undefined, TransformT>): InputSignalWithTransform<T | undefined, TransformT>;
     required: {
         <T>(opts?: InputOptionsWithoutTransform<T>): InputSignal<T>;
         <T, TransformT>(opts: InputOptionsWithTransform<T, TransformT>): InputSignalWithTransform<T, TransformT>;

--- a/packages/core/src/authoring/input/input.ts
+++ b/packages/core/src/authoring/input/input.ts
@@ -51,6 +51,8 @@ export interface InputFunction {
   <T>(): InputSignal<T | undefined>;
   /** Declares an input of type `T` with an explicit initial value. */
   <T>(initialValue: T, opts?: InputOptionsWithoutTransform<T>): InputSignal<T>;
+  /** Declares an input of type `T|undefined` without an initial value, but with input options */
+  <T>(initialValue: undefined, opts: InputOptionsWithoutTransform<T>): InputSignal<T | undefined>;
   /**
    * Declares an input of type `T` with an initial value and a transform
    * function.
@@ -62,6 +64,16 @@ export interface InputFunction {
     initialValue: T,
     opts: InputOptionsWithTransform<T, TransformT>,
   ): InputSignalWithTransform<T, TransformT>;
+  /**
+   * Declares an input of type `T|undefined` without an initial value and with a transform
+   * function.
+   *
+   * The input accepts values of type `TransformT` and the given
+   * transform function will transform the value to type `T|undefined`.
+   */ <T, TransformT>(
+    initialValue: undefined,
+    opts: InputOptionsWithTransform<T | undefined, TransformT>,
+  ): InputSignalWithTransform<T | undefined, TransformT>;
 
   /**
    * Initializes a required input.

--- a/packages/core/test/authoring/signal_input_signature_test.ts
+++ b/packages/core/test/authoring/signal_input_signature_test.ts
@@ -68,6 +68,24 @@ export class InputSignatureTest {
   /** string | undefined */
   withNoInitialValue = input<string>();
 
+  /** undefined */
+  initialValueUndefinedWithoutOptions = input(undefined);
+  /** undefined */
+  initialValueUndefinedWithOptions = input(undefined, {});
+  /** @internal */
+  __shouldErrorIfInitialValueUndefinedExplicitReadWithoutOptions = input<string>(
+    // @ts-expect-error
+    undefined,
+  );
+  /** string | undefined, unknown */
+  initialValueUndefinedWithUntypedTransform = input(undefined, {transform: (bla) => ''});
+  /** string | undefined, string */
+  initialValueUndefinedWithTypedTransform = input(undefined, {transform: (bla: string) => ''});
+  /** string | undefined, string */
+  initialValueUndefinedExplicitReadWithTransform = input<string, string>(undefined, {
+    transform: (bla) => '',
+  });
+
   /** string */
   requiredNoInitialValue = input.required<string>();
   /** string | undefined */


### PR DESCRIPTION
…n the type argument of `input`

This commit introduces an overload for `input` to accept `undefined` as initial value if only options are needed to be provided, inferring an input of type `T|undefined`. Prior to this change, the type argument as specified needed to include `|undefined` explicitly even though that isn't necessary when passing options isn't needed.

**Note:** this is an experiment to determine if such change could impact existing code, it is yet to be determined if this is the direction we want to take.

Relates to #53909