### PR TITLE
test: check current hydration bundle sizes

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -54,8 +54,8 @@
   },
   "platform-server-hydration/browser": {
     "uncompressed": {
-      "main": 212989,
-      "polyfills": 33807,
+      "main": 221976,
+      "polyfills": 34544,
       "event-dispatch-contract.min": 476
     }
   }


### PR DESCRIPTION
This is purely for running the bundle size integration test. Ignore.

