### PR TITLE
[revert] feat(forms): add ability to clear a FormRecord

### DIFF
--- a/goldens/public-api/forms/index.api.md
+++ b/goldens/public-api/forms/index.api.md
@@ -534,9 +534,6 @@ export interface FormRecord<TControl> {
     addControl(name: string, control: TControl, options?: {
         emitEvent?: boolean;
     }): void;
-    clear(options?: {
-        emitEvent?: boolean;
-    }): void;
     contains(controlName: string): boolean;
     getRawValue(): {
         [key: string]: ɵRawValue<TControl>;

--- a/packages/forms/src/form_builder.ts
+++ b/packages/forms/src/form_builder.ts
@@ -75,28 +75,24 @@ export type ɵElement<T, N extends null> =
   // through the distributive conditional type. This is the officially recommended solution:
   // https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types
   //
-  // Note: Because `FormRecord` implementation extends `FormGroup`, it must be checked BEFORE `FormGroup`
-  // in the following clauses (otherwise it may incorrectly be inferred to `FormGroup`).
-  //
-  //
   // Identify FormControl container types.
   [T] extends [FormControl<infer U>]
     ? FormControl<U>
     : // Or FormControl containers that are optional in their parent group.
       [T] extends [FormControl<infer U> | undefined]
       ? FormControl<U>
-      : // FormRecord containers.
-        [T] extends [FormRecord<infer U>]
-        ? FormRecord<U>
-        : // Optional FormRecord containers.
-          [T] extends [FormRecord<infer U> | undefined]
-          ? FormRecord<U>
-          : // FormGroup containers.
-            [T] extends [FormGroup<infer U>]
-            ? FormGroup<U>
-            : // Optional FormGroup containers.
-              [T] extends [FormGroup<infer U> | undefined]
-              ? FormGroup<U>
+      : // FormGroup containers.
+        [T] extends [FormGroup<infer U>]
+        ? FormGroup<U>
+        : // Optional FormGroup containers.
+          [T] extends [FormGroup<infer U> | undefined]
+          ? FormGroup<U>
+          : // FormRecord containers.
+            [T] extends [FormRecord<infer U>]
+            ? FormRecord<U>
+            : // Optional FormRecord containers.
+              [T] extends [FormRecord<infer U> | undefined]
+              ? FormRecord<U>
               : // FormArray containers.
                 [T] extends [FormArray<infer U>]
                 ? FormArray<U>

--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -724,25 +724,7 @@ export const isFormGroup = (control: unknown): control is FormGroup => control i
  */
 export class FormRecord<TControl extends AbstractControl = AbstractControl> extends FormGroup<{
   [key: string]: TControl;
-}> {
-  /**
-   * Clear all controls from this record.
-   *
-   * This method also updates the value and validity of the control.
-   *
-   * @param options Specifies whether this FormGroup instance should emit events after a
-   *     control is removed.
-   * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
-   * `valueChanges` observables emit events with the latest status and value when the controls are
-   * removed. When false, no events are emitted.
-   */
-  clear(options: {emitEvent?: boolean} = {}): void {
-    this._forEachChild((child) => child._registerOnCollectionChange(() => {}));
-    this.controls = {};
-    this.updateValueAndValidity({emitEvent: options.emitEvent});
-    this._onCollectionChange();
-  }
-}
+}> {}
 
 export interface FormRecord<TControl> {
   /**
@@ -765,19 +747,6 @@ export interface FormRecord<TControl> {
    * See `FormGroup#removeControl` for additional information.
    */
   removeControl(name: string, options?: {emitEvent?: boolean}): void;
-
-  /**
-   * Clear all controls from this record.
-   *
-   * This method also updates the value and validity of the control.
-   *
-   * @param options Specifies whether this FormGroup instance should emit events after a
-   *     control is removed.
-   * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
-   * `valueChanges` observables emit events with the latest status and value when the controls are
-   * removed. When false, no events are emitted.
-   */
-  clear(options?: {emitEvent?: boolean}): void;
 
   /**
    * Replace an existing control.

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -2599,7 +2599,7 @@ import {StatusChangeEvent} from '../src/model/abstract_model';
         r = new FormRecord({one: c1, two: c2});
       });
 
-      it('should remove all controls', () => {
+      it('should remove control if new control is null', () => {
         r.clear();
         expect(r.controls['one']).not.toBeDefined();
         expect(r.controls['two']).not.toBeDefined();
@@ -2613,14 +2613,7 @@ import {StatusChangeEvent} from '../src/model/abstract_model';
         expect(logger).toEqual(['change!']);
       });
 
-      it('should only emit status change event once', () => {
-        const logger: string[] = [];
-        r.statusChanges.subscribe(() => logger.push('change!'));
-        r.clear();
-        expect(logger).toEqual(['change!']);
-      });
-
-      it('should not emit event when called with `emitEvent: false`', () => {
+      it('should not emit event when `FormGroup.clearControls` called with `emitEvent: false`', () => {
         const logger: string[] = [];
         r.valueChanges.subscribe(() => logger.push('value change'));
         r.statusChanges.subscribe(() => logger.push('status change'));

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -13,7 +13,6 @@ import {
   FormArray,
   FormControl,
   FormGroup,
-  FormRecord,
   ValidationErrors,
   Validators,
   ValueChangeEvent,
@@ -2586,40 +2585,6 @@ import {StatusChangeEvent} from '../src/model/abstract_model';
         'baz.not.ok': new FormControl('baz'),
       });
       expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
-    });
-
-    describe('clear()', () => {
-      let c1: FormControl;
-      let c2: FormControl;
-      let r: FormRecord;
-
-      beforeEach(() => {
-        c1 = new FormControl('one');
-        c2 = new FormControl('two');
-        r = new FormRecord({one: c1, two: c2});
-      });
-
-      it('should remove control if new control is null', () => {
-        r.clear();
-        expect(r.controls['one']).not.toBeDefined();
-        expect(r.controls['two']).not.toBeDefined();
-        expect(r.value).toEqual({});
-      });
-
-      it('should only emit value change event once', () => {
-        const logger: string[] = [];
-        r.valueChanges.subscribe(() => logger.push('change!'));
-        r.clear();
-        expect(logger).toEqual(['change!']);
-      });
-
-      it('should not emit event when `FormGroup.clearControls` called with `emitEvent: false`', () => {
-        const logger: string[] = [];
-        r.valueChanges.subscribe(() => logger.push('value change'));
-        r.statusChanges.subscribe(() => logger.push('status change'));
-        r.clear({emitEvent: false});
-        expect(logger).toEqual([]);
-      });
     });
   });
 })();


### PR DESCRIPTION
This PR reverts commits from https://github.com/angular/angular/pull/50750 due to a breakage in Google's codebase.