### PR TITLE
fix(directive): add optional autoUniqueId property

### DIFF
--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -344,6 +344,28 @@ export interface Directive {
   standalone?: boolean;
 
   /**
+   * This property, `autoUniqueId`, is an optional boolean that determines
+   * whether the directive should automatically generate a unique identifier
+   * for its instances.
+   *
+   * If set to `true`, the directive will create and assign a unique ID to
+   * each instance upon initialization, ensuring that elements rendered by
+   * the directive can be uniquely identified in the DOM. This is especially
+   * useful in scenarios where multiple instances of the directive are used
+   * within the same component or view, preventing ID conflicts.
+   *
+   * When `autoUniqueId` is `false` (or not provided), it implies that
+   * the user of the directive must manually handle the unique ID assignment,
+   * providing more control but requiring additional setup from the developer.
+   *
+   * Automatically generating unique IDs can enhance the accessibility of
+   * components, as screen readers and other assistive technologies can
+   * refer to elements by their unique identifiers, improving the user
+   * experience for those relying on such tools.
+   */
+  autoUniqueId?: boolean;
+
+  /**
    * // TODO(signals): Remove internal and add public documentation
    *
    * @internal

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -42,6 +42,10 @@ import {
   transitiveScopesFor,
 } from './module';
 import {isComponent, verifyStandaloneImport} from './util';
+import {
+  generateUniqueId,
+  generateUniqueIdTemplate,
+} from '@angular/core/src/render3/util/id_generator_utils';
 
 /**
  * Keep track of the compilation depth to avoid reentrancy issues during JIT compilation. This
@@ -217,6 +221,15 @@ export function compileComponent(type: Type<any>, metadata: Component): void {
     // Make the property configurable in dev mode to allow overriding in tests
     configurable: !!ngDevMode,
   });
+
+  const autoUniqueId = metadata.autoUniqueId || false;
+
+  if (autoUniqueId && !!metadata.template) {
+    const prefix = `${type.name}`;
+    const instanceId = generateUniqueId(prefix);
+
+    metadata.template = generateUniqueIdTemplate(metadata.template!, instanceId);
+  }
 }
 
 /**

--- a/packages/core/src/render3/util/id_generator_utils.ts
+++ b/packages/core/src/render3/util/id_generator_utils.ts
@@ -1,0 +1,42 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+let uniqueIdCounter = 0;
+
+/**
+ * Generates a unique ID based on the provided base ID.
+ * @param baseId The base identifier for the component instance.
+ * @returns A unique ID string.
+ */
+export function generateUniqueId(baseId: string): string {
+  return `${baseId}-${uniqueIdCounter++}`;
+}
+
+/**
+ * Utility function to replace IDs in a template string with unique IDs.
+ * @param template The component template string.
+ * @param instanceId The unique instance ID to prepend.
+ * @returns A modified template string with unique IDs.
+ */
+export function generateUniqueIdTemplate(template: string, instanceId: string): string {
+  return template
+    .replace(/id="([^"]+)"/g, `id="${instanceId}-$1"`)
+    .replace(/for="([^"]+)"/g, `for="${instanceId}-$1"`)
+    .replace(/aria-labelledby="([^"]+)"/g, `aria-labelledby="${instanceId}-$1"`)
+    .replace(/aria-describedby="([^"]+)"/g, `aria-describedby="${instanceId}-$1"`)
+    .replace(/aria-controls="([^"]+)"/g, `aria-controls="${instanceId}-$1"`)
+    .replace(/aria-flowto="([^"]+)"/g, `aria-flowto="${instanceId}-$1"`)
+    .replace(/aria-haspopup="([^"]+)"/g, `aria-haspopup="${instanceId}-$1"`)
+    .replace(/aria-current="([^"]+)"/g, `aria-current="${instanceId}-$1"`)
+    .replace(/aria-owns="([^"]+)"/g, `aria-owns="${instanceId}-$1"`)
+    .replace(/aria-details="([^"]+)"/g, `aria-details="${instanceId}-$1"`)
+    .replace(/aria-activedescendant="([^"]+)"/g, `aria-activedescendant="${instanceId}-$1"`)
+    .replace(/aria-invalid="([^"]+)"/g, `aria-invalid="${instanceId}-$1"`)
+    .replace(/data-target="([^"]+)"/g, `data-target="${instanceId}-$1"`)
+    .replace(/data-controls="([^"]+)"/g, `data-controls="${instanceId}-$1"`);
+}

--- a/packages/core/test/metadata/resource_loading_spec.ts
+++ b/packages/core/test/metadata/resource_loading_spec.ts
@@ -199,4 +199,29 @@ Did you run and wait for 'resolveComponentResources()'?`.trim(),
       expect(metadata.template).toBe('response for test://content');
     });
   });
+  describe('When compiling a component with autoUniqueId', () => {
+    function fetch(url: string): Promise<Response> {
+      return Promise.resolve({
+        text() {
+          return 'response for ' + url;
+        },
+      } as any as Response);
+    }
+    const MyComponent: ComponentType<any> = class MyComponent {} as any;
+    const metadata: Component = {
+      template: '<div id="my-element"></div>',
+      autoUniqueId: true,
+    };
+
+    beforeEach(() => {
+      compileComponent(MyComponent, metadata);
+    });
+
+    it('should prefix IDs when autoUniqueId is true', async () => {
+      await resolveComponentResources(fetch);
+
+      expect(MyComponent.ɵcmp).toBeDefined();
+      expect(metadata.template).toBe('<div id="MyComponent-0-my-element"></div>');
+    });
+  });
 });


### PR DESCRIPTION
Add an optional `autoUniqueId` boolean property to the directive interface to enhance flexibility in directive instantiation.

Fixes #55062

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, the directive interface does not support the flexibility to generate unique IDs automatically, which limits its usability in certain scenarios.
Issue Number: #55062


## What is the new behavior?
This PR introduces an optional autoUniqueId boolean property to the directive interface. When set to true, it enables the directive to automatically generate a unique ID for each instance, enhancing flexibility during instantiation.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
