### PR TITLE
refactor(core): support external runtime styles via a component feature

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1524,6 +1524,7 @@ export interface RendererType2 {
         [kind: string]: any;
     };
     encapsulation: ViewEncapsulation;
+    getExternalStyles?: ((encapsulationId?: string) => string[]) | null;
     id: string;
     styles: string[];
 }

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -177,6 +177,7 @@ export {
   ɵɵsetNgModuleScope,
   ɵɵgetComponentDepsFactory,
   ɵɵStandaloneFeature,
+  ɵɵExternalStylesFeature,
   ɵɵstyleMap,
   ɵɵstyleMapInterpolate1,
   ɵɵstyleMapInterpolate2,

--- a/packages/core/src/render/api_flags.ts
+++ b/packages/core/src/render/api_flags.ts
@@ -39,6 +39,12 @@ export interface RendererType2 {
    * This is useful for renderers that delegate to other renderers.
    */
   data: {[kind: string]: any};
+
+  /**
+   * A function added by the {@link ɵɵExternalStylesFeature} and used by the framework to create
+   * the list of external runtime style URLs.
+   */
+  getExternalStyles?: ((encapsulationId?: string) => string[]) | null;
 }
 
 /**

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -357,6 +357,7 @@ export function ɵɵdefineComponent<T>(
       pipeDefs: null!, // assigned in noSideEffects
       dependencies: (baseDef.standalone && componentDefinition.dependencies) || null,
       getStandaloneInjector: null,
+      getExternalStyles: null,
       signals: componentDefinition.signals ?? false,
       data: componentDefinition.data || {},
       encapsulation: componentDefinition.encapsulation || ViewEncapsulation.Emulated,

--- a/packages/core/src/render3/features/external_styles_feature.ts
+++ b/packages/core/src/render3/features/external_styles_feature.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentDef, ComponentDefFeature} from '../interfaces/definition';
+
+/**
+ * A feature that adds support for external runtime styles for a component.
+ * An external runtime style is a URL to a CSS stylesheet that contains the styles
+ * for a given component. For browsers, this URL will be used in an appended `link` element
+ * when the component is rendered. This feature is typically used for Hot Module Replacement
+ * (HMR) of component stylesheets by leveraging preexisting global stylesheet HMR available
+ * in most development servers.
+ *
+ * @codeGenApi
+ */
+export function ɵɵExternalStylesFeature(styleUrls: string[]): ComponentDefFeature {
+  return (definition: ComponentDef<unknown>) => {
+    if (styleUrls.length < 1) {
+      return;
+    }
+
+    definition.getExternalStyles = (encapsulationId) => {
+      // Add encapsulation ID search parameter `component` to support external style encapsulation
+      const urls = styleUrls.map(
+        (value) =>
+          value + '?ngcomp' + (encapsulationId ? '=' + encodeURIComponent(encapsulationId) : ''),
+      );
+
+      return urls;
+    };
+  };
+}

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -14,6 +14,7 @@ import {ɵɵInputTransformsFeature} from './features/input_transforms_feature';
 import {ɵɵNgOnChangesFeature} from './features/ng_onchanges_feature';
 import {ɵɵProvidersFeature} from './features/providers_feature';
 import {ɵɵStandaloneFeature} from './features/standalone_feature';
+import {ɵɵExternalStylesFeature} from './features/external_styles_feature';
 import {
   ComponentDef,
   ComponentTemplate,
@@ -255,4 +256,5 @@ export {
   ɵɵsetComponentScope,
   ɵɵsetNgModuleScope,
   ɵɵStandaloneFeature,
+  ɵɵExternalStylesFeature,
 };

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -401,6 +401,12 @@ export interface ComponentDef<T> extends DirectiveDef<T> {
     | null;
 
   /**
+   * A function added by the {@link ɵɵExternalStylesFeature} and used by the framework to create
+   * the list of external runtime style URLs.
+   */
+  getExternalStyles: ((encapsulationId?: string) => string[]) | null;
+
+  /**
    * Used to store the result of `noSideEffects` function so that it is not removed by closure
    * compiler. The property should never be read.
    */

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -51,6 +51,7 @@ export const angularCoreEnv: {[name: string]: unknown} = (() => ({
   'ɵɵInheritDefinitionFeature': r3.ɵɵInheritDefinitionFeature,
   'ɵɵInputTransformsFeature': r3.ɵɵInputTransformsFeature,
   'ɵɵStandaloneFeature': r3.ɵɵStandaloneFeature,
+  'ɵɵExternalStylesFeature': r3.ɵɵExternalStylesFeature,
   'ɵɵnextContext': r3.ɵɵnextContext,
   'ɵɵnamespaceHTML': r3.ɵɵnamespaceHTML,
   'ɵɵnamespaceMathML': r3.ɵɵnamespaceMathML,

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -813,6 +813,9 @@
     "name": "createLView"
   },
   {
+    "name": "createLinkElement"
+  },
+  {
     "name": "createNodeInjector"
   },
   {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -876,6 +876,9 @@
     "name": "createLView"
   },
   {
+    "name": "createLinkElement"
+  },
+  {
     "name": "createNodeInjector"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -669,6 +669,9 @@
     "name": "createLView"
   },
   {
+    "name": "createLinkElement"
+  },
+  {
     "name": "createNodeInjector"
   },
   {

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -750,6 +750,9 @@
     "name": "createLView"
   },
   {
+    "name": "createLinkElement"
+  },
+  {
     "name": "createNodeInjector"
   },
   {
@@ -1480,6 +1483,9 @@
   },
   {
     "name": "init_exhaustive_check_no_changes"
+  },
+  {
+    "name": "init_external_styles_feature"
   },
   {
     "name": "init_fields"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -957,6 +957,9 @@
     "name": "createLView"
   },
   {
+    "name": "createLinkElement"
+  },
+  {
     "name": "createNodeInjector"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -921,6 +921,9 @@
     "name": "createLView"
   },
   {
+    "name": "createLinkElement"
+  },
+  {
     "name": "createNodeInjector"
   },
   {

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -729,6 +729,9 @@
     "name": "createLView"
   },
   {
+    "name": "createLinkElement"
+  },
+  {
     "name": "createNodeInjector"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1083,6 +1083,9 @@
     "name": "createLView"
   },
   {
+    "name": "createLinkElement"
+  },
+  {
     "name": "createNewSegmentChildren"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -600,6 +600,9 @@
     "name": "createLView"
   },
   {
+    "name": "createLinkElement"
+  },
+  {
     "name": "createNodeInjector"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -786,6 +786,9 @@
     "name": "createLView"
   },
   {
+    "name": "createLinkElement"
+  },
+  {
     "name": "createNodeInjector"
   },
   {

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -460,6 +460,7 @@ class ShadowDomRenderer extends DefaultDomRenderer2 {
 
 class NoneEncapsulationDomRenderer extends DefaultDomRenderer2 {
   private readonly styles: string[];
+  private readonly styleUrls?: string[];
 
   constructor(
     eventManager: EventManager,
@@ -473,10 +474,11 @@ class NoneEncapsulationDomRenderer extends DefaultDomRenderer2 {
   ) {
     super(eventManager, doc, ngZone, platformIsServer);
     this.styles = compId ? shimStylesContent(compId, component.styles) : component.styles;
+    this.styleUrls = component.getExternalStyles?.(compId);
   }
 
   applyStyles(): void {
-    this.sharedStylesHost.addStyles(this.styles);
+    this.sharedStylesHost.addStyles(this.styles, this.styleUrls);
   }
 
   override destroy(): void {
@@ -484,7 +486,7 @@ class NoneEncapsulationDomRenderer extends DefaultDomRenderer2 {
       return;
     }
 
-    this.sharedStylesHost.removeStyles(this.styles);
+    this.sharedStylesHost.removeStyles(this.styles, this.styleUrls);
   }
 }
 

--- a/packages/platform-browser/test/dom/shared_styles_host_spec.ts
+++ b/packages/platform-browser/test/dom/shared_styles_host_spec.ts
@@ -21,43 +21,98 @@ describe('SharedStylesHost', () => {
     someHost = getDOM().createElement('div');
   });
 
-  it('should add existing styles to new hosts', () => {
-    ssh.addStyles(['a {};']);
-    ssh.addHost(someHost);
-    expect(someHost.innerHTML).toEqual('<style>a {};</style>');
+  describe('inline', () => {
+    it('should add existing styles to new hosts', () => {
+      ssh.addStyles(['a {};']);
+      ssh.addHost(someHost);
+      expect(someHost.innerHTML).toEqual('<style>a {};</style>');
+    });
+
+    it('should add new styles to hosts', () => {
+      ssh.addHost(someHost);
+      ssh.addStyles(['a {};']);
+      expect(someHost.innerHTML).toEqual('<style>a {};</style>');
+    });
+
+    it('should add styles only once to hosts', () => {
+      ssh.addStyles(['a {};']);
+      ssh.addHost(someHost);
+      ssh.addStyles(['a {};']);
+      expect(someHost.innerHTML).toEqual('<style>a {};</style>');
+    });
+
+    it('should use the document head as default host', () => {
+      ssh.addStyles(['a {};', 'b {};']);
+      expect(doc.head).toHaveText('a {};b {};');
+    });
+
+    it('should remove style nodes on destroy', () => {
+      ssh.addStyles(['a {};']);
+      ssh.addHost(someHost);
+      expect(someHost.innerHTML).toEqual('<style>a {};</style>');
+
+      ssh.ngOnDestroy();
+      expect(someHost.innerHTML).toEqual('');
+    });
+
+    it(`should add 'nonce' attribute when a nonce value is provided`, () => {
+      ssh = new SharedStylesHost(doc, 'app-id', '{% nonce %}');
+      ssh.addStyles(['a {};']);
+      ssh.addHost(someHost);
+      expect(someHost.innerHTML).toEqual('<style nonce="{% nonce %}">a {};</style>');
+    });
   });
 
-  it('should add new styles to hosts', () => {
-    ssh.addHost(someHost);
-    ssh.addStyles(['a {};']);
-    expect(someHost.innerHTML).toEqual('<style>a {};</style>');
-  });
+  describe('external', () => {
+    it('should add existing styles to new hosts', () => {
+      ssh.addStyles([], ['component-1.css']);
+      ssh.addHost(someHost);
+      expect(someHost.innerHTML).toEqual('<link rel="stylesheet" href="component-1.css">');
+    });
 
-  it('should add styles only once to hosts', () => {
-    ssh.addStyles(['a {};']);
-    ssh.addHost(someHost);
-    ssh.addStyles(['a {};']);
-    expect(someHost.innerHTML).toEqual('<style>a {};</style>');
-  });
+    it('should add new styles to hosts', () => {
+      ssh.addHost(someHost);
+      ssh.addStyles([], ['component-1.css']);
+      expect(someHost.innerHTML).toEqual('<link rel="stylesheet" href="component-1.css">');
+    });
 
-  it('should use the document head as default host', () => {
-    ssh.addStyles(['a {};', 'b {};']);
-    expect(doc.head).toHaveText('a {};b {};');
-  });
+    it('should add styles only once to hosts', () => {
+      ssh.addStyles([], ['component-1.css']);
+      ssh.addHost(someHost);
+      ssh.addStyles([], ['component-1.css']);
+      expect(someHost.innerHTML).toEqual('<link rel="stylesheet" href="component-1.css">');
+    });
 
-  it('should remove style nodes on destroy', () => {
-    ssh.addStyles(['a {};']);
-    ssh.addHost(someHost);
-    expect(someHost.innerHTML).toEqual('<style>a {};</style>');
+    it('should use the document head as default host', () => {
+      ssh.addStyles([], ['component-1.css', 'component-2.css']);
+      expect(doc.head.innerHTML).toContain('<link rel="stylesheet" href="component-1.css">');
+      expect(doc.head.innerHTML).toContain('<link rel="stylesheet" href="component-2.css">');
+    });
 
-    ssh.ngOnDestroy();
-    expect(someHost.innerHTML).toEqual('');
-  });
+    it('should remove style nodes on destroy', () => {
+      ssh.addStyles([], ['component-1.css']);
+      ssh.addHost(someHost);
+      expect(someHost.innerHTML).toEqual('<link rel="stylesheet" href="component-1.css">');
 
-  it(`should add 'nonce' attribute when a nonce value is provided`, () => {
-    ssh = new SharedStylesHost(doc, 'app-id', '{% nonce %}');
-    ssh.addStyles(['a {};']);
-    ssh.addHost(someHost);
-    expect(someHost.innerHTML).toEqual('<style nonce="{% nonce %}">a {};</style>');
+      ssh.ngOnDestroy();
+      expect(someHost.innerHTML).toEqual('');
+    });
+
+    it(`should add 'nonce' attribute when a nonce value is provided`, () => {
+      ssh = new SharedStylesHost(doc, 'app-id', '{% nonce %}');
+      ssh.addStyles([], ['component-1.css']);
+      ssh.addHost(someHost);
+      expect(someHost.innerHTML).toEqual(
+        '<link rel="stylesheet" href="component-1.css" nonce="{% nonce %}">',
+      );
+    });
+
+    it('should keep search parameters of urls', () => {
+      ssh.addHost(someHost);
+      ssh.addStyles([], ['component-1.css?ngcomp=ng-app-c123456789']);
+      expect(someHost.innerHTML).toEqual(
+        '<link rel="stylesheet" href="component-1.css?ngcomp=ng-app-c123456789">',
+      );
+    });
   });
 });


### PR DESCRIPTION
The shared style host now has the capability to add component styles as link elements with external style references. This is currently unused within the runtime but is an enabling feature for upcoming features such as automatic component style HMR and development server deferred stylesheet processing. Instead of inline style content that is then added to a `style` element for each host node, a `link` element with a stylesheet `rel` attribute and a `href` attribute can now be created. The development server must be configured to provide the relevant component stylesheet upon request. The Angular CLI development server will provide this functionality once this capability is enabled. Since the primary use of this capability is development mode and will not be used for production code, server (SSR) style reuse is currently not yet implemented but may be implemented in the future.

A component feature is used to provide the DOM renderer access to any external styles that were emitted at compile time. When external styles are present, the `getExternalStyles` function will be present on the runtime component metadata object. The DOM render will use this function to access and encapsulate the external style URLs as required by the component. This approach minimizes the code present when no components within the application use external runtime styles.