### PR TITLE
Improve experience of signal input migration in VSCode extension

### DIFF
--- a/packages/core/schematics/migrations/output-migration/output-migration.spec.ts
+++ b/packages/core/schematics/migrations/output-migration/output-migration.spec.ts
@@ -278,27 +278,31 @@ async function verify(testCase: {before: string; after: string}) {
 
 function populateDeclarationTestCase(declaration: string): string {
   return `
-      import {
-        Directive,
-        Output,
-        EventEmitter,
-        Subject
-      } from '@angular/core';
-  
-      @Directive()
-      export class TestDir {
-        ${declaration}
-      }
-    `;
+import {
+  Directive,
+  Output,
+  EventEmitter,
+  Subject
+} from '@angular/core';
+
+@Directive()
+export class TestDir {
+  ${declaration}
+}
+`;
 }
 
 function populateExpectedResult(declaration: string): string {
   return `
-      import { Directive, Subject, output } from '@angular/core';
-  
-      @Directive()
-      export class TestDir {
-        ${declaration}
-      }
-    `;
+import {
+  Directive,
+  Subject,
+  output
+} from '@angular/core';
+
+@Directive()
+export class TestDir {
+  ${declaration}
+}
+`;
 }

--- a/packages/core/schematics/migrations/output-migration/output-migration.spec.ts
+++ b/packages/core/schematics/migrations/output-migration/output-migration.spec.ts
@@ -52,17 +52,17 @@ describe('outputs', () => {
             import {Directive, Output, EventEmitter} from '@angular/core';
 
             const aliasParam = { alias: 'otherChange' } as const;
-      
+
             @Directive()
             export class TestDir {
               @Output(aliasParam) someChange = new EventEmitter();
             }
           `,
           after: `
-            import { Directive, output } from '@angular/core';
+            import {Directive, output} from '@angular/core';
 
             const aliasParam = { alias: 'otherChange' } as const;
-      
+
             @Directive()
             export class TestDir {
               readonly someChange = output(aliasParam);
@@ -122,7 +122,7 @@ describe('outputs', () => {
             }
           `,
           after: `
-            import { Directive, output } from '@angular/core';
+            import {Directive, output} from '@angular/core';
 
             @Directive()
             export class TestDir {
@@ -174,7 +174,7 @@ describe('outputs', () => {
           }
         `,
           after: `
-          import { Directive, output } from '@angular/core';
+          import {Directive, output} from '@angular/core';
 
           @Directive()
           export class TestDir {

--- a/packages/core/schematics/migrations/signal-migration/src/best_effort_mode.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/best_effort_mode.ts
@@ -11,6 +11,8 @@ import {KnownInputs} from './input_detection/known_inputs';
 
 /** Input reasons that cannot be ignored. */
 const nonIgnorableInputIncompatibilities: InputIncompatibilityReason[] = [
+  // Explicitly filtered inputs cannot be skipped via best effort mode.
+  InputIncompatibilityReason.SkippedViaConfigFilter,
   // There is no good output for accessor inputs.
   InputIncompatibilityReason.Accessor,
   // There is no good output for such inputs. We can't perform "conversion".

--- a/packages/core/schematics/migrations/signal-migration/src/convert-input/convert_to_signal.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/convert-input/convert_to_signal.ts
@@ -87,7 +87,9 @@ export function convertToSignalInput(
     typeArguments.push(resolvedType);
 
     if (metadata.transform !== null) {
-      typeArguments.push(metadata.transform.type.node);
+      // Note: The TCB code generation may use the same type node and attach
+      // synthetic comments for error reporting. We remove those explicitly here.
+      typeArguments.push(ts.setSyntheticTrailingComments(metadata.transform.type.node, undefined));
     }
   }
 

--- a/packages/core/schematics/migrations/signal-migration/src/migration.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/migration.ts
@@ -81,6 +81,8 @@ export class SignalInputMigration extends TsurgeComplexMigration<
     this.config.reportProgressFn?.(10, 'Analyzing project (input usages)..');
     const {inheritanceGraph} = executeAnalysisPhase(host, knownInputs, result, analysisDeps);
 
+    filterInputsViaConfig(result, knownInputs, this.config);
+
     this.config.reportProgressFn?.(40, 'Checking inheritance..');
     pass4__checkInheritanceOfInputs(host, inheritanceGraph, metaRegistry, knownInputs);
     if (this.config.bestEffortMode) {
@@ -141,6 +143,7 @@ export class SignalInputMigration extends TsurgeComplexMigration<
       inheritanceGraph = analysisRes.inheritanceGraph;
       populateKnownInputsFromGlobalData(knownInputs, globalMetadata);
 
+      filterInputsViaConfig(result, knownInputs, this.config);
       pass4__checkInheritanceOfInputs(
         host,
         inheritanceGraph,
@@ -152,7 +155,6 @@ export class SignalInputMigration extends TsurgeComplexMigration<
       }
     }
 
-    filterInputsViaConfig(result, knownInputs, this.config);
     executeMigrationPhase(host, knownInputs, result, analysisDeps);
 
     return result.replacements;

--- a/packages/core/schematics/migrations/signal-migration/src/migration_config.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/migration_config.ts
@@ -19,7 +19,13 @@ export interface MigrationConfig {
    * Whether the given input should be migrated. With batch execution, this
    * callback fires for foreign inputs from other compilation units too.
    *
-   * Treating the input as non-migrated means that no references to it are
+   * Treating an input as non-migrated means that no references to it are
+   * migrated, nor the actual declaration (if it's part of the sources).
+   *
+   * If no function is specified here, the migration will migrate all
+   * inputs and references it discovers in compilation units. This is the
+   * running assumption for batch mode and LSC mode where the migration
+   * assumes all seen inputs (even those in `.d.ts`) are intended to be
    * migrated.
    */
   shouldMigrateInput?: (input: KnownInputInfo) => boolean;

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/imports.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/imports.ts
@@ -1,0 +1,12 @@
+// tslint:disable
+// prettier-ignore
+
+import {
+  Directive,
+  Input
+} from '@angular/core';
+
+@Directive()
+export class TestCmp {
+  @Input() disabled = false;
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden.txt
@@ -2,7 +2,7 @@
 
 // tslint:disable
 
-import { input } from '@angular/core';
+import {input} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -27,7 +27,7 @@ it('should work', () => {
 
 // tslint:disable
 
-import { Directive, Input, input } from '@angular/core';
+import {Directive, Input, input} from '@angular/core';
 
 class BaseNonAngular {
   disabled: string = '';
@@ -78,7 +78,7 @@ class BothInputImported {
 import { UnwrapSignalInputs } from "google3/javascript/angular2/testing/catalyst";
 // tslint:disable
 
-import { input } from '@angular/core';
+import {input} from '@angular/core';
 
 // angular2/testing/catalyst
 // ^^ this allows the advisor to even consider this file.
@@ -116,7 +116,7 @@ export class MyComp {
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 @Component({
   template: `
@@ -188,7 +188,7 @@ class DerivedExternal extends Base2 {
 
 // tslint:disable
 
-import { Directive, Component, input } from '@angular/core';
+import {Directive, Component, input} from '@angular/core';
 
 // Material form field test case
 
@@ -237,7 +237,7 @@ export class MatFormFieldTest {
 
 // tslint:disable
 
-import { input } from '@angular/core';
+import {input} from '@angular/core';
 
 class ExistingSignalImport {
   signalInput = input<boolean>();
@@ -269,7 +269,7 @@ export class WithGetters {
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 @Component({
   template: '',
@@ -322,7 +322,7 @@ class HostBindingsShared2 {
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 const complex = 'some global variable';
 
@@ -385,7 +385,7 @@ export class TestCmp {
 
 // tslint:disable
 
-import { Component, Input, input } from '@angular/core';
+import {Component, Input, input} from '@angular/core';
 
 interface Vehicle {}
 interface Car extends Vehicle {
@@ -521,7 +521,7 @@ x.incompatible = null;
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 @Component({template: ''})
 class IndexAccessInput {
@@ -579,7 +579,7 @@ describe('bla', () => {
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 @Component({
   template: `
@@ -605,7 +605,7 @@ export class InlineTmpl {
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 @Component({
   jit: true,
@@ -626,7 +626,7 @@ class JitTrueComponentExternalTmpl {
 
 // tslint:disable
 
-import { input } from '@angular/core';
+import {input} from '@angular/core';
 
 class MyTestCmp {
   readonly someInput = input.required<boolean | string>();
@@ -672,7 +672,7 @@ export class ManualInstantiation {
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 function CustomDecorator() {
   return (a: any, b: any) => {};
@@ -690,7 +690,7 @@ protected readonly usingCustomDecorator = input(true);
 
 // tslint:disable
 
-import { input } from '@angular/core';
+import {input} from '@angular/core';
 
 export class TestCmp {
   readonly shared = input<{
@@ -712,7 +712,7 @@ export class TestCmp {
 
 // tslint:disable
 
-import { Directive, input } from '@angular/core';
+import {Directive, input} from '@angular/core';
 
 @Directive()
 export class Narrowing {
@@ -756,7 +756,7 @@ export class Narrowing {
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 interface Config {
   bla?: string;
@@ -776,7 +776,7 @@ export class NestedTemplatePropAccess {
 
 // tslint:disable
 
-import { Directive, input } from '@angular/core';
+import {Directive, input} from '@angular/core';
 
 @Directive()
 export class NonNullAssertions {
@@ -793,7 +793,7 @@ export class NonNullAssertions {
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 @Component({})
 export class ObjectExpansion {
@@ -839,7 +839,7 @@ function assertValidLoadingInput(dir: AppComponent) {
 
 // tslint:disable
 
-import { Directive, input } from '@angular/core';
+import {Directive, input} from '@angular/core';
 
 @Directive()
 class OptionalInput {
@@ -884,7 +884,7 @@ export const COMPLEX_VAR = {
 
 // tslint:disable
 
-import { input } from '@angular/core';
+import {input} from '@angular/core';
 import {COMPLEX_VAR} from './required-no-explicit-type-extra';
 
 export const CONST = {field: true};
@@ -901,7 +901,7 @@ export class RequiredNoExplicitType {
 
 // tslint:disable
 
-import { input } from '@angular/core';
+import {input} from '@angular/core';
 
 class Required {
   readonly simpleInput = input.required<string>();
@@ -918,7 +918,7 @@ class Required {
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 @Component({
   template: `
@@ -934,7 +934,7 @@ class WithSafePropertyReads {
 
 // tslint:disable
 
-import { input } from '@angular/core';
+import {input} from '@angular/core';
 
 export class TestCmp {
   readonly shared = input(false);
@@ -956,7 +956,7 @@ export class TestCmp {
 
 // tslint:disable
 
-import { Directive, Component, input } from '@angular/core';
+import {Directive, Component, input} from '@angular/core';
 
 @Directive()
 class SomeDir {
@@ -1025,7 +1025,7 @@ spyOn<MyComp>(new MyComp(), 'myInput').and.returnValue();
 
 // tslint:disable
 
-import { Component, Input, input } from '@angular/core';
+import {Component, Input, input} from '@angular/core';
 
 @Component({
   template: `
@@ -1061,7 +1061,7 @@ export class MyComp {
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 @Component({
   template: `
@@ -1079,7 +1079,7 @@ export class TemplateObjectShorthand {
 
 // tslint:disable
 
-import { Component, Input, input } from '@angular/core';
+import {Component, Input, input} from '@angular/core';
 
 @Component({
   template: `
@@ -1101,7 +1101,7 @@ class TwoWayBinding {
 
 // tslint:disable
 
-import { Input, input } from '@angular/core';
+import {Input, input} from '@angular/core';
 import {COMPLEX_VAR} from './required-no-explicit-type-extra';
 
 function x(v: string | undefined): string | undefined {
@@ -1125,7 +1125,7 @@ export class TransformFunctions {
 
 // tslint:disable
 
-import { Directive, input } from '@angular/core';
+import {Directive, input} from '@angular/core';
 
 // see: button-base Material.
 
@@ -1138,7 +1138,7 @@ class TransformIncompatibleTypes {
 
 // tslint:disable
 
-import { Input, input } from '@angular/core';
+import {Input, input} from '@angular/core';
 
 export class WithSettersAndGetters {
   @Input()
@@ -1180,7 +1180,7 @@ class WithGettersExternalRef {
 
 // tslint:disable
 
-import { input } from '@angular/core';
+import {input} from '@angular/core';
 
 class WithJsdoc {
   /**

--- a/packages/core/schematics/migrations/signal-migration/test/golden.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden.txt
@@ -367,6 +367,20 @@ class MyComp {
     }
   }
 }
+@@@@@@ imports.ts @@@@@@
+
+// tslint:disable
+// prettier-ignore
+
+import {
+  Directive,
+  input
+} from '@angular/core';
+
+@Directive()
+export class TestCmp {
+  readonly disabled = input(false);
+}
 @@@@@@ index.ts @@@@@@
 
 // tslint:disable

--- a/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
@@ -2,7 +2,7 @@
 
 // tslint:disable
 
-import { input } from '@angular/core';
+import {input} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -27,7 +27,7 @@ it('should work', () => {
 
 // tslint:disable
 
-import { Directive, input } from '@angular/core';
+import {Directive, input} from '@angular/core';
 
 class BaseNonAngular {
   disabled: string = '';
@@ -61,7 +61,7 @@ class Sub3 implements BaseNonAngularInterface {
 
 // tslint:disable
 
-import { input } from '@angular/core';
+import {input} from '@angular/core';
 
 class BothInputImported {
   readonly decoratorInput = input(true);
@@ -78,7 +78,7 @@ class BothInputImported {
 import { UnwrapSignalInputs } from "google3/javascript/angular2/testing/catalyst";
 // tslint:disable
 
-import { input } from '@angular/core';
+import {input} from '@angular/core';
 
 // angular2/testing/catalyst
 // ^^ this allows the advisor to even consider this file.
@@ -100,7 +100,7 @@ it('should work', () => {
 
 // tslint:disable
 
-import { Directive, input } from '@angular/core';
+import {Directive, input} from '@angular/core';
 
 @Directive()
 export class MyComp {
@@ -116,7 +116,7 @@ export class MyComp {
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 @Component({
   template: `
@@ -143,7 +143,7 @@ class Option {
 
 // tslint:disable
 
-import { Directive, input } from '@angular/core';
+import {Directive, input} from '@angular/core';
 
 @Directive()
 class Base {
@@ -163,7 +163,7 @@ export class Base2 {
 
 // tslint:disable
 
-import { Directive, input } from '@angular/core';
+import {Directive, input} from '@angular/core';
 
 @Directive()
 class Base {
@@ -188,7 +188,7 @@ class DerivedExternal extends Base2 {
 
 // tslint:disable
 
-import { Directive, Component, input } from '@angular/core';
+import {Directive, Component, input} from '@angular/core';
 
 // Material form field test case
 
@@ -237,7 +237,7 @@ export class MatFormFieldTest {
 
 // tslint:disable
 
-import { input } from '@angular/core';
+import {input} from '@angular/core';
 
 class ExistingSignalImport {
   signalInput = input<boolean>();
@@ -269,7 +269,7 @@ export class WithGetters {
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 @Component({
   template: '',
@@ -322,7 +322,7 @@ class HostBindingsShared2 {
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 const complex = 'some global variable';
 
@@ -385,7 +385,7 @@ export class TestCmp {
 
 // tslint:disable
 
-import { Component, Input, input } from '@angular/core';
+import {Component, Input, input} from '@angular/core';
 
 interface Vehicle {}
 interface Car extends Vehicle {
@@ -521,7 +521,7 @@ x.incompatible = null;
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 @Component({template: ''})
 class IndexAccessInput {
@@ -579,7 +579,7 @@ describe('bla', () => {
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 @Component({
   template: `
@@ -605,7 +605,7 @@ export class InlineTmpl {
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 @Component({
   jit: true,
@@ -626,7 +626,7 @@ class JitTrueComponentExternalTmpl {
 
 // tslint:disable
 
-import { input } from '@angular/core';
+import {input} from '@angular/core';
 
 class MyTestCmp {
   readonly someInput = input.required<boolean | string>();
@@ -662,7 +662,7 @@ new ManualInstantiation();
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 @Component({})
 export class ManualInstantiation {
@@ -672,7 +672,7 @@ export class ManualInstantiation {
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 function CustomDecorator() {
   return (a: any, b: any) => {};
@@ -690,7 +690,7 @@ protected readonly usingCustomDecorator = input(true);
 
 // tslint:disable
 
-import { input } from '@angular/core';
+import {input} from '@angular/core';
 
 export class TestCmp {
   readonly shared = input<{
@@ -712,7 +712,7 @@ export class TestCmp {
 
 // tslint:disable
 
-import { Directive, input } from '@angular/core';
+import {Directive, input} from '@angular/core';
 
 @Directive()
 export class Narrowing {
@@ -756,7 +756,7 @@ export class Narrowing {
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 interface Config {
   bla?: string;
@@ -776,7 +776,7 @@ export class NestedTemplatePropAccess {
 
 // tslint:disable
 
-import { Directive, input } from '@angular/core';
+import {Directive, input} from '@angular/core';
 
 @Directive()
 export class NonNullAssertions {
@@ -793,7 +793,7 @@ export class NonNullAssertions {
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 @Component({})
 export class ObjectExpansion {
@@ -839,7 +839,7 @@ function assertValidLoadingInput(dir: AppComponent) {
 
 // tslint:disable
 
-import { Directive, input } from '@angular/core';
+import {Directive, input} from '@angular/core';
 
 @Directive()
 class OptionalInput {
@@ -849,7 +849,7 @@ class OptionalInput {
 
 // tslint:disable
 
-import { Component, Directive, QueryList, input } from '@angular/core';
+import {Component, Directive, QueryList, input} from '@angular/core';
 
 @Component({
   template: `
@@ -884,7 +884,7 @@ export const COMPLEX_VAR = {
 
 // tslint:disable
 
-import { input } from '@angular/core';
+import {input} from '@angular/core';
 import {COMPLEX_VAR} from './required-no-explicit-type-extra';
 
 export const CONST = {field: true};
@@ -901,7 +901,7 @@ export class RequiredNoExplicitType {
 
 // tslint:disable
 
-import { input } from '@angular/core';
+import {input} from '@angular/core';
 
 class Required {
   readonly simpleInput = input.required<string>();
@@ -918,7 +918,7 @@ class Required {
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 @Component({
   template: `
@@ -934,7 +934,7 @@ class WithSafePropertyReads {
 
 // tslint:disable
 
-import { input } from '@angular/core';
+import {input} from '@angular/core';
 
 export class TestCmp {
   readonly shared = input(false);
@@ -956,7 +956,7 @@ export class TestCmp {
 
 // tslint:disable
 
-import { Directive, Component, input } from '@angular/core';
+import {Directive, Component, input} from '@angular/core';
 
 @Directive()
 class SomeDir {
@@ -1007,7 +1007,7 @@ export class ScopeMismatchTest {
 
 // tslint:disable
 
-import { input } from '@angular/core';
+import {input} from '@angular/core';
 
 class MyComp {
   readonly myInput = input(() => { });
@@ -1025,7 +1025,7 @@ spyOn<MyComp>(new MyComp(), 'myInput').and.returnValue();
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 @Component({
   template: `
@@ -1061,7 +1061,7 @@ export class MyComp {
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 @Component({
   template: `
@@ -1079,7 +1079,7 @@ export class TemplateObjectShorthand {
 
 // tslint:disable
 
-import { Component, input } from '@angular/core';
+import {Component, input} from '@angular/core';
 
 @Component({
   template: `
@@ -1101,7 +1101,7 @@ class TwoWayBinding {
 
 // tslint:disable
 
-import { Input, input } from '@angular/core';
+import {Input, input} from '@angular/core';
 import {COMPLEX_VAR} from './required-no-explicit-type-extra';
 
 function x(v: string | undefined): string | undefined {
@@ -1125,7 +1125,7 @@ export class TransformFunctions {
 
 // tslint:disable
 
-import { Directive, input } from '@angular/core';
+import {Directive, input} from '@angular/core';
 
 // see: button-base Material.
 
@@ -1138,7 +1138,7 @@ class TransformIncompatibleTypes {
 
 // tslint:disable
 
-import { Input, input } from '@angular/core';
+import {Input, input} from '@angular/core';
 
 export class WithSettersAndGetters {
   @Input()
@@ -1180,7 +1180,7 @@ class WithGettersExternalRef {
 
 // tslint:disable
 
-import { input } from '@angular/core';
+import {input} from '@angular/core';
 
 class WithJsdoc {
   /**

--- a/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
@@ -367,6 +367,20 @@ class MyComp {
     }
   }
 }
+@@@@@@ imports.ts @@@@@@
+
+// tslint:disable
+// prettier-ignore
+
+import {
+  Directive,
+  input
+} from '@angular/core';
+
+@Directive()
+export class TestCmp {
+  readonly disabled = input(false);
+}
 @@@@@@ index.ts @@@@@@
 
 // tslint:disable

--- a/packages/core/schematics/migrations/signal-queries-migration/migration.spec.ts
+++ b/packages/core/schematics/migrations/signal-queries-migration/migration.spec.ts
@@ -249,7 +249,7 @@ describe('signal queries migration', () => {
     ]);
 
     const actual = fs.readFile(absoluteFrom('/app.component.ts'));
-    expect(actual).toContain(`import { ElementRef, Directive, viewChild } from '@angular/core';`);
+    expect(actual).toContain(`import {ElementRef, Directive, viewChild} from '@angular/core';`);
     expect(actual).toContain(`label = viewChild<ElementRef>('labelRef')`);
   });
 
@@ -276,7 +276,7 @@ describe('signal queries migration', () => {
 
     const actual = fs.readFile(absoluteFrom('/app.component.ts'));
     expect(actual).toContain(
-      `import { ViewChild, ElementRef, Directive, viewChild } from '@angular/core';`,
+      `import {ViewChild, ElementRef, Directive, viewChild} from '@angular/core';`,
     );
     expect(actual).toContain(`label = viewChild<ElementRef>('labelRef')`);
     expect(actual).toContain(`@ViewChild('labelRef2') label2?: ElementRef;`);

--- a/packages/core/schematics/utils/tsurge/helpers/apply_import_manager.ts
+++ b/packages/core/schematics/utils/tsurge/helpers/apply_import_manager.ts
@@ -50,13 +50,23 @@ export function applyImportManagerChanges(
     const isMultiline =
       oldBindings.getText().includes('\n') ||
       (newBindings.elements.length >= 6 && oldBindings.elements.length <= 3);
+    const hasSpaceBetweenBraces = oldBindings.getText().startsWith('{ ');
+
+    let formatFlags =
+      ts.ListFormat.NamedImportsOrExportsElements |
+      ts.ListFormat.Indented |
+      ts.ListFormat.Braces |
+      ts.ListFormat.PreserveLines |
+      (isMultiline ? ts.ListFormat.MultiLine : ts.ListFormat.SingleLine);
+
+    if (hasSpaceBetweenBraces) {
+      formatFlags |= ts.ListFormat.SpaceBetweenBraces;
+    } else {
+      formatFlags &= ~ts.ListFormat.SpaceBetweenBraces;
+    }
 
     const printedBindings = printer.printList(
-      ts.ListFormat.NamedImportsOrExportsElements |
-        ts.ListFormat.Indented |
-        ts.ListFormat.Braces |
-        ts.ListFormat.PreserveLines |
-        (isMultiline ? ts.ListFormat.MultiLine : ts.ListFormat.SingleLine),
+      formatFlags,
       newBindings.elements,
       oldBindings.getSourceFile(),
     );

--- a/packages/language-service/src/refactorings/convert_to_signal_input.ts
+++ b/packages/language-service/src/refactorings/convert_to_signal_input.ts
@@ -199,7 +199,7 @@ abstract class BaseConvertToSignalInputRefactoring implements ActiveRefactoring 
 
 export class ConvertToSignalInputRefactoring extends BaseConvertToSignalInputRefactoring {
   static id = 'convert-to-signal-input-safe-mode';
-  static description = 'Convert this @Input() to a signal input (safe)';
+  static description = 'Convert @Input() to a signal input (safe)';
   override config: MigrationConfig = {};
 }
 export class ConvertToSignalInputBestEffortRefactoring extends BaseConvertToSignalInputRefactoring {

--- a/packages/language-service/test/signal_input_refactoring_action_spec.ts
+++ b/packages/language-service/test/signal_input_refactoring_action_spec.ts
@@ -117,7 +117,7 @@ describe('Signal input refactoring action', () => {
             span: {start: 127, length: '@Input() bla = true;'.length},
           },
           // Import (since there is just a single input).
-          {newText: '{ Directive, input }', span: {start: 16, length: 18}},
+          {newText: '{Directive, input}', span: {start: 16, length: 18}},
         ],
       },
     ]);


### PR DESCRIPTION
See individual commits

The import manager changes are important as otherwise content jumps a lot when migrating.