### PR TITLE
fix(migrations): properly migrate output aliases

### DIFF
--- a/packages/core/schematics/migrations/output-migration/output-migration.spec.ts
+++ b/packages/core/schematics/migrations/output-migration/output-migration.spec.ts
@@ -42,34 +42,22 @@ describe('outputs', () => {
 
       it('should take alias into account', async () => {
         await verifyDeclaration({
-          before: `@Output({alias: 'otherChange'}) readonly someChange = new EventEmitter();`,
+          before: `@Output('otherChange') readonly someChange = new EventEmitter();`,
           after: `readonly someChange = output({ alias: 'otherChange' });`,
         });
       });
 
-      it('should support alias as statically analyzable reference', async () => {
-        await verify({
-          before: `
+      it('should not migrate aliases that do not evaluate to static string', async () => {
+        await verifyNoChange(`
             import {Directive, Output, EventEmitter} from '@angular/core';
 
-            const aliasParam = { alias: 'otherChange' } as const;
+            const someConst = 'otherChange' as const;
 
             @Directive()
             export class TestDir {
               @Output(aliasParam) someChange = new EventEmitter();
             }
-          `,
-          after: `
-            import {Directive, output} from '@angular/core';
-
-            const aliasParam = { alias: 'otherChange' } as const;
-
-            @Directive()
-            export class TestDir {
-              readonly someChange = output(aliasParam);
-            }
-          `,
-        });
+          `);
       });
 
       it('should add readonly modifier', async () => {

--- a/packages/core/schematics/migrations/output-migration/output-migration.ts
+++ b/packages/core/schematics/migrations/output-migration/output-migration.ts
@@ -148,13 +148,21 @@ export class OutputMigration extends TsurgeFunnelMigration<
                 outputFile,
               )
             ) {
-              filesWithOutputDeclarations.add(node.getSourceFile());
-              addOutputReplacement(
-                outputFieldReplacements,
-                outputDef.id,
-                outputFile,
-                calculateDeclarationReplacement(info, node, outputDef.aliasParam),
-              );
+              const aliasParam = outputDef.aliasParam;
+              const aliasOptionValue = aliasParam ? evaluator.evaluate(aliasParam) : undefined;
+
+              if (aliasOptionValue == undefined || typeof aliasOptionValue === 'string') {
+                filesWithOutputDeclarations.add(node.getSourceFile());
+                addOutputReplacement(
+                  outputFieldReplacements,
+                  outputDef.id,
+                  outputFile,
+                  calculateDeclarationReplacement(info, node, aliasOptionValue?.toString()),
+                );
+              } else {
+                problematicUsages[outputDef.id] = true;
+                problematicDeclarationCount++;
+              }
             }
           } else {
             problematicDeclarationCount++;

--- a/packages/core/schematics/migrations/output-migration/output-replacements.ts
+++ b/packages/core/schematics/migrations/output-migration/output-replacements.ts
@@ -8,7 +8,7 @@
 
 import ts from 'typescript';
 
-import {ImportManager} from '../../../../compiler-cli/private/migrations';
+import {ImportManager, PartialEvaluator} from '../../../../compiler-cli/private/migrations';
 import {
   ProgramInfo,
   ProjectFile,
@@ -25,7 +25,7 @@ const printer = ts.createPrinter();
 export function calculateDeclarationReplacement(
   info: ProgramInfo,
   node: ts.PropertyDeclaration,
-  aliasParam?: ts.Expression,
+  aliasParam?: string,
 ): Replacement {
   const sf = node.getSourceFile();
   const payloadTypes =
@@ -36,7 +36,19 @@ export function calculateDeclarationReplacement(
   const outputCall = ts.factory.createCallExpression(
     ts.factory.createIdentifier('output'),
     payloadTypes,
-    aliasParam ? [aliasParam] : [],
+    aliasParam !== undefined
+      ? [
+          ts.factory.createObjectLiteralExpression(
+            [
+              ts.factory.createPropertyAssignment(
+                'alias',
+                ts.factory.createStringLiteral(aliasParam, true),
+              ),
+            ],
+            false,
+          ),
+        ]
+      : [],
   );
 
   const existingModifiers = (node.modifiers ?? []).filter(


### PR DESCRIPTION
Before this fix the output migration was incorrectly assuming that the @Output decorator takes its params as an object. What happens in reality is that the @Output decorator is taking alias as the only argument, without any object literal wrapper.
