### PR TITLE
refactor(migrations): fix `peformance.now()` not available in input schematic

### DIFF
--- a/packages/core/schematics/migrations/signal-migration/src/passes/reference_resolution/index.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/reference_resolution/index.ts
@@ -60,8 +60,12 @@ export function createFindAllSourceFileReferencesVisitor<D extends ClassFieldDes
     tsTypes: 0,
   };
 
+  // Schematic NodeJS execution may not have `global.performance` defined.
+  const currentTimeInMs = () =>
+    typeof global.performance !== 'undefined' ? global.performance.now() : Date.now();
+
   const visitor = (node: ts.Node) => {
-    let lastTime = performance.now();
+    let lastTime = currentTimeInMs();
 
     if (ts.isClassDeclaration(node)) {
       identifyTemplateReferences(
@@ -76,16 +80,16 @@ export function createFindAllSourceFileReferencesVisitor<D extends ClassFieldDes
         result,
         knownFields,
       );
-      perfCounters.template += (performance.now() - lastTime) / 1000;
-      lastTime = performance.now();
+      perfCounters.template += (currentTimeInMs() - lastTime) / 1000;
+      lastTime = currentTimeInMs();
 
       identifyHostBindingReferences(node, programInfo, checker, reflector, result, knownFields);
 
       perfCounters.hostBindings += (performance.now() - lastTime) / 1000;
-      lastTime = performance.now();
+      lastTime = currentTimeInMs();
     }
 
-    lastTime = performance.now();
+    lastTime = currentTimeInMs();
 
     // find references, but do not capture input declarations itself.
     if (
@@ -106,7 +110,7 @@ export function createFindAllSourceFileReferencesVisitor<D extends ClassFieldDes
     }
 
     perfCounters.tsReferences += (performance.now() - lastTime) / 1000;
-    lastTime = performance.now();
+    lastTime = currentTimeInMs();
     // Detect `Partial<T>` references.
     // Those are relevant to be tracked as they may be updated in Catalyst to
     // unwrap signal inputs. Commonly people use `Partial` in Catalyst to type


### PR DESCRIPTION
In schematics, `performance.now()` is not available. This breaks execution.