### PR TITLE
ci: disable adev tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,10 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Build adev in fast mode to ensure it continues to work
         run: yarn bazel build //adev:build --config=release
-      - name: Run tests
-        run: yarn bazel test //adev/...
+      # TODO: re-enable tests once the next release is shipped
+      # Tests are broken because of https://github.com/angular/angular/issues/54858
+      # - name: Run tests
+      # run: yarn bazel test //adev/...
 
   publish-snapshots:
     runs-on:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -114,8 +114,10 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Build adev in fast mode to ensure it continues to work
         run: yarn bazel build //adev:build --config=release
-      - name: Run tests
-        run: yarn bazel test //adev/...
+      # TODO: re-enable tests once the next release is shipped
+      # Tests are broken because of https://github.com/angular/angular/issues/54858
+      # - name: Run tests
+      #   run: yarn bazel test //adev/...
 
   zone-js:
     runs-on:


### PR DESCRIPTION
The changes in #58288 are responsible for breaking the tests (see #54858). We'll re-enable them on the next release.
