### PR TITLE
docs(docs-infra): display navigation items as HTML.

### DIFF
--- a/adev/shared-docs/components/navigation-list/navigation-list.component.html
+++ b/adev/shared-docs/components/navigation-list/navigation-list.component.html
@@ -29,7 +29,7 @@
               routerLinkActive="docs-faceted-list-item-active"
               (click)="emitClickOnLink()"
             >
-              <span>{{ item.label }}</span>
+              <span [innerHtml]="item.label"></span>
               @if (item.children && !item.isExpanded) {
                 <docs-icon>chevron_right</docs-icon>
               }
@@ -39,7 +39,7 @@
           <!-- Nav Section Header -->
           @if (item.level !== collapsableLevel() && item.level !== expandableLevel()) {
             <div class="docs-secondary-nav-header">
-              <span>{{ item.label }}</span>
+              <span [innerHtml]="item.label"></span>
             </div>
           }
 


### PR DESCRIPTION
fixes #57872
