### PR TITLE
build: remove redundant no-prerender Bazel flags for adev

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -158,8 +158,6 @@ test:saucelabs --flaky_test_attempts=1
 
 # --ng_perf will ask the Ivy compiler to produce performance results for each build.
 build --flag_alias=ng_perf=//packages/compiler-cli:ng_perf
-# --prerender_adev will run adev build/serve in a full mode, performing prerendering
-build --flag_alias=prerender_adev=//adev:prerender_adev
 
 ####################################################
 # User bazel configuration

--- a/.github/workflows/adev-preview-build.yml
+++ b/.github/workflows/adev-preview-build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install node modules
         run: yarn install --frozen-lockfile
       - name: Build adev to ensure it continues to work
-        run: yarn bazel build //adev:build --prerender_adev --config=release
+        run: yarn bazel build //adev:build --config=release
       - uses: angular/dev-infra/github-actions/previews/pack-and-upload-artifact@8d3cb7b9e1b3edd1dc168376689d27407d2dfa7a
         with:
           workflow-artifact-name: 'adev-preview'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
       - name: Install node modules
         run: yarn install --frozen-lockfile
       - name: Build adev to ensure it continues to work
-        run: yarn bazel build //adev:build --prerender_adev --config=release
+        run: yarn bazel build //adev:build --config=release
       - name: Deploy to firebase
         uses: ./.github/actions/deploy-docs-site
         with:

--- a/adev/BUILD.bazel
+++ b/adev/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@npm//@angular/build-tooling/bazel/remote-execution:index.bzl", "ENABLE_NETWORK")
 load("@npm//@angular/build-tooling/bazel/http-server:index.bzl", "http_server")
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@build_bazel_rules_nodejs//:index.bzl", "copy_to_bin")
 load("@npm//@angular-devkit/architect-cli:index.bzl", "architect", "architect_test")
 load("@bazel_skylib//lib:collections.bzl", "collections")
@@ -114,36 +113,12 @@ copy_to_bin(
     srcs = APPLICATION_FILES,
 )
 
-bool_flag(
-    name = "prerender_adev",
-    build_setting_default = False,
-)
-
-config_setting(
-    name = "no_prerender",
-    flag_values = {
-        ":prerender_adev": "false",
-    },
-)
-
-config_setting(
-    name = "prerender",
-    flag_values = {
-        ":prerender_adev": "true",
-    },
-)
-
-config_based_architect_flags = select({
-    ":no_prerender": ["--no-prerender"],
-    ":prerender": ["--prerender"],
-})
-
 architect(
     name = "build",
     args = [
         "angular-dev:build",
         "--output-path=build",
-    ] + config_based_architect_flags,
+    ],
     chdir = "$(RULEDIR)",
     data = ensure_local_package_deps(APPLICATION_DEPS) + APPLICATION_ASSETS + [
         ":application_files_bin",


### PR DESCRIPTION
These flags were previously used to disable prerendering in CI builds. However, this led to issues with non-compliant code being introduced. Since then, prerendering has been consistently enabled, making these flags redundant.
