### PR TITLE
docs: move JSDoc before functions

### DIFF
--- a/packages/common/src/pipes/number_pipe.ts
+++ b/packages/common/src/pipes/number_pipe.ts
@@ -83,13 +83,6 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 export class DecimalPipe implements PipeTransform {
   constructor(@Inject(LOCALE_ID) private _locale: string) {}
 
-  transform(value: number | string, digitsInfo?: string, locale?: string): string | null;
-  transform(value: null | undefined, digitsInfo?: string, locale?: string): null;
-  transform(
-    value: number | string | null | undefined,
-    digitsInfo?: string,
-    locale?: string,
-  ): string | null;
   /**
    * @param value The value to be formatted.
    * @param digitsInfo Sets digit and decimal representation.
@@ -97,6 +90,13 @@ export class DecimalPipe implements PipeTransform {
    * @param locale Specifies what locale format rules to use.
    * [See more](#locale).
    */
+  transform(value: number | string, digitsInfo?: string, locale?: string): string | null;
+  transform(value: null | undefined, digitsInfo?: string, locale?: string): null;
+  transform(
+    value: number | string | null | undefined,
+    digitsInfo?: string,
+    locale?: string,
+  ): string | null;
   transform(
     value: number | string | null | undefined,
     digitsInfo?: string,


### PR DESCRIPTION
Move the JSDoc before functions for correct view of params
Same problem like in #57187, but with [DecimalPipe](https://angular.dev/api/common/DecimalPipe#)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
