### PR TITLE
docs: declare Event Replay feature as stable

### DIFF
--- a/adev/src/content/guide/hydration.md
+++ b/adev/src/content/guide/hydration.md
@@ -75,7 +75,6 @@ bootstrapApplication(App, {
 });
 ```
 
-IMPORTANT: the Event Replay feature is currently in [Developer Preview](/reference/releases#developer-preview).
 
 ## Constraints
 

--- a/packages/platform-browser/src/hydration.ts
+++ b/packages/platform-browser/src/hydration.ts
@@ -111,7 +111,6 @@ export function withI18nSupport(): HydrationFeature<HydrationFeatureKind.I18nSup
  *   providers: [provideClientHydration(withEventReplay())]
  * });
  * ```
- * @developerPreview
  * @publicApi
  * @see {@link provideClientHydration}
  */


### PR DESCRIPTION
This commit drops the `@developerPreview` annotation from the `withEventReplay()` function, which effectively makes the Event Replay feature stable.

cc @alan-agius4 @iteriani @tbondwilkinson @thePunderWoman  

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No