### PR TITLE
refactor(migrations): remove `standalone:true`

### DIFF
--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -2,7 +2,7 @@
   "schematics": {
     "explicit-standalone-flag": {
       "version": "19.0.0",
-      "description": "Updates non-standalone Directives, Component and Pipes to standalone:false",
+      "description": "Updates non-standalone Directives, Component and Pipes to 'standalone:false' and removes 'standalone:true' from those who are standalone",
       "factory": "./bundles/explicit-standalone-flag#migrate"
     },
     "pending-tasks": {

--- a/packages/core/schematics/migrations/explicit-standalone-flag/migration.ts
+++ b/packages/core/schematics/migrations/explicit-standalone-flag/migration.ts
@@ -90,8 +90,7 @@ export function migrateFile(sourceFile: ts.SourceFile, rewriteFn: RewriteFn) {
 
         newProperties = [...properties, standaloneFalseProperty];
       } else if (standaloneProp.value === ts.SyntaxKind.TrueKeyword) {
-        // TODO: uncomment once we want to enable removing `standalone: true`
-        // newProperties = properties.filter((p) => p !== standaloneProp.property);
+        newProperties = properties.filter((p) => p !== standaloneProp.property);
       }
 
       if (newProperties) {

--- a/packages/core/schematics/test/explicit_standalone_flag_spec.ts
+++ b/packages/core/schematics/test/explicit_standalone_flag_spec.ts
@@ -116,8 +116,7 @@ describe('explicit-standalone-flag migration', () => {
     expect(content).toContain('standalone: false');
   });
 
-  // TODO: Change this test once we enable removing standalone:true
-  it('should not remove standalone:true', async () => {
+  it('should remove standalone:true', async () => {
     writeFile(
       '/index.ts',
       `
@@ -135,8 +134,7 @@ describe('explicit-standalone-flag migration', () => {
 
     const content = tree.readContent('/index.ts').replace(/\s+/g, ' ');
 
-    // TODO: alter this expectation once we enable removing standalone:true
-    expect(content).toContain('standalone: true');
+    expect(content).not.toContain('standalone: true');
   });
 
   it('should not update a directive with standalone:false', async () => {


### PR DESCRIPTION
This commit re-enables the code that removes `standalone: true` in the `explicit-standalone-flag` migration
