### PR TITLE
fix(migrations): account for explicit standalone: false in migration

### DIFF
--- a/packages/core/schematics/test/standalone_migration_spec.ts
+++ b/packages/core/schematics/test/standalone_migration_spec.ts
@@ -2218,6 +2218,32 @@ describe('standalone migration', () => {
     );
   });
 
+  it('should handle a directive that is explicitly standalone: false', async () => {
+    writeFile(
+      'module.ts',
+      `
+      import {NgModule, Directive} from '@angular/core';
+
+      @Directive({selector: '[dir]', standalone: false})
+      export class MyDir {}
+
+      @NgModule({declarations: [MyDir], exports: [MyDir]})
+      export class Mod {}
+    `,
+    );
+
+    await runMigration('convert-to-standalone');
+
+    const result = tree.readContent('module.ts');
+
+    expect(stripWhitespace(result)).toContain(
+      stripWhitespace(`@Directive({selector: '[dir]', standalone: true})`),
+    );
+    expect(stripWhitespace(result)).toContain(
+      stripWhitespace(`@NgModule({imports: [MyDir], exports: [MyDir]})`),
+    );
+  });
+
   it('should remove a module that only has imports and exports', async () => {
     writeFile(
       'app.module.ts',


### PR DESCRIPTION
Fixes that the standalone migration was duplicating the `standalone` flag if the declaration was `standalone: false`.