### PR TITLE
fix(http): preserve all headers from Headers object

### DIFF
--- a/packages/common/http/src/headers.ts
+++ b/packages/common/http/src/headers.ts
@@ -56,21 +56,15 @@ export class HttpHeaders {
           const index = line.indexOf(':');
           if (index > 0) {
             const name = line.slice(0, index);
-            const key = name.toLowerCase();
             const value = line.slice(index + 1).trim();
-            this.maybeSetNormalizedName(name, key);
-            if (this.headers.has(key)) {
-              this.headers.get(key)!.push(value);
-            } else {
-              this.headers.set(key, [value]);
-            }
+            this.addHeaderEntry(name, value);
           }
         });
       };
     } else if (typeof Headers !== 'undefined' && headers instanceof Headers) {
       this.headers = new Map<string, string[]>();
-      headers.forEach((values: string, name: string) => {
-        this.setHeaderEntries(name, values);
+      headers.forEach((value: string, name: string) => {
+        this.addHeaderEntry(name, value);
       });
     } else {
       this.lazyInit = () => {
@@ -246,6 +240,16 @@ export class HttpHeaders {
           }
         }
         break;
+    }
+  }
+
+  private addHeaderEntry(name: string, value: string) {
+    const key = name.toLowerCase();
+    this.maybeSetNormalizedName(name, key);
+    if (this.headers.has(key)) {
+      this.headers.get(key)!.push(value);
+    } else {
+      this.headers.set(key, [value]);
     }
   }
 

--- a/packages/common/http/test/headers_spec.ts
+++ b/packages/common/http/test/headers_spec.ts
@@ -46,6 +46,16 @@ describe('HttpHeaders', () => {
       expect(headers.getAll('foo')).toEqual(['second']);
     });
 
+    it('should keep all values when initialized from a Headers object with duplicate headers', () => {
+      const standardHeaders = new Headers([
+        ['Set-Cookie', 'cookie1=foo'],
+        ['Set-Cookie', 'cookie2=bar'],
+      ]);
+      const headers = new HttpHeaders(standardHeaders);
+
+      expect(headers.getAll('Set-Cookie')).toEqual(['cookie1=foo', 'cookie2=bar']);
+    });
+
     it('should throw an error when null is passed as header', () => {
       // Note: the `strictNullChecks` set to `false` in TS config would make `null`
       // valid value within the headers object, thus this test verifies this scenario.


### PR DESCRIPTION
when initialized from a `Headers` object containing multiple values for the same header, `HttpHeaders` now contains all the header values instead of only having one of them.

Fixes #57798

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When initialized from a `Headers` object containing multiple values for the same header, `HttpHeaders` contained only one of the header values.

Issue Number: #57798

## What is the new behavior?

It now contains all the header values, as in the original `Headers` object.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

(It does change the behavior of the HttpHeaders class, which might cause behavior changes in existing code, but the old behavior was a bug). 
