### PR TITLE
refactor(migrations): correct catalyst import in signal input migration

### DIFF
--- a/packages/core/schematics/migrations/signal-migration/src/passes/9_migrate_ts_type_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/9_migrate_ts_type_references.ts
@@ -49,9 +49,15 @@ export function pass9__migrateTypeScriptTypeReferences(
 
       const firstArg = reference.from.node.typeArguments[0];
       const sf = firstArg.getSourceFile();
+      // Naive detection of the import. Sufficient for this test file migration.
+      const catalystImport = sf.text.includes(
+        'google3/javascript/angular2/testing/catalyst/fake_async',
+      )
+        ? 'google3/javascript/angular2/testing/catalyst/fake_async'
+        : 'google3/javascript/angular2/testing/catalyst/async';
 
       const unwrapImportExpr = importManager.addImport({
-        exportModuleSpecifier: 'google3/javascript/angular2/testing/catalyst',
+        exportModuleSpecifier: catalystImport,
         exportSymbolName: 'UnwrapSignalInputs',
         requestedFile: sf,
       });

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/catalyst_async_test.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/catalyst_async_test.ts
@@ -2,7 +2,7 @@
 
 import {Input} from '@angular/core';
 
-// google3/javascript/angular2/testing/catalyst/fake_async
+// google3/javascript/angular2/testing/catalyst/async
 // ^^ this allows the advisor to even consider this file.
 
 function it(msg: string, fn: () => void) {}

--- a/packages/core/schematics/migrations/signal-migration/test/golden.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden.txt
@@ -73,14 +73,37 @@ class BothInputImported {
     this.decoratorInput = false;
   }
 }
-@@@@@@ catalyst_test.ts @@@@@@
+@@@@@@ catalyst_async_test.ts @@@@@@
 
-import { UnwrapSignalInputs } from "google3/javascript/angular2/testing/catalyst";
+import { UnwrapSignalInputs } from "google3/javascript/angular2/testing/catalyst/async";
 // tslint:disable
 
 import {input} from '@angular/core';
 
-// angular2/testing/catalyst
+// google3/javascript/angular2/testing/catalyst/async
+// ^^ this allows the advisor to even consider this file.
+
+function it(msg: string, fn: () => void) {}
+function bootstrapTemplate(tmpl: string, inputs: unknown) {}
+
+class MyComp {
+  readonly hello = input('');
+}
+
+it('should work', () => {
+  const inputs = {
+    hello: 'test',
+  } as Partial<UnwrapSignalInputs<MyComp>>;
+  bootstrapTemplate('<my-comp [hello]="hello">', inputs);
+});
+@@@@@@ catalyst_test.ts @@@@@@
+
+import { UnwrapSignalInputs } from "google3/javascript/angular2/testing/catalyst/fake_async";
+// tslint:disable
+
+import {input} from '@angular/core';
+
+// google3/javascript/angular2/testing/catalyst/fake_async
 // ^^ this allows the advisor to even consider this file.
 
 function it(msg: string, fn: () => void) {}

--- a/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
@@ -73,14 +73,37 @@ class BothInputImported {
     this.decoratorInput = false;
   }
 }
-@@@@@@ catalyst_test.ts @@@@@@
+@@@@@@ catalyst_async_test.ts @@@@@@
 
-import { UnwrapSignalInputs } from "google3/javascript/angular2/testing/catalyst";
+import { UnwrapSignalInputs } from "google3/javascript/angular2/testing/catalyst/async";
 // tslint:disable
 
 import {input} from '@angular/core';
 
-// angular2/testing/catalyst
+// google3/javascript/angular2/testing/catalyst/async
+// ^^ this allows the advisor to even consider this file.
+
+function it(msg: string, fn: () => void) {}
+function bootstrapTemplate(tmpl: string, inputs: unknown) {}
+
+class MyComp {
+  readonly hello = input('');
+}
+
+it('should work', () => {
+  const inputs = {
+    hello: 'test',
+  } as Partial<UnwrapSignalInputs<MyComp>>;
+  bootstrapTemplate('<my-comp [hello]="hello">', inputs);
+});
+@@@@@@ catalyst_test.ts @@@@@@
+
+import { UnwrapSignalInputs } from "google3/javascript/angular2/testing/catalyst/fake_async";
+// tslint:disable
+
+import {input} from '@angular/core';
+
+// google3/javascript/angular2/testing/catalyst/fake_async
 // ^^ this allows the advisor to even consider this file.
 
 function it(msg: string, fn: () => void) {}


### PR DESCRIPTION
The paths changed as part of an LSC a while ago. This commit updates the migration to reflect this.