### PR TITLE
refactor(core): add externalStyles component definition metadata linkage

### DIFF
--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -301,6 +301,11 @@ interface ComponentDefinition<T> extends Omit<DirectiveDefinition<T>, 'features'
   styles?: string[];
 
   /**
+   * A set of stylesheet URLs that the component needs to be present for component to render correctly.
+   */
+  externalStyles?: string[];
+
+  /**
    * The strategy that the default change detector uses to detect changes.
    * When set, takes effect the next time change detection is triggered.
    */
@@ -366,6 +371,10 @@ export function ɵɵdefineComponent<T>(
       tView: null,
       id: '',
     };
+
+    if (componentDefinition.externalStyles) {
+      def.data['externalStyles'] = componentDefinition.externalStyles;
+    }
 
     initFeatures(def);
     const dependencies = componentDefinition.dependencies;

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -352,6 +352,10 @@ export interface ComponentDef<T> extends DirectiveDef<T> {
   readonly data: {
     [kind: string]: any;
     animation?: any[];
+    /**
+     * A set of style URLs that the component needs to be present for component to render correctly.
+     */
+    externalStyles?: string[];
   };
 
   /** Whether or not this component's ChangeDetectionStrategy is OnPush */


### PR DESCRIPTION
To allow the DOM renderer within platform-browser to access the AOT compiler's generated external styles metadata, the runtime data structures for component definitions must be updated to add the related field (`externalStyles`). The `ɵɵdefineComponent` runtime function has been adjusted to add the `externalStyles` field to the runtime definition for the component based on the AOT compiled metadata in the generated code. The field will not be present if no external styles were emitted for the component. This limits the additional processing during rendering when not in a mode that leverages external component stylesheets.