### PR TITLE
docs: mark `afterRenderEffect` as experimental.

### DIFF
--- a/packages/core/src/render3/reactivity/after_render_effect.ts
+++ b/packages/core/src/render3/reactivity/after_render_effect.ts
@@ -334,6 +334,9 @@ export function afterRenderEffect<E = never, W = never, M = never>(
   options?: Omit<AfterRenderOptions, 'phase'>,
 ): AfterRenderRef;
 
+/**
+ * @experimental
+ */
 export function afterRenderEffect<E = never, W = never, M = never>(
   callbackOrSpec:
     | ((onCleanup: EffectCleanupRegisterFn) => void)


### PR DESCRIPTION
On overloaded funtions, the jsdoc tag must be on the implementation.
