### PR TITLE
refactor(docs-infra): cleanup `AfterRenderSequence` for reference list

### DIFF
--- a/adev/src/app/features/references/api-reference-list/api-reference-list.component.ts
+++ b/adev/src/app/features/references/api-reference-list/api-reference-list.component.ts
@@ -10,7 +10,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
-  EnvironmentInjector,
+  Injector,
   afterNextRender,
   computed,
   effect,
@@ -43,7 +43,7 @@ export default class ApiReferenceList {
   private readonly apiReferenceManager = inject(ApiReferenceManager);
   private readonly router = inject(Router);
   filterInput = viewChild.required(TextField, {read: ElementRef});
-  private readonly injector = inject(EnvironmentInjector);
+  private readonly injector = inject(Injector);
 
   private readonly allGroups = this.apiReferenceManager.apiGroups;
 


### PR DESCRIPTION
In this commit, we're replacing the provided injector in `afterNextRender` with a node injector because it was previously mistakenly passing an `EnvironmentInjector`. The `EnvironmentInjector` resolves `DestroyRef` to itself, meaning that `AfterRenderSequence` is essentially never destroyed (since the environment injector is not destroyed either).