### PR TITLE
docs: fix typo in requirements for NG8106

### DIFF
--- a/adev/src/content/reference/extended-diagnostics/NG8106.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8106.md
@@ -27,7 +27,7 @@ move this to the value assignment of the binding.
 ## Configuration requirements
 
 [`strictTemplates`](tools/cli/template-typecheck#strict-mode) must be enabled for any extended diagnostic to emit.
-`invalidBananaInBox` has no additional requirements beyond `strictTemplates`.
+`suffixNotSupported` has no additional requirements beyond `strictTemplates`.
 
 ## What if I can't avoid this?
 


### PR DESCRIPTION
https://angular.dev/extended-diagnostics/NG8106#configuration-requirements

"Configuration requirements" referred to the wrong diagnostic (`invalidBananaInBox`) likely due to a copy-paste error

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Documentation for `suffixNotSupported` talks about `invalidBananaInBox`.

## What is the new behavior?
Documentation for `suffixNotSupported` talks about `suffixNotSupported`, follows the same formula as most other diagnostics.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
