### PR TITLE
build: Update prettierrc to always use trailing commas

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,5 +6,6 @@
   "singleQuote": true,
   "semi": true,
   "quoteProps": "preserve",
-  "bracketSpacing": false
+  "bracketSpacing": false,
+  "trailingComma": "all"
 }


### PR DESCRIPTION
This updates the prettierrc to reflect how the code seems to already be formatted. I noticed that without this my IDE seemed to be introducing formatting changes on save.