### PR TITLE
refactor: cleanup initializers that use ctor params

### DIFF
--- a/packages/common/testing/src/navigation/fake_navigation.ts
+++ b/packages/common/testing/src/navigation/fake_navigation.ts
@@ -72,7 +72,7 @@ export class FakeNavigation implements Navigation {
   private canSetInitialEntry = true;
 
   /** `EventTarget` to dispatch events. */
-  private eventTarget: EventTarget = this.window.document.createElement('div');
+  private eventTarget: EventTarget;
 
   /** The next unique id for created entries. Replace recreates this id. */
   private nextId = 0;
@@ -100,6 +100,7 @@ export class FakeNavigation implements Navigation {
     private readonly window: Window,
     startURL: `http${string}`,
   ) {
+    this.eventTarget = this.window.document.createElement('div');
     // First entry.
     this.setInitialEntryForTesting(startURL);
   }

--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -76,7 +76,7 @@ export function recognize(
 const MAX_ALLOWED_REDIRECTS = 31;
 
 export class Recognizer {
-  private applyRedirects = new ApplyRedirects(this.urlSerializer, this.urlTree);
+  private applyRedirects: ApplyRedirects;
   private absoluteRedirectCount = 0;
   allowRedirects = true;
 
@@ -88,7 +88,9 @@ export class Recognizer {
     private urlTree: UrlTree,
     private paramsInheritanceStrategy: ParamsInheritanceStrategy,
     private readonly urlSerializer: UrlSerializer,
-  ) {}
+  ) {
+    this.applyRedirects = new ApplyRedirects(this.urlSerializer, this.urlTree);
+  }
 
   private noMatchError(e: NoMatch): RuntimeError<RuntimeErrorCode.NO_MATCH> {
     return new RuntimeError(

--- a/packages/router/src/router_outlet_context.ts
+++ b/packages/router/src/router_outlet_context.ts
@@ -20,7 +20,7 @@ import {getClosestRouteInjector} from './utils/config';
 export class OutletContext {
   outlet: RouterOutletContract | null = null;
   route: ActivatedRoute | null = null;
-  children = new ChildrenOutletContexts(this.rootInjector);
+  children: ChildrenOutletContexts;
   attachRef: ComponentRef<any> | null = null;
   get injector(): EnvironmentInjector {
     return getClosestRouteInjector(this.route?.snapshot) ?? this.rootInjector;
@@ -28,7 +28,9 @@ export class OutletContext {
   // TODO(atscott): Only here to avoid a "breaking" change in a patch/minor. Remove in v19.
   set injector(_: EnvironmentInjector) {}
 
-  constructor(private readonly rootInjector: EnvironmentInjector) {}
+  constructor(private readonly rootInjector: EnvironmentInjector) {
+    this.children = new ChildrenOutletContexts(this.rootInjector);
+  }
 }
 
 /**


### PR DESCRIPTION
Fix initializer of instance members that reference identifiers declared in the constructor.

When public class fields are enabled, such cases throw TS2729: property used before its initialization.
