### PR TITLE
refactor(docs-infra): use reactive APIs in adev components

### DIFF
--- a/adev/src/app/features/references/api-item-label/api-item-label.component.html
+++ b/adev/src/app/features/references/api-item-label/api-item-label.component.html
@@ -1,3 +1,1 @@
-@if (apiItemType()) {
-  {{ apiItemType()! | adevApiLabel: labelMode() }}
-}
+{{ type() | adevApiLabel: mode() }}

--- a/adev/src/app/features/references/api-item-label/api-item-label.component.spec.ts
+++ b/adev/src/app/features/references/api-item-label/api-item-label.component.spec.ts
@@ -25,7 +25,7 @@ describe('ApiItemLabel', () => {
   });
 
   it('should by default display short label for Class', () => {
-    component.type = ApiItemType.CLASS;
+    fixture.componentRef.setInput('type', ApiItemType.CLASS);
     fixture.detectChanges();
 
     const label = fixture.nativeElement.innerText;
@@ -34,8 +34,8 @@ describe('ApiItemLabel', () => {
   });
 
   it('should display full label for Class when labelMode equals full', () => {
-    component.type = ApiItemType.CLASS;
-    component.mode = 'full';
+    fixture.componentRef.setInput('type', ApiItemType.CLASS);
+    fixture.componentRef.setInput('mode', 'full');
     fixture.detectChanges();
 
     const label = fixture.nativeElement.innerText;
@@ -44,8 +44,8 @@ describe('ApiItemLabel', () => {
   });
 
   it('should display short label for Class when labelMode equals short', () => {
-    component.type = ApiItemType.CLASS;
-    component.mode = 'short';
+    fixture.componentRef.setInput('type', ApiItemType.CLASS);
+    fixture.componentRef.setInput('mode', 'short');
     fixture.detectChanges();
 
     const label = fixture.nativeElement.innerText;

--- a/adev/src/app/features/references/api-item-label/api-item-label.component.ts
+++ b/adev/src/app/features/references/api-item-label/api-item-label.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, Input, signal} from '@angular/core';
+import {ChangeDetectionStrategy, Component, input} from '@angular/core';
 import {ApiItemType} from '../interfaces/api-item-type';
 import {ApiLabel} from '../pipes/api-label.pipe';
 
@@ -16,19 +16,12 @@ import {ApiLabel} from '../pipes/api-label.pipe';
   templateUrl: './api-item-label.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
-    '[attr.data-type]': 'apiItemType()',
-    '[attr.data-mode]': 'labelMode()',
+    '[attr.data-type]': 'type()',
+    '[attr.data-mode]': 'mode()',
   },
   imports: [ApiLabel],
 })
 export default class ApiItemLabel {
-  @Input({required: true}) set type(value: ApiItemType) {
-    this.apiItemType.set(value);
-  }
-  @Input({required: true}) set mode(value: 'short' | 'full') {
-    this.labelMode.set(value);
-  }
-
-  protected apiItemType = signal<ApiItemType | undefined>(undefined);
-  protected labelMode = signal<'short' | 'full'>('short');
+  readonly type = input.required<ApiItemType>();
+  readonly mode = input.required<'short' | 'full'>();
 }

--- a/adev/src/app/features/references/api-items-section/api-items-section.component.html
+++ b/adev/src/app/features/references/api-items-section/api-items-section.component.html
@@ -1,22 +1,22 @@
 <header class="adev-api-items-section-header">
-  <h3 [attr.id]="group.id">
-    @if (group.isFeatured) {
+  <h3 [id]="group().id">
+    @if (group().isFeatured) {
       <docs-icon aria-hidden>star</docs-icon>
     }
     <!-- we use innerHtml because the title can be an html string-->
     <a
       routerLink="/api"
-      [fragment]="group.id"
+      [fragment]="group().id"
       queryParamsHandling="preserve"
       class="adev-api-anchor"
       tabindex="-1"
-      [innerHtml]="group.title"
+      [innerHtml]="group().title"
     ></a>
   </h3>
 </header>
 
 <ul class="adev-api-items-section-grid">
-  @for (apiItem of group.items; track apiItem.url) {
+  @for (apiItem of group().items; track apiItem.url) {
     <li [class.adev-api-items-section-item-deprecated]="apiItem.isDeprecated">
       <a
         [routerLink]="'/' + apiItem.url"
@@ -37,7 +37,7 @@
       @if (apiItem.isFeatured) {
         <docs-icon
           class="adev-api-items-section-item-featured"
-          [class.adev-api-item-in-featured-section]="group.isFeatured"
+          [class.adev-api-item-in-featured-section]="group().isFeatured"
           [class.adev-api-items-section-item-featured-active]="apiItem.isFeatured"
         >
           star

--- a/adev/src/app/features/references/api-items-section/api-items-section.component.spec.ts
+++ b/adev/src/app/features/references/api-items-section/api-items-section.component.spec.ts
@@ -66,7 +66,7 @@ describe('ApiItemsSection', () => {
   });
 
   it('should render star icon for featured group', () => {
-    component.group = fakeFeaturedGroup;
+    fixture.componentRef.setInput('group', fakeFeaturedGroup);
     fixture.detectChanges();
 
     const starIcon = fixture.debugElement.query(By.css('.adev-api-items-section-header docs-icon'));
@@ -75,7 +75,7 @@ describe('ApiItemsSection', () => {
   });
 
   it('should not render star icon for standard group', () => {
-    component.group = fakeGroup;
+    fixture.componentRef.setInput('group', fakeGroup);
     fixture.detectChanges();
 
     const starIcon = fixture.debugElement.query(By.css('.adev-api-items-section-header docs-icon'));
@@ -84,7 +84,7 @@ describe('ApiItemsSection', () => {
   });
 
   it('should render list of all APIs of provided group', () => {
-    component.group = fakeFeaturedGroup;
+    fixture.componentRef.setInput('group', fakeFeaturedGroup);
     fixture.detectChanges();
 
     const apis = fixture.debugElement.queryAll(By.css('.adev-api-items-section-grid li'));
@@ -93,7 +93,7 @@ describe('ApiItemsSection', () => {
   });
 
   it('should display deprecated icon for deprecated API', () => {
-    component.group = fakeFeaturedGroup;
+    fixture.componentRef.setInput('group', fakeFeaturedGroup);
     fixture.detectChanges();
 
     const deprecatedApiIcons = fixture.debugElement.queryAll(
@@ -107,7 +107,7 @@ describe('ApiItemsSection', () => {
   });
 
   it('should display star icon for featured API', () => {
-    component.group = fakeFeaturedGroup;
+    fixture.componentRef.setInput('group', fakeFeaturedGroup);
     fixture.detectChanges();
 
     const featuredApiIcons = fixture.debugElement.queryAll(

--- a/adev/src/app/features/references/api-items-section/api-items-section.component.ts
+++ b/adev/src/app/features/references/api-items-section/api-items-section.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, input} from '@angular/core';
 import {RouterLink} from '@angular/router';
 import {ApiItemsGroup} from '../interfaces/api-items-group';
 import ApiItemLabel from '../api-item-label/api-item-label.component';
@@ -21,5 +21,5 @@ import {IconComponent} from '@angular/docs';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export default class ApiItemsSection {
-  @Input({required: true}) group!: ApiItemsGroup;
+  group = input.required<ApiItemsGroup>();
 }

--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.html
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.html
@@ -1,8 +1,8 @@
 <div class="adev-header-and-tabs docs-scroll-track-transparent">
-  <docs-viewer [docContent]="headerInnerHtml()" class="docs-reference-header"></docs-viewer>
+  <docs-viewer [docContent]="parsedDocContent().header" class="docs-reference-header"></docs-viewer>
 
-  <mat-tab-group class="docs-reference-tabs" animationDuration="0ms" mat-stretch-tabs="false" [selectedIndex]="selectedTabIndex()">
-    @for (tab of tabs(); track tab) {
+  <mat-tab-group class="docs-reference-tabs" animationDuration="0ms" mat-stretch-tabs="false" [selectedIndex]="selectedTabIndex()" (selectedIndexChange)="tabChange($event)">
+    @for (tab of tabs(); track tab.url) {
       <mat-tab [label]="tab.title">
         <div class="adev-reference-tab-body">
           <docs-viewer [docContent]="tab.content"></docs-viewer>
@@ -12,10 +12,10 @@
   </mat-tab-group>
 </div>
 
-@if (canDisplayCards() && membersMarginTopInPx() > 0) {
+@if (isApiTabActive() && membersMarginTopInPx() > 0) {
   <docs-viewer
     class="docs-reference-members-container"
-    [docContent]="membersInnerHtml()"
+    [docContent]="parsedDocContent().members"
     [style.marginTop.px]="membersMarginTopInPx()"
     (contentLoaded)="membersCardsLoaded()">
   </docs-viewer>


### PR DESCRIPTION
This is a relatively small refactoring to a couple of adev components. The goal here is to use new reactive APIs in the idiomatic way.
