### PR TITLE
refactor(core): move static `AfterRenderImpl.PHASES` to a top-level variable

### DIFF
--- a/packages/core/src/render3/after_render/manager.ts
+++ b/packages/core/src/render3/after_render/manager.ts
@@ -32,15 +32,15 @@ export class AfterRenderManager {
   });
 }
 
-export class AfterRenderImpl {
-  static readonly PHASES = /* @__PURE__ **/ (() =>
-    [
-      AfterRenderPhase.EarlyRead,
-      AfterRenderPhase.Write,
-      AfterRenderPhase.MixedReadWrite,
-      AfterRenderPhase.Read,
-    ] as const)();
+export const AFTER_RENDER_PHASES = /* @__PURE__ **/ (() =>
+  [
+    AfterRenderPhase.EarlyRead,
+    AfterRenderPhase.Write,
+    AfterRenderPhase.MixedReadWrite,
+    AfterRenderPhase.Read,
+  ] as const)();
 
+export class AfterRenderImpl {
   private readonly ngZone = inject(NgZone);
   private readonly scheduler = inject(ChangeDetectionScheduler);
   private readonly errorHandler = inject(ErrorHandler, {optional: true});
@@ -60,7 +60,7 @@ export class AfterRenderImpl {
    */
   execute(): void {
     this.executing = true;
-    for (const phase of AfterRenderImpl.PHASES) {
+    for (const phase of AFTER_RENDER_PHASES) {
       for (const sequence of this.sequences) {
         if (sequence.erroredOrDestroyed || !sequence.hooks[phase]) {
           continue;

--- a/packages/core/src/render3/reactivity/after_render_effect.ts
+++ b/packages/core/src/render3/reactivity/after_render_effect.ts
@@ -25,7 +25,12 @@ import {
 } from '../../change_detection/scheduling/zoneless_scheduling';
 import {Injector} from '../../di/injector';
 import {inject} from '../../di/injector_compatibility';
-import {AfterRenderImpl, AfterRenderManager, AfterRenderSequence} from '../after_render/manager';
+import {
+  AFTER_RENDER_PHASES,
+  AfterRenderImpl,
+  AfterRenderManager,
+  AfterRenderSequence,
+} from '../after_render/manager';
 import {AfterRenderPhase, type AfterRenderRef} from '../after_render/api';
 import {NOOP_AFTER_RENDER_REF, type AfterRenderOptions} from '../after_render/hooks';
 import {DestroyRef} from '../../linker/destroy_ref';
@@ -177,7 +182,7 @@ class AfterRenderEffectSequence extends AfterRenderSequence {
     super(impl, [undefined, undefined, undefined, undefined], false, destroyRef);
 
     // Setup a reactive node for each phase.
-    for (const phase of AfterRenderImpl.PHASES) {
+    for (const phase of AFTER_RENDER_PHASES) {
       const effectHook = effectHooks[phase];
       if (effectHook === undefined) {
         continue;


### PR DESCRIPTION

Improves code minification.
