### PR TITLE
fix(core): Ensure the `ViewContext` is retained after closure minific…

### DIFF
--- a/packages/core/src/render3/view_context.ts
+++ b/packages/core/src/render3/view_context.ts
@@ -18,6 +18,7 @@ export class ViewContext {
 
   /**
    * @internal
+   * @nocollapse
    */
   static __NG_ELEMENT_ID__ = injectViewContext;
 }


### PR DESCRIPTION
…ation

In order to survive closure minification correctly, static properties need to be annotated with `@nocollapse`.

For more history, see https://github.com/angular/angular/pull/28050
