### PR TITLE
fix(elements): custom-element now handle input alias name

### DIFF
--- a/packages/elements/src/create-custom-element.ts
+++ b/packages/elements/src/create-custom-element.ts
@@ -237,8 +237,8 @@ export function createCustomElement<P>(
   }
 
   // Add getters and setters to the prototype for each property input.
-  inputs.forEach(({propName, transform}) => {
-    Object.defineProperty(NgElementImpl.prototype, propName, {
+  inputs.forEach(({propName, templateName, transform}) => {
+    Object.defineProperty(NgElementImpl.prototype, templateName, {
       get(): any {
         return this.ngElementStrategy.getInputValue(propName);
       },

--- a/packages/elements/test/create-custom-element_spec.ts
+++ b/packages/elements/test/create-custom-element_spec.ts
@@ -29,7 +29,7 @@ import {
 
 interface WithFooBar {
   fooFoo: string;
-  barBar: string;
+  barbar: string;
   fooTransformed: unknown;
   fooSignal: string | null;
 }
@@ -85,7 +85,7 @@ describe('createCustomElement', () => {
     expect(strategy.connectedElement).toBe(element);
 
     expect(strategy.getInputValue('fooFoo')).toBe('value-foo-foo');
-    expect(strategy.getInputValue('barBar')).toBe('value-barbar');
+    expect(strategy.getInputValue('barbar')).toBe('value-barbar');
     expect(strategy.getInputValue('fooTransformed')).toBe(true);
     expect(strategy.getInputValue('fooSignal')).toBe('value-signal');
   });
@@ -108,7 +108,7 @@ describe('createCustomElement', () => {
 
     expect(strategy.connectedElement).toBe(element);
     expect(strategy.getInputValue('fooFoo')).toBe('value-foo-foo');
-    expect(strategy.getInputValue('barBar')).toBe('value-barbar');
+    expect(strategy.getInputValue('barbar')).toBe('value-barbar');
     expect(strategy.getInputValue('fooTransformed')).toBe(true);
     expect(strategy.getInputValue('fooSignal')).toBe('value-signal');
   });
@@ -182,12 +182,12 @@ describe('createCustomElement', () => {
   it('should properly set getters/setters on the element', () => {
     const element = new NgElementCtor(injector);
     element.fooFoo = 'foo-foo-value';
-    element.barBar = 'barBar-value';
+    element.barbar = 'barbar-value';
     element.fooTransformed = 'truthy';
     element.fooSignal = 'value-signal';
 
     expect(strategy.inputs.get('fooFoo')).toBe('foo-foo-value');
-    expect(strategy.inputs.get('barBar')).toBe('barBar-value');
+    expect(strategy.inputs.get('barbar')).toBe('barbar-value');
     expect(strategy.inputs.get('fooTransformed')).toBe(true);
     expect(strategy.inputs.get('fooSignal')).toBe('value-signal');
   });
@@ -201,12 +201,12 @@ describe('createCustomElement', () => {
     strategyFactory.create = TestStrategyFactory.prototype.create;
 
     element.fooFoo = 'foo-foo-value';
-    element.barBar = 'barBar-value';
+    element.barbar = 'barbar-value';
     element.fooTransformed = 'truthy';
     element.fooSignal = 'value-signal';
 
     expect(strategy.inputs.get('fooFoo')).toBe('foo-foo-value');
-    expect(strategy.inputs.get('barBar')).toBe('barBar-value');
+    expect(strategy.inputs.get('barbar')).toBe('barbar-value');
     expect(strategy.inputs.get('fooTransformed')).toBe(true);
     expect(strategy.inputs.get('fooSignal')).toBe('value-signal');
   });
@@ -216,12 +216,12 @@ describe('createCustomElement', () => {
     const {selector, ElementCtor} = createTestCustomElement(strategyFactory);
     const element = Object.assign(document.createElement(selector), {
       fooFoo: 'foo-prop-value',
-      barBar: 'bar-prop-value',
+      barbar: 'bar-prop-value',
       fooTransformed: 'truthy' as unknown,
       fooSignal: 'value-signal',
     });
     expect(element.fooFoo).toBe('foo-prop-value');
-    expect(element.barBar).toBe('bar-prop-value');
+    expect(element.barbar).toBe('bar-prop-value');
     expect(element.fooTransformed).toBe('truthy');
     expect(element.fooSignal).toBe('value-signal');
 
@@ -229,12 +229,12 @@ describe('createCustomElement', () => {
     customElements.define(selector, ElementCtor);
     testContainer.appendChild(element);
     expect(element.fooFoo).toBe('foo-prop-value');
-    expect(element.barBar).toBe('bar-prop-value');
+    expect(element.barbar).toBe('bar-prop-value');
     expect(element.fooTransformed).toBe(true);
     expect(element.fooSignal).toBe('value-signal');
 
     expect(strategy.inputs.get('fooFoo')).toBe('foo-prop-value');
-    expect(strategy.inputs.get('barBar')).toBe('bar-prop-value');
+    expect(strategy.inputs.get('barbar')).toBe('bar-prop-value');
     expect(strategy.inputs.get('fooTransformed')).toBe(true);
     expect(strategy.inputs.get('fooSignal')).toBe('value-signal');
   });
@@ -244,12 +244,12 @@ describe('createCustomElement', () => {
     const {selector, ElementCtor} = createTestCustomElement(strategyFactory);
     const element = Object.assign(document.createElement(selector), {
       fooFoo: 'foo-prop-value',
-      barBar: 'bar-prop-value',
+      barbar: 'bar-prop-value',
       fooTransformed: 'truthy' as unknown,
       fooSignal: 'value-signal',
     });
     expect(element.fooFoo).toBe('foo-prop-value');
-    expect(element.barBar).toBe('bar-prop-value');
+    expect(element.barbar).toBe('bar-prop-value');
     expect(element.fooTransformed).toBe('truthy');
     expect(element.fooSignal).toBe('value-signal');
 
@@ -257,23 +257,23 @@ describe('createCustomElement', () => {
     // property.
     customElements.define(selector, ElementCtor);
     customElements.upgrade(element);
-    element.barBar = 'bar-prop-value-2';
+    element.barbar = 'bar-prop-value-2';
     element.fooTransformed = '';
     element.fooSignal = 'value-signal-changed';
     expect(element.fooFoo).toBe('foo-prop-value');
-    expect(element.barBar).toBe('bar-prop-value-2');
+    expect(element.barbar).toBe('bar-prop-value-2');
     expect(element.fooTransformed).toBe('');
     expect(element.fooSignal).toBe('value-signal-changed');
 
     // Insert the element into the DOM.
     testContainer.appendChild(element);
     expect(element.fooFoo).toBe('foo-prop-value');
-    expect(element.barBar).toBe('bar-prop-value-2');
+    expect(element.barbar).toBe('bar-prop-value-2');
     expect(element.fooTransformed).toBe(false);
     expect(element.fooSignal).toBe('value-signal-changed');
 
     expect(strategy.inputs.get('fooFoo')).toBe('foo-prop-value');
-    expect(strategy.inputs.get('barBar')).toBe('bar-prop-value-2');
+    expect(strategy.inputs.get('barbar')).toBe('bar-prop-value-2');
     expect(strategy.inputs.get('fooTransformed')).toBe(false);
     expect(strategy.inputs.get('fooSignal')).toBe('value-signal-changed');
   });
@@ -283,12 +283,12 @@ describe('createCustomElement', () => {
     const {selector, ElementCtor} = createTestCustomElement(strategyFactory);
     const element = Object.assign(document.createElement(selector), {
       fooFoo: 'foo-prop-value',
-      barBar: 'bar-prop-value',
+      barbar: 'bar-prop-value',
       fooTransformed: 'truthy' as unknown,
       fooSignal: 'value-signal',
     });
     expect(element.fooFoo).toBe('foo-prop-value');
-    expect(element.barBar).toBe('bar-prop-value');
+    expect(element.barbar).toBe('bar-prop-value');
     expect(element.fooTransformed).toBe('truthy');
     expect(element.fooSignal).toBe('value-signal');
 
@@ -299,19 +299,19 @@ describe('createCustomElement', () => {
     element.setAttribute('barbar', 'bar-attr-value');
     element.setAttribute('foo-transformed', '');
     expect(element.fooFoo).toBe('foo-prop-value');
-    expect(element.barBar).toBe('bar-attr-value');
+    expect(element.barbar).toBe('bar-attr-value');
     expect(element.fooTransformed).toBe(false);
     expect(element.fooSignal).toBe('value-signal');
 
     // Insert the element into the DOM.
     testContainer.appendChild(element);
     expect(element.fooFoo).toBe('foo-prop-value');
-    expect(element.barBar).toBe('bar-attr-value');
+    expect(element.barbar).toBe('bar-attr-value');
     expect(element.fooTransformed).toBe(false);
     expect(element.fooSignal).toBe('value-signal');
 
     expect(strategy.inputs.get('fooFoo')).toBe('foo-prop-value');
-    expect(strategy.inputs.get('barBar')).toBe('bar-attr-value');
+    expect(strategy.inputs.get('barbar')).toBe('bar-attr-value');
     expect(strategy.inputs.get('fooTransformed')).toBe(false);
     expect(strategy.inputs.get('fooSignal')).toBe('value-signal');
   });
@@ -334,12 +334,12 @@ describe('createCustomElement', () => {
 
   @Component({
     selector: 'test-component',
-    template: 'TestComponent|foo({{ fooFoo }})|bar({{ barBar }})',
+    template: 'TestComponent|foo({{ fooFoo }})|bar({{ barbar }})',
     standalone: false,
   })
   class TestComponent {
     @Input() fooFoo: string = 'foo';
-    @Input('barbar') barBar!: string;
+    @Input('barbar') barbar!: string;
     @Input({transform: (value: unknown) => !!value}) fooTransformed!: boolean;
 
     // This needs to apply the decorator and pass `isSignal`, because


### PR DESCRIPTION
input alias option is not working and this PR fixed the issue

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #58302 


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
