### PR TITLE
build: update ts target to ES2022

### DIFF
--- a/integration/animations-async/tsconfig.json
+++ b/integration/animations-async/tsconfig.json
@@ -7,7 +7,7 @@
     "esModuleInterop": true,
     "declaration": false,
     "experimentalDecorators": true,
-    "module": "esnext",
+    "module": "es2022",
     "moduleResolution": "node",
     "importHelpers": true,
     "target": "es2022",

--- a/integration/animations/tsconfig.json
+++ b/integration/animations/tsconfig.json
@@ -7,10 +7,10 @@
     "esModuleInterop": true,
     "declaration": false,
     "experimentalDecorators": true,
-    "module": "esnext",
+    "module": "es2022",
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es2022",
     "typeRoots": [
       "node_modules/@types"
     ],

--- a/integration/cli-elements-universal/tsconfig.json
+++ b/integration/cli-elements-universal/tsconfig.json
@@ -14,8 +14,8 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
-    "module": "es2020",
+    "target": "es2022",
+    "module": "es2022",
     "lib": [
       "es2018",
       "dom"

--- a/integration/cli-hello-world-ivy-i18n/tsconfig.json
+++ b/integration/cli-hello-world-ivy-i18n/tsconfig.json
@@ -7,10 +7,10 @@
     "esModuleInterop": true,
     "declaration": false,
     "experimentalDecorators": true,
-    "module": "esnext",
+    "module": "es2022",
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es2022",
     "typeRoots": [
       "node_modules/@types"
     ],

--- a/integration/cli-hello-world-lazy/tsconfig.json
+++ b/integration/cli-hello-world-lazy/tsconfig.json
@@ -7,10 +7,10 @@
     "esModuleInterop": true,
     "declaration": false,
     "experimentalDecorators": true,
-    "module": "esnext",
+    "module": "es2022",
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es2022",
     "typeRoots": [
       "node_modules/@types"
     ],

--- a/integration/cli-hello-world-mocha/tsconfig.json
+++ b/integration/cli-hello-world-mocha/tsconfig.json
@@ -7,10 +7,10 @@
     "esModuleInterop": true,
     "declaration": false,
     "experimentalDecorators": true,
-    "module": "esnext",
+    "module": "es2022",
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es2022",
     "typeRoots": [
       "node_modules/@types"
     ],

--- a/integration/cli-hello-world/tsconfig.json
+++ b/integration/cli-hello-world/tsconfig.json
@@ -7,10 +7,10 @@
     "esModuleInterop": true,
     "declaration": false,
     "experimentalDecorators": true,
-    "module": "esnext",
+    "module": "es2022",
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es2022",
     "typeRoots": ["node_modules/@types"],
     "lib": ["es2018", "dom"]
   },

--- a/integration/cli-signal-inputs/tsconfig.json
+++ b/integration/cli-signal-inputs/tsconfig.json
@@ -8,10 +8,10 @@
     "strict": true,
     "declaration": false,
     "experimentalDecorators": true,
-    "module": "esnext",
+    "module": "es2022",
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es2022",
     "typeRoots": ["node_modules/@types"],
     "lib": ["es2018", "dom"]
   },

--- a/integration/defer/tsconfig.json
+++ b/integration/defer/tsconfig.json
@@ -7,10 +7,10 @@
     "esModuleInterop": true,
     "declaration": false,
     "experimentalDecorators": true,
-    "module": "esnext",
+    "module": "es2022",
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es2022",
     "typeRoots": [
       "node_modules/@types"
     ],

--- a/integration/dynamic-compiler/tsconfig.json
+++ b/integration/dynamic-compiler/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2020",
-    "module": "es2020",
+    "target": "es2022",
+    "module": "es2022",
     "moduleResolution": "node",
     "declaration": false,
     "removeComments": true,

--- a/integration/forms/tsconfig.json
+++ b/integration/forms/tsconfig.json
@@ -7,10 +7,10 @@
     "esModuleInterop": true,
     "declaration": false,
     "experimentalDecorators": true,
-    "module": "esnext",
+    "module": "es2022",
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es2022",
     "typeRoots": [
       "node_modules/@types"
     ],

--- a/integration/ivy-i18n/tsconfig.json
+++ b/integration/ivy-i18n/tsconfig.json
@@ -7,10 +7,10 @@
     "esModuleInterop": true,
     "declaration": false,
     "experimentalDecorators": true,
-    "module": "esnext",
+    "module": "es2022",
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es2022",
     "typeRoots": [
       "node_modules/@types"
     ],

--- a/integration/ng-add-localize/tsconfig.json
+++ b/integration/ng-add-localize/tsconfig.json
@@ -17,7 +17,7 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "target": "es2017",
-    "module": "es2020",
+    "module": "es2022",
     "lib": [
       "es2018",
       "dom"

--- a/integration/ng_elements/tsconfig.json
+++ b/integration/ng_elements/tsconfig.json
@@ -7,7 +7,7 @@
     "module": "es2015",
     "moduleResolution": "node",
     "strictNullChecks": true,
-    "target": "es2015",
+    "target": "es2022",
     "sourceMap": false,
     "experimentalDecorators": true,
     "outDir": "built",

--- a/integration/ng_update_migrations/tsconfig.json
+++ b/integration/ng_update_migrations/tsconfig.json
@@ -6,12 +6,12 @@
     "sourceMap": true,
     "esModuleInterop": true,
     "declaration": false,
-    "module": "esnext",
+    "module": "es2022",
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es2022",
     "typeRoots": [
       "node_modules/@types"
     ],

--- a/integration/standalone-bootstrap/tsconfig.json
+++ b/integration/standalone-bootstrap/tsconfig.json
@@ -7,10 +7,10 @@
     "esModuleInterop": true,
     "declaration": false,
     "experimentalDecorators": true,
-    "module": "esnext",
+    "module": "es2022",
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es2022",
     "typeRoots": [
       "node_modules/@types"
     ],

--- a/integration/trusted-types/tsconfig.json
+++ b/integration/trusted-types/tsconfig.json
@@ -14,8 +14,8 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
-    "module": "es2020",
+    "target": "es2022",
+    "module": "es2022",
     "lib": [
       "es2018",
       "dom"


### PR DESCRIPTION
Our integration tests are based on the CLI. CLI build force the target to ES2022 else it logs a warning
