### PR TITLE
fix(core): cleanup `rxResource` abort listener

### DIFF
--- a/packages/common/http/src/resource.ts
+++ b/packages/common/http/src/resource.ts
@@ -358,6 +358,7 @@ class HttpResourceImpl<T>
             }
 
             send({error});
+            abortSignal.removeEventListener('abort', onAbort);
           },
           complete: () => {
             if (resolve) {

--- a/packages/core/rxjs-interop/src/rx_resource.ts
+++ b/packages/core/rxjs-interop/src/rx_resource.ts
@@ -75,7 +75,10 @@ export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T |
 
       sub = streamFn(params).subscribe({
         next: (value) => send({value}),
-        error: (error) => send({error}),
+        error: (error) => {
+          send({error});
+          params.abortSignal.removeEventListener('abort', onAbort);
+        },
         complete: () => {
           if (resolve) {
             send({error: new Error('Resource completed before producing a value')});


### PR DESCRIPTION
The observable terminates immediately when `error` is called, and no further emissions or completion notifications occur. Thus, we have to remove the `abort` listener in both the `error` and `complete` notifications.