### PR TITLE
refactor(docs-infra): allow table of contents to be GCed

### DIFF
--- a/adev/shared-docs/components/table-of-contents/table-of-contents.component.ts
+++ b/adev/shared-docs/components/table-of-contents/table-of-contents.component.ts
@@ -6,7 +6,14 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, Input, computed, inject} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  Input,
+  computed,
+  inject,
+} from '@angular/core';
 import {RouterLink} from '@angular/router';
 import {TableOfContentsLevel} from '../../interfaces/index';
 import {TableOfContentsLoader} from '../../services/table-of-contents-loader.service';
@@ -27,6 +34,8 @@ export class TableOfContents {
 
   private readonly scrollSpy = inject(TableOfContentsScrollSpy);
   private readonly tableOfContentsLoader = inject(TableOfContentsLoader);
+  private readonly destroyRef = inject(DestroyRef);
+
   tableOfContentItems = this.tableOfContentsLoader.tableOfContentItems;
 
   activeItemId = this.scrollSpy.activeItemId;
@@ -35,7 +44,7 @@ export class TableOfContents {
 
   ngAfterViewInit() {
     this.tableOfContentsLoader.buildTableOfContent(this.contentSourceElement);
-    this.scrollSpy.startListeningToScroll(this.contentSourceElement);
+    this.scrollSpy.startListeningToScroll(this.contentSourceElement, this.destroyRef);
   }
 
   scrollToTop(): void {

--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
@@ -75,7 +75,6 @@ export class DocViewer implements OnChanges {
   private readonly elementRef = inject(ElementRef);
   private readonly location = inject(Location);
   private readonly navigationState = inject(NavigationState);
-  private readonly platformId = inject(PLATFORM_ID);
   private readonly router = inject(Router);
   private readonly viewContainer = inject(ViewContainerRef);
   private readonly environmentInjector = inject(EnvironmentInjector);
@@ -85,6 +84,8 @@ export class DocViewer implements OnChanges {
   // tslint:disable-next-line:no-unused-variable
   private animateContent = false;
   private readonly pendingTasks = inject(PendingTasks);
+
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
   private countOfExamples = 0;
 
@@ -97,11 +98,10 @@ export class DocViewer implements OnChanges {
   }
 
   async renderContentsAndRunClientSetup(content?: string): Promise<void> {
-    const isBrowser = isPlatformBrowser(this.platformId);
     const contentContainer = this.elementRef.nativeElement;
 
     if (content) {
-      if (isBrowser && !(this.document as any).startViewTransition) {
+      if (this.isBrowser && !(this.document as any).startViewTransition) {
         // Apply a special class to the host node to trigger animation.
         // Note: when a page is hydrated, the `content` would be empty,
         // so we don't trigger an animation to avoid a content flickering
@@ -112,7 +112,7 @@ export class DocViewer implements OnChanges {
       contentContainer.innerHTML = content;
     }
 
-    if (isBrowser) {
+    if (this.isBrowser) {
       // First we setup event listeners on the HTML we just loaded.
       // We want to do this before things like the example viewers are loaded.
       this.setupAnchorListeners(contentContainer);
@@ -300,6 +300,14 @@ export class DocViewer implements OnChanges {
     // purposes and for hydration serialization to pick it up
     // during SSG.
     this.appRef.attachView(componentRef.hostView);
+
+    // This is wrapped with `isBrowser` in for hydration purposes.
+    if (this.isBrowser) {
+      // The `docs-viewer` may be rendered multiple times when navigating
+      // between pages, which will create new components that need to be
+      // destroyed for gradual cleanup.
+      this.destroyRef.onDestroy(() => componentRef.destroy());
+    }
 
     return componentRef;
   }

--- a/adev/shared-docs/services/table-of-contents-scroll-spy.service.spec.ts
+++ b/adev/shared-docs/services/table-of-contents-scroll-spy.service.spec.ts
@@ -6,17 +6,19 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {DestroyRef} from '@angular/core';
+import {DOCUMENT, ViewportScroller} from '@angular/common';
 import {TestBed, discardPeriodicTasks, fakeAsync, tick} from '@angular/core/testing';
 
 import {WINDOW} from '../providers';
 
 import {TableOfContentsLoader} from './table-of-contents-loader.service';
 import {SCROLL_EVENT_DELAY, TableOfContentsScrollSpy} from './table-of-contents-scroll-spy.service';
-import {DOCUMENT, ViewportScroller} from '@angular/common';
 import {TableOfContentsLevel} from '../interfaces';
 
 describe('TableOfContentsScrollSpy', () => {
   let service: TableOfContentsScrollSpy;
+  let destroyRef: DestroyRef;
   const fakeWindow = {
     addEventListener: () => {},
     removeEventListener: () => {},
@@ -68,6 +70,7 @@ describe('TableOfContentsScrollSpy', () => {
     const tableOfContentsLoaderSpy = TestBed.inject(TableOfContentsLoader);
     tableOfContentsLoaderSpy.tableOfContentItems.set(fakeToCItems);
     service = TestBed.inject(TableOfContentsScrollSpy);
+    destroyRef = TestBed.inject(DestroyRef);
   });
 
   it('should be created', () => {
@@ -94,7 +97,7 @@ describe('TableOfContentsScrollSpy', () => {
     const scrollableContainer = doc;
     const setActiveItemIdSpy = spyOn(service as any, 'setActiveItemId');
 
-    service.startListeningToScroll(doc.querySelector('fake-selector'));
+    service.startListeningToScroll(doc.querySelector('fake-selector'), destroyRef);
 
     scrollableContainer.dispatchEvent(new Event('scroll'));
     tick(SCROLL_EVENT_DELAY - 2);
@@ -118,7 +121,7 @@ describe('TableOfContentsScrollSpy', () => {
     const doc = TestBed.inject(DOCUMENT);
     const scrollableContainer = doc;
 
-    service.startListeningToScroll(doc.querySelector('fake-selector'));
+    service.startListeningToScroll(doc.querySelector('fake-selector'), destroyRef);
 
     fakeWindow.scrollY = 1238;
     scrollableContainer.dispatchEvent(new Event('scroll'));
@@ -133,7 +136,7 @@ describe('TableOfContentsScrollSpy', () => {
     const doc = TestBed.inject(DOCUMENT);
     const scrollableContainer = doc;
 
-    service.startListeningToScroll(doc.querySelector('fake-selector'));
+    service.startListeningToScroll(doc.querySelector('fake-selector'), destroyRef);
 
     fakeWindow.scrollY = 99;
     scrollableContainer.dispatchEvent(new Event('scroll'));


### PR DESCRIPTION
This commit updates the table of contents functionality to clean up correctly whenever the user navigates to other pages and nodes are removed from the DOM.

Currently, calling `renderComponent` with the `TableOfContents` keeps creating a new table of contents component without removing the previous one, as they are created manually.

This leads to memory leaks because the components cannot be collected properly, even if the user navigates to the home page where there is no TOC component.

![Screenshot from 2024-10-01 18-26-06](https://github.com/user-attachments/assets/b6e888ed-0fb4-4819-9a08-d3f00bbfd800)
