### PR TITLE
refactor: remove `standalone: true` 

### DIFF
--- a/integration/animations-async/src/app/app.component.ts
+++ b/integration/animations-async/src/app/app.component.ts
@@ -4,6 +4,5 @@ import {RouterModule} from '@angular/router';
   selector: 'app-root',
   template: `<router-outlet/>`,
   imports: [RouterModule],
-  standalone: true,
 })
 export class AppComponent {}

--- a/integration/animations-async/src/app/open-close.component.ts
+++ b/integration/animations-async/src/app/open-close.component.ts
@@ -33,7 +33,6 @@ import {Component} from '@angular/core';
         font-size: 20px;
       }`,
   ],
-  standalone: true,
 })
 export class OpenCloseComponent {
   isOpen = true;

--- a/integration/animations/src/app/app.component.ts
+++ b/integration/animations/src/app/app.component.ts
@@ -4,6 +4,5 @@ import {RouterModule} from '@angular/router';
   selector: 'app-root',
   template: `<router-outlet/>`,
   imports: [RouterModule],
-  standalone: true,
 })
 export class AppComponent {}

--- a/integration/animations/src/app/open-close.component.ts
+++ b/integration/animations/src/app/open-close.component.ts
@@ -33,7 +33,6 @@ import {Component} from '@angular/core';
         font-size: 20px;
       }`,
   ],
-  standalone: true,
 })
 export class OpenCloseComponent {
   isOpen = true;

--- a/integration/cli-hello-world-lazy/src/app/app.component.ts
+++ b/integration/cli-hello-world-lazy/src/app/app.component.ts
@@ -4,7 +4,6 @@ import {RouterOutlet} from '@angular/router';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [RouterOutlet, CommonModule],
   templateUrl: './app.component.html',
 })

--- a/integration/cli-hello-world-lazy/src/app/lazy/lazy.component.ts
+++ b/integration/cli-hello-world-lazy/src/app/lazy/lazy.component.ts
@@ -1,7 +1,6 @@
 import {Component} from '@angular/core';
 
 @Component({
-  standalone: true,
   selector: 'app-lazy',
   template: '<p>lazy works!</p>',
 })

--- a/integration/cli-signal-inputs/src/app/app.component.ts
+++ b/integration/cli-signal-inputs/src/app/app.component.ts
@@ -3,7 +3,6 @@ import {ChangeDetectionStrategy, Component, viewChildren} from '@angular/core';
 import {GreetComponent} from './greet.component';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   template: `
     <greet [firstName]="firstName" [lastName]="lastName" [decoratorInput]="10" />

--- a/integration/cli-signal-inputs/src/app/greet.component.spec.ts
+++ b/integration/cli-signal-inputs/src/app/greet.component.spec.ts
@@ -29,7 +29,6 @@ describe('greet component', () => {
 });
 
 @Component({
-  standalone: true,
   template: `
     <greet [firstName]="firstName" (clickFromInside)="clickCount = clickCount + 1"
            (clickFromInside2)="clickCount2 = clickCount2 + 1"/>

--- a/integration/cli-signal-inputs/src/app/greet.component.ts
+++ b/integration/cli-signal-inputs/src/app/greet.component.ts
@@ -9,7 +9,6 @@ import {Subject} from 'rxjs';
 
     <button (click)="dispatchOutputEvent()"><button>
   `,
-  standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class GreetComponent {

--- a/integration/defer/src/app/app.component.ts
+++ b/integration/defer/src/app/app.component.ts
@@ -3,7 +3,6 @@ import {Component} from '@angular/core';
 import {DeferComponent} from './defer.component';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   imports: [DeferComponent],
   template: `

--- a/integration/defer/src/app/defer.component.ts
+++ b/integration/defer/src/app/defer.component.ts
@@ -1,7 +1,6 @@
 import {Component} from '@angular/core';
 
 @Component({
-  standalone: true,
   selector: 'defer-cmp',
   template: `
     <h2>Defer-loaded component</h2>

--- a/integration/platform-server-hydration/src/app/app.component.ts
+++ b/integration/platform-server-hydration/src/app/app.component.ts
@@ -3,7 +3,6 @@ import {RouterOutlet} from '@angular/router';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [RouterOutlet],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css',

--- a/integration/platform-server/projects/standalone/src/app/app.component.ts
+++ b/integration/platform-server/projects/standalone/src/app/app.component.ts
@@ -4,7 +4,6 @@ import {RouterOutlet} from '@angular/router';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [CommonModule, RouterOutlet],
   template: '<router-outlet></router-outlet>',
 })

--- a/integration/platform-server/projects/standalone/src/app/helloworld/hello-world.component.ts
+++ b/integration/platform-server/projects/standalone/src/app/helloworld/hello-world.component.ts
@@ -10,7 +10,6 @@ import {Component} from '@angular/core';
 
 @Component({
   selector: 'hello-world-app',
-  standalone: true,
   template: `
     <div>Hello {{ name }}!</div>
   `,

--- a/integration/platform-server/projects/standalone/src/app/http-transferstate-lazy-on-init/http-transfer-state-on-init.component.ts
+++ b/integration/platform-server/projects/standalone/src/app/http-transferstate-lazy-on-init/http-transfer-state-on-init.component.ts
@@ -11,7 +11,6 @@ import {Component, OnInit} from '@angular/core';
 
 @Component({
   selector: 'transfer-state-http',
-  standalone: true,
   template: ` <div class="one">{{ responseOne }}</div> `,
   providers: [HttpClient],
 })

--- a/integration/platform-server/projects/standalone/src/app/http-transferstate-lazy/http-transfer-state.component.ts
+++ b/integration/platform-server/projects/standalone/src/app/http-transferstate-lazy/http-transfer-state.component.ts
@@ -11,7 +11,6 @@ import {Component, OnInit} from '@angular/core';
 
 @Component({
   selector: 'transfer-state-http',
-  standalone: true,
   template: `
     <div class="one">{{ responseOne }}</div>
     <div class="two">{{ responseTwo }}</div>

--- a/integration/platform-server/projects/standalone/src/app/transferstate/transfer-state.component.ts
+++ b/integration/platform-server/projects/standalone/src/app/transferstate/transfer-state.component.ts
@@ -14,7 +14,6 @@ const COUNTER_KEY = makeStateKey<number>('counter');
 
 @Component({
   selector: 'transfer-state',
-  standalone: true,
   template: ` <div>{{ counter }}</div> `,
   providers: [HttpClient],
 })

--- a/integration/standalone-bootstrap/src/app/app.component.ts
+++ b/integration/standalone-bootstrap/src/app/app.component.ts
@@ -1,7 +1,6 @@
 import {Component} from '@angular/core';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   template: `
     <h1>Standalone Bootstrap app</h1>

--- a/modules/benchmarks/src/defer/baseline/app.component.ts
+++ b/modules/benchmarks/src/defer/baseline/app.component.ts
@@ -15,7 +15,6 @@ let trustedEmptyColor: SafeStyle;
 let trustedGreyColor: SafeStyle;
 
 @Component({
-  standalone: true,
   selector: 'app',
   template: `
     <table>

--- a/modules/benchmarks/src/defer/main/app.component.ts
+++ b/modules/benchmarks/src/defer/main/app.component.ts
@@ -15,7 +15,6 @@ let trustedEmptyColor: SafeStyle;
 let trustedGreyColor: SafeStyle;
 
 @Component({
-  standalone: true,
   selector: 'app',
   template: `
     <table>

--- a/modules/benchmarks/src/hydration/table.ts
+++ b/modules/benchmarks/src/hydration/table.ts
@@ -15,7 +15,6 @@ let trustedEmptyColor: SafeStyle;
 let trustedGreyColor: SafeStyle;
 
 @Component({
-  standalone: true,
   selector: 'app',
   template: ``,
 })
@@ -27,7 +26,6 @@ export class AppComponent {
 }
 
 @Component({
-  standalone: true,
   selector: 'table-cmp',
   template: `
     <table>

--- a/modules/benchmarks/src/ng_template_outlet_context/ng2/index.ts
+++ b/modules/benchmarks/src/ng_template_outlet_context/ng2/index.ts
@@ -12,7 +12,6 @@ import {bootstrapApplication} from '@angular/platform-browser';
 
 @Component({
   selector: 'deep',
-  standalone: true,
   imports: [NgIf],
   template: `<deep *ngIf="depth > 1" [depth]="depth - 1" /> Level: {{ depth }}`,
 })
@@ -22,7 +21,6 @@ class Deep {
 
 @Component({
   selector: 'app-component',
-  standalone: true,
   imports: [NgTemplateOutlet, Deep],
   template: `
     <button id="swapOutFull" (click)="swapOutFull()">Swap out full context</button>

--- a/modules/ssr-benchmarks/src/app/app.component.ts
+++ b/modules/ssr-benchmarks/src/app/app.component.ts
@@ -11,7 +11,6 @@ import {testData} from '../../test-data';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   template: `
     <table>
       <tbody>

--- a/packages/common/src/directives/ng_class.ts
+++ b/packages/common/src/directives/ng_class.ts
@@ -68,7 +68,6 @@ interface CssClassState {
  */
 @Directive({
   selector: '[ngClass]',
-  standalone: true,
 })
 export class NgClass implements DoCheck {
   private initialClasses = EMPTY_ARRAY;

--- a/packages/common/src/directives/ng_component_outlet.ts
+++ b/packages/common/src/directives/ng_component_outlet.ts
@@ -93,7 +93,6 @@ import {
  */
 @Directive({
   selector: '[ngComponentOutlet]',
-  standalone: true,
 })
 export class NgComponentOutlet implements OnChanges, DoCheck, OnDestroy {
   @Input() ngComponentOutlet: Type<any> | null = null;

--- a/packages/common/src/directives/ng_for_of.ts
+++ b/packages/common/src/directives/ng_for_of.ts
@@ -167,7 +167,6 @@ export class NgForOfContext<T, U extends NgIterable<T> = NgIterable<T>> {
  */
 @Directive({
   selector: '[ngFor][ngForOf]',
-  standalone: true,
 })
 export class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> implements DoCheck {
   /**

--- a/packages/common/src/directives/ng_if.ts
+++ b/packages/common/src/directives/ng_if.ts
@@ -156,7 +156,6 @@ import {
  */
 @Directive({
   selector: '[ngIf]',
-  standalone: true,
 })
 export class NgIf<T = unknown> {
   private _context: NgIfContext<T> = new NgIfContext<T>();

--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -273,7 +273,6 @@ export interface ImagePlaceholderConfig {
  * @publicApi
  */
 @Directive({
-  standalone: true,
   selector: 'img[ngSrc]',
   host: {
     '[style.position]': 'fill ? "absolute" : null',

--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -214,7 +214,6 @@ export interface ImagePlaceholderConfig {
  *
  * // ... or a standalone Component
  * @Component({
- *   standalone: true
  *   imports: [NgOptimizedImage],
  * })
  * class MyStandaloneComponent {}

--- a/packages/common/src/directives/ng_plural.ts
+++ b/packages/common/src/directives/ng_plural.ts
@@ -45,7 +45,6 @@ import {SwitchView} from './ng_switch';
  */
 @Directive({
   selector: '[ngPlural]',
-  standalone: true,
 })
 export class NgPlural {
   private _activeView?: SwitchView;
@@ -104,7 +103,6 @@ export class NgPlural {
  */
 @Directive({
   selector: '[ngPluralCase]',
-  standalone: true,
 })
 export class NgPluralCase {
   constructor(

--- a/packages/common/src/directives/ng_style.ts
+++ b/packages/common/src/directives/ng_style.ts
@@ -55,7 +55,6 @@ import {
  */
 @Directive({
   selector: '[ngStyle]',
-  standalone: true,
 })
 export class NgStyle implements DoCheck {
   private _ngStyle: {[key: string]: string} | null | undefined = null;

--- a/packages/common/src/directives/ng_switch.ts
+++ b/packages/common/src/directives/ng_switch.ts
@@ -114,7 +114,6 @@ export class SwitchView {
  */
 @Directive({
   selector: '[ngSwitch]',
-  standalone: true,
 })
 export class NgSwitch {
   private _defaultViews: SwitchView[] = [];
@@ -200,7 +199,6 @@ export class NgSwitch {
  */
 @Directive({
   selector: '[ngSwitchCase]',
-  standalone: true,
 })
 export class NgSwitchCase implements DoCheck {
   private _view: SwitchView;
@@ -247,7 +245,6 @@ export class NgSwitchCase implements DoCheck {
  */
 @Directive({
   selector: '[ngSwitchDefault]',
-  standalone: true,
 })
 export class NgSwitchDefault {
   constructor(

--- a/packages/common/src/directives/ng_template_outlet.ts
+++ b/packages/common/src/directives/ng_template_outlet.ts
@@ -44,7 +44,6 @@ import {
  */
 @Directive({
   selector: '[ngTemplateOutlet]',
-  standalone: true,
 })
 export class NgTemplateOutlet<C = unknown> implements OnChanges {
   private _viewRef: EmbeddedViewRef<C> | null = null;

--- a/packages/common/src/pipes/async_pipe.ts
+++ b/packages/common/src/pipes/async_pipe.ts
@@ -97,7 +97,6 @@ const _subscribableStrategy = new SubscribableStrategy();
 @Pipe({
   name: 'async',
   pure: false,
-  standalone: true,
 })
 export class AsyncPipe implements OnDestroy, PipeTransform {
   private _ref: ChangeDetectorRef | null;

--- a/packages/common/src/pipes/case_conversion_pipes.ts
+++ b/packages/common/src/pipes/case_conversion_pipes.ts
@@ -27,7 +27,6 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  */
 @Pipe({
   name: 'lowercase',
-  standalone: true,
 })
 export class LowerCasePipe implements PipeTransform {
   /**
@@ -76,7 +75,6 @@ const unicodeWordMatch =
  */
 @Pipe({
   name: 'titlecase',
-  standalone: true,
 })
 export class TitleCasePipe implements PipeTransform {
   /**
@@ -108,7 +106,6 @@ export class TitleCasePipe implements PipeTransform {
  */
 @Pipe({
   name: 'uppercase',
-  standalone: true,
 })
 export class UpperCasePipe implements PipeTransform {
   /**

--- a/packages/common/src/pipes/date_pipe.ts
+++ b/packages/common/src/pipes/date_pipe.ts
@@ -218,7 +218,6 @@ export const DATE_PIPE_DEFAULT_OPTIONS = new InjectionToken<DatePipeConfig>(
  */
 @Pipe({
   name: 'date',
-  standalone: true,
 })
 export class DatePipe implements PipeTransform {
   constructor(

--- a/packages/common/src/pipes/i18n_plural_pipe.ts
+++ b/packages/common/src/pipes/i18n_plural_pipe.ts
@@ -30,7 +30,6 @@ const _INTERPOLATION_REGEXP: RegExp = /#/g;
  */
 @Pipe({
   name: 'i18nPlural',
-  standalone: true,
 })
 export class I18nPluralPipe implements PipeTransform {
   constructor(private _localization: NgLocalization) {}

--- a/packages/common/src/pipes/i18n_select_pipe.ts
+++ b/packages/common/src/pipes/i18n_select_pipe.ts
@@ -29,7 +29,6 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  */
 @Pipe({
   name: 'i18nSelect',
-  standalone: true,
 })
 export class I18nSelectPipe implements PipeTransform {
   /**

--- a/packages/common/src/pipes/json_pipe.ts
+++ b/packages/common/src/pipes/json_pipe.ts
@@ -26,7 +26,6 @@ import {Pipe, PipeTransform} from '@angular/core';
 @Pipe({
   name: 'json',
   pure: false,
-  standalone: true,
 })
 export class JsonPipe implements PipeTransform {
   /**

--- a/packages/common/src/pipes/keyvalue_pipe.ts
+++ b/packages/common/src/pipes/keyvalue_pipe.ts
@@ -54,7 +54,6 @@ export interface KeyValue<K, V> {
 @Pipe({
   name: 'keyvalue',
   pure: false,
-  standalone: true,
 })
 export class KeyValuePipe implements PipeTransform {
   constructor(private readonly differs: KeyValueDiffers) {}

--- a/packages/common/src/pipes/number_pipe.ts
+++ b/packages/common/src/pipes/number_pipe.ts
@@ -78,7 +78,6 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  */
 @Pipe({
   name: 'number',
-  standalone: true,
 })
 export class DecimalPipe implements PipeTransform {
   constructor(@Inject(LOCALE_ID) private _locale: string) {}
@@ -137,7 +136,6 @@ export class DecimalPipe implements PipeTransform {
  */
 @Pipe({
   name: 'percent',
-  standalone: true,
 })
 export class PercentPipe implements PipeTransform {
   constructor(@Inject(LOCALE_ID) private _locale: string) {}
@@ -204,7 +202,6 @@ export class PercentPipe implements PipeTransform {
  */
 @Pipe({
   name: 'currency',
-  standalone: true,
 })
 export class CurrencyPipe implements PipeTransform {
   constructor(

--- a/packages/common/src/pipes/slice_pipe.ts
+++ b/packages/common/src/pipes/slice_pipe.ts
@@ -48,7 +48,6 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 @Pipe({
   name: 'slice',
   pure: false,
-  standalone: true,
 })
 export class SlicePipe implements PipeTransform {
   /**

--- a/packages/common/test/directives/ng_class_spec.ts
+++ b/packages/common/test/directives/ng_class_spec.ts
@@ -467,7 +467,6 @@ describe('binding to CSS class list', () => {
         selector: 'test-component',
         imports: [NgClass],
         template: `<div class="{{ 'option-' + level }}" [ngClass]="'option-' + level"></div>`,
-        standalone: true,
       })
       class TestComponent {
         level = 1;
@@ -488,7 +487,6 @@ describe('binding to CSS class list', () => {
         selector: 'test-component',
         imports: [NgClass],
         template: `<div trailing-space [ngClass]="{foo: applyClasses}"></div>`,
-        standalone: true,
       })
       class TestComponent {
         applyClasses = true;

--- a/packages/common/test/directives/ng_component_outlet_spec.ts
+++ b/packages/common/test/directives/ng_component_outlet_spec.ts
@@ -284,7 +284,6 @@ describe('insert/remove', () => {
 
   it('should be available as a standalone directive', () => {
     @Component({
-      standalone: true,
       template: 'Hello World',
     })
     class HelloWorldComp {}
@@ -293,7 +292,6 @@ describe('insert/remove', () => {
       selector: 'test-component',
       imports: [NgComponentOutlet],
       template: ` <ng-container *ngComponentOutlet="component"></ng-container> `,
-      standalone: true,
     })
     class TestComponent {
       component = HelloWorldComp;
@@ -475,7 +473,6 @@ export class TestModule3 {}
 
 @Component({
   selector: 'cmp-with-inputs',
-  standalone: true,
   template: `foo: {{ foo }}, bar: {{ bar }}, baz: {{ baz }}`,
 })
 class ComponentWithInputs {
@@ -486,7 +483,6 @@ class ComponentWithInputs {
 
 @Component({
   selector: 'another-cmp-with-inputs',
-  standalone: true,
   template: `[ANOTHER] foo: {{ foo }}, bar: {{ bar }}, baz: {{ baz }}`,
 })
 class AnotherComponentWithInputs {
@@ -497,7 +493,6 @@ class AnotherComponentWithInputs {
 
 @Component({
   selector: 'test-cmp',
-  standalone: true,
   imports: [NgComponentOutlet],
   template: `<ng-template *ngComponentOutlet="currentComponent; inputs: inputs"></ng-template>`,
 })

--- a/packages/common/test/directives/ng_for_spec.ts
+++ b/packages/common/test/directives/ng_for_spec.ts
@@ -394,7 +394,6 @@ describe('ngFor', () => {
       selector: 'test-component',
       imports: [NgForOf],
       template: ` <ng-container *ngFor="let item of items">{{ item }}|</ng-container> `,
-      standalone: true,
     })
     class TestComponent {
       items = [1, 2, 3];
@@ -411,7 +410,6 @@ describe('ngFor', () => {
       selector: 'test-component',
       imports: [NgFor],
       template: ` <ng-container *ngFor="let item of items">{{ item }}|</ng-container> `,
-      standalone: true,
     })
     class TestComponent {
       items = [1, 2, 3];

--- a/packages/common/test/directives/ng_if_spec.ts
+++ b/packages/common/test/directives/ng_if_spec.ts
@@ -261,7 +261,6 @@ describe('ngIf directive', () => {
           <div *ngIf="true">Hello</div>
           <div *ngIf="false">World</div>
         `,
-        standalone: true,
       })
       class TestComponent {}
 

--- a/packages/common/test/directives/ng_plural_spec.ts
+++ b/packages/common/test/directives/ng_plural_spec.ts
@@ -153,7 +153,6 @@ it('should be available as a standalone directive', () => {
       '<ng-template ngPluralCase="=0"><li>no messages</li></ng-template>' +
       '<ng-template ngPluralCase="=1"><li>one message</li></ng-template>' +
       '</ul>',
-    standalone: true,
   })
   class TestComponent {
     switchValue = 1;

--- a/packages/common/test/directives/ng_style_spec.ts
+++ b/packages/common/test/directives/ng_style_spec.ts
@@ -242,7 +242,6 @@ describe('NgStyle', () => {
       selector: 'test-component',
       imports: [NgStyle],
       template: `<div [ngStyle]="{'width.px': expr}"></div>`,
-      standalone: true,
     })
     class TestComponent {
       expr = 400;

--- a/packages/common/test/directives/ng_switch_spec.ts
+++ b/packages/common/test/directives/ng_switch_spec.ts
@@ -150,7 +150,6 @@ describe('NgSwitch', () => {
         '<li *ngSwitchCase="\'a\'">when a</li>' +
         '<li *ngSwitchDefault>when default</li>' +
         '</ul>',
-      standalone: true,
     })
     class TestComponent {
       switchValue = 'a';

--- a/packages/common/test/directives/ng_template_outlet_spec.ts
+++ b/packages/common/test/directives/ng_template_outlet_spec.ts
@@ -337,7 +337,6 @@ describe('NgTemplateOutlet', () => {
         <ng-template #tpl>Hello World</ng-template>
         <ng-container *ngTemplateOutlet="tpl"></ng-container>
       `,
-      standalone: true,
     })
     class TestComponent {}
 
@@ -354,7 +353,6 @@ describe('NgTemplateOutlet', () => {
         <ng-template #tpl let-name>Name:{{ name }}</ng-template>
         <ng-template [ngTemplateOutlet]="tpl" [ngTemplateOutletContext]="ctx"></ng-template>
       `,
-      standalone: true,
     })
     class TestComponent {
       ctx: {$implicit: string} | undefined = undefined;

--- a/packages/common/test/pipes/async_pipe_spec.ts
+++ b/packages/common/test/pipes/async_pipe_spec.ts
@@ -284,7 +284,6 @@ describe('AsyncPipe', () => {
       selector: 'test-component',
       imports: [AsyncPipe],
       template: '{{ value | async }}',
-      standalone: true,
     })
     class TestComponent {
       value = of('foo');

--- a/packages/common/test/pipes/case_conversion_pipes_spec.ts
+++ b/packages/common/test/pipes/case_conversion_pipes_spec.ts
@@ -45,7 +45,6 @@ describe('LowerCasePipe', () => {
       selector: 'test-component',
       imports: [LowerCasePipe],
       template: '{{ value | lowercase }}',
-      standalone: true,
     })
     class TestComponent {
       value = 'FOO';
@@ -137,7 +136,6 @@ describe('TitleCasePipe', () => {
       selector: 'test-component',
       imports: [TitleCasePipe],
       template: '{{ value | titlecase }}',
-      standalone: true,
     })
     class TestComponent {
       value = 'foo';
@@ -186,7 +184,6 @@ describe('UpperCasePipe', () => {
       selector: 'test-component',
       imports: [UpperCasePipe],
       template: '{{ value | uppercase }}',
-      standalone: true,
     })
     class TestComponent {
       value = 'foo';

--- a/packages/common/test/pipes/date_pipe_spec.ts
+++ b/packages/common/test/pipes/date_pipe_spec.ts
@@ -82,7 +82,6 @@ describe('DatePipe', () => {
         selector: 'test-component',
         imports: [DatePipe],
         template: '{{ value | date }}',
-        standalone: true,
         providers: [{provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: {dateFormat: 'shortDate'}}],
       })
       class TestComponent {
@@ -101,7 +100,6 @@ describe('DatePipe', () => {
         selector: 'test-component',
         imports: [DatePipe],
         template: '{{ value | date }}',
-        standalone: true,
       })
       class TestComponent {
         value = '2017-01-11T10:14:39+0000';
@@ -176,7 +174,6 @@ describe('DatePipe', () => {
         selector: 'test-component',
         imports: [DatePipe],
         template: '{{ value | date }}',
-        standalone: true,
         providers: [{provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: {timezone: '-1200'}}],
       })
       class TestComponent {
@@ -195,7 +192,6 @@ describe('DatePipe', () => {
         selector: 'test-component',
         imports: [DatePipe],
         template: '{{ value | date }}',
-        standalone: true,
       })
       class TestComponent {
         value = '2017-01-11T00:00:00';
@@ -218,7 +214,6 @@ describe('DatePipe', () => {
       selector: 'test-component',
       imports: [DatePipe],
       template: '{{ value | date }}',
-      standalone: true,
     })
     class TestComponent {
       value = '2017-01-11T10:14:39+0000';

--- a/packages/common/test/pipes/i18n_plural_pipe_spec.ts
+++ b/packages/common/test/pipes/i18n_plural_pipe_spec.ts
@@ -67,7 +67,6 @@ describe('I18nPluralPipe', () => {
       selector: 'test-component',
       imports: [I18nPluralPipe],
       template: '{{ value | i18nPlural:mapping }}',
-      standalone: true,
     })
     class TestComponent {
       value = 1;

--- a/packages/common/test/pipes/i18n_select_pipe_spec.ts
+++ b/packages/common/test/pipes/i18n_select_pipe_spec.ts
@@ -43,7 +43,6 @@ describe('I18nSelectPipe', () => {
         selector: 'test-component',
         imports: [I18nSelectPipe],
         template: '{{ value | i18nSelect:mapping }}',
-        standalone: true,
       })
       class TestComponent {
         value = 'other';

--- a/packages/common/test/pipes/json_pipe_spec.ts
+++ b/packages/common/test/pipes/json_pipe_spec.ts
@@ -85,7 +85,6 @@ describe('JsonPipe', () => {
       selector: 'test-component',
       imports: [JsonPipe],
       template: '{{ value | json }}',
-      standalone: true,
     })
     class TestComponent {
       value = {'a': 1};

--- a/packages/common/test/pipes/keyvalue_pipe_spec.ts
+++ b/packages/common/test/pipes/keyvalue_pipe_spec.ts
@@ -221,7 +221,6 @@ describe('KeyValuePipe', () => {
       selector: 'test-component',
       imports: [KeyValuePipe, JsonPipe],
       template: '{{ value | keyvalue | json }}',
-      standalone: true,
     })
     class TestComponent {
       value = {'b': 1, 'a': 2};

--- a/packages/common/test/pipes/number_pipe_spec.ts
+++ b/packages/common/test/pipes/number_pipe_spec.ts
@@ -83,7 +83,6 @@ describe('Number pipes', () => {
         selector: 'test-component',
         imports: [DecimalPipe],
         template: '{{ value | number }}',
-        standalone: true,
       })
       class TestComponent {
         value = 12345;
@@ -136,7 +135,6 @@ describe('Number pipes', () => {
         selector: 'test-component',
         imports: [PercentPipe],
         template: '{{ value | percent }}',
-        standalone: true,
       })
       class TestComponent {
         value = 15;
@@ -234,7 +232,6 @@ describe('Number pipes', () => {
         selector: 'test-component',
         imports: [CurrencyPipe],
         template: '{{ value | currency }}',
-        standalone: true,
       })
       class TestComponent {
         value = 15;

--- a/packages/common/test/pipes/slice_pipe_spec.ts
+++ b/packages/common/test/pipes/slice_pipe_spec.ts
@@ -121,7 +121,6 @@ describe('SlicePipe', () => {
       selector: 'test-component',
       imports: [SlicePipe],
       template: '{{ title | slice:0:5 }}',
-      standalone: true,
     })
     class TestComponent {
       title = 'Hello World!';

--- a/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
@@ -1010,7 +1010,6 @@ runInEachFileSystem(() => {
             import {SomeModule} from './some_where';
 
             @Component({
-              standalone: true,
               selector: 'main',
               template: '<span>Hi!</span>',
               imports: [SomeModule],
@@ -1101,7 +1100,6 @@ runInEachFileSystem(() => {
             import {SomeModule} from './some_where';
 
             @Component({
-              standalone: true,
               selector: 'main',
               template: '<span>Hi!</span>',
               schemas: [CUSTOM_ELEMENTS_SCHEMA],

--- a/packages/compiler-cli/test/ngtsc/authoring_inputs_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/authoring_inputs_spec.ts
@@ -245,7 +245,6 @@ runInEachFileSystem(() => {
         }
 
         @Component({
-          standalone: true,
           template: \`<div dir [(value)]="value"></div>\`,
           imports: [TestDir],
         })
@@ -269,14 +268,12 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[directiveName]',
-            standalone: true,
           })
           export class TestDir {
             data = input(1);
           }
 
           @Component({
-            standalone: true,
             template: \`<div directiveName [data]="false"></div>\`,
             imports: [TestDir],
           })
@@ -300,7 +297,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[directiveName]',
-            standalone: true,
           })
           export class TestDir {
             data = input.required({
@@ -309,7 +305,6 @@ runInEachFileSystem(() => {
           }
 
           @Component({
-            standalone: true,
             template: \`<div directiveName [data]="false"></div>\`,
             imports: [TestDir],
           })
@@ -333,14 +328,12 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[directiveName]',
-            standalone: true,
           })
           export class TestDir {
             data = input.required<boolean>();
           }
 
           @Component({
-            standalone: true,
             template: \`<div directiveName></div>\`,
             imports: [TestDir],
           })
@@ -366,7 +359,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[directiveName]',
-            standalone: true,
           })
           export class TestDir {
             #data = input.required<boolean>();
@@ -393,7 +385,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[directiveName]',
-            standalone: true,
           })
           export class TestDir {
             private data = input.required<boolean>();
@@ -420,7 +411,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[directiveName]',
-            standalone: true,
           })
           export class TestDir {
             protected data = input.required<boolean>();

--- a/packages/compiler-cli/test/ngtsc/authoring_models_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/authoring_models_spec.ts
@@ -249,14 +249,12 @@ runInEachFileSystem(() => {
 
         @Directive({
           selector: '[dir]',
-          standalone: true,
         })
         export class TestDir {
           value = model(1);
         }
 
         @Component({
-          standalone: true,
           template: \`<div dir [(value)]="value()"></div>\`,
           imports: [TestDir],
         })
@@ -280,14 +278,12 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
           })
           export class TestDir {
             value = model(1);
           }
 
           @Component({
-            standalone: true,
             template: \`<div dir [(value)]="value"></div>\`,
             imports: [TestDir],
           })
@@ -310,14 +306,12 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
           })
           export class TestDir {
             value = model(1);
           }
 
           @Component({
-            standalone: true,
             template: \`<div dir [(value)]="value"></div>\`,
             imports: [TestDir],
           })
@@ -340,7 +334,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
           })
           export class TestDir {
             @Input() value = 0;
@@ -348,7 +341,6 @@ runInEachFileSystem(() => {
           }
 
           @Component({
-            standalone: true,
             template: \`<div dir [(value)]="value"></div>\`,
             imports: [TestDir],
           })
@@ -371,14 +363,12 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
           })
           export class TestDir {
             value = model(1);
           }
 
           @Component({
-            standalone: true,
             template: \`<div dir [(value)]="value"></div>\`,
             imports: [TestDir],
           })
@@ -403,14 +393,12 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
           })
           export class TestDir {
             value = model(1);
           }
 
           @Component({
-            standalone: true,
             template: \`<div dir [(value)]="value"></div>\`,
             imports: [TestDir],
           })
@@ -432,14 +420,12 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
           })
           export class TestDir {
             value = model(1);
           }
 
           @Component({
-            standalone: true,
             template: \`<div dir (valueChange)="acceptsString($event)"></div>\`,
             imports: [TestDir],
           })
@@ -464,14 +450,12 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
           })
           export class TestDir {
             value = model.required<number>();
           }
 
           @Component({
-            standalone: true,
             template: \`<div dir></div>\`,
             imports: [TestDir],
           })
@@ -495,14 +479,12 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
           })
           export class TestDir<T extends {id: string}> {
             value = model.required<T>();
           }
 
           @Component({
-            standalone: true,
             template: \`<div dir [(value)]="value"></div>\`,
             imports: [TestDir],
           })
@@ -529,14 +511,12 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
           })
           export class TestDir<T extends {id: string}> {
             value = model.required<T>();
           }
 
           @Component({
-            standalone: true,
             template: \`<div dir [(value)]="value"></div>\`,
             imports: [TestDir],
           })
@@ -563,14 +543,12 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
           })
           export class TestDir {
             value = model(0);
           }
 
           @Component({
-            standalone: true,
             template: \`<div dir [value]="value"></div>\`,
             imports: [TestDir],
           })
@@ -596,14 +574,12 @@ runInEachFileSystem(() => {
 
         @Directive({
           selector: '[dir]',
-          standalone: true,
         })
         export class TestDir<T> {
           value = model.required<T>();
         }
 
         @Component({
-          standalone: true,
           template: \`<div dir [(value)]="value"></div>\`,
           imports: [TestDir],
         })
@@ -627,7 +603,6 @@ runInEachFileSystem(() => {
 
         @Directive({
           selector: '[dir]',
-          standalone: true,
         })
         export class TestDir {
           @Input() value = 0;
@@ -635,7 +610,6 @@ runInEachFileSystem(() => {
         }
 
         @Component({
-          standalone: true,
           template: \`<div dir [(value)]="value"></div>\`,
           imports: [TestDir],
         })
@@ -662,7 +636,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
           })
           export class TestDir {
             @Input() value = 0;
@@ -670,7 +643,6 @@ runInEachFileSystem(() => {
           }
 
           @Component({
-            standalone: true,
             template: \`<div dir [(value)]="value"></div>\`,
             imports: [TestDir],
           })
@@ -694,7 +666,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[directiveName]',
-            standalone: true,
           })
           export class TestDir {
             #data = model.required<boolean>();
@@ -721,7 +692,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[directiveName]',
-            standalone: true,
           })
           export class TestDir {
             private data = model.required<boolean>();
@@ -748,7 +718,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[directiveName]',
-            standalone: true,
           })
           export class TestDir {
             protected data = model.required<boolean>();

--- a/packages/compiler-cli/test/ngtsc/defer_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/defer_spec.ts
@@ -31,7 +31,6 @@ runInEachFileSystem(() => {
         import { Component } from '@angular/core';
 
         @Component({
-          standalone: true,
           selector: 'cmp-a',
           template: 'CmpA!'
         })
@@ -47,14 +46,12 @@ runInEachFileSystem(() => {
 
         @Component({
           selector: 'local-dep',
-          standalone: true,
           template: 'Local dependency',
         })
         export class LocalDep {}
 
         @Component({
           selector: 'test-cmp',
-          standalone: true,
           imports: [CmpA, LocalDep],
           template: \`
             @defer {
@@ -86,7 +83,6 @@ runInEachFileSystem(() => {
           import { Component } from '@angular/core';
 
           @Component({
-            standalone: true,
             selector: 'cmp-a',
             template: 'CmpA!'
           })
@@ -102,7 +98,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'test-cmp',
-            standalone: true,
             imports: [CmpA],
             template: \`
               @defer {
@@ -132,7 +127,6 @@ runInEachFileSystem(() => {
           import { Component } from '@angular/core';
 
           @Component({
-            standalone: true,
             selector: 'cmp-a',
             template: 'CmpA!'
           })
@@ -148,7 +142,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'test-cmp',
-            standalone: true,
             imports: [CmpA],
             template: \`
               @defer {
@@ -185,14 +178,12 @@ runInEachFileSystem(() => {
           import { Component } from '@angular/core';
 
           @Component({
-            standalone: true,
             selector: 'cmp-a',
             template: 'CmpA!'
           })
           export class CmpA {}
 
           @Component({
-            standalone: true,
             selector: 'cmp-b',
             template: 'CmpB!'
           })
@@ -208,7 +199,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'test-cmp',
-            standalone: true,
             imports: [CmpA, CmpB],
             template: \`
               @defer {
@@ -247,14 +237,12 @@ runInEachFileSystem(() => {
           import { Component } from '@angular/core';
 
           @Component({
-            standalone: true,
             selector: 'cmp-a',
             template: 'CmpA!'
           })
           export class CmpA {}
 
           @Component({
-            standalone: true,
             selector: 'cmp-b',
             template: 'CmpB!'
           })
@@ -270,7 +258,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'test-cmp',
-            standalone: true,
             imports: [CmpA, CmpB],
             template: \`
               @defer {
@@ -306,7 +293,6 @@ runInEachFileSystem(() => {
           import { Component } from '@angular/core';
 
           @Component({
-            standalone: true,
             selector: 'cmp-a',
             template: 'CmpA!'
           })
@@ -322,7 +308,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'test-cmp',
-            standalone: true,
             imports: [forwardRef(() => CmpA)],
             template: \`
               @defer {
@@ -355,7 +340,6 @@ runInEachFileSystem(() => {
           export class Foo {}
 
           @Component({
-            standalone: true,
             selector: 'cmp-a',
             template: 'CmpA!'
           })
@@ -373,7 +357,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'test-cmp',
-            standalone: true,
             imports: [CmpA],
             template: \`
               @defer {
@@ -403,7 +386,6 @@ runInEachFileSystem(() => {
             export class Foo {}
 
             @Component({
-              standalone: true,
               selector: 'cmp-a',
               template: 'CmpA!'
             })
@@ -422,7 +404,6 @@ runInEachFileSystem(() => {
 
             @Component({
               selector: 'test-cmp',
-              standalone: true,
               imports: [CmpA],
               template: \`
                 @defer {
@@ -452,7 +433,6 @@ runInEachFileSystem(() => {
             export class Foo {}
 
             @Component({
-              standalone: true,
               selector: 'cmp-a',
               template: 'CmpA!'
             })
@@ -471,7 +451,6 @@ runInEachFileSystem(() => {
 
             @Component({
               selector: 'test-cmp',
-              standalone: true,
               imports: [CmpA],
               template: \`
                 @defer {
@@ -501,7 +480,6 @@ runInEachFileSystem(() => {
             export class Foo {}
 
             @Component({
-              standalone: true,
               selector: 'cmp-a',
               template: 'CmpA!'
             })
@@ -520,7 +498,6 @@ runInEachFileSystem(() => {
 
             @Component({
               selector: 'test-cmp',
-              standalone: true,
               imports: [CmpA],
               template: \`
                 @defer {
@@ -548,14 +525,12 @@ runInEachFileSystem(() => {
           import { Component } from '@angular/core';
 
           @Component({
-            standalone: true,
             selector: 'cmp-a',
             template: 'CmpA!'
           })
           export class CmpA {}
 
           @Component({
-            standalone: true,
             selector: 'cmp-b',
             template: 'CmpB!'
           })
@@ -572,7 +547,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'test-cmp',
-            standalone: true,
             imports: [CmpA, CmpB],
             template: \`
               @defer {
@@ -603,7 +577,6 @@ runInEachFileSystem(() => {
           `
           import { Component } from '@angular/core';
           @Component({
-            standalone: true,
             selector: 'cmp-a',
             template: 'CmpA!'
           })
@@ -617,13 +590,11 @@ runInEachFileSystem(() => {
           import CmpA from './cmp-a';
           @Component({
             selector: 'local-dep',
-            standalone: true,
             template: 'Local dependency',
           })
           export class LocalDep {}
           @Component({
             selector: 'test-cmp',
-            standalone: true,
             imports: [CmpA, LocalDep],
             template: \`
               @defer {
@@ -657,7 +628,6 @@ runInEachFileSystem(() => {
           import { Component } from '@angular/core';
 
           @Component({
-            standalone: true,
             selector: 'cmp',
             template: 'Cmp!'
           })
@@ -674,7 +644,6 @@ runInEachFileSystem(() => {
           const topLevelConst: Cmp = null!;
 
           @Component({
-            standalone: true,
             imports: [Cmp],
             template: \`
               @defer {
@@ -715,7 +684,6 @@ runInEachFileSystem(() => {
           import { Component } from '@angular/core';
 
           @Component({
-            standalone: true,
             selector: 'cmp',
             template: 'Cmp!'
           })
@@ -730,7 +698,6 @@ runInEachFileSystem(() => {
           import { Cmp } from './cmp';
 
           @Component({
-            standalone: true,
             imports: [Cmp],
             template: \`
               @defer {
@@ -763,7 +730,7 @@ runInEachFileSystem(() => {
         `
         import { Pipe } from '@angular/core';
 
-        @Pipe({name: 'test', standalone: true})
+        @Pipe({name: 'test'})
         export class TestPipe {
           transform() {
             return 1;
@@ -780,7 +747,6 @@ runInEachFileSystem(() => {
 
         @Component({
           selector: 'test-cmp',
-          standalone: true,
           imports: [TestPipe],
           template: '@defer (when 1 | test) { hello }',
         })
@@ -802,7 +768,7 @@ runInEachFileSystem(() => {
         `
         import { Pipe } from '@angular/core';
 
-        @Pipe({name: 'test', standalone: true})
+        @Pipe({name: 'test'})
         export class TestPipe {
           transform() {
             return 1;
@@ -819,7 +785,6 @@ runInEachFileSystem(() => {
 
         @Component({
           selector: 'test-cmp',
-          standalone: true,
           imports: [TestPipe],
           template: '@defer (when 1 | test) { hello }',
         })
@@ -841,7 +806,7 @@ runInEachFileSystem(() => {
         `
         import { Pipe } from '@angular/core';
 
-        @Pipe({name: 'test', standalone: true})
+        @Pipe({name: 'test'})
         export class TestPipe {
           transform() {
             return 1;
@@ -858,7 +823,6 @@ runInEachFileSystem(() => {
 
         @Component({
           selector: 'test-cmp',
-          standalone: true,
           imports: [TestPipe],
           template: '@defer (when 1 | test) { {{1 | test}} }',
         })
@@ -886,7 +850,6 @@ runInEachFileSystem(() => {
           import {Component} from '@angular/core';
 
           @Component({
-            standalone: true,
             selector: 'deferred-cmp-a',
             template: 'DeferredCmpA contents',
           })
@@ -901,7 +864,6 @@ runInEachFileSystem(() => {
           import {Component} from '@angular/core';
 
           @Component({
-            standalone: true,
             selector: 'deferred-cmp-b',
             template: 'DeferredCmpB contents',
           })
@@ -918,7 +880,6 @@ runInEachFileSystem(() => {
           import {DeferredCmpB} from './deferred-b';
 
           @Component({
-            standalone: true,
             // @ts-ignore
             deferredImports: [DeferredCmpA, DeferredCmpB],
             template: \`
@@ -972,7 +933,6 @@ runInEachFileSystem(() => {
             import {Component} from '@angular/core';
 
             @Component({
-              standalone: true,
               selector: 'eager-cmp-a',
               template: 'EagerCmpA contents',
             })
@@ -987,7 +947,6 @@ runInEachFileSystem(() => {
             import {Component} from '@angular/core';
 
             @Component({
-              standalone: true,
               selector: 'deferred-cmp-a',
               template: 'DeferredCmpA contents',
             })
@@ -1002,7 +961,6 @@ runInEachFileSystem(() => {
             import {Component} from '@angular/core';
 
             @Component({
-              standalone: true,
               selector: 'deferred-cmp-b',
               template: 'DeferredCmpB contents',
             })
@@ -1020,7 +978,6 @@ runInEachFileSystem(() => {
             import {EagerCmpA} from './eager-a';
 
             @Component({
-              standalone: true,
               imports: [EagerCmpA],
               // @ts-ignore
               deferredImports: [DeferredCmpA, DeferredCmpB],
@@ -1085,7 +1042,6 @@ runInEachFileSystem(() => {
               @Injectable()
               class MyInjectable {}
               @Component({
-                standalone: true,
                 // @ts-ignore
                 deferredImports: [MyInjectable],
                 template: '',
@@ -1108,7 +1064,6 @@ runInEachFileSystem(() => {
               @NgModule()
               class MyModule {}
               @Component({
-                standalone: true,
                 // @ts-ignore
                 deferredImports: [MyModule],
                 template: '',
@@ -1129,7 +1084,6 @@ runInEachFileSystem(() => {
             `
               import {Component} from '@angular/core';
               @Component({
-                standalone: true,
                 selector: 'deferred-cmp-a',
                 template: 'DeferredCmpA contents',
               })
@@ -1143,7 +1097,6 @@ runInEachFileSystem(() => {
             `
               import {Component} from '@angular/core';
               @Component({
-                standalone: true,
                 selector: 'deferred-cmp-b',
                 template: 'DeferredCmpB contents',
               })
@@ -1159,7 +1112,6 @@ runInEachFileSystem(() => {
               import {DeferredCmpA} from './deferred-a';
               import {DeferredCmpB} from './deferred-b';
               @Component({
-                standalone: true,
                 // @ts-ignore
                 deferredImports: [DeferredCmpA, DeferredCmpB],
                 template: \`
@@ -1186,7 +1138,6 @@ runInEachFileSystem(() => {
             `
               import {Component} from '@angular/core';
               @Component({
-                standalone: true,
                 selector: 'deferred-cmp-a',
                 template: 'DeferredCmpA contents',
               })
@@ -1201,7 +1152,6 @@ runInEachFileSystem(() => {
               import {Component} from '@angular/core';
               import {DeferredCmpA} from './deferred-a';
               @Component({
-                standalone: true,
                 // @ts-ignore
                 deferredImports: [DeferredCmpA],
                 imports: [DeferredCmpA],
@@ -1226,7 +1176,6 @@ runInEachFileSystem(() => {
             `
               import {Pipe} from '@angular/core';
               @Pipe({
-                standalone: true,
                 name: 'deferredPipeA'
               })
               export class DeferredPipeA {
@@ -1240,7 +1189,6 @@ runInEachFileSystem(() => {
             `
               import {Pipe} from '@angular/core';
               @Pipe({
-                standalone: true,
                 name: 'deferredPipeB'
               })
               export class DeferredPipeB {
@@ -1256,7 +1204,6 @@ runInEachFileSystem(() => {
               import {DeferredPipeA} from './deferred-pipe-a';
               import {DeferredPipeB} from './deferred-pipe-b';
               @Component({
-                standalone: true,
                 // @ts-ignore
                 deferredImports: [DeferredPipeA, DeferredPipeB],
                 template: \`
@@ -1281,7 +1228,6 @@ runInEachFileSystem(() => {
             `
             import {Component} from '@angular/core';
             @Component({
-              standalone: true,
               selector: 'deferred-cmp-a',
               template: 'DeferredCmpA contents',
             })
@@ -1296,7 +1242,6 @@ runInEachFileSystem(() => {
             import {Component} from '@angular/core';
             import {DeferredCmpA} from './deferred-a';
             @Component({
-              standalone: true,
               // @ts-ignore
               deferredImports: [DeferredCmpA],
               template: \`
@@ -1327,7 +1272,6 @@ runInEachFileSystem(() => {
             `
               import {Component} from '@angular/core';
               @Component({
-                standalone: true,
                 selector: 'deferred-cmp-a',
                 template: 'DeferredCmpA contents',
               })
@@ -1342,7 +1286,6 @@ runInEachFileSystem(() => {
               import {Component} from '@angular/core';
               import {DeferredCmpA} from './deferred-a';
               @Component({
-                standalone: true,
                 // @ts-ignore
                 deferredImports: [DeferredCmpA],
                 template: \`
@@ -1377,7 +1320,6 @@ runInEachFileSystem(() => {
           import {Component} from '@angular/core';
 
           @Component({
-            standalone: true,
             selector: 'cmp-a',
             template: 'CmpA!'
           })
@@ -1393,14 +1335,12 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'local-dep',
-            standalone: true,
             template: 'Local dependency',
           })
           export class LocalDep {}
 
           @Component({
             selector: 'test-cmp',
-            standalone: true,
             imports: [CmpA, LocalDep],
             template: \`
               @defer {
@@ -1440,7 +1380,6 @@ runInEachFileSystem(() => {
             import {Component} from '@angular/core';
 
             @Component({
-              standalone: true,
               selector: 'cmp-a',
               template: 'CmpA!'
             })
@@ -1456,7 +1395,6 @@ runInEachFileSystem(() => {
 
             @Component({
               selector: 'test-cmp',
-              standalone: true,
               imports: [CmpA],
               template: \`
                 @defer {
@@ -1497,7 +1435,6 @@ runInEachFileSystem(() => {
         import {Component} from '@angular/core';
 
         @Component({
-          standalone: true,
           selector: 'cmp-a',
           template: 'CmpA!'
         })
@@ -1513,14 +1450,12 @@ runInEachFileSystem(() => {
 
         @Component({
           selector: 'local-dep',
-          standalone: true,
           template: 'Local dependency',
         })
         export class LocalDep {}
 
         @Component({
           selector: 'test-cmp',
-          standalone: true,
           imports: [CmpA, LocalDep],
           template: \`
             @defer {

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/directive_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/directive_doc_extraction_spec.ts
@@ -36,7 +36,6 @@ runInEachFileSystem(() => {
         `
         import {Directive} from '@angular/core';
         @Directive({
-          standalone: true,
           selector: 'user-profile',
           exportAs: 'userProfile',
         })
@@ -61,7 +60,6 @@ runInEachFileSystem(() => {
         `
         import {Component} from '@angular/core';
         @Component({
-          standalone: true,
           selector: 'user-profile',
           exportAs: 'userProfile',
           template: '',
@@ -146,7 +144,6 @@ runInEachFileSystem(() => {
         `
         import {Directive, EventEmitter, Input, Output} from '@angular/core';
         @Directive({
-          standalone: true,
           selector: 'user-profile',
           exportAs: 'userProfile',
         })
@@ -203,7 +200,6 @@ runInEachFileSystem(() => {
         `
         import {Component, EventEmitter, Input, Output} from '@angular/core';
         @Component({
-          standalone: true,
           selector: 'user-profile',
           exportAs: 'userProfile',
           template: '',
@@ -251,7 +247,6 @@ runInEachFileSystem(() => {
         `
         import {Component, EventEmitter, Input, Output} from '@angular/core';
         @Component({
-          standalone: true,
           selector: 'user-profile',
           exportAs: 'userProfile',
           template: '',

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/pipe_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/pipe_doc_extraction_spec.ts
@@ -30,7 +30,6 @@ runInEachFileSystem(() => {
         `
         import {Pipe} from '@angular/core';
         @Pipe({
-          standalone: true,
           name: 'shorten',
         })
         export class ShortenPipe {

--- a/packages/compiler-cli/test/ngtsc/hmr_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/hmr_spec.ts
@@ -41,7 +41,6 @@ runInEachFileSystem(() => {
           @Component({
             selector: 'cmp',
             template: 'hello',
-            standalone: true,
           })
           export class Cmp {}
         `,
@@ -71,7 +70,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dep]',
-            standalone: true,
           })
           export class Dep {}
         `,
@@ -85,7 +83,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'cmp',
-            standalone: true,
             template: '<div dep><div>',
             imports: [Dep],
           })
@@ -132,7 +129,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'cmp',
-            standalone: true,
             template: '@if (true) {hello}',
           })
           export class Cmp {}
@@ -157,7 +153,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'cmp',
-            standalone: true,
             template: '<ng-content select="header"/><ng-content/>',
           })
           export class Cmp {}
@@ -184,7 +179,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dep]',
-            standalone: true,
           })
           export class Dep {}
         `,
@@ -198,7 +192,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'cmp',
-            standalone: true,
             template: '@defer (on timer(1000)) {<div dep></div>}',
             imports: [Dep],
           })
@@ -234,7 +227,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'cmp',
-            standalone: true,
             template: '{{#invalid}}',
           })
           export class Cmp {}
@@ -254,7 +246,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: '[dir]',
-            standalone: true
           })
           export class Dir {}
         `,

--- a/packages/compiler-cli/test/ngtsc/host_directives_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/host_directives_spec.ts
@@ -36,13 +36,11 @@ runInEachFileSystem(() => {
 
         @Directive({
           selector: '[dir-a]',
-          standalone: true
         })
         export class DirectiveA {}
 
         @Directive({
           selector: '[dir-b]',
-          standalone: true
         })
         export class DirectiveB {}
 
@@ -81,7 +79,6 @@ runInEachFileSystem(() => {
 
         @Directive({
           selector: '[dir-a]',
-          standalone: true
         })
         export class HostDir {
           @Input() value: number;
@@ -131,7 +128,6 @@ runInEachFileSystem(() => {
 
         @Directive({
           selector: '[dir-a]',
-          standalone: true
         })
         export class HostDir {
           @Input('valueAlias') value: number;
@@ -179,19 +175,17 @@ runInEachFileSystem(() => {
         `
         import {Directive, Component} from '@angular/core';
 
-        @Directive({standalone: true})
+        @Directive({})
         export class DirectiveA {
         }
 
         @Directive({
-          standalone: true,
           hostDirectives: [DirectiveA],
         })
         export class DirectiveB {
         }
 
         @Directive({
-          standalone: true,
           hostDirectives: [DirectiveB],
         })
         export class DirectiveC {
@@ -263,7 +257,6 @@ runInEachFileSystem(() => {
         }
 
         @Directive({
-          standalone: true,
           hostDirectives: [{directive: forwardRef(() => DirectiveA), inputs: ['value']}],
         })
         export class DirectiveB {
@@ -317,7 +310,6 @@ runInEachFileSystem(() => {
 
         @Directive({
           selector: '[dir-a]',
-          standalone: true
         })
         export class DirectiveA {}
       `,
@@ -330,7 +322,6 @@ runInEachFileSystem(() => {
 
         @Directive({
           selector: '[dir-b]',
-          standalone: true
         })
         export class DirectiveB {
           @Input() input: any;
@@ -485,7 +476,7 @@ runInEachFileSystem(() => {
         `
             import {Directive, Component, Input} from '@angular/core';
 
-            @Directive({standalone: true})
+            @Directive({})
             export class HostDir {
               @Input({alias: 'inputAlias', required: true})
               input: any;
@@ -494,13 +485,11 @@ runInEachFileSystem(() => {
             @Directive({
               selector: '[dir]',
               hostDirectives: [{directive: HostDir, inputs: ['inputAlias: customAlias']}],
-              standalone: true
             })
             export class Dir {}
 
             @Component({
               template: '<div dir></div>',
-              standalone: true,
               imports: [Dir]
             })
             class App {}
@@ -520,7 +509,7 @@ runInEachFileSystem(() => {
         `
             import {Directive, Component, Input} from '@angular/core';
 
-            @Directive({standalone: true})
+            @Directive({})
             export class HostDir {
               @Input({alias: 'inputAlias', required: true})
               input: any;
@@ -529,13 +518,11 @@ runInEachFileSystem(() => {
             @Directive({
               selector: '[dir]',
               hostDirectives: [{directive: HostDir, inputs: ['inputAlias: customAlias']}],
-              standalone: true
             })
             export class Dir {}
 
             @Component({
               template: '<div dir [customAlias]="value"></div>',
-              standalone: true,
               imports: [Dir]
             })
             class App {
@@ -602,7 +589,6 @@ runInEachFileSystem(() => {
 
           @Component({
             template: '',
-            standalone: true,
           })
           export class HostComp {}
 
@@ -691,7 +677,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir-a]',
-            standalone: true,
             hostDirectives: [HostDirB]
           })
           export class HostDirA {}
@@ -719,7 +704,7 @@ runInEachFileSystem(() => {
           `
           import {Directive, Output, EventEmitter} from '@angular/core';
 
-          @Directive({standalone: true})
+          @Directive({})
           class HostDir {
             @Output() foo = new EventEmitter();
           }
@@ -748,7 +733,7 @@ runInEachFileSystem(() => {
           `
           import {Directive, Output, EventEmitter} from '@angular/core';
 
-          @Directive({standalone: true})
+          @Directive({})
           class HostDir {
             @Output('alias') foo = new EventEmitter();
           }
@@ -777,7 +762,7 @@ runInEachFileSystem(() => {
           `
           import {Directive, Input} from '@angular/core';
 
-          @Directive({standalone: true})
+          @Directive({})
           class HostDir {
             @Input() foo: any;
           }
@@ -806,7 +791,7 @@ runInEachFileSystem(() => {
           `
           import {Directive, Input} from '@angular/core';
 
-          @Directive({standalone: true})
+          @Directive({})
           class HostDir {
             @Input('alias') foo: any;
           }
@@ -832,7 +817,7 @@ runInEachFileSystem(() => {
           `
           import {Directive, Input} from '@angular/core';
 
-          @Directive({selector: '[host-dir]', standalone: true})
+          @Directive({selector: '[host-dir]'})
           class HostDir {
             @Input('colorAlias') color?: string;
             @Input() buttonColor?: string;
@@ -860,7 +845,7 @@ runInEachFileSystem(() => {
           `
             import {Directive, Input} from '@angular/core';
 
-            @Directive({selector: '[host-dir]', standalone: true})
+            @Directive({selector: '[host-dir]'})
             class HostDir {
               @Input('colorAlias') color?: string;
               @Input('buttonColorAlias') buttonColor?: string;
@@ -887,7 +872,7 @@ runInEachFileSystem(() => {
           `
           import {Directive, Input} from '@angular/core';
 
-          @Directive({selector: '[host-dir]', standalone: true})
+          @Directive({selector: '[host-dir]'})
           class HostDir {
             @Input('color') color?: string;
           }
@@ -910,7 +895,7 @@ runInEachFileSystem(() => {
           `
           import {Directive, Output, EventEmitter} from '@angular/core';
 
-          @Directive({selector: '[host-dir]', standalone: true})
+          @Directive({selector: '[host-dir]'})
           class HostDir {
             @Output('clickedAlias') clicked = new EventEmitter();
             @Output('tappedAlias') tapped = new EventEmitter();
@@ -937,7 +922,7 @@ runInEachFileSystem(() => {
           `
           import {Directive, Output, EventEmitter} from '@angular/core';
 
-          @Directive({selector: '[host-dir]', standalone: true})
+          @Directive({selector: '[host-dir]'})
           class HostDir {
             @Output('clicked') clicked = new EventEmitter();
           }
@@ -962,7 +947,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir-a]',
-            standalone: true
           })
           export class HostDir {
             @Input({required: true}) input: any;
@@ -992,7 +976,6 @@ runInEachFileSystem(() => {
 
               @Directive({
                 selector: '[dir-a]',
-                standalone: true
               })
               export class HostDir {
                 @Input({required: true, alias: 'inputAlias'}) input: any;
@@ -1022,7 +1005,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir-a]',
-            standalone: true
           })
           export class HostDir {
             @Input({required: true, alias: 'inputAlias'}) input: any;
@@ -1050,7 +1032,6 @@ runInEachFileSystem(() => {
 
               @Directive({
                 selector: '[dir-a]',
-                standalone: true
               })
               export class HostDir {
                 @Input({required: true, alias: 'inputAlias'}) input: any;
@@ -1079,14 +1060,12 @@ runInEachFileSystem(() => {
           @Directive({
             outputs: ['opened: triggerOpened'],
             selector: '[trigger]',
-            standalone: true,
           })
           export class Trigger {
             opened = new EventEmitter();
           }
 
           @Directive({
-            standalone: true,
             selector: '[host]',
             hostDirectives: [{directive: Trigger, outputs: ['triggerOpened']}]
           })
@@ -1104,7 +1083,7 @@ runInEachFileSystem(() => {
           `
           import {Directive, EventEmitter} from '@angular/core';
 
-          @Directive({standalone: true})
+          @Directive({})
           export abstract class Base {
             opened = new EventEmitter();
           }
@@ -1112,12 +1091,10 @@ runInEachFileSystem(() => {
           @Directive({
             outputs: ['opened: triggerOpened'],
             selector: '[trigger]',
-            standalone: true,
           })
           export class Trigger extends Base {}
 
           @Directive({
-            standalone: true,
             selector: '[host]',
             hostDirectives: [{directive: Trigger, outputs: ['triggerOpened: hostOpened']}]
           })

--- a/packages/compiler-cli/test/ngtsc/incremental_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/incremental_spec.ts
@@ -592,7 +592,6 @@ runInEachFileSystem(() => {
         import {DepModule} from './provider-dep';
 
         @Component({
-          standalone: true,
           template: '',
           imports: [DepModule],
         })

--- a/packages/compiler-cli/test/ngtsc/local_compilation_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/local_compilation_spec.ts
@@ -140,7 +140,7 @@ runInEachFileSystem(() => {
           `
         import {NgModule, Component} from '@angular/core';
 
-        @Component({template:'', standalone: true})
+        @Component({template:''})
         export class Comp3 {
         }
 
@@ -154,7 +154,7 @@ runInEachFileSystem(() => {
           `
         import {Component} from '@angular/core';
 
-        @Component({template:'', standalone: true})
+        @Component({template:''})
         export class Comp2 {
         }
         `,
@@ -787,7 +787,6 @@ runInEachFileSystem(() => {
           import {SomeThing2} from 'some-where2';
 
           @Component({
-            standalone: true,
             imports: [SomeThing, forwardRef(()=>SomeThing2)],
             selector: 'test-main',
             template: '<span>Hello world!</span>',
@@ -816,7 +815,6 @@ runInEachFileSystem(() => {
           const NG_IMPORTS = [SomeThing, forwardRef(()=>SomeThing2)];
 
           @Component({
-            standalone: true,
             imports: NG_IMPORTS,
             selector: 'test-main',
             template: '<span>Hello world!</span>',
@@ -841,7 +839,6 @@ runInEachFileSystem(() => {
       import {Component} from '@angular/core';
 
       @Component({
-        standalone: true,
         imports: [],
         selector: 'test-main',
         template: '<span>Hello world!</span>',
@@ -866,7 +863,6 @@ runInEachFileSystem(() => {
           import {Component} from '@angular/core';
 
           @Component({
-            standalone: true,
             selector: 'test-main',
             template: '<span>Hello world!</span>',
           })
@@ -1072,7 +1068,6 @@ runInEachFileSystem(() => {
           import * as SomeWhere4 from './some-where4'
 
           @Component({
-            standalone: true,
             selector: 'test-main',
             template: '<span>Hello world</span>',
           })
@@ -1148,9 +1143,7 @@ runInEachFileSystem(() => {
           import * as SomeWhere3 from './some-where3'
           import * as SomeWhere4 from './some-where4'
 
-          @Directive({
-            standalone: true,
-          })
+          @Directive({})
           export class MainDirective {
             constructor(
               private someService1: SomeService1,
@@ -1224,7 +1217,6 @@ runInEachFileSystem(() => {
 
           @Pipe({
             name: 'pipe',
-            standalone: true,
           })
           export class MainPipe {
             constructor(
@@ -1863,7 +1855,7 @@ runInEachFileSystem(() => {
           import {ExternalDirective} from 'some_where';
           import * as n from 'some_where2';
 
-          @Directive({standalone: true})
+          @Directive({})
           export class LocalDirective {
           }
 
@@ -1922,9 +1914,7 @@ runInEachFileSystem(() => {
           `
           import {Directive, Component} from '@angular/core';
 
-          @Directive({
-            standalone: true
-          })
+          @Directive({})
           export class LocalDirective {
           }
 
@@ -1960,14 +1950,12 @@ runInEachFileSystem(() => {
           import {ExternalDirective} from 'some_where';
 
           @Directive({
-            standalone: true,
             hostDirectives: [ExternalDirective],
           })
           export class LocalDirective {
           }
 
           @Directive({
-            standalone: true,
             hostDirectives: [LocalDirective],
           })
           export class LocalDirective2 {
@@ -2004,13 +1992,12 @@ runInEachFileSystem(() => {
           }
 
           @Directive({
-            standalone: true,
             hostDirectives: [{directive: forwardRef(() => DirectiveA), inputs: ['value']}],
           })
           export class DirectiveB {
           }
 
-          @Directive({standalone: true})
+          @Directive({})
           export class DirectiveA {
             @Input() value: any;
           }
@@ -2186,7 +2173,6 @@ runInEachFileSystem(() => {
           `
           import {Component} from '@angular/core';
           @Component({
-            standalone: true,
             selector: 'deferred-cmp-a',
             template: 'DeferredCmpA contents',
           })
@@ -2200,7 +2186,6 @@ runInEachFileSystem(() => {
           `
           import {Component} from '@angular/core';
           @Component({
-            standalone: true,
             selector: 'deferred-cmp-b',
             template: 'DeferredCmpB contents',
           })
@@ -2216,7 +2201,6 @@ runInEachFileSystem(() => {
           import {DeferredCmpA} from './deferred-a';
           import {DeferredCmpB} from './deferred-b';
           @Component({
-            standalone: true,
             deferredImports: [DeferredCmpA, DeferredCmpB],
             template: \`
               @defer {
@@ -2267,7 +2251,6 @@ runInEachFileSystem(() => {
           `
           import {Component} from '@angular/core';
           @Component({
-            standalone: true,
             selector: 'deferred-cmp-a',
             template: 'DeferredCmpA contents',
           })
@@ -2282,7 +2265,6 @@ runInEachFileSystem(() => {
           import {Component} from '@angular/core';
           import {DeferredCmpA} from './deferred-a';
           @Component({
-            standalone: true,
             imports: [DeferredCmpA],
             template: \`
               @defer {
@@ -2320,7 +2302,6 @@ runInEachFileSystem(() => {
           `
               import {Component} from '@angular/core';
               @Component({
-                standalone: true,
                 selector: 'eager-cmp-a',
                 template: 'EagerCmpA contents',
               })
@@ -2334,7 +2315,6 @@ runInEachFileSystem(() => {
           `
               import {Component} from '@angular/core';
               @Component({
-                standalone: true,
                 selector: 'deferred-cmp-a',
                 template: 'DeferredCmpA contents',
               })
@@ -2348,7 +2328,6 @@ runInEachFileSystem(() => {
           `
               import {Component} from '@angular/core';
               @Component({
-                standalone: true,
                 selector: 'deferred-cmp-b',
                 template: 'DeferredCmpB contents',
               })
@@ -2365,7 +2344,6 @@ runInEachFileSystem(() => {
               import {DeferredCmpB} from './deferred-b';
               import {EagerCmpA} from './eager-a';
               @Component({
-                standalone: true,
                 imports: [EagerCmpA],
                 deferredImports: [DeferredCmpA, DeferredCmpB],
                 template: \`
@@ -2427,7 +2405,6 @@ runInEachFileSystem(() => {
               import {Component} from '@angular/core';
 
               @Component({
-                standalone: true,
                 selector: 'deferred-cmp-a',
                 template: 'DeferredCmpA contents',
               })
@@ -2435,7 +2412,6 @@ runInEachFileSystem(() => {
               }
 
               @Component({
-                standalone: true,
                 selector: 'deferred-cmp-b',
                 template: 'DeferredCmpB contents',
               })
@@ -2455,7 +2431,6 @@ runInEachFileSystem(() => {
               import {DeferredCmpA, DeferredCmpB} from './deferred-deps';
 
               @Component({
-                standalone: true,
                 deferredImports: [DeferredCmpA],
                 template: \`
                   @defer {
@@ -2466,7 +2441,6 @@ runInEachFileSystem(() => {
               export class AppCmpA {}
 
               @Component({
-                standalone: true,
                 deferredImports: [DeferredCmpB],
                 template: \`
                   @defer {
@@ -2521,7 +2495,6 @@ runInEachFileSystem(() => {
               import {Component} from '@angular/core';
 
               @Component({
-                standalone: true,
                 selector: 'deferred-cmp-a',
                 template: 'DeferredCmpA contents',
               })
@@ -2529,7 +2502,6 @@ runInEachFileSystem(() => {
               }
 
               @Component({
-                standalone: true,
                 selector: 'deferred-cmp-b',
                 template: 'DeferredCmpB contents',
               })
@@ -2553,7 +2525,6 @@ runInEachFileSystem(() => {
               import {DeferredCmpA, DeferredCmpB, utilityFn} from './deferred-deps';
 
               @Component({
-                standalone: true,
                 deferredImports: [DeferredCmpA],
                 template: \`
                   @defer {
@@ -2568,7 +2539,6 @@ runInEachFileSystem(() => {
               }
 
               @Component({
-                standalone: true,
                 deferredImports: [DeferredCmpB],
                 template: \`
                   @defer {
@@ -2579,7 +2549,6 @@ runInEachFileSystem(() => {
               export class AppCmpB {}
 
               @Component({
-                standalone: true,
                 template: 'Component without any dependencies'
               })
               export class ComponentWithoutDeps {}

--- a/packages/compiler-cli/test/ngtsc/ls_typecheck_helpers_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ls_typecheck_helpers_spec.ts
@@ -41,7 +41,6 @@ runInEachFileSystem(() => {
 		 import {Component} from '@angular/core';
 
 		 @Component({
-			 standalone: true,
 			 selector: 'test-cmp',
 			 template: '<div></div>',
 		 })
@@ -148,7 +147,6 @@ runInEachFileSystem(() => {
 			  @Component({
 				  selector: 'app-cmp',
 				  template: '<div></div>',
-				  standalone: true,
 			  })
 			  export class AppCmp {}
 			`,
@@ -201,7 +199,6 @@ runInEachFileSystem(() => {
 		   import {Component} from '@angular/core';
 
 		   @Component({
-			   standalone: true,
 			   selector: 'one-cmp',
 			   template: '<div></div>',
 		   })
@@ -215,7 +212,6 @@ runInEachFileSystem(() => {
 		   import {Component} from '@angular/core';
 
 		   @Component({
-			   standalone: true,
 			   selector: 'two-cmp',
 			   template: '<div></div>',
 		   })
@@ -239,7 +235,6 @@ runInEachFileSystem(() => {
 
 			 @Pipe({
 				name: 'foo-pipe',
-				standalone: true,
 			  })
 			  export class OnePipe {
 			  }
@@ -252,7 +247,6 @@ runInEachFileSystem(() => {
 			 import {Component} from '@angular/core';
 
 			 @Component({
-				 standalone: true,
 				 selector: 'two-cmp',
 				 template: '<div></div>',
 			 })
@@ -275,7 +269,6 @@ runInEachFileSystem(() => {
 			 import {Component} from '@angular/core';
 
 			 @Component({
-				 standalone: true,
 				 selector: 'one-cmp',
 				 template: '<div></div>',
 			 })
@@ -289,7 +282,6 @@ runInEachFileSystem(() => {
 			 import {Component} from '@angular/core';
 
 			 @Component({
-				 standalone: true,
 				 selector: 'two-cmp',
 				 template: '<div></div>',
 			 })
@@ -323,7 +315,6 @@ runInEachFileSystem(() => {
 			 import {Component} from '@angular/core';
 
 			 @Component({
-				 standalone: true,
 				 selector: 'one-cmp',
 				 template: '<div></div>',
 			 })
@@ -394,14 +385,12 @@ runInEachFileSystem(() => {
 					import {Component} from '@angular/core';
 
 					@Component({
-						standalone: true,
 						selector: 'one-cmp',
 						template: '<div></div>',
 					})
 					export class OneCmp {}
 
 					@Component({
-						standalone: true,
 						selector: 'two-cmp',
 						template: '<div></div>',
 					})

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -2903,7 +2903,7 @@ runInEachFileSystem((os: string) => {
 
           const NOT_A_FUNCTION: any = null!;
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class Dir {
             @Input({transform: NOT_A_FUNCTION}) value!: number;
           }
@@ -2923,7 +2923,6 @@ runInEachFileSystem((os: string) => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
             inputs: [{
               name: 'value',
               transform: NOT_A_FUNCTION
@@ -2948,7 +2947,7 @@ runInEachFileSystem((os: string) => {
           `
               import {Directive, Input} from '@angular/core';
 
-              @Directive({selector: '[dir]', standalone: true})
+              @Directive({selector: '[dir]'})
               export class Dir {
                 @Input({transform: (val) => 1}) value!: number;
               }
@@ -2967,7 +2966,7 @@ runInEachFileSystem((os: string) => {
           `
           import {Directive, Input} from '@angular/core';
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class Dir {
             @Input({transform: <T>(val: T) => 1}) value!: number;
           }
@@ -2986,7 +2985,7 @@ runInEachFileSystem((os: string) => {
           `
           import {Directive, Input} from '@angular/core';
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class Dir {
             @Input({transform: (val: string) => 1}) value!: number;
 
@@ -3019,7 +3018,7 @@ runInEachFileSystem((os: string) => {
             import {Directive, Input} from '@angular/core';
             import {toNumber} from './util';
 
-            @Directive({selector: '[dir]', standalone: true})
+            @Directive({selector: '[dir]'})
             export class Dir {
               @Input({transform: toNumber}) value!: number;
             }
@@ -3050,7 +3049,7 @@ runInEachFileSystem((os: string) => {
               import {Directive, Input} from '@angular/core';
               import {toNumber} from './util';
 
-              @Directive({selector: '[dir]', standalone: true})
+              @Directive({selector: '[dir]'})
               export class Dir {
                 @Input({transform: toNumber}) value!: number;
               }
@@ -3085,7 +3084,7 @@ runInEachFileSystem((os: string) => {
               import {Directive, Input} from '@angular/core';
               import {toNumber} from './util';
 
-              @Directive({selector: '[dir]', standalone: true})
+              @Directive({selector: '[dir]'})
               export class Dir {
                 @Input({transform: toNumber}) value!: number;
               }
@@ -3108,7 +3107,7 @@ runInEachFileSystem((os: string) => {
             foo: boolean;
           }
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class Dir {
             @Input({transform: (val: InternalType) => 1}) val!: number;
           }
@@ -3131,7 +3130,7 @@ runInEachFileSystem((os: string) => {
             return (innerValue: string) => outerValue;
           }
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class Dir {
             @Input({transform: createTransform(1)}) value!: number;
           }
@@ -7526,7 +7525,6 @@ runInEachFileSystem((os: string) => {
         import {Directive, NgModule} from '@angular/core';
 
         @Directive({
-          standalone: true,
         })
         class HostDir {}
 
@@ -8881,14 +8879,12 @@ runInEachFileSystem((os: string) => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true
           })
           export class Dir extends BaseDir {}
 
           @Component({
             selector: 'test-cmp',
             template: '<div dir></div>',
-            standalone: true,
             imports: [Dir]
           })
           export class Cmp {}
@@ -8915,14 +8911,12 @@ runInEachFileSystem((os: string) => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true
           })
           export class Dir extends BaseDir {}
 
           @Component({
             selector: 'test-cmp',
             template: '<div dir [input]="value"></div>',
-            standalone: true,
             imports: [Dir]
           })
           export class Cmp {
@@ -9401,14 +9395,12 @@ runInEachFileSystem((os: string) => {
                 import {Component, Directive} from '@angular/core';
 
                 @Directive({
-                  standalone: true,
                   selector: '[sandbox]',
                   inputs: ['sandbox']
                 })
                 class Dir {}
 
                 @Component({
-                  standalone: true,
                   imports: [Dir],
                   template: \`
                     <div [sandbox]="''" [title]="'Hi!'"></div>
@@ -10276,7 +10268,6 @@ runInEachFileSystem((os: string) => {
         import {Component, NgModule} from '@angular/core';
 
         @Component({
-          standalone: true,
           selector: 'standalone-component',
           template: '...',
         })
@@ -10303,7 +10294,6 @@ runInEachFileSystem((os: string) => {
         import {Component, NgModule, forwardRef} from '@angular/core';
 
         @Component({
-          standalone: true,
           selector: 'standalone-component',
           template: '...',
         })
@@ -10329,7 +10319,6 @@ runInEachFileSystem((os: string) => {
         import { Component } from '@angular/core';
 
         @Component({
-          standalone: true,
           template: 'My email is foo@bar.com',
         })
         export class TestCmp {}
@@ -10359,7 +10348,6 @@ runInEachFileSystem((os: string) => {
           export class DepModule {}
 
           @Component({
-            standalone: true,
             selector: 'standalone-cmp',
             imports: [DepModule],
             template: '',
@@ -10833,7 +10821,6 @@ runInEachFileSystem((os: string) => {
             import {Component} from '@angular/core';
 
             @Component({
-              standalone: true,
               template: '...',
             })
             export class Comp {}

--- a/packages/compiler-cli/test/ngtsc/standalone_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/standalone_spec.ts
@@ -38,14 +38,12 @@ runInEachFileSystem(() => {
 
               @Directive({
                 selector: '[dir]',
-                standalone: true,
               })
               export class TestDir {}
 
               @Component({
                 selector: 'test-cmp',
                 template: '<div dir></div>',
-                standalone: true,
                 imports: [TestDir],
               })
               export class TestCmp {}
@@ -74,7 +72,6 @@ runInEachFileSystem(() => {
               @Component({
                 selector: 'test-cmp',
                 template: '<test-cmp></test-cmp>',
-                standalone: true,
               })
               export class TestCmp {}
             `,
@@ -92,7 +89,6 @@ runInEachFileSystem(() => {
           import {Pipe} from '@angular/core';
 
           @Pipe({
-            standalone: true,
             name: 'test',
           })
           export class TestPipe {
@@ -115,7 +111,6 @@ runInEachFileSystem(() => {
           import {Directive} from '@angular/core';
 
           @Directive({
-            standalone: true,
             selector: '[dir]',
           })
           export class TestDir {}
@@ -128,7 +123,6 @@ runInEachFileSystem(() => {
           import {TestDir} from './dep';
 
           @Component({
-            standalone: true,
             imports: [TestDir],
             selector: 'test-cmp',
             template: '<div dir></div>',
@@ -153,7 +147,6 @@ runInEachFileSystem(() => {
           import {TestType} from './test';
 
           @Directive({
-            standalone: true,
             selector: '[dir]',
           })
           export class TestDir {
@@ -172,7 +165,6 @@ runInEachFileSystem(() => {
           }
 
           @Component({
-            standalone: true,
             imports: [TestDir],
             selector: 'test-cmp',
             template: '<div dir></div>',
@@ -219,7 +211,6 @@ runInEachFileSystem(() => {
           import {Module} from './module';
 
           @Component({
-            standalone: true,
             imports: [forwardRef(() => Module)],
             selector: 'standalone-cmp',
             template: '<module-cmp></module-cmp>',
@@ -246,7 +237,6 @@ runInEachFileSystem(() => {
 
               @Directive({
                 selector: '[dir]',
-                standalone: true,
               })
               export class TestDir {}
 
@@ -273,7 +263,6 @@ runInEachFileSystem(() => {
 
               @Component({
                 selector: 'test-cmp',
-                standalone: true,
                 template: '<is-unknown></is-unknown>',
                 schemas: [NO_ERRORS_SCHEMA],
               })
@@ -343,7 +332,6 @@ runInEachFileSystem(() => {
               @Component({
                 selector: 'test-cmp',
                 template: '<div dir></div>',
-                standalone: true,
                 imports: [TestModule],
               })
               export class TestCmp {}
@@ -361,7 +349,6 @@ runInEachFileSystem(() => {
 
               @Directive({
                 selector: '[dir]',
-                standalone: true,
               })
               export class TestDir {}
 
@@ -370,7 +357,6 @@ runInEachFileSystem(() => {
               @Component({
                 selector: 'test-cmp',
                 template: '<div dir></div>',
-                standalone: true,
                 imports: [DIRECTIVES],
               })
               export class TestCmp {}
@@ -388,7 +374,6 @@ runInEachFileSystem(() => {
 
               @Directive({
                 selector: '[dir]',
-                standalone: true,
               })
               export class TestDir {}
 
@@ -397,7 +382,6 @@ runInEachFileSystem(() => {
               @Component({
                 selector: 'test-cmp',
                 template: '<div dir></div>',
-                standalone: true,
                 imports: [TestDir, DIRECTIVES],
               })
               export class TestCmp {}
@@ -428,7 +412,6 @@ runInEachFileSystem(() => {
           @Component({
             selector: 'test-cmp',
             template: '<div dir></div>',
-            standalone: true,
             imports: [TestDir],
           })
           export class TestCmp {}
@@ -462,7 +445,6 @@ runInEachFileSystem(() => {
              @Component({
                selector: 'test-cmp',
                template: '<div></div>',
-               standalone: true,
                // @ts-ignore
                imports: [moduleWithProviders()],
              })
@@ -473,7 +455,6 @@ runInEachFileSystem(() => {
              @Component({
                selector: 'test-cmp',
                template: '<div></div>',
-               standalone: true,
                // @ts-ignore
                imports: IMPORTS,
              })
@@ -509,7 +490,6 @@ runInEachFileSystem(() => {
           @Component({
             selector: 'test-cmp',
             template: '<div></div>',
-            standalone: true,
             // @ts-ignore
             imports: [TestModule.forRoot()],
           })
@@ -544,7 +524,6 @@ runInEachFileSystem(() => {
             @Component({
               selector: 'test-cmp',
               template: '<div dir></div>',
-              standalone: true,
               imports: [TestDir],
             })
             export class TestCmp {}
@@ -584,7 +563,6 @@ runInEachFileSystem(() => {
           export class NotStandaloneModule {}
 
           @Component({
-            standalone: true,
             selector: 'is-standalone',
             template: '',
           })
@@ -593,7 +571,6 @@ runInEachFileSystem(() => {
           }
 
           @Component({
-            standalone: true,
             selector: 'test-cmp',
             imports: [NotStandaloneModule, IsStandaloneCmp],
             template: '<not-standalone [value]="3"></not-standalone><is-standalone [value]="true"></is-standalone>',
@@ -615,7 +592,6 @@ runInEachFileSystem(() => {
           import {Component, Input} from '@angular/core';
 
           @Component({
-            standalone: true,
             selector: 'dep-cmp',
             template: '',
           })
@@ -646,14 +622,13 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'test',
-            standalone: true,
             imports: [forwardRef(() => StandaloneComponent)],
             template: "<other-standalone></other-standalone>"
           })
           class TestComponent {
           }
 
-          @Component({selector: 'other-standalone', standalone: true, template: ""})
+          @Component({selector: 'other-standalone', template: ""})
           class StandaloneComponent {
           }
         `,
@@ -677,7 +652,6 @@ runInEachFileSystem(() => {
               @Component({
                 selector: 'test-cmp',
                 template: 'Test',
-                standalone: true,
               })
               export class TestCmp {}
 
@@ -702,7 +676,6 @@ runInEachFileSystem(() => {
 
           @Pipe({
             name: 'test',
-            standalone: true,
           })
           export class TestPipe {}
 
@@ -727,7 +700,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'st-cmp',
-            standalone: true,
             template: 'Test',
           })
           export class StandaloneCmp {}
@@ -758,7 +730,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[st-dir]',
-            standalone: true,
           })
           export class StandaloneDir {}
 
@@ -788,7 +759,6 @@ runInEachFileSystem(() => {
 
           @Pipe({
             name: 'stpipe',
-            standalone: true,
           })
           export class StandalonePipe {
             transform(value: any): any {
@@ -824,7 +794,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
           })
           export class TestDir {}
 
@@ -879,7 +848,6 @@ runInEachFileSystem(() => {
 
               @Directive({
                 selector: '[dir]',
-                standalone: true,
               })
               export class TestDir {}
             `,
@@ -896,7 +864,6 @@ runInEachFileSystem(() => {
 
               @Pipe({
                 name: 'testpipe',
-                standalone: true,
               })
               export class TestPipe {}
             `,
@@ -925,7 +892,6 @@ runInEachFileSystem(() => {
           import {StandaloneDir} from './lib';
 
           @Component({
-            standalone: true,
             selector: 'test-cmp',
             template: '<div dir></div>',
             imports: [StandaloneDir],
@@ -957,7 +923,6 @@ runInEachFileSystem(() => {
           import {StandaloneCmp} from './lib';
 
           @Component({
-            standalone: true,
             selector: 'test-cmp',
             template: '<standalone-cmp></standalone-cmp>',
             imports: [StandaloneCmp],
@@ -990,7 +955,6 @@ runInEachFileSystem(() => {
           import {StandalonePipe} from './lib';
 
           @Component({
-            standalone: true,
             selector: 'test-cmp',
             template: '{{value | standalone}}',
             imports: [StandalonePipe],
@@ -1026,7 +990,6 @@ runInEachFileSystem(() => {
           import {DECLARATIONS} from 'external';
 
           @Component({
-            standalone: true,
             selector: 'test-cmp',
             template: '<div dir></div>',
             imports: [DECLARATIONS],
@@ -1058,7 +1021,6 @@ runInEachFileSystem(() => {
           export class DepModule {}
 
           @Component({
-            standalone: true,
             selector: 'standalone-cmp',
             imports: [DepModule],
             template: '',
@@ -1097,7 +1059,6 @@ runInEachFileSystem(() => {
             import {DepModule} from './dep';
 
             @Component({
-              standalone: true,
               selector: 'standalone-cmp',
               imports: [DepModule],
               template: '',
@@ -1136,7 +1097,6 @@ runInEachFileSystem(() => {
               import {DepCmp} from './dep';
 
               @Component({
-                standalone: true,
                 selector: 'standalone-cmp',
                 imports: [DepCmp],
                 template: '<dep-cmp/>',
@@ -1163,13 +1123,11 @@ runInEachFileSystem(() => {
           import {Directive, NgModule, Pipe} from '@angular/core';
 
           @Directive({
-            standalone: true,
             selector: '[dir]',
           })
           export class StandaloneDir {}
 
           @Pipe({
-            standalone: true,
             name: 'standalone',
           })
           export class StandalonePipe {
@@ -1199,7 +1157,6 @@ runInEachFileSystem(() => {
             export class DepModule {}
 
             @Component({
-              standalone: true,
               selector: 'test-cmp',
               imports: [DepModule],
               template: '',

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -93,7 +93,6 @@ runInEachFileSystem(() => {
 
         @Component({
           selector: 'sub-cmp',
-          standalone: true,
           template: '',
         })
         class Sub { // intentionally not exported
@@ -102,7 +101,6 @@ runInEachFileSystem(() => {
 
         @Component({
           template: \`<sub-cmp [someInput]="''" />\`,
-          standalone: true,
           imports: [Sub],
         })
         export class MyComponent {}
@@ -550,7 +548,7 @@ runInEachFileSystem(() => {
         `
         import {Component, Directive, Input, Output, EventEmitter} from '@angular/core';
 
-        @Directive({selector: '[dir]', standalone: true})
+        @Directive({selector: '[dir]'})
         export class Dir<T extends {id: string}> {
           @Input() val!: T;
           @Output() valChange = new EventEmitter<T>();
@@ -558,7 +556,6 @@ runInEachFileSystem(() => {
 
         @Component({
           template: '<input dir [(val)]="invalidType">',
-          standalone: true,
           imports: [Dir],
         })
         export class FooCmp {
@@ -583,7 +580,7 @@ runInEachFileSystem(() => {
         `
             import {Component, Directive, Input, Output, EventEmitter} from '@angular/core';
 
-            @Directive({selector: '[dir]', standalone: true})
+            @Directive({selector: '[dir]'})
             export class Dir {
               @Input()
               set val(value: string | null | undefined) {
@@ -599,7 +596,6 @@ runInEachFileSystem(() => {
 
             @Component({
               template: '<input dir [(val)]="nullableType">',
-              standalone: true,
               imports: [Dir],
             })
             export class FooCmp {
@@ -621,7 +617,7 @@ runInEachFileSystem(() => {
 
         type TestFn = (val: number | null | undefined) => string;
 
-        @Directive({selector: '[dir]', standalone: true})
+        @Directive({selector: '[dir]'})
         export class Dir {
           @Input() val!: TestFn;
           @Output() valChange = new EventEmitter<TestFn>();
@@ -629,7 +625,6 @@ runInEachFileSystem(() => {
 
         @Component({
           template: '<input dir [(val)]="invalidType">',
-          standalone: true,
           imports: [Dir],
         })
         export class FooCmp {
@@ -654,7 +649,6 @@ runInEachFileSystem(() => {
         import {Component} from '@angular/core';
 
         @Component({
-          standalone: true,
           template: \`
             <ng-content>
               <button (click)="acceptsNumber('hello')"></button>
@@ -681,7 +675,6 @@ runInEachFileSystem(() => {
         import {Component} from '@angular/core';
 
         @Component({
-          standalone: true,
           template: \`
             <ng-content>
               <input #input/>
@@ -707,7 +700,6 @@ runInEachFileSystem(() => {
         import {Component} from '@angular/core';
 
         @Component({
-          standalone: true,
           template: \` {{typeof {} === 'foobar'}} \`,
         })
         class TestCmp {
@@ -727,7 +719,6 @@ runInEachFileSystem(() => {
         import {Component} from '@angular/core';
 
         @Component({
-          standalone: true,
           // should be !(typeof {} === 'object')
           template: \` {{!typeof {} === 'object'}} \`,
         })
@@ -2366,14 +2357,13 @@ runInEachFileSystem(() => {
 
           export function toNumber(val: boolean | string) { return 1; }
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class CoercionDir {
             @Input({transform: toNumber}) val!: number;
           }
 
           @Component({
             template: '<input dir [val]="invalidType">',
-            standalone: true,
             imports: [CoercionDir],
           })
           export class FooCmp {
@@ -2395,14 +2385,13 @@ runInEachFileSystem(() => {
           `
             import {Component, Directive, Input} from '@angular/core';
 
-            @Directive({selector: '[dir]', standalone: true})
+            @Directive({selector: '[dir]'})
             export class CoercionDir {
               @Input({transform: (val: boolean | string) => 1}) val!: number;
             }
 
             @Component({
               template: '<input dir [val]="invalidType">',
-              standalone: true,
               imports: [CoercionDir],
             })
             export class FooCmp {
@@ -2428,7 +2417,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
             inputs: [{
               name: 'val',
               transform: toNumber
@@ -2440,7 +2428,6 @@ runInEachFileSystem(() => {
 
           @Component({
             template: '<input dir [val]="invalidType">',
-            standalone: true,
             imports: [CoercionDir],
           })
           export class FooCmp {
@@ -2462,14 +2449,13 @@ runInEachFileSystem(() => {
           `
           import {Component, Directive, Input} from '@angular/core';
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class CoercionDir {
             @Input({transform: parseInt}) val!: number;
           }
 
           @Component({
             template: '<input dir [val]="invalidType">',
-            standalone: true,
             imports: [CoercionDir],
           })
           export class FooCmp {
@@ -2515,14 +2501,13 @@ runInEachFileSystem(() => {
           import {Component, Directive, Input} from '@angular/core';
           import {toNumber} from './utils';
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class CoercionDir {
             @Input({transform: toNumber}) val!: number;
           }
 
           @Component({
             template: '<input dir [val]="invalidType">',
-            standalone: true,
             imports: [CoercionDir],
           })
           export class FooCmp {
@@ -2571,14 +2556,13 @@ runInEachFileSystem(() => {
               import {Component, Directive, Input} from '@angular/core';
               import {externalToNumber} from 'external';
 
-              @Directive({selector: '[dir]', standalone: true})
+              @Directive({selector: '[dir]'})
               export class CoercionDir {
                 @Input({transform: externalToNumber}) val!: number;
               }
 
               @Component({
                 template: '<input dir [val]="invalidType">',
-                standalone: true,
                 imports: [CoercionDir],
               })
               export class FooCmp {
@@ -2633,7 +2617,7 @@ runInEachFileSystem(() => {
             foo: string;
           }
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class CoercionDir {
             @Input({transform: (val: GenericWrapper<ExportedClass>) => 1}) importedVal!: number;
             @Input({transform: (val: GenericWrapper<LocalInterface>) => 1}) localVal!: number;
@@ -2641,7 +2625,6 @@ runInEachFileSystem(() => {
 
           @Component({
             template: '<input dir [importedVal]="invalidType" [localVal]="invalidType">',
-            standalone: true,
             imports: [CoercionDir],
           })
           export class FooCmp {
@@ -2688,14 +2671,13 @@ runInEachFileSystem(() => {
           import {Component, Directive, Input} from '@angular/core';
           import {CoercionType} from './types';
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class CoercionDir {
             @Input({transform: (val: CoercionType<string>) => 1}) val!: number;
           }
 
           @Component({
             template: '<input dir [val]="invalidType">',
-            standalone: true,
             imports: [CoercionDir],
           })
           export class FooCmp {
@@ -2735,14 +2717,13 @@ runInEachFileSystem(() => {
           import {Component, Directive, Input} from '@angular/core';
           import {ExternalGenericWrapper, ExternalClass} from 'external';
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class CoercionDir {
             @Input({transform: (val: ExternalGenericWrapper<ExternalClass>) => 1}) val!: number;
           }
 
           @Component({
             template: '<input dir [val]="invalidType">',
-            standalone: true,
             imports: [CoercionDir],
           })
           export class FooCmp {
@@ -2770,14 +2751,13 @@ runInEachFileSystem(() => {
           `
               import {Component, Directive, Input} from '@angular/core';
 
-              @Directive({selector: '[dir]', standalone: true})
+              @Directive({selector: '[dir]'})
               export class CoercionDir {
                 @Input({transform: () => 1}) val!: number;
               }
 
               @Component({
                 template: '<input dir [val]="invalidType">',
-                standalone: true,
                 imports: [CoercionDir],
               })
               export class FooCmp {
@@ -2798,14 +2778,13 @@ runInEachFileSystem(() => {
 
           export function toNumber(val: number | boolean) { return 1; }
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class CoercionDir {
             @Input({transform: toNumber}) val!: number;
           }
 
           @Component({
             template: '<input dir val="test">',
-            standalone: true,
             imports: [CoercionDir],
           })
           export class FooCmp {}
@@ -2845,7 +2824,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
             hostDirectives: [{
               directive: HostDir,
               inputs: ['val']
@@ -2855,7 +2833,6 @@ runInEachFileSystem(() => {
 
           @Component({
             template: '<input dir [val]="invalidType">',
-            standalone: true,
             imports: [CoercionDir],
           })
           export class FooCmp {
@@ -2901,13 +2878,11 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true
           })
           export class CoercionDir extends Parent {}
 
           @Component({
             template: '<input dir [val]="invalidType">',
-            standalone: true,
             imports: [CoercionDir],
           })
           export class FooCmp {
@@ -2940,7 +2915,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
           })
           export class Dir {
             @Input({transform: (val: HTMLInputElement | ElementRef<HTMLInputElement>) => {
@@ -2950,7 +2924,6 @@ runInEachFileSystem(() => {
           }
 
           @Component({
-            standalone: true,
             imports: [Dir],
             template: '<div dir [expectsInput]="someDiv"></div>',
           })
@@ -2977,7 +2950,7 @@ runInEachFileSystem(() => {
 
           export function toNumber(val: boolean | string) { return 1; }
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class CoercionDir {
             @Input({transform: toNumber}) val!: number;
             @Output() valChange = new EventEmitter<number>();
@@ -2985,7 +2958,6 @@ runInEachFileSystem(() => {
 
           @Component({
             template: '<input dir [(val)]="invalidType">',
-            standalone: true,
             imports: [CoercionDir],
           })
           export class FooCmp {
@@ -3323,7 +3295,6 @@ runInEachFileSystem(() => {
         @Component({
           selector: 'blah',
           template: '<foo>test</foo>',
-          standalone: true,
         })
         export class FooCmp {}
         @NgModule({
@@ -3347,7 +3318,6 @@ runInEachFileSystem(() => {
           @Component({
             selector: 'my-comp',
             template: '...',
-            standalone: true,
           })
           export class MyComp {}
 
@@ -3355,7 +3325,6 @@ runInEachFileSystem(() => {
             selector: 'blah',
             imports: [MyComp],
             template: '<my-comp [foo]="true"></my-comp>',
-            standalone: true,
           })
           export class FooCmp {}
         `,
@@ -3401,7 +3370,6 @@ runInEachFileSystem(() => {
         @Component({
           selector: 'blah',
           template: '<my-foo>test</my-foo>',
-          standalone: true,
         })
         export class FooCmp {}
         @NgModule({
@@ -3696,7 +3664,6 @@ runInEachFileSystem(() => {
                   </mfrac>
                 </math>
               \`,
-              standalone: true,
             })
             export class MathCmp {}
           `,
@@ -4019,7 +3986,6 @@ suppress
           import {Component, Directive, NgModule, Input} from '@angular/core';
 
           @Directive({
-            standalone: true,
           })
           class HostDir {
             @Input() input: number;
@@ -4067,7 +4033,6 @@ suppress
           import {Component, Directive, NgModule, Output, EventEmitter} from '@angular/core';
 
           @Directive({
-            standalone: true,
           })
           class HostDir {
             @Output() stringEvent = new EventEmitter<string>();
@@ -4120,7 +4085,6 @@ suppress
           import {Component, Directive, NgModule, Input, Output} from '@angular/core';
 
           @Directive({
-            standalone: true,
           })
           class HostDir {
             @Input() input: number;
@@ -4170,7 +4134,6 @@ suppress
           import {Component, Directive, NgModule, Output, EventEmitter} from '@angular/core';
 
           @Directive({
-            standalone: true,
             exportAs: 'hostDir',
           })
           class HostDir {}
@@ -4212,7 +4175,6 @@ suppress
           import {Component, Directive, NgModule, Input} from '@angular/core';
 
           @Directive({
-            standalone: true
           })
           class HostDirParent {
             @Input() input: number;
@@ -4220,7 +4182,6 @@ suppress
           }
 
           @Directive({
-            standalone: true,
           })
           class HostDir extends HostDirParent {}
 
@@ -4265,7 +4226,6 @@ suppress
           import {Component, Directive, NgModule, Output, EventEmitter} from '@angular/core';
 
           @Directive({
-            standalone: true
           })
           class HostDirParent {
             @Output() stringEvent = new EventEmitter<string>();
@@ -4273,7 +4233,6 @@ suppress
           }
 
           @Directive({
-            standalone: true,
           })
           class HostDir extends HostDirParent {}
 
@@ -4323,7 +4282,6 @@ suppress
           import {Component, Directive, NgModule, Input} from '@angular/core';
 
           @Directive({
-            standalone: true,
           })
           class HostDir {
             @Input('ownInputAlias') input: number;
@@ -4371,7 +4329,6 @@ suppress
           import {Component, Directive, NgModule, Output, EventEmitter} from '@angular/core';
 
           @Directive({
-            standalone: true,
           })
           class HostDir {
             @Output('ownStringAlias') stringEvent = new EventEmitter<string>();
@@ -4458,7 +4415,6 @@ suppress
       @Component({
         template: '<lib-post />',
         imports: [PostModule],
-        standalone: true,
       })
       export class Main { }
        `,
@@ -4477,7 +4433,6 @@ suppress
           import {Component, Directive, NgModule, Input} from '@angular/core';
 
           @Directive({
-            standalone: true,
           })
           class HostDir {
             @Input() input: number;
@@ -4530,7 +4485,6 @@ suppress
           import {Component, Directive, NgModule, Output, EventEmitter} from '@angular/core';
 
           @Directive({
-            standalone: true,
           })
           class HostDir {
             @Output() stringEvent = new EventEmitter<string>();
@@ -4601,7 +4555,6 @@ suppress
                 {{does_not_exist_error}}
               }
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -4626,7 +4579,6 @@ suppress
             template: \`
               @defer (when isVisible() || does_not_exist) {Hello}
             \`,
-            standalone: true,
           })
           export class Main {
             isVisible() {
@@ -4652,7 +4604,6 @@ suppress
             template: \`
               @defer (prefetch when isVisible() || does_not_exist) {Hello}
             \`,
-            standalone: true,
           })
           export class Main {
             isVisible() {
@@ -4678,7 +4629,6 @@ suppress
             template: \`
               @defer (hydrate when isVisible() || does_not_exist) {Hello}
             \`,
-            standalone: true,
           })
           export class Main {
             isVisible() {
@@ -4704,7 +4654,6 @@ suppress
             template: \`
               @defer (on viewport(does_not_exist)) {Hello}
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -4731,7 +4680,6 @@ suppress
                 <button #trigger></button>
               </ng-template>
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -4764,7 +4712,6 @@ suppress
                 {{does_not_exist_else}}
               }
             \`,
-            standalone: true,
           })
           export class Main {
             expr = false;
@@ -4799,7 +4746,6 @@ suppress
                 two
               }
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -4823,7 +4769,6 @@ suppress
             template: \`@if (value === 1; as alias) {
               {{acceptsNumber(alias)}}
             }\`,
-            standalone: true,
           })
           export class Main {
             value = 1;
@@ -4851,7 +4796,6 @@ suppress
             template: \`@if (value; as alias) {
               {{acceptsNumber(alias)}}
             }\`,
-            standalone: true,
           })
           export class Main {
             value: 'one' | 0 = 0;
@@ -4879,7 +4823,6 @@ suppress
             template: \`@if (value; as alias) {
               <button (click)="acceptsNumber(alias)"></button>
             }\`,
-            standalone: true,
           })
           export class Main {
             value: 'one' | 0 = 0;
@@ -4906,7 +4849,6 @@ suppress
             template: \`@if (value; as alias) {
               {{ value.length }}
             }\`,
-            standalone: true,
           })
           export class Main {
             value!: string|undefined;
@@ -4927,7 +4869,6 @@ suppress
             template: \`@if (value(); as alias) {
               {{ alias.length }}
             }\`,
-            standalone: true,
           })
           export class Main {
             value!: () => string|undefined;
@@ -4953,7 +4894,6 @@ suppress
                 {{alias}}
               }
             \`,
-            standalone: true,
           })
           export class Main {
             value = 1;
@@ -4981,7 +4921,6 @@ suppress
                 }
               }
             \`,
-            standalone: true,
           })
           export class Main {
             value = 1;
@@ -5013,7 +4952,6 @@ suppress
                 {{acceptsNumber(expr)}}
               }
             \`,
-            standalone: true,
           })
           export class Main {
             expr: 'hello' | 1 = 'hello';
@@ -5043,7 +4981,6 @@ suppress
                 <button (click)="acceptsNumber(expr)"></button>
               }
             \`,
-            standalone: true,
           })
           export class Main {
             expr: 'hello' | 1 = 'hello';
@@ -5075,7 +5012,6 @@ suppress
                 <button (click)="acceptsNumber(expr)"></button>
               }
             \`,
-            standalone: true,
           })
           export class Main {
             expr: 'hello' | 1 | 2 = 'hello';
@@ -5109,7 +5045,6 @@ suppress
                 <button (click)="acceptsNumber(expr)"></button>
               }
             \`,
-            standalone: true,
           })
           export class Main {
             expr: 'hello' | 1 | 2 = 'hello';
@@ -5139,7 +5074,6 @@ suppress
                  <button (click)="test()"></button>
                }
              \`,
-             standalone: true,
            })
            export class Main {
              test() {}
@@ -5173,7 +5107,6 @@ suppress
                 }
               }
             \`,
-            standalone: true,
           })
           export class Main {
             expr: any;
@@ -5203,7 +5136,6 @@ suppress
                 }
               }
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -5234,7 +5166,6 @@ suppress
                 }
               }
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -5264,7 +5195,6 @@ suppress
                     }
                   }
                 \`,
-                standalone: true,
               })
               export class Main {
                 value = 'zero';
@@ -5293,7 +5223,6 @@ suppress
                 }
               }
             \`,
-            standalone: true,
           })
           export class Main {
             expr: 'hello' | 1 = 'hello';
@@ -5328,7 +5257,6 @@ suppress
                 }
               }
             \`,
-            standalone: true,
           })
           export class Main {
             expr: 'hello' | 1 = 'hello';
@@ -5374,7 +5302,6 @@ suppress
                 }
               }
             \`,
-            standalone: true,
           })
           export class Main {
             value: Foo | Bar = { type: 'foo', foo: 'foo' };
@@ -5406,7 +5333,6 @@ suppress
                 }
               }
             \`,
-            standalone: true,
           })
           export class Main {
             expr = true;
@@ -5433,7 +5359,6 @@ suppress
                 }
               }
             \`,
-            standalone: true,
           })
           export class Main {
             expr: 'hello' | 1 = 'hello';
@@ -5469,7 +5394,6 @@ suppress
                 }
               }
             \`,
-            standalone: true,
           })
           export class Main {
             expr: 1 | 2 | 'hello' = 'hello';
@@ -5726,7 +5650,6 @@ suppress
 
           @Directive({
             selector: '[twoWayDir]',
-            standalone: true
           })
           export class TwoWayDir {
             @Input() value: number = 0;
@@ -5739,7 +5662,6 @@ suppress
                 <button twoWayDir [(value)]="$index"></button>
               }
             \`,
-            standalone: true,
             imports: [TwoWayDir]
           })
           export class Main {
@@ -5762,7 +5684,6 @@ suppress
 
           @Directive({
             selector: '[twoWayDir]',
-            standalone: true
           })
           export class TwoWayDir {
             @Input() value: number = 0;
@@ -5775,7 +5696,6 @@ suppress
                 <button twoWayDir [(value)]="current"></button>
               }
             \`,
-            standalone: true,
             imports: [TwoWayDir]
           })
           export class Main {
@@ -5892,7 +5812,6 @@ suppress
 
           @Component({
             selector: 'test-cmp',
-            standalone: true,
             template: '@for (item of items; track $index + $count) {}',
           })
           export class TestCmp {
@@ -5916,7 +5835,6 @@ suppress
 
               @Component({
                 selector: 'test-cmp',
-                standalone: true,
                 template: '@for (item of items; let c = $count; track $index + c) {}',
               })
               export class TestCmp {
@@ -5940,7 +5858,6 @@ suppress
 
             @Component({
               selector: 'test-cmp',
-              standalone: true,
               template: \`
                 <input #ref/>
                 @for (item of items; track $index + ref.value) {}
@@ -5967,7 +5884,6 @@ suppress
 
             @Component({
               selector: 'test-cmp',
-              standalone: true,
               template: \`
                 <input #ref/>
 
@@ -5997,7 +5913,6 @@ suppress
 
             @Component({
               selector: 'test-cmp',
-              standalone: true,
               template: \`
                 <ng-template let-foo>
                   @for (item of items; track $index + foo.value) {}
@@ -6025,7 +5940,6 @@ suppress
 
           @Component({
             selector: 'test-cmp',
-            standalone: true,
             template: \`
               @for (parent of items; track $index) {
                 @for (item of parent.items; track parent) {}
@@ -6053,7 +5967,6 @@ suppress
 
             @Component({
               selector: 'test-cmp',
-              standalone: true,
               template: \`
                 @if (expr; as alias) {
                   @for (item of items; track $index + alias) {}
@@ -6080,7 +5993,7 @@ suppress
           `
           import { Component, Pipe } from '@angular/core';
 
-          @Pipe({name: 'test', standalone: true})
+          @Pipe({name: 'test'})
           export class TestPipe {
             transform(value: any) {
               return value;
@@ -6089,7 +6002,6 @@ suppress
 
           @Component({
             selector: 'test-cmp',
-            standalone: true,
             imports: [TestPipe],
             template: '@for (item of items; track item | test) {}',
           })
@@ -6112,7 +6024,7 @@ suppress
           `
           import {Component, Pipe} from '@angular/core';
 
-          @Pipe({name: 'fakeAsync', standalone: true})
+          @Pipe({name: 'fakeAsync'})
           export class FakeAsyncPipe {
             transform<T>(value: Iterable<T>): Iterable<T> | null | undefined {
               return null;
@@ -6125,7 +6037,6 @@ suppress
                 {{item}}
               }
             \`,
-            standalone: true,
             imports: [FakeAsyncPipe]
           })
           export class Main {
@@ -6172,7 +6083,6 @@ suppress
           import {Component, Directive, Input} from '@angular/core';
 
           @Directive({
-            standalone: true,
             selector: '[dir]'
           })
           export class Dir {
@@ -6180,7 +6090,6 @@ suppress
           }
 
           @Component({
-            standalone: true,
             imports: [Dir],
             template: \`
               @for (document of documents; track document) {
@@ -6211,12 +6120,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content/> <ng-content select="bar, [foo]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6250,12 +6157,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content/> <ng-content select="bar, [foo]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6289,12 +6194,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content select="[foo]"/> <ng-content select="[bar]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6332,12 +6235,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content select="[foo]"/> <ng-content select="[bar]"/> <ng-content select="[baz]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6377,12 +6278,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content/> <ng-content select="bar, [foo]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6416,12 +6315,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content/> <ng-content select="bar, [foo]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6457,12 +6354,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content select="[foo]"/> <ng-content select="[bar]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6498,12 +6393,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content select="[foo]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6539,12 +6432,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content select="[foo]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             preserveWhitespaces: true,
             template: \`
@@ -6579,12 +6470,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content select="[foo]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6611,12 +6500,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content select="[foo]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6645,12 +6532,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6685,12 +6570,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content/> <ng-content select="bar, [foo]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6723,12 +6606,10 @@ suppress
               @Component({
                 selector: 'comp',
                 template: '<ng-content/> <ng-content select="bar, [foo]"/>',
-                standalone: true,
               })
               class Comp {}
 
               @Component({
-                standalone: true,
                 imports: [Comp],
                 template: \`
                   <comp>
@@ -6756,12 +6637,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content/> <ng-content select="bar, [foo]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6799,12 +6678,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content select="[foo]"/> <ng-content select="[bar]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6862,7 +6739,6 @@ suppress
               @let one = 1;
               {{acceptsString(one)}}
             \`,
-            standalone: true,
           })
           export class Main {
             acceptsString(value: string) {}
@@ -6891,7 +6767,6 @@ suppress
                 <span>{{acceptsString(one)}}</span>
               </div>
             \`,
-            standalone: true,
           })
           export class Main {
             acceptsString(value: string) {}
@@ -6917,7 +6792,6 @@ suppress
             template: \`
               @let value = {} + 1;
             \`,
-            standalone: true,
           })
           export class Main {
           }
@@ -6946,7 +6820,6 @@ suppress
                 {{expectsString(value)}}
               }
             \`,
-            standalone: true,
           })
           export class Main {
             cond: boolean = true;
@@ -6977,7 +6850,6 @@ suppress
                 <button (click)="expectsString(value)">Click me</button>
               }
             \`,
-            standalone: true,
           })
           export class Main {
             cond: boolean = true;
@@ -7017,7 +6889,6 @@ suppress
               </ng-template>
 
             \`,
-            standalone: true,
           })
           export class Main {
             expectsString(value: string) {}
@@ -7046,7 +6917,6 @@ suppress
 
               {{value}}
             \`,
-            standalone: true,
           })
           export class Main {
           }
@@ -7074,7 +6944,6 @@ suppress
                 {{value}}
               }
             \`,
-            standalone: true,
           })
           export class Main {
           }
@@ -7097,7 +6966,6 @@ suppress
               @let value = 1;
               {{expectsString(value)}}
             \`,
-            standalone: true,
           })
           export class Main {
             value = 'one';
@@ -7128,7 +6996,6 @@ suppress
                 {{expectsString(value)}}
               }
             \`,
-            standalone: true,
           })
           export class Main {
             expectsString(value: string) {}
@@ -7157,7 +7024,6 @@ suppress
                 {{value}}
               }
             \`,
-            standalone: true,
           })
           export class Main {
           }
@@ -7183,7 +7049,6 @@ suppress
               @let value = 1;
               {{value}}
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -7208,7 +7073,6 @@ suppress
               <input #value>
               {{value}}
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -7235,7 +7099,6 @@ suppress
                   {{value}}
                 </div>
               \`,
-              standalone: true,
               imports: [CommonModule],
             })
             export class Main {
@@ -7266,7 +7129,6 @@ suppress
                 {{value}}
               }
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -7287,7 +7149,6 @@ suppress
               {{value}}
               @let value = 1;
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -7313,7 +7174,6 @@ suppress
                 @let value = 1;
               </ng-template>
             \`,
-            standalone: true,
           })
           export class Main {
           }
@@ -7338,7 +7198,6 @@ suppress
               @let value = 1;
               {{this.value}}
             \`,
-            standalone: true,
           })
           export class Main {
           }
@@ -7360,7 +7219,6 @@ suppress
             template: \`
               @let value = value;
             \`,
-            standalone: true,
           })
           export class Main {
           }
@@ -7384,7 +7242,6 @@ suppress
             template: \`
               @let value = value.a.b.c;
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -7407,7 +7264,6 @@ suppress
             template: \`
               @let value = value();
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -7431,7 +7287,6 @@ suppress
               <button (click)="expectsString(value)">Click me</button>
               @let value = 1;
             \`,
-            standalone: true,
           })
           export class Main {
             expectsString(value: string) {}
@@ -7460,7 +7315,6 @@ suppress
 
               @let value = 1;
             \`,
-            standalone: true,
           })
           export class Main {
             expectsString(value: string) {}
@@ -7483,7 +7337,6 @@ suppress
               @let value = 1;
               <button (click)="value = 2">Click me</button>
             \`,
-            standalone: true,
           })
           export class Main {
           }
@@ -7506,7 +7359,6 @@ suppress
               @let value = 1;
               <button (click)="this.value = 2">Click me</button>
             \`,
-            standalone: true,
           })
           export class Main {
           }
@@ -7525,7 +7377,6 @@ suppress
           import {Component, Directive, Input, Output, EventEmitter} from '@angular/core';
           @Directive({
             selector: '[twoWayDir]',
-            standalone: true
           })
           export class TwoWayDir {
             @Input() value: number = 0;
@@ -7536,7 +7387,6 @@ suppress
               @let nonWritable = 1;
               <button twoWayDir [(value)]="nonWritable"></button>
             \`,
-            standalone: true,
             imports: [TwoWayDir]
           })
           export class Main {
@@ -7557,7 +7407,6 @@ suppress
           import {Component, Directive, Input, Output, EventEmitter, signal} from '@angular/core';
           @Directive({
             selector: '[twoWayDir]',
-            standalone: true
           })
           export class TwoWayDir {
             @Input() value: number = 0;
@@ -7568,7 +7417,6 @@ suppress
               @let writable = signalValue;
               <button twoWayDir [(value)]="writable"></button>
             \`,
-            standalone: true,
             imports: [TwoWayDir]
           })
           export class Main {
@@ -7594,7 +7442,6 @@ suppress
               }
               @let value = 123;
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -7621,7 +7468,6 @@ suppress
 
               @let value = [1, 2, 3];
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -7650,7 +7496,6 @@ suppress
 
               @let value = [1, 2, 3];
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -7671,7 +7516,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[used]', standalone: true})
+            @Directive({selector: '[used]'})
             export class UsedDir {}
           `,
         );
@@ -7681,7 +7526,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[unused]', standalone: true})
+            @Directive({selector: '[unused]'})
             export class UnusedDir {}
           `,
         );
@@ -7700,7 +7545,6 @@ suppress
                 <span used></span>
               </section>
             \`,
-            standalone: true,
             imports: [UsedDir, UnusedDir]
           })
           export class MyComp {}
@@ -7722,7 +7566,7 @@ suppress
           `
             import {Pipe} from '@angular/core';
 
-            @Pipe({name: 'used', standalone: true})
+            @Pipe({name: 'used'})
             export class UsedPipe {
               transform(value: number) {
                 return value * 2;
@@ -7736,7 +7580,7 @@ suppress
           `
             import {Pipe} from '@angular/core';
 
-            @Pipe({name: 'unused', standalone: true})
+            @Pipe({name: 'unused'})
             export class UnusedPipe {
               transform(value: number) {
                 return value * 2;
@@ -7759,7 +7603,6 @@ suppress
                 <span [attr.id]="1 | used"></span>
               </section>
             \`,
-            standalone: true,
             imports: [UsedPipe, UnusedPipe]
           })
           export class MyComp {}
@@ -7781,10 +7624,10 @@ suppress
           `
           import {Component, Directive, Pipe} from '@angular/core';
 
-          @Directive({selector: '[used]', standalone: true})
+          @Directive({selector: '[used]'})
           export class UsedDir {}
 
-          @Pipe({name: 'used', standalone: true})
+          @Pipe({name: 'used'})
           export class UsedPipe {
             transform(value: number) {
               return value * 2;
@@ -7800,7 +7643,6 @@ suppress
                 }
               </section>
             \`,
-            standalone: true,
             imports: [UsedDir, UsedPipe]
           })
           export class MyComp {}
@@ -7817,10 +7659,10 @@ suppress
           `
           import {Component, Directive, Pipe} from '@angular/core';
 
-          @Directive({selector: '[unused]', standalone: true})
+          @Directive({selector: '[unused]'})
           export class UnusedDir {}
 
-          @Pipe({name: 'unused', standalone: true})
+          @Pipe({name: 'unused'})
           export class UnusedPipe {
             transform(value: number) {
               return value * 2;
@@ -7829,7 +7671,6 @@ suppress
 
           @Component({
             template: '',
-            standalone: true,
             imports: [UnusedDir, UnusedPipe]
           })
           export class MyComp {}
@@ -7870,7 +7711,6 @@ suppress
 
           @Component({
             template: '',
-            standalone: true,
             imports: [UnusedModule]
           })
           export class MyComp {}
@@ -7895,12 +7735,11 @@ suppress
           `
           import {Component, Directive} from '@angular/core';
 
-          @Directive({selector: '[unused]', standalone: true})
+          @Directive({selector: '[unused]'})
           export class UnusedDir {}
 
           @Component({
             template: '',
-            standalone: true,
             imports: [UnusedDir]
           })
           export class MyComp {}
@@ -7949,7 +7788,6 @@ suppress
                 <span *ngIf="true"></span>
               </section>
             \`,
-            standalone: true,
             imports: [NgFor, NgIf, PercentPipe]
           })
           export class MyComp {}
@@ -7974,7 +7812,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[used]', standalone: true})
+            @Directive({selector: '[used]'})
             export class UsedDir {}
           `,
         );
@@ -7984,7 +7822,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[other-used]', standalone: true})
+            @Directive({selector: '[other-used]'})
             export class OtherUsedDir {}
           `,
         );
@@ -7994,7 +7832,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[unused]', standalone: true})
+            @Directive({selector: '[unused]'})
             export class UnusedDir {}
           `,
         );
@@ -8016,7 +7854,6 @@ suppress
                 <span used></span>
               </section>
             \`,
-            standalone: true,
             imports: [UsedDir, COMMON]
           })
           export class MyComp {}
@@ -8038,7 +7875,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[used]', standalone: true})
+            @Directive({selector: '[used]'})
             export class UsedDir {}
           `,
         );
@@ -8048,7 +7885,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[unused]', standalone: true})
+            @Directive({selector: '[unused]'})
             export class UnusedDir {}
           `,
         );
@@ -8069,7 +7906,6 @@ suppress
                 <span used></span>
               </section>
             \`,
-            standalone: true,
             imports: IMPORTS
           })
           export class MyComp {}
@@ -8091,7 +7927,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[used]', standalone: true})
+            @Directive({selector: '[used]'})
             export class UsedDir {}
           `,
         );
@@ -8101,7 +7937,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[other-used]', standalone: true})
+            @Directive({selector: '[other-used]'})
             export class OtherUsedDir {}
           `,
         );
@@ -8111,7 +7947,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[unused]', standalone: true})
+            @Directive({selector: '[unused]'})
             export class UnusedDir {}
           `,
         );
@@ -8140,7 +7976,6 @@ suppress
                 <span used></span>
               </section>
             \`,
-            standalone: true,
             imports: [UsedDir, ...COMMON]
           })
           export class MyComp {}
@@ -8157,7 +7992,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[used]', standalone: true})
+            @Directive({selector: '[used]'})
             export class UsedDir {}
           `,
         );
@@ -8167,7 +8002,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[other-used]', standalone: true})
+            @Directive({selector: '[other-used]'})
             export class OtherUsedDir {}
           `,
         );
@@ -8177,7 +8012,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[unused]', standalone: true})
+            @Directive({selector: '[unused]'})
             export class UnusedDir {}
           `,
         );
@@ -8206,7 +8041,6 @@ suppress
                 <span used></span>
               </section>
             \`,
-            standalone: true,
             imports: [UsedDir, COMMON]
           })
           export class MyComp {}
@@ -8223,7 +8057,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[used]', standalone: true})
+            @Directive({selector: '[used]'})
             export class UsedDir {}
           `,
         );
@@ -8233,7 +8067,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[other-used]', standalone: true})
+            @Directive({selector: '[other-used]'})
             export class OtherUsedDir {}
           `,
         );
@@ -8243,7 +8077,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[unused]', standalone: true})
+            @Directive({selector: '[unused]'})
             export class UnusedDir {}
           `,
         );
@@ -8265,7 +8099,6 @@ suppress
                 <span used></span>
               </section>
             \`,
-            standalone: true,
             imports: [UsedDir, COMMON]
           })
           export class MyComp {}

--- a/packages/core/rxjs-interop/test/to_observable_spec.ts
+++ b/packages/core/rxjs-interop/test/to_observable_spec.ts
@@ -25,7 +25,6 @@ describe('toObservable()', () => {
 
   @Component({
     template: '',
-    standalone: true,
   })
   class Cmp {}
 

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/index_spec.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/index_spec.ts
@@ -27,7 +27,6 @@ describe('bla', () => {
       // Define `Ng2Component`
       @Component({
         selector: 'ng2',
-        standalone: true,
         template: '<div *ngIf="show()"><ng1A></ng1A> | <ng1B></ng1B></div>',
         imports: [NgIf],
       })

--- a/packages/core/schematics/migrations/signal-migration/test/golden.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden.txt
@@ -703,7 +703,6 @@ describe('bla', () => {
       // Define `Ng2Component`
       @Component({
         selector: 'ng2',
-        standalone: true,
         template: '<div *ngIf="show()"><ng1A></ng1A> | <ng1B></ng1B></div>',
         imports: [NgIf],
       })

--- a/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
@@ -673,7 +673,6 @@ describe('bla', () => {
       // Define `Ng2Component`
       @Component({
         selector: 'ng2',
-        standalone: true,
         template: '<div *ngIf="show()"><ng1A></ng1A> | <ng1B></ng1B></div>',
         imports: [NgIf],
       })

--- a/packages/core/schematics/test/control_flow_migration_spec.ts
+++ b/packages/core/schematics/test/control_flow_migration_spec.ts
@@ -5151,7 +5151,6 @@ describe('control flow migration', () => {
         @Component({
           selector: 'declare-comp',
           templateUrl: './comp.html',
-          standalone: true,
           imports: [NgIf],
         })
         class DeclareComp {

--- a/packages/core/schematics/test/standalone_migration_spec.ts
+++ b/packages/core/schematics/test/standalone_migration_spec.ts
@@ -2881,7 +2881,6 @@ describe('standalone migration', () => {
       @Component({
         selector: 'my-comp',
         template: '<my-button>Hello</my-button>',
-        standalone: true,
         imports: [MyButton]
       })
       export class MyComp {}
@@ -2952,7 +2951,6 @@ describe('standalone migration', () => {
       @Component({
         selector: 'my-comp',
         template: '<my-button>Hello</my-button>',
-        standalone: true,
         imports: [MyButton]
       })
       export class MyComp {}
@@ -3232,7 +3230,6 @@ describe('standalone migration', () => {
         selector: 'my-comp',
         template: '<my-button my-dir unrelated>Hello</my-button>',
         imports: [ButtonModule, Unrelated],
-        standalone: true,
       })
       export class MyComp {}
     `,
@@ -3251,7 +3248,6 @@ describe('standalone migration', () => {
         selector: 'my-comp',
         template: '<my-button my-dir unrelated>Hello</my-button>',
         imports: [MyButton, MyDir, Unrelated],
-        standalone: true,
       })
       export class MyComp {}
     `),

--- a/packages/core/src/di/forward_ref.ts
+++ b/packages/core/src/di/forward_ref.ts
@@ -41,7 +41,6 @@ const __forward_ref__ = getClosureSafeProperty({__forward_ref__: getClosureSafeP
  * ### Circular standalone reference import example
  * ```ts
  * @Component({
- *   standalone: true,
  *   imports: [ChildComponent],
  *   selector: 'app-parent',
  *   template: `<app-child [hideParent]="hideParent"></app-child>`,
@@ -52,7 +51,6 @@ const __forward_ref__ = getClosureSafeProperty({__forward_ref__: getClosureSafeP
  *
  *
  * @Component({
- *   standalone: true,
  *   imports: [CommonModule, forwardRef(() => ParentComponent)],
  *   selector: 'app-child',
  *   template: `<app-parent *ngIf="!hideParent"></app-parent>`,

--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -103,7 +103,6 @@ import {EmbeddedViewRef, ViewRef} from './view_ref';
  *
  * ```typescript
  * @Component({
- *   standalone: true,
  *   selector: 'dynamic',
  *   template: `<span>This is a content of a dynamic component.</span>`,
  * })
@@ -112,7 +111,6 @@ import {EmbeddedViewRef, ViewRef} from './view_ref';
  * }
  *
  * @Component({
- *   standalone: true,
  *   selector: 'app',
  *   template: `<main>Hi! This is the main content.</main>`,
  * })

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -61,7 +61,6 @@ export interface DirectiveDecorator {
    *
    * ```ts
    * @Directive({
-   *   standalone: true,
    *   selector: 'my-directive',
    * })
    * class MyDirective {}

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -29,7 +29,6 @@ import {assertComponentDef} from './errors';
  *
  * ```typescript
  * @Component({
- *   standalone: true,
  *   template: `Hello {{ name }}!`
  * })
  * class HelloComponent {
@@ -37,7 +36,6 @@ import {assertComponentDef} from './errors';
  * }
  *
  * @Component({
- *   standalone: true,
  *   template: `<div id="hello-component-host"></div>`
  * })
  * class RootComponent {}
@@ -149,7 +147,6 @@ export interface ComponentMirror<C> {
  *
  * ```typescript
  * @Component({
- *   standalone: true,
  *   selector: 'foo-component',
  *   template: `
  *     <ng-content></ng-content>

--- a/packages/core/test/acceptance/after_render_hook_spec.ts
+++ b/packages/core/test/acceptance/after_render_hook_spec.ts
@@ -900,12 +900,12 @@ describe('after render hooks', () => {
         const appRef = TestBed.inject(ApplicationRef);
 
         const counter = signal(0);
-        @Component({standalone: true, template: '{{counter()}}'})
+        @Component({template: '{{counter()}}'})
         class Reader {
           counter = counter;
         }
 
-        @Component({standalone: true, template: ''})
+        @Component({template: ''})
         class Writer {
           ngAfterViewInit(): void {
             counter.set(1);

--- a/packages/core/test/acceptance/after_render_hook_spec.ts
+++ b/packages/core/test/acceptance/after_render_hook_spec.ts
@@ -238,7 +238,6 @@ describe('after render hooks', () => {
         let log: string[] = [];
 
         @Component({
-          standalone: true,
           template: ``,
         })
         class MyComp {
@@ -1362,7 +1361,6 @@ describe('after render hooks', () => {
 
       @Component({
         selector: 'test-component',
-        standalone: true,
         template: ` {{counter()}} `,
       })
       class TestCmp {
@@ -1391,7 +1389,6 @@ describe('after render hooks', () => {
     it('allows updating state and calling markForCheck in afterRender', async () => {
       @Component({
         selector: 'test-component',
-        standalone: true,
         template: ` {{counter}} `,
       })
       class TestCmp {
@@ -1423,7 +1420,6 @@ describe('after render hooks', () => {
       const counter = signal(0);
       @Component({
         selector: 'test-component',
-        standalone: true,
         template: `{{counter()}}`,
       })
       class TestCmp {
@@ -1465,7 +1461,6 @@ describe('after render hooks', () => {
 
       @Component({
         selector: 'test-component',
-        standalone: true,
         template: ` {{counter()}} `,
       })
       class TestCmp {

--- a/packages/core/test/acceptance/authoring/model_inputs_spec.ts
+++ b/packages/core/test/acceptance/authoring/model_inputs_spec.ts
@@ -24,7 +24,7 @@ import {TestBed} from '@angular/core/testing';
 
 describe('model inputs', () => {
   it('should support two-way binding to a signal', () => {
-    @Directive({selector: '[dir]', standalone: true})
+    @Directive({selector: '[dir]'})
     class Dir {
       value = model(0);
     }
@@ -59,7 +59,7 @@ describe('model inputs', () => {
   });
 
   it('should support two-way binding to a non-signal value', () => {
-    @Directive({selector: '[dir]', standalone: true})
+    @Directive({selector: '[dir]'})
     class Dir {
       value = model(0);
     }
@@ -94,7 +94,7 @@ describe('model inputs', () => {
   });
 
   it('should support two-way binding a signal to a non-model input/output pair', () => {
-    @Directive({selector: '[dir]', standalone: true})
+    @Directive({selector: '[dir]'})
     class Dir {
       @Input() value = 0;
       @Output() valueChange = new EventEmitter<number>();
@@ -132,7 +132,7 @@ describe('model inputs', () => {
   });
 
   it('should support a one-way property binding to a model', () => {
-    @Directive({selector: '[dir]', standalone: true})
+    @Directive({selector: '[dir]'})
     class Dir {
       value = model(0);
     }
@@ -170,7 +170,7 @@ describe('model inputs', () => {
   it('should emit to the change output when the model changes', () => {
     const emittedValues: number[] = [];
 
-    @Directive({selector: '[dir]', standalone: true})
+    @Directive({selector: '[dir]'})
     class Dir {
       value = model(0);
     }
@@ -210,7 +210,7 @@ describe('model inputs', () => {
   it('should not emit to the change event when then property binding changes', () => {
     const emittedValues: number[] = [];
 
-    @Directive({selector: '[dir]', standalone: true})
+    @Directive({selector: '[dir]'})
     class Dir {
       value = model(0);
     }
@@ -241,7 +241,7 @@ describe('model inputs', () => {
   it('should support binding to the model input and output separately', () => {
     const emittedValues: number[] = [];
 
-    @Directive({selector: '[dir]', standalone: true})
+    @Directive({selector: '[dir]'})
     class Dir {
       value = model(0);
     }
@@ -281,7 +281,7 @@ describe('model inputs', () => {
   });
 
   it('should support two-way binding to a model with an alias', () => {
-    @Directive({selector: '[dir]', standalone: true})
+    @Directive({selector: '[dir]'})
     class Dir {
       value = model(0, {alias: 'alias'});
     }
@@ -319,7 +319,7 @@ describe('model inputs', () => {
   it('should support binding to an aliased model input and output separately', () => {
     const emittedValues: number[] = [];
 
-    @Directive({selector: '[dir]', standalone: true})
+    @Directive({selector: '[dir]'})
     class Dir {
       value = model(0, {alias: 'alias'});
     }
@@ -359,7 +359,7 @@ describe('model inputs', () => {
   });
 
   it('should throw if a required model input is accessed too early', () => {
-    @Directive({selector: '[dir]', standalone: true})
+    @Directive({selector: '[dir]'})
     class Dir {
       value = model.required<number>();
 
@@ -382,7 +382,7 @@ describe('model inputs', () => {
   });
 
   it('should throw if a required model input is updated too early', () => {
-    @Directive({selector: '[dir]', standalone: true})
+    @Directive({selector: '[dir]'})
     class Dir {
       value = model.required<number>();
 
@@ -407,7 +407,7 @@ describe('model inputs', () => {
   it('should stop emitting to the output on destroy', () => {
     let emittedEvents = 0;
 
-    @Directive({selector: '[dir]', standalone: true})
+    @Directive({selector: '[dir]'})
     class Dir {
       value = model(0);
     }
@@ -445,7 +445,7 @@ describe('model inputs', () => {
       value = model(0);
     }
 
-    @Directive({selector: '[dir]', standalone: true})
+    @Directive({selector: '[dir]'})
     class Dir extends BaseDir {}
 
     @Component({
@@ -517,7 +517,7 @@ describe('model inputs', () => {
   it('should support ngOnChanges for two-way model bindings', () => {
     const changes: SimpleChange[] = [];
 
-    @Directive({selector: '[dir]', standalone: true})
+    @Directive({selector: '[dir]'})
     class Dir implements OnChanges {
       value = model(0);
 
@@ -566,7 +566,7 @@ describe('model inputs', () => {
   });
 
   it('should not throw for mixed model and output subscriptions', () => {
-    @Directive({selector: '[dir]', standalone: true})
+    @Directive({selector: '[dir]'})
     class Dir {
       model = model(0);
       @Output() output = new EventEmitter();
@@ -590,7 +590,7 @@ describe('model inputs', () => {
   });
 
   it('should support two-way binding to a signal @for loop variable', () => {
-    @Directive({selector: '[dir]', standalone: true})
+    @Directive({selector: '[dir]'})
     class Dir {
       value = model(0);
     }

--- a/packages/core/test/acceptance/authoring/model_inputs_spec.ts
+++ b/packages/core/test/acceptance/authoring/model_inputs_spec.ts
@@ -31,7 +31,6 @@ describe('model inputs', () => {
 
     @Component({
       template: '<div [(value)]="value" dir></div>',
-      standalone: true,
       imports: [Dir],
     })
     class App {
@@ -67,7 +66,6 @@ describe('model inputs', () => {
 
     @Component({
       template: '<div [(value)]="value" dir></div>',
-      standalone: true,
       imports: [Dir],
     })
     class App {
@@ -104,7 +102,6 @@ describe('model inputs', () => {
 
     @Component({
       template: '<div [(value)]="value" dir></div>',
-      standalone: true,
       imports: [Dir],
     })
     class App {
@@ -142,7 +139,6 @@ describe('model inputs', () => {
 
     @Component({
       template: '<div [value]="value" dir></div>',
-      standalone: true,
       imports: [Dir],
     })
     class App {
@@ -181,7 +177,6 @@ describe('model inputs', () => {
 
     @Component({
       template: '<div (valueChange)="changed($event)" dir></div>',
-      standalone: true,
       imports: [Dir],
     })
     class App {
@@ -222,7 +217,6 @@ describe('model inputs', () => {
 
     @Component({
       template: '<div [value]="value()" (valueChange)="changed($event)" dir></div>',
-      standalone: true,
       imports: [Dir],
     })
     class App {
@@ -254,7 +248,6 @@ describe('model inputs', () => {
 
     @Component({
       template: '<div [value]="value()" (valueChange)="changed($event)" dir></div>',
-      standalone: true,
       imports: [Dir],
     })
     class App {
@@ -295,7 +288,6 @@ describe('model inputs', () => {
 
     @Component({
       template: '<div [(alias)]="value" dir></div>',
-      standalone: true,
       imports: [Dir],
     })
     class App {
@@ -334,7 +326,6 @@ describe('model inputs', () => {
 
     @Component({
       template: '<div [alias]="value()" (aliasChange)="changed($event)" dir></div>',
-      standalone: true,
       imports: [Dir],
     })
     class App {
@@ -379,7 +370,6 @@ describe('model inputs', () => {
 
     @Component({
       template: '<div [(value)]="value" dir></div>',
-      standalone: true,
       imports: [Dir],
     })
     class App {
@@ -403,7 +393,6 @@ describe('model inputs', () => {
 
     @Component({
       template: '<div [(value)]="value" dir></div>',
-      standalone: true,
       imports: [Dir],
     })
     class App {
@@ -425,7 +414,6 @@ describe('model inputs', () => {
 
     @Component({
       template: '<div (valueChange)="changed()" dir></div>',
-      standalone: true,
       imports: [Dir],
     })
     class App {
@@ -462,7 +450,6 @@ describe('model inputs', () => {
 
     @Component({
       template: '<div [(value)]="value" dir></div>',
-      standalone: true,
       imports: [Dir],
     })
     class App {
@@ -494,7 +481,6 @@ describe('model inputs', () => {
   it('should reflect changes to a two-way-bound signal in the DOM', () => {
     @Directive({
       selector: '[dir]',
-      standalone: true,
       host: {
         '(click)': 'increment()',
       },
@@ -509,7 +495,6 @@ describe('model inputs', () => {
 
     @Component({
       template: '<button [(value)]="value" dir></button> Current value: {{value()}}',
-      standalone: true,
       imports: [Dir],
     })
     class App {
@@ -545,7 +530,6 @@ describe('model inputs', () => {
 
     @Component({
       template: '<div [(value)]="value" dir></div>',
-      standalone: true,
       imports: [Dir],
     })
     class App {
@@ -594,7 +578,6 @@ describe('model inputs', () => {
       template: `
         <div dir (model)="noop()" (output)="noop()" (model2)="noop()" (output2)="noop()"></div>
       `,
-      standalone: true,
       imports: [Dir],
     })
     class App {
@@ -618,7 +601,6 @@ describe('model inputs', () => {
           <div [(value)]="value" dir></div>
         }
       `,
-      standalone: true,
       imports: [Dir],
     })
     class App {

--- a/packages/core/test/acceptance/authoring/output_function_spec.ts
+++ b/packages/core/test/acceptance/authoring/output_function_spec.ts
@@ -30,7 +30,6 @@ describe('output() function', () => {
   it('should support emitting values', () => {
     @Directive({
       selector: '[dir]',
-      standalone: true,
     })
     class Dir {
       onBla = output<number>();
@@ -38,7 +37,6 @@ describe('output() function', () => {
 
     @Component({
       template: '<div dir (onBla)="values.push($event)"></div>',
-      standalone: true,
       imports: [Dir],
     })
     class App {
@@ -60,7 +58,6 @@ describe('output() function', () => {
   it('should support emitting void values', () => {
     @Directive({
       selector: '[dir]',
-      standalone: true,
     })
     class Dir {
       onBla = output();
@@ -68,7 +65,6 @@ describe('output() function', () => {
 
     @Component({
       template: '<div dir (onBla)="count = count + 1"></div>',
-      standalone: true,
       imports: [Dir],
     })
     class App {
@@ -90,7 +86,6 @@ describe('output() function', () => {
   it('should error when emitting to a destroyed output', () => {
     @Directive({
       selector: '[dir]',
-      standalone: true,
     })
     class Dir {
       onBla = output<number>();
@@ -102,7 +97,6 @@ describe('output() function', () => {
           <div dir (onBla)="values.push($event)"></div>
         }
       `,
-      standalone: true,
       imports: [Dir],
     })
     class App {
@@ -128,7 +122,6 @@ describe('output() function', () => {
   it('should error when subscribing to a destroyed output', () => {
     @Directive({
       selector: '[dir]',
-      standalone: true,
     })
     class Dir {
       onBla = output<number>();
@@ -140,7 +133,6 @@ describe('output() function', () => {
           <div dir (onBla)="values.push($event)"></div>
         }
       `,
-      standalone: true,
       imports: [Dir],
     })
     class App {
@@ -168,7 +160,6 @@ describe('output() function', () => {
   it('should run listeners outside of `emit` reactive context', () => {
     @Directive({
       selector: '[dir]',
-      standalone: true,
     })
     class Dir {
       onBla = output();
@@ -184,7 +175,6 @@ describe('output() function', () => {
 
     @Component({
       template: '<div dir (onBla)="fnUsingSomeSignal()"></div>',
-      standalone: true,
       imports: [Dir],
     })
     class App {
@@ -212,7 +202,6 @@ describe('output() function', () => {
     it('should support using a `Subject` as source', () => {
       @Directive({
         selector: '[dir]',
-        standalone: true,
       })
       class Dir {
         onBla$ = new Subject<number>();
@@ -221,7 +210,6 @@ describe('output() function', () => {
 
       @Component({
         template: '<div dir (onBla)="values.push($event)"></div>',
-        standalone: true,
         imports: [Dir],
       })
       class App {
@@ -243,7 +231,6 @@ describe('output() function', () => {
     it('should support using a `BehaviorSubject` as source', () => {
       @Directive({
         selector: '[dir]',
-        standalone: true,
       })
       class Dir {
         onBla$ = new BehaviorSubject<number>(1);
@@ -252,7 +239,6 @@ describe('output() function', () => {
 
       @Component({
         template: '<div dir (onBla)="values.push($event)"></div>',
-        standalone: true,
         imports: [Dir],
       })
       class App {
@@ -274,7 +260,6 @@ describe('output() function', () => {
     it('should support using an `EventEmitter` as source', () => {
       @Directive({
         selector: '[dir]',
-        standalone: true,
       })
       class Dir {
         onBla$ = new EventEmitter<number>();
@@ -283,7 +268,6 @@ describe('output() function', () => {
 
       @Component({
         template: '<div dir (onBla)="values.push($event)"></div>',
-        standalone: true,
         imports: [Dir],
       })
       class App {
@@ -305,7 +289,6 @@ describe('output() function', () => {
     it('should support lazily creating an observer upon subscription', () => {
       @Directive({
         selector: '[dir]',
-        standalone: true,
       })
       class Dir {
         streamStarted = false;
@@ -322,7 +305,6 @@ describe('output() function', () => {
           <div dir></div>
           <div dir (onBla)="true"></div>
         `,
-        standalone: true,
         imports: [Dir],
       })
       class App {}
@@ -340,7 +322,6 @@ describe('output() function', () => {
     it('should report subscription listener errors to `ErrorHandler` and continue', () => {
       @Directive({
         selector: '[dir]',
-        standalone: true,
       })
       class Dir {
         onBla = output();
@@ -350,7 +331,6 @@ describe('output() function', () => {
         template: `
           <div dir (onBla)="true"></div>
         `,
-        standalone: true,
         imports: [Dir],
       })
       class App {}

--- a/packages/core/test/acceptance/authoring/signal_inputs_spec.ts
+++ b/packages/core/test/acceptance/authoring/signal_inputs_spec.ts
@@ -36,7 +36,6 @@ describe('signal inputs', () => {
   it('should be possible to bind to an input', () => {
     @Component({
       selector: 'input-comp',
-      standalone: true,
       template: 'input:{{input()}}',
     })
     class InputComp {
@@ -44,7 +43,6 @@ describe('signal inputs', () => {
     }
 
     @Component({
-      standalone: true,
       template: `<input-comp [input]="value" />`,
       imports: [InputComp],
     })
@@ -66,7 +64,6 @@ describe('signal inputs', () => {
   it('should be possible to use an input in a computed expression', () => {
     @Component({
       selector: 'input-comp',
-      standalone: true,
       template: 'changed:{{changed()}}',
     })
     class InputComp {
@@ -75,7 +72,6 @@ describe('signal inputs', () => {
     }
 
     @Component({
-      standalone: true,
       template: `<input-comp [input]="value" />`,
       imports: [InputComp],
     })
@@ -99,7 +95,6 @@ describe('signal inputs', () => {
 
     @Component({
       selector: 'input-comp',
-      standalone: true,
       template: '',
     })
     class InputComp {
@@ -113,7 +108,6 @@ describe('signal inputs', () => {
     }
 
     @Component({
-      standalone: true,
       template: `<input-comp [input]="value" />`,
       imports: [InputComp],
     })
@@ -137,7 +131,6 @@ describe('signal inputs', () => {
   it('should support transforms', () => {
     @Component({
       selector: 'input-comp',
-      standalone: true,
       template: 'input:{{input()}}',
     })
     class InputComp {
@@ -145,7 +138,6 @@ describe('signal inputs', () => {
     }
 
     @Component({
-      standalone: true,
       template: `<input-comp [input]="value" />`,
       imports: [InputComp],
     })
@@ -165,7 +157,6 @@ describe('signal inputs', () => {
     let transformRunCount = 0;
     @Component({
       selector: 'input-comp',
-      standalone: true,
       template: '',
     })
     class InputComp {
@@ -175,7 +166,6 @@ describe('signal inputs', () => {
     }
 
     @Component({
-      standalone: true,
       template: `<input-comp [input]="value" />`,
       imports: [InputComp],
     })
@@ -193,7 +183,6 @@ describe('signal inputs', () => {
   it('should throw error if a required input is accessed too early', () => {
     @Component({
       selector: 'input-comp',
-      standalone: true,
       template: 'input:{{input()}}',
     })
     class InputComp {
@@ -205,7 +194,6 @@ describe('signal inputs', () => {
     }
 
     @Component({
-      standalone: true,
       template: `<input-comp [input]="value" />`,
       imports: [InputComp],
     })
@@ -226,13 +214,11 @@ describe('signal inputs', () => {
 
     @Component({
       selector: 'input-comp',
-      standalone: true,
       template: 'input:{{input()}}',
     })
     class InputComp extends BaseDir {}
 
     @Component({
-      standalone: true,
       template: `<input-comp [input]="value" />`,
       imports: [InputComp],
     })
@@ -260,7 +246,6 @@ describe('signal inputs', () => {
 
     @Component({
       template: '<div [(value)]="value" dir></div>',
-      standalone: true,
       imports: [Dir],
     })
     class App {

--- a/packages/core/test/acceptance/authoring/signal_inputs_spec.ts
+++ b/packages/core/test/acceptance/authoring/signal_inputs_spec.ts
@@ -238,7 +238,7 @@ describe('signal inputs', () => {
   });
 
   it('should support two-way binding to signal input and @Output decorated member', () => {
-    @Directive({selector: '[dir]', standalone: true})
+    @Directive({selector: '[dir]'})
     class Dir {
       value = input(0);
       @Output() valueChange = new EventEmitter<number>();

--- a/packages/core/test/acceptance/authoring/signal_queries_spec.ts
+++ b/packages/core/test/acceptance/authoring/signal_queries_spec.ts
@@ -28,7 +28,6 @@ describe('queries as signals', () => {
   describe('view', () => {
     it('should query for an optional element in a template', () => {
       @Component({
-        standalone: true,
         template: `<div #el></div>`,
       })
       class AppComponent {
@@ -51,7 +50,6 @@ describe('queries as signals', () => {
       let result: {} | undefined = {};
 
       @Component({
-        standalone: true,
         template: `<div #el></div>`,
       })
       class AppComponent {
@@ -68,7 +66,6 @@ describe('queries as signals', () => {
 
     it('should query for a required element in a template', () => {
       @Component({
-        standalone: true,
         template: `<div #el></div>`,
       })
       class AppComponent {
@@ -88,7 +85,6 @@ describe('queries as signals', () => {
 
     it('should throw if required query is read in the constructor', () => {
       @Component({
-        standalone: true,
         template: `<div #el></div>`,
       })
       class AppComponent {
@@ -107,7 +103,6 @@ describe('queries as signals', () => {
 
     it('should query for multiple elements in a template', () => {
       @Component({
-        standalone: true,
         template: `
           <div #el></div>
           @if (show) {
@@ -144,7 +139,6 @@ describe('queries as signals', () => {
       let result: readonly ElementRef[] | undefined;
 
       @Component({
-        standalone: true,
         template: `<div #el></div>`,
       })
       class AppComponent {
@@ -161,7 +155,6 @@ describe('queries as signals', () => {
 
     it('should return the same array instance when there were no changes in results', () => {
       @Component({
-        standalone: true,
         template: `<div #el></div>`,
       })
       class AppComponent {
@@ -183,7 +176,6 @@ describe('queries as signals', () => {
       let computeCount = 0;
 
       @Component({
-        standalone: true,
         template: `
             <div #el></div>
             @if (show) {
@@ -212,7 +204,6 @@ describe('queries as signals', () => {
 
     it('should return the same array instance when there were no changes in results after view manipulation', () => {
       @Component({
-        standalone: true,
         template: `
             <div #el></div>
             @if (show) {
@@ -242,7 +233,6 @@ describe('queries as signals', () => {
 
     it('should be empty when no query matches exist', () => {
       @Component({
-        standalone: true,
         template: ``,
       })
       class AppComponent {
@@ -299,7 +289,6 @@ describe('queries as signals', () => {
     it('should run content queries defined on components', () => {
       @Component({
         selector: 'query-cmp',
-        standalone: true,
         template: `{{noOfEls()}}`,
       })
       class QueryComponent {
@@ -316,7 +305,6 @@ describe('queries as signals', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [QueryComponent],
         template: `
           <query-cmp>
@@ -347,7 +335,6 @@ describe('queries as signals', () => {
     it('should run content queries defined on directives', () => {
       @Directive({
         selector: '[query]',
-        standalone: true,
         host: {'[textContent]': `noOfEls()`},
       })
       class QueryDir {
@@ -364,7 +351,6 @@ describe('queries as signals', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [QueryDir],
         template: `
           <div query>
@@ -398,7 +384,6 @@ describe('queries as signals', () => {
 
       @Directive({
         selector: '[declare]',
-        standalone: true,
       })
       class DeclareQuery {
         results = contentChildren(MarkerForResults);
@@ -413,7 +398,6 @@ describe('queries as signals', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [MarkerForResults, InspectsQueryResults, DeclareQuery],
         template: `
                 <div declare>
@@ -437,7 +421,6 @@ describe('queries as signals', () => {
     it('should be empty when no query matches exist', () => {
       @Directive({
         selector: '[declare]',
-        standalone: true,
       })
       class DeclareQuery {
         result = contentChild('unknown');
@@ -445,7 +428,6 @@ describe('queries as signals', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [DeclareQuery],
         template: `<div declare></div>`,
       })
@@ -508,7 +490,6 @@ describe('queries as signals', () => {
       let recomputeCount = 0;
 
       @Component({
-        standalone: true,
         template: `
           <div #el></div>
           @if (show) {
@@ -544,7 +525,6 @@ describe('queries as signals', () => {
       let recomputeCount = 0;
 
       @Component({
-        standalone: true,
         template: `
           <div #el></div>
           @if (show) {
@@ -583,7 +563,6 @@ describe('queries as signals', () => {
       // https://github.com/angular/angular/issues/54450
       @Component({
         selector: 'query-cmp',
-        standalone: true,
         template: ``,
       })
       class QueryComponent {
@@ -592,7 +571,6 @@ describe('queries as signals', () => {
       }
 
       @Component({
-        standalone: true,
         template: ``,
       })
       class TestComponent {
@@ -615,7 +593,6 @@ describe('queries as signals', () => {
   describe('mix of signal and decorator queries', () => {
     it('should allow specifying both types of queries in one component', () => {
       @Component({
-        standalone: true,
         template: `
           <div #el></div>
           @if (show) {
@@ -649,7 +626,6 @@ describe('queries as signals', () => {
 
     it('should allow combination via inheritance of both types of queries in one component', () => {
       @Component({
-        standalone: true,
         template: `
             <div #el></div>
             @if (show) {
@@ -663,7 +639,6 @@ describe('queries as signals', () => {
       }
 
       @Component({
-        standalone: true,
         template: `
             <div #el></div>
             @if (show) {

--- a/packages/core/test/acceptance/authoring/signal_queries_spec.ts
+++ b/packages/core/test/acceptance/authoring/signal_queries_spec.ts
@@ -379,7 +379,7 @@ describe('queries as signals', () => {
     });
 
     it('should not return partial results during the first-time view rendering', () => {
-      @Directive({selector: '[marker]', standalone: true})
+      @Directive({selector: '[marker]'})
       class MarkerForResults {}
 
       @Directive({
@@ -389,7 +389,7 @@ describe('queries as signals', () => {
         results = contentChildren(MarkerForResults);
       }
 
-      @Directive({selector: '[inspect]', standalone: true})
+      @Directive({selector: '[inspect]'})
       class InspectsQueryResults {
         constructor(declaration: DeclareQuery) {
           // we should _not_ get partial query results while the view is still creating

--- a/packages/core/test/acceptance/bootstrap_spec.ts
+++ b/packages/core/test/acceptance/bootstrap_spec.ts
@@ -305,7 +305,6 @@ describe('bootstrap', () => {
         'should throw when standalone component is used in @NgModule.bootstrap',
         withBody('<my-app></my-app>', async () => {
           @Component({
-            standalone: true,
             selector: 'standalone-comp',
             template: '...',
           })
@@ -384,7 +383,6 @@ describe('bootstrap', () => {
         'should throw when standalone component wrapped in `forwardRef` is used in @NgModule.bootstrap',
         withBody('<my-app></my-app>', async () => {
           @Component({
-            standalone: true,
             selector: 'standalone-comp',
             template: '...',
           })

--- a/packages/core/test/acceptance/bootstrap_spec.ts
+++ b/packages/core/test/acceptance/bootstrap_spec.ts
@@ -61,10 +61,10 @@ describe('bootstrap', () => {
   it(
     'should allow injecting VCRef into the root (bootstrapped) component',
     withBody('before|<test-cmp></test-cmp>|after', async () => {
-      @Component({selector: 'dynamic-cmp', standalone: true, template: 'dynamic'})
+      @Component({selector: 'dynamic-cmp', template: 'dynamic'})
       class DynamicCmp {}
 
-      @Component({selector: 'test-cmp', standalone: true, template: '(test)'})
+      @Component({selector: 'test-cmp', template: '(test)'})
       class TestCmp {
         constructor(public vcRef: ViewContainerRef) {}
       }

--- a/packages/core/test/acceptance/change_detection_signals_in_zones_spec.ts
+++ b/packages/core/test/acceptance/change_detection_signals_in_zones_spec.ts
@@ -126,7 +126,7 @@ describe('CheckAlways components', () => {
       }
     }
 
-    @Component({template: '<a-comp />-<b-comp />', standalone: true, imports: [A, B]})
+    @Component({template: '<a-comp />-<b-comp />', imports: [A, B]})
     class App {}
 
     const fixture = TestBed.createComponent(App);
@@ -159,7 +159,7 @@ describe('CheckAlways components', () => {
         }
       }
     }
-    @Component({template: '{{val()}}<child />', standalone: true, imports: [Child]})
+    @Component({template: '{{val()}}<child />', imports: [Child]})
     class App {
       val = val;
     }

--- a/packages/core/test/acceptance/change_detection_signals_in_zones_spec.ts
+++ b/packages/core/test/acceptance/change_detection_signals_in_zones_spec.ts
@@ -29,7 +29,6 @@ describe('CheckAlways components', () => {
   it('can read a signal', () => {
     @Component({
       template: `{{value()}}`,
-      standalone: true,
     })
     class CheckAlwaysCmp {
       value = signal('initial');
@@ -48,7 +47,6 @@ describe('CheckAlways components', () => {
   it('should properly remove stale dependencies from the signal graph', () => {
     @Component({
       template: `{{show() ? name() + ' aged ' + age() : 'anonymous'}}`,
-      standalone: true,
     })
     class CheckAlwaysCmp {
       name = signal('John');
@@ -81,7 +79,6 @@ describe('CheckAlways components', () => {
     const value = signal('initial');
     @Component({
       template: `{{value()}}`,
-      standalone: true,
       selector: 'check-always',
     })
     class CheckAlwaysCmp {
@@ -89,7 +86,6 @@ describe('CheckAlways components', () => {
     }
     @Component({
       template: `<check-always />`,
-      standalone: true,
       imports: [CheckAlwaysCmp],
       changeDetection: ChangeDetectionStrategy.OnPush,
     })
@@ -110,7 +106,6 @@ describe('CheckAlways components', () => {
 
     @Component({
       template: '{{val()}}',
-      standalone: true,
       selector: 'a-comp',
     })
     class A {
@@ -118,7 +113,6 @@ describe('CheckAlways components', () => {
     }
     @Component({
       template: '{{val()}}',
-      standalone: true,
       selector: 'b-comp',
     })
     class B {
@@ -155,7 +149,6 @@ describe('CheckAlways components', () => {
     @Component({
       template: '',
       selector: 'child',
-      standalone: true,
     })
     class Child {
       ngDoCheck() {
@@ -187,7 +180,6 @@ describe('CheckAlways components', () => {
     const val = signal(0);
     @Component({
       template: '{{val()}}',
-      standalone: true,
     })
     class App {
       val = val;
@@ -212,7 +204,6 @@ describe('OnPush components with signals', () => {
     @Component({
       template: `{{value()}}{{incrementTemplateExecutions()}}`,
       changeDetection: ChangeDetectionStrategy.OnPush,
-      standalone: true,
     })
     class OnPushCmp {
       numTemplateExecutions = 0;
@@ -243,7 +234,6 @@ describe('OnPush components with signals', () => {
     @Component({
       template: `{{memo()}}{{incrementTemplateExecutions()}}`,
       changeDetection: ChangeDetectionStrategy.OnPush,
-      standalone: true,
     })
     class OnPushCmp {
       numTemplateExecutions = 0;
@@ -278,7 +268,6 @@ describe('OnPush components with signals', () => {
       selector: 'child',
       template: `child`,
       changeDetection: ChangeDetectionStrategy.OnPush,
-      standalone: true,
     })
     class ChildReadingSignalCmp {
       constructor() {
@@ -293,7 +282,6 @@ describe('OnPush components with signals', () => {
             <ng-template [ngIf]="true"><child></child></ng-template>
           `,
       changeDetection: ChangeDetectionStrategy.OnPush,
-      standalone: true,
       imports: [NgIf, ChildReadingSignalCmp],
     })
     class OnPushCmp {
@@ -323,7 +311,6 @@ describe('OnPush components with signals', () => {
 
     @Component({
       selector: 'with-input-setter',
-      standalone: true,
       template: '{{test}}',
     })
     class WithInputSetter {
@@ -342,7 +329,6 @@ describe('OnPush components with signals', () => {
             <ng-template [ngIf]="true"><with-input-setter [testInput]="'input'" /></ng-template>
           `,
       changeDetection: ChangeDetectionStrategy.OnPush,
-      standalone: true,
       imports: [NgIf, WithInputSetter],
     })
     class OnPushCmp {
@@ -373,7 +359,6 @@ describe('OnPush components with signals', () => {
 
     @Component({
       selector: 'with-query-setter',
-      standalone: true,
       template: '<div #el>child</div>',
     })
     class WithQuerySetter {
@@ -393,7 +378,6 @@ describe('OnPush components with signals', () => {
          <ng-template [ngIf]="true"><with-query-setter /></ng-template>
        `,
       changeDetection: ChangeDetectionStrategy.OnPush,
-      standalone: true,
       imports: [NgIf, WithQuerySetter],
     })
     class OnPushCmp {
@@ -425,7 +409,6 @@ describe('OnPush components with signals', () => {
       selector: 'child',
       host: {'[class.blue]': 'useBlue()'},
       changeDetection: ChangeDetectionStrategy.OnPush,
-      standalone: true,
     })
     class MyCmp {
       useBlue = useBlue;
@@ -455,7 +438,6 @@ describe('OnPush components with signals', () => {
       selector: 'child',
       host: {'[class.blue]': 'useBlue()'},
       changeDetection: ChangeDetectionStrategy.OnPush,
-      standalone: true,
     })
     class ChildCmp {
       useBlue = signal(false);
@@ -471,7 +453,6 @@ describe('OnPush components with signals', () => {
       template: `<child />`,
       changeDetection: ChangeDetectionStrategy.OnPush,
       imports: [ChildCmp],
-      standalone: true,
     })
     class ParentCmp {}
     const fixture = TestBed.createComponent(ParentCmp);
@@ -495,7 +476,6 @@ describe('OnPush components with signals', () => {
       selector: 'child',
       host: {'[class.blue]': 'useBlue()'},
       changeDetection: ChangeDetectionStrategy.OnPush,
-      standalone: true,
     })
     class ChildCmp {
       useBlue = signal(false);
@@ -505,7 +485,6 @@ describe('OnPush components with signals', () => {
       template: `<child /> {{parentSignalValue()}}`,
       changeDetection: ChangeDetectionStrategy.OnPush,
       imports: [ChildCmp],
-      standalone: true,
       selector: 'parent',
     })
     class ParentCmp {
@@ -517,7 +496,6 @@ describe('OnPush components with signals', () => {
       template: `<parent />`,
       changeDetection: ChangeDetectionStrategy.OnPush,
       imports: [ParentCmp],
-      standalone: true,
     })
     class TestWrapper {}
 
@@ -550,7 +528,6 @@ describe('OnPush components with signals', () => {
     const counter = signal(0);
 
     @Directive({
-      standalone: true,
       selector: '[misunderstood]',
     })
     class MisunderstoodDir {
@@ -561,7 +538,6 @@ describe('OnPush components with signals', () => {
 
     @Component({
       selector: 'test-component',
-      standalone: true,
       imports: [MisunderstoodDir],
       template: `
           {{counter()}}<div misunderstood></div>{{ 'force advance()' }}
@@ -583,7 +559,6 @@ describe('OnPush components with signals', () => {
     const counter = signal(0);
 
     @Directive({
-      standalone: true,
       selector: '[misunderstood]',
     })
     class MisunderstoodDir {
@@ -594,7 +569,6 @@ describe('OnPush components with signals', () => {
 
     @Component({
       selector: 'test-component',
-      standalone: true,
       imports: [MisunderstoodDir],
       template: `
           {{counter()}}<div misunderstood></div>
@@ -614,7 +588,6 @@ describe('OnPush components with signals', () => {
   it('should allow writing to signals in afterViewInit', () => {
     @Component({
       template: '{{loading()}}',
-      standalone: true,
     })
     class MyComp {
       loading = signal(true);
@@ -634,7 +607,6 @@ describe('OnPush components with signals', () => {
 
     @Component({
       template: '{{val()}}{{incrementChecks()}}',
-      standalone: true,
       changeDetection: ChangeDetectionStrategy.OnPush,
     })
     class App {
@@ -664,7 +636,6 @@ describe('OnPush components with signals', () => {
         @if (true) { }
         {{val()}}
         `,
-          standalone: true,
           changeDetection: ChangeDetectionStrategy.OnPush,
         })
         class MyComp {
@@ -685,7 +656,6 @@ describe('OnPush components with signals', () => {
         {{createEmbeddedView(template)}}
         {{val()}}
         `,
-          standalone: true,
           changeDetection: ChangeDetectionStrategy.OnPush,
         })
         class MyComp {
@@ -708,7 +678,6 @@ describe('OnPush components with signals', () => {
       @Component({
         selector: 'signal-component',
         changeDetection: ChangeDetectionStrategy.OnPush,
-        standalone: true,
         imports: [NgIf],
         template: `<div *ngIf="true"> {{value()}} </div>`,
       })
@@ -727,7 +696,6 @@ describe('OnPush components with signals', () => {
       @Component({
         selector: 'signal-component',
         changeDetection: ChangeDetectionStrategy.OnPush,
-        standalone: true,
         imports: [NgFor],
         template: `<div *ngFor="let i of [1,2,3]"> {{value()}} </div>`,
       })
@@ -746,7 +714,6 @@ describe('OnPush components with signals', () => {
       @Component({
         selector: 'signal-component',
         changeDetection: ChangeDetectionStrategy.OnPush,
-        standalone: true,
         imports: [NgIf],
         template: `
           {{componentSignal()}}
@@ -776,7 +743,6 @@ describe('OnPush components with signals', () => {
     it('re-executes deep embedded template if signal updates', () => {
       @Component({
         selector: 'signal-component',
-        standalone: true,
         changeDetection: ChangeDetectionStrategy.OnPush,
         imports: [NgIf],
         template: `
@@ -807,7 +773,6 @@ describe('OnPush components with signals', () => {
         template: `
             <ng-template #template>{{value()}}</ng-template>
           `,
-        standalone: true,
       })
       class Test {
         value = signal('initial');
@@ -839,7 +804,6 @@ describe('OnPush components with signals', () => {
         template: `
             <ng-template #template>{{value()}}</ng-template>
           `,
-        standalone: true,
       })
       class Test {
         value = signal('initial');
@@ -873,7 +837,6 @@ describe('OnPush components with signals', () => {
     @Component({
       selector: 'signal-component',
       changeDetection: ChangeDetectionStrategy.OnPush,
-      standalone: true,
       template: `{{value()}}`,
     })
     class SignalComponent {
@@ -891,7 +854,6 @@ describe('OnPush components with signals', () => {
       <signal-component></signal-component>
       {{incrementChecks()}}`,
       changeDetection: ChangeDetectionStrategy.OnPush,
-      standalone: true,
       imports: [SignalComponent],
     })
     class OnPushParent {
@@ -956,7 +918,6 @@ describe('OnPush components with signals', () => {
     @Component({
       template: '',
       selector: 'child',
-      standalone: true,
     })
     class Child {
       ngOnInit() {
@@ -967,7 +928,6 @@ describe('OnPush components with signals', () => {
     @Component({
       template: '{{val()}} <child />',
       imports: [Child],
-      standalone: true,
     })
     class SignalComponent {
       val = val;
@@ -986,7 +946,6 @@ describe('OnPush components with signals', () => {
     @Component({
       template: '{{double()}}',
       selector: 'child',
-      standalone: true,
     })
     class Child {
       double = double;
@@ -995,7 +954,6 @@ describe('OnPush components with signals', () => {
     @Component({
       template: '|{{double()}}|<child />|',
       imports: [Child],
-      standalone: true,
     })
     class SignalComponent {
       double = double;

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -125,7 +125,7 @@ describe('change detection', () => {
         }
       }
 
-      @Component({template: '<ng-template #template></ng-template>', standalone: true})
+      @Component({template: '<ng-template #template></ng-template>'})
       class Container {
         @ViewChild('template', {read: ViewContainerRef, static: true}) vcr!: ViewContainerRef;
       }

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -115,7 +115,6 @@ describe('change detection', () => {
       @Component({
         selector: 'onpush',
         template: '',
-        standalone: true,
         changeDetection: ChangeDetectionStrategy.OnPush,
       })
       class OnPushComponent {
@@ -235,7 +234,6 @@ describe('change detection', () => {
         selector: `test-cmpt`,
         template: `{{counter}}|<ng-template #vc></ng-template>`,
         changeDetection: ChangeDetectionStrategy.OnPush,
-        standalone: true,
       })
       class TestCmpt {
         counter = 0;
@@ -249,7 +247,6 @@ describe('change detection', () => {
       @Component({
         selector: 'dynamic-cmpt',
         template: `dynamic|{{binding}}`,
-        standalone: true,
         changeDetection: ChangeDetectionStrategy.OnPush,
       })
       class DynamicCmpt {
@@ -1410,7 +1407,6 @@ describe('change detection', () => {
 
         @Component({
           changeDetection: ChangeDetectionStrategy.OnPush,
-          standalone: true,
           template: '{{state}}{{resolveReadPromise()}}',
         })
         class MyApp {

--- a/packages/core/test/acceptance/change_detection_transplanted_view_spec.ts
+++ b/packages/core/test/acceptance/change_detection_transplanted_view_spec.ts
@@ -986,7 +986,6 @@ describe('change detection for transplanted views', () => {
 
     it('does not cause error if running change detection on detached view', () => {
       @Component({
-        standalone: true,
         selector: 'insertion',
         template: `<ng-container #vc></ng-container>`,
       })
@@ -999,7 +998,6 @@ describe('change detection for transplanted views', () => {
       }
 
       @Component({
-        standalone: true,
         template: `
           <ng-template #transplantedTemplate></ng-template>
           <insertion [template]="transplantedTemplate"></insertion>
@@ -1017,7 +1015,6 @@ describe('change detection for transplanted views', () => {
 
     it('backwards reference still updated if detaching root during change detection', () => {
       @Component({
-        standalone: true,
         selector: 'insertion',
         template: `<ng-container #vc></ng-container>`,
         changeDetection: ChangeDetectionStrategy.OnPush,
@@ -1033,7 +1030,6 @@ describe('change detection for transplanted views', () => {
       @Component({
         template: '<ng-template #template>{{value}}</ng-template>',
         selector: 'declaration',
-        standalone: true,
       })
       class Declaration {
         @ViewChild('template', {static: true}) transplantedTemplate!: TemplateRef<{}>;
@@ -1041,7 +1037,6 @@ describe('change detection for transplanted views', () => {
       }
 
       @Component({
-        standalone: true,
         template: `
           <insertion [template]="declaration?.transplantedTemplate"></insertion>
           <declaration [value]="value"></declaration>
@@ -1079,7 +1074,6 @@ describe('change detection for transplanted views', () => {
     @Component({
       selector: 'insertion',
       imports: [NgTemplateOutlet],
-      standalone: true,
       template: ` <ng-container [ngTemplateOutlet]="template"> </ng-container>`,
     })
     class Insertion {
@@ -1090,7 +1084,6 @@ describe('change detection for transplanted views', () => {
     @Component({
       imports: [Insertion, AsyncPipe],
       template: `<ng-template #myTmpl> {{newObservable() | async}} </ng-template>`,
-      standalone: true,
       selector: 'declaration',
     })
     class Declaration {
@@ -1100,7 +1093,6 @@ describe('change detection for transplanted views', () => {
       }
     }
     @Component({
-      standalone: true,
       imports: [Declaration, Insertion],
       template: '<insertion [template]="declaration.template"/><declaration #declaration/>',
     })
@@ -1137,7 +1129,6 @@ describe('change detection for transplanted views', () => {
       fail('console errored with ' + v);
     });
     @Component({
-      standalone: true,
       selector: 'insertion',
       template: `<ng-container #vc></ng-container>`,
       changeDetection: ChangeDetectionStrategy.OnPush,
@@ -1151,7 +1142,6 @@ describe('change detection for transplanted views', () => {
     }
 
     @Component({
-      standalone: true,
       template: `
           <ng-template #template>hello world</ng-template>
           <insertion [template]="transplantedTemplate"></insertion>

--- a/packages/core/test/acceptance/component_spec.ts
+++ b/packages/core/test/acceptance/component_spec.ts
@@ -491,7 +491,6 @@ describe('component', () => {
       @Component({
         selector: 'comp',
         template: '<comp *ngIf="recurse"/>hello',
-        standalone: true,
         imports: [Comp, NgIf],
       })
       class Comp {
@@ -500,7 +499,6 @@ describe('component', () => {
 
       @Component({
         template: '<comp [recurse]="true"/>',
-        standalone: true,
         imports: [Comp],
       })
       class App {}
@@ -521,7 +519,6 @@ describe('component', () => {
       @Component({
         selector: 'comp',
         template: '<comp *ngIf="recurse"/>hello',
-        standalone: true,
         imports: [forwardRef(() => Comp), NgIf],
       })
       class Comp {
@@ -530,7 +527,6 @@ describe('component', () => {
 
       @Component({
         template: '<comp [recurse]="true"/>',
-        standalone: true,
         imports: [Comp],
       })
       class App {}
@@ -805,7 +801,6 @@ describe('component', () => {
   describe('createComponent', () => {
     it('should create an instance of a standalone component', () => {
       @Component({
-        standalone: true,
         template: 'Hello {{ name }}!',
       })
       class StandaloneComponent {
@@ -858,7 +853,6 @@ describe('component', () => {
 
     it('should render projected content', () => {
       @Component({
-        standalone: true,
         template: `
           <ng-content></ng-content>|
           <ng-content></ng-content>|
@@ -890,7 +884,6 @@ describe('component', () => {
     it('should be able to inject tokens from EnvironmentInjector', () => {
       const A = new InjectionToken('A');
       @Component({
-        standalone: true,
         template: 'Token: {{ a }}',
       })
       class StandaloneComponent {
@@ -912,7 +905,6 @@ describe('component', () => {
       const A = new InjectionToken('A');
       const B = new InjectionToken('B');
       @Component({
-        standalone: true,
         template: '{{ a }} and {{ b }}',
       })
       class ChildStandaloneComponent {
@@ -921,7 +913,6 @@ describe('component', () => {
       }
 
       @Component({
-        standalone: true,
         template: 'Tokens: <div #target></div>',
         providers: [{provide: A, useValue: 'ElementInjector(A)'}],
       })
@@ -961,7 +952,6 @@ describe('component', () => {
       const selector = 'standalone-comp';
       @Component({
         selector,
-        standalone: true,
         template: 'Hello {{ name }}!',
       })
       class StandaloneComponent {
@@ -988,7 +978,6 @@ describe('component', () => {
       () => {
         @Component({
           selector: '.some-class',
-          standalone: true,
           template: 'Hello {{ name }}!',
         })
         class StandaloneComponent {
@@ -1048,7 +1037,6 @@ describe('component', () => {
 
       @Component({
         selector: 'standalone-component',
-        standalone: true,
         template: `
           <ng-content></ng-content>
           <ng-content select="content-selector-a"></ng-content>

--- a/packages/core/test/acceptance/content_spec.ts
+++ b/packages/core/test/acceptance/content_spec.ts
@@ -1682,7 +1682,7 @@ describe('projection', () => {
         value = 0;
       }
 
-      @Component({standalone: true, imports: [Projection], template: `<projection/>`})
+      @Component({imports: [Projection], template: `<projection/>`})
       class App {
         @ViewChild(Projection) projection!: Projection;
       }
@@ -1715,7 +1715,7 @@ describe('projection', () => {
         }
       }
 
-      @Component({standalone: true, imports: [Projection], template: `<projection/>`})
+      @Component({imports: [Projection], template: `<projection/>`})
       class App {}
 
       const fixture = TestBed.createComponent(App);

--- a/packages/core/test/acceptance/content_spec.ts
+++ b/packages/core/test/acceptance/content_spec.ts
@@ -1539,12 +1539,10 @@ describe('projection', () => {
           `<ng-content select="[two]">Two fallback</ng-content>` +
           `<ng-content select="[three]">Three fallback</ng-content>
         `,
-        standalone: true,
       })
       class Projection {}
 
       @Component({
-        standalone: true,
         imports: [Projection],
         template: `
           <projection>
@@ -1566,12 +1564,10 @@ describe('projection', () => {
       @Component({
         selector: 'projection',
         template: `<ng-content>Fallback content</ng-content>`,
-        standalone: true,
       })
       class Projection {}
 
       @Component({
-        standalone: true,
         imports: [Projection],
         template: `
             <projection>
@@ -1594,12 +1590,10 @@ describe('projection', () => {
       @Component({
         selector: 'projection',
         template: `<ng-content select="div">I have no divs</ng-content>|<ng-content select="span">I have no spans</ng-content>`,
-        standalone: true,
       })
       class Projection {}
 
       @Component({
-        standalone: true,
         imports: [Projection],
         template: `
           <projection>
@@ -1622,12 +1616,10 @@ describe('projection', () => {
       @Component({
         selector: 'projection',
         template: `<ng-content>Wildcard fallback</ng-content>|<ng-content select="span">Span fallback</ng-content>`,
-        standalone: true,
       })
       class Projection {}
 
       @Component({
-        standalone: true,
         imports: [Projection],
         template: `
           <projection>
@@ -1664,12 +1656,10 @@ describe('projection', () => {
       @Component({
         selector: 'projection',
         template: `<ng-content>Fallback</ng-content>`,
-        standalone: true,
       })
       class Projection {}
 
       @Component({
-        standalone: true,
         imports: [Projection],
         template: `
           <projection><ng-container/></projection>
@@ -1687,7 +1677,6 @@ describe('projection', () => {
       @Component({
         selector: 'projection',
         template: `<ng-content>Value: {{value}}</ng-content>`,
-        standalone: true,
       })
       class Projection {
         value = 0;
@@ -1717,7 +1706,6 @@ describe('projection', () => {
 
           Value: {{value}}
         `,
-        standalone: true,
       })
       class Projection {
         value = 0;
@@ -1744,7 +1732,6 @@ describe('projection', () => {
 
       @Directive({
         selector: 'fallback-dir',
-        standalone: true,
       })
       class FallbackDir implements OnDestroy {
         constructor() {
@@ -1759,13 +1746,11 @@ describe('projection', () => {
       @Component({
         selector: 'projection',
         template: `<ng-content><fallback-dir/></ng-content>`,
-        standalone: true,
         imports: [FallbackDir],
       })
       class Projection {}
 
       @Component({
-        standalone: true,
         imports: [Projection],
         template: `
           @if (hasProjection) {
@@ -1791,7 +1776,6 @@ describe('projection', () => {
 
       @Directive({
         selector: 'fallback-dir',
-        standalone: true,
       })
       class FallbackDir {
         constructor() {
@@ -1802,7 +1786,6 @@ describe('projection', () => {
       @Component({
         selector: 'projection',
         template: `<ng-content><fallback-dir/></ng-content>`,
-        standalone: true,
         imports: [FallbackDir],
       })
       class Projection {
@@ -1810,7 +1793,6 @@ describe('projection', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [Projection],
         template: `<projection/>`,
       })
@@ -1828,7 +1810,6 @@ describe('projection', () => {
     it('should be able to inject the host component from inside the fallback content', () => {
       @Directive({
         selector: 'fallback-dir',
-        standalone: true,
       })
       class FallbackDir {
         host = inject(Projection);
@@ -1837,7 +1818,6 @@ describe('projection', () => {
       @Component({
         selector: 'projection',
         template: `<ng-content><fallback-dir/></ng-content>`,
-        standalone: true,
         imports: [FallbackDir],
       })
       class Projection {
@@ -1845,7 +1825,6 @@ describe('projection', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [Projection],
         template: `<projection/>`,
       })
@@ -1861,7 +1840,6 @@ describe('projection', () => {
 
     it('should render the fallback content if content is not provided through projectableNodes', () => {
       @Component({
-        standalone: true,
         template:
           `<ng-content>One fallback</ng-content>|` +
           `<ng-content>Two fallback</ng-content>|<ng-content>Three fallback</ng-content>`,
@@ -1886,7 +1864,6 @@ describe('projection', () => {
 
     it('should render the content through projectableNodes along with fallback', () => {
       @Component({
-        standalone: true,
         template:
           `<ng-content>One fallback</ng-content>|` +
           `<ng-content>Two fallback</ng-content>|<ng-content>Three fallback</ng-content>`,
@@ -1914,7 +1891,6 @@ describe('projection', () => {
       @Component({
         selector: 'projection',
         template: `<ng-container #ref/><ng-template #template><ng-content>Fallback</ng-content></ng-template>`,
-        standalone: true,
       })
       class Projection {
         @ViewChild('template') template!: TemplateRef<unknown>;
@@ -1926,7 +1902,6 @@ describe('projection', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [Projection],
         template: `<projection/>`,
       })
@@ -1950,7 +1925,6 @@ describe('projection', () => {
           <ng-content select="[inner-header]">Inner header fallback</ng-content>
           <ng-content select="[inner-footer]">Inner footer fallback</ng-content>
         `,
-        standalone: true,
       })
       class InnerProjection {}
 
@@ -1962,13 +1936,11 @@ describe('projection', () => {
             <ng-content select="[outer-footer]" inner-footer>Outer footer fallback</ng-content>
           </inner-projection>
         `,
-        standalone: true,
         imports: [InnerProjection],
       })
       class Projection {}
 
       @Component({
-        standalone: true,
         imports: [Projection],
         template: `
           <projection>
@@ -1990,7 +1962,6 @@ describe('projection', () => {
 
       @Component({
         selector: 'fallback',
-        standalone: true,
         template: 'Fallback',
       })
       class Fallback {
@@ -2002,13 +1973,11 @@ describe('projection', () => {
       @Component({
         selector: 'projection',
         template: `<ng-content><fallback/></ng-content>`,
-        standalone: true,
         imports: [Fallback],
       })
       class Projection {}
 
       @Component({
-        standalone: true,
         imports: [Projection],
         template: `<projection>Hello</projection>`,
       })
@@ -2026,12 +1995,10 @@ describe('projection', () => {
         @Component({
           selector: 'projection',
           template: `<ng-content>Fallback</ng-content>`,
-          standalone: true,
         })
         class Projection {}
 
         @Component({
-          standalone: true,
           imports: [Projection],
           template: `
             <projection>Content</projection>
@@ -2054,12 +2021,10 @@ describe('projection', () => {
         @Component({
           selector: 'projection',
           template: `<ng-content>Fallback</ng-content>`,
-          standalone: true,
         })
         class Projection {}
 
         @Component({
-          standalone: true,
           imports: [Projection],
           template: `
             <projection/>

--- a/packages/core/test/acceptance/control_flow_for_spec.ts
+++ b/packages/core/test/acceptance/control_flow_for_spec.ts
@@ -129,7 +129,7 @@ describe('control flow - for', () => {
   });
 
   it('should be able to use pipes injecting ChangeDetectorRef in for loop blocks', () => {
-    @Pipe({name: 'test', standalone: true})
+    @Pipe({name: 'test'})
     class TestPipe implements PipeTransform {
       changeDetectorRef = inject(ChangeDetectorRef);
 
@@ -730,7 +730,7 @@ describe('control flow - for', () => {
     it('should project an @for with a single root node with a data binding', () => {
       let directiveCount = 0;
 
-      @Directive({standalone: true, selector: '[foo]'})
+      @Directive({selector: '[foo]'})
       class Foo {
         @Input('foo') value: any;
 

--- a/packages/core/test/acceptance/control_flow_for_spec.ts
+++ b/packages/core/test/acceptance/control_flow_for_spec.ts
@@ -141,7 +141,6 @@ describe('control flow - for', () => {
     @Component({
       template: '@for (item of items | test; track item;) {{{item}}|}',
       imports: [TestPipe],
-      standalone: true,
     })
     class TestComponent {
       items = [1, 2, 3];
@@ -156,7 +155,6 @@ describe('control flow - for', () => {
     @Directive({
       selector: '[dir]',
       exportAs: 'dir',
-      standalone: true,
     })
     class Dir {
       data = [1];
@@ -168,7 +166,6 @@ describe('control flow - for', () => {
 
     @Component({
       selector: 'app-root',
-      standalone: true,
       imports: [Dir],
       template: `
         <div [dir] #dir="dir"></div>
@@ -589,14 +586,12 @@ describe('control flow - for', () => {
       ];
 
       @Component({
-        standalone: true,
         template: ``,
         selector: 'child-cmp',
       })
       class ChildCmp {}
 
       @Component({
-        standalone: true,
         imports: [ChildCmp],
         template: `
           @for(task of tasks; track task.id) {
@@ -622,14 +617,12 @@ describe('control flow - for', () => {
   describe('content projection', () => {
     it('should project an @for with a single root node into the root node slot', () => {
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
       class TestComponent {}
 
       @Component({
-        standalone: true,
         imports: [TestComponent],
         template: `
         <test>Before @for (item of items; track $index) {
@@ -649,14 +642,12 @@ describe('control flow - for', () => {
 
     it('should project an @empty block with a single root node into the root node slot', () => {
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
       class TestComponent {}
 
       @Component({
-        standalone: true,
         imports: [TestComponent],
         template: `
         <test>Before @for (item of items; track $index) {} @empty {
@@ -676,7 +667,6 @@ describe('control flow - for', () => {
 
     it('should allow @for and @empty blocks to be projected into different slots', () => {
       @Component({
-        standalone: true,
         selector: 'test',
         template:
           'Main: <ng-content/> Loop slot: <ng-content select="[loop]"/> Empty slot: <ng-content select="[empty]"/>',
@@ -684,7 +674,6 @@ describe('control flow - for', () => {
       class TestComponent {}
 
       @Component({
-        standalone: true,
         imports: [TestComponent],
         template: `
         <test>Before @for (item of items; track $index) {
@@ -714,14 +703,12 @@ describe('control flow - for', () => {
 
     it('should project an @for with multiple root nodes into the catch-all slot', () => {
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
       class TestComponent {}
 
       @Component({
-        standalone: true,
         imports: [TestComponent],
         template: `
         <test>Before @for (item of items; track $index) {
@@ -753,14 +740,12 @@ describe('control flow - for', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
       class TestComponent {}
 
       @Component({
-        standalone: true,
         imports: [TestComponent, Foo],
         template: `
         <test>Before @for (item of items; track $index) {
@@ -781,14 +766,12 @@ describe('control flow - for', () => {
 
     it('should project an @for with an ng-container root node', () => {
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
       class TestComponent {}
 
       @Component({
-        standalone: true,
         imports: [TestComponent],
         template: `
         <test>Before @for (item of items; track $index) {
@@ -813,14 +796,12 @@ describe('control flow - for', () => {
     // This test is to ensure that we don't regress if it happens in the future.
     it('should project an @for with single root node and comments into the root node slot', () => {
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
       class TestComponent {}
 
       @Component({
-        standalone: true,
         imports: [TestComponent],
         template: `
         <test>Before @for (item of items; track $index) {
@@ -842,14 +823,12 @@ describe('control flow - for', () => {
 
     it('should project the root node when preserveWhitespaces is enabled and there are no whitespace nodes', () => {
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
       class TestComponent {}
 
       @Component({
-        standalone: true,
         imports: [TestComponent],
         preserveWhitespaces: true,
         // Note the whitespace due to the indentation inside @for.
@@ -867,14 +846,12 @@ describe('control flow - for', () => {
 
     it('should not project the root node when preserveWhitespaces is enabled and there are whitespace nodes', () => {
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
       class TestComponent {}
 
       @Component({
-        standalone: true,
         imports: [TestComponent],
         preserveWhitespaces: true,
         // Note the whitespace due to the indentation inside @for.
@@ -895,14 +872,12 @@ describe('control flow - for', () => {
 
     it('should not project the root node across multiple layers of @for', () => {
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
       class TestComponent {}
 
       @Component({
-        standalone: true,
         imports: [TestComponent],
         template: `
         <test>Before @for (item of items; track $index) {
@@ -923,14 +898,12 @@ describe('control flow - for', () => {
 
     it('should project an @for with a single root template node into the root node slot', () => {
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
       class TestComponent {}
 
       @Component({
-        standalone: true,
         imports: [TestComponent, NgIf],
         template: `<test>Before @for (item of items; track $index) {
         <span *ngIf="true" foo>{{item}}</span>
@@ -953,7 +926,6 @@ describe('control flow - for', () => {
       let directiveCount = 0;
 
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
@@ -961,7 +933,6 @@ describe('control flow - for', () => {
 
       @Directive({
         selector: '[foo]',
-        standalone: true,
       })
       class FooDirective {
         constructor() {
@@ -970,7 +941,6 @@ describe('control flow - for', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [TestComponent, FooDirective],
         template: `<test>Before @for (item of items; track $index) {
         <span foo>{{item}}</span>
@@ -992,7 +962,6 @@ describe('control flow - for', () => {
       let directiveCount = 0;
 
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
@@ -1000,7 +969,6 @@ describe('control flow - for', () => {
 
       @Directive({
         selector: '[templateDir]',
-        standalone: true,
       })
       class TemplateDirective implements OnInit {
         constructor(
@@ -1017,7 +985,6 @@ describe('control flow - for', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [TestComponent, TemplateDirective],
         template: `<test>Before @for (item of items; track $index) {
         <span *templateDir foo>{{item}}</span>
@@ -1039,7 +1006,6 @@ describe('control flow - for', () => {
       let directiveCount = 0;
 
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
@@ -1047,7 +1013,6 @@ describe('control flow - for', () => {
 
       @Directive({
         selector: '[templateDir]',
-        standalone: true,
       })
       class TemplateDirective implements OnInit {
         constructor(
@@ -1064,7 +1029,6 @@ describe('control flow - for', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [TestComponent, TemplateDirective],
         template: `<test>Before @for (item of items; track $index) {
         <ng-template templateDir foo>{{item}}</ng-template>

--- a/packages/core/test/acceptance/control_flow_if_spec.ts
+++ b/packages/core/test/acceptance/control_flow_if_spec.ts
@@ -48,7 +48,6 @@ describe('control flow - if', () => {
 
   it('should expose expression value in context', () => {
     @Component({
-      standalone: true,
       template: '@if (show; as alias) {{{show}} aliased to {{alias}}}',
     })
     class TestComponent {
@@ -66,7 +65,6 @@ describe('control flow - if', () => {
 
   it('should not expose the aliased expression to `if` and `else if` blocks', () => {
     @Component({
-      standalone: true,
       template: `
           @if (value === 1; as alias) {
             If: {{value}} as {{alias || 'unavailable'}}
@@ -96,7 +94,6 @@ describe('control flow - if', () => {
 
   it('should expose the context to nested conditional blocks', () => {
     @Component({
-      standalone: true,
       imports: [MultiplyPipe],
       template: `
           @if (value | multiply:2; as root) {
@@ -135,7 +132,6 @@ describe('control flow - if', () => {
     let logs: any[] = [];
 
     @Component({
-      standalone: true,
       imports: [MultiplyPipe],
       template: `
           @if (value | multiply:2; as root) {
@@ -186,7 +182,6 @@ describe('control flow - if', () => {
 
   it('should expose expression value passed through a pipe in context', () => {
     @Component({
-      standalone: true,
       template: '@if (value | multiply:2; as alias) {{{value}} aliased to {{alias}}}',
       imports: [MultiplyPipe],
     })
@@ -205,7 +200,6 @@ describe('control flow - if', () => {
 
   it('should destroy all views if there is nothing to display', () => {
     @Component({
-      standalone: true,
       template: '@if (show) {Something}',
     })
     class TestComponent {
@@ -223,7 +217,6 @@ describe('control flow - if', () => {
 
   it('should be able to use pipes in conditional expressions', () => {
     @Component({
-      standalone: true,
       imports: [MultiplyPipe],
       template: `
           @if ((value | multiply:2) === 2) {
@@ -264,7 +257,6 @@ describe('control flow - if', () => {
     }
 
     @Component({
-      standalone: true,
       template: '@if (show | test) {Something}',
       imports: [TestPipe],
     })
@@ -279,7 +271,6 @@ describe('control flow - if', () => {
 
   it('should support a condition with the a typeof expression', () => {
     @Component({
-      standalone: true,
       template: `
           @if (typeof value === 'string') {
             {{value.length}}
@@ -304,14 +295,12 @@ describe('control flow - if', () => {
   describe('content projection', () => {
     it('should project an @if with a single root node into the root node slot', () => {
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
       class TestComponent {}
 
       @Component({
-        standalone: true,
         imports: [TestComponent],
         template: `
         <test>Before @if (true) {
@@ -340,14 +329,12 @@ describe('control flow - if', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
       class TestComponent {}
 
       @Component({
-        standalone: true,
         imports: [TestComponent, Foo],
         template: `
         <test>Before @if (true) {
@@ -368,14 +355,12 @@ describe('control flow - if', () => {
 
     it('should project an @if with multiple root nodes into the catch-all slot', () => {
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
       class TestComponent {}
 
       @Component({
-        standalone: true,
         imports: [TestComponent],
         template: `
         <test>Before @if (true) {
@@ -394,14 +379,12 @@ describe('control flow - if', () => {
 
     it('should project an @if with an ng-container root node', () => {
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
       class TestComponent {}
 
       @Component({
-        standalone: true,
         imports: [TestComponent],
         template: `
         <test>Before @if (true) {
@@ -424,14 +407,12 @@ describe('control flow - if', () => {
     // This test is to ensure that we don't regress if it happens in the future.
     it('should project an @if with a single root node and comments into the root node slot', () => {
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
       class TestComponent {}
 
       @Component({
-        standalone: true,
         imports: [TestComponent],
         template: `
         <test>Before @if (true) {
@@ -451,7 +432,6 @@ describe('control flow - if', () => {
 
     it('should project @if an @else content into separate slots', () => {
       @Component({
-        standalone: true,
         selector: 'test',
         template:
           'if: (<ng-content select="[if_case]"/>),  else: (<ng-content select="[else_case]"/>)',
@@ -459,7 +439,6 @@ describe('control flow - if', () => {
       class TestComponent {}
 
       @Component({
-        standalone: true,
         imports: [TestComponent],
         template: `
         <test>
@@ -490,14 +469,12 @@ describe('control flow - if', () => {
 
     it('should project @if an @else content into separate slots when if has default content', () => {
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'if: (<ng-content />),  else: (<ng-content select="[else_case]"/>)',
       })
       class TestComponent {}
 
       @Component({
-        standalone: true,
         imports: [TestComponent],
         template: `
               <test>
@@ -528,14 +505,12 @@ describe('control flow - if', () => {
 
     it('should project @if an @else content into separate slots when else has default content', () => {
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'if: (<ng-content select="[if_case]"/>),  else: (<ng-content/>)',
       })
       class TestComponent {}
 
       @Component({
-        standalone: true,
         imports: [TestComponent],
         template: `
         <test>
@@ -566,14 +541,12 @@ describe('control flow - if', () => {
 
     it('should project the root node when preserveWhitespaces is enabled and there are no whitespace nodes', () => {
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
       class TestComponent {}
 
       @Component({
-        standalone: true,
         imports: [TestComponent],
         preserveWhitespaces: true,
         template: '<test>Before @if (true) {<span foo>one</span>} After</test>',
@@ -587,14 +560,12 @@ describe('control flow - if', () => {
 
     it('should not project the root node when preserveWhitespaces is enabled and there are whitespace nodes', () => {
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
       class TestComponent {}
 
       @Component({
-        standalone: true,
         imports: [TestComponent],
         preserveWhitespaces: true,
         // Note the whitespace due to the indentation inside @if.
@@ -613,14 +584,12 @@ describe('control flow - if', () => {
 
     it('should not project the root node across multiple layers of @if', () => {
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
       class TestComponent {}
 
       @Component({
-        standalone: true,
         imports: [TestComponent],
         template: `
         <test>Before @if (true) {
@@ -639,14 +608,12 @@ describe('control flow - if', () => {
 
     it('should project an @if with a single root template node into the root node slot', () => {
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
       class TestComponent {}
 
       @Component({
-        standalone: true,
         imports: [TestComponent, NgFor],
         template: `<test>Before @if (true) {
         <span *ngFor="let item of items" foo>{{item}}</span>
@@ -669,7 +636,6 @@ describe('control flow - if', () => {
       let directiveCount = 0;
 
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
@@ -677,7 +643,6 @@ describe('control flow - if', () => {
 
       @Directive({
         selector: '[foo]',
-        standalone: true,
       })
       class FooDirective {
         constructor() {
@@ -686,7 +651,6 @@ describe('control flow - if', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [TestComponent, FooDirective],
         template: `<test>Before @if (true) {
         <span foo>foo</span>
@@ -706,7 +670,6 @@ describe('control flow - if', () => {
       let directiveCount = 0;
 
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
@@ -714,7 +677,6 @@ describe('control flow - if', () => {
 
       @Directive({
         selector: '[templateDir]',
-        standalone: true,
       })
       class TemplateDirective implements OnInit {
         constructor(
@@ -731,7 +693,6 @@ describe('control flow - if', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [TestComponent, TemplateDirective],
         template: `<test>Before @if (true) {
         <span *templateDir foo>foo</span>
@@ -751,7 +712,6 @@ describe('control flow - if', () => {
       let directiveCount = 0;
 
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
       })
@@ -759,7 +719,6 @@ describe('control flow - if', () => {
 
       @Directive({
         selector: '[templateDir]',
-        standalone: true,
       })
       class TemplateDirective implements OnInit {
         constructor(
@@ -776,7 +735,6 @@ describe('control flow - if', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [TestComponent, TemplateDirective],
         template: `<test>Before @if (true) {
           <ng-template templateDir foo>foo</ng-template>
@@ -796,7 +754,6 @@ describe('control flow - if', () => {
       let directiveCount = 0;
 
       @Component({
-        standalone: true,
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select=".foo"/>',
       })
@@ -804,7 +761,6 @@ describe('control flow - if', () => {
 
       @Directive({
         selector: '.foo',
-        standalone: true,
       })
       class TemplateDirective {
         constructor() {
@@ -813,7 +769,6 @@ describe('control flow - if', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [TestComponent, TemplateDirective],
         template: `<test>Before @if (condition) {
           <div class="foo">foo</div>

--- a/packages/core/test/acceptance/control_flow_if_spec.ts
+++ b/packages/core/test/acceptance/control_flow_if_spec.ts
@@ -22,7 +22,7 @@ import {
 import {TestBed} from '@angular/core/testing';
 
 // Basic shared pipe used during testing.
-@Pipe({name: 'multiply', pure: true, standalone: true})
+@Pipe({name: 'multiply', pure: true})
 class MultiplyPipe implements PipeTransform {
   transform(value: number, amount: number) {
     return value * amount;
@@ -31,7 +31,7 @@ class MultiplyPipe implements PipeTransform {
 
 describe('control flow - if', () => {
   it('should add and remove views based on conditions change', () => {
-    @Component({standalone: true, template: '@if (show) {Something} @else {Nothing}'})
+    @Component({template: '@if (show) {Something} @else {Nothing}'})
     class TestComponent {
       show = true;
     }
@@ -247,7 +247,7 @@ describe('control flow - if', () => {
   });
 
   it('should be able to use pipes injecting ChangeDetectorRef in if blocks', () => {
-    @Pipe({name: 'test', standalone: true})
+    @Pipe({name: 'test'})
     class TestPipe implements PipeTransform {
       changeDetectorRef = inject(ChangeDetectorRef);
 
@@ -319,7 +319,7 @@ describe('control flow - if', () => {
     it('should project an @if with a single root node with a data binding', () => {
       let directiveCount = 0;
 
-      @Directive({standalone: true, selector: '[foo]'})
+      @Directive({selector: '[foo]'})
       class Foo {
         @Input('foo') value: any;
 

--- a/packages/core/test/acceptance/control_flow_switch_spec.ts
+++ b/packages/core/test/acceptance/control_flow_switch_spec.ts
@@ -10,7 +10,7 @@ import {ChangeDetectorRef, Component, inject, Pipe, PipeTransform} from '@angula
 import {TestBed} from '@angular/core/testing';
 
 // Basic shared pipe used during testing.
-@Pipe({name: 'multiply', pure: true, standalone: true})
+@Pipe({name: 'multiply', pure: true})
 class MultiplyPipe implements PipeTransform {
   transform(value: number, amount: number) {
     return value * amount;
@@ -105,7 +105,7 @@ describe('control flow - switch', () => {
   });
 
   it('should be able to use pipes injecting ChangeDetectorRef in switch blocks', () => {
-    @Pipe({name: 'test', standalone: true})
+    @Pipe({name: 'test'})
     class TestPipe implements PipeTransform {
       changeDetectorRef = inject(ChangeDetectorRef);
 

--- a/packages/core/test/acceptance/control_flow_switch_spec.ts
+++ b/packages/core/test/acceptance/control_flow_switch_spec.ts
@@ -20,7 +20,6 @@ class MultiplyPipe implements PipeTransform {
 describe('control flow - switch', () => {
   it('should show a template based on a matching case', () => {
     @Component({
-      standalone: true,
       template: `
           @switch (case) {
             @case (0) {case 0}
@@ -49,7 +48,6 @@ describe('control flow - switch', () => {
 
   it('should be able to use a pipe in the switch expression', () => {
     @Component({
-      standalone: true,
       imports: [MultiplyPipe],
       template: `
           @switch (case | multiply:2) {
@@ -79,7 +77,6 @@ describe('control flow - switch', () => {
 
   it('should be able to use a pipe in the case expression', () => {
     @Component({
-      standalone: true,
       imports: [MultiplyPipe],
       template: `
           @switch (case) {
@@ -118,7 +115,6 @@ describe('control flow - switch', () => {
     }
 
     @Component({
-      standalone: true,
       template: `
         @switch (case | test) {
           @case (0 | test) {Zero}
@@ -138,7 +134,6 @@ describe('control flow - switch', () => {
 
   it('should project @switch cases into appropriate slots when selectors are used for all cases', () => {
     @Component({
-      standalone: true,
       selector: 'test',
       template:
         'case 1: (<ng-content select="[case_1]"/>), case 2: (<ng-content select="[case_2]"/>), case 3: (<ng-content select="[case_3]"/>)',
@@ -146,7 +141,6 @@ describe('control flow - switch', () => {
     class TestComponent {}
 
     @Component({
-      standalone: true,
       imports: [TestComponent],
       template: `
             <test>
@@ -183,7 +177,6 @@ describe('control flow - switch', () => {
 
   it('should project @switch cases into appropriate slots when selectors are used for some cases', () => {
     @Component({
-      standalone: true,
       selector: 'test',
       template:
         'case 1: (<ng-content select="[case_1]"/>), case 2: (<ng-content />), case 3: (<ng-content select="[case_3]"/>)',
@@ -191,7 +184,6 @@ describe('control flow - switch', () => {
     class TestComponent {}
 
     @Component({
-      standalone: true,
       imports: [TestComponent],
       template: `
           <test>

--- a/packages/core/test/acceptance/csp_spec.ts
+++ b/packages/core/test/acceptance/csp_spec.ts
@@ -45,14 +45,12 @@ describe('CSP integration', () => {
         selector: 'uses-styles',
         template: '',
         styles: [testStyles],
-        standalone: true,
         encapsulation: ViewEncapsulation.Emulated,
       })
       class UsesStyles {}
 
       @Component({
         selector: 'app',
-        standalone: true,
         template: '<uses-styles></uses-styles>',
         imports: [UsesStyles],
       })
@@ -73,14 +71,12 @@ describe('CSP integration', () => {
         selector: 'uses-styles',
         template: '',
         styles: [testStyles],
-        standalone: true,
         encapsulation: ViewEncapsulation.None,
       })
       class UsesStyles {}
 
       @Component({
         selector: 'app',
-        standalone: true,
         template: '<uses-styles></uses-styles>',
         imports: [UsesStyles],
       })
@@ -107,7 +103,6 @@ describe('CSP integration', () => {
         selector: 'uses-styles',
         template: '',
         styles: [testStyles],
-        standalone: true,
         encapsulation: ViewEncapsulation.ShadowDom,
       })
       class UsesStyles {
@@ -118,7 +113,6 @@ describe('CSP integration', () => {
 
       @Component({
         selector: 'app',
-        standalone: true,
         template: '<uses-styles></uses-styles>',
         imports: [UsesStyles],
       })
@@ -140,7 +134,6 @@ describe('CSP integration', () => {
 
       @Component({
         selector: 'app',
-        standalone: true,
         template: '<uses-styles></uses-styles>',
         imports: [UsesStyles],
       })

--- a/packages/core/test/acceptance/csp_spec.ts
+++ b/packages/core/test/acceptance/csp_spec.ts
@@ -129,7 +129,7 @@ describe('CSP integration', () => {
   it(
     'should prefer nonce provided through DI over one provided in the DOM',
     withBody('<app ngCspNonce="dom-nonce"></app>', async () => {
-      @Component({selector: 'uses-styles', template: '', styles: [testStyles], standalone: true})
+      @Component({selector: 'uses-styles', template: '', styles: [testStyles]})
       class UsesStyles {}
 
       @Component({

--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -278,7 +278,7 @@ describe('@defer', () => {
   });
 
   it('should be able to use pipes injecting ChangeDetectorRef in defer blocks', async () => {
-    @Pipe({name: 'test', standalone: true})
+    @Pipe({name: 'test'})
     class TestPipe implements PipeTransform {
       changeDetectorRef = inject(ChangeDetectorRef);
 
@@ -2301,7 +2301,7 @@ describe('@defer', () => {
     }));
 
     it('should resolve a trigger on a component outside the defer block', fakeAsync(() => {
-      @Component({selector: 'some-comp', template: '<button></button>', standalone: true})
+      @Component({selector: 'some-comp', template: '<button></button>'})
       class SomeComp {}
 
       @Component({
@@ -2395,7 +2395,7 @@ describe('@defer', () => {
     }));
 
     it('should resolve a trigger that is on a component in a parent embedded view', fakeAsync(() => {
-      @Component({selector: 'some-comp', template: '<button></button>', standalone: true})
+      @Component({selector: 'some-comp', template: '<button></button>'})
       class SomeComp {}
 
       @Component({
@@ -2453,7 +2453,7 @@ describe('@defer', () => {
     }));
 
     it('should resolve a trigger that is a component inside the placeholder', fakeAsync(() => {
-      @Component({selector: 'some-comp', template: '<button></button>', standalone: true})
+      @Component({selector: 'some-comp', template: '<button></button>'})
       class SomeComp {}
 
       @Component({

--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -137,7 +137,6 @@ async function verifyTimeline(
 function createFixture(template: string) {
   @Component({
     selector: 'nested-cmp',
-    standalone: true,
     template: '{{ block }}',
   })
   class NestedCmp {
@@ -145,7 +144,6 @@ function createFixture(template: string) {
   }
 
   @Component({
-    standalone: true,
     selector: 'simple-app',
     imports: [NestedCmp],
     template,
@@ -203,13 +201,11 @@ describe('@defer', () => {
   it('should transition between placeholder, loading and loaded states', async () => {
     @Component({
       selector: 'my-lazy-cmp',
-      standalone: true,
       template: 'Hi!',
     })
     class MyLazyCmp {}
 
     @Component({
-      standalone: true,
       selector: 'simple-app',
       imports: [MyLazyCmp],
       template: `
@@ -248,13 +244,11 @@ describe('@defer', () => {
   it('should work when only main block is present', async () => {
     @Component({
       selector: 'my-lazy-cmp',
-      standalone: true,
       template: 'Hi!',
     })
     class MyLazyCmp {}
 
     @Component({
-      standalone: true,
       selector: 'simple-app',
       imports: [MyLazyCmp],
       template: `
@@ -294,7 +288,6 @@ describe('@defer', () => {
     }
 
     @Component({
-      standalone: true,
       imports: [TestPipe],
       template: `@defer (when isVisible | test; prefetch when isVisible | test) {Hello}`,
     })
@@ -323,7 +316,6 @@ describe('@defer', () => {
     // code is wrapped using the `@defer` block.
     const logs: string[] = [];
     @Directive({
-      standalone: true,
       selector: '[dirA]',
     })
     class DirA {
@@ -333,7 +325,6 @@ describe('@defer', () => {
     }
 
     @Directive({
-      standalone: true,
       selector: '[dirB]',
     })
     class DirB {
@@ -343,7 +334,6 @@ describe('@defer', () => {
     }
 
     @Directive({
-      standalone: true,
       selector: '[dirC]',
     })
     class DirC {
@@ -353,7 +343,6 @@ describe('@defer', () => {
     }
 
     @Component({
-      standalone: true,
       // Directive order is intentional here (different from the order
       // in which they are defined on the host element).
       imports: [DirC, DirB, DirA],
@@ -387,7 +376,6 @@ describe('@defer', () => {
     it('should render when @defer is used inside of an OnPush component', async () => {
       @Component({
         selector: 'my-lazy-cmp',
-        standalone: true,
         template: '{{ foo }}',
       })
       class MyLazyCmp {
@@ -395,7 +383,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'simple-app',
         imports: [MyLazyCmp],
         changeDetection: ChangeDetectionStrategy.OnPush,
@@ -420,7 +407,6 @@ describe('@defer', () => {
     it('should render when @defer-loaded component uses OnPush', async () => {
       @Component({
         selector: 'my-lazy-cmp',
-        standalone: true,
         changeDetection: ChangeDetectionStrategy.OnPush,
         template: '{{ foo }}',
       })
@@ -429,7 +415,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'simple-app',
         imports: [MyLazyCmp],
         template: `
@@ -453,7 +438,6 @@ describe('@defer', () => {
     it('should render when both @defer-loaded and host component use OnPush', async () => {
       @Component({
         selector: 'my-lazy-cmp',
-        standalone: true,
         changeDetection: ChangeDetectionStrategy.OnPush,
         template: '{{ foo }}',
       })
@@ -462,7 +446,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'simple-app',
         imports: [MyLazyCmp],
         changeDetection: ChangeDetectionStrategy.OnPush,
@@ -487,7 +470,6 @@ describe('@defer', () => {
     it('should render when both OnPush components used in other blocks (e.g. @placeholder)', async () => {
       @Component({
         selector: 'my-lazy-cmp',
-        standalone: true,
         changeDetection: ChangeDetectionStrategy.OnPush,
         template: '{{ foo }}',
       })
@@ -497,7 +479,6 @@ describe('@defer', () => {
 
       @Component({
         selector: 'another-lazy-cmp',
-        standalone: true,
         changeDetection: ChangeDetectionStrategy.OnPush,
         template: '{{ foo }}',
       })
@@ -506,7 +487,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'simple-app',
         imports: [MyLazyCmp, AnotherLazyCmp],
         changeDetection: ChangeDetectionStrategy.OnPush,
@@ -550,7 +530,6 @@ describe('@defer', () => {
     it('should support `on immediate` condition', async () => {
       @Component({
         selector: 'nested-cmp',
-        standalone: true,
         template: 'Rendering {{ block }} block.',
       })
       class NestedCmp {
@@ -558,7 +537,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'root-app',
         imports: [NestedCmp],
         template: `
@@ -623,7 +601,6 @@ describe('@defer', () => {
     it('should support directive matching in all blocks', async () => {
       @Component({
         selector: 'nested-cmp',
-        standalone: true,
         template: 'Rendering {{ block }} block.',
       })
       class NestedCmp {
@@ -631,7 +608,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'simple-app',
         imports: [NestedCmp],
         template: `
@@ -822,7 +798,6 @@ describe('@defer', () => {
     it('should render an error block when loading fails', async () => {
       @Component({
         selector: 'nested-cmp',
-        standalone: true,
         template: 'Rendering {{ block }} block.',
       })
       class NestedCmp {
@@ -830,7 +805,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'simple-app',
         imports: [NestedCmp],
         template: `
@@ -889,13 +863,11 @@ describe('@defer', () => {
     it('should report an error to the ErrorHandler if no `@error` block is defined', async () => {
       @Component({
         selector: 'nested-cmp',
-        standalone: true,
         template: 'NestedCmp',
       })
       class NestedCmp {}
 
       @Component({
-        standalone: true,
         selector: 'simple-app',
         imports: [NestedCmp],
         template: `
@@ -959,7 +931,6 @@ describe('@defer', () => {
     it('should not render `@error` block if loaded component has errors', async () => {
       @Component({
         selector: 'cmp-with-error',
-        standalone: true,
         template: 'CmpWithError',
       })
       class CmpWithError {
@@ -969,7 +940,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'simple-app',
         imports: [CmpWithError],
         template: `
@@ -1045,7 +1015,6 @@ describe('@defer', () => {
         it(`should log an error in the handler when there is no error block with devMode:${devMode}`, async () => {
           @Component({
             selector: 'nested-cmp',
-            standalone: true,
             template: 'Rendering {{ block }} block.',
           })
           class NestedCmp {
@@ -1053,7 +1022,6 @@ describe('@defer', () => {
           }
 
           @Component({
-            standalone: true,
             selector: 'simple-app',
             imports: [NestedCmp],
             template: `
@@ -1126,7 +1094,6 @@ describe('@defer', () => {
     it('should query for components within each block', async () => {
       @Component({
         selector: 'nested-cmp',
-        standalone: true,
         template: 'Rendering {{ block }} block.',
       })
       class NestedCmp {
@@ -1134,7 +1101,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'simple-app',
         imports: [NestedCmp],
         template: `
@@ -1192,21 +1158,18 @@ describe('@defer', () => {
     it('should be able to project content into each block', async () => {
       @Component({
         selector: 'cmp-a',
-        standalone: true,
         template: 'CmpA',
       })
       class CmpA {}
 
       @Component({
         selector: 'cmp-b',
-        standalone: true,
         template: 'CmpB',
       })
       class CmpB {}
 
       @Component({
         selector: 'nested-cmp',
-        standalone: true,
         template: 'Rendering {{ block }} block.',
       })
       class NestedCmp {
@@ -1214,7 +1177,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'my-app',
         imports: [NestedCmp],
         template: `
@@ -1238,7 +1200,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'root-app',
         imports: [MyCmp, CmpA, CmpB],
         template: `
@@ -1303,14 +1264,12 @@ describe('@defer', () => {
     it('should be able to have nested blocks', async () => {
       @Component({
         selector: 'cmp-a',
-        standalone: true,
         template: 'CmpA',
       })
       class CmpA {}
 
       @Component({
         selector: 'nested-cmp',
-        standalone: true,
         template: 'Rendering {{ block }} block.',
       })
       class NestedCmp {
@@ -1318,7 +1277,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'root-app',
         imports: [NestedCmp, CmpA],
         template: `
@@ -1377,13 +1335,11 @@ describe('@defer', () => {
     it('should handle nested blocks that defer load the same dep', async () => {
       @Component({
         selector: 'cmp-a',
-        standalone: true,
         template: 'CmpA',
       })
       class CmpA {}
 
       @Component({
-        standalone: true,
         selector: 'root-app',
         imports: [CmpA],
         template: `
@@ -1495,7 +1451,6 @@ describe('@defer', () => {
     it('should be able to prefetch resources', async () => {
       @Component({
         selector: 'nested-cmp',
-        standalone: true,
         template: 'Rendering {{ block }} block.',
       })
       class NestedCmp {
@@ -1503,7 +1458,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'root-app',
         imports: [NestedCmp],
         template: `
@@ -1576,7 +1530,6 @@ describe('@defer', () => {
     it('should handle a case when prefetching fails', async () => {
       @Component({
         selector: 'nested-cmp',
-        standalone: true,
         template: 'Rendering {{ block }} block.',
       })
       class NestedCmp {
@@ -1584,7 +1537,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'root-app',
         imports: [NestedCmp],
         template: `
@@ -1656,7 +1608,6 @@ describe('@defer', () => {
     it('should work when loading and prefetching were kicked off at the same time', async () => {
       @Component({
         selector: 'nested-cmp',
-        standalone: true,
         template: 'Rendering {{ block }} block.',
       })
       class NestedCmp {
@@ -1664,7 +1615,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'root-app',
         imports: [NestedCmp],
         template: `
@@ -1724,7 +1674,6 @@ describe('@defer', () => {
     it('should support `prefetch on idle` condition', async () => {
       @Component({
         selector: 'nested-cmp',
-        standalone: true,
         template: 'Rendering {{ block }} block.',
       })
       class NestedCmp {
@@ -1732,7 +1681,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'root-app',
         imports: [NestedCmp],
         template: `
@@ -1801,7 +1749,6 @@ describe('@defer', () => {
     it('should trigger prefetching based on `on idle` only once', async () => {
       @Component({
         selector: 'nested-cmp',
-        standalone: true,
         template: 'Rendering {{ block }} block.',
       })
       class NestedCmp {
@@ -1809,7 +1756,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'root-app',
         imports: [NestedCmp],
         template: `
@@ -1882,7 +1828,6 @@ describe('@defer', () => {
     it('should trigger fetching based on `on idle` only once', async () => {
       @Component({
         selector: 'nested-cmp',
-        standalone: true,
         template: 'Rendering {{ block }} block.',
       })
       class NestedCmp {
@@ -1890,7 +1835,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'root-app',
         imports: [NestedCmp],
         template: `
@@ -1952,7 +1896,6 @@ describe('@defer', () => {
     it('should support `prefetch on immediate` condition', async () => {
       @Component({
         selector: 'nested-cmp',
-        standalone: true,
         template: 'Rendering {{ block }} block.',
       })
       class NestedCmp {
@@ -1960,7 +1903,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'root-app',
         imports: [NestedCmp],
         template: `
@@ -2031,7 +1973,6 @@ describe('@defer', () => {
     it('should delay nested defer blocks with `on idle` triggers', async () => {
       @Component({
         selector: 'nested-cmp',
-        standalone: true,
         template: 'Primary block content.',
       })
       class NestedCmp {
@@ -2040,13 +1981,11 @@ describe('@defer', () => {
 
       @Component({
         selector: 'another-nested-cmp',
-        standalone: true,
         template: 'Nested block component.',
       })
       class AnotherNestedCmp {}
 
       @Component({
-        standalone: true,
         selector: 'root-app',
         imports: [NestedCmp, AnotherNestedCmp],
         template: `
@@ -2129,7 +2068,6 @@ describe('@defer', () => {
     it('should not request idle callback for each block in a for loop', async () => {
       @Component({
         selector: 'nested-cmp',
-        standalone: true,
         template: 'Rendering {{ block }} block.',
       })
       class NestedCmp {
@@ -2137,7 +2075,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'root-app',
         imports: [NestedCmp],
         template: `
@@ -2200,7 +2137,6 @@ describe('@defer', () => {
     it('should delay nested defer blocks with `on idle` triggers', async () => {
       @Component({
         selector: 'nested-cmp',
-        standalone: true,
         template: 'Primary block content.',
       })
       class NestedCmp {
@@ -2209,13 +2145,11 @@ describe('@defer', () => {
 
       @Component({
         selector: 'another-nested-cmp',
-        standalone: true,
         template: 'Nested block component.',
       })
       class AnotherNestedCmp {}
 
       @Component({
-        standalone: true,
         selector: 'root-app',
         imports: [NestedCmp, AnotherNestedCmp],
         template: `
@@ -2296,7 +2230,6 @@ describe('@defer', () => {
 
     it('should clear idle handlers when defer block is triggered', async () => {
       @Component({
-        standalone: true,
         selector: 'root-app',
         template: `
           @defer (when isVisible; on idle; prefetch on idle) {
@@ -2339,7 +2272,6 @@ describe('@defer', () => {
   describe('trigger resolution', () => {
     it('should resolve a trigger is outside the defer block', fakeAsync(() => {
       @Component({
-        standalone: true,
         template: `
             @defer (on interaction(trigger)) {
               Main content
@@ -2373,7 +2305,6 @@ describe('@defer', () => {
       class SomeComp {}
 
       @Component({
-        standalone: true,
         imports: [SomeComp],
         template: `
             @defer (on interaction(trigger)) {
@@ -2405,7 +2336,6 @@ describe('@defer', () => {
 
     it('should resolve a trigger that is on a parent element', fakeAsync(() => {
       @Component({
-        standalone: true,
         template: `
             <button #trigger>
               <div>
@@ -2434,7 +2364,6 @@ describe('@defer', () => {
 
     it('should resolve a trigger that is inside a parent embedded view', fakeAsync(() => {
       @Component({
-        standalone: true,
         template: `
             @if (cond) {
               <button #trigger></button>
@@ -2470,7 +2399,6 @@ describe('@defer', () => {
       class SomeComp {}
 
       @Component({
-        standalone: true,
         imports: [SomeComp],
         template: `
               @if (cond) {
@@ -2504,7 +2432,6 @@ describe('@defer', () => {
 
     it('should resolve a trigger that is inside the placeholder', fakeAsync(() => {
       @Component({
-        standalone: true,
         template: `
               @defer (on interaction(trigger)) {
                 Main content
@@ -2530,7 +2457,6 @@ describe('@defer', () => {
       class SomeComp {}
 
       @Component({
-        standalone: true,
         imports: [SomeComp],
         template: `
               @defer (on interaction(trigger)) {
@@ -2556,7 +2482,6 @@ describe('@defer', () => {
   describe('interaction triggers', () => {
     it('should load the deferred content when the trigger is clicked', fakeAsync(() => {
       @Component({
-        standalone: true,
         template: `
               @defer (on interaction(trigger)) {
                 Main content
@@ -2586,7 +2511,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         template: `
               @defer (on interaction(trigger)) {
                 Main content
@@ -2612,7 +2536,6 @@ describe('@defer', () => {
 
     it('should load the deferred content when an implicit trigger is clicked', fakeAsync(() => {
       @Component({
-        standalone: true,
         template: `
              @defer (on interaction) {
                Main content
@@ -2636,7 +2559,6 @@ describe('@defer', () => {
 
     it('should load the deferred content if a child of the trigger is clicked', fakeAsync(() => {
       @Component({
-        standalone: true,
         template: `
               @defer (on interaction(trigger)) {
                 Main content
@@ -2665,7 +2587,6 @@ describe('@defer', () => {
 
     it('should support multiple deferred blocks with the same trigger', fakeAsync(() => {
       @Component({
-        standalone: true,
         template: `
              @defer (on interaction(trigger)) {
               Main content 1
@@ -2696,7 +2617,6 @@ describe('@defer', () => {
 
     it('should unbind the trigger events when the deferred block is loaded', fakeAsync(() => {
       @Component({
-        standalone: true,
         template: `
              @defer (on interaction(trigger)) {Main content}
              <button #trigger></button>
@@ -2721,7 +2641,6 @@ describe('@defer', () => {
 
     it('should unbind the trigger events when the trigger is destroyed', fakeAsync(() => {
       @Component({
-        standalone: true,
         template: `
             @if (renderBlock) {
               @defer (on interaction(trigger)) {Main content}
@@ -2749,7 +2668,6 @@ describe('@defer', () => {
 
     it('should unbind the trigger events when the deferred block is destroyed', fakeAsync(() => {
       @Component({
-        standalone: true,
         template: `
               @if (renderBlock) {
                 @defer (on interaction(trigger)) {Main content}
@@ -2778,7 +2696,6 @@ describe('@defer', () => {
 
     it('should remove placeholder content on interaction', fakeAsync(() => {
       @Component({
-        standalone: true,
         template: `
            @defer (on interaction(trigger)) {
              Main content
@@ -2811,7 +2728,6 @@ describe('@defer', () => {
 
     it('should prefetch resources on interaction', fakeAsync(() => {
       @Component({
-        standalone: true,
         selector: 'root-app',
         template: `
               @defer (when isLoaded; prefetch on interaction(trigger)) {Main content}
@@ -2855,7 +2771,6 @@ describe('@defer', () => {
 
     it('should prefetch resources on interaction with an implicit trigger', fakeAsync(() => {
       @Component({
-        standalone: true,
         selector: 'root-app',
         template: `
              @defer (when isLoaded; prefetch on interaction) {
@@ -2909,7 +2824,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         template: `
               @defer (on hover(trigger)) {
                 Main content
@@ -2940,7 +2854,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         template: `
              @defer (on hover) {
                Main content
@@ -2970,7 +2883,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         template: `
               @defer (on hover(trigger)) {
                 Main content 1
@@ -3007,7 +2919,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         template: `
              @defer (on hover(trigger)) {
               Main content
@@ -3040,7 +2951,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         template: `
             @if (renderBlock) {
               @defer (on hover(trigger)) {
@@ -3076,7 +2986,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         template: `
               @if (renderBlock) {
                 @defer (on hover(trigger)) {
@@ -3113,7 +3022,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'root-app',
         template: `
               @defer (when isLoaded; prefetch on hover(trigger)) {
@@ -3165,7 +3073,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'root-app',
         template: `
              @defer (when isLoaded; prefetch on hover) {
@@ -3216,7 +3123,6 @@ describe('@defer', () => {
     it('should trigger based on `on timer` condition', async () => {
       @Component({
         selector: 'nested-cmp',
-        standalone: true,
         template: 'Rendering {{ block }} block.',
       })
       class NestedCmp {
@@ -3224,7 +3130,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'root-app',
         imports: [NestedCmp],
         template: `
@@ -3292,7 +3197,6 @@ describe('@defer', () => {
 
     it('should trigger nested `on timer` condition', async () => {
       @Component({
-        standalone: true,
         selector: 'root-app',
         template: `
           @defer (on timer(100ms)) {
@@ -3339,7 +3243,6 @@ describe('@defer', () => {
     it('should trigger prefetching based on `on timer` condition', async () => {
       @Component({
         selector: 'nested-cmp',
-        standalone: true,
         template: 'Rendering {{ block }} block.',
       })
       class NestedCmp {
@@ -3347,7 +3250,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'root-app',
         imports: [NestedCmp],
         template: `
@@ -3428,7 +3330,6 @@ describe('@defer', () => {
       const clearSpy = spyOn(globalThis, 'clearTimeout');
 
       @Component({
-        standalone: true,
         selector: 'root-app',
         template: `
               @defer (when isVisible; on timer(200ms); prefetch on timer(100ms)) {
@@ -3554,7 +3455,6 @@ describe('@defer', () => {
 
     it('should load the deferred content when the trigger is in the viewport', fakeAsync(() => {
       @Component({
-        standalone: true,
         template: `
               @defer (on viewport(trigger)) {
                 Main content
@@ -3581,7 +3481,6 @@ describe('@defer', () => {
 
     it('should load the deferred content when an implicit trigger is in the viewport', fakeAsync(() => {
       @Component({
-        standalone: true,
         template: `
              @defer (on viewport) {
                Main content
@@ -3607,7 +3506,6 @@ describe('@defer', () => {
 
     it('should not load the content if the trigger is not in the view yet', fakeAsync(() => {
       @Component({
-        standalone: true,
         template: `
              @defer (on viewport(trigger)) {
               Main content
@@ -3645,7 +3543,6 @@ describe('@defer', () => {
 
     it('should support multiple deferred blocks with the same trigger', fakeAsync(() => {
       @Component({
-        standalone: true,
         template: `
             @defer (on viewport(trigger)) {
               Main content 1
@@ -3677,7 +3574,6 @@ describe('@defer', () => {
 
     it('should stop observing the trigger when the deferred block is loaded', fakeAsync(() => {
       @Component({
-        standalone: true,
         template: `
             @defer (on viewport(trigger)) {
               Main content
@@ -3705,7 +3601,6 @@ describe('@defer', () => {
 
     it('should stop observing the trigger when the trigger is destroyed', fakeAsync(() => {
       @Component({
-        standalone: true,
         template: `
            @if (renderBlock) {
              @defer (on viewport(trigger)) {
@@ -3736,7 +3631,6 @@ describe('@defer', () => {
 
     it('should stop observing the trigger when the deferred block is destroyed', fakeAsync(() => {
       @Component({
-        standalone: true,
         template: `
              @if (renderBlock) {
               @defer (on viewport(trigger)) {
@@ -3768,7 +3662,6 @@ describe('@defer', () => {
 
     it('should disconnect the intersection observer once all deferred blocks have been loaded', fakeAsync(() => {
       @Component({
-        standalone: true,
         template: `
             <button #triggerOne></button>
             @defer (on viewport(triggerOne)) {
@@ -3808,7 +3701,6 @@ describe('@defer', () => {
 
     it('should prefetch resources when the trigger comes into the viewport', fakeAsync(() => {
       @Component({
-        standalone: true,
         selector: 'root-app',
         template: `
              @defer (when isLoaded; prefetch on viewport(trigger)) {
@@ -3855,7 +3747,6 @@ describe('@defer', () => {
 
     it('should prefetch resources when an implicit trigger comes into the viewport', fakeAsync(() => {
       @Component({
-        standalone: true,
         selector: 'root-app',
         template: `
              @defer (when isLoaded; prefetch on viewport) {
@@ -3903,7 +3794,6 @@ describe('@defer', () => {
 
     it('should load deferred content in a loop', fakeAsync(() => {
       @Component({
-        standalone: true,
         template: `
               @for (item of items; track item) {
                 @defer (on viewport) {d{{item}} }
@@ -3944,7 +3834,6 @@ describe('@defer', () => {
   describe('DOM-based events cleanup', () => {
     it('should unbind `interaction` trigger events when the deferred block is loaded', async () => {
       @Component({
-        standalone: true,
         template: `
           @defer (
             when isVisible;
@@ -3994,7 +3883,6 @@ describe('@defer', () => {
 
     it('should unbind `hover` trigger events when the deferred block is loaded', async () => {
       @Component({
-        standalone: true,
         template: `
           @defer (
             when isVisible;
@@ -4067,7 +3955,6 @@ describe('@defer', () => {
       const TokenB = new InjectionToken('B');
 
       @Component({
-        standalone: true,
         selector: 'parent-cmp',
         template: '<ng-content />',
         providers: [{provide: TokenA, useValue: 'TokenA.ParentCmp'}],
@@ -4075,7 +3962,6 @@ describe('@defer', () => {
       class ParentCmp {}
 
       @Component({
-        standalone: true,
         selector: 'child-cmp',
         template: 'Token A: {{ parentTokenA }} | Token B: {{ parentTokenB }}',
       })
@@ -4085,7 +3971,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'app-root',
         template: `
           <parent-cmp>
@@ -4145,7 +4030,6 @@ describe('@defer', () => {
 
         @Component({
           selector: 'lazy',
-          standalone: true,
           imports: [MyModule],
           template: `
           Lazy Component! Token: {{ token }}
@@ -4156,7 +4040,6 @@ describe('@defer', () => {
         }
 
         @Component({
-          standalone: true,
           imports: [Lazy],
           template: `
           @defer (on immediate) {
@@ -4167,7 +4050,6 @@ describe('@defer', () => {
         class Dialog {}
 
         @Component({
-          standalone: true,
           selector: 'app-root',
           providers: [{provide: TokenA, useValue: 'TokenA from RootCmp'}],
           template: `
@@ -4260,14 +4142,12 @@ describe('@defer', () => {
       @Component({
         selector: 'chart-collection',
         template: '<chart />',
-        standalone: true,
         imports: [ChartsModule],
       })
       class ChartCollectionComponent {}
 
       @Component({
         selector: 'app-root',
-        standalone: true,
         template: `
           @for(item of items; track $index) {
             @defer (when isVisible) {
@@ -4336,14 +4216,12 @@ describe('@defer', () => {
       class MyModuleA {}
 
       @Component({
-        standalone: true,
         imports: [RouterOutlet],
         template: '<router-outlet />',
       })
       class App {}
 
       @Component({
-        standalone: true,
         selector: 'another-child',
         imports: [CommonModule, MyModuleA],
         template: 'another child: {{route.snapshot.url[0]}} | token: {{tokenA}}',
@@ -4357,7 +4235,6 @@ describe('@defer', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [CommonModule, AnotherChild],
         template: `
           child: {{route.snapshot.url[0]}} |

--- a/packages/core/test/acceptance/destroy_ref_spec.ts
+++ b/packages/core/test/acceptance/destroy_ref_spec.ts
@@ -82,7 +82,6 @@ describe('DestroyRef', () => {
 
       @Component({
         selector: 'test',
-        standalone: true,
         template: ``,
       })
       class TestCmp {
@@ -103,7 +102,6 @@ describe('DestroyRef', () => {
 
       @Directive({
         selector: '[withCleanup]',
-        standalone: true,
       })
       class WithCleanupDirective {
         constructor() {
@@ -113,7 +111,6 @@ describe('DestroyRef', () => {
 
       @Component({
         selector: 'test',
-        standalone: true,
         imports: [WithCleanupDirective],
         // note: we are trying to register a LView-level cleanup _before_ TView-level one (event
         // listener)
@@ -136,7 +133,6 @@ describe('DestroyRef', () => {
 
       @Directive({
         selector: '[withCleanup]',
-        standalone: true,
       })
       class WithCleanupDirective {
         constructor() {
@@ -146,7 +142,6 @@ describe('DestroyRef', () => {
 
       @Component({
         selector: 'test',
-        standalone: true,
         imports: [WithCleanupDirective, NgIf],
         template: `<ng-template [ngIf]="show"><div withCleanup></div></ng-template>`,
       })
@@ -167,7 +162,6 @@ describe('DestroyRef', () => {
       const onDestroySpy = jasmine.createSpy('destroy spy');
       @Component({
         selector: 'child',
-        standalone: true,
         template: '',
       })
       class Child {
@@ -176,7 +170,6 @@ describe('DestroyRef', () => {
         }
       }
       @Component({
-        standalone: true,
         imports: [Child, NgIf],
         template: '<child *ngIf="showChild"></child>',
       })
@@ -197,7 +190,6 @@ describe('DestroyRef', () => {
 
     @Component({
       selector: 'test',
-      standalone: true,
       template: ``,
     })
     class TestCmp {
@@ -223,7 +215,6 @@ describe('DestroyRef', () => {
 
     @Component({
       selector: 'test',
-      standalone: true,
       template: ``,
     })
     class TestCmp {
@@ -251,7 +242,6 @@ describe('DestroyRef', () => {
   it('should throw when trying to register destroy callback on destroyed LView', () => {
     @Component({
       selector: 'test',
-      standalone: true,
       template: ``,
     })
     class TestCmp {
@@ -272,7 +262,6 @@ describe('DestroyRef', () => {
 
     @Component({
       selector: 'test',
-      standalone: true,
       template: ``,
     })
     class TestCmp {

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -309,7 +309,6 @@ describe('importProvidersFrom', () => {
     class ModuleA {}
 
     @Component({
-      standalone: true,
       template: '',
       imports: [ModuleA],
     })
@@ -3909,7 +3908,6 @@ describe('di', () => {
       const TOKEN = new InjectionToken<string>('TOKEN');
 
       @Component({
-        standalone: true,
         selector: 'test-cmp',
         template: '{{value}}',
         providers: [{provide: TOKEN, useValue: 'injected value'}],
@@ -3938,7 +3936,6 @@ describe('di', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'test-cmp',
         template: '{{service.value}}',
         providers: [Service, {provide: TOKEN, useValue: 'injected value'}],
@@ -3956,7 +3953,6 @@ describe('di', () => {
       const TOKEN = new InjectionToken<string>('TOKEN');
 
       @Component({
-        standalone: true,
         selector: 'test-cmp',
         template: '{{value}}',
       })
@@ -4033,7 +4029,6 @@ describe('di', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'test-cmp',
         template: '{{service.value}}',
         providers: [{provide: TOKEN, useValue: 'injected value'}],
@@ -4059,7 +4054,6 @@ describe('di', () => {
         const TOKEN = new InjectionToken<string>('TOKEN');
 
         @Component({
-          standalone: true,
           template: '',
         })
         class TestCmp {
@@ -4075,7 +4069,6 @@ describe('di', () => {
           factory: () => 'from root',
         });
         @Component({
-          standalone: true,
           template: '',
           providers: [{provide: TOKEN, useValue: 'from component'}],
         })
@@ -4093,7 +4086,6 @@ describe('di', () => {
         });
 
         @Component({
-          standalone: true,
           template: '',
         })
         class TestCmp {
@@ -4107,7 +4099,6 @@ describe('di', () => {
         const TOKEN = new InjectionToken<string>('TOKEN');
 
         @Component({
-          standalone: true,
           selector: 'child',
           template: '{{value}}',
         })
@@ -4116,7 +4107,6 @@ describe('di', () => {
         }
 
         @Component({
-          standalone: true,
           imports: [ChildCmp],
           template: '<child></child>',
           providers: [{provide: TOKEN, useValue: 'from parent'}],
@@ -4136,7 +4126,6 @@ describe('di', () => {
         });
 
         @Component({
-          standalone: true,
           template: '',
         })
         class TestCmp {
@@ -4156,7 +4145,6 @@ describe('di', () => {
         const TOKEN = new InjectionToken<string>('TOKEN');
 
         @Component({
-          standalone: true,
           template: '',
         })
         class TestCmp {
@@ -4177,7 +4165,6 @@ describe('di', () => {
         const TOKEN = new InjectionToken<string>('TOKEN');
 
         @Component({
-          standalone: true,
           template: '',
         })
         class TestCmp {
@@ -4212,7 +4199,6 @@ describe('di', () => {
           factory: () => 'from root',
         });
         @Component({
-          standalone: true,
           template: '',
           providers: [{provide: TOKEN, useValue: 'from component'}],
         })
@@ -4242,7 +4228,6 @@ describe('di', () => {
         });
 
         @Component({
-          standalone: true,
           template: '',
         })
         class TestCmp {
@@ -4267,7 +4252,6 @@ describe('di', () => {
         const TOKEN = new InjectionToken<string>('TOKEN');
 
         @Component({
-          standalone: true,
           selector: 'child',
           template: '{{ a }}|{{ b }}',
         })
@@ -4278,7 +4262,6 @@ describe('di', () => {
         }
 
         @Component({
-          standalone: true,
           imports: [ChildCmp],
           template: '<child></child>',
           providers: [{provide: TOKEN, useValue: 'from parent'}],
@@ -4349,7 +4332,6 @@ describe('di', () => {
       });
 
       @Component({
-        standalone: true,
         template: '',
         providers: [{provide: TOKEN, useValue: 'from component'}],
       })
@@ -4374,7 +4356,6 @@ describe('di', () => {
 
     it('should support node injectors', () => {
       @Component({
-        standalone: true,
         template: '',
       })
       class TestCmp {
@@ -4896,7 +4877,6 @@ describe('di', () => {
       }
 
       @Component({
-        standalone: true,
         template: '<div dir some-attr="foo" other="ignore"></div>',
         imports: [Dir],
       })
@@ -4916,7 +4896,6 @@ describe('di', () => {
       }
 
       @Component({
-        standalone: true,
         template: '<ng-template dir some-attr="foo" other="ignore"></ng-template>',
         imports: [Dir],
       })
@@ -4936,7 +4915,6 @@ describe('di', () => {
       }
 
       @Component({
-        standalone: true,
         template: '<ng-container dir some-attr="foo" other="ignore"></ng-container>',
         imports: [Dir],
       })
@@ -4958,7 +4936,6 @@ describe('di', () => {
       }
 
       @Component({
-        standalone: true,
         template: `
           <div
             dir
@@ -4990,7 +4967,6 @@ describe('di', () => {
       }
 
       @Component({
-        standalone: true,
         template: '<div dir other="ignore"></div>',
         imports: [Dir],
       })
@@ -5010,7 +4986,6 @@ describe('di', () => {
       }
 
       @Component({
-        standalone: true,
         template: '<div dir other="ignore"></div>',
         imports: [Dir],
       })
@@ -5032,7 +5007,6 @@ describe('di', () => {
       }
 
       @Component({
-        standalone: true,
         template: `
           <div dir some-attr="foo" svg:exists="testExistValue" other="otherValue"></div>
         `,
@@ -5064,7 +5038,6 @@ describe('di', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [Dir],
         template: `
           <div
@@ -5098,7 +5071,6 @@ describe('di', () => {
       }
 
       @Component({
-        standalone: true,
         template: '<div dir title="foo {{value}}" other="ignore"></div>',
         imports: [Dir],
       })
@@ -5123,7 +5095,6 @@ describe('di', () => {
       }
 
       @Component({
-        standalone: true,
         template: '<div dir some-attr="foo" other="ignore"></div>',
         imports: [Dir],
       })
@@ -5145,7 +5116,6 @@ describe('di', () => {
       }
 
       @Component({
-        standalone: true,
         template: '<div dir other="ignore"></div>',
         imports: [Dir],
       })
@@ -5167,7 +5137,6 @@ describe('di', () => {
       }
 
       @Component({
-        standalone: true,
         template: '<div dir other="ignore"></div>',
         imports: [Dir],
       })
@@ -5189,7 +5158,6 @@ describe('di', () => {
       }
 
       @Component({
-        standalone: true,
         template: `
           <div dir #v1></div>
           <span dir #v2></span>
@@ -5223,7 +5191,6 @@ describe('di', () => {
       }
 
       @Component({
-        standalone: true,
         template: '<ng-container dir></ng-container>',
         imports: [Dir],
       })
@@ -5232,7 +5199,6 @@ describe('di', () => {
       }
 
       @Component({
-        standalone: true,
         template: '<ng-template dir></ng-template>',
         imports: [Dir],
       })
@@ -5256,7 +5222,6 @@ describe('di', () => {
       }
 
       @Component({
-        standalone: true,
         template: '<ng-container dir></ng-container>',
         imports: [Dir],
       })

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -4871,7 +4871,7 @@ describe('di', () => {
 
   describe('HostAttributeToken', () => {
     it('should inject an attribute on an element node', () => {
-      @Directive({selector: '[dir]', standalone: true})
+      @Directive({selector: '[dir]'})
       class Dir {
         value = inject(new HostAttributeToken('some-attr'));
       }
@@ -4890,7 +4890,7 @@ describe('di', () => {
     });
 
     it('should inject an attribute on <ng-template>', () => {
-      @Directive({selector: '[dir]', standalone: true})
+      @Directive({selector: '[dir]'})
       class Dir {
         value = inject(new HostAttributeToken('some-attr'));
       }
@@ -4909,7 +4909,7 @@ describe('di', () => {
     });
 
     it('should inject an attribute on <ng-container>', () => {
-      @Directive({selector: '[dir]', standalone: true})
+      @Directive({selector: '[dir]'})
       class Dir {
         value = inject(new HostAttributeToken('some-attr'));
       }
@@ -4928,7 +4928,7 @@ describe('di', () => {
     });
 
     it('should be able to inject different kinds of attributes', () => {
-      @Directive({selector: '[dir]', standalone: true})
+      @Directive({selector: '[dir]'})
       class Dir {
         className = inject(new HostAttributeToken('class'));
         inlineStyles = inject(new HostAttributeToken('style'));
@@ -4961,7 +4961,7 @@ describe('di', () => {
     });
 
     it('should throw a DI error when injecting a non-existent attribute', () => {
-      @Directive({selector: '[dir]', standalone: true})
+      @Directive({selector: '[dir]'})
       class Dir {
         value = inject(new HostAttributeToken('some-attr'));
       }
@@ -4980,7 +4980,7 @@ describe('di', () => {
     });
 
     it('should not throw a DI error when injecting a non-existent attribute with optional: true', () => {
-      @Directive({selector: '[dir]', standalone: true})
+      @Directive({selector: '[dir]'})
       class Dir {
         value = inject(new HostAttributeToken('some-attr'), {optional: true});
       }
@@ -4999,7 +4999,7 @@ describe('di', () => {
     });
 
     it('should not inject attributes with namespace', () => {
-      @Directive({selector: '[dir]', standalone: true})
+      @Directive({selector: '[dir]'})
       class Dir {
         value = inject(new HostAttributeToken('some-attr'), {optional: true});
         namespaceExists = inject(new HostAttributeToken('svg:exist'), {optional: true});
@@ -5026,7 +5026,7 @@ describe('di', () => {
     });
 
     it('should not inject attributes representing bindings and outputs', () => {
-      @Directive({selector: '[dir]', standalone: true})
+      @Directive({selector: '[dir]'})
       class Dir {
         @Input() binding!: string;
         @Output() output = new EventEmitter();
@@ -5065,7 +5065,7 @@ describe('di', () => {
     });
 
     it('should not inject data-bound attributes', () => {
-      @Directive({selector: '[dir]', standalone: true})
+      @Directive({selector: '[dir]'})
       class Dir {
         value = inject(new HostAttributeToken('title'), {optional: true});
       }
@@ -5089,7 +5089,7 @@ describe('di', () => {
     it('should inject an attribute using @Inject', () => {
       const TOKEN = new HostAttributeToken('some-attr');
 
-      @Directive({selector: '[dir]', standalone: true})
+      @Directive({selector: '[dir]'})
       class Dir {
         constructor(@Inject(TOKEN) readonly value: string) {}
       }
@@ -5110,7 +5110,7 @@ describe('di', () => {
     it('should throw when injecting a non-existent attribute using @Inject', () => {
       const TOKEN = new HostAttributeToken('some-attr');
 
-      @Directive({selector: '[dir]', standalone: true})
+      @Directive({selector: '[dir]'})
       class Dir {
         constructor(@Inject(TOKEN) readonly value: string) {}
       }
@@ -5131,7 +5131,7 @@ describe('di', () => {
     it('should not throw when injecting a non-existent attribute using @Inject @Optional', () => {
       const TOKEN = new HostAttributeToken('some-attr');
 
-      @Directive({selector: '[dir]', standalone: true})
+      @Directive({selector: '[dir]'})
       class Dir {
         constructor(@Inject(TOKEN) @Optional() readonly value: string | null) {}
       }
@@ -5152,7 +5152,7 @@ describe('di', () => {
 
   describe('HOST_TAG_NAME', () => {
     it('should inject the tag name on an element node', () => {
-      @Directive({selector: '[dir]', standalone: true})
+      @Directive({selector: '[dir]'})
       class Dir {
         value = inject(HOST_TAG_NAME);
       }
@@ -5185,7 +5185,7 @@ describe('di', () => {
     });
 
     it('should throw a DI error when injecting into non-DOM nodes', () => {
-      @Directive({selector: '[dir]', standalone: true})
+      @Directive({selector: '[dir]'})
       class Dir {
         value = inject(HOST_TAG_NAME);
       }
@@ -5216,7 +5216,7 @@ describe('di', () => {
     });
 
     it('should not throw a DI error when injecting into non-DOM nodes with optional: true', () => {
-      @Directive({selector: '[dir]', standalone: true})
+      @Directive({selector: '[dir]'})
       class Dir {
         value = inject(HOST_TAG_NAME, {optional: true});
       }

--- a/packages/core/test/acceptance/directive_spec.ts
+++ b/packages/core/test/acceptance/directive_spec.ts
@@ -864,7 +864,7 @@ describe('directives', () => {
     });
 
     it('should transform aliased inputs coming from host directives', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {
         @Input({transform: (value: string) => (value ? 1 : 0)}) value = -1;
       }

--- a/packages/core/test/acceptance/env_injector_standalone_spec.ts
+++ b/packages/core/test/acceptance/env_injector_standalone_spec.ts
@@ -25,7 +25,7 @@ describe('environment injector and standalone components', () => {
     @NgModule({providers: [ModuleService]})
     class Module {}
 
-    @Component({standalone: true, imports: [Module]})
+    @Component({imports: [Module]})
     class StandaloneComponent {}
 
     const parentEnvInjector = TestBed.inject(EnvironmentInjector);
@@ -42,7 +42,7 @@ describe('environment injector and standalone components', () => {
     @NgModule({providers: [ModuleService]})
     class Module {}
 
-    @Component({standalone: true, imports: [Module]})
+    @Component({imports: [Module]})
     class StandaloneComponent {}
 
     @NgModule({imports: [StandaloneComponent], exports: [StandaloneComponent]})
@@ -62,10 +62,10 @@ describe('environment injector and standalone components', () => {
     @NgModule({providers: [{provide: ModuleService, useClass: ModuleService, multi: true}]})
     class Module {}
 
-    @Component({standalone: true, imports: [Module]})
+    @Component({imports: [Module]})
     class StandaloneComponent1 {}
 
-    @Component({standalone: true, imports: [Module]})
+    @Component({imports: [Module]})
     class StandaloneComponent2 {}
 
     @NgModule({

--- a/packages/core/test/acceptance/environment_injector_spec.ts
+++ b/packages/core/test/acceptance/environment_injector_spec.ts
@@ -233,7 +233,6 @@ describe('environment injector', () => {
       });
 
       @Component({
-        standalone: true,
         template: '',
         providers: [{provide: TOKEN, useValue: 'from component'}],
       })

--- a/packages/core/test/acceptance/hmr_spec.ts
+++ b/packages/core/test/acceptance/hmr_spec.ts
@@ -1193,7 +1193,7 @@ describe('hot module replacement', () => {
         }
       }
 
-      @Directive({selector: '[dir-a]', standalone: true})
+      @Directive({selector: '[dir-a]'})
       class DirA implements OnDestroy {
         constructor() {
           initLog.push('DirA init');
@@ -1204,7 +1204,7 @@ describe('hot module replacement', () => {
         }
       }
 
-      @Directive({selector: '[dir-b]', standalone: true})
+      @Directive({selector: '[dir-b]'})
       class DirB implements OnDestroy {
         constructor() {
           initLog.push('DirB init');
@@ -1240,7 +1240,7 @@ describe('hot module replacement', () => {
       const initLog: string[] = [];
       let destroyCount = 0;
 
-      @Directive({selector: '[dir-a]', standalone: true})
+      @Directive({selector: '[dir-a]'})
       class DirA implements OnDestroy {
         constructor() {
           initLog.push('DirA init');
@@ -1251,7 +1251,7 @@ describe('hot module replacement', () => {
         }
       }
 
-      @Directive({selector: '[dir-b]', standalone: true})
+      @Directive({selector: '[dir-b]'})
       class DirB implements OnDestroy {
         constructor() {
           initLog.push('DirB init');
@@ -1306,14 +1306,14 @@ describe('hot module replacement', () => {
       let instance!: ChildCmp;
       const injectedInstances: [unknown, ChildCmp][] = [];
 
-      @Directive({selector: '[dir-a]', standalone: true})
+      @Directive({selector: '[dir-a]'})
       class DirA {
         constructor() {
           injectedInstances.push([this, inject(ChildCmp)]);
         }
       }
 
-      @Directive({selector: '[dir-b]', standalone: true})
+      @Directive({selector: '[dir-b]'})
       class DirB {
         constructor() {
           injectedInstances.push([this, inject(ChildCmp)]);
@@ -1360,14 +1360,14 @@ describe('hot module replacement', () => {
       const token = new InjectionToken<string>('TEST_TOKEN');
       const injectedValues: [unknown, string][] = [];
 
-      @Directive({selector: '[dir-a]', standalone: true})
+      @Directive({selector: '[dir-a]'})
       class DirA {
         constructor() {
           injectedValues.push([this, inject(token)]);
         }
       }
 
-      @Directive({selector: '[dir-b]', standalone: true})
+      @Directive({selector: '[dir-b]'})
       class DirB {
         constructor() {
           injectedValues.push([this, inject(token)]);
@@ -1410,14 +1410,14 @@ describe('hot module replacement', () => {
       const token = new InjectionToken<string>('TEST_TOKEN');
       const injectedValues: [unknown, string][] = [];
 
-      @Directive({selector: '[dir-a]', standalone: true})
+      @Directive({selector: '[dir-a]'})
       class DirA {
         constructor() {
           injectedValues.push([this, inject(token)]);
         }
       }
 
-      @Directive({selector: '[dir-b]', standalone: true})
+      @Directive({selector: '[dir-b]'})
       class DirB {
         constructor() {
           injectedValues.push([this, inject(token)]);

--- a/packages/core/test/acceptance/hmr_spec.ts
+++ b/packages/core/test/acceptance/hmr_spec.ts
@@ -37,7 +37,6 @@ describe('hot module replacement', () => {
     let instance!: ChildCmp;
     const initialMetadata: Component = {
       selector: 'child-cmp',
-      standalone: true,
       template: 'Hello <strong>{{state}}</strong>',
     };
 
@@ -51,7 +50,6 @@ describe('hot module replacement', () => {
     }
 
     @Component({
-      standalone: true,
       imports: [ChildCmp],
       template: '<child-cmp/>',
     })
@@ -104,7 +102,6 @@ describe('hot module replacement', () => {
   it('should recreate multiple usages of a complex component', () => {
     const initialMetadata: Component = {
       selector: 'child-cmp',
-      standalone: true,
       template: '<span>ChildCmp (orig)</span><h1>{{ text }}</h1>',
     };
 
@@ -114,7 +111,6 @@ describe('hot module replacement', () => {
     }
 
     @Component({
-      standalone: true,
       imports: [ChildCmp],
       template: `
         <i>Unrelated node #1</i>
@@ -197,7 +193,6 @@ describe('hot module replacement', () => {
   it('should not recreate sub-classes of a component being replaced', () => {
     const initialMetadata: Component = {
       selector: 'child-cmp',
-      standalone: true,
       template: 'Base class',
     };
 
@@ -206,13 +201,11 @@ describe('hot module replacement', () => {
 
     @Component({
       selector: 'child-sub-cmp',
-      standalone: true,
       template: 'Sub class',
     })
     class ChildSubCmp extends ChildCmp {}
 
     @Component({
-      standalone: true,
       imports: [ChildCmp, ChildSubCmp],
       template: `<child-cmp/>|<child-sub-cmp/>`,
     })
@@ -247,7 +240,6 @@ describe('hot module replacement', () => {
   it('should continue binding inputs to a component that is replaced', () => {
     const initialMetadata: Component = {
       selector: 'child-cmp',
-      standalone: true,
       template: '<span>{{staticValue}}</span><strong>{{dynamicValue}}</strong>',
     };
 
@@ -258,7 +250,6 @@ describe('hot module replacement', () => {
     }
 
     @Component({
-      standalone: true,
       imports: [ChildCmp],
       template: `<child-cmp staticValue="1" [dynamicValue]="dynamicValue"/>`,
     })
@@ -331,7 +322,6 @@ describe('hot module replacement', () => {
   it('should recreate a component used inside @for', () => {
     const initialMetadata: Component = {
       selector: 'child-cmp',
-      standalone: true,
       template: 'Hello <strong>{{value}}</strong>',
     };
 
@@ -341,7 +331,6 @@ describe('hot module replacement', () => {
     }
 
     @Component({
-      standalone: true,
       imports: [ChildCmp],
       template: `
         @for (current of items; track current.id) {
@@ -417,7 +406,6 @@ describe('hot module replacement', () => {
     it('should update ViewChildren query results', async () => {
       @Component({
         selector: 'child-cmp',
-        standalone: true,
         template: '<span>ChildCmp {{ text }}</span>',
       })
       class ChildCmp {
@@ -426,7 +414,6 @@ describe('hot module replacement', () => {
 
       let instance!: ParentCmp;
       const initialMetadata: Component = {
-        standalone: true,
         selector: 'parent-cmp',
         imports: [ChildCmp],
         template: `
@@ -445,7 +432,6 @@ describe('hot module replacement', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [ParentCmp],
         template: `<parent-cmp/>`,
       })
@@ -475,7 +461,6 @@ describe('hot module replacement', () => {
     it('should update ViewChild when the string points to a different element', async () => {
       let instance!: ParentCmp;
       const initialMetadata: Component = {
-        standalone: true,
         selector: 'parent-cmp',
         template: `
           <div>
@@ -496,7 +481,6 @@ describe('hot module replacement', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [ParentCmp],
         template: `<parent-cmp/>`,
       })
@@ -529,14 +513,12 @@ describe('hot module replacement', () => {
       const token = new InjectionToken<DirA | DirB>('token');
 
       @Directive({
-        standalone: true,
         selector: '[dir-a]',
         providers: [{provide: token, useExisting: DirA}],
       })
       class DirA {}
 
       @Directive({
-        standalone: true,
         selector: '[dir-b]',
         providers: [{provide: token, useExisting: DirB}],
       })
@@ -544,7 +526,6 @@ describe('hot module replacement', () => {
 
       let instance!: ParentCmp;
       const initialMetadata: Component = {
-        standalone: true,
         selector: 'parent-cmp',
         imports: [DirA, DirB],
         template: `<div #ref dir-a></div>`,
@@ -560,7 +541,6 @@ describe('hot module replacement', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [ParentCmp],
         template: `<parent-cmp/>`,
       })
@@ -587,7 +567,6 @@ describe('hot module replacement', () => {
       const token = new InjectionToken<Dir>('token');
 
       @Directive({
-        standalone: true,
         selector: '[dir]',
         providers: [{provide: token, useExisting: Dir}],
       })
@@ -595,7 +574,6 @@ describe('hot module replacement', () => {
 
       let instance!: ParentCmp;
       const initialMetadata: Component = {
-        standalone: true,
         selector: 'parent-cmp',
         imports: [Dir],
         template: `<div #ref dir></div>`,
@@ -611,7 +589,6 @@ describe('hot module replacement', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [ParentCmp],
         template: `<parent-cmp/>`,
       })
@@ -634,7 +611,6 @@ describe('hot module replacement', () => {
   describe('content projection', () => {
     it('should work with content projection', () => {
       const initialMetadata: Component = {
-        standalone: true,
         selector: 'parent-cmp',
         template: `<ng-content/>`,
       };
@@ -643,7 +619,6 @@ describe('hot module replacement', () => {
       class ParentCmp {}
 
       @Component({
-        standalone: true,
         imports: [ParentCmp],
         template: `
           <parent-cmp>
@@ -700,7 +675,6 @@ describe('hot module replacement', () => {
     it('should handle elements moving around into different slots', () => {
       // Start off with a single catch-all slot.
       const initialMetadata: Component = {
-        standalone: true,
         selector: 'parent-cmp',
         template: `<ng-content/>`,
       };
@@ -709,7 +683,6 @@ describe('hot module replacement', () => {
       class ParentCmp {}
 
       @Component({
-        standalone: true,
         imports: [ParentCmp],
         template: `
           <parent-cmp>
@@ -786,7 +759,6 @@ describe('hot module replacement', () => {
 
     it('should handle default content for ng-content', () => {
       const initialMetadata: Component = {
-        standalone: true,
         selector: 'parent-cmp',
         template: `
           <ng-content select="will-not-match">
@@ -799,7 +771,6 @@ describe('hot module replacement', () => {
       class ParentCmp {}
 
       @Component({
-        standalone: true,
         imports: [ParentCmp],
         template: `
           <parent-cmp>
@@ -845,7 +816,6 @@ describe('hot module replacement', () => {
     it('should only invoke the init/destroy hooks inside the content when replacing the template', () => {
       @Component({
         template: '',
-        standalone: true,
         selector: 'child-cmp',
       })
       class ChildCmp implements OnInit, OnDestroy {
@@ -861,7 +831,6 @@ describe('hot module replacement', () => {
       }
 
       const initialMetadata: Component = {
-        standalone: true,
         template: `
           <child-cmp text="A"/>
           <child-cmp text="B"/>
@@ -891,7 +860,6 @@ describe('hot module replacement', () => {
           <parent-cmp text="A"/>
           <parent-cmp text="B"/>
         `,
-        standalone: true,
         imports: [ParentCmp],
       })
       class RootCmp {}
@@ -951,7 +919,6 @@ describe('hot module replacement', () => {
     it('should invoke checked hooks both on the host and the content being replaced', () => {
       @Component({
         template: '',
-        standalone: true,
         selector: 'child-cmp',
       })
       class ChildCmp implements DoCheck {
@@ -963,7 +930,6 @@ describe('hot module replacement', () => {
       }
 
       const initialMetadata: Component = {
-        standalone: true,
         template: `<child-cmp text="A"/>`,
         imports: [ChildCmp],
         selector: 'parent-cmp',
@@ -979,7 +945,6 @@ describe('hot module replacement', () => {
 
       @Component({
         template: `<parent-cmp/>`,
-        standalone: true,
         imports: [ParentCmp],
       })
       class RootCmp {}
@@ -1039,7 +1004,6 @@ describe('hot module replacement', () => {
       const values: string[] = [];
       const initialMetadata: Component = {
         selector: 'child-cmp',
-        standalone: true,
         template: '',
       };
 
@@ -1056,7 +1020,6 @@ describe('hot module replacement', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [ChildCmp],
         template: `<child-cmp [value]="value"/>`,
       })
@@ -1113,7 +1076,6 @@ describe('hot module replacement', () => {
       let count = 0;
       const initialMetadata: Component = {
         selector: 'child-cmp',
-        standalone: true,
         template: '<button (click)="clicked()"></button>',
       };
 
@@ -1127,7 +1089,6 @@ describe('hot module replacement', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [ChildCmp],
         template: `<child-cmp (changed)="onChange()"/>`,
       })
@@ -1165,7 +1126,6 @@ describe('hot module replacement', () => {
       let count = 0;
       const initialMetadata: Component = {
         selector: 'child-cmp',
-        standalone: true,
         template: '<button (click)="clicked()"></button>',
       };
 
@@ -1179,7 +1139,6 @@ describe('hot module replacement', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [ChildCmp],
         template: `<child-cmp (changed)="onChange()"/>`,
       })
@@ -1220,7 +1179,6 @@ describe('hot module replacement', () => {
       let destroyCount = 0;
       const initialMetadata: Component = {
         selector: 'child-cmp',
-        standalone: true,
         template: '',
       };
 
@@ -1258,7 +1216,6 @@ describe('hot module replacement', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [ChildCmp, DirA, DirB],
         template: `<child-cmp dir-a dir-b/>`,
       })
@@ -1307,7 +1264,6 @@ describe('hot module replacement', () => {
 
       const initialMetadata: Component = {
         selector: 'child-cmp',
-        standalone: true,
         template: '',
         hostDirectives: [DirA, DirB],
       };
@@ -1324,7 +1280,6 @@ describe('hot module replacement', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [ChildCmp],
         template: '<child-cmp/>',
       })
@@ -1367,7 +1322,6 @@ describe('hot module replacement', () => {
 
       const initialMetadata: Component = {
         selector: 'child-cmp',
-        standalone: true,
         template: '<div dir-a></div>',
         imports: [DirA, DirB],
       };
@@ -1380,7 +1334,6 @@ describe('hot module replacement', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [ChildCmp],
         template: '<child-cmp/>',
       })
@@ -1423,7 +1376,6 @@ describe('hot module replacement', () => {
 
       const initialMetadata: Component = {
         selector: 'child-cmp',
-        standalone: true,
         template: '<div dir-a></div>',
         imports: [DirA, DirB],
         providers: [{provide: token, useValue: 'provided value'}],
@@ -1433,7 +1385,6 @@ describe('hot module replacement', () => {
       class ChildCmp {}
 
       @Component({
-        standalone: true,
         imports: [ChildCmp],
         template: '<child-cmp/>',
       })
@@ -1475,7 +1426,6 @@ describe('hot module replacement', () => {
 
       const initialMetadata: Component = {
         selector: 'child-cmp',
-        standalone: true,
         template: '<div dir-a></div>',
         imports: [DirA, DirB],
         viewProviders: [{provide: token, useValue: 'provided value'}],
@@ -1485,7 +1435,6 @@ describe('hot module replacement', () => {
       class ChildCmp {}
 
       @Component({
-        standalone: true,
         imports: [ChildCmp],
         template: '<child-cmp/>',
       })
@@ -1512,7 +1461,6 @@ describe('hot module replacement', () => {
     it('should maintain attribute host bindings on a replaced component', () => {
       const initialMetadata: Component = {
         selector: 'child-cmp',
-        standalone: true,
         template: 'Hello',
         host: {
           '[attr.bar]': 'state',
@@ -1525,7 +1473,6 @@ describe('hot module replacement', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [ChildCmp],
         template: `<child-cmp [state]="state" [attr.foo]="'The state is ' + state"/>`,
       })
@@ -1566,7 +1513,6 @@ describe('hot module replacement', () => {
     it('should maintain class host bindings on a replaced component', () => {
       const initialMetadata: Component = {
         selector: 'child-cmp',
-        standalone: true,
         template: 'Hello',
         host: {
           '[class.bar]': 'state',
@@ -1579,7 +1525,6 @@ describe('hot module replacement', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [ChildCmp],
         template: `<child-cmp class="static" [state]="state" [class.foo]="state"/>`,
       })
@@ -1607,7 +1552,6 @@ describe('hot module replacement', () => {
     it('should maintain style host bindings on a replaced component', () => {
       const initialMetadata: Component = {
         selector: 'child-cmp',
-        standalone: true,
         template: 'Hello',
         host: {
           '[style.height]': 'state ? "5px" : "20px"',
@@ -1620,7 +1564,6 @@ describe('hot module replacement', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [ChildCmp],
         template: `<child-cmp style="opacity: 0.5;" [state]="state" [style.width]="state ? '3px' : '12px'"/>`,
       })
@@ -1671,7 +1614,6 @@ describe('hot module replacement', () => {
 
       const initialMetadata: Component = {
         selector: 'child-cmp',
-        standalone: true,
         template: '<span i18n>hello</span>',
       };
 
@@ -1679,7 +1621,6 @@ describe('hot module replacement', () => {
       class ChildCmp {}
 
       @Component({
-        standalone: true,
         imports: [ChildCmp],
         template: '<child-cmp/>',
       })
@@ -1699,7 +1640,6 @@ describe('hot module replacement', () => {
 
       const initialMetadata: Component = {
         selector: 'child-cmp',
-        standalone: true,
         template: '<ng-content/>',
       };
 
@@ -1707,7 +1647,6 @@ describe('hot module replacement', () => {
       class ChildCmp {}
 
       @Component({
-        standalone: true,
         imports: [ChildCmp],
         template: `<child-cmp i18n>hello</child-cmp>`,
       })
@@ -1742,7 +1681,6 @@ describe('hot module replacement', () => {
       let instance!: ChildCmp;
       const initialMetadata: Component = {
         selector: 'child-cmp',
-        standalone: true,
         template: '<span i18n>Hello {{name}}!</span>',
       };
 
@@ -1756,7 +1694,6 @@ describe('hot module replacement', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [ChildCmp],
         template: '<child-cmp/>',
       })
@@ -1795,7 +1732,6 @@ describe('hot module replacement', () => {
 
       const initialMetadata: Component = {
         selector: 'child-cmp',
-        standalone: true,
         template: '<ng-content/>',
       };
 
@@ -1803,7 +1739,6 @@ describe('hot module replacement', () => {
       class ChildCmp {}
 
       @Component({
-        standalone: true,
         imports: [ChildCmp],
         template: '<child-cmp i18n>Hello {{name}}!</child-cmp>',
       })
@@ -1848,7 +1783,6 @@ describe('hot module replacement', () => {
       let instance!: ChildCmp;
       const initialMetadata: Component = {
         selector: 'child-cmp',
-        standalone: true,
         template: '<span i18n>{count, select, 10 {ten} 20 {twenty} other {other}}</span>',
       };
 
@@ -1862,7 +1796,6 @@ describe('hot module replacement', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [ChildCmp],
         template: '<child-cmp/>',
       })
@@ -1903,7 +1836,6 @@ describe('hot module replacement', () => {
 
       const initialMetadata: Component = {
         selector: 'child-cmp',
-        standalone: true,
         template: '<ng-content/>',
       };
 
@@ -1911,7 +1843,6 @@ describe('hot module replacement', () => {
       class ChildCmp {}
 
       @Component({
-        standalone: true,
         imports: [ChildCmp],
         template: '<child-cmp i18n>{count, select, 10 {ten} 20 {twenty} other {other}}</child-cmp>',
       })

--- a/packages/core/test/acceptance/host_directives_spec.ts
+++ b/packages/core/test/acceptance/host_directives_spec.ts
@@ -88,14 +88,14 @@ describe('host directives', () => {
       }
     }
 
-    @Directive({standalone: true})
+    @Directive({})
     class HostDir {
       constructor() {
         logs.push('HostDir');
       }
     }
 
-    @Directive({standalone: true})
+    @Directive({})
     class OtherHostDir {
       constructor() {
         logs.push('OtherHostDir');
@@ -174,14 +174,14 @@ describe('host directives', () => {
       }
     }
 
-    @Directive({standalone: true})
+    @Directive({})
     class Chain3_2 {
       constructor() {
         logs.push('Chain3 - level 2');
       }
     }
 
-    @Directive({standalone: true, hostDirectives: [Chain3_2]})
+    @Directive({hostDirectives: [Chain3_2]})
     class Chain3 {
       constructor() {
         logs.push('Chain3 - level 1');
@@ -205,7 +205,7 @@ describe('host directives', () => {
       }
     }
 
-    @Directive({standalone: true})
+    @Directive({})
     class SelectorMatchedHostDir {
       constructor() {
         logs.push('SelectorMatchedHostDir');
@@ -256,14 +256,14 @@ describe('host directives', () => {
     let firstHostDirInstance!: FirstHostDir;
     let secondHostDirInstance!: SecondHostDir;
 
-    @Directive({standalone: true})
+    @Directive({})
     class SecondHostDir {
       constructor() {
         secondHostDirInstance = this;
       }
     }
 
-    @Directive({standalone: true, hostDirectives: [SecondHostDir]})
+    @Directive({hostDirectives: [SecondHostDir]})
     class FirstHostDir {
       constructor() {
         firstHostDirInstance = this;
@@ -303,12 +303,12 @@ describe('host directives', () => {
   });
 
   it('should be able to reference exported host directives', () => {
-    @Directive({standalone: true, exportAs: 'secondHost'})
+    @Directive({exportAs: 'secondHost'})
     class SecondHostDir {
       name = 'SecondHost';
     }
 
-    @Directive({standalone: true, hostDirectives: [SecondHostDir], exportAs: 'firstHost'})
+    @Directive({hostDirectives: [SecondHostDir], exportAs: 'firstHost'})
     class FirstHostDir {
       name = 'FirstHost';
     }
@@ -341,42 +341,42 @@ describe('host directives', () => {
   it('should execute inherited host directives in the correct order', () => {
     const logs: string[] = [];
 
-    @Directive({standalone: true})
+    @Directive({})
     class HostGrandparent_1 {
       constructor() {
         logs.push('HostGrandparent_1');
       }
     }
 
-    @Directive({standalone: true})
+    @Directive({})
     class HostGrandparent_2 {
       constructor() {
         logs.push('HostGrandparent_2');
       }
     }
 
-    @Directive({standalone: true, hostDirectives: [HostGrandparent_1, HostGrandparent_2]})
+    @Directive({hostDirectives: [HostGrandparent_1, HostGrandparent_2]})
     class Grandparent {
       constructor() {
         logs.push('Grandparent');
       }
     }
 
-    @Directive({standalone: true})
+    @Directive({})
     class HostParent_1 {
       constructor() {
         logs.push('HostParent_1');
       }
     }
 
-    @Directive({standalone: true})
+    @Directive({})
     class HostParent_2 {
       constructor() {
         logs.push('HostParent_2');
       }
     }
 
-    @Directive({standalone: true, hostDirectives: [HostParent_1, HostParent_2]})
+    @Directive({hostDirectives: [HostParent_1, HostParent_2]})
     class Parent extends Grandparent {
       constructor() {
         super();
@@ -384,14 +384,14 @@ describe('host directives', () => {
       }
     }
 
-    @Directive({standalone: true})
+    @Directive({})
     class HostDir_1 {
       constructor() {
         logs.push('HostDir_1');
       }
     }
 
-    @Directive({standalone: true})
+    @Directive({})
     class HostDir_2 {
       constructor() {
         logs.push('HostDir_2');
@@ -437,7 +437,7 @@ describe('host directives', () => {
     it('should invoke lifecycle hooks from the host directives', () => {
       const logs: string[] = [];
 
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir implements OnInit, AfterViewInit, AfterViewChecked {
         ngOnInit() {
           logs.push('HostDir - ngOnInit');
@@ -452,7 +452,7 @@ describe('host directives', () => {
         }
       }
 
-      @Directive({standalone: true})
+      @Directive({})
       class OtherHostDir implements OnInit, AfterViewInit, AfterViewChecked {
         ngOnInit() {
           logs.push('OtherHostDir - ngOnInit');
@@ -516,7 +516,7 @@ describe('host directives', () => {
       const logs: string[] = [];
 
       // Utility so we don't have to repeat the logging code.
-      @Directive({standalone: true})
+      @Directive({})
       abstract class LogsLifecycles implements OnInit, AfterViewInit {
         abstract name: string;
 
@@ -529,12 +529,12 @@ describe('host directives', () => {
         }
       }
 
-      @Directive({standalone: true})
+      @Directive({})
       class ChildHostDir extends LogsLifecycles {
         override name = 'ChildHostDir';
       }
 
-      @Directive({standalone: true})
+      @Directive({})
       class OtherChildHostDir extends LogsLifecycles {
         override name = 'OtherChildHostDir';
       }
@@ -548,12 +548,12 @@ describe('host directives', () => {
         override name = 'Child';
       }
 
-      @Directive({standalone: true})
+      @Directive({})
       class ParentHostDir extends LogsLifecycles {
         override name = 'ParentHostDir';
       }
 
-      @Directive({standalone: true})
+      @Directive({})
       class OtherParentHostDir extends LogsLifecycles {
         override name = 'OtherParentHostDir';
       }
@@ -610,7 +610,7 @@ describe('host directives', () => {
       let logs: string[] = [];
 
       // Utility so we don't have to repeat the logging code.
-      @Directive({standalone: true})
+      @Directive({})
       abstract class LogsLifecycles implements OnChanges {
         @Input() someInput: any;
         abstract name: string;
@@ -620,12 +620,12 @@ describe('host directives', () => {
         }
       }
 
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir extends LogsLifecycles {
         override name = 'HostDir';
       }
 
-      @Directive({standalone: true})
+      @Directive({})
       class OtherHostDir extends LogsLifecycles {
         override name = 'OtherHostDir';
       }
@@ -686,7 +686,7 @@ describe('host directives', () => {
     it('should apply the host bindings from all host directives', () => {
       const clicks: string[] = [];
 
-      @Directive({standalone: true, host: {'host-dir-attr': 'true', '(click)': 'handleClick()'}})
+      @Directive({host: {'host-dir-attr': 'true', '(click)': 'handleClick()'}})
       class HostDir {
         handleClick() {
           clicks.push('HostDir');
@@ -737,10 +737,10 @@ describe('host directives', () => {
     });
 
     it('should have the host bindings take precedence over the ones from the host directives', () => {
-      @Directive({standalone: true, host: {'id': 'host-dir'}})
+      @Directive({host: {'id': 'host-dir'}})
       class HostDir {}
 
-      @Directive({standalone: true, host: {'id': 'other-host-dir'}})
+      @Directive({host: {'id': 'other-host-dir'}})
       class OtherHostDir {}
 
       @Directive({
@@ -771,14 +771,14 @@ describe('host directives', () => {
       let firstHostDirInstance!: FirstHostDir;
       let secondHostDirInstance!: SecondHostDir;
 
-      @Directive({standalone: true})
+      @Directive({})
       class SecondHostDir {
         constructor() {
           secondHostDirInstance = this;
         }
       }
 
-      @Directive({standalone: true, hostDirectives: [SecondHostDir]})
+      @Directive({hostDirectives: [SecondHostDir]})
       class FirstHostDir {
         constructor() {
           firstHostDirInstance = this;
@@ -829,7 +829,7 @@ describe('host directives', () => {
         hostDir = inject(HostDir);
       }
 
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {
         constructor() {
           hostDirectiveInstance = this;
@@ -868,7 +868,7 @@ describe('host directives', () => {
       let firstHostDirInstance!: FirstHostDir;
       let secondHostDirInstance!: SecondHostDir;
 
-      @Directive({standalone: true})
+      @Directive({})
       class SecondHostDir {
         host = inject(Host);
 
@@ -877,7 +877,7 @@ describe('host directives', () => {
         }
       }
 
-      @Directive({standalone: true, hostDirectives: [SecondHostDir]})
+      @Directive({hostDirectives: [SecondHostDir]})
       class FirstHostDir {
         host = inject(Host);
 
@@ -921,7 +921,7 @@ describe('host directives', () => {
       let firstHostDirInstance!: FirstHostDir;
       let secondHostDirInstance!: SecondHostDir;
 
-      @Directive({standalone: true, providers: [{provide: token, useValue: 'SecondDir'}]})
+      @Directive({providers: [{provide: token, useValue: 'SecondDir'}]})
       class SecondHostDir {
         tokenValue = inject(token);
 
@@ -979,7 +979,7 @@ describe('host directives', () => {
       const firstToken = new InjectionToken<string>('firstToken');
       const secondToken = new InjectionToken<string>('secondToken');
 
-      @Directive({standalone: true, providers: [{provide: secondToken, useValue: 'SecondDir'}]})
+      @Directive({providers: [{provide: secondToken, useValue: 'SecondDir'}]})
       class SecondHostDir {}
 
       @Directive({
@@ -1018,7 +1018,7 @@ describe('host directives', () => {
       const token = new InjectionToken<string>('token');
       let tokenValue: string | undefined;
 
-      @Directive({standalone: true, providers: [{provide: token, useValue: 'host-dir'}]})
+      @Directive({providers: [{provide: token, useValue: 'host-dir'}]})
       class HostDir {}
 
       @Component({
@@ -1057,7 +1057,7 @@ describe('host directives', () => {
       const token = new InjectionToken<string>('token');
       let tokenValue: string | null = null;
 
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {
         constructor() {
           tokenValue = inject(token, {optional: true});
@@ -1087,7 +1087,7 @@ describe('host directives', () => {
     });
 
     it('should throw a circular dependency error if a host and a host directive inject each other', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {
         host = inject(Host);
       }
@@ -1116,7 +1116,7 @@ describe('host directives', () => {
     it('should inject a valid ChangeDetectorRef when attached to a component', () => {
       type InternalChangeDetectorRef = ChangeDetectorRef & {_lView: unknown};
 
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {
         changeDetectorRef = inject(ChangeDetectorRef) as InternalChangeDetectorRef;
       }
@@ -1164,7 +1164,7 @@ describe('host directives', () => {
     it('should not emit to an output of a host directive that has not been exposed', () => {
       let hostDirectiveInstance: HostDir | undefined;
 
-      @Directive({standalone: true, host: {'(click)': 'hasBeenClicked.emit()'}})
+      @Directive({host: {'(click)': 'hasBeenClicked.emit()'}})
       class HostDir {
         @Output() hasBeenClicked = new EventEmitter<void>();
 
@@ -1200,7 +1200,7 @@ describe('host directives', () => {
     });
 
     it('should emit to an output of a host directive that has been exposed', () => {
-      @Directive({standalone: true, host: {'(click)': 'hasBeenClicked.emit("hello")'}})
+      @Directive({host: {'(click)': 'hasBeenClicked.emit("hello")'}})
       class HostDir {
         @Output() hasBeenClicked = new EventEmitter<string>();
       }
@@ -1236,7 +1236,7 @@ describe('host directives', () => {
     });
 
     it('should emit to an output of a host directive that has been exposed under an alias', () => {
-      @Directive({standalone: true, host: {'(click)': 'hasBeenClicked.emit("hello")'}})
+      @Directive({host: {'(click)': 'hasBeenClicked.emit("hello")'}})
       class HostDir {
         @Output() hasBeenClicked = new EventEmitter<string>();
       }
@@ -1270,7 +1270,7 @@ describe('host directives', () => {
     });
 
     it('should alias to the public name of the host directive output, not the private one', () => {
-      @Directive({standalone: true, host: {'(click)': 'hasBeenClicked.emit("hello")'}})
+      @Directive({host: {'(click)': 'hasBeenClicked.emit("hello")'}})
       class HostDir {
         @Output('wasClicked') hasBeenClicked = new EventEmitter<string>();
       }
@@ -1307,7 +1307,7 @@ describe('host directives', () => {
     });
 
     it('should emit to an output of a host that has the same name as a non-exposed output of a host directive', () => {
-      @Directive({standalone: true, host: {'(click)': 'hasBeenClicked.emit("HostDir")'}})
+      @Directive({host: {'(click)': 'hasBeenClicked.emit("HostDir")'}})
       class HostDir {
         @Output() hasBeenClicked = new EventEmitter<string>();
       }
@@ -1341,7 +1341,7 @@ describe('host directives', () => {
     });
 
     it('should emit to an output of a host that has the same name as an exposed output of a host directive', () => {
-      @Directive({standalone: true, host: {'(click)': 'hasBeenClicked.emit("HostDir")'}})
+      @Directive({host: {'(click)': 'hasBeenClicked.emit("HostDir")'}})
       class HostDir {
         @Output() hasBeenClicked = new EventEmitter<string>();
       }
@@ -1377,7 +1377,7 @@ describe('host directives', () => {
     });
 
     it('should emit to an output of a host that has the same name as the alias of a host directive output', () => {
-      @Directive({standalone: true, host: {'(click)': 'hasBeenClicked.emit("HostDir")'}})
+      @Directive({host: {'(click)': 'hasBeenClicked.emit("HostDir")'}})
       class HostDir {
         @Output() hasBeenClicked = new EventEmitter<string>();
       }
@@ -1413,7 +1413,7 @@ describe('host directives', () => {
     });
 
     it('should not expose the same output more than once', () => {
-      @Directive({standalone: true, host: {'(click)': 'hasBeenClicked.emit()'}})
+      @Directive({host: {'(click)': 'hasBeenClicked.emit()'}})
       class HostDir {
         @Output() hasBeenClicked = new EventEmitter<void>();
       }
@@ -1452,7 +1452,7 @@ describe('host directives', () => {
         @Output() hasBeenClicked = new EventEmitter<string>();
       }
 
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir extends ParentDir {}
 
       @Directive({
@@ -1481,12 +1481,12 @@ describe('host directives', () => {
     });
 
     it('should emit to an output that was exposed from one host directive, but not another', () => {
-      @Directive({standalone: true, host: {'(click)': 'hasBeenClicked.emit("ExposedHostDir")'}})
+      @Directive({host: {'(click)': 'hasBeenClicked.emit("ExposedHostDir")'}})
       class ExposedHostDir {
         @Output() hasBeenClicked = new EventEmitter<string>();
       }
 
-      @Directive({standalone: true, host: {'(click)': 'hasBeenClicked.emit("UnExposedHostDir")'}})
+      @Directive({host: {'(click)': 'hasBeenClicked.emit("UnExposedHostDir")'}})
       class UnExposedHostDir {
         @Output() hasBeenClicked = new EventEmitter<string>();
       }
@@ -1566,7 +1566,7 @@ describe('host directives', () => {
     });
 
     it('should emit to an output of an inherited host directive that has been exposed', () => {
-      @Directive({standalone: true, host: {'(click)': 'hasBeenClicked.emit("hello")'}})
+      @Directive({host: {'(click)': 'hasBeenClicked.emit("hello")'}})
       class HostDir {
         @Output() hasBeenClicked = new EventEmitter<string>();
       }
@@ -1609,7 +1609,7 @@ describe('host directives', () => {
 
   describe('inputs', () => {
     it('should not set an input of a host directive that has not been exposed', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {
         @Input() color?: string;
       }
@@ -1638,7 +1638,7 @@ describe('host directives', () => {
     });
 
     it('should set the input of a host directive that has been exposed', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {
         @Input() color?: string;
       }
@@ -1670,7 +1670,7 @@ describe('host directives', () => {
     });
 
     it('should set an input of a host directive that has been exposed under an alias', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {
         @Input() color?: string;
       }
@@ -1702,7 +1702,7 @@ describe('host directives', () => {
     });
 
     it('should alias to the public name of the host directive input, not the private one', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {
         @Input('colorAlias') color?: string;
       }
@@ -1734,7 +1734,7 @@ describe('host directives', () => {
     });
 
     it('should set an input of a host that has the same name as a non-exposed input of a host directive', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {
         @Input() color?: string;
       }
@@ -1774,7 +1774,7 @@ describe('host directives', () => {
     });
 
     it('should set an input of a host that has the same name as an exposed input of a host directive', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {
         @Input() color?: string;
       }
@@ -1814,7 +1814,7 @@ describe('host directives', () => {
     });
 
     it('should set an input of a host that has the same name as the alias of a host directive input', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {
         @Input() color?: string;
       }
@@ -1859,7 +1859,7 @@ describe('host directives', () => {
         @Input() color?: string;
       }
 
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir extends ParentDir {}
 
       @Directive({
@@ -1891,12 +1891,12 @@ describe('host directives', () => {
     });
 
     it('should set an input that was exposed from one host directive, but not another', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class ExposedHostDir {
         @Input() color?: string;
       }
 
-      @Directive({standalone: true})
+      @Directive({})
       class UnExposedHostDir {
         @Input() color?: string;
       }
@@ -1934,12 +1934,12 @@ describe('host directives', () => {
     });
 
     it('should set inputs from different host directives that have been aliased to the same name', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class FirstHostDir {
         @Input() firstColor?: string;
       }
 
-      @Directive({standalone: true})
+      @Directive({})
       class SecondHostDir {
         @Input() secondColor?: string;
       }
@@ -1980,7 +1980,7 @@ describe('host directives', () => {
     });
 
     it('should not set a static input of a host directive that has not been exposed', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {
         @Input() color?: string;
       }
@@ -2008,7 +2008,7 @@ describe('host directives', () => {
     });
 
     it('should set a static input of a host directive that has been exposed', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {
         @Input() color?: string;
       }
@@ -2035,7 +2035,7 @@ describe('host directives', () => {
     });
 
     it('should set a static input of a host directive that has been exposed under an alias', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {
         @Input() color?: string;
       }
@@ -2062,7 +2062,7 @@ describe('host directives', () => {
     });
 
     it('should alias to the public name of a static host directive input, not the private one', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {
         @Input('colorAlias') color?: string;
       }
@@ -2089,12 +2089,12 @@ describe('host directives', () => {
     });
 
     it('should set a static input that was exposed from one host directive, but not another', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class ExposedHostDir {
         @Input() color?: string;
       }
 
-      @Directive({standalone: true})
+      @Directive({})
       class UnExposedHostDir {
         @Input() color?: string;
       }
@@ -2124,12 +2124,12 @@ describe('host directives', () => {
     });
 
     it('should set static inputs from different host directives that have been aliased to the same name', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class FirstHostDir {
         @Input() firstColor?: string;
       }
 
-      @Directive({standalone: true})
+      @Directive({})
       class SecondHostDir {
         @Input() secondColor?: string;
       }
@@ -2165,7 +2165,7 @@ describe('host directives', () => {
     it('should not expose an input under its host directive alias if a host directive is not applied', () => {
       const logs: string[] = [];
 
-      @Directive({selector: '[host-dir]', standalone: true})
+      @Directive({selector: '[host-dir]'})
       class HostDir implements OnChanges {
         @Input('colorAlias') color?: string;
 
@@ -2206,7 +2206,7 @@ describe('host directives', () => {
     });
 
     it('should set the input of an inherited host directive that has been exposed', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {
         @Input() color?: string;
       }
@@ -2248,7 +2248,7 @@ describe('host directives', () => {
       let firstDirChangeEvent: SimpleChanges | undefined;
       let secondDirChangeEvent: SimpleChanges | undefined;
 
-      @Directive({standalone: true})
+      @Directive({})
       class FirstHostDir implements OnChanges {
         @Input() color?: string;
 
@@ -2257,7 +2257,7 @@ describe('host directives', () => {
         }
       }
 
-      @Directive({standalone: true})
+      @Directive({})
       class SecondHostDir implements OnChanges {
         @Input() color?: string;
 
@@ -2335,7 +2335,7 @@ describe('host directives', () => {
       let firstDirChangeEvent: SimpleChanges | undefined;
       let secondDirChangeEvent: SimpleChanges | undefined;
 
-      @Directive({standalone: true})
+      @Directive({})
       class FirstHostDir implements OnChanges {
         @Input('firstAlias') color?: string;
 
@@ -2344,7 +2344,7 @@ describe('host directives', () => {
         }
       }
 
-      @Directive({standalone: true})
+      @Directive({})
       class SecondHostDir implements OnChanges {
         @Input('secondAlias') color?: string;
 
@@ -2422,7 +2422,7 @@ describe('host directives', () => {
       let firstDirChangeEvent: SimpleChanges | undefined;
       let secondDirChangeEvent: SimpleChanges | undefined;
 
-      @Directive({standalone: true})
+      @Directive({})
       class FirstHostDir implements OnChanges {
         @Input() color?: string;
 
@@ -2431,7 +2431,7 @@ describe('host directives', () => {
         }
       }
 
-      @Directive({standalone: true})
+      @Directive({})
       class SecondHostDir implements OnChanges {
         @Input() color?: string;
 
@@ -2488,7 +2488,7 @@ describe('host directives', () => {
     it('should invoke ngOnChanges when a static aliased host directive input is set', () => {
       let latestChangeEvent: SimpleChanges | undefined;
 
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir implements OnChanges {
         @Input('colorAlias') color?: string;
 
@@ -2532,14 +2532,14 @@ describe('host directives', () => {
       let otherHostDirInstance!: OtherHostDir;
       let plainDirInstance!: PlainDir;
 
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {
         constructor() {
           hostDirInstance = this;
         }
       }
 
-      @Directive({standalone: true})
+      @Directive({})
       class OtherHostDir {
         constructor() {
           otherHostDirInstance = this;
@@ -2588,7 +2588,7 @@ describe('host directives', () => {
     it('should be able to retrieve components that have host directives using ng.getComponent', () => {
       let compInstance!: Comp;
 
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {}
 
       @Component({
@@ -2621,7 +2621,7 @@ describe('host directives', () => {
     it('should be able to retrieve components that have host directives using DebugNode.componentInstance', () => {
       let compInstance!: Comp;
 
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {}
 
       @Component({
@@ -2652,7 +2652,7 @@ describe('host directives', () => {
     });
 
     it('should be able to query by a host directive', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {}
 
       @Component({
@@ -2742,7 +2742,7 @@ describe('host directives', () => {
     it('should invoke lifecycle hooks on host directives applied to a root component', () => {
       const logs: string[] = [];
 
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir implements OnInit, AfterViewInit, AfterViewChecked {
         ngOnInit() {
           logs.push('HostDir - ngOnInit');
@@ -2757,7 +2757,7 @@ describe('host directives', () => {
         }
       }
 
-      @Directive({standalone: true})
+      @Directive({})
       class OtherHostDir implements OnInit, AfterViewInit, AfterViewChecked {
         ngOnInit() {
           logs.push('OtherHostDir - ngOnInit');
@@ -2865,14 +2865,14 @@ describe('host directives', () => {
       it('should support host event bindings coming from the host directives', () => {
         const logs: string[] = [];
 
-        @Directive({standalone: true, host: {'(click)': 'handleClick()'}})
+        @Directive({host: {'(click)': 'handleClick()'}})
         class HostDir {
           handleClick() {
             logs.push('HostDir');
           }
         }
 
-        @Directive({standalone: true, host: {'(click)': 'handleClick()'}})
+        @Directive({host: {'(click)': 'handleClick()'}})
         class OtherHostDir {
           handleClick() {
             logs.push('OtherHostDir');
@@ -2900,10 +2900,10 @@ describe('host directives', () => {
       });
 
       it('should have the host bindings of the root component take precedence over the ones from the host directives', () => {
-        @Directive({standalone: true, host: {'id': 'host-dir'}})
+        @Directive({host: {'id': 'host-dir'}})
         class HostDir {}
 
-        @Directive({standalone: true, host: {'id': 'other-host-dir'}})
+        @Directive({host: {'id': 'other-host-dir'}})
         class OtherHostDir {}
 
         @Component({
@@ -2924,7 +2924,7 @@ describe('host directives', () => {
       it('should allow the host directive to inject the root component', () => {
         let hostDirInstance!: HostDir;
 
-        @Directive({standalone: true})
+        @Directive({})
         class HostDir {
           host = inject(HostComp);
 
@@ -2949,7 +2949,7 @@ describe('host directives', () => {
       it('should allow the root component to inject the host directive', () => {
         let hostDirInstance!: HostDir;
 
-        @Directive({standalone: true})
+        @Directive({})
         class HostDir {
           constructor() {
             hostDirInstance = this;
@@ -2976,7 +2976,7 @@ describe('host directives', () => {
         let firstHostDirInstance!: FirstHostDir;
         let secondHostDirInstance!: SecondHostDir;
 
-        @Directive({standalone: true, providers: [{provide: token, useValue: 'SecondDir'}]})
+        @Directive({providers: [{provide: token, useValue: 'SecondDir'}]})
         class SecondHostDir {
           tokenValue = inject(token);
 
@@ -3026,7 +3026,7 @@ describe('host directives', () => {
         const firstToken = new InjectionToken<string>('firstToken');
         const secondToken = new InjectionToken<string>('secondToken');
 
-        @Directive({standalone: true, providers: [{provide: secondToken, useValue: 'SecondDir'}]})
+        @Directive({providers: [{provide: secondToken, useValue: 'SecondDir'}]})
         class SecondHostDir {}
 
         @Directive({
@@ -3056,7 +3056,7 @@ describe('host directives', () => {
         let hostDirInstance!: HostDir;
         let otherHostDirInstance!: OtherHostDir;
 
-        @Directive({standalone: true})
+        @Directive({})
         class HostDir {
           @Input() color?: string;
 
@@ -3065,7 +3065,7 @@ describe('host directives', () => {
           }
         }
 
-        @Directive({standalone: true})
+        @Directive({})
         class OtherHostDir {
           @Input() color?: string;
 
@@ -3109,7 +3109,7 @@ describe('host directives', () => {
       it('should set inputs that only exist on a host directive when using `setInput`', () => {
         let hostDirInstance!: HostDir;
 
-        @Directive({standalone: true})
+        @Directive({})
         class HostDir {
           @Input() color?: string;
 
@@ -3146,7 +3146,7 @@ describe('host directives', () => {
       it('should set inputs that only exist on the root component when using `setInput`', () => {
         let hostDirInstance!: HostDir;
 
-        @Directive({standalone: true})
+        @Directive({})
         class HostDir {
           @Input() color?: string;
 
@@ -3179,7 +3179,7 @@ describe('host directives', () => {
       it('should use the input name alias in `setInput`', () => {
         let hostDirInstance!: HostDir;
 
-        @Directive({standalone: true})
+        @Directive({})
         class HostDir {
           @Input('alias') color?: string;
 
@@ -3222,7 +3222,7 @@ describe('host directives', () => {
       it('should invoke ngOnChanges when setting host directive inputs using setInput', () => {
         let latestChanges: SimpleChanges | undefined;
 
-        @Directive({standalone: true})
+        @Directive({})
         class HostDir implements OnChanges {
           @Input('alias') color?: string;
 
@@ -3271,13 +3271,13 @@ describe('host directives', () => {
     });
 
     it('should throw an error if a host directive is applied multiple times to a root component', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class DuplicateHostDir {}
 
-      @Directive({standalone: true, hostDirectives: [DuplicateHostDir]})
+      @Directive({hostDirectives: [DuplicateHostDir]})
       class HostDir {}
 
-      @Directive({standalone: true, hostDirectives: [HostDir, DuplicateHostDir]})
+      @Directive({hostDirectives: [HostDir, DuplicateHostDir]})
       class Dir {}
 
       @Component({
@@ -3342,7 +3342,7 @@ describe('host directives', () => {
     });
 
     it('should throw an error if a host directive matches multiple times in a template', () => {
-      @Directive({standalone: true, selector: '[dir]'})
+      @Directive({selector: '[dir]'})
       class HostDir {}
 
       @Directive({
@@ -3351,7 +3351,7 @@ describe('host directives', () => {
       })
       class Dir {}
 
-      @Component({template: '<div dir></div>', standalone: true, imports: [HostDir, Dir]})
+      @Component({template: '<div dir></div>', imports: [HostDir, Dir]})
       class App {}
 
       expect(() => TestBed.createComponent(App)).toThrowError(
@@ -3360,7 +3360,7 @@ describe('host directives', () => {
     });
 
     it('should throw an error if a host directive matches multiple times on a component', () => {
-      @Directive({standalone: true, selector: '[dir]'})
+      @Directive({selector: '[dir]'})
       class HostDir {}
 
       @Component({
@@ -3399,10 +3399,10 @@ describe('host directives', () => {
     });
 
     it('should throw an error if a host directive appears multiple times in a chain', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class DuplicateHostDir {}
 
-      @Directive({standalone: true, hostDirectives: [DuplicateHostDir]})
+      @Directive({hostDirectives: [DuplicateHostDir]})
       class HostDir {}
 
       @Directive({
@@ -3426,7 +3426,7 @@ describe('host directives', () => {
     });
 
     it('should throw an error if a host directive is a component', () => {
-      @Component({standalone: true, template: '', selector: 'host-comp'})
+      @Component({template: '', selector: 'host-comp'})
       class HostComp {}
 
       @Directive({
@@ -3450,7 +3450,7 @@ describe('host directives', () => {
     });
 
     it('should throw an error if a host directive output does not exist', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {
         @Output() foo = new EventEmitter();
       }
@@ -3481,7 +3481,7 @@ describe('host directives', () => {
     });
 
     it('should throw an error if a host directive output alias does not exist', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {
         @Output('alias') foo = new EventEmitter();
       }
@@ -3512,7 +3512,7 @@ describe('host directives', () => {
     });
 
     it('should throw an error if a host directive input does not exist', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {
         @Input() foo: any;
       }
@@ -3543,7 +3543,7 @@ describe('host directives', () => {
     });
 
     it('should throw an error if a host directive input alias does not exist', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {
         @Input('alias') foo: any;
       }
@@ -3569,7 +3569,7 @@ describe('host directives', () => {
     });
 
     it('should throw an error if a host directive tries to alias to an existing input', () => {
-      @Directive({selector: '[host-dir]', standalone: true})
+      @Directive({selector: '[host-dir]'})
       class HostDir {
         @Input('colorAlias') color?: string;
         @Input() buttonColor?: string;
@@ -3601,7 +3601,7 @@ describe('host directives', () => {
     });
 
     it('should throw an error if a host directive tries to alias to an existing input alias', () => {
-      @Directive({selector: '[host-dir]', standalone: true})
+      @Directive({selector: '[host-dir]'})
       class HostDir {
         @Input('colorAlias') color?: string;
         @Input('buttonColorAlias') buttonColor?: string;
@@ -3633,7 +3633,7 @@ describe('host directives', () => {
     });
 
     it('should not throw if a host directive input aliases to the same name', () => {
-      @Directive({selector: '[host-dir]', standalone: true})
+      @Directive({selector: '[host-dir]'})
       class HostDir {
         @Input('color') color?: string;
       }
@@ -3661,7 +3661,7 @@ describe('host directives', () => {
     });
 
     it('should throw an error if a host directive tries to alias to an existing output alias', () => {
-      @Directive({selector: '[host-dir]', standalone: true})
+      @Directive({selector: '[host-dir]'})
       class HostDir {
         @Output('clickedAlias') clicked = new EventEmitter();
         @Output('tappedAlias') tapped = new EventEmitter();
@@ -3695,7 +3695,7 @@ describe('host directives', () => {
     });
 
     it('should not throw if a host directive output aliases to the same name', () => {
-      @Directive({selector: '[host-dir]', standalone: true})
+      @Directive({selector: '[host-dir]'})
       class HostDir {
         @Output('clicked') clicked = new EventEmitter();
       }
@@ -3739,7 +3739,7 @@ describe('host directives', () => {
       })
       class Host {}
 
-      @Component({template: '<div host></div>', standalone: true, imports: [Host]})
+      @Component({template: '<div host></div>', imports: [Host]})
       class App {}
 
       expect(() => {
@@ -3749,7 +3749,7 @@ describe('host directives', () => {
     });
 
     it('should not throw when exposing an inherited aliased binding', () => {
-      @Directive({standalone: true})
+      @Directive({})
       abstract class Base {
         opened = new EventEmitter();
       }
@@ -3766,7 +3766,7 @@ describe('host directives', () => {
       })
       class Host {}
 
-      @Component({template: '<div host></div>', standalone: true, imports: [Host]})
+      @Component({template: '<div host></div>', imports: [Host]})
       class App {}
 
       expect(() => {
@@ -3776,13 +3776,13 @@ describe('host directives', () => {
     });
 
     it('should throw an error if a duplicate directive is inherited', () => {
-      @Directive({standalone: true})
+      @Directive({})
       class HostDir {}
 
-      @Directive({standalone: true, hostDirectives: [HostDir]})
+      @Directive({hostDirectives: [HostDir]})
       class Grandparent {}
 
-      @Directive({standalone: true})
+      @Directive({})
       class Parent extends Grandparent {}
 
       @Directive({

--- a/packages/core/test/acceptance/host_directives_spec.ts
+++ b/packages/core/test/acceptance/host_directives_spec.ts
@@ -37,7 +37,6 @@ describe('host directives', () => {
     const logs: string[] = [];
 
     @Directive({
-      standalone: true,
       host: {'host-dir-attr': '', 'class': 'host-dir', 'style': 'height: 50px'},
     })
     class HostDir {
@@ -127,7 +126,6 @@ describe('host directives', () => {
         'id': 'leaf-id',
       },
       providers: [{provide: token, useValue: 'leaf value'}],
-      standalone: true,
     })
     class Chain1_3 {
       constructor(@Inject(token) tokenValue: string) {
@@ -137,7 +135,6 @@ describe('host directives', () => {
     }
 
     @Directive({
-      standalone: true,
       hostDirectives: [Chain1_3],
     })
     class Chain1_2 {
@@ -147,7 +144,6 @@ describe('host directives', () => {
     }
 
     @Directive({
-      standalone: true,
       hostDirectives: [Chain1_2],
     })
     class Chain1 {
@@ -157,7 +153,6 @@ describe('host directives', () => {
     }
 
     @Directive({
-      standalone: true,
       host: {
         'class': 'middle',
         'id': 'middle-id',
@@ -171,7 +166,6 @@ describe('host directives', () => {
     }
 
     @Directive({
-      standalone: true,
       hostDirectives: [Chain2_2],
     })
     class Chain2 {
@@ -700,7 +694,6 @@ describe('host directives', () => {
       }
 
       @Directive({
-        standalone: true,
         host: {'other-host-dir-attr': 'true', '(click)': 'handleClick()'},
       })
       class OtherHostDir {
@@ -938,7 +931,6 @@ describe('host directives', () => {
       }
 
       @Directive({
-        standalone: true,
         hostDirectives: [SecondHostDir],
         providers: [{provide: token, useValue: 'FirstDir'}],
       })
@@ -991,7 +983,6 @@ describe('host directives', () => {
       class SecondHostDir {}
 
       @Directive({
-        standalone: true,
         hostDirectives: [SecondHostDir],
         providers: [{provide: firstToken, useValue: 'FirstDir'}],
       })
@@ -1531,7 +1522,6 @@ describe('host directives', () => {
 
     it('should emit to outputs from different host directives that have been aliased to the same name', () => {
       @Directive({
-        standalone: true,
         host: {'(click)': 'firstHasBeenClicked.emit("FirstHostDir")'},
       })
       class FirstHostDir {
@@ -1539,7 +1529,6 @@ describe('host directives', () => {
       }
 
       @Directive({
-        standalone: true,
         host: {'(click)': 'secondHasBeenClicked.emit("SecondHostDir")'},
       })
       class SecondHostDir {
@@ -2187,13 +2176,11 @@ describe('host directives', () => {
 
       @Directive({
         selector: '[dir]',
-        standalone: true,
         hostDirectives: [{directive: HostDir, inputs: ['colorAlias: buttonColor']}],
       })
       class Dir {}
 
       @Component({
-        standalone: true,
         imports: [Dir, HostDir],
         // Note that `[dir]` doesn't match on the `button` on purpose.
         // The wrong behavior would be if the `buttonColor` binding worked on `host-dir`.
@@ -2722,7 +2709,6 @@ describe('host directives', () => {
       const logs: string[] = [];
 
       @Directive({
-        standalone: true,
         host: {'host-dir-attr': '', 'class': 'host-dir', 'style': 'height: 50px'},
       })
       class HostDir {
@@ -2824,7 +2810,6 @@ describe('host directives', () => {
     describe('host bindings', () => {
       it('should support host attribute bindings coming from the host directives', () => {
         @Directive({
-          standalone: true,
           host: {
             '[attr.host-dir-only]': 'value',
             '[attr.shadowed-attr]': 'value',
@@ -2835,7 +2820,6 @@ describe('host directives', () => {
         }
 
         @Directive({
-          standalone: true,
           host: {
             '[attr.other-host-dir-only]': 'value',
             '[attr.shadowed-attr]': 'value',
@@ -3002,7 +2986,6 @@ describe('host directives', () => {
         }
 
         @Directive({
-          standalone: true,
           hostDirectives: [SecondHostDir],
           providers: [{provide: token, useValue: 'FirstDir'}],
         })
@@ -3047,7 +3030,6 @@ describe('host directives', () => {
         class SecondHostDir {}
 
         @Directive({
-          standalone: true,
           hostDirectives: [SecondHostDir],
           providers: [{provide: firstToken, useValue: 'FirstDir'}],
         })
@@ -3366,7 +3348,6 @@ describe('host directives', () => {
       @Directive({
         selector: '[dir]',
         hostDirectives: [HostDir],
-        standalone: true,
       })
       class Dir {}
 
@@ -3385,14 +3366,12 @@ describe('host directives', () => {
       @Component({
         selector: 'comp',
         hostDirectives: [HostDir],
-        standalone: true,
         template: '',
       })
       class Comp {}
 
       const baseAppMetadata = {
         template: '<comp dir></comp>',
-        standalone: true,
       };
 
       const expectedError =
@@ -3749,14 +3728,12 @@ describe('host directives', () => {
       @Directive({
         outputs: ['opened: triggerOpened'],
         selector: '[trigger]',
-        standalone: true,
       })
       class Trigger {
         opened = new EventEmitter();
       }
 
       @Directive({
-        standalone: true,
         selector: '[host]',
         hostDirectives: [{directive: Trigger, outputs: ['triggerOpened']}],
       })
@@ -3780,12 +3757,10 @@ describe('host directives', () => {
       @Directive({
         outputs: ['opened: triggerOpened'],
         selector: '[trigger]',
-        standalone: true,
       })
       class Trigger extends Base {}
 
       @Directive({
-        standalone: true,
         selector: '[host]',
         hostDirectives: [{directive: Trigger, outputs: ['triggerOpened: hostOpened']}],
       })

--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -563,7 +563,6 @@ describe('runtime i18n', () => {
 
     @Component({
       selector: 'defer-comp',
-      standalone: true,
       template:
         '<div i18n>Content: @defer (when isLoaded) {before<span>middle</span>after} ' +
         '@placeholder {before<div>placeholder</div>after}!</div>',

--- a/packages/core/test/acceptance/inherit_definition_feature_spec.ts
+++ b/packages/core/test/acceptance/inherit_definition_feature_spec.ts
@@ -794,14 +794,12 @@ describe('inheritance', () => {
         }
 
         @Directive({
-          standalone: true,
           selector: 'dir',
           inputs: ['someInput'],
         })
         class ActualDir extends Base {}
 
         @Component({
-          standalone: true,
           imports: [ActualDir],
           template: `<dir someInput="newValue">`,
         })
@@ -825,13 +823,11 @@ describe('inheritance', () => {
         }
 
         @Directive({
-          standalone: true,
           selector: 'dir',
         })
         class ActualDir extends Base {}
 
         @Component({
-          standalone: true,
           imports: [ActualDir],
           template: `<dir publicName="newValue">`,
         })

--- a/packages/core/test/acceptance/injector_profiler_spec.ts
+++ b/packages/core/test/acceptance/injector_profiler_spec.ts
@@ -802,7 +802,7 @@ describe('getInjectorProviders', () => {
   it('should be able to determine providers in a lazy route that has providers', fakeAsync(() => {
     class MyService {}
 
-    @Component({selector: 'my-comp-b', template: 'hello world', standalone: true})
+    @Component({selector: 'my-comp-b', template: 'hello world'})
     class MyStandaloneComponentB {
       injector = inject(Injector);
     }
@@ -863,7 +863,7 @@ describe('getInjectorProviders', () => {
   it('should be able to get injector providers for element injectors created by components rendering in an ngFor', () => {
     class MyService {}
 
-    @Component({selector: 'item-cmp', template: 'item', standalone: true, providers: [MyService]})
+    @Component({selector: 'item-cmp', template: 'item', providers: [MyService]})
     class ItemComponent {
       injector = inject(Injector);
     }
@@ -902,7 +902,7 @@ describe('getInjectorProviders', () => {
   it('should be able to get injector providers for element injectors created by components rendering in a @for', () => {
     class MyService {}
 
-    @Component({selector: 'item-cmp', template: 'item', standalone: true, providers: [MyService]})
+    @Component({selector: 'item-cmp', template: 'item', providers: [MyService]})
     class ItemComponent {
       injector = inject(Injector);
     }
@@ -1168,7 +1168,7 @@ describe('getDependenciesFromInjectable', () => {
     @NgModule({imports: [ModuleB, ModuleC]})
     class ModuleD {}
 
-    @Component({selector: 'my-comp', template: 'hello world', imports: [ModuleD], standalone: true})
+    @Component({selector: 'my-comp', template: 'hello world', imports: [ModuleD]})
     class MyStandaloneComponent {
       myService = inject(MyService);
     }

--- a/packages/core/test/acceptance/injector_profiler_spec.ts
+++ b/packages/core/test/acceptance/injector_profiler_spec.ts
@@ -385,7 +385,6 @@ describe('getInjectorMetadata', () => {
     @Component({
       selector: 'lazy-comp',
       template: `lazy component`,
-      standalone: true,
       imports: [ModuleB],
     })
     class LazyComponent {
@@ -398,7 +397,6 @@ describe('getInjectorMetadata', () => {
     }
 
     @Component({
-      standalone: true,
       imports: [RouterOutlet, ModuleA],
       template: `<router-outlet/>`,
     })
@@ -667,7 +665,6 @@ describe('getInjectorProviders', () => {
       selector: 'my-comp-c',
       template: 'hello world',
       imports: [ModuleE, ModuleC],
-      standalone: true,
     })
     class MyStandaloneComponentC {}
 
@@ -675,7 +672,6 @@ describe('getInjectorProviders', () => {
       selector: 'my-comp-b',
       template: 'hello world',
       imports: [ModuleD, ModuleF],
-      standalone: true,
     })
     class MyStandaloneComponentB {}
 
@@ -686,7 +682,6 @@ describe('getInjectorProviders', () => {
          <my-comp-c/>
         `,
       imports: [ModuleD, MyStandaloneComponentB, MyStandaloneComponentC],
-      standalone: true,
     })
     class MyStandaloneComponent {}
 
@@ -743,7 +738,6 @@ describe('getInjectorProviders', () => {
       selector: 'my-comp-b',
       template: 'hello world',
       imports: [ModuleA],
-      standalone: true,
     })
     class MyStandaloneComponentB {
       injector = inject(Injector);
@@ -753,7 +747,6 @@ describe('getInjectorProviders', () => {
       selector: 'my-comp',
       template: `<router-outlet/>`,
       imports: [MyStandaloneComponentB, RouterOutlet],
-      standalone: true,
     })
     class MyStandaloneComponent {
       injector = inject(Injector);
@@ -818,7 +811,6 @@ describe('getInjectorProviders', () => {
       selector: 'my-comp',
       template: `<router-outlet/>`,
       imports: [MyStandaloneComponentB, RouterOutlet],
-      standalone: true,
     })
     class MyStandaloneComponent {
       injector = inject(Injector);
@@ -882,7 +874,6 @@ describe('getInjectorProviders', () => {
         <item-cmp *ngFor="let item of items"></item-cmp>
        `,
       imports: [ItemComponent, NgForOf],
-      standalone: true,
     })
     class MyStandaloneComponent {
       injector = inject(Injector);
@@ -924,7 +915,6 @@ describe('getInjectorProviders', () => {
         }
        `,
       imports: [ItemComponent],
-      standalone: true,
     })
     class MyStandaloneComponent {
       injector = inject(Injector);
@@ -978,7 +968,6 @@ describe('getDependenciesFromInjectable', () => {
 
     @Directive({
       selector: '[my-directive]',
-      standalone: true,
     })
     class MyStandaloneDirective {
       serviceFromHost = inject(MyServiceH, {host: true, optional: true});
@@ -993,7 +982,6 @@ describe('getDependenciesFromInjectable', () => {
       selector: 'my-comp-c',
       template: 'hello world',
       imports: [],
-      standalone: true,
     })
     class MyStandaloneComponentC {}
 
@@ -1001,7 +989,6 @@ describe('getDependenciesFromInjectable', () => {
       selector: 'my-comp-b',
       template: '<my-comp-c my-directive/>',
       imports: [MyStandaloneComponentC, MyStandaloneDirective],
-      standalone: true,
     })
     class MyStandaloneComponentB {
       myService = inject(MyService, {optional: true});
@@ -1019,7 +1006,6 @@ describe('getDependenciesFromInjectable', () => {
       template: `<router-outlet/>`,
       imports: [RouterOutlet, ModuleA],
       providers: [MyServiceG, {provide: MyServiceH, useValue: 'MyStandaloneComponent'}],
-      standalone: true,
     })
     class MyStandaloneComponent {
       injector = inject(Injector);
@@ -1262,7 +1248,6 @@ describe('getInjectorResolutionPath', () => {
     @Component({
       selector: 'lazy-comp',
       template: `lazy component`,
-      standalone: true,
       imports: [ModuleB],
     })
     class LazyComponent {
@@ -1272,7 +1257,6 @@ describe('getInjectorResolutionPath', () => {
     }
 
     @Component({
-      standalone: true,
       imports: [RouterOutlet, ModuleA],
       template: `<router-outlet/>`,
     })

--- a/packages/core/test/acceptance/internal_spec.ts
+++ b/packages/core/test/acceptance/internal_spec.ts
@@ -21,7 +21,6 @@ describe('internal utilities', () => {
   describe('getClosestComponentName', () => {
     it('should get the name from a node placed inside a root component', () => {
       @Component({
-        standalone: true,
         template: `<section><div class="target"></div></section>`,
       })
       class App {}
@@ -36,12 +35,10 @@ describe('internal utilities', () => {
       @Component({
         selector: 'comp',
         template: `<section><div class="target"></div></section>`,
-        standalone: true,
       })
       class Comp {}
 
       @Component({
-        standalone: true,
         template: `<comp/>`,
         imports: [Comp],
       })
@@ -57,12 +54,10 @@ describe('internal utilities', () => {
       @Component({
         selector: 'comp',
         template: `<section><div class="target"></div></section>`,
-        standalone: true,
       })
       class Comp {}
 
       @Component({
-        standalone: true,
         template: `
           @for (current of [1]; track $index) {
             <comp/>
@@ -81,12 +76,10 @@ describe('internal utilities', () => {
     it('should get the name from a node that has a directive', () => {
       @Directive({
         selector: 'dir',
-        standalone: true,
       })
       class Dir {}
 
       @Component({
-        standalone: true,
         template: `<section><dir class="target"></dir></section>`,
         imports: [Dir],
       })
@@ -100,7 +93,6 @@ describe('internal utilities', () => {
 
     it('should return null when not placed in a component', () => {
       @Component({
-        standalone: true,
         template: '',
       })
       class App {}
@@ -114,12 +106,10 @@ describe('internal utilities', () => {
       @Component({
         selector: 'comp',
         template: `<section><div class="target"></div></section>`,
-        standalone: true,
       })
       class Comp {}
 
       @Component({
-        standalone: true,
         template: `<ng-container #insertionPoint/>`,
       })
       class App {
@@ -141,7 +131,6 @@ describe('internal utilities', () => {
       @Component({
         selector: 'comp',
         template: `<section><div class="target"></div></section>`,
-        standalone: true,
       })
       class Comp {}
 

--- a/packages/core/test/acceptance/let_spec.ts
+++ b/packages/core/test/acceptance/let_spec.ts
@@ -23,7 +23,6 @@ import {TestBed} from '@angular/core/testing';
 describe('@let declarations', () => {
   it('should update the value of a @let declaration over time', () => {
     @Component({
-      standalone: true,
       template: `
         @let multiplier = 2;
         @let result = value * multiplier;
@@ -51,7 +50,6 @@ describe('@let declarations', () => {
     const values: number[] = [];
 
     @Component({
-      standalone: true,
       template: `
         @let result = value * 2;
         <button (click)="log(result)"></button>
@@ -81,7 +79,6 @@ describe('@let declarations', () => {
 
   it('should be able to access @let declarations through multiple levels of views', () => {
     @Component({
-      standalone: true,
       template: `
         @if (true) {
           @if (true) {
@@ -110,7 +107,6 @@ describe('@let declarations', () => {
 
   it('should be able to access @let declarations from parent view before they are declared', () => {
     @Component({
-      standalone: true,
       template: `
         @if (true) {
           {{value}} times {{multiplier}} is {{result}}
@@ -142,7 +138,6 @@ describe('@let declarations', () => {
 
     @Directive({
       selector: '[dir]',
-      standalone: true,
     })
     class TestDirective {
       @Output() testEvent = new EventEmitter<void>();
@@ -153,7 +148,6 @@ describe('@let declarations', () => {
     }
 
     @Component({
-      standalone: true,
       imports: [TestDirective],
       template: `
         <div dir (testEvent)="callback(value)"></div>
@@ -196,7 +190,6 @@ describe('@let declarations', () => {
     }
 
     @Component({
-      standalone: true,
       template: `
         @let result = value | double;
         Result: {{result}}
@@ -218,7 +211,6 @@ describe('@let declarations', () => {
 
   it('should be able to use local references inside @let declarations', () => {
     @Component({
-      standalone: true,
       template: `
         <input #firstName value="Frodo" name="first-name">
         <input #lastName value="Baggins">
@@ -240,7 +232,6 @@ describe('@let declarations', () => {
 
   it('should be able to proxy a local reference through @let declarations', () => {
     @Component({
-      standalone: true,
       template: `
         <input #input value="foo">
 
@@ -271,7 +262,6 @@ describe('@let declarations', () => {
     let calls = 0;
 
     @Component({
-      standalone: true,
       template: `
         @let one = getOne();
         @let two = one + getTwo();
@@ -302,7 +292,6 @@ describe('@let declarations', () => {
 
   it('should resolve a @let declaration correctly within an embedded view that uses a value from parent view and cannot be optimized', () => {
     @Component({
-      standalone: true,
       template: `
         @let foo = value + 1;
 
@@ -333,7 +322,6 @@ describe('@let declarations', () => {
 
   it('should not be able to access @let declarations using a query', () => {
     @Component({
-      standalone: true,
       template: `
         @let value = 1;
         {{value}}
@@ -355,12 +343,10 @@ describe('@let declarations', () => {
         @let value = 123;
         <ng-content>The value is {{value}}</ng-content>
       `,
-      standalone: true,
     })
     class InnerComponent {}
 
     @Component({
-      standalone: true,
       template: '<inner/>',
       imports: [InnerComponent],
     })
@@ -379,12 +365,10 @@ describe('@let declarations', () => {
         <ng-content>Fallback content</ng-content>
         <ng-content select="footer">Fallback footer</ng-content>
       `,
-      standalone: true,
     })
     class InnerComponent {}
 
     @Component({
-      standalone: true,
       template: `
         <inner>
           @let one = 1;
@@ -408,7 +392,6 @@ describe('@let declarations', () => {
 
   it('should give precedence to @let declarations over component properties', () => {
     @Component({
-      standalone: true,
       template: `
         @let value = '@let';
 
@@ -428,7 +411,6 @@ describe('@let declarations', () => {
 
   it('should give precedence to local @let definition over one from a parent view', () => {
     @Component({
-      standalone: true,
       template: `
         @let value = 'parent';
 
@@ -447,7 +429,6 @@ describe('@let declarations', () => {
 
   it('should be able to use @for loop variables in @let declarations', () => {
     @Component({
-      standalone: true,
       template: `
         @for (value of values; track $index) {
           @let calculation = value * $index;

--- a/packages/core/test/acceptance/let_spec.ts
+++ b/packages/core/test/acceptance/let_spec.ts
@@ -180,7 +180,7 @@ describe('@let declarations', () => {
   });
 
   it('should be able to use pipes injecting ChangeDetectorRef in a let declaration', () => {
-    @Pipe({name: 'double', standalone: true})
+    @Pipe({name: 'double'})
     class DoublePipe implements PipeTransform {
       changeDetectorRef = inject(ChangeDetectorRef);
 

--- a/packages/core/test/acceptance/listener_spec.ts
+++ b/packages/core/test/acceptance/listener_spec.ts
@@ -226,13 +226,11 @@ describe('event listeners', () => {
     it('should support local refs in listeners', () => {
       @Component({
         selector: 'my-comp',
-        standalone: true,
         template: ``,
       })
       class MyComp {}
 
       @Component({
-        standalone: true,
         imports: [MyComp],
         template: `
           <my-comp #comp></my-comp>
@@ -768,7 +766,6 @@ describe('event listeners', () => {
 
       @Directive({
         selector: '[hostListenerDir]',
-        standalone: true,
       })
       class HostListenerDir {
         @HostListener('click')
@@ -778,7 +775,6 @@ describe('event listeners', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [HostListenerDir],
         template: `<button hostListenerDir>Click</button>`,
       })
@@ -801,7 +797,6 @@ describe('event listeners', () => {
 
       @Directive({
         selector: '[hostListenerDir]',
-        standalone: true,
       })
       class HostListenerDir {
         @HostListener('document:click')
@@ -811,7 +806,6 @@ describe('event listeners', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [HostListenerDir],
         template: `<button hostListenerDir>Click</button>`,
       })

--- a/packages/core/test/acceptance/ng_module_spec.ts
+++ b/packages/core/test/acceptance/ng_module_spec.ts
@@ -98,7 +98,6 @@ describe('NgModule', () => {
     it('should throw when a standalone component is added to NgModule declarations', () => {
       @Component({
         selector: 'my-comp',
-        standalone: true,
         template: '',
       })
       class MyComp {}
@@ -120,7 +119,6 @@ describe('NgModule', () => {
     it('should throw when a standalone directive is added to NgModule declarations', () => {
       @Directive({
         selector: '[my-dir]',
-        standalone: true,
       })
       class MyDir {}
 
@@ -148,7 +146,6 @@ describe('NgModule', () => {
     it('should throw when a standalone pipe is added to NgModule declarations', () => {
       @Pipe({
         name: 'my-pipe',
-        standalone: true,
       })
       class MyPipe {}
 
@@ -177,7 +174,6 @@ describe('NgModule', () => {
       @Component({
         selector: 'my-comp',
         template: '',
-        standalone: true,
       })
       class MyComp {}
 
@@ -443,7 +439,6 @@ describe('NgModule', () => {
     it('should log an error about unknown element for a standalone component without CUSTOM_ELEMENTS_SCHEMA', () => {
       @Component({
         template: `<custom-el></custom-el>`,
-        standalone: true,
       })
       class MyComp {}
 
@@ -457,7 +452,6 @@ describe('NgModule', () => {
     it('should not log an error about unknown element for a standalone component with CUSTOM_ELEMENTS_SCHEMA', () => {
       @Component({
         template: `<custom-el></custom-el>`,
-        standalone: true,
         schemas: [CUSTOM_ELEMENTS_SCHEMA],
       })
       class MyComp {}
@@ -657,7 +651,6 @@ describe('NgModule', () => {
           `is used in a template, but not imported in a standalone component`,
         () => {
           @Component({
-            standalone: true,
             template: `<div *${directive}="expr"></div>`,
           })
           class App {

--- a/packages/core/test/acceptance/pipe_spec.ts
+++ b/packages/core/test/acceptance/pipe_spec.ts
@@ -354,7 +354,7 @@ describe('pipe', () => {
     }
 
     // The generated code corresponds to the following decorator:
-    // @Pipe({name: 'sayHello', pure: true, standalone: true})
+    // @Pipe({name: 'sayHello', pure: true})
     class SayHelloPipe extends ParentPipe implements PipeTransform {
       transform() {
         return this.sayHelloService.getHello();

--- a/packages/core/test/acceptance/pipe_spec.ts
+++ b/packages/core/test/acceptance/pipe_spec.ts
@@ -369,7 +369,6 @@ describe('pipe', () => {
     }
 
     @Component({
-      standalone: true,
       selector: 'app',
       template: '{{ value | sayHello }}',
       imports: [SayHelloPipe],

--- a/packages/core/test/acceptance/query_spec.ts
+++ b/packages/core/test/acceptance/query_spec.ts
@@ -908,7 +908,7 @@ describe('query logic', () => {
     });
 
     it('should report results to appropriate queries where deep content queries are nested', () => {
-      @Directive({selector: '[content-query]', standalone: true, exportAs: 'query'})
+      @Directive({selector: '[content-query]', exportAs: 'query'})
       class ContentQueryDirective {
         @ContentChildren('foo, bar, baz', {descendants: true}) qlist!: QueryList<ElementRef>;
       }
@@ -941,7 +941,7 @@ describe('query logic', () => {
     });
 
     it('should support nested shallow content queries', () => {
-      @Directive({selector: '[content-query]', standalone: true, exportAs: 'query'})
+      @Directive({selector: '[content-query]', exportAs: 'query'})
       class ContentQueryDirective {
         @ContentChildren('foo') qlist!: QueryList<ElementRef>;
       }
@@ -972,12 +972,12 @@ describe('query logic', () => {
     });
 
     it('should respect shallow flag on content queries when mixing deep and shallow queries', () => {
-      @Directive({selector: '[shallow-content-query]', standalone: true, exportAs: 'shallow-query'})
+      @Directive({selector: '[shallow-content-query]', exportAs: 'shallow-query'})
       class ShallowContentQueryDirective {
         @ContentChildren('foo') qlist!: QueryList<ElementRef>;
       }
 
-      @Directive({selector: '[deep-content-query]', standalone: true, exportAs: 'deep-query'})
+      @Directive({selector: '[deep-content-query]', exportAs: 'deep-query'})
       class DeepContentQueryDirective {
         @ContentChildren('foo', {descendants: true}) qlist!: QueryList<ElementRef>;
       }
@@ -1009,7 +1009,7 @@ describe('query logic', () => {
     });
 
     it('should support shallow ContentChild queries', () => {
-      @Directive({selector: '[query-dir]', standalone: true})
+      @Directive({selector: '[query-dir]'})
       class ContentQueryDirective {
         @ContentChild('foo', {descendants: false}) shallow: ElementRef | undefined;
         // ContentChild queries have {descendants: true} option by default
@@ -1074,7 +1074,7 @@ describe('query logic', () => {
   });
 
   describe('query order', () => {
-    @Directive({selector: '[text]', standalone: true})
+    @Directive({selector: '[text]'})
     class TextDirective {
       @Input() text: string | undefined;
     }
@@ -1464,10 +1464,10 @@ describe('query logic', () => {
   });
 
   describe('read option', () => {
-    @Directive({selector: '[child]', standalone: true})
+    @Directive({selector: '[child]'})
     class Child {}
 
-    @Directive({selector: '[otherChild]', standalone: true})
+    @Directive({selector: '[otherChild]'})
     class OtherChild {}
 
     it('should query using type predicate and read ElementRef', () => {
@@ -1700,7 +1700,7 @@ describe('query logic', () => {
     });
 
     it('should read component instance if element queried for is a component host', () => {
-      @Component({selector: 'child-cmp', standalone: true, template: ''})
+      @Component({selector: 'child-cmp', template: ''})
       class ChildCmp {}
 
       @Component({
@@ -1744,7 +1744,7 @@ describe('query logic', () => {
     });
 
     it('should read directive instance if element queried for has an exported directive with a matching name', () => {
-      @Directive({selector: '[child]', exportAs: 'child', standalone: true})
+      @Directive({selector: '[child]', exportAs: 'child'})
       class ChildDirective {}
 
       @Component({
@@ -1764,10 +1764,10 @@ describe('query logic', () => {
     });
 
     it('should read all matching directive instances from a given element', () => {
-      @Directive({selector: '[child1]', exportAs: 'child1', standalone: true})
+      @Directive({selector: '[child1]', exportAs: 'child1'})
       class Child1Dir {}
 
-      @Directive({selector: '[child2]', exportAs: 'child2', standalone: true})
+      @Directive({selector: '[child2]', exportAs: 'child2'})
       class Child2Dir {}
 
       @Component({
@@ -1788,7 +1788,7 @@ describe('query logic', () => {
     });
 
     it('should read multiple locals exporting the same directive from a given element', () => {
-      @Directive({selector: '[child]', exportAs: 'child', standalone: true})
+      @Directive({selector: '[child]', exportAs: 'child'})
       class ChildDir {}
 
       @Component({
@@ -1839,7 +1839,7 @@ describe('query logic', () => {
     });
 
     it('should match on exported directive name and read a requested token', () => {
-      @Directive({selector: '[child]', exportAs: 'child', standalone: true})
+      @Directive({selector: '[child]', exportAs: 'child'})
       class ChildDir {}
 
       @Component({
@@ -1859,7 +1859,7 @@ describe('query logic', () => {
     });
 
     it('should support reading a mix of ElementRef and directive instances', () => {
-      @Directive({selector: '[child]', exportAs: 'child', standalone: true})
+      @Directive({selector: '[child]', exportAs: 'child'})
       class ChildDir {}
 
       @Component({
@@ -1880,7 +1880,7 @@ describe('query logic', () => {
     });
 
     it('should not add results to selector-based query if a requested token cant be read', () => {
-      @Directive({selector: '[child]', standalone: true})
+      @Directive({selector: '[child]'})
       class ChildDir {}
 
       @Component({
@@ -1899,10 +1899,10 @@ describe('query logic', () => {
     });
 
     it('should not add results to directive-based query if only read token matches', () => {
-      @Directive({selector: '[child]', standalone: true})
+      @Directive({selector: '[child]'})
       class ChildDir {}
 
-      @Directive({selector: '[otherChild]', standalone: true})
+      @Directive({selector: '[otherChild]'})
       class OtherChildDir {}
 
       @Component({

--- a/packages/core/test/acceptance/query_spec.ts
+++ b/packages/core/test/acceptance/query_spec.ts
@@ -886,14 +886,12 @@ describe('query logic', () => {
     it('should not match directive host with content queries', () => {
       @Directive({
         selector: '[content-query]',
-        standalone: true,
       })
       class ContentQueryDirective {
         @ContentChildren('foo', {descendants: true}) foos!: QueryList<ElementRef>;
       }
 
       @Component({
-        standalone: true,
         imports: [ContentQueryDirective],
         template: `<div content-query #foo></div>`,
       })
@@ -916,7 +914,6 @@ describe('query logic', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [ContentQueryDirective],
         template: `
           <div content-query #out="query">
@@ -950,7 +947,6 @@ describe('query logic', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [ContentQueryDirective],
         template: `
           <div content-query #out="query">
@@ -987,7 +983,6 @@ describe('query logic', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [ShallowContentQueryDirective, DeepContentQueryDirective],
         template: `
           <div shallow-content-query #shallow="shallow-query" deep-content-query #deep="deep-query">
@@ -1022,7 +1017,6 @@ describe('query logic', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [ContentQueryDirective],
         template: `
           <div query-dir>
@@ -1046,14 +1040,12 @@ describe('query logic', () => {
     it('should support view and content queries matching the same element', () => {
       @Directive({
         selector: '[content-query]',
-        standalone: true,
       })
       class ContentQueryDirective {
         @ContentChildren('foo') foos!: QueryList<ElementRef>;
       }
 
       @Component({
-        standalone: true,
         imports: [ContentQueryDirective],
         template: `
           <div content-query>
@@ -1089,7 +1081,6 @@ describe('query logic', () => {
 
     it('should register view query matches from top to bottom', () => {
       @Component({
-        standalone: true,
         imports: [TextDirective],
         template: `
           <span text="A"></span>
@@ -1119,14 +1110,12 @@ describe('query logic', () => {
     it('should register content query matches from top to bottom', () => {
       @Directive({
         selector: '[content-query]',
-        standalone: true,
       })
       class ContentQueryDirective {
         @ContentChildren(TextDirective, {descendants: true}) texts!: QueryList<TextDirective>;
       }
 
       @Component({
-        standalone: true,
         imports: [TextDirective, ContentQueryDirective],
         template: `
           <div content-query>
@@ -1483,7 +1472,6 @@ describe('query logic', () => {
 
     it('should query using type predicate and read ElementRef', () => {
       @Component({
-        standalone: true,
         imports: [Child],
         template: `<div child></div>`,
       })
@@ -1503,7 +1491,6 @@ describe('query logic', () => {
 
     it('should query using type predicate and read another directive type', () => {
       @Component({
-        standalone: true,
         imports: [Child, OtherChild],
         template: `<div child otherChild></div>`,
       })
@@ -1521,7 +1508,6 @@ describe('query logic', () => {
 
     it('should not add results to query if a requested token cant be read', () => {
       @Component({
-        standalone: true,
         imports: [Child],
         template: `<div child></div>`,
       })
@@ -1538,7 +1524,6 @@ describe('query logic', () => {
 
     it('should query using local ref and read ElementRef by default', () => {
       @Component({
-        standalone: true,
         template: `
           <div #foo></div>
           <div></div>
@@ -1560,7 +1545,6 @@ describe('query logic', () => {
 
     it('should query for multiple elements and read ElementRef by default', () => {
       @Component({
-        standalone: true,
         template: `
           <div #foo></div>
           <div></div>
@@ -1584,7 +1568,6 @@ describe('query logic', () => {
 
     it('should read ElementRef from an element when explicitly asked for', () => {
       @Component({
-        standalone: true,
         template: `
           <div #foo></div>
           <div></div>
@@ -1606,7 +1589,6 @@ describe('query logic', () => {
 
     it('should query for <ng-container> and read ElementRef with a native element pointing to comment node', () => {
       @Component({
-        standalone: true,
         template: `<ng-container #foo></ng-container>`,
       })
       class TestCmp {
@@ -1623,7 +1605,6 @@ describe('query logic', () => {
 
     it('should query for <ng-container> and read ElementRef without explicit read option', () => {
       @Component({
-        standalone: true,
         template: `<ng-container #foo></ng-container>`,
       })
       class TestCmp {
@@ -1640,7 +1621,6 @@ describe('query logic', () => {
 
     it('should read ViewContainerRef from element nodes when explicitly asked for', () => {
       @Component({
-        standalone: true,
         template: `<div #foo></div>`,
       })
       class TestCmp {
@@ -1657,7 +1637,6 @@ describe('query logic', () => {
 
     it('should read ViewContainerRef from ng-template nodes when explicitly asked for', () => {
       @Component({
-        standalone: true,
         template: `<ng-template #foo></ng-template>`,
       })
       class TestCmp {
@@ -1674,7 +1653,6 @@ describe('query logic', () => {
 
     it('should read ElementRef with a native element pointing to comment DOM node from ng-template', () => {
       @Component({
-        standalone: true,
         template: `<ng-template #foo></ng-template>`,
       })
       class TestCmp {
@@ -1691,7 +1669,6 @@ describe('query logic', () => {
 
     it('should read TemplateRef from ng-template by default', () => {
       @Component({
-        standalone: true,
         template: `<ng-template #foo></ng-template>`,
       })
       class TestCmp {
@@ -1708,7 +1685,6 @@ describe('query logic', () => {
 
     it('should read TemplateRef from ng-template when explicitly asked for', () => {
       @Component({
-        standalone: true,
         template: `<ng-template #foo></ng-template>`,
       })
       class TestCmp {
@@ -1728,7 +1704,6 @@ describe('query logic', () => {
       class ChildCmp {}
 
       @Component({
-        standalone: true,
         imports: [ChildCmp],
         template: `<child-cmp #foo></child-cmp>`,
       })
@@ -1748,13 +1723,11 @@ describe('query logic', () => {
       @Component({
         selector: 'child-cmp',
         exportAs: 'child',
-        standalone: true,
         template: '',
       })
       class ChildCmp {}
 
       @Component({
-        standalone: true,
         imports: [ChildCmp],
         template: `<child-cmp #foo="child"></child-cmp>`,
       })
@@ -1775,7 +1748,6 @@ describe('query logic', () => {
       class ChildDirective {}
 
       @Component({
-        standalone: true,
         imports: [ChildDirective],
         template: `<div #foo="child" child></div>`,
       })
@@ -1799,7 +1771,6 @@ describe('query logic', () => {
       class Child2Dir {}
 
       @Component({
-        standalone: true,
         imports: [Child1Dir, Child2Dir],
         template: `<div #foo="child1" child1 #bar="child2" child2></div>`,
       })
@@ -1821,7 +1792,6 @@ describe('query logic', () => {
       class ChildDir {}
 
       @Component({
-        standalone: true,
         imports: [ChildDir],
         template: `<div child #foo="child" #bar="child"></div>`,
       })
@@ -1873,7 +1843,6 @@ describe('query logic', () => {
       class ChildDir {}
 
       @Component({
-        standalone: true,
         imports: [ChildDir],
         template: `<div child #foo="child"></div>`,
       })
@@ -1894,7 +1863,6 @@ describe('query logic', () => {
       class ChildDir {}
 
       @Component({
-        standalone: true,
         imports: [ChildDir],
         template: `<div #foo #bar="child" child></div>`,
       })
@@ -1916,7 +1884,6 @@ describe('query logic', () => {
       class ChildDir {}
 
       @Component({
-        standalone: true,
         imports: [],
         template: `<div #foo></div>`,
       })
@@ -1939,7 +1906,6 @@ describe('query logic', () => {
       class OtherChildDir {}
 
       @Component({
-        standalone: true,
         imports: [Child],
         template: `<div child></div>`,
       })
@@ -1956,7 +1922,6 @@ describe('query logic', () => {
 
     it('should not add results to TemplateRef-based query if only read token matches', () => {
       @Component({
-        standalone: true,
         template: `<div></div>`,
       })
       class TestCmp {
@@ -1972,7 +1937,6 @@ describe('query logic', () => {
 
     it('should not add results to the query in case no match found (via TemplateRef)', () => {
       @Component({
-        standalone: true,
         template: `<div></div>`,
       })
       class TestCmp {
@@ -1988,7 +1952,6 @@ describe('query logic', () => {
 
     it('should query templates if the type is TemplateRef (and respect "read" option)', () => {
       @Component({
-        standalone: true,
         template: `
           <ng-template #foo><div>Test</div></ng-template>
           <ng-template #bar><div>Test</div></ng-template>
@@ -2015,7 +1978,6 @@ describe('query logic', () => {
 
     it('should match using string selector and directive as a read argument', () => {
       @Component({
-        standalone: true,
         imports: [Child],
         template: `<div child #foo></div>`,
       })

--- a/packages/core/test/acceptance/renderer_factory_spec.ts
+++ b/packages/core/test/acceptance/renderer_factory_spec.ts
@@ -134,7 +134,6 @@ describe('renderer factory lifecycle', () => {
 
   it('should pass in the component styles directly into the underlying renderer', () => {
     @Component({
-      standalone: true,
       styles: ['.some-css-class { color: red; }'],
       template: '...',
       encapsulation: ViewEncapsulation.ShadowDom,
@@ -153,7 +152,6 @@ describe('renderer factory lifecycle', () => {
       const animB = {name: 'b'};
 
       @Component({
-        standalone: true,
         template: '',
         animations: [animA, animB],
       })
@@ -170,7 +168,6 @@ describe('renderer factory lifecycle', () => {
 
     it('should include animations in the renderType data array even if the array is empty', () => {
       @Component({
-        standalone: true,
         template: '...',
         animations: [],
       })
@@ -184,7 +181,6 @@ describe('renderer factory lifecycle', () => {
 
     it('should allow [@trigger] bindings to be picked up by the underlying renderer', () => {
       @Component({
-        standalone: true,
         template: '<div @fooAnimation></div>',
         animations: [],
       })
@@ -216,7 +212,6 @@ describe('renderer factory lifecycle', () => {
   it('should not invoke renderer destroy method for embedded views', () => {
     @Component({
       selector: 'comp',
-      standalone: true,
       imports: [CommonModule],
       template: `
         <div>Root view</div>

--- a/packages/core/test/acceptance/security_spec.ts
+++ b/packages/core/test/acceptance/security_spec.ts
@@ -140,7 +140,6 @@ describe('iframe processing', () => {
               `as a static attribute (checking \`${securityAttr}\`)`,
             () => {
               @Component({
-                standalone: true,
                 selector: 'my-comp',
                 template: `
                   <iframe
@@ -160,7 +159,6 @@ describe('iframe processing', () => {
               `making sure it's case-insensitive)`,
             () => {
               @Component({
-                standalone: true,
                 selector: 'my-comp',
                 template: `
                   <iframe
@@ -179,7 +177,6 @@ describe('iframe processing', () => {
               `using a property binding (checking \`${securityAttr}\`)`,
             () => {
               @Component({
-                standalone: true,
                 selector: 'my-comp',
                 template: `<iframe ${srcAttr}="${TEST_IFRAME_URL}" [${securityAttr}]="''"></iframe>`,
               })
@@ -194,7 +191,6 @@ describe('iframe processing', () => {
               `using a property interpolation (checking \`${securityAttr}\`)`,
             () => {
               @Component({
-                standalone: true,
                 selector: 'my-comp',
                 template: `<iframe ${srcAttr}="${TEST_IFRAME_URL}" ${securityAttr}="{{''}}"></iframe>`,
               })
@@ -210,7 +206,6 @@ describe('iframe processing', () => {
               `sure it's case-insensitive)`,
             () => {
               @Component({
-                standalone: true,
                 selector: 'my-comp',
                 template: `
                     <iframe
@@ -230,7 +225,6 @@ describe('iframe processing', () => {
               `using a property binding (checking \`${securityAttr}\`)`,
             () => {
               @Component({
-                standalone: true,
                 selector: 'my-comp',
                 template: `
                     <iframe
@@ -251,7 +245,6 @@ describe('iframe processing', () => {
               `sure it's case-insensitive)`,
             () => {
               @Component({
-                standalone: true,
                 selector: 'my-comp',
                 template: `
                     <iframe
@@ -268,7 +261,6 @@ describe('iframe processing', () => {
 
           it(`should allow changing \`${srcAttr}\` after initial render`, () => {
             @Component({
-              standalone: true,
               selector: 'my-comp',
               template: `
                     <iframe
@@ -302,7 +294,6 @@ describe('iframe processing', () => {
 
       it('should work when a directive sets a security-sensitive attribute as a static attribute', () => {
         @Directive({
-          standalone: true,
           selector: '[dir]',
           host: {
             'src': TEST_IFRAME_URL,
@@ -311,7 +302,6 @@ describe('iframe processing', () => {
         })
         class IframeDir {}
         @Component({
-          standalone: true,
           imports: [IframeDir],
           selector: 'my-comp',
           template: '<iframe dir></iframe>',
@@ -323,7 +313,6 @@ describe('iframe processing', () => {
 
       it('should work when a directive sets a security-sensitive host attribute on a non-iframe element', () => {
         @Directive({
-          standalone: true,
           selector: '[dir]',
           host: {
             'src': TEST_IFRAME_URL,
@@ -333,7 +322,6 @@ describe('iframe processing', () => {
         class Dir {}
 
         @Component({
-          standalone: true,
           imports: [Dir],
           selector: 'my-comp',
           template: '<img dir>',
@@ -351,7 +339,6 @@ describe('iframe processing', () => {
           'which also has a structural directive (*ngIf)',
         () => {
           @Component({
-            standalone: true,
             imports: [NgIf],
             selector: 'my-comp',
             template: `<iframe *ngIf="visible" src="${TEST_IFRAME_URL}" sandbox=""></iframe>`,
@@ -366,7 +353,6 @@ describe('iframe processing', () => {
 
       it('should work when a security-sensitive attribute is set between `src` and `srcdoc`', () => {
         @Component({
-          standalone: true,
           selector: 'my-comp',
           template: `<iframe src="${TEST_IFRAME_URL}" sandbox srcdoc="Hi!"></iframe>`,
         })
@@ -377,7 +363,6 @@ describe('iframe processing', () => {
 
       it('should work when a directive sets a security-sensitive attribute before setting `src`', () => {
         @Directive({
-          standalone: true,
           selector: '[dir]',
           host: {
             'sandbox': '',
@@ -387,7 +372,6 @@ describe('iframe processing', () => {
         class IframeDir {}
 
         @Component({
-          standalone: true,
           imports: [IframeDir],
           selector: 'my-comp',
           template: '<iframe dir></iframe>',
@@ -403,7 +387,6 @@ describe('iframe processing', () => {
           '(directive attribute after `sandbox`)',
         () => {
           @Directive({
-            standalone: true,
             selector: '[dir]',
             host: {
               'src': TEST_IFRAME_URL,
@@ -412,7 +395,6 @@ describe('iframe processing', () => {
           class IframeDir {}
 
           @Component({
-            standalone: true,
             imports: [IframeDir],
             selector: 'my-comp',
             template: '<iframe sandbox dir></iframe>',
@@ -428,7 +410,6 @@ describe('iframe processing', () => {
           "as an attribute binding (checking that it's case-insensitive)",
         () => {
           @Directive({
-            standalone: true,
             selector: '[dir]',
             host: {
               '[attr.SANDBOX]': "''",
@@ -437,7 +418,6 @@ describe('iframe processing', () => {
           class IframeDir {}
 
           @Component({
-            standalone: true,
             imports: [IframeDir],
             selector: 'my-comp',
             template: `<IFRAME dir src="${TEST_IFRAME_URL}"></IFRAME>`,
@@ -454,7 +434,6 @@ describe('iframe processing', () => {
           '(directive attribute before `sandbox`)',
         () => {
           @Directive({
-            standalone: true,
             selector: '[dir]',
             host: {
               'src': TEST_IFRAME_URL,
@@ -463,7 +442,6 @@ describe('iframe processing', () => {
           class IframeDir {}
 
           @Component({
-            standalone: true,
             imports: [IframeDir],
             selector: 'my-comp',
             template: '<iframe dir sandbox></iframe>',
@@ -480,7 +458,6 @@ describe('iframe processing', () => {
           '(directive attribute after `src`)',
         () => {
           @Directive({
-            standalone: true,
             selector: '[dir]',
             host: {
               'sandbox': '',
@@ -489,7 +466,6 @@ describe('iframe processing', () => {
           class IframeDir {}
 
           @Component({
-            standalone: true,
             imports: [IframeDir],
             selector: 'my-comp',
             template: `<iframe src="${TEST_IFRAME_URL}" dir></iframe>`,
@@ -502,7 +478,6 @@ describe('iframe processing', () => {
 
       it('should work when a security-sensitive attribute is set as a static attribute', () => {
         @Component({
-          standalone: true,
           selector: 'my-comp',
           template: `
             <iframe referrerPolicy="no-referrer" src="${TEST_IFRAME_URL}"></iframe>
@@ -521,7 +496,6 @@ describe('iframe processing', () => {
           'as a property binding and an <iframe> is wrapped into another element',
         () => {
           @Component({
-            standalone: true,
             selector: 'my-comp',
             template: `
                 <section>
@@ -543,7 +517,6 @@ describe('iframe processing', () => {
           '(directive attribute before `src`)',
         () => {
           @Directive({
-            standalone: true,
             selector: '[dir]',
             host: {
               'sandbox': '',
@@ -552,7 +525,6 @@ describe('iframe processing', () => {
           class IframeDir {}
 
           @Component({
-            standalone: true,
             imports: [IframeDir],
             selector: 'my-comp',
             template: `<iframe dir src="${TEST_IFRAME_URL}"></iframe>`,
@@ -568,7 +540,6 @@ describe('iframe processing', () => {
           'before the directive that sets an `src` attribute value',
         () => {
           @Directive({
-            standalone: true,
             selector: '[set-src]',
             host: {
               'src': TEST_IFRAME_URL,
@@ -577,7 +548,6 @@ describe('iframe processing', () => {
           class DirThatSetsSrc {}
 
           @Directive({
-            standalone: true,
             selector: '[set-sandbox]',
             host: {
               'sandbox': '',
@@ -586,7 +556,6 @@ describe('iframe processing', () => {
           class DirThatSetsSandbox {}
 
           @Component({
-            standalone: true,
             imports: [DirThatSetsSandbox, DirThatSetsSrc],
             selector: 'my-comp',
             // Important note: even though the `set-sandbox` goes after the `set-src`,
@@ -605,7 +574,6 @@ describe('iframe processing', () => {
           'a host directive that sets an `src` attribute value',
         () => {
           @Directive({
-            standalone: true,
             selector: '[set-src-dir]',
             host: {
               'src': TEST_IFRAME_URL,
@@ -614,7 +582,6 @@ describe('iframe processing', () => {
           class DirThatSetsSrc {}
 
           @Directive({
-            standalone: true,
             selector: '[dir]',
             hostDirectives: [DirThatSetsSrc],
             host: {
@@ -624,7 +591,6 @@ describe('iframe processing', () => {
           class DirThatSetsSandbox {}
 
           @Component({
-            standalone: true,
             imports: [DirThatSetsSandbox],
             selector: 'my-comp',
             template: '<iframe dir></iframe>',
@@ -640,7 +606,6 @@ describe('iframe processing', () => {
           'a host directive that sets a security-sensitive attribute value',
         () => {
           @Directive({
-            standalone: true,
             selector: '[set-sandbox-dir]',
             host: {
               'sandbox': '',
@@ -649,7 +614,6 @@ describe('iframe processing', () => {
           class DirThatSetsSandbox {}
 
           @Directive({
-            standalone: true,
             selector: '[dir]',
             hostDirectives: [DirThatSetsSandbox],
             host: {
@@ -659,7 +623,6 @@ describe('iframe processing', () => {
           class DirThatSetsSrc {}
 
           @Component({
-            standalone: true,
             imports: [DirThatSetsSrc],
             selector: 'my-comp',
             template: '<iframe dir></iframe>',
@@ -675,7 +638,6 @@ describe('iframe processing', () => {
           'with security-sensitive attributes set via property bindings',
         () => {
           @Component({
-            standalone: true,
             selector: 'my-comp',
             template: `
                 <ng-container #container></ng-container>
@@ -711,7 +673,6 @@ describe('iframe processing', () => {
             'a property binding on an <iframe> inside i18n block',
           () => {
             @Component({
-              standalone: true,
               selector: 'my-comp',
               template: `
                   <section i18n>
@@ -731,7 +692,6 @@ describe('iframe processing', () => {
             'a property binding on an <iframe> annotated with i18n attribute',
           () => {
             @Component({
-              standalone: true,
               selector: 'my-comp',
               template: `
                   <iframe i18n src="${TEST_IFRAME_URL}" [sandbox]="''">
@@ -746,7 +706,6 @@ describe('iframe processing', () => {
 
         it('should work when a security-sensitive attributes are marked for translation', () => {
           @Component({
-            standalone: true,
             selector: 'my-comp',
             template: `
               <iframe src="${TEST_IFRAME_URL}" i18n-sandbox sandbox="">

--- a/packages/core/test/acceptance/standalone_injector_spec.ts
+++ b/packages/core/test/acceptance/standalone_injector_spec.ts
@@ -30,7 +30,6 @@ describe('standalone injector', () => {
 
     @Component({
       selector: 'standalone',
-      standalone: true,
       imports: [ModuleWithAService],
       template: `({{service.value}})`,
     })
@@ -81,7 +80,6 @@ describe('standalone injector', () => {
 
     @Component({
       selector: 'standalone',
-      standalone: true,
       imports: [ModuleWithAService],
       template: `{{service.value}}`,
     })

--- a/packages/core/test/acceptance/standalone_spec.ts
+++ b/packages/core/test/acceptance/standalone_spec.ts
@@ -50,7 +50,7 @@ describe('standalone components, directives, and pipes', () => {
       @Input() level = 0;
     }
 
-    @Component({standalone: true, template: '<tree [level]="3"></tree>', imports: [TreeCmp]})
+    @Component({template: '<tree [level]="3"></tree>', imports: [TreeCmp]})
     class StandaloneCmp {}
 
     const fixture = TestBed.createComponent(StandaloneCmp);
@@ -82,6 +82,7 @@ describe('standalone components, directives, and pipes', () => {
     @Component({
       selector: 'inner-cmp',
       template: 'Look at me, no NgModule!',
+      /** Don't remove that standalone property */
       standalone: true,
     })
     class InnerCmp {}
@@ -141,7 +142,7 @@ describe('standalone components, directives, and pipes', () => {
     })
     class StandaloneDir {}
 
-    @Pipe({name: 'standalonePipe', standalone: true})
+    @Pipe({name: 'standalonePipe'})
     class StandalonePipe implements PipeTransform {
       transform(value: any) {
         return `|${value}`;
@@ -487,10 +488,10 @@ describe('standalone components, directives, and pipes', () => {
   });
 
   it('should support nested arrays in @Component.imports', () => {
-    @Directive({selector: '[red]', standalone: true, host: {'[attr.red]': 'true'}})
+    @Directive({selector: '[red]', host: {'[attr.red]': 'true'}})
     class RedIdDirective {}
 
-    @Pipe({name: 'blue', pure: true, standalone: true})
+    @Pipe({name: 'blue', pure: true})
     class BluePipe implements PipeTransform {
       transform() {
         return 'blue';
@@ -510,10 +511,10 @@ describe('standalone components, directives, and pipes', () => {
   });
 
   it('should support readonly arrays in @Component.imports', () => {
-    @Directive({selector: '[red]', standalone: true, host: {'[attr.red]': 'true'}})
+    @Directive({selector: '[red]', host: {'[attr.red]': 'true'}})
     class RedIdDirective {}
 
-    @Pipe({name: 'blue', pure: true, standalone: true})
+    @Pipe({name: 'blue', pure: true})
     class BluePipe implements PipeTransform {
       transform() {
         return 'blue';
@@ -535,7 +536,7 @@ describe('standalone components, directives, and pipes', () => {
   });
 
   it('should deduplicate declarations', () => {
-    @Component({selector: 'test-red', standalone: true, template: 'red(<ng-content></ng-content>)'})
+    @Component({selector: 'test-red', template: 'red(<ng-content></ng-content>)'})
     class RedComponent {}
 
     @Component({
@@ -697,7 +698,7 @@ describe('standalone components, directives, and pipes', () => {
     })
     class TestComponent {}
 
-    @Component({selector: 'other-standalone', standalone: true, template: `standalone component`})
+    @Component({selector: 'other-standalone', template: `standalone component`})
     class StandaloneComponent {}
 
     const fixture = TestBed.createComponent(TestComponent);
@@ -822,7 +823,7 @@ describe('standalone components, directives, and pipes', () => {
         @Input() in: string | undefined;
       }
 
-      @Component({selector: 'standalone', template: 'standalone: {{in}}', standalone: true})
+      @Component({selector: 'standalone', template: 'standalone: {{in}}'})
       class StandaloneCmp extends RegularCmp {}
 
       const fixture = TestBed.createComponent(StandaloneCmp);
@@ -832,7 +833,7 @@ describe('standalone components, directives, and pipes', () => {
     });
 
     it('should allow extending a regular component and turn it into a standalone one', () => {
-      @Component({selector: 'standalone', template: 'standalone: {{in}}', standalone: true})
+      @Component({selector: 'standalone', template: 'standalone: {{in}}'})
       class StandaloneCmp {
         @Input() in: string | undefined;
       }
@@ -904,7 +905,7 @@ describe('standalone components, directives, and pipes', () => {
     });
 
     it('should return `true` if directive is standalone', () => {
-      @Directive({selector: '[standaloneDir]', standalone: true})
+      @Directive({selector: '[standaloneDir]'})
       class StandAloneDirective {}
 
       expect(isStandalone(StandAloneDirective)).toBeTrue();
@@ -918,7 +919,7 @@ describe('standalone components, directives, and pipes', () => {
     });
 
     it('should return `true` if pipe is standalone', () => {
-      @Pipe({name: 'standalonePipe', standalone: true})
+      @Pipe({name: 'standalonePipe'})
       class StandAlonePipe {}
 
       expect(isStandalone(StandAlonePipe)).toBeTrue();

--- a/packages/core/test/acceptance/standalone_spec.ts
+++ b/packages/core/test/acceptance/standalone_spec.ts
@@ -31,7 +31,6 @@ import {TestBed} from '@angular/core/testing';
 describe('standalone components, directives, and pipes', () => {
   it('should render a standalone component', () => {
     @Component({
-      standalone: true,
       template: 'Look at me, no NgModule!',
     })
     class StandaloneCmp {}
@@ -44,7 +43,6 @@ describe('standalone components, directives, and pipes', () => {
   it('should render a recursive standalone component', () => {
     @Component({
       selector: 'tree',
-      standalone: true,
       template: `({{level}})<ng-template [ngIf]="level > 0"><tree [level]="level - 1"></tree></ng-template>`,
       imports: [CommonModule],
     })
@@ -116,7 +114,6 @@ describe('standalone components, directives, and pipes', () => {
     class Module {}
 
     @Component({
-      standalone: true,
       template: '<inner-cmp></inner-cmp>',
       imports: [Module],
     })
@@ -132,7 +129,6 @@ describe('standalone components, directives, and pipes', () => {
   it('should allow exporting standalone components, directives, and pipes from NgModule', () => {
     @Component({
       selector: 'standalone-cmp',
-      standalone: true,
       template: `standalone`,
     })
     class StandaloneCmp {}
@@ -142,7 +138,6 @@ describe('standalone components, directives, and pipes', () => {
       host: {
         '[attr.id]': '"standalone"',
       },
-      standalone: true,
     })
     class StandaloneDir {}
 
@@ -182,7 +177,6 @@ describe('standalone components, directives, and pipes', () => {
 
   it('should render a standalone component with dependencies and ambient providers', () => {
     @Component({
-      standalone: true,
       template: 'Inner',
       selector: 'inner-cmp',
     })
@@ -196,7 +190,6 @@ describe('standalone components, directives, and pipes', () => {
     class ModuleWithAProvider {}
 
     @Component({
-      standalone: true,
       template: 'Outer<inner-cmp></inner-cmp>{{service.value}}',
       imports: [InnerCmp, ModuleWithAProvider],
     })
@@ -218,7 +211,6 @@ describe('standalone components, directives, and pipes', () => {
     class ModuleWithAProvider {}
 
     @Component({
-      standalone: true,
       template: 'Inner({{service.value}})',
       selector: 'inner-cmp',
       imports: [ModuleWithAProvider],
@@ -228,7 +220,6 @@ describe('standalone components, directives, and pipes', () => {
     }
 
     @Component({
-      standalone: true,
       template: 'Outer<inner-cmp></inner-cmp>{{service.value}}',
       imports: [InnerCmp],
     })
@@ -263,7 +254,6 @@ describe('standalone components, directives, and pipes', () => {
     @Component({
       selector: 'duplicate-selector',
       template: `ComponentA: {{ service ? 'service found' : 'service not found' }}`,
-      standalone: true,
       imports: [MyModuleA],
     })
     class ComponentA {
@@ -273,7 +263,6 @@ describe('standalone components, directives, and pipes', () => {
     @Component({
       selector: 'duplicate-selector',
       template: `ComponentB: {{ service ? 'service found' : 'service not found' }}`,
-      standalone: true,
       imports: [MyModuleB],
     })
     class ComponentB {
@@ -286,7 +275,6 @@ describe('standalone components, directives, and pipes', () => {
         <ng-container [ngComponentOutlet]="ComponentA" />
         <ng-container [ngComponentOutlet]="ComponentB" />
       `,
-      standalone: true,
       imports: [NgComponentOutlet],
     })
     class AppCmp {
@@ -311,7 +299,6 @@ describe('standalone components, directives, and pipes', () => {
     class Module {}
 
     @Component({
-      standalone: true,
       template: 'Inner({{service.value}})',
       selector: 'inner-cmp',
       imports: [Module],
@@ -321,7 +308,6 @@ describe('standalone components, directives, and pipes', () => {
     }
 
     @Component({
-      standalone: true,
       template: '<ng-template #insert></ng-template>',
       imports: [InnerCmp],
     })
@@ -359,7 +345,6 @@ describe('standalone components, directives, and pipes', () => {
     class Module {}
 
     @Component({
-      standalone: true,
       template: 'Inner({{service.value}})',
       selector: 'inner-cmp',
       imports: [Module],
@@ -369,7 +354,6 @@ describe('standalone components, directives, and pipes', () => {
     }
 
     @Component({
-      standalone: true,
       template: '<ng-template #insert></ng-template>',
       imports: [InnerCmp],
     })
@@ -416,7 +400,6 @@ describe('standalone components, directives, and pipes', () => {
     class Module {}
 
     @Component({
-      standalone: true,
       template: 'Inner({{service.value}})',
       selector: 'inner-cmp',
       imports: [Module],
@@ -426,7 +409,6 @@ describe('standalone components, directives, and pipes', () => {
     }
 
     @Component({
-      standalone: true,
       template: '<ng-template #insert></ng-template>',
       imports: [InnerCmp],
     })
@@ -456,7 +438,6 @@ describe('standalone components, directives, and pipes', () => {
   it('should render a recursive cycle of standalone components', () => {
     @Component({
       selector: 'cmp-a',
-      standalone: true,
       template: '<ng-template [ngIf]="false"><cmp-c></cmp-c></ng-template>A',
       imports: [forwardRef(() => StandaloneCmpC)],
     })
@@ -464,7 +445,6 @@ describe('standalone components, directives, and pipes', () => {
 
     @Component({
       selector: 'cmp-b',
-      standalone: true,
       template: '(<cmp-a></cmp-a>)B',
       imports: [StandaloneCmpA],
     })
@@ -472,7 +452,6 @@ describe('standalone components, directives, and pipes', () => {
 
     @Component({
       selector: 'cmp-c',
-      standalone: true,
       template: '(<cmp-b></cmp-b>)C',
       imports: [StandaloneCmpB],
     })
@@ -495,7 +474,6 @@ describe('standalone components, directives, and pipes', () => {
     class ExportingModule {}
     @Component({
       selector: 'standalone',
-      standalone: true,
       imports: [ExportingModule],
       template: `({{service.value}})`,
     })
@@ -521,7 +499,6 @@ describe('standalone components, directives, and pipes', () => {
 
     @Component({
       selector: 'standalone',
-      standalone: true,
       template: `<div red>{{'' | blue}}</div>`,
       imports: [[RedIdDirective, [BluePipe]]],
     })
@@ -547,7 +524,6 @@ describe('standalone components, directives, and pipes', () => {
 
     @Component({
       selector: 'standalone',
-      standalone: true,
       template: `<div red>{{'' | blue}}</div>`,
       imports: [DirAndPipe],
     })
@@ -580,7 +556,6 @@ describe('standalone components, directives, and pipes', () => {
 
     @Component({
       selector: 'standalone',
-      standalone: true,
       template: `<test-red><test-blue>orange</test-blue></test-red>`,
       imports: [RedComponent, RedComponent, BlueAModule, BlueBModule],
     })
@@ -596,7 +571,6 @@ describe('standalone components, directives, and pipes', () => {
   it('should error when forwardRef does not resolve to a truthy value', () => {
     @Component({
       selector: 'test',
-      standalone: true,
       imports: [forwardRef(() => null)],
       template: '',
     })
@@ -618,7 +592,6 @@ describe('standalone components, directives, and pipes', () => {
 
     @Component({
       selector: 'standalone',
-      standalone: true,
       template: '',
       imports: [NonStandaloneCmp],
     })
@@ -640,7 +613,6 @@ describe('standalone components, directives, and pipes', () => {
 
     @Component({
       selector: 'standalone',
-      standalone: true,
       template: '',
       imports: [NonStandaloneDirective],
     })
@@ -662,7 +634,6 @@ describe('standalone components, directives, and pipes', () => {
 
     @Component({
       selector: 'standalone',
-      standalone: true,
       template: '',
       imports: [NonStandalonePipe],
     })
@@ -680,7 +651,6 @@ describe('standalone components, directives, and pipes', () => {
 
     @Component({
       selector: 'standalone',
-      standalone: true,
       template: '',
       imports: [SthElse],
     })
@@ -705,7 +675,6 @@ describe('standalone components, directives, and pipes', () => {
     }
 
     @Component({
-      standalone: true,
       template: '',
       // we need to import a module with a provider in a nested array since module with providers
       // are disallowed on the type level
@@ -723,7 +692,6 @@ describe('standalone components, directives, and pipes', () => {
   it('should support forwardRef imports', () => {
     @Component({
       selector: 'test',
-      standalone: true,
       imports: [forwardRef(() => StandaloneComponent)],
       template: `(<other-standalone></other-standalone>)`,
     })
@@ -740,7 +708,6 @@ describe('standalone components, directives, and pipes', () => {
   describe('schemas', () => {
     it('should allow schemas in standalone component', () => {
       @Component({
-        standalone: true,
         template: '<maybe-custom-elm></maybe-custom-elm>',
         schemas: [NO_ERRORS_SCHEMA],
       })
@@ -778,7 +745,6 @@ describe('standalone components, directives, and pipes', () => {
     it('should warn the user when an unknown element is present', () => {
       const spy = spyOn(console, 'error');
       @Component({
-        standalone: true,
         template: '<unknown-tag></unknown-tag>',
       })
       class AppCmp {}
@@ -792,7 +758,6 @@ describe('standalone components, directives, and pipes', () => {
     it('should warn the user when multiple unknown elements are present', () => {
       const spy = spyOn(console, 'error');
       @Component({
-        standalone: true,
         template: '<unknown-tag-A></unknown-tag-A><unknown-tag-B></unknown-tag-B>',
       })
       class AppCmp {}
@@ -809,7 +774,6 @@ describe('standalone components, directives, and pipes', () => {
     it('should not warn the user when an unknown element is present inside an ng-template', () => {
       const spy = spyOn(console, 'error');
       @Component({
-        standalone: true,
         template: '<ng-template><unknown-tag></unknown-tag><ng-template>',
       })
       class AppCmp {}
@@ -822,7 +786,6 @@ describe('standalone components, directives, and pipes', () => {
     it('should warn the user when an unknown element is present in an instantiated embedded view', () => {
       const spy = spyOn(console, 'error');
       @Component({
-        standalone: true,
         template: '<ng-template [ngIf]="true"><unknown-tag></unknown-tag><ng-template>',
         imports: [CommonModule],
       })
@@ -891,13 +854,11 @@ describe('standalone components, directives, and pipes', () => {
       @Component({
         selector: 'inner',
         template: 'inner',
-        standalone: true,
       })
       class InnerCmp {}
 
       @Component({
         selector: 'standalone',
-        standalone: true,
         template: 'standalone: {{in}}; (<inner></inner>)',
         imports: [InnerCmp],
       })
@@ -986,7 +947,6 @@ describe('standalone components, directives, and pipes', () => {
     it('should render a recursive cycle of standalone components', () => {
       @Component({
         selector: 'cmp-a',
-        standalone: true,
         template: '<ng-template [ngIf]="false"><cmp-c></cmp-c></ng-template>A',
         imports: [forwardRef(() => StandaloneCmpC)],
       })
@@ -994,7 +954,6 @@ describe('standalone components, directives, and pipes', () => {
 
       @Component({
         selector: 'cmp-b',
-        standalone: true,
         template: '(<cmp-a></cmp-a>)B',
         imports: [StandaloneCmpA],
       })
@@ -1002,7 +961,6 @@ describe('standalone components, directives, and pipes', () => {
 
       @Component({
         selector: 'cmp-c',
-        standalone: true,
         template: '(<cmp-b></cmp-b>)C',
         imports: [StandaloneCmpB],
       })

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -331,7 +331,6 @@ describe('styling', () => {
     it('should allow null in a class array binding', () => {
       @Component({
         template: `<div [class]="['a', null, 'c']" [class.extra]="true"></div>`,
-        standalone: true,
       })
       class Cmp {}
 
@@ -344,7 +343,6 @@ describe('styling', () => {
     it('should allow undefined in a class array binding', () => {
       @Component({
         template: `<div [class]="['a', undefined, 'c']" [class.extra]="true"></div>`,
-        standalone: true,
       })
       class Cmp {}
 
@@ -357,7 +355,6 @@ describe('styling', () => {
     it('should allow zero in a class array binding', () => {
       @Component({
         template: `<div [class]="['a', 0, 'c']" [class.extra]="true"></div>`,
-        standalone: true,
       })
       class Cmp {}
 
@@ -370,7 +367,6 @@ describe('styling', () => {
     it('should allow false in a class array binding', () => {
       @Component({
         template: `<div [class]="['a', false, 'c']" [class.extra]="true"></div>`,
-        standalone: true,
       })
       class Cmp {}
 
@@ -383,7 +379,6 @@ describe('styling', () => {
     it('should ignore an empty string in a class array binding', () => {
       @Component({
         template: `<div [class]="['a', '', 'c']" [class.extra]="true"></div>`,
-        standalone: true,
       })
       class Cmp {}
 
@@ -396,7 +391,6 @@ describe('styling', () => {
     it('should ignore a string containing spaces in a class array binding', () => {
       @Component({
         template: `<div [class]="['a', 'hello there', 'c']" [class.extra]="true"></div>`,
-        standalone: true,
       })
       class Cmp {}
 
@@ -409,7 +403,6 @@ describe('styling', () => {
     it('should ignore a string containing spaces in a class object literal binding', () => {
       @Component({
         template: `<div [class]="{a: true, 'hello there': true, c: true}" [class.extra]="true"></div>`,
-        standalone: true,
       })
       class Cmp {}
 
@@ -422,7 +415,6 @@ describe('styling', () => {
     it('should ignore an object literal in a class array binding', () => {
       @Component({
         template: `<div [class]="['a', {foo: true}, 'c']" [class.extra]="true"></div>`,
-        standalone: true,
       })
       class Cmp {}
 
@@ -435,7 +427,6 @@ describe('styling', () => {
     it('should handle a string array in a class array binding', () => {
       @Component({
         template: `<div [class]="['a', ['foo', 'bar'], 'c']" [class.extra]="true"></div>`,
-        standalone: true,
       })
       class Cmp {}
 

--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -744,7 +744,6 @@ describe('bootstrap', () => {
       @Component({
         template: '',
         host: {'[class]': 'clazz'},
-        standalone: true,
         changeDetection: ChangeDetectionStrategy.OnPush,
       })
       class HostBindingComp {

--- a/packages/core/test/bundling/animations-standalone/index.ts
+++ b/packages/core/test/bundling/animations-standalone/index.ts
@@ -18,7 +18,6 @@ import {BrowserAnimationsModule, provideAnimations} from '@angular/platform-brow
   animations: [
     trigger('myAnimation', [transition('* => on', [animate(1000, style({opacity: 1}))])]),
   ],
-  standalone: true,
 })
 class AnimationsComponent {
   exp: any = false;
@@ -29,7 +28,6 @@ class AnimationsComponent {
   template: `
      <app-animations></app-animations>
    `,
-  standalone: true,
   imports: [AnimationsComponent],
 })
 class RootComponent {}

--- a/packages/core/test/bundling/defer/defer.component.ts
+++ b/packages/core/test/bundling/defer/defer.component.ts
@@ -9,7 +9,6 @@
 import {Component} from '@angular/core';
 
 @Component({
-  standalone: true,
   selector: 'defer-cmp',
   template: `
     <h2>Defer-loaded component</h2>

--- a/packages/core/test/bundling/defer/index.ts
+++ b/packages/core/test/bundling/defer/index.ts
@@ -12,7 +12,6 @@ import {bootstrapApplication} from '@angular/platform-browser';
 import {DeferComponent} from './defer.component';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   imports: [DeferComponent],
   template: `

--- a/packages/core/test/bundling/hydration/index.ts
+++ b/packages/core/test/bundling/hydration/index.ts
@@ -10,7 +10,6 @@ import {Component} from '@angular/core';
 import {bootstrapApplication, provideClientHydration} from '@angular/platform-browser';
 
 @Component({
-  standalone: true,
   selector: 'hello-world',
   template: 'Hello World!',
 })

--- a/packages/core/test/bundling/image-directive/e2e/basic/basic.ts
+++ b/packages/core/test/bundling/image-directive/e2e/basic/basic.ts
@@ -11,7 +11,6 @@ import {Component} from '@angular/core';
 
 @Component({
   selector: 'basic',
-  standalone: true,
   imports: [NgOptimizedImage],
   template: `<img ngSrc="/e2e/a.png" width="150" height="150" priority>`,
   providers: [

--- a/packages/core/test/bundling/image-directive/e2e/fill-mode/fill-mode.ts
+++ b/packages/core/test/bundling/image-directive/e2e/fill-mode/fill-mode.ts
@@ -11,7 +11,6 @@ import {Component} from '@angular/core';
 
 @Component({
   selector: 'fill-mode-passing',
-  standalone: true,
   imports: [NgOptimizedImage],
   template: `
     <!-- Make sure an image in the fill mode has the size of a container -->
@@ -23,7 +22,6 @@ import {Component} from '@angular/core';
 export class FillModePassingComponent {}
 @Component({
   selector: 'fill-mode-failing',
-  standalone: true,
   imports: [NgOptimizedImage],
   template: `
     <div style="position: relative; width: 100%;">

--- a/packages/core/test/bundling/image-directive/e2e/image-distortion/image-distortion.ts
+++ b/packages/core/test/bundling/image-directive/e2e/image-distortion/image-distortion.ts
@@ -11,7 +11,6 @@ import {Component} from '@angular/core';
 
 @Component({
   selector: 'image-distortion-passing',
-  standalone: true,
   imports: [NgOptimizedImage],
   template: `
      <!-- All the images in this template should not throw -->
@@ -66,7 +65,6 @@ import {Component} from '@angular/core';
 export class ImageDistortionPassingComponent {}
 @Component({
   selector: 'image-distortion-failing',
-  standalone: true,
   imports: [NgOptimizedImage],
   template: `
      <!-- With the exception of the priority image, all the images in this template should throw -->

--- a/packages/core/test/bundling/image-directive/e2e/image-perf-warnings-lazy/image-perf-warnings-lazy.ts
+++ b/packages/core/test/bundling/image-directive/e2e/image-perf-warnings-lazy/image-perf-warnings-lazy.ts
@@ -10,7 +10,6 @@ import {Component} from '@angular/core';
 
 @Component({
   selector: 'image-perf-warnings-lazy',
-  standalone: true,
   template: `
     <!-- 'a.png' should be treated as an LCP element -->
     <img src="/e2e/a.png" width="2500" height="2500" loading="lazy">

--- a/packages/core/test/bundling/image-directive/e2e/image-perf-warnings-oversized/image-perf-warnings-oversized.ts
+++ b/packages/core/test/bundling/image-directive/e2e/image-perf-warnings-oversized/image-perf-warnings-oversized.ts
@@ -10,7 +10,6 @@ import {Component} from '@angular/core';
 
 @Component({
   selector: 'image-perf-warnings-oversized',
-  standalone: true,
   template: `
       <!-- Image is rendered too small  -->
       <div style="width: 200px; height: 200px">

--- a/packages/core/test/bundling/image-directive/e2e/image-perf-warnings-oversized/svg-no-perf-oversized-warnings.ts
+++ b/packages/core/test/bundling/image-directive/e2e/image-perf-warnings-oversized/svg-no-perf-oversized-warnings.ts
@@ -10,7 +10,6 @@ import {Component} from '@angular/core';
 
 @Component({
   selector: 'svg-no-perf-oversized-warnings',
-  standalone: true,
   template: `
       <!-- Image is rendered too small  -->
       <div style="width: 200px; height: 200px">

--- a/packages/core/test/bundling/image-directive/e2e/lcp-check/lcp-check.ts
+++ b/packages/core/test/bundling/image-directive/e2e/lcp-check/lcp-check.ts
@@ -11,7 +11,6 @@ import {Component} from '@angular/core';
 
 @Component({
   selector: 'lcp-check',
-  standalone: true,
   imports: [NgOptimizedImage],
   template: `
     <!--

--- a/packages/core/test/bundling/image-directive/e2e/oversized-image/oversized-image.ts
+++ b/packages/core/test/bundling/image-directive/e2e/oversized-image/oversized-image.ts
@@ -16,7 +16,6 @@ const imageLoader = {
 
 @Component({
   selector: 'oversized-image-passing',
-  standalone: true,
   imports: [NgOptimizedImage],
   providers: [imageLoader],
   template: `
@@ -35,7 +34,6 @@ export class OversizedImageComponentPassing {}
 
 @Component({
   selector: 'oversized-image-failing',
-  standalone: true,
   imports: [NgOptimizedImage],
   providers: [imageLoader],
   template: `

--- a/packages/core/test/bundling/image-directive/e2e/preconnect-check/preconnect-check.ts
+++ b/packages/core/test/bundling/image-directive/e2e/preconnect-check/preconnect-check.ts
@@ -11,7 +11,6 @@ import {Component, Inject} from '@angular/core';
 
 @Component({
   selector: 'preconnect-check',
-  standalone: true,
   imports: [NgOptimizedImage],
   template: `
     <img ngSrc="/e2e/a.png" width="50" height="50" priority>

--- a/packages/core/test/bundling/image-directive/index.ts
+++ b/packages/core/test/bundling/image-directive/index.ts
@@ -29,7 +29,6 @@ import {PlaygroundComponent} from './playground';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [RouterModule],
   template: '<router-outlet></router-outlet>',
 })

--- a/packages/core/test/bundling/image-directive/playground.ts
+++ b/packages/core/test/bundling/image-directive/playground.ts
@@ -44,7 +44,6 @@ import {Component} from '@angular/core';
       <img ngSrc="hermes2.jpeg" ngSrcset="100w, 200w, 1000w, 2000w" width="1791" height="1008">
     </main>
   `,
-  standalone: true,
   imports: [NgOptimizedImage],
   providers: [provideImgixLoader('https://aurora-project.imgix.net')],
 })

--- a/packages/core/test/bundling/router/index.ts
+++ b/packages/core/test/bundling/router/index.ts
@@ -28,7 +28,6 @@ import {
     <li><a routerLink="/item/3" routerLinkActive="active">List Item 3</a></li>
   </ul>
   `,
-  standalone: true,
   imports: [RouterLink, RouterLinkActive],
 })
 class ListComponent {}
@@ -38,7 +37,6 @@ class ListComponent {}
   template: `
   Item {{id}}
   <p><button (click)="viewList()">Back to List</button></p>`,
-  standalone: true,
 })
 class ItemComponent implements OnInit {
   id = -1;
@@ -61,7 +59,6 @@ class ItemComponent implements OnInit {
 @Component({
   selector: 'app-root',
   template: `<router-outlet></router-outlet>`,
-  standalone: true,
   imports: [RouterOutlet],
 })
 class RootComponent {}

--- a/packages/core/test/bundling/standalone_bootstrap/index.ts
+++ b/packages/core/test/bundling/standalone_bootstrap/index.ts
@@ -10,7 +10,6 @@ import {Component} from '@angular/core';
 import {bootstrapApplication} from '@angular/platform-browser';
 
 @Component({
-  standalone: true,
   selector: 'hello-world',
   template: 'Hello World!',
 })

--- a/packages/core/test/change_detection_scheduler_spec.ts
+++ b/packages/core/test/change_detection_scheduler_spec.ts
@@ -199,7 +199,6 @@ describe('Angular with zoneless enabled', () => {
     it('when creating a view', async () => {
       @Component({
         template: '<ng-template #ref>{{"binding"}}</ng-template>',
-        standalone: true,
       })
       class TestComponent {
         @ViewChild(TemplateRef) template!: TemplateRef<unknown>;
@@ -221,14 +220,12 @@ describe('Angular with zoneless enabled', () => {
     it('when inserting a view', async () => {
       @Component({
         template: '{{"binding"}}',
-        standalone: true,
       })
       class DynamicCmp {
         elementRef = inject(ElementRef);
       }
       @Component({
         template: '<ng-template #ref></ng-template>',
-        standalone: true,
       })
       class TestComponent {
         @ViewChild('ref', {read: ViewContainerRef}) viewContainer!: ViewContainerRef;
@@ -248,14 +245,12 @@ describe('Angular with zoneless enabled', () => {
     it('when destroying a view (with animations)', async () => {
       @Component({
         template: '{{"binding"}}',
-        standalone: true,
       })
       class DynamicCmp {
         elementRef = inject(ElementRef);
       }
       @Component({
         template: '<ng-template #ref></ng-template>',
-        standalone: true,
       })
       class TestComponent {
         @ViewChild('ref', {read: ViewContainerRef}) viewContainer!: ViewContainerRef;
@@ -296,7 +291,6 @@ describe('Angular with zoneless enabled', () => {
         let renderHookCalls = 0;
         @Component({
           template: '{{"binding"}}',
-          standalone: true,
         })
         class DynamicCmp {
           elementRef = inject(ElementRef);
@@ -304,7 +298,6 @@ describe('Angular with zoneless enabled', () => {
         @Component({
           selector: 'app',
           template: '<ng-template #ref></ng-template>',
-          standalone: true,
         })
         class App {
           @ViewChild('ref', {read: ViewContainerRef}) viewContainer!: ViewContainerRef;
@@ -354,7 +347,6 @@ describe('Angular with zoneless enabled', () => {
       @Component({
         selector: 'dynamic-cmp',
         template: '{{"binding"}}',
-        standalone: true,
       })
       class DynamicCmp {
         elementRef = inject(ElementRef);
@@ -426,7 +418,6 @@ describe('Angular with zoneless enabled', () => {
       let checks = 0;
       @Component({
         template: '',
-        standalone: true,
       })
       class Dummy {
         ngDoCheck() {
@@ -498,7 +489,6 @@ describe('Angular with zoneless enabled', () => {
   it('change detects embedded view when attached to a host on ApplicationRef and declaration is marked for check', async () => {
     @Component({
       template: '<ng-template #template><div>{{thing}}</div></ng-template>',
-      standalone: true,
     })
     class DynamicCmp {
       @ViewChild('template') templateRef!: TemplateRef<{}>;
@@ -506,7 +496,6 @@ describe('Angular with zoneless enabled', () => {
     }
     @Component({
       template: '',
-      standalone: true,
     })
     class Host {
       readonly vcr = inject(ViewContainerRef);
@@ -531,7 +520,6 @@ describe('Angular with zoneless enabled', () => {
   it('change detects embedded view when attached directly to ApplicationRef and declaration is marked for check', async () => {
     @Component({
       template: '<ng-template #template><div>{{thing}}</div></ng-template>',
-      standalone: true,
     })
     class DynamicCmp {
       @ViewChild('template') templateRef!: TemplateRef<{}>;
@@ -610,7 +598,6 @@ describe('Angular with zoneless enabled', () => {
     }
     @Component({
       template: '{{thing}}',
-      standalone: true,
     })
     class App {
       thing = 'initial';
@@ -635,7 +622,6 @@ describe('Angular with zoneless enabled', () => {
     };
     @Component({
       template: '',
-      standalone: true,
     })
     class App {
       cdr = inject(ChangeDetectorRef);
@@ -743,7 +729,6 @@ describe('Angular with scheduler and ZoneJS', () => {
     }
     let called = false;
     @Component({
-      standalone: true,
       imports: [ComponentWithOutput],
       template: '<component-with-output (out)="onOut()" />',
     })

--- a/packages/core/test/change_detection_scheduler_spec.ts
+++ b/packages/core/test/change_detection_scheduler_spec.ts
@@ -74,7 +74,7 @@ describe('Angular with zoneless enabled', () => {
   describe('notifies scheduler', () => {
     it('contributes to application stableness', async () => {
       const val = signal('initial');
-      @Component({template: '{{val()}}', standalone: true})
+      @Component({template: '{{val()}}'})
       class TestComponent {
         val = val;
       }
@@ -92,7 +92,7 @@ describe('Angular with zoneless enabled', () => {
 
     it('when signal updates', async () => {
       const val = signal('initial');
-      @Component({template: '{{val()}}', standalone: true})
+      @Component({template: '{{val()}}'})
       class TestComponent {
         val = val;
       }
@@ -107,7 +107,7 @@ describe('Angular with zoneless enabled', () => {
     });
 
     it('when using markForCheck()', async () => {
-      @Component({template: '{{val}}', standalone: true})
+      @Component({template: '{{val}}'})
       class TestComponent {
         cdr = inject(ChangeDetectorRef);
         val = 'initial';
@@ -127,7 +127,7 @@ describe('Angular with zoneless enabled', () => {
     });
 
     it('on input binding', async () => {
-      @Component({template: '{{val}}', standalone: true})
+      @Component({template: '{{val}}'})
       class TestComponent {
         @Input() val = 'initial';
       }
@@ -142,7 +142,7 @@ describe('Angular with zoneless enabled', () => {
     });
 
     it('on event listener bound in template', async () => {
-      @Component({template: '<div (click)="updateVal()">{{val}}</div>', standalone: true})
+      @Component({template: '<div (click)="updateVal()">{{val}}</div>'})
       class TestComponent {
         val = 'initial';
 
@@ -163,7 +163,7 @@ describe('Angular with zoneless enabled', () => {
     });
 
     it('on event listener bound in host', async () => {
-      @Component({host: {'(click)': 'updateVal()'}, template: '{{val}}', standalone: true})
+      @Component({host: {'(click)': 'updateVal()'}, template: '{{val}}'})
       class TestComponent {
         val = 'initial';
 
@@ -182,7 +182,7 @@ describe('Angular with zoneless enabled', () => {
     });
 
     it('with async pipe', async () => {
-      @Component({template: '{{val | async}}', standalone: true, imports: [AsyncPipe]})
+      @Component({template: '{{val | async}}', imports: [AsyncPipe]})
       class TestComponent {
         val = new BehaviorSubject('initial');
       }
@@ -381,7 +381,7 @@ describe('Angular with zoneless enabled', () => {
 
     it('when a stable subscription synchronously causes another notification', async () => {
       const val = signal('initial');
-      @Component({template: '{{val()}}', standalone: true})
+      @Component({template: '{{val()}}'})
       class TestComponent {
         val = val;
       }
@@ -447,7 +447,7 @@ describe('Angular with zoneless enabled', () => {
   it('can recover when an error is re-thrown by the ErrorHandler', async () => {
     const val = signal('initial');
     let throwError = false;
-    @Component({template: '{{val()}}{{maybeThrow()}}', standalone: true})
+    @Component({template: '{{val()}}{{maybeThrow()}}'})
     class TestComponent {
       val = val;
       maybeThrow() {
@@ -541,7 +541,7 @@ describe('Angular with zoneless enabled', () => {
   });
 
   it('does not fail when global timing functions are patched and unpatched', async () => {
-    @Component({template: '', standalone: true})
+    @Component({template: ''})
     class App {
       cdr = inject(ChangeDetectorRef);
     }
@@ -574,7 +574,7 @@ describe('Angular with zoneless enabled', () => {
         changeDetectionRuns++;
       });
     });
-    @Component({template: '', standalone: true})
+    @Component({template: ''})
     class MyComponent {
       cdr = inject(ChangeDetectorRef);
     }
@@ -698,7 +698,7 @@ describe('Angular with scheduler and ZoneJS', () => {
     TestBed.configureTestingModule({
       providers: [provideZoneChangeDetection({ignoreChangesOutsideZone: true})],
     });
-    @Component({template: '{{thing()}}', standalone: true})
+    @Component({template: '{{thing()}}'})
     class App {
       thing = signal('initial');
     }
@@ -723,7 +723,7 @@ describe('Angular with scheduler and ZoneJS', () => {
       });
     });
 
-    @Component({selector: 'component-with-output', template: '', standalone: true})
+    @Component({selector: 'component-with-output', template: ''})
     class ComponentWithOutput {
       @Output() out = new EventEmitter();
     }
@@ -753,7 +753,7 @@ describe('Angular with scheduler and ZoneJS', () => {
   });
 
   it('updating signal outside of zone still schedules update when in hybrid mode', async () => {
-    @Component({template: '{{thing()}}', standalone: true})
+    @Component({template: '{{thing()}}'})
     class App {
       thing = signal('initial');
     }
@@ -771,7 +771,7 @@ describe('Angular with scheduler and ZoneJS', () => {
   });
 
   it('updating signal in another "Angular" zone schedules update when in hybrid mode', async () => {
-    @Component({template: '{{thing()}}', standalone: true})
+    @Component({template: '{{thing()}}'})
     class App {
       thing = signal('initial');
     }
@@ -790,7 +790,7 @@ describe('Angular with scheduler and ZoneJS', () => {
   });
 
   it('updating signal in a child zone of Angular does not schedule extra CD', async () => {
-    @Component({template: '{{thing()}}', standalone: true})
+    @Component({template: '{{thing()}}'})
     class App {
       thing = signal('initial');
     }
@@ -807,7 +807,7 @@ describe('Angular with scheduler and ZoneJS', () => {
   });
 
   it('updating signal in a child Angular zone of Angular does not schedule extra CD', async () => {
-    @Component({template: '{{thing()}}', standalone: true})
+    @Component({template: '{{thing()}}'})
     class App {
       thing = signal('initial');
     }
@@ -837,7 +837,7 @@ describe('Angular with scheduler and ZoneJS', () => {
         changeDetectionRuns++;
       });
     });
-    @Component({template: '', standalone: true})
+    @Component({template: ''})
     class MyComponent {
       cdr = inject(ChangeDetectorRef);
       ngDoCheck() {
@@ -867,7 +867,7 @@ describe('Angular with scheduler and ZoneJS', () => {
         provideZoneChangeDetection({runCoalescing: true, ignoreChangesOutsideZone: false}),
       ],
     });
-    @Component({template: '{{thing()}}', standalone: true})
+    @Component({template: '{{thing()}}'})
     class App {
       thing = signal('initial');
     }
@@ -895,7 +895,7 @@ describe('Angular with scheduler and ZoneJS', () => {
         provideZoneChangeDetection({runCoalescing: true, ignoreChangesOutsideZone: false}),
       ],
     });
-    @Component({template: '{{thing()}}', standalone: true})
+    @Component({template: '{{thing()}}'})
     class App {
       thing = signal('initial');
     }

--- a/packages/core/test/component_fixture_spec.ts
+++ b/packages/core/test/component_fixture_spec.ts
@@ -43,14 +43,12 @@ class SimpleComp {
 
 @Component({
   selector: 'deferred-comp',
-  standalone: true,
   template: `<div>Deferred Component</div>`,
 })
 class DeferredComp {}
 
 @Component({
   selector: 'second-deferred-comp',
-  standalone: true,
   template: `<div>More Deferred Component</div>`,
 })
 class SecondDeferredComp {}
@@ -363,7 +361,6 @@ describe('ComponentFixture', () => {
   it('throws errors that happen during detectChanges', () => {
     @Component({
       template: '',
-      standalone: true,
     })
     class App {
       ngOnInit() {
@@ -378,7 +375,6 @@ describe('ComponentFixture', () => {
   describe('errors during ApplicationRef.tick', () => {
     @Component({
       template: '',
-      standalone: true,
     })
     class ThrowingThing {
       ngOnInit() {
@@ -387,7 +383,6 @@ describe('ComponentFixture', () => {
     }
     @Component({
       template: '',
-      standalone: true,
     })
     class Blank {}
 
@@ -417,7 +412,6 @@ describe('ComponentFixture', () => {
     it('should return all defer blocks in the component', async () => {
       @Component({
         selector: 'defer-comp',
-        standalone: true,
         imports: [DeferredComp, SecondDeferredComp],
         template: `<div>
             @defer (on immediate) {
@@ -472,7 +466,6 @@ describe('ComponentFixture', () => {
     it('throws errors that happen during detectChanges', () => {
       @Component({
         template: '',
-        standalone: true,
       })
       class App {
         ngOnInit() {
@@ -566,7 +559,6 @@ describe('ComponentFixture with zoneless', () => {
   it('throws errors that happen during detectChanges', () => {
     @Component({
       template: '',
-      standalone: true,
     })
     class App {
       ngOnInit() {
@@ -581,7 +573,6 @@ describe('ComponentFixture with zoneless', () => {
   it('rejects whenStable promise when errors happen during detectChanges', async () => {
     @Component({
       template: '',
-      standalone: true,
     })
     class App {
       ngOnInit() {
@@ -596,7 +587,6 @@ describe('ComponentFixture with zoneless', () => {
   it('can disable checkNoChanges', () => {
     @Component({
       template: '{{thing}}',
-      standalone: true,
     })
     class App {
       thing = 1;
@@ -614,7 +604,6 @@ describe('ComponentFixture with zoneless', () => {
   it('runs change detection when autoDetect is false', () => {
     @Component({
       template: '{{thing()}}',
-      standalone: true,
     })
     class App {
       thing = signal(1);

--- a/packages/core/test/defer_fixture_spec.ts
+++ b/packages/core/test/defer_fixture_spec.ts
@@ -13,7 +13,6 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 @Component({
   selector: 'second-deferred-comp',
-  standalone: true,
   template: `<div class="more">More Deferred Component</div>`,
 })
 class SecondDeferredComp {}
@@ -24,7 +23,6 @@ describe('DeferFixture', () => {
   it('should start in manual behavior mode', async () => {
     @Component({
       selector: 'defer-comp',
-      standalone: true,
       imports: [SecondDeferredComp],
       template: `
         <div>
@@ -51,7 +49,6 @@ describe('DeferFixture', () => {
   it('should start in manual trigger mode by default', async () => {
     @Component({
       selector: 'defer-comp',
-      standalone: true,
       imports: [SecondDeferredComp],
       template: `
         <div>
@@ -76,7 +73,6 @@ describe('DeferFixture', () => {
   it('should defer load immediately on playthrough', async () => {
     @Component({
       selector: 'defer-comp',
-      standalone: true,
       imports: [SecondDeferredComp],
       template: `
         <div>
@@ -110,7 +106,6 @@ describe('DeferFixture', () => {
   it('should not defer load immediately when set to manual', async () => {
     @Component({
       selector: 'defer-comp',
-      standalone: true,
       imports: [SecondDeferredComp],
       template: `
         <div>
@@ -145,7 +140,6 @@ describe('DeferFixture', () => {
   it('should render a completed defer state', async () => {
     @Component({
       selector: 'defer-comp',
-      standalone: true,
       imports: [SecondDeferredComp],
       template: `
         <div>
@@ -173,7 +167,6 @@ describe('DeferFixture', () => {
   it('should not wait forever if application is unstable for a long time', async () => {
     @Component({
       selector: 'defer-comp',
-      standalone: true,
       imports: [SecondDeferredComp],
       template: `
         <div>
@@ -206,7 +199,6 @@ describe('DeferFixture', () => {
   it('should work with templates that have local refs', async () => {
     @Component({
       selector: 'defer-comp',
-      standalone: true,
       imports: [SecondDeferredComp],
       template: `
         <ng-template #template>Hello</ng-template>
@@ -235,7 +227,6 @@ describe('DeferFixture', () => {
   it('should render a placeholder defer state', async () => {
     @Component({
       selector: 'defer-comp',
-      standalone: true,
       imports: [SecondDeferredComp],
       template: `
         <div>
@@ -268,7 +259,6 @@ describe('DeferFixture', () => {
   it('should render a loading defer state', async () => {
     @Component({
       selector: 'defer-comp',
-      standalone: true,
       imports: [SecondDeferredComp],
       template: `
         <div>
@@ -301,7 +291,6 @@ describe('DeferFixture', () => {
   it('should render an error defer state', async () => {
     @Component({
       selector: 'defer-comp',
-      standalone: true,
       imports: [SecondDeferredComp],
       template: `
         <div>
@@ -334,7 +323,6 @@ describe('DeferFixture', () => {
   it('should throw when rendering a template that does not exist', async () => {
     @Component({
       selector: 'defer-comp',
-      standalone: true,
       imports: [SecondDeferredComp],
       template: `
         <div>
@@ -367,7 +355,6 @@ describe('DeferFixture', () => {
   it('should transition between states when `after` and `minimum` are used', async () => {
     @Component({
       selector: 'defer-comp',
-      standalone: true,
       imports: [SecondDeferredComp],
       template: `
         <div>
@@ -405,7 +392,6 @@ describe('DeferFixture', () => {
   it('should get child defer blocks', async () => {
     @Component({
       selector: 'deferred-comp',
-      standalone: true,
       imports: [SecondDeferredComp],
       template: `
         <div>
@@ -419,7 +405,6 @@ describe('DeferFixture', () => {
 
     @Component({
       selector: 'defer-comp',
-      standalone: true,
       imports: [DeferredComp],
       template: `
         <div>

--- a/packages/core/test/playground/zone-signal-input/index.ts
+++ b/packages/core/test/playground/zone-signal-input/index.ts
@@ -11,7 +11,6 @@ import {bootstrapApplication} from '@angular/platform-browser';
 
 @Component({
   selector: 'greet',
-  standalone: true,
   template: `
     {{ counter() }} -- {{label()}}
 
@@ -45,7 +44,6 @@ export class Greet<T> {
 }
 
 @Component({
-  standalone: true,
   selector: 'my-app',
   template: `
     Hello <greet [counter]="3" [bla4Public]="10" #ok

--- a/packages/core/test/render3/change_detection_spec.ts
+++ b/packages/core/test/render3/change_detection_spec.ts
@@ -18,7 +18,6 @@ describe('change detection', () => {
       const log: string[] = [];
       @Component({
         selector: 'my-comp',
-        standalone: true,
         template: '{{ value }}',
       })
       class MyComponent {

--- a/packages/core/test/render3/component_ref_spec.ts
+++ b/packages/core/test/render3/component_ref_spec.ts
@@ -48,7 +48,6 @@ describe('ComponentFactory', () => {
     it('should correctly populate default properties', () => {
       @Component({
         selector: 'test[foo], bar',
-        standalone: true,
         template: '',
       })
       class TestComponent {}
@@ -67,7 +66,6 @@ describe('ComponentFactory', () => {
 
       @Component({
         selector: 'test[foo], bar',
-        standalone: true,
         template: `
           <ng-content></ng-content>
           <ng-content select="a"></ng-content>
@@ -407,7 +405,6 @@ describe('ComponentFactory', () => {
       let log: string[] = [];
       @Component({
         template: `{{in}}`,
-        standalone: true,
       })
       class DynamicCmp {
         @Input()
@@ -429,7 +426,6 @@ describe('ComponentFactory', () => {
     it('marks parents dirty so component is not "shielded" by a non-dirty OnPush parent', () => {
       @Component({
         template: `{{input}}`,
-        standalone: true,
         selector: 'dynamic',
       })
       class DynamicCmp {
@@ -438,7 +434,6 @@ describe('ComponentFactory', () => {
 
       @Component({
         template: '<ng-template #template></ng-template>',
-        standalone: true,
         imports: [DynamicCmp],
         changeDetection: ChangeDetectionStrategy.OnPush,
       })

--- a/packages/core/test/render3/deps_tracker_spec.ts
+++ b/packages/core/test/render3/deps_tracker_spec.ts
@@ -215,7 +215,7 @@ describe('runtime dependency tracker', () => {
         @Directive({standalone: true})
         class Directive1 {}
 
-        @Pipe({name: 'pipe1', standalone: true})
+        @Pipe({name: 'pipe1'})
         class Pipe1 {}
 
         @Component({standalone: true})
@@ -733,7 +733,7 @@ describe('runtime dependency tracker', () => {
       @Directive({standalone: true})
       class Directive1 {}
 
-      @Pipe({name: 'pipe1', standalone: true})
+      @Pipe({name: 'pipe1'})
       class Pipe1 {}
 
       class MainComponent {}
@@ -758,7 +758,7 @@ describe('runtime dependency tracker', () => {
       @Directive({standalone: true})
       class Directive1 {}
 
-      @Pipe({name: 'pipe1', standalone: true})
+      @Pipe({name: 'pipe1'})
       class Pipe1 {}
 
       class MainComponent {}
@@ -879,7 +879,7 @@ describe('runtime dependency tracker', () => {
       @Directive({standalone: true})
       class Directive1 {}
 
-      @Pipe({name: 'pipe1', standalone: true})
+      @Pipe({name: 'pipe1'})
       class Pipe1 {}
 
       @Component({
@@ -930,7 +930,7 @@ describe('runtime dependency tracker', () => {
       @Directive({standalone: true})
       class Directive1 {}
 
-      @Pipe({name: 'pipe1', standalone: true})
+      @Pipe({name: 'pipe1'})
       class Pipe1 {}
 
       @Component({
@@ -981,7 +981,7 @@ describe('runtime dependency tracker', () => {
       @Directive({standalone: true})
       class Directive1 {}
 
-      @Pipe({name: 'pipe1', standalone: true})
+      @Pipe({name: 'pipe1'})
       class Pipe1 {}
 
       class MainComponent {}
@@ -1014,7 +1014,7 @@ describe('runtime dependency tracker', () => {
       @Directive({standalone: true})
       class Directive1 {}
 
-      @Pipe({name: 'pipe1', standalone: true})
+      @Pipe({name: 'pipe1'})
       class Pipe1 {}
 
       @Component({
@@ -1172,7 +1172,7 @@ describe('runtime dependency tracker', () => {
         @Directive({standalone: true})
         class Directive1 {}
 
-        @Pipe({name: 'pipe1', standalone: true})
+        @Pipe({name: 'pipe1'})
         class Pipe1 {}
 
         @Component({standalone: true})
@@ -1196,7 +1196,7 @@ describe('runtime dependency tracker', () => {
         @Directive({standalone: true})
         class Directive1 {}
 
-        @Pipe({name: 'pipe1', standalone: true})
+        @Pipe({name: 'pipe1'})
         class Pipe1 {}
 
         @Component({standalone: true})

--- a/packages/core/test/render3/deps_tracker_spec.ts
+++ b/packages/core/test/render3/deps_tracker_spec.ts
@@ -1347,9 +1347,7 @@ describe('runtime dependency tracker', () => {
     });
 
     it('should return false for standalone component', () => {
-      @Component({
-        standalone: true,
-      })
+      @Component({})
       class MainComponent {}
 
       expect(depsTracker.isOrphanComponent(MainComponent as ComponentType<any>)).toBeFalse();

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -29,10 +29,10 @@ describe('di', () => {
   describe('directive injection', () => {
     describe('flags', () => {
       it('should check only the current node with @Self even with false positive', () => {
-        @Directive({selector: '[notOnSelf]', standalone: true})
+        @Directive({selector: '[notOnSelf]'})
         class DirNotOnSelf {}
 
-        @Directive({selector: '[tryInjectFromSelf]', standalone: true})
+        @Directive({selector: '[tryInjectFromSelf]'})
         class DirTryInjectFromSelf {
           constructor(@Self() private dir: DirNotOnSelf) {}
         }

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -43,7 +43,6 @@ describe('di', () => {
               <div tryInjectFromSelf></div>
             </div>
           `,
-          standalone: true,
           imports: [DirNotOnSelf, DirTryInjectFromSelf],
         })
         class App {}

--- a/packages/core/test/render3/instructions_spec.ts
+++ b/packages/core/test/render3/instructions_spec.ts
@@ -158,7 +158,6 @@ describe('instructions', () => {
     it('should instantiate nodes at high indices', () => {
       @Component({
         selector: 'comp',
-        standalone: true,
         template: '{{ name }}',
       })
       class Comp {
@@ -323,7 +322,6 @@ describe('instructions', () => {
     it('should create tView only once for each nested level', () => {
       @Component({
         selector: 'nested-loops',
-        standalone: true,
         template: `
           <ul *ngFor="let row of rows">
             <li *ngFor="let col of row.cols">{{col}}</li>

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -18,7 +18,6 @@ import {SecurityContext} from '../../src/sanitization/security';
 describe('element discovery', () => {
   it('should only monkey-patch immediate child nodes in a component', () => {
     @Component({
-      standalone: true,
       template: '<div><p></p></div>',
     })
     class StructuredComp {}
@@ -37,7 +36,6 @@ describe('element discovery', () => {
   it('should only monkey-patch immediate child nodes in a sub component', () => {
     @Component({
       selector: 'child-comp',
-      standalone: true,
       template: `
         <div></div>
         <div></div>
@@ -48,7 +46,6 @@ describe('element discovery', () => {
 
     @Component({
       selector: 'parent-comp',
-      standalone: true,
       imports: [ChildComp],
       template: `
         <section>
@@ -75,7 +72,6 @@ describe('element discovery', () => {
     @Component({
       selector: 'structured-comp',
       imports: [CommonModule],
-      standalone: true,
       template: `
         <section>
           <ng-container *ngIf="true">
@@ -111,7 +107,6 @@ describe('element discovery', () => {
   it('should return a context object from a given dom node', () => {
     @Component({
       selector: 'structured-comp',
-      standalone: true,
       template: `
         <section></section>
         <div></div>
@@ -140,7 +135,6 @@ describe('element discovery', () => {
   it('should cache the element context on a element was preemptively monkey-patched', () => {
     @Component({
       selector: 'structured-comp',
-      standalone: true,
       template: `
         <section></section>
       `,
@@ -165,7 +159,6 @@ describe('element discovery', () => {
   it("should cache the element context on an intermediate element that isn't preemptively monkey-patched", () => {
     @Component({
       selector: 'structured-comp',
-      standalone: true,
       template: `
             <section>
               <p></p>
@@ -191,7 +184,6 @@ describe('element discovery', () => {
   it('should be able to pull in element context data even if the element is decorated using styling', () => {
     @Component({
       selector: 'structured-comp',
-      standalone: true,
       template: `
             <section></section>
           `,
@@ -232,7 +224,6 @@ describe('element discovery', () => {
        */
     @Component({
       selector: 'projector-comp',
-      standalone: true,
       template: `
             welcome
             <header>
@@ -246,7 +237,6 @@ describe('element discovery', () => {
 
     @Component({
       selector: 'parent-comp',
-      standalone: true,
       imports: [ProjectorComp],
       template: `
             <section>
@@ -310,7 +300,6 @@ describe('element discovery', () => {
   it('should return `null` when an element context is retrieved that is a DOM node that was not created by Angular', () => {
     @Component({
       selector: 'structured-comp',
-      standalone: true,
       template: `
              <section></section>
            `,
@@ -331,7 +320,6 @@ describe('element discovery', () => {
   it('should by default monkey-patch the bootstrap component with context details', () => {
     @Component({
       selector: 'structured-comp',
-      standalone: true,
       template: ``,
     })
     class StructuredComp {}
@@ -365,7 +353,6 @@ describe('element discovery', () => {
 
     @Directive({
       selector: '[my-dir-1]',
-      standalone: true,
     })
     class MyDir1 {
       constructor() {
@@ -375,7 +362,6 @@ describe('element discovery', () => {
 
     @Directive({
       selector: '[my-dir-2]',
-      standalone: true,
     })
     class MyDir2 {
       constructor() {
@@ -385,7 +371,6 @@ describe('element discovery', () => {
 
     @Directive({
       selector: '[my-dir-3]',
-      standalone: true,
     })
     class MyDir3 {
       constructor() {
@@ -395,7 +380,6 @@ describe('element discovery', () => {
 
     @Component({
       selector: 'structured-comp',
-      standalone: true,
       imports: [MyDir1, MyDir2, MyDir3],
       template: `
             <div my-dir-1 my-dir-2></div>
@@ -453,7 +437,6 @@ describe('element discovery', () => {
 
     @Directive({
       selector: '[my-dir-1]',
-      standalone: true,
     })
     class MyDir1 {
       constructor() {
@@ -463,7 +446,6 @@ describe('element discovery', () => {
 
     @Directive({
       selector: '[my-dir-2]',
-      standalone: true,
     })
     class MyDir2 {
       constructor() {
@@ -473,7 +455,6 @@ describe('element discovery', () => {
 
     @Component({
       selector: 'child-comp',
-      standalone: true,
       template: `
              <div></div>
            `,
@@ -486,7 +467,6 @@ describe('element discovery', () => {
 
     @Component({
       selector: 'parent-comp',
-      standalone: true,
       imports: [ChildComp, MyDir1, MyDir2],
       template: `
              <child-comp my-dir-1 my-dir-2></child-comp>
@@ -541,7 +521,6 @@ describe('element discovery', () => {
   it('should monkey-patch sub components with the view data and then replace them with the context result once a lookup occurs', () => {
     @Component({
       selector: 'child-comp',
-      standalone: true,
       template: `
             <div></div>
             <div></div>
@@ -552,7 +531,6 @@ describe('element discovery', () => {
 
     @Component({
       selector: 'parent-comp',
-      standalone: true,
       imports: [ChildComp],
       template: `
             <section>
@@ -589,7 +567,6 @@ describe('sanitization', () => {
   it('should sanitize data using the provided sanitization interface', () => {
     @Component({
       selector: 'sanitize-this',
-      standalone: true,
       template: `
         <a [href]="href"></a>
       `,
@@ -632,7 +609,6 @@ describe('sanitization', () => {
 
     @Directive({
       selector: '[unsafeUrlHostBindingDir]',
-      standalone: true,
     })
     class UnsafeUrlHostBindingDir {
       @HostBinding() cite: any = 'http://cite-dir-value';
@@ -644,7 +620,6 @@ describe('sanitization', () => {
 
     @Component({
       selector: 'sanitize-this',
-      standalone: true,
       imports: [UnsafeUrlHostBindingDir],
       template: `
         <blockquote unsafeUrlHostBindingDir></blockquote>

--- a/packages/core/test/render3/microtask_effect_spec.ts
+++ b/packages/core/test/render3/microtask_effect_spec.ts
@@ -47,7 +47,6 @@ describe('microtask effects', () => {
       const log: string[] = [];
       @Component({
         selector: 'test-cmp',
-        standalone: true,
         template: '',
       })
       class Cmp {
@@ -74,7 +73,6 @@ describe('microtask effects', () => {
     const someSignal = signal('initial');
 
     @Component({
-      standalone: true,
       template: '',
     })
     class App {
@@ -149,7 +147,6 @@ describe('microtask effects', () => {
     }
 
     @Component({
-      standalone: true,
       template: '',
       providers: [{provide: ErrorHandler, useClass: FakeErrorHandler}],
     })
@@ -175,7 +172,6 @@ describe('microtask effects', () => {
 
     @Component({
       selector: 'test-cmp',
-      standalone: true,
       template: '',
     })
     class Cmp {
@@ -211,7 +207,6 @@ describe('microtask effects', () => {
 
     @Component({
       selector: 'test-cmp',
-      standalone: true,
       template: '',
     })
     class Cmp implements AfterViewInit {
@@ -238,7 +233,6 @@ describe('microtask effects', () => {
     withBody('<test-cmp></test-cmp>', async () => {
       @Component({
         selector: 'test-cmp',
-        standalone: true,
         template: '',
       })
       class Cmp {
@@ -268,7 +262,6 @@ describe('microtask effects', () => {
   it('should allow writing to signals in ngOnChanges', () => {
     @Component({
       selector: 'with-input',
-      standalone: true,
       template: '{{inSignal()}}',
     })
     class WithInput implements OnChanges {
@@ -284,7 +277,6 @@ describe('microtask effects', () => {
 
     @Component({
       selector: 'test-cmp',
-      standalone: true,
       imports: [WithInput],
       template: `<with-input [in]="'A'" />|<with-input [in]="'B'" />`,
     })
@@ -298,7 +290,6 @@ describe('microtask effects', () => {
   it('should allow writing to signals in a constructor', () => {
     @Component({
       selector: 'with-constructor',
-      standalone: true,
       template: '{{state()}}',
     })
     class WithConstructor {
@@ -311,7 +302,6 @@ describe('microtask effects', () => {
 
     @Component({
       selector: 'test-cmp',
-      standalone: true,
       imports: [WithConstructor],
       template: `<with-constructor />`,
     })
@@ -325,7 +315,6 @@ describe('microtask effects', () => {
   it('should allow writing to signals in input setters', () => {
     @Component({
       selector: 'with-input-setter',
-      standalone: true,
       template: '{{state()}}',
     })
     class WithInputSetter {
@@ -339,7 +328,6 @@ describe('microtask effects', () => {
 
     @Component({
       selector: 'test-cmp',
-      standalone: true,
       imports: [WithInputSetter],
       template: `
           <with-input-setter [testInput]="'binding'" />|<with-input-setter testInput="static" />
@@ -355,7 +343,6 @@ describe('microtask effects', () => {
   it('should allow writing to signals in query result setters', () => {
     @Component({
       selector: 'with-query',
-      standalone: true,
       template: '{{items().length}}',
     })
     class WithQuery {
@@ -369,7 +356,6 @@ describe('microtask effects', () => {
 
     @Component({
       selector: 'test-cmp',
-      standalone: true,
       imports: [WithQuery],
       template: `<with-query><div #item></div></with-query>`,
     })
@@ -385,7 +371,6 @@ describe('microtask effects', () => {
 
     @Component({
       selector: 'with-query-setter',
-      standalone: true,
       template: '<div #el></div>',
     })
     class WithQuerySetter {
@@ -401,7 +386,6 @@ describe('microtask effects', () => {
 
     @Component({
       selector: 'test-cmp',
-      standalone: true,
       template: ``,
     })
     class Cmp {
@@ -434,7 +418,6 @@ describe('microtask effects', () => {
   it('should allow toObservable subscription in template (with async pipe)', () => {
     @Component({
       selector: 'test-cmp',
-      standalone: true,
       imports: [AsyncPipe],
       template: '{{counter$ | async}}',
     })
@@ -453,7 +436,6 @@ describe('microtask effects', () => {
     it('when created during bootstrapping', () => {
       let log: string[] = [];
       @Component({
-        standalone: true,
         selector: 'test-cmp',
         template: '',
       })
@@ -478,7 +460,6 @@ describe('microtask effects', () => {
       let log: string[] = [];
 
       @Component({
-        standalone: true,
         selector: 'test-cmp',
         template: '',
       })
@@ -494,7 +475,6 @@ describe('microtask effects', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'driver-cmp',
         imports: [TestCmp],
         template: `
@@ -520,7 +500,6 @@ describe('microtask effects', () => {
     it('when created dynamically', () => {
       let log: string[] = [];
       @Component({
-        standalone: true,
         selector: 'test-cmp',
         template: '',
       })
@@ -536,7 +515,6 @@ describe('microtask effects', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'driver-cmp',
         template: '',
       })
@@ -570,7 +548,6 @@ describe('microtask effects', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'test-cmp',
         template: '',
         providers: [EffectService],
@@ -593,7 +570,6 @@ describe('microtask effects', () => {
     it('if multiple effects are created', () => {
       let log: string[] = [];
       @Component({
-        standalone: true,
         selector: 'test-cmp',
         template: '',
       })
@@ -685,7 +661,6 @@ describe('microtask effects in TestBed', () => {
     const log: string[] = [];
     @Component({
       selector: 'test-cmp',
-      standalone: true,
       template: '',
     })
     class Cmp {
@@ -721,7 +696,6 @@ describe('microtask effects in TestBed', () => {
     const log: string[] = [];
     @Component({
       selector: 'test-cmp',
-      standalone: true,
       template: '',
     })
     class Cmp {
@@ -765,7 +739,6 @@ describe('microtask effects in TestBed', () => {
     let observed = '';
     @Component({
       selector: 'test-cmp',
-      standalone: true,
       template: '',
     })
     class Cmp {

--- a/packages/core/test/render3/providers_helper.ts
+++ b/packages/core/test/render3/providers_helper.ts
@@ -26,7 +26,6 @@ export function expectProvidersScenario(defs: {
   ngModule?: Type<any>;
 }): void {
   @Component({
-    standalone: true,
     selector: 'view-child',
     template: 'view-child',
     encapsulation: ViewEncapsulation.None,
@@ -40,7 +39,6 @@ export function expectProvidersScenario(defs: {
   }
 
   @Directive({
-    standalone: true,
     selector: 'view-child',
     providers: defs.viewChild?.directiveProviders ?? [],
   })
@@ -51,7 +49,6 @@ export function expectProvidersScenario(defs: {
   }
 
   @Component({
-    standalone: true,
     selector: 'content-child',
     template: 'content-child',
     encapsulation: ViewEncapsulation.None,
@@ -65,7 +62,6 @@ export function expectProvidersScenario(defs: {
   }
 
   @Directive({
-    standalone: true,
     selector: 'content-child',
     providers: defs.contentChild?.directiveProviders ?? [],
   })
@@ -76,7 +72,6 @@ export function expectProvidersScenario(defs: {
   }
 
   @Component({
-    standalone: true,
     imports: [ViewChildComponent, ViewChildDirective],
     selector: 'parent',
     template: '<view-child></view-child>',
@@ -91,7 +86,6 @@ export function expectProvidersScenario(defs: {
   }
 
   @Directive({
-    standalone: true,
     selector: 'parent',
     providers: defs.parent?.directiveProviders ?? [],
   })
@@ -101,7 +95,6 @@ export function expectProvidersScenario(defs: {
     }
   }
   @Directive({
-    standalone: true,
     selector: 'parent',
     providers: defs.parent?.directive2Providers ?? [],
   })
@@ -112,7 +105,6 @@ export function expectProvidersScenario(defs: {
   }
 
   @Component({
-    standalone: true,
     imports: [
       ParentComponent,
       // Note: tests are sensitive to the ordering here - the providers from `ParentDirective`

--- a/packages/core/test/render3/providers_spec.ts
+++ b/packages/core/test/render3/providers_spec.ts
@@ -1045,7 +1045,6 @@ describe('providers', () => {
     let hostComponent: HostComponent | null = null;
 
     @Component({
-      standalone: true,
       template: `{{s}}`,
       selector: 'embedded-cmp',
     })
@@ -1054,7 +1053,6 @@ describe('providers', () => {
     }
 
     @Component({
-      standalone: true,
       selector: 'host-cmp',
       template: `foo`,
       providers: [{provide: String, useValue: 'From host component'}],
@@ -1066,7 +1064,6 @@ describe('providers', () => {
     }
 
     @Component({
-      standalone: true,
       imports: [HostComponent],
       template: `<host-cmp></host-cmp>`,
       providers: [{provide: String, useValue: 'From app component'}],
@@ -1197,7 +1194,6 @@ describe('providers', () => {
     }
 
     @Component({
-      standalone: true,
       selector: 'my-cmp',
       template: `<p></p>`,
       providers: [{provide: String, useValue: 'From my component'}],
@@ -1206,7 +1202,6 @@ describe('providers', () => {
     class MyComponent {}
 
     @Component({
-      standalone: true,
       imports: [MyComponent],
       template: `<my-cmp></my-cmp>`,
       providers: [

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -31,7 +31,6 @@ describe('query', () => {
 
       @Directive({
         selector: '[myDir]',
-        standalone: true,
         providers: [Service, {provide: Alias, useExisting: Service}],
       })
       class MyDirective {
@@ -48,7 +47,6 @@ describe('query', () => {
           selector: 'app',
           template: '<div myDir></div>',
           imports: [MyDirective],
-          standalone: true,
         })
         class App {
           @ViewChild(MyDirective) directive!: MyDirective;
@@ -67,7 +65,6 @@ describe('query', () => {
       it('should resolve a provider if given as read token', () => {
         @Component({
           selector: 'app',
-          standalone: true,
           template: '<div myDir></div>',
           imports: [MyDirective],
         })
@@ -85,7 +82,6 @@ describe('query', () => {
   it('should restore queries if view changes', () => {
     @Directive({
       selector: '[someDir]',
-      standalone: true,
     })
     class SomeDir {
       constructor(
@@ -98,7 +94,6 @@ describe('query', () => {
 
     @Component({
       selector: 'app',
-      standalone: true,
       template: `
         <div *someDir></div>
         <div #foo></div>

--- a/packages/core/test/render3/reactive_safety_spec.ts
+++ b/packages/core/test/render3/reactive_safety_spec.ts
@@ -44,7 +44,6 @@ describe('reactive safety', () => {
   describe('view creation', () => {
     it('should be safe to call ViewContainerRef.createEmbeddedView', () => {
       @Component({
-        standalone: true,
         template: `<ng-template #tmpl>Template</ng-template>`,
       })
       class TestCmp {
@@ -60,7 +59,6 @@ describe('reactive safety', () => {
 
     it('should be safe to call TemplateRef.create', () => {
       @Component({
-        standalone: true,
         template: `<ng-template #tmpl>Template</ng-template>`,
       })
       class TestCmp {
@@ -75,7 +73,6 @@ describe('reactive safety', () => {
 
     it('should be safe to call createComponent', () => {
       @Component({
-        standalone: true,
         template: '',
       })
       class TestCmp {
@@ -90,7 +87,6 @@ describe('reactive safety', () => {
 
     it('should be safe to call ComponentFactory.create()', () => {
       @Component({
-        standalone: true,
         template: '',
       })
       class TestCmp {
@@ -107,7 +103,6 @@ describe('reactive safety', () => {
 
     it('should be safe to flip @if to true', () => {
       @Component({
-        standalone: true,
         template: `
           @if (cond) {
             (creating this view should not throw)
@@ -130,7 +125,6 @@ describe('reactive safety', () => {
   describe('view destruction', () => {
     it('should be safe to destroy a ComponentRef', () => {
       @Component({
-        standalone: true,
         template: '',
       })
       class HostCmp {
@@ -138,7 +132,6 @@ describe('reactive safety', () => {
       }
 
       @Component({
-        standalone: true,
         template: '',
       })
       class GuestCmp {
@@ -227,7 +220,6 @@ describe('reactive safety', () => {
   describe('outputs', () => {
     it('should be safe to emit an output', () => {
       @Component({
-        standalone: true,
         template: '',
       })
       class TestCmp {

--- a/packages/core/test/render3/reactivity_spec.ts
+++ b/packages/core/test/render3/reactivity_spec.ts
@@ -65,7 +65,6 @@ describe('reactivity', () => {
         const log: string[] = [];
         @Component({
           selector: 'test-cmp',
-          standalone: true,
           template: '',
         })
         class Cmp {
@@ -175,7 +174,6 @@ describe('reactivity', () => {
 
       @Component({
         selector: 'test-cmp',
-        standalone: true,
         template: '',
       })
       class Cmp {
@@ -211,7 +209,6 @@ describe('reactivity', () => {
 
       @Component({
         selector: 'test-cmp',
-        standalone: true,
         template: '',
       })
       class Cmp implements AfterViewInit {
@@ -267,7 +264,6 @@ describe('reactivity', () => {
       const log: number[] = [];
 
       @Component({
-        standalone: true,
         template: '',
       })
       class TestCmp {
@@ -294,7 +290,6 @@ describe('reactivity', () => {
 
       const source = signal('');
       @Component({
-        standalone: true,
         changeDetection: ChangeDetectionStrategy.OnPush,
         template: '{{ data }}',
       })
@@ -338,7 +333,6 @@ describe('reactivity', () => {
       }
 
       @Component({
-        standalone: true,
         changeDetection: ChangeDetectionStrategy.OnPush,
         providers: [Service],
         template: '{{ service.data }}',
@@ -364,7 +358,6 @@ describe('reactivity', () => {
       const source = signal('');
 
       @Directive({
-        standalone: true,
         selector: '[dir]',
       })
       class Dir {
@@ -385,7 +378,6 @@ describe('reactivity', () => {
       }
 
       @Component({
-        standalone: true,
         imports: [Dir],
         template: `<ng-template dir let-data>{{data}}</ng-template>`,
         changeDetection: ChangeDetectionStrategy.OnPush,
@@ -408,7 +400,6 @@ describe('reactivity', () => {
         const log: number[] = [];
 
         @Component({
-          standalone: true,
           template: '',
         })
         class TestCmp {
@@ -432,9 +423,7 @@ describe('reactivity', () => {
 
       it('should destroy effects when the parent component is destroyed', () => {
         let destroyed = false;
-        @Component({
-          standalone: true,
-        })
+        @Component({})
         class TestCmp {
           constructor() {
             effect((onCleanup) => onCleanup(() => (destroyed = true)));
@@ -450,9 +439,7 @@ describe('reactivity', () => {
 
       it('should destroy effects when their view is destroyed, separately from DestroyRef', () => {
         let destroyed = false;
-        @Component({
-          standalone: true,
-        })
+        @Component({})
         class TestCmp {
           readonly injector = Injector.create({providers: [], parent: inject(Injector)});
 
@@ -470,9 +457,7 @@ describe('reactivity', () => {
 
       it('should destroy effects when their DestroyRef is separately destroyed', () => {
         let destroyed = false;
-        @Component({
-          standalone: true,
-        })
+        @Component({})
         class TestCmp {
           readonly injector = Injector.create({providers: [], parent: inject(Injector)});
 
@@ -502,7 +487,6 @@ describe('reactivity', () => {
     it('should allow writing to signals in ngOnChanges', () => {
       @Component({
         selector: 'with-input',
-        standalone: true,
         template: '{{inSignal()}}',
       })
       class WithInput implements OnChanges {
@@ -518,7 +502,6 @@ describe('reactivity', () => {
 
       @Component({
         selector: 'test-cmp',
-        standalone: true,
         imports: [WithInput],
         template: `<with-input [in]="'A'" />|<with-input [in]="'B'" />`,
       })
@@ -532,7 +515,6 @@ describe('reactivity', () => {
     it('should allow writing to signals in a constructor', () => {
       @Component({
         selector: 'with-constructor',
-        standalone: true,
         template: '{{state()}}',
       })
       class WithConstructor {
@@ -545,7 +527,6 @@ describe('reactivity', () => {
 
       @Component({
         selector: 'test-cmp',
-        standalone: true,
         imports: [WithConstructor],
         template: `<with-constructor />`,
       })
@@ -559,7 +540,6 @@ describe('reactivity', () => {
     it('should allow writing to signals in input setters', () => {
       @Component({
         selector: 'with-input-setter',
-        standalone: true,
         template: '{{state()}}',
       })
       class WithInputSetter {
@@ -573,7 +553,6 @@ describe('reactivity', () => {
 
       @Component({
         selector: 'test-cmp',
-        standalone: true,
         imports: [WithInputSetter],
         template: `
           <with-input-setter [testInput]="'binding'" />|<with-input-setter testInput="static" />
@@ -589,7 +568,6 @@ describe('reactivity', () => {
     it('should allow writing to signals in query result setters', () => {
       @Component({
         selector: 'with-query',
-        standalone: true,
         template: '{{items().length}}',
       })
       class WithQuery {
@@ -603,7 +581,6 @@ describe('reactivity', () => {
 
       @Component({
         selector: 'test-cmp',
-        standalone: true,
         imports: [WithQuery],
         template: `<with-query><div #item></div></with-query>`,
       })
@@ -619,7 +596,6 @@ describe('reactivity', () => {
 
       @Component({
         selector: 'with-query-setter',
-        standalone: true,
         template: '<div #el></div>',
       })
       class WithQuerySetter {
@@ -635,7 +611,6 @@ describe('reactivity', () => {
 
       @Component({
         selector: 'test-cmp',
-        standalone: true,
         template: ``,
       })
       class Cmp {
@@ -668,7 +643,6 @@ describe('reactivity', () => {
     it('should allow toObservable subscription in template (with async pipe)', () => {
       @Component({
         selector: 'test-cmp',
-        standalone: true,
         imports: [AsyncPipe],
         template: '{{counter$ | async}}',
       })
@@ -704,7 +678,6 @@ describe('reactivity', () => {
       it('when created during bootstrapping', () => {
         let log: string[] = [];
         @Component({
-          standalone: true,
           selector: 'test-cmp',
           template: '',
         })
@@ -729,7 +702,6 @@ describe('reactivity', () => {
         let log: string[] = [];
 
         @Component({
-          standalone: true,
           selector: 'test-cmp',
           template: '',
         })
@@ -745,7 +717,6 @@ describe('reactivity', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'driver-cmp',
           imports: [TestCmp],
           template: `
@@ -771,7 +742,6 @@ describe('reactivity', () => {
       it('when created dynamically', () => {
         let log: string[] = [];
         @Component({
-          standalone: true,
           selector: 'test-cmp',
           template: '',
         })
@@ -787,7 +757,6 @@ describe('reactivity', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'driver-cmp',
           template: '',
         })
@@ -820,7 +789,6 @@ describe('reactivity', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'test-cmp',
           template: '',
           providers: [EffectService],
@@ -843,7 +811,6 @@ describe('reactivity', () => {
       it('if multiple effects are created', () => {
         let log: string[] = [];
         @Component({
-          standalone: true,
           selector: 'test-cmp',
           template: '',
         })

--- a/packages/core/test/test_bed_effect_spec.ts
+++ b/packages/core/test/test_bed_effect_spec.ts
@@ -32,7 +32,6 @@ describe('effects in TestBed', () => {
     const log: string[] = [];
     @Component({
       selector: 'test-cmp',
-      standalone: true,
       template: '',
     })
     class Cmp {
@@ -68,7 +67,6 @@ describe('effects in TestBed', () => {
     const log: string[] = [];
     @Component({
       selector: 'test-cmp',
-      standalone: true,
       template: '',
     })
     class Cmp {
@@ -112,7 +110,6 @@ describe('effects in TestBed', () => {
     let observed = '';
     @Component({
       selector: 'test-cmp',
-      standalone: true,
       template: '',
     })
     class Cmp {
@@ -137,7 +134,6 @@ describe('effects in TestBed', () => {
     let observed: string | null = null;
 
     @Component({
-      standalone: true,
       template: '',
     })
     class Cmp {
@@ -163,7 +159,6 @@ describe('effects in TestBed', () => {
     const log: string[] = [];
 
     @Component({
-      standalone: true,
       template: `{{ sentinel }}`,
     })
     class TestCmp {

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -237,21 +237,18 @@ describe('TestBed with Standalone types', () => {
   it('should override dependencies of standalone components', () => {
     @Component({
       selector: 'dep',
-      standalone: true,
       template: 'main dep',
     })
     class MainDep {}
 
     @Component({
       selector: 'dep',
-      standalone: true,
       template: 'mock dep',
     })
     class MockDep {}
 
     @Component({
       selector: 'app-root',
-      standalone: true,
       imports: [MainDep],
       template: '<dep />',
     })
@@ -284,7 +281,6 @@ describe('TestBed with Standalone types', () => {
     const A = new InjectionToken('A');
 
     @Component({
-      standalone: true,
       template: '{{ a }}',
       providers: [{provide: A, useValue: 'A'}],
     })
@@ -316,7 +312,6 @@ describe('TestBed with Standalone types', () => {
 
     @Component({
       selector: 'dep',
-      standalone: true,
       template: '{{ service.id }}',
       providers: [Service],
     })
@@ -325,7 +320,6 @@ describe('TestBed with Standalone types', () => {
     }
 
     @Component({
-      standalone: true,
       template: '<dep />',
       imports: [Dep],
     })
@@ -361,7 +355,6 @@ describe('TestBed with Standalone types', () => {
     class ComponentDependenciesModule {}
 
     @Component({
-      standalone: true,
       template: '{{ a }}',
       imports: [ComponentDependenciesModule],
     })
@@ -388,7 +381,6 @@ describe('TestBed with Standalone types', () => {
     class ComponentDependenciesModule {}
 
     @Component({
-      standalone: true,
       template: '{{ a }}',
       imports: [ComponentDependenciesModule],
     })
@@ -410,7 +402,6 @@ describe('TestBed with Standalone types', () => {
 
   it('should allow overriding a template of a standalone component', () => {
     @Component({
-      standalone: true,
       template: 'Original',
     })
     class MyStandaloneComp {}
@@ -428,7 +419,6 @@ describe('TestBed with Standalone types', () => {
   it('should allow overriding the set of directives and pipes used in a standalone component', () => {
     @Directive({
       selector: '[dir]',
-      standalone: true,
       host: {'[id]': 'id'},
     })
     class MyStandaloneDirectiveA {
@@ -437,7 +427,6 @@ describe('TestBed with Standalone types', () => {
 
     @Directive({
       selector: '[dir]',
-      standalone: true,
       host: {'[id]': 'id'},
     })
     class MyStandaloneDirectiveB {
@@ -458,7 +447,6 @@ describe('TestBed with Standalone types', () => {
     }
 
     @Component({
-      standalone: true,
       template: '<div dir>{{ name | pipe }}</div>',
       imports: [MyStandalonePipeA, MyStandaloneDirectiveA],
     })
@@ -483,7 +471,6 @@ describe('TestBed with Standalone types', () => {
   it('should reflect overrides on imported standalone directive', () => {
     @Directive({
       selector: '[dir]',
-      standalone: true,
       host: {'[id]': 'id'},
     })
     class DepStandaloneDirective {
@@ -492,7 +479,6 @@ describe('TestBed with Standalone types', () => {
 
     @Component({
       selector: 'standalone-cmp',
-      standalone: true,
       template: 'Original MyStandaloneComponent',
     })
     class DepStandaloneComponent {
@@ -500,7 +486,6 @@ describe('TestBed with Standalone types', () => {
     }
 
     @Component({
-      standalone: true,
       template: '<standalone-cmp dir>Hello world!</standalone-cmp>',
       imports: [DepStandaloneDirective, DepStandaloneComponent],
     })
@@ -526,7 +511,6 @@ describe('TestBed with Standalone types', () => {
     const TOKEN_A = new InjectionToken('TOKEN_A');
     @Pipe({
       name: 'testPipe',
-      standalone: true,
     })
     class TestPipe {
       constructor(@Inject(TOKEN_A) private token: string) {}
@@ -544,7 +528,6 @@ describe('TestBed with Standalone types', () => {
 
     @Component({
       selector: 'test-component',
-      standalone: true,
       imports: [TestNgModule],
       template: `{{ 'original value' | testPipe }}`,
     })
@@ -588,7 +571,6 @@ describe('TestBed with Standalone types', () => {
     class TestModule {}
 
     @Component({
-      standalone: true,
       selector: 'app-root',
       template: `<test-cmp #testCmpCtrl></test-cmp>`,
       imports: [TestModule],
@@ -663,7 +645,6 @@ describe('TestBed', () => {
 
   it('should not allow overrides of the `standalone` field', () => {
     @Component({
-      standalone: true,
       selector: 'standalone-comp',
       template: '...',
     })
@@ -1613,7 +1594,6 @@ describe('TestBed', () => {
      * Function returns a class that represents AOT-compiled version of the following Component:
      *
      * @Component({
-     *  standalone: true,
      *  imports: [...],
      *  selector: '...',
      *  template: '...',
@@ -1631,7 +1611,6 @@ describe('TestBed', () => {
       class ComponentClass {
         static ɵfac = () => new ComponentClass();
         static ɵcmp = defineComponent({
-          standalone: true,
           type: ComponentClass,
           selectors: [[selector]],
           decls: 2,
@@ -1665,7 +1644,6 @@ describe('TestBed', () => {
                 args: [
                   {
                     selector,
-                    standalone: true,
                     imports: [...dependencies, ...deferrableSymbols],
                     template: `<div>root cmp!</div>`,
                   },
@@ -1682,7 +1660,6 @@ describe('TestBed', () => {
 
     it('should handle async metadata on root and nested components', async () => {
       @Component({
-        standalone: true,
         selector: 'cmp-a',
         template: 'CmpA!',
       })
@@ -1728,7 +1705,6 @@ describe('TestBed', () => {
       class ThisModuleProvidesService {}
 
       @Component({
-        standalone: true,
         selector: 'child',
         imports: [ThisModuleProvidesService],
         template: '<h1>{{value}}</h1>',
@@ -1739,7 +1715,6 @@ describe('TestBed', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'parent',
         imports: [ChildCmp],
         template: `
@@ -1769,7 +1744,6 @@ describe('TestBed', () => {
                 args: [
                   {
                     selector: 'parent',
-                    standalone: true,
                     imports: [...deferrableSymbols],
                     template: `<div>root cmp!</div>`,
                   },

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -433,13 +433,13 @@ describe('TestBed with Standalone types', () => {
       id = 'B';
     }
 
-    @Pipe({name: 'pipe', standalone: true})
+    @Pipe({name: 'pipe'})
     class MyStandalonePipeA {
       transform(value: string): string {
         return `transformed ${value} (A)`;
       }
     }
-    @Pipe({name: 'pipe', standalone: true})
+    @Pipe({name: 'pipe'})
     class MyStandalonePipeB {
       transform(value: string): string {
         return `transformed ${value} (B)`;
@@ -657,7 +657,7 @@ describe('TestBed', () => {
     })
     class NonStandaloneComponent {}
 
-    @Directive({standalone: true})
+    @Directive({})
     class StandaloneDirective {}
 
     @Directive({
@@ -665,7 +665,7 @@ describe('TestBed', () => {
     })
     class NonStandaloneDirective {}
 
-    @Pipe({standalone: true, name: 'test'})
+    @Pipe({name: 'test'})
     class StandalonePipe {}
 
     @Pipe({
@@ -1611,6 +1611,7 @@ describe('TestBed', () => {
       class ComponentClass {
         static ɵfac = () => new ComponentClass();
         static ɵcmp = defineComponent({
+          standalone: true,
           type: ComponentClass,
           selectors: [[selector]],
           decls: 2,

--- a/packages/core/test/zone/ng_zone_spec.ts
+++ b/packages/core/test/zone/ng_zone_spec.ts
@@ -935,7 +935,6 @@ function commonTests() {
       }
 
       @Component({
-        standalone: true,
         template: `
           <div class="clickable" (click)="clicked = true"></div>
           {{clicked ? 'clicked' : '' }}

--- a/packages/elements/test/component-factory-strategy_spec.ts
+++ b/packages/elements/test/component-factory-strategy_spec.ts
@@ -215,7 +215,6 @@ describe('ComponentFactoryNgElementStrategy', () => {
 
     it('should detect changes even when updated during CD', async () => {
       @Component({
-        standalone: true,
         template: ``,
       })
       class DriverCmp {
@@ -358,7 +357,6 @@ describe('ComponentFactoryNgElementStrategy', () => {
 });
 
 @Directive({
-  standalone: true,
   selector: '[cdTracker]',
 })
 export class CdTrackerDir {
@@ -371,7 +369,6 @@ export class CdTrackerDir {
 
 @Component({
   selector: 'fake-component',
-  standalone: true,
   imports: [CdTrackerDir],
   template: `
     <ng-container cdTracker></ng-container>

--- a/packages/elements/test/create-custom-element-env_spec.ts
+++ b/packages/elements/test/create-custom-element-env_spec.ts
@@ -26,7 +26,6 @@ describe('createCustomElement with env injector', () => {
 
   it('should use provided EnvironmentInjector to create a custom element', async () => {
     @Component({
-      standalone: true,
       template: `Hello, standalone element!`,
     })
     class TestStandaloneCmp {}

--- a/packages/examples/router/testing/test/router_testing_harness_examples.spec.ts
+++ b/packages/examples/router/testing/test/router_testing_harness_examples.spec.ts
@@ -63,7 +63,6 @@ describe('navigate for test examples', () => {
   it('test a ActivatedRoute', async () => {
     // #docregion ActivatedRoute
     @Component({
-      standalone: true,
       imports: [AsyncPipe],
       template: `search: {{ (route.queryParams | async)?.query }}`,
     })

--- a/packages/forms/test/form_builder_spec.ts
+++ b/packages/forms/test/form_builder_spec.ts
@@ -264,7 +264,6 @@ import {of} from 'rxjs';
 
     it('should be injectable', () => {
       @Component({
-        standalone: true,
         template: '...',
       })
       class MyComp {
@@ -291,7 +290,6 @@ import {of} from 'rxjs';
 
     it('should be injectable as NonNullableFormBuilder', () => {
       @Component({
-        standalone: true,
         template: '...',
       })
       class MyComp {

--- a/packages/forms/test/ng_control_status_spec.ts
+++ b/packages/forms/test/ng_control_status_spec.ts
@@ -20,7 +20,6 @@ describe('status host binding classes', () => {
     @Component({
       selector: 'test-cmp',
       template: `<input type="text" [formControl]="control">`,
-      standalone: true,
       imports: [FormsModule, ReactiveFormsModule],
       changeDetection: ChangeDetectionStrategy.OnPush,
     })

--- a/packages/language-service/test/code_fixes_spec.ts
+++ b/packages/language-service/test/code_fixes_spec.ts
@@ -340,7 +340,6 @@ describe('code fixes', () => {
          @Component({
            selector: 'bar',
            template: '<div>bar</div>',
-           standalone: true,
          })
          export class BarComponent {}
          `,
@@ -589,7 +588,6 @@ describe('code fixes', () => {
 
          @Component({
           selector: 'used-cmp',
-          standalone: true,
           template: '',
          })
          export class UsedComponent {}
@@ -604,7 +602,6 @@ describe('code fixes', () => {
               </div>
             </section>
            \`,
-           standalone: true,
            imports: [UnusedDirective, UsedDirective, UnusedPipe, UsedComponent],
          })
          export class AppComponent {}
@@ -640,7 +637,6 @@ describe('code fixes', () => {
 
          @Component({
            template: '',
-           standalone: true,
            imports: [UnusedDirective, UnusedPipe],
          })
          export class AppComponent {}

--- a/packages/language-service/test/code_fixes_spec.ts
+++ b/packages/language-service/test/code_fixes_spec.ts
@@ -246,7 +246,6 @@ describe('code fixes', () => {
          @Component({
            selector: 'foo',
            template: '<bar></bar>',
-           standalone: true
          })
          export class FooComponent {}
          `,
@@ -255,7 +254,6 @@ describe('code fixes', () => {
          @Component({
            selector: 'bar',
            template: '<div>bar</div>',
-           standalone: true
          })
          export class BarComponent {}
          `,
@@ -283,7 +281,6 @@ describe('code fixes', () => {
          @Component({
            selector: 'foo',
            template: '<bar></bar>',
-           standalone: true
          })
          export class FooComponent {}
          `,
@@ -367,7 +364,6 @@ describe('code fixes', () => {
         @Component({
           selector: 'foo',
           template: '{{"hello"|bar}}',
-          standalone: true
         })
         export class FooComponent {}
         `,
@@ -375,7 +371,6 @@ describe('code fixes', () => {
         import {Pipe} from '@angular/core';
         @Pipe({
           name: 'bar',
-          standalone: true
         })
         export class BarPipe implements PipeTransform {
           transform(value: unknown, ...args: unknown[]): unknown {
@@ -408,7 +403,6 @@ describe('code fixes', () => {
          @Component({
            selector: 'foo',
            template: '<bar></bar>',
-           standalone: true
          })
          export class FooComponent {}
          `,
@@ -460,7 +454,6 @@ describe('code fixes', () => {
          @Component({
            selector: 'foo',
            template: '<bar></bar>',
-           standalone: true
          })
          export class FooComponent {}
          `,
@@ -469,7 +462,6 @@ describe('code fixes', () => {
          @Component({
            selector: 'bar',
            template: '<div>bar</div>',
-           standalone: true
          })
          class BarComponent {}
          export default BarComponent;
@@ -499,7 +491,6 @@ describe('code fixes', () => {
          @Component({
            selector: 'foo',
            template: '<bar></bar>',
-           standalone: true
          })
          export class FooComponent {}
          `,
@@ -508,7 +499,6 @@ describe('code fixes', () => {
          @Component({
            selector: 'bar',
            template: '<div>bar</div>',
-           standalone: true
          })
          class BarComponent {}
          export default BarComponent;
@@ -539,7 +529,6 @@ describe('code fixes', () => {
          @Component({
            selector: 'foo',
            template: '<bar></bar>',
-           standalone: true
          })
          export class FooComponent {}
          `,
@@ -548,7 +537,6 @@ describe('code fixes', () => {
          @Component({
            selector: 'bar',
            template: '<div>bar</div>',
-           standalone: true
          })
          class BarComponent {}
          export default BarComponent;
@@ -577,13 +565,13 @@ describe('code fixes', () => {
         'app.ts': `
          import {Component, Directive, Pipe} from '@angular/core';
 
-         @Directive({selector: '[used]', standalone: true})
+         @Directive({selector: '[used]'})
          export class UsedDirective {}
 
-         @Directive({selector: '[unused]', standalone: true})
+         @Directive({selector: '[unused]'})
          export class UnusedDirective {}
 
-         @Pipe({name: 'unused', standalone: true})
+         @Pipe({name: 'unused'})
          export class UnusedPipe {}
 
          @Component({
@@ -629,10 +617,10 @@ describe('code fixes', () => {
         'app.ts': `
          import {Component, Directive, Pipe} from '@angular/core';
 
-         @Directive({selector: '[unused]', standalone: true})
+         @Directive({selector: '[unused]'})
          export class UnusedDirective {}
 
-         @Pipe({name: 'unused', standalone: true})
+         @Pipe({name: 'unused'})
          export class UnusedPipe {}
 
          @Component({

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -1077,7 +1077,6 @@ describe('completions', () => {
           const {templateFile} = setup(`<input dir my>`, '', {
             'Dir': `
               @Directive({
-                standalone: true,
                 inputs: ['myInput']
               })
               export class HostDir {
@@ -1111,7 +1110,6 @@ describe('completions', () => {
           const {templateFile} = setup(`<input dir my>`, '', {
             'Dir': `
               @Directive({
-                standalone: true,
                 inputs: ['myInput']
               })
               export class HostDir {
@@ -1141,7 +1139,6 @@ describe('completions', () => {
           const {templateFile} = setup(`<input dir ali>`, '', {
             'Dir': `
               @Directive({
-                standalone: true,
                 inputs: ['myInput']
               })
               export class HostDir {
@@ -1175,7 +1172,6 @@ describe('completions', () => {
           const {templateFile} = setup(`<input dir ali>`, '', {
             'Dir': `
                   @Directive({
-                    standalone: true,
                     inputs: ['myInput: myPublicInput']
                   })
                   export class HostDir {
@@ -1545,7 +1541,6 @@ describe('completions', () => {
         const {templateFile} = setup(`<input dir (my)>`, '', {
           'Dir': `
             @Directive({
-              standalone: true,
               outputs: ['myOutput']
             })
             export class HostDir {
@@ -1579,7 +1574,6 @@ describe('completions', () => {
         const {templateFile} = setup(`<input dir (my)>`, '', {
           'Dir': `
             @Directive({
-              standalone: true,
               outputs: ['myOutput']
             })
             export class HostDir {
@@ -1608,7 +1602,6 @@ describe('completions', () => {
         const {templateFile} = setup(`<input dir (ali)>`, '', {
           'Dir': `
             @Directive({
-              standalone: true,
               outputs: ['myOutput: myPublicOutput']
             })
             export class HostDir {

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -838,7 +838,7 @@ describe('completions', () => {
         '',
         {},
         `
-        @Component({selector: 'other-cmp', template: 'unimportant', standalone: true})
+        @Component({selector: 'other-cmp', template: 'unimportant'})
         export class OtherCmp {}
       `,
       );

--- a/packages/language-service/test/diagnostic_spec.ts
+++ b/packages/language-service/test/diagnostic_spec.ts
@@ -546,7 +546,6 @@ describe('getSemanticDiagnostics', () => {
       @Component({
         templateUrl: './test.ng.html',
         imports: [PostModule],
-        standalone: true,
       })
       export class Main { }
        `,

--- a/packages/language-service/test/references_and_rename_spec.ts
+++ b/packages/language-service/test/references_and_rename_spec.ts
@@ -1831,7 +1831,6 @@ describe('find references and rename locations', () => {
 
         @Component({
           template: '@if (x; as aliasX) { {{aliasX}} {{aliasX + "second"}} }',
-          standalone: true
         })
         export class AppCmp {
           x?: string;

--- a/packages/language-service/test/type_definitions_spec.ts
+++ b/packages/language-service/test/type_definitions_spec.ts
@@ -66,7 +66,6 @@ describe('type definitions', () => {
 
           @Component({
             templateUrl: 'app.html',
-            standalone: true,
             imports: [MyDir],
           })
           export class AppCmp {}
@@ -102,7 +101,6 @@ describe('type definitions', () => {
 
           @Component({
             templateUrl: 'app.html',
-            standalone: true,
             imports: [MyDir],
           })
           export class AppCmp {
@@ -141,7 +139,6 @@ describe('type definitions', () => {
 
           @Component({
             templateUrl: 'app.html',
-            standalone: true,
             imports: [MyDir],
           })
           export class AppCmp {
@@ -177,7 +174,6 @@ describe('type definitions', () => {
 
         @Component({
           templateUrl: 'app.html',
-          standalone: true,
           imports: [MyDir],
         })
         export class AppCmp {

--- a/packages/language-service/test/type_definitions_spec.ts
+++ b/packages/language-service/test/type_definitions_spec.ts
@@ -58,7 +58,6 @@ describe('type definitions', () => {
 
           @Directive({
             selector: 'my-dir',
-            standalone: true
           })
           export class MyDir {
             firstName = input<string>();
@@ -93,7 +92,6 @@ describe('type definitions', () => {
 
           @Directive({
             selector: 'my-dir',
-            standalone: true
           })
           export class MyDir {
             nameChanges = output<string>();
@@ -131,7 +129,6 @@ describe('type definitions', () => {
 
           @Directive({
             selector: 'my-dir',
-            standalone: true
           })
           export class MyDir {
             nameChanges = outputFromObservable(new EventEmitter<number>());
@@ -166,7 +163,6 @@ describe('type definitions', () => {
 
         @Directive({
           selector: 'my-dir',
-          standalone: true
         })
         export class MyDir {
           twoWayValue = model<string>();

--- a/packages/platform-browser/animations/test/animation_renderer_spec.ts
+++ b/packages/platform-browser/animations/test/animation_renderer_spec.ts
@@ -468,7 +468,7 @@ import {el} from '../../testing/src/browser_util';
           constructor(rendererFactory: RendererFactory2) {}
         }
 
-        @Component({selector: 'app-root', template: 'app-root content', standalone: true})
+        @Component({selector: 'app-root', template: 'app-root content'})
         class AppComponent {}
 
         const appRef = await bootstrapApplication(AppComponent, {
@@ -500,7 +500,7 @@ import {el} from '../../testing/src/browser_util';
     it(
       'should clear bootstrapped component contents when async animations are used',
       withBody('<div>before</div><app-root></app-root><div>after</div>', async () => {
-        @Component({selector: 'app-root', template: 'app-root content', standalone: true})
+        @Component({selector: 'app-root', template: 'app-root content'})
         class AppComponent {}
 
         const appRef = await bootstrapApplication(AppComponent, {

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -77,7 +77,6 @@ export {ApplicationConfig};
  *
  * ```typescript
  * @Component({
- *   standalone: true,
  *   template: 'Hello world!'
  * })
  * class RootComponent {}

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -224,7 +224,6 @@ describe('bootstrap factory method', () => {
     const NAME = new InjectionToken<string>('name');
 
     @Component({
-      standalone: true,
       selector: 'hello-app',
       template: 'Hello from {{ name }}!',
     })
@@ -233,7 +232,6 @@ describe('bootstrap factory method', () => {
     }
 
     @Component({
-      standalone: true,
       selector: 'hello-app-2',
       template: 'Hello from {{ name }}!',
     })
@@ -242,7 +240,6 @@ describe('bootstrap factory method', () => {
     }
 
     @Component({
-      standalone: true,
       selector: 'hello-app',
       template: 'Hello from {{ name }}!',
     })
@@ -376,7 +373,6 @@ describe('bootstrap factory method', () => {
 
     it('should throw when trying to bootstrap a standalone directive', async () => {
       @Directive({
-        standalone: true,
         selector: '[dir]',
       })
       class StandaloneDirective {}
@@ -415,7 +411,6 @@ describe('bootstrap factory method', () => {
       let state: TransferState | undefined;
       @Component({
         selector: 'hello-app',
-        standalone: true,
         template: '...',
       })
       class StandaloneComponent {
@@ -446,7 +441,6 @@ describe('bootstrap factory method', () => {
 
     describe('with animations', () => {
       @Component({
-        standalone: true,
         selector: 'hello-app',
         template:
           '<div @myAnimation (@myAnimation.start)="onStart($event)">Hello from AnimationCmp!</div>',
@@ -509,7 +503,6 @@ describe('bootstrap factory method', () => {
         template: '',
         selector: 'hello-app',
         imports: [SomeModule],
-        standalone: true,
       })
       class AnimationCmp {}
 

--- a/packages/platform-browser/test/browser/bootstrap_standalone_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_standalone_spec.ts
@@ -46,7 +46,6 @@ describe('bootstrapApplication for standalone components', () => {
 
       @Component({
         selector: 'test-app',
-        standalone: true,
         template: `({{testToken}})`,
         imports: [AmbientModule],
       })
@@ -70,7 +69,6 @@ describe('bootstrapApplication for standalone components', () => {
     withBody('<test-app></test-app>', async () => {
       @Component({
         selector: 'test-app',
-        standalone: true,
         template: ``,
       })
       class StandaloneCmp {}
@@ -114,7 +112,6 @@ describe('bootstrapApplication for standalone components', () => {
       @Component({
         selector: 'test-app',
         template: `({{service.ambientToken}})`,
-        standalone: true,
         imports: [AmbientModule],
       })
       class StandaloneCmp {
@@ -143,7 +140,6 @@ describe('bootstrapApplication for standalone components', () => {
       @Component({
         selector: 'test-app',
         template: '...',
-        standalone: true,
         imports: [BrowserModule],
       })
       class StandaloneCmp {}
@@ -177,7 +173,6 @@ describe('bootstrapApplication for standalone components', () => {
       @Component({
         selector: 'test-app',
         template: '...',
-        standalone: true,
         imports: [SomeDependencyModule],
       })
       class StandaloneCmp {}
@@ -216,7 +211,6 @@ describe('bootstrapApplication for standalone components', () => {
 
       @Component({
         selector: 'test-app',
-        standalone: true,
         template: 'Hello',
       })
       class ComponentWithOnDestroy {

--- a/packages/platform-server/test/event_replay_spec.ts
+++ b/packages/platform-server/test/event_replay_spec.ts
@@ -126,7 +126,6 @@ describe('event replay', () => {
 
     @Component({
       selector: 'app',
-      standalone: true,
       template: `
         <button id="btn" (click)="onClick()" #localRef></button>
       `,
@@ -154,7 +153,6 @@ describe('event replay', () => {
     const innerOnClickSpy = jasmine.createSpy();
     @Component({
       selector: 'app-card',
-      standalone: true,
       template: `
         <div class="card">
           <button id="inner-button" (click)="onClick()"></button>
@@ -169,7 +167,6 @@ describe('event replay', () => {
     @Component({
       selector: 'app',
       imports: [CardComponent],
-      standalone: true,
       template: `
         <app-card>
           <h2>Card Title</h2>
@@ -200,7 +197,6 @@ describe('event replay', () => {
 
   it('should remove jsaction attributes, but continue listening to events.', async () => {
     @Component({
-      standalone: true,
       selector: 'app',
       template: `
             <div (click)="onClick()" id="1">
@@ -230,7 +226,6 @@ describe('event replay', () => {
 
   it(`should add 'nonce' attribute to event record script when 'ngCspNonce' is provided`, async () => {
     @Component({
-      standalone: true,
       selector: 'app',
       template: `
             <div (click)="onClick()">
@@ -253,7 +248,6 @@ describe('event replay', () => {
     it('should propagate events', async () => {
       const onClickSpy = jasmine.createSpy();
       @Component({
-        standalone: true,
         selector: 'app',
         template: `
             <div id="top" (click)="onClick()">
@@ -285,7 +279,6 @@ describe('event replay', () => {
 
     it('should not propagate events if stopPropagation is called', async () => {
       @Component({
-        standalone: true,
         selector: 'app',
         template: `
             <div id="top" (click)="onClick($event)">
@@ -321,7 +314,6 @@ describe('event replay', () => {
       let latestTarget: EventTarget | null = null;
       let latestCurrentTarget: EventTarget | null = null;
       @Component({
-        standalone: true,
         selector: 'app',
         template: `
             <div id="top" (click)="onClick($event)">
@@ -362,7 +354,6 @@ describe('event replay', () => {
   describe('event dispatch script', () => {
     it('should not be present on a page when hydration is disabled', async () => {
       @Component({
-        standalone: true,
         selector: 'app',
         template: '<input (click)="onClick()" />',
       })
@@ -380,7 +371,6 @@ describe('event replay', () => {
 
     it('should not be present on a page if there are no events to replay', async () => {
       @Component({
-        standalone: true,
         selector: 'app',
         template: 'Some text',
       })
@@ -407,7 +397,6 @@ describe('event replay', () => {
 
     it('should not replay mouse events', async () => {
       @Component({
-        standalone: true,
         selector: 'app',
         template: '<div (mouseenter)="doThing()"><div>',
       })
@@ -424,7 +413,6 @@ describe('event replay', () => {
 
     it('should not be present on a page where event replay is not enabled', async () => {
       @Component({
-        standalone: true,
         selector: 'app',
         template: '<input (click)="onClick()" />',
       })
@@ -444,7 +432,6 @@ describe('event replay', () => {
 
     it('should be retained if there are events to replay', async () => {
       @Component({
-        standalone: true,
         selector: 'app',
         template: '<input (click)="onClick()" />',
       })

--- a/packages/platform-server/test/full_app_hydration_spec.ts
+++ b/packages/platform-server/test/full_app_hydration_spec.ts
@@ -121,14 +121,12 @@ describe('platform-server full application hydration integration', () => {
     describe('annotations', () => {
       it('should add hydration annotations to component host nodes during ssr', async () => {
         @Component({
-          standalone: true,
           selector: 'nested',
           template: 'This is a nested component.',
         })
         class NestedComponent {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NestedComponent],
           template: `
@@ -146,14 +144,12 @@ describe('platform-server full application hydration integration', () => {
 
       it('should skip local ref slots while producing hydration annotations', async () => {
         @Component({
-          standalone: true,
           selector: 'nested',
           template: 'This is a nested component.',
         })
         class NestedComponent {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NestedComponent],
           template: `
@@ -172,7 +168,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should skip embedded views from an ApplicationRef during annotation', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             <ng-template #tmpl>Hi!</ng-template>
@@ -198,7 +193,6 @@ describe('platform-server full application hydration integration', () => {
     describe('server rendering', () => {
       it('should wipe out existing host element content when server side rendering', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             <div>Some content</div>
@@ -220,7 +214,6 @@ describe('platform-server full application hydration integration', () => {
     describe('hydration', () => {
       it('should remove ngh attributes after hydration on the client', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: 'Hi!',
         })
@@ -244,7 +237,6 @@ describe('platform-server full application hydration integration', () => {
       describe('basic scenarios', () => {
         it('should support text-only contents', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               This is hydrated content.
@@ -270,7 +262,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should hydrate root components with empty templates', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: '',
           })
@@ -294,14 +285,12 @@ describe('platform-server full application hydration integration', () => {
 
         it('should hydrate child components with empty templates', async () => {
           @Component({
-            standalone: true,
             selector: 'child',
             template: '',
           })
           class ChildComponent {}
 
           @Component({
-            standalone: true,
             imports: [ChildComponent],
             selector: 'app',
             template: '<child />',
@@ -326,7 +315,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support a single text interpolation', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               {{ text }}
@@ -354,7 +342,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support text and HTML elements', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               <header>Header</header>
@@ -382,7 +369,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support text and HTML elements in nested components', async () => {
           @Component({
-            standalone: true,
             selector: 'nested-cmp',
             template: `
               <h1>Hello World!</h1>
@@ -392,7 +378,6 @@ describe('platform-server full application hydration integration', () => {
           class NestedComponent {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             imports: [NestedComponent],
             template: `
@@ -431,7 +416,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support elements with local refs', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               <header #headerRef>Header</header>
@@ -459,7 +443,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should handle extra child nodes within a root app component', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               <div>Some content</div>
@@ -489,7 +472,6 @@ describe('platform-server full application hydration integration', () => {
       describe('ng-container', () => {
         it('should support empty containers', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               This is an empty container: <ng-container></ng-container>
@@ -515,7 +497,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support non-empty containers', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               This is a non-empty container:
@@ -545,7 +526,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support nested containers', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               This is a non-empty container:
@@ -589,13 +569,11 @@ describe('platform-server full application hydration integration', () => {
         it('should support element containers with *ngIf', async () => {
           @Component({
             selector: 'cmp',
-            standalone: true,
             template: 'Hi!',
           })
           class Cmp {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             imports: [NgIf],
             template: `
@@ -636,7 +614,6 @@ describe('platform-server full application hydration integration', () => {
         describe('*ngIf', () => {
           it('should work with *ngIf on ng-container nodes', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgIf],
               template: `
@@ -667,7 +644,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should work with empty containers on ng-container nodes', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgIf],
               template: `
@@ -696,7 +672,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should work with *ngIf on element nodes', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgIf],
               template: `
@@ -723,7 +698,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should work with empty containers on element nodes', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgIf],
               template: `
@@ -745,7 +719,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should work with *ngIf on component host nodes', async () => {
             @Component({
-              standalone: true,
               selector: 'nested-cmp',
               imports: [NgIf],
               template: `
@@ -755,7 +728,6 @@ describe('platform-server full application hydration integration', () => {
             class NestedComponent {}
 
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgIf, NestedComponent],
               template: `
@@ -784,7 +756,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should support nested *ngIfs', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgIf],
               template: `
@@ -819,7 +790,6 @@ describe('platform-server full application hydration integration', () => {
         describe('*ngFor', () => {
           it('should support *ngFor on <ng-container> nodes', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgIf, NgFor],
               template: `
@@ -856,7 +826,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should support *ngFor on element nodes', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgIf, NgFor],
               template: `
@@ -893,7 +862,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should support *ngFor on host component nodes', async () => {
             @Component({
-              standalone: true,
               selector: 'nested-cmp',
               imports: [NgIf],
               template: `
@@ -903,7 +871,6 @@ describe('platform-server full application hydration integration', () => {
             class NestedComponent {}
 
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgIf, NgFor, NestedComponent],
               template: `
@@ -938,7 +905,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should support compact serialization for *ngFor', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgIf, NgFor],
               template: `
@@ -981,7 +947,6 @@ describe('platform-server full application hydration integration', () => {
         describe('*ngComponentOutlet', () => {
           it('should support hydration on <ng-container> nodes', async () => {
             @Component({
-              standalone: true,
               selector: 'nested-cmp',
               imports: [NgIf],
               template: `
@@ -991,7 +956,6 @@ describe('platform-server full application hydration integration', () => {
             class NestedComponent {}
 
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgComponentOutlet],
               template: `
@@ -1021,7 +985,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should support hydration on element nodes', async () => {
             @Component({
-              standalone: true,
               selector: 'nested-cmp',
               imports: [NgIf],
               template: `
@@ -1031,7 +994,6 @@ describe('platform-server full application hydration integration', () => {
             class NestedComponent {}
 
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgComponentOutlet],
               template: `
@@ -1062,7 +1024,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should support hydration for nested components', async () => {
             @Component({
-              standalone: true,
               selector: 'nested-cmp',
               imports: [NgIf],
               template: `
@@ -1072,7 +1033,6 @@ describe('platform-server full application hydration integration', () => {
             class NestedComponent {}
 
             @Component({
-              standalone: true,
               selector: 'other-nested-cmp',
               imports: [NgComponentOutlet],
               template: `
@@ -1085,7 +1045,6 @@ describe('platform-server full application hydration integration', () => {
             }
 
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgComponentOutlet],
               template: `
@@ -1117,7 +1076,6 @@ describe('platform-server full application hydration integration', () => {
         describe('*ngTemplateOutlet', () => {
           it('should work with <ng-container>', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgTemplateOutlet],
               template: `
@@ -1147,7 +1105,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should work with element nodes', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgTemplateOutlet],
               template: `
@@ -1180,7 +1137,6 @@ describe('platform-server full application hydration integration', () => {
         describe('ViewContainerRef', () => {
           it('should work with ViewContainerRef.createComponent', async () => {
             @Component({
-              standalone: true,
               selector: 'dynamic',
               template: `
                 <span>This is a content of a dynamic component.</span>
@@ -1189,7 +1145,6 @@ describe('platform-server full application hydration integration', () => {
             class DynamicComponent {}
 
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgIf, NgFor],
               template: `
@@ -1224,7 +1179,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should work with ViewContainerRef.createEmbeddedView', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgIf, NgFor],
               template: `
@@ -1262,7 +1216,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should hydrate dynamically created components using root component as an anchor', async () => {
             @Component({
-              standalone: true,
               imports: [CommonModule],
               selector: 'dynamic',
               template: `
@@ -1272,7 +1225,6 @@ describe('platform-server full application hydration integration', () => {
             class DynamicComponent {}
 
             @Component({
-              standalone: true,
               selector: 'app',
               template: `
                     <main>Hi! This is the main content.</main>
@@ -1310,7 +1262,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should hydrate embedded views when using root component as an anchor', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               template: `
                 <ng-template #tmpl>
@@ -1353,7 +1304,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should hydrate dynamically created components using root component as an anchor', async () => {
             @Component({
-              standalone: true,
               imports: [CommonModule],
               selector: 'nested-dynamic-a',
               template: `
@@ -1363,7 +1313,6 @@ describe('platform-server full application hydration integration', () => {
             class NestedDynamicComponentA {}
 
             @Component({
-              standalone: true,
               imports: [CommonModule],
               selector: 'nested-dynamic-b',
               template: `
@@ -1373,7 +1322,6 @@ describe('platform-server full application hydration integration', () => {
             class NestedDynamicComponentB {}
 
             @Component({
-              standalone: true,
               imports: [CommonModule],
               selector: 'dynamic',
               template: `
@@ -1390,7 +1338,6 @@ describe('platform-server full application hydration integration', () => {
             }
 
             @Component({
-              standalone: true,
               selector: 'app',
               template: `
                     <main>Hi! This is the main content.</main>
@@ -1469,7 +1416,6 @@ describe('platform-server full application hydration integration', () => {
               "another component's host node as an anchor",
             async () => {
               @Component({
-                standalone: true,
                 selector: 'another-dynamic',
                 template: `<span>This is a content of another dynamic component.</span>`,
               })
@@ -1478,7 +1424,6 @@ describe('platform-server full application hydration integration', () => {
               }
 
               @Component({
-                standalone: true,
                 selector: 'dynamic',
                 template: `<span>This is a content of a dynamic component.</span>`,
               })
@@ -1492,7 +1437,6 @@ describe('platform-server full application hydration integration', () => {
               }
 
               @Component({
-                standalone: true,
                 selector: 'app',
                 template: `<main>Hi! This is the main content.</main>`,
               })
@@ -1532,7 +1476,6 @@ describe('platform-server full application hydration integration', () => {
               "another component's host node as an anchor",
             async () => {
               @Component({
-                standalone: true,
                 selector: 'dynamic',
                 template: `
                       <ng-template #tmpl>
@@ -1553,7 +1496,6 @@ describe('platform-server full application hydration integration', () => {
               }
 
               @Component({
-                standalone: true,
                 selector: 'app',
                 template: `<main>Hi! This is the main content.</main>`,
               })
@@ -1594,7 +1536,6 @@ describe('platform-server full application hydration integration', () => {
               '(that is being created) and the first dehydrated view in the list',
             async () => {
               @Component({
-                standalone: true,
                 selector: 'app',
                 template: `
                     <ng-template #tmplH1>
@@ -1661,7 +1602,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should allow injecting ViewContainerRef in the root component', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               template: `Hello World!`,
             })
@@ -1693,7 +1633,6 @@ describe('platform-server full application hydration integration', () => {
         describe('<ng-template>', () => {
           it('should support unused <ng-template>s', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               template: `
                 <ng-template #a>Some content</ng-template>
@@ -1730,7 +1669,6 @@ describe('platform-server full application hydration integration', () => {
         describe('transplanted views', () => {
           it('should work when passing TemplateRef to a different component', async () => {
             @Component({
-              standalone: true,
               imports: [CommonModule],
               selector: 'insertion-component',
               template: `
@@ -1742,7 +1680,6 @@ describe('platform-server full application hydration integration', () => {
             }
 
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [InsertionComponent, CommonModule],
               template: `
@@ -1782,7 +1719,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should append skip hydration flag if component uses i18n blocks and no `withI18nSupport()` call present', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: '<div i18n>Hi!</div>',
           })
@@ -1805,7 +1741,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should not append skip hydration flag if component uses i18n blocks', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
             <div i18n>Hi!</div>
@@ -1821,7 +1756,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should not append skip hydration flag if component uses i18n blocks inside embedded views', async () => {
           @Component({
-            standalone: true,
             imports: [NgIf],
             selector: 'app',
             template: `
@@ -1840,7 +1774,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should not append skip hydration flag if component uses i18n blocks on <ng-container>s', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               <ng-container i18n>Hi!</ng-container>
@@ -1856,7 +1789,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should not append skip hydration flag if component uses i18n blocks (with *ngIfs on <ng-container>s)', async () => {
           @Component({
-            standalone: true,
             imports: [CommonModule],
             selector: 'app',
             template: `
@@ -1878,7 +1810,6 @@ describe('platform-server full application hydration integration', () => {
           });
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `<div i18n>Some <strong>strong</strong> content</div>`,
           })
@@ -1907,14 +1838,12 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support projecting translated content', async () => {
           @Component({
-            standalone: true,
             selector: 'app-content',
             template: `<ng-content select="span"></ng-content><ng-content select="div"></ng-content>`,
           })
           class ContentComponent {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `<div i18n><app-content><div>one</div><span>two</span></app-content></div>`,
             imports: [ContentComponent],
@@ -1944,7 +1873,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should work when i18n content is not projected', async () => {
           @Component({
-            standalone: true,
             selector: 'app-content',
             template: `
               @if (false) {
@@ -1956,7 +1884,6 @@ describe('platform-server full application hydration integration', () => {
           class ContentComponent {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               <app-content>
@@ -1994,14 +1921,12 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support interleaving projected content', async () => {
           @Component({
-            standalone: true,
             selector: 'app-content',
             template: `Start <ng-content select="div" /> Middle <ng-content select="span" /> End`,
           })
           class ContentComponent {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               <app-content i18n>
@@ -2038,14 +1963,12 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support disjoint nodes', async () => {
           @Component({
-            standalone: true,
             selector: 'app-content',
             template: `Start <ng-content select=":not(span)" /> Middle <ng-content select="span" /> End`,
           })
           class ContentComponent {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               <app-content i18n>
@@ -2086,14 +2009,12 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support nested content projection', async () => {
           @Component({
-            standalone: true,
             selector: 'app-content-inner',
             template: `Start <ng-content select=":not(span)" /> Middle <ng-content select="span" /> End`,
           })
           class InnerContentComponent {}
 
           @Component({
-            standalone: true,
             selector: 'app-content-outer',
             template: `<app-content-inner><ng-content /></app-content-inner>`,
             imports: [InnerContentComponent],
@@ -2101,7 +2022,6 @@ describe('platform-server full application hydration integration', () => {
           class OuterContentComponent {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               <app-content-outer i18n>
@@ -2140,14 +2060,12 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support hosting projected content', async () => {
           @Component({
-            standalone: true,
             selector: 'app-content',
             template: `<span i18n>Start <ng-content /> End</span>`,
           })
           class ContentComponent {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `<div><app-content>Middle</app-content></div>`,
             imports: [ContentComponent],
@@ -2177,14 +2095,12 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support projecting multiple elements', async () => {
           @Component({
-            standalone: true,
             selector: 'app-content',
             template: `<ng-content />`,
           })
           class ContentComponent {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               <app-content i18n>
@@ -2220,14 +2136,12 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support disconnecting i18n nodes during projection', async () => {
           @Component({
-            standalone: true,
             selector: 'app-content',
             template: `Start <ng-content select="span" /> End`,
           })
           class ContentComponent {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               <app-content i18n>
@@ -2263,14 +2177,12 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support using translated views as view container anchors', async () => {
           @Component({
-            standalone: true,
             selector: 'dynamic-cmp',
             template: `DynamicComponent content`,
           })
           class DynamicComponent {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `<div i18n><div #target>one</div><span>two</span></div>`,
           })
@@ -2315,7 +2227,6 @@ describe('platform-server full application hydration integration', () => {
           });
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `<div i18n><div>one</div><span>two</span></div>`,
           })
@@ -2349,7 +2260,6 @@ describe('platform-server full application hydration integration', () => {
           });
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `<div i18n>Some {case, plural, other {normal}} content</div>`,
           })
@@ -2384,7 +2294,6 @@ describe('platform-server full application hydration integration', () => {
           });
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `<div i18n>Hello <strong>World</strong>!</div>`,
           })
@@ -2413,7 +2322,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should cleanup dehydrated ICU cases', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `<div i18n>{isServer, select, true { This is a SERVER-ONLY content } false { This is a CLIENT-ONLY content }}</div>`,
           })
@@ -2455,7 +2363,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should hydrate ICUs (simple)', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `<div i18n>{{firstCase}} {firstCase, plural, =1 {item} other {items}}, {{secondCase}} {secondCase, plural, =1 {item} other {items}}</div>`,
           })
@@ -2487,7 +2394,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should hydrate ICUs (nested)', async () => {
           @Component({
-            standalone: true,
             selector: 'simple-component',
             template: `<div i18n>{firstCase, select, 1 {one-{secondCase, select, 1 {one} 2 {two}}} 2 {two-{secondCase, select, 1 {one} 2 {two}}}}</div>`,
           })
@@ -2497,7 +2403,6 @@ describe('platform-server full application hydration integration', () => {
           }
 
           @Component({
-            standalone: true,
             imports: [SimpleComponent],
             selector: 'app',
             template: `
@@ -2534,7 +2439,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should hydrate containers', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
                 <ng-container i18n>
@@ -2572,7 +2476,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should hydrate when using the *ngFor directive', async () => {
           @Component({
-            standalone: true,
             imports: [NgFor],
             selector: 'app',
             template: `
@@ -2610,7 +2513,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should hydrate when using @for control flow', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
                 <ol i18n>
@@ -2653,14 +2555,12 @@ describe('platform-server full application hydration integration', () => {
             });
 
             @Component({
-              standalone: true,
               selector: 'cmp-a',
               template: `<ng-content />`,
             })
             class CmpA {}
 
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [CmpA],
               template: `
@@ -2699,14 +2599,12 @@ describe('platform-server full application hydration integration', () => {
             });
 
             @Component({
-              standalone: true,
               selector: 'cmp-a',
               template: `<ng-content />`,
             })
             class CmpA {}
 
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [CmpA],
               template: `
@@ -2747,7 +2645,6 @@ describe('platform-server full application hydration integration', () => {
       describe('support is disabled', () => {
         it('should append skip hydration flag if component uses i18n blocks', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
             <div i18n>Hi!</div>
@@ -2772,7 +2669,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should keep the skip hydration flag if component uses i18n blocks', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             host: {ngSkipHydration: 'true'},
             template: `
@@ -2798,7 +2694,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should append skip hydration flag if component uses i18n blocks inside embedded views', async () => {
           @Component({
-            standalone: true,
             imports: [NgIf],
             selector: 'app',
             template: `
@@ -2826,7 +2721,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should append skip hydration flag if component uses i18n blocks on <ng-container>s', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               <ng-container i18n>Hi!</ng-container>
@@ -2851,7 +2745,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should append skip hydration flag if component uses i18n blocks (with *ngIfs on <ng-container>s)', async () => {
           @Component({
-            standalone: true,
             imports: [CommonModule],
             selector: 'app',
             template: `
@@ -2877,7 +2770,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should *not* throw when i18n attributes are used', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               <div i18n-title title="Hello world">Hi!</div>
@@ -2906,7 +2798,6 @@ describe('platform-server full application hydration integration', () => {
             'excluded using `ngSkipHydration`',
           async () => {
             @Component({
-              standalone: true,
               selector: 'nested',
               template: `
                 <div i18n>Hi!</div>
@@ -2915,7 +2806,6 @@ describe('platform-server full application hydration integration', () => {
             class NestedComponent {}
 
             @Component({
-              standalone: true,
               imports: [NestedComponent],
               selector: 'app',
               template: `
@@ -2944,7 +2834,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should exclude components with i18n from hydration automatically', async () => {
           @Component({
-            standalone: true,
             selector: 'nested',
             template: `
             <div i18n>Hi!</div>
@@ -2953,7 +2842,6 @@ describe('platform-server full application hydration integration', () => {
           class NestedComponent {}
 
           @Component({
-            standalone: true,
             imports: [NestedComponent],
             selector: 'app',
             template: `
@@ -2986,13 +2874,11 @@ describe('platform-server full application hydration integration', () => {
       it('should not trigger defer blocks on the server', async () => {
         @Component({
           selector: 'my-lazy-cmp',
-          standalone: true,
           template: 'Hi!',
         })
         class MyLazyCmp {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [MyLazyCmp],
           template: `
@@ -3056,21 +2942,18 @@ describe('platform-server full application hydration integration', () => {
       it('should hydrate a placeholder block', async () => {
         @Component({
           selector: 'my-lazy-cmp',
-          standalone: true,
           template: 'Hi!',
         })
         class MyLazyCmp {}
 
         @Component({
           selector: 'my-placeholder-cmp',
-          standalone: true,
           imports: [NgIf],
           template: '<div *ngIf="true">Hi!</div>',
         })
         class MyPlaceholderCmp {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [MyLazyCmp, MyPlaceholderCmp],
           template: `
@@ -3116,21 +2999,18 @@ describe('platform-server full application hydration integration', () => {
       it('should render nothing on the server if no placeholder block is provided', async () => {
         @Component({
           selector: 'my-lazy-cmp',
-          standalone: true,
           template: 'Hi!',
         })
         class MyLazyCmp {}
 
         @Component({
           selector: 'my-placeholder-cmp',
-          standalone: true,
           imports: [NgIf],
           template: '<div *ngIf="true">Hi!</div>',
         })
         class MyPlaceholderCmp {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [MyLazyCmp, MyPlaceholderCmp],
           template: `
@@ -3169,13 +3049,11 @@ describe('platform-server full application hydration integration', () => {
         // when `on viewport` trigger is used for a defer block.
         @Component({
           selector: 'my-lazy-cmp',
-          standalone: true,
           template: 'Hi!',
         })
         class MyLazyCmp {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [MyLazyCmp],
           template: `
@@ -3215,13 +3093,11 @@ describe('platform-server full application hydration integration', () => {
       it('should not hydrate when an entire block in skip hydration section', async () => {
         @Component({
           selector: 'my-lazy-cmp',
-          standalone: true,
           template: 'Hi!',
         })
         class MyLazyCmp {}
 
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: `
              <main>
@@ -3233,14 +3109,12 @@ describe('platform-server full application hydration integration', () => {
 
         @Component({
           selector: 'my-placeholder-cmp',
-          standalone: true,
           imports: [NgIf],
           template: '<div *ngIf="true">Hi!</div>',
         })
         class MyPlaceholderCmp {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [MyLazyCmp, MyPlaceholderCmp, ProjectorCmp],
           template: `
@@ -3293,13 +3167,11 @@ describe('platform-server full application hydration integration', () => {
       it('should not hydrate when a placeholder block in skip hydration section', async () => {
         @Component({
           selector: 'my-lazy-cmp',
-          standalone: true,
           template: 'Hi!',
         })
         class MyLazyCmp {}
 
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: `
              <main>
@@ -3311,14 +3183,12 @@ describe('platform-server full application hydration integration', () => {
 
         @Component({
           selector: 'my-placeholder-cmp',
-          standalone: true,
           imports: [NgIf],
           template: '<div *ngIf="true">Hi!</div>',
         })
         class MyPlaceholderCmp {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [MyLazyCmp, MyPlaceholderCmp, ProjectorCmp],
           template: `
@@ -3372,7 +3242,6 @@ describe('platform-server full application hydration integration', () => {
     describe('ShadowDom encapsulation', () => {
       it('should append skip hydration flag if component uses ShadowDom encapsulation', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           encapsulation: ViewEncapsulation.ShadowDom,
           template: `Hi!`,
@@ -3390,7 +3259,6 @@ describe('platform-server full application hydration integration', () => {
           '(but keep parent and sibling elements hydratable)',
         async () => {
           @Component({
-            standalone: true,
             selector: 'shadow-dom',
             encapsulation: ViewEncapsulation.ShadowDom,
             template: `ShadowDom component`,
@@ -3399,7 +3267,6 @@ describe('platform-server full application hydration integration', () => {
           class ShadowDomComponent {}
 
           @Component({
-            standalone: true,
             selector: 'regular',
             template: `<p>Regular component</p>`,
           })
@@ -3408,7 +3275,6 @@ describe('platform-server full application hydration integration', () => {
           }
 
           @Component({
-            standalone: true,
             selector: 'app',
             imports: [RegularComponent, ShadowDomComponent],
             template: `
@@ -3434,7 +3300,6 @@ describe('platform-server full application hydration integration', () => {
     describe('ngSkipHydration', () => {
       it('should skip hydrating elements with ngSkipHydration attribute', async () => {
         @Component({
-          standalone: true,
           selector: 'nested-cmp',
           template: `
             <h1>Hello World!</h1>
@@ -3446,7 +3311,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NestedComponent],
           template: `
@@ -3477,7 +3341,6 @@ describe('platform-server full application hydration integration', () => {
         'should skip hydrating elements when host element ' + 'has the ngSkipHydration attribute',
         async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
             <main>Main content</main>
@@ -3516,7 +3379,6 @@ describe('platform-server full application hydration integration', () => {
           '(when component with `ngSkipHydration` goes first)',
         async () => {
           @Component({
-            standalone: true,
             selector: 'nested',
             imports: [NgIf],
             template: `
@@ -3526,7 +3388,6 @@ describe('platform-server full application hydration integration', () => {
           class Nested {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             imports: [NgIf, Nested],
             template: `
@@ -3560,7 +3421,6 @@ describe('platform-server full application hydration integration', () => {
           '(view containers with embedded views as projection root nodes)',
         async () => {
           @Component({
-            standalone: true,
             selector: 'regular-cmp',
             template: `
                 <ng-content />
@@ -3569,7 +3429,6 @@ describe('platform-server full application hydration integration', () => {
           class RegularCmp {}
 
           @Component({
-            standalone: true,
             selector: 'deeply-nested',
             host: {ngSkipHydration: 'true'},
             template: `
@@ -3579,7 +3438,6 @@ describe('platform-server full application hydration integration', () => {
           class DeeplyNested {}
 
           @Component({
-            standalone: true,
             selector: 'deeply-nested-wrapper',
             host: {ngSkipHydration: 'true'},
             imports: [RegularCmp],
@@ -3592,7 +3450,6 @@ describe('platform-server full application hydration integration', () => {
           class DeeplyNestedWrapper {}
 
           @Component({
-            standalone: true,
             selector: 'layout',
             imports: [DeeplyNested, DeeplyNestedWrapper],
             template: `
@@ -3606,7 +3463,6 @@ describe('platform-server full application hydration integration', () => {
           class Layout {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             imports: [NgIf, Layout],
             template: `
@@ -3639,14 +3495,12 @@ describe('platform-server full application hydration integration', () => {
           '(view containers with components as projection root nodes)',
         async () => {
           @Component({
-            standalone: true,
             selector: 'dynamic-cmp',
             template: `DynamicComponent content`,
           })
           class DynamicComponent {}
 
           @Component({
-            standalone: true,
             selector: 'regular-cmp',
             template: `
             <ng-content />
@@ -3655,7 +3509,6 @@ describe('platform-server full application hydration integration', () => {
           class RegularCmp {}
 
           @Component({
-            standalone: true,
             selector: 'deeply-nested',
             host: {ngSkipHydration: 'true'},
             template: `
@@ -3665,7 +3518,6 @@ describe('platform-server full application hydration integration', () => {
           class DeeplyNested {}
 
           @Component({
-            standalone: true,
             selector: 'deeply-nested-wrapper',
             host: {ngSkipHydration: 'true'},
             imports: [RegularCmp],
@@ -3678,7 +3530,6 @@ describe('platform-server full application hydration integration', () => {
           class DeeplyNestedWrapper {}
 
           @Component({
-            standalone: true,
             selector: 'layout',
             imports: [DeeplyNested, DeeplyNestedWrapper],
             template: `
@@ -3692,7 +3543,6 @@ describe('platform-server full application hydration integration', () => {
           class Layout {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             imports: [NgIf, Layout],
             template: `
@@ -3739,7 +3589,6 @@ describe('platform-server full application hydration integration', () => {
           '(with ng-containers as projection root nodes)',
         async () => {
           @Component({
-            standalone: true,
             selector: 'regular-cmp',
             template: `
                 <ng-content />
@@ -3748,7 +3597,6 @@ describe('platform-server full application hydration integration', () => {
           class RegularCmp {}
 
           @Component({
-            standalone: true,
             selector: 'deeply-nested',
             host: {ngSkipHydration: 'true'},
             template: `
@@ -3758,7 +3606,6 @@ describe('platform-server full application hydration integration', () => {
           class DeeplyNested {}
 
           @Component({
-            standalone: true,
             selector: 'deeply-nested-wrapper',
             host: {ngSkipHydration: 'true'},
             imports: [RegularCmp],
@@ -3771,7 +3618,6 @@ describe('platform-server full application hydration integration', () => {
           class DeeplyNestedWrapper {}
 
           @Component({
-            standalone: true,
             selector: 'layout',
             imports: [DeeplyNested, DeeplyNestedWrapper],
             template: `
@@ -3785,7 +3631,6 @@ describe('platform-server full application hydration integration', () => {
           class Layout {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             imports: [NgIf, Layout],
             template: `
@@ -3818,7 +3663,6 @@ describe('platform-server full application hydration integration', () => {
           '(when component without `ngSkipHydration` goes first)',
         async () => {
           @Component({
-            standalone: true,
             selector: 'nested',
             imports: [NgIf],
             template: `
@@ -3828,7 +3672,6 @@ describe('platform-server full application hydration integration', () => {
           class Nested {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             imports: [NgIf, Nested],
             template: `
@@ -3859,7 +3702,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should hydrate when the value of an attribute is "ngskiphydration"', async () => {
         @Component({
-          standalone: true,
           selector: 'nested-cmp',
           template: `
             <h1>Hello World!</h1>
@@ -3871,7 +3713,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NestedComponent],
           template: `
@@ -3900,14 +3741,12 @@ describe('platform-server full application hydration integration', () => {
 
       it('should skip hydrating elements with ngSkipHydration host binding', async () => {
         @Component({
-          standalone: true,
           selector: 'second-cmp',
           template: `<div>Not hydrated</div>`,
         })
         class SecondCmd {}
 
         @Component({
-          standalone: true,
           imports: [SecondCmd],
           selector: 'nested-cmp',
           template: `<second-cmp />`,
@@ -3916,7 +3755,6 @@ describe('platform-server full application hydration integration', () => {
         class NestedCmp {}
 
         @Component({
-          standalone: true,
           imports: [NestedCmp],
           selector: 'app',
           template: `
@@ -3943,7 +3781,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should skip hydrating all child content of an element with ngSkipHydration attribute', async () => {
         @Component({
-          standalone: true,
           selector: 'nested-cmp',
           template: `
               <h1>Hello World!</h1>
@@ -3955,7 +3792,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NestedComponent],
           template: `
@@ -3987,7 +3823,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should skip hydrating when ng-containers exist and ngSkipHydration attribute is present', async () => {
         @Component({
-          standalone: true,
           selector: 'nested-cmp',
           template: `
               <h1>Hello World!</h1>
@@ -3997,7 +3832,6 @@ describe('platform-server full application hydration integration', () => {
         class NestedComponent {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NestedComponent],
           template: `
@@ -4037,7 +3871,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should skip hydrating and safely allow DOM manipulation inside block that was skipped', async () => {
         @Component({
-          standalone: true,
           selector: 'nested-cmp',
           template: `
               <h1>Hello World!</h1>
@@ -4055,7 +3888,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NestedComponent],
           template: `
@@ -4085,7 +3917,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should skip hydrating and safely allow adding and removing DOM nodes inside block that was skipped', async () => {
         @Component({
-          standalone: true,
           selector: 'nested-cmp',
           template: `
               <h1>Hello World!</h1>
@@ -4106,7 +3937,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NestedComponent],
           template: `
@@ -4136,7 +3966,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should skip hydrating elements with ngSkipHydration attribute on ViewContainerRef host', async () => {
         @Component({
-          standalone: true,
           selector: 'nested-cmp',
           template: `<p>Just some text</p>`,
         })
@@ -4154,7 +3983,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           imports: [NestedComponent],
           template: `
@@ -4168,7 +3996,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp],
           selector: 'app',
           template: `
@@ -4199,7 +4026,6 @@ describe('platform-server full application hydration integration', () => {
           'which is not a component host',
         async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
                 <header ngSkipHydration>Header</header>
@@ -4233,14 +4059,12 @@ describe('platform-server full application hydration integration', () => {
           'which is not a component host (when using host bindings)',
         async () => {
           @Directive({
-            standalone: true,
             selector: '[dir]',
             host: {ngSkipHydration: 'true'},
           })
           class Dir {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             imports: [Dir],
             template: `
@@ -4277,7 +4101,6 @@ describe('platform-server full application hydration integration', () => {
     describe('corrupted text nodes restoration', () => {
       it('should support empty text nodes', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             This is hydrated content.
@@ -4313,7 +4136,6 @@ describe('platform-server full application hydration integration', () => {
           '(when interpolation is on a new line)',
         async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
                 <div>
@@ -4354,7 +4176,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should not treat text nodes with `&nbsp`s as empty', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             <div>&nbsp;{{ text }}&nbsp;</div>
@@ -4391,7 +4212,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should support restoration of multiple text nodes in a row', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             This is hydrated content.<span>{{emptyText}}{{moreText}}{{andMoreText}}</span>.
@@ -4424,7 +4244,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should support projected text node content with plain text nodes', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NgIf],
           template: `
@@ -4457,7 +4276,6 @@ describe('platform-server full application hydration integration', () => {
     describe('post-hydration cleanup', () => {
       it('should cleanup unclaimed views in a component (when using elements)', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NgIf],
           template: `
@@ -4504,7 +4322,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should cleanup unclaimed views in a component (when using <ng-container>s)', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NgIf],
           template: `
@@ -4554,7 +4371,6 @@ describe('platform-server full application hydration integration', () => {
           'root component is used as an anchor for ViewContainerRef',
         async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             imports: [NgIf],
             template: `
@@ -4633,7 +4449,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should cleanup within inner containers', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NgIf],
           template: `
@@ -4687,7 +4502,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should reconcile *ngFor-generated views', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NgIf, NgFor],
           template: `
@@ -4739,7 +4553,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should cleanup dehydrated views within dynamically created components', async () => {
         @Component({
-          standalone: true,
           imports: [CommonModule],
           selector: 'dynamic',
           template: `
@@ -4757,7 +4570,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NgIf, NgFor],
           template: `
@@ -4808,7 +4620,6 @@ describe('platform-server full application hydration integration', () => {
         const observedChildCountLog: number[] = [];
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NgIf],
           template: `
@@ -4851,7 +4662,6 @@ describe('platform-server full application hydration integration', () => {
         const observedChildCountLog: number[] = [];
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NgIf],
           template: `
@@ -4904,7 +4714,6 @@ describe('platform-server full application hydration integration', () => {
     describe('content projection', () => {
       it('should project plain text', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: `
             <main>
@@ -4915,7 +4724,6 @@ describe('platform-server full application hydration integration', () => {
         class ProjectorCmp {}
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp],
           selector: 'app',
           template: `
@@ -4951,7 +4759,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should allow re-projection of child content', async () => {
         @Component({
-          standalone: true,
           selector: 'mat-step',
           template: `<ng-template><ng-content /></ng-template>`,
         })
@@ -4960,7 +4767,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'mat-stepper',
           imports: [NgTemplateOutlet],
           template: `
@@ -4974,14 +4780,12 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'nested-cmp',
           template: 'Nested cmp content',
         })
         class NestedCmp {}
 
         @Component({
-          standalone: true,
           imports: [MatStepper, MatStep, NgIf, NestedCmp],
           selector: 'app',
           template: `
@@ -5038,7 +4842,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should project plain text and HTML elements', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: `
             <main>
@@ -5049,7 +4852,6 @@ describe('platform-server full application hydration integration', () => {
         class ProjectorCmp {}
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp],
           selector: 'app',
           template: `
@@ -5079,7 +4881,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should support re-projection of contents', async () => {
         @Component({
-          standalone: true,
           selector: 'reprojector-cmp',
           template: `
             <main>
@@ -5090,7 +4891,6 @@ describe('platform-server full application hydration integration', () => {
         class ReprojectorCmp {}
 
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           imports: [ReprojectorCmp],
           template: `
@@ -5104,7 +4904,6 @@ describe('platform-server full application hydration integration', () => {
         class ProjectorCmp {}
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp],
           selector: 'app',
           template: `
@@ -5133,7 +4932,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle multiple nodes projected in a single slot', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: `
             <ng-content select="foo" />
@@ -5149,7 +4947,6 @@ describe('platform-server full application hydration integration', () => {
         class BarCmp {}
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp, FooCmp, BarCmp],
           selector: 'app',
           template: `
@@ -5180,7 +4977,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle multiple nodes projected in a single slot (different order)', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: `
             <ng-content select="foo" />
@@ -5196,7 +4992,6 @@ describe('platform-server full application hydration integration', () => {
         class BarCmp {}
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp, FooCmp, BarCmp],
           selector: 'app',
           template: `
@@ -5227,7 +5022,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle empty projection slots within <ng-container>', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           imports: [CommonModule],
           template: `
@@ -5243,7 +5037,6 @@ describe('platform-server full application hydration integration', () => {
         class ProjectorCmp {}
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp],
           selector: 'app',
           template: `
@@ -5273,7 +5066,6 @@ describe('platform-server full application hydration integration', () => {
           '(when no other elements are present)',
         async () => {
           @Component({
-            standalone: true,
             selector: 'projector-cmp',
             imports: [CommonModule],
             template: `
@@ -5286,7 +5078,6 @@ describe('platform-server full application hydration integration', () => {
           class ProjectorCmp {}
 
           @Component({
-            standalone: true,
             imports: [ProjectorCmp],
             selector: 'app',
             template: `
@@ -5317,7 +5108,6 @@ describe('platform-server full application hydration integration', () => {
           '(when no other elements are present)',
         async () => {
           @Component({
-            standalone: true,
             selector: 'projector-cmp',
             template: `
               <ng-content select="[left]"></ng-content>
@@ -5327,7 +5117,6 @@ describe('platform-server full application hydration integration', () => {
           class ProjectorCmp {}
 
           @Component({
-            standalone: true,
             imports: [ProjectorCmp],
             selector: 'app',
             template: `
@@ -5355,7 +5144,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should project contents into different slots', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: `
             <div>
@@ -5369,7 +5157,6 @@ describe('platform-server full application hydration integration', () => {
         class ProjectorCmp {}
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp],
           selector: 'app',
           template: `
@@ -5403,7 +5190,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle view container nodes that go after projection slots', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           imports: [CommonModule],
           template: `
@@ -5418,7 +5204,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp],
           selector: 'app',
           template: `
@@ -5448,7 +5233,6 @@ describe('platform-server full application hydration integration', () => {
           '(when view container host node is <ng-container>)',
         async () => {
           @Component({
-            standalone: true,
             selector: 'projector-cmp',
             imports: [CommonModule],
             template: `
@@ -5463,7 +5247,6 @@ describe('platform-server full application hydration integration', () => {
           }
 
           @Component({
-            standalone: true,
             imports: [ProjectorCmp],
             selector: 'app',
             template: `
@@ -5492,7 +5275,6 @@ describe('platform-server full application hydration integration', () => {
       describe('partial projection', () => {
         it('should support cases when some element nodes are not projected', async () => {
           @Component({
-            standalone: true,
             selector: 'projector-cmp',
             template: `
               <div>
@@ -5506,7 +5288,6 @@ describe('platform-server full application hydration integration', () => {
           class ProjectorCmp {}
 
           @Component({
-            standalone: true,
             imports: [ProjectorCmp],
             selector: 'app',
             template: `
@@ -5540,14 +5321,12 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support cases when some element nodes are not projected', async () => {
           @Component({
-            standalone: true,
             selector: 'app-dropdown-content',
             template: `<ng-content />`,
           })
           class DropdownContentComponent {}
 
           @Component({
-            standalone: true,
             selector: 'app-dropdown',
             template: `
               @if (false) {
@@ -5558,7 +5337,6 @@ describe('platform-server full application hydration integration', () => {
           class DropdownComponent {}
 
           @Component({
-            standalone: true,
             imports: [DropdownComponent, DropdownContentComponent],
             selector: 'app-menu',
             template: `
@@ -5573,7 +5351,6 @@ describe('platform-server full application hydration integration', () => {
 
           @Component({
             selector: 'app',
-            standalone: true,
             imports: [MenuComponent],
             template: `
               <app-menu>
@@ -5606,14 +5383,12 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support cases when view containers are not projected', async () => {
           @Component({
-            standalone: true,
             selector: 'projector-cmp',
             template: `No content projection slots.`,
           })
           class ProjectorCmp {}
 
           @Component({
-            standalone: true,
             imports: [ProjectorCmp],
             selector: 'app',
             template: `
@@ -5645,21 +5420,18 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support cases when component nodes are not projected', async () => {
           @Component({
-            standalone: true,
             selector: 'projector-cmp',
             template: `No content projection slots.`,
           })
           class ProjectorCmp {}
 
           @Component({
-            standalone: true,
             selector: 'nested',
             template: 'This is a nested component.',
           })
           class NestedComponent {}
 
           @Component({
-            standalone: true,
             imports: [ProjectorCmp, NestedComponent],
             selector: 'app',
             template: `
@@ -5691,7 +5463,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support cases when component nodes are not projected in nested components', async () => {
           @Component({
-            standalone: true,
             selector: 'projector-cmp',
             template: `
                 <main>
@@ -5702,14 +5473,12 @@ describe('platform-server full application hydration integration', () => {
           class ProjectorCmp {}
 
           @Component({
-            standalone: true,
             selector: 'nested',
             template: 'No content projection slots.',
           })
           class NestedComponent {}
 
           @Component({
-            standalone: true,
             imports: [ProjectorCmp, NestedComponent],
             selector: 'app',
             template: `
@@ -5742,7 +5511,6 @@ describe('platform-server full application hydration integration', () => {
 
       it("should project contents with *ngIf's", async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: `
             <main>
@@ -5753,7 +5521,6 @@ describe('platform-server full application hydration integration', () => {
         class ProjectorCmp {}
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp, CommonModule],
           selector: 'app',
           template: `
@@ -5784,7 +5551,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should project contents with *ngFor', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: `
             <main>
@@ -5795,7 +5561,6 @@ describe('platform-server full application hydration integration', () => {
         class ProjectorCmp {}
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp, CommonModule],
           selector: 'app',
           template: `
@@ -5826,7 +5591,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should support projecting contents outside of a current host element', async () => {
         @Component({
-          standalone: true,
           selector: 'dynamic-cmp',
           template: `<div #target></div>`,
         })
@@ -5839,7 +5603,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: `
             <ng-template #ref>
@@ -5878,7 +5641,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp, CommonModule],
           selector: 'app',
           template: `
@@ -5917,21 +5679,18 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle projected containers inside other containers', async () => {
         @Component({
-          standalone: true,
           selector: 'child-comp',
           template: '<ng-content />',
         })
         class ChildComp {}
 
         @Component({
-          standalone: true,
           selector: 'root-comp',
           template: '<ng-content />',
         })
         class RootComp {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [CommonModule, RootComp, ChildComp],
           template: `
@@ -5964,7 +5723,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should throw an error when projecting DOM nodes via ViewContainerRef.createComponent API', async () => {
         @Component({
-          standalone: true,
           selector: 'dynamic',
           template: `
               <ng-content />
@@ -5974,7 +5732,6 @@ describe('platform-server full application hydration integration', () => {
         class DynamicComponent {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NgIf, NgFor],
           template: `
@@ -6017,7 +5774,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should throw an error when projecting DOM nodes via createComponent function call', async () => {
         @Component({
-          standalone: true,
           selector: 'dynamic',
           template: `
               <ng-content />
@@ -6027,7 +5783,6 @@ describe('platform-server full application hydration integration', () => {
         class DynamicComponent {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NgIf, NgFor],
           template: `
@@ -6072,7 +5827,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should support cases when <ng-content> is used with *ngIf="false"', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           imports: [NgIf],
           template: `
@@ -6085,7 +5839,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp],
           selector: 'app',
           template: `
@@ -6137,7 +5890,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should support cases when <ng-content> is used with *ngIf="true"', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           imports: [NgIf],
           template: `
@@ -6150,7 +5902,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp],
           selector: 'app',
           template: `
@@ -6202,7 +5953,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should support slots with fallback content', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: `
             <div>
@@ -6218,7 +5968,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp],
           selector: 'app',
           template: `<projector-cmp></projector-cmp>`,
@@ -6248,7 +5997,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should support mixed slots with and without fallback content', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: `
             <div>
@@ -6264,7 +6012,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp],
           selector: 'app',
           template: `
@@ -6307,7 +6054,6 @@ describe('platform-server full application hydration integration', () => {
     describe('unsupported Zone.js config', () => {
       it('should log a warning when a noop zone is used', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `Hi!`,
         })
@@ -6340,7 +6086,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should log a warning when a custom zone is used', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `Hi!`,
         })
@@ -6377,7 +6122,6 @@ describe('platform-server full application hydration integration', () => {
     describe('error handling', () => {
       it('should handle text node mismatch', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
         <div id="abc">This is an original content</div>
@@ -6414,7 +6158,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should not crash when a node can not be found during hydration', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
         Some text.
@@ -6453,7 +6196,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle element node mismatch', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
         <div id="abc">
@@ -6493,7 +6235,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle <ng-container> node mismatch', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
         <b>Bold text</b>
@@ -6536,7 +6277,6 @@ describe('platform-server full application hydration integration', () => {
           '(when it is wrapped into a non-container node)',
         async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
           <div id="abc" class="wrapper">
@@ -6578,7 +6318,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle <ng-template> node mismatch', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [CommonModule],
           template: `
@@ -6619,7 +6358,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle node mismatches in nested components', async () => {
         @Component({
-          standalone: true,
           selector: 'nested-cmp',
           imports: [CommonModule],
           template: `
@@ -6639,7 +6377,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NestedComponent],
           template: `<nested-cmp />`,
@@ -6669,7 +6406,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle sibling count mismatch', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [CommonModule],
           template: `
@@ -6709,7 +6445,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle ViewContainerRef node mismatch', async () => {
         @Directive({
-          standalone: true,
           selector: 'b',
         })
         class SimpleDir {
@@ -6717,7 +6452,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [CommonModule, SimpleDir],
           template: `
@@ -6757,7 +6491,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle a mismatch for a node that goes after a ViewContainerRef node', async () => {
         @Directive({
-          standalone: true,
           selector: 'b',
         })
         class SimpleDir {
@@ -6765,7 +6498,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [CommonModule, SimpleDir],
           template: `
@@ -6805,14 +6537,12 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle a case when a node is not found (removed)', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: '<ng-content />',
         })
         class ProjectorComponent {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [CommonModule, ProjectorComponent],
           template: `
@@ -6844,14 +6574,12 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle a case when a node is not found (detached)', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: '<ng-content />',
         })
         class ProjectorComponent {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [CommonModule, ProjectorComponent],
           template: `
@@ -6892,7 +6620,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle a case when a node is not found (invalid DOM)', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [CommonModule],
           template: `
@@ -6933,7 +6660,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should log a warning when there was no hydration info in the TransferState', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `Hi!`,
         })
@@ -6975,7 +6701,6 @@ describe('platform-server full application hydration integration', () => {
           'but a client mode marker is present',
         async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `Hi!`,
           })
@@ -7002,7 +6727,6 @@ describe('platform-server full application hydration integration', () => {
     describe('@if', () => {
       it('should work with `if`s that have different value on the client and on the server', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
               @if (isServer) { <b>This is a SERVER-ONLY content</b> }
@@ -7060,7 +6784,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should support nested `if`s', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             This is a non-empty block:
@@ -7096,7 +6819,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should hydrate `else` blocks', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             @if (conditionA) {
@@ -7146,7 +6868,6 @@ describe('platform-server full application hydration integration', () => {
     describe('@switch', () => {
       it('should work with `switch`es that have different value on the client and on the server', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
               @switch (isServer) {
@@ -7197,7 +6918,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should cleanup rendered case if none of the cases match on the client', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
               @switch (label) {
@@ -7248,7 +6968,6 @@ describe('platform-server full application hydration integration', () => {
     describe('@for', () => {
       it('should hydrate for loop content', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             @for (item of items; track item) {
@@ -7285,7 +7004,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should hydrate @empty block content', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             @for (item of items; track item) {
@@ -7320,7 +7038,6 @@ describe('platform-server full application hydration integration', () => {
           'on the server and main content on the client',
         async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
                 @for (item of items; track item) {
@@ -7372,7 +7089,6 @@ describe('platform-server full application hydration integration', () => {
           'on the client and main content on the server',
         async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               @for (item of items; track item) {
@@ -7421,7 +7137,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle different number of items rendered on the client and on the server', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
                 @for (item of items; track item) {
@@ -7474,7 +7189,6 @@ describe('platform-server full application hydration integration', () => {
       it('should handle a reconciliation with swaps', async () => {
         @Component({
           selector: 'app',
-          standalone: true,
           template: `
                 @for(item of items; track item) {
                   <div>{{ item }}</div>
@@ -7523,7 +7237,6 @@ describe('platform-server full application hydration integration', () => {
     describe('@let', () => {
       it('should handle a let declaration', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             @let greeting = name + '!!!';
@@ -7558,7 +7271,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle multiple let declarations that depend on each other', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             @let plusOne = value + 1;
@@ -7597,7 +7309,6 @@ describe('platform-server full application hydration integration', () => {
       it('should handle a let declaration using a pipe that injects ChangeDetectorRef', async () => {
         @Pipe({
           name: 'double',
-          standalone: true,
         })
         class DoublePipe implements PipeTransform {
           changeDetectorRef = inject(ChangeDetectorRef);
@@ -7608,7 +7319,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [DoublePipe],
           template: `
@@ -7644,7 +7354,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle let declarations referenced through multiple levels of views', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             @if (true) {
@@ -7692,12 +7401,10 @@ describe('platform-server full application hydration integration', () => {
             <ng-content>Fallback content</ng-content>
             <ng-content select="footer">Fallback footer</ng-content>
           `,
-          standalone: true,
         })
         class InnerComponent {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             <inner>
@@ -7735,7 +7442,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle let declaration before and directly inside of an embedded view', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             @let before = 'before';
@@ -7767,7 +7473,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle let declaration before, directly inside of and after an embedded view', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             @let before = 'before';
@@ -7801,7 +7506,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle let declaration with array inside of an embedded view', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             @let foo = ['foo'];
@@ -7834,7 +7538,6 @@ describe('platform-server full application hydration integration', () => {
     describe('zoneless', () => {
       it('should not produce "unsupported configuration" warnings for zoneless mode', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             <header>Header</header>
@@ -7877,7 +7580,6 @@ describe('platform-server full application hydration integration', () => {
         const ngZone = TestBed.inject(NgZone);
 
         @Component({
-          standalone: true,
           selector: 'lazy',
           template: `LazyCmp content`,
         })
@@ -7897,7 +7599,6 @@ describe('platform-server full application hydration integration', () => {
         ];
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [RouterOutlet],
           template: `
@@ -7938,7 +7639,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should cleanup dehydrated views in routed components that use ViewContainerRef', async () => {
         @Component({
-          standalone: true,
           selector: 'cmp-a',
           template: `
             @if (isServer) {
@@ -7961,7 +7661,6 @@ describe('platform-server full application hydration integration', () => {
         ];
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [RouterOutlet],
           template: `

--- a/packages/platform-server/test/full_app_hydration_spec.ts
+++ b/packages/platform-server/test/full_app_hydration_spec.ts
@@ -4940,10 +4940,10 @@ describe('platform-server full application hydration integration', () => {
         })
         class ProjectorCmp {}
 
-        @Component({selector: 'foo', standalone: true, template: ''})
+        @Component({selector: 'foo', template: ''})
         class FooCmp {}
 
-        @Component({selector: 'bar', standalone: true, template: ''})
+        @Component({selector: 'bar', template: ''})
         class BarCmp {}
 
         @Component({
@@ -4985,10 +4985,10 @@ describe('platform-server full application hydration integration', () => {
         })
         class ProjectorCmp {}
 
-        @Component({selector: 'foo', standalone: true, template: ''})
+        @Component({selector: 'foo', template: ''})
         class FooCmp {}
 
-        @Component({selector: 'bar', standalone: true, template: ''})
+        @Component({selector: 'bar', template: ''})
         class BarCmp {}
 
         @Component({

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -949,7 +949,6 @@ class HiddenModule {}
 
         it('appends SSR integrity marker comment when hydration is enabled', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: ``,
           })
@@ -1255,7 +1254,6 @@ class HiddenModule {}
         const ngZone = TestBed.inject(NgZone);
 
         @Component({
-          standalone: true,
           selector: 'lazy',
           template: `LazyCmp content`,
         })

--- a/packages/router/src/components/empty_outlet.ts
+++ b/packages/router/src/components/empty_outlet.ts
@@ -25,7 +25,6 @@ export {ɵEmptyOutletComponent as EmptyOutletComponent};
 @Component({
   template: `<router-outlet></router-outlet>`,
   imports: [RouterOutlet],
-  standalone: true,
 })
 export class ɵEmptyOutletComponent {}
 

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -134,7 +134,6 @@ import {RuntimeErrorCode} from '../errors';
  */
 @Directive({
   selector: '[routerLink]',
-  standalone: true,
 })
 export class RouterLink implements OnChanges, OnDestroy {
   /**

--- a/packages/router/src/directives/router_link_active.ts
+++ b/packages/router/src/directives/router_link_active.ts
@@ -103,7 +103,6 @@ import {RouterLink} from './router_link';
 @Directive({
   selector: '[routerLinkActive]',
   exportAs: 'routerLinkActive',
-  standalone: true,
 })
 export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit {
   @ContentChildren(RouterLink, {descendants: true}) links!: QueryList<RouterLink>;

--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -206,7 +206,6 @@ export interface RouterOutletContract {
 @Directive({
   selector: 'router-outlet',
   exportAs: 'outlet',
-  standalone: true,
 })
 export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
   private activated: ComponentRef<any> | null = null;

--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -150,7 +150,6 @@ describe('bootstrap', () => {
   it('should finish navigation when initial navigation is enabledBlocking and component renavigates on render', async () => {
     @Component({
       template: '',
-      standalone: true,
     })
     class Renavigate {
       constructor(router: Router) {
@@ -159,7 +158,6 @@ describe('bootstrap', () => {
     }
     @Component({
       template: '',
-      standalone: true,
     })
     class BlankCmp {}
 

--- a/packages/router/test/create_url_tree.spec.ts
+++ b/packages/router/test/create_url_tree.spec.ts
@@ -642,7 +642,6 @@ describe('createUrlTreeFromSnapshot', async () => {
   it('can create a UrlTree relative to empty path named parent', fakeAsync(() => {
     @Component({
       template: `<router-outlet></router-outlet>`,
-      standalone: true,
       imports: [RouterModule],
     })
     class MainPageComponent {
@@ -666,7 +665,6 @@ describe('createUrlTreeFromSnapshot', async () => {
 
     @Component({
       template: '<router-outlet name="main-page"></router-outlet>',
-      standalone: true,
       imports: [RouterModule],
     })
     class RootCmp {}
@@ -702,7 +700,6 @@ describe('createUrlTreeFromSnapshot', async () => {
 
     @Component({
       template: `main`,
-      standalone: true,
       imports: [RouterModule],
     })
     class GuardedComponent {}
@@ -712,7 +709,6 @@ describe('createUrlTreeFromSnapshot', async () => {
 
     @Component({
       template: '<router-outlet></router-outlet>',
-      standalone: true,
       imports: [RouterModule],
     })
     class RootCmp {}

--- a/packages/router/test/create_url_tree.spec.ts
+++ b/packages/router/test/create_url_tree.spec.ts
@@ -704,7 +704,7 @@ describe('createUrlTreeFromSnapshot', async () => {
     })
     class GuardedComponent {}
 
-    @Component({template: 'sibling', standalone: true})
+    @Component({template: 'sibling'})
     class SiblingComponent {}
 
     @Component({

--- a/packages/router/test/default_export_component.ts
+++ b/packages/router/test/default_export_component.ts
@@ -9,7 +9,6 @@
 import {Component} from '@angular/core';
 
 @Component({
-  standalone: true,
   template: 'default exported',
   selector: 'test-route',
 })

--- a/packages/router/test/default_export_routes.ts
+++ b/packages/router/test/default_export_routes.ts
@@ -10,7 +10,6 @@ import {Component} from '@angular/core';
 import {Routes} from '@angular/router';
 
 @Component({
-  standalone: true,
   template: 'default exported',
   selector: 'test-route',
 })

--- a/packages/router/test/directives/router_outlet.spec.ts
+++ b/packages/router/test/directives/router_outlet.spec.ts
@@ -31,7 +31,6 @@ import {InjectionToken} from '../../../core/src/di';
 describe('router outlet name', () => {
   it('should support name binding', fakeAsync(() => {
     @Component({
-      standalone: true,
       template: '<router-outlet [name]="name"></router-outlet>',
       imports: [RouterOutlet],
     })
@@ -41,7 +40,6 @@ describe('router outlet name', () => {
 
     @Component({
       template: 'popup component',
-      standalone: true,
     })
     class PopupCmp {}
 
@@ -55,7 +53,6 @@ describe('router outlet name', () => {
 
   it('should be able to change the name of the outlet', fakeAsync(() => {
     @Component({
-      standalone: true,
       template: '<router-outlet [name]="name"></router-outlet>',
       imports: [RouterOutlet],
     })
@@ -65,13 +62,11 @@ describe('router outlet name', () => {
 
     @Component({
       template: 'hello world',
-      standalone: true,
     })
     class GreetingCmp {}
 
     @Component({
       template: 'goodbye cruel world',
-      standalone: true,
     })
     class FarewellCmp {}
 
@@ -102,7 +97,6 @@ describe('router outlet name', () => {
 
   it('should support outlets in ngFor', fakeAsync(() => {
     @Component({
-      standalone: true,
       template: `
             <div *ngFor="let outlet of outlets">
                 <router-outlet [name]="outlet"></router-outlet>
@@ -116,19 +110,16 @@ describe('router outlet name', () => {
 
     @Component({
       template: 'component 1',
-      standalone: true,
     })
     class Cmp1 {}
 
     @Component({
       template: 'component 2',
-      standalone: true,
     })
     class Cmp2 {}
 
     @Component({
       template: 'component 3',
-      standalone: true,
     })
     class Cmp3 {}
 
@@ -164,7 +155,6 @@ describe('router outlet name', () => {
 
   it('should not activate if route is changed', fakeAsync(() => {
     @Component({
-      standalone: true,
       template: '<div *ngIf="initDone"><router-outlet></router-outlet></div>',
       imports: [RouterOutlet, CommonModule],
     })
@@ -177,7 +167,6 @@ describe('router outlet name', () => {
 
     @Component({
       template: 'child component',
-      standalone: true,
     })
     class ChildCmp {}
 
@@ -362,7 +351,6 @@ describe('component input binding', () => {
   it('Should have inputs available to all outlets after navigation', async () => {
     @Component({
       template: '{{myInput}}',
-      standalone: true,
     })
     class MyComponent {
       @Input() myInput?: string;
@@ -371,7 +359,6 @@ describe('component input binding', () => {
     @Component({
       template: '<router-outlet/>',
       imports: [RouterOutlet],
-      standalone: true,
     })
     class OutletWrapper {}
 
@@ -403,7 +390,6 @@ describe('injectors', () => {
 
     @Component({
       template: '',
-      standalone: true,
     })
     class Child {
       constructor() {
@@ -419,7 +405,6 @@ describe('injectors', () => {
     @Component({
       template: '<router-outlet/>',
       imports: [RouterOutlet, ModWithProviders],
-      standalone: true,
     })
     class App {}
 
@@ -438,7 +423,6 @@ describe('injectors', () => {
     const TOKEN = new InjectionToken<any>('');
     @Component({
       template: '',
-      standalone: true,
     })
     class Child {
       constructor() {
@@ -449,7 +433,6 @@ describe('injectors', () => {
     @Component({
       template: '<router-outlet/>',
       imports: [RouterOutlet],
-      standalone: true,
     })
     class App {}
 
@@ -521,7 +504,6 @@ describe('router outlet data', () => {
   it('overrides parent provided data with nested', async () => {
     @Component({
       imports: [RouterOutlet],
-      standalone: true,
       template: `{{outletData()}}|<router-outlet [routerOutletData]="'child'" />`,
     })
     class Child {
@@ -529,7 +511,6 @@ describe('router outlet data', () => {
     }
 
     @Component({
-      standalone: true,
       template: '{{outletData()}}',
     })
     class GrandChild {
@@ -558,7 +539,6 @@ describe('router outlet data', () => {
   it('does not inherit ancestor data when not provided in nested', async () => {
     @Component({
       imports: [RouterOutlet],
-      standalone: true,
       template: `{{outletData()}}|<router-outlet />`,
     })
     class Child {
@@ -566,7 +546,6 @@ describe('router outlet data', () => {
     }
 
     @Component({
-      standalone: true,
       template: '{{outletData() ?? "not provided"}}',
     })
     class GrandChild {

--- a/packages/router/test/directives/router_outlet.spec.ts
+++ b/packages/router/test/directives/router_outlet.spec.ts
@@ -457,12 +457,12 @@ describe('injectors', () => {
 
 describe('router outlet data', () => {
   it('is injectable even when not set', async () => {
-    @Component({template: '', standalone: true})
+    @Component({template: ''})
     class MyComponent {
       data = inject(ROUTER_OUTLET_DATA);
     }
 
-    @Component({template: '<router-outlet />', standalone: true, imports: [RouterOutlet]})
+    @Component({template: '<router-outlet />', imports: [RouterOutlet]})
     class App {}
 
     TestBed.configureTestingModule({
@@ -479,7 +479,7 @@ describe('router outlet data', () => {
   });
 
   it('can set and update value', async () => {
-    @Component({template: '', standalone: true})
+    @Component({template: ''})
     class MyComponent {
       data = inject(ROUTER_OUTLET_DATA);
     }

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -253,7 +253,6 @@ for (const browserAPI of ['navigation', 'history'] as const) {
           },
         ]);
         @Component({
-          standalone: true,
           imports: [RouterLink],
           template: `<a #simpleLink [routerLink]="'/simple'" [info]="simpleLink"></a>`,
         })
@@ -5873,7 +5872,6 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       it('should allow guards as functions', fakeAsync(() => {
         @Component({
           template: '',
-          standalone: true,
         })
         class BlankCmp {}
         const router = TestBed.inject(Router);
@@ -5932,7 +5930,6 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       it('should allow DI in plain function guards', fakeAsync(() => {
         @Component({
           template: '',
-          standalone: true,
         })
         class BlankCmp {}
 
@@ -6883,7 +6880,6 @@ for (const browserAPI of ['navigation', 'history'] as const) {
         const fixture = createRoot(router, RootCmp);
 
         @Component({
-          standalone: true,
           imports: [RouterModule],
           template: '[right outlet component: <router-outlet></router-outlet>]',
         })

--- a/packages/router/test/page_title_strategy_spec.ts
+++ b/packages/router/test/page_title_strategy_spec.ts
@@ -123,7 +123,7 @@ describe('title strategy', () => {
     });
 
     it('pushes updates through the title observable', async () => {
-      @Component({template: '', standalone: true})
+      @Component({template: ''})
       class HomeCmp {
         private readonly title$ = inject(ActivatedRoute).title.pipe(takeUntilDestroyed());
         title?: string;

--- a/packages/router/test/router_link_active.spec.ts
+++ b/packages/router/test/router_link_active.spec.ts
@@ -12,7 +12,6 @@ import {Router, RouterLink, RouterLinkActive, provideRouter} from '@angular/rout
 describe('RouterLinkActive', () => {
   it('removes initial active class even if never active', async () => {
     @Component({
-      standalone: true,
       imports: [RouterLinkActive, RouterLink],
       template: '<a class="active" routerLinkActive="active" routerLink="/abc123"></a>',
     })

--- a/packages/router/test/router_link_spec.ts
+++ b/packages/router/test/router_link_spec.ts
@@ -209,7 +209,6 @@ describe('RouterLink', () => {
 
   it('can use a UrlTree as the input', async () => {
     @Component({
-      standalone: true,
       template: '<a [routerLink]="urlTree">link</a>',
       imports: [RouterLink],
     })
@@ -225,7 +224,6 @@ describe('RouterLink', () => {
 
   it('cannnot use a UrlTree with queryParams', () => {
     @Component({
-      standalone: true,
       template: '<a [routerLink]="urlTree" [queryParams]="{}">link</a>',
       imports: [RouterLink],
     })

--- a/packages/router/test/router_navigation_extras.spec.ts
+++ b/packages/router/test/router_navigation_extras.spec.ts
@@ -99,5 +99,5 @@ describe('`navigationExtras handling with redirects`', () => {
   });
 });
 
-@Component({selector: 'simple-cmp', template: `simple`, standalone: true})
+@Component({selector: 'simple-cmp', template: `simple`})
 class SimpleCmp {}

--- a/packages/router/test/router_preloader.spec.ts
+++ b/packages/router/test/router_preloader.spec.ts
@@ -732,7 +732,7 @@ describe('RouterPreloader', () => {
     });
 
     it('base case', fakeAsync(() => {
-      @Component({template: '', standalone: true})
+      @Component({template: ''})
       class LoadedComponent {}
 
       const preloader = TestBed.inject(RouterPreloader);
@@ -774,7 +774,7 @@ describe('RouterPreloader', () => {
     }));
 
     it('should recover from errors', fakeAsync(() => {
-      @Component({template: '', standalone: true})
+      @Component({template: ''})
       class LoadedComponent {}
 
       const preloader = TestBed.inject(RouterPreloader);
@@ -796,7 +796,7 @@ describe('RouterPreloader', () => {
     }));
 
     it('works when there is both loadComponent and loadChildren', fakeAsync(() => {
-      @Component({template: '', standalone: true})
+      @Component({template: ''})
       class LoadedComponent {}
 
       @NgModule({
@@ -825,7 +825,7 @@ describe('RouterPreloader', () => {
     }));
 
     it('loadComponent does not block loadChildren', fakeAsync(() => {
-      @Component({template: '', standalone: true})
+      @Component({template: ''})
       class LoadedComponent {}
 
       lazyComponentSpy.and.returnValue(of(LoadedComponent).pipe(delay(5)));
@@ -868,7 +868,7 @@ describe('RouterPreloader', () => {
     }));
 
     it('loads nested components', () => {
-      @Component({template: '', standalone: true})
+      @Component({template: ''})
       class LoadedComponent {}
       lazyComponentSpy.and.returnValue(LoadedComponent);
 

--- a/packages/router/test/standalone.spec.ts
+++ b/packages/router/test/standalone.spec.ts
@@ -11,7 +11,7 @@ import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing'
 import {By} from '@angular/platform-browser';
 import {provideRoutes, Router, RouterModule, ROUTES} from '@angular/router';
 
-@Component({template: '<div>simple standalone</div>', standalone: true})
+@Component({template: '<div>simple standalone</div>'})
 export class SimpleStandaloneComponent {}
 
 @Component({template: '<div>not standalone</div>', standalone: false})

--- a/packages/router/test/standalone.spec.ts
+++ b/packages/router/test/standalone.spec.ts
@@ -19,7 +19,6 @@ export class NotStandaloneComponent {}
 
 @Component({
   template: '<router-outlet></router-outlet>',
-  standalone: true,
   imports: [RouterModule],
 })
 export class RootCmp {}

--- a/packages/router/test/view_transitions.spec.ts
+++ b/packages/router/test/view_transitions.spec.ts
@@ -30,7 +30,6 @@ describe('view transitions', () => {
 
   @Component({
     selector: 'test-app',
-    standalone: true,
     template: ``,
   })
   class App {}
@@ -62,7 +61,6 @@ describe('view transitions', () => {
     @Component({
       selector: 'component-b',
       template: `b`,
-      standalone: true,
     })
     class ComponentB {}
 
@@ -83,7 +81,6 @@ describe('view transitions', () => {
     it('should not create a view transition if only the fragment changes', async () => {
       @Component({
         selector: 'test-app',
-        standalone: true,
         template: `{{checks}}`,
       })
       class App {

--- a/packages/router/testing/src/router_testing_harness.ts
+++ b/packages/router/testing/src/router_testing_harness.ts
@@ -42,7 +42,6 @@ export class RootFixtureService {
 }
 
 @Component({
-  standalone: true,
   template: '<router-outlet [routerOutletData]="routerOutletData()"></router-outlet>',
   imports: [RouterOutlet],
 })

--- a/packages/upgrade/static/test/integration/downgrade_component_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_component_spec.ts
@@ -1069,7 +1069,7 @@ withEachNg1Version(() => {
     afterEach(() => destroyPlatform());
 
     it('should downgrade a standalone component using NgModule APIs', waitForAsync(() => {
-      @Component({selector: 'ng2', standalone: true, template: 'Hi from Angular!'})
+      @Component({selector: 'ng2', template: 'Hi from Angular!'})
       class Ng2Component {}
 
       const ng1Module = angular

--- a/packages/upgrade/static/test/integration/upgrade_component_spec.ts
+++ b/packages/upgrade/static/test/integration/upgrade_component_spec.ts
@@ -4780,7 +4780,7 @@ withEachNg1Version(() => {
         const ng1Component: angular.IComponent = {template: `I'm from AngularJS!`};
 
         // Define `Ng1ComponentFacade` (standalone)
-        @Directive({selector: 'ng1', standalone: true})
+        @Directive({selector: 'ng1'})
         class Ng1ComponentStandaloneFacade extends UpgradeComponent {
           constructor(elementRef: ElementRef, injector: Injector) {
             super('ng1', elementRef, injector);


### PR DESCRIPTION
On top of #58236, 

This PR removes `standalone: true` where it's not necessary anymore (angular's pipes, directives, components) as well as in the unit tests. 

See individual commits. 