### PR TITLE
refactor(migrations): do not migrate inputs or queries when declared with `@HostBinding`

### DIFF
--- a/packages/core/schematics/migrations/signal-migration/src/input_detection/input_decorator.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/input_detection/input_decorator.ts
@@ -35,6 +35,7 @@ import {InputNode, isInputContainerNode} from '../input_detection/input_node';
 export interface ExtractedInput extends InputMapping {
   inSourceFile: boolean;
   inputDecorator: Decorator | null;
+  fieldDecorators: Decorator[];
 }
 
 /** Attempts to extract metadata of a potential TypeScript `@Input()` declaration. */
@@ -89,6 +90,8 @@ function extractDtsInput(node: ts.Node, metadataReader: DtsMetadataReader): Extr
         ...inputMapping,
         inputDecorator: null,
         inSourceFile: false,
+        // Inputs from `.d.ts` cannot have any field decorators applied.
+        fieldDecorators: [],
       };
 }
 
@@ -153,6 +156,7 @@ function extractSourceCodeInput(
     inSourceFile: true,
     transform: transformResult,
     inputDecorator,
+    fieldDecorators: decorators,
   };
 }
 

--- a/packages/core/schematics/migrations/signal-migration/src/passes/3_check_incompatible_patterns.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/3_check_incompatible_patterns.ts
@@ -12,6 +12,8 @@ import {MigrationHost} from '../migration_host';
 import {GroupedTsAstVisitor} from '../utils/grouped_ts_ast_visitor';
 import {InheritanceGraph} from '../utils/inheritance_graph';
 import {checkIncompatiblePatterns} from './problematic_patterns/common_incompatible_patterns';
