### PR TITLE
docs: correct key usage in sectionStyles and update template binding

### DIFF
--- a/adev/src/content/guide/templates/binding.md
+++ b/adev/src/content/guide/templates/binding.md
@@ -203,7 +203,7 @@ You can also set multiple style values in one binding. Angular accepts the follo
 @Component({
   template: `
     <ul [style]="listStyles"> ... </ul>
-    <section [class]="sectionStyles"> ... </section>
+    <section [style]="sectionStyles"> ... </section>
   `,
   ...
 })
@@ -211,7 +211,7 @@ export class UserProfile {
   listStyles = 'display: flex; padding: 8px';
   sectionStyles = {
     border: '1px solid black',
-    font-weight: 'bold',
+    'font-weight': 'bold',
   };
 }
 ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [✅] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [✅] Tests for the changes have been added (for bug fixes / features)
- [✅] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [✅] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This PR fixes an issue related to object key formatting in sectionStyles and updates the template binding in the <section> element to apply dynamic styles correctly.