### PR TITLE
Fix CI failures

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/GOLDEN_PARTIAL.js
@@ -70,76 +70,64 @@ export declare class TodoModule {
 /****************************************************************************************************
  * PARTIAL FILE: operators.js
  ****************************************************************************************************/
-import { Component, NgModule, Pipe } from '@angular/core';
+import { Component, Pipe } from '@angular/core';
 import * as i0 from "@angular/core";
+export class IdentityPipe {
+    transform(value) {
+        return value;
+    }
+}
+IdentityPipe.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: IdentityPipe, deps: [], target: i0.ɵɵFactoryTarget.Pipe });
+IdentityPipe.ɵpipe = i0.ɵɵngDeclarePipe({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: IdentityPipe, isStandalone: true, name: "identity" });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: IdentityPipe, decorators: [{
+            type: Pipe,
+            args: [{ name: 'identity' }]
+        }] });
 export class MyApp {
     constructor() {
         this.foo = { bar: 'baz' };
     }
 }
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
-MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: false, selector: "ng-component", ngImport: i0, template: `
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
     {{ 1 + 2 }}
-	{{ (1 % 2) + 3 / 4 * 5 }}
-	{{ +1 }}
-  {{ typeof {} === 'object' }}
-  {{ !(typeof {} === 'object') }}
-  {{ typeof foo?.bar === 'string' }}
-  {{ typeof foo?.bar | identity }}
-`, isInline: true, dependencies: [{ kind: "pipe", type: i0.forwardRef(() => IdentityPipe), name: "identity" }] });
+    {{ (1 % 2) + 3 / 4 * 5 }}
+    {{ +1 }}
+    {{ typeof {} === 'object' }}
+    {{ !(typeof {} === 'object') }}
+    {{ typeof foo?.bar === 'string' }}
+    {{ typeof foo?.bar | identity }}
+  `, isInline: true, dependencies: [{ kind: "pipe", type: IdentityPipe, name: "identity" }] });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
             type: Component,
             args: [{
                     template: `
     {{ 1 + 2 }}
-	{{ (1 % 2) + 3 / 4 * 5 }}
-	{{ +1 }}
-  {{ typeof {} === 'object' }}
-  {{ !(typeof {} === 'object') }}
-  {{ typeof foo?.bar === 'string' }}
-  {{ typeof foo?.bar | identity }}
-`,
-                    standalone: false
+    {{ (1 % 2) + 3 / 4 * 5 }}
+    {{ +1 }}
+    {{ typeof {} === 'object' }}
+    {{ !(typeof {} === 'object') }}
+    {{ typeof foo?.bar === 'string' }}
+    {{ typeof foo?.bar | identity }}
+  `,
+                    imports: [IdentityPipe],
                 }]
-        }] });
-export class IdentityPipe {
-    transform(value) { return value; }
-}
-IdentityPipe.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: IdentityPipe, deps: [], target: i0.ɵɵFactoryTarget.Pipe });
-IdentityPipe.ɵpipe = i0.ɵɵngDeclarePipe({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: IdentityPipe, name: "identity" });
-i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: IdentityPipe, decorators: [{
-            type: Pipe,
-            args: [{ name: 'identity' }]
-        }] });
-export class MyModule {
-}
-MyModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
-MyModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, declarations: [MyApp, IdentityPipe] });
-MyModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule });
-i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, decorators: [{
-            type: NgModule,
-            args: [{ declarations: [MyApp, IdentityPipe] }]
         }] });
 
 /****************************************************************************************************
  * PARTIAL FILE: operators.d.ts
  ****************************************************************************************************/
 import * as i0 from "@angular/core";
