### PR TITLE
refactor(core): Improve `explicit-standalone-flag` migration.

### DIFF
--- a/packages/core/schematics/migrations/explicit-standalone-flag/index.ts
+++ b/packages/core/schematics/migrations/explicit-standalone-flag/index.ts
@@ -20,7 +20,7 @@ export function migrate(): Rule {
 
     if (!allPaths.length) {
       throw new SchematicsException(
-        'Could not find any tsconfig file. Cannot run the standalone:false migration.',
+        'Could not find any tsconfig file. Cannot run the explicit-standalone-flag migration.',
       );
     }
 

--- a/packages/core/schematics/migrations/signal-migration/src/utils/class_member_names.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/utils/class_member_names.ts
@@ -8,7 +8,7 @@
 
 import ts from 'typescript';
 
-export function getMemberName(member: ts.ClassElement): string | null {
+export function getMemberName(member: ts.ClassElement | ts.PropertyAssignment): string | null {
   if (member.name === undefined) {
     return null;
   }


### PR DESCRIPTION
Keep standalone:true

This commit also adds the support of handling standalone proparties assigned by variables (or via shorthand assignments). 