### PR TITLE
ci: run the proper command for post update tasks in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
   "lockFileMaintenance": {"enabled": true},
   "labels": ["target: patch", "area: build & ci", "action: merge"],
   "postUpgradeTasks": {
-    "commands": ["yarn install", "yarn update-generated-files"],
+    "commands": ["yarn install", "yarn ng-dev misc update-generated-files"],
     "executionMode": "update"
   },
   "ignoreDeps": [


### PR DESCRIPTION
Properly run the ng-dev command instead of calling for a yarn script