+export declare class IdentityPipe {
+    transform(value: any): any;
+    static ɵfac: i0.ɵɵFactoryDeclaration<IdentityPipe, never>;
+    static ɵpipe: i0.ɵɵPipeDeclaration<IdentityPipe, "identity", true>;
+}
 export declare class MyApp {
     foo: {
         bar?: string;
     };
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
-    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
-}
-export declare class IdentityPipe {
-    transform(value: any): any;
-    static ɵfac: i0.ɵɵFactoryDeclaration<IdentityPipe, never>;
-    static ɵpipe: i0.ɵɵPipeDeclaration<IdentityPipe, "identity", false>;
-}
-export declare class MyModule {
-    static ɵfac: i0.ɵɵFactoryDeclaration<MyModule, never>;
-    static ɵmod: i0.ɵɵNgModuleDeclaration<MyModule, [typeof MyApp, typeof IdentityPipe], never, never>;
-    static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
 }
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/operators.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/operators.ts
@@ -1,26 +1,24 @@
-import {Component, NgModule, Pipe} from '@angular/core';
+import {Component, Pipe} from '@angular/core';
+
+@Pipe({name: 'identity'})
+export class IdentityPipe {
+  transform(value: any) {
+    return value;
+  }
+}
 
 @Component({
-    template: `
+  template: `
     {{ 1 + 2 }}
-	{{ (1 % 2) + 3 / 4 * 5 }}
-	{{ +1 }}
-  {{ typeof {} === 'object' }}
-  {{ !(typeof {} === 'object') }}
-  {{ typeof foo?.bar === 'string' }}
-  {{ typeof foo?.bar | identity }}
-`,
-    standalone: false
+    {{ (1 % 2) + 3 / 4 * 5 }}
+    {{ +1 }}
+    {{ typeof {} === 'object' }}
+    {{ !(typeof {} === 'object') }}
+    {{ typeof foo?.bar === 'string' }}
+    {{ typeof foo?.bar | identity }}
+  `,
+  imports: [IdentityPipe],
 })
 export class MyApp {
-    foo: {bar?: string} = {bar: 'baz'};
-}
-
-@Pipe ({name: 'identity'})
-export class IdentityPipe {
-    transform(value: any) { return value; }
-}
-
-@NgModule({declarations: [MyApp, IdentityPipe]})
-export class MyModule {
+  foo: {bar?: string} = {bar: 'baz'};
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/operators_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/operators_template.js
@@ -10,7 +10,7 @@ template: function MyApp_Template(rf, $ctx$) {
 		typeof i0.ɵɵpureFunction0(9, _c0) === "object", " ", 
 		!(typeof i0.ɵɵpureFunction0(10, _c0) === "object"), " ", 
 		typeof (ctx.foo == null ? null : ctx.foo.bar) === "string", " ", 
-		i0.ɵɵpipeBind1(1, 7, typeof (ctx.foo == null ? null : ctx.foo.bar)), "\n"
+		i0.ɵɵpipeBind1(1, 7, typeof (ctx.foo == null ? null : ctx.foo.bar)), " "
 	  );	
 	}
   }

--- a/packages/compiler/src/expression_parser/serializer.ts
+++ b/packages/compiler/src/expression_parser/serializer.ts
@@ -136,6 +136,10 @@ class SerializeExpressionVisitor implements expr.AstVisitor {
       .join(', ')})`;
   }
 
+  visitTypeofExpresion(ast: expr.TypeofExpression, context: any) {
+    return `typeof ${ast.expression.visit(this, context)}`;
+  }
+
   visitASTWithSource(ast: expr.ASTWithSource, context: any): string {
     return ast.ast.visit(this, context);
   }

--- a/packages/compiler/test/i18n/i18n_parser_spec.ts
+++ b/packages/compiler/test/i18n/i18n_parser_spec.ts
@@ -348,7 +348,7 @@ describe('I18nParser', () => {
     });
 
     it('should preserve whitespace when preserving significant whitespace', () => {
-      const html = '<div i18n="m|d">{{   foo   }}</div>';
+      const html = '<div i18n="m|d">hello {{   foo   }}</div>';
       expect(
         _humanizeMessages(
           html,
@@ -356,11 +356,11 @@ describe('I18nParser', () => {
           /* implicitAttrs */ undefined,
           /* preserveSignificantWhitespace */ true,
         ),
-      ).toEqual([[['[<ph name="INTERPOLATION">   foo   </ph>]'], 'm', 'd', '']]);
+      ).toEqual([[['[hello , <ph name="INTERPOLATION">   foo   </ph>]'], 'm', 'd', '']]);
     });
 
     it('should normalize whitespace when not preserving significant whitespace', () => {
-      const html = '<div i18n="m|d">{{   foo   }}</div>';
+      const html = '<div i18n="m|d">hello {{   foo   }}</div>';
       expect(
         _humanizeMessages(
           html,
@@ -368,7 +368,7 @@ describe('I18nParser', () => {
           /* implicitAttrs */ undefined,
           /* preserveSignificantWhitespace */ false,
         ),
-      ).toEqual([[['[, <ph name="INTERPOLATION">foo</ph>, ]'], 'm', 'd', '']]);
+      ).toEqual([[['[hello , <ph name="INTERPOLATION">foo</ph>, ]'], 'm', 'd', '']]);
     });
   });
 });


### PR DESCRIPTION
Includes the following changes to fix the broken CI:

### fix(compiler): handle typeof expressions in serializer
Fixes that some changes which landed at the same time caused a compilation error in the serialized.

### test(compiler-cli): fix broken test
Fixes a test that broke because a pipe wasn't marked explicitly as `standalone: false`.

### test(compiler): update failing tests
Fixes some tests that started failing, because angular#58154 made it so placeholder-only messages are extracted while angular#58176 added some tests that only contain placeholders.