### PR TITLE
ci: temporarily disable adev tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,10 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Build adev in fast mode to ensure it continues to work
         run: yarn bazel build //adev:build --config=release
-      - name: Run tests
-        run: yarn bazel test //adev/...
+      # TODO: re-enable tests once the next release is shipped
+      # Tests are broken because of https://github.com/angular/angular/issues/54858
+      # - name: Run tests
+      # run: yarn bazel test //adev/...
 
   publish-snapshots:
     runs-on:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -114,8 +114,10 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Build adev in fast mode to ensure it continues to work
         run: yarn bazel build //adev:build --config=release
-      - name: Run tests
-        run: yarn bazel test //adev/...
+      # TODO: re-enable tests once the next release is shipped
+      # Tests are broken because of https://github.com/angular/angular/issues/54858
+      # - name: Run tests
+      #   run: yarn bazel test //adev/...
 
   zone-js:
     runs-on:


### PR DESCRIPTION
This disables adev tests until the next release. This is due to #54858.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] CI related changes


Issue Number: #54858




## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

