### PR TITLE
refactor(core):  standalone by default for JIT compiled directives

### DIFF
--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -163,7 +163,7 @@ export function compileComponent(type: Type<any>, metadata: Component): void {
             meta,
           ) as ComponentDef<unknown>;
 
-          if (metadata.standalone) {
+          if (meta.isStandalone) {
             // Patch the component definition for standalone components with `directiveDefs` and
             // `pipeDefs` functions which lazily compute the directives/pipes available in the
             // standalone component. Also set `dependencies` to the lazily resolved list of imports.
@@ -197,7 +197,7 @@ export function compileComponent(type: Type<any>, metadata: Component): void {
         }
 
         if (metadata.schemas) {
-          if (metadata.standalone) {
+          if (meta.isStandalone) {
             ngComponentDef.schemas = metadata.schemas;
           } else {
             throw new Error(
@@ -206,7 +206,7 @@ export function compileComponent(type: Type<any>, metadata: Component): void {
               )} but is only valid on a component that is standalone.`,
             );
           }
-        } else if (metadata.standalone) {
+        } else if (meta.isStandalone) {
           ngComponentDef.schemas = [];
         }
       }

--- a/packages/core/test/acceptance/standalone_spec.ts
+++ b/packages/core/test/acceptance/standalone_spec.ts
@@ -62,14 +62,33 @@ describe('standalone components, directives, and pipes', () => {
 
   it('should render a standalone component with a standalone dependency', () => {
     @Component({
-      standalone: true,
       selector: 'inner-cmp',
       template: 'Look at me, no NgModule!',
     })
     class InnerCmp {}
 
     @Component({
+      template: '<inner-cmp></inner-cmp>',
+      imports: [InnerCmp],
+    })
+    class StandaloneCmp {}
+
+    const fixture = TestBed.createComponent(StandaloneCmp);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.innerHTML).toEqual(
+      '<inner-cmp>Look at me, no NgModule!</inner-cmp>',
+    );
+  });
+
+  it('should render a standalone component (with standalone: true) with a standalone dependency', () => {
+    @Component({
+      selector: 'inner-cmp',
+      template: 'Look at me, no NgModule!',
       standalone: true,
+    })
+    class InnerCmp {}
+
+    @Component({
       template: '<inner-cmp></inner-cmp>',
       imports: [InnerCmp],
     })


### PR DESCRIPTION
This commit fixes the standalone by default for JIT compiled directives (like in unit tests)