### PR TITLE
refactor(migrations): do not accidentally detect read as incompatible write

### DIFF
--- a/packages/core/schematics/migrations/signal-migration/src/passes/reference_resolution/identify_ts_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/reference_resolution/identify_ts_references.ts
@@ -96,9 +96,11 @@ export function identifyPotentialTypeScriptReference<D extends ClassFieldDescrip
     return;
   }
 
-  const accessParent = unwrapParent(traverseAccess(node).parent);
+  const access = unwrapParent(traverseAccess(node));
+  const accessParent = access.parent;
   const isWriteReference =
     ts.isBinaryExpression(accessParent) &&
+    accessParent.left === access &&
     writeBinaryOperators.includes(accessParent.operatorToken.kind);
 
   // track accesses from source files to known fields.

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/writing_to_inputs.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/writing_to_inputs.ts
@@ -1,0 +1,18 @@
+// tslint:disable
+
+import {Input} from '@angular/core';
+
+export class TestCmp {
+  @Input() testParenthesisInput = false;
+  @Input() notMutated = true;
+
+  testParenthesis() {
+    // prettier-ignore
+    ((this.testParenthesisInput)) = true;
+  }
+
+  testNotMutated() {
+    let fixture: boolean;
+    fixture = this.notMutated;
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden.txt
@@ -1355,3 +1355,25 @@ class WithJsdoc {
 
   readonly withCommentInside = input</* intended */ boolean>();
 }
+@@@@@@ writing_to_inputs.ts @@@@@@
+
+// tslint:disable
+
+import {Input, input} from '@angular/core';
+
+export class TestCmp {
+  // TODO: Skipped for migration because:
+  //  Your application code writes to the input. This prevents migration.
+  @Input() testParenthesisInput = false;
+  readonly notMutated = input(true);
+
+  testParenthesis() {
+    // prettier-ignore
+    ((this.testParenthesisInput)) = true;
+  }
+
+  testNotMutated() {
+    let fixture: boolean;
+    fixture = this.notMutated();
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
@@ -1307,3 +1307,23 @@ class WithJsdoc {
 
   readonly withCommentInside = input</* intended */ boolean>();
 }
+@@@@@@ writing_to_inputs.ts @@@@@@
+
+// tslint:disable
+
+import {input} from '@angular/core';
+
+export class TestCmp {
+  readonly testParenthesisInput = input(false);
+  readonly notMutated = input(true);
+
+  testParenthesis() {
+    // prettier-ignore
+    ((this.testParenthesisInput)) = true;
+  }
+
+  testNotMutated() {
+    let fixture: boolean;
+    fixture = this.notMutated();
+  }
+}


### PR DESCRIPTION
Fixes that the signal input and queries migration detects code like `fixture = bla.componentInstance.field` as an incompatible write because it's part of a binary expression, but we didn't check whether it's part of the left side.