### PR TITLE
fix(compiler-cli): defer symbols only used in types

### DIFF
--- a/packages/compiler-cli/src/ngtsc/imports/src/deferred_symbol_tracker.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/deferred_symbol_tracker.ts
@@ -171,7 +171,7 @@ export class DeferredSymbolTracker {
     }
 
     const symbolsMap = this.imports.get(importDecl)!;
-    for (const [symbol, refs] of symbolsMap) {
+    for (const refs of symbolsMap.values()) {
       if (refs === AssumeEager || refs.size > 0) {
         // There may be still eager references to this symbol.
         return false;
@@ -201,8 +201,9 @@ export class DeferredSymbolTracker {
   ): Set<ts.Identifier> {
     const results = new Set<ts.Identifier>();
     const visit = (node: ts.Node): void => {
-      if (node === importDecl) {
-        // Don't record references from the declaration itself.
+      // Don't record references from the declaration itself or inside
+      // type nodes which will be stripped from the JS output.
+      if (node === importDecl || ts.isTypeNode(node)) {
         return;
       }
 


### PR DESCRIPTION
Currently we don't defer any symbols that have references outside of the `import` statement and the `imports` array. This is a bit too aggressive, because it's possible that the symbol is only used for types (e.g. `viewChild<SomeCmp>('ref')`) which will be stripped when emitting to JS.

These changes expand the logic so that references inside type nodes aren't considered.

**Note:** one special case is when the symbol is used in constructor-based DI (e.g. `constructor(someCmp: SomeCmp)`, because these constructors will be compiled to `directiveInject` calls. We don't need to worry about them, because the compiler introduces an additional `import * as i1 from './some-cmp';` import that it uses to refer to the symbol.

Fixes #55991.