### PR TITLE
fix(core): allow signal write error

### DIFF
--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -71,9 +71,7 @@ export function publishSignalConfiguration(): void {
   setThrowInvalidWriteToSignalError(() => {
     throw new RuntimeError(
       RuntimeErrorCode.SIGNAL_WRITE_FROM_ILLEGAL_CONTEXT,
-      ngDevMode &&
-        'Writing to signals is not allowed in a `computed` or an `effect` by default. ' +
-          'Use `allowSignalWrites` in the `CreateEffectOptions` to enable this inside effects.',
+      ngDevMode && 'Writing to signals is not allowed in a `computed`.',
     );
   });
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Now that effects allow to write to signals (see https://github.com/angular/angular/commit/4e890cc5ac6eaa04a6f7ca988908812a65991c14), the SIGNAL_WRITE_FROM_ILLEGAL_CONTEXT error is only thrown in `computed` functions.

## What is the new behavior?

This commit updates the error message to remove the mention of effects and of the deprecated `allowSignalWrites` option.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
