### PR TITLE
fix(docs-infra): resolve Mermaid from Bazel root path

### DIFF
--- a/adev/shared-docs/pipeline/guides/mermaid/index.ts
+++ b/adev/shared-docs/pipeline/guides/mermaid/index.ts
@@ -24,7 +24,7 @@ function getMermaidScriptTagData() {
   }
 
   return (mermaidScriptTagData = {
-    path: runfiles.resolveWorkspaceRelative('node_modules/mermaid/dist/mermaid.js'),
+    path: runfiles.resolve('npm/node_modules/mermaid/dist/mermaid.js'),
   });
 }
 


### PR DESCRIPTION
This update addresses a build failure on Windows caused by the previous method, which was incompatible with the Windows environment.

Closes #57920
