### PR TITLE
build: Add `LICENSE` file to the generated packages

### DIFF
--- a/packages/bazel/src/ng_package/ng_package.bzl
+++ b/packages/bazel/src/ng_package/ng_package.bzl
@@ -478,6 +478,13 @@ def _ng_package_impl(ctx):
         # placeholder
         packager_args.add("")
 
+    if ctx.file.license:
+        packager_inputs.append(ctx.file.license)
+        packager_args.add(ctx.file.license.path)
+    else:
+        #placeholder
+        packager_args.add("")
+
     packager_args.add(_serialize_files_for_arg(fesm2022))
     packager_args.add(_serialize_files_for_arg(esm2022))
     packager_args.add(_serialize_files_for_arg(static_files))
@@ -536,6 +543,10 @@ _NG_PACKAGE_ATTRS = dict(PKG_NPM_ATTRS, **{
         The contents of the file will be copied to the top of the resulting bundles.
         Configured substitutions are applied like with other files in the package.""",
         allow_single_file = [".txt"],
+    ),
+    "license": attr.label(
+        doc = """A textfile that will be copied to the root of the npm package.""",
+        allow_single_file = True,
     ),
     "deps": attr.label_list(
         doc = """ Targets that produce production JavaScript outputs, such as `ts_library`.""",

--- a/packages/bazel/src/ng_package/packager.ts
+++ b/packages/bazel/src/ng_package/packager.ts
@@ -68,6 +68,9 @@ function main(args: string[]): void {
     // Path to the package's README.md.
     readmeMd,
 
+    // Path to the package's LICENSE file.
+    licenseFile,
+
     // List of rolled-up flat ES2022 modules
     fesm2022Arg,
 
@@ -89,6 +92,10 @@ function main(args: string[]): void {
 
   if (readmeMd) {
     copyFile(readmeMd, 'README.md');
+  }
+
+  if (licenseFile) {
+    copyFile(licenseFile, 'LICENSE');
   }
 
   /**

--- a/packages/bazel/test/ng_package/example_package.golden
+++ b/packages/bazel/test/ng_package/example_package.golden
@@ -1,3 +1,4 @@
+LICENSE
 README.md
 _index.scss
 a11y
@@ -23,6 +24,31 @@ package.json
 secondary
   secondary/index.d.ts
 some-file.txt
+--- LICENSE ---
+
+The MIT License
+
+Copyright (c) 2010-2024 Google LLC. https://angular.dev/license
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
 --- README.md ---
 
 Angular

--- a/packages/bazel/test/ng_package/example_with_ts_library_package.golden
+++ b/packages/bazel/test/ng_package/example_with_ts_library_package.golden
@@ -1,3 +1,4 @@
+LICENSE
 README.md
 fesm2022
   fesm2022/example-with-ts-library.mjs
@@ -12,6 +13,31 @@ portal
   portal/index.d.ts
 utils
   utils/index.d.ts
+--- LICENSE ---
+
+The MIT License
+
+Copyright (c) 2010-2024 Google LLC. https://angular.dev/license
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
 --- README.md ---
 
 Angular

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -188,12 +188,14 @@ def ng_module(name, tsconfig = None, entry_point = None, testonly = False, deps 
         **kwargs
     )
 
-def ng_package(name, readme_md = None, license_banner = None, deps = [], **kwargs):
+def ng_package(name, readme_md = None, license_banner = None, license = None, deps = [], **kwargs):
     """Default values for ng_package"""
     if not readme_md:
         readme_md = "//packages:README.md"
     if not license_banner:
         license_banner = "//packages:license-banner.txt"
+    if not license:
+        license = "//:LICENSE"
     visibility = kwargs.pop("visibility", None)
 
     common_substitutions = dict(kwargs.pop("substitutions", {}), **PKG_GROUP_REPLACEMENTS)
@@ -209,6 +211,7 @@ def ng_package(name, readme_md = None, license_banner = None, deps = [], **kwarg
         deps = deps,
         validate = True,
         readme_md = readme_md,
+        license = license,
         license_banner = license_banner,
         substitutions = select({
             "//:stamp": stamped_substitutions,


### PR DESCRIPTION
This commit adds a parameter to `ng_package` to specify a license file that will be bundled with the generated packages.

fixes #58029
