### PR TITLE
docs(platform-browser): remove typos of withHttpTransferCacheOptions description

### DIFF
--- a/packages/platform-browser/src/hydration.ts
+++ b/packages/platform-browser/src/hydration.ts
@@ -71,9 +71,9 @@ export function withNoHttpTransferCache(): HydrationFeature<HydrationFeatureKind
 }
 
 /**
- * The function accepts a an object, which allows to configure cache parameters,
+ * The function accepts an object, which allows to configure cache parameters,
  * such as which headers should be included (no headers are included by default),
- * wether POST requests should be cached or a callback function to determine if a
+ * whether POST requests should be cached or a callback function to determine if a
  * particular request should be cached.
  *
  * @publicApi


### PR DESCRIPTION
Remove two typos in the withHttpTransferCacheOptions function description

- Correct spelling of "whether"
- Chang spelling from "a an" to "an"

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Description of the withHttpTransferCacheOptions API description should have no spelling errors.
https://angular.dev/api/platform-browser/withHttpTransferCacheOptions

Issue Number: N/A


## What is the new behavior?
Description of the withHttpTransferCacheOptions API description has no spelling errors.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
