### PR TITLE
fix(platform-server): destroy `PlatformRef` when error happens duringthe `bootstrap()` phase

### DIFF
--- a/packages/core/src/platform/platform_ref.ts
+++ b/packages/core/src/platform/platform_ref.ts
@@ -79,7 +79,11 @@ export class PlatformRef {
       allAppProviders,
     );
 
-    return bootstrap({moduleRef, allPlatformModules: this._modules});
+    return bootstrap({
+      moduleRef,
+      allPlatformModules: this._modules,
+      platformInjector: this.injector,
+    });
   }
 
   /**


### PR DESCRIPTION
The `bootstrap()` phase might fail e.g. due to an rejected promise in some `APP_INIIALIZER`. If `PlatformRef` is not destroyed, then the main app's injector is not destroyed and therefore `ngOnDestroy` hooks of singleton services is not called on the end (failure) of SSR.

This could lead to possible memory leaks in custom SSR apps, if their singleton services' `ngOnDestroy` hooks contained an important teardown logic (e.g. unsubscribing from RxJS observable).

Note: I needed to fix by the way another thing too: now we destroy `moduleRef` when `platformInjector` is destroyed - by setting a `PLATFORM_DESTROY_LISTENER`

Patch port of #58112
