### PR TITLE
refactor(core): avoid injecting DestroyRef in EventEmitter

### DIFF
--- a/packages/core/src/event_emitter.ts
+++ b/packages/core/src/event_emitter.ts
@@ -118,10 +118,9 @@ class EventEmitter_ extends Subject<any> implements OutputRef<any> {
     super();
     this.__isAsync = isAsync;
 
-    // Attempt to retrieve a `DestroyRef` and `PendingTasks` optionally.
+    // Attempt to retrieve `PendingTasks` optionally.
     // For backwards compatibility reasons, this cannot be required.
     if (isInInjectionContext()) {
-      this.destroyRef = inject(DestroyRef, {optional: true}) ?? undefined;
       this.pendingTasks = inject(PendingTasksInternal, {optional: true}) ?? undefined;
     }
   }

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -174,9 +174,6 @@
     "name": "DefaultDomRenderer2"
   },
   {
-    "name": "DestroyRef"
-  },
-  {
     "name": "DomAdapter"
   },
   {
@@ -382,9 +379,6 @@
   },
   {
     "name": "NodeInjector"
-  },
-  {
-    "name": "NodeInjectorDestroyRef"
   },
   {
     "name": "NodeInjectorFactory"
@@ -1098,9 +1092,6 @@
     "name": "injectArgs"
   },
   {
-    "name": "injectDestroyRef"
-  },
-  {
     "name": "injectElementRef"
   },
   {
@@ -1465,9 +1456,6 @@
   },
   {
     "name": "shouldSearchParent"
-  },
-  {
-    "name": "storeLViewOnDestroy"
   },
   {
     "name": "stringify"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -198,9 +198,6 @@
     "name": "DefaultDomRenderer2"
   },
   {
-    "name": "DestroyRef"
-  },
-  {
     "name": "DomAdapter"
   },
   {
@@ -418,9 +415,6 @@
   },
   {
     "name": "NodeInjector"
-  },
-  {
-    "name": "NodeInjectorDestroyRef"
   },
   {
     "name": "NodeInjectorFactory"
@@ -1170,9 +1164,6 @@
     "name": "injectArgs"
   },
   {
-    "name": "injectDestroyRef"
-  },
-  {
     "name": "injectElementRef"
   },
   {
@@ -1543,9 +1534,6 @@
   },
   {
     "name": "shouldSearchParent"
-  },
-  {
-    "name": "storeLViewOnDestroy"
   },
   {
     "name": "stringify"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -120,9 +120,6 @@
     "name": "DepComponent"
   },
   {
-    "name": "DestroyRef"
-  },
-  {
     "name": "DomAdapter"
   },
   {
@@ -316,9 +313,6 @@
   },
   {
     "name": "NodeInjector"
-  },
-  {
-    "name": "NodeInjectorDestroyRef"
   },
   {
     "name": "NodeInjectorFactory"
@@ -933,9 +927,6 @@
     "name": "injectArgs"
   },
   {
-    "name": "injectDestroyRef"
-  },
-  {
     "name": "injectElementRef"
   },
   {
@@ -1249,9 +1240,6 @@
   },
   {
     "name": "shouldSearchParent"
-  },
-  {
-    "name": "storeLViewOnDestroy"
   },
   {
     "name": "stringify"

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -147,9 +147,6 @@
     "name": "DeferDependenciesLoadingState"
   },
   {
-    "name": "DestroyRef"
-  },
-  {
     "name": "DomAdapter"
   },
   {
@@ -361,9 +358,6 @@
   },
   {
     "name": "NodeInjector"
-  },
-  {
-    "name": "NodeInjectorDestroyRef"
   },
   {
     "name": "NodeInjectorFactory"
@@ -2184,9 +2178,6 @@
     "name": "injectArgs"
   },
   {
-    "name": "injectDestroyRef"
-  },
-  {
     "name": "injectElementRef"
   },
   {
@@ -2428,9 +2419,6 @@
   },
   {
     "name": "removeFromArray"
-  },
-  {
-    "name": "removeLViewOnDestroy"
   },
   {
     "name": "renderComponent"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -174,9 +174,6 @@
     "name": "DefaultValueAccessor"
   },
   {
-    "name": "DestroyRef"
-  },
-  {
     "name": "DomAdapter"
   },
   {
@@ -445,9 +442,6 @@
   },
   {
     "name": "NodeInjector"
-  },
-  {
-    "name": "NodeInjectorDestroyRef"
   },
   {
     "name": "NodeInjectorFactory"
@@ -1344,9 +1338,6 @@
     "name": "injectArgs"
   },
   {
-    "name": "injectDestroyRef"
-  },
-  {
     "name": "injectElementRef"
   },
   {
@@ -1867,9 +1858,6 @@
   },
   {
     "name": "signalSetFn"
-  },
-  {
-    "name": "storeLViewOnDestroy"
   },
   {
     "name": "stringify"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -180,9 +180,6 @@
     "name": "DefaultValueAccessor"
   },
   {
-    "name": "DestroyRef"
-  },
-  {
     "name": "DomAdapter"
   },
   {
@@ -430,9 +427,6 @@
   },
   {
     "name": "NodeInjector"
-  },
-  {
-    "name": "NodeInjectorDestroyRef"
   },
   {
     "name": "NodeInjectorFactory"
@@ -1305,9 +1299,6 @@
     "name": "injectChangeDetectorRef"
   },
   {
-    "name": "injectDestroyRef"
-  },
-  {
     "name": "injectElementRef"
   },
   {
@@ -1849,9 +1840,6 @@
   },
   {
     "name": "stashEventListener"
-  },
-  {
-    "name": "storeLViewOnDestroy"
   },
   {
     "name": "stringify"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -78,9 +78,6 @@
     "name": "DOCUMENT2"
   },
   {
-    "name": "DestroyRef"
-  },
-  {
     "name": "DomAdapter"
   },
   {
@@ -238,9 +235,6 @@
   },
   {
     "name": "NodeInjector"
-  },
-  {
-    "name": "NodeInjectorDestroyRef"
   },
   {
     "name": "NodeInjectorFactory"
@@ -741,9 +735,6 @@
     "name": "injectArgs"
   },
   {
-    "name": "injectDestroyRef"
-  },
-  {
     "name": "injectElementRef"
   },
   {
@@ -985,9 +976,6 @@
   },
   {
     "name": "shouldSearchParent"
-  },
-  {
-    "name": "storeLViewOnDestroy"
   },
   {
     "name": "stringify"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -120,9 +120,6 @@
     "name": "DefaultDomRenderer2"
   },
   {
-    "name": "DestroyRef"
-  },
-  {
     "name": "DomAdapter"
   },
   {
@@ -346,9 +343,6 @@
   },
   {
     "name": "NodeInjector"
-  },
-  {
-    "name": "NodeInjectorDestroyRef"
   },
   {
     "name": "NodeInjectorFactory"
@@ -1005,9 +999,6 @@
     "name": "injectArgs"
   },
   {
-    "name": "injectDestroyRef"
-  },
-  {
     "name": "injectElementRef"
   },
   {
@@ -1366,9 +1357,6 @@
   },
   {
     "name": "sortAndConcatParams"
-  },
-  {
-    "name": "storeLViewOnDestroy"
   },
   {
     "name": "stringify"

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -21,9 +21,6 @@
     "name": "ConsumerObserver"
   },
   {
-    "name": "DestroyRef"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -94,9 +91,6 @@
   },
   {
     "name": "NgZone"
-  },
-  {
-    "name": "NodeInjectorDestroyRef"
   },
   {
     "name": "NullInjector"
@@ -262,9 +256,6 @@
   },
   {
     "name": "injectArgs"
-  },
-  {
-    "name": "injectDestroyRef"
   },
   {
     "name": "injectInjectorOnly"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -183,9 +183,6 @@
     "name": "DefaultUrlSerializer"
   },
   {
-    "name": "DestroyRef"
-  },
-  {
     "name": "DomAdapter"
   },
   {
@@ -475,9 +472,6 @@
   },
   {
     "name": "NodeInjector"
-  },
-  {
-    "name": "NodeInjectorDestroyRef"
   },
   {
     "name": "NodeInjectorFactory"
@@ -1560,9 +1554,6 @@
     "name": "injectChangeDetectorRef"
   },
   {
-    "name": "injectDestroyRef"
-  },
-  {
     "name": "injectElementRef"
   },
   {
@@ -2104,9 +2095,6 @@
   },
   {
     "name": "standardizeConfig"
-  },
-  {
-    "name": "storeLViewOnDestroy"
   },
   {
     "name": "stringify"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -102,9 +102,6 @@
     "name": "DefaultDomRenderer2"
   },
   {
-    "name": "DestroyRef"
-  },
-  {
     "name": "DomAdapter"
   },
   {
@@ -283,9 +280,6 @@
   },
   {
     "name": "NodeInjector"
-  },
-  {
-    "name": "NodeInjectorDestroyRef"
   },
   {
     "name": "NodeInjectorFactory"
@@ -828,9 +822,6 @@
     "name": "injectArgs"
   },
   {
-    "name": "injectDestroyRef"
-  },
-  {
     "name": "injectElementRef"
   },
   {
@@ -1093,9 +1084,6 @@
   },
   {
     "name": "shouldSearchParent"
-  },
-  {
-    "name": "storeLViewOnDestroy"
   },
   {
     "name": "stringify"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -123,9 +123,6 @@
     "name": "DefaultIterableDifferFactory"
   },
   {
-    "name": "DestroyRef"
-  },
-  {
     "name": "DomAdapter"
   },
   {
@@ -334,9 +331,6 @@
   },
   {
     "name": "NodeInjector"
-  },
-  {
-    "name": "NodeInjectorDestroyRef"
   },
   {
     "name": "NodeInjectorFactory"
@@ -1110,9 +1104,6 @@
     "name": "injectArgs"
   },
   {
-    "name": "injectDestroyRef"
-  },
-  {
     "name": "injectElementRef"
   },
   {
@@ -1492,9 +1483,6 @@
   },
   {
     "name": "stashEventListener"
-  },
-  {
-    "name": "storeLViewOnDestroy"
   },
   {
     "name": "stringify"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the new behavior?

`destroyRef` is never used in `EventEmitter` so we can spare the injection and leave it undefined. The field still needs to be there as it is declared in the `OutputRef` interface.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
