### PR TITLE
refactor(core): drop the `Mutable` utility type.

### DIFF
--- a/packages/core/src/interface/type.ts
+++ b/packages/core/src/interface/type.ts
@@ -38,10 +38,6 @@ export interface Type<T> extends Function {
   new (...args: any[]): T;
 }
 
-export type Mutable<T extends {[x: string]: any}, K extends string> = {
-  [P in K]: T[P];
-};
-
 /**
  * Returns a writable type version of type.
  *

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -8,7 +8,7 @@
 
 import {ChangeDetectionStrategy} from '../change_detection/constants';
 import {formatRuntimeError, RuntimeErrorCode} from '../errors';
-import {Mutable, Type} from '../interface/type';
+import {Type, Writable} from '../interface/type';
 import {NgModuleDef} from '../metadata/ng_module_def';
 import {SchemaMetadata} from '../metadata/schema';
 import {ViewEncapsulation} from '../metadata/view';
@@ -338,14 +338,14 @@ interface ComponentDefinition<T> extends Omit<DirectiveDefinition<T>, 'features'
  */
 export function ɵɵdefineComponent<T>(
   componentDefinition: ComponentDefinition<T>,
-): Mutable<ComponentDef<any>, keyof ComponentDef<any>> {
+): ComponentDef<any> {
   return noSideEffects(() => {
     // Initialize ngDevMode. This must be the first statement in ɵɵdefineComponent.
     // See the `initNgDevMode` docstring for more information.
     (typeof ngDevMode === 'undefined' || ngDevMode) && initNgDevMode();
 
     const baseDef = getNgDirectiveDef(componentDefinition as DirectiveDefinition<T>);
-    const def: Mutable<ComponentDef<T>, keyof ComponentDef<T>> = {
+    const def: Writable<ComponentDef<T>> = {
       ...baseDef,
       decls: componentDefinition.decls,
       vars: componentDefinition.vars,
@@ -558,7 +558,7 @@ function parseAndConvertBindingsForDefinition<T>(
  */
 export function ɵɵdefineDirective<T>(
   directiveDefinition: DirectiveDefinition<T>,
-): Mutable<DirectiveDef<any>, keyof DirectiveDef<any>> {
+): DirectiveDef<any> {
   return noSideEffects(() => {
     const def = getNgDirectiveDef(directiveDefinition);
     initFeatures(def);
@@ -649,9 +649,7 @@ export function getNgModuleDef<T>(type: any, throwNotFound?: boolean): NgModuleD
   return ngModuleDef;
 }
 
-function getNgDirectiveDef<T>(
-  directiveDefinition: DirectiveDefinition<T>,
-): Mutable<DirectiveDef<T>, keyof DirectiveDef<T>> {
+function getNgDirectiveDef<T>(directiveDefinition: DirectiveDefinition<T>): DirectiveDef<T> {
   const declaredInputs: Record<string, string> = {};
 
   return {
@@ -680,11 +678,7 @@ function getNgDirectiveDef<T>(
   };
 }
 
-function initFeatures<T>(
-  definition:
-    | Mutable<DirectiveDef<T>, keyof DirectiveDef<T>>
-    | Mutable<ComponentDef<T>, keyof ComponentDef<T>>,
-): void {
+function initFeatures<T>(definition: DirectiveDef<T> | ComponentDef<T>): void {
   definition.features?.forEach((fn) => fn(definition));
 }
 

--- a/packages/core/src/render3/features/input_transforms_feature.ts
+++ b/packages/core/src/render3/features/input_transforms_feature.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Mutable} from '../../interface/type';
+import {Writable} from '../../interface/type';
 import {DirectiveDef, InputTransformFunction} from '../interfaces/definition';
 
 /**
@@ -32,5 +32,5 @@ export function ɵɵInputTransformsFeature<T>(definition: DirectiveDef<T>): void
     }
   }
 
-  (definition as Mutable<DirectiveDef<T>, 'inputTransforms'>).inputTransforms = inputTransforms;
+  (definition as Writable<DirectiveDef<T>>).inputTransforms = inputTransforms;
 }


### PR DESCRIPTION
The complexity of this type isn't necessary, `Writable` is well suited where it was used.
