### PR TITLE
fix(compiler): ignore placeholder-only i18n messages

### DIFF
--- a/packages/compiler/test/i18n/extractor_merger_spec.ts
+++ b/packages/compiler/test/i18n/extractor_merger_spec.ts
@@ -100,6 +100,10 @@ describe('Extractor', () => {
       expect(extract('<div i18n="m|d"></div>')).toEqual([]);
     });
 
+    it('should not create a message for placeholder-only elements', () => {
+      expect(extract('<div i18n="m|d">{{ foo }}</div>')).toEqual([]);
+    });
+
     it('should ignore implicit elements in translatable elements', () => {
       expect(extract('<div i18n="m|d"><p></p></div>', ['p'])).toEqual([
         [['<ph tag name="START_PARAGRAPH"></ph name="CLOSE_PARAGRAPH">'], 'm', 'd', ''],
@@ -405,6 +409,10 @@ describe('Extractor', () => {
 
     it('should not create a message for empty attributes', () => {
       expect(extract('<div i18n-title="m|d" title></div>')).toEqual([]);
+    });
+
+    it('should not create a message for placeholder-only attributes', () => {
+      expect(extract('<div i18n-title="m|d" title="{{ foo }}"></div>')).toEqual([]);
     });
   });
 

--- a/packages/compiler/test/i18n/whitespace_sensitivity_spec.ts
+++ b/packages/compiler/test/i18n/whitespace_sensitivity_spec.ts
@@ -18,7 +18,7 @@ describe('i18nPreserveWhitespaceForLegacyExtraction', () => {
       const initial = extractMessages(
         `
 <div i18n>Hello, World!</div>
-<div i18n>{{ abc }}</div>
+<div i18n>Hello {{ abc }}</div>
 <div i18n>Start {{ abc }} End</div>
 <div i18n>{{ first }} middle {{ end }}</div>
 <div i18n><a href="/foo">First Second</a></div>
@@ -41,7 +41,7 @@ Test case is disabled by omitting the i18n attribute.
   Hello, World!
 </div>
 <div i18n>
-  {{ abc }}
+  Hello {{ abc }}
 </div>
 <div i18n>
   Start {{ abc }} End
@@ -111,7 +111,7 @@ Test case is disabled by omitting the i18n attribute.
   Hello, World!
 </div>
 <div i18n>
-  {{ abc }}
+  Hello {{ abc }}
 </div>
 <div i18n>
   Start {{ abc }} End
@@ -171,7 +171,7 @@ Test case is disabled by omitting the i18n attribute.
     Hello, World!
   </div>
   <div i18n>
-    {{ abc }}
+    Hello {{ abc }}
   </div>
   <div i18n>
     Start {{ abc }} End
@@ -237,7 +237,7 @@ Test case is disabled by omitting the i18n attribute.
   exceeds line length.
 </div>
 <div i18n>
-  {{ veryLongExpressionWhichMaybeExceedsLineLength | async }}
+  Hello {{ veryLongExpressionWhichMaybeExceedsLineLength | async }}
 </div>
 <div i18n>
   This is a long {{ abc }} which maybe
@@ -280,7 +280,7 @@ Test case is disabled by omitting the i18n attribute.
   maybe exceeds line length.
 </div>
 <div i18n>
-  {{
+  Hello {{
     veryLongExpressionWhichMaybeExceedsLineLength
     | async
   }}
@@ -346,7 +346,7 @@ Test case is disabled by omitting the i18n attribute.
       const initial = extractMessages(
         `
 <div i18n> Hello, World! </div>
-<div i18n> {{ abc }} </div>
+<div i18n> Hello {{ abc }} </div>
 <div i18n> Start {{ abc }} End </div>
 <div i18n> {{ first }} middle {{ end }} </div>
 <div i18n> <a href="/foo">Foo</a> </div>
@@ -357,7 +357,7 @@ Test case is disabled by omitting the i18n attribute.
 
 i18nPreserveWhitespaceForLegacyExtraction does not support trimming ICU case text.
 Test case is disabled by omitting the i18n attribute.
-<div>{
+<div>Hello {
   apples, plural,
   =1 { One apple. }
   =other { Many apples. }
@@ -369,7 +369,7 @@ Test case is disabled by omitting the i18n attribute.
       const trimmed = extractMessages(
         `
 <div i18n>Hello, World!</div>
-<div i18n>{{ abc }}</div>
+<div i18n>Hello {{ abc }}</div>
 <div i18n>Start {{ abc }} End</div>
 <div i18n>{{ first }} middle {{ end }}</div>
 <div i18n><a href="/foo">Foo</a></div>
@@ -380,7 +380,7 @@ Test case is disabled by omitting the i18n attribute.
 
 i18nPreserveWhitespaceForLegacyExtraction does not support trimming ICU case text.
 Test case is disabled by omitting the i18n attribute.
-<div>{
+<div>Hello {
   apples, plural,
   =1 {One apple.}
   =other {Many apples.}


### PR DESCRIPTION
Message which only contain a single placeholder cannot be translated, there is no static text to be translated. Therefore these messages can be skipped and shouldn't be extracted at all.

Ideally, Angular would throw an error if a message is only a placeholder, since it should not contain an `i18n` attribute at all. However this would be a breaking change and require a migration which isn't in scope right now. We can explore converting this to a hard error sometime in the future.

Note that this change is not gated on any flag and is currently targeting `patch`. I think this is reasonable because placeholder-only messages are useless to extract, but it is an observable behavior change. If we think that's too risky, I can put it behind a flag or target `major`.