### PR TITLE
refactor(devtools): Use chrome.devtools.performance types

### DIFF
--- a/devtools/projects/shell-browser/src/app/app.component.ts
+++ b/devtools/projects/shell-browser/src/app/app.component.ts
@@ -27,18 +27,14 @@ export class AppComponent implements OnInit {
     chrome.devtools.network.onNavigated.addListener(() => {
       window.location.reload();
     });
-    // At the moment the chrome.devtools.performance namespace does not
-    // have an entry in DefinitelyTyped, so this is a temporary
-    // workaround to prevent TypeScript failures while the corresponding
-    // type is added upstream.
-    const chromeDevToolsPerformance = (chrome.devtools as any).performance;
+    const chromeDevToolsPerformance = chrome.devtools.performance;
     chromeDevToolsPerformance?.onProfilingStarted?.addListener?.(this.onProfilingStartedListener);
     chromeDevToolsPerformance?.onProfilingStopped?.addListener?.(this.onProfilingStoppedListener);
 
     this._cd.detectChanges();
   }
   ngOnDestroy(): void {
-    const chromeDevToolsPerformance = (chrome.devtools as any).performance;
+    const chromeDevToolsPerformance = chrome.devtools.performance;
     chromeDevToolsPerformance?.onProfilingStarted?.removeListener?.(
       this.onProfilingStartedListener,
     );


### PR DESCRIPTION
The chrome.devtools.performance types were added to the DefinitelyTyped module and as such we don't need to make use of any to circumvent the missing types.

See: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70231

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

No behavior was changed

Issue Number: N/A


## What is the new behavior?

No behavior was changed

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
