### PR TITLE
Improve tree shakebility

### DIFF
--- a/adev/src/content/api-examples/upgrade/static/ts/full/module.ts
+++ b/adev/src/content/api-examples/upgrade/static/ts/full/module.ts
@@ -105,7 +105,7 @@ export class Ng1HeroComponentWrapper extends UpgradeComponent {
   // The names of the input and output properties here must match the names of the
   // `<` and `&` bindings in the AngularJS component that is being wrapped
   @Input() hero!: Hero;
-  @Output() onRemove!: EventEmitter<void>;
+  @Output() onRemove: EventEmitter<void> = new EventEmitter();
 
   constructor(elementRef: ElementRef, injector: Injector) {
     // We must pass the name of the directive as used by AngularJS to the super

--- a/adev/src/content/api-examples/upgrade/static/ts/lite/module.ts
+++ b/adev/src/content/api-examples/upgrade/static/ts/lite/module.ts
@@ -116,7 +116,7 @@ class Ng1HeroComponentWrapper extends UpgradeComponent {
   // The names of the input and output properties here must match the names of the
   // `<` and `&` bindings in the AngularJS component that is being wrapped.
   @Input() hero!: Hero;
-  @Output() onRemove!: EventEmitter<void>;
+  @Output() onRemove: EventEmitter<void> = new EventEmitter();
 
   constructor(elementRef: ElementRef, injector: Injector) {
     // We must pass the name of the directive as used by AngularJS to the super.

--- a/devtools/projects/ng-devtools-backend/src/lib/highlighter.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/highlighter.ts
@@ -103,10 +103,19 @@ export function highlightHydrationElement(el: Node, status: HydrationStatus) {
 }
 
 export function unHighlight(): void {
-  if (selectedElementOverlay) {
-    document.body.removeChild(selectedElementOverlay);
-    selectedElementOverlay = null;
+  if (!selectedElementOverlay) {
+    return;
   }
+
+  for (const node of document.body.childNodes) {
+    if (node === selectedElementOverlay) {
+      document.body.removeChild(selectedElementOverlay);
+
+      break;
+    }
+  }
+
+  selectedElementOverlay = null;
 }
 
 export function removeHydrationHighlights(): void {

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -47,7 +47,7 @@
   },
   "defer": {
     "uncompressed": {
-      "main": 11497,
+      "main": 12094,
       "polyfills": 33807,
       "defer.component": 345
     }

--- a/packages/bazel/src/ng_module/ng_module.bzl
+++ b/packages/bazel/src/ng_module/ng_module.bzl
@@ -208,10 +208,6 @@ def _ngc_tsconfig(ctx, files, srcs, **kwargs):
     # https://github.com/bazelbuild/rules_nodejs/blob/901df3868e3ceda177d3ed181205e8456a5592ea/third_party/github.com/bazelbuild/rules_typescript/internal/common/tsconfig.bzl#L195
     # TODO(devversion): In the future, combine prodmode and devmode so we can get rid of the
     # ambiguous terminology and concept that can result in slow-down for development workflows.
-    # TODO(alanagius): The below causes a drastic size increase when enabled (4Kb in the //integration/forms:test). This is mainly due to Babel transforms for Safari 15.
-    # https://github.com/angular/angular-cli/blob/3e8bdf72d6b7e2925d2822da807b726f88a77e1a/packages/angular_devkit/build_angular/src/babel/presets/application.ts#L199-L204
-    # https://www.diffchecker.com/9Ge3pexk
-    tsconfig["compilerOptions"]["useDefineForClassFields"] = False
     tsconfig["compilerOptions"]["target"] = "es2022"
     tsconfig["compilerOptions"]["module"] = "esnext"
 

--- a/packages/bazel/test/ng_package/example_package.golden
+++ b/packages/bazel/test/ng_package/example_package.golden
@@ -128,9 +128,9 @@ import * as i0 from '@angular/core';
 import { NgModule } from '@angular/core';
 
 class A11yModule {
-    static { this.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: A11yModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule }); }
-    static { this.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0", ngImport: i0, type: A11yModule }); }
-    static { this.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: A11yModule }); }
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: A11yModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
+    static ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0", ngImport: i0, type: A11yModule });
+    static ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: A11yModule });
 }
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: A11yModule, decorators: [{
             type: NgModule,
@@ -157,8 +157,8 @@ import * as i0 from '@angular/core';
 import { Injectable } from '@angular/core';
 
 class MySecondService {
-    static { this.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: MySecondService, deps: [], target: i0.ɵɵFactoryTarget.Injectable }); }
-    static { this.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: MySecondService, providedIn: 'root' }); }
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: MySecondService, deps: [], target: i0.ɵɵFactoryTarget.Injectable });
+    static ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: MySecondService, providedIn: 'root' });
 }
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: MySecondService, decorators: [{
             type: Injectable,
@@ -166,11 +166,12 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport
         }] });
 
 class MyService {
+    secondService;
     constructor(secondService) {
         this.secondService = secondService;
     }
-    static { this.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: MyService, deps: [{ token: MySecondService }], target: i0.ɵɵFactoryTarget.Injectable }); }
-    static { this.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: MyService, providedIn: 'root' }); }
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: MyService, deps: [{ token: MySecondService }], target: i0.ɵɵFactoryTarget.Injectable });
+    static ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: MyService, providedIn: 'root' });
 }
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: MyService, decorators: [{
             type: Injectable,
@@ -197,9 +198,9 @@ import * as i0 from '@angular/core';
 import { NgModule } from '@angular/core';
 
 class SecondaryModule {
-    static { this.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule }); }
-    static { this.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule }); }
-    static { this.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule }); }
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
+    static ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule });
+    static ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule });
 }
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule, decorators: [{
             type: NgModule,
@@ -227,9 +228,9 @@ import * as i0 from '@angular/core';
 import { NgModule } from '@angular/core';
 
 class MyModule {
-    static { this.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: MyModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule }); }
-    static { this.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0", ngImport: i0, type: MyModule }); }
-    static { this.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: MyModule }); }
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: MyModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
+    static ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0", ngImport: i0, type: MyModule });
+    static ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: MyModule });
 }
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: MyModule, decorators: [{
             type: NgModule,

--- a/packages/bazel/test/ng_package/example_with_ts_library_package.golden
+++ b/packages/bazel/test/ng_package/example_with_ts_library_package.golden
@@ -76,9 +76,9 @@ import * as i0 from '@angular/core';
 import { NgModule } from '@angular/core';
 
 class PortalModule {
-    static { this.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: PortalModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule }); }
-    static { this.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0", ngImport: i0, type: PortalModule }); }
-    static { this.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: PortalModule }); }
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: PortalModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
+    static ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0", ngImport: i0, type: PortalModule });
+    static ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: PortalModule });
 }
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: PortalModule, decorators: [{
             type: NgModule,

--- a/packages/bazel/test/ngc-wrapped/ivy_enabled/ng_module_ivy_test.ts
+++ b/packages/bazel/test/ngc-wrapped/ivy_enabled/ng_module_ivy_test.ts
@@ -15,6 +15,6 @@ describe('ng_module with ivy enabled', () => {
       'packages/bazel/test/ngc-wrapped/ivy_enabled/test_module_default_compilation.mjs',
     );
     const fileContent = readFileSync(outputFile, 'utf8');
-    expect(fileContent).toContain(`static { this.ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent`);
+    expect(fileContent).toContain(`static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent`);
   });
 });

