### PR TITLE
docs: change wording in ComponentDecorator to incorporate components without NgModule

### DIFF
--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -404,6 +404,8 @@ export interface ComponentDecorator {
    * When running Angular with NgModule, a component must belong to an NgModule in
    * order for it to be available to another component or application. To make it a
    * member of an NgModule, list it in the `declarations` field of the `NgModule` metadata.
+   * However, Angular now recommends using standalone components, which do not require an 
+   * NgModule and can be directly imported and used in other components or applications.
    *
    * Note that, in addition to these options for configuring a directive,
    * you can control a component's runtime behavior by implementing

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -401,9 +401,9 @@ export interface ComponentDecorator {
    * Unlike other directives, only one component can be instantiated for a given element in a
    * template.
    *
-   * A component must belong to an NgModule in order for it to be available
-   * to another component or application. To make it a member of an NgModule,
-   * list it in the `declarations` field of the `NgModule` metadata.
+   * When running Angular with NgModule, a component must belong to an NgModule in
+   * order for it to be available to another component or application. To make it a
+   * member of an NgModule, list it in the `declarations` field of the `NgModule` metadata.
    *
    * Note that, in addition to these options for configuring a directive,
    * you can control a component's runtime behavior by implementing

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -401,9 +401,8 @@ export interface ComponentDecorator {
    * Unlike other directives, only one component can be instantiated for a given element in a
    * template.
    *
-   * Angular now recommends using standalone components, which do not require an 
-   * NgModule and can be directly imported and used in other components or applications.
-   * However, if running Angular with NgModule, a component must belong to an NgModule in
+   * Standalone components can be directly imported in any other standalone component or NgModule.
+   * NgModule based apps on the other hand require components to belong to an NgModule in
    * order for it to be available to another component or application. To make it a
    * member of an NgModule, list it in the `declarations` field of the `NgModule` metadata.
    *

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -401,11 +401,11 @@ export interface ComponentDecorator {
    * Unlike other directives, only one component can be instantiated for a given element in a
    * template.
    *
-   * When running Angular with NgModule, a component must belong to an NgModule in
+   * Angular now recommends using standalone components, which do not require an 
+   * NgModule and can be directly imported and used in other components or applications.
+   * However, if running Angular with NgModule, a component must belong to an NgModule in
    * order for it to be available to another component or application. To make it a
    * member of an NgModule, list it in the `declarations` field of the `NgModule` metadata.
-   * However, Angular now recommends using standalone components, which do not require an 
-   * NgModule and can be directly imported and used in other components or applications.
    *
    * Note that, in addition to these options for configuring a directive,
    * you can control a component's runtime behavior by implementing

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -403,7 +403,7 @@ export interface ComponentDecorator {
    *
    * Standalone components can be directly imported in any other standalone component or NgModule.
    * NgModule based apps on the other hand require components to belong to an NgModule in
-   * order for it to be available to another component or application. To make it a
+   * order for them to be available to another component or application. To make a component a
    * member of an NgModule, list it in the `declarations` field of the `NgModule` metadata.
    *
    * Note that, in addition to these options for configuring a directive,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The documentation insists that a component must belong to an NgModule in order for it to be available to another component or application.

Issue Number: #57689 


## What is the new behavior?
The documentation still provides instructions to make a component a member of an NgModule, but only when running Angular with NgModule

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
