### PR TITLE
fix(core): Clear lView from IcuIteratorState when stack is empty to prevent memory leak

### DIFF
--- a/packages/core/src/render3/instructions/i18n_icu_container_visitor.ts
+++ b/packages/core/src/render3/instructions/i18n_icu_container_visitor.ts
@@ -54,6 +54,8 @@ function icuContainerIteratorNext(state: IcuIteratorState): RNode | null {
     }
   } else {
     if (state.stack.length === 0) {
+      // Clear the lView to prevent a memory leak until the next change detection cycle.
+      state.lView = undefined;
       return null;
     } else {
       state.removes = state.stack.pop();


### PR DESCRIPTION
If a component template contains an icu expression, it can being retained until the next change detection cycle for that template section. This results in a net retention of only ever a single copy of the given lView but that creates an opportunity for compounding leaks.

Change the icu i18n_icu_container_visitor to free the IcuIteratorState retained lView when the stack is empty so that garbage collection can occur when the view is discarded.

I didn't see an existing test file for the icu iterator validation so wasn't sure where to put a test case to verify the new behavior regarding the IcuIteratorState.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Component templates with i18n icu expressions are retaining the lView until change detection is run again on that template. This is due to the `IcuIteratorState` establishing a reference to the corresponding lView and then not releasing it when the stack is empty.

Issue Number: N/A


## What is the new behavior?

The IcuIteratorState clears the lView property retainer when the iterator stack is empty. This allows the components to be garbage collected when the component/lView is discarded.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
