### PR TITLE
refactor(compiler): prevent object methods being recognised as entities

### DIFF
--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -672,7 +672,7 @@ class _Tokenizer {
       } else {
         const name = this._cursor.getChars(nameStart);
         this._cursor.advance();
-        const char = NAMED_ENTITIES[name];
+        const char = NAMED_ENTITIES.hasOwnProperty(name) && NAMED_ENTITIES[name];
         if (!char) {
           throw this._createError(_unknownEntityErrorMsg(name), this._cursor.getSpan(start));
         }

--- a/packages/compiler/test/ml_parser/lexer_spec.ts
+++ b/packages/compiler/test/ml_parser/lexer_spec.ts
@@ -2204,6 +2204,16 @@ describe('HtmlLexer', () => {
         [TokenType.ENCODED_ENTITY, 'Unexpected character "EOF"', '0:6'],
       ]);
     });
+
+    it('should not parse js object methods', () => {
+      expect(tokenizeAndHumanizeErrors('&valueOf;')).toEqual([
+        [
+          TokenType.ENCODED_ENTITY,
+          'Unknown entity "valueOf" - use the "&#<decimal>;" or  "&#x<hex>;" syntax',
+          '0:0',
+        ],
+      ]);
+    });
   });
 
   describe('regular text', () => {


### PR DESCRIPTION
With this commit object methods (like `valueOf`, `toString` are not considered as valid entities anymore.

