### PR TITLE
Update ssr.md

### DIFF
--- a/adev/src/content/guide/ssr.md
+++ b/adev/src/content/guide/ssr.md
@@ -101,14 +101,12 @@ import { Component, ViewChild, afterNextRender } from '@angular/core';
   selector: 'my-cmp',
   template: `<span #content>{{ ... }}</span>`,
 })
-export class MyComponent {
-  @ViewChild('content') contentRef: ElementRef;
+export class MyComponent implements AfterViewInit {
+  @ViewChild('content') contentRef!: ElementRef;
 
-  constructor() {
-    afterNextRender(() => {
-      // Safe to check `scrollHeight` because this will only run in the browser, not the server.
-      console.log('content height: ' + this.contentRef.nativeElement.scrollHeight);
-    });
+  ngAfterViewInit() {
+    // Safe to check `scrollHeight` because this will only run in the browser, not the server.
+    console.log('content height: ' + this.contentRef.nativeElement.scrollHeight);
   }
 }
 


### PR DESCRIPTION
Constructor: Although it runs when the component is initialized, the DOM is not yet ready, making it unsuitable for DOM manipulations.

ngAfterViewInit: It runs after the DOM is fully rendered, making it the ideal place to access and manipulate DOM elements. That's why we use this method instead of the constructor.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x ] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


##Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
