### PR TITLE
fix(compiler): transform pseudo selectors correctly for the encapsulated view

### DIFF
--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -982,7 +982,7 @@ const _cssColonHostContextReGlobal = new RegExp(_polyfillHostContext + _parenSuf
 const _cssColonHostContextRe = new RegExp(_polyfillHostContext + _parenSuffix, 'im');
 const _polyfillHostNoCombinator = _polyfillHost + '-no-combinator';
 const _polyfillHostNoCombinatorWithinPseudoFunction = new RegExp(
-  `:.*(.*${_polyfillHostNoCombinator}.*)`,
+  `:.*\\(.*${_polyfillHostNoCombinator}.*\\)`,
 );
 const _polyfillExactHostNoCombinatorReGlobal = /-shadowcsshost-no-combinator/g;
 const _polyfillHostNoCombinatorRe = /-shadowcsshost-no-combinator([^\s]*)/;

--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -618,7 +618,7 @@ export class ShadowCss {
       let selector = rule.selector;
       let content = rule.content;
       if (rule.selector[0] !== '@') {
-        selector = this._scopeSelector(rule.selector, scopeSelector, hostSelector);
+        selector = this._scopeSelector({selector, scopeSelector, hostSelector});
       } else if (scopedAtRuleIdentifiers.some((atRule) => rule.selector.startsWith(atRule))) {
         content = this._scopeSelectors(rule.content, scopeSelector, hostSelector);
       } else if (rule.selector.startsWith('@font-face') || rule.selector.startsWith('@page')) {
@@ -658,15 +658,34 @@ export class ShadowCss {
     });
   }
 
-  private _scopeSelector(selector: string, scopeSelector: string, hostSelector: string): string {
+  private _scopeSelector({
+    selector,
+    scopeSelector,
+    hostSelector,
+    shouldScope,
+  }: {
+    selector: string;
+    scopeSelector: string;
+    hostSelector: string;
+    shouldScope?: boolean;
+  }): string {
+    // Split the selector into independent parts by `,` (comma) unless
+    // comma is within parenthesis, for example `:is(.one, two)`.
+    const selectorSplitRe = / ?,(?![^\(]*\)) ?/;
+
     return selector
-      .split(/ ?, ?/)
+      .split(selectorSplitRe)
       .map((part) => part.split(_shadowDeepSelectors))
       .map((deepParts) => {
         const [shallowPart, ...otherParts] = deepParts;
         const applyScope = (shallowPart: string) => {
           if (this._selectorNeedsScoping(shallowPart, scopeSelector)) {
-            return this._applySelectorScope(shallowPart, scopeSelector, hostSelector);
+            return this._applySelectorScope({
+              selector: shallowPart,
+              scopeSelector,
+              hostSelector,
+              shouldScope,
+            });
           } else {
             return shallowPart;
           }
@@ -715,11 +734,17 @@ export class ShadowCss {
 
   // return a selector with [name] suffix on each simple selector
   // e.g. .foo.bar > .zot becomes .foo[name].bar[name] > .zot[name]  /** @internal */
-  private _applySelectorScope(
-    selector: string,
-    scopeSelector: string,
-    hostSelector: string,
-  ): string {
+  private _applySelectorScope({
+    selector,
+    scopeSelector,
+    hostSelector,
+    shouldScope,
+  }: {
+    selector: string;
+    scopeSelector: string;
+    hostSelector: string;
+    shouldScope?: boolean;
+  }): string {
     const isRe = /\[is=([^\]]*)\]/g;
     scopeSelector = scopeSelector.replace(isRe, (_: string, ...parts: string[]) => parts[0]);
 
@@ -748,13 +773,46 @@ export class ShadowCss {
       return scopedP;
     };
 
+    // Wraps `_scopeSelectorPart()` to not use it directly on selectors with
+    // pseudo selector functions like `:where()`. Selectors within pseudo selector
+    // functions are recursively sent to `_scopeSelector()` with the `shouldScope`
+    // argument, so the selectors get scoped correctly.
+    const _pseudoFunctionAwareScopeSelectorPart = (selectorPart: string) => {
+      let scopedPart = '';
+
+      const cssPseudoSelectorFunctionMatch = selectorPart.match(_cssPseudoSelectorFunctionPrefix);
+      if (cssPseudoSelectorFunctionMatch) {
+        const [cssPseudoSelectorFunction] = cssPseudoSelectorFunctionMatch;
+        // Unwrap the pseudo selector, to scope its contents.
+        // For example, `:where(selectorToScope)` -> `selectorToScope`.
+        const selectorToScope = selectorPart.slice(cssPseudoSelectorFunction.length, -1);
+
+        const scopedInnerPart = this._scopeSelector({
+          selector: selectorToScope,
+          scopeSelector,
+          hostSelector,
+          shouldScope: shouldScopeIndicator,
+        });
+        // Put the result back into the pseudo selector function.
+        scopedPart = `${cssPseudoSelectorFunction}${scopedInnerPart})`;
+      } else {
+        shouldScopeIndicator =
+          shouldScopeIndicator || selectorPart.includes(_polyfillHostNoCombinator);
+        scopedPart = shouldScopeIndicator ? _scopeSelectorPart(selectorPart) : selectorPart;
+      }
+
+      return scopedPart;
+    };
+
     const safeContent = new SafeSelector(selector);
     selector = safeContent.content();
 
     let scopedSelector = '';
     let startIndex = 0;
     let res: RegExpExecArray | null;
-    const sep = /( |>|\+|~(?!=))\s*/g;
+    // Spaces aren't used as a delimeter if they are within parenthesis, for example
+    // `:where(.one .two)` stays intact.
+    const sep = /( (?![^\(]*\))|>|\+|~(?!=))\s*/g;
 
     // If a selector appears before :host it should not be shimmed as it
     // matches on ancestor elements and not on elements in the host's shadow
@@ -769,7 +827,7 @@ export class ShadowCss {
     //   `:host-context(tag)`)
     const hasHost = selector.includes(_polyfillHostNoCombinator);
     // Only scope parts after the first `-shadowcsshost-no-combinator` when it is present
-    let shouldScope = !hasHost;
+    let shouldScopeIndicator = shouldScope ?? !hasHost;
 
     while ((res = sep.exec(selector)) !== null) {
       const separator = res[1];
@@ -788,15 +846,13 @@ export class ShadowCss {
         continue;
       }
 
-      shouldScope = shouldScope || part.includes(_polyfillHostNoCombinator);
-      const scopedPart = shouldScope ? _scopeSelectorPart(part) : part;
+      const scopedPart = _pseudoFunctionAwareScopeSelectorPart(part);
       scopedSelector += `${scopedPart} ${separator} `;
       startIndex = sep.lastIndex;
     }
 
     const part = selector.substring(startIndex);
-    shouldScope = shouldScope || part.includes(_polyfillHostNoCombinator);
-    scopedSelector += shouldScope ? _scopeSelectorPart(part) : part;
+    scopedSelector += _pseudoFunctionAwareScopeSelectorPart(part);
 
     // replace the placeholders with their original values
     return safeContent.restore(scopedSelector);
@@ -864,6 +920,7 @@ class SafeSelector {
   }
 }
 
+const _cssPseudoSelectorFunctionPrefix = /^:(where|is)\(/gi;
 const _cssContentNextSelectorRe =
   /polyfill-next-selector[^}]*content:[\s]*?(['"])(.*?)\1[;\s]*}([^{]*?){/gim;
 const _cssContentRuleRe = /(polyfill-rule)[^}]*(content:[\s]*(['"])(.*?)\3)[;\s]*[^}]*}/gim;

--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -340,7 +340,7 @@ export class ShadowCss {
    *    captures how many (if any) leading whitespaces are present or a comma
    *  - (?:(?:(['"])((?:\\\\|\\\2|(?!\2).)+)\2)|(-?[A-Za-z][\w\-]*))
    *    captures two different possible keyframes, ones which are quoted or ones which are valid css
-   * idents (custom properties excluded)
+   * indents (custom properties excluded)
    *  - (?=[,\s;]|$)
    *    simply matches the end of the possible keyframe, valid endings are: a comma, a space, a
    * semicolon or the end of the string
@@ -461,7 +461,7 @@ export class ShadowCss {
    */
   private _scopeCssText(cssText: string, scopeSelector: string, hostSelector: string): string {
     const unscopedRules = this._extractUnscopedRulesFromCssText(cssText);
-    // replace :host and :host-context -shadowcsshost and -shadowcsshost respectively
+    // replace :host and :host-context with -shadowcsshost and -shadowcsshostcontext respectively
     cssText = this._insertPolyfillHostInCssText(cssText);
     cssText = this._convertColonHost(cssText);
     cssText = this._convertColonHostContext(cssText);
@@ -618,7 +618,12 @@ export class ShadowCss {
       let selector = rule.selector;
       let content = rule.content;
       if (rule.selector[0] !== '@') {
-        selector = this._scopeSelector({selector, scopeSelector, hostSelector});
+        selector = this._scopeSelector({
+          selector,
+          scopeSelector,
+          hostSelector,
+          isParentSelector: true,
+        });
       } else if (scopedAtRuleIdentifiers.some((atRule) => rule.selector.startsWith(atRule))) {
         content = this._scopeSelectors(rule.content, scopeSelector, hostSelector);
       } else if (rule.selector.startsWith('@font-face') || rule.selector.startsWith('@page')) {
@@ -658,20 +663,30 @@ export class ShadowCss {
     });
   }
 
+  private _safeSelector: SafeSelector | undefined;
+  private _shouldScopeIndicator: boolean | undefined;
+
+  // `isParentSelector` is used to distinguish the selectors which are coming from
+  // the initial selector string and any nested selectors, parsed recursively,
+  // for example `selector = 'a:where(.one)'` could be the parent, while recursive call
+  // would have `selector = '.one'`.
   private _scopeSelector({
     selector,
     scopeSelector,
     hostSelector,
-    shouldScope,
+    isParentSelector = false,
   }: {
     selector: string;
     scopeSelector: string;
     hostSelector: string;
-    shouldScope?: boolean;
+    isParentSelector?: boolean;
   }): string {
     // Split the selector into independent parts by `,` (comma) unless
     // comma is within parenthesis, for example `:is(.one, two)`.
-    const selectorSplitRe = / ?,(?![^\(]*\)) ?/;
+    // Negative lookup after comma allows not splitting inside nested parenthesis,
+    // up to three levels (((,))).
+    const selectorSplitRe =
+      / ?,(?!(?:[^)(]*(?:\([^)(]*(?:\([^)(]*(?:\([^)(]*\)[^)(]*)*\)[^)(]*)*\)[^)(]*)*\))) ?/;
 
     return selector
       .split(selectorSplitRe)
@@ -684,7 +699,7 @@ export class ShadowCss {
               selector: shallowPart,
               scopeSelector,
               hostSelector,
-              shouldScope,
+              isParentSelector,
             });
           } else {
             return shallowPart;
@@ -718,9 +733,9 @@ export class ShadowCss {
     if (_polyfillHostRe.test(selector)) {
       const replaceBy = `[${hostSelector}]`;
       return selector
-        .replace(_polyfillHostNoCombinatorRe, (hnc, selector) => {
+        .replace(_polyfillHostNoCombinatorReGlobal, (_hnc, selector) => {
           return selector.replace(
-            /([^:]*)(:*)(.*)/,
+            /([^:\)]*)(:*)(.*)/,
             (_: string, before: string, colon: string, after: string) => {
               return before + replaceBy + colon + after;
             },
@@ -738,12 +753,12 @@ export class ShadowCss {
     selector,
     scopeSelector,
     hostSelector,
-    shouldScope,
+    isParentSelector,
   }: {
     selector: string;
     scopeSelector: string;
     hostSelector: string;
-    shouldScope?: boolean;
+    isParentSelector?: boolean;
   }): string {
     const isRe = /\[is=([^\]]*)\]/g;
     scopeSelector = scopeSelector.replace(isRe, (_: string, ...parts: string[]) => parts[0]);
@@ -759,6 +774,10 @@ export class ShadowCss {
 
       if (p.includes(_polyfillHostNoCombinator)) {
         scopedP = this._applySimpleSelectorScope(p, scopeSelector, hostSelector);
+        if (_polyfillHostNoCombinatorWithinPseudoFunction.test(p)) {
+          const [_, before, colon, after] = scopedP.match(/([^:]*)(:*)(.*)/)!;
+          scopedP = before + attrName + colon + after;
+        }
       } else {
         // remove :host since it should be unnecessary
         const t = p.replace(_polyfillHostRe, '');
@@ -775,44 +794,66 @@ export class ShadowCss {
 
     // Wraps `_scopeSelectorPart()` to not use it directly on selectors with
     // pseudo selector functions like `:where()`. Selectors within pseudo selector
-    // functions are recursively sent to `_scopeSelector()` with the `shouldScope`
-    // argument, so the selectors get scoped correctly.
+    // functions are recursively sent to `_scopeSelector()`.
     const _pseudoFunctionAwareScopeSelectorPart = (selectorPart: string) => {
       let scopedPart = '';
 
-      const cssPseudoSelectorFunctionMatch = selectorPart.match(_cssPseudoSelectorFunctionPrefix);
-      if (cssPseudoSelectorFunctionMatch) {
-        const [cssPseudoSelectorFunction] = cssPseudoSelectorFunctionMatch;
+      const cssPrefixWithPseudoSelectorFunctionMatch = selectorPart.match(
+        _cssPrefixWithPseudoSelectorFunction,
+      );
+      if (cssPrefixWithPseudoSelectorFunctionMatch) {
+        const [cssPseudoSelectorFunction, mainSelector, pseudoSelector] =
+          cssPrefixWithPseudoSelectorFunctionMatch;
+        const hasOuterHostNoCombinator = mainSelector.includes(_polyfillHostNoCombinator);
+        const scopedMainSelector = mainSelector.replace(
+          _polyfillHostNoCombinatorReGlobal,
+          `[${hostSelector}]`,
+        );
+
         // Unwrap the pseudo selector, to scope its contents.
-        // For example, `:where(selectorToScope)` -> `selectorToScope`.
+        // For example,
+        // - `:where(selectorToScope)` -> `selectorToScope`;
+        // - `div:is(.foo, .bar)` -> `.foo, .bar`.
         const selectorToScope = selectorPart.slice(cssPseudoSelectorFunction.length, -1);
+
+        if (selectorToScope.includes(_polyfillHostNoCombinator)) {
+          this._shouldScopeIndicator = true;
+        }
 
         const scopedInnerPart = this._scopeSelector({
           selector: selectorToScope,
           scopeSelector,
           hostSelector,
-          shouldScope: shouldScopeIndicator,
         });
+
         // Put the result back into the pseudo selector function.
-        scopedPart = `${cssPseudoSelectorFunction}${scopedInnerPart})`;
+        scopedPart = `${scopedMainSelector}:${pseudoSelector}(${scopedInnerPart})`;
+
+        this._shouldScopeIndicator = this._shouldScopeIndicator || hasOuterHostNoCombinator;
       } else {
-        shouldScopeIndicator =
-          shouldScopeIndicator || selectorPart.includes(_polyfillHostNoCombinator);
-        scopedPart = shouldScopeIndicator ? _scopeSelectorPart(selectorPart) : selectorPart;
+        this._shouldScopeIndicator =
+          this._shouldScopeIndicator || selectorPart.includes(_polyfillHostNoCombinator);
+        scopedPart = this._shouldScopeIndicator ? _scopeSelectorPart(selectorPart) : selectorPart;
       }
 
       return scopedPart;
     };
 
-    const safeContent = new SafeSelector(selector);
-    selector = safeContent.content();
+    if (isParentSelector) {
+      this._safeSelector = new SafeSelector(selector);
+      selector = this._safeSelector.content();
+    }
 
     let scopedSelector = '';
     let startIndex = 0;
     let res: RegExpExecArray | null;
     // Combinators aren't used as a delimiter if they are within parenthesis,
     // for example `:where(.one .two)` stays intact.
-    const sep = /( |>|\+|~(?!=))(?![^\(]*\))\s*/g;
+    // Similarly to selector separation by comma initially, negative lookahead
+    // is used here to not break selectors within nested parenthesis up to three
+    // nested layers.
+    const sep =
+      /( |>|\+|~(?!=))(?!([^)(]*(?:\([^)(]*(?:\([^)(]*(?:\([^)(]*\)[^)(]*)*\)[^)(]*)*\)[^)(]*)*\)))\s*/g;
 
     // If a selector appears before :host it should not be shimmed as it
     // matches on ancestor elements and not on elements in the host's shadow
@@ -826,8 +867,13 @@ export class ShadowCss {
     // - `tag :host` -> `tag [h]` (`tag` is not scoped because it's considered part of a
     //   `:host-context(tag)`)
     const hasHost = selector.includes(_polyfillHostNoCombinator);
-    // Only scope parts after the first `-shadowcsshost-no-combinator` when it is present
-    let shouldScopeIndicator = shouldScope ?? !hasHost;
+    // Only scope parts after or on the same level as the first `-shadowcsshost-no-combinator`
+    // when it is present. The selector has the same level when it is a part of a pseudo
+    // selector, like `:where()`, for example `:where(:host, .foo)` would result in `.foo`
+    // being scoped.
+    if (isParentSelector || this._shouldScopeIndicator) {
+      this._shouldScopeIndicator = !hasHost;
+    }
 
     while ((res = sep.exec(selector)) !== null) {
       const separator = res[1];
@@ -855,7 +901,8 @@ export class ShadowCss {
     scopedSelector += _pseudoFunctionAwareScopeSelectorPart(part);
 
     // replace the placeholders with their original values
-    return safeContent.restore(scopedSelector);
+    // using values stored inside the `safeSelector` instance.
+    return this._safeSelector!.restore(scopedSelector);
   }
 
   private _insertPolyfillHostInCssText(selector: string): string {
@@ -920,7 +967,7 @@ class SafeSelector {
   }
 }
 
-const _cssPseudoSelectorFunctionPrefix = /^:(where|is)\(/gi;
+const _cssPrefixWithPseudoSelectorFunction = /^([^:]*):(where|is)\(/i;
 const _cssContentNextSelectorRe =
   /polyfill-next-selector[^}]*content:[\s]*?(['"])(.*?)\1[;\s]*}([^{]*?){/gim;
 const _cssContentRuleRe = /(polyfill-rule)[^}]*(content:[\s]*(['"])(.*?)\3)[;\s]*[^}]*}/gim;
@@ -934,7 +981,11 @@ const _cssColonHostRe = new RegExp(_polyfillHost + _parenSuffix, 'gim');
 const _cssColonHostContextReGlobal = new RegExp(_polyfillHostContext + _parenSuffix, 'gim');
 const _cssColonHostContextRe = new RegExp(_polyfillHostContext + _parenSuffix, 'im');
 const _polyfillHostNoCombinator = _polyfillHost + '-no-combinator';
+const _polyfillHostNoCombinatorWithinPseudoFunction = new RegExp(
+  `:.*(.*${_polyfillHostNoCombinator}.*)`,
+);
 const _polyfillHostNoCombinatorRe = /-shadowcsshost-no-combinator([^\s]*)/;
+const _polyfillHostNoCombinatorReGlobal = new RegExp(_polyfillHostNoCombinatorRe, 'g');
 const _shadowDOMSelectorsRe = [
   /::shadow/g,
   /::content/g,

--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -806,7 +806,7 @@ export class ShadowCss {
           cssPrefixWithPseudoSelectorFunctionMatch;
         const hasOuterHostNoCombinator = mainSelector.includes(_polyfillHostNoCombinator);
         const scopedMainSelector = mainSelector.replace(
-          _polyfillHostNoCombinatorReGlobal,
+          _polyfillExactHostNoCombinatorReGlobal,
           `[${hostSelector}]`,
         );
 
@@ -984,6 +984,7 @@ const _polyfillHostNoCombinator = _polyfillHost + '-no-combinator';
 const _polyfillHostNoCombinatorWithinPseudoFunction = new RegExp(
   `:.*(.*${_polyfillHostNoCombinator}.*)`,
 );
+const _polyfillExactHostNoCombinatorReGlobal = /-shadowcsshost-no-combinator/g;
 const _polyfillHostNoCombinatorRe = /-shadowcsshost-no-combinator([^\s]*)/;
 const _polyfillHostNoCombinatorReGlobal = new RegExp(_polyfillHostNoCombinatorRe, 'g');
 const _shadowDOMSelectorsRe = [

--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -541,7 +541,7 @@ export class ShadowCss {
    * .foo<scopeName> .bar { ... }
    */
   private _convertColonHostContext(cssText: string): string {
-    return cssText.replace(_cssColonHostContextReGlobal, (selectorText) => {
+    return cssText.replace(_cssColonHostContextReGlobal, (selectorText, pseudoPrefix) => {
       // We have captured a selector that contains a `:host-context` rule.
 
       // For backward compatibility `:host-context` may contain a comma separated list of selectors.
@@ -596,10 +596,12 @@ export class ShadowCss {
       }
 
       // The context selectors now must be combined with each other to capture all the possible
-      // selectors that `:host-context` can match. See `combineHostContextSelectors()` for more
+      // selectors that `:host-context` can match. See `_combineHostContextSelectors()` for more
       // info about how this is done.
       return contextSelectorGroups
-        .map((contextSelectors) => combineHostContextSelectors(contextSelectors, selectorText))
+        .map((contextSelectors) =>
+          _combineHostContextSelectors(contextSelectors, selectorText, pseudoPrefix),
+        )
         .join(', ');
     });
   }
@@ -802,18 +804,12 @@ export class ShadowCss {
         _cssPrefixWithPseudoSelectorFunction,
       );
       if (cssPrefixWithPseudoSelectorFunctionMatch) {
-        const [cssPseudoSelectorFunction, mainSelector, pseudoSelector] =
-          cssPrefixWithPseudoSelectorFunctionMatch;
-        const hasOuterHostNoCombinator = mainSelector.includes(_polyfillHostNoCombinator);
-        const scopedMainSelector = mainSelector.replace(
-          _polyfillExactHostNoCombinatorReGlobal,
-          `[${hostSelector}]`,
-        );
+        const [cssPseudoSelectorFunction] = cssPrefixWithPseudoSelectorFunctionMatch;
 
-        // Unwrap the pseudo selector, to scope its contents.
+        // Unwrap the pseudo selector to scope its contents.
         // For example,
         // - `:where(selectorToScope)` -> `selectorToScope`;
-        // - `div:is(.foo, .bar)` -> `.foo, .bar`.
+        // - `:is(.foo, .bar)` -> `.foo, .bar`.
         const selectorToScope = selectorPart.slice(cssPseudoSelectorFunction.length, -1);
 
         if (selectorToScope.includes(_polyfillHostNoCombinator)) {
@@ -827,9 +823,7 @@ export class ShadowCss {
         });
 
         // Put the result back into the pseudo selector function.
-        scopedPart = `${scopedMainSelector}:${pseudoSelector}(${scopedInnerPart})`;
-
-        this._shouldScopeIndicator = this._shouldScopeIndicator || hasOuterHostNoCombinator;
+        scopedPart = `${cssPseudoSelectorFunction}${scopedInnerPart})`;
       } else {
         this._shouldScopeIndicator =
           this._shouldScopeIndicator || selectorPart.includes(_polyfillHostNoCombinator);
@@ -967,7 +961,8 @@ class SafeSelector {
   }
 }
 
-const _cssPrefixWithPseudoSelectorFunction = /^([^:]*):(where|is)\(/i;
+const _cssScopedPseudoFunctionPrefix = '(:(where|is)\\()?';
+const _cssPrefixWithPseudoSelectorFunction = /^:(where|is)\(/i;
 const _cssContentNextSelectorRe =
   /polyfill-next-selector[^}]*content:[\s]*?(['"])(.*?)\1[;\s]*}([^{]*?){/gim;
 const _cssContentRuleRe = /(polyfill-rule)[^}]*(content:[\s]*(['"])(.*?)\3)[;\s]*[^}]*}/gim;
@@ -978,13 +973,15 @@ const _polyfillHost = '-shadowcsshost';
 const _polyfillHostContext = '-shadowcsscontext';
 const _parenSuffix = '(?:\\((' + '(?:\\([^)(]*\\)|[^)(]*)+?' + ')\\))?([^,{]*)';
 const _cssColonHostRe = new RegExp(_polyfillHost + _parenSuffix, 'gim');
-const _cssColonHostContextReGlobal = new RegExp(_polyfillHostContext + _parenSuffix, 'gim');
+const _cssColonHostContextReGlobal = new RegExp(
+  _cssScopedPseudoFunctionPrefix + '(' + _polyfillHostContext + _parenSuffix + ')',
+  'gim',
+);
 const _cssColonHostContextRe = new RegExp(_polyfillHostContext + _parenSuffix, 'im');
 const _polyfillHostNoCombinator = _polyfillHost + '-no-combinator';
 const _polyfillHostNoCombinatorWithinPseudoFunction = new RegExp(
   `:.*\\(.*${_polyfillHostNoCombinator}.*\\)`,
 );
-const _polyfillExactHostNoCombinatorReGlobal = /-shadowcsshost-no-combinator/g;
 const _polyfillHostNoCombinatorRe = /-shadowcsshost-no-combinator([^\s]*)/;
 const _polyfillHostNoCombinatorReGlobal = new RegExp(_polyfillHostNoCombinatorRe, 'g');
 const _shadowDOMSelectorsRe = [
@@ -1237,7 +1234,11 @@ function unescapeQuotes(str: string, isQuoted: boolean): string {
  * @param contextSelectors an array of context selectors that will be combined.
  * @param otherSelectors the rest of the selectors that are not context selectors.
  */
-function combineHostContextSelectors(contextSelectors: string[], otherSelectors: string): string {
+function _combineHostContextSelectors(
+  contextSelectors: string[],
+  otherSelectors: string,
+  pseudoPrefix = '',
+): string {
   const hostMarker = _polyfillHostNoCombinator;
   _polyfillHostRe.lastIndex = 0; // reset the regex to ensure we get an accurate test
   const otherSelectorsHasHost = _polyfillHostRe.test(otherSelectors);
@@ -1266,8 +1267,8 @@ function combineHostContextSelectors(contextSelectors: string[], otherSelectors:
   return combined
     .map((s) =>
       otherSelectorsHasHost
-        ? `${s}${otherSelectors}`
-        : `${s}${hostMarker}${otherSelectors}, ${s} ${hostMarker}${otherSelectors}`,
+        ? `${pseudoPrefix}${s}${otherSelectors}`
+        : `${pseudoPrefix}${s}${hostMarker}${otherSelectors}, ${pseudoPrefix}${s} ${hostMarker}${otherSelectors}`,
     )
     .join(',');
 }

--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -810,9 +810,9 @@ export class ShadowCss {
     let scopedSelector = '';
     let startIndex = 0;
     let res: RegExpExecArray | null;
-    // Spaces aren't used as a delimeter if they are within parenthesis, for example
+    // Combinators aren't used as a delimeter if they are within parenthesis, for example
     // `:where(.one .two)` stays intact.
-    const sep = /( (?![^\(]*\))|>|\+|~(?!=))\s*/g;
+    const sep = /( |>|\+|~(?!=))(?![^\(]*\))\s*/g;
 
     // If a selector appears before :host it should not be shimmed as it
     // matches on ancestor elements and not on elements in the host's shadow

--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -810,8 +810,8 @@ export class ShadowCss {
     let scopedSelector = '';
     let startIndex = 0;
     let res: RegExpExecArray | null;
-    // Combinators aren't used as a delimeter if they are within parenthesis, for example
-    // `:where(.one .two)` stays intact.
+    // Combinators aren't used as a delimiter if they are within parenthesis,
+    // for example `:where(.one .two)` stays intact.
     const sep = /( |>|\+|~(?!=))(?![^\(]*\))\s*/g;
 
     // If a selector appears before :host it should not be shimmed as it

--- a/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
+++ b/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
@@ -107,6 +107,42 @@ describe('ShadowCss, :host and :host-context', () => {
   });
 
   describe(':host-context', () => {
+    it('should transform :host-context with pseudo selectors', () => {
+      expect(
+        shim(':host-context(backdrop:not(.borderless)) .backdrop {}', 'contenta', 'hosta'),
+      ).toEqualCss(
+        'backdrop:not(.borderless)[hosta] .backdrop[contenta], backdrop:not(.borderless) [hosta] .backdrop[contenta] {}',
+      );
+      expect(shim(':where(:host-context(backdrop)) {}', 'contenta', 'hosta')).toEqualCss(
+        ':where(backdrop[hosta]), :where(backdrop [hosta]) {}',
+      );
+      expect(shim(':where(:host-context(outer1)) :host(bar) {}', 'contenta', 'hosta')).toEqualCss(
+        ':where(outer1) bar[hosta] {}',
+      );
+      expect(
+        shim(':where(:host-context(.one)) :where(:host-context(.two)) {}', 'contenta', 'a-host'),
+      ).toEqualCss(
+        ':where(.one.two[a-host]), ' + // `one` and `two` both on the host
+          ':where(.one.two [a-host]), ' + // `one` and `two` are both on the same ancestor
+          ':where(.one .two[a-host]), ' + // `one` is an ancestor and `two` is on the host
+          ':where(.one .two [a-host]), ' + // `one` and `two` are both ancestors (in that order)
+          ':where(.two .one[a-host]), ' + // `two` is an ancestor and `one` is on the host
+          ':where(.two .one [a-host])' + // `two` and `one` are both ancestors (in that order)
+          ' {}',
+      );
+      expect(
+        shim(':where(:host-context(backdrop)) .foo ~ .bar {}', 'contenta', 'hosta'),
+      ).toEqualCss(
+        ':where(backdrop[hosta]) .foo[contenta] ~ .bar[contenta], :where(backdrop [hosta]) .foo[contenta] ~ .bar[contenta] {}',
+      );
+      expect(shim(':where(:host-context(backdrop)) :host {}', 'contenta', 'hosta')).toEqualCss(
+        ':where(backdrop) [hosta] {}',
+      );
+      expect(shim('div:where(:host-context(backdrop)) :host {}', 'contenta', 'hosta')).toEqualCss(
+        'div:where(backdrop) [hosta] {}',
+      );
+    });
+
     it('should handle tag selector', () => {
       expect(shim(':host-context(div) {}', 'contenta', 'a-host')).toEqualCss(
         'div[a-host], div [a-host] {}',

--- a/packages/compiler/test/shadow_css/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css/shadow_css_spec.ts
@@ -69,7 +69,7 @@ describe('ShadowCss', () => {
     expect(shim('[attr] {}', 'contenta')).toEqualCss('[attr][contenta] {}');
   });
 
-  it('should transform :host with attributes and pseudo selectors', () => {
+  it('should transform :host and :host-context with attributes and pseudo selectors', () => {
     expect(shim(':host [attr] {}', 'contenta', 'hosta')).toEqualCss('[hosta] [attr][contenta] {}');
     expect(shim(':host(create-first-project) {}', 'contenta', 'hosta')).toEqualCss(
       'create-first-project[hosta] {}',
@@ -77,6 +77,11 @@ describe('ShadowCss', () => {
     expect(shim(':host[attr] {}', 'contenta', 'hosta')).toEqualCss('[attr][hosta] {}');
     expect(shim(':host[attr]:where(:not(.cm-button)) {}', 'contenta', 'hosta')).toEqualCss(
       '[hosta][attr]:where(:not(.cm-button)) {}',
+    );
+    expect(
+      shim(':host-context(backdrop:not(.borderless)) .backdrop {}', 'contenta', 'hosta'),
+    ).toEqualCss(
+      'backdrop:not(.borderless)[hosta] .backdrop[contenta], backdrop:not(.borderless) [hosta] .backdrop[contenta] {}',
     );
   });
 

--- a/packages/compiler/test/shadow_css/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css/shadow_css_spec.ts
@@ -67,7 +67,17 @@ describe('ShadowCss', () => {
     expect(shim('one[attr] {}', 'contenta')).toEqualCss('one[attr][contenta] {}');
     expect(shim('[is="one"] {}', 'contenta')).toEqualCss('[is="one"][contenta] {}');
     expect(shim('[attr] {}', 'contenta')).toEqualCss('[attr][contenta] {}');
+  });
+
+  it('should transform :host with attributes and pseudo selectors', () => {
     expect(shim(':host [attr] {}', 'contenta', 'hosta')).toEqualCss('[hosta] [attr][contenta] {}');
+    expect(shim(':host(create-first-project) {}', 'contenta', 'hosta')).toEqualCss(
+      'create-first-project[hosta] {}',
+    );
+    expect(shim(':host[attr] {}', 'contenta', 'hosta')).toEqualCss('[attr][hosta] {}');
+    expect(shim(':host[attr]:where(:not(.cm-button)) {}', 'contenta', 'hosta')).toEqualCss(
+      '[hosta][attr]:where(:not(.cm-button)) {}',
+    );
   });
 
   it('should handle escaped sequences in selectors', () => {

--- a/packages/compiler/test/shadow_css/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css/shadow_css_spec.ts
@@ -104,6 +104,15 @@ describe('ShadowCss', () => {
     expect(shim(':where(.one, .two) {}', 'contenta', 'hosta')).toEqualCss(
       ':where(.one[contenta], .two[contenta]) {}',
     );
+    expect(shim(':where(.one > .two) {}', 'contenta', 'hosta')).toEqualCss(
+      ':where(.one[contenta] > .two[contenta]) {}',
+    );
+    expect(shim(':where(> .one) {}', 'contenta', 'hosta')).toEqualCss(
+      ':where( > .one[contenta]) {}',
+    );
+    expect(shim(':where(:not(.one) ~ .two) {}', 'contenta', 'hosta')).toEqualCss(
+      ':where([contenta]:not(.one) ~ .two[contenta]) {}',
+    );
 
     // :is()
     expect(shim('div:is(.foo) {}', 'contenta', 'a-host')).toEqualCss('div[contenta]:is(.foo) {}');
@@ -147,6 +156,9 @@ describe('ShadowCss', () => {
     expect(shim('div:has(a) :host {}', 'contenta', 'hosta')).toEqualCss('div:has(a) [hosta] {}');
     expect(shim(':has(a) :host :has(b) {}', 'contenta', 'hosta')).toEqualCss(
       ':has(a) [hosta] [contenta]:has(b) {}',
+    );
+    expect(shim('div:has(~ .one) {}', 'contenta', 'hosta')).toEqualCss(
+      'div[contenta]:has(~ .one) {}',
     );
     // Unlike `:is()` or `:where()` the attribute selector isn't placed inside
     // of `:has()`. That is deliberate, `[contenta]:has(a)` would select all


### PR DESCRIPTION
fix scoping and transforming logic of the `shimCssText` for the components with encapsulated view:
- add support for pseudo selector functions
- apply content scoping for inner selectors of `:is()` and `:where()`
- allow multiple comma separated selectors inside pseudo selectors

Fixes #45686

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Pseudo selector functions aren't parsed/transformed correctly at the moment
The provided examples inside the issue are added as unit tests as well as other test cases.
Issue Number: #45686 


## What is the new behavior?
Specified in unit tests.
- selectors are parsed by comma if comma is not inside the parenthesis, for example `:where(.one, .two)` stays as a single selector for scoping, previously it was split into two parts `:where(.one` and `.two)`.
- selector parts aren't broken into pieces by combinators if they are within parenthesis, for example `:where(.one > .two)` isn't split
- selectors within `:is()` and `:where()` are being scoped internally, that is especially important for `:where()` since this selectors doesn't increase specificity, allowing overloading theme specific values not risking order related issues.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
