### PR TITLE
docs(animations): reflect that the position parameter is actually a f…

### DIFF
--- a/packages/animations/src/players/animation_player.ts
+++ b/packages/animations/src/players/animation_player.ts
@@ -75,12 +75,12 @@ export interface AnimationPlayer {
   reset(): void;
   /**
    * Sets the position of the animation.
-   * @param position A 0-based offset into the duration, in milliseconds.
+   * @param position A fractional value, representing the progress through the animation.
    */
   setPosition(position: number): void;
   /**
    * Reports the current position of the animation.
-   * @returns A 0-based offset into the duration, in milliseconds.
+   * @returns A fractional value, representing the progress through the animation.
    */
   getPosition(): number;
   /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [✓] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [✓] Tests for the changes have been added (for bug fixes / features)
- [✓] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [✓] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [✓] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- The comment in the setPosition method describes position as a "0-based offset into the duration, in milliseconds."
- However, the code uses position as a fractional value between 0 and 1.

Issue Number:  [57915](https://github.com/angular/angular/issues/57915)

## What is the new behavior?

- The comment has been updated to correctly describe position as a fractional value between 0 and 1.
- No functional changes to the code, just improved clarity in the documentation.


## Does this PR introduce a breaking change?

- [ ] Yes
- [✓] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
