### PR TITLE
refactor(core): add internal utility to resolve the component name of a node

### DIFF
--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -145,3 +145,5 @@ export {
   enableProfiling as ɵenableProfiling,
   disableProfiling as ɵdisableProfiling,
 } from './profiler';
+
+export {getClosestComponentName as ɵgetClosestComponentName} from './internal/get_closest_component_name';

--- a/packages/core/src/internal/README.md
+++ b/packages/core/src/internal/README.md
@@ -1,0 +1,3 @@
+Contains utilities exposed specifically for g3-internal functionality.
+
+These APIs are not considered public.

--- a/packages/core/src/internal/get_closest_component_name.ts
+++ b/packages/core/src/internal/get_closest_component_name.ts
@@ -1,0 +1,48 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {ComponentDef} from '../render3';
+import {readPatchedLView} from '../render3/context_discovery';
+import {isComponentHost, isLContainer, isLView} from '../render3/interfaces/type_checks';
+import {HEADER_OFFSET, HOST, TVIEW} from '../render3/interfaces/view';
+import {getTNode} from '../render3/util/view_utils';
+
+/**
+ * Gets the class name of the closest component to a node.
+ * Warning! this function will return minified names if the name of the component is minified. The
+ * consumer of the function is responsible for resolving the minified name to its original name.
+ * @param node Node from which to start the search.
+ */
+export function getClosestComponentName(node: Node): string | null {
+  let currentNode = node as Node | null;
+
+  while (currentNode) {
+    const lView = readPatchedLView(currentNode);
+
+    if (lView !== null) {
+      for (let i = HEADER_OFFSET; i < lView.length; i++) {
+        const current = lView[i];
+
+        if ((!isLView(current) && !isLContainer(current)) || current[HOST] !== currentNode) {
+          continue;
+        }
+
+        const tView = lView[TVIEW];
+        const tNode = getTNode(tView, i);
+        if (isComponentHost(tNode)) {
+          const def = tView.data[tNode.directiveStart + tNode.componentOffset] as ComponentDef<{}>;
+          return def.debugInfo?.className || def.type.name;
+        }
+      }
+    }
+
+    currentNode = currentNode.parentNode;
+  }
+
+  return null;
+}

--- a/packages/core/test/acceptance/internal_spec.ts
+++ b/packages/core/test/acceptance/internal_spec.ts
@@ -1,0 +1,159 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  Component,
+  createComponent,
+  Directive,
+  EnvironmentInjector,
+  ɵgetClosestComponentName as getClosestComponentName,
+  ViewChild,
+  ViewContainerRef,
+} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+
+describe('internal utilities', () => {
+  describe('getClosestComponentName', () => {
+    it('should get the name from a node placed inside a root component', () => {
+      @Component({
+        standalone: true,
+        template: `<section><div class="target"></div></section>`,
+      })
+      class App {}
+
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+      expect(getClosestComponentName(fixture.nativeElement)).toBe('App');
+      expect(getClosestComponentName(fixture.nativeElement.querySelector('.target'))).toBe('App');
+    });
+
+    it('should get the name from a node placed inside a component', () => {
+      @Component({
+        selector: 'comp',
+        template: `<section><div class="target"></div></section>`,
+        standalone: true,
+      })
+      class Comp {}
+
+      @Component({
+        standalone: true,
+        template: `<comp/>`,
+        imports: [Comp],
+      })
+      class App {}
+
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+      expect(getClosestComponentName(fixture.nativeElement.querySelector('comp'))).toBe('Comp');
+      expect(getClosestComponentName(fixture.nativeElement.querySelector('.target'))).toBe('Comp');
+    });
+
+    it('should get the name from a node placed inside a repeated component', () => {
+      @Component({
+        selector: 'comp',
+        template: `<section><div class="target"></div></section>`,
+        standalone: true,
+      })
+      class Comp {}
+
+      @Component({
+        standalone: true,
+        template: `
+          @for (current of [1]; track $index) {
+            <comp/>
+          }
+        `,
+        imports: [Comp],
+      })
+      class App {}
+
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+      expect(getClosestComponentName(fixture.nativeElement.querySelector('comp'))).toBe('Comp');
+      expect(getClosestComponentName(fixture.nativeElement.querySelector('.target'))).toBe('Comp');
+    });
+
+    it('should get the name from a node that has a directive', () => {
+      @Directive({
+        selector: 'dir',
+        standalone: true,
+      })
+      class Dir {}
+
+      @Component({
+        standalone: true,
+        template: `<section><dir class="target"></dir></section>`,
+        imports: [Dir],
+      })
+      class App {}
+
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+      expect(getClosestComponentName(fixture.nativeElement)).toBe('App');
+      expect(getClosestComponentName(fixture.nativeElement.querySelector('.target'))).toBe('App');
+    });
+
+    it('should return null when not placed in a component', () => {
+      @Component({
+        standalone: true,
+        template: '',
+      })
+      class App {}
+
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+      expect(getClosestComponentName(document.body)).toBe(null);
+    });
+
+    it('should get the name from a node placed inside a dynamically-created component through ViewContainerRef', () => {
+      @Component({
+        selector: 'comp',
+        template: `<section><div class="target"></div></section>`,
+        standalone: true,
+      })
+      class Comp {}
+
+      @Component({
+        standalone: true,
+        template: `<ng-container #insertionPoint/>`,
+      })
+      class App {
+        @ViewChild('insertionPoint', {read: ViewContainerRef}) vcr!: ViewContainerRef;
+      }
+
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      const ref = fixture.componentInstance.vcr.createComponent(Comp);
+      fixture.detectChanges();
+
+      expect(getClosestComponentName(fixture.nativeElement.querySelector('comp'))).toBe('Comp');
+      expect(getClosestComponentName(fixture.nativeElement.querySelector('.target'))).toBe('Comp');
+      ref.destroy();
+    });
+
+    it('should get the name from a node placed inside a dynamically-created component through createComponent', () => {
+      @Component({
+        selector: 'comp',
+        template: `<section><div class="target"></div></section>`,
+        standalone: true,
+      })
+      class Comp {}
+
+      TestBed.configureTestingModule({});
+      const ref = createComponent(Comp, {environmentInjector: TestBed.inject(EnvironmentInjector)});
+      ref.changeDetectorRef.detectChanges();
+
+      expect(getClosestComponentName(ref.location.nativeElement)).toBe('Comp');
+      expect(getClosestComponentName(ref.location.nativeElement.querySelector('.target'))).toBe(
+        'Comp',
+      );
+      ref.destroy();
+    });
+  });
+});

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -1500,6 +1500,9 @@
     "name": "init_framework_injector_profiler"
   },
   {
+    "name": "init_get_closest_component_name"
+  },
+  {
     "name": "init_get_current_view"
   },
   {


### PR DESCRIPTION
Adds a utility, meant for internal consumption, that will return the class name of the closest component node to an element.