### PR TITLE
Experimental Resource API

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1531,6 +1531,59 @@ export interface RendererType2 {
 export function resolveForwardRef<T>(type: T): T;
 
 // @public
+export interface Resource<T> {
+    readonly error: Signal<unknown>;
+    hasValue(): this is Resource<T> & {
+        value: Signal<T>;
+    };
+    readonly isLoading: Signal<boolean>;
+    reload(): boolean;
+    readonly status: Signal<ResourceStatus>;
+    readonly value: Signal<T | undefined>;
+}
+
+// @public
+export function resource<T, R>(options: ResourceOptions<T, R>): ResourceRef<T>;
+
+// @public
+export type ResourceLoader<T, R> = (param: ResourceLoaderParams<R>) => PromiseLike<T>;
+
+// @public
+export interface ResourceLoaderParams<R> {
+    // (undocumented)
+    abortSignal: AbortSignal;
+    // (undocumented)
+    previous: {
+        status: ResourceStatus;
+    };
+    // (undocumented)
+    request: Exclude<NoInfer<R>, undefined>;
+}
+
+// @public
+export interface ResourceOptions<T, R> {
+    equal?: ValueEqualityFn<T>;
+    injector?: Injector;
+    loader: ResourceLoader<T, R>;
+    request?: () => R;
+}
+
+// @public
+export interface ResourceRef<T> extends WritableResource<T> {
+    destroy(): void;
+}
+
+// @public
+export enum ResourceStatus {
+    Error = 1,
+    Idle = 0,
+    Loading = 2,
+    Local = 5,
+    Reloading = 3,
+    Resolved = 4
+}
+
+// @public
 export function runInInjectionContext<ReturnT>(injector: Injector, fn: () => ReturnT): ReturnT;
 
 // @public
@@ -1860,6 +1913,20 @@ export abstract class ViewRef extends ChangeDetectorRef {
     abstract destroy(): void;
     abstract get destroyed(): boolean;
     abstract onDestroy(callback: Function): void;
+}
+
+// @public
+export interface WritableResource<T> extends Resource<T> {
+    // (undocumented)
+    asReadonly(): Resource<T>;
+    // (undocumented)
+    hasValue(): this is WritableResource<T> & {
+        value: WritableSignal<T>;
+    };
+    set(value: T | undefined): void;
+    update(updater: (value: T | undefined) => T | undefined): void;
+    // (undocumented)
+    readonly value: WritableSignal<T | undefined>;
 }
 
 // @public

--- a/goldens/public-api/core/rxjs-interop/index.api.md
+++ b/goldens/public-api/core/rxjs-interop/index.api.md
@@ -10,6 +10,9 @@ import { MonoTypeOperatorFunction } from 'rxjs';
 import { Observable } from 'rxjs';
 import { OutputOptions } from '@angular/core';
 import { OutputRef } from '@angular/core';
+import { ResourceLoaderParams } from '@angular/core';
+import { ResourceOptions } from '@angular/core';
+import { ResourceRef } from '@angular/core';
 import { Signal } from '@angular/core';
 import { Subscribable } from 'rxjs';
 import { ValueEqualityFn } from '@angular/core/primitives/signals';
@@ -19,6 +22,15 @@ export function outputFromObservable<T>(observable: Observable<T>, opts?: Output
 
 // @public
 export function outputToObservable<T>(ref: OutputRef<T>): Observable<T>;
+
+// @public
+export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T>;
+
+// @public
+export interface RxResourceOptions<T, R> extends Omit<ResourceOptions<T, R>, 'loader'> {
+    // (undocumented)
+    loader: (params: ResourceLoaderParams<R>) => Observable<T>;
+}
 
 // @public
 export function takeUntilDestroyed<T>(destroyRef?: DestroyRef): MonoTypeOperatorFunction<T>;

--- a/packages/core/rxjs-interop/src/index.ts
+++ b/packages/core/rxjs-interop/src/index.ts
@@ -15,3 +15,4 @@ export {
   toObservableMicrotask as ɵtoObservableMicrotask,
 } from './to_observable';
 export {toSignal, ToSignalOptions} from './to_signal';
+export {RxResourceOptions, rxResource} from './rx_resource';

--- a/packages/core/rxjs-interop/src/rx_resource.ts
+++ b/packages/core/rxjs-interop/src/rx_resource.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  assertInInjectionContext,
+  ResourceOptions,
+  resource,
+  ResourceLoaderParams,
+  ResourceRef,
+} from '@angular/core';
+import {firstValueFrom, Observable, Subject} from 'rxjs';
+import {takeUntil} from 'rxjs/operators';
+
+/**
+ * Like `ResourceOptions` but uses an RxJS-based `loader`.
+ *
+ * @experimental
+ */
+export interface RxResourceOptions<T, R> extends Omit<ResourceOptions<T, R>, 'loader'> {
+  loader: (params: ResourceLoaderParams<R>) => Observable<T>;
+}
+
+/**
+ * Like `resource` but uses an RxJS based `loader` which maps the request to an `Observable` of the
+ * resource's value. Like `firstValueFrom`, only the first emission of the Observable is considered.
+ *
+ * @experimental
+ */
+export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T> {
+  opts?.injector || assertInInjectionContext(rxResource);
+  return resource<T, R>({
+    ...opts,
+    loader: (params) => {
+      const cancelled = new Subject<void>();
+      params.abortSignal.addEventListener('abort', () => cancelled.next());
+      return firstValueFrom(opts.loader(params).pipe(takeUntil(cancelled)));
+    },
+  });
+}

--- a/packages/core/rxjs-interop/test/rx_resource_spec.ts
+++ b/packages/core/rxjs-interop/test/rx_resource_spec.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {of, Observable} from 'rxjs';
+import {TestBed} from '@angular/core/testing';
+import {ApplicationRef, Injector, signal} from '@angular/core';
+import {rxResource} from '@angular/core/rxjs-interop';
+
+describe('rxResource()', () => {
+  it('should fetch data using an observable loader', async () => {
+    const injector = TestBed.inject(Injector);
+    const appRef = TestBed.inject(ApplicationRef);
+    const res = rxResource({
+      loader: () => of(1),
+      injector,
+    });
+    await appRef.whenStable();
+    expect(res.value()).toBe(1);
+  });
+
+  it('should cancel the fetch when a new request comes in', async () => {
+    const injector = TestBed.inject(Injector);
+    const appRef = TestBed.inject(ApplicationRef);
+    let unsub = false;
+    const request = signal(1);
+    const res = rxResource({
+      request,
+      loader: ({request}) =>
+        new Observable((sub) => {
+          if (request === 2) {
+            sub.next(true);
+          }
+          return () => {
+            if (request === 1) {
+              unsub = true;
+            }
+          };
+        }),
+      injector,
+    });
+
+    // Wait for the resource to reach loading state.
+    await waitFor(() => res.isLoading());
+
+    // Setting request = 2 should cancel request = 1
+    request.set(2);
+    await appRef.whenStable();
+    expect(unsub).toBe(true);
+  });
+});
+
+async function waitFor(fn: () => boolean): Promise<void> {
+  while (!fn()) {
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+}

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -89,6 +89,7 @@ export {ErrorHandler} from './error_handler';
 export * from './core_private_export';
 export * from './core_render3_private_export';
 export * from './core_reactivity_export';
+export * from './resource';
 export {SecurityContext} from './sanitization/security';
 export {Sanitizer} from './sanitization/sanitizer';
 export {

--- a/packages/core/src/pending_tasks.ts
+++ b/packages/core/src/pending_tasks.ts
@@ -36,6 +36,10 @@ export class PendingTasksInternal implements OnDestroy {
     return taskId;
   }
 
+  has(taskId: number): boolean {
+    return this.pendingTasks.has(taskId);
+  }
+
   remove(taskId: number): void {
     this.pendingTasks.delete(taskId);
     if (this.pendingTasks.size === 0 && this._hasPendingTasks) {
@@ -90,6 +94,10 @@ export class PendingTasks {
   add(): () => void {
     const taskId = this.internalPendingTasks.add();
     return () => {
+      if (!this.internalPendingTasks.has(taskId)) {
+        // This pending task has already been cleared.
+        return;
+      }
       // Notifying the scheduler will hold application stability open until the next tick.
       this.scheduler.notify(NotificationSource.PendingTaskRemoved);
       this.internalPendingTasks.remove(taskId);

--- a/packages/core/src/resource/api.ts
+++ b/packages/core/src/resource/api.ts
@@ -1,0 +1,191 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Injector} from '../di/injector';
+import {Signal, ValueEqualityFn} from '../render3/reactivity/api';
+import {WritableSignal} from '../render3/reactivity/signal';
+
+/**
+ * Status of a `Resource`.
+ *
+ * @experimental
+ */
+export enum ResourceStatus {
+  /**
+   * The resource has no valid request and will not perform any loading.
+   *
+   * `value()` will be `undefined`.
+   */
+  Idle,
+
+  /**
+   * Loading failed with an error.
+   *
+   * `value()` will be `undefined`.
+   */
+  Error,
+
+  /**
+   * The resource is currently loading a new value as a result of a change in its `request`.
+   *
+   * `value()` will be `undefined`.
+   */
+  Loading,
+
+  /**
+   * The resource is currently reloading a fresh value for the same request.
+   *
+   * `value()` will continue to return the previously fetched value during the reloading operation.
+   */
+  Reloading,
+
+  /**
+   * Loading has completed and the resource has the value returned from the loader.
+   */
+  Resolved,
+
+  /**
+   * The resource's value was set locally via `.set()` or `.update()`.
+   */
+  Local,
+}
+
+/**
+ * A Resource is an asynchronous dependency (for example, the results of an API call) that is
+ * managed and delivered through signals.
+ *
+ * The usual way of creating a `Resource` is through the `resource` function, but various other APIs
+ * may present `Resource` instances to describe their own concepts.
+ *
+ * @experimental
+ */
+export interface Resource<T> {
+  /**
+   * The current value of the `Resource`, or `undefined` if there is no current value.
+   */
+  readonly value: Signal<T | undefined>;
+
+  /**
+   * The current status of the `Resource`, which describes what the resource is currently doing and
+   * what can be expected of its `value`.
+   */
+  readonly status: Signal<ResourceStatus>;
+
+  /**
+   * When in the `error` state, this returns the last known error from the `Resource`.
+   */
+  readonly error: Signal<unknown>;
+
+  /**
+   * Whether this resource is loading a new value (or reloading the existing one).
+   */
+  readonly isLoading: Signal<boolean>;
+
+  /**
+   * Whether this resource has a valid current value.
+   *
+   * This function is reactive.
+   */
+  hasValue(): this is Resource<T> & {value: Signal<T>};
+
+  /**
+   * Instructs the resource to re-load any asynchronous dependency it may have.
+   *
+   * Note that the resource will not enter its reloading state until the actual backend request is
+   * made.
+   *
+   * @returns true if a reload was initiated, false if a reload was unnecessary or unsupported
+   */
+  reload(): boolean;
+}
+
+/**
+ * A `Resource` with a mutable value.
+ *
+ * Overwriting the value of a resource sets it to the 'local' state.
+ *
+ * @experimental
+ */
+export interface WritableResource<T> extends Resource<T> {
+  readonly value: WritableSignal<T | undefined>;
+  hasValue(): this is WritableResource<T> & {value: WritableSignal<T>};
+
+  /**
+   * Convenience wrapper for `value.set`.
+   */
+  set(value: T | undefined): void;
+
+  /**
+   * Convenience wrapper for `value.update`.
+   */
+  update(updater: (value: T | undefined) => T | undefined): void;
+  asReadonly(): Resource<T>;
+}
+
+/**
+ * A `WritableResource` created through the `resource` function.
+ *
+ * @experimental
+ */
+export interface ResourceRef<T> extends WritableResource<T> {
+  /**
+   * Manually destroy the resource, which cancels pending requests and returns it to `idle` state.
+   */
+  destroy(): void;
+}
+
+/**
+ * Parameter to a `ResourceLoader` which gives the request and other options for the current loading
+ * operation.
+ *
+ * @experimental
+ */
+export interface ResourceLoaderParams<R> {
+  request: Exclude<NoInfer<R>, undefined>;
+  abortSignal: AbortSignal;
+  previous: {
+    status: ResourceStatus;
+  };
+}
+
+/**
+ * Loading function for a `Resource`.
+ *
+ * @experimental
+ */
+export type ResourceLoader<T, R> = (param: ResourceLoaderParams<R>) => PromiseLike<T>;
+
+/**
+ * Options to the `resource` function, for creating a resource.
+ *
+ * @experimental
+ */
+export interface ResourceOptions<T, R> {
+  /**
+   * A reactive function which determines the request to be made. Whenever the request changes, the
+   * loader will be triggered to fetch a new value for the resource.
+   *
+   * If a request function isn't provided, the loader won't rerun unless the resource is reloaded.
+   */
+  request?: () => R;
+
+  /**
+   * Loading function which returns a `Promise` of the resource's value for a given request.
+   */
+  loader: ResourceLoader<T, R>;
+
+  /**
+   * Equality function used to compare the return value of the loader.
+   */
+  equal?: ValueEqualityFn<T>;
+
+  /**
+   * Overrides the `Injector` used by `resource`.
+   */
+  injector?: Injector;
+}

--- a/packages/core/src/resource/index.ts
+++ b/packages/core/src/resource/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+export * from './api';
+export {resource} from './resource';

--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -1,0 +1,274 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {untracked} from '../render3/reactivity/untracked';
+import {computed} from '../render3/reactivity/computed';
+import {signal, WritableSignal} from '../render3/reactivity/signal';
+import {Signal} from '../render3/reactivity/api';
+import {effect, EffectRef} from '../render3/reactivity/effect';
+import {
+  ResourceOptions,
+  ResourceStatus,
+  WritableResource,
+  ResourceLoader,
+  Resource,
+  ResourceRef,
+} from './api';
+import {ValueEqualityFn, SIGNAL, SignalNode} from '@angular/core/primitives/signals';
+import {Injector} from '../di/injector';
+import {assertInInjectionContext} from '../di/contextual';
+import {inject} from '../di/injector_compatibility';
+import {PendingTasks} from '../pending_tasks';
+import {DestroyRef} from '../linker';
+
+/**
+ * Constructs a `Resource` that projects a reactive request to an asynchronous operation defined by
+ * a loader function, which exposes the result of the loading operation via signals.
+ *
+ * Note that `resource` is intended for _read_ operations, not operations which perform mutations.
+ * `resource` will cancel in-progress loads via the `AbortSignal` when destroyed or when a new
+ * request object becomes available, which could prematurely abort mutations.
+ *
+ * @experimental
+ */
+export function resource<T, R>(options: ResourceOptions<T, R>): ResourceRef<T> {
+  options?.injector || assertInInjectionContext(resource);
+  const request = (options.request ?? (() => null)) as () => R;
+  return new WritableResourceImpl<T, R>(request, options.loader, options.equal, options.injector);
+}
+
+/**
+ * Base class for `WritableResource` which handles the state operations and is unopinionated on the
+ * actual async operation.
+ *
+ * Mainly factored out for better readability.
+ */
+abstract class BaseWritableResource<T> implements WritableResource<T> {
+  readonly value: WritableSignal<T | undefined>;
+  readonly status = signal<ResourceStatus>(ResourceStatus.Idle);
+  readonly error = signal<unknown>(undefined);
+
+  protected readonly rawSetValue: (value: T | undefined) => void;
+
+  constructor(equal: ValueEqualityFn<T> | undefined) {
+    this.value = signal<T | undefined>(undefined, {
+      equal: equal ? wrapEqualityFn(equal) : undefined,
+    });
+    this.rawSetValue = this.value.set;
+    this.value.set = (value: T | undefined) => this.set(value);
+    this.value.update = (fn: (value: T | undefined) => T | undefined) =>
+      this.set(fn(untracked(this.value)));
+  }
+
+  set(value: T | undefined): void {
+    // Set the value signal and check whether its `version` changes. This will tell us
+    // if the value signal actually updated or not.
+    const prevVersion = (this.value[SIGNAL] as SignalNode<T>).version;
+    this.rawSetValue(value);
+    if ((this.value[SIGNAL] as SignalNode<T>).version === prevVersion) {
+      // The value must've been equal to the previous, so no need to change states.
+      return;
+    }
+
+    // We're departing from whatever state the resource was in previously, and entering
+    // Local state.
+    this.onLocalValue();
+    this.status.set(ResourceStatus.Local);
+    this.error.set(undefined);
+  }
+
+  update(updater: (value: T | undefined) => T | undefined): void {
+    this.value.update(updater);
+  }
+
+  readonly isLoading = computed(
+    () => this.status() === ResourceStatus.Loading || this.status() === ResourceStatus.Reloading,
+  );
+
+  hasValue(): this is WritableResource<T> & {value: WritableSignal<T>} {
+    return (
+      this.status() === ResourceStatus.Resolved ||
+      this.status() === ResourceStatus.Local ||
+      this.status() === ResourceStatus.Reloading
+    );
+  }
+
+  asReadonly(): Resource<T> {
+    return this;
+  }
+
+  /**
+   * Put the resource in a state with a given value.
+   */
+  protected setValueState(status: ResourceStatus, value: T | undefined = undefined): void {
+    this.status.set(status);
+    this.rawSetValue(value);
+    this.error.set(undefined);
+  }
+
+  /**
+   * Put the resource into the error state.
+   */
+  protected setErrorState(err: unknown): void {
+    this.status.set(ResourceStatus.Error);
+    this.value.set(undefined);
+    this.error.set(err);
+  }
+
+  /**
+   * Called when the resource is transitioning to local state.
+   *
+   * For example, this can be used to cancel any in-progress loading operations.
+   */
+  protected abstract onLocalValue(): void;
+
+  public abstract reload(): boolean;
+}
+
+class WritableResourceImpl<T, R> extends BaseWritableResource<T> implements ResourceRef<T> {
+  private readonly request: Signal<{request: R; reload: WritableSignal<number>}>;
+  private readonly pendingTasks: PendingTasks;
+  private readonly effectRef: EffectRef;
+
+  private pendingController: AbortController | undefined;
+  private resolvePendingTask: (() => void) | undefined = undefined;
+
+  constructor(
+    requestFn: () => R,
+    private readonly loaderFn: ResourceLoader<T, R>,
+    equal: ValueEqualityFn<T> | undefined,
+    injector: Injector | undefined,
+  ) {
+    super(equal);
+    injector = injector ?? inject(Injector);
+    this.pendingTasks = injector.get(PendingTasks);
+
+    this.request = computed(() => ({
+      // The current request as defined for this resource.
+      request: requestFn(),
+
+      // A counter signal which increments from 0, re-initialized for each request (similar to the
+      // `linkedSignal` pattern). A value other than 0 indicates a refresh operation.
+      reload: signal(0),
+    }));
+
+    // The actual data-fetching effect.
+    this.effectRef = effect(this.loadEffect.bind(this), {injector, manualCleanup: true});
+
+    // Cancel any pending request when the resource itself is destroyed.
+    injector.get(DestroyRef).onDestroy(() => this.destroy());
+  }
+
+  override reload(): boolean {
+    // We don't want to restart in-progress loads.
+    const status = untracked(this.status);
+    if (
+      status === ResourceStatus.Idle ||
+      status === ResourceStatus.Loading ||
+      status === ResourceStatus.Reloading
+    ) {
+      return false;
+    }
+
+    untracked(this.request).reload.update((v) => v + 1);
+    return true;
+  }
+
+  destroy(): void {
+    this.effectRef.destroy();
+
+    this.abortInProgressLoad();
+    this.setValueState(ResourceStatus.Idle);
+  }
+
+  private async loadEffect(): Promise<void> {
+    // Capture the status before any state transitions.
+    const previousStatus = untracked(this.status);
+
+    // Cancel any previous loading attempts.
+    this.abortInProgressLoad();
+
+    const request = this.request();
+    if (request.request === undefined) {
+      // An undefined request means there's nothing to load.
+      this.setValueState(ResourceStatus.Idle);
+      return;
+    }
+
+    // Subscribing here allows us to refresh the load later by updating the refresh signal. At the
+    // same time, we update the status according to whether we're reloading or loading.
+    if (request.reload() === 0) {
+      this.setValueState(ResourceStatus.Loading); // value becomes undefined
+    } else {
+      this.status.set(ResourceStatus.Reloading); // value persists
+    }
+
+    // Capturing _this_ load's pending task in a local variable is important here. We may attempt to
+    // resolve it twice:
+    //
+    //  1. when the loading function promise resolves/rejects
+    //  2. when cancelling the loading operation
+    //
+    // After the loading operation is cancelled, `this.resolvePendingTask` no longer represents this
+    // particular task, but this `await` may eventually resolve/reject. Thus, when we cancel in
+    // response to (1) below, we need to cancel the locally saved task.
+    const resolvePendingTask = (this.resolvePendingTask = this.pendingTasks.add());
+
+    const {signal: abortSignal} = (this.pendingController = new AbortController());
+    try {
+      // The actual loading is run through `untracked` - only the request side of `resource` is
+      // reactive. This avoids any confusion with signals tracking or not tracking depending on
+      // which side of the `await` they are.
+      const result = await untracked(() =>
+        this.loaderFn({
+          abortSignal,
+          request: request.request as Exclude<R, undefined>,
+          previous: {
+            status: previousStatus,
+          },
+        }),
+      );
+      if (abortSignal.aborted) {
+        // This load operation was cancelled.
+        return;
+      }
+      // Success :)
+      this.setValueState(ResourceStatus.Resolved, result);
+    } catch (err) {
+      if (abortSignal.aborted) {
+        // This load operation was cancelled.
+        return;
+      }
+      // Fail :(
+      this.setErrorState(err);
+    } finally {
+      // Resolve the pending task now that loading is done.
+      resolvePendingTask();
+    }
+  }
+
+  private abortInProgressLoad(): void {
+    this.pendingController?.abort();
+    this.pendingController = undefined;
+
+    // Once the load is aborted, we no longer want to block stability on its resolution.
+    this.resolvePendingTask?.();
+    this.resolvePendingTask = undefined;
+  }
+
+  protected override onLocalValue(): void {
+    this.abortInProgressLoad();
+  }
+}
+
+/**
+ * Wraps an equality function to handle either value being `undefined`.
+ */
+function wrapEqualityFn<T>(equal: ValueEqualityFn<T>): ValueEqualityFn<T | undefined> {
+  return (a, b) => (a === undefined || b === undefined ? a === b : equal(a, b));
+}

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -1107,6 +1107,9 @@
     "name": "init_api4"
   },
   {
+    "name": "init_api5"
+  },
+  {
     "name": "init_api_flags"
   },
   {
@@ -1957,6 +1960,12 @@
   },
   {
     "name": "init_reportUnhandledError"
+  },
+  {
+    "name": "init_resource"
+  },
+  {
+    "name": "init_resource2"
   },
   {
     "name": "init_resource_loading"

--- a/packages/core/test/resource/BUILD.bazel
+++ b/packages/core/test/resource/BUILD.bazel
@@ -1,0 +1,30 @@
+load("//tools:defaults.bzl", "jasmine_node_test", "karma_web_test_suite", "ng_module")
+
+package(default_visibility = ["//visibility:private"])
+
+ng_module(
+    name = "resource_lib",
+    testonly = True,
+    srcs = glob(
+        ["**/*.ts"],
+    ),
+    deps = [
+        "//packages/core",
+        "//packages/core/testing",
+    ],
+)
+
+jasmine_node_test(
+    name = "resource",
+    bootstrap = ["//tools/testing:node"],
+    deps = [
+        ":resource_lib",
+    ],
+)
+
+karma_web_test_suite(
+    name = "resource_web",
+    deps = [
+        ":resource_lib",
+    ],
+)

--- a/packages/core/test/resource/resource_spec.ts
+++ b/packages/core/test/resource/resource_spec.ts
@@ -1,0 +1,379 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  createEnvironmentInjector,
+  EnvironmentInjector,
+  Injector,
+  resource,
+  ResourceStatus,
+  signal,
+} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+
+abstract class MockBackend<T, R> {
+  protected pending = new Map<
+    T,
+    {resolve: (r: R) => void; reject: (reason: any) => void; promise: Promise<R>}
+  >();
+
+  fetch(request: T): Promise<R> {
+    const p = new Promise<R>((resolve, reject) => {
+      this.pending.set(request, {resolve, reject, promise: undefined!});
+    });
+    this.pending.get(request)!.promise = p;
+    return p;
+  }
+
+  abort(req: T) {
+    this.reject(req, 'aborted');
+  }
+
+  reject(req: T, reason: any) {
+    const entry = this.pending.get(req);
+    if (entry) {
+      this.pending.delete(req);
+      entry.reject(reason);
+    }
+
+    return Promise.resolve();
+  }
+
+  async flush() {
+    const allPending = Array.from(this.pending.values()).map((pending) => pending.promise);
+
+    for (const [req, {resolve}] of this.pending) {
+      resolve(this.prepareResponse(req));
+    }
+    this.pending.clear();
+
+    return Promise.all(allPending);
+  }
+
+  protected abstract prepareResponse(request: T): R;
+}
+
+class MockEchoBackend<T> extends MockBackend<T, T> {
+  override prepareResponse(request: T) {
+    return request;
+  }
+}
+
+class MockResponseCountingBackend extends MockBackend<number, string> {
+  counter = 0;
+  override prepareResponse(request: number) {
+    return request + ':' + this.counter++;
+  }
+}
+
+describe('resource', () => {
+  it('should expose data and status based on reactive request', async () => {
+    const counter = signal(0);
+    const backend = new MockEchoBackend();
+    const echoResource = resource({
+      request: () => ({counter: counter()}),
+      loader: (params) => backend.fetch(params.request),
+      injector: TestBed.inject(Injector),
+    });
+
+    // a freshly created resource is in the idle state
+    expect(echoResource.status()).toBe(ResourceStatus.Idle);
+    expect(echoResource.isLoading()).toBeFalse();
+    expect(echoResource.hasValue()).toBeFalse();
+    expect(echoResource.value()).toBeUndefined();
+    expect(echoResource.error()).toBe(undefined);
+
+    // flush effect to kick off a request
+    // THINK: testing patterns around a resource?
+    TestBed.flushEffects();
+    expect(echoResource.status()).toBe(ResourceStatus.Loading);
+    expect(echoResource.isLoading()).toBeTrue();
+    expect(echoResource.hasValue()).toBeFalse();
+    expect(echoResource.value()).toBeUndefined();
+    expect(echoResource.error()).toBe(undefined);
+
+    await backend.flush();
+    expect(echoResource.status()).toBe(ResourceStatus.Resolved);
+    expect(echoResource.isLoading()).toBeFalse();
+    expect(echoResource.hasValue()).toBeTrue();
+    expect(echoResource.value()).toEqual({counter: 0});
+    expect(echoResource.error()).toBe(undefined);
+
+    counter.update((c) => c + 1);
+    TestBed.flushEffects();
+    await backend.flush();
+    expect(echoResource.status()).toBe(ResourceStatus.Resolved);
+    expect(echoResource.isLoading()).toBeFalse();
+    expect(echoResource.hasValue()).toBeTrue();
+    expect(echoResource.value()).toEqual({counter: 1});
+    expect(echoResource.error()).toBe(undefined);
+  });
+
+  it('should expose errors thrown during resource loading', async () => {
+    const backend = new MockEchoBackend();
+    const requestParam = {};
+    const echoResource = resource({
+      request: () => requestParam,
+      loader: (params) => backend.fetch(params.request),
+      injector: TestBed.inject(Injector),
+    });
+
+    TestBed.flushEffects();
+    await backend.reject(requestParam, 'Something went wrong....');
+
+    expect(echoResource.status()).toBe(ResourceStatus.Error);
+    expect(echoResource.isLoading()).toBeFalse();
+    expect(echoResource.value()).toEqual(undefined);
+    expect(echoResource.error()).toBe('Something went wrong....');
+  });
+
+  it('should _not_ load if the request resolves to undefined', () => {
+    const counter = signal(0);
+    const backend = new MockEchoBackend();
+    const echoResource = resource({
+      request: () => (counter() > 5 ? {counter: counter()} : undefined),
+      loader: (params) => backend.fetch(params.request),
+      injector: TestBed.inject(Injector),
+    });
+
+    TestBed.flushEffects();
+    expect(echoResource.status()).toBe(ResourceStatus.Idle);
+    expect(echoResource.isLoading()).toBeFalse();
+
+    counter.set(10);
+    TestBed.flushEffects();
+    expect(echoResource.isLoading()).toBeTrue();
+  });
+
+  it('should cancel pending requests before starting a new one', async () => {
+    const counter = signal(0);
+    const backend = new MockEchoBackend<{counter: number}>();
+    const aborted: {counter: number}[] = [];
+    const echoResource = resource<{counter: number}, {counter: number}>({
+      request: () => ({counter: counter()}),
+      loader: ({request, abortSignal}) => {
+        abortSignal.addEventListener('abort', () => backend.abort(request));
+        return backend.fetch(request).catch((reason) => {
+          if (reason === 'aborted') {
+            aborted.push(request);
+          }
+          throw new Error(reason);
+        });
+      },
+      injector: TestBed.inject(Injector),
+    });
+
+    // start a request without resolving the previous one
+    TestBed.flushEffects();
+    await Promise.resolve();
+
+    // start a new request and resolve all
+    counter.update((c) => c + 1);
+    TestBed.flushEffects();
+    await backend.flush();
+    expect(echoResource.status()).toBe(ResourceStatus.Resolved);
+    expect(echoResource.value()).toEqual({counter: 1});
+    expect(echoResource.error()).toBe(undefined);
+
+    expect(aborted).toEqual([{counter: 0}]);
+  });
+
+  it('should cancel pending requests when the resource is destroyed via injector', async () => {
+    const counter = signal(0);
+    const backend = new MockEchoBackend<{counter: number}>();
+    const aborted: {counter: number}[] = [];
+    const injector = createEnvironmentInjector([], TestBed.inject(EnvironmentInjector));
+    const echoResource = resource<{counter: number}, {counter: number}>({
+      request: () => ({counter: counter()}),
+      loader: ({request, abortSignal}) => {
+        abortSignal.addEventListener('abort', () => backend.abort(request));
+        return backend.fetch(request).catch((reason) => {
+          if (reason === 'aborted') {
+            aborted.push(request);
+          }
+          throw new Error(reason);
+        });
+      },
+      injector,
+    });
+
+    // start a request without resolving the previous one
+    TestBed.flushEffects();
+    await Promise.resolve();
+
+    injector.destroy();
+    await backend.flush();
+    expect(echoResource.status()).toBe(ResourceStatus.Idle);
+    expect(echoResource.value()).toBe(undefined);
+    expect(echoResource.error()).toBe(undefined);
+
+    expect(aborted).toEqual([{counter: 0}]);
+  });
+
+  it('should cancel pending requests when the resource is manually destroyed', async () => {
+    const counter = signal(0);
+    const backend = new MockEchoBackend<{counter: number}>();
+    const aborted: {counter: number}[] = [];
+    const injector = createEnvironmentInjector([], TestBed.inject(EnvironmentInjector));
+    const echoResource = resource<{counter: number}, {counter: number}>({
+      request: () => ({counter: counter()}),
+      loader: ({request, abortSignal}) => {
+        abortSignal.addEventListener('abort', () => backend.abort(request));
+        return backend.fetch(request).catch((reason) => {
+          if (reason === 'aborted') {
+            aborted.push(request);
+          }
+          throw new Error(reason);
+        });
+      },
+      injector,
+    });
+
+    // start a request without resolving the previous one
+    TestBed.flushEffects();
+    await Promise.resolve();
+
+    echoResource.destroy();
+    await backend.flush();
+
+    expect(echoResource.status()).toBe(ResourceStatus.Idle);
+    expect(echoResource.value()).toBe(undefined);
+    expect(echoResource.error()).toBe(undefined);
+
+    expect(aborted).toEqual([{counter: 0}]);
+  });
+
+  it('should not respond to reactive state changes in a loader', async () => {
+    const unrelated = signal('a');
+    const backend = new MockResponseCountingBackend();
+    const res = resource<string, number>({
+      request: () => 0,
+      loader: (params) => {
+        // read reactive state and assure it is _not_ tracked
+        unrelated();
+        return backend.fetch(params.request);
+      },
+      injector: TestBed.inject(Injector),
+    });
+
+    TestBed.flushEffects();
+    await backend.flush();
+    expect(res.value()).toBe('0:0');
+
+    unrelated.set('b');
+    TestBed.flushEffects();
+    // there is no chang in the status
+    expect(res.status()).toBe(ResourceStatus.Resolved);
+    await backend.flush();
+    // there is no chang in the value
+    expect(res.value()).toBe('0:0');
+  });
+
+  it('should allow setting local state', async () => {
+    const counter = signal(0);
+    const backend = new MockEchoBackend();
+    const echoResource = resource({
+      request: () => ({counter: counter()}),
+      loader: (params) => backend.fetch(params.request),
+      injector: TestBed.inject(Injector),
+    });
+
+    TestBed.flushEffects();
+    await backend.flush();
+
+    expect(echoResource.status()).toBe(ResourceStatus.Resolved);
+    expect(echoResource.isLoading()).toBeFalse();
+    expect(echoResource.value()).toEqual({counter: 0});
+    expect(echoResource.error()).toBe(undefined);
+
+    echoResource.value.set({counter: 100});
+    expect(echoResource.status()).toBe(ResourceStatus.Local);
+    expect(echoResource.isLoading()).toBeFalse();
+    expect(echoResource.hasValue()).toBeTrue();
+    expect(echoResource.value()).toEqual({counter: 100});
+    expect(echoResource.error()).toBe(undefined);
+
+    counter.set(1);
+    TestBed.flushEffects();
+    await backend.flush();
+    expect(echoResource.status()).toBe(ResourceStatus.Resolved);
+    expect(echoResource.value()).toEqual({counter: 1});
+    expect(echoResource.error()).toBe(undefined);
+
+    // state setter is also exposed on the resource directly
+    echoResource.set({counter: 200});
+    expect(echoResource.status()).toBe(ResourceStatus.Local);
+    expect(echoResource.hasValue()).toBeTrue();
+    expect(echoResource.value()).toEqual({counter: 200});
+  });
+
+  it('should allow re-fetching data', async () => {
+    const backend = new MockResponseCountingBackend();
+    const res = resource<string, number>({
+      request: () => 0,
+      loader: (params) => backend.fetch(params.request),
+      injector: TestBed.inject(Injector),
+    });
+
+    TestBed.flushEffects();
+    await backend.flush();
+    expect(res.status()).toBe(ResourceStatus.Resolved);
+    expect(res.value()).toBe('0:0');
+    expect(res.error()).toBe(undefined);
+
+    res.reload();
+    TestBed.flushEffects();
+    await backend.flush();
+    expect(res.status()).toBe(ResourceStatus.Resolved);
+    expect(res.isLoading()).toBeFalse();
+    expect(res.value()).toBe('0:1');
+    expect(res.error()).toBe(undefined);
+
+    // calling refresh multiple times should _not_ result in multiple requests
+    res.reload();
+    TestBed.flushEffects();
+    res.reload();
+    TestBed.flushEffects();
+    await backend.flush();
+    expect(res.value()).toBe('0:2');
+  });
+
+  it('should respect provided equality function for the results signal', async () => {
+    const res = resource({
+      loader: async () => 0,
+      equal: (a, b) => true,
+      injector: TestBed.inject(Injector),
+    });
+
+    res.value.set(5);
+    expect(res.status()).toBe(ResourceStatus.Local);
+    expect(res.value()).toBe(5);
+    expect(res.error()).toBe(undefined);
+
+    res.value.set(10);
+    expect(res.status()).toBe(ResourceStatus.Local);
+    expect(res.value()).toBe(5); // equality blocked writes
+    expect(res.error()).toBe(undefined);
+  });
+
+  it('should convert writable resource to its read-only version', () => {
+    const res = resource({
+      loader: async () => 0,
+      equal: (a, b) => true,
+      injector: TestBed.inject(Injector),
+    });
+
+    const readonlyRes = res.asReadonly();
+
+    // @ts-expect-error
+    readonlyRes.asReadonly;
+
+    // @ts-expect-error
+    readonlyRes.value.set;
+  });
+});


### PR DESCRIPTION
Implement a new experimental API, called `resource()`. Resources are asynchronous dependencies that are managed and delivered through the signal graph. Resources are defined by their reactive request function and their asynchronous loader, which retrieves the value of the resource for a given request value. For example, a "current user" resource may retrieve data for the current user, where the request function derives the API call to make from a signal of the current user id.
    
Resources are represented by the `Resource<T>` type, which includes signals for the resource's current value as well as its state. `WritableResource<T>` extends that type to allow for local mutations of the resource through its `value` signal (which is therefore two-way bindable).

Also, implementations of an rxjs-interop APIs which produce `Resource`s from RxJS Observables. `rxResource()` is a flavor of `resource()` which uses a projection to an `Observable` as its loader (like `switchMap`).