### PR TITLE
fix(compiler): add more specific matcher for hydrate never block

### DIFF
--- a/packages/compiler/src/render3/r3_deferred_blocks.ts
+++ b/packages/compiler/src/render3/r3_deferred_blocks.ts
@@ -32,7 +32,7 @@ const HYDRATE_WHEN_PATTERN = /^hydrate\s+when\s/;
 const HYDRATE_ON_PATTERN = /^hydrate\s+on\s/;
 
 /** Pattern to identify a `hydrate never` trigger. */
-const HYDRATE_NEVER_PATTERN = /^hydrate\s+never\s*/;
+const HYDRATE_NEVER_PATTERN = /^hydrate\s+never$/;
 
 /** Pattern to identify a `minimum` parameter in a block. */
 const MINIMUM_PARAMETER_PATTERN = /^minimum\s/;

--- a/packages/compiler/src/render3/r3_deferred_blocks.ts
+++ b/packages/compiler/src/render3/r3_deferred_blocks.ts
@@ -32,7 +32,7 @@ const HYDRATE_WHEN_PATTERN = /^hydrate\s+when\s/;
 const HYDRATE_ON_PATTERN = /^hydrate\s+on\s/;
 
 /** Pattern to identify a `hydrate never` trigger. */
-const HYDRATE_NEVER_PATTERN = /^hydrate\s+never$/;
+const HYDRATE_NEVER_PATTERN = /^hydrate\s+never(\s*)$/;
 
 /** Pattern to identify a `minimum` parameter in a block. */
 const MINIMUM_PARAMETER_PATTERN = /^minimum\s/;

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -1419,6 +1419,12 @@ describe('R3 template transform', () => {
         );
       });
 
+      it('should report `hydrate never` used with additonal characters', () => {
+        expect(() => parse('@defer (hydrate nevermind) {hello}')).toThrowError(
+          /Unrecognized trigger/,
+        );
+      });
+
       it('should report when `hydrate never` is used together with another `hydrate` trigger', () => {
         // Extra trigger after `hydrate never`.
         expect(() =>

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -1425,6 +1425,26 @@ describe('R3 template transform', () => {
         );
       });
 
+      it('should not report an error when `hydrate never` is used with additonal blocks', () => {
+        expect(() => parse('@defer (hydrate never; on idle;) {hello}')).not.toThrowError(
+          /Unrecognized trigger/,
+        );
+      });
+
+      it('should not report an error when `hydrate never` is used with spaces', () => {
+        expect(() => parse('@defer(hydrate never ; on idle ;) {hello}')).not.toThrowError(
+          /Unrecognized trigger/,
+        );
+      });
+
+      it('should not report an error when `hydrate never` is used after another block', () => {
+        expect(() =>
+          parse(`@defer(
+        on idle;
+        hydrate never) {hello}`),
+        ).not.toThrowError(/Unrecognized trigger/);
+      });
+
       it('should report when `hydrate never` is used together with another `hydrate` trigger', () => {
         // Extra trigger after `hydrate never`.
         expect(() =>

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -1420,7 +1420,7 @@ describe('R3 template transform', () => {
       });
 
       it('should report `hydrate never` used with additonal characters', () => {
-        expect(() => parse('@defer (hydrate nevermind) {hello}')).toThrowError(
+        expect(() => parse('@defer (hydrate never, and thank you) {hello}')).toThrowError(
           /Unrecognized trigger/,
         );
       });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #58358

## What is the new behavior?

No additional characters are allowed in the "hydrate never" block.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<img src="https://media3.giphy.com/media/Qw4X3FGaZ6y9cLu1EwE/giphy.gif"/>