### PR TITLE
refactore(core): remove `ComponentFactoryResolver` related dead code

### DIFF
--- a/packages/core/src/linker/component_factory_resolver.ts
+++ b/packages/core/src/linker/component_factory_resolver.ts
@@ -11,21 +11,9 @@ import {stringify} from '../util/stringify';
 
 import {ComponentFactory} from './component_factory';
 
-export function noComponentFactoryError(component: Function) {
-  const error = Error(`No component factory found for ${stringify(component)}.`);
-  (error as any)[ERROR_COMPONENT] = component;
-  return error;
-}
-
-const ERROR_COMPONENT = 'ngComponent';
-
-export function getComponent(error: Error): Type<any> {
-  return (error as any)[ERROR_COMPONENT];
-}
-
 class _NullComponentFactoryResolver implements ComponentFactoryResolver {
   resolveComponentFactory<T>(component: {new (...args: any[]): T}): ComponentFactory<T> {
-    throw noComponentFactoryError(component);
+    throw Error(`No component factory found for ${stringify(component)}.`);
   }
 }
 


### PR DESCRIPTION
`getComponent` wasn't used anymore, we can remove `ERROR_COMPONENT`.
Note: This piece of code lands in the main bundle of a default CLI project. 
