### PR TITLE
docs(core): fix typo

### DIFF
--- a/adev/src/content/guide/templates/binding.md
+++ b/adev/src/content/guide/templates/binding.md
@@ -208,7 +208,7 @@ You can also set multiple style values in one binding. Angular accepts the follo
   ...
 })
 export class UserProfile {
-  listStyle = 'display: flex; padding: 8px';
+  listStyles = 'display: flex; padding: 8px';
   sectionStyles = {
     border: '1px solid black',
     font-weight: 'bold',


### PR DESCRIPTION
Fix typo where two variable names should be the same but are different.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Variables listStyles and listStyle have different names but should be named the same.

Issue Number: N/A


## What is the new behavior?

The variable in the Angular template and in the Angular class have both the same identifier: listStyles


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This is my first contribution to Angular :)
