### PR TITLE
feat(core): Promote `takeUntilDestroyed` to stable.

### DIFF
--- a/packages/core/rxjs-interop/src/take_until_destroyed.ts
+++ b/packages/core/rxjs-interop/src/take_until_destroyed.ts
@@ -18,7 +18,7 @@ import {takeUntil} from 'rxjs/operators';
  *     passed explicitly to use `takeUntilDestroyed` outside of an [injection
  * context](guide/di/dependency-injection-context). Otherwise, the current `DestroyRef` is injected.
  *
- * @developerPreview
+ * @publicApi
  */
 export function takeUntilDestroyed<T>(destroyRef?: DestroyRef): MonoTypeOperatorFunction<T> {
   if (!destroyRef) {


### PR DESCRIPTION
`takeUntilDestroyed` is now part of the public API.
