### PR TITLE
docs(docs-infra): remove more unused standalone imports

### DIFF
--- a/adev/shared-docs/components/breadcrumb/breadcrumb.component.ts
+++ b/adev/shared-docs/components/breadcrumb/breadcrumb.component.ts
@@ -9,13 +9,12 @@
 import {ChangeDetectionStrategy, Component, OnInit, inject, signal} from '@angular/core';
 import {NavigationState} from '../../services/index';
 import {NavigationItem} from '../../interfaces/index';
-import {NgFor, NgIf} from '@angular/common';
 import {RouterLink} from '@angular/router';
 
 @Component({
   selector: 'docs-breadcrumb',
   standalone: true,
-  imports: [NgIf, NgFor, RouterLink],
+  imports: [RouterLink],
   templateUrl: './breadcrumb.component.html',
   styleUrls: ['./breadcrumb.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/adev/shared-docs/components/cookie-popup/cookie-popup.component.ts
+++ b/adev/shared-docs/components/cookie-popup/cookie-popup.component.ts
@@ -7,7 +7,6 @@
  */
 
 import {ChangeDetectionStrategy, Component, inject, signal} from '@angular/core';
-import {NgIf} from '@angular/common';
 import {LOCAL_STORAGE} from '../../providers/index';
 import {setCookieConsent} from '../../utils';
 
@@ -21,7 +20,6 @@ export const STORAGE_KEY = 'docs-accepts-cookies';
 @Component({
   selector: 'docs-cookie-popup',
   standalone: true,
-  imports: [NgIf],
   templateUrl: './cookie-popup.component.html',
   styleUrls: ['./cookie-popup.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/adev/shared-docs/components/table-of-contents/table-of-contents.component.ts
+++ b/adev/shared-docs/components/table-of-contents/table-of-contents.component.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {NgFor, NgIf} from '@angular/common';
 import {ChangeDetectionStrategy, Component, Input, computed, inject} from '@angular/core';
 import {RouterLink} from '@angular/router';
 import {TableOfContentsLevel} from '../../interfaces/index';
@@ -20,7 +19,7 @@ import {IconComponent} from '../icon/icon.component';
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './table-of-contents.component.html',
   styleUrls: ['./table-of-contents.component.scss'],
-  imports: [NgIf, NgFor, RouterLink, IconComponent],
+  imports: [RouterLink, IconComponent],
 })
 export class TableOfContents {
   // Element that contains the content from which the Table of Contents is built


### PR DESCRIPTION
I ran the documentation for fun and was greeted with the new warnings* about unused imports in standalone components

Related issue: [docs(docs-infra): remove unused standalone imports #57680](https://github.com/angular/angular/pull/57680). I did not notice other issues or PRs about these three files and the unused imports.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
When building the docs, the CLI gave the new warnings about unused imports in standalone components.

Issue Number: N/A

## What is the new behavior?
Unused imports were removed from three components

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

N/A