### PR TITLE
fix(http): cleanup JSONP script listeners once loading completed

### DIFF
--- a/packages/common/http/src/jsonp.ts
+++ b/packages/common/http/src/jsonp.ts
@@ -163,6 +163,9 @@ export class JsonpClientBackend implements HttpBackend {
       // the response callback from the window. This logic is used in both the
       // success, error, and cancellation paths, so it's extracted out for convenience.
       const cleanup = () => {
+        node.removeEventListener('load', onLoad);
+        node.removeEventListener('error', onError);
+
         // Remove the <script> tag if it's still on the page.
         node.remove();
 


### PR DESCRIPTION
This commit removes event listeners from the `script` element once loading is
complete. If the element is not garbage collected properly, in Firefox, the script
element still appears in the memory tree view, captured by
`__zone_symbol__loadfalse -> HTMLScriptElement -> GC Roots`. We should always be good
citizens and clean up event listeners when we no longer need them, as browser's garbage
collectors work differently. Calling `remove()` on the node doesn't guarantee that the
node can be collected.