### PR TITLE
refactor(core): allow passing passive option to `addEventListener()`

### DIFF
--- a/goldens/public-api/core/rxjs-interop/index.api.md
+++ b/goldens/public-api/core/rxjs-interop/index.api.md
@@ -24,9 +24,6 @@ export function outputFromObservable<T>(observable: Observable<T>, opts?: Output
 export function outputToObservable<T>(ref: OutputRef<T>): Observable<T>;
 
 // @public
-export function pendingUntilEvent<T>(injector?: Injector): MonoTypeOperatorFunction<T>;
-
-// @public
 export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T>;
 
 // @public

--- a/goldens/public-api/forms/index.api.md
+++ b/goldens/public-api/forms/index.api.md
@@ -534,6 +534,9 @@ export interface FormRecord<TControl> {
     addControl(name: string, control: TControl, options?: {
         emitEvent?: boolean;
     }): void;
+    clear(options?: {
+        emitEvent?: boolean;
+    }): void;
     contains(controlName: string): boolean;
     getRawValue(): {
         [key: string]: ɵRawValue<TControl>;

--- a/packages/core/primitives/event-dispatch/README.md
+++ b/packages/core/primitives/event-dispatch/README.md
@@ -166,6 +166,15 @@ This code should be compiled/bundled/minified separately from the main
 application bundle. Code size is critical here since this code will be inlined
 at the top of the page and will block rendering content.
 
+For scroll-blocking events like `touchstart`, `touchmove`, `wheel` and `mousewheel`,
+you can optimize scrolling performance by passing the `passive` option to the
+`addEvent` function. This allows the browser to continue scrolling smoothly even
+while the event listener is processing. For example:
+
+```javascript
+eventContract.addEvent(eventType, prefixedEventType, /* passive= */ true);
+```
+
 ### 2. Embed the `EventContract`
 
 In your server rendered application, embed the contract bundle at the top of

--- a/packages/core/primitives/event-dispatch/src/event_contract_container.ts
+++ b/packages/core/primitives/event-dispatch/src/event_contract_container.ts
@@ -17,6 +17,7 @@ export interface EventContractContainerManager {
   addEventListener(
     eventType: string,
     getHandler: (element: Element) => (event: Event) => void,
+    passive?: boolean,
   ): void;
 
   cleanUp(): void;
@@ -50,7 +51,11 @@ export class EventContractContainer implements EventContractContainerManager {
    * and maintains a reference to resulting handler in order to remove it
    * later if desired.
    */
-  addEventListener(eventType: string, getHandler: (element: Element) => (event: Event) => void) {
+  addEventListener(
+    eventType: string,
+    getHandler: (element: Element) => (event: Event) => void,
+    passive?: boolean,
+  ) {
     // In iOS, event bubbling doesn't happen automatically in any DOM element,
     // unless it has an onclick attribute or DOM event handler attached to it.
     // This breaks JsAction in some cases. See "Making Elements Clickable"
@@ -66,7 +71,7 @@ export class EventContractContainer implements EventContractContainerManager {
       (this.element as HTMLElement).style.cursor = 'pointer';
     }
     this.handlerInfos.push(
-      eventLib.addEventListener(this.element, eventType, getHandler(this.element)),
+      eventLib.addEventListener(this.element, eventType, getHandler(this.element), passive),
     );
   }
 

--- a/packages/core/primitives/event-dispatch/src/event_contract_multi_container.ts
+++ b/packages/core/primitives/event-dispatch/src/event_contract_multi_container.ts
@@ -30,9 +30,13 @@ export class EventContractMultiContainer implements EventContractContainerManage
    * and maintains a reference to resulting handler in order to remove it
    * later if desired.
    */
-  addEventListener(eventType: string, getHandler: (element: Element) => (event: Event) => void) {
+  addEventListener(
+    eventType: string,
+    getHandler: (element: Element) => (event: Event) => void,
+    passive?: boolean,
+  ) {
     const eventHandlerInstaller = (container: EventContractContainer) => {
-      container.addEventListener(eventType, getHandler);
+      container.addEventListener(eventType, getHandler, passive);
     };
     for (let i = 0; i < this.containers.length; i++) {
       eventHandlerInstaller(this.containers[i]);

--- a/packages/core/primitives/event-dispatch/src/event_handler.ts
+++ b/packages/core/primitives/event-dispatch/src/event_handler.ts
@@ -17,4 +17,6 @@ export interface EventHandlerInfo {
   handler: (event: Event) => void;
 
   capture: boolean;
+
+  passive?: boolean;
 }

--- a/packages/core/primitives/event-dispatch/src/eventcontract.ts
+++ b/packages/core/primitives/event-dispatch/src/eventcontract.ts
@@ -149,8 +149,11 @@ export class EventContract implements UnrenamedEventContract {
    *     to subscribe to jsaction="transitionEnd:foo" while the underlying
    *     event is webkitTransitionEnd in one browser and mozTransitionEnd
    *     in another.
+   *
+   * @param passive A boolean value that, if `true`, indicates that the event
+   *     handler will never call `preventDefault()`.
    */
-  addEvent(eventType: string, prefixedEventType?: string) {
+  addEvent(eventType: string, prefixedEventType?: string, passive?: boolean) {
     if (eventType in this.eventHandlers || !this.containerManager) {
       return;
     }
@@ -174,11 +177,15 @@ export class EventContract implements UnrenamedEventContract {
       this.browserEventTypeToExtraEventTypes[browserEventType] = eventTypes;
     }
 
-    this.containerManager.addEventListener(browserEventType, (element: Element) => {
-      return (event: Event) => {
-        eventHandler(eventType, event, element);
-      };
-    });
+    this.containerManager.addEventListener(
+      browserEventType,
+      (element: Element) => {
+        return (event: Event) => {
+          eventHandler(eventType, event, element);
+        };
+      },
+      passive,
+    );
   }
 
   /**

--- a/packages/core/primitives/event-dispatch/test/event_test.ts
+++ b/packages/core/primitives/event-dispatch/test/event_test.ts
@@ -70,40 +70,128 @@ describe('event test.ts', () => {
     divInternal = document.createElement('div');
   });
 
-  it('add event listener w3 c', () => {
-    const eventInfo = jsactionEvent.addEventListener(divInternal, 'click', () => {});
+  it('add event listener click w3 c', () => {
+    const addEventListenerSpy = spyOn(divInternal, 'addEventListener').and.callThrough();
+    const handler = () => {};
+    const eventInfo = jsactionEvent.addEventListener(divInternal, 'click', handler);
+    expect(addEventListenerSpy).toHaveBeenCalledOnceWith('click', handler, false);
     expect(eventInfo.eventType).toBe('click');
     expect(eventInfo.capture).toBe(false);
+    expect(eventInfo.passive).toBeUndefined();
   });
 
   it('add event listener focus w3 c', () => {
-    const eventInfo = jsactionEvent.addEventListener(divInternal, 'focus', () => {});
+    const addEventListenerSpy = spyOn(divInternal, 'addEventListener').and.callThrough();
+    const handler = () => {};
+    const eventInfo = jsactionEvent.addEventListener(divInternal, 'focus', handler);
+    expect(addEventListenerSpy).toHaveBeenCalledOnceWith('focus', handler, true);
     expect(eventInfo.eventType).toBe('focus');
     expect(eventInfo.capture).toBe(true);
+    expect(eventInfo.passive).toBeUndefined();
   });
 
   it('add event listener blur w3 c', () => {
-    const eventInfo = jsactionEvent.addEventListener(divInternal, 'blur', () => {});
+    const addEventListenerSpy = spyOn(divInternal, 'addEventListener').and.callThrough();
+    const handler = () => {};
+    const eventInfo = jsactionEvent.addEventListener(divInternal, 'blur', handler);
+    expect(addEventListenerSpy).toHaveBeenCalledOnceWith('blur', handler, true);
     expect(eventInfo.eventType).toBe('blur');
     expect(eventInfo.capture).toBe(true);
+    expect(eventInfo.passive).toBeUndefined();
   });
 
   it('add event listener error w3 c', () => {
-    const eventInfo = jsactionEvent.addEventListener(divInternal, 'error', () => {});
+    const addEventListenerSpy = spyOn(divInternal, 'addEventListener').and.callThrough();
+    const handler = () => {};
+    const eventInfo = jsactionEvent.addEventListener(divInternal, 'error', handler);
+    expect(addEventListenerSpy).toHaveBeenCalledOnceWith('error', handler, true);
     expect(eventInfo.eventType).toBe('error');
     expect(eventInfo.capture).toBe(true);
+    expect(eventInfo.passive).toBeUndefined();
   });
 
   it('add event listener load w3 c', () => {
-    const eventInfo = jsactionEvent.addEventListener(divInternal, 'load', () => {});
+    const addEventListenerSpy = spyOn(divInternal, 'addEventListener').and.callThrough();
+    const handler = () => {};
+    const eventInfo = jsactionEvent.addEventListener(divInternal, 'load', handler);
+    expect(addEventListenerSpy).toHaveBeenCalledOnceWith('load', handler, true);
     expect(eventInfo.eventType).toBe('load');
     expect(eventInfo.capture).toBe(true);
+    expect(eventInfo.passive).toBeUndefined();
   });
 
   it('add event listener toggle w3 c', () => {
-    const eventInfo = jsactionEvent.addEventListener(divInternal, 'toggle', () => {});
+    const addEventListenerSpy = spyOn(divInternal, 'addEventListener').and.callThrough();
+    const handler = () => {};
+    const eventInfo = jsactionEvent.addEventListener(divInternal, 'toggle', handler);
+    expect(addEventListenerSpy).toHaveBeenCalledOnceWith('toggle', handler, true);
     expect(eventInfo.eventType).toBe('toggle');
     expect(eventInfo.capture).toBe(true);
+    expect(eventInfo.passive).toBeUndefined();
+  });
+
+  it('add event listener touchstart w3 c', () => {
+    const addEventListenerSpy = spyOn(divInternal, 'addEventListener').and.callThrough();
+    const handler = () => {};
+    const eventInfo = jsactionEvent.addEventListener(divInternal, 'touchstart', handler);
+    expect(addEventListenerSpy).toHaveBeenCalledOnceWith('touchstart', handler, false);
+    expect(eventInfo.eventType).toBe('touchstart');
+    expect(eventInfo.capture).toBe(false);
+    expect(eventInfo.passive).toBeUndefined();
+  });
+
+  it('add event listener touchstart w3 c with passive:false', () => {
+    const addEventListenerSpy = spyOn(divInternal, 'addEventListener').and.callThrough();
+    const handler = () => {};
+    const eventInfo = jsactionEvent.addEventListener(divInternal, 'touchstart', handler, false);
+    expect(addEventListenerSpy).toHaveBeenCalledOnceWith('touchstart', handler, {
+      capture: false,
+      passive: false,
+    });
+    expect(eventInfo.eventType).toBe('touchstart');
+    expect(eventInfo.capture).toBe(false);
+    expect(eventInfo.passive).toBe(false);
+  });
+
+  it('add event listener touchstart w3 c with passive:true', () => {
+    const addEventListenerSpy = spyOn(divInternal, 'addEventListener').and.callThrough();
+    const handler = () => {};
+    const eventInfo = jsactionEvent.addEventListener(divInternal, 'touchstart', handler, true);
+    expect(addEventListenerSpy).toHaveBeenCalledOnceWith('touchstart', handler, {
+      capture: false,
+      passive: true,
+    });
+    expect(eventInfo.eventType).toBe('touchstart');
+    expect(eventInfo.capture).toBe(false);
+    expect(eventInfo.passive).toBe(true);
+  });
+
+  it('remove event listener touchstart w3 c', () => {
+    const removeEventListenerSpy = spyOn(divInternal, 'removeEventListener').and.callThrough();
+    const handler = () => {};
+    const eventInfo = jsactionEvent.addEventListener(divInternal, 'touchstart', handler);
+    jsactionEvent.removeEventListener(divInternal, eventInfo);
+    expect(removeEventListenerSpy).toHaveBeenCalledOnceWith('touchstart', handler, false);
+  });
+
+  it('remove event listener touchstart w3 c with passive:false', () => {
+    const removeEventListenerSpy = spyOn(divInternal, 'removeEventListener').and.callThrough();
+    const handler = () => {};
+    const eventInfo = jsactionEvent.addEventListener(divInternal, 'touchstart', handler, false);
+    jsactionEvent.removeEventListener(divInternal, eventInfo);
+    expect(removeEventListenerSpy).toHaveBeenCalledOnceWith('touchstart', handler, {
+      capture: false,
+    });
+  });
+
+  it('remove event listener touchstart w3 c with passive:true', () => {
+    const removeEventListenerSpy = spyOn(divInternal, 'removeEventListener').and.callThrough();
+    const handler = () => {};
+    const eventInfo = jsactionEvent.addEventListener(divInternal, 'touchstart', handler, true);
+    jsactionEvent.removeEventListener(divInternal, eventInfo);
+    expect(removeEventListenerSpy).toHaveBeenCalledOnceWith('touchstart', handler, {
+      capture: false,
+    });
   });
 
   it('is modified click event mac meta key', () => {

--- a/packages/core/primitives/event-dispatch/test/eventcontract_test.ts
+++ b/packages/core/primitives/event-dispatch/test/eventcontract_test.ts
@@ -244,6 +244,52 @@ describe('EventContract', () => {
     expect(registeredEventTypes).toEqual(['webkitanimationend']);
   });
 
+  it('adds event listener without passive option', () => {
+    const container = getRequiredElementById('container');
+    const addEventListenerSpy = spyOn(container, 'addEventListener');
+
+    const eventContractContainerManager = new EventContractMultiContainer();
+    const eventContract = createEventContract({eventContractContainerManager, eventTypes: []});
+    eventContract.addEvent('touchstart');
+    eventContractContainerManager.addContainer(container);
+
+    expect(addEventListenerSpy).toHaveBeenCalledOnceWith(
+      'touchstart',
+      jasmine.any(Function),
+      false,
+    );
+  });
+
+  it('adds event listener for passive:false event', () => {
+    const container = getRequiredElementById('container');
+    const addEventListenerSpy = spyOn(container, 'addEventListener');
+
+    const eventContractContainerManager = new EventContractMultiContainer();
+    const eventContract = createEventContract({eventContractContainerManager, eventTypes: []});
+    eventContract.addEvent('touchstart', '', false);
+    eventContractContainerManager.addContainer(container);
+
+    expect(addEventListenerSpy).toHaveBeenCalledOnceWith('touchstart', jasmine.any(Function), {
+      capture: false,
+      passive: false,
+    });
+  });
+
+  it('adds event listener for passive:true event', () => {
+    const container = getRequiredElementById('container');
+    const addEventListenerSpy = spyOn(container, 'addEventListener');
+
+    const eventContractContainerManager = new EventContractMultiContainer();
+    const eventContract = createEventContract({eventContractContainerManager, eventTypes: []});
+    eventContract.addEvent('touchstart', '', true);
+    eventContractContainerManager.addContainer(container);
+
+    expect(addEventListenerSpy).toHaveBeenCalledOnceWith('touchstart', jasmine.any(Function), {
+      capture: false,
+      passive: true,
+    });
+  });
+
   it('queues events until dispatcher is registered', () => {
     const container = getRequiredElementById('click-container');
     const targetElement = getRequiredElementById('click-target-element');

--- a/packages/core/rxjs-interop/src/index.ts
+++ b/packages/core/rxjs-interop/src/index.ts
@@ -15,5 +15,4 @@ export {
   toObservableMicrotask as ɵtoObservableMicrotask,
 } from './to_observable';
 export {toSignal, ToSignalOptions} from './to_signal';
-export {pendingUntilEvent} from './pending_until_event';
 export {RxResourceOptions, rxResource} from './rx_resource';

--- a/packages/core/schematics/migrations/output-migration/output-migration.ts
+++ b/packages/core/schematics/migrations/output-migration/output-migration.ts
@@ -291,7 +291,10 @@ export class OutputMigration extends TsurgeFunnelMigration<
     });
   }
 
-  override async merge(units: CompilationUnitData[]): Promise<Serializable<CompilationUnitData>> {
+  override async combine(
+    unitA: CompilationUnitData,
+    unitB: CompilationUnitData,
+  ): Promise<Serializable<CompilationUnitData>> {
     const outputFields: Record<ClassFieldUniqueKey, OutputMigrationData> = {};
     const importReplacements: Record<
       ProjectFileID,
@@ -299,7 +302,7 @@ export class OutputMigration extends TsurgeFunnelMigration<
     > = {};
     const problematicUsages: Record<ClassFieldUniqueKey, true> = {};
 
-    for (const unit of units) {
+    for (const unit of [unitA, unitB]) {
       for (const declIdStr of Object.keys(unit.outputFields)) {
         const declId = declIdStr as ClassFieldUniqueKey;
         // THINK: detect clash? Should we have an utility to merge data based on unique IDs?
@@ -322,6 +325,13 @@ export class OutputMigration extends TsurgeFunnelMigration<
       importReplacements,
       problematicUsages,
     });
+  }
+
+  override async globalMeta(
+    combinedData: CompilationUnitData,
+  ): Promise<Serializable<CompilationUnitData>> {
+    // Noop here as we don't have any form of special global metadata.
+    return confirmAsSerializable(combinedData);
   }
 
   override async stats(globalMetadata: CompilationUnitData): Promise<MigrationStats> {

--- a/packages/core/schematics/migrations/signal-migration/src/migration.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/migration.ts
@@ -18,7 +18,7 @@ import {MigrationHost} from './migration_host';
 import {executeAnalysisPhase} from './phase_analysis';
 import {pass4__checkInheritanceOfInputs} from './passes/4_check_inheritance';
 import {getCompilationUnitMetadata} from './batch/extract';
-import {mergeCompilationUnitData} from './batch/merge_unit_data';
+import {convertToGlobalMeta, combineCompilationUnitData} from './batch/merge_unit_data';
 import {Replacement} from '../../../utils/tsurge/replacement';
 import {populateKnownInputsFromGlobalData} from './batch/populate_global_data';
 import {executeMigrationPhase} from './phase_migrate';
@@ -28,10 +28,8 @@ import {
   ClassIncompatibilityReason,
   FieldIncompatibilityReason,
 } from './passes/problematic_patterns/incompatibility';
-import {isInputDescriptor} from './utils/input_id';
 import {MigrationConfig} from './migration_config';
 import {ClassFieldUniqueKey} from './passes/reference_resolution/known_fields';
-import {MigrationStats} from '../../../utils/tsurge';
 import {createNgtscProgram} from '../../../utils/tsurge/helpers/ngtsc_program';
 
 /**
@@ -124,8 +122,8 @@ export class SignalInputMigration extends TsurgeComplexMigration<
 
     // Non-batch mode!
     if (this.config.upgradeAnalysisPhaseToAvoidBatch) {
-      const merged = await this.merge([unitData]);
-      const {replacements} = await this.migrate(merged, info, {
+      const globalMeta = await this.globalMeta(unitData);
+      const {replacements} = await this.migrate(globalMeta, info, {
         knownInputs,
         result,
         host,
@@ -143,8 +141,17 @@ export class SignalInputMigration extends TsurgeComplexMigration<
     return confirmAsSerializable(unitData);
   }
 
-  override async merge(units: CompilationUnitData[]): Promise<Serializable<CompilationUnitData>> {
-    return confirmAsSerializable(mergeCompilationUnitData(units));
+  override async combine(
+    unitA: CompilationUnitData,
+    unitB: CompilationUnitData,
+  ): Promise<Serializable<CompilationUnitData>> {
+    return confirmAsSerializable(combineCompilationUnitData(unitA, unitB));
+  }
+
+  override async globalMeta(
+    combinedData: CompilationUnitData,
+  ): Promise<Serializable<CompilationUnitData>> {
+    return confirmAsSerializable(convertToGlobalMeta(combinedData));
   }
 
   override async migrate(

--- a/packages/core/schematics/migrations/signal-migration/test/BUILD.bazel
+++ b/packages/core/schematics/migrations/signal-migration/test/BUILD.bazel
@@ -103,7 +103,8 @@ integration_test(
     ],
     commands = [
         "$(rootpath :batch_runner) analyze ./golden-test",
-        "$(rootpath :batch_runner) merge ./golden-test",
+        "$(rootpath :batch_runner) combine-all ./golden-test",
+        "$(rootpath :batch_runner) global-meta ./golden-test",
         "$(rootpath :batch_runner) migrate ./golden-test",
         "$(rootpath :golden_test_runner) ./golden-test ./golden.txt",
     ],

--- a/packages/core/schematics/migrations/signal-migration/test/batch_runner.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/batch_runner.ts
@@ -53,18 +53,24 @@ async function main() {
       // write individual result.
       await fs.promises.writeFile(extractResultFile, extractResult);
     });
-  } else if (mode === 'merge') {
+  } else if (mode === 'combine-all') {
     const metadataFiles = files.map((f) => path.resolve(path.join(sourceDir, `${f}.extract.json`)));
-    const mergeResult = await promiseExec(`migration merge ${metadataFiles.join(' ')}`);
+    const mergeResult = await promiseExec(`migration combine-all ${metadataFiles.join(' ')}`);
 
     // write merge result.
-    await fs.promises.writeFile(path.join(sourceDir, 'merged.json'), mergeResult);
+    await fs.promises.writeFile(path.join(sourceDir, 'combined.json'), mergeResult);
+  } else if (mode === 'global-meta') {
+    const combinedUnitFile = path.join(sourceDir, 'combined.json');
+    const globalMeta = await promiseExec(`migration global-meta ${combinedUnitFile}`);
+
+    // write global meta result.
+    await fs.promises.writeFile(path.join(sourceDir, 'global_meta.json'), globalMeta);
   } else if (mode === 'migrate') {
     schedule(files, maxParallel, async (fileName) => {
       const filePath = path.join(sourceDir, fileName);
       // tsconfig should exist from analyze phase.
       const tmpTsconfigName = path.join(sourceDir, `${fileName}.tsconfig.json`);
-      const mergeMetadataFile = path.join(sourceDir, 'merged.json');
+      const mergeMetadataFile = path.join(sourceDir, 'global_meta.json');
 
       // migrate in parallel.
       await promiseExec(

--- a/packages/core/schematics/ng-generate/signal-input-migration/index.ts
+++ b/packages/core/schematics/ng-generate/signal-input-migration/index.ts
@@ -15,6 +15,7 @@ import {groupReplacementsByFile} from '../../utils/tsurge/helpers/group_replacem
 import {setFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {CompilationUnitData} from '../../migrations/signal-migration/src/batch/unit_data';
 import {ProjectRootRelativePath, TextUpdate} from '../../utils/tsurge';
+import {synchronouslyCombineUnitData} from '../../utils/tsurge/helpers/combine_units';
 
 interface Options {
   path: string;
@@ -77,13 +78,19 @@ export function migrate(options: Options): Rule {
     context.logger.info(`Processing analysis data between targets..`);
     context.logger.info(``);
 
-    const merged = await migration.merge(unitResults);
+    const combined = await synchronouslyCombineUnitData(migration, unitResults);
+    if (combined === null) {
+      context.logger.error('Migration failed unexpectedly with no analysis data');
+      return;
+    }
+
+    const globalMeta = await migration.globalMeta(combined);
     const replacementsPerFile: Map<ProjectRootRelativePath, TextUpdate[]> = new Map();
 
     for (const {info, tsconfigPath} of programInfos) {
       context.logger.info(`Migrating: ${tsconfigPath}..`);
 
-      const {replacements} = await migration.migrate(merged, info);
+      const {replacements} = await migration.migrate(globalMeta, info);
       const changesPerFile = groupReplacementsByFile(replacements);
 
       for (const [file, changes] of changesPerFile) {
@@ -104,7 +111,7 @@ export function migrate(options: Options): Rule {
       tree.commitUpdate(recorder);
     }
 
-    const {counters} = await migration.stats(merged);
+    const {counters} = await migration.stats(globalMeta);
     const migratedInputs = counters.sourceInputs - counters.incompatibleInputs;
 
     context.logger.info('');

--- a/packages/core/schematics/ng-generate/signal-queries-migration/index.ts
+++ b/packages/core/schematics/ng-generate/signal-queries-migration/index.ts
@@ -17,6 +17,7 @@ import {
   CompilationUnitData,
   SignalQueriesMigration,
 } from '../../migrations/signal-queries-migration/migration';
+import {synchronouslyCombineUnitData} from '../../utils/tsurge/helpers/combine_units';
 
 interface Options {
   path: string;
@@ -79,13 +80,19 @@ export function migrate(options: Options): Rule {
     context.logger.info(`Processing analysis data between targets..`);
     context.logger.info(``);
 
-    const merged = await migration.merge(unitResults);
+    const combined = await synchronouslyCombineUnitData(migration, unitResults);
+    if (combined === null) {
+      context.logger.error('Migration failed unexpectedly with no analysis data');
+      return;
+    }
+
+    const globalMeta = await migration.globalMeta(combined);
     const replacementsPerFile: Map<ProjectRootRelativePath, TextUpdate[]> = new Map();
 
     for (const {info, tsconfigPath} of programInfos) {
       context.logger.info(`Migrating: ${tsconfigPath}..`);
 
-      const {replacements} = await migration.migrate(merged, info);
+      const {replacements} = await migration.migrate(globalMeta, info);
       const changesPerFile = groupReplacementsByFile(replacements);
 
       for (const [file, changes] of changesPerFile) {
@@ -111,7 +118,7 @@ export function migrate(options: Options): Rule {
 
     const {
       counters: {queriesCount, incompatibleQueries, multiQueries},
-    } = await migration.stats(merged);
+    } = await migration.stats(globalMeta);
     const migratedQueries = queriesCount - incompatibleQueries;
 
     context.logger.info('');

--- a/packages/core/schematics/utils/tsurge/base_migration.ts
+++ b/packages/core/schematics/utils/tsurge/base_migration.ts
@@ -73,8 +73,22 @@ export abstract class TsurgeBaseMigration<UnitAnalysisMetadata, CombinedGlobalMe
   /** Analyzes the given TypeScript project and returns serializable compilation unit data. */
   abstract analyze(info: ProgramInfo): Promise<Serializable<UnitAnalysisMetadata>>;
 
-  /** Merges all compilation unit data from previous analysis phases into a global result. */
-  abstract merge(units: UnitAnalysisMetadata[]): Promise<Serializable<CombinedGlobalMetadata>>;
+  /**
+   * Combines two unit analyses into a single analysis metadata.
+   * This is necessary to allow for parallel merging of metadata.
+   */
+  abstract combine(
+    unitA: UnitAnalysisMetadata,
+    unitB: UnitAnalysisMetadata,
+  ): Promise<Serializable<UnitAnalysisMetadata>>;
+
+  /**
+   * Converts combined compilation into global metadata result that
+   * is then available for migrate and stats stages.
+   */
+  abstract globalMeta(
+    combinedData: UnitAnalysisMetadata,
+  ): Promise<Serializable<CombinedGlobalMetadata>>;
 
   /** Extract statistics based on the global metadata. */
   abstract stats(globalMetadata: CombinedGlobalMetadata): Promise<MigrationStats>;

--- a/packages/core/schematics/utils/tsurge/executors/combine_exec.ts
+++ b/packages/core/schematics/utils/tsurge/executors/combine_exec.ts
@@ -10,14 +10,15 @@ import {Serializable} from '../helpers/serializable';
 import {TsurgeMigration} from '../migration';
 
 /**
- * Executes the merge phase for the given migration against
- * the given set of analysis unit data.
+ * Executes the combine phase for the given migration against
+ * two unit analyses.
  *
- * @returns the serializable migration global data.
+ * @returns the serializable combined unit data.
  */
-export async function executeMergePhase<UnitData, GlobalData>(
+export async function executeCombinePhase<UnitData, GlobalData>(
   migration: TsurgeMigration<UnitData, GlobalData>,
-  units: UnitData[],
-): Promise<Serializable<GlobalData>> {
-  return await migration.merge(units);
+  unitA: UnitData,
+  unitB: UnitData,
+): Promise<Serializable<UnitData>> {
+  return await migration.combine(unitA, unitB);
 }

--- a/packages/core/schematics/utils/tsurge/executors/global_meta_exec.ts
+++ b/packages/core/schematics/utils/tsurge/executors/global_meta_exec.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Serializable} from '../helpers/serializable';
+import {TsurgeMigration} from '../migration';
+
+/**
+ * Executes the `globalMeta` stage for the given migration
+ * to convert the combined unit data into global meta.
+ *
+ * @returns the serializable global meta.
+ */
+export async function executeGlobalMetaPhase<UnitData, GlobalData>(
+  migration: TsurgeMigration<UnitData, GlobalData>,
+  combinedUnitData: UnitData,
+): Promise<Serializable<GlobalData>> {
+  return await migration.globalMeta(combinedUnitData);
+}

--- a/packages/core/schematics/utils/tsurge/helpers/combine_units.ts
+++ b/packages/core/schematics/utils/tsurge/helpers/combine_units.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {TsurgeMigration} from '../migration';
+
+/**
+ * Synchronously combines unit data for the given migration.
+ *
+ * Note: This helper is useful for testing and execution of
+ * Tsurge migrations in non-batchable environments. In general,
+ * prefer parallel execution of combining via e.g. Beam combiners.
+ */
+export async function synchronouslyCombineUnitData<UnitData>(
+  migration: TsurgeMigration<UnitData, unknown>,
+  unitDatas: UnitData[],
+): Promise<UnitData | null> {
+  if (unitDatas.length === 0) {
+    return null;
+  }
+  if (unitDatas.length === 1) {
+    return unitDatas[0];
+  }
+
+  let combined = unitDatas[0];
+
+  for (let i = 1; i < unitDatas.length; i++) {
+    const other = unitDatas[i];
+    combined = await migration.combine(combined, other);
+  }
+
+  return combined;
+}

--- a/packages/core/schematics/utils/tsurge/testing/run_single.ts
+++ b/packages/core/schematics/utils/tsurge/testing/run_single.ts
@@ -62,11 +62,11 @@ export async function runTsurgeMigration<UnitData, GlobalData>(
   const info = migration.prepareProgram(baseInfo);
 
   const unitData = await migration.analyze(info);
-  const merged = await migration.merge([unitData]);
+  const globalMeta = await migration.globalMeta(unitData);
   const {replacements} =
     migration instanceof TsurgeFunnelMigration
-      ? await migration.migrate(merged)
-      : await migration.migrate(merged, info);
+      ? await migration.migrate(globalMeta)
+      : await migration.migrate(globalMeta, info);
 
   const updates = groupReplacementsByFile(replacements);
   for (const [rootRelativePath, changes] of updates.entries()) {
@@ -76,6 +76,6 @@ export async function runTsurgeMigration<UnitData, GlobalData>(
 
   return {
     fs: mockFs,
-    getStatistics: () => migration.stats(merged),
+    getStatistics: () => migration.stats(globalMeta),
   };
 }

--- a/packages/forms/src/form_builder.ts
+++ b/packages/forms/src/form_builder.ts
@@ -75,24 +75,28 @@ export type ɵElement<T, N extends null> =
   // through the distributive conditional type. This is the officially recommended solution:
   // https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types
   //
+  // Note: Because `FormRecord` implementation extends `FormGroup`, it must be checked BEFORE `FormGroup`
+  // in the following clauses (otherwise it may incorrectly be inferred to `FormGroup`).
+  //
+  //
   // Identify FormControl container types.
   [T] extends [FormControl<infer U>]
     ? FormControl<U>
     : // Or FormControl containers that are optional in their parent group.
       [T] extends [FormControl<infer U> | undefined]
       ? FormControl<U>
-      : // FormGroup containers.
-        [T] extends [FormGroup<infer U>]
-        ? FormGroup<U>
-        : // Optional FormGroup containers.
-          [T] extends [FormGroup<infer U> | undefined]
-          ? FormGroup<U>
-          : // FormRecord containers.
-            [T] extends [FormRecord<infer U>]
-            ? FormRecord<U>
-            : // Optional FormRecord containers.
-              [T] extends [FormRecord<infer U> | undefined]
-              ? FormRecord<U>
+      : // FormRecord containers.
+        [T] extends [FormRecord<infer U>]
+        ? FormRecord<U>
+        : // Optional FormRecord containers.
+          [T] extends [FormRecord<infer U> | undefined]
+          ? FormRecord<U>
+          : // FormGroup containers.
+            [T] extends [FormGroup<infer U>]
+            ? FormGroup<U>
+            : // Optional FormGroup containers.
+              [T] extends [FormGroup<infer U> | undefined]
+              ? FormGroup<U>
               : // FormArray containers.
                 [T] extends [FormArray<infer U>]
                 ? FormArray<U>

--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -724,7 +724,25 @@ export const isFormGroup = (control: unknown): control is FormGroup => control i
  */
 export class FormRecord<TControl extends AbstractControl = AbstractControl> extends FormGroup<{
   [key: string]: TControl;
-}> {}
+}> {
+  /**
+   * Clear all controls from this record.
+   *
+   * This method also updates the value and validity of the control.
+   *
+   * @param options Specifies whether this FormGroup instance should emit events after a
+   *     control is removed.
+   * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
+   * `valueChanges` observables emit events with the latest status and value when the controls are
+   * removed. When false, no events are emitted.
+   */
+  clear(options: {emitEvent?: boolean} = {}): void {
+    this._forEachChild((child) => child._registerOnCollectionChange(() => {}));
+    this.controls = {};
+    this.updateValueAndValidity({emitEvent: options.emitEvent});
+    this._onCollectionChange();
+  }
+}
 
 export interface FormRecord<TControl> {
   /**
@@ -747,6 +765,19 @@ export interface FormRecord<TControl> {
    * See `FormGroup#removeControl` for additional information.
    */
   removeControl(name: string, options?: {emitEvent?: boolean}): void;
+
+  /**
+   * Clear all controls from this record.
+   *
+   * This method also updates the value and validity of the control.
+   *
+   * @param options Specifies whether this FormGroup instance should emit events after a
+   *     control is removed.
+   * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
+   * `valueChanges` observables emit events with the latest status and value when the controls are
+   * removed. When false, no events are emitted.
+   */
+  clear(options?: {emitEvent?: boolean}): void;
 
   /**
    * Replace an existing control.

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -13,6 +13,7 @@ import {
   FormArray,
   FormControl,
   FormGroup,
+  FormRecord,
   ValidationErrors,
   Validators,
   ValueChangeEvent,
@@ -2585,6 +2586,47 @@ import {StatusChangeEvent} from '../src/model/abstract_model';
         'baz.not.ok': new FormControl('baz'),
       });
       expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    describe('clear()', () => {
+      let c1: FormControl;
+      let c2: FormControl;
+      let r: FormRecord;
+
+      beforeEach(() => {
+        c1 = new FormControl('one');
+        c2 = new FormControl('two');
+        r = new FormRecord({one: c1, two: c2});
+      });
+
+      it('should remove all controls', () => {
+        r.clear();
+        expect(r.controls['one']).not.toBeDefined();
+        expect(r.controls['two']).not.toBeDefined();
+        expect(r.value).toEqual({});
+      });
+
+      it('should only emit value change event once', () => {
+        const logger: string[] = [];
+        r.valueChanges.subscribe(() => logger.push('change!'));
+        r.clear();
+        expect(logger).toEqual(['change!']);
+      });
+
+      it('should only emit status change event once', () => {
+        const logger: string[] = [];
+        r.statusChanges.subscribe(() => logger.push('change!'));
+        r.clear();
+        expect(logger).toEqual(['change!']);
+      });
+
+      it('should not emit event when called with `emitEvent: false`', () => {
+        const logger: string[] = [];
+        r.valueChanges.subscribe(() => logger.push('value change'));
+        r.statusChanges.subscribe(() => logger.push('status change'));
+        r.clear({emitEvent: false});
+        expect(logger).toEqual([]);
+      });
     });
   });
 })();

--- a/packages/language-service/src/refactorings/convert_to_signal_queries/apply_query_refactoring.ts
+++ b/packages/language-service/src/refactorings/convert_to_signal_queries/apply_query_refactoring.ts
@@ -55,8 +55,8 @@ export async function applySignalQueriesRefactoring(
   });
 
   const unitData = await migration.analyze(programInfo);
-  const merged = await migration.merge([unitData]);
-  const {replacements, knownQueries} = await migration.migrate(merged, programInfo);
+  const globalMeta = await migration.globalMeta(unitData);
+  const {replacements, knownQueries} = await migration.migrate(globalMeta, programInfo);
 
   const targetQueries = Array.from(knownQueries.knownQueryIDs.values()).filter((descriptor) =>
     shouldMigrateQuery(descriptor, projectFile(descriptor.node.getSourceFile(), programInfo)),


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
This PR makes event library's `addEventListener()` calls `EventTarget.addEventListener()` with `options` instead of `useCapture`. This allows us to pass or override `passive` option for improving scroll performance in future PRs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 - Passing `options` to `EventTarget.addEventListener` is not supported in IE11
 - `removeEventListener()` doesn't recognize `passive` option