### PR TITLE
fix wrongful string interpolation on angular.dev tutorial

### DIFF
--- a/adev/src/content/tutorials/first-app/steps/14-http/README.md
+++ b/adev/src/content/tutorials/first-app/steps/14-http/README.md
@@ -33,7 +33,7 @@ JSON Server is an open source tool used to create mock REST APIs. You'll use it 
                     "name": "Acme Fresh Start Housing",
                     "city": "Chicago",
                     "state": "IL",
-                    "photo": "${this.baseUrl}/bernard-hermant-CLKGGwIBTaY-unsplash.jpg",
+                    "photo": "https://angular.dev/assets/images/tutorials/common/bernard-hermant-CLKGGwIBTaY-unsplash.jpg",
                     "availableUnits": 4,
                     "wifi": true,
                     "laundry": true
@@ -43,7 +43,7 @@ JSON Server is an open source tool used to create mock REST APIs. You'll use it 
                     "name": "A113 Transitional Housing",
                     "city": "Santa Monica",
                     "state": "CA",
-                    "photo": "${this.baseUrl}/brandon-griggs-wR11KBaB86U-unsplash.jpg",
+                    "photo": "https://angular.dev/assets/images/tutorials/common/brandon-griggs-wR11KBaB86U-unsplash.jpg",
                     "availableUnits": 0,
                     "wifi": false,
                     "laundry": true
@@ -53,7 +53,7 @@ JSON Server is an open source tool used to create mock REST APIs. You'll use it 
                     "name": "Warm Beds Housing Support",
                     "city": "Juneau",
                     "state": "AK",
-                    "photo": "${this.baseUrl}/i-do-nothing-but-love-lAyXdl1-Wmc-unsplash.jpg",
+                    "photo": "https://angular.dev/assets/images/tutorials/common/i-do-nothing-but-love-lAyXdl1-Wmc-unsplash.jpg",
                     "availableUnits": 1,
                     "wifi": false,
                     "laundry": false
@@ -63,7 +63,7 @@ JSON Server is an open source tool used to create mock REST APIs. You'll use it 
                     "name": "Homesteady Housing",
                     "city": "Chicago",
                     "state": "IL",
-                    "photo": "${this.baseUrl}/ian-macdonald-W8z6aiwfi1E-unsplash.jpg",
+                    "photo": "https://angular.dev/assets/images/tutorials/common/ian-macdonald-W8z6aiwfi1E-unsplash.jpg",
                     "availableUnits": 1,
                     "wifi": true,
                     "laundry": false
@@ -73,7 +73,7 @@ JSON Server is an open source tool used to create mock REST APIs. You'll use it 
                     "name": "Happy Homes Group",
                     "city": "Gary",
                     "state": "IN",
-                    "photo": "${this.baseUrl}/krzysztof-hepner-978RAXoXnH4-unsplash.jpg",
+                    "photo": "https://angular.dev/assets/images/tutorials/common/krzysztof-hepner-978RAXoXnH4-unsplash.jpg",
                     "availableUnits": 1,
                     "wifi": true,
                     "laundry": false
@@ -83,7 +83,7 @@ JSON Server is an open source tool used to create mock REST APIs. You'll use it 
                     "name": "Hopeful Apartment Group",
                     "city": "Oakland",
                     "state": "CA",
-                    "photo": "${this.baseUrl}/r-architecture-JvQ0Q5IkeMM-unsplash.jpg",
+                    "photo": "https://angular.dev/assets/images/tutorials/common/r-architecture-JvQ0Q5IkeMM-unsplash.jpg",
                     "availableUnits": 2,
                     "wifi": true,
                     "laundry": true
@@ -93,7 +93,7 @@ JSON Server is an open source tool used to create mock REST APIs. You'll use it 
                     "name": "Seriously Safe Towns",
                     "city": "Oakland",
                     "state": "CA",
-                    "photo": "${this.baseUrl}/phil-hearing-IYfp2Ixe9nM-unsplash.jpg",
+                    "photo": "https://angular.dev/assets/images/tutorials/common/phil-hearing-IYfp2Ixe9nM-unsplash.jpg",
                     "availableUnits": 5,
                     "wifi": true,
                     "laundry": true
@@ -103,7 +103,7 @@ JSON Server is an open source tool used to create mock REST APIs. You'll use it 
                     "name": "Hopeful Housing Solutions",
                     "city": "Oakland",
                     "state": "CA",
-                    "photo": "${this.baseUrl}/r-architecture-GGupkreKwxA-unsplash.jpg",
+                    "photo": "https://angular.dev/assets/images/tutorials/common/r-architecture-GGupkreKwxA-unsplash.jpg",
                     "availableUnits": 2,
                     "wifi": true,
                     "laundry": true
@@ -113,7 +113,7 @@ JSON Server is an open source tool used to create mock REST APIs. You'll use it 
                     "name": "Seriously Safe Towns",
                     "city": "Oakland",
                     "state": "CA",
-                    "photo": "${this.baseUrl}/saru-robert-9rP3mxf8qWI-unsplash.jpg",
+                    "photo": "https://angular.dev/assets/images/tutorials/common/saru-robert-9rP3mxf8qWI-unsplash.jpg",
                     "availableUnits": 10,
                     "wifi": false,
                     "laundry": false
@@ -123,7 +123,7 @@ JSON Server is an open source tool used to create mock REST APIs. You'll use it 
                     "name": "Capital Safe Towns",
                     "city": "Portland",
                     "state": "OR",
-                    "photo": "${this.baseUrl}/webaliser-_TPTXZd9mOo-unsplash.jpg",
+                    "photo": "https://angular.dev/assets/images/tutorials/common/webaliser-_TPTXZd9mOo-unsplash.jpg",
                     "availableUnits": 6,
                     "wifi": true,
                     "laundry": true


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Looks like the json content in https://angular.dev/tutorials/first-app/14-http was copied from the .ts code without removing the ${} interpolation.

fixes #57037 

## What is the new behavior?
${} clauses where changed for the intended value

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
