### PR TITLE
feat(core): promote `outputFromObservable` & `outputToObservable` to stable

### DIFF
--- a/packages/core/rxjs-interop/src/output_from_observable.ts
+++ b/packages/core/rxjs-interop/src/output_from_observable.ts
@@ -80,7 +80,7 @@ class OutputFromObservableRef<T> implements OutputRef<T> {
  * }
  * ```
  *
- * @developerPreview
+ * @publicApi
  */
 export function outputFromObservable<T>(
   observable: Observable<T>,

--- a/packages/core/rxjs-interop/src/output_to_observable.ts
+++ b/packages/core/rxjs-interop/src/output_to_observable.ts
@@ -15,7 +15,7 @@ import {Observable} from 'rxjs';
  *
  * You can subscribe to the output via `Observable.subscribe` then.
  *
- * @developerPreview
+ * @publicApi
  */
 export function outputToObservable<T>(ref: OutputRef<T>): Observable<T> {
   const destroyRef = ɵgetOutputDestroyRef(ref);


### PR DESCRIPTION
Alongside the promotion of `output()` to stable, we promote those 2 related interops.
