### PR TITLE
docs: Correct missing validator and wrong input field name in tutorial

### DIFF
--- a/adev/src/content/tutorials/learn-angular/steps/18-forms-validation/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/18-forms-validation/answer/src/app/app.component.ts
@@ -7,7 +7,7 @@ import {ReactiveFormsModule, Validators} from '@angular/forms';
   template: `
     <form [formGroup]="profileForm">
       <input type="text" formControlName="name" name="name" />
-      <input type="email" formControlName="email" name="password" />
+      <input type="email" formControlName="email" name="email" />
       <button type="submit" [disabled]="!profileForm.valid">Submit</button>
     </form>
   `,
@@ -17,6 +17,6 @@ import {ReactiveFormsModule, Validators} from '@angular/forms';
 export class AppComponent {
   profileForm = new FormGroup({
     name: new FormControl('', Validators.required),
-    email: new FormControl('', Validators.required),
+    email: new FormControl('', [Validators.required, Validators.email]),
   });
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In the answer for Tutorial 18, one of the validators is missing, and an input field has an incorrect name.

Issue Number: N/A


## What is the new behavior?
The answer for Tutorial 18 has been corrected to include the missing validator and to rename the input field correctly. This ensures that the tutorial functions as intended and users can follow it without encountering errors.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
