### PR TITLE
docs: correct `HashLocationStrategy` example url

### DIFF
--- a/packages/common/src/location/location_strategy.ts
+++ b/packages/common/src/location/location_strategy.ts
@@ -22,7 +22,7 @@ import {joinWithSlash, normalizeQueryParams} from './util';
  * interact with application route state.
  *
  * For instance, `HashLocationStrategy` produces URLs like
- * <code class="no-auto-link">http://example.com#/foo</code>,
+ * <code class="no-auto-link">http://example.com/#/foo</code>,
  * and `PathLocationStrategy` produces
  * <code class="no-auto-link">http://example.com/foo</code> as an equivalent URL.
  *


### PR DESCRIPTION
This is probably the smallest fix in the Angular repo. 😁