### PR TITLE
fix(docs-infra): do not focus h1 from docs-top-level-banner

### DIFF
--- a/adev/src/app/app.component.html
+++ b/adev/src/app/app.component.html
@@ -1,8 +1,9 @@
+<button (click)="focusFirstHeading()" class="adev-skip">Skip to main content</button>
+
 @defer (when isBrowser) {
   <adev-progress-bar />
   <docs-top-level-banner id="ng-survey-2024" link="https://goo.gle/angular-survey-2024" text="Take the 2024 Angular Developer Survey today!"  />
 }
-<button (click)="focusFirstHeading()" class="adev-skip">Skip to main content</button>
 
 <div class="adev-nav"></div>
 @if (displaySecondaryNav()) {

--- a/adev/src/app/app.component.ts
+++ b/adev/src/app/app.component.ts
@@ -16,7 +16,7 @@ import {
   signal,
   WritableSignal,
 } from '@angular/core';
-import {NavigationEnd, NavigationSkipped, Router, RouterLink, RouterOutlet} from '@angular/router';
+import {NavigationEnd, NavigationSkipped, Router, RouterOutlet} from '@angular/router';
 import {filter, map, skip} from 'rxjs/operators';
 import {
   CookiePopup,
@@ -87,7 +87,7 @@ export class AppComponent implements OnInit {
       return;
     }
 
-    const h1 = this.document.querySelector<HTMLHeadingElement>('h1');
+    const h1 = this.document.querySelector<HTMLHeadingElement>('h1:not(docs-top-level-banner h1)');
     h1?.focus();
   }
 


### PR DESCRIPTION
fix(docs-infra): do not focus h1 from docs-top-level-banner

Do not focus heading from docs-top-level-banner.
Move the `Skip to main content` button to the top of DOM tree.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
