### PR TITLE
feat(http): promote `withRequestsMadeViaParent` to stable.

### DIFF
--- a/packages/common/http/src/provider.ts
+++ b/packages/common/http/src/provider.ts
@@ -276,7 +276,7 @@ export function withJsonpSupport(): HttpFeature<HttpFeatureKind.JsonpSupport> {
  * this option.
  *
  * @see {@link provideHttpClient}
- * @developerPreview
+ * @publicApi
  */
 export function withRequestsMadeViaParent(): HttpFeature<HttpFeatureKind.RequestsMadeViaParent> {
   return makeHttpFeature(HttpFeatureKind.RequestsMadeViaParent, [


### PR DESCRIPTION
Introduced back in v15 by #47502, its usage with fix with #55652 for the `FetchBackend` which will become the default `HttpBackend` with #58212
