### PR TITLE
docs: fix spelling of "set up"

### DIFF
--- a/adev/README.md
+++ b/adev/README.md
@@ -6,7 +6,7 @@ The content is written primarily in Markdown format located in `src/content`. Fo
 
 ## Local Development
 
-For local development, [yarn](https://yarnpkg.com/) is the preferred package manager. You can setup a local environment with the following commands
+For local development, [yarn](https://yarnpkg.com/) is the preferred package manager. You can set up a local environment with the following commands
 :
 
 ```bash

--- a/adev/src/content/best-practices/runtime-performance/zone-pollution.md
+++ b/adev/src/content/best-practices/runtime-performance/zone-pollution.md
@@ -35,7 +35,7 @@ class AppComponent implements OnInit {
 
 The preceding snippet instructs Angular to call `setInterval` outside the Angular Zone and skip running change detection after `pollForUpdates` runs.
 
-Third-party libraries commonly trigger unnecessary change detection cycles when their APIs are invoked within the Angular zone. This phenomenon particularly affects libraries that setup event listeners or initiate other tasks (such as timers, XHR requests, etc.). Avoid these extra cycles by calling library APIs outside the Angular zone:
+Third-party libraries commonly trigger unnecessary change detection cycles when their APIs are invoked within the Angular zone. This phenomenon particularly affects libraries that set up event listeners or initiate other tasks (such as timers, XHR requests, etc.). Avoid these extra cycles by calling library APIs outside the Angular zone:
 
 <docs-code header="Move the plot initialization outside of the Zone" language='ts' linenums>
 import { Component, NgZone, OnInit } from '@angular/core';

--- a/adev/src/content/guide/templates/two-way-binding.md
+++ b/adev/src/content/guide/templates/two-way-binding.md
@@ -37,7 +37,7 @@ To use two-way binding with native form controls, you need to:
 1. Use the `ngModel` directive with the two-way binding syntax (e.g., `[(ngModel)]`)
 1. Assign it the state that you want it to update (e.g., `firstName`)
 
-Once that is setup, Angular will ensure that any updates in the text input will reflect correctly inside of the component state!
+Once that is set up, Angular will ensure that any updates in the text input will reflect correctly inside of the component state!
 
 Learn more about [`NgModel`](guide/directives#displaying-and-updating-properties-with-ngmodel) in the official docs.
 

--- a/adev/src/content/introduction/installation.md
+++ b/adev/src/content/introduction/installation.md
@@ -13,7 +13,7 @@ If you just want to play around with Angular in your browser without setting up 
   </docs-card>
 </docs-card-container>
 
-## Setup a new project locally
+## Set up a new project locally
 
 If you're starting a new project, you'll most likely want to create a local project so that you can use tooling such as Git.
 

--- a/adev/src/content/reference/errors/NG0403.md
+++ b/adev/src/content/reference/errors/NG0403.md
@@ -35,7 +35,7 @@ platformBrowser().bootstrapModule(AppModule);
 
 ## Debugging the error
 
-Please make sure that the NgModule that is used for bootstrapping is setup correctly:
+Please make sure that the NgModule that is used for bootstrapping is set up correctly:
 
 - either the `bootstrap` property exists (and contains a non-empty array) in the `@NgModule` annotation
 - or the `ngDoBootstrap` method exists on the NgModule class

--- a/adev/src/content/tools/cli/end-to-end.md
+++ b/adev/src/content/tools/cli/end-to-end.md
@@ -2,7 +2,7 @@
 
 End-to-end or (E2E) testing is a form of testing used to assert your entire application works as expected from start to finish or _"end-to-end"_. E2E testing differs from unit testing in that it is completely decoupled from the underlying implementation details of your code. It is typically used to validate an application in a way that mimics the way a user would interact with it. This page serves as a guide to getting started with end-to-end testing in Angular using the Angular CLI.
 
-## Setup E2E Testing
+## Set Up E2E Testing
 
 The Angular CLI downloads and installs everything you need to run end-to-end tests for your Angular application.
 

--- a/adev/src/content/tutorials/learn-angular/steps/12-enable-routing/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/12-enable-routing/README.md
@@ -2,7 +2,7 @@
 
 For most apps, there comes a point where the app requires more than a single page. When that time inevitably comes, routing becomes a big part of the performance story for users.
 
-In this activity, you'll learn how to setup and configure your app to use Angular Router.
+In this activity, you'll learn how to set up and configure your app to use Angular Router.
 
 <hr>
 
@@ -72,6 +72,6 @@ export class AppComponent {}
 
 </docs-workflow>
 
-Your app is now setup to use Angular Router. Nice work! 🙌
+Your app is now set up to use Angular Router. Nice work! 🙌
 
 Keep the momentum going to learn the next step of defining the routes for our app.

--- a/adev/src/content/tutorials/learn-angular/steps/15-forms/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/15-forms/README.md
@@ -4,7 +4,7 @@ Forms are a big part of many apps because they enable your app to accept user in
 
 In Angular, there are two types of forms: template-driven and reactive. You'll learn about both over the next few activities.
 
-In this activity, you'll learn how to setup a form using a template-driven approach.
+In this activity, you'll learn how to set up a form using a template-driven approach.
 
 <hr>
 

--- a/adev/src/content/tutorials/learn-angular/steps/16-form-control-values/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/16-form-control-values/README.md
@@ -1,6 +1,6 @@
 # Getting form control value
 
-Now that your forms are setup with Angular, the next step is to access the values from the form controls.
+Now that your forms are set up with Angular, the next step is to access the values from the form controls.
 
 In this activity, you'll learn how to get the value from your form input.
 

--- a/adev/src/content/tutorials/learn-angular/steps/17-reactive-forms/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/17-reactive-forms/README.md
@@ -2,7 +2,7 @@
 
 When you want to manage your forms programmatically instead of relying purely on the template, reactive forms are the answer.
 
-In this activity, you'll learn how to setup reactive forms.
+In this activity, you'll learn how to set up reactive forms.
 
 <hr>
 

--- a/devtools/docs/release.md
+++ b/devtools/docs/release.md
@@ -65,7 +65,7 @@ Then upload it:
 
 1.  Go to the Firefox Addons [page](https://addons.mozilla.org/developers/addons)
 1.  Find the email and password [on Valentine](http://valentine/#/show/1651707871496288)
-1.  Setup Google Authenticator with the 2FA QR code.
+1.  Set up Google Authenticator with the 2FA QR code.
     *   You can find the QR code [on Valentine as well](http://valentine/#/show/1651792043556329)
 
 The Firefox publishing process is slightly more involved than Chrome. In particular, they

--- a/packages/misc/angular-in-memory-web-api/README.md
+++ b/packages/misc/angular-in-memory-web-api/README.md
@@ -140,7 +140,7 @@ export class AppModule { ... }
 * Always import the `HttpClientInMemoryWebApiModule` _after_ the `HttpClientModule`
 to ensure that the in-memory backend provider supersedes the Angular version.
 
-* You can setup the in-memory web api within a lazy loaded feature module by calling the `.forFeature` method as you would `.forRoot`.
+* You can set up the in-memory web api within a lazy loaded feature module by calling the `.forFeature` method as you would `.forRoot`.
 
 * In production, you want HTTP requests to go to the real server and probably have no need for the _in-memory_ provider.
 CLI-based apps can exclude the provider in production builds like this:
@@ -155,7 +155,7 @@ CLI-based apps can exclude the provider in production builds like this:
 
 # Examples
 The [tests](https://github.com/angular/angular/blob/main/packages/misc/angular-in-memory-web-api/test)
-are a good place to learn how to setup and use this in-memory web api library.
+are a good place to learn how to set up and use this in-memory web api library.
 
 See also the example source code in the official Angular.dev documentation such as the
 [HttpClient](https://angular.dev/guide/http) guide and the


### PR DESCRIPTION
Fix spelling of the word "set up" in docs. "Setup" (one word) is a noun whereas "set up" (two words) is a verb.

Fixes #58361

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #58361


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
