### PR TITLE
refactor(core): remove deprecated `factories` Property in `KeyValueDiffers`

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1107,8 +1107,6 @@ export class KeyValueDiffers {
     // (undocumented)
     static create<S>(factories: KeyValueDifferFactory[], parent?: KeyValueDiffers): KeyValueDiffers;
     static extend<S>(factories: KeyValueDifferFactory[]): StaticProvider;
-    // @deprecated (undocumented)
-    factories: KeyValueDifferFactory[];
     // (undocumented)
     find(kv: any): KeyValueDifferFactory;
     // (undocumented)

--- a/packages/core/src/change_detection/differs/keyvalue_differs.ts
+++ b/packages/core/src/change_detection/differs/keyvalue_differs.ts
@@ -129,10 +129,7 @@ export class KeyValueDiffers {
     factory: defaultKeyValueDiffersFactory,
   });
 
-  /**
-   * @deprecated v4.0.0 - Should be private.
-   */
-  factories: KeyValueDifferFactory[];
+  private readonly factories: KeyValueDifferFactory[];
 
   constructor(factories: KeyValueDifferFactory[]) {
     this.factories = factories;


### PR DESCRIPTION


BREAKING CHANGE: The deprecated `factories` property in `KeyValueDiffers` has been removed.

