### PR TITLE
refactor(core): introduce debugName optional arg to ReactiveNode

### DIFF
--- a/goldens/public-api/core/primitives/signals/index.api.md
+++ b/goldens/public-api/core/primitives/signals/index.api.md
@@ -81,6 +81,7 @@ export interface ReactiveNode {
     // (undocumented)
     consumerMarkedDirty(node: unknown): void;
     consumerOnSignalRead(node: unknown): void;
+    debugName?: string;
     dirty: boolean;
     lastCleanEpoch: Version;
     liveConsumerIndexOfThis: number[] | undefined;

--- a/packages/core/primitives/signals/src/graph.ts
+++ b/packages/core/primitives/signals/src/graph.ts
@@ -179,6 +179,11 @@ export interface ReactiveNode {
    * Called when a signal is read within this consumer.
    */
   consumerOnSignalRead(node: unknown): void;
+
+  /**
+   * A debug name for the reactive node. Used in Angular DevTools to identify the node.
+   */
+  debugName?: string;
 }
 
 interface ConsumerNode extends ReactiveNode {


### PR DESCRIPTION
This commit contains the changes to core/primitives that used to be in https://github.com/angular/angular/pull/57073 but were [moved for g3sync](https://github.com/angular/angular/pull/57073#pullrequestreview-2283691431) 