### PR TITLE
fix(common): Don't include statusText in HttpErrorResponse.message, deprecate HttpResponseBase.statusText

### DIFF
--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -2195,6 +2195,7 @@ export abstract class HttpResponseBase {
     readonly headers: HttpHeaders;
     readonly ok: boolean;
     readonly status: number;
+    // @deprecated
     readonly statusText: string;
     readonly type: HttpEventType.Response | HttpEventType.ResponseHeader;
     readonly url: string | null;

--- a/packages/common/http/src/response.ts
+++ b/packages/common/http/src/response.ts
@@ -167,6 +167,8 @@ export abstract class HttpResponseBase {
    * Textual description of response status code, defaults to OK.
    *
    * Do not depend on this.
+   *
+   * @deprecated With HTTP/2 and later versions, this will incorrectly remain set to 'OK' even when the status code of a response is not 200.
    */
   readonly statusText: string;
 
@@ -363,9 +365,7 @@ export class HttpErrorResponse extends HttpResponseBase implements Error {
     if (this.status >= 200 && this.status < 300) {
       this.message = `Http failure during parsing for ${init.url || '(unknown url)'}`;
     } else {
-      this.message = `Http failure response for ${init.url || '(unknown url)'}: ${init.status} ${
-        init.statusText
-      }`;
+      this.message = `Http failure response for ${init.url || '(unknown url)'}: ${init.status}`;
     }
     this.error = init.error || null;
   }


### PR DESCRIPTION
Since HTTP/2, responses no longer contain a status text besides the status code, which caused our default value of 'OK' to be used in HttpErrorResponse.message. As discussed in #57580, we are opting to not change the default value to match the fetch spec (https://fetch.spec.whatwg.org/#concept-response-status-message), instead, we are deprecating the statusText field, and not using it in our own code.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #23334

## What is the new behavior?
The `HttpResponseBase.statusText` field is deprecated, and it is not used in `HttpErrorResponse.message` anymore.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This was discussed in #57580.