### PR TITLE
feat(core): change effect() execution timing & no-op `allowSignalWrites`

### DIFF
--- a/packages/core/src/render3/reactivity/patch.ts
+++ b/packages/core/src/render3/reactivity/patch.ts
@@ -9,4 +9,4 @@
 /**
  * Controls whether effects use the legacy `microtaskEffect` by default.
  */
-export const USE_MICROTASK_EFFECT_BY_DEFAULT = true;
+export const USE_MICROTASK_EFFECT_BY_DEFAULT = false;


### PR DESCRIPTION
This commit flips the flag that was added in 4e890cc, putting the new effect timing into... effect :)

BREAKING CHANGE:

Generally this PR has two implications:

* effects which are triggered outside of change detection run as part of
  the change detection process instead of as a microtask. Depending on the
  specifics of application/test setup, this can result in them executing
  earlier or later (or requiring additional test steps to trigger; see below
  examples).

* effects which are triggered during change detection (e.g. by input signals) run _earlier_, before the component's template.

We've seen a few common failure cases:

* Tests which used to rely on the `Promise` timing of effects now need to `await whenStable()` or call `.detectChanges()` in order for effects to run.

* Tests which use faked clocks may need to fast-forward/flush the clock to cause effects to run.

* `effect()`s triggered during CD could rely on the application being fully rendered (for example, they could easily read computed styles, etc). With the change, they run before the component's updates and can get incorrect answers. The recent `afterRenderEffect()` API is a natural replacement for this style of effect.

* `effect()`s which synchronize with the forms system are particularly timing-sensitive and might need to adjust their initialization timing.

Fixes #55311
Fixes #55808
Fixes #55644
Fixes #56863