### PR TITLE
docs: Correct input field name in tutorial answer 18

### DIFF
--- a/adev/src/content/tutorials/learn-angular/steps/18-forms-validation/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/18-forms-validation/answer/src/app/app.component.ts
@@ -7,7 +7,7 @@ import {ReactiveFormsModule, Validators} from '@angular/forms';
   template: `
     <form [formGroup]="profileForm">
       <input type="text" formControlName="name" name="name" />
-      <input type="email" formControlName="email" name="password" />
+      <input type="email" formControlName="email" name="email" />
       <button type="submit" [disabled]="!profileForm.valid">Submit</button>
     </form>
   `,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In Tutorial 18: Validating Forms, there was an error in the provided answer. The input field for the email had the input name incorrectly set to “password” instead of “email”.


## What is the new behavior?
The error has been corrected so that the input field for the email now has the correct input name “email” instead of “password”. This ensures that users of the tutorial no longer mistakenly believe that changing the input field name is part of the solution.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
