### PR TITLE
docs: fix backtick escaping in a Markdown file

### DIFF
--- a/adev/src/content/guide/templates/expression-syntax.md
+++ b/adev/src/content/guide/templates/expression-syntax.md
@@ -19,10 +19,10 @@ Angular supports a subset of [literal values](https://developer.mozilla.org/en-U
 
 ### Unsupported literals
 
-| Literal type    | Example value       |
-| --------------- | ------------------- |
-| Template string | `\`Hello ${name}\`` |
-| RegExp          | `/\d+/`             |
+| Literal type    | Example value         |
+| --------------- | --------------------- |
+| Template string | `` `Hello ${name}` `` |
+| RegExp          | `/\d+/`               |
 
 ## Globals
 


### PR DESCRIPTION
Fix backtick escaping for the template string example in the documentation on expression syntax.

Closes #58382

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
there is an incorrect backtick escaping in the [section](https://angular.dev/guide/templates/expression-syntax#unsupported-literals) about unsupported literals the documentation on expression syntax (highlighted on the first screenshot and without highlighting on the second one)

![Image](https://github.com/user-attachments/assets/7629901a-953f-4ae2-9b53-aa59f41c871b)
![Image](https://github.com/user-attachments/assets/b1cd079d-b0bd-446e-84d5-51e0df1873bb)

Issue Number: #58382


## What is the new behavior?
the syntax is highlighted correctly

highlighted with a cursor
<img width="529" alt="Screenshot 2024-10-27 at 7 13 30 PM" src="https://github.com/user-attachments/assets/76072317-b084-420d-9a1b-9e8d480c2b4f">

without cursor highlighting
<img width="519" alt="Screenshot 2024-10-27 at 7 13 14 PM" src="https://github.com/user-attachments/assets/198d429b-130e-4418-9a9f-2bbca39324ae">

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

