### PR TITLE
refactor(platform-browser): reduce runtime code size of shared style host

### DIFF
--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -1356,6 +1356,9 @@
     "name": "remove"
   },
   {
+    "name": "removeAll"
+  },
+  {
     "name": "removeClass"
   },
   {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -1431,6 +1431,9 @@
     "name": "remove"
   },
   {
+    "name": "removeAll"
+  },
+  {
     "name": "removeClass"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -1158,6 +1158,9 @@
     "name": "remove"
   },
   {
+    "name": "removeAll"
+  },
+  {
     "name": "removeFromArray"
   },
   {

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -2406,6 +2406,9 @@
     "name": "remove"
   },
   {
+    "name": "removeAll"
+  },
+  {
     "name": "removeFromArray"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1725,6 +1725,9 @@
     "name": "remove"
   },
   {
+    "name": "removeAll"
+  },
+  {
     "name": "removeFromArray"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1692,6 +1692,9 @@
     "name": "remove"
   },
   {
+    "name": "removeAll"
+  },
+  {
     "name": "removeFromArray"
   },
   {

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -1269,6 +1269,9 @@
     "name": "remove"
   },
   {
+    "name": "removeAll"
+  },
+  {
     "name": "removeDehydratedView"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1965,6 +1965,9 @@
     "name": "remove"
   },
   {
+    "name": "removeAll"
+  },
+  {
     "name": "removeFromArray"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -1020,6 +1020,9 @@
     "name": "remove"
   },
   {
+    "name": "removeAll"
+  },
+  {
     "name": "removeFromArray"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1374,6 +1374,9 @@
     "name": "remove"
   },
   {
+    "name": "removeAll"
+  },
+  {
     "name": "removeFromArray"
   },
   {


### PR DESCRIPTION
The `SharedStylesHost` class has been refactored to both reduce the runtime code size and also modernize some of the code structures. The class is also adjusted to better support reuse via subclassing or other reuses in the future. Additional comments have been added to improve readability as well. The code reduction in a prerelease newly generated Angular CLI application for production is ~410 bytes.

Before:
```
Initial chunk files   | Names         |  Raw size | Estimated transfer size
main-GOQKBZBZ.js      | main          | 208.67 kB |                56.41 kB
polyfills-FFHMD2TL.js | polyfills     |  34.52 kB |                11.28 kB
styles-5INURTSO.css   | styles        |   0 bytes |                 0 bytes

                      | Initial total | 243.19 kB |                67.69 kB
```

After:
```
Initial chunk files   | Names         |  Raw size | Estimated transfer size
main-CRTDDKPH.js      | main          | 208.26 kB |                56.32 kB
polyfills-FFHMD2TL.js | polyfills     |  34.52 kB |                11.28 kB
styles-5INURTSO.css   | styles        |   0 bytes |                 0 bytes

                      | Initial total | 242.78 kB |                67.61 kB
```