### PR TITLE
ci: update integration test payload size

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -47,7 +47,7 @@
   },
   "defer": {
     "uncompressed": {
-      "main": 12148,
+      "main": 11497,
       "polyfills": 33807,
       "defer.component": 371
     }


### PR DESCRIPTION
This commit updates a golden file with payload sizes for integration apps. One of the sizes got dropped below the threshold (but not significantly), most likely due to changes merged earlier (dependency updates, CLI changes, etc).

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes

## Does this PR introduce a breaking change?

- [x] Yes
- [x] No