### PR TITLE
refactor(compiler): trim expression whitespace when `preserveSignificantWhitespace === false`

### DIFF
--- a/packages/compiler-cli/src/transformers/i18n.ts
+++ b/packages/compiler-cli/src/transformers/i18n.ts
@@ -57,13 +57,7 @@ export function i18nSerialize(
 
   switch (format) {
     case 'xmb':
-      serializer = new Xmb(
-        // Whenever we disable whitespace preservation, we also want to stop preserving
-        // placeholders because they contain whitespace we want to drop too. Whitespace
-        // inside `{{ name }}` should be ignored for the same reasons as whitespace
-        // outside placeholders.
-        /* preservePlaceholders */ options.i18nPreserveWhitespaceForLegacyExtraction,
-      );
+      serializer = new Xmb();
       break;
     case 'xliff2':
     case 'xlf2':

--- a/packages/compiler/src/expression_parser/serializer.ts
+++ b/packages/compiler/src/expression_parser/serializer.ts
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import * as expr from './ast';
+
+/** Serializes the given AST into a normalized string format. */
+export function serialize(expression: expr.ASTWithSource): string {
+  return expression.visit(new SerializeExpressionVisitor());
+}
+
+class SerializeExpressionVisitor implements expr.AstVisitor {
+  visitUnary(ast: expr.Unary, context: any): string {
+    return `${ast.operator}${ast.expr.visit(this, context)}`;
+  }
+
+  visitBinary(ast: expr.Binary, context: any): string {
+    return `${ast.left.visit(this, context)} ${ast.operation} ${ast.right.visit(this, context)}`;
+  }
+
+  visitChain(ast: expr.Chain, context: any): string {
+    return ast.expressions.map((e) => e.visit(this, context)).join('; ');
+  }
+
+  visitConditional(ast: expr.Conditional, context: any): string {
+    return `${ast.condition.visit(this, context)} ? ${ast.trueExp.visit(
+      this,
+      context,
+    )} : ${ast.falseExp.visit(this, context)}`;
+  }
+
+  visitThisReceiver(): string {
+    return 'this';
+  }
+
+  visitImplicitReceiver(): string {
+    return '';
+  }
+
+  visitInterpolation(ast: expr.Interpolation, context: any): string {
+    return interleave(
+      ast.strings,
+      ast.expressions.map((e) => e.visit(this, context)),
+    ).join('');
+  }
+
+  visitKeyedRead(ast: expr.KeyedRead, context: any): string {
+    return `${ast.receiver.visit(this, context)}[${ast.key.visit(this, context)}]`;
+  }
+
+  visitKeyedWrite(ast: expr.KeyedWrite, context: any): string {
+    return `${ast.receiver.visit(this, context)}[${ast.key.visit(
+      this,
+      context,
+    )}] = ${ast.value.visit(this, context)}`;
+  }
+
+  visitLiteralArray(ast: expr.LiteralArray, context: any): string {
+    return `[${ast.expressions.map((e) => e.visit(this, context)).join(', ')}]`;
+  }
+
+  visitLiteralMap(ast: expr.LiteralMap, context: any): string {
+    return `{${zip(
+      ast.keys.map((literal) => (literal.quoted ? `'${literal.key}'` : literal.key)),
+      ast.values.map((value) => value.visit(this, context)),
+    )
+      .map(([key, value]) => `${key}: ${value}`)
+      .join(', ')}}`;
+  }
+
+  visitLiteralPrimitive(ast: expr.LiteralPrimitive): string {
+    if (ast.value === null) return 'null';
+
+    switch (typeof ast.value) {
+      case 'number':
+      case 'boolean':
+        return ast.value.toString();
+      case 'undefined':
+        return 'undefined';
+      case 'string':
+        return `'${ast.value.replace(/'/g, `\\'`)}'`;
+      default:
+        throw new Error(`Unsupported primitive type: ${ast.value}`);
+    }
+  }
+
+  visitPipe(ast: expr.BindingPipe, context: any): string {
+    return `${ast.exp.visit(this, context)} | ${ast.name}`;
+  }
+
+  visitPrefixNot(ast: expr.PrefixNot, context: any): string {
+    return `!${ast.expression.visit(this, context)}`;
+  }
+
+  visitNonNullAssert(ast: expr.NonNullAssert, context: any): string {
+    return `${ast.expression.visit(this, context)}!`;
+  }
+
+  visitPropertyRead(ast: expr.PropertyRead, context: any): string {
+    if (ast.receiver instanceof expr.ImplicitReceiver) {
+      return ast.name;
+    } else {
+      return `${ast.receiver.visit(this, context)}.${ast.name}`;
+    }
+  }
+
+  visitPropertyWrite(ast: expr.PropertyWrite, context: any): string {
+    if (ast.receiver instanceof expr.ImplicitReceiver) {
+      return `${ast.name} = ${ast.value.visit(this, context)}`;
+    } else {
+      return `${ast.receiver.visit(this, context)}.${ast.name} = ${ast.value.visit(this, context)}`;
+    }
+  }
+
+  visitSafePropertyRead(ast: expr.SafePropertyRead, context: any): string {
+    return `${ast.receiver.visit(this, context)}?.${ast.name}`;
+  }
+
+  visitSafeKeyedRead(ast: expr.SafeKeyedRead, context: any): string {
+    return `${ast.receiver.visit(this, context)}?.[${ast.key.visit(this, context)}]`;
+  }
+
+  visitCall(ast: expr.Call, context: any): string {
+    return `${ast.receiver.visit(this, context)}(${ast.args
+      .map((e) => e.visit(this, context))
+      .join(', ')})`;
+  }
+
+  visitSafeCall(ast: expr.SafeCall, context: any): string {
+    return `${ast.receiver.visit(this, context)}?.(${ast.args
+      .map((e) => e.visit(this, context))
+      .join(', ')})`;
+  }
+
+  visitASTWithSource(ast: expr.ASTWithSource, context: any): string {
+    return ast.ast.visit(this, context);
+  }
+}
+
+/** Zips the two input arrays into a single array of pairs of elements at the same index. */
+function zip<Left, Right>(left: Left[], right: Right[]): Array<[Left, Right]> {
+  if (left.length !== right.length) throw new Error('Array lengths must match');
+
+  return left.map((l, i) => [l, right[i]]);
+}
+
+/**
+ * Interleaves the two arrays, starting with the first item on the left, then the first item
+ * on the right, second item from the left, and so on. When the first array's items are exhausted,
+ * the remaining items from the other array are included with no interleaving.
+ */
+function interleave<Left, Right>(left: Left[], right: Right[]): Array<Left | Right> {
+  const result: Array<Left | Right> = [];
+
+  for (let index = 0; index < Math.max(left.length, right.length); index++) {
+    if (index < left.length) result.push(left[index]);
+    if (index < right.length) result.push(right[index]);
+  }
+
+  return result;
+}

--- a/packages/compiler/src/i18n/digest.ts
+++ b/packages/compiler/src/i18n/digest.ts
@@ -32,15 +32,15 @@ export function computeDigest(message: i18n.Message): string {
 /**
  * Return the message id or compute it using the XLIFF2/XMB/$localize digest.
  */
-export function decimalDigest(message: i18n.Message, preservePlaceholders: boolean): string {
-  return message.id || computeDecimalDigest(message, preservePlaceholders);
+export function decimalDigest(message: i18n.Message): string {
+  return message.id || computeDecimalDigest(message);
 }
 
 /**
  * Compute the message id using the XLIFF2/XMB/$localize digest.
  */
-export function computeDecimalDigest(message: i18n.Message, preservePlaceholders: boolean): string {
-  const visitor = new _SerializerIgnoreExpVisitor(preservePlaceholders);
+export function computeDecimalDigest(message: i18n.Message): string {
+  const visitor = new _SerializerIgnoreIcuExpVisitor();
   const parts = message.nodes.map((a) => a.visit(visitor, null));
   return computeMsgId(parts.join(''), message.meaning);
 }
@@ -100,22 +100,11 @@ export function serializeNodes(nodes: i18n.Node[]): string[] {
 /**
  * Serialize the i18n ast to something xml-like in order to generate an UID.
  *
- * Ignore the expressions so that message IDs stays identical if only the expression changes.
+ * Ignore the ICU expressions so that message IDs stays identical if only the expression changes.
  *
  * @internal
  */
-class _SerializerIgnoreExpVisitor extends _SerializerVisitor {
-  constructor(private readonly preservePlaceholders: boolean) {
-    super();
-  }
-
-  override visitPlaceholder(ph: i18n.Placeholder, context: any): string {
-    // Do not take the expression into account when `preservePlaceholders` is disabled.
-    return this.preservePlaceholders
-      ? super.visitPlaceholder(ph, context)
-      : `<ph name="${ph.name}"/>`;
-  }
-
+class _SerializerIgnoreIcuExpVisitor extends _SerializerVisitor {
   override visitIcu(icu: i18n.Icu): string {
     let strCases = Object.keys(icu.cases).map((k: string) => `${k} {${icu.cases[k].visit(this)}}`);
     // Do not take the expression into account

--- a/packages/compiler/src/i18n/extractor_merger.ts
+++ b/packages/compiler/src/i18n/extractor_merger.ts
@@ -352,7 +352,8 @@ class _Visitor implements html.Visitor {
       // When dropping significant whitespace we need to retain whitespace tokens or
       // else we won't be able to reuse source spans because empty tokens would be
       // removed and cause a mismatch.
-      !this._preserveSignificantWhitespace /* retainEmptyTokens */,
+      /* retainEmptyTokens */ !this._preserveSignificantWhitespace,
+      /* preserveExpressionWhitespace */ this._preserveSignificantWhitespace,
     );
   }
 

--- a/packages/compiler/src/i18n/i18n_html_parser.ts
+++ b/packages/compiler/src/i18n/i18n_html_parser.ts
@@ -79,7 +79,7 @@ function createSerializer(format?: string): Serializer {
 
   switch (format) {
     case 'xmb':
-      return new Xmb(/* preservePlaceholders */ true);
+      return new Xmb();
     case 'xtb':
       return new Xtb();
     case 'xliff2':

--- a/packages/compiler/src/i18n/serializers/xliff2.ts
+++ b/packages/compiler/src/i18n/serializers/xliff2.ts
@@ -128,7 +128,7 @@ export class Xliff2 extends Serializer {
   }
 
   override digest(message: i18n.Message): string {
-    return decimalDigest(message, /* preservePlaceholders */ true);
+    return decimalDigest(message);
   }
 }
 

--- a/packages/compiler/src/i18n/serializers/xmb.ts
+++ b/packages/compiler/src/i18n/serializers/xmb.ts
@@ -48,10 +48,6 @@ const _DOCTYPE = `<!ELEMENT messagebundle (msg)*>
 <!ELEMENT ex (#PCDATA)>`;
 
 export class Xmb extends Serializer {
-  constructor(private readonly preservePlaceholders: boolean = true) {
-    super();
-  }
-
   override write(messages: i18n.Message[], locale: string | null): string {
     const exampleVisitor = new ExampleVisitor();
     const visitor = new _Visitor();
@@ -108,7 +104,7 @@ export class Xmb extends Serializer {
   }
 
   override digest(message: i18n.Message): string {
-    return digest(message, this.preservePlaceholders);
+    return digest(message);
   }
 
   override createNameMapper(message: i18n.Message): PlaceholderMapper {
@@ -206,8 +202,8 @@ class _Visitor implements i18n.Visitor {
   }
 }
 
-export function digest(message: i18n.Message, preservePlaceholders: boolean): string {
-  return decimalDigest(message, preservePlaceholders);
+export function digest(message: i18n.Message): string {
+  return decimalDigest(message);
 }
 
 // TC requires at least one non-empty example on placeholders

--- a/packages/compiler/src/i18n/serializers/xtb.ts
+++ b/packages/compiler/src/i18n/serializers/xtb.ts
@@ -57,7 +57,7 @@ export class Xtb extends Serializer {
   }
 
   override digest(message: i18n.Message): string {
-    return digest(message, /* preservePlaceholders */ true);
+    return digest(message);
   }
 
   override createNameMapper(message: i18n.Message): PlaceholderMapper {

--- a/packages/compiler/src/render3/view/i18n/meta.ts
+++ b/packages/compiler/src/render3/view/i18n/meta.ts
@@ -256,9 +256,7 @@ export class I18nMetaVisitor implements html.Visitor {
    */
   private _setMessageId(message: i18n.Message, meta: string | i18n.I18nMeta): void {
     if (!message.id) {
-      message.id =
-        (meta instanceof i18n.Message && meta.id) ||
-        decimalDigest(message, /* preservePlaceholders */ this.preserveSignificantWhitespace);
+      message.id = (meta instanceof i18n.Message && meta.id) || decimalDigest(message);
     }
   }
 
@@ -270,13 +268,7 @@ export class I18nMetaVisitor implements html.Visitor {
    */
   private _setLegacyIds(message: i18n.Message, meta: string | i18n.I18nMeta): void {
     if (this.enableI18nLegacyMessageIdFormat) {
-      message.legacyIds = [
-        computeDigest(message),
-        computeDecimalDigest(
-          message,
-          /* preservePlaceholders */ this.preserveSignificantWhitespace,
-        ),
-      ];
+      message.legacyIds = [computeDigest(message), computeDecimalDigest(message)];
     } else if (typeof meta !== 'string') {
       // This occurs if we are doing the 2nd pass after whitespace removal (see `parseTemplate()` in
       // `packages/compiler/src/render3/view/template.ts`).

--- a/packages/compiler/src/render3/view/i18n/meta.ts
+++ b/packages/compiler/src/render3/view/i18n/meta.ts
@@ -90,6 +90,7 @@ export class I18nMetaVisitor implements html.Visitor {
       this.interpolationConfig,
       this.containerBlocks,
       this.retainEmptyTokens,
+      /* preserveExpressionWhitespace */ this.preserveSignificantWhitespace,
     );
     const message = createI18nMessage(nodes, meaning, description, customId, visitNodeFn);
     this._setMessageId(message, meta);

--- a/packages/compiler/test/expression_parser/serializer_spec.ts
+++ b/packages/compiler/test/expression_parser/serializer_spec.ts
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import * as expr from '../../src/expression_parser/ast';
+import {Lexer} from '../../src/expression_parser/lexer';
+import {Parser} from '../../src/expression_parser/parser';
+import {serialize} from '../../src/expression_parser/serializer';
+
+const parser = new Parser(new Lexer());
+
+function parse(expression: string): expr.ASTWithSource {
+  return parser.parseBinding(expression, /* location */ '', /* absoluteOffset */ 0);
+}
+
+function parseAction(expression: string): expr.ASTWithSource {
+  return parser.parseAction(expression, /* location */ '', /* absoluteOffset */ 0);
+}
+
+describe('serializer', () => {
+  describe('serialize', () => {
+    it('serializes unary plus', () => {
+      expect(serialize(parse(' + 1234 '))).toBe('+1234');
+    });
+
+    it('serializes unary negative', () => {
+      expect(serialize(parse(' - 1234 '))).toBe('-1234');
+    });
+
+    it('serializes binary operations', () => {
+      expect(serialize(parse(' 1234   +   4321 '))).toBe('1234 + 4321');
+    });
+
+    it('serializes chains', () => {
+      expect(serialize(parseAction(' 1234;   4321 '))).toBe('1234; 4321');
+    });
+
+    it('serializes conditionals', () => {
+      expect(serialize(parse(' cond   ?   1234   :   4321 '))).toBe('cond ? 1234 : 4321');
+    });
+
+    it('serializes `this`', () => {
+      expect(serialize(parse(' this '))).toBe('this');
+    });
+
+    it('serializes keyed reads', () => {
+      expect(serialize(parse(' foo   [bar] '))).toBe('foo[bar]');
+    });
+
+    it('serializes keyed write', () => {
+      expect(serialize(parse(' foo   [bar]   =   baz '))).toBe('foo[bar] = baz');
+    });
+
+    it('serializes array literals', () => {
+      expect(serialize(parse(' [   foo,   bar,   baz   ] '))).toBe('[foo, bar, baz]');
+    });
+
+    it('serializes object literals', () => {
+      expect(serialize(parse(' {   foo:   bar,   baz:   test   } '))).toBe('{foo: bar, baz: test}');
+    });
+
+    it('serializes primitives', () => {
+      expect(serialize(parse(` 'test' `))).toBe(`'test'`);
+      expect(serialize(parse(' "test" '))).toBe(`'test'`);
+      expect(serialize(parse(' true '))).toBe('true');
+      expect(serialize(parse(' false '))).toBe('false');
+      expect(serialize(parse(' 1234 '))).toBe('1234');
+      expect(serialize(parse(' null '))).toBe('null');
+      expect(serialize(parse(' undefined '))).toBe('undefined');
+    });
+
+    it('escapes string literals', () => {
+      expect(serialize(parse(` 'Hello, \\'World\\'...' `))).toBe(`'Hello, \\'World\\'...'`);
+      expect(serialize(parse(` 'Hello, \\"World\\"...' `))).toBe(`'Hello, "World"...'`);
+    });
+
+    it('serializes pipes', () => {
+      expect(serialize(parse(' foo   |   pipe '))).toBe('foo | pipe');
+    });
+
+    it('serializes not prefixes', () => {
+      expect(serialize(parse(' !   foo '))).toBe('!foo');
+    });
+
+    it('serializes non-null assertions', () => {
+      expect(serialize(parse(' foo   ! '))).toBe('foo!');
+    });
+
+    it('serializes property reads', () => {
+      expect(serialize(parse(' foo   .   bar '))).toBe('foo.bar');
+    });
+
+    it('serializes property writes', () => {
+      expect(serialize(parseAction(' foo   .   bar   =   baz '))).toBe('foo.bar = baz');
+    });
+
+    it('serializes safe property reads', () => {
+      expect(serialize(parse(' foo   ?.   bar '))).toBe('foo?.bar');
+    });
+
+    it('serializes safe keyed reads', () => {
+      expect(serialize(parse(' foo   ?.   [   bar   ] '))).toBe('foo?.[bar]');
+    });
+
+    it('serializes calls', () => {
+      expect(serialize(parse(' foo   (   ) '))).toBe('foo()');
+      expect(serialize(parse(' foo   (   bar   ) '))).toBe('foo(bar)');
+      expect(serialize(parse(' foo   (   bar   ,   ) '))).toBe('foo(bar, )');
+      expect(serialize(parse(' foo   (   bar   ,   baz   ) '))).toBe('foo(bar, baz)');
+    });
+
+    it('serializes safe calls', () => {
+      expect(serialize(parse(' foo   ?.   (   ) '))).toBe('foo?.()');
+      expect(serialize(parse(' foo   ?.   (   bar   ) '))).toBe('foo?.(bar)');
+      expect(serialize(parse(' foo   ?.   (   bar   ,   ) '))).toBe('foo?.(bar, )');
+      expect(serialize(parse(' foo   ?.   (   bar   ,   baz   ) '))).toBe('foo?.(bar, baz)');
+    });
+  });
+});

--- a/packages/compiler/test/i18n/i18n_ast_spec.ts
+++ b/packages/compiler/test/i18n/i18n_ast_spec.ts
@@ -16,6 +16,7 @@ describe('Message', () => {
     DEFAULT_INTERPOLATION_CONFIG,
     DEFAULT_CONTAINER_BLOCKS,
     /* retainEmptyTokens */ false,
+    /* preserveExpressionWhitespace */ true,
   );
   describe('messageText()', () => {
     it('should serialize simple text', () => {

--- a/packages/compiler/test/i18n/i18n_parser_spec.ts
+++ b/packages/compiler/test/i18n/i18n_parser_spec.ts
@@ -227,6 +227,34 @@ describe('I18nParser', () => {
         [['{count, plural, =0 {[{sex, select, male {[m]}}]}}'], '', '', ''],
       ]);
     });
+
+    it('should preserve whitespace when preserving significant whitespace', () => {
+      const html = '<div i18n="m|d">{count, plural, =0 {{{   foo   }}}}</div>';
+      expect(
+        _humanizeMessages(
+          html,
+          /* implicitTags */ undefined,
+          /* implicitAttrs */ undefined,
+          /* preserveSignificantWhitespace */ true,
+        ),
+      ).toEqual([
+        [['{count, plural, =0 {[[<ph name="INTERPOLATION">   foo   </ph>]]}}'], 'm', 'd', ''],
+      ]);
+    });
+
+    it('should normalize whitespace when not preserving significant whitespace', () => {
+      const html = '<div i18n="m|d">{count, plural, =0 {{{   foo   }}}}</div>';
+      expect(
+        _humanizeMessages(
+          html,
+          /* implicitTags */ undefined,
+          /* implicitAttrs */ undefined,
+          /* preserveSignificantWhitespace */ false,
+        ),
+      ).toEqual([
+        [['{count, plural, =0 {[[, <ph name="INTERPOLATION">foo</ph>, ]]}}'], 'm', 'd', ''],
+      ]);
+    });
   });
 
   describe('implicit elements', () => {
@@ -318,6 +346,30 @@ describe('I18nParser', () => {
         '',
       ]);
     });
+
+    it('should preserve whitespace when preserving significant whitespace', () => {
+      const html = '<div i18n="m|d">{{   foo   }}</div>';
+      expect(
+        _humanizeMessages(
+          html,
+          /* implicitTags */ undefined,
+          /* implicitAttrs */ undefined,
+          /* preserveSignificantWhitespace */ true,
+        ),
+      ).toEqual([[['[<ph name="INTERPOLATION">   foo   </ph>]'], 'm', 'd', '']]);
+    });
+
+    it('should normalize whitespace when not preserving significant whitespace', () => {
+      const html = '<div i18n="m|d">{{   foo   }}</div>';
+      expect(
+        _humanizeMessages(
+          html,
+          /* implicitTags */ undefined,
+          /* implicitAttrs */ undefined,
+          /* preserveSignificantWhitespace */ false,
+        ),
+      ).toEqual([[['[, <ph name="INTERPOLATION">foo</ph>, ]'], 'm', 'd', '']]);
+    });
   });
 });
 
@@ -325,24 +377,24 @@ export function _humanizeMessages(
   html: string,
   implicitTags: string[] = [],
   implicitAttrs: {[k: string]: string[]} = {},
+  preserveSignificantWhitespace = true,
 ): [string[], string, string, string][] {
-  return _extractMessages(html, implicitTags, implicitAttrs).map((message) => [
-    serializeNodes(message.nodes),
-    message.meaning,
-    message.description,
-    message.id,
-  ]) as [string[], string, string, string][];
+  return _extractMessages(html, implicitTags, implicitAttrs, preserveSignificantWhitespace).map(
+    (message) => [serializeNodes(message.nodes), message.meaning, message.description, message.id],
+  ) as [string[], string, string, string][];
 }
 
 function _humanizePlaceholders(
   html: string,
   implicitTags: string[] = [],
   implicitAttrs: {[k: string]: string[]} = {},
+  preserveSignificantWhitespace = true,
 ): string[] {
-  return _extractMessages(html, implicitTags, implicitAttrs).map((msg) =>
-    Object.keys(msg.placeholders)
-      .map((name) => `${name}=${msg.placeholders[name].text}`)
-      .join(', '),
+  return _extractMessages(html, implicitTags, implicitAttrs, preserveSignificantWhitespace).map(
+    (msg) =>
+      Object.keys(msg.placeholders)
+        .map((name) => `${name}=${msg.placeholders[name].text}`)
+        .join(', '),
   );
 }
 
@@ -350,11 +402,13 @@ function _humanizePlaceholdersToMessage(
   html: string,
   implicitTags: string[] = [],
   implicitAttrs: {[k: string]: string[]} = {},
+  preserveSignificantWhitespace = true,
 ): string[] {
-  return _extractMessages(html, implicitTags, implicitAttrs).map((msg) =>
-    Object.keys(msg.placeholderToMessage)
-      .map((k) => `${k}=${digest(msg.placeholderToMessage[k])}`)
-      .join(', '),
+  return _extractMessages(html, implicitTags, implicitAttrs, preserveSignificantWhitespace).map(
+    (msg) =>
+      Object.keys(msg.placeholderToMessage)
+        .map((k) => `${k}=${digest(msg.placeholderToMessage[k])}`)
+        .join(', '),
   );
 }
 
@@ -362,6 +416,7 @@ export function _extractMessages(
   html: string,
   implicitTags: string[] = [],
   implicitAttrs: {[k: string]: string[]} = {},
+  preserveSignificantWhitespace = true,
 ): Message[] {
   const htmlParser = new HtmlParser();
   const parseResult = htmlParser.parse(html, 'extractor spec', {tokenizeExpansionForms: true});
@@ -374,6 +429,6 @@ export function _extractMessages(
     DEFAULT_INTERPOLATION_CONFIG,
     implicitTags,
     implicitAttrs,
-    /* preserveSignificantWhitespace */ true,
+    preserveSignificantWhitespace,
   ).messages;
 }

--- a/packages/compiler/test/i18n/integration_xmb_xtb_spec.ts
+++ b/packages/compiler/test/i18n/integration_xmb_xtb_spec.ts
@@ -24,7 +24,7 @@ xdescribe('i18n XMB/XTB integration spec', () => {
     beforeEach(waitForAsync(() => configureCompiler(XTB + LF_LINE_ENDING_XTB, 'xtb')));
 
     it('should extract from templates', () => {
-      const serializer = new Xmb(/* preservePlaceholders */ true);
+      const serializer = new Xmb();
       const serializedXmb = serializeTranslations(HTML, serializer);
 
       XMB.forEach((x) => {
@@ -43,7 +43,7 @@ xdescribe('i18n XMB/XTB integration spec', () => {
     beforeEach(waitForAsync(() => configureCompiler(XTB + CRLF_LINE_ENDING_XTB, 'xtb')));
 
     it('should extract from templates (with CRLF line endings)', () => {
-      const serializer = new Xmb(/* preservePlaceholders */ true);
+      const serializer = new Xmb();
       const serializedXmb = serializeTranslations(HTML.replace(/\n/g, '\r\n'), serializer);
 
       XMB.forEach((x) => {

--- a/packages/compiler/test/i18n/serializers/xmb_spec.ts
+++ b/packages/compiler/test/i18n/serializers/xmb_spec.ts
@@ -70,7 +70,7 @@ lines</msg>
 
   it('should throw when trying to load an xmb file', () => {
     expect(() => {
-      const serializer = new Xmb(/* preservePlaceholders */ true);
+      const serializer = new Xmb();
       serializer.load(XMB, 'url');
     }).toThrowError(/Unsupported/);
   });
@@ -78,7 +78,7 @@ lines</msg>
 
 function toXmb(html: string, url: string, locale: string | null = null): string {
   const catalog = new MessageBundle(new HtmlParser(), [], {}, locale);
-  const serializer = new Xmb(/* preservePlaceholders */ true);
+  const serializer = new Xmb();
 
   catalog.updateFromTemplate(html, url, DEFAULT_INTERPOLATION_CONFIG);
 

--- a/packages/compiler/test/i18n/whitespace_sensitivity_spec.ts
+++ b/packages/compiler/test/i18n/whitespace_sensitivity_spec.ts
@@ -461,7 +461,7 @@ function extractMessages(source: string, preserveWhitespace: boolean): Assertabl
 
   const messages = bundle.getMessages();
 
-  const xmbSerializer = new Xmb(/* preservePlaceholders */ preserveWhitespace);
+  const xmbSerializer = new Xmb();
   return messages.map((message) => ({
     id: xmbSerializer.digest(message),
     text: message.nodes.map((node) => node.visit(debugSerializer)).join(''),


### PR DESCRIPTION
This PR trims whitespace in expressions when `preserveSignificantWhitespace === false`. This allows messages to be a bit more durable to insignificant whitespace changes. For example, reformatting the following:

```html
<div i18n>Hello, {{ name }}!</div>
```

Into:

```html
<div i18n>Hello, {{
  name
}}!</div>
```

Is a whitespace-only change which has no visible effect to translators. Therefore we trim whitespace before extracting messages and normalize it to a standard format (`{{name}}`).

This PR also removes the functionality for ignoring placeholder expressions entirely (originally added as part of dab722f9c899d775bb886a1d5beb5970f79c4cd8). Ideally, we wouldn't take placeholders into account at all, since whether an expression is `{{foo}}` or `{{bar}}` is also irrelevant to the translator. However doing so causes some challenges with TC, so we can't go that far just yet (see http://b/367255149#comment10). Therefore this PR rolls back that particular feature and replaces it with this one which trims expression whitespace instead.