### PR TITLE
refactor(migrations): assign incompatibility reasons for query migration

### DIFF
--- a/packages/core/schematics/migrations/signal-migration/src/passes/problematic_patterns/check_inheritance.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/problematic_patterns/check_inheritance.ts
@@ -13,7 +13,6 @@ import assert from 'assert';
 import ts from 'typescript';
 import {getMemberName} from '../../utils/class_member_names';
 import {InheritanceGraph} from '../../utils/inheritance_graph';
-import {topologicalSort} from '../../utils/inheritance_sort';
 import {ClassFieldDescriptor, KnownFields} from '../reference_resolution/known_fields';
 
 export interface InheritanceTracker<D extends ClassFieldDescriptor> {

--- a/packages/core/schematics/migrations/signal-migration/src/passes/problematic_patterns/incompatibility.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/problematic_patterns/incompatibility.ts
@@ -23,10 +23,11 @@ export enum FieldIncompatibilityReason {
   PotentiallyNarrowedInTemplateButNoSupportYet = 6,
   SignalInput__RequiredButNoGoodExplicitTypeExtractable = 7,
   SignalInput__QuestionMarkButNoGoodExplicitTypeExtractable = 8,
-  WriteAssignment = 9,
-  Accessor = 10,
-  OutsideOfMigrationScope = 11,
-  SkippedViaConfigFilter = 12,
+  SignalQueries__QueryListProblematicFieldAccessed = 9,
+  WriteAssignment = 10,
+  Accessor = 11,
+  OutsideOfMigrationScope = 12,
+  SkippedViaConfigFilter = 13,
 }
 
 /** Reasons why a whole class and its fields cannot be migrated. */

--- a/packages/core/schematics/migrations/signal-migration/src/passes/problematic_patterns/incompatibility_human.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/problematic_patterns/incompatibility_human.ts
@@ -63,6 +63,11 @@ export function getMessageForFieldIncompatibility(
           'The migration needs to be able to resolve a type, so that it can include `undefined` in your type. ' +
           'Consider adding an explicit type to make the migration possible.',
       };
+    case FieldIncompatibilityReason.SignalQueries__QueryListProblematicFieldAccessed:
+      return {
+        short: `There are references to this query that cannot be migrated automatically.`,
+        extra: "For example, it's not possible to migrate `.changes` or `.dirty` trivially.",
+      };
     case FieldIncompatibilityReason.SkippedViaConfigFilter:
       return {
         short: `This ${fieldName.single} is not part of the current migration scope.`,

--- a/packages/core/schematics/migrations/signal-queries-migration/incompatibility.ts
+++ b/packages/core/schematics/migrations/signal-queries-migration/incompatibility.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {FieldIncompatibilityReason} from '../signal-migration/src';
+import {pickFieldIncompatibility} from '../signal-migration/src/passes/problematic_patterns/incompatibility';
+import {ClassFieldUniqueKey} from '../signal-migration/src/passes/reference_resolution/known_fields';
+import type {GlobalUnitData} from './migration';
+
+export function markFieldIncompatibleInMetadata(
+  data: GlobalUnitData,
+  id: ClassFieldUniqueKey,
+  reason: FieldIncompatibilityReason,
+) {
+  const existing = data.problematicQueries[id as ClassFieldUniqueKey];
+  if (existing === undefined) {
+    data.problematicQueries[id as ClassFieldUniqueKey] = {
+      fieldReason: reason,
+      classReason: null,
+    };
+  } else if (existing.fieldReason === null) {
+    existing.fieldReason = reason;
+  } else {
+    existing.fieldReason = pickFieldIncompatibility(
+      {reason, context: null},
+      {reason: existing.fieldReason, context: null},
+    ).reason;
+  }
+}

--- a/packages/core/schematics/migrations/signal-queries-migration/known_queries.ts
+++ b/packages/core/schematics/migrations/signal-queries-migration/known_queries.ts
@@ -53,11 +53,8 @@ export class KnownQueries
 
   markClassIncompatible(node: ts.ClassDeclaration, reason: ClassIncompatibilityReason): void {
     this.classToQueryFields.get(node)?.forEach((f) => {
-      if (this.globalMetadata.problematicQueries[f.key] === undefined) {
-        this.globalMetadata.problematicQueries[f.key] = {classReason: reason, fieldReason: null};
-      } else {
-        this.globalMetadata.problematicQueries[f.key].classReason = reason;
-      }
+      this.globalMetadata.problematicQueries[f.key] ??= {classReason: null, fieldReason: null};
+      this.globalMetadata.problematicQueries[f.key].classReason = reason;
     });
   }
 

--- a/packages/core/schematics/migrations/signal-queries-migration/known_queries.ts
+++ b/packages/core/schematics/migrations/signal-queries-migration/known_queries.ts
@@ -17,6 +17,16 @@ import {
 import {getClassFieldDescriptorForSymbol} from './field_tracking';
 import type {GlobalUnitData} from './migration';
 import {InheritanceTracker} from '../signal-migration/src/passes/problematic_patterns/check_inheritance';
+import {
+  FieldIncompatibility,
+  getMessageForClassIncompatibility,
+  getMessageForFieldIncompatibility,
+} from '../signal-migration/src';
+import {
+  ClassIncompatibilityReason,
+  FieldIncompatibilityReason,
+} from '../signal-migration/src/passes/problematic_patterns/incompatibility';
+import {markFieldIncompatibleInMetadata} from './incompatibility';
 
 export class KnownQueries
   implements
@@ -34,16 +44,20 @@ export class KnownQueries
   ) {}
 
   isFieldIncompatible(descriptor: ClassFieldDescriptor): boolean {
-    return this.globalMetadata.problematicQueries[descriptor.key] !== undefined;
+    return this.getIncompatibilityForField(descriptor) !== null;
   }
 
-  markFieldIncompatible(field: ClassFieldDescriptor): void {
-    this.globalMetadata.problematicQueries[field.key] = true;
+  markFieldIncompatible(field: ClassFieldDescriptor, incompatibility: FieldIncompatibility): void {
+    markFieldIncompatibleInMetadata(this.globalMetadata, field.key, incompatibility.reason);
   }
 
-  markClassIncompatible(node: ts.ClassDeclaration): void {
+  markClassIncompatible(node: ts.ClassDeclaration, reason: ClassIncompatibilityReason): void {
     this.classToQueryFields.get(node)?.forEach((f) => {
-      this.globalMetadata.problematicQueries[f.key] = true;
+      if (this.globalMetadata.problematicQueries[f.key] === undefined) {
+        this.globalMetadata.problematicQueries[f.key] = {classReason: reason, fieldReason: null};
+      } else {
+        this.globalMetadata.problematicQueries[f.key].classReason = reason;
+      }
     });
   }
 
@@ -84,16 +98,56 @@ export class KnownQueries
     parent: ClassFieldDescriptor,
   ): void {
     if (this.isFieldIncompatible(parent) || this.isFieldIncompatible(derived)) {
-      this.markFieldIncompatible(parent);
-      this.markFieldIncompatible(derived);
+      // TODO: What to do here??
     }
   }
 
   captureUnknownDerivedField(field: ClassFieldDescriptor): void {
-    this.markFieldIncompatible(field);
+    this.markFieldIncompatible(field, {
+      context: null,
+      reason: FieldIncompatibilityReason.OverriddenByDerivedClass,
+    });
   }
 
   captureUnknownParentField(field: ClassFieldDescriptor): void {
-    this.markFieldIncompatible(field);
+    this.markFieldIncompatible(field, {
+      context: null,
+      reason: FieldIncompatibilityReason.TypeConflictWithBaseClass,
+    });
+  }
+
+  getIncompatibilityForField(
+    descriptor: ClassFieldDescriptor,
+  ): FieldIncompatibility | ClassIncompatibilityReason | null {
+    const problematicInfo = this.globalMetadata.problematicQueries[descriptor.key];
+    if (problematicInfo === undefined) {
+      return null;
+    }
+    if (problematicInfo.fieldReason !== null) {
+      return {context: null, reason: problematicInfo.fieldReason};
+    }
+    if (problematicInfo.classReason !== null) {
+      return problematicInfo.classReason;
+    }
+    return null;
+  }
+
+  getIncompatibilityTextForField(
+    field: ClassFieldDescriptor,
+  ): {short: string; extra: string} | null {
+    const incompatibilityInfo = this.globalMetadata.problematicQueries[field.key];
+    if (incompatibilityInfo.fieldReason !== null) {
+      return getMessageForFieldIncompatibility(incompatibilityInfo.fieldReason, {
+        single: 'query',
+        plural: 'queries',
+      });
+    }
+    if (incompatibilityInfo.classReason !== null) {
+      return getMessageForClassIncompatibility(incompatibilityInfo.classReason, {
+        single: 'query',
+        plural: 'queries',
+      });
+    }
+    return null;
   }
 }

--- a/packages/language-service/src/refactorings/convert_to_signal_queries/individual_query_refactoring.ts
+++ b/packages/language-service/src/refactorings/convert_to_signal_queries/individual_query_refactoring.ts
@@ -8,10 +8,6 @@
 
 import {CompilerOptions} from '@angular/compiler-cli';
 import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
-import {
-  isInputContainerNode,
-  MigrationConfig,
-} from '@angular/core/schematics/migrations/signal-migration/src';
 import {ApplyRefactoringProgressFn, ApplyRefactoringResult} from '@angular/language-service/api';
 import ts from 'typescript';
 import {isTypeScriptFile} from '../../utils';
@@ -20,6 +16,7 @@ import type {ActiveRefactoring} from '../refactoring';
 import {applySignalQueriesRefactoring} from './apply_query_refactoring';
 import {isDecoratorQueryClassField} from './decorators';
 import {isDirectiveOrComponent} from '../../utils/decorators';
+import {MigrationConfig} from '../../../../core/schematics/migrations/signal-queries-migration';
 
 /**
  * Base language service refactoring action that can convert a
@@ -92,7 +89,7 @@ abstract class BaseConvertFieldToSignalQueryRefactoring implements ActiveRefacto
     }
 
     const containingClassElement = ts.findAncestor(node, ts.isClassElement);
-    if (containingClassElement === undefined || !isInputContainerNode(containingClassElement)) {
+    if (containingClassElement === undefined) {
       return {edits: [], errorMessage: 'Selected node does not belong to a query.'};
     }
 

--- a/packages/language-service/test/signal_queries_refactoring_action_spec.ts
+++ b/packages/language-service/test/signal_queries_refactoring_action_spec.ts
@@ -1,0 +1,183 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {initMockFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
+
+import {createModuleAndProjectWithDeclarations, LanguageServiceTestEnv} from '../testing';
+
+describe('Signal queries refactoring action', () => {
+  let env: LanguageServiceTestEnv;
+  beforeEach(() => {
+    initMockFileSystem('Native');
+    env = LanguageServiceTestEnv.setup();
+  });
+
+  describe('individual fields', () => {
+    it('should support refactoring an `@ViewChild` property', () => {
+      const files = {
+        'app.ts': `
+        import {ViewChild, Component} from '@angular/core';
+
+        @Component({template: ''})
+        export class AppComponent {
+          @ViewChild('ref') ref!: ElementRef;
+        }
+     `,
+      };
+
+      const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+      appFile.moveCursorToText('re¦f!: ElementRef');
+      const refactorings = project.getRefactoringsAtPosition('app.ts', appFile.cursor);
+
+      expect(refactorings.length).toBe(1);
+      expect(refactorings[0].name).toBe('convert-field-to-signal-query-safe-mode');
+    });
+
+    it('should not support refactoring a non-Angular property', () => {
+      const files = {
+        'app.ts': `
+        import {Directive} from '@angular/core';
+
+        @Directive({})
+        export class AppComponent {
+          bla = true;
+        }
+     `,
+      };
+
+      const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+      appFile.moveCursorToText('bl¦a');
+      const refactorings = project.getRefactoringsAtPosition('app.ts', appFile.cursor);
+
+      expect(refactorings.length).toBe(0);
+    });
+
+    it('should not support refactoring a signal query property', () => {
+      const files = {
+        'app.ts': `
+        import {Directive, viewChild} from '@angular/core';
+
+        @Directive({})
+        export class AppComponent {
+          bla = viewChild('ref');
+        }
+     `,
+      };
+
+      const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+      appFile.moveCursorToText('bl¦a');
+      const refactorings = project.getRefactoringsAtPosition('app.ts', appFile.cursor);
+
+      expect(refactorings.length).toBe(0);
+    });
+
+    it('should compute edits for migration', async () => {
+      const files = {
+        'app.ts': `
+          import {ViewChild, Component} from '@angular/core';
+
+          @Component({template: ''})
+          export class AppComponent {
+            @ViewChild('ref') ref!: ElementRef;
+          }
+     `,
+      };
+
+      const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+      appFile.moveCursorToText('re¦f!: ElementRef');
+
+      const refactorings = project.getRefactoringsAtPosition('app.ts', appFile.cursor);
+      expect(refactorings.length).toBe(1);
+      expect(refactorings[0].name).toBe('convert-field-to-signal-query-safe-mode');
+
+      const edits = await project.applyRefactoring(
+        'app.ts',
+        appFile.cursor,
+        refactorings[0].name,
+        () => {},
+      );
+      expect(edits?.errorMessage).toBeUndefined();
+      expect(edits?.edits).toEqual([
+        {
+          fileName: '/test/app.ts',
+          textChanges: [
+            // Query declaration.
+            {
+              newText: `readonly ref = viewChild.required<ElementRef>('ref');`,
+              span: {start: 151, length: `@ViewChild('ref') ref!: ElementRef;`.length},
+            },
+            // Import (since there is just a single query).
+            {newText: '{Component, viewChild}', span: {start: 18, length: 22}},
+          ],
+        },
+      ]);
+    });
+
+    it('should show an error if the query is incompatible', async () => {
+      const files = {
+        'app.ts': `
+          import {Directive, ViewChild} from '@angular/core';
+
+          @Directive({})
+          export class AppComponent {
+            @ViewChild('ref') bla: ElementRef|null = null;
+
+            click() {
+              this.bla = null;
+            }
+          }
+     `,
+      };
+
+      const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+      appFile.moveCursorToText('bl¦a: ElementRef');
+
+      const refactorings = project.getRefactoringsAtPosition('app.ts', appFile.cursor);
+      expect(refactorings.length).toBe(1);
+      expect(refactorings[0].name).toBe('convert-field-to-signal-query-safe-mode');
+
+      const edits = await project.applyRefactoring(
+        'app.ts',
+        appFile.cursor,
+        refactorings[0].name,
+        () => {},
+      );
+      expect(edits?.errorMessage).toContain(`Query field "bla" could not be migrated`);
+      expect(edits?.errorMessage).toContain(`Your application code writes to the query.`);
+      expect(edits?.edits).toEqual([]);
+    });
+
+    it('should not suggest options when inside an accessor query body', async () => {
+      const files = {
+        'app.ts': `
+          import {Directive, ElementRef, ViewChild} from '@angular/core';
+
+          @Directive({})
+          export class AppComponent {
+            @ViewChild()
+            set bla(res: ElementRef) {
+              // inside
+            };
+          }
+     `,
+      };
+
+      const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+      appFile.moveCursorToText('insid¦e');
+
+      const refactorings = project.getRefactoringsAtPosition('app.ts', appFile.cursor);
+      expect(refactorings.length).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
Instead of skipping queries without any reasoning, we should categorize fields that couldn't be migrated. This is also important for the VSCode integration— similar to how it's done with the inputs migration.

We are fully sharing the problematic pattern detection etc. This means we are also sharing the enum. Not super ideal, but enables the best sharing of code.