### PR TITLE
fix(docs-infra): allow tutorial component to be GCed

### DIFF
--- a/adev/src/app/features/tutorial/split-resizer-handler.service.ts
+++ b/adev/src/app/features/tutorial/split-resizer-handler.service.ts
@@ -11,7 +11,7 @@ import {DOCUMENT} from '@angular/common';
 import {DestroyRef, ElementRef, Injectable, inject, signal} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {fromEvent, combineLatest} from 'rxjs';
-import {map, filter} from 'rxjs/operators';
+import {map, filter, finalize} from 'rxjs/operators';
 
 interface ResizingData {
   isProgress: boolean;
@@ -148,6 +148,7 @@ export class SplitResizerHandler {
             !!origin && (keyEvent.key === 'ArrowLeft' || keyEvent.key === 'ArrowRight'),
         ),
         takeUntilDestroyed(this.destroyRef),
+        finalize(() => this.focusMonitor.stopMonitoring(this.resizer)),
       )
       .subscribe(([_, keyEvent]) => {
         const shift = keyEvent.key === 'ArrowLeft' ? -1 : 1;

--- a/adev/src/app/features/tutorial/tutorial.component.ts
+++ b/adev/src/app/features/tutorial/tutorial.component.ts
@@ -22,6 +22,7 @@ import {
   Type,
   ViewChild,
 } from '@angular/core';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {
   ClickOutside,
   DocContent,
@@ -110,6 +111,7 @@ export default class Tutorial implements AfterViewInit {
         filter(() =>
           Boolean(this.route?.routeConfig?.path?.startsWith(`${PagePrefix.TUTORIALS}/`)),
         ),
+        takeUntilDestroyed(),
       )
       .subscribe((data) => {
         const docContent = (data['docContent'] as DocContent | undefined)?.contents ?? null;


### PR DESCRIPTION
This commit updates the tutorial component's functionality to unsubscribe from the route data observable and stop monitoring the resizer element when the component is destroyed. This is necessary because `monitor` adds event listeners that prevent the element and component from being garbage collected.

![Screenshot from 2024-10-01 13-45-00](https://github.com/user-attachments/assets/00240fa5-0a2d-4a3b-86dc-320c7a018cf7)
