### PR TITLE
ci: disable bazel-saucelabs job

### DIFF
--- a/.github/actions/saucelabs-legacy/action.yml
+++ b/.github/actions/saucelabs-legacy/action.yml
@@ -1,0 +1,46 @@
+name: 'Saucelabs legacy test job'
+description: 'Runs tests against Saucelabs (outside of Bazel)'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Initialize environment
+      uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@8d3cb7b9e1b3edd1dc168376689d27407d2dfa7a
+      with:
+        cache-node-modules: true
+    - name: Install node modules
+      run: yarn install --frozen-lockfile
+    - name: Setup Bazel
+      uses: angular/dev-infra/github-actions/bazel/setup@8d3cb7b9e1b3edd1dc168376689d27407d2dfa7a
+    - name: Setup Saucelabs Variables
+      uses: angular/dev-infra/github-actions/saucelabs@8d3cb7b9e1b3edd1dc168376689d27407d2dfa7a
+    - name: Starting Saucelabs tunnel service
+      run: ./tools/saucelabs/sauce-service.sh run &
+    # Build test fixtures for a test that rely on Bazel-generated fixtures. Note that disabling
+    # specific tests which are reliant on such generated fixtures is not an option as SystemJS
+    # in the Saucelabs legacy job always fetches referenced files, even if the imports would be
+    # guarded by an check to skip in the Saucelabs legacy job. We should be good running such
+    # test in all supported browsers on Saucelabs anyway until this job can be removed.
+    - name: Preparing Bazel-generated fixtures required in legacy tests
+      run: |
+        yarn bazel build //packages/core/test:downleveled_es5_fixture //packages/common/locales
+        # Needed for the ES5 downlevel reflector test in `packages/core/test/reflection`.
+        mkdir -p dist/legacy-test-out/core/test/reflection/
+        cp dist/bin/packages/core/test/reflection/es5_downleveled_inheritance_fixture.js \
+          dist/legacy-test-out/core/test/reflection/es5_downleveled_inheritance_fixture.js
+        # Locale files are needed for i18n tests running within Saucelabs. These are added
+        # directly as sources so that the TypeScript compilation of `/packages/tsconfig.json`
+        # can succeed. Note that the base locale and currencies files are checked-in, so
+        # we do not need to re-generate those through Bazel.
+        mkdir -p packages/common/locales/extra
+        cp dist/bin/packages/common/locales/*.ts packages/common/locales
+        cp dist/bin/packages/common/locales/extra/*.ts packages/common/locales/extra
+    - name: Build bundle of tests to run on Saucelabs
+      run: node tools/legacy-saucelabs/build-saucelabs-test-bundle.mjs
+    - name: Wait and confirm Saucelabs tunnel has connected
+      run: ./tools/saucelabs/sauce-service.sh ready-wait
+      timeout-minutes: 3
+    - name: Running tests on Saucelabs.
+      run: KARMA_WEB_TEST_MODE=SL_REQUIRED yarn karma start ./karma-js.conf.js --single-run
+    - name: Stop Saucelabs tunnel service
+      run: ./tools/saucelabs/sauce-service.sh stop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI (push)
 
 on:
   push:
@@ -152,31 +152,12 @@ jobs:
       - run: yarn --cwd packages/zone.js/test/typings install --frozen-lockfile --non-interactive
       - run: yarn --cwd packages/zone.js/test/typings test
 
-  bazel-saucelabs:
+  saucelabs:
     runs-on: ubuntu-latest-4core
     env:
-      JOBS: 2
+      SAUCE_TUNNEL_IDENTIFIER: angular-framework-${{ github.run_number }}
     steps:
-      - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@8d3cb7b9e1b3edd1dc168376689d27407d2dfa7a
-        with:
-          cache-node-modules: true
-      - name: Install node modules
-        run: yarn install --frozen-lockfile
-      - name: Setup Bazel
-        uses: angular/dev-infra/github-actions/bazel/setup@8d3cb7b9e1b3edd1dc168376689d27407d2dfa7a
-      - name: Setup Bazel Remote Caching
-        uses: angular/dev-infra/github-actions/bazel/configure-remote@8d3cb7b9e1b3edd1dc168376689d27407d2dfa7a
-      - name: Setup Saucelabs Variables
-        uses: angular/dev-infra/github-actions/saucelabs@8d3cb7b9e1b3edd1dc168376689d27407d2dfa7a
-      - name: Set up Sauce Tunnel Daemon
-        run: yarn bazel run //tools/saucelabs-daemon/background-service -- $JOBS &
-        env:
-          SAUCE_TUNNEL_IDENTIFIER: angular-framework-${{ github.run_number }}
-      - name: Run all saucelabs bazel tests
-        run: |
-          TESTS=$(./node_modules/.bin/bazelisk query --output label '(kind(karma_web_test, ...) intersect attr("tags", "saucelabs", ...)) except attr("tags", "fixme-saucelabs", ...)')
-          yarn bazel test --config=saucelabs --jobs=$JOBS ${TESTS}
+      - uses: ../actions/saucelabs-legacy
 
   adev-deploy:
     needs: [adev]

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,0 +1,34 @@
+name: Manual jobs
+
+on:
+  workflow_dispatch:
+    inputs: {}
+
+jobs:
+  # Bazel saucelabs job resides in `manual.yml` because it's currently unstable, but
+  # kept as "runnable" for debugging/stabilization effort purposes.
+  bazel-saucelabs:
+    runs-on: ubuntu-latest-4core
+    env:
+      JOBS: 2
+    steps:
+      - name: Initialize environment
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@8d3cb7b9e1b3edd1dc168376689d27407d2dfa7a
+        with:
+          cache-node-modules: true
+      - name: Install node modules
+        run: yarn install --frozen-lockfile
+      - name: Setup Bazel
+        uses: angular/dev-infra/github-actions/bazel/setup@8d3cb7b9e1b3edd1dc168376689d27407d2dfa7a
+      - name: Setup Bazel Remote Caching
+        uses: angular/dev-infra/github-actions/bazel/configure-remote@8d3cb7b9e1b3edd1dc168376689d27407d2dfa7a
+      - name: Setup Saucelabs Variables
+        uses: angular/dev-infra/github-actions/saucelabs@8d3cb7b9e1b3edd1dc168376689d27407d2dfa7a
+      - name: Set up Sauce Tunnel Daemon
+        run: yarn bazel run //tools/saucelabs-daemon/background-service -- $JOBS &
+        env:
+          SAUCE_TUNNEL_IDENTIFIER: angular-framework-${{ github.run_number }}
+      - name: Run all saucelabs bazel tests
+        run: |
+          TESTS=$(./node_modules/.bin/bazelisk query --output label '(kind(karma_web_test, ...) intersect attr("tags", "saucelabs", ...)) except attr("tags", "fixme-saucelabs", ...)')
+          yarn bazel test --config=saucelabs --jobs=$JOBS ${TESTS}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -168,43 +168,4 @@ jobs:
     env:
       SAUCE_TUNNEL_IDENTIFIER: angular-framework-${{ github.run_number }}
     steps:
-      - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@8d3cb7b9e1b3edd1dc168376689d27407d2dfa7a
-        with:
-          cache-node-modules: true
-      - name: Install node modules
-        run: yarn install --frozen-lockfile
-      - name: Setup Bazel
-        uses: angular/dev-infra/github-actions/bazel/setup@8d3cb7b9e1b3edd1dc168376689d27407d2dfa7a
-      - name: Setup Saucelabs Variables
-        uses: angular/dev-infra/github-actions/saucelabs@8d3cb7b9e1b3edd1dc168376689d27407d2dfa7a
-      - name: Starting Saucelabs tunnel service
-        run: ./tools/saucelabs/sauce-service.sh run &
-      # Build test fixtures for a test that rely on Bazel-generated fixtures. Note that disabling
-      # specific tests which are reliant on such generated fixtures is not an option as SystemJS
-      # in the Saucelabs legacy job always fetches referenced files, even if the imports would be
-      # guarded by an check to skip in the Saucelabs legacy job. We should be good running such
-      # test in all supported browsers on Saucelabs anyway until this job can be removed.
-      - name: Preparing Bazel-generated fixtures required in legacy tests
-        run: |
-          yarn bazel build //packages/core/test:downleveled_es5_fixture //packages/common/locales
-          # Needed for the ES5 downlevel reflector test in `packages/core/test/reflection`.
-          mkdir -p dist/legacy-test-out/core/test/reflection/
-          cp dist/bin/packages/core/test/reflection/es5_downleveled_inheritance_fixture.js \
-            dist/legacy-test-out/core/test/reflection/es5_downleveled_inheritance_fixture.js
-          # Locale files are needed for i18n tests running within Saucelabs. These are added
-          # directly as sources so that the TypeScript compilation of `/packages/tsconfig.json`
-          # can succeed. Note that the base locale and currencies files are checked-in, so
-          # we do not need to re-generate those through Bazel.
-          mkdir -p packages/common/locales/extra
-          cp dist/bin/packages/common/locales/*.ts packages/common/locales
-          cp dist/bin/packages/common/locales/extra/*.ts packages/common/locales/extra
-      - name: Build bundle of tests to run on Saucelabs
-        run: node tools/legacy-saucelabs/build-saucelabs-test-bundle.mjs
-      - name: Wait and confirm Saucelabs tunnel has connected
-        run: ./tools/saucelabs/sauce-service.sh ready-wait
-        timeout-minutes: 3
-      - name: Running tests on Saucelabs.
-        run: KARMA_WEB_TEST_MODE=SL_REQUIRED yarn karma start ./karma-js.conf.js --single-run
-      - name: Stop Saucelabs tunnel service
-        run: ./tools/saucelabs/sauce-service.sh stop
+      - uses: ../actions/saucelabs-legacy


### PR DESCRIPTION
Disables the `bazel-saucelabs` job in `main`, and re-uses the PR legacy saucelabs job to run on `main` instead (which is much more stable and reliable).