### PR TITLE
docs(forms): Correct Comment at FormControl Constructor

### DIFF
--- a/packages/forms/src/model/form_control.ts
+++ b/packages/forms/src/model/form_control.ts
@@ -379,14 +379,11 @@ export interface ɵFormControlCtor {
   /**
    * Creates a new `FormControl` instance.
    *
-   * @param formState Initializes the control with an initial value,
+   * @param value Initializes the control with an initial value,
    * or an object that defines the initial value and disabled state.
    *
-   * @param validatorOrOpts A synchronous validator function, or an array of
-   * such functions, or a `FormControlOptions` object that contains validation functions
-   * and a validation trigger.
-   *
-   * @param asyncValidator A single async validator or array of async validator functions
+   * @param opts A `FormControlOptions` object that contains validation functions and a
+   * validation trigger. `nonNullable` have to be `true`
    */
   new <T = any>(
     value: FormControlState<T> | T,
@@ -412,6 +409,18 @@ export interface ɵFormControlCtor {
     asyncValidator: AsyncValidatorFn | AsyncValidatorFn[],
   ): FormControl<T | null>;
 
+  /**
+   * Creates a new `FormControl` instance.
+   *
+   * @param value Initializes the control with an initial value,
+   * or an object that defines the initial value and disabled state.
+   *
+   * @param validatorOrOpts A synchronous validator function, or an array of
+   * such functions, or a `FormControlOptions` object that contains validation functions
+   * and a validation trigger.
+   *
+   * @param asyncValidator A single async validator or array of async validator functions
+   */
   new <T = any>(
     value: FormControlState<T> | T,
     validatorOrOpts?: ValidatorFn | ValidatorFn[] | FormControlOptions | null,


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The Comment of the FormControl constructors doesn't match the constructors.
One comment uses the wrong parameter names and the other is not existing

## What is the new behavior?
Every non-deprecated constructor of FormControls have a matching comment now.


## Does this PR introduce a breaking change?

[ ] Yes
[x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
