### PR TITLE
fix(migrations): change imports to be G3 compatible

### DIFF
--- a/packages/compiler-cli/private/migrations.ts
+++ b/packages/compiler-cli/private/migrations.ts
@@ -12,6 +12,7 @@
  */
 
 export {forwardRefResolver} from '../src/ngtsc/annotations';
+export {AbsoluteFsPath} from '../src/ngtsc/file_system';
 export {Reference} from '../src/ngtsc/imports';
 export {
   DynamicValue,

--- a/packages/core/schematics/migrations/output-migration/output-replacements.ts
+++ b/packages/core/schematics/migrations/output-migration/output-replacements.ts
@@ -7,15 +7,15 @@
  */
 
 import ts from 'typescript';
+
+import {AbsoluteFsPath, ImportManager} from '../../../../compiler-cli/private/migrations';
 import {
-  Replacement,
-  TextUpdate,
   ProjectRelativePath,
   projectRelativePath,
+  Replacement,
+  TextUpdate,
 } from '../../utils/tsurge';
-import {absoluteFromSourceFile, AbsoluteFsPath} from '@angular/compiler-cli';
 import {applyImportManagerChanges} from '../../utils/tsurge/helpers/apply_import_manager';
-import {ImportManager} from '../../../../compiler-cli/private/migrations';
 
 const printer = ts.createPrinter();
 
@@ -80,7 +80,6 @@ export function calculateImportReplacements(
     const addOnly: Replacement[] = [];
     const addRemove: Replacement[] = [];
 
-    const absolutePath = absoluteFromSourceFile(sf);
     importManager.addImport({
       requestedFile: sf,
       exportModuleSpecifier: '@angular/core',


### PR DESCRIPTION
A set of fixes to the import paths - the goal is to make the output migration compatible with the G3 infrastructure.
