### PR TITLE
refactor(router): publishing getLoadedRoutes using the global utils function

### DIFF
--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -145,3 +145,4 @@ export {
 export {VERSION} from './version';
 
 export * from './private_export';
+import './router_devtools';

--- a/packages/router/src/router_devtools.ts
+++ b/packages/router/src/router_devtools.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ɵpublishExternalGlobalUtil} from '@angular/core';
+import {Route} from './models';
+
+function getLoadedRoutes(route: Route): Route[] | undefined {
+  return route._loadedRoutes;
+}
+
+ɵpublishExternalGlobalUtil('ɵgetLoadedRoutes', getLoadedRoutes);

--- a/packages/router/src/router_devtools.ts
+++ b/packages/router/src/router_devtools.ts
@@ -9,7 +9,7 @@
 import {ɵpublishExternalGlobalUtil} from '@angular/core';
 import {Route} from './models';
 
-function getLoadedRoutes(route: Route): Route[] | undefined {
+export function getLoadedRoutes(route: Route): Route[] | undefined {
   return route._loadedRoutes;
 }
 

--- a/packages/router/test/router_devtools.spec.ts
+++ b/packages/router/test/router_devtools.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component} from '@angular/core';
+import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {Router, RouterModule} from '@angular/router';
+import {getLoadedRoutes} from '../src/router_devtools';
+
+@Component({template: '<div>simple standalone</div>', standalone: true})
+export class SimpleStandaloneComponent {}
+
+@Component({
+  template: '<router-outlet></router-outlet>',
+  standalone: true,
+  imports: [RouterModule],
+})
+export class RootCmp {}
+
+describe('router_devtools', () => {
+  describe('getLoadedRoutes', () => {
+    it('should return loaded routes when called with load children', fakeAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          RouterModule.forRoot([
+            {
+              path: 'lazy',
+              component: RootCmp,
+              loadChildren: () => [{path: 'simple', component: SimpleStandaloneComponent}],
+            },
+          ]),
+        ],
+      });
+
+      const root = TestBed.createComponent(RootCmp);
+
+      const router = TestBed.inject(Router);
+      router.navigateByUrl('/lazy/simple');
+      advance(root);
+      expect(root.nativeElement.innerHTML).toContain('simple standalone');
+
+      const loadedRoutes = getLoadedRoutes(router.config[0]);
+      const loadedPath = loadedRoutes && loadedRoutes[0].path;
+      expect(loadedPath).toEqual('simple');
+    }));
+  });
+
+  it('should return undefined when called without load children', fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        RouterModule.forRoot([
+          {
+            path: 'lazy',
+            component: RootCmp,
+          },
+        ]),
+      ],
+    });
+
+    const root = TestBed.createComponent(RootCmp);
+
+    const router = TestBed.inject(Router);
+    router.navigateByUrl('/lazy');
+    advance(root);
+    expect(root.nativeElement.innerHTML).toContain('');
+
+    const loadedRoutes = getLoadedRoutes(router.config[0]);
+    const loadedPath = loadedRoutes && loadedRoutes[0].path;
+    expect(loadedPath).toEqual(undefined);
+  }));
+});
+
+function advance(fixture: ComponentFixture<unknown>) {
+  tick();
+  fixture.detectChanges();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -408,9 +408,9 @@
     tslib "^2.3.0"
 
 "@angular/core@^19.0.0-next":
-  version "19.0.0-next.5"
-  resolved "https://registry.yarnpkg.com/@angular/core/-/core-19.0.0-next.5.tgz#f15698a1070c34f8050030d9c37ebe7a6f78070b"
-  integrity sha512-QF7sSS7PsTXUEVZEhVO8f49rp43bpS52HQopylv075Sbj43UihDQ1C3vwfg3d97mpcgw6kNXB0s0iovBs0Z6ew==
+  version "19.0.0-next.10"
+  resolved "https://registry.yarnpkg.com/@angular/core/-/core-19.0.0-next.10.tgz#e61e28d12741bd81fb75ccd1efd1b3840f38b341"
+  integrity sha512-//emUO2j82yEXszfn4ml6w8zaDQkd5vHbejmyPAiL5maTDkRNlsUP4Q5DEloxLBzMksnhJkBLz1Q1f4pxXWnIA==
   dependencies:
     tslib "^2.3.0"
 


### PR DESCRIPTION
Angular DevTools uses globally available functions to provide debugging information to the framework. This commit exports `getLoadedRoutes` function using the `ɵpublishExternalGlobalUtil` function added in PR: https://github.com/angular/angular/commit/f5cd8f7ab498f35dc2ec3c6662d4443135989720.

Follow-up PRs that will:
- Add a new router example in the Angular DevTools demo application.
- Implement the router graph in the Angular DevTools to view the routes that are loaded in the application

