### PR TITLE
fix(compiler-cli): extended diagnostics not validating ICUs

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/api/api.ts
@@ -228,7 +228,10 @@ class TemplateVisitor<Code extends ErrorCode>
   visitBoundText(text: TmplAstBoundText): void {
     this.visitAst(text.value);
   }
-  visitIcu(icu: TmplAstIcu): void {}
+  visitIcu(icu: TmplAstIcu): void {
+    Object.keys(icu.vars).forEach((key) => this.visit(icu.vars[key]));
+    Object.keys(icu.placeholders).forEach((key) => this.visit(icu.placeholders[key]));
+  }
 
   visitDeferredBlock(deferred: TmplAstDeferredBlock): void {
     deferred.visitAll(this);

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/unused_let_declaration/unused_let_declaration_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/unused_let_declaration/unused_let_declaration_spec.ts
@@ -108,5 +108,14 @@ runInEachFileSystem(() => {
 
       expect(diags.length).toBe(0);
     });
+
+    it('should not report a @let declaration that is only used in an ICU', () => {
+      const diags = diagnose(`
+        @let value = 1;
+        <h1 i18n>{value, select, 1 {one} 2 {two} other {other}}</h1>
+      `);
+
+      expect(diags.length).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
The visitor that all extended diagnostics are based on hadn't implemented the `visitIcu` method which meant that it wasn't detecting any code inside of them.

Fixes #57838.