### PR TITLE
docs: update two-way-binding page

### DIFF
--- a/adev/src/content/guide/templates/two-way-binding.md
+++ b/adev/src/content/guide/templates/two-way-binding.md
@@ -70,7 +70,7 @@ export class AppComponent {
 
 ```angular-ts
 // './counter/counter.component.ts';
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, output } from '@angular/core';
 
 @Component({
   selector: 'app-counter',
@@ -83,7 +83,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 })
 export class CounterComponent {
   @Input() count: number;
-  @Output() countChange = new EventEmitter<number>();
+  countChange = output<number>();
 
   updateCount(amount: number): void {
     this.count += amount;
@@ -99,19 +99,19 @@ If we break down the example above to its core , each two-way binding for compon
 The child component must contain:
 
 1. An `@Input()` property
-1. A corresponding `@Output()` event emitter that has the exact same name as the input property plus "Change" at the end. The emitter must also emit the same type as the input property.
+1. A corresponding `output()` event emitter that has the exact same name as the input property plus "Change" at the end. The emitter must also emit the same type as the input property.
 1. A method that emits to the event emitter with the updated value of the `@Input()`.
 
 Here is a simplified example:
 
 ```angular-ts
 // './counter/counter.component.ts';
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, output } from '@angular/core';
 
 @Component({ // Omitted for brevity })
 export class CounterComponent {
   @Input() count: number;
-  @Output() countChange = new EventEmitter<number>();
+  countChange = output<number>();
 
   updateCount(amount: number): void {
     this.count += amount;


### PR DESCRIPTION
Replace Output() decorator usage with the new output function.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Now the two-way-binding page is using the @Output() decorator style in all the examples.

## What is the new behavior?
The documentation uses the new output function.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
