### PR TITLE
Revert "feat(compiler): add support for the `typeof` keyword in template expressions. (#58183)"

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -25,7 +25,6 @@ import {
   LiteralPrimitive,
   NonNullAssert,
   PrefixNot,
-  TypeofExpression,
   PropertyRead,
   PropertyWrite,
   SafeCall,
@@ -272,13 +271,6 @@ class AstTranslator implements AstVisitor {
   visitPrefixNot(ast: PrefixNot): ts.Expression {
     const expression = wrapForDiagnostics(this.translate(ast.expression));
     const node = ts.factory.createLogicalNot(expression);
-    addParseSpanInfo(node, ast.sourceSpan);
-    return node;
-  }
-
-  visitTypeofExpresion(ast: TypeofExpression): ts.Expression {
-    const expression = wrapForDiagnostics(this.translate(ast.expression));
-    const node = ts.factory.createTypeOfExpression(expression);
     addParseSpanInfo(node, ast.sourceSpan);
     return node;
   }
@@ -547,9 +539,6 @@ class VeSafeLhsInferenceBugDetector implements AstVisitor {
     return true;
   }
   visitPrefixNot(ast: PrefixNot): boolean {
-    return ast.expression.visit(this);
-  }
-  visitTypeofExpresion(ast: PrefixNot): boolean {
     return ast.expression.visit(this);
   }
   visitNonNullAssert(ast: PrefixNot): boolean {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -61,14 +61,6 @@ describe('type check blocks', () => {
     );
   });
 
-  it('should handle typeof expressions', () => {
-    expect(tcb('{{typeof a}}')).toContain('typeof (((this).a))');
-    expect(tcb('{{!(typeof a)}}')).toContain('!(typeof (((this).a)))');
-    expect(tcb('{{!(typeof a === "object")}}')).toContain(
-      '!((typeof (((this).a))) === ("object"))',
-    );
-  });
-
   it('should handle attribute values for directive inputs', () => {
     const TEMPLATE = `<div dir inputA="value"></div>`;
     const DIRECTIVES: TestDeclaration[] = [

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/GOLDEN_PARTIAL.js
@@ -70,23 +70,16 @@ export declare class TodoModule {
 /****************************************************************************************************
  * PARTIAL FILE: operators.js
  ****************************************************************************************************/
-import { Component, NgModule, Pipe } from '@angular/core';
+import { Component, NgModule } from '@angular/core';
 import * as i0 from "@angular/core";
 export class MyApp {
-    constructor() {
-        this.foo = { bar: 'baz' };
-    }
 }
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: false, selector: "ng-component", ngImport: i0, template: `
     {{ 1 + 2 }}
 	{{ (1 % 2) + 3 / 4 * 5 }}
 	{{ +1 }}
-  {{ typeof {} === 'object' }}
-  {{ !(typeof {} === 'object') }}
-  {{ typeof foo?.bar === 'string' }}
-  {{ typeof foo?.bar | identity }}
-`, isInline: true, dependencies: [{ kind: "pipe", type: i0.forwardRef(() => IdentityPipe), name: "identity" }] });
+`, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
             type: Component,
             args: [{
@@ -94,31 +87,18 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
     {{ 1 + 2 }}
 	{{ (1 % 2) + 3 / 4 * 5 }}
 	{{ +1 }}
-  {{ typeof {} === 'object' }}
-  {{ !(typeof {} === 'object') }}
-  {{ typeof foo?.bar === 'string' }}
-  {{ typeof foo?.bar | identity }}
 `,
                     standalone: false
                 }]
         }] });
-export class IdentityPipe {
-    transform(value) { return value; }
-}
-IdentityPipe.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: IdentityPipe, deps: [], target: i0.ɵɵFactoryTarget.Pipe });
-IdentityPipe.ɵpipe = i0.ɵɵngDeclarePipe({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: IdentityPipe, name: "identity" });
-i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: IdentityPipe, decorators: [{
-            type: Pipe,
-            args: [{ name: 'identity' }]
-        }] });
 export class MyModule {
 }
 MyModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
-MyModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, declarations: [MyApp, IdentityPipe] });
+MyModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, declarations: [MyApp] });
 MyModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, decorators: [{
             type: NgModule,
-            args: [{ declarations: [MyApp, IdentityPipe] }]
+            args: [{ declarations: [MyApp] }]
         }] });
 
 /****************************************************************************************************
@@ -126,20 +106,12 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
  ****************************************************************************************************/
 import * as i0 from "@angular/core";
 export declare class MyApp {
-    foo: {
-        bar?: string;
-    };
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
 }
