### PR TITLE
refactor(migrations): avoid TS error 18003 when no files found

### DIFF
--- a/packages/core/schematics/utils/tsurge/helpers/ngtsc_program.ts
+++ b/packages/core/schematics/utils/tsurge/helpers/ngtsc_program.ts
@@ -17,9 +17,12 @@ import {
 import {NgtscProgram} from '@angular/compiler-cli/src/ngtsc/program';
 import {BaseProgramInfo} from '../program_info';
 
+/** Code of the error raised by TypeScript when a tsconfig doesn't match any files. */
+const NO_INPUTS_ERROR_CODE = 18003;
+
 /**
  * Parses the configuration of the given TypeScript project and creates
- * an instance of the Angular compiler for for the project.
+ * an instance of the Angular compiler for the project.
  */
 export function createNgtscProgram(
   absoluteTsconfigPath: string,
@@ -33,10 +36,13 @@ export function createNgtscProgram(
 
   const tsconfig = readConfiguration(absoluteTsconfigPath, {}, fs);
 
-  if (tsconfig.errors.length > 0) {
+  // Skip the "No inputs found..." error since we don't want to interrupt the migration if a
+  // tsconfig doesn't match a file. This will result in an empty `Program` which is still valid.
+  const errors = tsconfig.errors.filter((diag) => diag.code !== NO_INPUTS_ERROR_CODE);
+
+  if (errors.length) {
     throw new Error(
-      `Tsconfig could not be parsed or is invalid:\n\n` +
-        `${tsconfig.errors.map((e) => e.messageText)}`,
+      `Tsconfig could not be parsed or is invalid:\n\n` + `${errors.map((e) => e.messageText)}`,
     );
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

When running a migration, tsurge creates a TS program from the tsconfig files found. This can result in a 18003 error when no files are found (based on the includes/files of the config).

For example, the signal input migration throws in a CLI project that has no spec files:

```
ng g @angular/core:signal-inputs --defaults
Tsconfig could not be parsed or is invalid:

No inputs were found in config file '/tsconfig.spec.json'. Specified 'include' paths were '["src/**/*.spec.ts","src/**/*.d.ts"]' and 'exclude' paths were '["/out-tsc/spec"]'.
```

A similar issue has already been raised in the CDK migration (see https://github.com/angular/components/issues/27055).

## What is the new behavior?


This was solved in the CDK (credits to @crisbeto) by ignoring the 18003 error (see 9c1112d408361a47c98dfd470b8e990cbd1753db).

This PR does the same in tsurge.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
