### PR TITLE
refactor(core): adding publish global utils function

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -99,6 +99,7 @@ export {
 export {createComponent, reflectComponentType, ComponentMirror} from './render3/component';
 export {isStandalone} from './render3/definition';
 export {AfterRenderPhase, AfterRenderRef} from './render3/after_render/api';
+export {publishExternalGlobalUtil as ɵpublishExternalGlobalUtil} from './render3/util/global_utils';
 export {
   AfterRenderOptions,
   afterRender,


### PR DESCRIPTION
Angular DevTools uses globally available functions to provide debugging information to the framework. This commit adds a new function to the framework that will allow Angular DevTools to publish these functions to the global namespace.

Follow up PRs that will use this arg will:
- Add a new function in the router package to publish `getLoadedRoutes` function to the global namespace
- Implement the router graph in the Angular DevTools to view the routes that are loaded in the application
