### PR TITLE
docs(@angular/cli): add Playwright to E2E tools

### DIFF
--- a/adev/src/content/tools/cli/end-to-end.md
+++ b/adev/src/content/tools/cli/end-to-end.md
@@ -23,6 +23,7 @@ For example:
 Cypress: ng add @cypress/schematic
 Nightwatch: ng add @nightwatch/schematics
 WebdriverIO: ng add @wdio/schematics
+Playwright: ng add playwright-ng-schematics
 Puppeteer: ng add @puppeteer/ng-schematics
 
 Would you like to add a package with "e2e" capabilities now?
@@ -30,6 +31,7 @@ No
 ❯ Cypress
 Nightwatch
 WebdriverIO
+Playwright
 Puppeteer
 
 </docs-code>
@@ -55,4 +57,5 @@ Note, their isn't anything "special" about running your tests with any of the in
 | Cypress      | [Getting started with Cypress](https://docs.cypress.io/guides/end-to-end-testing/writing-your-first-end-to-end-test) |
 | Nightwatch   | [Getting started with Nightwatch](https://nightwatchjs.org/guide/writing-tests/introduction.html)                    |
 | WebdriverIO  | [Getting started with Webdriver.io](https://webdriver.io/docs/gettingstarted)                                        |
+| Playwright   | [Getting started with Playwright](https://playwright.dev/docs/writing-tests)                                         |
 | Puppeteer    | [Getting started with Puppeteer](https://pptr.dev)                                                                   |


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

E2E docs don't list Playwright.


## What is the new behavior?

Added Playwright to the list of e2e testing tools.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Goes hand in hand with https://github.com/angular/angular-cli/pull/28377. Just like in that PR, I'm happy to change the ordering of tools if you think Playwright should be in a different position in the list.