### PR TITLE
refactor(docs-infra): allow playground component to be cleaned up properly

### DIFF
--- a/adev/src/app/features/playground/playground.component.spec.ts
+++ b/adev/src/app/features/playground/playground.component.spec.ts
@@ -6,56 +6,44 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {WINDOW} from '@angular/docs';
 
-import {
-  EMBEDDED_EDITOR_SELECTOR,
-  EmbeddedEditor,
-  NodeRuntimeSandbox,
-  EmbeddedTutorialManager,
-} from '../../editor';
+import {NodeRuntimeSandbox, EmbeddedTutorialManager} from '../../editor';
 
-import {mockAsyncProvider} from '../../core/services/inject-async';
 import TutorialPlayground from './playground.component';
-
-@Component({
-  selector: EMBEDDED_EDITOR_SELECTOR,
-  template: '<div>FakeEmbeddedEditor</div>',
-})
-class FakeEmbeddedEditor {}
-
-class FakeNodeRuntimeSandbox {
-  init() {
-    return Promise.resolve();
-  }
-}
 
 describe('TutorialPlayground', () => {
   let component: TutorialPlayground;
   let fixture: ComponentFixture<TutorialPlayground>;
+
+  const fakeWindow = {
+    location: {
+      search: window.location.search,
+    },
+  };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [TutorialPlayground],
       providers: [
         {
+          provide: WINDOW,
+          useValue: fakeWindow,
+        },
+        {
           provide: EmbeddedTutorialManager,
           useValue: {
             fetchAndSetTutorialFiles: () => {},
           },
         },
-        mockAsyncProvider(NodeRuntimeSandbox, FakeNodeRuntimeSandbox),
+        {
+          provide: NodeRuntimeSandbox,
+          useVaue: {
+            init: () => {},
+          },
+        },
       ],
-    });
-
-    TestBed.overrideComponent(TutorialPlayground, {
-      remove: {
-        imports: [EmbeddedEditor],
-      },
-      add: {
-        imports: [FakeEmbeddedEditor],
-      },
     });
 
     fixture = TestBed.createComponent(TutorialPlayground);

--- a/adev/src/app/features/playground/playground.component.ts
+++ b/adev/src/app/features/playground/playground.component.ts
@@ -12,18 +12,21 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  DestroyRef,
   EnvironmentInjector,
   PLATFORM_ID,
   Type,
   inject,
 } from '@angular/core';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
+import {CdkMenu, CdkMenuItem, CdkMenuTrigger} from '@angular/cdk/menu';
 import {IconComponent, PlaygroundTemplate} from '@angular/docs';
+import {forkJoin, switchMap, tap} from 'rxjs';
 
 import {injectAsync} from '../../core/services/inject-async';
-import {EmbeddedTutorialManager} from '../../editor/index';
+import type {EmbeddedTutorialManager, NodeRuntimeSandbox} from '../../editor/index';
 
 import PLAYGROUND_ROUTE_DATA_JSON from '../../../../src/assets/tutorials/playground/routes.json';
-import {CdkMenu, CdkMenuItem, CdkMenuTrigger} from '@angular/cdk/menu';
 
 @Component({
   selector: 'adev-playground',
@@ -38,34 +41,44 @@ import {CdkMenu, CdkMenuItem, CdkMenuTrigger} from '@angular/cdk/menu';
 })
 export default class PlaygroundComponent implements AfterViewInit {
   private readonly changeDetectorRef = inject(ChangeDetectorRef);
-  private readonly embeddedTutorialManager = inject(EmbeddedTutorialManager);
   private readonly environmentInjector = inject(EnvironmentInjector);
-  private readonly platformId = inject(PLATFORM_ID);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
   readonly templates = PLAYGROUND_ROUTE_DATA_JSON.templates;
   readonly defaultTemplate = PLAYGROUND_ROUTE_DATA_JSON.defaultTemplate;
   readonly starterTemplate = PLAYGROUND_ROUTE_DATA_JSON.starterTemplate;
 
+  protected nodeRuntimeSandbox?: NodeRuntimeSandbox;
   protected embeddedEditorComponent?: Type<unknown>;
   protected selectedTemplate: PlaygroundTemplate = this.defaultTemplate;
 
-  async ngAfterViewInit(): Promise<void> {
-    if (isPlatformBrowser(this.platformId)) {
-      const [embeddedEditorComponent, nodeRuntimeSandbox] = await Promise.all([
-        import('../../editor/index').then((c) => c.EmbeddedEditor),
-        injectAsync(this.environmentInjector, () =>
-          import('../../editor/index').then((c) => c.NodeRuntimeSandbox),
-        ),
-      ]);
-
-      this.embeddedEditorComponent = embeddedEditorComponent;
-
-      this.changeDetectorRef.markForCheck();
-
-      await this.loadTemplate(this.defaultTemplate.path);
-
-      await nodeRuntimeSandbox.init();
+  ngAfterViewInit(): void {
+    if (!this.isBrowser) {
+      return;
     }
+
+    // If using `async-await`, `this` will be captured until the function is executed
+    // and completed, which can lead to a memory leak if the user navigates away from
+    // the playground component to another page.
+    forkJoin({
+      nodeRuntimeSandbox: injectAsync(this.environmentInjector, () =>
+        import('../../editor/index').then((c) => c.NodeRuntimeSandbox),
+      ),
+      embeddedEditorComponent: import('../../editor/index').then((c) => c.EmbeddedEditor),
+    })
+      .pipe(
+        tap(({nodeRuntimeSandbox, embeddedEditorComponent}) => {
+          this.nodeRuntimeSandbox = nodeRuntimeSandbox;
+          this.embeddedEditorComponent = embeddedEditorComponent;
+        }),
+        switchMap(() => this.loadTemplate(this.defaultTemplate.path)),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.changeDetectorRef.markForCheck();
+        this.nodeRuntimeSandbox!.init();
+      });
   }
 
   async newProject() {
@@ -78,6 +91,10 @@ export default class PlaygroundComponent implements AfterViewInit {
   }
 
   private async loadTemplate(tutorialPath: string) {
-    await this.embeddedTutorialManager.fetchAndSetTutorialFiles(tutorialPath);
+    const embeddedTutorialManager = await injectAsync(this.environmentInjector, () =>
+      import('../../editor/index').then((c) => c.EmbeddedTutorialManager),
+    );
+
+    await embeddedTutorialManager.fetchAndSetTutorialFiles(tutorialPath);
   }
 }


### PR DESCRIPTION
In this commit, we're replacing the `async-await` style in the playground component with the `from()`
observable, which allows us to invert a dependency and avoid memory leaks. Because an `async` function
has a closure, just like any other function in JavaScript, using `await` captures `this` until the
promise is resolved.

![Screenshot from 2024-10-02 13-07-15](https://github.com/user-attachments/assets/85c2184e-74fc-4e47-ae1b-3628c388af98)
