### PR TITLE
refactor(core): allow passing passive option to addEvent

### DIFF
--- a/goldens/public-api/core/primitives/event-dispatch/index.api.md
+++ b/goldens/public-api/core/primitives/event-dispatch/index.api.md
@@ -28,7 +28,7 @@ export interface EarlyJsactionDataContainer {
 // @public
 export class EventContract implements UnrenamedEventContract {
     constructor(containerManager: EventContractContainerManager);
-    addEvent(eventType: string, prefixedEventType?: string): void;
+    addEvent(eventType: string, prefixedEventType?: string, passive?: boolean): void;
     cleanUp(): void;
     ecrd(dispatcher: Dispatcher, restriction: Restriction): void;
     handler(eventType: string): EventHandler | undefined;
@@ -42,7 +42,7 @@ export class EventContract implements UnrenamedEventContract {
 // @public
 export class EventContractContainer implements EventContractContainerManager {
     constructor(element: Element);
-    addEventListener(eventType: string, getHandler: (element: Element) => (event: Event) => void): void;
+    addEventListener(eventType: string, getHandler: (element: Element) => (event: Event) => void, passive?: boolean): void;
     cleanUp(): void;
     // (undocumented)
     readonly element: Element;

--- a/packages/core/primitives/event-dispatch/README.md
+++ b/packages/core/primitives/event-dispatch/README.md
@@ -166,6 +166,14 @@ This code should be compiled/bundled/minified separately from the main
 application bundle. Code size is critical here since this code will be inlined
 at the top of the page and will block rendering content.
 
+For scroll-blocking events like `touchstart`, `touchmove`, `wheel` and `mousewheel`,
+you can optimize scrolling performance by passing the `passive` option to the
+`addEvent` function. This allows the browser to continue scrolling smoothly even
+while the event listener is processing. For example:
+```javascript
+eventContract.addEvent(eventType, prefixedEventType, /* passive= */ true);
+```
+
 ### 2. Embed the `EventContract`
 
 In your server rendered application, embed the contract bundle at the top of

--- a/packages/core/primitives/event-dispatch/src/event_contract_container.ts
+++ b/packages/core/primitives/event-dispatch/src/event_contract_container.ts
@@ -17,6 +17,7 @@ export interface EventContractContainerManager {
   addEventListener(
     eventType: string,
     getHandler: (element: Element) => (event: Event) => void,
+    passive?: boolean,
   ): void;
 
   cleanUp(): void;
@@ -50,7 +51,11 @@ export class EventContractContainer implements EventContractContainerManager {
    * and maintains a reference to resulting handler in order to remove it
    * later if desired.
    */
-  addEventListener(eventType: string, getHandler: (element: Element) => (event: Event) => void) {
+  addEventListener(
+    eventType: string,
+    getHandler: (element: Element) => (event: Event) => void,
+    passive?: boolean,
+  ) {
     // In iOS, event bubbling doesn't happen automatically in any DOM element,
     // unless it has an onclick attribute or DOM event handler attached to it.
     // This breaks JsAction in some cases. See "Making Elements Clickable"
@@ -66,7 +71,7 @@ export class EventContractContainer implements EventContractContainerManager {
       (this.element as HTMLElement).style.cursor = 'pointer';
     }
     this.handlerInfos.push(
-      eventLib.addEventListener(this.element, eventType, getHandler(this.element)),
+      eventLib.addEventListener(this.element, eventType, getHandler(this.element), passive),
     );
   }
 

--- a/packages/core/primitives/event-dispatch/src/event_contract_multi_container.ts
+++ b/packages/core/primitives/event-dispatch/src/event_contract_multi_container.ts
@@ -30,9 +30,13 @@ export class EventContractMultiContainer implements EventContractContainerManage
    * and maintains a reference to resulting handler in order to remove it
    * later if desired.
    */
-  addEventListener(eventType: string, getHandler: (element: Element) => (event: Event) => void) {
+  addEventListener(
+    eventType: string,
+    getHandler: (element: Element) => (event: Event) => void,
+    passive?: boolean,
+  ) {
     const eventHandlerInstaller = (container: EventContractContainer) => {
-      container.addEventListener(eventType, getHandler);
+      container.addEventListener(eventType, getHandler, passive);
     };
     for (let i = 0; i < this.containers.length; i++) {
       eventHandlerInstaller(this.containers[i]);

--- a/packages/core/primitives/event-dispatch/src/event_handler.ts
+++ b/packages/core/primitives/event-dispatch/src/event_handler.ts
@@ -17,4 +17,6 @@ export interface EventHandlerInfo {
   handler: (event: Event) => void;
 
   capture: boolean;
+
+  passive?: boolean;
 }

--- a/packages/core/primitives/event-dispatch/src/eventcontract.ts
+++ b/packages/core/primitives/event-dispatch/src/eventcontract.ts
@@ -149,8 +149,11 @@ export class EventContract implements UnrenamedEventContract {
    *     to subscribe to jsaction="transitionEnd:foo" while the underlying
    *     event is webkitTransitionEnd in one browser and mozTransitionEnd
    *     in another.
+   *
+   * @param passive A boolean value that, if `true`, indicates that the event
+   *     handler will never call `preventDefault()`.
    */
-  addEvent(eventType: string, prefixedEventType?: string) {
+  addEvent(eventType: string, prefixedEventType?: string, passive?: boolean) {
     if (eventType in this.eventHandlers || !this.containerManager) {
       return;
     }
@@ -174,11 +177,15 @@ export class EventContract implements UnrenamedEventContract {
       this.browserEventTypeToExtraEventTypes[browserEventType] = eventTypes;
     }
 
-    this.containerManager.addEventListener(browserEventType, (element: Element) => {
-      return (event: Event) => {
-        eventHandler(eventType, event, element);
-      };
-    });
+    this.containerManager.addEventListener(
+      browserEventType,
+      (element: Element) => {
+        return (event: Event) => {
+          eventHandler(eventType, event, element);
+        };
+      },
+      passive,
+    );
   }
 
   /**

--- a/packages/core/primitives/event-dispatch/test/event_test.ts
+++ b/packages/core/primitives/event-dispatch/test/event_test.ts
@@ -70,40 +70,128 @@ describe('event test.ts', () => {
     divInternal = document.createElement('div');
   });
 
-  it('add event listener w3 c', () => {
-    const eventInfo = jsactionEvent.addEventListener(divInternal, 'click', () => {});
+  it('add event listener click w3 c', () => {
+    const addEventListenerSpy = spyOn(divInternal, 'addEventListener').and.callThrough();
+    const handler = () => {};
+    const eventInfo = jsactionEvent.addEventListener(divInternal, 'click', handler);
+    expect(addEventListenerSpy).toHaveBeenCalledOnceWith('click', handler, false);
     expect(eventInfo.eventType).toBe('click');
     expect(eventInfo.capture).toBe(false);
+    expect(eventInfo.passive).toBeUndefined();
   });
 
   it('add event listener focus w3 c', () => {
-    const eventInfo = jsactionEvent.addEventListener(divInternal, 'focus', () => {});
+    const addEventListenerSpy = spyOn(divInternal, 'addEventListener').and.callThrough();
+    const handler = () => {};
+    const eventInfo = jsactionEvent.addEventListener(divInternal, 'focus', handler);
+    expect(addEventListenerSpy).toHaveBeenCalledOnceWith('focus', handler, true);
     expect(eventInfo.eventType).toBe('focus');
     expect(eventInfo.capture).toBe(true);
+    expect(eventInfo.passive).toBeUndefined();
   });
 
   it('add event listener blur w3 c', () => {
-    const eventInfo = jsactionEvent.addEventListener(divInternal, 'blur', () => {});
+    const addEventListenerSpy = spyOn(divInternal, 'addEventListener').and.callThrough();
+    const handler = () => {};
+    const eventInfo = jsactionEvent.addEventListener(divInternal, 'blur', handler);
+    expect(addEventListenerSpy).toHaveBeenCalledOnceWith('blur', handler, true);
     expect(eventInfo.eventType).toBe('blur');
     expect(eventInfo.capture).toBe(true);
+    expect(eventInfo.passive).toBeUndefined();
   });
 
   it('add event listener error w3 c', () => {
-    const eventInfo = jsactionEvent.addEventListener(divInternal, 'error', () => {});
+    const addEventListenerSpy = spyOn(divInternal, 'addEventListener').and.callThrough();
+    const handler = () => {};
+    const eventInfo = jsactionEvent.addEventListener(divInternal, 'error', handler);
+    expect(addEventListenerSpy).toHaveBeenCalledOnceWith('error', handler, true);
     expect(eventInfo.eventType).toBe('error');
     expect(eventInfo.capture).toBe(true);
+    expect(eventInfo.passive).toBeUndefined();
   });
 
   it('add event listener load w3 c', () => {
-    const eventInfo = jsactionEvent.addEventListener(divInternal, 'load', () => {});
+    const addEventListenerSpy = spyOn(divInternal, 'addEventListener').and.callThrough();
+    const handler = () => {};
+    const eventInfo = jsactionEvent.addEventListener(divInternal, 'load', handler);
+    expect(addEventListenerSpy).toHaveBeenCalledOnceWith('load', handler, true);
     expect(eventInfo.eventType).toBe('load');
     expect(eventInfo.capture).toBe(true);
+    expect(eventInfo.passive).toBeUndefined();
   });
 
   it('add event listener toggle w3 c', () => {
-    const eventInfo = jsactionEvent.addEventListener(divInternal, 'toggle', () => {});
+    const addEventListenerSpy = spyOn(divInternal, 'addEventListener').and.callThrough();
+    const handler = () => {};
+    const eventInfo = jsactionEvent.addEventListener(divInternal, 'toggle', handler);
+    expect(addEventListenerSpy).toHaveBeenCalledOnceWith('toggle', handler, true);
     expect(eventInfo.eventType).toBe('toggle');
     expect(eventInfo.capture).toBe(true);
+    expect(eventInfo.passive).toBeUndefined();
+  });
+
+  it('add event listener touchstart w3 c', () => {
+    const addEventListenerSpy = spyOn(divInternal, 'addEventListener').and.callThrough();
+    const handler = () => {};
+    const eventInfo = jsactionEvent.addEventListener(divInternal, 'touchstart', handler);
+    expect(addEventListenerSpy).toHaveBeenCalledOnceWith('touchstart', handler, false);
+    expect(eventInfo.eventType).toBe('touchstart');
+    expect(eventInfo.capture).toBe(false);
+    expect(eventInfo.passive).toBeUndefined();
+  });
+
+  it('add event listener touchstart w3 c with passive:false', () => {
+    const addEventListenerSpy = spyOn(divInternal, 'addEventListener').and.callThrough();
+    const handler = () => {};
+    const eventInfo = jsactionEvent.addEventListener(divInternal, 'touchstart', handler, false);
+    expect(addEventListenerSpy).toHaveBeenCalledOnceWith('touchstart', handler, {
+      capture: false,
+      passive: false,
+    });
+    expect(eventInfo.eventType).toBe('touchstart');
+    expect(eventInfo.capture).toBe(false);
+    expect(eventInfo.passive).toBe(false);
+  });
+
+  it('add event listener touchstart w3 c with passive:true', () => {
+    const addEventListenerSpy = spyOn(divInternal, 'addEventListener').and.callThrough();
+    const handler = () => {};
+    const eventInfo = jsactionEvent.addEventListener(divInternal, 'touchstart', handler, true);
+    expect(addEventListenerSpy).toHaveBeenCalledOnceWith('touchstart', handler, {
+      capture: false,
+      passive: true,
+    });
+    expect(eventInfo.eventType).toBe('touchstart');
+    expect(eventInfo.capture).toBe(false);
+    expect(eventInfo.passive).toBe(true);
+  });
+
+  it('remove event listener touchstart w3 c', () => {
+    const removeEventListenerSpy = spyOn(divInternal, 'removeEventListener').and.callThrough();
+    const handler = () => {};
+    const eventInfo = jsactionEvent.addEventListener(divInternal, 'touchstart', handler);
+    jsactionEvent.removeEventListener(divInternal, eventInfo);
+    expect(removeEventListenerSpy).toHaveBeenCalledOnceWith('touchstart', handler, false);
+  });
+
+  it('remove event listener touchstart w3 c with passive:false', () => {
+    const removeEventListenerSpy = spyOn(divInternal, 'removeEventListener').and.callThrough();
+    const handler = () => {};
+    const eventInfo = jsactionEvent.addEventListener(divInternal, 'touchstart', handler, false);
+    jsactionEvent.removeEventListener(divInternal, eventInfo);
+    expect(removeEventListenerSpy).toHaveBeenCalledOnceWith('touchstart', handler, {
+      capture: false,
+    });
+  });
+
+  it('remove event listener touchstart w3 c with passive:true', () => {
+    const removeEventListenerSpy = spyOn(divInternal, 'removeEventListener').and.callThrough();
+    const handler = () => {};
+    const eventInfo = jsactionEvent.addEventListener(divInternal, 'touchstart', handler, true);
+    jsactionEvent.removeEventListener(divInternal, eventInfo);
+    expect(removeEventListenerSpy).toHaveBeenCalledOnceWith('touchstart', handler, {
+      capture: false,
+    });
   });
 
   it('is modified click event mac meta key', () => {

--- a/packages/core/primitives/event-dispatch/test/eventcontract_test.ts
+++ b/packages/core/primitives/event-dispatch/test/eventcontract_test.ts
@@ -244,6 +244,52 @@ describe('EventContract', () => {
     expect(registeredEventTypes).toEqual(['webkitanimationend']);
   });
 
+  it('adds event listener without passive option', () => {
+    const container = getRequiredElementById('container');
+    const addEventListenerSpy = spyOn(container, 'addEventListener');
+
+    const eventContractContainerManager = new EventContractMultiContainer();
+    const eventContract = createEventContract({eventContractContainerManager, eventTypes: []});
+    eventContract.addEvent('touchstart');
+    eventContractContainerManager.addContainer(container);
+
+    expect(addEventListenerSpy).toHaveBeenCalledOnceWith(
+      'touchstart',
+      jasmine.any(Function),
+      false,
+    );
+  });
+
+  it('adds event listener for passive:false event', () => {
+    const container = getRequiredElementById('container');
+    const addEventListenerSpy = spyOn(container, 'addEventListener');
+
+    const eventContractContainerManager = new EventContractMultiContainer();
+    const eventContract = createEventContract({eventContractContainerManager, eventTypes: []});
+    eventContract.addEvent('touchstart', '', false);
+    eventContractContainerManager.addContainer(container);
+
+    expect(addEventListenerSpy).toHaveBeenCalledOnceWith('touchstart', jasmine.any(Function), {
+      capture: false,
+      passive: false,
+    });
+  });
+
+  it('adds event listener for passive:true event', () => {
+    const container = getRequiredElementById('container');
+    const addEventListenerSpy = spyOn(container, 'addEventListener');
+
+    const eventContractContainerManager = new EventContractMultiContainer();
+    const eventContract = createEventContract({eventContractContainerManager, eventTypes: []});
+    eventContract.addEvent('touchstart', '', true);
+    eventContractContainerManager.addContainer(container);
+
+    expect(addEventListenerSpy).toHaveBeenCalledOnceWith('touchstart', jasmine.any(Function), {
+      capture: false,
+      passive: true,
+    });
+  });
+
   it('queues events until dispatcher is registered', () => {
     const container = getRequiredElementById('click-container');
     const targetElement = getRequiredElementById('click-target-element');


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
This PR makes event library's `addEventListener()` calls `EventTarget.addEventListener()` with `options` instead of `useCapture`. This allows us to pass or override `passive` option for improving scroll performance in future PRs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 - Passing `options` to `EventTarget.addEventListener` is not supported in IE11
 - `removeEventListener()` doesn't recognize `passive` option
 - This PR is created because I messed up https://github.com/angular/angular/pull/58198 :)