### PR TITLE
Fix typo in tutorial - change style.css to styles.css to correct style sheet file name

### DIFF
--- a/adev/src/content/tutorials/first-app/steps/01-hello-world/README.md
+++ b/adev/src/content/tutorials/first-app/steps/01-hello-world/README.md
@@ -54,7 +54,7 @@ In the **Explorer** pane of your IDE:
 1. Open the `src` directory to see these files.
     1. In the file explorer, find the Angular app files (`/src`).
         1. `index.html` is the app's top level HTML template.
-        1. `style.css` is the app's top level style sheet.
+        1. `styles.css` is the app's top level style sheet.
         1. `main.ts` is where the app starts running.
         1. `favicon.ico` is the app's icon, just as you would find in any web site.
     1. In the file explorer, find the Angular app's component files (`/app`).


### PR DESCRIPTION
docs: fix typo in tutorial - change style.css to styles.css to correct style sheet file name

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The name of the Angular app's top level style sheet file is mistakenly called style.css in the tutorial.

Issue Number: N/A


## What is the new behavior?
The name of the Angular app's top level style sheet file is corrected to styles.css in the tutorial.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