--- a/packages/common/src/viewport_scroller.ts
+++ b/packages/common/src/viewport_scroller.ts
@@ -20,7 +20,7 @@ export abstract class ViewportScroller {
   // De-sugared tree-shakable injection
   // See #23917
   /** @nocollapse */
-  static ɵprov = /** @pureOrBreakMyCode */ ɵɵdefineInjectable({
+  static ɵprov = /** @pureOrBreakMyCode */ /* @__PURE__ */ ɵɵdefineInjectable({
     token: ViewportScroller,
     providedIn: 'root',
     factory: () =>

--- a/packages/compiler-cli/linker/src/file_linker/linker_environment.ts
+++ b/packages/compiler-cli/linker/src/file_linker/linker_environment.ts
@@ -15,10 +15,8 @@ import {DEFAULT_LINKER_OPTIONS, LinkerOptions} from './linker_options';
 import {Translator} from './translator';
 
 export class LinkerEnvironment<TStatement, TExpression> {
-  readonly translator = new Translator<TStatement, TExpression>(this.factory);
-  readonly sourceFileLoader = this.options.sourceMapping
-    ? new SourceFileLoader(this.fileSystem, this.logger, {})
-    : null;
+  readonly translator: Translator<TStatement, TExpression>;
+  readonly sourceFileLoader: SourceFileLoader | null;
 
   private constructor(
     readonly fileSystem: ReadonlyFileSystem,
@@ -26,7 +24,12 @@ export class LinkerEnvironment<TStatement, TExpression> {
     readonly host: AstHost<TExpression>,
     readonly factory: AstFactory<TStatement, TExpression>,
     readonly options: LinkerOptions,
-  ) {}
+  ) {
+    this.translator = new Translator<TStatement, TExpression>(this.factory);
+    this.sourceFileLoader = this.options.sourceMapping
+      ? new SourceFileLoader(this.fileSystem, this.logger, {})
+      : null;
+  }
 
   static create<TStatement, TExpression>(
     fileSystem: ReadonlyFileSystem,

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -48,13 +48,15 @@ export class NgtscTestEnvironment {
   private multiCompileHostExt: MultiCompileHostExt | null = null;
   private oldProgram: Program | null = null;
   private changedResources: Set<string> | null = null;
-  private commandLineArgs = ['-p', this.basePath];
+  private commandLineArgs: string[];
 
   private constructor(
     private fs: FileSystem,
     readonly outDir: AbsoluteFsPath,
     readonly basePath: AbsoluteFsPath,
-  ) {}
+  ) {
+    this.commandLineArgs = ['-p', this.basePath];
+  }
 
   /**
    * Set up a new testing environment.

--- a/packages/core/src/cached_injector_service.ts
+++ b/packages/core/src/cached_injector_service.ts
@@ -51,7 +51,7 @@ export class CachedInjectorService implements OnDestroy {
   }
 
   /** @nocollapse */
-  static ɵprov = /** @pureOrBreakMyCode */ defineInjectable({
+  static ɵprov = /** @pureOrBreakMyCode */ /* @__PURE__ */ defineInjectable({
     token: CachedInjectorService,
     providedIn: 'environment',
     factory: () => new CachedInjectorService(),

--- a/packages/core/src/change_detection/differs/iterable_differs.ts
+++ b/packages/core/src/change_detection/differs/iterable_differs.ts
@@ -193,7 +193,7 @@ export function defaultIterableDiffersFactory() {
  */
 export class IterableDiffers {
   /** @nocollapse */
-  static ɵprov = /** @pureOrBreakMyCode */ ɵɵdefineInjectable({
+  static ɵprov = /** @pureOrBreakMyCode */ /* @__PURE__ */ ɵɵdefineInjectable({
     token: IterableDiffers,
     providedIn: 'root',
     factory: defaultIterableDiffersFactory,

--- a/packages/core/src/change_detection/differs/keyvalue_differs.ts
+++ b/packages/core/src/change_detection/differs/keyvalue_differs.ts
@@ -123,7 +123,7 @@ export function defaultKeyValueDiffersFactory() {
  */
 export class KeyValueDiffers {
   /** @nocollapse */
-  static ɵprov = /** @pureOrBreakMyCode */ ɵɵdefineInjectable({
+  static ɵprov = /** @pureOrBreakMyCode */ /* @__PURE__ */ ɵɵdefineInjectable({
     token: KeyValueDiffers,
     providedIn: 'root',
     factory: defaultKeyValueDiffersFactory,

--- a/packages/core/src/defer/idle_scheduler.ts
+++ b/packages/core/src/defer/idle_scheduler.ts
@@ -122,7 +122,7 @@ export class IdleScheduler {
   }
 
   /** @nocollapse */
-  static ɵprov = /** @pureOrBreakMyCode */ ɵɵdefineInjectable({
+  static ɵprov = /** @pureOrBreakMyCode */ /* @__PURE__ */ ɵɵdefineInjectable({
     token: IdleScheduler,
     providedIn: 'root',
     factory: () => new IdleScheduler(),

--- a/packages/core/src/defer/registry.ts
+++ b/packages/core/src/defer/registry.ts
@@ -49,7 +49,7 @@ export class DeferBlockRegistry {
   hydrating = new Set();
 
   /** @nocollapse */
-  static ɵprov = /** @pureOrBreakMyCode */ ɵɵdefineInjectable({
+  static ɵprov = /** @pureOrBreakMyCode */ /* @__PURE__ */ ɵɵdefineInjectable({
     token: DeferBlockRegistry,
     providedIn: 'root',
     factory: () => new DeferBlockRegistry(),

--- a/packages/core/src/defer/timer_scheduler.ts
+++ b/packages/core/src/defer/timer_scheduler.ts
@@ -217,7 +217,7 @@ export class TimerScheduler {
   }
 
   /** @nocollapse */
-  static ɵprov = /** @pureOrBreakMyCode */ ɵɵdefineInjectable({
+  static ɵprov = /** @pureOrBreakMyCode */ /* @__PURE__ */ ɵɵdefineInjectable({
     token: TimerScheduler,
     providedIn: 'root',
     factory: () => new TimerScheduler(),

--- a/packages/core/src/di/injector.ts
+++ b/packages/core/src/di/injector.ts
@@ -134,7 +134,7 @@ export abstract class Injector {
   }
 
   /** @nocollapse */
-  static ɵprov = /** @pureOrBreakMyCode */ ɵɵdefineInjectable({
+  static ɵprov = /** @pureOrBreakMyCode */ /* @__PURE__ */ ɵɵdefineInjectable({
     token: Injector,
     providedIn: 'any',
     factory: () => ɵɵinject(INJECTOR),

--- a/packages/core/src/linker/query_list.ts
+++ b/packages/core/src/linker/query_list.ts
@@ -66,14 +66,7 @@ export class QueryList<T> implements Iterable<T> {
    *     has occurred. Or if it should fire when query is recomputed. (recomputing could resolve in
    *     the same result)
    */
-  constructor(private _emitDistinctChangesOnly: boolean = false) {
-    // This function should be declared on the prototype, but doing so there will cause the class
-    // declaration to have side-effects and become not tree-shakable. For this reason we do it in
-    // the constructor.
-    // [Symbol.iterator](): Iterator<T> { ... }
-    const proto = QueryList.prototype;
-    if (!proto[Symbol.iterator]) proto[Symbol.iterator] = symbolIterator;
-  }
+  constructor(private _emitDistinctChangesOnly: boolean = false) {}
 
   /**
    * Returns the QueryList entry at `index`.
@@ -193,10 +186,5 @@ export class QueryList<T> implements Iterable<T> {
     }
   }
 
-  // The implementation of `Symbol.iterator` should be declared here, but this would cause
-  // tree-shaking issues with `QueryList. So instead, it's added in the constructor (see comments
-  // there) and this declaration is left here to ensure that TypeScript considers QueryList to
-  // implement the Iterable interface. This is required for template type-checking of NgFor loops
-  // over QueryLists to work correctly, since QueryList must be assignable to NgIterable.
-  [Symbol.iterator]!: () => Iterator<T>;
+  [Symbol.iterator]: () => Iterator<T> = /** @__PURE__*/ (() => symbolIterator)();
 }

--- a/packages/core/src/pending_tasks.ts
+++ b/packages/core/src/pending_tasks.ts
@@ -55,7 +55,7 @@ export class PendingTasksInternal implements OnDestroy {
   }
 
   /** @nocollapse */
-  static ɵprov = /** @pureOrBreakMyCode */ ɵɵdefineInjectable({
+  static ɵprov = /** @pureOrBreakMyCode */ /* @__PURE__ */ ɵɵdefineInjectable({
     token: PendingTasksInternal,
     providedIn: 'root',
     factory: () => new PendingTasksInternal(),
@@ -134,7 +134,7 @@ export class PendingTasks {
   }
 
   /** @nocollapse */
-  static ɵprov = /** @pureOrBreakMyCode */ ɵɵdefineInjectable({
+  static ɵprov = /** @pureOrBreakMyCode */ /* @__PURE__ */ ɵɵdefineInjectable({
     token: PendingTasks,
     providedIn: 'root',
     factory: () => new PendingTasks(),

--- a/packages/core/src/render3/after_render/manager.ts
+++ b/packages/core/src/render3/after_render/manager.ts
@@ -33,12 +33,13 @@ export class AfterRenderManager {
 }
 
 export class AfterRenderImpl {
-  static readonly PHASES = [
-    AfterRenderPhase.EarlyRead,
-    AfterRenderPhase.Write,
-    AfterRenderPhase.MixedReadWrite,
-    AfterRenderPhase.Read,
-  ] as const;
+  static readonly PHASES = /* @__PURE__ **/ (() =>
+    [
+      AfterRenderPhase.EarlyRead,
+      AfterRenderPhase.Write,
+      AfterRenderPhase.MixedReadWrite,
+      AfterRenderPhase.Read,
+    ] as const)();
 
   private readonly ngZone = inject(NgZone);
   private readonly scheduler = inject(ChangeDetectionScheduler);

--- a/packages/core/src/render3/after_render/manager.ts
+++ b/packages/core/src/render3/after_render/manager.ts
@@ -25,7 +25,7 @@ export class AfterRenderManager {
   }
 
   /** @nocollapse */
-  static ɵprov = /** @pureOrBreakMyCode */ ɵɵdefineInjectable({
+  static ɵprov = /** @pureOrBreakMyCode */ /* @__PURE__ */ ɵɵdefineInjectable({
     token: AfterRenderManager,
     providedIn: 'root',
     factory: () => new AfterRenderManager(),
@@ -124,7 +124,7 @@ export class AfterRenderImpl {
   }
 
   /** @nocollapse */
-  static ɵprov = /** @pureOrBreakMyCode */ ɵɵdefineInjectable({
+  static ɵprov = /** @pureOrBreakMyCode */ /* @__PURE__ */ ɵɵdefineInjectable({
     token: AfterRenderImpl,
     providedIn: 'root',
     factory: () => new AfterRenderImpl(),

--- a/packages/core/src/render3/features/ng_onchanges_feature.ts
+++ b/packages/core/src/render3/features/ng_onchanges_feature.ts
@@ -36,9 +36,20 @@ import {DirectiveDef, DirectiveDefFeature} from '../interfaces/definition';
  *
  * @codeGenApi
  */
-export function ɵɵNgOnChangesFeature<T>(): DirectiveDefFeature {
-  return NgOnChangesFeatureImpl;
-}
+export const ɵɵNgOnChangesFeature = /* @__PURE__ */ (() => {
+  function ngOnChangesFeature<T>(definition: DirectiveDef<T>): void {
+    if (definition.type.prototype.ngOnChanges) {
+      definition.setInput = ngOnChangesSetInput;
+    }
+  }
+
+  // This option ensures that the ngOnChanges lifecycle hook will be inherited
+  // from superclasses (in InheritDefinitionFeature).
+  /** @nocollapse */
+  (ngOnChangesFeature as DirectiveDefFeature).ngInherit = true;
+
+  return ngOnChangesFeature;
+})();
 
 export function NgOnChangesFeatureImpl<T>(definition: DirectiveDef<T>) {
   if (definition.type.prototype.ngOnChanges) {
@@ -46,12 +57,6 @@ export function NgOnChangesFeatureImpl<T>(definition: DirectiveDef<T>) {
   }
   return rememberChangeHistoryAndInvokeOnChangesHook;
 }
-
-// This option ensures that the ngOnChanges lifecycle hook will be inherited
-// from superclasses (in InheritDefinitionFeature).
-/** @nocollapse */
-// tslint:disable-next-line:no-toplevel-property-access
-(ɵɵNgOnChangesFeature as DirectiveDefFeature).ngInherit = true;
 
 /**
  * This is a synthetic lifecycle hook which gets inserted into `TView.preOrderHooks` to simulate

--- a/packages/core/src/render3/features/ng_onchanges_feature.ts
+++ b/packages/core/src/render3/features/ng_onchanges_feature.ts
@@ -36,19 +36,15 @@ import {DirectiveDef, DirectiveDefFeature} from '../interfaces/definition';
  *
  * @codeGenApi
  */
-export const ɵɵNgOnChangesFeature = /* @__PURE__ */ (() => {
-  function ngOnChangesFeature<T>(definition: DirectiveDef<T>): void {
-    if (definition.type.prototype.ngOnChanges) {
-      definition.setInput = ngOnChangesSetInput;
-    }
-  }
+export const ɵɵNgOnChangesFeature: () => DirectiveDefFeature = /* @__PURE__ */ (() => {
+  const ɵɵNgOnChangesFeatureImpl = () => NgOnChangesFeatureImpl;
 
   // This option ensures that the ngOnChanges lifecycle hook will be inherited
   // from superclasses (in InheritDefinitionFeature).
   /** @nocollapse */
-  (ngOnChangesFeature as DirectiveDefFeature).ngInherit = true;
+  ɵɵNgOnChangesFeatureImpl.ngInherit = true;
 
-  return ngOnChangesFeature;
+  return ɵɵNgOnChangesFeatureImpl;
 })();
 
 export function NgOnChangesFeatureImpl<T>(definition: DirectiveDef<T>) {

--- a/packages/core/src/render3/reactivity/effect.ts
+++ b/packages/core/src/render3/reactivity/effect.ts
@@ -231,7 +231,7 @@ export interface RootEffectNode extends EffectNode {
  * Not public API, which guarantees `EffectScheduler` only ever comes from the application root
  * injector.
  */
-export const APP_EFFECT_SCHEDULER = new InjectionToken('', {
+export const APP_EFFECT_SCHEDULER = /* @__PURE__ */ new InjectionToken('', {
   providedIn: 'root',
   factory: () => inject(EffectScheduler),
 });

--- a/packages/core/src/render3/reactivity/microtask_effect.ts
+++ b/packages/core/src/render3/reactivity/microtask_effect.ts
@@ -49,7 +49,7 @@ export class MicrotaskEffectScheduler extends ZoneAwareEffectScheduler {
   }
 
   /** @nocollapse */
-  static ɵprov = /** @pureOrBreakMyCode */ ɵɵdefineInjectable({
+  static ɵprov = /** @pureOrBreakMyCode */ /* @__PURE__ */ ɵɵdefineInjectable({
     token: MicrotaskEffectScheduler,
     providedIn: 'root',
     factory: () => new MicrotaskEffectScheduler(),

--- a/packages/core/src/render3/reactivity/root_effect_scheduler.ts
+++ b/packages/core/src/render3/reactivity/root_effect_scheduler.ts
@@ -37,7 +37,7 @@ export abstract class EffectScheduler {
   abstract flush(): void;
 
   /** @nocollapse */
-  static ɵprov = /** @pureOrBreakMyCode */ ɵɵdefineInjectable({
+  static ɵprov = /** @pureOrBreakMyCode */ /* @__PURE__ */ ɵɵdefineInjectable({
     token: EffectScheduler,
     providedIn: 'root',
     factory: () => new ZoneAwareEffectScheduler(),

--- a/packages/core/src/render3/standalone_service.ts
+++ b/packages/core/src/render3/standalone_service.ts
@@ -57,7 +57,7 @@ export class StandaloneService implements OnDestroy {
   }
 
   /** @nocollapse */
-  static ɵprov = /** @pureOrBreakMyCode */ defineInjectable({
+  static ɵprov = /** @pureOrBreakMyCode */ /* @__PURE__ */ defineInjectable({
     token: StandaloneService,
     providedIn: 'environment',
     factory: () => new StandaloneService(inject(EnvironmentInjector)),

--- a/packages/core/src/sanitization/sanitizer.ts
+++ b/packages/core/src/sanitization/sanitizer.ts
@@ -17,7 +17,7 @@ import {SecurityContext} from './security';
 export abstract class Sanitizer {
   abstract sanitize(context: SecurityContext, value: {} | string | null): string | null;
   /** @nocollapse */
-  static ɵprov = /** @pureOrBreakMyCode */ ɵɵdefineInjectable({
+  static ɵprov = /** @pureOrBreakMyCode */ /* @__PURE__ */ ɵɵdefineInjectable({
     token: Sanitizer,
     providedIn: 'root',
     factory: () => null,

--- a/packages/core/src/transfer_state.ts
+++ b/packages/core/src/transfer_state.ts
@@ -74,7 +74,7 @@ function initTransferState(): TransferState {
  */
 export class TransferState {
   /** @nocollapse */
-  static ɵprov = /** @pureOrBreakMyCode */ ɵɵdefineInjectable({
+  static ɵprov = /** @pureOrBreakMyCode */ /* @__PURE__ */ ɵɵdefineInjectable({
     token: TransferState,
     providedIn: 'root',
     factory: initTransferState,

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -2707,11 +2707,17 @@ describe('di', () => {
             standalone: false,
           })
           class MyComp {
-            tokenViaInjector = this.injector.get(NON_EXISTING_PROVIDER, null, InjectFlags.Optional);
+            tokenViaInjector;
             constructor(
               public injector: Injector,
               @Inject(NON_EXISTING_PROVIDER) @Optional() public tokenViaConstructor: string,
-            ) {}
+            ) {
+              this.tokenViaInjector = this.injector.get(
+                NON_EXISTING_PROVIDER,
+                null,
+                InjectFlags.Optional,
+              );
+            }
           }
           TestBed.configureTestingModule({declarations: [MyComp]});
           const fixture = TestBed.createComponent(MyComp);
@@ -2748,11 +2754,13 @@ describe('di', () => {
             standalone: false,
           })
           class ChildComponent {
-            tokenViaInjector = this.injector.get(TOKEN, null, InjectFlags.SkipSelf);
+            tokenViaInjector;
             constructor(
               public injector: Injector,
               @Inject(TOKEN) @SkipSelf() public tokenViaConstructor: string,
-            ) {}
+            ) {
+              this.tokenViaInjector = this.injector.get(TOKEN, null, InjectFlags.SkipSelf);
+            }
           }
 
           TestBed.configureTestingModule({
@@ -2774,11 +2782,13 @@ describe('di', () => {
             standalone: false,
           })
           class DirectiveString {
-            tokenViaInjector = this.injector.get(TOKEN, null, InjectFlags.Host);
+            tokenViaInjector;
             constructor(
               public injector: Injector,
               @Inject(TOKEN) @Host() public tokenViaConstructor: string,
-            ) {}
+            ) {
+              this.tokenViaInjector = this.injector.get(TOKEN, null, InjectFlags.Host);
+            }
           }
 
           @Component({
@@ -2809,21 +2819,24 @@ describe('di', () => {
             standalone: false,
           })
           class DirectiveB {
-            public tokenSelfViaInjector = this.injector.get(
-              DirectiveA,
-              null,
-              InjectFlags.Self | InjectFlags.Optional,
-            );
-            public tokenHostViaInjector = this.injector.get(
-              DirectiveA,
-              null,
-              InjectFlags.Host | InjectFlags.Optional,
-            );
+            tokenSelfViaInjector;
+            tokenHostViaInjector;
             constructor(
               public injector: Injector,
               @Inject(DirectiveA) @Self() @Optional() public tokenSelfViaConstructor: DirectiveA,
               @Inject(DirectiveA) @Host() @Optional() public tokenHostViaConstructor: DirectiveA,
-            ) {}
+            ) {
+              this.tokenSelfViaInjector = this.injector.get(
+                DirectiveA,
+                null,
+                InjectFlags.Self | InjectFlags.Optional,
+              );
+              this.tokenHostViaInjector = this.injector.get(
+                DirectiveA,
+                null,
+                InjectFlags.Host | InjectFlags.Optional,
+              );
+            }
           }
 
           @Component({
@@ -2888,8 +2901,10 @@ describe('di', () => {
 
       @Injectable({providedIn: forwardRef(() => Module)})
       class Provider {
-        constructor(private _dep: ProviderDep) {}
-        value = this._dep.getNumber() + 2;
+        constructor(private _dep: ProviderDep) {
+          this.value = this._dep.getNumber() + 2;
+        }
+        value;
       }
 
       @Component({

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -4050,8 +4050,10 @@ describe('styling', () => {
         standalone: false,
       })
       class HostBindingTestComponent {
-        style: SafeStyle = this.sanitizer.bypassSecurityTrustStyle('color: white; display: block;');
-        constructor(private sanitizer: DomSanitizer) {}
+        style: SafeStyle;
+        constructor(private sanitizer: DomSanitizer) {
+          this.style = this.sanitizer.bypassSecurityTrustStyle('color: white; display: block;');
+        }
       }
       TestBed.configureTestingModule({declarations: [HostBindingTestComponent]});
       const fixture = TestBed.createComponent(HostBindingTestComponent);

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -18,9 +18,6 @@
     "name": "AfterRenderManager"
   },
   {
-    "name": "AfterRenderPhase"
-  },
-  {
     "name": "AnimationAstBuilderContext"
   },
   {
@@ -567,16 +564,7 @@
     "name": "ZoneStablePendingTask"
   },
   {
-    "name": "_AfterRenderImpl"
-  },
-  {
-    "name": "_AnimationDriver"
-  },
-  {
     "name": "_CACHED_BODY"
-  },
-  {
-    "name": "_ComponentFactoryResolver"
   },
   {
     "name": "_DOM"
@@ -591,10 +579,13 @@
     "name": "_NullComponentFactoryResolver"
   },
   {
-    "name": "_SpecialCasedStyles"
+    "name": "__defProp"
   },
   {
     "name": "__forward_ref__"
+  },
+  {
+    "name": "__publicField"
   },
   {
     "name": "_applyRootElementTransformImpl"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -21,9 +21,6 @@
     "name": "AfterRenderManager"
   },
   {
-    "name": "AfterRenderPhase"
-  },
-  {
     "name": "AnimationAstBuilderContext"
   },
   {
@@ -627,16 +624,7 @@
     "name": "ZoneStablePendingTask"
   },
   {
-    "name": "_AfterRenderImpl"
-  },
-  {
-    "name": "_AnimationDriver"
-  },
-  {
     "name": "_CACHED_BODY"
-  },
-  {
-    "name": "_ComponentFactoryResolver"
   },
   {
     "name": "_DOM"
@@ -651,10 +639,13 @@
     "name": "_NullComponentFactoryResolver"
   },
   {
-    "name": "_SpecialCasedStyles"
+    "name": "__defProp"
   },
   {
     "name": "__forward_ref__"
+  },
+  {
+    "name": "__publicField"
   },
   {
     "name": "_applyRootElementTransformImpl"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -15,9 +15,6 @@
     "name": "AfterRenderManager"
   },
   {
-    "name": "AfterRenderPhase"
-  },
-  {
     "name": "AnonymousSubject"
   },
   {
@@ -474,12 +471,6 @@
     "name": "ZoneStablePendingTask"
   },
   {
-    "name": "_AfterRenderImpl"
-  },
-  {
-    "name": "_ComponentFactoryResolver"
-  },
-  {
     "name": "_DOM"
   },
   {
@@ -489,7 +480,13 @@
     "name": "_NullComponentFactoryResolver"
   },
   {
+    "name": "__defProp"
+  },
+  {
     "name": "__forward_ref__"
+  },
+  {
+    "name": "__publicField"
   },
   {
     "name": "_applyRootElementTransformImpl"

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -9,13 +9,7 @@
     "name": "APP_INITIALIZER"
   },
   {
-    "name": "AfterRenderImpl"
-  },
-  {
     "name": "AfterRenderManager"
-  },
-  {
-    "name": "AfterRenderPhase"
   },
   {
     "name": "AnonymousSubject"
@@ -369,9 +363,6 @@
     "name": "NgModuleRef"
   },
   {
-    "name": "NgOnChangesFeatureImpl"
-  },
-  {
     "name": "NgZone"
   },
   {
@@ -541,9 +532,6 @@
   },
   {
     "name": "ZoneStablePendingTask"
-  },
-  {
-    "name": "_AfterRenderImpl"
   },
   {
     "name": "_DOM"
@@ -2629,9 +2617,6 @@
   },
   {
     "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "ɵɵNgOnChangesFeature"
   },
   {
     "name": "ɵɵdefer"

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -9,6 +9,9 @@
     "name": "APP_INITIALIZER"
   },
   {
+    "name": "AfterRenderImpl"
+  },
+  {
     "name": "AfterRenderManager"
   },
   {
@@ -543,9 +546,6 @@
     "name": "_AfterRenderImpl"
   },
   {
-    "name": "_ComponentFactoryResolver"
-  },
-  {
     "name": "_DOM"
   },
   {
@@ -565,6 +565,9 @@
   },
   {
     "name": "__getOwnPropNames"
+  },
+  {
+    "name": "__publicField"
   },
   {
     "name": "_applyRootElementTransformImpl"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -27,9 +27,6 @@
     "name": "AfterRenderManager"
   },
   {
-    "name": "AfterRenderPhase"
-  },
-  {
     "name": "AnonymousSubject"
   },
   {
@@ -438,9 +435,6 @@
     "name": "NgModuleRef2"
   },
   {
-    "name": "NgOnChangesFeatureImpl"
-  },
-  {
     "name": "NgZone"
   },
   {
@@ -663,12 +657,6 @@
     "name": "ZoneStablePendingTask"
   },
   {
-    "name": "_AfterRenderImpl"
-  },
-  {
-    "name": "_ComponentFactoryResolver"
-  },
-  {
     "name": "_DOM"
   },
   {
@@ -690,7 +678,13 @@
     "name": "__await"
   },
   {
+    "name": "__defProp"
+  },
+  {
     "name": "__forward_ref__"
+  },
+  {
+    "name": "__publicField"
   },
   {
     "name": "_applyRootElementTransformImpl"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -435,6 +435,9 @@
     "name": "NgModuleRef2"
   },
   {
+    "name": "NgOnChangesFeatureImpl"
+  },
+  {
     "name": "NgZone"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -420,6 +420,9 @@
     "name": "NgModuleRef2"
   },
   {
+    "name": "NgOnChangesFeatureImpl"
+  },
+  {
     "name": "NgZone"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -30,9 +30,6 @@
     "name": "AfterRenderManager"
   },
   {
-    "name": "AfterRenderPhase"
-  },
-  {
     "name": "AnonymousSubject"
   },
   {
@@ -423,9 +420,6 @@
     "name": "NgModuleRef2"
   },
   {
-    "name": "NgOnChangesFeatureImpl"
-  },
-  {
     "name": "NgZone"
   },
   {
@@ -648,12 +642,6 @@
     "name": "ZoneStablePendingTask"
   },
   {
-    "name": "_AfterRenderImpl"
-  },
-  {
-    "name": "_ComponentFactoryResolver"
-  },
-  {
     "name": "_DOM"
   },
   {
@@ -675,7 +663,13 @@
     "name": "__await"
   },
   {
+    "name": "__defProp"
+  },
+  {
     "name": "__forward_ref__"
+  },
+  {
+    "name": "__publicField"
   },
   {
     "name": "_applyRootElementTransformImpl"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -12,9 +12,6 @@
     "name": "AfterRenderManager"
   },
   {
-    "name": "AfterRenderPhase"
-  },
-  {
     "name": "AnonymousSubject"
   },
   {
@@ -360,12 +357,6 @@
     "name": "ZoneStablePendingTask"
   },
   {
-    "name": "_AfterRenderImpl"
-  },
-  {
-    "name": "_ComponentFactoryResolver"
-  },
-  {
     "name": "_DOM"
   },
   {
@@ -375,7 +366,13 @@
     "name": "_NullComponentFactoryResolver"
   },
   {
+    "name": "__defProp"
+  },
+  {
     "name": "__forward_ref__"
+  },
+  {
+    "name": "__publicField"
   },
   {
     "name": "_applyRootElementTransformImpl"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -15,9 +15,6 @@
     "name": "AfterRenderManager"
   },
   {
-    "name": "AfterRenderPhase"
-  },
-  {
     "name": "AnonymousSubject"
   },
   {
@@ -525,12 +522,6 @@
     "name": "ZoneStablePendingTask"
   },
   {
-    "name": "_AfterRenderImpl"
-  },
-  {
-    "name": "_ComponentFactoryResolver"
-  },
-  {
     "name": "_DOM"
   },
   {
@@ -546,7 +537,13 @@
     "name": "__await"
   },
   {
+    "name": "__defProp"
+  },
+  {
     "name": "__forward_ref__"
+  },
+  {
+    "name": "__publicField"
   },
   {
     "name": "_applyRootElementTransformImpl"

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -1,51 +1,15 @@
 [
   {
-    "name": "AfterRenderPhase"
-  },
-  {
-    "name": "AnonymousSubject"
-  },
-  {
-    "name": "BehaviorSubject"
-  },
-  {
     "name": "CIRCULAR"
   },
   {
-    "name": "COMPLETE_NOTIFICATION"
-  },
-  {
-    "name": "ChangeDetectionScheduler"
-  },
-  {
-    "name": "ConsumerObserver"
-  },
-  {
-    "name": "DestroyRef"
-  },
-  {
     "name": "EMPTY_ARRAY"
-  },
-  {
-    "name": "EMPTY_OBSERVER"
-  },
-  {
-    "name": "EMPTY_PAYLOAD"
-  },
-  {
-    "name": "EMPTY_SUBSCRIPTION"
   },
   {
     "name": "ENVIRONMENT_INITIALIZER"
   },
   {
     "name": "EnvironmentInjector"
-  },
-  {
-    "name": "ErrorHandler"
-  },
-  {
-    "name": "EventEmitter"
   },
   {
     "name": "INJECTOR"
@@ -93,22 +57,7 @@
     "name": "NULL_INJECTOR"
   },
   {
-    "name": "NgZone"
-  },
-  {
-    "name": "NodeInjectorDestroyRef"
-  },
-  {
     "name": "NullInjector"
-  },
-  {
-    "name": "ObjectUnsubscribedError"
-  },
-  {
-    "name": "Observable"
-  },
-  {
-    "name": "PendingTasksInternal"
   },
   {
     "name": "R3Injector"
@@ -117,16 +66,7 @@
     "name": "RuntimeError"
   },
   {
-    "name": "SafeSubscriber"
-  },
-  {
     "name": "ScopedService"
-  },
-  {
-    "name": "Subject"
-  },
-  {
-    "name": "Subscriber"
   },
   {
     "name": "Subscription"
@@ -141,16 +81,13 @@
     "name": "UnsubscriptionError"
   },
   {
-    "name": "_AfterRenderImpl"
-  },
-  {
-    "name": "_Injector"
+    "name": "__defProp"
   },
   {
     "name": "__forward_ref__"
   },
   {
-    "name": "_bind"
+    "name": "__publicField"
   },
   {
     "name": "_currentInjector"
@@ -162,28 +99,10 @@
     "name": "activeConsumer"
   },
   {
-    "name": "angularZoneInstanceIdProperty"
-  },
-  {
     "name": "arrRemove"
   },
   {
     "name": "assertNotDestroyed"
-  },
-  {
-    "name": "bind"
-  },
-  {
-    "name": "checkStable"
-  },
-  {
-    "name": "config"
-  },
-  {
-    "name": "context"
-  },
-  {
-    "name": "convertToBitFlags"
   },
   {
     "name": "createErrorClass"
@@ -195,16 +114,10 @@
     "name": "createLFrame"
   },
   {
-    "name": "createNotification"
-  },
-  {
     "name": "deepForEach"
   },
   {
     "name": "deepForEachProvider"
-  },
-  {
-    "name": "errorContext"
   },
   {
     "name": "execFinalizer"
@@ -222,9 +135,6 @@
     "name": "getFactoryDef"
   },
   {
-    "name": "getInjectImplementation"
-  },
-  {
     "name": "getInjectableDef"
   },
   {
@@ -237,31 +147,10 @@
     "name": "getOwnDefinition"
   },
   {
-    "name": "getPromiseCtor"
-  },
-  {
-    "name": "handleStoppedNotification"
-  },
-  {
-    "name": "handleUnhandledError"
-  },
-  {
-    "name": "hasApplyArgsData"
-  },
-  {
-    "name": "identity"
-  },
-  {
     "name": "importProvidersFrom"
   },
   {
-    "name": "inject"
-  },
-  {
     "name": "injectArgs"
-  },
-  {
-    "name": "injectDestroyRef"
   },
   {
     "name": "injectInjectorOnly"
@@ -276,16 +165,10 @@
     "name": "internalImportProvidersFrom"
   },
   {
-    "name": "isAngularZoneProperty"
-  },
-  {
     "name": "isEnvironmentProviders"
   },
   {
     "name": "isFunction"
-  },
-  {
-    "name": "isSubscription"
   },
   {
     "name": "isTypeProvider"
@@ -295,24 +178,6 @@
   },
   {
     "name": "makeRecord"
-  },
-  {
-    "name": "ngZoneInstanceId"
-  },
-  {
-    "name": "noop"
-  },
-  {
-    "name": "noop2"
-  },
-  {
-    "name": "observable"
-  },
-  {
-    "name": "onEnter"
-  },
-  {
-    "name": "onLeave"
   },
   {
     "name": "processInjectorTypesWithProviders"
@@ -331,12 +196,6 @@
   },
   {
     "name": "stringify"
-  },
-  {
-    "name": "timeoutProvider"
-  },
-  {
-    "name": "updateMicroTaskStatus"
   },
   {
     "name": "walkProviderTree"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -456,6 +456,9 @@
     "name": "NgModuleRef2"
   },
   {
+    "name": "NgOnChangesFeatureImpl"
+  },
+  {
     "name": "NgZone"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -33,9 +33,6 @@
     "name": "AfterRenderManager"
   },
   {
-    "name": "AfterRenderPhase"
-  },
-  {
     "name": "AnonymousSubject"
   },
   {
@@ -459,9 +456,6 @@
     "name": "NgModuleRef2"
   },
   {
-    "name": "NgOnChangesFeatureImpl"
-  },
-  {
     "name": "NgZone"
   },
   {
@@ -795,12 +789,6 @@
     "name": "ZoneStablePendingTask"
   },
   {
-    "name": "_AfterRenderImpl"
-  },
-  {
-    "name": "_ComponentFactoryResolver"
-  },
-  {
     "name": "_DOM"
   },
   {
@@ -816,7 +804,16 @@
     "name": "__await"
   },
   {
+    "name": "__defProp"
+  },
+  {
     "name": "__forward_ref__"
+  },
+  {
+    "name": "__publicField"
+  },
+  {
+    "name": "_a"
   },
   {
     "name": "_applyRootElementTransformImpl"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -12,9 +12,6 @@
     "name": "AfterRenderManager"
   },
   {
-    "name": "AfterRenderPhase"
-  },
-  {
     "name": "AnonymousSubject"
   },
   {
@@ -420,12 +417,6 @@
     "name": "ZoneStablePendingTask"
   },
   {
-    "name": "_AfterRenderImpl"
-  },
-  {
-    "name": "_ComponentFactoryResolver"
-  },
-  {
     "name": "_DOM"
   },
   {
@@ -435,7 +426,13 @@
     "name": "_NullComponentFactoryResolver"
   },
   {
+    "name": "__defProp"
+  },
+  {
     "name": "__forward_ref__"
+  },
+  {
+    "name": "__publicField"
   },
   {
     "name": "_applyRootElementTransformImpl"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -15,9 +15,6 @@
     "name": "AfterRenderManager"
   },
   {
-    "name": "AfterRenderPhase"
-  },
-  {
     "name": "AnonymousSubject"
   },
   {
@@ -546,12 +543,6 @@
     "name": "ZoneStablePendingTask"
   },
   {
-    "name": "_AfterRenderImpl"
-  },
-  {
-    "name": "_ComponentFactoryResolver"
-  },
-  {
     "name": "_DOM"
   },
   {
@@ -567,7 +558,13 @@
     "name": "_NullComponentFactoryResolver"
   },
   {
+    "name": "__defProp"
+  },
+  {
     "name": "__forward_ref__"
+  },
+  {
+    "name": "__publicField"
   },
   {
     "name": "_applyRootElementTransformImpl"

--- a/packages/examples/upgrade/static/ts/full/module.ts
+++ b/packages/examples/upgrade/static/ts/full/module.ts
@@ -103,7 +103,7 @@ export class Ng1HeroComponentWrapper extends UpgradeComponent {
   // The names of the input and output properties here must match the names of the
   // `<` and `&` bindings in the AngularJS component that is being wrapped
   @Input() hero!: Hero;
-  @Output() onRemove!: EventEmitter<void>;
+  @Output() onRemove: EventEmitter<void> = new EventEmitter();
 
   constructor(elementRef: ElementRef, injector: Injector) {
     // We must pass the name of the directive as used by AngularJS to the super

--- a/packages/examples/upgrade/static/ts/lite-multi/module.ts
+++ b/packages/examples/upgrade/static/ts/lite-multi/module.ts
@@ -113,8 +113,10 @@ const appModule = angular
     controller: [
       'ng2AService',
       class Ng1AController {
-        value = this.ng2AService.getValue();
-        constructor(private ng2AService: Ng2AService) {}
+        value: string;
+        constructor(private ng2AService: Ng2AService) {
+          this.value = this.ng2AService.getValue();
+        }
       },
     ],
   })

--- a/packages/examples/upgrade/static/ts/lite/module.ts
+++ b/packages/examples/upgrade/static/ts/lite/module.ts
@@ -116,7 +116,7 @@ class Ng1HeroComponentWrapper extends UpgradeComponent {
   // The names of the input and output properties here must match the names of the
   // `<` and `&` bindings in the AngularJS component that is being wrapped.
   @Input() hero!: Hero;
-  @Output() onRemove!: EventEmitter<void>;
+  @Output() onRemove: EventEmitter<void> = new EventEmitter();
 
   constructor(elementRef: ElementRef, injector: Injector) {
     // We must pass the name of the directive as used by AngularJS to the super.

--- a/packages/forms/test/form_array_spec.ts
+++ b/packages/forms/test/form_array_spec.ts
@@ -1538,7 +1538,7 @@ import {asyncValidator} from './util';
         describe('can be extended', () => {
           it('by a simple strongly-typed array', () => {
             abstract class StringFormArray extends FormArray {
-              override value!: string[];
+              override value: string[] = [];
             }
           });
 
@@ -1546,8 +1546,8 @@ import {asyncValidator} from './util';
             abstract class OtherTypedFormArray<
               TControls extends Array<AbstractControl<unknown>>,
             > extends FormArray {
-              override controls!: TControls;
-              override value!: never[];
+              override controls: TControls = {} as TControls;
+              override value: string[] = [];
             }
           });
         });

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -11,7 +11,6 @@ import {
   ASTWithSource,
   BindingPipe,
   BindingType,
-  Call,
   EmptyExpr,
   ImplicitReceiver,
   LiteralPrimitive,
@@ -41,6 +40,7 @@ import {
   PotentialDirective,
   SymbolKind,
   TemplateDeclarationSymbol,
+  TemplateTypeChecker,
 } from '@angular/compiler-cli/src/ngtsc/typecheck/api';
 import ts from 'typescript';
 
@@ -123,12 +123,12 @@ function buildBlockSnippet(insertSnippet: boolean, blockName: string, withParens
  * @param N type of the template node in question, narrowed accordingly.
  */
 export class CompletionBuilder<N extends TmplAstNode | AST> {
-  private readonly typeChecker = this.compiler.getCurrentProgram().getTypeChecker();
-  private readonly templateTypeChecker = this.compiler.getTemplateTypeChecker();
-  private readonly nodeParent = this.targetDetails.parent;
-  private readonly nodeContext = nodeContextFromTarget(this.targetDetails.context);
-  private readonly template = this.targetDetails.template;
-  private readonly position = this.targetDetails.position;
+  private readonly typeChecker: ts.TypeChecker;
+  private readonly templateTypeChecker: TemplateTypeChecker;
+  private readonly nodeParent: TmplAstNode | AST | null;
+  private readonly nodeContext: CompletionNodeContext;
+  private readonly template: TmplAstTemplate | null;
+  private readonly position: number;
 
   constructor(
     private readonly tsLS: ts.LanguageService,
@@ -136,7 +136,14 @@ export class CompletionBuilder<N extends TmplAstNode | AST> {
     private readonly component: ts.ClassDeclaration,
     private readonly node: N,
     private readonly targetDetails: TemplateTarget,
-  ) {}
+  ) {
+    this.typeChecker = this.compiler.getCurrentProgram().getTypeChecker();
+    this.templateTypeChecker = this.compiler.getTemplateTypeChecker();
+    this.nodeParent = this.targetDetails.parent;
+    this.nodeContext = nodeContextFromTarget(this.targetDetails.context);
+    this.template = this.targetDetails.template;
+    this.position = this.targetDetails.position;
+  }
 
   /**
    * Analogue for `ts.LanguageService.getCompletionsAtPosition`.

--- a/packages/language-service/src/definitions.ts
+++ b/packages/language-service/src/definitions.ts
@@ -26,6 +26,7 @@ import {
   SymbolKind,
   TcbLocation,
   TemplateSymbol,
+  TemplateTypeChecker,
 } from '@angular/compiler-cli/src/ngtsc/typecheck/api';
 import ts from 'typescript';
 
@@ -55,12 +56,14 @@ interface HasTcbLocation {
 }
 
 export class DefinitionBuilder {
-  private readonly ttc = this.compiler.getTemplateTypeChecker();
+  private readonly ttc: TemplateTypeChecker;
 
   constructor(
     private readonly tsLS: ts.LanguageService,
     private readonly compiler: NgCompiler,
-  ) {}
+  ) {
+    this.ttc = this.compiler.getTemplateTypeChecker();
+  }
 
   getDefinitionAndBoundSpan(
     fileName: string,

--- a/packages/language-service/src/quick_info.ts
+++ b/packages/language-service/src/quick_info.ts
@@ -47,8 +47,8 @@ import {
 } from './utils';
 
 export class QuickInfoBuilder {
-  private readonly typeChecker = this.compiler.getCurrentProgram().getTypeChecker();
-  private readonly parent = this.positionDetails.parent;
+  private readonly typeChecker: ts.TypeChecker;
+  private readonly parent: TmplAstNode | AST | null;
 
   constructor(
     private readonly tsLS: ts.LanguageService,
@@ -56,7 +56,10 @@ export class QuickInfoBuilder {
     private readonly component: ts.ClassDeclaration,
     private node: TmplAstNode | AST,
     private readonly positionDetails: TemplateTarget,
-  ) {}
+  ) {
+    this.typeChecker = this.compiler.getCurrentProgram().getTypeChecker();
+    this.parent = this.positionDetails.parent;
+  }
 
   get(): ts.QuickInfo | undefined {
     if (this.node instanceof TmplAstDeferredTrigger || this.node instanceof TmplAstBlockNode) {

--- a/packages/language-service/src/references_and_rename.ts
+++ b/packages/language-service/src/references_and_rename.ts
@@ -10,12 +10,11 @@ import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
 import {absoluteFrom} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {MetaKind, PipeMeta} from '@angular/compiler-cli/src/ngtsc/metadata';
 import {PerfPhase} from '@angular/compiler-cli/src/ngtsc/perf';
-import {SymbolKind} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
+import {SymbolKind, TemplateTypeChecker} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
 import ts from 'typescript';
 
 import {
   convertToTemplateDocumentSpan,
-  createLocationKey,
   FilePosition,
   getParentClassMeta,
   getRenameTextAndSpanAtPosition,
@@ -26,12 +25,14 @@ import {collectMemberMethods, findTightestNode} from './utils/ts_utils';
 import {getTemplateInfoAtPosition, TemplateInfo} from './utils';
 
 export class ReferencesBuilder {
-  private readonly ttc = this.compiler.getTemplateTypeChecker();
+  private readonly ttc: TemplateTypeChecker;
 
   constructor(
     private readonly tsLS: ts.LanguageService,
     private readonly compiler: NgCompiler,
-  ) {}
+  ) {
+    this.ttc = this.compiler.getTemplateTypeChecker();
+  }
 
   getReferencesAtPosition(filePath: string, position: number): ts.ReferenceEntry[] | undefined {
     this.ttc.generateAllTypeCheckBlocks();
@@ -162,12 +163,14 @@ function isDirectRenameContext(
 }
 
 export class RenameBuilder {
-  private readonly ttc = this.compiler.getTemplateTypeChecker();
+  private readonly ttc: TemplateTypeChecker;
 
   constructor(
     private readonly tsLS: ts.LanguageService,
     private readonly compiler: NgCompiler,
-  ) {}
+  ) {
+    this.ttc = this.compiler.getTemplateTypeChecker();
+  }
 
   getRenameInfo(
     filePath: string,

--- a/packages/localize/tools/src/translate/source_files/source_file_translation_handler.ts
+++ b/packages/localize/tools/src/translate/source_files/source_file_translation_handler.ts
@@ -27,14 +27,17 @@ import {makeLocalePlugin} from './locale_plugin';
  * message.
  */
 export class SourceFileTranslationHandler implements TranslationHandler {
-  private sourceLocaleOptions: TranslatePluginOptions = {
-    ...this.translationOptions,
-    missingTranslation: 'ignore',
-  };
+  private sourceLocaleOptions: TranslatePluginOptions;
+
   constructor(
     private fs: FileSystem,
     private translationOptions: TranslatePluginOptions = {},
-  ) {}
+  ) {
+    this.sourceLocaleOptions = {
+      ...this.translationOptions,
+      missingTranslation: 'ignore',
+    };
+  }
 
   canTranslate(relativeFilePath: PathSegment | AbsoluteFsPath, _contents: Uint8Array): boolean {
     return this.fs.extname(relativeFilePath) === '.js';

--- a/packages/service-worker/worker/testing/events.ts
+++ b/packages/service-worker/worker/testing/events.ts
@@ -111,16 +111,17 @@ export class MockExtendableMessageEvent
 }
 
 export class MockNotificationEvent extends MockExtendableEvent implements NotificationEvent {
-  readonly notification = {
-    ...this._notification,
-    close: () => undefined,
-  } as Notification;
+  readonly notification: Notification;
 
   constructor(
     private _notification: Partial<Notification>,
     readonly action = '',
   ) {
     super('notification');
+    this.notification = {
+      ...this._notification,
+      close: () => undefined,
+    } as Notification;
   }
 }
 

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -27,11 +27,14 @@ import {normalizeUrl, parseUrl} from './utils';
 const EMPTY_SERVER_STATE = new MockServerStateBuilder().build();
 
 export class SwTestHarnessBuilder {
-  private origin = parseUrl(this.scopeUrl).origin;
+  private origin: string;
   private server = EMPTY_SERVER_STATE;
-  private caches = new MockCacheStorage(this.origin);
+  private caches: MockCacheStorage;
 
-  constructor(private scopeUrl = 'http://localhost/') {}
+  constructor(private scopeUrl = 'http://localhost/') {
+    this.origin = parseUrl(this.scopeUrl).origin;
+    this.caches = new MockCacheStorage(this.origin);
+  }
 
   withCacheState(cache: string): SwTestHarnessBuilder {
     this.caches = new MockCacheStorage(this.origin, cache);

--- a/packages/tsconfig-build.json
+++ b/packages/tsconfig-build.json
@@ -19,8 +19,6 @@
     "moduleResolution": "node",
     "module": "esnext",
     "target": "es2022",
-    // Keep the below in sync with ng_module.bzl
-    "useDefineForClassFields": false,
     "lib": ["es2020", "dom", "dom.iterable"],
     "skipLibCheck": true,
     // don't auto-discover @types/node, it results in a ///<reference in the .d.ts output

--- a/tools/saucelabs-daemon/background-service/saucelabs-daemon.ts
+++ b/tools/saucelabs-daemon/background-service/saucelabs-daemon.ts
@@ -59,11 +59,7 @@ export class SaucelabsDaemon {
   /** Map that contains test ids with their claimed browser. */
   private _runningTests = new Map<number, RemoteBrowser>();
 
-  /** Server used for communication with the Karma launcher. */
-  private _server = new IpcServer(this);
-
-  /** Base selenium capabilities that will be added to each browser. */
-  private _baseCapabilities = {...defaultCapabilities, ...this._userCapabilities};
+  private _baseCapabilities;
 
   /** Id of the keep alive interval that ensures no remote browsers time out. */
   private _keepAliveIntervalId: NodeJS.Timeout | null = null;
@@ -85,6 +81,9 @@ export class SaucelabsDaemon {
   ) {
     // Starts the keep alive loop for all active browsers, running every 15 seconds.
     this._keepAliveIntervalId = setInterval(() => this._keepAliveBrowsers(), 15_000);
+
+    /** Base selenium capabilities that will be added to each browser. */
+    this._baseCapabilities = {...defaultCapabilities, ...this._userCapabilities};
   }
 
   /**


### PR DESCRIPTION
**refactor(core): eliminate top-level property access in `ɵɵNgOnChangesFeature`**

Top-level property access was causing dead code elimination (DCE) and tree-shaking issues. This commit modifies `ɵɵNgOnChangesFeature` to prevent these bailouts.


**refactor(core): make AfterRenderImpl tree-shakable by moving PHASES**

Marked the PHASES constant within AfterRenderImpl as @__PURE__ to enable better tree-shaking during bundling. This optimization ensures that unused code is more effectively eliminated, improving overall bundle size and performance.

**refactor: add `@__PURE__` next to `@pureOrBreakMyCode` for improved bundler compatibility**

Added the `@__PURE__` annotation alongside `@pureOrBreakMyCode` to improve compatibility with third-party bundlers. This refactor follows optimization best practices, ensuring broader support across different tools, as `@pureOrBreakMyCode` was only supported by Closure Compiler.

**build: remove usages of `useDefineForClassFields: false`**

When setting `"useDefineForClassFields": false`, static fields are compiled within a block that relies on the `this` context. This output makes it more difficult for bundlers to treeshake and eliminate unused code.


----

**Before** 
main.ts
```ts
import { InjectionToken } from "@angular/core";
console.log(new InjectionToken('foo'));
```


```
Initial chunk files   | Names         |  Raw size | Estimated transfer size
main-EGPQ2PJY.js      | main          |  77.50 kB |                15.57 kB

```
**Now**
```
Initial chunk files   | Names         | Raw size | Estimated transfer size
main-JLPNM4W5.js      | main          |  3.03 kB |                 1.28 kB
```
