### PR TITLE
refactor(migrations): support parallel tsurge metadata merging

### DIFF
--- a/packages/core/schematics/migrations/signal-migration/src/batch/test_bin.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/batch/test_bin.ts
@@ -9,11 +9,12 @@
 import fs from 'fs';
 import path from 'path';
 import {executeAnalyzePhase} from '../../../../utils/tsurge/executors/analyze_exec';
-import {executeMergePhase} from '../../../../utils/tsurge/executors/merge_exec';
+import {executeCombinePhase} from '../../../../utils/tsurge/executors/combine_exec';
 import {executeMigratePhase} from '../../../../utils/tsurge/executors/migrate_exec';
 import {SignalInputMigration} from '../migration';
 import {writeMigrationReplacements} from '../write_replacements';
 import {CompilationUnitData} from './unit_data';
+import {executeGlobalMetaPhase} from '../../../../utils/tsurge/executors/global_meta_exec';
 
 main().catch((e) => {
   console.error(e);
@@ -27,19 +28,16 @@ async function main() {
   if (mode === 'extract') {
     const analyzeResult = await executeAnalyzePhase(migration, path.resolve(args[0]));
     process.stdout.write(JSON.stringify(analyzeResult));
-  } else if (mode === 'merge') {
-    const mergedResult = await executeMergePhase(
-      migration,
-      await Promise.all(
-        args.map((p) =>
-          fs.promises
-            .readFile(path.resolve(p), 'utf8')
-            .then((data) => JSON.parse(data) as CompilationUnitData),
-        ),
-      ),
-    );
+  } else if (mode === 'combine') {
+    const unitAPromise = readUnitMeta(path.resolve(args[0]));
+    const unitBPromise = readUnitMeta(path.resolve(args[1]));
+
+    const [unitA, unitB] = await Promise.all([unitAPromise, unitBPromise]);
+    const mergedResult = await executeCombinePhase(migration, unitA, unitB);
 
     process.stdout.write(JSON.stringify(mergedResult));
+  } else if (mode === 'globalMeta') {
+    await executeGlobalMetaPhase(migration, await readUnitMeta(args[0]));
   } else if (mode === 'migrate') {
     const {replacements, projectRoot} = await executeMigratePhase(
       migration,
@@ -49,4 +47,10 @@ async function main() {
 
     writeMigrationReplacements(replacements, projectRoot);
   }
+}
+
+async function readUnitMeta(filePath: string): Promise<CompilationUnitData> {
+  return fs.promises
+    .readFile(filePath, 'utf8')
+    .then((data) => JSON.parse(data) as CompilationUnitData);
 }

--- a/packages/core/schematics/migrations/signal-migration/src/batch/test_bin.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/batch/test_bin.ts
@@ -9,12 +9,12 @@
 import fs from 'fs';
 import path from 'path';
 import {executeAnalyzePhase} from '../../../../utils/tsurge/executors/analyze_exec';
-import {executeCombinePhase} from '../../../../utils/tsurge/executors/combine_exec';
 import {executeMigratePhase} from '../../../../utils/tsurge/executors/migrate_exec';
 import {SignalInputMigration} from '../migration';
 import {writeMigrationReplacements} from '../write_replacements';
 import {CompilationUnitData} from './unit_data';
 import {executeGlobalMetaPhase} from '../../../../utils/tsurge/executors/global_meta_exec';
+import {synchronouslyCombineUnitData} from '../../../../utils/tsurge/helpers/combine_units';
 
 main().catch((e) => {
   console.error(e);
@@ -28,16 +28,16 @@ async function main() {
   if (mode === 'extract') {
     const analyzeResult = await executeAnalyzePhase(migration, path.resolve(args[0]));
     process.stdout.write(JSON.stringify(analyzeResult));
-  } else if (mode === 'combine') {
-    const unitAPromise = readUnitMeta(path.resolve(args[0]));
-    const unitBPromise = readUnitMeta(path.resolve(args[1]));
-
-    const [unitA, unitB] = await Promise.all([unitAPromise, unitBPromise]);
-    const mergedResult = await executeCombinePhase(migration, unitA, unitB);
+  } else if (mode === 'combine-all') {
+    const unitPromises = args.map((f) => readUnitMeta(path.resolve(f)));
+    const units = await Promise.all(unitPromises);
+    const mergedResult = await synchronouslyCombineUnitData(migration, units);
 
     process.stdout.write(JSON.stringify(mergedResult));
-  } else if (mode === 'globalMeta') {
-    await executeGlobalMetaPhase(migration, await readUnitMeta(args[0]));
+  } else if (mode === 'global-meta') {
+    const metaResult = await executeGlobalMetaPhase(migration, await readUnitMeta(args[0]));
+
+    process.stdout.write(JSON.stringify(metaResult));
   } else if (mode === 'migrate') {
     const {replacements, projectRoot} = await executeMigratePhase(
       migration,

--- a/packages/core/schematics/migrations/signal-migration/src/migration.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/migration.ts
@@ -18,7 +18,7 @@ import {MigrationHost} from './migration_host';
 import {executeAnalysisPhase} from './phase_analysis';
 import {pass4__checkInheritanceOfInputs} from './passes/4_check_inheritance';
 import {getCompilationUnitMetadata} from './batch/extract';
-import {mergeCompilationUnitData} from './batch/merge_unit_data';
+import {convertToGlobalMeta, combineCompilationUnitData} from './batch/merge_unit_data';
 import {Replacement} from '../../../utils/tsurge/replacement';
 import {populateKnownInputsFromGlobalData} from './batch/populate_global_data';
 import {executeMigrationPhase} from './phase_migrate';
@@ -28,10 +28,8 @@ import {
   ClassIncompatibilityReason,
   FieldIncompatibilityReason,
 } from './passes/problematic_patterns/incompatibility';
-import {isInputDescriptor} from './utils/input_id';
 import {MigrationConfig} from './migration_config';
 import {ClassFieldUniqueKey} from './passes/reference_resolution/known_fields';
-import {MigrationStats} from '../../../utils/tsurge';
 import {createNgtscProgram} from '../../../utils/tsurge/helpers/ngtsc_program';
 
 /**
@@ -124,8 +122,8 @@ export class SignalInputMigration extends TsurgeComplexMigration<
 
     // Non-batch mode!
     if (this.config.upgradeAnalysisPhaseToAvoidBatch) {
-      const merged = await this.merge([unitData]);
-      const {replacements} = await this.migrate(merged, info, {
+      const globalMeta = await this.globalMeta(unitData);
+      const {replacements} = await this.migrate(globalMeta, info, {
         knownInputs,
         result,
         host,
@@ -143,8 +141,17 @@ export class SignalInputMigration extends TsurgeComplexMigration<
     return confirmAsSerializable(unitData);
   }
 
-  override async merge(units: CompilationUnitData[]): Promise<Serializable<CompilationUnitData>> {
-    return confirmAsSerializable(mergeCompilationUnitData(units));
+  override async combine(
+    unitA: CompilationUnitData,
+    unitB: CompilationUnitData,
+  ): Promise<Serializable<CompilationUnitData>> {
+    return confirmAsSerializable(combineCompilationUnitData(unitA, unitB));
+  }
+
+  override async globalMeta(
+    combinedData: CompilationUnitData,
+  ): Promise<Serializable<CompilationUnitData>> {
+    return confirmAsSerializable(convertToGlobalMeta(combinedData));
   }
 
   override async migrate(

--- a/packages/core/schematics/migrations/signal-migration/test/BUILD.bazel
+++ b/packages/core/schematics/migrations/signal-migration/test/BUILD.bazel
@@ -103,7 +103,8 @@ integration_test(
     ],
     commands = [
         "$(rootpath :batch_runner) analyze ./golden-test",
-        "$(rootpath :batch_runner) merge ./golden-test",
+        "$(rootpath :batch_runner) combine-all ./golden-test",
+        "$(rootpath :batch_runner) global-meta ./golden-test",
         "$(rootpath :batch_runner) migrate ./golden-test",
         "$(rootpath :golden_test_runner) ./golden-test ./golden.txt",
     ],

--- a/packages/core/schematics/migrations/signal-migration/test/batch_runner.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/batch_runner.ts
@@ -53,18 +53,24 @@ async function main() {
       // write individual result.
       await fs.promises.writeFile(extractResultFile, extractResult);
     });
-  } else if (mode === 'merge') {
+  } else if (mode === 'combine-all') {
     const metadataFiles = files.map((f) => path.resolve(path.join(sourceDir, `${f}.extract.json`)));
-    const mergeResult = await promiseExec(`migration merge ${metadataFiles.join(' ')}`);
+    const mergeResult = await promiseExec(`migration combine-all ${metadataFiles.join(' ')}`);
 
     // write merge result.
-    await fs.promises.writeFile(path.join(sourceDir, 'merged.json'), mergeResult);
+    await fs.promises.writeFile(path.join(sourceDir, 'combined.json'), mergeResult);
+  } else if (mode === 'global-meta') {
+    const combinedUnitFile = path.join(sourceDir, 'combined.json');
+    const globalMeta = await promiseExec(`migration global-meta ${combinedUnitFile}`);
+
+    // write global meta result.
+    await fs.promises.writeFile(path.join(sourceDir, 'global_meta.json'), globalMeta);
   } else if (mode === 'migrate') {
     schedule(files, maxParallel, async (fileName) => {
       const filePath = path.join(sourceDir, fileName);
       // tsconfig should exist from analyze phase.
       const tmpTsconfigName = path.join(sourceDir, `${fileName}.tsconfig.json`);
-      const mergeMetadataFile = path.join(sourceDir, 'merged.json');
+      const mergeMetadataFile = path.join(sourceDir, 'global_meta.json');
 
       // migrate in parallel.
       await promiseExec(

--- a/packages/core/schematics/ng-generate/signal-input-migration/index.ts
+++ b/packages/core/schematics/ng-generate/signal-input-migration/index.ts
@@ -15,6 +15,7 @@ import {groupReplacementsByFile} from '../../utils/tsurge/helpers/group_replacem
 import {setFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {CompilationUnitData} from '../../migrations/signal-migration/src/batch/unit_data';
 import {ProjectRootRelativePath, TextUpdate} from '../../utils/tsurge';
+import {synchronouslyCombineUnitData} from '../../utils/tsurge/helpers/combine_units';
 
 interface Options {
   path: string;
@@ -77,13 +78,19 @@ export function migrate(options: Options): Rule {
     context.logger.info(`Processing analysis data between targets..`);
     context.logger.info(``);
 
-    const merged = await migration.merge(unitResults);
+    const combined = await synchronouslyCombineUnitData(migration, unitResults);
+    if (combined === null) {
+      context.logger.error('Migration failed unexpectedly with no analysis data');
+      return;
+    }
+
+    const globalMeta = await migration.globalMeta(combined);
     const replacementsPerFile: Map<ProjectRootRelativePath, TextUpdate[]> = new Map();
 
     for (const {info, tsconfigPath} of programInfos) {
       context.logger.info(`Migrating: ${tsconfigPath}..`);
 
-      const {replacements} = await migration.migrate(merged, info);
+      const {replacements} = await migration.migrate(globalMeta, info);
       const changesPerFile = groupReplacementsByFile(replacements);
 
       for (const [file, changes] of changesPerFile) {
@@ -104,7 +111,7 @@ export function migrate(options: Options): Rule {
       tree.commitUpdate(recorder);
     }
 
-    const {counters} = await migration.stats(merged);
+    const {counters} = await migration.stats(globalMeta);
     const migratedInputs = counters.sourceInputs - counters.incompatibleInputs;
 
     context.logger.info('');

--- a/packages/core/schematics/ng-generate/signal-queries-migration/index.ts
+++ b/packages/core/schematics/ng-generate/signal-queries-migration/index.ts
@@ -17,6 +17,7 @@ import {
   CompilationUnitData,
   SignalQueriesMigration,
 } from '../../migrations/signal-queries-migration/migration';
+import {synchronouslyCombineUnitData} from '../../utils/tsurge/helpers/combine_units';
 
 interface Options {
   path: string;
@@ -79,13 +80,19 @@ export function migrate(options: Options): Rule {
     context.logger.info(`Processing analysis data between targets..`);
     context.logger.info(``);
 
-    const merged = await migration.merge(unitResults);
+    const combined = await synchronouslyCombineUnitData(migration, unitResults);
+    if (combined === null) {
+      context.logger.error('Migration failed unexpectedly with no analysis data');
+      return;
+    }
+
+    const globalMeta = await migration.globalMeta(combined);
     const replacementsPerFile: Map<ProjectRootRelativePath, TextUpdate[]> = new Map();
 
     for (const {info, tsconfigPath} of programInfos) {
       context.logger.info(`Migrating: ${tsconfigPath}..`);
 
-      const {replacements} = await migration.migrate(merged, info);
+      const {replacements} = await migration.migrate(globalMeta, info);
       const changesPerFile = groupReplacementsByFile(replacements);
 
       for (const [file, changes] of changesPerFile) {
@@ -111,7 +118,7 @@ export function migrate(options: Options): Rule {
 
     const {
       counters: {queriesCount, incompatibleQueries, multiQueries},
-    } = await migration.stats(merged);
+    } = await migration.stats(globalMeta);
     const migratedQueries = queriesCount - incompatibleQueries;
 
     context.logger.info('');

--- a/packages/core/schematics/utils/tsurge/base_migration.ts
+++ b/packages/core/schematics/utils/tsurge/base_migration.ts
@@ -73,8 +73,22 @@ export abstract class TsurgeBaseMigration<UnitAnalysisMetadata, CombinedGlobalMe
   /** Analyzes the given TypeScript project and returns serializable compilation unit data. */
   abstract analyze(info: ProgramInfo): Promise<Serializable<UnitAnalysisMetadata>>;
 
-  /** Merges all compilation unit data from previous analysis phases into a global result. */
-  abstract merge(units: UnitAnalysisMetadata[]): Promise<Serializable<CombinedGlobalMetadata>>;
+  /**
+   * Combines two unit analyses into a single analysis metadata.
+   * This is necessary to allow for parallel merging of metadata.
+   */
+  abstract combine(
+    unitA: UnitAnalysisMetadata,
+    unitB: UnitAnalysisMetadata,
+  ): Promise<Serializable<UnitAnalysisMetadata>>;
+
+  /**
+   * Converts combined compilation into global metadata result that
+   * is then available for migrate and stats stages.
+   */
+  abstract globalMeta(
+    combinedData: UnitAnalysisMetadata,
+  ): Promise<Serializable<CombinedGlobalMetadata>>;
 
   /** Extract statistics based on the global metadata. */
   abstract stats(globalMetadata: CombinedGlobalMetadata): Promise<MigrationStats>;

--- a/packages/core/schematics/utils/tsurge/executors/combine_exec.ts
+++ b/packages/core/schematics/utils/tsurge/executors/combine_exec.ts
@@ -10,14 +10,15 @@ import {Serializable} from '../helpers/serializable';
 import {TsurgeMigration} from '../migration';
 
 /**
- * Executes the merge phase for the given migration against
- * the given set of analysis unit data.
+ * Executes the combine phase for the given migration against
+ * two unit analyses.
  *
- * @returns the serializable migration global data.
+ * @returns the serializable combined unit data.
  */
-export async function executeMergePhase<UnitData, GlobalData>(
+export async function executeCombinePhase<UnitData, GlobalData>(
   migration: TsurgeMigration<UnitData, GlobalData>,
-  units: UnitData[],
-): Promise<Serializable<GlobalData>> {
-  return await migration.merge(units);
+  unitA: UnitData,
+  unitB: UnitData,
+): Promise<Serializable<UnitData>> {
+  return await migration.combine(unitA, unitB);
 }

--- a/packages/core/schematics/utils/tsurge/executors/global_meta_exec.ts
+++ b/packages/core/schematics/utils/tsurge/executors/global_meta_exec.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Serializable} from '../helpers/serializable';
+import {TsurgeMigration} from '../migration';
+
+/**
+ * Executes the `globalMeta` stage for the given migration
+ * to convert the combined unit data into global meta.
+ *
+ * @returns the serializable global meta.
+ */
+export async function executeGlobalMetaPhase<UnitData, GlobalData>(
+  migration: TsurgeMigration<UnitData, GlobalData>,
+  combinedUnitData: UnitData,
+): Promise<Serializable<GlobalData>> {
+  return await migration.globalMeta(combinedUnitData);
+}

--- a/packages/core/schematics/utils/tsurge/helpers/combine_units.ts
+++ b/packages/core/schematics/utils/tsurge/helpers/combine_units.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {TsurgeMigration} from '../migration';
+
+/**
+ * Synchronously combines unit data for the given migration.
+ *
+ * Note: This helper is useful for testing and execution of
+ * Tsurge migrations in non-batchable environments. In general,
+ * prefer parallel execution of combining via e.g. Beam combiners.
+ */
+export async function synchronouslyCombineUnitData<UnitData>(
+  migration: TsurgeMigration<UnitData, unknown>,
+  unitDatas: UnitData[],
+): Promise<UnitData | null> {
+  if (unitDatas.length === 0) {
+    return null;
+  }
+  if (unitDatas.length === 1) {
+    return unitDatas[0];
+  }
+
+  let combined = unitDatas[0];
+
+  for (let i = 1; i < unitDatas.length; i++) {
+    const other = unitDatas[i];
+    combined = await migration.combine(combined, other);
+  }
+
+  return combined;
+}

--- a/packages/core/schematics/utils/tsurge/testing/run_single.ts
+++ b/packages/core/schematics/utils/tsurge/testing/run_single.ts
@@ -62,11 +62,11 @@ export async function runTsurgeMigration<UnitData, GlobalData>(
   const info = migration.prepareProgram(baseInfo);
 
   const unitData = await migration.analyze(info);
-  const merged = await migration.merge([unitData]);
+  const globalMeta = await migration.globalMeta(unitData);
   const {replacements} =
     migration instanceof TsurgeFunnelMigration
-      ? await migration.migrate(merged)
-      : await migration.migrate(merged, info);
+      ? await migration.migrate(globalMeta)
+      : await migration.migrate(globalMeta, info);
 
   const updates = groupReplacementsByFile(replacements);
   for (const [rootRelativePath, changes] of updates.entries()) {
@@ -76,6 +76,6 @@ export async function runTsurgeMigration<UnitData, GlobalData>(
 
   return {
     fs: mockFs,
-    getStatistics: () => migration.stats(merged),
+    getStatistics: () => migration.stats(globalMeta),
   };
 }

--- a/packages/language-service/src/refactorings/convert_to_signal_queries/apply_query_refactoring.ts
+++ b/packages/language-service/src/refactorings/convert_to_signal_queries/apply_query_refactoring.ts
@@ -55,8 +55,8 @@ export async function applySignalQueriesRefactoring(
   });
 
   const unitData = await migration.analyze(programInfo);
-  const merged = await migration.merge([unitData]);
-  const {replacements, knownQueries} = await migration.migrate(merged, programInfo);
+  const globalMeta = await migration.globalMeta(unitData);
+  const {replacements, knownQueries} = await migration.migrate(globalMeta, programInfo);
 
   const targetQueries = Array.from(knownQueries.knownQueryIDs.values()).filter((descriptor) =>
     shouldMigrateQuery(descriptor, projectFile(descriptor.node.getSourceFile(), programInfo)),


### PR DESCRIPTION
This is helpful and important for large scale migrations where a single
call for merging _all_ unit data's can be subject to memory / disk
resource constraints. Consider a compilation unit data for every target
in Google3, and those being merged in a single program.