### PR TITLE
refactor(core): test EventEmitter completion on destroy with outputToObservable

### DIFF
--- a/packages/core/rxjs-interop/test/output_to_observable_spec.ts
+++ b/packages/core/rxjs-interop/test/output_to_observable_spec.ts
@@ -49,6 +49,30 @@ describe('outputToObservable()', () => {
     expect(subscription.closed).toBe(true);
   });
 
+  it('should complete EventEmitter upon directive destroy', () => {
+    const eventEmitter = TestBed.runInInjectionContext(() => new EventEmitter<number>());
+    const observable = outputToObservable(eventEmitter);
+
+    let completed = false;
+    const subscription = observable.subscribe({
+      complete: () => (completed = true),
+    });
+
+    eventEmitter.next(1);
+    eventEmitter.next(2);
+
+    expect(completed).toBe(false);
+    expect(subscription.closed).toBe(false);
+    expect(eventEmitter.observed).toBe(true);
+
+    // destroy `EnvironmentInjector`.
+    TestBed.resetTestingModule();
+
+    expect(completed).toBe(true);
+    expect(subscription.closed).toBe(true);
+    expect(eventEmitter.observed).toBe(false);
+  });
+
   describe('with `outputFromObservable()` as source', () => {
     it('should allow subscription', () => {
       const subject = new Subject<number>();

--- a/packages/core/src/event_emitter.ts
+++ b/packages/core/src/event_emitter.ts
@@ -121,6 +121,9 @@ class EventEmitter_ extends Subject<any> implements OutputRef<any> {
     // Attempt to retrieve a `DestroyRef` and `PendingTasks` optionally.
     // For backwards compatibility reasons, this cannot be required.
     if (isInInjectionContext()) {
+      // `DestroyRef` is optional because it is not available in all contexts.
+      // But it is useful to properly complete the `EventEmitter` if used with `outputToObservable`
+      // when the component/directive is destroyed. (See `outputToObservable` for more details.)
       this.destroyRef = inject(DestroyRef, {optional: true}) ?? undefined;
       this.pendingTasks = inject(PendingTasksInternal, {optional: true}) ?? undefined;
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

A unit test has been added to check that `EventEmitter` properly completes upon component/directive destrouction when used with `outputToObservable`. It explains why `destroyRef` has to be injected in `EventEmitter` in the first place.

This is a follow-up to https://github.com/angular/angular/pull/58219 With this test, the PR would have failed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
