### PR TITLE
refactor(migrations): improve query migration type detection

### DIFF
--- a/packages/core/schematics/migrations/signal-queries-migration/BUILD.bazel
+++ b/packages/core/schematics/migrations/signal-queries-migration/BUILD.bazel
@@ -37,6 +37,7 @@ ts_library(
         "//packages/compiler-cli",
         "//packages/compiler-cli/src/ngtsc/file_system/testing",
         "//packages/core/schematics/utils/tsurge",
+        "@npm//typescript",
     ],
 )
 

--- a/packages/core/schematics/migrations/signal-queries-migration/migration.ts
+++ b/packages/core/schematics/migrations/signal-queries-migration/migration.ts
@@ -501,6 +501,8 @@ export class SignalQueriesMigration extends TsurgeComplexMigration<
           importManager,
           info,
           printer,
+          info.userOptions,
+          checker,
         ),
       );
     }


### PR DESCRIPTION
* Improves handling of the query migration is `strict = false` w/ `strictNullChecks` is configured in the project. There is a special case that needs to be handled; similar to the input migration.

* Improves readability of the code for normal type generic insertion. The current logic was a little confusing