### PR TITLE
docs(upgrade): change example wording on Input tutorial

### DIFF
--- a/adev/src/content/tutorials/learn-angular/steps/8-input/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/8-input/README.md
@@ -31,7 +31,7 @@ Make sure you bind the property `occupation` in your `UserComponent`.
 <docs-code header="user.component.ts" language="angular-ts">
 @Component({
   ...
-  template: `<p>The user's name is {{occupation}}</p>`
+  template: `<p>The user's occupation is {{occupation}}</p>`
 })
 </docs-code>
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

On the [Component Communication with @Input](https://angular.dev/tutorials/learn-angular/8-input) example from the tutorial, we're presented with an example for passing an `occupation` (`string`) prop with an `Angular Developer` value. But the parent component in the example that will receive the prop includes the statement: 

`The user's name is {{occupation}}`

While doing the tutorial I thought maybe we could re-phrase that so it made a little bit more sense, so I thought about changing it to:

`The user's occupation is {{occupation}}`

Which feels more 'correct'.

Issue Number: N/A


## What is the new behavior?

The behavior is exactly the same except now the example reads `The user's occupation is {{occupation}}` instead of `The user's name is {{occupation}}`

Note that while the answer does expect the statement to be `The user's name is {{ name }}`, this changes come _before_ the instructions to follow for that part of the tutorial, this is just the example right before that and it does not modify the answer or the instructions in any case, it's just the previous example.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Thank you for your hard work!
Best regards! :heart: 