### PR TITLE
refactor(core): add initial implementation of function to replace metadata at runtime

### DIFF
--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -410,6 +410,8 @@ export class Identifiers {
   static forwardRef: o.ExternalReference = {name: 'forwardRef', moduleName: CORE};
   static resolveForwardRef: o.ExternalReference = {name: 'resolveForwardRef', moduleName: CORE};
 
+  static replaceMetadata: o.ExternalReference = {name: 'ɵɵreplaceMedata', moduleName: CORE};
+
   static ɵɵdefineInjectable: o.ExternalReference = {name: 'ɵɵdefineInjectable', moduleName: CORE};
   static declareInjectable: o.ExternalReference = {name: 'ɵɵngDeclareInjectable', moduleName: CORE};
   static InjectableDeclaration: o.ExternalReference = {

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -248,6 +248,7 @@ export {
   ɵɵdeclareLet,
   ɵɵstoreLet,
   ɵɵreadContextLet,
+  ɵɵreplaceMedata,
 } from './render3/index';
 export {CONTAINER_HEADER_OFFSET as ɵCONTAINER_HEADER_OFFSET} from './render3/interfaces/container';
 export {LContext as ɵLContext} from './render3/interfaces/context';

--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -22,7 +22,7 @@ import {assertNodeInjector} from '../render3/assert';
 import {ComponentFactory as R3ComponentFactory} from '../render3/component_ref';
 import {getComponentDef} from '../render3/definition';
 import {getParentInjectorLocation, NodeInjector} from '../render3/di';
-import {addToViewTree, createLContainer} from '../render3/instructions/shared';
+import {addToEndOfViewTree, createLContainer} from '../render3/instructions/shared';
 import {
   CONTAINER_HEADER_OFFSET,
   DEHYDRATED_VIEWS,
@@ -703,7 +703,7 @@ export function createContainerRef(
     // `_locateOrCreateAnchorNode`).
     lContainer = createLContainer(slotValue, hostLView, null!, hostTNode);
     hostLView[hostTNode.index] = lContainer;
-    addToViewTree(hostLView, lContainer);
+    addToEndOfViewTree(hostLView, lContainer);
   }
   _locateOrCreateAnchorNode(lContainer, hostLView, hostTNode, slotValue);
 

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -30,7 +30,6 @@ import {Renderer2, RendererFactory2} from '../render/api';
 import {Sanitizer} from '../sanitization/sanitizer';
 import {assertDefined, assertGreaterThan, assertIndexInRange} from '../util/assert';
 
-import {AfterRenderManager} from './after_render/manager';
 import {assertComponentType, assertNoDuplicateDirectives} from './assert';
 import {attachPatchData} from './context_discovery';
 import {getComponentDef} from './definition';
@@ -41,10 +40,11 @@ import {reportUnknownPropertyError} from './instructions/element_validation';
 import {markViewDirty} from './instructions/mark_view_dirty';
 import {renderView} from './instructions/render';
 import {
-  addToViewTree,
+  addToEndOfViewTree,
   createLView,
   createTView,
   executeContentQueries,
+  getInitialLViewFlagsFromDef,
   getOrCreateComponentTView,
   getOrCreateTNode,
   initializeDirectives,
@@ -534,17 +534,11 @@ function createRootComponentView(
     hydrationInfo = retrieveHydrationInfo(hostRNode, rootView[INJECTOR]!);
   }
   const viewRenderer = environment.rendererFactory.createRenderer(hostRNode, rootComponentDef);
-  let lViewFlags = LViewFlags.CheckAlways;
-  if (rootComponentDef.signals) {
-    lViewFlags = LViewFlags.SignalView;
-  } else if (rootComponentDef.onPush) {
-    lViewFlags = LViewFlags.Dirty;
-  }
   const componentView = createLView(
     rootView,
     getOrCreateComponentTView(rootComponentDef),
     null,
-    lViewFlags,
+    getInitialLViewFlagsFromDef(rootComponentDef),
     rootView[tNode.index],
     tNode,
     environment,
@@ -558,7 +552,7 @@ function createRootComponentView(
     markAsComponentHost(tView, tNode, rootDirectives.length - 1);
   }
 
-  addToViewTree(rootView, componentView);
+  addToEndOfViewTree(rootView, componentView);
 
   // Store component view at node index, with node as the HOST
   return (rootView[tNode.index] = componentView);

--- a/packages/core/src/render3/hmr.ts
+++ b/packages/core/src/render3/hmr.ts
@@ -1,0 +1,227 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Type} from '../interface/type';
+import {assertDefined} from '../util/assert';
+import {assertLView} from './assert';
+import {getComponentDef} from './definition';
+import {assertComponentDef} from './errors';
+import {refreshView} from './instructions/change_detection';
+import {renderView} from './instructions/render';
+import {
+  createLView,
+  getInitialLViewFlagsFromDef,
+  getOrCreateComponentTView,
+} from './instructions/shared';
+import {CONTAINER_HEADER_OFFSET} from './interfaces/container';
+import {ComponentDef} from './interfaces/definition';
+import {getTrackedLViews} from './interfaces/lview_tracking';
+import {isTNodeShape, TElementNode, TNodeFlags, TNodeType} from './interfaces/node';
+import {isLContainer, isLView} from './interfaces/type_checks';
+import {
+  CHILD_HEAD,
+  CHILD_TAIL,
+  CONTEXT,
+  ENVIRONMENT,
+  FLAGS,
+  HEADER_OFFSET,
+  HOST,
+  LView,
+  LViewFlags,
+  NEXT,
+  PARENT,
+  T_HOST,
+  TVIEW,
+} from './interfaces/view';
+import {assertTNodeType} from './node_assert';
+import {destroyLView, removeViewFromDOM} from './node_manipulation';
+
+/**
+ * Replaces the metadata of a component type and re-renders all live instances of the component.
+ * @param type Class whose metadata will be replaced.
+ * @param applyMetadata Callback that will apply a new set of metadata on the `type` when invoked.
+ * @codeGenApi
+ */
+export function ɵɵreplaceMedata(type: Type<unknown>, applyMetadata: () => void) {
+  ngDevMode && assertComponentDef(type);
+  const oldDef = getComponentDef(type)!;
+
+  // The reason `applyMetadata` is a callback that is invoked (almost) immediately is because
+  // the compiler usually produces more code than just the component definition, e.g. there
+  // can be functions for embedded views, the variables for the constant pool and `setClassMetadata`
+  // calls. The callback allows us to keep them isolate from the rest of the app and to invoke
+  // them at the right time.
+  applyMetadata();
+
+  // If a `tView` hasn't been created yet, it means that this component hasn't been instantianted
+  // before. In this case there's nothing left for us to do aside from patching it in.
+  if (oldDef.tView) {
+    const trackedViews = getTrackedLViews().values();
+    for (const root of trackedViews) {
+      // Note: we have the additional check, because `IsRoot` can also indicate
+      // a component created through something like `createComponent`.
+      if (root[FLAGS] & LViewFlags.IsRoot && root[PARENT] === null) {
+        recreateMatchingLViews(oldDef, root);
+      }
+    }
+  }
+}
+
+/**
+ * Finds all LViews matching a specific component definition and recreates them.
+ * @param def Component definition to search for.
+ * @param rootLView View from which to start the search.
+ */
+function recreateMatchingLViews(def: ComponentDef<unknown>, rootLView: LView): void {
+  ngDevMode &&
+    assertDefined(
+      def.tView,
+      'Expected a component definition that has been instantiated at least once',
+    );
+
+  const tView = rootLView[TVIEW];
+
+  // Use `tView` to match the LView since `instanceof` can
+  // produce false positives when using inheritance.
+  if (tView === def.tView) {
+    ngDevMode && assertComponentDef(def.type);
+    recreateLView(getComponentDef(def.type)!, rootLView);
+    return;
+  }
+
+  for (let i = HEADER_OFFSET; i < tView.bindingStartIndex; i++) {
+    const current = rootLView[i];
+
+    if (isLContainer(current)) {
+      for (let i = CONTAINER_HEADER_OFFSET; i < current.length; i++) {
+        recreateMatchingLViews(def, current[i]);
+      }
+    } else if (isLView(current)) {
+      recreateMatchingLViews(def, current);
+    }
+  }
+}
+
+/**
+ * Recreates an LView in-place from a new component definition.
+ * @param def Definition from which to recreate the view.
+ * @param lView View to be recreated.
+ */
+function recreateLView(def: ComponentDef<unknown>, lView: LView<unknown>): void {
+  const instance = lView[CONTEXT];
+  const host = lView[HOST]!;
+  // In theory the parent can also be an LContainer, but it appears like that's
+  // only the case for embedded views which we won't be replacing here.
+  const parentLView = lView[PARENT] as LView;
+  ngDevMode && assertLView(parentLView);
+  const tNode = lView[T_HOST] as TElementNode;
+  ngDevMode && assertTNodeType(tNode, TNodeType.Element);
+
+  // Recreate the TView since the template might've changed.
+  const newTView = getOrCreateComponentTView(def);
+
+  // Create a new LView from the new TView, but reusing the existing TNode and DOM node.
+  const newLView = createLView(
+    parentLView,
+    newTView,
+    instance,
+    getInitialLViewFlagsFromDef(def),
+    host,
+    tNode,
+    null,
+    lView[ENVIRONMENT].rendererFactory.createRenderer(host, def),
+    null,
+    null,
+    null,
+  );
+
+  // Detach the LView from its current place in the tree so we don't
+  // start traversing any siblings and modifying their structure.
+  replaceLViewInTree(parentLView, lView, newLView, tNode.index);
+
+  // Destroy the detached LView.
+  destroyLView(lView[TVIEW], lView);
+
+  // Remove the nodes associated with the destroyed LView. This removes the
+  // descendants, but not the host which we want to stay in place.
+  removeViewFromDOM(lView[TVIEW], lView);
+
+  // Reset the content projection state of the TNode before the first render.
+  // Note that this has to happen after the LView has been destroyed or we
+  // risk some projected nodes not being removed correctly.
+  resetProjectionState(tNode);
+
+  // Creation pass for the new view.
+  renderView(newTView, newLView, instance);
+
+  // Update pass for the new view.
+  refreshView(newTView, newLView, newTView.template, instance);
+}
+
+/**
+ * Replaces one LView in the tree with another one.
+ * @param parentLView Parent of the LView being replaced.
+ * @param oldLView LView being replaced.
+ * @param newLView Replacement LView to be inserted.
+ * @param index Index at which the LView should be inserted.
+ */
+function replaceLViewInTree(
+  parentLView: LView,
+  oldLView: LView,
+  newLView: LView,
+  index: number,
+): void {
+  // Update the sibling whose `NEXT` pointer refers to the old view.
+  for (let i = HEADER_OFFSET; i < parentLView[TVIEW].bindingStartIndex; i++) {
+    const current = parentLView[i];
+
+    if ((isLView(current) || isLContainer(current)) && current[NEXT] === oldLView) {
+      current[NEXT] = newLView;
+      break;
+    }
+  }
+
+  // Set the new view as the head, if the old view was first.
+  if (parentLView[CHILD_HEAD] === oldLView) {
+    parentLView[CHILD_HEAD] = newLView;
+  }
+
+  // Set the new view as the tail, if the old view was last.
+  if (parentLView[CHILD_TAIL] === oldLView) {
+    parentLView[CHILD_TAIL] = newLView;
+  }
+
+  // Update the `NEXT` pointer to the same as the old view.
+  newLView[NEXT] = oldLView[NEXT];
+
+  // Clear out the `NEXT` of the old view.
+  oldLView[NEXT] = null;
+
+  // Insert the new LView at the correct index.
+  parentLView[index] = newLView;
+}
+
+/**
+ * Child nodes mutate the `projection` state of their parent node as they're being projected.
+ * This function resets the `project` back to its initial state.
+ * @param tNode
+ */
+function resetProjectionState(tNode: TElementNode): void {
+  // The `projection` is mutated by child nodes as they're being projected. We need to
+  // reset it to the initial state so projection works after the template is swapped out.
+  if (tNode.projection !== null) {
+    for (const current of tNode.projection) {
+      if (isTNodeShape(current)) {
+        // Reset `projectionNext` since it can affect the traversal order during projection.
+        current.projectionNext = null;
+        current.flags &= ~TNodeFlags.isProjected;
+      }
+    }
+    tNode.projection = null;
+  }
+}

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -219,6 +219,7 @@ export {ɵɵresolveBody, ɵɵresolveDocument, ɵɵresolveWindow} from './util/mi
 export {ɵɵtemplateRefExtractor} from './view_engine_compatibility_prebound';
 export {ɵɵgetComponentDepsFactory} from './local_compilation';
 export {ɵsetClassDebugInfo} from './debug/set_debug_info';
+export {ɵɵreplaceMedata} from './hmr';
 
 export {
   ComponentDebugMetadata,

--- a/packages/core/src/render3/instructions/template.ts
+++ b/packages/core/src/render3/instructions/template.ts
@@ -37,7 +37,7 @@ import {
 import {getConstant} from '../util/view_utils';
 
 import {
-  addToViewTree,
+  addToEndOfViewTree,
   createDirectivesInstances,
   createLContainer,
   createTView,
@@ -146,7 +146,7 @@ export function declareTemplate(
 
   const lContainer = createLContainer(comment, declarationLView, comment, tNode);
   declarationLView[adjustedIndex] = lContainer;
-  addToViewTree(declarationLView, lContainer);
+  addToEndOfViewTree(declarationLView, lContainer);
 
   // If hydration is enabled, looks up dehydrated views in the DOM
   // using hydration annotation info and stores those views on LContainer.

--- a/packages/core/src/render3/interfaces/lview_tracking.ts
+++ b/packages/core/src/render3/interfaces/lview_tracking.ts
@@ -38,3 +38,8 @@ export function unregisterLView(lView: LView): void {
   ngDevMode && assertNumber(lView[ID], 'Cannot stop tracking an LView that does not have an ID');
   TRACKED_LVIEWS.delete(lView[ID]);
 }
+
+/** Gets the currently-tracked views. */
+export function getTrackedLViews(): ReadonlyMap<number, LView> {
+  return TRACKED_LVIEWS;
+}

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -211,6 +211,9 @@ export function compileComponent(type: Type<any>, metadata: Component): void {
       }
       return ngComponentDef;
     },
+    set: (def: ComponentDef<unknown> | null) => {
+      ngComponentDef = def;
+    },
     // Make the property configurable in dev mode to allow overriding in tests
     configurable: !!ngDevMode,
   });

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -215,4 +215,6 @@ export const angularCoreEnv: {[name: string]: unknown} = (() => ({
   'ɵɵtwoWayProperty': r3.ɵɵtwoWayProperty,
   'ɵɵtwoWayBindingSet': r3.ɵɵtwoWayBindingSet,
   'ɵɵtwoWayListener': r3.ɵɵtwoWayListener,
+
+  'ɵɵreplaceMedata': r3.ɵɵreplaceMedata,
 }))();

--- a/packages/core/test/acceptance/hmr_spec.ts
+++ b/packages/core/test/acceptance/hmr_spec.ts
@@ -1,0 +1,2041 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  Component,
+  Directive,
+  DoCheck,
+  ElementRef,
+  EventEmitter,
+  inject,
+  InjectionToken,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Output,
+  QueryList,
+  SimpleChanges,
+  Type,
+  ViewChild,
+  ViewChildren,
+  ɵNG_COMP_DEF,
+  ɵɵreplaceMedata,
+} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {compileComponent} from '@angular/core/src/render3/jit/directive';
+import {clearTranslations, loadTranslations} from '@angular/localize';
+import {computeMsgId} from '@angular/compiler';
+
+describe('hot module replacement', () => {
+  it('should recreate a single usage of a basic component', () => {
+    let instance!: ChildCmp;
+    const initialMetadata: Component = {
+      selector: 'child-cmp',
+      standalone: true,
+      template: 'Hello <strong>{{state}}</strong>',
+    };
+
+    @Component(initialMetadata)
+    class ChildCmp {
+      state = 0;
+
+      constructor() {
+        instance = this;
+      }
+    }
+
+    @Component({
+      standalone: true,
+      imports: [ChildCmp],
+      template: '<child-cmp/>',
+    })
+    class RootCmp {}
+
+    const fixture = TestBed.createComponent(RootCmp);
+    fixture.detectChanges();
+    markNodesAsCreatedInitially(fixture.nativeElement);
+
+    expectHTML(
+      fixture.nativeElement,
+      `
+        <child-cmp>
+          Hello <strong>0</strong>
+        </child-cmp>
+      `,
+    );
+
+    instance.state = 1;
+    fixture.detectChanges();
+    expectHTML(
+      fixture.nativeElement,
+      `
+        <child-cmp>
+          Hello <strong>1</strong>
+        </child-cmp>
+      `,
+    );
+
+    replaceMetadata(ChildCmp, {
+      ...initialMetadata,
+      template: `Changed <strong>{{state}}</strong>!`,
+    });
+    fixture.detectChanges();
+
+    const recreatedNodes = childrenOf(...fixture.nativeElement.querySelectorAll('child-cmp'));
+    verifyNodesRemainUntouched(fixture.nativeElement, recreatedNodes);
+    verifyNodesWereRecreated(recreatedNodes);
+
+    expectHTML(
+      fixture.nativeElement,
+      `
+        <child-cmp>
+          Changed <strong>1</strong>!
+        </child-cmp>
+      `,
+    );
+  });
+
+  it('should recreate multiple usages of a complex component', () => {
+    const initialMetadata: Component = {
+      selector: 'child-cmp',
+      standalone: true,
+      template: '<span>ChildCmp (orig)</span><h1>{{ text }}</h1>',
+    };
+
+    @Component(initialMetadata)
+    class ChildCmp {
+      @Input() text = '[empty]';
+    }
+
+    @Component({
+      standalone: true,
+      imports: [ChildCmp],
+      template: `
+        <i>Unrelated node #1</i>
+        <child-cmp text="A"/>
+        <u>Unrelated node #2</u>
+        <child-cmp text="B"/>
+        <b>Unrelated node #3</b>
+        <main>
+          <child-cmp text="C"/>
+        </main>
+      `,
+    })
+    class RootCmp {}
+
+    const fixture = TestBed.createComponent(RootCmp);
+    fixture.detectChanges();
+    markNodesAsCreatedInitially(fixture.nativeElement);
+
+    expectHTML(
+      fixture.nativeElement,
+      `
+        <i>Unrelated node #1</i>
+        <child-cmp text="A">
+          <span>ChildCmp (orig)</span><h1>A</h1>
+        </child-cmp>
+        <u>Unrelated node #2</u>
+        <child-cmp text="B">
+          <span>ChildCmp (orig)</span><h1>B</h1>
+        </child-cmp>
+        <b>Unrelated node #3</b>
+        <main>
+          <child-cmp text="C">
+            <span>ChildCmp (orig)</span><h1>C</h1>
+          </child-cmp>
+        </main>
+      `,
+    );
+
+    replaceMetadata(ChildCmp, {
+      ...initialMetadata,
+      template: `
+        <p title="extra attr">ChildCmp (hmr)</p>
+        <h2>{{ text }}</h2>
+        <div>Extra node!</div>
+      `,
+    });
+    fixture.detectChanges();
+
+    const recreatedNodes = childrenOf(...fixture.nativeElement.querySelectorAll('child-cmp'));
+    verifyNodesRemainUntouched(fixture.nativeElement, recreatedNodes);
+    verifyNodesWereRecreated(recreatedNodes);
+
+    expectHTML(
+      fixture.nativeElement,
+      `
+        <i>Unrelated node #1</i>
+        <child-cmp text="A">
+          <p title="extra attr">ChildCmp (hmr)</p>
+          <h2>A</h2>
+          <div>Extra node!</div>
+        </child-cmp>
+        <u>Unrelated node #2</u>
+        <child-cmp text="B">
+          <p title="extra attr">ChildCmp (hmr)</p>
+          <h2>B</h2>
+          <div>Extra node!</div>
+        </child-cmp>
+        <b>Unrelated node #3</b>
+        <main>
+          <child-cmp text="C">
+            <p title="extra attr">ChildCmp (hmr)</p>
+            <h2>C</h2>
+            <div>Extra node!</div>
+          </child-cmp>
+        </main>
+      `,
+    );
+  });
+
+  it('should not recreate sub-classes of a component being replaced', () => {
+    const initialMetadata: Component = {
+      selector: 'child-cmp',
+      standalone: true,
+      template: 'Base class',
+    };
+
+    @Component(initialMetadata)
+    class ChildCmp {}
+
+    @Component({
+      selector: 'child-sub-cmp',
+      standalone: true,
+      template: 'Sub class',
+    })
+    class ChildSubCmp extends ChildCmp {}
+
+    @Component({
+      standalone: true,
+      imports: [ChildCmp, ChildSubCmp],
+      template: `<child-cmp/>|<child-sub-cmp/>`,
+    })
+    class RootCmp {}
+
+    const fixture = TestBed.createComponent(RootCmp);
+    fixture.detectChanges();
+
+    expectHTML(
+      fixture.nativeElement,
+      `
+        <child-cmp>Base class</child-cmp>|
+        <child-sub-cmp>Sub class</child-sub-cmp>
+      `,
+    );
+
+    replaceMetadata(ChildCmp, {
+      ...initialMetadata,
+      template: `Replaced!`,
+    });
+    fixture.detectChanges();
+
+    expectHTML(
+      fixture.nativeElement,
+      `
+        <child-cmp>Replaced!</child-cmp>|
+        <child-sub-cmp>Sub class</child-sub-cmp>
+      `,
+    );
+  });
+
+  it('should continue binding inputs to a component that is replaced', () => {
+    const initialMetadata: Component = {
+      selector: 'child-cmp',
+      standalone: true,
+      template: '<span>{{staticValue}}</span><strong>{{dynamicValue}}</strong>',
+    };
+
+    @Component(initialMetadata)
+    class ChildCmp {
+      @Input() staticValue = '0';
+      @Input() dynamicValue = '0';
+    }
+
+    @Component({
+      standalone: true,
+      imports: [ChildCmp],
+      template: `<child-cmp staticValue="1" [dynamicValue]="dynamicValue"/>`,
+    })
+    class RootCmp {
+      dynamicValue = '1';
+    }
+
+    const fixture = TestBed.createComponent(RootCmp);
+    fixture.detectChanges();
+
+    expectHTML(
+      fixture.nativeElement,
+      `
+        <child-cmp staticvalue="1">
+          <span>1</span>
+          <strong>1</strong>
+        </child-cmp>
+      `,
+    );
+
+    fixture.componentInstance.dynamicValue = '2';
+    fixture.detectChanges();
+    expectHTML(
+      fixture.nativeElement,
+      `
+        <child-cmp staticvalue="1">
+          <span>1</span>
+          <strong>2</strong>
+        </child-cmp>
+      `,
+    );
+
+    replaceMetadata(ChildCmp, {
+      ...initialMetadata,
+      template: `
+        <main>
+          <span>{{staticValue}}</span>
+          <strong>{{dynamicValue}}</strong>
+        </main>
+      `,
+    });
+    fixture.detectChanges();
+    expectHTML(
+      fixture.nativeElement,
+      `
+        <child-cmp staticvalue="1">
+          <main>
+            <span>1</span>
+            <strong>2</strong>
+          </main>
+        </child-cmp>
+      `,
+    );
+
+    fixture.componentInstance.dynamicValue = '3';
+    fixture.detectChanges();
+    expectHTML(
+      fixture.nativeElement,
+      `
+        <child-cmp staticvalue="1">
+          <main>
+            <span>1</span>
+            <strong>3</strong>
+          </main>
+        </child-cmp>
+      `,
+    );
+  });
+
+  it('should recreate a component used inside @for', () => {
+    const initialMetadata: Component = {
+      selector: 'child-cmp',
+      standalone: true,
+      template: 'Hello <strong>{{value}}</strong>',
+    };
+
+    @Component(initialMetadata)
+    class ChildCmp {
+      @Input() value = '[empty]';
+    }
+
+    @Component({
+      standalone: true,
+      imports: [ChildCmp],
+      template: `
+        @for (current of items; track current.id) {
+          <child-cmp [value]="current.name"/>
+          <hr>
+        }
+      `,
+    })
+    class RootCmp {
+      items = [
+        {name: 'A', id: 1},
+        {name: 'B', id: 2},
+        {name: 'C', id: 3},
+      ];
+    }
+
+    const fixture = TestBed.createComponent(RootCmp);
+    fixture.detectChanges();
+    markNodesAsCreatedInitially(fixture.nativeElement);
+
+    expectHTML(
+      fixture.nativeElement,
+      `
+        <child-cmp>Hello <strong>A</strong></child-cmp>
+        <hr>
+        <child-cmp>Hello <strong>B</strong></child-cmp>
+        <hr>
+        <child-cmp>Hello <strong>C</strong></child-cmp>
+        <hr>
+      `,
+    );
+
+    replaceMetadata(ChildCmp, {
+      ...initialMetadata,
+      template: `Changed <strong>{{value}}</strong>!`,
+    });
+    fixture.detectChanges();
+
+    let recreatedNodes = childrenOf(...fixture.nativeElement.querySelectorAll('child-cmp'));
+    verifyNodesRemainUntouched(fixture.nativeElement, recreatedNodes);
+    verifyNodesWereRecreated(recreatedNodes);
+
+    expectHTML(
+      fixture.nativeElement,
+      `
+        <child-cmp>Changed <strong>A</strong>!</child-cmp>
+        <hr>
+        <child-cmp>Changed <strong>B</strong>!</child-cmp>
+        <hr>
+        <child-cmp>Changed <strong>C</strong>!</child-cmp>
+        <hr>
+      `,
+    );
+
+    fixture.componentInstance.items.pop();
+    fixture.detectChanges();
+
+    expectHTML(
+      fixture.nativeElement,
+      `
+        <child-cmp>Changed <strong>A</strong>!</child-cmp>
+        <hr>
+        <child-cmp>Changed <strong>B</strong>!</child-cmp>
+        <hr>
+      `,
+    );
+    recreatedNodes = childrenOf(...fixture.nativeElement.querySelectorAll('child-cmp'));
+    verifyNodesRemainUntouched(fixture.nativeElement, recreatedNodes);
+    verifyNodesWereRecreated(recreatedNodes);
+  });
+
+  describe('queries', () => {
+    it('should update ViewChildren query results', async () => {
+      @Component({
+        selector: 'child-cmp',
+        standalone: true,
+        template: '<span>ChildCmp {{ text }}</span>',
+      })
+      class ChildCmp {
+        @Input() text = '[empty]';
+      }
+
+      let instance!: ParentCmp;
+      const initialMetadata: Component = {
+        standalone: true,
+        selector: 'parent-cmp',
+        imports: [ChildCmp],
+        template: `
+          <child-cmp text="A"/>
+          <child-cmp text="B"/>
+        `,
+      };
+
+      @Component(initialMetadata)
+      class ParentCmp {
+        @ViewChildren(ChildCmp) childCmps!: QueryList<ChildCmp>;
+
+        constructor() {
+          instance = this;
+        }
+      }
+
+      @Component({
+        standalone: true,
+        imports: [ParentCmp],
+        template: `<parent-cmp/>`,
+      })
+      class RootCmp {}
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+
+      const initialComps = instance.childCmps.toArray().slice();
+      expect(initialComps.length).toBe(2);
+
+      replaceMetadata(ParentCmp, {
+        ...initialMetadata,
+        template: `
+          <child-cmp text="A"/>
+          <child-cmp text="B"/>
+          <child-cmp text="C"/>
+          <child-cmp text="D"/>
+        `,
+      });
+      fixture.detectChanges();
+
+      expect(instance.childCmps.length).toBe(4);
+      expect(instance.childCmps.toArray().every((c) => !initialComps.includes(c))).toBe(true);
+    });
+
+    it('should update ViewChild when the string points to a different element', async () => {
+      let instance!: ParentCmp;
+      const initialMetadata: Component = {
+        standalone: true,
+        selector: 'parent-cmp',
+        template: `
+          <div>
+            <span>
+              <strong #ref></strong>
+            </span>
+          </div>
+        `,
+      };
+
+      @Component(initialMetadata)
+      class ParentCmp {
+        @ViewChild('ref') ref!: ElementRef<HTMLElement>;
+
+        constructor() {
+          instance = this;
+        }
+      }
+
+      @Component({
+        standalone: true,
+        imports: [ParentCmp],
+        template: `<parent-cmp/>`,
+      })
+      class RootCmp {}
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+      expect(instance.ref.nativeElement.tagName).toBe('STRONG');
+
+      replaceMetadata(ParentCmp, {
+        ...initialMetadata,
+        template: `
+          <div>
+            <span>
+              <strong></strong>
+            </span>
+          </div>
+
+          <main>
+            <span #ref></span>
+          </main>
+        `,
+      });
+      fixture.detectChanges();
+
+      expect(instance.ref.nativeElement.tagName).toBe('SPAN');
+    });
+
+    it('should update ViewChild when the injection token points to a different directive', async () => {
+      const token = new InjectionToken<DirA | DirB>('token');
+
+      @Directive({
+        standalone: true,
+        selector: '[dir-a]',
+        providers: [{provide: token, useExisting: DirA}],
+      })
+      class DirA {}
+
+      @Directive({
+        standalone: true,
+        selector: '[dir-b]',
+        providers: [{provide: token, useExisting: DirB}],
+      })
+      class DirB {}
+
+      let instance!: ParentCmp;
+      const initialMetadata: Component = {
+        standalone: true,
+        selector: 'parent-cmp',
+        imports: [DirA, DirB],
+        template: `<div #ref dir-a></div>`,
+      };
+
+      @Component(initialMetadata)
+      class ParentCmp {
+        @ViewChild('ref', {read: token}) ref!: DirA | DirB;
+
+        constructor() {
+          instance = this;
+        }
+      }
+
+      @Component({
+        standalone: true,
+        imports: [ParentCmp],
+        template: `<parent-cmp/>`,
+      })
+      class RootCmp {}
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+      expect(instance.ref).toBeInstanceOf(DirA);
+
+      replaceMetadata(ParentCmp, {
+        ...initialMetadata,
+        template: `
+          <section>
+            <div #ref dir-b></div>
+          </section>
+        `,
+      });
+      fixture.detectChanges();
+
+      expect(instance.ref).toBeInstanceOf(DirB);
+    });
+
+    it('should update ViewChild when the injection token stops pointing to anything', async () => {
+      const token = new InjectionToken<Dir>('token');
+
+      @Directive({
+        standalone: true,
+        selector: '[dir]',
+        providers: [{provide: token, useExisting: Dir}],
+      })
+      class Dir {}
+
+      let instance!: ParentCmp;
+      const initialMetadata: Component = {
+        standalone: true,
+        selector: 'parent-cmp',
+        imports: [Dir],
+        template: `<div #ref dir></div>`,
+      };
+
+      @Component(initialMetadata)
+      class ParentCmp {
+        @ViewChild('ref', {read: token}) ref!: Dir;
+
+        constructor() {
+          instance = this;
+        }
+      }
+
+      @Component({
+        standalone: true,
+        imports: [ParentCmp],
+        template: `<parent-cmp/>`,
+      })
+      class RootCmp {}
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+      expect(instance.ref).toBeInstanceOf(Dir);
+
+      replaceMetadata(ParentCmp, {
+        ...initialMetadata,
+        template: `<div #ref></div>`,
+      });
+      fixture.detectChanges();
+
+      expect(instance.ref).toBeFalsy();
+    });
+  });
+
+  describe('content projection', () => {
+    it('should work with content projection', () => {
+      const initialMetadata: Component = {
+        standalone: true,
+        selector: 'parent-cmp',
+        template: `<ng-content/>`,
+      };
+
+      @Component(initialMetadata)
+      class ParentCmp {}
+
+      @Component({
+        standalone: true,
+        imports: [ParentCmp],
+        template: `
+          <parent-cmp>
+            <h1>Projected H1</h1>
+            <h2>Projected H2</h2>
+          </parent-cmp>
+        `,
+      })
+      class RootCmp {}
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+
+      markNodesAsCreatedInitially(fixture.nativeElement);
+      expectHTML(
+        fixture.nativeElement,
+        `
+          <parent-cmp>
+            <h1>Projected H1</h1>
+            <h2>Projected H2</h2>
+          </parent-cmp>
+        `,
+      );
+
+      replaceMetadata(ParentCmp, {
+        ...initialMetadata,
+        template: `
+          <section>
+            <ng-content/>
+          </section>
+        `,
+      });
+      fixture.detectChanges();
+
+      // <h1> and <h2> nodes were not re-created, since they
+      // belong to a parent component, which wasn't HMR'ed.
+      verifyNodesRemainUntouched(fixture.nativeElement.querySelector('h1'));
+      verifyNodesRemainUntouched(fixture.nativeElement.querySelector('h2'));
+      verifyNodesWereRecreated(fixture.nativeElement.querySelectorAll('section'));
+
+      expectHTML(
+        fixture.nativeElement,
+        `
+          <parent-cmp>
+            <section>
+              <h1>Projected H1</h1>
+              <h2>Projected H2</h2>
+            </section>
+          </parent-cmp>
+        `,
+      );
+    });
+
+    it('should handle elements moving around into different slots', () => {
+      // Start off with a single catch-all slot.
+      const initialMetadata: Component = {
+        standalone: true,
+        selector: 'parent-cmp',
+        template: `<ng-content/>`,
+      };
+
+      @Component(initialMetadata)
+      class ParentCmp {}
+
+      @Component({
+        standalone: true,
+        imports: [ParentCmp],
+        template: `
+          <parent-cmp>
+            <div one="1">one</div>
+            <div two="2">two</div>
+          </parent-cmp>
+        `,
+      })
+      class RootCmp {}
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+      markNodesAsCreatedInitially(fixture.nativeElement);
+      expectHTML(
+        fixture.nativeElement,
+        `
+          <parent-cmp>
+            <div one="1">one</div>
+            <div two="2">two</div>
+          </parent-cmp>
+        `,
+      );
+
+      // Swap out the catch-all slot with two specific slots.
+      // Note that we also changed the order of `one` and `two`.
+      replaceMetadata(ParentCmp, {
+        ...initialMetadata,
+        template: `
+          <section><ng-content select="[two]"/></section>
+          <main><ng-content select="[one]"/></main>
+        `,
+      });
+      fixture.detectChanges();
+
+      verifyNodesRemainUntouched(fixture.nativeElement.querySelector('[one]'));
+      verifyNodesRemainUntouched(fixture.nativeElement.querySelector('[two]'));
+      verifyNodesWereRecreated(fixture.nativeElement.querySelectorAll('section, main'));
+      expectHTML(
+        fixture.nativeElement,
+        `
+          <parent-cmp>
+            <section><div two="2">two</div></section>
+            <main><div one="1">one</div></main>
+          </parent-cmp>
+        `,
+      );
+
+      // Swap with a slot that matches nothing.
+      replaceMetadata(ParentCmp, {
+        ...initialMetadata,
+        template: `<ng-content select="does-not-match"/>`,
+      });
+      fixture.detectChanges();
+      expectHTML(fixture.nativeElement, '<parent-cmp></parent-cmp>');
+
+      // Swap with a slot that only one of the nodes matches.
+      replaceMetadata(ParentCmp, {
+        ...initialMetadata,
+        template: `<span><ng-content select="[one]"/></span>`,
+      });
+      fixture.detectChanges();
+
+      expectHTML(
+        fixture.nativeElement,
+        `
+        <parent-cmp>
+          <span><div one="1">one</div></span>
+        </parent-cmp>
+      `,
+      );
+      verifyNodesRemainUntouched(fixture.nativeElement.querySelector('[one]'));
+      verifyNodesWereRecreated(fixture.nativeElement.querySelectorAll('span'));
+    });
+
+    it('should handle default content for ng-content', () => {
+      const initialMetadata: Component = {
+        standalone: true,
+        selector: 'parent-cmp',
+        template: `
+          <ng-content select="will-not-match">
+            <div class="default-content">Default content</div>
+          </ng-content>
+        `,
+      };
+
+      @Component(initialMetadata)
+      class ParentCmp {}
+
+      @Component({
+        standalone: true,
+        imports: [ParentCmp],
+        template: `
+          <parent-cmp>
+            <span>Some content</span>
+          </parent-cmp>
+        `,
+      })
+      class RootCmp {}
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+
+      expectHTML(
+        fixture.nativeElement,
+        `
+          <parent-cmp>
+            <div class="default-content">Default content</div>
+          </parent-cmp>
+        `,
+      );
+
+      replaceMetadata(ParentCmp, {
+        ...initialMetadata,
+        template: `
+          <ng-content>
+            <div class="default-content">Default content</div>
+          </ng-content>
+        `,
+      });
+      fixture.detectChanges();
+      expectHTML(
+        fixture.nativeElement,
+        `
+          <parent-cmp>
+            <span>Some content</span>
+          </parent-cmp>
+        `,
+      );
+    });
+  });
+
+  describe('lifecycle hooks', () => {
+    it('should only invoke the init/destroy hooks inside the content when replacing the template', () => {
+      @Component({
+        template: '',
+        standalone: true,
+        selector: 'child-cmp',
+      })
+      class ChildCmp implements OnInit, OnDestroy {
+        @Input() text = '[empty]';
+
+        ngOnInit() {
+          logs.push(`ChildCmp ${this.text} init`);
+        }
+
+        ngOnDestroy() {
+          logs.push(`ChildCmp ${this.text} destroy`);
+        }
+      }
+
+      const initialMetadata: Component = {
+        standalone: true,
+        template: `
+          <child-cmp text="A"/>
+          <child-cmp text="B"/>
+        `,
+        imports: [ChildCmp],
+        selector: 'parent-cmp',
+      };
+      let logs: string[] = [];
+
+      @Component(initialMetadata)
+      class ParentCmp implements OnInit, OnDestroy {
+        @Input() text = '[empty]';
+
+        ngOnInit() {
+          logs.push(`ParentCmp ${this.text} init`);
+        }
+
+        ngOnDestroy() {
+          logs.push(`ParentCmp ${this.text} destroy`);
+        }
+      }
+
+      @Component({
+        // Note that we test two of the same component one after the other
+        // specifically because during testing it was a problematic pattern.
+        template: `
+          <parent-cmp text="A"/>
+          <parent-cmp text="B"/>
+        `,
+        standalone: true,
+        imports: [ParentCmp],
+      })
+      class RootCmp {}
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+
+      expect(logs).toEqual([
+        'ParentCmp A init',
+        'ParentCmp B init',
+        'ChildCmp A init',
+        'ChildCmp B init',
+        'ChildCmp A init',
+        'ChildCmp B init',
+      ]);
+
+      logs = [];
+      replaceMetadata(ParentCmp, {
+        ...initialMetadata,
+        template: `
+          <child-cmp text="C"/>
+          <child-cmp text="D"/>
+          <child-cmp text="E"/>
+        `,
+      });
+      fixture.detectChanges();
+
+      expect(logs).toEqual([
+        'ChildCmp A destroy',
+        'ChildCmp B destroy',
+        'ChildCmp C init',
+        'ChildCmp D init',
+        'ChildCmp E init',
+        'ChildCmp A destroy',
+        'ChildCmp B destroy',
+        'ChildCmp C init',
+        'ChildCmp D init',
+        'ChildCmp E init',
+      ]);
+
+      logs = [];
+      replaceMetadata(ParentCmp, {
+        ...initialMetadata,
+        template: '',
+      });
+      fixture.detectChanges();
+      expect(logs).toEqual([
+        'ChildCmp C destroy',
+        'ChildCmp D destroy',
+        'ChildCmp E destroy',
+        'ChildCmp C destroy',
+        'ChildCmp D destroy',
+        'ChildCmp E destroy',
+      ]);
+    });
+
+    it('should invoke checked hooks both on the host and the content being replaced', () => {
+      @Component({
+        template: '',
+        standalone: true,
+        selector: 'child-cmp',
+      })
+      class ChildCmp implements DoCheck {
+        @Input() text = '[empty]';
+
+        ngDoCheck() {
+          logs.push(`ChildCmp ${this.text} checked`);
+        }
+      }
+
+      const initialMetadata: Component = {
+        standalone: true,
+        template: `<child-cmp text="A"/>`,
+        imports: [ChildCmp],
+        selector: 'parent-cmp',
+      };
+      let logs: string[] = [];
+
+      @Component(initialMetadata)
+      class ParentCmp implements DoCheck {
+        ngDoCheck() {
+          logs.push(`ParentCmp checked`);
+        }
+      }
+
+      @Component({
+        template: `<parent-cmp/>`,
+        standalone: true,
+        imports: [ParentCmp],
+      })
+      class RootCmp {}
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+      expect(logs).toEqual(['ParentCmp checked', 'ChildCmp A checked']);
+
+      fixture.detectChanges();
+      expect(logs).toEqual([
+        'ParentCmp checked',
+        'ChildCmp A checked',
+        'ParentCmp checked',
+        'ChildCmp A checked',
+      ]);
+
+      logs = [];
+      replaceMetadata(ParentCmp, {
+        ...initialMetadata,
+        template: '',
+      });
+      fixture.detectChanges();
+      expect(logs).toEqual(['ParentCmp checked']);
+      fixture.detectChanges();
+      expect(logs).toEqual(['ParentCmp checked', 'ParentCmp checked']);
+
+      logs = [];
+      replaceMetadata(ParentCmp, {
+        ...initialMetadata,
+        template: `
+          <child-cmp text="A"/>
+          <child-cmp text="B"/>
+        `,
+      });
+      fixture.detectChanges();
+      expect(logs).toEqual([
+        'ChildCmp A checked',
+        'ChildCmp B checked',
+        'ParentCmp checked',
+        'ChildCmp A checked',
+        'ChildCmp B checked',
+      ]);
+      fixture.detectChanges();
+      expect(logs).toEqual([
+        'ChildCmp A checked',
+        'ChildCmp B checked',
+        'ParentCmp checked',
+        'ChildCmp A checked',
+        'ChildCmp B checked',
+        'ParentCmp checked',
+        'ChildCmp A checked',
+        'ChildCmp B checked',
+      ]);
+    });
+
+    it('should dispatch ngOnChanges on a replaced component', () => {
+      const values: string[] = [];
+      const initialMetadata: Component = {
+        selector: 'child-cmp',
+        standalone: true,
+        template: '',
+      };
+
+      @Component(initialMetadata)
+      class ChildCmp implements OnChanges {
+        @Input() value = 0;
+
+        ngOnChanges(changes: SimpleChanges) {
+          const change = changes['value'];
+          values.push(
+            `${change.previousValue} - ${change.currentValue} - ${change.isFirstChange()}`,
+          );
+        }
+      }
+
+      @Component({
+        standalone: true,
+        imports: [ChildCmp],
+        template: `<child-cmp [value]="value"/>`,
+      })
+      class RootCmp {
+        value = 1;
+      }
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+      expect(values).toEqual(['undefined - 1 - true']);
+
+      fixture.componentInstance.value++;
+      fixture.detectChanges();
+      expect(values).toEqual(['undefined - 1 - true', '1 - 2 - false']);
+
+      replaceMetadata(ChildCmp, {
+        ...initialMetadata,
+        template: 'Changed',
+      });
+      fixture.detectChanges();
+
+      fixture.componentInstance.value++;
+      fixture.detectChanges();
+      expect(values).toEqual(['undefined - 1 - true', '1 - 2 - false', '2 - 3 - false']);
+
+      fixture.componentInstance.value++;
+      fixture.detectChanges();
+      expect(values).toEqual([
+        'undefined - 1 - true',
+        '1 - 2 - false',
+        '2 - 3 - false',
+        '3 - 4 - false',
+      ]);
+
+      replaceMetadata(ChildCmp, {
+        ...initialMetadata,
+        template: 'Changed!!!',
+      });
+      fixture.detectChanges();
+      fixture.componentInstance.value++;
+      fixture.detectChanges();
+      expect(values).toEqual([
+        'undefined - 1 - true',
+        '1 - 2 - false',
+        '2 - 3 - false',
+        '3 - 4 - false',
+        '4 - 5 - false',
+      ]);
+    });
+  });
+
+  describe('event listeners', () => {
+    it('should continue emitting to output after component has been replaced', () => {
+      let count = 0;
+      const initialMetadata: Component = {
+        selector: 'child-cmp',
+        standalone: true,
+        template: '<button (click)="clicked()"></button>',
+      };
+
+      @Component(initialMetadata)
+      class ChildCmp {
+        @Output() changed = new EventEmitter();
+
+        clicked() {
+          this.changed.emit();
+        }
+      }
+
+      @Component({
+        standalone: true,
+        imports: [ChildCmp],
+        template: `<child-cmp (changed)="onChange()"/>`,
+      })
+      class RootCmp {
+        onChange() {
+          count++;
+        }
+      }
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+      markNodesAsCreatedInitially(fixture.nativeElement);
+      expect(count).toBe(0);
+
+      fixture.nativeElement.querySelector('button').click();
+      fixture.detectChanges();
+      expect(count).toBe(1);
+
+      replaceMetadata(ChildCmp, {
+        ...initialMetadata,
+        template: '<button class="replacement" (click)="clicked()"></button>',
+      });
+      fixture.detectChanges();
+
+      const recreatedNodes = childrenOf(...fixture.nativeElement.querySelectorAll('child-cmp'));
+      verifyNodesRemainUntouched(fixture.nativeElement, recreatedNodes);
+      verifyNodesWereRecreated(recreatedNodes);
+
+      fixture.nativeElement.querySelector('.replacement').click();
+      fixture.detectChanges();
+      expect(count).toBe(2);
+    });
+
+    it('should stop emitting if replaced with an element that no longer has the listener', () => {
+      let count = 0;
+      const initialMetadata: Component = {
+        selector: 'child-cmp',
+        standalone: true,
+        template: '<button (click)="clicked()"></button>',
+      };
+
+      @Component(initialMetadata)
+      class ChildCmp {
+        @Output() changed = new EventEmitter();
+
+        clicked() {
+          this.changed.emit();
+        }
+      }
+
+      @Component({
+        standalone: true,
+        imports: [ChildCmp],
+        template: `<child-cmp (changed)="onChange()"/>`,
+      })
+      class RootCmp {
+        onChange() {
+          count++;
+        }
+      }
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+      markNodesAsCreatedInitially(fixture.nativeElement);
+      expect(count).toBe(0);
+
+      fixture.nativeElement.querySelector('button').click();
+      fixture.detectChanges();
+      expect(count).toBe(1);
+
+      replaceMetadata(ChildCmp, {
+        ...initialMetadata,
+        template: '<button (click)="clicked()"></button>',
+      });
+      fixture.detectChanges();
+
+      const recreatedNodes = childrenOf(...fixture.nativeElement.querySelectorAll('child-cmp'));
+      verifyNodesRemainUntouched(fixture.nativeElement, recreatedNodes);
+      verifyNodesWereRecreated(recreatedNodes);
+
+      fixture.nativeElement.querySelector('button').click();
+      fixture.detectChanges();
+      expect(count).toBe(2);
+    });
+  });
+
+  describe('directives', () => {
+    it('should not destroy template-matched directives on a component being replaced', () => {
+      const initLog: string[] = [];
+      let destroyCount = 0;
+      const initialMetadata: Component = {
+        selector: 'child-cmp',
+        standalone: true,
+        template: '',
+      };
+
+      @Component(initialMetadata)
+      class ChildCmp implements OnDestroy {
+        constructor() {
+          initLog.push('ChildCmp init');
+        }
+
+        ngOnDestroy() {
+          destroyCount++;
+        }
+      }
+
+      @Directive({selector: '[dir-a]', standalone: true})
+      class DirA implements OnDestroy {
+        constructor() {
+          initLog.push('DirA init');
+        }
+
+        ngOnDestroy() {
+          destroyCount++;
+        }
+      }
+
+      @Directive({selector: '[dir-b]', standalone: true})
+      class DirB implements OnDestroy {
+        constructor() {
+          initLog.push('DirB init');
+        }
+
+        ngOnDestroy() {
+          destroyCount++;
+        }
+      }
+
+      @Component({
+        standalone: true,
+        imports: [ChildCmp, DirA, DirB],
+        template: `<child-cmp dir-a dir-b/>`,
+      })
+      class RootCmp {}
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+      markNodesAsCreatedInitially(fixture.nativeElement);
+      expect(initLog).toEqual(['ChildCmp init', 'DirA init', 'DirB init']);
+      expect(destroyCount).toBe(0);
+
+      replaceMetadata(ChildCmp, {
+        ...initialMetadata,
+        template: 'Hello!',
+      });
+      fixture.detectChanges();
+      expect(initLog).toEqual(['ChildCmp init', 'DirA init', 'DirB init']);
+      expect(destroyCount).toBe(0);
+    });
+
+    it('should not destroy host directives on a component being replaced', () => {
+      const initLog: string[] = [];
+      let destroyCount = 0;
+
+      @Directive({selector: '[dir-a]', standalone: true})
+      class DirA implements OnDestroy {
+        constructor() {
+          initLog.push('DirA init');
+        }
+
+        ngOnDestroy() {
+          destroyCount++;
+        }
+      }
+
+      @Directive({selector: '[dir-b]', standalone: true})
+      class DirB implements OnDestroy {
+        constructor() {
+          initLog.push('DirB init');
+        }
+
+        ngOnDestroy() {
+          destroyCount++;
+        }
+      }
+
+      const initialMetadata: Component = {
+        selector: 'child-cmp',
+        standalone: true,
+        template: '',
+        hostDirectives: [DirA, DirB],
+      };
+
+      @Component(initialMetadata)
+      class ChildCmp implements OnDestroy {
+        constructor() {
+          initLog.push('ChildCmp init');
+        }
+
+        ngOnDestroy() {
+          destroyCount++;
+        }
+      }
+
+      @Component({
+        standalone: true,
+        imports: [ChildCmp],
+        template: '<child-cmp/>',
+      })
+      class RootCmp {}
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+      markNodesAsCreatedInitially(fixture.nativeElement);
+      expect(initLog).toEqual(['DirA init', 'DirB init', 'ChildCmp init']);
+      expect(destroyCount).toBe(0);
+
+      replaceMetadata(ChildCmp, {
+        ...initialMetadata,
+        template: 'Hello!',
+      });
+      fixture.detectChanges();
+      expect(initLog).toEqual(['DirA init', 'DirB init', 'ChildCmp init']);
+      expect(destroyCount).toBe(0);
+    });
+  });
+
+  describe('dependency injection', () => {
+    it('should be able to inject a component that is replaced', () => {
+      let instance!: ChildCmp;
+      const injectedInstances: [unknown, ChildCmp][] = [];
+
+      @Directive({selector: '[dir-a]', standalone: true})
+      class DirA {
+        constructor() {
+          injectedInstances.push([this, inject(ChildCmp)]);
+        }
+      }
+
+      @Directive({selector: '[dir-b]', standalone: true})
+      class DirB {
+        constructor() {
+          injectedInstances.push([this, inject(ChildCmp)]);
+        }
+      }
+
+      const initialMetadata: Component = {
+        selector: 'child-cmp',
+        standalone: true,
+        template: '<div dir-a></div>',
+        imports: [DirA, DirB],
+      };
+
+      @Component(initialMetadata)
+      class ChildCmp {
+        constructor() {
+          instance = this;
+        }
+      }
+
+      @Component({
+        standalone: true,
+        imports: [ChildCmp],
+        template: '<child-cmp/>',
+      })
+      class RootCmp {}
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+      expect(instance).toBeInstanceOf(ChildCmp);
+      expect(injectedInstances).toEqual([[jasmine.any(DirA), instance]]);
+
+      replaceMetadata(ChildCmp, {
+        ...initialMetadata,
+        template: '<div dir-b></div>',
+      });
+      fixture.detectChanges();
+
+      expect(injectedInstances).toEqual([
+        [jasmine.any(DirA), instance],
+        [jasmine.any(DirB), instance],
+      ]);
+    });
+
+    it('should be able to inject a token coming from a component that is replaced', () => {
+      const token = new InjectionToken<string>('TEST_TOKEN');
+      const injectedValues: [unknown, string][] = [];
+
+      @Directive({selector: '[dir-a]', standalone: true})
+      class DirA {
+        constructor() {
+          injectedValues.push([this, inject(token)]);
+        }
+      }
+
+      @Directive({selector: '[dir-b]', standalone: true})
+      class DirB {
+        constructor() {
+          injectedValues.push([this, inject(token)]);
+        }
+      }
+
+      const initialMetadata: Component = {
+        selector: 'child-cmp',
+        standalone: true,
+        template: '<div dir-a></div>',
+        imports: [DirA, DirB],
+        providers: [{provide: token, useValue: 'provided value'}],
+      };
+
+      @Component(initialMetadata)
+      class ChildCmp {}
+
+      @Component({
+        standalone: true,
+        imports: [ChildCmp],
+        template: '<child-cmp/>',
+      })
+      class RootCmp {}
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+      expect(injectedValues).toEqual([[jasmine.any(DirA), 'provided value']]);
+
+      replaceMetadata(ChildCmp, {
+        ...initialMetadata,
+        template: '<div dir-b></div>',
+      });
+      fixture.detectChanges();
+
+      expect(injectedValues).toEqual([
+        [jasmine.any(DirA), 'provided value'],
+        [jasmine.any(DirB), 'provided value'],
+      ]);
+    });
+
+    it('should be able to access the viewProviders of a component that is being replaced', () => {
+      const token = new InjectionToken<string>('TEST_TOKEN');
+      const injectedValues: [unknown, string][] = [];
+
+      @Directive({selector: '[dir-a]', standalone: true})
+      class DirA {
+        constructor() {
+          injectedValues.push([this, inject(token)]);
+        }
+      }
+
+      @Directive({selector: '[dir-b]', standalone: true})
+      class DirB {
+        constructor() {
+          injectedValues.push([this, inject(token)]);
+        }
+      }
+
+      const initialMetadata: Component = {
+        selector: 'child-cmp',
+        standalone: true,
+        template: '<div dir-a></div>',
+        imports: [DirA, DirB],
+        viewProviders: [{provide: token, useValue: 'provided value'}],
+      };
+
+      @Component(initialMetadata)
+      class ChildCmp {}
+
+      @Component({
+        standalone: true,
+        imports: [ChildCmp],
+        template: '<child-cmp/>',
+      })
+      class RootCmp {}
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+      expect(injectedValues).toEqual([[jasmine.any(DirA), 'provided value']]);
+
+      replaceMetadata(ChildCmp, {
+        ...initialMetadata,
+        template: '<div dir-b></div>',
+      });
+      fixture.detectChanges();
+
+      expect(injectedValues).toEqual([
+        [jasmine.any(DirA), 'provided value'],
+        [jasmine.any(DirB), 'provided value'],
+      ]);
+    });
+  });
+
+  describe('host bindings', () => {
+    it('should maintain attribute host bindings on a replaced component', () => {
+      const initialMetadata: Component = {
+        selector: 'child-cmp',
+        standalone: true,
+        template: 'Hello',
+        host: {
+          '[attr.bar]': 'state',
+        },
+      };
+
+      @Component(initialMetadata)
+      class ChildCmp {
+        @Input() state = 0;
+      }
+
+      @Component({
+        standalone: true,
+        imports: [ChildCmp],
+        template: `<child-cmp [state]="state" [attr.foo]="'The state is ' + state"/>`,
+      })
+      class RootCmp {
+        state = 0;
+      }
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+
+      expectHTML(
+        fixture.nativeElement,
+        `<child-cmp foo="The state is 0" bar="0">Hello</child-cmp>`,
+      );
+
+      fixture.componentInstance.state = 1;
+      fixture.detectChanges();
+      expectHTML(
+        fixture.nativeElement,
+        `<child-cmp foo="The state is 1" bar="1">Hello</child-cmp>`,
+      );
+
+      replaceMetadata(ChildCmp, {...initialMetadata, template: `Changed`});
+      fixture.detectChanges();
+      expectHTML(
+        fixture.nativeElement,
+        `<child-cmp foo="The state is 1" bar="1">Changed</child-cmp>`,
+      );
+
+      fixture.componentInstance.state = 2;
+      fixture.detectChanges();
+      expectHTML(
+        fixture.nativeElement,
+        `<child-cmp foo="The state is 2" bar="2">Changed</child-cmp>`,
+      );
+    });
+
+    it('should maintain class host bindings on a replaced component', () => {
+      const initialMetadata: Component = {
+        selector: 'child-cmp',
+        standalone: true,
+        template: 'Hello',
+        host: {
+          '[class.bar]': 'state',
+        },
+      };
+
+      @Component(initialMetadata)
+      class ChildCmp {
+        @Input() state = false;
+      }
+
+      @Component({
+        standalone: true,
+        imports: [ChildCmp],
+        template: `<child-cmp class="static" [state]="state" [class.foo]="state"/>`,
+      })
+      class RootCmp {
+        state = false;
+      }
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+      expectHTML(fixture.nativeElement, `<child-cmp class="static">Hello</child-cmp>`);
+
+      fixture.componentInstance.state = true;
+      fixture.detectChanges();
+      expectHTML(fixture.nativeElement, `<child-cmp class="static foo bar">Hello</child-cmp>`);
+
+      replaceMetadata(ChildCmp, {...initialMetadata, template: `Changed`});
+      fixture.detectChanges();
+      expectHTML(fixture.nativeElement, `<child-cmp class="static foo bar">Changed</child-cmp>`);
+
+      fixture.componentInstance.state = false;
+      fixture.detectChanges();
+      expectHTML(fixture.nativeElement, `<child-cmp class="static">Changed</child-cmp>`);
+    });
+
+    it('should maintain style host bindings on a replaced component', () => {
+      const initialMetadata: Component = {
+        selector: 'child-cmp',
+        standalone: true,
+        template: 'Hello',
+        host: {
+          '[style.height]': 'state ? "5px" : "20px"',
+        },
+      };
+
+      @Component(initialMetadata)
+      class ChildCmp {
+        @Input() state = false;
+      }
+
+      @Component({
+        standalone: true,
+        imports: [ChildCmp],
+        template: `<child-cmp style="opacity: 0.5;" [state]="state" [style.width]="state ? '3px' : '12px'"/>`,
+      })
+      class RootCmp {
+        state = false;
+      }
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+      expectHTML(
+        fixture.nativeElement,
+        `<child-cmp style="opacity: 0.5; width: 12px; height: 20px;">Hello</child-cmp>`,
+      );
+
+      fixture.componentInstance.state = true;
+      fixture.detectChanges();
+      expectHTML(
+        fixture.nativeElement,
+        `<child-cmp style="opacity: 0.5; width: 3px; height: 5px;">Hello</child-cmp>`,
+      );
+
+      replaceMetadata(ChildCmp, {...initialMetadata, template: `Changed`});
+      fixture.detectChanges();
+      expectHTML(
+        fixture.nativeElement,
+        `<child-cmp style="opacity: 0.5; width: 3px; height: 5px;">Changed</child-cmp>`,
+      );
+
+      fixture.componentInstance.state = false;
+      fixture.detectChanges();
+      expectHTML(
+        fixture.nativeElement,
+        `<child-cmp style="opacity: 0.5; width: 12px; height: 20px;">Changed</child-cmp>`,
+      );
+    });
+  });
+
+  describe('i18n', () => {
+    afterEach(() => {
+      clearTranslations();
+    });
+
+    it('should replace components that use i18n within their template', () => {
+      loadTranslations({
+        [computeMsgId('hello')]: 'здравей',
+        [computeMsgId('goodbye')]: 'довиждане',
+      });
+
+      const initialMetadata: Component = {
+        selector: 'child-cmp',
+        standalone: true,
+        template: '<span i18n>hello</span>',
+      };
+
+      @Component(initialMetadata)
+      class ChildCmp {}
+
+      @Component({
+        standalone: true,
+        imports: [ChildCmp],
+        template: '<child-cmp/>',
+      })
+      class RootCmp {}
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+      expectHTML(fixture.nativeElement, '<child-cmp><span>здравей</span></child-cmp>');
+
+      replaceMetadata(ChildCmp, {...initialMetadata, template: '<strong i18n>goodbye</strong>!'});
+      fixture.detectChanges();
+      expectHTML(fixture.nativeElement, '<child-cmp><strong>довиждане</strong>!</child-cmp>');
+    });
+
+    it('should replace components that use i18n in their projected content', () => {
+      loadTranslations({[computeMsgId('hello')]: 'здравей'});
+
+      const initialMetadata: Component = {
+        selector: 'child-cmp',
+        standalone: true,
+        template: '<ng-content/>',
+      };
+
+      @Component(initialMetadata)
+      class ChildCmp {}
+
+      @Component({
+        standalone: true,
+        imports: [ChildCmp],
+        template: `<child-cmp i18n>hello</child-cmp>`,
+      })
+      class RootCmp {}
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+      markNodesAsCreatedInitially(fixture.nativeElement);
+      expectHTML(fixture.nativeElement, '<child-cmp>здравей</child-cmp>');
+
+      replaceMetadata(ChildCmp, {
+        ...initialMetadata,
+        template: 'Hello translates to <strong><ng-content/></strong>!',
+      });
+      fixture.detectChanges();
+
+      const recreatedNodes = childrenOf(...fixture.nativeElement.querySelectorAll('child-cmp'));
+      verifyNodesRemainUntouched(fixture.nativeElement, recreatedNodes);
+      verifyNodesWereRecreated(recreatedNodes);
+      expectHTML(
+        fixture.nativeElement,
+        '<child-cmp>Hello translates to <strong>здравей</strong>!</child-cmp>',
+      );
+    });
+
+    it('should replace components that use i18n with interpolations', () => {
+      loadTranslations({
+        [computeMsgId('hello')]: 'здравей',
+        [computeMsgId('Hello {$INTERPOLATION}!')]: 'Здравей {$INTERPOLATION}!',
+      });
+
+      let instance!: ChildCmp;
+      const initialMetadata: Component = {
+        selector: 'child-cmp',
+        standalone: true,
+        template: '<span i18n>Hello {{name}}!</span>',
+      };
+
+      @Component(initialMetadata)
+      class ChildCmp {
+        name = 'Frodo';
+
+        constructor() {
+          instance = this;
+        }
+      }
+
+      @Component({
+        standalone: true,
+        imports: [ChildCmp],
+        template: '<child-cmp/>',
+      })
+      class RootCmp {}
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+      expectHTML(fixture.nativeElement, '<child-cmp><span>Здравей Frodo!</span></child-cmp>');
+
+      replaceMetadata(ChildCmp, {...initialMetadata, template: '<strong i18n>hello</strong>'});
+      fixture.detectChanges();
+      expectHTML(fixture.nativeElement, '<child-cmp><strong>здравей</strong></child-cmp>');
+
+      replaceMetadata(ChildCmp, {
+        ...initialMetadata,
+        template: '<main><section i18n>Hello {{name}}!</section></main>',
+      });
+      fixture.detectChanges();
+      expectHTML(
+        fixture.nativeElement,
+        '<child-cmp><main><section>Здравей Frodo!</section></main></child-cmp>',
+      );
+
+      instance.name = 'Bilbo';
+      fixture.detectChanges();
+      expectHTML(
+        fixture.nativeElement,
+        '<child-cmp><main><section>Здравей Bilbo!</section></main></child-cmp>',
+      );
+    });
+
+    it('should replace components that use i18n with interpolations in their projected content', () => {
+      loadTranslations({
+        [computeMsgId('Hello {$INTERPOLATION}!')]: 'Здравей {$INTERPOLATION}!',
+      });
+
+      const initialMetadata: Component = {
+        selector: 'child-cmp',
+        standalone: true,
+        template: '<ng-content/>',
+      };
+
+      @Component(initialMetadata)
+      class ChildCmp {}
+
+      @Component({
+        standalone: true,
+        imports: [ChildCmp],
+        template: '<child-cmp i18n>Hello {{name}}!</child-cmp>',
+      })
+      class RootCmp {
+        name = 'Frodo';
+      }
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+      markNodesAsCreatedInitially(fixture.nativeElement);
+      expectHTML(fixture.nativeElement, '<child-cmp>Здравей Frodo!</child-cmp>');
+
+      replaceMetadata(ChildCmp, {
+        ...initialMetadata,
+        template: 'The text translates to <strong><ng-content/></strong>!',
+      });
+      fixture.detectChanges();
+      expectHTML(
+        fixture.nativeElement,
+        '<child-cmp>The text translates to <strong>Здравей Frodo!</strong>!</child-cmp>',
+      );
+
+      const recreatedNodes = childrenOf(...fixture.nativeElement.querySelectorAll('child-cmp'));
+      verifyNodesRemainUntouched(fixture.nativeElement, recreatedNodes);
+      verifyNodesWereRecreated(recreatedNodes);
+
+      fixture.componentInstance.name = 'Bilbo';
+      fixture.detectChanges();
+      expectHTML(
+        fixture.nativeElement,
+        '<child-cmp>The text translates to <strong>Здравей Bilbo!</strong>!</child-cmp>',
+      );
+    });
+
+    it('should replace components that use i18n with ICUs', () => {
+      loadTranslations({
+        [computeMsgId('hello')]: 'здравей',
+        [computeMsgId('{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}')]:
+          '{VAR_SELECT, select, 10 {десет} 20 {двадесет} other {друго}}',
+      });
+
+      let instance!: ChildCmp;
+      const initialMetadata: Component = {
+        selector: 'child-cmp',
+        standalone: true,
+        template: '<span i18n>{count, select, 10 {ten} 20 {twenty} other {other}}</span>',
+      };
+
+      @Component(initialMetadata)
+      class ChildCmp {
+        count = 10;
+
+        constructor() {
+          instance = this;
+        }
+      }
+
+      @Component({
+        standalone: true,
+        imports: [ChildCmp],
+        template: '<child-cmp/>',
+      })
+      class RootCmp {}
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+      expectHTML(fixture.nativeElement, '<child-cmp><span>десет</span></child-cmp>');
+
+      replaceMetadata(ChildCmp, {...initialMetadata, template: '<strong i18n>hello</strong>'});
+      fixture.detectChanges();
+      expectHTML(fixture.nativeElement, '<child-cmp><strong>здравей</strong></child-cmp>');
+
+      replaceMetadata(ChildCmp, {
+        ...initialMetadata,
+        template:
+          '<main><section i18n>{count, select, 10 {ten} 20 {twenty} other {other}}</section></main>',
+      });
+      fixture.detectChanges();
+      expectHTML(
+        fixture.nativeElement,
+        '<child-cmp><main><section>десет</section></main></child-cmp>',
+      );
+
+      instance.count = 20;
+      fixture.detectChanges();
+      expectHTML(
+        fixture.nativeElement,
+        '<child-cmp><main><section>двадесет</section></main></child-cmp>',
+      );
+    });
+
+    it('should replace components that use i18n with ICUs in their projected content', () => {
+      loadTranslations({
+        [computeMsgId('{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}')]:
+          '{VAR_SELECT, select, 10 {десет} 20 {двадесет} other {друго}}',
+      });
+
+      const initialMetadata: Component = {
+        selector: 'child-cmp',
+        standalone: true,
+        template: '<ng-content/>',
+      };
+
+      @Component(initialMetadata)
+      class ChildCmp {}
+
+      @Component({
+        standalone: true,
+        imports: [ChildCmp],
+        template: '<child-cmp i18n>{count, select, 10 {ten} 20 {twenty} other {other}}</child-cmp>',
+      })
+      class RootCmp {
+        count = 10;
+      }
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+      markNodesAsCreatedInitially(fixture.nativeElement);
+      expectHTML(fixture.nativeElement, '<child-cmp>десет</child-cmp>');
+
+      replaceMetadata(ChildCmp, {
+        ...initialMetadata,
+        template: 'The text translates to <strong><ng-content/></strong>!',
+      });
+      fixture.detectChanges();
+
+      const recreatedNodes = childrenOf(...fixture.nativeElement.querySelectorAll('child-cmp'));
+      verifyNodesRemainUntouched(fixture.nativeElement, recreatedNodes);
+      verifyNodesWereRecreated(recreatedNodes);
+      expectHTML(
+        fixture.nativeElement,
+        '<child-cmp>The text translates to <strong>десет</strong>!</child-cmp>',
+      );
+
+      fixture.componentInstance.count = 20;
+      fixture.detectChanges();
+      expectHTML(
+        fixture.nativeElement,
+        '<child-cmp>The text translates to <strong>двадесет</strong>!</child-cmp>',
+      );
+    });
+  });
+
+  // Testing utilities
+
+  // Field that we'll monkey-patch onto DOM elements that were created
+  // initially, so that we can verify that some nodes were *not* re-created
+  // during HMR operation. We do it for *testing* purposes only.
+  const CREATED_INITIALLY_MARKER = '__ngCreatedInitially__';
+
+  function replaceMetadata(type: Type<unknown>, metadata: Component) {
+    ɵɵreplaceMedata(type, () => {
+      // TODO: the content of this callback is a hacky workaround to invoke the compiler in a test.
+      // in reality the callback will be generated by the compiler to be something along the lines
+      // of `MyComp[ɵcmp] = /* metadata */`.
+      // TODO: in reality this callback should also include `setClassMetadata` and
+      // `setClassDebugInfo`.
+      (type as any)[ɵNG_COMP_DEF] = null;
+      compileComponent(type, metadata);
+    });
+  }
+
+  function expectHTML(element: HTMLElement, expectation: string) {
+    const actual = element.innerHTML
+      .replace(/<!--(\W|\w)*?-->/g, '')
+      .replace(/\sng-reflect-\S*="[^"]*"/g, '');
+    expect(actual.replace(/\s/g, '') === expectation.replace(/\s/g, ''))
+      .withContext(`HTML does not match expectation. Actual HTML:\n${actual}`)
+      .toBe(true);
+  }
+
+  function setMarker(node: Node) {
+    (node as any)[CREATED_INITIALLY_MARKER] = true;
+  }
+
+  function hasMarker(node: Node): boolean {
+    return !!(node as any)[CREATED_INITIALLY_MARKER];
+  }
+
+  function markNodesAsCreatedInitially(root: HTMLElement) {
+    let current: Node | null = root;
+    while (current) {
+      setMarker(current);
+      if (current.firstChild) {
+        markNodesAsCreatedInitially(current.firstChild as HTMLElement);
+      }
+      current = current.nextSibling;
+    }
+  }
+
+  function childrenOf(...nodes: Node[]): Node[] {
+    const result: Node[] = [];
+    for (const node of nodes) {
+      let current: Node | null = node.firstChild;
+      while (current) {
+        result.push(current);
+        current = current.nextSibling;
+      }
+    }
+    return result;
+  }
+
+  function verifyNodesRemainUntouched(root: HTMLElement, exceptions: Node[] = []) {
+    if (!root) {
+      throw new Error('Root node must be provided');
+    }
+
+    let current: Node | null = root;
+    while (current) {
+      if (!hasMarker(current)) {
+        if (exceptions.includes(current)) {
+          // This node was re-created intentionally,
+          // do not inspect child nodes.
+          break;
+        } else {
+          throw new Error(`Unexpected state: node was re-created: ${(current as any).innerHTML}`);
+        }
+      }
+      if (current.firstChild) {
+        verifyNodesRemainUntouched(current.firstChild as HTMLElement, exceptions);
+      }
+      current = current.nextSibling;
+    }
+  }
+
+  function verifyNodesWereRecreated(nodes: Iterable<Node>) {
+    nodes = Array.from(nodes);
+
+    for (const node of nodes) {
+      if (hasMarker(node)) {
+        throw new Error(`Unexpected state: node was *not* re-created: ${(node as any).innerHTML}`);
+      }
+    }
+  }
+});

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -660,7 +660,7 @@
     "name": "addPropertyBinding"
   },
   {
-    "name": "addToViewTree"
+    "name": "addToEndOfViewTree"
   },
   {
     "name": "allocExpando"
@@ -973,6 +973,9 @@
   },
   {
     "name": "getFirstLContainer"
+  },
+  {
+    "name": "getInitialLViewFlagsFromDef"
   },
   {
     "name": "getInjectImplementation"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -717,7 +717,7 @@
     "name": "addPropertyBinding"
   },
   {
-    "name": "addToViewTree"
+    "name": "addToEndOfViewTree"
   },
   {
     "name": "allocExpando"
@@ -1036,6 +1036,9 @@
   },
   {
     "name": "getFirstLContainer"
+  },
+  {
+    "name": "getInitialLViewFlagsFromDef"
   },
   {
     "name": "getInjectImplementation"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -543,7 +543,7 @@
     "name": "addPropertyBinding"
   },
   {
-    "name": "addToViewTree"
+    "name": "addToEndOfViewTree"
   },
   {
     "name": "allocExpando"
@@ -808,6 +808,9 @@
   },
   {
     "name": "getFirstLContainer"
+  },
+  {
+    "name": "getInitialLViewFlagsFromDef"
   },
   {
     "name": "getInjectImplementation"

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -609,7 +609,7 @@
     "name": "addPropertyBinding"
   },
   {
-    "name": "addToViewTree"
+    "name": "addToEndOfViewTree"
   },
   {
     "name": "allocExpando"
@@ -913,6 +913,9 @@
   },
   {
     "name": "getFirstNativeNode"
+  },
+  {
+    "name": "getInitialLViewFlagsFromDef"
   },
   {
     "name": "getInjectImplementation"
@@ -1507,6 +1510,9 @@
   },
   {
     "name": "init_graph"
+  },
+  {
+    "name": "init_hmr"
   },
   {
     "name": "init_hooks"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -762,7 +762,7 @@
     "name": "addToArray"
   },
   {
-    "name": "addToViewTree"
+    "name": "addToEndOfViewTree"
   },
   {
     "name": "addValidators"
@@ -1159,6 +1159,9 @@
   },
   {
     "name": "getFirstNativeNode"
+  },
+  {
+    "name": "getInitialLViewFlagsFromDef"
   },
   {
     "name": "getInjectImplementation"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -744,7 +744,7 @@
     "name": "addToArray"
   },
   {
-    "name": "addToViewTree"
+    "name": "addToEndOfViewTree"
   },
   {
     "name": "addValidators"
@@ -1117,6 +1117,9 @@
   },
   {
     "name": "getFirstNativeNode"
+  },
+  {
+    "name": "getInitialLViewFlagsFromDef"
   },
   {
     "name": "getInjectImplementation"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -891,7 +891,7 @@
     "name": "addToArray"
   },
   {
-    "name": "addToViewTree"
+    "name": "addToEndOfViewTree"
   },
   {
     "name": "advanceActivatedRoute"
@@ -1372,6 +1372,9 @@
   },
   {
     "name": "getInherited"
+  },
+  {
+    "name": "getInitialLViewFlagsFromDef"
   },
   {
     "name": "getInjectImplementation"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -636,7 +636,7 @@
     "name": "addToArray"
   },
   {
-    "name": "addToViewTree"
+    "name": "addToEndOfViewTree"
   },
   {
     "name": "allocExpando"
@@ -946,6 +946,9 @@
   },
   {
     "name": "getFirstNativeNode"
+  },
+  {
+    "name": "getInitialLViewFlagsFromDef"
   },
   {
     "name": "getInjectImplementation"


### PR DESCRIPTION
Adds the new `ɵɵreplaceMedata` function that can be used to replace the metadata of a component class and re-render all instances in place without refreshing the page. The function isn't used anywhere at the moment, but it will be necessary for future functionality.