### PR TITLE
refactor(migrations): avoid flow node traversal limit by optimizing traversal

### DIFF
--- a/packages/core/schematics/migrations/signal-migration/src/flow_analysis/flow_node_traversal.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/flow_analysis/flow_node_traversal.ts
@@ -34,14 +34,21 @@ export function traverseFlowForInterestingNodes(flow: FlowNode): ts.Node[] | nul
   let interestingNodes: ts.Node[] = [];
 
   const queue: FlowNode[] = [flow];
+  const seen = new Set<FlowNode>();
 
   while (queue.length) {
     flow = queue.shift()!;
 
+    // Flow already visited, don't repeat work unnecessarily.
+    if (seen.has(flow)) {
+      continue;
+    }
+    seen.add(flow);
+
     if (++flowDepth === 2000) {
       // We have made 2000 recursive invocations. To avoid overflowing the call stack we report an
       // error and disable further control flow analysis in the containing function or module body.
-      return null;
+      return interestingNodes;
     }
 
     const flags = flow.flags;

--- a/packages/core/schematics/migrations/signal-migration/src/flow_analysis/flow_node_traversal.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/flow_analysis/flow_node_traversal.ts
@@ -35,7 +35,7 @@ export function traverseFlowForInterestingNodes(flow: FlowNode): ts.Node[] | nul
 
   const queue = new Set<FlowNode>([flow]);
 
-  // Seen is evolved during iteration, and new items will be added
+  // Queue is evolved during iteration, and new items will be added
   // to the end of the iteration. Effectively implementing a queue
   // with deduping out of the box.
   for (const flow of queue) {

--- a/packages/core/schematics/migrations/signal-migration/src/flow_analysis/flow_node_traversal.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/flow_analysis/flow_node_traversal.ts
@@ -33,18 +33,12 @@ export function traverseFlowForInterestingNodes(flow: FlowNode): ts.Node[] | nul
   let flowDepth = 0;
   let interestingNodes: ts.Node[] = [];
 
-  const queue: FlowNode[] = [flow];
-  const seen = new Set<FlowNode>();
+  const queue = new Set<FlowNode>([flow]);
 
-  while (queue.length) {
-    flow = queue.shift()!;
-
-    // Flow already visited, don't repeat work unnecessarily.
-    if (seen.has(flow)) {
-      continue;
-    }
-    seen.add(flow);
-
+  // Seen is evolved during iteration, and new items will be added
+  // to the end of the iteration. Effectively implementing a queue
+  // with deduping out of the box.
+  for (const flow of queue) {
     if (++flowDepth === 2000) {
       // We have made 2000 recursive invocations. To avoid overflowing the call stack we report an
       // error and disable further control flow analysis in the containing function or module body.
@@ -54,7 +48,7 @@ export function traverseFlowForInterestingNodes(flow: FlowNode): ts.Node[] | nul
     const flags = flow.flags;
     if (flags & FlowFlags.Assignment) {
       const assignment = flow as FlowAssignment;
-      queue.push(assignment.antecedent);
+      queue.add(assignment.antecedent);
 
       if (ts.isVariableDeclaration(assignment.node)) {
         interestingNodes.push(assignment.node.name);
@@ -64,37 +58,39 @@ export function traverseFlowForInterestingNodes(flow: FlowNode): ts.Node[] | nul
         interestingNodes.push(assignment.node);
       }
     } else if (flags & FlowFlags.Call) {
-      queue.push((flow as FlowCall).antecedent);
+      queue.add((flow as FlowCall).antecedent);
       // Arguments can be narrowed using `FlowCall`s.
       // See: node_modules/typescript/stable/src/compiler/checker.ts;l=28786-28810
       interestingNodes.push(...(flow as FlowCall).node.arguments);
     } else if (flags & FlowFlags.Condition) {
-      queue.push((flow as FlowCondition).antecedent);
+      queue.add((flow as FlowCondition).antecedent);
       interestingNodes.push((flow as FlowCondition).node);
     } else if (flags & FlowFlags.SwitchClause) {
-      queue.push((flow as FlowSwitchClause).antecedent);
+      queue.add((flow as FlowSwitchClause).antecedent);
       // The switch expression can be narrowed, so it's an interesting node.
       interestingNodes.push((flow as FlowSwitchClause).node.switchStatement.expression);
     } else if (flags & FlowFlags.Label) {
       // simple label, a single ancestor.
       if ((flow as FlowLabel).antecedent?.length === 1) {
-        queue.push((flow as FlowLabel).antecedent![0]);
+        queue.add((flow as FlowLabel).antecedent![0]);
         continue;
       }
 
       if (flags & FlowFlags.BranchLabel) {
         // Normal branches. e.g. switch.
-        queue.push(...((flow as FlowLabel).antecedent ?? []));
+        for (const f of (flow as FlowLabel).antecedent ?? []) {
+          queue.add(f);
+        }
       } else {
         // Branch for loops.
         // The first antecedent always points to the flow node before the loop
         // was entered. All other narrowing expressions, if present, are direct
         // antecedents of the starting flow node, so we only need to look at the first.
         // See: node_modules/typescript/stable/src/compiler/checker.ts;l=28108-28109
-        queue.push((flow as FlowLabel).antecedent![0]);
+        queue.add((flow as FlowLabel).antecedent![0]);
       }
     } else if (flags & FlowFlags.ArrayMutation) {
-      queue.push((flow as FlowArrayMutation).antecedent);
+      queue.add((flow as FlowArrayMutation).antecedent);
       // Array mutations are never interesting for inputs, as we cannot migrate
       // assignments to inputs.
     } else if (flags & FlowFlags.ReduceLabel) {
@@ -103,8 +99,10 @@ export function traverseFlowForInterestingNodes(flow: FlowNode): ts.Node[] | nul
       // TODO: explore this more.
 
       // See: node_modules/typescript/stable/src/compiler/binder.ts;l=1636-1649.
-      queue.push((flow as FlowReduceLabel).antecedent);
-      queue.push(...(flow as FlowReduceLabel).node.antecedents);
+      queue.add((flow as FlowReduceLabel).antecedent);
+      for (const f of (flow as FlowReduceLabel).node.antecedents) {
+        queue.add(f);
+      }
     } else if (flags & FlowFlags.Start) {
       // Note: TS itself only ever continues with parent control flows, if the pre-determined `flowContainer`
       // of the referenced is different. E.g. narrowing might decide to choose a higher flow container if we


### PR DESCRIPTION
Instead of traversing the same paths multiple times, we should avoid this extra work and optimize. This solves some issues in super large files with extremely complex flow graphs. E.g. large `ngOnChanges` functions in Pantheon.

For an example of a flow graph where it doesn't make sense to re-visit nodes that have multiple incoming edges, see this internal screenshot: https://screenshot.googleplex.com/6ub4e5e5gbzJAvH
