### PR TITLE
refactor(core): Add mouseover to hover dom triggers

### DIFF
--- a/packages/core/src/defer/dom_triggers.ts
+++ b/packages/core/src/defer/dom_triggers.ts
@@ -47,10 +47,10 @@ const interactionTriggers = new WeakMap<Element, DeferEventEntry>();
 const viewportTriggers = new WeakMap<Element, DeferEventEntry>();
 
 /** Names of the events considered as interaction events. */
-const interactionEventNames = ['click', 'keydown'] as const;
+export const interactionEventNames = ['click', 'keydown'] as const;
 
 /** Names of the events considered as hover events. */
-const hoverEventNames = ['mouseenter', 'focusin'] as const;
+export const hoverEventNames = ['mouseenter', 'mouseover', 'focusin'] as const;
 
 /** `IntersectionObserver` used to observe `viewport` triggers. */
 let intersectionObserver: IntersectionObserver | null = null;

--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -3027,8 +3027,9 @@ describe('@defer', () => {
       fixture.detectChanges();
       flush();
 
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(3);
       expect(spy).toHaveBeenCalledWith('mouseenter', jasmine.any(Function), jasmine.any(Object));
+      expect(spy).toHaveBeenCalledWith('mouseover', jasmine.any(Function), jasmine.any(Object));
       expect(spy).toHaveBeenCalledWith('focusin', jasmine.any(Function), jasmine.any(Object));
     }));
 
@@ -3062,8 +3063,9 @@ describe('@defer', () => {
       fixture.componentInstance.renderBlock = false;
       fixture.detectChanges();
 
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(3);
       expect(spy).toHaveBeenCalledWith('mouseenter', jasmine.any(Function), jasmine.any(Object));
+      expect(spy).toHaveBeenCalledWith('mouseover', jasmine.any(Function), jasmine.any(Object));
       expect(spy).toHaveBeenCalledWith('focusin', jasmine.any(Function), jasmine.any(Object));
     }));
 
@@ -3098,8 +3100,9 @@ describe('@defer', () => {
       fixture.componentInstance.renderBlock = false;
       fixture.detectChanges();
 
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(3);
       expect(spy).toHaveBeenCalledWith('mouseenter', jasmine.any(Function), jasmine.any(Object));
+      expect(spy).toHaveBeenCalledWith('mouseover', jasmine.any(Function), jasmine.any(Object));
       expect(spy).toHaveBeenCalledWith('focusin', jasmine.any(Function), jasmine.any(Object));
     }));
 
@@ -4021,9 +4024,14 @@ describe('@defer', () => {
       fixture.detectChanges();
 
       // Verify that trigger element is cleaned up.
-      expect(triggerSpy).toHaveBeenCalledTimes(2);
+      expect(triggerSpy).toHaveBeenCalledTimes(3);
       expect(triggerSpy).toHaveBeenCalledWith(
         'mouseenter',
+        jasmine.any(Function),
+        jasmine.any(Object),
+      );
+      expect(triggerSpy).toHaveBeenCalledWith(
+        'mouseover',
         jasmine.any(Function),
         jasmine.any(Object),
       );
@@ -4034,9 +4042,14 @@ describe('@defer', () => {
       );
 
       // Verify that prefetch trigger element is cleaned up.
-      expect(prefetchSpy).toHaveBeenCalledTimes(2);
+      expect(prefetchSpy).toHaveBeenCalledTimes(3);
       expect(prefetchSpy).toHaveBeenCalledWith(
         'mouseenter',
+        jasmine.any(Function),
+        jasmine.any(Object),
+      );
+      expect(prefetchSpy).toHaveBeenCalledWith(
+        'mouseover',
         jasmine.any(Function),
         jasmine.any(Object),
       );


### PR DESCRIPTION
Unfortunately mouseenter is a synthetic event, meaning it does not bubble in the same ways. So mouseover needs to be included in this list in order to get proper browser replayability of the mouse hovering events.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->


- [x] Refactoring (no functional changes, no api changes)




## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

