### PR TITLE
refactor(@angular/core): wrap `AFTER_RENDER_PHASE_EFFECT_NODE` in an IIFE for Tree-shaking

### DIFF
--- a/packages/core/src/render3/reactivity/after_render_effect.ts
+++ b/packages/core/src/render3/reactivity/after_render_effect.ts
@@ -67,7 +67,7 @@ interface AfterRenderPhaseEffectNode extends SignalNode<unknown> {
   phaseFn(previousValue?: unknown): unknown;
 }
 
-const AFTER_RENDER_PHASE_EFFECT_NODE = {
+const AFTER_RENDER_PHASE_EFFECT_NODE = /* @__PURE__ */ (() => ({
   ...SIGNAL_NODE,
   consumerIsAlwaysLive: true,
   consumerAllowSignalWrites: true,
@@ -140,7 +140,7 @@ const AFTER_RENDER_PHASE_EFFECT_NODE = {
 
     return this.signal;
   },
-};
+}))();
 
 /**
  * An `AfterRenderSequence` that manages an `afterRenderEffect`'s phase effects.

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -705,9 +705,6 @@
     "name": "configureViewWithDirective"
   },
   {
-    "name": "consumerAfterComputation"
-  },
-  {
     "name": "consumerBeforeComputation"
   },
   {
@@ -775,9 +772,6 @@
   },
   {
     "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultEquals"
   },
   {
     "name": "defaultErrorHandler"


### PR DESCRIPTION

Currently, `AFTER_RENDER_PHASE_EFFECT_NODE` is not tree-shakable. By wrapping it in an IIFE, it will be annotated as pure, allowing unused code to be removed during the tree-shaking process.

This issue was discovered while investigating: https://github.com/angular/angular/issues/58296.