-export declare class IdentityPipe {
-    transform(value: any): any;
-    static ɵfac: i0.ɵɵFactoryDeclaration<IdentityPipe, never>;
-    static ɵpipe: i0.ɵɵPipeDeclaration<IdentityPipe, "identity", false>;
-}
 export declare class MyModule {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyModule, never>;
-    static ɵmod: i0.ɵɵNgModuleDeclaration<MyModule, [typeof MyApp, typeof IdentityPipe], never, never>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MyModule, [typeof MyApp], never, never>;
     static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
 }
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/operators.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/operators.ts
@@ -1,26 +1,16 @@
-import {Component, NgModule, Pipe} from '@angular/core';
+import {Component, NgModule} from '@angular/core';
 
 @Component({
     template: `
     {{ 1 + 2 }}
 	{{ (1 % 2) + 3 / 4 * 5 }}
 	{{ +1 }}
-  {{ typeof {} === 'object' }}
-  {{ !(typeof {} === 'object') }}
-  {{ typeof foo?.bar === 'string' }}
-  {{ typeof foo?.bar | identity }}
 `,
     standalone: false
 })
 export class MyApp {
-    foo: {bar?: string} = {bar: 'baz'};
 }
 
-@Pipe ({name: 'identity'})
-export class IdentityPipe {
-    transform(value: any) { return value; }
-}
-
-@NgModule({declarations: [MyApp, IdentityPipe]})
+@NgModule({declarations: [MyApp]})
 export class MyModule {
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/operators_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/operators_template.js
@@ -1,17 +1,8 @@
 template: function MyApp_Template(rf, $ctx$) {
 	if (rf & 1) {
 	  $i0$.ɵɵtext(0);
-	  i0.ɵɵpipe(1, "identity");
 	} if (rf & 2) {
-	  i0.ɵɵtextInterpolate7(" ", 
-		1 + 2, " ", 
-		1 % 2 + 3 / 4 * 5, " ", 
-		+1, " ", 
-		typeof i0.ɵɵpureFunction0(9, _c0) === "object", " ", 
-		!(typeof i0.ɵɵpureFunction0(10, _c0) === "object"), " ", 
-		typeof (ctx.foo == null ? null : ctx.foo.bar) === "string", " ", 
-		i0.ɵɵpipeBind1(1, 7, typeof (ctx.foo == null ? null : ctx.foo.bar)), "\n"
-	  );	
+	  i0.ɵɵtextInterpolate3(" ", 1 + 2, " ", 1 % 2 + 3 / 4 * 5, " ", +1, "\n");
 	}
   }
   

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -700,47 +700,6 @@ runInEachFileSystem(() => {
       expect(diags[0].messageText).toContain(`Property 'input' does not exist on type 'TestCmp'.`);
     });
 
-    it('should error on non valid typeof expressions', () => {
-      env.write(
-        'test.ts',
-        `
-        import {Component} from '@angular/core';
-
-        @Component({
-          standalone: true,
-          template: \` {{typeof {} === 'foobar'}} \`,
-        })
-        class TestCmp {
-        }
-        `,
-      );
-
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toContain(`This comparison appears to be unintentional`);
-    });
-
-    it('should error on misused logical not in typeof expressions', () => {
-      env.write(
-        'test.ts',
-        `
-        import {Component} from '@angular/core';
-
-        @Component({
-          standalone: true,
-          // should be !(typeof {} === 'object')
-          template: \` {{!typeof {} === 'object'}} \`,
-        })
-        class TestCmp {
-        }
-        `,
-      );
-
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toContain(`This comparison appears to be unintentional`);
-    });
-
     describe('strictInputTypes', () => {
       beforeEach(() => {
         env.write(

--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -373,19 +373,6 @@ export class PrefixNot extends AST {
   }
 }
 
-export class TypeofExpression extends AST {
-  constructor(
-    span: ParseSpan,
-    sourceSpan: AbsoluteSourceSpan,
-    public expression: AST,
-  ) {
-    super(span, sourceSpan);
-  }
-  override visit(visitor: AstVisitor, context: any = null): any {
-    return visitor.visitTypeofExpresion(this, context);
-  }
-}
-
 export class NonNullAssert extends AST {
   constructor(
     span: ParseSpan,
@@ -547,7 +534,6 @@ export interface AstVisitor {
   visitLiteralPrimitive(ast: LiteralPrimitive, context: any): any;
   visitPipe(ast: BindingPipe, context: any): any;
   visitPrefixNot(ast: PrefixNot, context: any): any;
-  visitTypeofExpresion(ast: TypeofExpression, context: any): any;
   visitNonNullAssert(ast: NonNullAssert, context: any): any;
   visitPropertyRead(ast: PropertyRead, context: any): any;
   visitPropertyWrite(ast: PropertyWrite, context: any): any;
@@ -613,9 +599,6 @@ export class RecursiveAstVisitor implements AstVisitor {
   }
   visitLiteralPrimitive(ast: LiteralPrimitive, context: any): any {}
   visitPrefixNot(ast: PrefixNot, context: any): any {
-    this.visit(ast.expression, context);
-  }
-  visitTypeofExpresion(ast: TypeofExpression, context: any) {
     this.visit(ast.expression, context);
   }
   visitNonNullAssert(ast: NonNullAssert, context: any): any {
@@ -730,10 +713,6 @@ export class AstTransformer implements AstVisitor {
 
   visitPrefixNot(ast: PrefixNot, context: any): AST {
     return new PrefixNot(ast.span, ast.sourceSpan, ast.expression.visit(this));
-  }
-
-  visitTypeofExpresion(ast: TypeofExpression, context: any): AST {
-    return new TypeofExpression(ast.span, ast.sourceSpan, ast.expression.visit(this));
   }
 
   visitNonNullAssert(ast: NonNullAssert, context: any): AST {
@@ -908,14 +887,6 @@ export class AstMemoryEfficientTransformer implements AstVisitor {
     const expression = ast.expression.visit(this);
     if (expression !== ast.expression) {
       return new PrefixNot(ast.span, ast.sourceSpan, expression);
-    }
-    return ast;
-  }
-
-  visitTypeofExpresion(ast: TypeofExpression, context: any): AST {
-    const expression = ast.expression.visit(this);
-    if (expression !== ast.expression) {
-      return new TypeofExpression(ast.span, ast.sourceSpan, expression);
     }
     return ast;
   }

--- a/packages/compiler/src/expression_parser/lexer.ts
+++ b/packages/compiler/src/expression_parser/lexer.ts
@@ -19,19 +19,7 @@ export enum TokenType {
   Error,
 }
 
-const KEYWORDS = [
-  'var',
-  'let',
-  'as',
-  'null',
-  'undefined',
-  'true',
-  'false',
-  'if',
-  'else',
-  'this',
-  'typeof',
-];
+const KEYWORDS = ['var', 'let', 'as', 'null', 'undefined', 'true', 'false', 'if', 'else', 'this'];
 
 export class Lexer {
   tokenize(text: string): Token[] {
@@ -109,10 +97,6 @@ export class Token {
 
   isKeywordThis(): boolean {
     return this.type == TokenType.Keyword && this.strValue == 'this';
-  }
-
-  isKeywordTypeof(): boolean {
-    return this.type === TokenType.Keyword && this.strValue === 'typeof';
   }
 
   isError(): boolean {
@@ -450,6 +434,18 @@ function isIdentifierStart(code: number): boolean {
     code == chars.$_ ||
     code == chars.$$
   );
+}
+
+export function isIdentifier(input: string): boolean {
+  if (input.length == 0) return false;
+  const scanner = new _Scanner(input);
+  if (!isIdentifierStart(scanner.peek)) return false;
+  scanner.advance();
+  while (scanner.peek !== chars.$EOF) {
+    if (!isIdentifierPart(scanner.peek)) return false;
+    scanner.advance();
+  }
+  return true;
 }
 
 function isIdentifierPart(code: number): boolean {

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -37,7 +37,6 @@ import {
   ParserError,
   ParseSpan,
   PrefixNot,
-  TypeofExpression,
   PropertyRead,
   PropertyWrite,
   RecursiveAstVisitor,
@@ -961,11 +960,6 @@ class _ParseAST {
           result = this.parsePrefix();
           return new PrefixNot(this.span(start), this.sourceSpan(start), result);
       }
-    } else if (this.next.isKeywordTypeof()) {
-      this.advance();
-      const start = this.inputIndex;
-      let result = this.parsePrefix();
-      return new TypeofExpression(this.span(start), this.sourceSpan(start), result);
     }
     return this.parseCallChain();
   }

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -1150,8 +1150,6 @@ function convertAst(
       convertAst(ast.expression, job, baseSourceSpan),
       convertSourceSpan(ast.span, baseSourceSpan),
     );
-  } else if (ast instanceof e.TypeofExpression) {
-    return o.typeofExpr(convertAst(ast.expression, job, baseSourceSpan));
   } else {
     throw new Error(
       `Unhandled expression type "${ast.constructor.name}" in file "${baseSourceSpan?.start.file.url}"`,

--- a/packages/compiler/test/expression_parser/lexer_spec.ts
+++ b/packages/compiler/test/expression_parser/lexer_spec.ts
@@ -185,12 +185,6 @@ describe('lexer', () => {
       expect(tokens[0].isKeywordUndefined()).toBe(true);
     });
 
-    it('should tokenize typeof', () => {
-      const tokens: Token[] = lex('typeof');
-      expectKeywordToken(tokens[0], 0, 6, 'typeof');
-      expect(tokens[0].isKeywordTypeof()).toBe(true);
-    });
-
     it('should ignore whitespace', () => {
       const tokens: Token[] = lex('a \t \n \r b');
       expectIdentifierToken(tokens[0], 0, 1, 'a');

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -98,11 +98,6 @@ describe('parser', () => {
       checkAction('null ?? undefined ?? 0');
     });
 
-    it('should parse typeof expression', () => {
-      checkAction(`typeof {} === "object"`);
-      checkAction('(!(typeof {} === "number"))', '!typeof {} === "number"');
-    });
-
     it('should parse grouped expressions', () => {
       checkAction('(1 + 2) * 3', '1 + 2 * 3');
     });

--- a/packages/compiler/test/expression_parser/utils/unparser.ts
+++ b/packages/compiler/test/expression_parser/utils/unparser.ts
@@ -24,7 +24,6 @@ import {
   LiteralPrimitive,
   NonNullAssert,
   PrefixNot,
-  TypeofExpression,
   PropertyRead,
   PropertyWrite,
   RecursiveAstVisitor,
@@ -190,11 +189,6 @@ class Unparser implements AstVisitor {
 
   visitPrefixNot(ast: PrefixNot, context: any) {
     this._expression += '!';
-    this._visit(ast.expression);
-  }
-
-  visitTypeofExpresion(ast: TypeofExpression, context: any) {
-    this._expression += 'typeof ';
     this._visit(ast.expression);
   }
 

--- a/packages/compiler/test/expression_parser/utils/validator.ts
+++ b/packages/compiler/test/expression_parser/utils/validator.ts
@@ -22,7 +22,6 @@ import {
   LiteralPrimitive,
   ParseSpan,
   PrefixNot,
-  TypeofExpression,
   PropertyRead,
   PropertyWrite,
   RecursiveAstVisitor,
@@ -111,10 +110,6 @@ class ASTValidator extends RecursiveAstVisitor {
 
   override visitPrefixNot(ast: PrefixNot, context: any): any {
     this.validate(ast, () => super.visitPrefixNot(ast, context));
-  }
-
-  override visitTypeofExpresion(ast: TypeofExpression, context: any): any {
-    this.validate(ast, () => super.visitTypeofExpresion(ast, context));
   }
 
   override visitPropertyRead(ast: PropertyRead, context: any): any {

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -87,10 +87,6 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
     this.recordAst(ast);
     super.visitPrefixNot(ast, null);
   }
-  override visitTypeofExpresion(ast: e.TypeofExpression) {
-    this.recordAst(ast);
-    super.visitTypeofExpresion(ast, null);
-  }
   override visitPropertyRead(ast: e.PropertyRead) {
     this.recordAst(ast);
     super.visitPropertyRead(ast, null);

--- a/packages/core/test/acceptance/control_flow_if_spec.ts
+++ b/packages/core/test/acceptance/control_flow_if_spec.ts
@@ -277,30 +277,6 @@ describe('control flow - if', () => {
     expect(fixture.nativeElement.textContent).toBe('Something');
   });
 
-  it('should support a condition with the a typeof expression', () => {
-    @Component({
-      standalone: true,
-      template: `
-          @if (typeof value === 'string') {
-            {{value.length}}
-          } @else {
-            {{value}}
-          }
-        `,
-    })
-    class TestComponent {
-      value: string | number = 'string';
-    }
-
-    const fixture = TestBed.createComponent(TestComponent);
-    fixture.detectChanges();
-    expect(fixture.nativeElement.textContent.trim()).toBe('6');
-
-    fixture.componentInstance.value = 42;
-    fixture.detectChanges();
-    expect(fixture.nativeElement.textContent.trim()).toBe('42');
-  });
-
   describe('content projection', () => {
     it('should project an @if with a single root node into the root node slot', () => {
       @Component({


### PR DESCRIPTION


This reverts commit 0c9d721ac157662b2602cf0278ba4b79325f6882. This breaks CI jobs in `main`, and sync into google3. PR was green and presubmit too; so I'm suspecting some rebase conflicts with other changes being merged at the same time.
