### PR TITLE
refactor(core): expose producerMarkClean utility

### DIFF
--- a/goldens/public-api/core/primitives/signals/index.api.md
+++ b/goldens/public-api/core/primitives/signals/index.api.md
@@ -55,6 +55,9 @@ export function producerAccessed(node: ReactiveNode): void;
 // @public
 export function producerIncrementEpoch(): void;
 
+// @public (undocumented)
+export function producerMarkClean(node: ReactiveNode): void;
+
 // @public
 export function producerNotifyConsumers(node: ReactiveNode): void;
 

--- a/packages/core/primitives/signals/index.ts
+++ b/packages/core/primitives/signals/index.ts
@@ -24,6 +24,7 @@ export {
   isReactive,
   producerAccessed,
   producerIncrementEpoch,
+  producerMarkClean,
   producerNotifyConsumers,
   producerUpdateValueVersion,
   producerUpdatesAllowed,

--- a/packages/core/primitives/signals/src/graph.ts
+++ b/packages/core/primitives/signals/src/graph.ts
@@ -280,16 +280,14 @@ export function producerUpdateValueVersion(node: ReactiveNode): void {
   if (!node.producerMustRecompute(node) && !consumerPollProducersForChange(node)) {
     // None of our producers report a change since the last time they were read, so no
     // recomputation of our value is necessary, and we can consider ourselves clean.
-    node.dirty = false;
-    node.lastCleanEpoch = epoch;
+    producerMarkClean(node);
     return;
   }
 
   node.producerRecomputeValue(node);
 
   // After recomputing the value, we're no longer dirty.
-  node.dirty = false;
-  node.lastCleanEpoch = epoch;
+  producerMarkClean(node);
 }
 
 /**
@@ -326,6 +324,11 @@ export function consumerMarkDirty(node: ReactiveNode): void {
   node.dirty = true;
   producerNotifyConsumers(node);
   node.consumerMarkedDirty?.(node);
+}
+
+export function producerMarkClean(node: ReactiveNode): void {
+  node.dirty = false;
+  node.lastCleanEpoch = epoch;
 }
 
 /**

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -1332,6 +1332,9 @@
     "name": "processInjectorTypesWithProviders"
   },
   {
+    "name": "producerMarkClean"
+  },
+  {
     "name": "producerRemoveLiveConsumerAtIndex"
   },
   {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -1410,6 +1410,9 @@
     "name": "processInjectorTypesWithProviders"
   },
   {
+    "name": "producerMarkClean"
+  },
+  {
     "name": "producerRemoveLiveConsumerAtIndex"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -1137,6 +1137,9 @@
     "name": "processInjectorTypesWithProviders"
   },
   {
+    "name": "producerMarkClean"
+  },
+  {
     "name": "producerRemoveLiveConsumerAtIndex"
   },
   {

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -2400,6 +2400,9 @@
     "name": "processInjectorTypesWithProviders"
   },
   {
+    "name": "producerMarkClean"
+  },
+  {
     "name": "producerRemoveLiveConsumerAtIndex"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1686,6 +1686,9 @@
     "name": "producerAddLiveConsumer"
   },
   {
+    "name": "producerMarkClean"
+  },
+  {
     "name": "producerNotifyConsumers"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1653,6 +1653,9 @@
     "name": "producerAddLiveConsumer"
   },
   {
+    "name": "producerMarkClean"
+  },
+  {
     "name": "producerNotifyConsumers"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -897,6 +897,9 @@
     "name": "processInjectorTypesWithProviders"
   },
   {
+    "name": "producerMarkClean"
+  },
+  {
     "name": "producerRemoveLiveConsumerAtIndex"
   },
   {

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -1242,6 +1242,9 @@
     "name": "processInjectorTypesWithProviders"
   },
   {
+    "name": "producerMarkClean"
+  },
+  {
     "name": "producerRemoveLiveConsumerAtIndex"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1926,6 +1926,9 @@
     "name": "producerAddLiveConsumer"
   },
   {
+    "name": "producerMarkClean"
+  },
+  {
     "name": "producerNotifyConsumers"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -996,6 +996,9 @@
     "name": "processInjectorTypesWithProviders"
   },
   {
+    "name": "producerMarkClean"
+  },
+  {
     "name": "producerRemoveLiveConsumerAtIndex"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1353,6 +1353,9 @@
     "name": "processInjectorTypesWithProviders"
   },
   {
+    "name": "producerMarkClean"
+  },
+  {
     "name": "producerRemoveLiveConsumerAtIndex"
   },
   {


### PR DESCRIPTION
This commit exposes the new producerMarkClean utility that makes it possible to mark a reactive node as clean following changes to the node's value. In practice it resets the dirty flag and all other internal flags as need. Prior to this change the cleanup code was duplicated.

The new utility will be used in the linkedSignal implementation.