+import {getAngularDecorators} from '@angular/compiler-cli/src/ngtsc/annotations';
+import {FieldIncompatibilityReason} from './problematic_patterns/incompatibility';
 
 /**
  * Phase where problematic patterns are detected and advise
@@ -24,6 +26,7 @@ import {checkIncompatiblePatterns} from './problematic_patterns/common_incompati
  * such.
  */
 export function pass3__checkIncompatiblePatterns(
+  host: MigrationHost,
   inheritanceGraph: InheritanceGraph,
   checker: ts.TypeChecker,
   groupedTsAstVisitor: GroupedTsAstVisitor,
@@ -32,4 +35,19 @@ export function pass3__checkIncompatiblePatterns(
   checkIncompatiblePatterns(inheritanceGraph, checker, groupedTsAstVisitor, knownInputs, () =>
     knownInputs.getAllInputContainingClasses(),
   );
+
+  for (const input of knownInputs.knownInputIds.values()) {
+    const hostBindingDecorators = getAngularDecorators(
+      input.metadata.fieldDecorators,
+      ['HostBinding'],
+      host.isMigratingCore,
+    );
+
+    if (hostBindingDecorators.length > 0) {
+      knownInputs.markFieldIncompatible(input.descriptor, {
+        context: hostBindingDecorators[0].node,
+        reason: FieldIncompatibilityReason.SignalIncompatibleWithHostBinding,
+      });
+    }
+  }
 }

--- a/packages/core/schematics/migrations/signal-migration/src/passes/problematic_patterns/incompatibility.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/problematic_patterns/incompatibility.ts
@@ -22,14 +22,15 @@ export enum FieldIncompatibilityReason {
   DerivedIsIncompatible = 5,
   SpyOnThatOverwritesField = 6,
   PotentiallyNarrowedInTemplateButNoSupportYet = 7,
-  SignalInput__RequiredButNoGoodExplicitTypeExtractable = 8,
-  SignalInput__QuestionMarkButNoGoodExplicitTypeExtractable = 9,
-  SignalQueries__QueryListProblematicFieldAccessed = 10,
-  SignalQueries__IncompatibleMultiUnionType = 11,
-  WriteAssignment = 12,
-  Accessor = 13,
-  OutsideOfMigrationScope = 14,
-  SkippedViaConfigFilter = 15,
+  SignalIncompatibleWithHostBinding = 8,
+  SignalInput__RequiredButNoGoodExplicitTypeExtractable = 9,
+  SignalInput__QuestionMarkButNoGoodExplicitTypeExtractable = 10,
+  SignalQueries__QueryListProblematicFieldAccessed = 11,
+  SignalQueries__IncompatibleMultiUnionType = 12,
+  WriteAssignment = 13,
+  Accessor = 14,
+  OutsideOfMigrationScope = 15,
+  SkippedViaConfigFilter = 16,
 }
 
 /** Field reasons that cannot be ignored. */

--- a/packages/core/schematics/migrations/signal-migration/src/passes/problematic_patterns/incompatibility_human.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/problematic_patterns/incompatibility_human.ts
@@ -44,6 +44,15 @@ export function getMessageForFieldIncompatibility(
           'The field in the subclass is incompatible for migration, so migrating this field would ' +
           'break your build.',
       };
+    case FieldIncompatibilityReason.SignalIncompatibleWithHostBinding:
+      return {
+        short:
+          `This ${fieldName.single} is used in combination with \`@HostBinding\` and ` +
+          `migrating would break.`,
+        extra:
+          `\`@HostBinding\` does not invoke the signal automatically and your code would. ` +
+          `break after migration. Use \`host\` of \`@Directive\`/\`@Component\`for host bindings.`,
+      };
     case FieldIncompatibilityReason.PotentiallyNarrowedInTemplateButNoSupportYet:
       return {
         short:

--- a/packages/core/schematics/migrations/signal-migration/src/phase_analysis.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/phase_analysis.ts
@@ -95,6 +95,7 @@ export function executeAnalysisPhase(
   );
   // Register pass 3. Check incompatible patterns pass.
   pass3__checkIncompatiblePatterns(
+    host,
     inheritanceGraph,
     typeChecker,
     pass2And3SourceFileVisitor,

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/host_bindings.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/host_bindings.ts
@@ -1,6 +1,6 @@
 // tslint:disable
 
-import {Component, Input} from '@angular/core';
+import {Component, Input, HostBinding} from '@angular/core';
 
 @Component({
   template: '',
@@ -18,6 +18,10 @@ class HostBindingTestCmp {
   nested = this;
 
   declare receiverNarrowing: this | undefined;
+
+  @HostBinding('[attr.bla]')
+  @Input()
+  myInput = 'initial';
 }
 
 const SHARED = {

--- a/packages/core/schematics/migrations/signal-migration/test/golden.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden.txt
@@ -396,7 +396,7 @@ export class WithGetters {
 
 // tslint:disable
 
-import {Component, input} from '@angular/core';
+import {Component, Input, HostBinding, input} from '@angular/core';
 
 @Component({
   template: '',
@@ -414,6 +414,13 @@ class HostBindingTestCmp {
   nested = this;
 
   declare receiverNarrowing: this | undefined;
+
+  // TODO: Skipped for migration because:
+  //  This input is used in combination with `@HostBinding` and migrating would
+  //  break.
+  @HostBinding('[attr.bla]')
+  @Input()
+  myInput = 'initial';
 }
 
 const SHARED = {

--- a/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
@@ -372,7 +372,7 @@ export class WithGetters {
 
 // tslint:disable
 
-import {Component, input} from '@angular/core';
+import {Component, HostBinding, input} from '@angular/core';
 
 @Component({
   template: '',
@@ -390,6 +390,9 @@ class HostBindingTestCmp {
   nested = this;
 
   declare receiverNarrowing: this | undefined;
+
+  @HostBinding('[attr.bla]')
+readonly myInput = input('initial');
 }
 
 const SHARED = {

--- a/packages/core/schematics/migrations/signal-queries-migration/identify_queries.ts
+++ b/packages/core/schematics/migrations/signal-queries-migration/identify_queries.ts
@@ -12,7 +12,7 @@ import {
   queryDecoratorNames,
 } from '@angular/compiler-cli/src/ngtsc/annotations';
 import {extractDecoratorQueryMetadata} from '@angular/compiler-cli/src/ngtsc/annotations/directive';
-import {ReflectionHost} from '@angular/compiler-cli/src/ngtsc/reflection';
+import {Decorator, ReflectionHost} from '@angular/compiler-cli/src/ngtsc/reflection';
 import ts from 'typescript';
 import {R3QueryMetadata} from '../../../../compiler';
 import {ProgramInfo} from '../../utils/tsurge';
@@ -27,6 +27,7 @@ export interface ExtractedQuery {
   args: ts.Expression[];
   queryInfo: R3QueryMetadata;
   node: (ts.PropertyDeclaration | ts.AccessorDeclaration) & {parent: ts.ClassDeclaration};
+  fieldDecorators: Decorator[];
 }
 
 /**
@@ -99,5 +100,6 @@ export function extractSourceQueryDefinition(
     args: decorator.args ?? [],
     queryInfo,
     node: node as typeof node & {parent: ts.ClassDeclaration},
+    fieldDecorators: decorators,
   };
 }

--- a/packages/core/schematics/migrations/signal-queries-migration/migration.ts
+++ b/packages/core/schematics/migrations/signal-queries-migration/migration.ts
@@ -7,7 +7,7 @@
  */
 
 import {ImportManager, PartialEvaluator} from '@angular/compiler-cli/private/migrations';
-import {QueryFunctionName} from '@angular/compiler-cli/src/ngtsc/annotations';
+import {getAngularDecorators, QueryFunctionName} from '@angular/compiler-cli/src/ngtsc/annotations';
 import {TypeScriptReflectionHost} from '@angular/compiler-cli/src/ngtsc/reflection';
 import assert from 'assert';
 import ts from 'typescript';
@@ -169,6 +169,21 @@ export class SignalQueriesMigration extends TsurgeComplexMigration<
             res.potentialProblematicQueries,
             extractedQuery.id,
             FieldIncompatibilityReason.SignalQueries__IncompatibleMultiUnionType,
+          );
+        }
+
+        // Migrating fields with `@HostBinding` is incompatible as
+        // the host binding decorator does not invoke the signal.
+        const hostBindingDecorators = getAngularDecorators(
+          extractedQuery.fieldDecorators,
+          ['HostBinding'],
+          /* isCore */ false,
+        );
+        if (hostBindingDecorators.length > 0) {
+          markFieldIncompatibleInMetadata(
+            res.potentialProblematicQueries,
+            extractedQuery.id,
+            FieldIncompatibilityReason.SignalIncompatibleWithHostBinding,
           );
         }
       }


### PR DESCRIPTION
The `@HostBinding` decorator may be currently applied to inputs directly, or queries. This
is not great and should be replaced with `host: {}` usages that are more close to template
expressions anyway.

Migrating the inputs or queries to signals would break with `@HostBinding`, because the
signals need to be invoked to access their underlying values. The `@HostBinding` does
not do this automatically, expectedly.
