### PR TITLE
refactor(router): drop special handling of the OutletInjector

### DIFF
--- a/packages/core/src/render3/util/injector_discovery_utils.ts
+++ b/packages/core/src/render3/util/injector_discovery_utils.ts
@@ -36,12 +36,7 @@ import {TContainerNode, TElementContainerNode, TElementNode, TNode} from '../int
 import {RElement} from '../interfaces/renderer_dom';
 import {INJECTOR, LView, TVIEW} from '../interfaces/view';
 
-import {
-  getParentInjectorIndex,
-  getParentInjectorView,
-  hasParentInjector,
-  isRouterOutletInjector,
-} from './injector_utils';
+import {getParentInjectorIndex, getParentInjectorView, hasParentInjector} from './injector_utils';
 import {getNativeByTNode} from './view_utils';
 
 /**
@@ -601,16 +596,7 @@ function getInjectorResolutionPathHelper(
  */
 function getInjectorParent(injector: Injector): Injector | null {
   if (injector instanceof R3Injector) {
-    const parent = injector.parent;
-    if (isRouterOutletInjector(parent)) {
-      // This is a special case for a `ChainedInjector` instance, which represents
-      // a combination of a Router's `OutletInjector` and an EnvironmentInjector,
-      // which represents a `@defer` block. Since the `OutletInjector` doesn't store
-      // any tokens itself, we point to the parent injector instead. See the
-      // `OutletInjector.__ngOutletInjector` field for additional information.
-      return (parent as ChainedInjector).parentInjector;
-    }
-    return parent;
+    return injector.parent;
   }
 
   let tNode: TElementNode | TContainerNode | TElementContainerNode | null;

--- a/packages/core/src/render3/util/injector_utils.ts
+++ b/packages/core/src/render3/util/injector_utils.ts
@@ -62,14 +62,3 @@ export function getParentInjectorView(location: RelativeInjectorLocation, startV
   }
   return parentView;
 }
-
-/**
- * Detects whether an injector is an instance of a `ChainedInjector`,
- * created based on the `OutletInjector`.
- */
-export function isRouterOutletInjector(currentInjector: Injector): boolean {
-  return (
-    currentInjector instanceof ChainedInjector &&
-    typeof (currentInjector.injector as any).__ngOutletInjector === 'function'
-  );
-}

--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -409,25 +409,6 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
 }
 
 class OutletInjector implements Injector {
-  /**
-   * This injector has a special handing for the `ActivatedRoute` and
-   * `ChildrenOutletContexts` tokens: it returns corresponding values for those
-   * tokens dynamically. This behavior is different from the regular injector logic,
-   * when we initialize and store a value, which is later returned for all inject
-   * requests.
-   *
-   * In some cases (e.g. when using `@defer`), this dynamic behavior requires special
-   * handling. This function allows to identify an instance of the `OutletInjector` and
-   * create an instance of it without referring to the class itself (so this logic can
-   * be invoked from the `core` package). This helps to retain dynamic behavior for the
-   * mentioned tokens.
-   *
-   * Note: it's a temporary solution and we should explore how to support this case better.
-   */
-  private __ngOutletInjector(parentInjector: Injector) {
-    return new OutletInjector(this.route, this.childContexts, parentInjector, this.outletData);
-  }
-
   constructor(
     private route: ActivatedRoute,
     private childContexts: ChildrenOutletContexts,


### PR DESCRIPTION
This commit updates the OutletInjector and related code to avoid special handling of that injector. The main code that had special handling was refactored to no longer require is in https://github.com/angular/angular/pull/56763, this commit completes the cleanup.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No