### PR TITLE
refactor(migrations): ensure project paths respect root directories

### DIFF
--- a/packages/core/schematics/migrations/signal-migration/src/batch/extract.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/batch/extract.ts
@@ -48,7 +48,7 @@ export function getCompilationUnitMetadata(knownInputs: KnownInputs, result: Mig
           kind: r.kind,
           target: r.target.key,
           from: {
-            fileId: r.from.fileId,
+            file: r.from.file,
             node: {positionEndInFile: r.from.node.getEnd()},
             isWrite: r.from.isWrite,
             isPartOfElementBinding: r.from.isPartOfElementBinding,
@@ -59,7 +59,7 @@ export function getCompilationUnitMetadata(knownInputs: KnownInputs, result: Mig
           kind: r.kind,
           target: r.target.key,
           from: {
-            fileId: r.from.fileId,
+            file: r.from.file,
             hostPropertyNode: {positionEndInFile: r.from.hostPropertyNode.getEnd()},
             isObjectShorthandExpression: r.from.isObjectShorthandExpression,
             read: {positionEndInFile: r.from.read.sourceSpan.end},
@@ -70,7 +70,7 @@ export function getCompilationUnitMetadata(knownInputs: KnownInputs, result: Mig
           kind: r.kind,
           target: {positionEndInFile: r.target.getEnd()},
           from: {
-            fileId: r.from.fileId,
+            file: r.from.file,
             node: {positionEndInFile: r.from.node.getEnd()},
           },
           isPartOfCatalystFile: r.isPartOfCatalystFile,
@@ -81,8 +81,8 @@ export function getCompilationUnitMetadata(knownInputs: KnownInputs, result: Mig
         kind: r.kind,
         target: r.target.key,
         from: {
-          originatingTsFileId: r.from.originatingTsFileId,
-          templateFileId: r.from.templateFileId,
+          originatingTsFile: r.from.originatingTsFile,
+          templateFile: r.from.templateFile,
           isObjectShorthandExpression: r.from.isObjectShorthandExpression,
           node: {positionEndInFile: r.from.node.sourceSpan.end.offset},
           read: {positionEndInFile: r.from.read.sourceSpan.end},

--- a/packages/core/schematics/migrations/signal-migration/src/batch/merge_unit_data.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/batch/merge_unit_data.ts
@@ -48,15 +48,15 @@ export function mergeCompilationUnitData(
 /** Computes a unique ID for the given reference. */
 function computeReferenceId(reference: SerializableForBatching<InputReference>): string {
   if (reference.kind === InputReferenceKind.InTemplate) {
-    return `${reference.from.templateFileId}@@${reference.from.read.positionEndInFile}`;
+    return `${reference.from.templateFile.id}@@${reference.from.read.positionEndInFile}`;
   } else if (reference.kind === InputReferenceKind.InHostBinding) {
     // `read` position is commonly relative to the host property node position— so we need
     // to make it absolute by incorporating the host node position.
     return (
-      `${reference.from.fileId}@@${reference.from.hostPropertyNode.positionEndInFile}` +
+      `${reference.from.file.id}@@${reference.from.hostPropertyNode.positionEndInFile}` +
       `@@${reference.from.read.positionEndInFile}`
     );
   } else {
-    return `${reference.from.fileId}@@${reference.from.node.positionEndInFile}`;
+    return `${reference.from.file.id}@@${reference.from.node.positionEndInFile}`;
   }
 }

--- a/packages/core/schematics/migrations/signal-migration/src/batch/test_bin.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/batch/test_bin.ts
@@ -41,12 +41,12 @@ async function main() {
 
     process.stdout.write(JSON.stringify(mergedResult));
   } else if (mode === 'migrate') {
-    const {replacements, projectDirAbsPath} = await executeMigratePhase(
+    const {replacements, projectRoot} = await executeMigratePhase(
       migration,
       JSON.parse(fs.readFileSync(path.resolve(args[1]), 'utf8')) as CompilationUnitData,
       path.resolve(args[0]),
     );
 
-    writeMigrationReplacements(replacements, projectDirAbsPath);
+    writeMigrationReplacements(replacements, projectRoot);
   }
 }

--- a/packages/core/schematics/migrations/signal-migration/src/cli.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/cli.ts
@@ -35,8 +35,8 @@ export async function main(absoluteTsconfigPath: string, bestEffortMode: boolean
     'Expected upgraded analysis phase results; batch mode is disabled.',
   );
 
-  const {replacements, projectAbsDirPath} = migration.upgradedAnalysisPhaseResults;
+  const {replacements, projectRoot} = migration.upgradedAnalysisPhaseResults;
 
   // Apply replacements
-  writeMigrationReplacements(replacements, projectAbsDirPath);
+  writeMigrationReplacements(replacements, projectRoot);
 }

--- a/packages/core/schematics/migrations/signal-migration/src/migration.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/migration.ts
@@ -40,7 +40,7 @@ export class SignalInputMigration extends TsurgeComplexMigration<
 > {
   upgradedAnalysisPhaseResults: {
     replacements: Replacement[];
-    projectAbsDirPath: AbsoluteFsPath;
+    projectRoot: AbsoluteFsPath;
     knownInputs: KnownInputs;
   } | null = null;
 
@@ -67,7 +67,7 @@ export class SignalInputMigration extends TsurgeComplexMigration<
     assert(info.ngCompiler !== null, 'Expected `NgCompiler` to be configured.');
     return {
       ...info,
-      ...prepareAnalysisInfo(info.program, info.ngCompiler, info.programAbsoluteRootPaths),
+      ...prepareAnalysisInfo(info.program, info.ngCompiler, info.programAbsoluteRootFileNames),
     };
   }
 
@@ -108,7 +108,7 @@ export class SignalInputMigration extends TsurgeComplexMigration<
       // Expose the upgraded analysis stage results.
       this.upgradedAnalysisPhaseResults = {
         replacements,
-        projectAbsDirPath: info.projectDirAbsPath,
+        projectRoot: info.projectRoot,
         knownInputs,
       };
     }
@@ -199,11 +199,5 @@ function filterInputsViaConfig(
 }
 
 function createMigrationHost(info: ProgramInfo, config: MigrationConfig): MigrationHost {
-  return new MigrationHost(
-    /* projectDir */ info.projectDirAbsPath,
-    /* isMigratingCore */ false,
-    info.userOptions,
-    config,
-    info.sourceFiles,
-  );
+  return new MigrationHost(/* isMigratingCore */ false, info, config, info.sourceFiles);
 }

--- a/packages/core/schematics/migrations/signal-migration/src/migration_host.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/migration_host.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import path from 'path';
-import ts from 'typescript';
 import {NgCompilerOptions} from '@angular/compiler-cli/src/ngtsc/core/api';
+import ts from 'typescript';
+import {ProgramInfo} from '../../../utils/tsurge';
 import {MigrationConfig} from './migration_config';
 
 /**
@@ -19,38 +19,20 @@ import {MigrationConfig} from './migration_config';
 export class MigrationHost {
   private _sourceFiles: WeakSet<ts.SourceFile>;
 
+  compilerOptions: NgCompilerOptions;
+
   constructor(
-    public projectDir: string,
     public isMigratingCore: boolean,
-    public compilerOptions: NgCompilerOptions,
+    public programInfo: ProgramInfo,
     public config: MigrationConfig,
     sourceFiles: readonly ts.SourceFile[],
   ) {
     this._sourceFiles = new WeakSet(sourceFiles);
+    this.compilerOptions = programInfo.userOptions;
   }
 
   /** Whether the given file is a source file to be migrated. */
   isSourceFileForCurrentMigration(file: ts.SourceFile): boolean {
     return this._sourceFiles.has(file);
-  }
-
-  /** Retrieves a unique serializable ID for the given source file or file path. */
-  fileToId(file: ts.SourceFile | string): string {
-    if (typeof file !== 'string') {
-      // Assume that declaration files may appear in different workers,
-      // and in practice e.g. the input is actually part of a `.ts` file.
-      if (file.isDeclarationFile) {
-        file = file.fileName.replace(/\.d\.ts$/, '.ts');
-      } else {
-        file = file.fileName;
-      }
-    }
-
-    return path.relative(this.projectDir, file);
-  }
-
-  /** Converts a serialized file ID to an absolute file path. */
-  idToFilePath(id: string): string {
-    return path.join(this.projectDir, id);
   }
 }

--- a/packages/core/schematics/migrations/signal-migration/src/passes/10_apply_import_manager.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/10_apply_import_manager.ts
@@ -11,6 +11,7 @@ import ts from 'typescript';
 import {applyImportManagerChanges} from '../../../../utils/tsurge/helpers/apply_import_manager';
 import {MigrationResult} from '../result';
 import {AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {ProgramInfo} from '../../../../utils/tsurge';
 
 /**
  * Phase that applies all changes recorded by the import manager in
@@ -20,7 +21,7 @@ export function pass10_applyImportManager(
   importManager: ImportManager,
   result: MigrationResult,
   sourceFiles: readonly ts.SourceFile[],
-  projectAbsPath: AbsoluteFsPath,
+  info: Pick<ProgramInfo, 'sortedRootDirs' | 'projectRoot'>,
 ) {
-  applyImportManagerChanges(importManager, result.replacements, sourceFiles, projectAbsPath);
+  applyImportManagerChanges(importManager, result.replacements, sourceFiles, info);
 }

--- a/packages/core/schematics/migrations/signal-migration/src/passes/2_find_source_file_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/2_find_source_file_references.ts
@@ -22,6 +22,7 @@ import {InputReferenceKind} from '../utils/input_reference';
 import {GroupedTsAstVisitor} from '../utils/grouped_ts_ast_visitor';
 import {ResourceLoader} from '@angular/compiler-cli/src/ngtsc/annotations';
 import {PartialEvaluator} from '@angular/compiler-cli/src/ngtsc/partial_evaluator';
+import {projectFile} from '../../../../utils/tsurge';
 
 /**
  * Phase where we iterate through all source file references and
@@ -123,7 +124,10 @@ export function pass2_IdentifySourceFileReferences(
       result.references.push({
         kind: InputReferenceKind.TsInputClassTypeReference,
         from: {
-          fileId: host.fileToId(partialDirectiveInCatalyst.referenceNode.getSourceFile()),
+          file: projectFile(
+            partialDirectiveInCatalyst.referenceNode.getSourceFile(),
+            host.programInfo,
+          ),
           node: partialDirectiveInCatalyst.referenceNode,
         },
         isPartialReference: true,

--- a/packages/core/schematics/migrations/signal-migration/src/passes/5_migrate_ts_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/5_migrate_ts_references.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
 import ts from 'typescript';
 import {KnownInputs} from '../input_detection/known_inputs';
 import {MigrationResult} from '../result';
@@ -20,6 +19,7 @@ import {
   migrateStandardTsReference,
   NarrowableTsReference,
 } from './migrate_ts_reference/standard_reference';
+import {ProgramInfo} from '../../../../utils/tsurge';
 
 /**
  * Phase that migrates TypeScript input references to be signal compatible.
@@ -50,7 +50,7 @@ export function pass5__migrateTypeScriptReferences(
   result: MigrationResult,
   checker: ts.TypeChecker,
   knownInputs: KnownInputs,
-  projectDirAbsPath: AbsoluteFsPath,
+  info: ProgramInfo,
 ) {
   const tsReferencesWithNarrowing = new Map<InputUniqueKey, NarrowableTsReference>();
   const tsReferencesInBindingElements = new Set<IdentifierOfBindingElement>();
@@ -90,7 +90,6 @@ export function pass5__migrateTypeScriptReferences(
     }
   }
 
-  migrateBindingElementInputReference(tsReferencesInBindingElements, projectDirAbsPath, result);
-
-  migrateStandardTsReference(tsReferencesWithNarrowing, checker, result, projectDirAbsPath);
+  migrateBindingElementInputReference(tsReferencesInBindingElements, info, result);
+  migrateStandardTsReference(tsReferencesWithNarrowing, checker, result, info);
 }

--- a/packages/core/schematics/migrations/signal-migration/src/passes/6_migrate_input_declarations.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/6_migrate_input_declarations.ts
@@ -12,8 +12,7 @@ import {convertToSignalInput} from '../convert-input/convert_to_signal';
 import assert from 'assert';
 import {KnownInputs} from '../input_detection/known_inputs';
 import {ImportManager} from '@angular/compiler-cli/src/ngtsc/translator';
-import {projectRelativePath, Replacement, TextUpdate} from '../../../../utils/tsurge/replacement';
-import {AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {ProgramInfo, projectFile, Replacement, TextUpdate} from '../../../../utils/tsurge';
 
 /**
  * Phase that migrates `@Input()` declarations to signal inputs and
@@ -24,7 +23,7 @@ export function pass6__migrateInputDeclarations(
   result: MigrationResult,
   knownInputs: KnownInputs,
   importManager: ImportManager,
-  projectDirAbsPath: AbsoluteFsPath,
+  info: ProgramInfo,
 ) {
   let filesWithMigratedInputs = new Set<ts.SourceFile>();
   let filesWithIncompatibleInputs = new WeakSet<ts.SourceFile>();
@@ -43,7 +42,7 @@ export function pass6__migrateInputDeclarations(
     filesWithMigratedInputs.add(sf);
     result.replacements.push(
       new Replacement(
-        projectRelativePath(sf, projectDirAbsPath),
+        projectFile(sf, info),
         new TextUpdate({
           position: input.node.getStart(),
           end: input.node.getEnd(),

--- a/packages/core/schematics/migrations/signal-migration/src/passes/7_migrate_template_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/7_migrate_template_references.ts
@@ -7,11 +7,10 @@
  */
 
 import {MigrationHost} from '../migration_host';
-import {AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {MigrationResult} from '../result';
 import {isTemplateInputReference} from '../utils/input_reference';
 import {KnownInputs} from '../input_detection/known_inputs';
-import {projectRelativePath, Replacement, TextUpdate} from '../../../../utils/tsurge/replacement';
+import {ProgramInfo, Replacement, TextUpdate} from '../../../../utils/tsurge';
 
 /**
  * Phase that migrates Angular template references to
@@ -21,7 +20,7 @@ export function pass7__migrateTemplateReferences(
   host: MigrationHost,
   result: MigrationResult,
   knownInputs: KnownInputs,
-  projectDirAbsPath: AbsoluteFsPath,
+  info: ProgramInfo,
 ) {
   const seenFileReferences = new Set<string>();
 
@@ -36,7 +35,7 @@ export function pass7__migrateTemplateReferences(
     }
 
     // Skip duplicate references. E.g. if a template is shared.
-    const fileReferenceId = `${reference.from.templateFileId}:${reference.from.read.sourceSpan.end}`;
+    const fileReferenceId = `${reference.from.templateFile.id}:${reference.from.read.sourceSpan.end}`;
     if (seenFileReferences.has(fileReferenceId)) {
       continue;
     }
@@ -49,7 +48,7 @@ export function pass7__migrateTemplateReferences(
 
     result.replacements.push(
       new Replacement(
-        projectRelativePath(host.idToFilePath(reference.from.templateFileId), projectDirAbsPath),
+        reference.from.templateFile,
         new TextUpdate({
           position: reference.from.read.sourceSpan.end,
           end: reference.from.read.sourceSpan.end,

--- a/packages/core/schematics/migrations/signal-migration/src/passes/8_migrate_host_bindings.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/8_migrate_host_bindings.ts
@@ -7,8 +7,7 @@
  */
 
 import ts from 'typescript';
-import {AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
-import {projectRelativePath, Replacement, TextUpdate} from '../../../../utils/tsurge/replacement';
+import {ProgramInfo, projectFile, Replacement, TextUpdate} from '../../../../utils/tsurge';
 import {MigrationResult} from '../result';
 import {isHostBindingInputReference} from '../utils/input_reference';
 import {KnownInputs} from '../input_detection/known_inputs';
@@ -20,7 +19,7 @@ import {KnownInputs} from '../input_detection/known_inputs';
 export function pass8__migrateHostBindings(
   result: MigrationResult,
   knownInputs: KnownInputs,
-  projectDirAbsPath: AbsoluteFsPath,
+  info: ProgramInfo,
 ) {
   const seenReferences = new WeakMap<ts.Node, Set<number>>();
 
@@ -55,7 +54,7 @@ export function pass8__migrateHostBindings(
 
     result.replacements.push(
       new Replacement(
-        projectRelativePath(bindingField.getSourceFile(), projectDirAbsPath),
+        projectFile(bindingField.getSourceFile(), info),
         new TextUpdate({position: readEndPos, end: readEndPos, toInsert: appendText}),
       ),
     );

--- a/packages/core/schematics/migrations/signal-migration/src/passes/9_migrate_ts_type_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/9_migrate_ts_type_references.ts
@@ -10,8 +10,7 @@ import ts from 'typescript';
 import {KnownInputs} from '../input_detection/known_inputs';
 import {MigrationResult} from '../result';
 import {isTsInputClassTypeReference} from '../utils/input_reference';
-import {AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
-import {projectRelativePath, Replacement, TextUpdate} from '../../../../utils/tsurge/replacement';
+import {ProgramInfo, projectFile, Replacement, TextUpdate} from '../../../../utils/tsurge';
 import assert from 'assert';
 import {ImportManager} from '@angular/compiler-cli/src/ngtsc/translator';
 
@@ -25,7 +24,7 @@ export function pass9__migrateTypeScriptTypeReferences(
   result: MigrationResult,
   knownInputs: KnownInputs,
   importManager: ImportManager,
-  projectDirAbsPath: AbsoluteFsPath,
+  info: ProgramInfo,
 ) {
   const seenTypeNodes = new WeakSet<ts.TypeReferenceNode>();
 
@@ -59,7 +58,7 @@ export function pass9__migrateTypeScriptTypeReferences(
 
       result.replacements.push(
         new Replacement(
-          projectRelativePath(sf, projectDirAbsPath),
+          projectFile(sf, info),
           new TextUpdate({
             position: firstArg.getStart(),
             end: firstArg.getStart(),
@@ -69,7 +68,7 @@ export function pass9__migrateTypeScriptTypeReferences(
       );
       result.replacements.push(
         new Replacement(
-          projectRelativePath(sf, projectDirAbsPath),
+          projectFile(sf, info),
           new TextUpdate({position: firstArg.getEnd(), end: firstArg.getEnd(), toInsert: '>'}),
         ),
       );

--- a/packages/core/schematics/migrations/signal-migration/src/passes/migrate_ts_reference/create_block_arrow_function.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/migrate_ts_reference/create_block_arrow_function.ts
@@ -7,7 +7,7 @@
  */
 
 import ts from 'typescript';
-import {ProjectRelativePath, Replacement, TextUpdate} from '../../../../../utils/tsurge';
+import {ProjectFile, Replacement, TextUpdate} from '../../../../../utils/tsurge';
 
 /**
  * Creates replacements to insert the given statement as
@@ -19,7 +19,7 @@ import {ProjectRelativePath, Replacement, TextUpdate} from '../../../../../utils
  */
 export function createNewBlockToInsertVariable(
   node: ts.ArrowFunction,
-  filePath: ProjectRelativePath,
+  file: ProjectFile,
   toInsert: string,
 ): Replacement[] {
   const sf = node.getSourceFile();
@@ -35,7 +35,7 @@ export function createNewBlockToInsertVariable(
   return [
     // Delete leading whitespace of the concise body.
     new Replacement(
-      filePath,
+      file,
       new TextUpdate({
         position: node.body.getFullStart(),
         end: node.body.getStart(),
@@ -45,7 +45,7 @@ export function createNewBlockToInsertVariable(
     // Insert leading block braces, and `toInsert` content.
     // Wrap the previous expression in a return now.
     new Replacement(
-      filePath,
+      file,
       new TextUpdate({
         position: node.body.getStart(),
         end: node.body.getStart(),
@@ -54,7 +54,7 @@ export function createNewBlockToInsertVariable(
     ),
     // Add trailing brace.
     new Replacement(
-      filePath,
+      file,
       new TextUpdate({
         position: node.body.getEnd(),
         end: node.body.getEnd(),

--- a/packages/core/schematics/migrations/signal-migration/src/passes/migrate_ts_reference/standard_reference.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/migrate_ts_reference/standard_reference.ts
@@ -10,8 +10,7 @@ import ts from 'typescript';
 import {InputUniqueKey} from '../../utils/input_id';
 import {analyzeControlFlow} from '../../flow_analysis';
 import {MigrationResult} from '../../result';
-import {projectRelativePath, Replacement, TextUpdate} from '../../../../../utils/tsurge';
-import {AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {ProgramInfo, projectFile, Replacement, TextUpdate} from '../../../../../utils/tsurge';
 import {traverseAccess} from '../../utils/traverse_access';
 import {UniqueNamesGenerator} from '../../utils/unique_names';
 import {createNewBlockToInsertVariable} from './create_block_arrow_function';
@@ -24,7 +23,7 @@ export function migrateStandardTsReference(
   tsReferencesWithNarrowing: Map<InputUniqueKey, NarrowableTsReference>,
   checker: ts.TypeChecker,
   result: MigrationResult,
-  projectDirAbsPath: AbsoluteFsPath,
+  info: ProgramInfo,
 ) {
   const nameGenerator = new UniqueNamesGenerator(['Value', 'Val', 'Input']);
 
@@ -42,7 +41,7 @@ export function migrateStandardTsReference(
         // Append `()` to unwrap the signal.
         result.replacements.push(
           new Replacement(
-            projectRelativePath(sf, projectDirAbsPath),
+            projectFile(sf, info),
             new TextUpdate({
               position: originalNode.getEnd(),
               end: originalNode.getEnd(),
@@ -59,7 +58,7 @@ export function migrateStandardTsReference(
         const replaceNode = traverseAccess(originalNode);
         result.replacements.push(
           new Replacement(
-            projectRelativePath(sf, projectDirAbsPath),
+            projectFile(sf, info),
             new TextUpdate({
               position: replaceNode.getStart(),
               end: replaceNode.getEnd(),
@@ -87,7 +86,7 @@ export function migrateStandardTsReference(
 
       const replaceNode = traverseAccess(originalNode);
       const fieldName = nameGenerator.generate(originalNode.text, referenceNodeInBlock);
-      const filePath = projectRelativePath(sf, projectDirAbsPath);
+      const filePath = projectFile(sf, info);
       const temporaryVariableStr = `const ${fieldName} = ${replaceNode.getText()}();`;
 
       idToSharedField.set(id, fieldName);
@@ -116,7 +115,7 @@ export function migrateStandardTsReference(
 
       result.replacements.push(
         new Replacement(
-          projectRelativePath(sf, projectDirAbsPath),
+          projectFile(sf, info),
           new TextUpdate({
             position: replaceNode.getStart(),
             end: replaceNode.getEnd(),

--- a/packages/core/schematics/migrations/signal-migration/src/passes/references/identify_host_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/references/identify_host_references.ts
@@ -26,6 +26,7 @@ import {
 import {MigrationHost} from '../../migration_host';
 import {MigrationResult} from '../../result';
 import {InputReferenceKind} from '../../utils/input_reference';
+import {projectFile} from '../../../../../utils/tsurge';
 
 /**
  * Checks host bindings of the given class and tracks all
@@ -164,7 +165,7 @@ export function identifyHostBindingReferences(
       from: {
         read: ref.read,
         isObjectShorthandExpression: ref.isObjectShorthandExpression,
-        fileId: host.fileToId(ref.context.getSourceFile()),
+        file: projectFile(ref.context.getSourceFile(), host.programInfo),
         hostPropertyNode: ref.context,
       },
       target: ref.targetInput,

--- a/packages/core/schematics/migrations/signal-migration/src/passes/references/identify_template_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/references/identify_template_references.ts
@@ -8,6 +8,7 @@
 
 import ts from 'typescript';
 import {ResourceLoader} from '@angular/compiler-cli/src/ngtsc/annotations';
+import {absoluteFrom} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {TemplateTypeChecker} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
 import {InputIncompatibilityReason} from '../../input_detection/incompatibility';
 import {KnownInputs} from '../../input_detection/known_inputs';
@@ -22,6 +23,7 @@ import {attemptExtractTemplateDefinition} from '../../utils/extract_template';
 import {NgCompilerOptions} from '@angular/compiler-cli/src/ngtsc/core/api';
 import {CompilationMode} from '@angular/compiler-cli/src/ngtsc/transform';
 import {TmplAstNode} from '@angular/compiler';
+import {projectFile} from '../../../../../utils/tsurge';
 
 /**
  * Checks whether the given class has an Angular template, and resolves
@@ -73,8 +75,8 @@ export function identifyTemplateReferences(
           read: res.read,
           node: res.context,
           isObjectShorthandExpression: res.isObjectShorthandExpression,
-          originatingTsFileId: host.fileToId(node.getSourceFile()),
-          templateFileId: host.fileToId(templateFilePath),
+          originatingTsFile: projectFile(node.getSourceFile(), host.programInfo),
+          templateFile: projectFile(absoluteFrom(templateFilePath), host.programInfo),
         },
         target: res.targetInput,
       });

--- a/packages/core/schematics/migrations/signal-migration/src/passes/references/identify_ts_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/references/identify_ts_references.ts
@@ -19,6 +19,7 @@ import {unwrapParent} from '../../utils/unwrap_parent';
 import {writeBinaryOperators} from '../../utils/write_operators';
 import {resolveBindingElement} from '../../utils/binding_elements';
 import {lookupPropertyAccess} from '../../../../../utils/tsurge/helpers/ast/lookup_property_access';
+import {projectFile} from '../../../../../utils/tsurge';
 
 /**
  * Checks whether given TypeScript reference refers to an Angular input, and captures
@@ -101,7 +102,7 @@ export function identifyPotentialTypeScriptReference(
     kind: InputReferenceKind.TsInputReference,
     from: {
       node,
-      fileId: host.fileToId(node.getSourceFile()),
+      file: projectFile(node.getSourceFile(), host.programInfo),
       isWrite: isWriteReference,
       isPartOfElementBinding: ts.isBindingElement(node.parent),
     },

--- a/packages/core/schematics/migrations/signal-migration/src/phase_migrate.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/phase_migrate.ts
@@ -31,8 +31,9 @@ export function executeMigrationPhase(
   host: MigrationHost,
   knownInputs: KnownInputs,
   result: MigrationResult,
-  {typeChecker, sourceFiles, projectDirAbsPath}: AnalysisProgramInfo,
+  info: AnalysisProgramInfo,
 ) {
+  const {typeChecker, sourceFiles} = info;
   const importManager = new ImportManager({
     // For the purpose of this migration, we always use `input` and don't alias
     // it to e.g. `input_1`.
@@ -40,16 +41,10 @@ export function executeMigrationPhase(
   });
 
   // Migrate passes.
-  pass5__migrateTypeScriptReferences(result, typeChecker, knownInputs, projectDirAbsPath);
-  pass6__migrateInputDeclarations(
-    typeChecker,
-    result,
-    knownInputs,
-    importManager,
-    projectDirAbsPath,
-  );
-  pass7__migrateTemplateReferences(host, result, knownInputs, projectDirAbsPath);
-  pass8__migrateHostBindings(result, knownInputs, projectDirAbsPath);
-  pass9__migrateTypeScriptTypeReferences(result, knownInputs, importManager, projectDirAbsPath);
-  pass10_applyImportManager(importManager, result, sourceFiles, projectDirAbsPath);
+  pass5__migrateTypeScriptReferences(result, typeChecker, knownInputs, info);
+  pass6__migrateInputDeclarations(typeChecker, result, knownInputs, importManager, info);
+  pass7__migrateTemplateReferences(host, result, knownInputs, info);
+  pass8__migrateHostBindings(result, knownInputs, info);
+  pass9__migrateTypeScriptTypeReferences(result, knownInputs, importManager, info);
+  pass10_applyImportManager(importManager, result, sourceFiles, info);
 }

--- a/packages/core/schematics/migrations/signal-migration/src/utils/input_id.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/utils/input_id.ts
@@ -9,6 +9,7 @@
 import ts from 'typescript';
 import {MigrationHost} from '../migration_host';
 import {InputNode} from '../input_detection/input_node';
+import {projectFile} from '../../../../utils/tsurge';
 
 /**
  * Unique key for an input in a project.
@@ -46,9 +47,14 @@ export function getInputDescriptor(host: MigrationHost, node: InputNode): InputD
     className = node.parent.name?.text ?? '<anonymous>';
   }
 
-  const fileId = host.fileToId(node.getSourceFile());
+  const file = projectFile(node.getSourceFile(), host.programInfo);
+  // Inputs may be detected in `.d.ts` files. Ensure that if the file IDs
+  // match regardless of extension. E.g. `/google3/blaze-out/bin/my_file.ts` should
+  // have the same ID as `/google3/my_file.ts`.
+  const id = file.id.replace(/\.d\.ts$/, '.ts');
+
   return {
-    key: `${fileId}@@${className}@@${node.name.text}` as unknown as InputUniqueKey,
+    key: `${id}@@${className}@@${node.name.text}` as unknown as InputUniqueKey,
     node,
   };
 }

--- a/packages/core/schematics/migrations/signal-migration/src/utils/input_reference.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/utils/input_reference.ts
@@ -9,6 +9,7 @@
 import ts from 'typescript';
 import {InputDescriptor} from './input_id';
 import {PropertyRead, TmplAstNode} from '@angular/compiler';
+import {ProjectFile} from '../../../../utils/tsurge';
 
 /** Possible types of references to input detected. */
 export enum InputReferenceKind {
@@ -23,10 +24,10 @@ export interface TemplateInputReference {
   kind: InputReferenceKind.InTemplate;
   /** From where the reference is made. */
   from: {
-    /** ID of the template file containing the reference. */
-    templateFileId: string;
-    /** ID of the TypeScript file that references, or contains the template. */
-    originatingTsFileId: string;
+    /** Template file containing the reference. */
+    templateFile: ProjectFile;
+    /** TypeScript file that references, or contains the template. */
+    originatingTsFile: ProjectFile;
     /** HTML AST node that contains the reference. */
     node: TmplAstNode;
     /** Expression AST node that represents the reference. */
@@ -43,8 +44,8 @@ export interface HostBindingInputReference {
   kind: InputReferenceKind.InHostBinding;
   /** From where the reference is made. */
   from: {
-    /** ID of the file that contains the host binding reference. */
-    fileId: string;
+    /** File that contains the host binding reference. */
+    file: ProjectFile;
     /** TypeScript property node containing the reference. */
     hostPropertyNode: ts.Node;
     /** Expression AST node that represents the reference. */
@@ -61,8 +62,8 @@ export interface TsInputReference {
   kind: InputReferenceKind.TsInputReference;
   /** From where the reference is made. */
   from: {
-    /** ID of the file that contains the TypeScript reference. */
-    fileId: string;
+    /** File that contains the TypeScript reference. */
+    file: ProjectFile;
     /** TypeScript AST node representing the reference. */
     node: ts.Identifier;
     /** Whether the reference is a write. */
@@ -82,8 +83,8 @@ export interface TsInputClassTypeReference {
   kind: InputReferenceKind.TsInputClassTypeReference;
   /** From where the reference is made. */
   from: {
-    /** ID of the file that contains the TypeScript reference. */
-    fileId: string;
+    /** File that contains the TypeScript reference. */
+    file: ProjectFile;
     /** TypeScript AST node representing the reference. */
     node: ts.TypeReferenceNode;
   };

--- a/packages/core/schematics/migrations/signal-migration/src/write_replacements.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/write_replacements.ts
@@ -13,12 +13,12 @@ import {AbsoluteFsPath, getFileSystem} from '@angular/compiler-cli/src/ngtsc/fil
 /** Applies the migration result and applies it to the file system. */
 export function writeMigrationReplacements(
   replacements: Replacement[],
-  projectDirAbsPath: AbsoluteFsPath,
+  projectRoot: AbsoluteFsPath,
 ) {
   const fs = getFileSystem();
 
   for (const [projectRelativePath, updates] of groupReplacementsByFile(replacements)) {
-    const filePath = fs.join(projectDirAbsPath, projectRelativePath);
+    const filePath = fs.join(projectRoot, projectRelativePath);
     const fileText = fs.readFile(filePath);
     const newText = applyTextUpdates(fileText, updates);
 

--- a/packages/core/schematics/migrations/signal-queries-migration/convert_query_property.ts
+++ b/packages/core/schematics/migrations/signal-queries-migration/convert_query_property.ts
@@ -8,8 +8,7 @@
 
 import ts from 'typescript';
 import {ExtractedQuery} from './identify_queries';
-import {projectRelativePath, Replacement, TextUpdate} from '../../utils/tsurge';
-import {AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {ProgramInfo, projectFile, Replacement, TextUpdate} from '../../utils/tsurge';
 import {ImportManager} from '@angular/compiler-cli/private/migrations';
 import assert from 'assert';
 import {WrappedNodeExpr} from '@angular/compiler';
@@ -43,7 +42,7 @@ export function computeReplacementsToMigrateQuery(
   node: ts.PropertyDeclaration,
   metadata: ExtractedQuery,
   importManager: ImportManager,
-  projectDirAbsPath: AbsoluteFsPath,
+  info: ProgramInfo,
 ): Replacement[] {
   const sf = node.getSourceFile();
   let newQueryFn = importManager.addImport({
@@ -134,7 +133,7 @@ export function computeReplacementsToMigrateQuery(
 
   return [
     new Replacement(
-      projectRelativePath(node.getSourceFile(), projectDirAbsPath),
+      projectFile(node.getSourceFile(), info),
       new TextUpdate({
         position: node.getStart(),
         end: node.getEnd(),

--- a/packages/core/schematics/migrations/signal-queries-migration/reference_tracking.ts
+++ b/packages/core/schematics/migrations/signal-queries-migration/reference_tracking.ts
@@ -8,6 +8,7 @@
 
 import ts from 'typescript';
 import {ClassPropertyID, getUniqueIDForClassProperty} from './identify_queries';
+import {ProgramInfo} from '../../utils/tsurge';
 
 /**
  * Attempts to resolve the given reference and determine a class
@@ -16,7 +17,7 @@ import {ClassPropertyID, getUniqueIDForClassProperty} from './identify_queries';
 export function getReferenceTargetId(
   node: ts.Identifier,
   checker: ts.TypeChecker,
-  projectDirAbsPath: string,
+  info: ProgramInfo,
 ): ClassPropertyID | null {
   const target = checker.getSymbolAtLocation(node);
   if (
@@ -26,5 +27,5 @@ export function getReferenceTargetId(
     return null;
   }
 
-  return getUniqueIDForClassProperty(target.valueDeclaration, projectDirAbsPath);
+  return getUniqueIDForClassProperty(target.valueDeclaration, info);
 }

--- a/packages/core/schematics/utils/tsurge/BUILD.bazel
+++ b/packages/core/schematics/utils/tsurge/BUILD.bazel
@@ -15,6 +15,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/file_system/testing",
         "//packages/compiler-cli/src/ngtsc/shims",
         "//packages/compiler-cli/src/ngtsc/translator",
+        "//packages/compiler-cli/src/ngtsc/util",
         "@npm//@types/diff",
         "@npm//@types/node",
         "@npm//chalk",

--- a/packages/core/schematics/utils/tsurge/base_migration.ts
+++ b/packages/core/schematics/utils/tsurge/base_migration.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import path from 'path';
 import {absoluteFrom, FileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {isShim} from '@angular/compiler-cli/src/ngtsc/shims';
 import {createNgtscProgram} from './helpers/ngtsc_program';
 import {BaseProgramInfo, ProgramInfo} from './program_info';
+import {getRootDirs} from '@angular/compiler-cli/src/ngtsc/util/src/typescript';
 
 /**
  * Base class for the possible Tsurge migration variants.
@@ -36,14 +36,24 @@ export abstract class TsurgeBaseMigration {
         !f.fileName.endsWith('.ngtypecheck.ts'),
     );
 
-    const basePath = path.dirname(info.tsconfigAbsolutePath);
-    const projectDirAbsPath = absoluteFrom(info.userOptions.rootDir ?? basePath);
+    // Sort it by length in reverse order (longest first). This speeds up lookups,
+    // since there's no need to keep going through the array once a match is found.
+    const sortedRootDirs = getRootDirs(info.host, info.userOptions).sort(
+      (a, b) => b.length - a.length,
+    );
+
+    // TODO: Consider also following TS's logic here, finding the common source root.
+    // See: Program#getCommonSourceDirectory.
+    const primaryRoot = absoluteFrom(
+      info.userOptions.rootDir ?? sortedRootDirs.at(-1) ?? info.program.getCurrentDirectory(),
+    );
 
     return {
       ...info,
       sourceFiles,
       fullProgramSourceFiles,
-      projectDirAbsPath,
+      sortedRootDirs,
+      projectRoot: primaryRoot,
     };
   }
 }

--- a/packages/core/schematics/utils/tsurge/executors/migrate_exec.ts
+++ b/packages/core/schematics/utils/tsurge/executors/migrate_exec.ts
@@ -24,12 +24,12 @@ export async function executeMigratePhase<UnitData, GlobalData>(
   migration: TsurgeMigration<UnitData, GlobalData>,
   globalMetadata: GlobalData,
   tsconfigAbsolutePath: string,
-): Promise<{replacements: Replacement[]; projectDirAbsPath: AbsoluteFsPath}> {
+): Promise<{replacements: Replacement[]; projectRoot: AbsoluteFsPath}> {
   const baseInfo = migration.createProgram(tsconfigAbsolutePath);
   const info = migration.prepareProgram(baseInfo);
 
   return {
     replacements: await migration.migrate(globalMetadata, info),
-    projectDirAbsPath: info.projectDirAbsPath,
+    projectRoot: info.projectRoot,
   };
 }

--- a/packages/core/schematics/utils/tsurge/helpers/apply_import_manager.ts
+++ b/packages/core/schematics/utils/tsurge/helpers/apply_import_manager.ts
@@ -8,8 +8,10 @@
 
 import ts from 'typescript';
 import {ImportManager} from '@angular/compiler-cli/src/ngtsc/translator';
-import {AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
-import {projectRelativePath, Replacement, TextUpdate} from '../replacement';
+import {absoluteFrom} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {Replacement, TextUpdate} from '../replacement';
+import {projectFile} from '../project_paths';
+import {ProgramInfo} from '../program_info';
 
 /**
  * Applies import manager changes, and writes them as replacements the
@@ -19,7 +21,7 @@ export function applyImportManagerChanges(
   importManager: ImportManager,
   replacements: Replacement[],
   sourceFiles: readonly ts.SourceFile[],
-  projectAbsPath: AbsoluteFsPath,
+  info: Pick<ProgramInfo, 'sortedRootDirs' | 'projectRoot'>,
 ) {
   const {newImports, updatedImports, deletedImports} = importManager.finalize();
   const printer = ts.createPrinter({});
@@ -35,7 +37,7 @@ export function applyImportManagerChanges(
       );
       replacements.push(
         new Replacement(
-          projectRelativePath(fileName, projectAbsPath),
+          projectFile(absoluteFrom(fileName), info),
           new TextUpdate({position: 0, end: 0, toInsert: `${printedImport}\n`}),
         ),
       );
@@ -72,7 +74,7 @@ export function applyImportManagerChanges(
     );
     replacements.push(
       new Replacement(
-        projectRelativePath(oldBindings.getSourceFile(), projectAbsPath),
+        projectFile(oldBindings.getSourceFile(), info),
         new TextUpdate({
           position: oldBindings.getStart(),
           end: oldBindings.getEnd(),
@@ -88,7 +90,7 @@ export function applyImportManagerChanges(
   for (const removedImport of deletedImports) {
     replacements.push(
       new Replacement(
-        projectRelativePath(removedImport.getSourceFile(), projectAbsPath),
+        projectFile(removedImport.getSourceFile(), info),
         new TextUpdate({
           position: removedImport.getStart(),
           end: removedImport.getEnd(),

--- a/packages/core/schematics/utils/tsurge/helpers/group_replacements.ts
+++ b/packages/core/schematics/utils/tsurge/helpers/group_replacements.ts
@@ -6,23 +6,25 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ProjectRelativePath, Replacement, TextUpdate} from '../replacement';
+import {Replacement, TextUpdate} from '../replacement';
+import {ProjectRootRelativePath} from '../project_paths';
 
 /**
- * Groups the given replacements per file path.
+ * Groups the given replacements per project relative
+ * file path.
  *
  * This allows for simple execution of the replacements
  * against a given file. E.g. via {@link applyTextUpdates}.
  */
 export function groupReplacementsByFile(
   replacements: Replacement[],
-): Map<ProjectRelativePath, TextUpdate[]> {
-  const result = new Map<ProjectRelativePath, TextUpdate[]>();
-  for (const {projectRelativePath, update} of replacements) {
-    if (!result.has(projectRelativePath)) {
-      result.set(projectRelativePath, []);
+): Map<ProjectRootRelativePath, TextUpdate[]> {
+  const result = new Map<ProjectRootRelativePath, TextUpdate[]>();
+  for (const {projectFile, update} of replacements) {
+    if (!result.has(projectFile.rootRelativePath)) {
+      result.set(projectFile.rootRelativePath, []);
     }
-    result.get(projectRelativePath)!.push(update);
+    result.get(projectFile.rootRelativePath)!.push(update);
   }
   return result;
 }

--- a/packages/core/schematics/utils/tsurge/helpers/ngtsc_program.ts
+++ b/packages/core/schematics/utils/tsurge/helpers/ngtsc_program.ts
@@ -60,7 +60,7 @@ export function createNgtscProgram(
     ngCompiler: ngtscProgram.compiler,
     program: ngtscProgram.getTsProgram(),
     userOptions: tsconfig.options,
-    programAbsoluteRootPaths: tsconfig.rootNames,
-    tsconfigAbsolutePath: absoluteTsconfigPath,
+    programAbsoluteRootFileNames: tsconfig.rootNames,
+    host: tsHost,
   };
 }

--- a/packages/core/schematics/utils/tsurge/index.ts
+++ b/packages/core/schematics/utils/tsurge/index.ts
@@ -11,3 +11,4 @@ export * from './program_info';
 export * from './replacement';
 export * from './helpers/unique_id';
 export * from './helpers/serializable';
+export * from './project_paths';

--- a/packages/core/schematics/utils/tsurge/program_info.ts
+++ b/packages/core/schematics/utils/tsurge/program_info.ts
@@ -21,8 +21,8 @@ export interface BaseProgramInfo {
   ngCompiler: NgCompiler | null;
   program: ts.Program;
   userOptions: NgCompilerOptions;
-  programAbsoluteRootPaths: string[];
-  tsconfigAbsolutePath: string;
+  programAbsoluteRootFileNames: string[];
+  host: Pick<ts.CompilerHost, 'getCanonicalFileName' | 'getCurrentDirectory'>;
 }
 
 /**
@@ -35,5 +35,15 @@ export interface BaseProgramInfo {
 export interface ProgramInfo extends BaseProgramInfo {
   sourceFiles: ts.SourceFile[];
   fullProgramSourceFiles: readonly ts.SourceFile[];
-  projectDirAbsPath: AbsoluteFsPath;
+  /**
+   * Root directories of the project.
+   * Sorted longest first for easy lookups.
+   */
+  sortedRootDirs: AbsoluteFsPath[];
+
+  /**
+   * Primary root directory.
+   * This is the shortest root directory, including all others.
+   */
+  projectRoot: AbsoluteFsPath;
 }

--- a/packages/core/schematics/utils/tsurge/project_paths.ts
+++ b/packages/core/schematics/utils/tsurge/project_paths.ts
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {
+  AbsoluteFsPath,
+  FileSystem,
+  getFileSystem,
+  isLocalRelativePath,
+} from '@angular/compiler-cli/src/ngtsc/file_system';
+import ts from 'typescript';
+import {ProgramInfo} from './program_info';
+
+/**
+ * Branded type representing a file ID. Practically, this
+ * is a relative path based on the most appropriate root dir.
+ *
+ * A project-relative path is relative to the longest root
+ * directory of the project. A project-relative path is always
+ * unique in the context of the project (like google3).
+ *
+ * This is a requirement and the fundamental concept of root directories.
+ * See: https://www.typescriptlang.org/tsconfig/#rootDirs.
+ *
+ * Note that compilation units are only sub-parts of the project
+ * and are assumed, and expected to always have the same root directories.
+ *
+ * File IDs are important for Tsurge, as replacements and paths
+ * should never refer to absolute paths. That is because the project
+ * may be put into different temporary directories in workers.
+ *
+ * E.g. Tsunami may have different project roots in different
+ * stages, or we can't reliably relativize paths after Tsunami completed.
+ * Or, paths may exist inside `blaze-out/XX/google3` but instead should be
+ * matching associable with the same path in its `.ts` compilation unit
+ *
+ * See {@link ProjectFile#id}
+ */
+export type ProjectFileID = string & {__projectFileID: true};
+
+/**
+ * Branded type representing an unsafe file path, relative to the
+ * primary project root.
+ *
+ * The path is unsafe for unique ID generation as it does not respect
+ * virtual roots as configured via `tsconfig#rootDirs`. Though, the
+ * path is useful for replacements, writing to disk.
+ *
+ * See {@link ProjectFile#rootRelativePath}
+ */
+export type ProjectRootRelativePath = string & {__unsafeProjectRootRelative: true};
+
+/**
+ * Type representing a file in the project.
+ *
+ * This construct is fully serializable between stages and
+ * workers.
+ */
+export interface ProjectFile {
+  /**
+   * Unique ID for the file.
+   *
+   * In practice, this is a file path relative to the most appropriate
+   * root directory. This allows identifying files, respecting the virtual
+   * root configuration. See: https://www.typescriptlang.org/tsconfig/#rootDirs.
+   *
+   * Use this for matching files, contributing to global metadata. IDs consider
+   * the following files as the same: `/blaze-out/fast-build/file.ts` and `/file.ts`.
+   */
+  id: ProjectFileID;
+
+  /**
+   * Unsafe path for the file, relative to the primary
+   * project root ({@link ProgramInfo.projectRoot})
+   *
+   * Use this with caution, and preferably not for unique ID
+   * generation across workers and stages because {@link id}
+   * is more suitable and respects virtual TS roots (`rootDirs`).
+   */
+  rootRelativePath: ProjectRootRelativePath;
+}
+
+/**
+ * Gets a project file instance for the given file.
+ *
+ * Use this helper for dealing with project paths throughout your
+ * migration. The return type is serializable.
+ *
+ * See {@link ProjectFile}.
+ */
+export function projectFile(
+  file: ts.SourceFile | AbsoluteFsPath,
+  {sortedRootDirs, projectRoot}: Pick<ProgramInfo, 'sortedRootDirs' | 'projectRoot'>,
+): ProjectFile {
+  const fs = getFileSystem();
+  const filePath = fs.resolve(typeof file === 'string' ? file : file.fileName);
+
+  // Sorted root directories are sorted longest to shortest. First match
+  // is the appropriate root directory for ID computation.
+  for (const rootDir of sortedRootDirs) {
+    if (!isWithinBasePath(fs, rootDir, filePath)) {
+      continue;
+    }
+    return {
+      id: fs.relative(rootDir, filePath) as string as ProjectFileID,
+      rootRelativePath: fs.relative(projectRoot, filePath) as string as ProjectRootRelativePath,
+    };
+  }
+
+  // E.g. project directory may be `src/`, but files may be looked up
+  // from `node_modules/`. This is fine, but in those cases, no root
+  // directory matches.
+  const rootRelativePath = fs.relative(projectRoot, filePath);
+  return {
+    id: rootRelativePath as string as ProjectFileID,
+    rootRelativePath: rootRelativePath as string as ProjectRootRelativePath,
+  };
+}
+
+/**
+ * Whether `path` is a descendant of the `base`?
+ * E.g. `a/b/c` is within `a/b` but not within `a/x`.
+ */
+function isWithinBasePath(fs: FileSystem, base: AbsoluteFsPath, path: AbsoluteFsPath): boolean {
+  return isLocalRelativePath(fs.relative(base, path));
+}

--- a/packages/core/schematics/utils/tsurge/replacement.ts
+++ b/packages/core/schematics/utils/tsurge/replacement.ts
@@ -6,29 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {
-  absoluteFrom,
-  AbsoluteFsPath,
-  getFileSystem,
-} from '@angular/compiler-cli/src/ngtsc/file_system';
 import MagicString from 'magic-string';
-import ts from 'typescript';
-
-/**
- * Branded type representing a project-relative path.
- *
- * This is important to enforce as replacements should be relative
- * to the project root, so that they can be serialized between phases.
- *
- * E.g. Tsunami may have different project roots in different stages, or
- * we can't reliably relativize paths after Tsunami completed.
- */
-export type ProjectRelativePath = string & {__projectRelativePath: true};
+import {ProjectFile} from './project_paths';
 
 /** A text replacement for the given file. */
 export class Replacement {
   constructor(
-    public projectRelativePath: ProjectRelativePath,
+    public projectFile: ProjectFile,
     public update: TextUpdate,
   ) {}
 }
@@ -42,17 +26,6 @@ export class TextUpdate {
       toInsert: string;
     },
   ) {}
-}
-
-/** Gets a project-relative relative for the given source file. */
-export function projectRelativePath(
-  file: ts.SourceFile | string,
-  projectAbsPath: AbsoluteFsPath,
-): ProjectRelativePath {
-  return getFileSystem().relative(
-    projectAbsPath,
-    typeof file === 'string' ? file : file.fileName,
-  ) as string as ProjectRelativePath;
 }
 
 /** Helper that applies updates to the given text. */

--- a/packages/core/schematics/utils/tsurge/test/output_migration.ts
+++ b/packages/core/schematics/utils/tsurge/test/output_migration.ts
@@ -6,15 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgtscProgram} from '@angular/compiler-cli/src/ngtsc/program';
-import {absoluteFromSourceFile} from '@angular/compiler-cli/src/ngtsc/file_system';
-import {TypeScriptReflectionHost} from '@angular/compiler-cli/src/ngtsc/reflection';
 import {DtsMetadataReader} from '@angular/compiler-cli/src/ngtsc/metadata';
+import {TypeScriptReflectionHost} from '@angular/compiler-cli/src/ngtsc/reflection';
 import {confirmAsSerializable} from '../helpers/serializable';
 import {TsurgeComplexMigration} from '../migration';
-import {projectRelativePath, Replacement, TextUpdate} from '../replacement';
-import {findOutputDeclarationsAndReferences, OutputID} from './output_helpers';
 import {ProgramInfo} from '../program_info';
+import {Replacement, TextUpdate} from '../replacement';
+import {findOutputDeclarationsAndReferences, OutputID} from './output_helpers';
+import {projectFile} from '../project_paths';
 
 type AnalysisUnit = {[id: OutputID]: {seenProblematicUsage: boolean}};
 type GlobalMetadata = {[id: OutputID]: {canBeMigrated: boolean}};
@@ -96,7 +95,7 @@ export class OutputMigration extends TsurgeComplexMigration<AnalysisUnit, Global
 
       replacements.push(
         new Replacement(
-          projectRelativePath(node.getSourceFile(), info.projectDirAbsPath),
+          projectFile(node.getSourceFile(), info),
           new TextUpdate({
             position: node.getStart(),
             end: node.getStart(),

--- a/packages/core/schematics/utils/tsurge/testing/index.ts
+++ b/packages/core/schematics/utils/tsurge/testing/index.ts
@@ -68,8 +68,8 @@ export async function runTsurgeMigration<UnitData, GlobalData>(
       : await migration.migrate(merged, info);
 
   const updates = groupReplacementsByFile(replacements);
-  for (const [projectRelativePath, changes] of updates.entries()) {
-    const absolutePath = mockFs.resolve('/', projectRelativePath);
+  for (const [rootRelativePath, changes] of updates.entries()) {
+    const absolutePath = mockFs.join(info.projectRoot, rootRelativePath);
     mockFs.writeFile(absolutePath, applyTextUpdates(mockFs.readFile(absolutePath), changes));
   }
 


### PR DESCRIPTION
Migrations may resolve files in e.g. `blaze-out` and try to compute a path for the file that is "recognizable" across workers. E.g. in one worker, it may be the actual `.ts` file inside the source tree, while in the other, the file may be inside `blaze-out`.

Tsurge currently expects project relative paths to be passed around. Those project relative paths are currently only based on the single root directory. Hence paths inside `blaze-out` would actually not be recognizable.

The fix idea here is that we always respect root directories when computing a project relative path. Think of the computed path as the unique path you'd also get when importing from your project root. You'd always get to the same file.

This is perfect for passing between workers, assuming those are the same project; but just sub-compilation units. The root dirs are expected to *match*. This is a fine assumption in 1P and 3P; and guaranteed.

One risk I could see is that later on, when we write replacements for such a relative path in 3P, it may be possible that the file actually resides in an actual root directory and not in
`<primaryRoot>/<relative-path>`. We should probably try to safely get back to the absolute path when writing replacements. TBD.