### PR TITLE
fix(devtools): remove existing highlight before highlighting another …

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/highlighter.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/highlighter.spec.ts
@@ -183,12 +183,17 @@ describe('highlighter', () => {
   });
 
   describe('highlightSelectedElement', () => {
+    function createElement(name: string) {
+      const element = document.createElement(name);
+      element.style.width = '25px';
+      element.style.height = '20px';
+      element.style.display = 'block';
+      document.body.appendChild(element);
+      return element;
+    }
+
     it('should show overlay', () => {
-      const appNode = document.createElement('app');
-      appNode.style.width = '25px';
-      appNode.style.height = '20px';
-      appNode.style.display = 'block';
-      document.body.appendChild(appNode);
+      const appNode = createElement('app');
       (window as any).ng = {
         getComponent: (el: any) => new (class FakeComponent {})(),
       };
@@ -201,6 +206,20 @@ describe('highlighter', () => {
 
       highlighter.unHighlight();
       expect(document.body.querySelectorAll('.ng-devtools-overlay').length).toBe(0);
+    });
+
+    it('should remove the previous overlay when calling highlightSelectedElement again', () => {
+      const appNode = createElement('app');
+      const appNode2 = createElement('app-two');
+
+      (window as any).ng = {
+        getComponent: (el: any) => new (class FakeComponent {})(),
+      };
+
+      highlighter.highlightSelectedElement(appNode);
+      highlighter.highlightSelectedElement(appNode2);
+      const overlay = document.body.querySelectorAll('.ng-devtools-overlay');
+      expect(overlay.length).toBe(1);
     });
   });
 });

--- a/devtools/projects/ng-devtools-backend/src/lib/highlighter.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/highlighter.ts
@@ -83,6 +83,7 @@ export function getDirectiveName(dir: Type<unknown> | undefined | null): string 
 }
 
 export function highlightSelectedElement(el: Node): void {
+  unHighlight();
   selectedElementOverlay = addHighlightForElement(el);
 }
 


### PR DESCRIPTION
…element

In this PR we will remove the exiting highlight before highlighting the another element so that the highlight always be one

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #57557


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
