### PR TITLE
docs: update function-based outputs names

### DIFF
--- a/adev/src/content/guide/components/output-function.md
+++ b/adev/src/content/guide/components/output-function.md
@@ -8,10 +8,10 @@ import {Component, output} from '@angular/core';
 
 @Component({...})
 export class MyComp {
-  onNameChange = output<string>()    // OutputEmitterRef<string>
+  nameChange = output<string>()    // OutputEmitterRef<string>
 
   setNewName(newName: string) {
-    this.onNameChange.emit(newName);
+    this.nameChange.emit(newName);
   }
 }
 </docs-code>
@@ -20,7 +20,7 @@ An output is automatically recognized by Angular whenever you use the `output` f
 Parent components can listen to outputs in templates by using the event binding syntax.
 
 ```angular-html
-<my-comp (onNameChange)="showNewName($event)" />
+<my-comp (nameChange)="showNewName($event)" />
 ```
 
 ## Aliasing an output
@@ -30,11 +30,11 @@ You can alias outputs to change their public name to be different.
 
 ```typescript
 class MyComp {
-  onNameChange = output({alias: 'ngxNameChange'});
+  nameChange = output({alias: 'ngxNameChange'});
 }
 ```
 
-This allows users to bind to your output using `(ngxNameChange)`, while inside your component you can access the output emitter using `this.onNameChange`.
+This allows users to bind to your output using `(ngxNameChange)`, while inside your component you can access the output emitter using `this.nameChange`.
 
 ## Subscribing programmatically
 
@@ -44,7 +44,7 @@ In those cases, parents can subscribe to outputs by directly accessing the prope
 ```ts
 const myComp = viewContainerRef.createComponent(...);
 
-myComp.instance.onNameChange.subscribe(newName => {
+myComp.instance.nameChange.subscribe(newName => {
   console.log(newName);
 });
 ```
@@ -85,13 +85,13 @@ import {outputToObservable} from '@angular/core/rxjs-interop';
 
 @Component(...)
 class MyComp {
-  onNameChange = output<string>();
+  nameChange = output<string>();
 }
 
 // Instance reference to `MyComp`.
 const myComp: MyComp;
 
-outputToObservable(this.myComp.instance.onNameChange) // Observable<string>
+outputToObservable(this.myComp.instance.nameChange) // Observable<string>
   .pipe(...)
   .subscribe(...);
 </docs-code>


### PR DESCRIPTION
According to **Choosing event names** for Outputs and this line `Always use camelCase output names. Avoid prefixing output names with "on".`  So I made updates for **Function-based outputs** chapter in all examples from onNameChange functions to nameChange functions

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
