### PR TITLE
docs(docs-infra): change mermaid diagram colors

### DIFF
--- a/adev/shared-docs/styles/docs/_mermaid.scss
+++ b/adev/shared-docs/styles/docs/_mermaid.scss
@@ -13,7 +13,7 @@
   g {
     rect {
       stroke: black !important; // border around the rectangles, same for dark/light theme
-      filter: drop-shadow(5px 5px 0px var(--vivid-pink));
+      filter: drop-shadow(5px 5px 0px var(--primary-contrast));
     }
   }
   .messageText,
@@ -61,5 +61,31 @@
   .nodeLabel {
     fill: var(--primary-contrast) !important;
     color: var(--primary-contrast) !important;
+  }
+
+  .eventNode {
+    polygon {
+      fill: var(--hot-pink) !important;
+      filter: none;
+      stroke: var(--hot-pink) !important;
+    }
+
+    .nodeLabel p {
+      color: var(--page-background) !important;
+      font-weight: 800 !important;
+    }
+  }
+
+  .checkedNode {
+    rect {
+      color: white !important;
+      filter: drop-shadow(5px 5px 0px var(--hot-pink));
+      stroke: var(--hot-pink) !important;
+    }
+
+    .nodeLabel p {
+      color: var(--hot-pink) !important;
+      font-weight: 800 !important;
+    }
   }
 }

--- a/adev/src/content/best-practices/runtime-performance/skipping-subtrees.md
+++ b/adev/src/content/best-practices/runtime-performance/skipping-subtrees.md
@@ -31,7 +31,7 @@ This section examines several common change detection scenarios to illustrate An
 
 If Angular handles an event within a component without `OnPush` strategy, the framework executes change detection on the entire component tree. Angular will skip descendant component subtrees with roots using `OnPush`, which have not received new inputs.
 
-As an example, if we set the change detection strategy of `MainComponent` to `OnPush` and the user interacts with a component outside the subtree with root `MainComponent`, Angular will check all the green components from the diagram below (`AppComponent`, `HeaderComponent`, `SearchComponent`, `ButtonComponent`) unless `MainComponent` receives new inputs:
+As an example, if we set the change detection strategy of `MainComponent` to `OnPush` and the user interacts with a component outside the subtree with root `MainComponent`, Angular will check all the pink components from the diagram below (`AppComponent`, `HeaderComponent`, `SearchComponent`, `ButtonComponent`) unless `MainComponent` receives new inputs:
 
 ```mermaid
 graph TD;
@@ -43,14 +43,11 @@ graph TD;
     main --- details[DetailsComponent];
     event>Event] --- search
 
-style main fill:#E4BE74,color:#000
-style login fill:#E4BE74,color:#000
-style details fill:#E4BE74,color:#000
-
-style app fill:#C1D5B0,color:#000
-style header fill:#C1D5B0,color:#000
-style button fill:#C1D5B0,color:#000
-style search fill:#C1D5B0,color:#000
+class app checkedNode
+class header checkedNode
+class button checkedNode
+class search checkedNode
+class event eventNode
 ```
 
 ## An event is handled by a component with OnPush
@@ -69,14 +66,13 @@ graph TD;
     main --- details[DetailsComponent];
     event>Event] --- main
 
-style login fill:#E4BE74,color:#000
-
-style app fill:#C1D5B0,color:#000
-style header fill:#C1D5B0,color:#000
-style button fill:#C1D5B0,color:#000
-style search fill:#C1D5B0,color:#000
-style main fill:#C1D5B0,color:#000
-style details fill:#C1D5B0,color:#000
+class app checkedNode
+class header checkedNode
+class button checkedNode
+class search checkedNode
+class main checkedNode
+class details checkedNode
+class event eventNode
 ```
 
 ## An event is handled by a descendant of a component with OnPush
@@ -95,13 +91,14 @@ graph TD;
     main --- details[DetailsComponent];
     event>Event] --- login
 
-style app fill:#C1D5B0,color:#000
-style header fill:#C1D5B0,color:#000
-style button fill:#C1D5B0,color:#000
-style search fill:#C1D5B0,color:#000
-style login fill:#C1D5B0,color:#000
-style main fill:#C1D5B0,color:#000
-style details fill:#C1D5B0,color:#000
+class app checkedNode
+class header checkedNode
+class button checkedNode
+class search checkedNode
+class login checkedNode
+class main checkedNode
+class details checkedNode
+class event eventNode
 ```
 
 ## New inputs to component with OnPush
@@ -120,15 +117,13 @@ graph TD;
     main --- details[DetailsComponent];
     event>Parent passes new input to MainComponent]
 
-style login fill:#E4BE74,color:#000
-
-linkStyle 1 stroke:green
-style app fill:#C1D5B0,color:#000
-style header fill:#C1D5B0,color:#000
-style button fill:#C1D5B0,color:#000
-style search fill:#C1D5B0,color:#000
-style main fill:#C1D5B0,color:#000
-style details fill:#C1D5B0,color:#000
+class app checkedNode
+class header checkedNode
+class button checkedNode
+class search checkedNode
+class main checkedNode
+class details checkedNode
+class event eventNode
 ```
 
 ## Edge cases


### PR DESCRIPTION
Change diagram colors to:
- Better match the overall site theme.
- Improve dark theme.
- Make the diagram easier to understand. "Unchecked" nodes have no color and "Checked" nodes match the color of the "Event" node that triggered the change detection.

Fixes #56314

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Colors and styling do not match the overall site style and do not work well with the dark theme (note the unreadable event label).

![before-light](https://github.com/user-attachments/assets/d9243732-2fc3-4c6e-8559-006a59f9d8f2)
![before-dark](https://github.com/user-attachments/assets/782facaf-1c19-4376-8382-0147fd2469f4)


Issue Number: #56314


## What is the new behavior?

![after-light](https://github.com/user-attachments/assets/47e67300-0aa4-410e-a3f4-14361a9a234a)
![after-dark](https://github.com/user-attachments/assets/aaf426a5-0dda-45be-8b0b-08556ebc092e)



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
