### PR TITLE
build: do not run renovate on signal migration TS versioning tests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -70,10 +70,7 @@
 
     {
       "matchPackagePrefixes": ["@angular/", "angular/", "@angular-devkit", "@schematics/"],
-      "matchPaths": [
-        "packages/**",
-        "adev/src/content/tutorials/**"
-      ],
+      "matchPaths": ["packages/**", "adev/src/content/tutorials/**"],
       "followTag": null
     },
 
@@ -101,7 +98,11 @@
     {"matchCurrentVersion": "0.0.0-PLACEHOLDER", "enabled": false},
 
     {
-      "matchPaths": ["integration/**", "packages/zone.js/test/typings/package.json"],
+      "matchPaths": [
+        "integration/**",
+        "packages/zone.js/test/typings/package.json",
+        "packages/core/schematics/migrations/signal-migration/test/**"
+      ],
       "enabled": false
     }
   ]


### PR DESCRIPTION
The versions for TypeScript should not be updated, as we explicitly test against older versions of TS.