### PR TITLE
refactor(migrations): check inheritance in signal queries migration

### DIFF
--- a/packages/core/schematics/migrations/signal-migration/src/passes/4_check_inheritance.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/4_check_inheritance.ts
@@ -9,9 +9,8 @@
 import {MetadataReader} from '@angular/compiler-cli/src/ngtsc/metadata';
 import assert from 'assert';
 import {KnownInputs} from '../input_detection/known_inputs';
-import {MigrationHost} from '../migration_host';
 import {InheritanceGraph} from '../utils/inheritance_graph';
-import {checkInheritanceOfInputs} from './problematic_patterns/check_inheritance';
+import {checkInheritanceOfKnownFields} from './problematic_patterns/check_inheritance';
 
 /**
  * Phase that propagates incompatibilities to derived classes or
@@ -38,7 +37,7 @@ export function pass4__checkInheritanceOfInputs(
   metaRegistry: MetadataReader,
   knownInputs: KnownInputs,
 ) {
-  checkInheritanceOfInputs(inheritanceGraph, metaRegistry, knownInputs, {
+  checkInheritanceOfKnownFields(inheritanceGraph, metaRegistry, knownInputs, {
     isClassWithKnownFields: (clazz) => knownInputs.isInputContainingClass(clazz),
     getFieldsForClass: (clazz) => {
       const directiveInfo = knownInputs.getDirectiveInfoForClass(clazz);

--- a/packages/core/schematics/migrations/signal-migration/src/passes/problematic_patterns/check_inheritance.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/problematic_patterns/check_inheritance.ts
@@ -38,7 +38,7 @@ import {ProblematicFieldRegistry} from './problematic_field_registry';
  * The logic here detects such cases and marks `bla` as incompatible. If `Derived`
  * would then have other derived classes as well, it would propagate the status.
  */
-export function checkInheritanceOfInputs<D extends ClassFieldDescriptor>(
+export function checkInheritanceOfKnownFields<D extends ClassFieldDescriptor>(
   inheritanceGraph: InheritanceGraph,
   metaRegistry: MetadataReader,
   fields: KnownFields<D> & ProblematicFieldRegistry<D>,

--- a/packages/core/schematics/migrations/signal-queries-migration/known_queries.ts
+++ b/packages/core/schematics/migrations/signal-queries-migration/known_queries.ts
@@ -8,6 +8,7 @@
 
 import ts from 'typescript';
 import {ProgramInfo} from '../../utils/tsurge';
+import {ProblematicFieldRegistry} from '../signal-migration/src/passes/problematic_patterns/problematic_field_registry';
 import {
   ClassFieldDescriptor,
   ClassFieldUniqueKey,
@@ -16,29 +17,46 @@ import {
 import {getClassFieldDescriptorForSymbol} from './field_tracking';
 import type {CompilationUnitData} from './migration';
 
-export class KnownQueries implements KnownFields<ClassFieldDescriptor> {
-  private readonly classToQueryFields = new WeakMap<
-    ts.ClassLikeDeclaration,
-    ClassFieldUniqueKey[]
-  >();
+export class KnownQueries
+  implements KnownFields<ClassFieldDescriptor>, ProblematicFieldRegistry<ClassFieldDescriptor>
+{
+  private readonly classToQueryFields = new Map<ts.ClassLikeDeclaration, ClassFieldDescriptor[]>();
   private readonly knownQueryIDs = new Set<ClassFieldUniqueKey>();
 
   fieldNamesToConsiderForReferenceLookup: Set<string>;
 
   constructor(
     private readonly info: ProgramInfo,
-    globalMetadata: CompilationUnitData,
+    private globalMetadata: CompilationUnitData,
   ) {
     this.fieldNamesToConsiderForReferenceLookup = new Set(
       Object.values(globalMetadata.knownQueryFields).map((f) => f.fieldName),
     );
   }
 
+  isFieldIncompatible(descriptor: ClassFieldDescriptor): boolean {
+    return this.globalMetadata.problematicQueries[descriptor.key] !== undefined;
+  }
+
+  markFieldIncompatible(field: ClassFieldDescriptor): void {
+    this.globalMetadata.problematicQueries[field.key] = true;
+  }
+
+  markClassIncompatible(node: ts.ClassDeclaration): void {
+    this.classToQueryFields.get(node)?.forEach((f) => {
+      this.globalMetadata.problematicQueries[f.key] = true;
+    });
+  }
+
   registerQueryField(queryField: ts.PropertyDeclaration, id: ClassFieldUniqueKey) {
     if (!this.classToQueryFields.has(queryField.parent)) {
       this.classToQueryFields.set(queryField.parent, []);
     }
-    this.classToQueryFields.get(queryField.parent)!.push(id);
+
+    this.classToQueryFields.get(queryField.parent)!.push({
+      key: id,
+      node: queryField,
+    });
     this.knownQueryIDs.add(id);
   }
 
@@ -54,7 +72,11 @@ export class KnownQueries implements KnownFields<ClassFieldDescriptor> {
     return this.classToQueryFields.has(clazz);
   }
 
-  getQueryFieldsOfClass(clazz: ts.ClassDeclaration): ClassFieldUniqueKey[] | undefined {
+  getQueryFieldsOfClass(clazz: ts.ClassDeclaration): ClassFieldDescriptor[] | undefined {
     return this.classToQueryFields.get(clazz);
+  }
+
+  getAllClassesWithQueries(): ts.ClassDeclaration[] {
+    return Array.from(this.classToQueryFields.keys()).filter((c) => ts.isClassDeclaration(c));
   }
 }


### PR DESCRIPTION
Notably the inheritance checking is less complete as the one in the input migration. That is because we can't efficiently determine query fields in the analyze phase of compilation units. Unless we aggresively consider every field of decorated classes as queries and complexify the merged metadata significantly, we can't reliably check for cases where a class is incompatible for migration because it overrides a member from a class that is in a different compilation unit.

This is an acceptable limitation though (maybe for now), as worst case, we would migrate the class and the other compilation unit would simply break. Not ideal, but migrations are impossible to be 100% correct in general— so not a surprise.

In the future, we may find ways to identify queries more reliably in analyze phase already. e.g. if the compiler were to include this metadata in the `.d.ts`, or if we decide to simply add this to the metadata, accepting potential significant HDD increase.