### PR TITLE
docs: update the name of the sub-navigation item at error encyclopedi…

### DIFF
--- a/adev/src/app/sub-navigation-data.ts
+++ b/adev/src/app/sub-navigation-data.ts
@@ -1219,7 +1219,7 @@ const REFERENCE_SUB_NAVIGATION_DATA: NavigationItem[] = [
         contentPath: 'reference/errors/NG0507',
       },
       {
-        label: 'NG0602: HTML content was altered after server-side rendering',
+        label: 'NG0602: Disallowed function call inside reactive context',
         path: 'errors/NG0602',
         contentPath: 'reference/errors/NG0602',
       },


### PR DESCRIPTION
…a menu

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When going through the **Errors Encyclopedia**, the same error name is shown twice (NG0602), but when clicking, it redirects to another error instead.

![image](https://github.com/user-attachments/assets/84896815-aca4-4ebd-896d-dd9d4b3a66ae)


Issue Number: N/A


## What is the new behavior?
The error name is updated to reflect the proper error it is redirecting to.

![image](https://github.com/user-attachments/assets/d097d749-ef2d-4cdc-ae6c-a888c637d5fc)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
