### PR TITLE
docs(docs-infra): Add NgModule exports for directives.

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/tab-description.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/tab-description.tsx
@@ -10,18 +10,41 @@ import {Fragment, h} from 'preact';
 import {DocEntryRenderable} from '../entities/renderables';
 import {normalizeTabUrl} from '../transforms/url-transforms';
 import {RawHtml} from './raw-html';
+import {CodeSymbol} from './code-symbols';
 
 const DESCRIPTION_TAB_NAME = 'Description';
 
 /** Component to render the description tab. */
 export function TabDescription(props: {entry: DocEntryRenderable}) {
-  if (!props.entry.htmlDescription || props.entry.htmlDescription === props.entry.shortHtmlDescription) {
-    return (<></>);
+  const exportedBy = props.entry.jsdocTags.filter((t) => t.name === 'ngModule');
+  if (
+    (!props.entry.htmlDescription ||
+      props.entry.htmlDescription === props.entry.shortHtmlDescription) &&
+    !exportedBy.length
+  ) {
+    return <></>;
   }
 
   return (
     <div data-tab={DESCRIPTION_TAB_NAME} data-tab-url={normalizeTabUrl(DESCRIPTION_TAB_NAME)}>
       <RawHtml value={props.entry.htmlDescription} />
+
+      {exportedBy.length ? (
+        <>
+          <hr />
+          <h2>Exported by</h2>
+
+          <ul>
+            {exportedBy.map((tag) => (
+              <li>
+                <CodeSymbol code={tag.comment} />
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : (
+        <></>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
This information is extracted from the @NgModule Jsdoc tag.

fixes #57906
