### PR TITLE
feat(core): mark input, output and model APIs as stable

### DIFF
--- a/adev/src/content/guide/components/output-function.md
+++ b/adev/src/content/guide/components/output-function.md
@@ -3,8 +3,6 @@
 The `output()` function declares an output in a directive or component.
 Outputs allow you to emit values to parent components.
 
-HELPFUL: The `output()` function is currently in [developer preview](/reference/releases#developer-preview).
-
 <docs-code language="ts" highlight="[[5], [8]]">
 import {Component, output} from '@angular/core';
 

--- a/adev/src/content/guide/signals/inputs.md
+++ b/adev/src/content/guide/signals/inputs.md
@@ -3,8 +3,6 @@
 Signal inputs allow values to be bound from parent components.
 Those values are exposed using a `Signal` and can change during the lifecycle of your component.
 
-HELPFUL: Signal inputs are currently in [developer preview](/reference/releases#developer-preview).
-
 Angular supports two variants of inputs:
 
 **Optional inputs**

--- a/adev/src/content/guide/signals/model.md
+++ b/adev/src/content/guide/signals/model.md
@@ -3,8 +3,6 @@
 **Model inputs** are a special type of input that enable a component to propagate new values
 back to another component.
 
-HELPFUL: Model inputs are currently in [developer preview](/reference/releases#developer-preview).
-
 When creating a component, you can define a model input similarly to how you create a standard
 input.
 

--- a/packages/core/src/authoring/input/input.ts
+++ b/packages/core/src/authoring/input/input.ts
@@ -40,7 +40,7 @@ export function inputRequiredFunction<ReadT, WriteT = ReadT>(
  * The function exposes an API for also declaring required inputs via the
  * `input.required` function.
  *
- * @developerPreview
+ * @publicAPI
  * @docsPrivate Ignored because `input` is the canonical API entry.
  */
 export interface InputFunction {
@@ -81,7 +81,7 @@ export interface InputFunction {
    * Consumers of your directive/component need to bind to this
    * input. If unset, a compile time error will be reported.
    *
-   * @developerPreview
+   * @publicAPI
    */
   required: {
     /** Declares a required input of type `T`. */
@@ -143,7 +143,7 @@ export interface InputFunction {
  * <span>{{firstName()}}</span>
  * ```
  *
- * @developerPreview
+ * @publicAPI
  * @initializerApiFunction
  */
 export const input: InputFunction = (() => {

--- a/packages/core/src/authoring/input/input_signal.ts
+++ b/packages/core/src/authoring/input/input_signal.ts
@@ -14,7 +14,7 @@ import {Signal} from '../../render3/reactivity/api';
 import {INPUT_SIGNAL_NODE, InputSignalNode, REQUIRED_UNSET_VALUE} from './input_signal_node';
 
 /**
- * @developerPreview
+ * @publicAPI
  *
  * Options for signal inputs.
  */
@@ -37,7 +37,7 @@ export interface InputOptions<T, TransformT> {
 /**
  * Signal input options without the transform option.
  *
- * @developerPreview
+ * @publicAPI
  */
 export type InputOptionsWithoutTransform<T> =
   // Note: We still keep a notion of `transform` for auto-completion.
@@ -45,7 +45,7 @@ export type InputOptionsWithoutTransform<T> =
 /**
  * Signal input options with the transform option required.
  *
- * @developerPreview
+ * @publicAPI
  */
 export type InputOptionsWithTransform<T, TransformT> = Required<
   Pick<InputOptions<T, TransformT>, 'transform'>
@@ -77,7 +77,7 @@ export const ɵINPUT_SIGNAL_BRAND_WRITE_TYPE = /* @__PURE__ */ Symbol();
  *
  * @see {@link InputSignal} for additional information.
  *
- * @developerPreview
+ * @publicAPI
  */
 export interface InputSignalWithTransform<T, TransformT> extends Signal<T> {
   [SIGNAL]: InputSignalNode<T, TransformT>;
@@ -94,7 +94,7 @@ export interface InputSignalWithTransform<T, TransformT> extends Signal<T> {
  *
  * @see {@link InputOptionsWithTransform} for inputs with transforms.
  *
- * @developerPreview
+ * @publicAPI
  */
 export interface InputSignal<T> extends InputSignalWithTransform<T, T> {}
 

--- a/packages/core/src/authoring/model/model.ts
+++ b/packages/core/src/authoring/model/model.ts
@@ -31,7 +31,7 @@ export function modelRequiredFunction<T>(): ModelSignal<T> {
  * The function exposes an API for also declaring required models via the
  * `model.required` function.
  *
- * @developerPreview
+ * @publicAPI
  * @docsPrivate Ignored because `model` is the canonical API entry.
  */
 export interface ModelFunction {
@@ -98,7 +98,7 @@ export interface ModelFunction {
  * }
  * ```
  *
- * @developerPreview
+ * @publicAPI
  * @initializerApiFunction
  */
 export const model: ModelFunction = (() => {

--- a/packages/core/src/authoring/model/model_signal.ts
+++ b/packages/core/src/authoring/model/model_signal.ts
@@ -25,7 +25,7 @@ import {OutputEmitterRef} from '../output/output_emitter_ref';
 import {OutputRef} from '../output/output_ref';
 
 /**
- * @developerPreview
+ * @publicAPI
  *
  * Options for model signals.
  */
@@ -43,7 +43,7 @@ export interface ModelOptions {
  * A model signal is a writeable signal that can be exposed as an output.
  * Whenever its value is updated, it emits to the output.
  *
- * @developerPreview
+ * @publicAPI
  */
 export interface ModelSignal<T> extends WritableSignal<T>, InputSignal<T>, OutputRef<T> {
   [SIGNAL]: InputSignalNode<T, T>;

--- a/packages/core/src/authoring/output/output.ts
+++ b/packages/core/src/authoring/output/output.ts
@@ -13,7 +13,7 @@ import {OutputEmitterRef} from './output_emitter_ref';
 /**
  * Options for declaring an output.
  *
- * @developerPreview
+ * @publicAPI
  */
 export interface OutputOptions {
   alias?: string;
@@ -58,9 +58,8 @@ export interface OutputOptions {
  *   this.nameChange.emit(newName);
  * }
  * ```
- *
- * @developerPreview
  * @initializerApiFunction {"showTypesInSignaturePreview": true}
+ * @publicAPI
  */
 export function output<T = void>(opts?: OutputOptions): OutputEmitterRef<T> {
   ngDevMode && assertInInjectionContext(output);

--- a/packages/core/src/authoring/output/output_emitter_ref.ts
+++ b/packages/core/src/authoring/output/output_emitter_ref.ts
@@ -26,7 +26,7 @@ import {OutputRef, OutputRefSubscription} from './output_ref';
  * <my-comp (valueChange)="processNewValue($event)" />
  * ```
  *
- * @developerPreview
+ * @publicAPI
  */
 export class OutputEmitterRef<T> implements OutputRef<T> {
   private destroyed = false;

--- a/packages/core/src/authoring/output/output_ref.ts
+++ b/packages/core/src/authoring/output/output_ref.ts
@@ -15,7 +15,7 @@ import {DestroyRef} from '../../linker/destroy_ref';
  * Note: Angular will automatically clean up subscriptions
  * when the directive/component of the output is destroyed.
  *
- * @developerPreview
+ * @publicAPI
  */
 export interface OutputRefSubscription {
   unsubscribe(): void;
@@ -24,7 +24,7 @@ export interface OutputRefSubscription {
 /**
  * A reference to an Angular output.
  *
- * @developerPreview
+ * @publicAPI
  */
 export interface OutputRef<T> {
   /**


### PR DESCRIPTION
This commit marks the input, output and model APIs as stable (along with the associated APIs) and thus exits the dev preview phase for those APIs.

Documentation updates will follow.
