### PR TITLE
refactor(migrations): fix virtual devkit file system not detecting directories

### DIFF
--- a/packages/compiler-cli/src/ngtsc/file_system/src/ts_read_directory.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/ts_read_directory.ts
@@ -100,10 +100,7 @@ export function createFileSystemTsReadDirectoryFn(
         return {files, directories};
       },
       (p) => fs.resolve(p),
-      (p) => {
-        const resolvedPath = fs.resolve(p);
-        return fs.exists(resolvedPath) && fs.stat(resolvedPath).isDirectory();
-      },
+      (p) => directoryExists(p),
     );
   };
 }

--- a/packages/core/schematics/utils/tsurge/helpers/angular_devkit/devkit_filesystem.ts
+++ b/packages/core/schematics/utils/tsurge/helpers/angular_devkit/devkit_filesystem.ts
@@ -14,7 +14,6 @@ import {
   dirname,
   Path as DevkitAbsPath,
   PathFragment as DevkitPathFragment,
-  resolve,
 } from '@angular-devkit/core';
 import {DirEntry, FileEntry, Tree} from '@angular-devkit/schematics';
 import {
@@ -90,7 +89,7 @@ export class DevkitMigrationFilesystem implements FileSystem {
   }
 
   exists(path: AbsoluteFsPath): boolean {
-    return this.tree.exists(path);
+    return statPath(this.tree, path) !== null;
   }
 
   readFile(path: AbsoluteFsPath): string {


### PR DESCRIPTION
The compiler and its file system implementation expects `fs.exists` to return `true` even for
directories. This caused issues with the TSConfig resolution as `/` was looked up.

We fix this by making use of `stat` which is equally expensive to `tree.exists`. The devkit tree's
don't expose directory existance checks out of the box.

Fixes #57887.