### PR TITLE
docs(service-worker): corrected default values ​​for navigation URLs

### DIFF
--- a/adev/src/content/ecosystem/service-workers/config.md
+++ b/adev/src/content/ecosystem/service-workers/config.md
@@ -318,7 +318,7 @@ If not specified, the default value depends on the data group's configured strat
 | Groups with the `performance` strategy | The default value is `false` and the service worker doesn't cache opaque responses. These groups would continue to return a cached response until `maxAge` expires, even if the error was due to a temporary network or server issue. Therefore, it would be problematic for the service worker to cache an error response. |
 
 <docs-callout title="Comment on opaque responses">
-  
+
 In case you are not familiar, an [opaque response](https://fetch.spec.whatwg.org#concept-filtered-response-opaque) is a special type of response returned when requesting a resource that is on a different origin which doesn't return CORS headers.
 One of the characteristics of an opaque response is that the service worker is not allowed to read its status, meaning it can't check if the request was successful or not.
 See [Introduction to `fetch()`](https://developers.google.com/web/updates/2015/03/introduction-to-fetch#response_types) for more details.
@@ -366,9 +366,9 @@ If the field is omitted, it defaults to:
 
 [
   '/**',           // Include all URLs.
-  '!/**/*.*',      // Exclude URLs to files.
-  '!/**/****',     // Exclude URLs containing `**` in the last segment.
-  '!/**/****/**',  // Exclude URLs containing `**` in any other segment.
+  '!/**/*.*',      // Exclude URLs to files (containing a file extension in the last segment).
+  '!/**/*__*',     // Exclude URLs containing `__` in the last segment.
+  '!/**/*__*/**',  // Exclude URLs containing `__` in any other segment.
 ]
 
 </docs-code>


### PR DESCRIPTION
The default value described in the documentation is inconsistent with the actual default value.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The navigationUrls defaults described in the service worker documentation do not match the actual defaults.

https://angular.dev/ecosystem/service-workers/config#matching-navigation-request-urls

![QQ_1728618169477](https://github.com/user-attachments/assets/d1f7fbac-2a6c-4037-8e6e-05dcb937ed71)


Issue Number: N/A


## What is the new behavior?

Fix the navigationUrls defaults in the document to the correct defaults.

https://github.com/angular/angular/blob/08b4a8af6e1b7974c3c4c13d4f6de6dbe7d1f2bb/packages/service-worker/config/src/generator.ts#L14-L19


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
