### PR TITLE
docs(core): add example of input -> observable -> signal interop

### DIFF
--- a/adev/src/content/guide/signals/rxjs-interop.md
+++ b/adev/src/content/guide/signals/rxjs-interop.md
@@ -129,3 +129,34 @@ outputToObservable(myComp.instance.onNameChange)
 ```
 
 See more details in the [output() API guide](/guide/components/output-fn).
+
+## Examples
+
+### Passing an input to a function returning an observable
+
+If you have a function that returns an observable and you want to pass an input (which is a signal) to it, you need to:
+
+1) Convert the input to an observable.
+2) Map that observable to the new observable.
+3) Convert the final observable back into a signal.
+
+```ts
+import { Component, computed, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { interval, switchMap } from 'rxjs';
+// This is a fake import.
+import { functionReturningObservable} from 'somewhere';
+
+@Component({
+  // ...
+})
+export class MyComponent {
+  readonly inputSignal = signal(1); // The input signal
+
+  readonly convertedSignal = toSignal(
+    toObservable(this.inputSignal).pipe(
+      switchMap((value) => functionReturningObservable(value))
+    );
+  );
+}
+```

--- a/adev/src/content/guide/signals/rxjs-interop.md
+++ b/adev/src/content/guide/signals/rxjs-interop.md
@@ -142,7 +142,7 @@ If you have a function that returns an observable and you want to pass an input 
 
 ```ts
 import { Component, computed, signal } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { interval, switchMap } from 'rxjs';
 // This is a fake import.
 import { functionReturningObservable} from 'somewhere';

--- a/adev/src/content/guide/signals/rxjs-interop.md
+++ b/adev/src/content/guide/signals/rxjs-interop.md
@@ -141,9 +141,9 @@ If you have a function that returns an observable and you want to pass an input 
 3) Convert the final observable back into a signal.
 
 ```ts
-import { Component, computed, signal } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { interval, switchMap } from 'rxjs';
+import { switchMap } from 'rxjs';
 // This is a fake import.
 import { functionReturningObservable} from 'somewhere';
 
@@ -151,7 +151,7 @@ import { functionReturningObservable} from 'somewhere';
   // ...
 })
 export class MyComponent {
-  readonly inputSignal = signal(1); // The input signal
+  readonly inputSignal = input.required<number>(1); // The input signal
 
   readonly convertedSignal = toSignal(
     toObservable(this.inputSignal).pipe(


### PR DESCRIPTION
Add a detailed example of doing interop between inputs and observables back to signals, since the necessary steps here are non-trivial.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X] ~Tests for the changes have been added (for bug fixes / features)~
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

No examples are given of passing inputs to functions that return observables and then converting them back to signals

## What is the new behavior?

Now there is an example.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I've seen this question come up a few times in angular-related chats, so I thought I'd just add docs that I could point to!