### PR TITLE
feat(core): Add ability to pass inputs to `TestBed.createComponent`

### DIFF
--- a/adev/src/content/guide/testing/utility-apis.md
+++ b/adev/src/content/guide/testing/utility-apis.md
@@ -78,6 +78,8 @@ These are rarely needed.
 ## The `ComponentFixture`
 
 The `TestBed.createComponent<T>` creates an instance of the component `T` and returns a strongly typed `ComponentFixture` for that component.
+You can also pass inputs to the `createComponent` method to ensure initial input values are set up correctly, for example
+`TestBed.createComponent(ExampleComponent, {inputs: {'name': 'Angular'}})`.
 
 The `ComponentFixture` properties and methods provide access to the component, its DOM representation, and aspects of its Angular environment.
 

--- a/goldens/public-api/core/testing/index.api.md
+++ b/goldens/public-api/core/testing/index.api.md
@@ -49,7 +49,7 @@ export class ComponentFixture<T> {
     whenStable(): Promise<any>;
 }
 
-// @public (undocumented)
+// @public
 export const ComponentFixtureAutoDetect: InjectionToken<boolean>;
 
 // @public (undocumented)
@@ -121,7 +121,7 @@ export interface TestBed {
     // (undocumented)
     configureTestingModule(moduleDef: TestModuleMetadata): TestBed;
     // (undocumented)
-    createComponent<T>(component: Type<T>): ComponentFixture<T>;
+    createComponent<T>(component: Type<T>, options?: TestBedCreateComponentOptions): ComponentFixture<T>;
     // (undocumented)
     execute(tokens: any[], fn: Function, context?: any): any;
     flushEffects(): void;
@@ -183,6 +183,13 @@ export interface TestBed {
 
 // @public
 export const TestBed: TestBedStatic;
+
+// @public
+export interface TestBedCreateComponentOptions {
+    inputs?: {
+        [templateName: string]: unknown;
+    };
+}
 
 // @public
 export interface TestBedStatic extends TestBed {

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -36,6 +36,14 @@ export class TestComponentRenderer {
 
 /**
  * @publicApi
+ *
+ * When true, ensures components created with `TestBed#createComponent` are attached to the application.
+ * This more closely matches production behavior for the vast majority of components in Angular.
+ * When using `ComponentFixtureAutoDetect`, consider also defining the initial inputs in the
+ * options of `TestBed#createComponent` to ensure they are set prior to the first change detection
+ * of the component.
+ *
+ * @see TestBedCreateComponentOptions
  */
 export const ComponentFixtureAutoDetect = new InjectionToken<boolean>('ComponentFixtureAutoDetect');
 

--- a/packages/core/testing/src/testing.ts
+++ b/packages/core/testing/src/testing.ts
@@ -29,6 +29,7 @@ export {
   inject,
   InjectSetupWrapper,
   withModule,
+  TestBedCreateComponentOptions,
 } from './test_bed';
 export {
   TestComponentRenderer,


### PR DESCRIPTION
This helps mitigate #57858 by allowing testers to pass inputs that will be set _within_ the `NgZone.run` call that wraps component initialization. This will ensure that inputs are set prior to the automatic `ApplicationRef.tick`.

resolves #57856
