### PR TITLE
fix(common): prevent warning about oversize image twice

### DIFF
--- a/packages/core/src/image_performance_warning.ts
+++ b/packages/core/src/image_performance_warning.ts
@@ -105,12 +105,10 @@ export class ImagePerformanceWarning implements OnDestroy {
       lcpElementLoadedCorrectly = false;
     images.forEach((image) => {
       if (!this.options?.disableImageSizeWarning) {
-        for (const image of images) {
-          // Image elements using the NgOptimizedImage directive are excluded,
-          // as that directive has its own version of this check.
-          if (!image.getAttribute('ng-img') && this.isOversized(image)) {
-            logOversizedImageWarning(image.src);
-          }
+        // Image elements using the NgOptimizedImage directive are excluded,
+        // as that directive has its own version of this check.
+        if (!image.getAttribute('ng-img') && this.isOversized(image)) {
+          logOversizedImageWarning(image.src);
         }
       }
       if (!this.options?.disableImageLazyLoadWarning && this.lcpImageUrl) {

--- a/packages/core/test/bundling/image-directive/BUILD.bazel
+++ b/packages/core/test/bundling/image-directive/BUILD.bazel
@@ -46,6 +46,7 @@ http_server(
         "e2e/a.png",
         "e2e/b.png",
         "e2e/logo-1500w.jpg",
+        "e2e/logo-1500w.svg",
         "e2e/logo-500w.jpg",
         "e2e/white-607x3.png",
         "index.html",


### PR DESCRIPTION
I’ve noticed that there was a loop inside a loop. Since we’re already iterating through `images` using `forEach`, it was running a `for` loop through `images` again. This was probably a mistake made when the functionality was initially added. The test actually verified that `logs.length` is `1`, but in the real environment, it logs twice (which is quite obvious due to the code).

I’ve also added the missing file to the Bazel target.