### PR TITLE
refactor(migrations): detect ternary narrowing in input and query migrations

### DIFF
--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/ternary_narrowing.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/ternary_narrowing.ts
@@ -1,0 +1,25 @@
+// tslint:disable
+
+import {Component, Input} from '@angular/core';
+
+@Component({
+  template: `
+    {{ narrowed ? narrowed.substring(0, 1) : 'Empty' }}
+    {{ justChecked ? 'true' : 'false' }}
+
+    {{ other?.safeRead ? other.safeRead : 'Empty' }}
+    {{ other?.safeRead2 ? other?.safeRead2 : 'Empty' }}
+  `,
+})
+export class TernaryNarrowing {
+  @Input() narrowed: string | undefined = undefined;
+  @Input() justChecked = true;
+
+  other?: OtherComponent;
+}
+
+@Component({template: ''})
+export class OtherComponent {
+  @Input() safeRead: string = '';
+  @Input() safeRead2: string = '';
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden.txt
@@ -1276,6 +1276,42 @@ export class MyComp {
     }
   }
 }
+@@@@@@ ternary_narrowing.ts @@@@@@
+
+// tslint:disable
+
+import {Component, Input, input} from '@angular/core';
+
+@Component({
+  template: `
+    {{ narrowed ? narrowed.substring(0, 1) : 'Empty' }}
+    {{ justChecked() ? 'true' : 'false' }}
+
+    {{ other?.safeRead ? other.safeRead : 'Empty' }}
+    {{ other?.safeRead2 ? other?.safeRead2 : 'Empty' }}
+  `,
+})
+export class TernaryNarrowing {
+  // TODO: Skipped for migration because:
+  //  This input is used in a control flow expression (e.g. `@if` or `*ngIf`)
+  //  and migrating would break narrowing currently.
+  @Input() narrowed: string | undefined = undefined;
+  readonly justChecked = input(true);
+
+  other?: OtherComponent;
+}
+
+@Component({template: ''})
+export class OtherComponent {
+  // TODO: Skipped for migration because:
+  //  This input is used in a control flow expression (e.g. `@if` or `*ngIf`)
+  //  and migrating would break narrowing currently.
+  @Input() safeRead: string = '';
+  // TODO: Skipped for migration because:
+  //  This input is used in a control flow expression (e.g. `@if` or `*ngIf`)
+  //  and migrating would break narrowing currently.
+  @Input() safeRead2: string = '';
+}
 @@@@@@ transform_functions.ts @@@@@@
 
 // tslint:disable

--- a/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
@@ -1228,6 +1228,33 @@ export class MyComp {
     }
   }
 }
+@@@@@@ ternary_narrowing.ts @@@@@@
+
+// tslint:disable
+
+import {Component, input} from '@angular/core';
+
+@Component({
+  template: `
+    {{ narrowed() ? narrowed().substring(0, 1) : 'Empty' }}
+    {{ justChecked() ? 'true' : 'false' }}
+
+    {{ other?.safeRead() ? other.safeRead() : 'Empty' }}
+    {{ other?.safeRead2() ? other?.safeRead2() : 'Empty' }}
+  `,
+})
+export class TernaryNarrowing {
+  readonly narrowed = input<string>();
+  readonly justChecked = input(true);
+
+  other?: OtherComponent;
+}
+
+@Component({template: ''})
+export class OtherComponent {
+  readonly safeRead = input<string>('');
+  readonly safeRead2 = input<string>('');
+}
 @@@@@@ transform_functions.ts @@@@@@
 
 // tslint:disable


### PR DESCRIPTION

We should skip inputs/queries that are part of ternary narrowing expressions. Those would break builds and we can quickly avoid this in the safe mode as detection is rather easy with the existing analysis data we have.