### PR TITLE
fix(migrations): add outputs migration to combined shorthand

### DIFF
--- a/packages/core/schematics/ng-generate/signals/BUILD.bazel
+++ b/packages/core/schematics/ng-generate/signals/BUILD.bazel
@@ -18,6 +18,7 @@ ts_library(
     srcs = glob(["**/*.ts"]),
     tsconfig = "//packages/core/schematics:tsconfig.json",
     deps = [
+        "//packages/core/schematics/ng-generate/output-migration",
         "//packages/core/schematics/ng-generate/signal-input-migration",
         "//packages/core/schematics/ng-generate/signal-queries-migration",
         "//packages/core/schematics/utils/tsurge/helpers/angular_devkit",

--- a/packages/core/schematics/ng-generate/signals/README.md
+++ b/packages/core/schematics/ng-generate/signals/README.md
@@ -1,9 +1,10 @@
 # Combined signals migration
 
 Combines all signal-related migrations into a single migration. It includes the following migrations:
-* Converting `@Input` to the signal-based `input`. [See documentation](https://github.com/angular/angular/blob/main/packages/core/schematics/ng-generate/signal-input-migration/README.md).
+* Converting `@Input` to the signal-based `input`.
+* Converting `@Output` to `output`.
 * Converting `@ViewChild`/`@ViewChildren` and `@ContentChild`/`@ContentChildren` to
-`viewChild`/`viewChildren` and `contentChild`/`contentChildren`. [See documentation](https://github.com/angular/angular/blob/main/packages/core/schematics/ng-generate/signal-input-migration/README.md).
+`viewChild`/`viewChildren` and `contentChild`/`contentChildren`.
 
 The primary use case for this migration is to offer developers interested in switching to signals a
 single entrypoint from which they can do so.

--- a/packages/core/schematics/ng-generate/signals/index.ts
+++ b/packages/core/schematics/ng-generate/signals/index.ts
@@ -9,9 +9,11 @@
 import {chain, Rule, SchematicsException} from '@angular-devkit/schematics';
 import {migrate as toSignalQueries} from '../signal-queries-migration';
 import {migrate as toSignalInputs} from '../signal-input-migration';
+import {migrate as toInitializerOutputs} from '../output-migration';
 
 const enum SupportedMigrations {
   inputs = 'inputs',
+  outputs = 'outputs',
   queries = 'queries',
 }
 
@@ -33,6 +35,10 @@ export function migrate(options: Options): Rule {
     switch (migration) {
       case SupportedMigrations.inputs:
         rules.push(toSignalInputs(options));
+        break;
+
+      case SupportedMigrations.outputs:
+        rules.push(toInitializerOutputs(options));
         break;
 
       case SupportedMigrations.queries:

--- a/packages/core/schematics/ng-generate/signals/schema.json
+++ b/packages/core/schematics/ng-generate/signals/schema.json
@@ -14,6 +14,7 @@
         "type": "string",
         "enum": [
           "inputs",
+          "outputs",
           "queries"
         ]
       },
@@ -26,6 +27,10 @@
           {
             "value": "inputs",
             "label": "Convert `@Input` to the signal-based `input`"
+          },
+          {
+            "value": "outputs",
+            "label": "Convert `@Output` to the new `output` function"
           },
           {
             "value": "queries",

--- a/packages/core/schematics/test/signals_migration_spec.ts
+++ b/packages/core/schematics/test/signals_migration_spec.ts
@@ -60,7 +60,7 @@ describe('combined signals migration', () => {
     writeFile(
       '/index.ts',
       `
-      import {ContentChild, Input, ElementRef, Component} from '@angular/core';
+      import {ContentChild, Input, ElementRef, Output, Component, EventEmitter} from '@angular/core';
 
       @Component({
         template: 'The value is {{value}}',
@@ -68,14 +68,15 @@ describe('combined signals migration', () => {
       export class SomeComponent {
         @ContentChild('ref') ref!: ElementRef;
         @Input('alias') value: string = 'initial';
+        @Output() clicked = new EventEmitter<void>();
       }`,
     );
 
-    await runMigration(['inputs', 'queries']);
+    await runMigration(['inputs', 'queries', 'outputs']);
 
     expect(stripWhitespace(tree.readContent('/index.ts'))).toBe(
       stripWhitespace(`
-      import {ElementRef, Component, input, contentChild} from '@angular/core';
+      import {ElementRef, Component, input, output, contentChild} from '@angular/core';
 
       @Component({
         template: 'The value is {{value()}}',
@@ -83,6 +84,7 @@ describe('combined signals migration', () => {
       export class SomeComponent {
         readonly ref = contentChild.required<ElementRef>('ref');
         readonly value = input<string>('initial', { alias: "alias" });
+        readonly clicked = output<void>();
       }
     `),
     );


### PR DESCRIPTION
Adds the `@Output` migration to the combined `@angular/core:signals` migration.