### PR TITLE
refactor(migrations): eagerly migrate `Partial<T>` references in google3

### DIFF
--- a/packages/core/schematics/migrations/signal-migration/src/input_detection/directive_info.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/input_detection/directive_info.ts
@@ -39,12 +39,14 @@ export class DirectiveInfo {
   constructor(public clazz: ts.ClassDeclaration) {}
 
   /**
-   * Checks whether there are any incompatible inputs for the
+   * Checks whether there are any migrated inputs for the
    * given class.
+   *
+   * Returns `false` if all inputs are incompatible.
    */
-  hasIncompatibleMembers(): boolean {
-    return Array.from(this.inputFields.values()).some(({descriptor}) =>
-      this.isInputMemberIncompatible(descriptor),
+  hasMigratedFields(): boolean {
+    return Array.from(this.inputFields.values()).some(
+      ({descriptor}) => !this.isInputMemberIncompatible(descriptor),
     );
   }
 

--- a/packages/core/schematics/migrations/signal-migration/src/passes/9_migrate_ts_type_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/9_migrate_ts_type_references.ts
@@ -7,12 +7,11 @@
  */
 
 import {ImportManager} from '@angular/compiler-cli/src/ngtsc/translator';
-import assert from 'assert';
-import ts from 'typescript';
+import {ProgramInfo} from '../../../../utils/tsurge';
+import {migrateTypeScriptTypeReferences} from './reference_migration/migrate_ts_type_references';
 import {ReferenceMigrationHost} from './reference_migration/reference_migration_host';
 import {ClassFieldDescriptor} from './reference_resolution/known_fields';
-import {ProgramInfo, projectFile, Replacement, TextUpdate} from '../../../../utils/tsurge';
-import {isTsClassTypeReference, Reference} from './reference_resolution/reference_kinds';
+import {Reference} from './reference_resolution/reference_kinds';
 
 /**
  * Migrates TypeScript "ts.Type" references. E.g.
@@ -26,58 +25,5 @@ export function pass9__migrateTypeScriptTypeReferences<D extends ClassFieldDescr
   importManager: ImportManager,
   info: ProgramInfo,
 ) {
-  const seenTypeNodes = new WeakSet<ts.TypeReferenceNode>();
-
-  for (const reference of references) {
-    // This pass only deals with TS input class type references.
-    if (!isTsClassTypeReference(reference)) {
-      continue;
-    }
-    // Skip references to classes that are not fully migrated.
-    if (!host.shouldMigrateReferencesToClass(reference.target)) {
-      continue;
-    }
-    // Skip duplicate references. E.g. in batching.
-    if (seenTypeNodes.has(reference.from.node)) {
-      continue;
-    }
-    seenTypeNodes.add(reference.from.node);
-
-    if (reference.isPartialReference && reference.isPartOfCatalystFile) {
-      assert(reference.from.node.typeArguments, 'Expected type arguments for partial reference.');
-      assert(reference.from.node.typeArguments.length === 1, 'Expected an argument for reference.');
-
-      const firstArg = reference.from.node.typeArguments[0];
-      const sf = firstArg.getSourceFile();
-      // Naive detection of the import. Sufficient for this test file migration.
-      const catalystImport = sf.text.includes(
-        'google3/javascript/angular2/testing/catalyst/fake_async',
-      )
-        ? 'google3/javascript/angular2/testing/catalyst/fake_async'
-        : 'google3/javascript/angular2/testing/catalyst/async';
-
-      const unwrapImportExpr = importManager.addImport({
-        exportModuleSpecifier: catalystImport,
-        exportSymbolName: 'UnwrapSignalInputs',
-        requestedFile: sf,
-      });
-
-      host.replacements.push(
-        new Replacement(
-          projectFile(sf, info),
-          new TextUpdate({
-            position: firstArg.getStart(),
-            end: firstArg.getStart(),
-            toInsert: `${host.printer.printNode(ts.EmitHint.Unspecified, unwrapImportExpr, sf)}<`,
-          }),
-        ),
-      );
-      host.replacements.push(
-        new Replacement(
-          projectFile(sf, info),
-          new TextUpdate({position: firstArg.getEnd(), end: firstArg.getEnd(), toInsert: '>'}),
-        ),
-      );
-    }
-  }
+  migrateTypeScriptTypeReferences(host, references, importManager, info);
 }

--- a/packages/core/schematics/migrations/signal-migration/src/passes/reference_migration/migrate_ts_type_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/reference_migration/migrate_ts_type_references.ts
@@ -7,8 +7,6 @@
  */
 
 import ts from 'typescript';
-import {KnownInputs} from '../../input_detection/known_inputs';
-import {MigrationResult} from '../../result';
 import {ProgramInfo, projectFile, Replacement, TextUpdate} from '../../../../../utils/tsurge';
 import assert from 'assert';
 import {ImportManager} from '@angular/compiler-cli/src/ngtsc/translator';
@@ -51,9 +49,15 @@ export function migrateTypeScriptTypeReferences<D extends ClassFieldDescriptor>(
 
       const firstArg = reference.from.node.typeArguments[0];
       const sf = firstArg.getSourceFile();
+      // Naive detection of the import. Sufficient for this test file migration.
+      const catalystImport = sf.text.includes(
+        'google3/javascript/angular2/testing/catalyst/fake_async',
+      )
+        ? 'google3/javascript/angular2/testing/catalyst/fake_async'
+        : 'google3/javascript/angular2/testing/catalyst/async';
 
       const unwrapImportExpr = importManager.addImport({
-        exportModuleSpecifier: 'google3/javascript/angular2/testing/catalyst',
+        exportModuleSpecifier: catalystImport,
         exportSymbolName: 'UnwrapSignalInputs',
         requestedFile: sf,
       });

--- a/packages/core/schematics/migrations/signal-migration/src/phase_migrate.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/phase_migrate.ts
@@ -49,7 +49,7 @@ export function executeMigrationPhase(
       knownInputs.has(inputDescr) && knownInputs.get(inputDescr)!.isIncompatible() === false,
     shouldMigrateReferencesToClass: (clazz) =>
       knownInputs.getDirectiveInfoForClass(clazz) !== undefined &&
-      knownInputs.getDirectiveInfoForClass(clazz)!.hasIncompatibleMembers() === false,
+      knownInputs.getDirectiveInfoForClass(clazz)!.hasMigratedFields(),
   };
 
   // Migrate passes.

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/catalyst_test_partial.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/catalyst_test_partial.ts
@@ -1,0 +1,18 @@
+// tslint:disable
+
+import {Component, Input} from '@angular/core';
+
+// @ts-ignore
+import {} from 'google3/javascript/angular2/testing/catalyst/fake_async';
+
+function renderComponent(inputs: Partial<TestableSecondaryRangePicker> = {}) {}
+
+@Component({
+  standalone: false,
+  jit: true,
+  template: '<bla [(ngModel)]="incompatible">',
+})
+class TestableSecondaryRangePicker {
+  @Input() bla = true;
+  @Input() incompatible = true;
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden.txt
@@ -127,6 +127,28 @@ it('should work', () => {
   } as Partial<UnwrapSignalInputs<MyComp>>;
   bootstrapTemplate('<my-comp [hello]="hello">', inputs);
 });
+@@@@@@ catalyst_test_partial.ts @@@@@@
+
+// tslint:disable
+
+import {Component, Input, input} from '@angular/core';
+
+// @ts-ignore
+import {UnwrapSignalInputs} from 'google3/javascript/angular2/testing/catalyst/fake_async';
+
+function renderComponent(inputs: Partial<UnwrapSignalInputs<TestableSecondaryRangePicker>> = {}) {}
+
+@Component({
+  standalone: false,
+  jit: true,
+  template: '<bla [(ngModel)]="incompatible">',
+})
+class TestableSecondaryRangePicker {
+  readonly bla = input(true);
+  // TODO: Skipped for migration because:
+  //  Your application code writes to the input. This prevents migration.
+  @Input() incompatible = true;
+}
 @@@@@@ constructor_initializations.ts @@@@@@
 
 // tslint:disable

--- a/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
@@ -119,6 +119,26 @@ it('should work', () => {
   } as Partial<UnwrapSignalInputs<MyComp>>;
   bootstrapTemplate('<my-comp [hello]="hello">', inputs);
 });
+@@@@@@ catalyst_test_partial.ts @@@@@@
+
+// tslint:disable
+
+import {Component, input} from '@angular/core';
+
+// @ts-ignore
+import {UnwrapSignalInputs} from 'google3/javascript/angular2/testing/catalyst/fake_async';
+
+function renderComponent(inputs: Partial<UnwrapSignalInputs<TestableSecondaryRangePicker>> = {}) {}
+
+@Component({
+  standalone: false,
+  jit: true,
+  template: '<bla [(ngModel)]="incompatible()">',
+})
+class TestableSecondaryRangePicker {
+  readonly bla = input(true);
+  readonly incompatible = input(true);
+}
 @@@@@@ constructor_initializations.ts @@@@@@
 
 // tslint:disable


### PR DESCRIPTION
Instead of only migrating `Partial<T>` references to unwrap signal inputs when all members are migrated, we should do this, even if just a subset of inputs of the class are migrated.

This is something we saw required manual fixups in google3— so this commit fixes this.