### PR TITLE
fix(service-worker): assign initializing client's app version, when a…

### DIFF
--- a/packages/service-worker/worker/testing/fetch.ts
+++ b/packages/service-worker/worker/testing/fetch.ts
@@ -122,7 +122,10 @@ export class MockRequest extends MockBody implements Request {
 
   url: string;
 
-  constructor(input: string | Request, init: RequestInit = {}) {
+  constructor(
+    input: string | Request,
+    init: RequestInit & {destination?: RequestDestination} = {},
+  ) {
     super((init.body as string | null) ?? null);
     if (typeof input !== 'string') {
       throw 'Not implemented';
@@ -149,6 +152,9 @@ export class MockRequest extends MockBody implements Request {
     }
     if (init.method !== undefined) {
       this.method = init.method;
+    }
+    if (init.destination !== undefined) {
+      this.destination = init.destination;
     }
   }
 

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -192,7 +192,11 @@ export class SwTestHarnessImpl
     this.skippedWaiting = true;
   }
 
-  handleFetch(req: Request, clientId = ''): [Promise<Response | undefined>, Promise<void>] {
+  handleFetch(
+    req: Request,
+    clientId = '',
+    resultingClientId?: string,
+  ): [Promise<Response | undefined>, Promise<void>] {
     if (!this.eventHandlers.has('fetch')) {
       throw new Error('No fetch handler registered');
     }
@@ -203,9 +207,12 @@ export class SwTestHarnessImpl
       this.clients.add(clientId, isNavigation ? req.url : this.scopeUrl);
     }
 
-    const event = isNavigation
-      ? new MockFetchEvent(req, '', clientId)
-      : new MockFetchEvent(req, clientId, '');
+    const event =
+      clientId && resultingClientId
+        ? new MockFetchEvent(req, clientId, resultingClientId)
+        : isNavigation
+          ? new MockFetchEvent(req, '', clientId)
+          : new MockFetchEvent(req, clientId, '');
     this.eventHandlers.get('fetch')!.call(this, event);
 
     return [event.response, event.ready];


### PR DESCRIPTION
… request is for worker script

When a new version of app is available in a service worker, and a client with old version exists, web workers initialized from a client with old version will now be properly assigned with the same version.

Before this change, a web worker was assigned with the newest version.

Fixes #57971

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #57971 


## What is the new behavior?

When a web worker script request is made to a service worker, it gets assigned the same version as the tab that created it.

## Does this PR introduce a breaking change?

_No, unless someone was relying on a faulty behavior_

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
