### PR TITLE
refactor(migrations): share signal conversion problematic pattern detection code 

### DIFF
--- a/packages/core/schematics/migrations/signal-migration/src/analysis_deps.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/analysis_deps.ts
@@ -45,13 +45,17 @@ export function prepareAnalysisInfo(
   compiler: NgCompiler,
   programAbsoluteRootPaths?: string[],
 ) {
-  // Get template type checker & analyze sync.
-  const templateTypeChecker = compiler.getTemplateTypeChecker();
+  // Analyze sync and retrieve necessary dependencies.
+  // Note: `getTemplateTypeChecker` requires the `enableTemplateTypeChecker` flag, but
+  // this has negative effects as it causes optional TCB operations to execute, which may
+  // error with unsuccessful reference emits that previously were ignored outside of the migration.
+  // The migration is resilient to TCB information missing, so this is fine, and all the information
+  // we need is part of required TCB operations anyway.
+  const {refEmitter, metaReader, templateTypeChecker} = compiler['ensureAnalyzed']();
 
   // Generate all type check blocks.
   templateTypeChecker.generateAllTypeCheckBlocks();
 
-  const {refEmitter, metaReader} = compiler['ensureAnalyzed']();
   const typeChecker = userProgram.getTypeChecker();
 
   const reflector = new TypeScriptReflectionHost(typeChecker);

--- a/packages/core/schematics/migrations/signal-migration/src/batch/populate_global_data.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/batch/populate_global_data.ts
@@ -26,12 +26,12 @@ export function populateKnownInputsFromGlobalData(
     const inputMetadata = knownInputs.get({key})!;
     if (!inputMetadata.isIncompatible() && info.isIncompatible) {
       if (info.isIncompatible.kind === IncompatibilityType.VIA_CLASS) {
-        knownInputs.markDirectiveAsIncompatible(
+        knownInputs.markClassIncompatible(
           inputMetadata.container.clazz,
           info.isIncompatible.reason,
         );
       } else {
-        knownInputs.markInputAsIncompatible(inputMetadata.descriptor, {
+        knownInputs.markFieldIncompatible(inputMetadata.descriptor, {
           context: null, // No context serializable.
           reason: info.isIncompatible.reason,
         });

--- a/packages/core/schematics/migrations/signal-migration/src/migration.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/migration.ts
@@ -52,7 +52,6 @@ export class SignalInputMigration extends TsurgeComplexMigration<
   // Override the default ngtsc program creation, to add extra flags.
   override createProgram(tsconfigAbsPath: string, fs?: FileSystem): BaseProgramInfo {
     return createNgtscProgram(tsconfigAbsPath, fs, {
-      _enableTemplateTypeChecker: true,
       _compilePoisonedComponents: true,
       // We want to migrate non-exported classes too.
       compileNonExportedClasses: true,

--- a/packages/core/schematics/migrations/signal-migration/src/migration.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/migration.ts
@@ -99,7 +99,7 @@ export class SignalInputMigration extends TsurgeComplexMigration<
     filterInputsViaConfig(result, knownInputs, this.config);
 
     this.config.reportProgressFn?.(40, 'Checking inheritance..');
-    pass4__checkInheritanceOfInputs(host, inheritanceGraph, metaRegistry, knownInputs);
+    pass4__checkInheritanceOfInputs(inheritanceGraph, metaRegistry, knownInputs);
     if (this.config.bestEffortMode) {
       filterIncompatibilitiesForBestEffortMode(knownInputs);
     }
@@ -159,12 +159,7 @@ export class SignalInputMigration extends TsurgeComplexMigration<
       populateKnownInputsFromGlobalData(knownInputs, globalMetadata);
 
       filterInputsViaConfig(result, knownInputs, this.config);
-      pass4__checkInheritanceOfInputs(
-        host,
-        inheritanceGraph,
-        analysisDeps.metaRegistry,
-        knownInputs,
-      );
+      pass4__checkInheritanceOfInputs(inheritanceGraph, analysisDeps.metaRegistry, knownInputs);
       if (this.config.bestEffortMode) {
         filterIncompatibilitiesForBestEffortMode(knownInputs);
       }
@@ -195,7 +190,7 @@ function filterInputsViaConfig(
   for (const input of knownInputs.knownInputIds.values()) {
     if (!config.shouldMigrateInput(input)) {
       skippedInputs.add(input.descriptor.key);
-      knownInputs.markInputAsIncompatible(input.descriptor, {
+      knownInputs.markFieldIncompatible(input.descriptor, {
         context: null,
         reason: InputIncompatibilityReason.SkippedViaConfigFilter,
       });

--- a/packages/core/schematics/migrations/signal-migration/src/passes/1_identify_inputs.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/1_identify_inputs.ts
@@ -63,7 +63,7 @@ export function pass1__IdentifySourceFileAndDeclarationInputs(
         );
 
         if (isInputMemberIncompatibility(conversionPreparation)) {
-          knownDecoratorInputs.markInputAsIncompatible(inputDescr, conversionPreparation);
+          knownDecoratorInputs.markFieldIncompatible(inputDescr, conversionPreparation);
           result.sourceInputs.set(inputDescr, null);
         } else {
           result.sourceInputs.set(inputDescr, conversionPreparation);

--- a/packages/core/schematics/migrations/signal-migration/src/passes/3_check_incompatible_patterns.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/3_check_incompatible_patterns.ts
@@ -6,16 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {unwrapExpression} from '@angular/compiler-cli/src/ngtsc/annotations/common';
-import assert from 'assert';
 import ts from 'typescript';
-import {ClassIncompatibilityReason} from '../input_detection/incompatibility';
 import {KnownInputs} from '../input_detection/known_inputs';
 import {MigrationHost} from '../migration_host';
-import {SpyOnInputPattern} from '../pattern_advisors/spy_on_pattern';
-import {getMemberName} from '../utils/class_member_names';
 import {GroupedTsAstVisitor} from '../utils/grouped_ts_ast_visitor';
 import {InheritanceGraph} from '../utils/inheritance_graph';
+import {checkIncompatiblePatterns} from './problematic_patterns/common_incompatible_patterns';
 
 /**
  * Phase where problematic patterns are detected and advise
@@ -28,89 +24,12 @@ import {InheritanceGraph} from '../utils/inheritance_graph';
  * such.
  */
 export function pass3__checkIncompatiblePatterns(
-  host: MigrationHost,
   inheritanceGraph: InheritanceGraph,
   checker: ts.TypeChecker,
   groupedTsAstVisitor: GroupedTsAstVisitor,
   knownInputs: KnownInputs,
 ) {
-  const inputClassSymbolsToClass = new Map<ts.Symbol, ts.ClassDeclaration>();
-
-  for (const input of knownInputs.getAllInputContainingClasses()) {
-    const classSymbol = checker.getTypeAtLocation(input).symbol;
-
-    assert(classSymbol != null, 'Expected a symbol to exist for the container of input.');
-    assert(classSymbol.valueDeclaration !== undefined, 'Expected declaration to exist for input.');
-    assert(
-      ts.isClassDeclaration(classSymbol.valueDeclaration),
-      'Expected declaration to be a class.',
-    );
-
-    // track class symbol for derived class checks.
-    inputClassSymbolsToClass.set(classSymbol, classSymbol.valueDeclaration);
-  }
-
-  const incompatibilityPatterns = [new SpyOnInputPattern(host, checker, knownInputs)];
-
-  const visitor = (node: ts.Node) => {
-    // Check for manual class instantiations.
-    if (ts.isNewExpression(node) && ts.isIdentifier(unwrapExpression(node.expression))) {
-      let newTarget = checker.getSymbolAtLocation(unwrapExpression(node.expression));
-      // Plain identifier references can point to alias symbols (e.g. imports).
-      if (newTarget !== undefined && newTarget.flags & ts.SymbolFlags.Alias) {
-        newTarget = checker.getAliasedSymbol(newTarget);
-      }
-      if (newTarget && inputClassSymbolsToClass.has(newTarget)) {
-        knownInputs.markDirectiveAsIncompatible(
-          inputClassSymbolsToClass.get(newTarget)!,
-          ClassIncompatibilityReason.ClassManuallyInstantiated,
-        );
-      }
-    }
-
-    // Detect possible problematic patterns.
-    incompatibilityPatterns.forEach((p) => p.detect(node));
-
-    const insidePropertyDeclaration = groupedTsAstVisitor.state.insidePropertyDeclaration;
-    // Check for problematic class references inside property declarations.
-    // These are likely problematic, causing type conflicts, if the containing
-    // class inherits a non-input member with the same name.
-    // Suddenly the derived class changes its signature, but the base class may not.
-    problematicReferencesCheck: if (
-      insidePropertyDeclaration !== null &&
-      ts.isIdentifier(node) &&
-      insidePropertyDeclaration.parent.heritageClauses !== undefined
-    ) {
-      let newTarget = checker.getSymbolAtLocation(unwrapExpression(node));
-      // Plain identifier references can point to alias symbols (e.g. imports).
-      if (newTarget !== undefined && newTarget.flags & ts.SymbolFlags.Alias) {
-        newTarget = checker.getAliasedSymbol(newTarget);
-      }
-      if (newTarget && inputClassSymbolsToClass.has(newTarget)) {
-        const memberName = getMemberName(insidePropertyDeclaration);
-        if (memberName === null) {
-          break problematicReferencesCheck;
-        }
-        const {derivedMembers, inherited} = inheritanceGraph.checkOverlappingMembers(
-          insidePropertyDeclaration.parent,
-          insidePropertyDeclaration,
-          memberName,
-        );
-
-        // Member is not inherited, or derived.
-        // Hence the reference is unproblematic and is expected to not
-        // cause any type conflicts.
-        if (derivedMembers.length === 0 && inherited === undefined) {
-          break problematicReferencesCheck;
-        }
-
-        knownInputs.markDirectiveAsIncompatible(
-          inputClassSymbolsToClass.get(newTarget)!,
-          ClassIncompatibilityReason.InputOwningClassReferencedInClassProperty,
-        );
-      }
-    }
-  };
-
-  groupedTsAstVisitor.register(visitor);
+  checkIncompatiblePatterns(inheritanceGraph, checker, groupedTsAstVisitor, knownInputs, () =>
+    knownInputs.getAllInputContainingClasses(),
+  );
 }

--- a/packages/core/schematics/migrations/signal-migration/src/passes/4_check_inheritance.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/4_check_inheritance.ts
@@ -6,20 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {MetadataReader} from '@angular/compiler-cli/src/ngtsc/metadata';
 import assert from 'assert';
-import {InputIncompatibilityReason} from '../input_detection/incompatibility';
-import {KnownInputInfo, KnownInputs} from '../input_detection/known_inputs';
-import {attemptRetrieveInputFromSymbol} from '../input_detection/nodes_to_input';
+import {KnownInputs} from '../input_detection/known_inputs';
 import {MigrationHost} from '../migration_host';
 import {InheritanceGraph} from '../utils/inheritance_graph';
-import {topologicalSort} from '../utils/inheritance_sort';
-import {getMemberName} from '../utils/class_member_names';
-import ts from 'typescript';
-import {MetadataReader} from '@angular/compiler-cli/src/ngtsc/metadata';
-import {Reference} from '@angular/compiler-cli/src/ngtsc/imports';
-import {ClassDeclaration} from '@angular/compiler-cli/src/ngtsc/reflection';
-import {isInputContainerNode} from '../input_detection/input_node';
-import {getInputDescriptor} from '../utils/input_id';
+import {checkInheritanceOfInputs} from './problematic_patterns/check_inheritance';
 
 /**
  * Phase that propagates incompatibilities to derived classes or
@@ -42,133 +34,16 @@ import {getInputDescriptor} from '../utils/input_id';
  * would then have other derived classes as well, it would propagate the status.
  */
 export function pass4__checkInheritanceOfInputs(
-  host: MigrationHost,
   inheritanceGraph: InheritanceGraph,
   metaRegistry: MetadataReader,
   knownInputs: KnownInputs,
 ) {
-  // Sort topologically and iterate super classes first, so that we can trivially
-  // propagate incompatibility statuses (and other checks) without having to check
-  // in both directions (derived classes, or base classes). This simplifies the logic
-  // further down in this function significantly.
-  const topologicalSortedClasses = topologicalSort(inheritanceGraph)
-    .filter((t) => ts.isClassDeclaration(t) && knownInputs.isInputContainingClass(t))
-    .reverse();
-
-  for (const inputClass of topologicalSortedClasses) {
-    // Note: Class parents of `inputClass` were already checked by
-    // the previous iterations (given the reverse topological sort)—
-    // hence it's safe to assume that incompatibility of parent classes will
-    // not change again, at a later time.
-
-    assert(ts.isClassDeclaration(inputClass), 'Expected input graph node to be always a class.');
-    const directiveInfo = knownInputs.getDirectiveInfoForClass(inputClass);
-    assert(directiveInfo !== undefined, 'Expected directive info to exist for input class.');
-
-    // Iterate through derived class chains and determine all inputs that are overridden
-    // via class metadata fields. e.g `@Component#inputs`. This is later used to mark a
-    // potential similar class input as incompatible— because those cannot be migrated.
-    const inputFieldNamesFromMetadataArray = new Set<string>();
-    for (const derivedClasses of inheritanceGraph.traceDerivedClasses(inputClass)) {
-      const derivedMeta =
-        ts.isClassDeclaration(derivedClasses) && derivedClasses.name !== undefined
-          ? metaRegistry.getDirectiveMetadata(new Reference(derivedClasses as ClassDeclaration))
-          : null;
-
-      if (derivedMeta !== null && derivedMeta.inputFieldNamesFromMetadataArray !== null) {
-        derivedMeta.inputFieldNamesFromMetadataArray.forEach((b) =>
-          inputFieldNamesFromMetadataArray.add(b),
-        );
-      }
-    }
-
-    // Check inheritance of every input in the given "directive class".
-    inputCheck: for (const info of directiveInfo.inputFields.values()) {
-      const inputNode = info.descriptor.node;
-      const {derivedMembers, inherited} = inheritanceGraph.checkOverlappingMembers(
-        inputClass,
-        inputNode,
-        getMemberName(inputNode)!,
-      );
-
-      // If we discover a derived, input re-declared via class metadata, then it
-      // will cause conflicts as we cannot migrate it/ nor mark it as signal-based.
-      if (inputFieldNamesFromMetadataArray.has(info.metadata.classPropertyName)) {
-        knownInputs.markInputAsIncompatible(info.descriptor, {
-          context: null,
-          reason: InputIncompatibilityReason.RedeclaredViaDerivedClassInputsArray,
-        });
-      }
-
-      for (const derived of derivedMembers) {
-        const derivedInput = attemptRetrieveInputFromSymbol(host.programInfo, derived, knownInputs);
-        if (derivedInput !== null) {
-          continue;
-        }
-
-        // If we discover a derived, non-input member, then it will cause
-        // conflicts, and we mark the current input as incompatible.
-        knownInputs.markInputAsIncompatible(info.descriptor, {
-          context: derived.valueDeclaration ?? inputNode,
-          reason: InputIncompatibilityReason.OverriddenByDerivedClass,
-        });
-
-        continue inputCheck;
-      }
-
-      // If there is no parent, we are done. Otherwise, check the parent
-      // to either inherit or check the incompatibility with the inheritance.
-      if (inherited === undefined) {
-        continue;
-      }
-      const {inheritedMemberInput} = analyzeInheritanceOfMember(
-        inherited,
-        inputNode,
-        host,
-        knownInputs,
-      );
-      // Parent is not an input, and hence will conflict..
-      if (inheritedMemberInput === undefined) {
-        knownInputs.markInputAsIncompatible(info.descriptor, {
-          context: inherited.valueDeclaration ?? inputNode,
-          reason: InputIncompatibilityReason.TypeConflictWithBaseClass,
-        });
-        continue;
-      }
-      // Parent is incompatible, so this input also needs to be.
-      // It cannot be migrated.
-      if (inheritedMemberInput.isIncompatible()) {
-        knownInputs.markInputAsIncompatible(info.descriptor, {
-          context: inheritedMemberInput.descriptor.node,
-          reason: InputIncompatibilityReason.ParentIsIncompatible,
-        });
-        continue;
-      }
-    }
-  }
-}
-
-function analyzeInheritanceOfMember(
-  inheritedMember: ts.Symbol,
-  member: ts.ClassElement,
-  host: MigrationHost,
-  knownInputs: KnownInputs,
-): {inheritedMemberInput: KnownInputInfo | undefined; memberInput: KnownInputInfo | undefined} {
-  // If the member itself is an input that is being migrated, we
-  // do not need to check, as overriding would be fine then— like before.
-  const memberInputDescr = isInputContainerNode(member) ? getInputDescriptor(host, member) : null;
-  const memberInput = memberInputDescr !== null ? knownInputs.get(memberInputDescr) : undefined;
-
-  const inheritedMemberInputId =
-    inheritedMember.valueDeclaration !== undefined &&
-    isInputContainerNode(inheritedMember.valueDeclaration)
-      ? getInputDescriptor(host, inheritedMember.valueDeclaration)
-      : null;
-  const inheritedMemberInput =
-    inheritedMemberInputId !== null ? knownInputs.get(inheritedMemberInputId) : undefined;
-
-  return {
-    inheritedMemberInput,
-    memberInput,
-  };
+  checkInheritanceOfInputs(inheritanceGraph, metaRegistry, knownInputs, {
+    isClassWithKnownFields: (clazz) => knownInputs.isInputContainingClass(clazz),
+    getFieldsForClass: (clazz) => {
+      const directiveInfo = knownInputs.getDirectiveInfoForClass(clazz);
+      assert(directiveInfo !== undefined, 'Expected directive info to exist for input.');
+      return Array.from(directiveInfo.inputFields.values()).map((i) => i.descriptor);
+    },
+  });
 }

--- a/packages/core/schematics/migrations/signal-migration/src/passes/problematic_patterns/check_inheritance.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/problematic_patterns/check_inheritance.ts
@@ -1,0 +1,147 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Reference} from '@angular/compiler-cli/src/ngtsc/imports';
+import {MetadataReader} from '@angular/compiler-cli/src/ngtsc/metadata';
+import {ClassDeclaration} from '@angular/compiler-cli/src/ngtsc/reflection';
+import assert from 'assert';
+import ts from 'typescript';
+import {InputIncompatibilityReason} from '../../input_detection/incompatibility';
+import {getMemberName} from '../../utils/class_member_names';
+import {InheritanceGraph} from '../../utils/inheritance_graph';
+import {topologicalSort} from '../../utils/inheritance_sort';
+import {ClassFieldDescriptor, KnownFields} from '../reference_resolution/known_fields';
+import {ProblematicFieldRegistry} from './problematic_field_registry';
+
+/**
+ * Phase that propagates incompatibilities to derived classes or
+ * base classes. For example, consider:
+ *
+ * ```
+ * class Base {
+ *   bla = true;
+ * }
+ *
+ * class Derived extends Base {
+ *   @Input() bla = false;
+ * }
+ * ```
+ *
+ * Whenever we migrate `Derived`, the inheritance would fail
+ * and result in a build breakage because `Base#bla` is not an Angular input.
+ *
+ * The logic here detects such cases and marks `bla` as incompatible. If `Derived`
+ * would then have other derived classes as well, it would propagate the status.
+ */
+export function checkInheritanceOfInputs<D extends ClassFieldDescriptor>(
+  inheritanceGraph: InheritanceGraph,
+  metaRegistry: MetadataReader,
+  fields: KnownFields<D> & ProblematicFieldRegistry<D>,
+  opts: {
+    getFieldsForClass: (node: ts.ClassDeclaration) => D[];
+    isClassWithKnownFields: (node: ts.ClassDeclaration) => boolean;
+  },
+) {
+  // Sort topologically and iterate super classes first, so that we can trivially
+  // propagate incompatibility statuses (and other checks) without having to check
+  // in both directions (derived classes, or base classes). This simplifies the logic
+  // further down in this function significantly.
+  const topologicalSortedClasses = topologicalSort(inheritanceGraph)
+    .filter((t) => ts.isClassDeclaration(t) && opts.isClassWithKnownFields(t))
+    .reverse();
+
+  for (const inputClass of topologicalSortedClasses) {
+    // Note: Class parents of `inputClass` were already checked by
+    // the previous iterations (given the reverse topological sort)—
+    // hence it's safe to assume that incompatibility of parent classes will
+    // not change again, at a later time.
+
+    assert(ts.isClassDeclaration(inputClass), 'Expected input graph node to be always a class.');
+    const classFields = opts.getFieldsForClass(inputClass);
+
+    // Iterate through derived class chains and determine all inputs that are overridden
+    // via class metadata fields. e.g `@Component#inputs`. This is later used to mark a
+    // potential similar class input as incompatible— because those cannot be migrated.
+    const inputFieldNamesFromMetadataArray = new Set<string>();
+    for (const derivedClasses of inheritanceGraph.traceDerivedClasses(inputClass)) {
+      const derivedMeta =
+        ts.isClassDeclaration(derivedClasses) && derivedClasses.name !== undefined
+          ? metaRegistry.getDirectiveMetadata(new Reference(derivedClasses as ClassDeclaration))
+          : null;
+
+      if (derivedMeta !== null && derivedMeta.inputFieldNamesFromMetadataArray !== null) {
+        derivedMeta.inputFieldNamesFromMetadataArray.forEach((b) =>
+          inputFieldNamesFromMetadataArray.add(b),
+        );
+      }
+    }
+
+    // Check inheritance of every input in the given "directive class".
+    inputCheck: for (const fieldDescr of classFields) {
+      const inputNode = fieldDescr.node;
+      const {derivedMembers, inherited} = inheritanceGraph.checkOverlappingMembers(
+        inputClass,
+        inputNode,
+        getMemberName(inputNode)!,
+      );
+
+      // If we discover a derived, input re-declared via class metadata, then it
+      // will cause conflicts as we cannot migrate it/ nor mark it as signal-based.
+      if (
+        fieldDescr.node.name !== undefined &&
+        (ts.isIdentifier(fieldDescr.node.name) || ts.isStringLiteralLike(fieldDescr.node.name)) &&
+        inputFieldNamesFromMetadataArray.has(fieldDescr.node.name.text)
+      ) {
+        fields.markFieldIncompatible(fieldDescr, {
+          context: null,
+          reason: InputIncompatibilityReason.RedeclaredViaDerivedClassInputsArray,
+        });
+      }
+
+      for (const derived of derivedMembers) {
+        const derivedInput = fields.attemptRetrieveDescriptorFromSymbol(derived);
+        if (derivedInput !== null) {
+          continue;
+        }
+
+        // If we discover a derived, non-input member, then it will cause
+        // conflicts, and we mark the current input as incompatible.
+        fields.markFieldIncompatible(fieldDescr, {
+          context: derived.valueDeclaration ?? inputNode,
+          reason: InputIncompatibilityReason.OverriddenByDerivedClass,
+        });
+
+        continue inputCheck;
+      }
+
+      // If there is no parent, we are done. Otherwise, check the parent
+      // to either inherit or check the incompatibility with the inheritance.
+      if (inherited === undefined) {
+        continue;
+      }
+      const inheritedMemberInput = fields.attemptRetrieveDescriptorFromSymbol(inherited);
+      // Parent is not an input, and hence will conflict..
+      if (inheritedMemberInput === null) {
+        fields.markFieldIncompatible(fieldDescr, {
+          context: inherited.valueDeclaration ?? inputNode,
+          reason: InputIncompatibilityReason.TypeConflictWithBaseClass,
+        });
+        continue;
+      }
+      // Parent is incompatible, so this input also needs to be.
+      // It cannot be migrated.
+      if (fields.isFieldIncompatible(inheritedMemberInput)) {
+        fields.markFieldIncompatible(fieldDescr, {
+          context: inheritedMemberInput.node,
+          reason: InputIncompatibilityReason.ParentIsIncompatible,
+        });
+        continue;
+      }
+    }
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/src/passes/problematic_patterns/common_incompatible_patterns.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/problematic_patterns/common_incompatible_patterns.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {unwrapExpression} from '@angular/compiler-cli/src/ngtsc/annotations/common';
+import assert from 'assert';
+import ts from 'typescript';
+import {ClassIncompatibilityReason} from '../../input_detection/incompatibility';
+import {SpyOnFieldPattern} from '../../pattern_advisors/spy_on_pattern';
+import {getMemberName} from '../../utils/class_member_names';
+import {GroupedTsAstVisitor} from '../../utils/grouped_ts_ast_visitor';
+import {InheritanceGraph} from '../../utils/inheritance_graph';
+import {ClassFieldDescriptor, KnownFields} from '../reference_resolution/known_fields';
+import {ProblematicFieldRegistry} from './problematic_field_registry';
+
+/**
+ * Phase where problematic patterns are detected and advise
+ * the migration to skip certain inputs.
+ *
+ * For example, detects classes that are instantiated manually. Those
+ * cannot be migrated as `input()` requires an injection context.
+ *
+ * In addition, spying onto an input may be problematic- so we skip migrating
+ * such.
+ */
+export function checkIncompatiblePatterns<D extends ClassFieldDescriptor>(
+  inheritanceGraph: InheritanceGraph,
+  checker: ts.TypeChecker,
+  groupedTsAstVisitor: GroupedTsAstVisitor,
+  fields: KnownFields<D> & ProblematicFieldRegistry<D>,
+  getAllClassesWithKnownFields: () => ts.ClassDeclaration[],
+) {
+  const inputClassSymbolsToClass = new Map<ts.Symbol, ts.ClassDeclaration>();
+
+  for (const knownFieldClass of getAllClassesWithKnownFields()) {
+    const classSymbol = checker.getTypeAtLocation(knownFieldClass).symbol;
+
+    assert(
+      classSymbol != null,
+      'Expected a symbol to exist for the container of known field class.',
+    );
+    assert(
+      classSymbol.valueDeclaration !== undefined,
+      'Expected declaration to exist for known field class.',
+    );
+    assert(
+      ts.isClassDeclaration(classSymbol.valueDeclaration),
+      'Expected declaration to be a class.',
+    );
+
+    // track class symbol for derived class checks.
+    inputClassSymbolsToClass.set(classSymbol, classSymbol.valueDeclaration);
+  }
+
+  const spyOnPattern = new SpyOnFieldPattern(checker, fields);
+
+  const visitor = (node: ts.Node) => {
+    // Check for manual class instantiations.
+    if (ts.isNewExpression(node) && ts.isIdentifier(unwrapExpression(node.expression))) {
+      let newTarget = checker.getSymbolAtLocation(unwrapExpression(node.expression));
+      // Plain identifier references can point to alias symbols (e.g. imports).
+      if (newTarget !== undefined && newTarget.flags & ts.SymbolFlags.Alias) {
+        newTarget = checker.getAliasedSymbol(newTarget);
+      }
+      if (newTarget && inputClassSymbolsToClass.has(newTarget)) {
+        fields.markClassIncompatible(
+          inputClassSymbolsToClass.get(newTarget)!,
+          ClassIncompatibilityReason.ClassManuallyInstantiated,
+        );
+      }
+    }
+
+    // Detect `spyOn` problematic usages and record them.
+    spyOnPattern.detect(node);
+
+    const insidePropertyDeclaration = groupedTsAstVisitor.state.insidePropertyDeclaration;
+    // Check for problematic class references inside property declarations.
+    // These are likely problematic, causing type conflicts, if the containing
+    // class inherits a non-input member with the same name.
+    // Suddenly the derived class changes its signature, but the base class may not.
+    problematicReferencesCheck: if (
+      insidePropertyDeclaration !== null &&
+      ts.isIdentifier(node) &&
+      insidePropertyDeclaration.parent.heritageClauses !== undefined
+    ) {
+      let newTarget = checker.getSymbolAtLocation(unwrapExpression(node));
+      // Plain identifier references can point to alias symbols (e.g. imports).
+      if (newTarget !== undefined && newTarget.flags & ts.SymbolFlags.Alias) {
+        newTarget = checker.getAliasedSymbol(newTarget);
+      }
+      if (newTarget && inputClassSymbolsToClass.has(newTarget)) {
+        const memberName = getMemberName(insidePropertyDeclaration);
+        if (memberName === null) {
+          break problematicReferencesCheck;
+        }
+        const {derivedMembers, inherited} = inheritanceGraph.checkOverlappingMembers(
+          insidePropertyDeclaration.parent,
+          insidePropertyDeclaration,
+          memberName,
+        );
+
+        // Member is not inherited, or derived.
+        // Hence the reference is unproblematic and is expected to not
+        // cause any type conflicts.
+        if (derivedMembers.length === 0 && inherited === undefined) {
+          break problematicReferencesCheck;
+        }
+
+        fields.markClassIncompatible(
+          inputClassSymbolsToClass.get(newTarget)!,
+          ClassIncompatibilityReason.InputOwningClassReferencedInClassProperty,
+        );
+      }
+    }
+  };
+
+  groupedTsAstVisitor.register(visitor);
+}

--- a/packages/core/schematics/migrations/signal-migration/src/passes/problematic_patterns/problematic_field_registry.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/problematic_patterns/problematic_field_registry.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+import {ClassFieldDescriptor} from '../reference_resolution/known_fields';
+import {
+  ClassIncompatibilityReason,
+  InputIncompatibilityReason,
+} from '../../input_detection/incompatibility';
+
+/**
+ * Interface describing a registry for identifying and checking
+ * of problematic fields that cannot be migrated due to given
+ * incompatibility reasons.
+ *
+ * This is useful for sharing the input incompatibility logic for e.g.
+ * inheritance or common patterns across migrations, like with the queries
+ * migration.
+ *
+ * Notably, the incompatibility reasons at this point are still tied to the
+ * "input" name. This is acceptable to simplify the mental complexity of parsing
+ * all related code.
+ */
+export interface ProblematicFieldRegistry<D extends ClassFieldDescriptor> {
+  isFieldIncompatible(descriptor: D): boolean;
+  markFieldIncompatible(
+    field: D,
+    info: {reason: InputIncompatibilityReason; context: ts.Node | null},
+  ): void;
+  markClassIncompatible(node: ts.ClassDeclaration, reason: ClassIncompatibilityReason): void;
+}

--- a/packages/core/schematics/migrations/signal-migration/src/passes/reference_resolution/known_fields.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/reference_resolution/known_fields.ts
@@ -24,7 +24,7 @@ export type ClassFieldUniqueKey = UniqueID<'ClassField Unique ID'>;
  * (not necessarily just within an isolated compilation unit)
  */
 export interface ClassFieldDescriptor {
-  node: ts.Node;
+  node: ts.ClassElement;
   key: ClassFieldUniqueKey;
 }
 
@@ -59,5 +59,5 @@ export interface KnownFields<D extends ClassFieldDescriptor> {
    * known fields. E.g. a reference to the class may be tracked when fields inside
    * are migrated to signal inputs and the public class signature therefore changed.
    */
-  shouldTrackReferencesToClass(clazz: ts.ClassDeclaration): boolean;
+  shouldTrackClassReference(clazz: ts.ClassDeclaration): boolean;
 }

--- a/packages/core/schematics/migrations/signal-migration/src/pattern_advisors/partial_directive_type.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/pattern_advisors/partial_directive_type.ts
@@ -61,7 +61,7 @@ export class PartialDirectiveTypeInCatalystTests<D extends ClassFieldDescriptor>
     if (
       symbol?.valueDeclaration === undefined ||
       !ts.isClassDeclaration(symbol.valueDeclaration) ||
-      !this.knownFields.shouldTrackReferencesToClass(symbol.valueDeclaration)
+      !this.knownFields.shouldTrackClassReference(symbol.valueDeclaration)
     ) {
       return null;
     }

--- a/packages/core/schematics/migrations/signal-migration/src/phase_analysis.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/phase_analysis.ts
@@ -86,7 +86,6 @@ export function executeAnalysisPhase(
   );
   // Register pass 3. Check incompatible patterns pass.
   pass3__checkIncompatiblePatterns(
-    host,
     inheritanceGraph,
     typeChecker,
     pass2And3SourceFileVisitor,
@@ -99,14 +98,14 @@ export function executeAnalysisPhase(
   // Determine incompatible inputs based on resolved references.
   for (const reference of result.references) {
     if (isTsReference(reference) && reference.from.isWrite) {
-      knownInputs.markInputAsIncompatible(reference.target, {
+      knownInputs.markFieldIncompatible(reference.target, {
         reason: InputIncompatibilityReason.WriteAssignment,
         context: reference.from.node,
       });
     }
     if (isTemplateReference(reference) || isHostBindingReference(reference)) {
       if (reference.from.isWrite) {
-        knownInputs.markInputAsIncompatible(reference.target, {
+        knownInputs.markFieldIncompatible(reference.target, {
           reason: InputIncompatibilityReason.WriteAssignment,
           // No TS node context available for template or host bindings.
           context: null,
@@ -118,7 +117,7 @@ export function executeAnalysisPhase(
     // https://github.com/angular/angular/pull/55456.
     if (isTemplateReference(reference)) {
       if (reference.from.isLikelyPartOfNarrowing) {
-        knownInputs.markInputAsIncompatible(reference.target, {
+        knownInputs.markFieldIncompatible(reference.target, {
           reason: InputIncompatibilityReason.PotentiallyNarrowedInTemplateButNoSupportYet,
           context: null,
         });

--- a/packages/core/schematics/migrations/signal-queries-migration/known_queries.ts
+++ b/packages/core/schematics/migrations/signal-queries-migration/known_queries.ts
@@ -50,7 +50,7 @@ export class KnownQueries implements KnownFields<ClassFieldDescriptor> {
     return null;
   }
 
-  shouldTrackReferencesToClass(clazz: ts.ClassDeclaration): boolean {
+  shouldTrackClassReference(clazz: ts.ClassDeclaration): boolean {
     return this.classToQueryFields.has(clazz);
   }
 

--- a/packages/core/schematics/migrations/signal-queries-migration/migration.ts
+++ b/packages/core/schematics/migrations/signal-queries-migration/migration.ts
@@ -57,6 +57,9 @@ export class SignalQueriesMigration extends TsurgeComplexMigration<
     // TODO: This stage for this migration doesn't necessarily need a full
     // compilation unit program.
 
+    // Pre-Analyze the program and get access to the template type checker.
+    const {templateTypeChecker} = await info.ngCompiler['ensureAnalyzed']();
+
     const {sourceFiles, program} = info;
     const checker = program.getTypeChecker();
     const reflector = new TypeScriptReflectionHost(checker);
@@ -82,7 +85,7 @@ export class SignalQueriesMigration extends TsurgeComplexMigration<
         reflector,
         info.ngCompiler['resourceManager'],
         evaluator,
-        info.ngCompiler.getTemplateTypeChecker(),
+        templateTypeChecker,
         // Eager, rather expensive tracking of all references.
         // We don't know yet if something refers to a different query or not, so we
         // eagerly detect such and later filter those problematic references that
@@ -140,6 +143,8 @@ export class SignalQueriesMigration extends TsurgeComplexMigration<
   ): Promise<Replacement[]> {
     assert(info.ngCompiler !== null, 'Expected queries migration to have an Angular program.');
 
+    // Pre-Analyze the program and get access to the template type checker.
+    const {templateTypeChecker} = await info.ngCompiler['ensureAnalyzed']();
     const {program, sourceFiles} = info;
     const checker = program.getTypeChecker();
     const reflector = new TypeScriptReflectionHost(checker);
@@ -206,7 +211,7 @@ export class SignalQueriesMigration extends TsurgeComplexMigration<
         reflector,
         info.ngCompiler['resourceManager'],
         evaluator,
-        info.ngCompiler.getTemplateTypeChecker(),
+        templateTypeChecker,
         knownQueries,
         referenceResult,
       ).visitor,

--- a/packages/core/schematics/migrations/signal-queries-migration/migration.ts
+++ b/packages/core/schematics/migrations/signal-queries-migration/migration.ts
@@ -89,7 +89,7 @@ export class SignalQueriesMigration extends TsurgeComplexMigration<
         // turned out to refer to queries.
         // TODO: Consider skipping this extra work when running in non-batch mode.
         {
-          shouldTrackReferencesToClass: (_class) => false,
+          shouldTrackClassReference: (_class) => false,
           attemptRetrieveDescriptorFromSymbol: (s) => getClassFieldDescriptorForSymbol(s, info),
           fieldNamesToConsiderForReferenceLookup: null,
         },

--- a/packages/core/schematics/utils/tsurge/helpers/ngtsc_program.ts
+++ b/packages/core/schematics/utils/tsurge/helpers/ngtsc_program.ts
@@ -45,8 +45,6 @@ export function createNgtscProgram(
     tsconfig.rootNames,
     {
       ...tsconfig.options,
-      // Migrations commonly make use of TCB information.
-      _enableTemplateTypeChecker: true,
       // Avoid checking libraries to speed up migrations.
       skipLibCheck: true,
       skipDefaultLibCheck: true,


### PR DESCRIPTION
See individual commits.

This allows us to e.g. detect when a pattern like this is discovered:

```ts
class BaseNonAngular {
  disabled: string = '';
}

@Directive()
class Sub implements BaseNonAngular {
  // should not be migrated because of the interface.
  @Input() disabled = '';
}
```

Same for queries migration, where we will re-use this logic/detection (and for other common patterns)