### PR TITLE
fix(core): update ComponentRef.setInput to use keyof C for input name

### DIFF
--- a/packages/core/src/linker/component_factory.ts
+++ b/packages/core/src/linker/component_factory.ts
@@ -31,7 +31,7 @@ export abstract class ComponentRef<C> {
    * @param name The name of an input.
    * @param value The new value of an input.
    */
-  abstract setInput(name: string, value: unknown): void;
+  abstract setInput(name: keyof C, value: unknown): void;
 
   /**
    * The host or anchor element for this component instance.


### PR DESCRIPTION
Update setInput method in ```ComponentRef``` to accept ```keyof C``` for the name parameter instead of ```string```. this improves type safety by ensuring that only valid keys of the component's inputs can be passed

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The ```ComponentRef.setInput``` method accepts ```name: string```, which does not enforce type safety for input keys and allows any string to be passed. With the introduction of the new Signal API, this could potentially lead to hard-to-notice errors. While using ```keyof C``` is a small improvement, it at least throws a build-time error if an invalid input name is passed. Ideally, it would be better to narrow the type to only accept inputs marked by the ```@Input()``` decorator, but I think it is only possible to narrow it with ```InputSignal``` in future.

Issue Number: N/A


## What is the new behavior?
The setInput method now accepts name: ```keyof C```, ensuring that only valid input keys from the component type ```C``` can be passed. This improves type safety.

## Does this PR introduce a breaking change?

- [x] Yes
- [x] No



Potentially if someone uses a wrong string name, this will throw a build error. However, since the code is non-functional anyway, is this truly a breaking change?

## Other information
