### PR TITLE
docs: remove an unnecessary whitespace

### DIFF
--- a/adev/src/content/guide/components/lifecycle.md
+++ b/adev/src/content/guide/components/lifecycle.md
@@ -175,8 +175,8 @@ During initialization, the first `ngDoCheck` runs after `ngOnInit`.
 
 ### ngAfterContentInit
 
-The `ngAfterContentInit` method runs once after all the children nested inside the component (
-its _content_) have been initialized.
+The `ngAfterContentInit` method runs once after all the children nested inside the component (its
+_content_) have been initialized.
 
 You can use this lifecycle hook to read the results of
 [content queries](guide/components/queries#content-queries). While you can access the initialized


### PR DESCRIPTION
Remove an unnecessary whitespace between an opening parenthesis and a word in the documentation on lifecycle.

Closes #58380

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
there is an unnecessary whitespace in the section about [`ngAfterContentInit`](https://angular.dev/guide/components/lifecycle#ngaftercontentinit) of the documentation on lifecycle (highlighted on the screenshot)

![Image](https://github.com/user-attachments/assets/366e3f36-468f-45f9-8b07-76866e31b0c8)

Issue Number: #58380


## What is the new behavior?
the unnecessary whitespace is removed
<img width="689" alt="Screenshot 2024-10-27 at 7 18 34 PM" src="https://github.com/user-attachments/assets/8a19c878-77b4-4f67-983d-7424e06a3e64">


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
