### PR TITLE
refactor(core): remove globalApi tag

### DIFF
--- a/packages/core/src/render3/util/change_detection_utils.ts
+++ b/packages/core/src/render3/util/change_detection_utils.ts
@@ -22,7 +22,6 @@ import {getRootComponents} from './discovery_utils';
  * @param component Component to {@link ChangeDetectorRef#markForCheck mark for check}.
  *
  * @publicApi
- * @globalApi ng
  */
 export function applyChanges(component: {}): void {
   ngDevMode && assertDefined(component, 'component');

--- a/packages/core/src/render3/util/discovery_utils.ts
+++ b/packages/core/src/render3/util/discovery_utils.ts
@@ -51,7 +51,6 @@ import {getLViewParent, unwrapRNode} from './view_utils';
  *    is no component associated with it.
  *
  * @publicApi
- * @globalApi ng
  */
 export function getComponent<T>(element: Element): T | null {
   ngDevMode && assertDomElement(element);
@@ -79,7 +78,6 @@ export function getComponent<T>(element: Element): T | null {
  *    inside any component.
  *
  * @publicApi
- * @globalApi ng
  */
 export function getContext<T extends {}>(element: Element): T | null {
   assertDomElement(element);
@@ -101,7 +99,6 @@ export function getContext<T extends {}>(element: Element): T | null {
  *    part of a component view.
  *
  * @publicApi
- * @globalApi ng
  */
 export function getOwningComponent<T>(elementOrDir: Element | {}): T | null {
   const context = getLContext(elementOrDir)!;
@@ -124,7 +121,6 @@ export function getOwningComponent<T>(elementOrDir: Element | {}): T | null {
  * @returns Root components associated with the target object.
  *
  * @publicApi
- * @globalApi ng
  */
 export function getRootComponents(elementOrDir: Element | {}): {}[] {
   const lView = readPatchedLView<{}>(elementOrDir);
@@ -139,7 +135,6 @@ export function getRootComponents(elementOrDir: Element | {}): {}[] {
  * @returns Injector associated with the element, component or directive instance.
  *
  * @publicApi
- * @globalApi ng
  */
 export function getInjector(elementOrDir: Element | {}): Injector {
   const context = getLContext(elementOrDir)!;
@@ -201,7 +196,6 @@ export function getInjectionTokens(element: Element): any[] {
  * @returns Array of directives associated with the node.
  *
  * @publicApi
- * @globalApi ng
  */
 export function getDirectives(node: Node): {}[] {
   // Skip text nodes because we can't have directives associated with them.
@@ -266,7 +260,6 @@ export interface ComponentDebugMetadata extends DirectiveDebugMetadata {
  * @returns metadata of the passed directive or component
  *
  * @publicApi
- * @globalApi ng
  */
 export function getDirectiveMetadata(
   directiveOrComponentInstance: any,
@@ -329,7 +322,6 @@ export function getLocalRefs(target: {}): {[key: string]: any} {
  * @returns Host element of the target.
  *
  * @publicApi
- * @globalApi ng
  */
 export function getHostElement(componentOrDirective: {}): Element {
   return getLContext(componentOrDirective)!.native as unknown as Element;
@@ -398,7 +390,6 @@ export interface Listener {
  * @returns Array of event listeners on the DOM element.
  *
  * @publicApi
- * @globalApi ng
  */
 export function getListeners(element: Element): Listener[] {
   ngDevMode && assertDomElement(element);

--- a/packages/localize/src/localize/src/localize.ts
+++ b/packages/localize/src/localize/src/localize.ts
@@ -141,7 +141,6 @@ export interface TranslateFn {
  * @param expressions a collection of the values of each placeholder in the template string.
  * @returns the translated string, with the `messageParts` and `expressions` interleaved together.
  *
- * @globalApi
  * @publicApi
  */
 export const $localize: LocalizeFn = function (


### PR DESCRIPTION
`@globalApi` was an AIO implementation detail that isn't relevant anymore.