### PR TITLE
docs(router): Document missing input for route binding

### DIFF
--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -730,6 +730,24 @@ export type ViewTransitionsFeature = RouterFeature<RouterFeatureKind.ViewTransit
  * );
  * ```
  *
+ * The router bindings information from any of the following sources:
+ *
+ *  - query parameters
+ *  - path and matrix parameters
+ *  - static route data
+ *  - data from resolvers
+ *
+ * Duplicate keys are resolved in the same order from above, from least to greatest,
+ * meaning that resolvers have the highest precedence and override any of the other information
+ * from the route.
+ *
+ * Importantly, when an input does not have an item in the route data with a matching key, this
+ * input is set to `undefined`. This prevents previous information from being
+ * retained if the data got removed from the route (i.e. if a query parameter is removed).
+ * Default values can be provided with a resolver on the route to ensure the value is always present
+ * or an input and use an input transform in the component.
+ *
+ * @see {@link guide/components/inputs#input-transforms input transforms}
  * @returns A set of providers for use with `provideRouter`.
  */
 export function withComponentInputBinding(): ComponentInputBindingFeature {


### PR DESCRIPTION
This commit clearly documents the approach used by router input binding when an input is not present in the route data.

resolves #52946
