### PR TITLE
refactor(core): Update defer schedulers to use injector

### DIFF
--- a/packages/core/src/defer/idle_scheduler.ts
+++ b/packages/core/src/defer/idle_scheduler.ts
@@ -6,18 +6,16 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {inject, ɵɵdefineInjectable} from '../di';
-import {INJECTOR, LView} from '../render3/interfaces/view';
+import {Injector, inject, ɵɵdefineInjectable} from '../di';
 import {NgZone} from '../zone';
 
 /**
  * Helper function to schedule a callback to be invoked when a browser becomes idle.
  *
  * @param callback A function to be invoked when a browser becomes idle.
- * @param lView LView that hosts an instance of a defer block.
+ * @param injector injector for the app
  */
-export function onIdle(callback: VoidFunction, lView: LView) {
-  const injector = lView[INJECTOR]!;
+export function onIdle(callback: VoidFunction, injector: Injector) {
   const scheduler = injector.get(IdleScheduler);
   const cleanupFn = () => scheduler.remove(callback);
   scheduler.add(callback);

--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -526,17 +526,18 @@ export function ɵɵdeferHydrateOnViewport(): void {}
  * Schedules triggering of a defer block for `on idle` and `on timer` conditions.
  */
 function scheduleDelayedTrigger(
-  scheduleFn: (callback: VoidFunction, lView: LView) => VoidFunction,
+  scheduleFn: (callback: VoidFunction, injector: Injector) => VoidFunction,
 ) {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
+  const injector = lView[INJECTOR]!;
 
   renderPlaceholder(lView, tNode);
 
   // Only trigger the scheduled trigger on the browser
   // since we don't want to delay the server response.
-  if (isPlatformBrowser(lView[INJECTOR]!)) {
-    const cleanupFn = scheduleFn(() => triggerDeferBlock(lView, tNode), lView);
+  if (isPlatformBrowser(injector)) {
+    const cleanupFn = scheduleFn(() => triggerDeferBlock(lView, tNode), injector);
     const lDetails = getLDeferBlockDetails(lView, tNode);
     storeTriggerCleanupFn(TriggerType.Regular, lDetails, cleanupFn);
   }
@@ -548,13 +549,14 @@ function scheduleDelayedTrigger(
  * @param scheduleFn A function that does the scheduling.
  */
 function scheduleDelayedPrefetching(
-  scheduleFn: (callback: VoidFunction, lView: LView) => VoidFunction,
+  scheduleFn: (callback: VoidFunction, injector: Injector) => VoidFunction,
 ) {
   const lView = getLView();
+  const injector = lView[INJECTOR]!;
 
   // Only trigger the scheduled trigger on the browser
   // since we don't want to delay the server response.
-  if (isPlatformBrowser(lView[INJECTOR]!)) {
+  if (isPlatformBrowser(injector)) {
     const tNode = getCurrentTNode()!;
     const tView = lView[TVIEW];
     const tDetails = getTDeferBlockDetails(tView, tNode);
@@ -562,7 +564,7 @@ function scheduleDelayedPrefetching(
     if (tDetails.loadingState === DeferDependenciesLoadingState.NOT_STARTED) {
       const lDetails = getLDeferBlockDetails(lView, tNode);
       const prefetch = () => triggerPrefetching(tDetails, lView, tNode);
-      const cleanupFn = scheduleFn(prefetch, lView);
+      const cleanupFn = scheduleFn(prefetch, injector);
       storeTriggerCleanupFn(TriggerType.Prefetch, lDetails, cleanupFn);
     }
   }
@@ -835,7 +837,7 @@ function scheduleDeferBlockUpdate(
       renderDeferBlockState(nextState, tNode, lContainer);
     }
   };
-  return scheduleTimerTrigger(timeout, callback, hostLView);
+  return scheduleTimerTrigger(timeout, callback, hostLView[INJECTOR]!);
 }
 
 /**

--- a/packages/core/src/defer/timer_scheduler.ts
+++ b/packages/core/src/defer/timer_scheduler.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ɵɵdefineInjectable} from '../di';
-import {INJECTOR, LView} from '../render3/interfaces/view';
+import {Injector, ɵɵdefineInjectable} from '../di';
 import {arrayInsert2, arraySplice} from '../util/array_utils';
 
 /**
@@ -15,7 +14,8 @@ import {arrayInsert2, arraySplice} from '../util/array_utils';
  * Invoking the returned function schedules a trigger.
  */
 export function onTimer(delay: number) {
-  return (callback: VoidFunction, lView: LView) => scheduleTimerTrigger(delay, callback, lView);
+  return (callback: VoidFunction, injector: Injector) =>
+    scheduleTimerTrigger(delay, callback, injector);
 }
 
 /**
@@ -23,10 +23,9 @@ export function onTimer(delay: number) {
  *
  * @param delay A number of ms to wait until firing a callback.
  * @param callback A function to be invoked after a timeout.
- * @param lView LView that hosts an instance of a defer block.
+ * @param injector injector for the app.
  */
-export function scheduleTimerTrigger(delay: number, callback: VoidFunction, lView: LView) {
-  const injector = lView[INJECTOR]!;
+export function scheduleTimerTrigger(delay: number, callback: VoidFunction, injector: Injector) {
   const scheduler = injector.get(TimerScheduler);
   const cleanupFn = () => scheduler.remove(callback);
   scheduler.add(delay, callback);


### PR DESCRIPTION
This updates the functions for defer scheduler triggers to use a passed in injector instead of an LView. This lays some groundwork for reusing these schedulers for incremental hydration.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->


- [x] Refactoring (no functional changes, no api changes)




## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No



