### PR TITLE
refactor(compiler-cli): Don't extract abstract overload multiple times

### DIFF
--- a/packages/compiler-cli/src/ngtsc/docs/src/class_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/class_extractor.ts
@@ -266,12 +266,27 @@ class ClassExtractor {
   }
 
   /** The result only contains properties, method implementations and abstracts */
-  private filterMethodOverloads(declarations: ts.Declaration[]) {
-    return declarations.filter((declaration) => {
+  private filterMethodOverloads(declarations: ts.Declaration[]): ts.Declaration[] {
+    return declarations.filter((declaration, index) => {
       if (ts.isFunctionDeclaration(declaration) || ts.isMethodDeclaration(declaration)) {
-        return (
-          !!declaration.body || ts.getCombinedModifierFlags(declaration) & ts.ModifierFlags.Abstract
-        );
+        if (ts.getCombinedModifierFlags(declaration) & ts.ModifierFlags.Abstract) {
+          // TS enforces that all declarations of an abstract method are consecutive
+          const previousDeclaration = declarations[index - 1];
+
+          const samePreviousAbstractMethod =
+            previousDeclaration &&
+            ts.isMethodDeclaration(previousDeclaration) &&
+            ts.getCombinedModifierFlags(previousDeclaration) & ts.ModifierFlags.Abstract &&
+            previousDeclaration.name.getText() === declaration.name?.getText();
+
+          // We just need a reference to one member
+          // In the case of Abstract Methods we only want to return the first abstract.
+          // Others with the same name are considered as overloads
+          // Later on, the function extractor will handle overloads and implementation detection
+          return !samePreviousAbstractMethod;
+        }
+
+        return !!declaration.body;
       }
       return true;
     });


### PR DESCRIPTION
Prior to this commit, each abstract method that was overloaded was extracted. With this commit it will be extracted only once. Every overload was and still will be supported by the signatures.

fixes #57693
