### PR TITLE
fix(platform-server): destroy `PlatformRef` when error happens during the `bootstrap()` phase, e.g. in `APP_INIIALIZER` - to prevent memory leaks in SSR

### DIFF
--- a/packages/core/src/platform/platform_ref.ts
+++ b/packages/core/src/platform/platform_ref.ts
@@ -79,7 +79,11 @@ export class PlatformRef {
       allAppProviders,
     );
 
-    return bootstrap({moduleRef, allPlatformModules: this._modules});
+    return bootstrap({
+      moduleRef,
+      allPlatformModules: this._modules,
+      platformInjector: this.injector,
+    });
   }
 
   /**

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -210,18 +210,21 @@ async function _render(platformRef: PlatformRef, applicationRef: ApplicationRef)
   }
 
   appendServerContextInfo(applicationRef);
-  const output = platformState.renderToString();
 
-  // Destroy the application in a macrotask, this allows pending promises to be settled and errors
-  // to be surfaced to the users.
-  await new Promise<void>((resolve) => {
+  return platformState.renderToString();
+}
+
+/**
+ * Destroy the application in a macrotask, this allows pending promises to be settled and errors
+ * to be surfaced to the users.
+ */
+function asyncDestroyPlatform(platformRef: PlatformRef): Promise<void> {
+  return new Promise<void>((resolve) => {
     setTimeout(() => {
       platformRef.destroy();
       resolve();
     }, 0);
   });
-
-  return output;
 }
 
 /**
@@ -264,9 +267,13 @@ export async function renderModule<T>(
 ): Promise<string> {
   const {document, url, extraProviders: platformProviders} = options;
   const platformRef = createServerPlatform({document, url, platformProviders});
-  const moduleRef = await platformRef.bootstrapModule(moduleType);
-  const applicationRef = moduleRef.injector.get(ApplicationRef);
-  return _render(platformRef, applicationRef);
+  try {
+    const moduleRef = await platformRef.bootstrapModule(moduleType);
+    const applicationRef = moduleRef.injector.get(ApplicationRef);
+    return await _render(platformRef, applicationRef);
+  } finally {
+    await asyncDestroyPlatform(platformRef);
+  }
 }
 
 /**
@@ -299,15 +306,17 @@ export async function renderApplication<T>(
 
   startMeasuring(renderAppLabel);
   const platformRef = createServerPlatform(options);
+  try {
+    startMeasuring(bootstrapLabel);
+    const applicationRef = await bootstrap();
+    stopMeasuring(bootstrapLabel);
 
-  startMeasuring(bootstrapLabel);
-  const applicationRef = await bootstrap();
-  stopMeasuring(bootstrapLabel);
-
-  startMeasuring(_renderLabel);
-  const rendered = await _render(platformRef, applicationRef);
-  stopMeasuring(_renderLabel);
-
-  stopMeasuring(renderAppLabel);
-  return rendered;
+    startMeasuring(_renderLabel);
+    const rendered = await _render(platformRef, applicationRef);
+    stopMeasuring(_renderLabel);
+    return rendered;
+  } finally {
+    await asyncDestroyPlatform(platformRef);
+    stopMeasuring(renderAppLabel);
+  }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`PlatformRef` is not destroyed if an error happens during the `bootstrap()` phase (e.g. in `APP_INITIALIZER`). Then the main app's injector is not destroyed and therefore `ngOnDestroy` hooks of singleton services were not called on the end (failure) of SSR. 

Note: This could lead to possible memory leaks in custom SSR apps, if their singleton services' `ngOnDestroy` hooks contained an important teardown logic (e.g. unsubscribing from RxJS observable).

Issue Number: https://github.com/angular/angular/issues/58111


## What is the new behavior?
- `PlatformRef` is guaranteed to be destroyed in `renderApplication()` and `renderModule()` functions of `@angular/platform-server` both in the case of successful render and in the case of a failure (resulting in a rejected promise)
- `PLATFORM_DESTROY_LISTENERS` that destroys the app's main injector is now set not only in case of `renderApplication()`, but also in case of `renderModule()`


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information