### PR TITLE
refactor(migrations): properly handle cases of `--strict=false` in signal input migration

### DIFF
--- a/packages/core/schematics/migrations/signal-migration/src/BUILD.bazel
+++ b/packages/core/schematics/migrations/signal-migration/src/BUILD.bazel
@@ -7,6 +7,7 @@ ts_library(
         exclude = ["test/**"],
     ),
     visibility = [
+        "//packages/core/schematics/migrations/signal-migration/test:__pkg__",
         "//packages/core/schematics/migrations/signal-queries-migration:__pkg__",
         "//packages/language-service:__subpackages__",
     ],

--- a/packages/core/schematics/migrations/signal-migration/src/convert-input/prepare_and_check.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/convert-input/prepare_and_check.ts
@@ -23,6 +23,7 @@ import assert from 'assert';
 export interface ConvertInputPreparation {
   resolvedType: ts.TypeNode | undefined;
   preferShorthandIfPossible: {originalType: ts.TypeNode} | null;
+  requiredButIncludedUndefinedPreviously: boolean;
   resolvedMetadata: ExtractedInput;
   originalInputDecorator: Decorator;
   initialValue: ts.Expression | undefined;
@@ -123,6 +124,7 @@ export function prepareAndCheckForConversion(
   }
 
   return {
+    requiredButIncludedUndefinedPreviously: metadata.required && node.questionToken !== undefined,
     resolvedMetadata: metadata,
     resolvedType: typeToAdd,
     preferShorthandIfPossible,

--- a/packages/core/schematics/migrations/signal-migration/src/passes/1_identify_inputs.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/1_identify_inputs.ts
@@ -55,7 +55,12 @@ export function pass1__IdentifySourceFileAndDeclarationInputs(
       // track source file inputs in the result of this target.
       // these are then later migrated in the migration phase.
       if (decoratorInput.inSourceFile && host.isSourceFileForCurrentMigration(sf)) {
-        const conversionPreparation = prepareAndCheckForConversion(node, decoratorInput, checker);
+        const conversionPreparation = prepareAndCheckForConversion(
+          node,
+          decoratorInput,
+          checker,
+          host.options,
+        );
 
         if (isInputMemberIncompatibility(conversionPreparation)) {
           knownDecoratorInputs.markInputAsIncompatible(inputDescr, conversionPreparation);

--- a/packages/core/schematics/migrations/signal-migration/test/BUILD.bazel
+++ b/packages/core/schematics/migrations/signal-migration/test/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@npm//@angular/build-tooling/bazel/integration:index.bzl", "integration_test")
 load("//packages/core/schematics/migrations/signal-migration/test/ts-versions:index.bzl", "TS_VERSIONS")
-load("//tools:defaults.bzl", "nodejs_binary", "ts_library")
+load("//tools:defaults.bzl", "jasmine_node_test", "nodejs_binary", "ts_library")
 
 ts_library(
     name = "test_runners_lib",
@@ -125,4 +125,21 @@ integration_test(
     tool_mappings = {
         "//packages/core/schematics/migrations/signal-migration/src:batch_test_bin": "migration",
     },
+)
+
+ts_library(
+    name = "test_lib",
+    testonly = True,
+    srcs = ["migration_spec.ts"],
+    deps = [
+        "//packages/compiler-cli/src/ngtsc/file_system",
+        "//packages/compiler-cli/src/ngtsc/file_system/testing",
+        "//packages/core/schematics/migrations/signal-migration/src",
+        "//packages/core/schematics/utils/tsurge",
+    ],
+)
+
+jasmine_node_test(
+    name = "test_jasmine",
+    srcs = [":test_lib"],
 )

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/non_null_assertions.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/non_null_assertions.ts
@@ -1,0 +1,15 @@
+// tslint:disable
+
+import {Input, Directive} from '@angular/core';
+
+@Directive()
+export class NonNullAssertions {
+  // We can't remove `undefined` from the type here. It's unclear
+  // whether it was just used as a workaround for required inputs, or
+  // it was actually meant to be part of the type.
+  @Input({required: true}) name?: string;
+
+  click() {
+    this.name!.charAt(0);
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden.txt
@@ -713,6 +713,23 @@ interface Config {
 export class NestedTemplatePropAccess {
   readonly config = input<Config>({});
 }
+@@@@@@ non_null_assertions.ts @@@@@@
+
+// tslint:disable
+
+import { Directive, input } from '@angular/core';
+
+@Directive()
+export class NonNullAssertions {
+  // We can't remove `undefined` from the type here. It's unclear
+  // whether it was just used as a workaround for required inputs, or
+  // it was actually meant to be part of the type.
+  readonly name = input.required<string | undefined>();
+
+  click() {
+    this.name()!.charAt(0);
+  }
+}
 @@@@@@ object_expansion.ts @@@@@@
 
 // tslint:disable

--- a/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
@@ -713,6 +713,23 @@ interface Config {
 export class NestedTemplatePropAccess {
   readonly config = input<Config>({});
 }
+@@@@@@ non_null_assertions.ts @@@@@@
+
+// tslint:disable
+
+import { Directive, input } from '@angular/core';
+
+@Directive()
+export class NonNullAssertions {
+  // We can't remove `undefined` from the type here. It's unclear
+  // whether it was just used as a workaround for required inputs, or
+  // it was actually meant to be part of the type.
+  readonly name = input.required<string | undefined>();
+
+  click() {
+    this.name()!.charAt(0);
+  }
+}
 @@@@@@ object_expansion.ts @@@@@@
 
 // tslint:disable

--- a/packages/core/schematics/migrations/signal-migration/test/migration_spec.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/migration_spec.ts
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {absoluteFrom} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {initMockFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
+import {runTsurgeMigration} from '../../../utils/tsurge/testing';
+import {SignalInputMigration} from '../src/migration';
+
+describe('signal input migration', () => {
+  beforeEach(() => {
+    initMockFileSystem('Native');
+  });
+
+  it(
+    'should properly handle declarations with loose property initialization ' +
+      'and strict null checks enabled',
+    async () => {
+      const fs = await runTsurgeMigration(
+        new SignalInputMigration(),
+        [
+          {
+            name: absoluteFrom('/app.component.ts'),
+            isProgramRootFile: true,
+            contents: `
+            import {Component, Input} from '@angular/core';
+
+            @Component({template: ''})
+            class AppComponent {
+              @Input() name: string;
+
+              doSmth() {
+                this.name.charAt(0);
+              }
+            }
+          `,
+          },
+        ],
+        {
+          strict: false,
+          strictNullChecks: true,
+        },
+      );
+
+      expect(fs.readFile(absoluteFrom('/app.component.ts'))).toContain(
+        'readonly name = input<string>(undefined!);',
+      );
+      expect(fs.readFile(absoluteFrom('/app.component.ts'))).toContain('this.name().charAt(0);');
+    },
+  );
+
+  it(
+    'should properly handle declarations with loose property initialization ' +
+      'and strict null checks disabled',
+    async () => {
+      const fs = await runTsurgeMigration(
+        new SignalInputMigration(),
+        [
+          {
+            name: absoluteFrom('/app.component.ts'),
+            isProgramRootFile: true,
+            contents: `
+            import {Component, Input} from '@angular/core';
+
+            @Component({template: ''})
+            class AppComponent {
+              @Input() name: string;
+
+              doSmth() {
+                this.name.charAt(0);
+              }
+            }
+          `,
+          },
+        ],
+        {
+          strict: false,
+        },
+      );
+
+      expect(fs.readFile(absoluteFrom('/app.component.ts'))).toContain(
+        // Shorthand not used here to keep behavior unchanged, and to not
+        // risk expanding the type. In practice `string|undefined` would be
+        // fine though as long as the consumers also have strict null checks disabled.
+        'readonly name = input<string>(undefined);',
+      );
+      expect(fs.readFile(absoluteFrom('/app.component.ts'))).toContain('this.name().charAt(0);');
+    },
+  );
+});

--- a/packages/core/schematics/utils/tsurge/testing/index.ts
+++ b/packages/core/schematics/utils/tsurge/testing/index.ts
@@ -15,6 +15,7 @@ import {
 } from '@angular/compiler-cli/src/ngtsc/file_system';
 import {groupReplacementsByFile} from '../helpers/group_replacements';
 import {applyTextUpdates} from '../replacement';
+import ts from 'typescript';
 
 /**
  * Runs the given migration against a fake set of files, emulating
@@ -30,6 +31,7 @@ import {applyTextUpdates} from '../replacement';
 export async function runTsurgeMigration<UnitData, GlobalData>(
   migration: TsurgeMigration<UnitData, GlobalData>,
   files: {name: AbsoluteFsPath; contents: string; isProgramRootFile?: boolean}[],
+  compilerOptions: ts.CompilerOptions = {},
 ): Promise<MockFileSystem> {
   const mockFs = getFileSystem();
   if (!(mockFs instanceof MockFileSystem)) {
@@ -47,7 +49,9 @@ export async function runTsurgeMigration<UnitData, GlobalData>(
     absoluteFrom('/tsconfig.json'),
     JSON.stringify({
       compilerOptions: {
+        strict: true,
         rootDir: '/',
+        ...compilerOptions,
       },
       files: rootFiles,
     }),


### PR DESCRIPTION
See individual commits