### PR TITLE
fix(core): Prevents trying to trigger incremental hydration on CSR

### DIFF
--- a/packages/core/src/event_delegation_utils.ts
+++ b/packages/core/src/event_delegation_utils.ts
@@ -78,15 +78,17 @@ export const sharedMapFunction = (rEl: RElement, jsActionMap: Map<string, Set<El
 };
 
 export function removeListenersFromBlocks(blockNames: string[], injector: Injector) {
-  let blockList: Element[] = [];
-  const jsActionMap = injector.get(BLOCK_ELEMENT_MAP);
-  for (let blockName of blockNames) {
-    if (jsActionMap.has(blockName)) {
-      blockList = [...blockList, ...jsActionMap.get(blockName)!];
+  if (blockNames.length > 0) {
+    let blockList: Element[] = [];
+    const jsActionMap = injector.get(BLOCK_ELEMENT_MAP);
+    for (let blockName of blockNames) {
+      if (jsActionMap.has(blockName)) {
+        blockList = [...blockList, ...jsActionMap.get(blockName)!];
+      }
     }
+    const replayList = new Set(blockList);
+    replayList.forEach(removeListeners);
   }
-  const replayList = new Set(blockList);
-  replayList.forEach(removeListeners);
 }
 
 export const removeListeners = (el: Element) => {

--- a/packages/core/src/hydration/blocks.ts
+++ b/packages/core/src/hydration/blocks.ts
@@ -62,9 +62,6 @@ export async function hydrateFromBlockName(
   deferBlock: DeferBlock | null;
   hydratedBlocks: Set<string>;
 }> {
-  if (blockName == null) {
-    return {deferBlock: null, hydratedBlocks};
-  }
   const deferBlockRegistry = injector.get(DeferBlockRegistry);
 
   // Make sure we don't hydrate/trigger the same thing multiple times

--- a/packages/core/src/hydration/blocks.ts
+++ b/packages/core/src/hydration/blocks.ts
@@ -62,6 +62,9 @@ export async function hydrateFromBlockName(
   deferBlock: DeferBlock | null;
   hydratedBlocks: Set<string>;
 }> {
+  if (blockName == null) {
+    return {deferBlock: null, hydratedBlocks};
+  }
   const deferBlockRegistry = injector.get(DeferBlockRegistry);
 
   // Make sure we don't hydrate/trigger the same thing multiple times
@@ -116,4 +119,5 @@ export async function incrementallyHydrateFromBlockName(
     // the hydration process has finished, which could result in problems
     await whenStable(injector.get(ApplicationRef));
   }
+  return Promise.resolve();
 }


### PR DESCRIPTION
Hydrate triggers were firing in CSR cases and attempting to find parent defer blocks. This prevents that from happening. In these cases, the defer block id will be empty.

fixes: #58359

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #58359



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
