### PR TITLE
refactor(forms): Expose a union type for parent form containers.

### DIFF
--- a/goldens/public-api/forms/index.api.md
+++ b/goldens/public-api/forms/index.api.md
@@ -328,6 +328,9 @@ export class FormBuilder {
 }
 
 // @public
+export type FormContainerDirective = NgForm | FormGroupDirective;
+
+// @public
 export interface FormControl<TValue = any> extends AbstractControl<TValue> {
     readonly defaultValue: TValue;
     getRawValue(): TValue;

--- a/packages/forms/src/directives.ts
+++ b/packages/forms/src/directives.ts
@@ -112,3 +112,11 @@ export const REACTIVE_DRIVEN_DIRECTIVES: Type<any>[] = [
 export class ɵInternalFormsSharedModule {}
 
 export {ɵInternalFormsSharedModule as InternalFormsSharedModule};
+
+/**
+ * @publicApi
+ *
+ * @description
+ * This type is typically used to represent a parent Directive
+ */
+export type FormContainerDirective = NgForm | FormGroupDirective;

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -17,7 +17,7 @@
  * explicitly.
  */
 
-export {ɵInternalFormsSharedModule} from './directives';
+export {ɵInternalFormsSharedModule, FormContainerDirective} from './directives';
 export {AbstractControlDirective} from './directives/abstract_control_directive';
 export {AbstractFormGroupDirective} from './directives/abstract_form_group_directive';
 export {CheckboxControlValueAccessor} from './directives/checkbox_value_accessor';


### PR DESCRIPTION
This commit exposes a new type to the public api.
It is intented to also include the upcomming `FormArrayDirective` (#55880)
