### PR TITLE
fix(migrations): properly replace imports across files

### DIFF
--- a/packages/core/schematics/migrations/output-migration/output-replacements.ts
+++ b/packages/core/schematics/migrations/output-migration/output-replacements.ts
@@ -68,9 +68,9 @@ export function calculateImportReplacements(info: ProgramInfo, sourceFiles: Set<
     {add: Replacement[]; addAndRemove: Replacement[]}
   > = {};
 
-  const importManager = new ImportManager();
-
   for (const sf of sourceFiles) {
+    const importManager = new ImportManager();
+
     const addOnly: Replacement[] = [];
     const addRemove: Replacement[] = [];
     const file = projectFile(sf, info);


### PR DESCRIPTION
This change fixes a bug where the output migration was interacting with the InputManager utility in the way that was resulting in incorrect import replacements.

The fix consists of making sure that a new ImportManager instance is created for each and every file containing @Output declarations.
