### PR TITLE
refactor(migrations): improve heuristic of untyped `.componentInstance` in signal migrations

### DIFF
--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/any_test.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/any_test.ts
@@ -1,13 +1,19 @@
 // tslint:disable
 
-import {Input} from '@angular/core';
+import {DebugElement, Input} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 function it(msg: string, fn: () => void) {}
+const harness = {
+  query<T>(v: T): DebugElement {
+    return null!;
+  },
+};
 
 class SubDir {
   @Input() name = 'John';
+  @Input() name2 = '';
 }
 
 class MyComp {
@@ -20,4 +26,12 @@ it('should work', () => {
   const sub = fixture.debugElement.query(By.directive(SubDir)).componentInstance;
 
   expect(sub.name).toBe('John');
+});
+
+it('should work2', () => {
+  const fixture = TestBed.createComponent(MyComp);
+  // `.componentInstance` is using `any` :O
+  const sub = harness.query(SubDir).componentInstance;
+
+  expect(sub.name2).toBe('John');
 });

--- a/packages/core/schematics/migrations/signal-migration/test/golden.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden.txt
@@ -2,14 +2,20 @@
 
 // tslint:disable
 
-import {input} from '@angular/core';
+import {DebugElement, input} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 function it(msg: string, fn: () => void) {}
+const harness = {
+  query<T>(v: T): DebugElement {
+    return null!;
+  },
+};
 
 class SubDir {
   readonly name = input('John');
+  readonly name2 = input('');
 }
 
 class MyComp {
@@ -22,6 +28,14 @@ it('should work', () => {
   const sub = fixture.debugElement.query(By.directive(SubDir)).componentInstance;
 
   expect(sub.name()).toBe('John');
+});
+
+it('should work2', () => {
+  const fixture = TestBed.createComponent(MyComp);
+  // `.componentInstance` is using `any` :O
+  const sub = harness.query(SubDir).componentInstance;
+
+  expect(sub.name2()).toBe('John');
 });
 @@@@@@ base_class.ts @@@@@@
 

--- a/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
@@ -2,14 +2,20 @@
 
 // tslint:disable
 
-import {input} from '@angular/core';
+import {DebugElement, input} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 function it(msg: string, fn: () => void) {}
+const harness = {
+  query<T>(v: T): DebugElement {
+    return null!;
+  },
+};
 
 class SubDir {
   readonly name = input('John');
+  readonly name2 = input('');
 }
 
 class MyComp {
@@ -22,6 +28,14 @@ it('should work', () => {
   const sub = fixture.debugElement.query(By.directive(SubDir)).componentInstance;
 
   expect(sub.name()).toBe('John');
+});
+
+it('should work2', () => {
+  const fixture = TestBed.createComponent(MyComp);
+  // `.componentInstance` is using `any` :O
+  const sub = harness.query(SubDir).componentInstance;
+
+  expect(sub.name2()).toBe('John');
 });
 @@@@@@ base_class.ts @@@@@@
 


### PR DESCRIPTION
We currently extend `.componentInstance` accesses (which are `any` for `DebugElement`). We are doing this for `By.directive(T)` invocations, but can expand this for other common expressions like with harnesses.

E.g.`harness.query(T).componentInstance`.
