### PR TITLE
Migration outputs in templates

### DIFF
--- a/packages/core/schematics/migrations/output-migration/BUILD.bazel
+++ b/packages/core/schematics/migrations/output-migration/BUILD.bazel
@@ -15,6 +15,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/imports",
         "//packages/compiler-cli/src/ngtsc/metadata",
         "//packages/compiler-cli/src/ngtsc/reflection",
+        "//packages/core/schematics/migrations/signal-migration/src",
         "//packages/core/schematics/utils/tsurge",
         "@npm//@types/node",
         "@npm//typescript",

--- a/packages/core/schematics/migrations/output-migration/output-migration.ts
+++ b/packages/core/schematics/migrations/output-migration/output-migration.ts
@@ -21,8 +21,8 @@ import {
 
 import {DtsMetadataReader} from '../../../../compiler-cli/src/ngtsc/metadata';
 import {TypeScriptReflectionHost} from '../../../../compiler-cli/src/ngtsc/reflection';
+import {PartialEvaluator} from '@angular/compiler-cli/private/migrations';
 import {
-  OutputID,
   getUniqueIdForProperty,
   isTargetOutputDeclaration,
   extractSourceOutputDefinition,
@@ -30,6 +30,8 @@ import {
   isPotentialNextCallUsage,
   isPotentialPipeCallUsage,
   isTestRunnerImport,
+  getTargetPropertyDeclaration,
+  checkNonTsReferenceCallsField,
 } from './output_helpers';
 import {
   calculateImportReplacements,
@@ -37,7 +39,18 @@ import {
   calculateNextFnReplacement,
   calculateCompleteCallReplacement,
   calculatePipeCallReplacement,
+  calculateNextFnReplacementInTemplate,
+  calculateNextFnReplacementInHostBinding,
 } from './output-replacements';
+
+import {createFindAllSourceFileReferencesVisitor} from '../signal-migration/src/passes/reference_resolution';
+import {
+  ClassFieldDescriptor,
+  ClassFieldUniqueKey,
+  KnownFields,
+} from '../signal-migration/src/passes/reference_resolution/known_fields';
+import {ReferenceResult} from '../signal-migration/src/passes/reference_resolution/reference_result';
+import {ReferenceKind} from '../signal-migration/src/passes/reference_resolution/reference_kinds';
 
 interface OutputMigrationData {
   file: ProjectFile;
@@ -45,8 +58,8 @@ interface OutputMigrationData {
 }
 
 interface CompilationUnitData {
-  outputFields: Record<OutputID, OutputMigrationData>;
-  problematicUsages: Record<OutputID, true>;
+  outputFields: Record<ClassFieldUniqueKey, OutputMigrationData>;
+  problematicUsages: Record<ClassFieldUniqueKey, true>;
   importReplacements: Record<ProjectFileID, {add: Replacement[]; addAndRemove: Replacement[]}>;
 }
 
@@ -56,14 +69,42 @@ export class OutputMigration extends TsurgeFunnelMigration<
 > {
   override async analyze(info: ProgramInfo): Promise<Serializable<CompilationUnitData>> {
     const {sourceFiles, program} = info;
-    const outputFieldReplacements: Record<OutputID, OutputMigrationData> = {};
-    const problematicUsages: Record<OutputID, true> = {};
+    const outputFieldReplacements: Record<ClassFieldUniqueKey, OutputMigrationData> = {};
+    const problematicUsages: Record<ClassFieldUniqueKey, true> = {};
 
     const filesWithOutputDeclarations = new Set<ts.SourceFile>();
 
     const checker = program.getTypeChecker();
     const reflector = new TypeScriptReflectionHost(checker);
     const dtsReader = new DtsMetadataReader(checker, reflector);
+    const evaluator = new PartialEvaluator(reflector, checker, null);
+    const ngCompiler = info.ngCompiler;
+
+    // TODO: use an assert instead?
+    if (ngCompiler === null) {
+      throw new Error('Requires ngCompiler to run the migration');
+    }
+    const resourceLoader = ngCompiler['resourceManager'];
+    // Pre-Analyze the program and get access to the template type checker.
+    const {templateTypeChecker} = ngCompiler['ensureAnalyzed']();
+    const knownFields: KnownFields<ClassFieldDescriptor> = {
+      // Note: We don't support cross-target migration of `Partial<T>` usages.
+      // This is an acceptable limitation for performance reasons.
+      shouldTrackClassReference: (node) => true,
+      attemptRetrieveDescriptorFromSymbol: (s) => {
+        const propDeclaration = getTargetPropertyDeclaration(s);
+        if (propDeclaration !== null) {
+          const classFieldID = getUniqueIdForProperty(info, propDeclaration);
+          if (classFieldID !== null) {
+            return {
+              node: propDeclaration,
+              key: classFieldID,
+            };
+          }
+        }
+        return null;
+      },
+    };
 
     let isTestFile = false;
 
@@ -166,6 +207,54 @@ export class OutputMigration extends TsurgeFunnelMigration<
       ts.forEachChild(sf, outputMigrationVisitor);
     }
 
+    // take care of the references in templates and host bindings
+    const referenceResult: ReferenceResult<ClassFieldDescriptor> = {references: []};
+    const {visitor: templateHostRefVisitor} = createFindAllSourceFileReferencesVisitor(
+      info,
+      checker,
+      reflector,
+      resourceLoader,
+      evaluator,
+      templateTypeChecker,
+      knownFields,
+      null, // TODO: capture known output names as an optimization
+      referenceResult,
+    );
+
+    // calculate template / host binding replacements
+    for (const sf of sourceFiles) {
+      ts.forEachChild(sf, templateHostRefVisitor);
+    }
+
+    for (const ref of referenceResult.references) {
+      // detect .next usages that should be migrated to .emit in template and host binding expressions
+      if (ref.kind === ReferenceKind.InTemplate) {
+        const callExpr = checkNonTsReferenceCallsField(ref, 'next');
+        if (callExpr !== null) {
+          addOutputReplacement(
+            outputFieldReplacements,
+            ref.target.key,
+            ref.from.templateFile,
+            calculateNextFnReplacementInTemplate(ref.from.templateFile, callExpr.nameSpan),
+          );
+        }
+      } else if (ref.kind === ReferenceKind.InHostBinding) {
+        const callExpr = checkNonTsReferenceCallsField(ref, 'next');
+        if (callExpr !== null) {
+          addOutputReplacement(
+            outputFieldReplacements,
+            ref.target.key,
+            ref.from.file,
+            calculateNextFnReplacementInHostBinding(
+              ref.from.file,
+              ref.from.hostPropertyNode.getStart() + 1,
+              callExpr.nameSpan,
+            ),
+          );
+        }
+      }
+    }
+
     // calculate import replacements but do so only for files that have output declarations
     const importReplacements = calculateImportReplacements(info, filesWithOutputDeclarations);
 
@@ -177,16 +266,16 @@ export class OutputMigration extends TsurgeFunnelMigration<
   }
 
   override async merge(units: CompilationUnitData[]): Promise<Serializable<CompilationUnitData>> {
-    const outputFields: Record<OutputID, OutputMigrationData> = {};
+    const outputFields: Record<ClassFieldUniqueKey, OutputMigrationData> = {};
     const importReplacements: Record<
       ProjectFileID,
       {add: Replacement[]; addAndRemove: Replacement[]}
     > = {};
-    const problematicUsages: Record<OutputID, true> = {};
+    const problematicUsages: Record<ClassFieldUniqueKey, true> = {};
 
     for (const unit of units) {
       for (const declIdStr of Object.keys(unit.outputFields)) {
-        const declId = declIdStr as OutputID;
+        const declId = declIdStr as ClassFieldUniqueKey;
         // THINK: detect clash? Should we have an utility to merge data based on unique IDs?
         outputFields[declId] = unit.outputFields[declId];
       }
@@ -197,7 +286,7 @@ export class OutputMigration extends TsurgeFunnelMigration<
       }
 
       for (const declIdStr of Object.keys(unit.problematicUsages)) {
-        const declId = declIdStr as OutputID;
+        const declId = declIdStr as ClassFieldUniqueKey;
         problematicUsages[declId] = unit.problematicUsages[declId];
       }
     }
@@ -220,7 +309,7 @@ export class OutputMigration extends TsurgeFunnelMigration<
 
     const replacements: Replacement[] = [];
     for (const declIdStr of Object.keys(globalData.outputFields)) {
-      const declId = declIdStr as OutputID;
+      const declId = declIdStr as ClassFieldUniqueKey;
       const outputField = globalData.outputFields[declId];
 
       if (!globalData.problematicUsages[declId]) {
@@ -248,8 +337,8 @@ export class OutputMigration extends TsurgeFunnelMigration<
 }
 
 function addOutputReplacement(
-  outputFieldReplacements: Record<OutputID, OutputMigrationData>,
-  outputId: OutputID,
+  outputFieldReplacements: Record<ClassFieldUniqueKey, OutputMigrationData>,
+  outputId: ClassFieldUniqueKey,
   file: ProjectFile,
   ...replacements: Replacement[]
 ): void {

--- a/packages/core/schematics/migrations/output-migration/output-migration.ts
+++ b/packages/core/schematics/migrations/output-migration/output-migration.ts
@@ -7,6 +7,7 @@
  */
 
 import ts from 'typescript';
+import assert from 'assert';
 import {
   confirmAsSerializable,
   MigrationStats,
@@ -79,18 +80,14 @@ export class OutputMigration extends TsurgeFunnelMigration<
     const dtsReader = new DtsMetadataReader(checker, reflector);
     const evaluator = new PartialEvaluator(reflector, checker, null);
     const ngCompiler = info.ngCompiler;
-
-    // TODO: use an assert instead?
-    if (ngCompiler === null) {
-      throw new Error('Requires ngCompiler to run the migration');
-    }
+    assert(ngCompiler !== null, 'Requires ngCompiler to run the migration');
     const resourceLoader = ngCompiler['resourceManager'];
     // Pre-Analyze the program and get access to the template type checker.
     const {templateTypeChecker} = ngCompiler['ensureAnalyzed']();
     const knownFields: KnownFields<ClassFieldDescriptor> = {
       // Note: We don't support cross-target migration of `Partial<T>` usages.
       // This is an acceptable limitation for performance reasons.
-      shouldTrackClassReference: (node) => true,
+      shouldTrackClassReference: (node) => false,
       attemptRetrieveDescriptorFromSymbol: (s) => {
         const propDeclaration = getTargetPropertyDeclaration(s);
         if (propDeclaration !== null) {

--- a/packages/core/schematics/migrations/output-migration/output_helpers.ts
+++ b/packages/core/schematics/migrations/output-migration/output_helpers.ts
@@ -16,14 +16,20 @@ import {DtsMetadataReader} from '../../../../compiler-cli/src/ngtsc/metadata';
 import {Reference} from '../../../../compiler-cli/src/ngtsc/imports';
 import {getAngularDecorators} from '../../../../compiler-cli/src/ngtsc/annotations';
 
-import {ProgramInfo, projectFile, UniqueID} from '../../utils/tsurge';
-
-/** Branded type for unique IDs of Angular `@Output`s. */
-export type OutputID = UniqueID<'output-node'>;
+import {ProgramInfo, projectFile} from '../../utils/tsurge';
+import {
+  ClassFieldDescriptor,
+  ClassFieldUniqueKey,
+} from '../signal-migration/src/passes/reference_resolution/known_fields';
+import {
+  HostBindingReference,
+  TemplateReference,
+} from '../signal-migration/src/passes/reference_resolution/reference_kinds';
+import {AST, PropertyRead} from '@angular/compiler';
 
 /** Type describing an extracted output query that can be migrated. */
 export interface ExtractedOutput {
-  id: OutputID;
+  id: ClassFieldUniqueKey;
   aliasParam?: ts.Expression;
 }
 
@@ -149,10 +155,13 @@ function getOutputDecorator(
 
 // THINK: this utility + type is not specific to @Output, really, maybe move it to tsurge?
 /** Computes an unique ID for a given Angular `@Output` property. */
-export function getUniqueIdForProperty(info: ProgramInfo, prop: ts.PropertyDeclaration): OutputID {
+export function getUniqueIdForProperty(
+  info: ProgramInfo,
+  prop: ts.PropertyDeclaration,
+): ClassFieldUniqueKey {
   const {id} = projectFile(prop.getSourceFile(), info);
   id.replace(/\.d\.ts$/, '.ts');
-  return `${id}@@${prop.parent.name ?? 'unknown-class'}@@${prop.name.getText()}` as OutputID;
+  return `${id}@@${prop.parent.name ?? 'unknown-class'}@@${prop.name.getText()}` as ClassFieldUniqueKey;
 }
 
 export function isTestRunnerImport(node: ts.Node) {
@@ -161,4 +170,54 @@ export function isTestRunnerImport(node: ts.Node) {
     return moduleSpecifier.includes('jasmine') || moduleSpecifier.includes('catalyst');
   }
   return false;
+}
+
+// TODO: code duplication with signals migration - sort it out
+
+/**
+ * Gets whether the given read is used to access
+ * the specified field.
+ *
+ * E.g. whether `<my-read>.toArray` is detected.
+ */
+export function checkNonTsReferenceAccessesField(
+  ref: HostBindingReference<ClassFieldDescriptor> | TemplateReference<ClassFieldDescriptor>,
+  fieldName: string,
+): PropertyRead | null {
+  const readFromPath = ref.from.readAstPath.at(-1) as PropertyRead | AST | undefined;
+  const parentRead = ref.from.readAstPath.at(-2) as PropertyRead | AST | undefined;
+
+  if (ref.from.read !== readFromPath) {
+    return null;
+  }
+  if (!(parentRead instanceof PropertyRead) || parentRead.name !== fieldName) {
+    return null;
+  }
+
+  return parentRead;
+}
+
+/**
+ * Gets whether the given reference is accessed to call the
+ * specified function on it.
+ *
+ * E.g. whether `<my-read>.toArray()` is detected.
+ */
+export function checkNonTsReferenceCallsField(
+  ref: TemplateReference<ClassFieldDescriptor> | HostBindingReference<ClassFieldDescriptor>,
+  fieldName: string,
+): PropertyRead | null {
+  const propertyAccess = checkNonTsReferenceAccessesField(ref, fieldName);
+  if (propertyAccess === null) {
+    return null;
+  }
+  const accessIdx = ref.from.readAstPath.indexOf(propertyAccess);
+  if (accessIdx === -1) {
+    return null;
+  }
+  const potentialRead = ref.from.readAstPath[accessIdx];
+  if (potentialRead === undefined) {
+    return null;
+  }
+  return potentialRead as PropertyRead;
 }

--- a/packages/core/schematics/migrations/signal-migration/src/BUILD.bazel
+++ b/packages/core/schematics/migrations/signal-migration/src/BUILD.bazel
@@ -7,6 +7,7 @@ ts_library(
         exclude = ["test/**"],
     ),
     visibility = [
+        "//packages/core/schematics/migrations/output-migration:__pkg__",
         "//packages/core/schematics/migrations/signal-migration/test:__pkg__",
         "//packages/core/schematics/migrations/signal-queries-migration:__pkg__",
         "//packages/core/schematics/ng-generate/signal-input-migration:__pkg__",


### PR DESCRIPTION
This change tracks usage of outputs in templates / host bindings. For now it replaces `.next` usage with `.emit` but we might need to add more processing if needed (ex. `.pipe` usage - for now I'm assuming that this is not very common / not happening).