### PR TITLE
refactor(localize): remove deprecated `name` option.

### DIFF
--- a/packages/localize/schematics/ng-add/index.ts
+++ b/packages/localize/schematics/ng-add/index.ts
@@ -40,6 +40,7 @@ function addPolyfillToConfig(projectName: string): Rule {
         case AngularBuilder.Browser:
         case AngularBuilder.BrowserEsbuild:
         case AngularBuilder.Application:
+        case AngularBuilder.BuildApplication:
           target.options ??= {};
           const value = target.options['polyfills'];
           if (typeof value === 'string') {
@@ -77,6 +78,7 @@ function addTypeScriptConfigTypes(projectName: string): Rule {
         case AngularBuilder.BrowserEsbuild:
         case AngularBuilder.Browser:
         case AngularBuilder.Application:
+        case AngularBuilder.BuildApplication:
           const value = target.options?.['tsConfig'];
           if (typeof value === 'string') {
             tsConfigFiles.add(value);
@@ -147,9 +149,7 @@ function moveToDependencies(host: Tree): Rule | void {
 }
 
 export default function (options: Schema): Rule {
-  // We favor the name option because the project option has a
-  // smart default which can be populated even when unspecified by the user.
-  const projectName = options.name ?? options.project;
+  const projectName = options.project;
 
   if (!projectName) {
     throw new SchematicsException('Option "project" is required.');

--- a/packages/localize/schematics/ng-add/schema.d.ts
+++ b/packages/localize/schematics/ng-add/schema.d.ts
@@ -12,11 +12,6 @@ export interface Schema {
    */
   project?: string;
   /**
-   * The name of the project.
-   * @deprecated use the `project` option instead.
-   */
-  name?: string;
-  /**
    * Will this project use $localize at runtime?
    *
    * If true then the dependency is included in the `dependencies` section of package.json, rather

--- a/packages/localize/schematics/ng-add/schema.json
+++ b/packages/localize/schematics/ng-add/schema.json
@@ -11,11 +11,6 @@
         "$source": "projectName"
       }
     },
-    "name": {
-      "type": "string",
-      "description": "The name of the project.",
-      "x-deprecated": "Use the \"project\" option instead."
-    },
     "useAtRuntime": {
       "type": "boolean",
       "description": "If set then `@angular/localize` is included in the `dependencies` section of `package.json`, rather than `devDependencies`, which is the default.",


### PR DESCRIPTION
BREAKING CHANGE: The `name` option in the `ng add @localize` schematic has been removed in favor of the `project` option.
