### PR TITLE
fix(localize): Adding  arb format to the list of valid formats in the…

### DIFF
--- a/packages/localize/tools/src/extract/cli.ts
+++ b/packages/localize/tools/src/extract/cli.ts
@@ -48,7 +48,18 @@ const options = yargs(args)
   .option('f', {
     alias: 'format',
     required: true,
-    choices: ['xmb', 'xlf', 'xlif', 'xliff', 'xlf2', 'xlif2', 'xliff2', 'json', 'legacy-migrate'],
+    choices: [
+      'xmb',
+      'xlf',
+      'xlif',
+      'xliff',
+      'xlf2',
+      'xlif2',
+      'xliff2',
+      'json',
+      'legacy-migrate',
+      'arb',
+    ],
     describe: 'The format of the translation file.',
     type: 'string',
   })


### PR DESCRIPTION
… localization extractor cli

Although the ARB format is supported, it's missing from the command's list of options.

Fix #58286

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #58286


## What is the new behavior?

Support arb format in extract localize cli

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

