### PR TITLE
refactor(language-service): Allow language service diagnostics to be ignored

### DIFF
--- a/packages/language-service/api.ts
+++ b/packages/language-service/api.ts
@@ -41,6 +41,11 @@ export interface PluginConfig {
    * If false, disables parsing of `@let` declarations in the compiler.
    */
   enableLetSyntax?: false;
+
+  /**
+   * A list of diagnostic codes that should be supressed in the language service.
+   */
+  suppressAngularDiagnosticCodes?: number[];
 }
 
 export type GetTcbResponse = {

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -88,7 +88,12 @@ export class LanguageService {
         const program = compiler.getCurrentProgram();
         const sourceFile = program.getSourceFile(fileName);
         if (sourceFile) {
-          const ngDiagnostics = compiler.getDiagnosticsForFile(sourceFile, OptimizeFor.SingleFile);
+          let ngDiagnostics = compiler.getDiagnosticsForFile(sourceFile, OptimizeFor.SingleFile);
+          if (this.config.suppressAngularDiagnosticCodes) {
+            ngDiagnostics = ngDiagnostics.filter(
+              (diag) => !this.config.suppressAngularDiagnosticCodes!.includes(diag.code),
+            );
+          }
           // There are several kinds of diagnostics returned by `NgCompiler` for a source file:
           //
           // 1. Angular-related non-template diagnostics from decorated classes within that


### PR DESCRIPTION
Add a check to the language service that ignores specified diagnostic codes.

This can be patched in g3 as needed, to ignore codes that are not relevant for g3 (or otherwise not compatible).