### PR TITLE
fix(migrations): replace leftover modules with their exports during pruning

### DIFF
--- a/packages/core/schematics/ng-generate/standalone-migration/index.ts
+++ b/packages/core/schematics/ng-generate/standalone-migration/index.ts
@@ -132,6 +132,7 @@ function standaloneMigration(
       printer,
       undefined,
       referenceLookupExcludedFiles,
+      knownInternalAliasRemapper,
     );
     pendingChanges = result.pendingChanges;
     filesToRemove = result.filesToRemove;


### PR DESCRIPTION
Currently during the module pruning stage of the standalone migration we assume that any leftover modules which only have `imports` and `exports` can safely be removed. That can be incorrect for the cases where some parts of the app were converted to standalone outside of the migration.

These changes update the logic so that such modules are replaced with the `exports` which are used within the specific component.

Fixes #51420.