### PR TITLE
feat(core): add "kind" to signal prototype nodes

### DIFF
--- a/goldens/public-api/core/primitives/signals/index.api.md
+++ b/goldens/public-api/core/primitives/signals/index.api.md
@@ -86,6 +86,7 @@ export interface ReactiveNode {
     consumerOnSignalRead(node: unknown): void;
     debugName?: string;
     dirty: boolean;
+    kind: string;
     lastCleanEpoch: Version;
     liveConsumerIndexOfThis: number[] | undefined;
     liveConsumerNode: ReactiveNode[] | undefined;

--- a/packages/core/primitives/signals/src/computed.ts
+++ b/packages/core/primitives/signals/src/computed.ts
@@ -101,6 +101,7 @@ const COMPUTED_NODE = /* @__PURE__ */ (() => {
     dirty: true,
     error: null,
     equal: defaultEquals,
+    kind: 'computed',
 
     producerMustRecompute(node: ComputedNode<unknown>): boolean {
       // Force a recomputation if there's no current value, or if the current value is in the

--- a/packages/core/primitives/signals/src/graph.ts
+++ b/packages/core/primitives/signals/src/graph.ts
@@ -66,6 +66,7 @@ export const REACTIVE_NODE: ReactiveNode = {
   liveConsumerIndexOfThis: undefined,
   consumerAllowSignalWrites: false,
   consumerIsAlwaysLive: false,
+  kind: 'unknown',
   producerMustRecompute: () => false,
   producerRecomputeValue: () => {},
   consumerMarkedDirty: () => {},
@@ -184,6 +185,16 @@ export interface ReactiveNode {
    * A debug name for the reactive node. Used in Angular DevTools to identify the node.
    */
   debugName?: string;
+
+  /**
+   * Kind of node. Example: 'signal', 'computed', 'input', 'effect'.
+   *
+   * ReactiveNode has this as 'unknown' by default, but derived node types should override this to
+   * make available the kind of signal that particular instance of a ReactiveNode represents.
+   *
+   * Used in Angular DevTools to identify the kind of signal.
+   */
+  kind: string;
 }
 
 interface ConsumerNode extends ReactiveNode {

--- a/packages/core/primitives/signals/src/signal.ts
+++ b/packages/core/primitives/signals/src/signal.ts
@@ -99,6 +99,7 @@ export const SIGNAL_NODE: SignalNode<unknown> = /* @__PURE__ */ (() => {
     ...REACTIVE_NODE,
     equal: defaultEquals,
     value: undefined,
+    kind: 'signal',
   };
 })();
 


### PR DESCRIPTION
This would enable debug APIs to determine the kind of a signal given a node for #57074 
