### PR TITLE
test: disable cache and analytics

### DIFF
--- a/integration/animations-async/angular.json
+++ b/integration/animations-async/angular.json
@@ -138,5 +138,11 @@
         }
       }
     }
+  },
+  "cli": {
+    "cache": {
+      "enabled": false
+    },
+    "analytics": false
   }
 }

--- a/integration/animations/angular.json
+++ b/integration/animations/angular.json
@@ -138,5 +138,11 @@
         }
       }
     }
+  },
+  "cli": {
+    "cache": {
+      "enabled": false
+    },
+    "analytics": false
   }
 }

--- a/integration/cli-elements-universal/angular.json
+++ b/integration/cli-elements-universal/angular.json
@@ -111,5 +111,11 @@
         }
       }
     }
+  },
+  "cli": {
+    "cache": {
+      "enabled": false
+    },
+    "analytics": false
   }
 }

--- a/integration/cli-hello-world-ivy-i18n/angular.json
+++ b/integration/cli-hello-world-ivy-i18n/angular.json
@@ -143,5 +143,11 @@
         }
       }
     }
+  },
+  "cli": {
+    "cache": {
+      "enabled": false
+    },
+    "analytics": false
   }
 }

--- a/integration/cli-hello-world-lazy/angular.json
+++ b/integration/cli-hello-world-lazy/angular.json
@@ -107,5 +107,11 @@
         }
       }
     }
+  },
+  "cli": {
+    "cache": {
+      "enabled": false
+    },
+    "analytics": false
   }
 }

--- a/integration/cli-hello-world-mocha/angular.json
+++ b/integration/cli-hello-world-mocha/angular.json
@@ -121,5 +121,11 @@
         }
       }
     }
+  },
+  "cli": {
+    "cache": {
+      "enabled": false
+    },
+    "analytics": false
   }
 }

--- a/integration/cli-hello-world/angular.json
+++ b/integration/cli-hello-world/angular.json
@@ -121,5 +121,11 @@
         }
       }
     }
+  },
+  "cli": {
+    "cache": {
+      "enabled": false
+    },
+    "analytics": false
   }
 }

--- a/integration/cli-signal-inputs/angular.json
+++ b/integration/cli-signal-inputs/angular.json
@@ -114,5 +114,11 @@
         }
       }
     }
+  },
+  "cli": {
+    "cache": {
+      "enabled": false
+    },
+    "analytics": false
   }
 }

--- a/integration/defer/angular.json
+++ b/integration/defer/angular.json
@@ -122,5 +122,11 @@
         }
       }
     }
+  },
+  "cli": {
+    "cache": {
+      "enabled": false
+    },
+    "analytics": false
   }
 }

--- a/integration/forms/angular.json
+++ b/integration/forms/angular.json
@@ -121,5 +121,11 @@
         }
       }
     }
+  },
+  "cli": {
+    "cache": {
+      "enabled": false
+    },
+    "analytics": false
   }
 }

--- a/integration/ivy-i18n/angular.json
+++ b/integration/ivy-i18n/angular.json
@@ -169,5 +169,11 @@
         }
       }
     }
+  },
+  "cli": {
+    "cache": {
+      "enabled": false
+    },
+    "analytics": false
   }
 }

--- a/integration/ng-add-localize/angular.json
+++ b/integration/ng-add-localize/angular.json
@@ -97,5 +97,11 @@
         }
       }
     }
+  },
+  "cli": {
+    "cache": {
+      "enabled": false
+    },
+    "analytics": false
   }
 }

--- a/integration/ng_update_migrations/angular.json
+++ b/integration/ng_update_migrations/angular.json
@@ -65,5 +65,11 @@
         }
       }
     }
+  },
+  "cli": {
+    "cache": {
+      "enabled": false
+    },
+    "analytics": false
   }
 }

--- a/integration/platform-server/angular.json
+++ b/integration/platform-server/angular.json
@@ -205,6 +205,9 @@
     }
   },
   "cli": {
-    "analytics": false
+    "analytics": false,
+    "cache": {
+      "enabled": false
+    }
   }
 }

--- a/integration/standalone-bootstrap/angular.json
+++ b/integration/standalone-bootstrap/angular.json
@@ -121,5 +121,11 @@
         }
       }
     }
+  },
+  "cli": {
+    "cache": {
+      "enabled": false
+    },
+    "analytics": false
   }
 }

--- a/integration/trusted-types/angular.json
+++ b/integration/trusted-types/angular.json
@@ -121,5 +121,11 @@
         }
       }
     }
+  },
+  "cli": {
+    "cache": {
+      "enabled": false
+    },
+    "analytics": false
   }
 }


### PR DESCRIPTION
In Bazel, the `CI` environment variable is not set due to its hermetic nature. As a result, caching is enabled by default, which includes Vite pre-bundling. This is unnecessary in CI environments.

In some cases, this leads to errors during CI runs when the Vite build is closed or canceled prematurely, resulting in the following errors:

```
Error: R] The build was canceled
Error: R] Terminating worker thread [plugin angular-vite-optimize-deps]
```
