### PR TITLE
feat(core): introduce the reactive linkedSignal

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1113,6 +1113,21 @@ export class KeyValueDiffers {
     static ɵprov: unknown;
 }
 
+// @public (undocumented)
+export function linkedSignal<D>(computation: () => D, options?: {
+    equal?: ValueEqualityFn<NoInfer<D>>;
+}): WritableSignal<D>;
+
+// @public (undocumented)
+export function linkedSignal<S, D>(options: {
+    source: () => S;
+    computation: (source: NoInfer<S>, previous?: {
+        source: NoInfer<S>;
+        value: NoInfer<D>;
+    }) => D;
+    equal?: ValueEqualityFn<NoInfer<D>>;
+}): WritableSignal<D>;
+
 // @public
 export const LOCALE_ID: InjectionToken<string>;
 

--- a/packages/core/src/core_reactivity_export_internal.ts
+++ b/packages/core/src/core_reactivity_export_internal.ts
@@ -16,6 +16,7 @@ export {
   WritableSignal,
   ɵunwrapWritableSignal,
 } from './render3/reactivity/signal';
+export {linkedSignal} from './render3/reactivity/linked_signal';
 export {untracked} from './render3/reactivity/untracked';
 export {
   CreateEffectOptions,

--- a/packages/core/src/render3/reactivity/linked_signal.ts
+++ b/packages/core/src/render3/reactivity/linked_signal.ts
@@ -1,0 +1,222 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {signalAsReadonlyFn, WritableSignal} from './signal';
+import {Signal, ValueEqualityFn} from './api';
+import {
+  producerMarkClean,
+  ReactiveNode,
+  SIGNAL,
+  signalSetFn,
+  signalUpdateFn,
+  producerUpdateValueVersion,
+  REACTIVE_NODE,
+  defaultEquals,
+  consumerBeforeComputation,
+  consumerAfterComputation,
+  producerAccessed,
+} from '@angular/core/primitives/signals';
+import {performanceMarkFeature} from '../../util/performance';
+
+type ComputationFn<S, D> = (source: S, previous?: {source: S; value: D}) => D;
+
+interface LinkedSignalNode<S, D> extends ReactiveNode {
+  /**
+   * Value of the source signal that was used to derive the computed value.
+   */
+  sourceValue: S;
+
+  /**
+   * Current state value, or one of the sentinel values (`UNSET`, `COMPUTING`,
+   * `ERROR`).
+   */
+  value: D;
+
+  /**
+   * If `value` is `ERRORED`, the error caught from the last computation attempt which will
+   * be re-thrown.
+   */
+  error: unknown;
+
+  /**
+   * The source function represents reactive dependency based on which the linked state is reset.
+   */
+  source: () => S;
+
+  /**
+   * The computation function which will produce a new value based on the source and, optionally - previous values.
+   */
+  computation: ComputationFn<S, D>;
+
+  equal: ValueEqualityFn<D>;
+}
+
+export type LinkedSignalGetter<S, D> = (() => D) & {
+  [SIGNAL]: LinkedSignalNode<S, D>;
+};
+
+const identityFn = <T>(v: T) => v;
+
+/**
+ * Create a linked signal which represents state that is (re)set from a linked reactive expression.
+ */
+function createLinkedSignal<S, D>(node: LinkedSignalNode<S, D>): WritableSignal<D> {
+  const linkedSignalGetter = () => {
+    // Check if the value needs updating before returning it.
+    producerUpdateValueVersion(node);
+
+    // Record that someone looked at this signal.
+    producerAccessed(node);
+
+    if (node.value === ERRORED) {
+      throw node.error;
+    }
+
+    return node.value;
+  };
+
+  const getter = linkedSignalGetter as LinkedSignalGetter<S, D> & WritableSignal<D>;
+  getter[SIGNAL] = node;
+
+  if (ngDevMode) {
+    getter.toString = () => `[LinkedSignal: ${getter()}]`;
+  }
+
+  getter.set = (newValue: D) => {
+    producerUpdateValueVersion(node);
+    signalSetFn(node, newValue);
+    producerMarkClean(node);
+  };
+
+  getter.update = (updateFn: (value: D) => D) => {
+    producerUpdateValueVersion(node);
+    signalUpdateFn(node, updateFn);
+    producerMarkClean(node);
+  };
+
+  getter.asReadonly = signalAsReadonlyFn.bind(getter as any) as () => Signal<D>;
+
+  return getter;
+}
+
+/**
+ * @experimental
+ */
+export function linkedSignal<D>(
+  computation: () => D,
+  options?: {equal?: ValueEqualityFn<NoInfer<D>>},
+): WritableSignal<D>;
+export function linkedSignal<S, D>(options: {
+  source: () => S;
+  computation: (source: NoInfer<S>, previous?: {source: NoInfer<S>; value: NoInfer<D>}) => D;
+  equal?: ValueEqualityFn<NoInfer<D>>;
+}): WritableSignal<D>;
+export function linkedSignal<S, D>(
+  optionsOrComputation:
+    | {
+        source: () => S;
+        computation: ComputationFn<S, D>;
+        equal?: ValueEqualityFn<D>;
+      }
+    | (() => D),
+  options?: {equal?: ValueEqualityFn<D>},
+): WritableSignal<D> {
+  performanceMarkFeature('NgSignals');
+
+  const isShorthand = typeof optionsOrComputation === 'function';
+  const node: LinkedSignalNode<unknown, unknown> = Object.create(LINKED_SIGNAL_NODE);
+  node.source = isShorthand ? optionsOrComputation : optionsOrComputation.source;
+  if (!isShorthand) {
+    node.computation = optionsOrComputation.computation as ComputationFn<unknown, unknown>;
+  }
+  const equal = isShorthand ? options?.equal : optionsOrComputation.equal;
+  if (equal) {
+    node.equal = equal as ValueEqualityFn<unknown>;
+  }
+  return createLinkedSignal(node as LinkedSignalNode<S, D>);
+}
+
+/**
+ * A dedicated symbol used before a state value has been set / calculated for the first time.
+ * Explicitly typed as `any` so we can use it as signal's value.
+ */
+const UNSET: any = /* @__PURE__ */ Symbol('UNSET');
+
+/**
+ * A dedicated symbol used in place of a linked signal value to indicate that a given computation
+ * is in progress. Used to detect cycles in computation chains.
+ * Explicitly typed as `any` so we can use it as signal's value.
+ */
+const COMPUTING: any = /* @__PURE__ */ Symbol('COMPUTING');
+
+/**
+ * A dedicated symbol used in place of a linked signal value to indicate that a given computation
+ * failed. The thrown error is cached until the computation gets dirty again or the state is set.
+ * Explicitly typed as `any` so we can use it as signal's value.
+ */
+const ERRORED: any = /* @__PURE__ */ Symbol('ERRORED');
+
+// Note: Using an IIFE here to ensure that the spread assignment is not considered
+// a side-effect, ending up preserving `LINKED_SIGNAL_NODE` and `REACTIVE_NODE`.
+// TODO: remove when https://github.com/evanw/esbuild/issues/3392 is resolved.
+const LINKED_SIGNAL_NODE = /* @__PURE__ */ (() => {
+  return {
+    ...REACTIVE_NODE,
+    value: UNSET,
+    dirty: true,
+    error: null,
+    equal: defaultEquals,
+    computation: identityFn,
+
+    producerMustRecompute(node: LinkedSignalNode<unknown, unknown>): boolean {
+      // Force a recomputation if there's no current value, or if the current value is in the
+      // process of being calculated (which should throw an error).
+      return node.value === UNSET || node.value === COMPUTING;
+    },
+
+    producerRecomputeValue(node: LinkedSignalNode<unknown, unknown>): void {
+      if (node.value === COMPUTING) {
+        // Our computation somehow led to a cyclic read of itself.
+        throw new Error('Detected cycle in computations.');
+      }
+
+      const oldValue = node.value;
+      node.value = COMPUTING;
+
+      const prevConsumer = consumerBeforeComputation(node);
+      let newValue: unknown;
+      try {
+        const newSourceValue = node.source();
+        const prev =
+          oldValue === UNSET || oldValue === ERRORED
+            ? undefined
+            : {
+                source: node.sourceValue,
+                value: oldValue,
+              };
+        newValue = node.computation(newSourceValue, prev);
+        node.sourceValue = newSourceValue;
+      } catch (err) {
+        newValue = ERRORED;
+        node.error = err;
+      } finally {
+        consumerAfterComputation(node, prevConsumer);
+      }
+
+      if (oldValue !== UNSET && newValue !== ERRORED && node.equal(oldValue, newValue)) {
+        // No change to `valueVersion` - old and new values are
+        // semantically equivalent.
+        node.value = oldValue;
+        return;
+      }
+
+      node.value = newValue;
+      node.version++;
+    },
+  };
+})();

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -1695,6 +1695,9 @@
     "name": "init_lift"
   },
   {
+    "name": "init_linked_signal"
+  },
+  {
     "name": "init_linker"
   },
   {

--- a/packages/core/test/signals/effect_util.ts
+++ b/packages/core/test/signals/effect_util.ts
@@ -15,11 +15,16 @@ let queue = new Set<Watch>();
  */
 export function testingEffect(
   effectFn: (onCleanup: (cleanupFn: WatchCleanupFn) => void) => void,
-): void {
+): () => void {
   const w = createWatch(effectFn, queue.add.bind(queue), true);
 
   // Effects start dirty.
   w.notify();
+
+  return () => {
+    queue.delete(w);
+    w.destroy();
+  };
 }
 
 export function flushEffects(): void {

--- a/packages/core/test/signals/linked_signal_spec.ts
+++ b/packages/core/test/signals/linked_signal_spec.ts
@@ -1,0 +1,249 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {isSignal, linkedSignal, signal, computed} from '@angular/core';
+import {testingEffect} from './effect_util';
+
+describe('linkedSignal', () => {
+  it('should conform to the writable signals contract', () => {
+    const firstLetter = linkedSignal({source: signal<string>('foo'), computation: (str) => str[0]});
+    expect(isSignal(firstLetter)).toBeTrue();
+
+    firstLetter.set('a');
+    expect(firstLetter()).toBe('a');
+
+    firstLetter.update((_) => 'b');
+    expect(firstLetter()).toBe('b');
+
+    const firstLetterReadonly = firstLetter.asReadonly();
+    expect(firstLetterReadonly()).toBe('b');
+    firstLetter.set('c');
+    expect(firstLetterReadonly()).toBe('c');
+
+    expect(firstLetter.toString()).toBe('[LinkedSignal: c]');
+  });
+
+  it('should conform to the writable signals contract - shorthand', () => {
+    const str = signal<string>('foo');
+    const firstLetter = linkedSignal(() => str()[0]);
+    expect(isSignal(firstLetter)).toBeTrue();
+
+    firstLetter.set('a');
+    expect(firstLetter()).toBe('a');
+
+    firstLetter.update((_) => 'b');
+    expect(firstLetter()).toBe('b');
+
+    const firstLetterReadonly = firstLetter.asReadonly();
+    expect(firstLetterReadonly()).toBe('b');
+    firstLetter.set('c');
+    expect(firstLetterReadonly()).toBe('c');
+  });
+
+  it('should update when the source changes', () => {
+    const options = signal(['apple', 'banana', 'fig']);
+    const choice = linkedSignal({
+      source: options,
+      computation: (options) => options[0],
+    });
+
+    expect(choice()).toBe('apple');
+
+    choice.set('fig');
+    expect(choice()).toBe('fig');
+
+    options.set(['orange', 'apple', 'pomegranate']);
+    expect(choice()).toBe('orange');
+  });
+
+  it('should expose previous source in the computation function', () => {
+    const options = signal(['apple', 'banana', 'fig']);
+    const choice = linkedSignal<string[], string>({
+      source: options,
+      computation: (options, previous) => {
+        if (previous !== undefined && options.includes(previous.value)) {
+          return previous.value;
+        } else {
+          return options[0];
+        }
+      },
+    });
+
+    expect(choice()).toBe('apple');
+
+    options.set(['orange', 'apple', 'pomegranate']);
+    expect(choice()).toBe('apple');
+  });
+
+  it('should expose previous value in the computation function', () => {
+    const options = signal(['apple', 'banana', 'fig']);
+    const choice = linkedSignal<string[], number>({
+      source: options,
+      computation: (options, previous) => {
+        if (previous !== undefined) {
+          const prevChoice = previous.source[previous.value];
+          const newIdx = options.indexOf(prevChoice);
+          return newIdx === -1 ? 0 : newIdx;
+        } else {
+          return 0;
+        }
+      },
+    });
+
+    expect(choice()).toBe(0);
+
+    choice.set(2); // choosing a fig
+    options.set(['banana', 'fig', 'apple']); // a fig moves to a new place in the updated resource
+    expect(choice()).toBe(1);
+  });
+
+  it('should expose previous value in the computation function in larger reactive graph', () => {
+    const options = signal(['apple', 'banana', 'fig']);
+    const choice = linkedSignal<string[], number>({
+      source: options,
+      computation: (options, previous) => {
+        if (previous !== undefined) {
+          const prevChoice = previous.source[previous.value];
+          const newIdx = options.indexOf(prevChoice);
+          return newIdx === -1 ? 0 : newIdx;
+        } else {
+          return 0;
+        }
+      },
+    });
+
+    const doubleChoice = computed(() => choice() * 2);
+
+    expect(doubleChoice()).toBe(0);
+
+    choice.set(2); // choosing a fig
+    options.set(['banana', 'fig', 'apple']); // a fig moves to a new place in the updated resource
+
+    expect(doubleChoice()).toBe(2);
+    expect(choice()).toBe(1);
+  });
+
+  it('should not update the value if the new choice is considered equal to the previous one', () => {
+    const counter = signal(0);
+    const choice = linkedSignal({
+      source: counter,
+      computation: (c) => c,
+      equal: (a, b) => true,
+    });
+
+    expect(choice()).toBe(0);
+
+    // updates from the "commanding signal" should follow equality rules
+    counter.update((c) => c + 1);
+    expect(choice()).toBe(0);
+
+    // the same equality rules should apply to the state signal
+    choice.set(10);
+    expect(choice()).toBe(0);
+  });
+
+  it('should support shorthand version', () => {
+    const options = signal(['apple', 'banana', 'fig']);
+    const choice = linkedSignal(() => options()[0]);
+
+    expect(choice()).toBe('apple');
+
+    choice.set('orange');
+    expect(options()).toEqual(['apple', 'banana', 'fig']);
+    expect(choice()).toBe('orange');
+
+    options.set(['banana', 'fig']);
+    expect(choice()).toBe('banana');
+  });
+
+  it('should have explicitly set value', () => {
+    const counter = signal(0);
+    const options = signal(['apple', 'banana', 'fig']);
+    const choice = linkedSignal(() => options()[0]);
+    expect(choice()).toBe('apple');
+
+    // state signal is updated while the "commanding" state has pending changes - we assume that the explicit state set is "more important" here
+    options.set(['orange', 'apple', 'pomegranate']);
+    choice.set('watermelon');
+    // unrelated state changes should not effect the test results
+    counter.update((c) => c + 1);
+    expect(choice()).toBe('watermelon');
+
+    // state signal is updated just before changes to the "commanding" state - here we default to the usual situation of the linked state triggering computation
+    choice.set('persimmon');
+    options.set(['apple', 'banana', 'fig']);
+    expect(choice()).toBe('apple');
+
+    // another change using the "update" code-path
+    options.set(['orange', 'apple', 'pomegranate']);
+    choice.update((f) => f.toUpperCase());
+    expect(choice()).toBe('ORANGE');
+  });
+
+  it('should have explicitly set value - live consumer', () => {
+    const options = signal(['apple', 'banana', 'fig']);
+    const choice = linkedSignal(() => options()[0]);
+    expect(choice()).toBe('apple');
+    // create an effect to mark the linkedSignal as live consumer
+    const watchDestroy = testingEffect(() => choice());
+
+    try {
+      // state signal is updated while the "commanding" state has pending changes - we assume that the explicit state set is "more important" here
+      const counter = signal(0);
+      options.set(['orange', 'apple', 'pomegranate']);
+      choice.set('watermelon');
+      // unrelated state changes should not effect the test results
+      counter.update((c) => c + 1);
+      expect(choice()).toBe('watermelon');
+
+      // state signal is updated just before changes to the "commanding" state - here we default to the usual situation of the linked state triggering computation
+      choice.set('persimmon');
+      options.set(['apple', 'banana', 'fig']);
+      expect(choice()).toBe('apple');
+
+      // another change using the "update" code-path
+      options.set(['orange', 'apple', 'pomegranate']);
+      choice.update((f) => f.toUpperCase());
+      expect(choice()).toBe('ORANGE');
+    } finally {
+      watchDestroy();
+    }
+  });
+
+  it('should capture linked signal dependencies even if the value is set before the initial read', () => {
+    const options = signal(['apple', 'banana', 'fig']);
+    const choice = linkedSignal(() => options()[0]);
+
+    choice.set('watermelon');
+    expect(choice()).toBe('watermelon');
+
+    options.set(['orange', 'apple', 'pomegranate']);
+    expect(choice()).toBe('orange');
+  });
+
+  it('should pull latest dependency values before state update', () => {
+    const options = signal(['apple', 'banana', 'fig']);
+    const choice = linkedSignal(() => options()[0]);
+
+    choice.update((fruit) => fruit.toUpperCase());
+    expect(choice()).toBe('APPLE');
+  });
+
+  it('should reset error state after manual state update', () => {
+    const choice = linkedSignal<string>(() => {
+      throw new Error("Can't compute");
+    });
+
+    expect(() => {
+      choice();
+    }).toThrowError("Can't compute");
+
+    choice.set('explicit');
+    expect(choice()).toBe('explicit');
+  });
+});


### PR DESCRIPTION
This change introduces the new reactive primitive: linkedSignal.

A linkedSignal represents state (hence the signal in the name) that is reset based on the provided computation. Conceptually it is a state that is maintained / valid only in the context of another source signal (context is deteremined by a computation).
