### PR TITLE
refactor(platform-server): remove `HttpClientModule` import

### DIFF
--- a/goldens/public-api/platform-server/index.api.md
+++ b/goldens/public-api/platform-server/index.api.md
@@ -7,9 +7,8 @@
 import { ApplicationRef } from '@angular/core';
 import { EnvironmentProviders } from '@angular/core';
 import * as i0 from '@angular/core';
-import * as i1 from '@angular/common/http';
-import * as i2 from '@angular/platform-browser/animations';
-import * as i3 from '@angular/platform-browser';
+import * as i1 from '@angular/platform-browser/animations';
+import * as i2 from '@angular/platform-browser';
 import { InjectionToken } from '@angular/core';
 import { PlatformRef } from '@angular/core';
 import { Provider } from '@angular/core';
@@ -67,7 +66,7 @@ export class ServerModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<ServerModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<ServerModule, never, [typeof i1.HttpClientModule, typeof i2.NoopAnimationsModule], [typeof i3.BrowserModule]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<ServerModule, never, [typeof i1.NoopAnimationsModule], [typeof i2.BrowserModule]>;
 }
 
 // @public (undocumented)

--- a/packages/platform-server/src/server.ts
+++ b/packages/platform-server/src/server.ts
@@ -14,7 +14,6 @@ import {
   ɵNullViewportScroller as NullViewportScroller,
   ɵPLATFORM_SERVER_ID as PLATFORM_SERVER_ID,
 } from '@angular/common';
-import {HttpClientModule} from '@angular/common/http';
 import {
   createPlatformFactory,
   Injector,
@@ -82,7 +81,7 @@ export const PLATFORM_SERVER_PROVIDERS: Provider[] = [
  */
 @NgModule({
   exports: [BrowserModule],
-  imports: [HttpClientModule, NoopAnimationsModule],
+  imports: [NoopAnimationsModule],
   providers: PLATFORM_SERVER_PROVIDERS,
 })
 export class ServerModule {}


### PR DESCRIPTION
This import is not necessary anymore.

fixes #57983
Note: The standalone counterpart was fixed by #50454