### PR TITLE
Internal inject migration fixes

### DIFF
--- a/packages/core/schematics/ng-generate/inject-migration/index.ts
+++ b/packages/core/schematics/ng-generate/inject-migration/index.ts
@@ -12,7 +12,8 @@ import {join, relative} from 'path';
 import {normalizePath} from '../../utils/change_tracker';
 import {canMigrateFile, createMigrationProgram} from '../../utils/typescript/compiler_host';
 
-import {migrateFile, MigrationOptions} from './migration';
+import {migrateFile} from './migration';
+import {MigrationOptions} from './analysis';
 
 interface Options extends MigrationOptions {
   path: string;

--- a/packages/core/schematics/ng-generate/inject-migration/internal.ts
+++ b/packages/core/schematics/ng-generate/inject-migration/internal.ts
@@ -7,7 +7,15 @@
  */
 
 import ts from 'typescript';
-import {isAccessedViaThis} from './analysis';
+import {isAccessedViaThis, parameterDeclaresProperty} from './analysis';
+
+/** Property that is a candidate to be combined. */
+interface CombineCandidate {
+  /** Node that declares the property. */
+  declaration: ts.PropertyDeclaration;
+  /** Value to which the property was initialized in the constructor. */
+  initializer: ts.Expression;
+}
 
 /**
  * Finds class property declarations without initializers whose constructor-based initialization
@@ -33,10 +41,10 @@ export function findUninitializedPropertiesToCombine(
   constructor: ts.ConstructorDeclaration,
   localTypeChecker: ts.TypeChecker,
 ): {
-  toCombine: Map<ts.PropertyDeclaration, ts.Expression>;
+  toCombine: CombineCandidate[];
   toHoist: ts.PropertyDeclaration[];
 } | null {
-  let toCombine: Map<ts.PropertyDeclaration, ts.Expression> | null = null;
+  let toCombine: CombineCandidate[] | null = null;
   let toHoist: ts.PropertyDeclaration[] = [];
 
   const membersToDeclarations = new Map<string, ts.PropertyDeclaration>();
@@ -64,8 +72,8 @@ export function findUninitializedPropertiesToCombine(
       const initializer = memberInitializers.get(name)!;
 
       if (!hasLocalReferences(initializer, constructor, localTypeChecker)) {
-        toCombine = toCombine || new Map();
-        toCombine.set(membersToDeclarations.get(name)!, initializer);
+        toCombine ??= [];
+        toCombine.push({declaration: membersToDeclarations.get(name)!, initializer});
       }
     } else {
       // Mark members that have no initializers and can't be combined to be hoisted above the
@@ -88,6 +96,84 @@ export function findUninitializedPropertiesToCombine(
 
   // If no members need to be combined, none need to be hoisted either.
   return toCombine === null ? null : {toCombine, toHoist};
+}
+
+/**
+ * In some cases properties may be declared out of order, but initialized in the correct order.
+ * The internal-specific migration will combine such properties which will result in a compilation
+ * error, for example:
+ *
+ * ```
+ * class MyClass {
+ *   foo: Foo;
+ *   bar: Bar;
+ *
+ *   constructor(bar: Bar) {
+ *     this.bar = bar;
+ *     this.foo = this.bar.getFoo();
+ *   }
+ * }
+ * ```
+ *
+ * Will become:
+ *
+ * ```
+ * class MyClass {
+ *   foo: Foo = this.bar.getFoo();
+ *   bar: Bar = inject(Bar);
+ * }
+ * ```
+ *
+ * This function determines if cases like this can be saved by reordering the properties so their
+ * declaration order matches the order in which they're initialized.
+ *
+ * @param toCombine Properties that are candidates to be combined.
+ * @param constructor
+ */
+export function shouldCombineInInitializationOrder(
+  toCombine: CombineCandidate[],
+  constructor: ts.ConstructorDeclaration,
+): boolean {
+  let combinedMemberReferenceCount = 0;
+  let otherMemberReferenceCount = 0;
+  const injectedMemberNames = new Set<string>();
+  const combinedMemberNames = new Set<string>();
+
+  // Collect the name of constructor parameters that declare new properties.
+  // These can be ignored since they'll be hoisted above other properties.
+  constructor.parameters.forEach((param) => {
+    if (parameterDeclaresProperty(param) && ts.isIdentifier(param.name)) {
+      injectedMemberNames.add(param.name.text);
+    }
+  });
+
+  // Collect the names of the properties being combined. We should only reorder
+  // the properties if at least one of them refers to another one.
+  toCombine.forEach(({declaration: {name}}) => {
+    if (ts.isStringLiteralLike(name) || ts.isIdentifier(name)) {
+      combinedMemberNames.add(name.text);
+    }
+  });
+
+  // Visit all the initializers and check all the property reads in the form of `this.<name>`.
+  // Skip over the ones referring to injected parameters since they're going to be hoisted.
+  const walkInitializer = (node: ts.Node) => {
+    if (ts.isPropertyAccessExpression(node) && node.expression.kind === ts.SyntaxKind.ThisKeyword) {
+      if (combinedMemberNames.has(node.name.text)) {
+        combinedMemberReferenceCount++;
+      } else if (!injectedMemberNames.has(node.name.text)) {
+        otherMemberReferenceCount++;
+      }
+    }
+
+    node.forEachChild(walkInitializer);
+  };
+  toCombine.forEach((candidate) => walkInitializer(candidate.initializer));
+
+  // If at the end there is at least one reference between a combined member and another,
+  // and there are no references to any other class members, we can safely reorder the
+  // properties based on how they were initialized.
+  return combinedMemberReferenceCount > 0 && otherMemberReferenceCount === 0;
 }
 
 /**

--- a/packages/core/schematics/ng-generate/inject-migration/migration.ts
+++ b/packages/core/schematics/ng-generate/inject-migration/migration.ts
@@ -163,14 +163,14 @@ function migrateClass(
   for (const member of node.members) {
     if (ts.isConstructorDeclaration(member) && member !== constructor) {
       removedMembers.add(member);
-      tracker.replaceText(sourceFile, member.getFullStart(), member.getFullWidth(), '');
+      tracker.removeNode(member, true);
     }
   }
 
   if (canRemoveConstructor(options, constructor, removedStatementCount, superCall)) {
     // Drop the constructor if it was empty.
     removedMembers.add(constructor);
-    tracker.replaceText(sourceFile, constructor.getFullStart(), constructor.getFullWidth(), '');
+    tracker.removeNode(constructor, true);
   } else {
     // If the constructor contains any statements, only remove the parameters.
     // We always do this no matter what is passed into `backwardsCompatibleConstructors`.
@@ -714,12 +714,7 @@ function applyInternalOnlyChanges(
       property.type,
       initializer,
     );
-    tracker.replaceText(
-      statement.getSourceFile(),
-      statement.getFullStart(),
-      statement.getFullWidth(),
-      '',
-    );
+    tracker.removeNode(statement, true);
     tracker.replaceNode(property, newProperty);
     removedStatements.add(statement);
   });
@@ -728,7 +723,7 @@ function applyInternalOnlyChanges(
     prependToClass.push(
       memberIndentation + printer.printNode(ts.EmitHint.Unspecified, decl, decl.getSourceFile()),
     );
-    tracker.replaceText(decl.getSourceFile(), decl.getFullStart(), decl.getFullWidth(), '');
+    tracker.removeNode(decl, true);
   });
 
   // If we added any hoisted properties, separate them visually with a new line.

--- a/packages/core/schematics/test/inject_migration_spec.ts
+++ b/packages/core/schematics/test/inject_migration_spec.ts
@@ -2062,5 +2062,25 @@ describe('inject migration', () => {
         `}`,
       ]);
     });
+
+    // There's an identical test above, but we want to ensure that the
+    // internal migration doesn't touch abstract classes either.
+    it('should not migrate abstract classes by default in the internal migration', async () => {
+      const initialContent = [
+        `import { Directive } from '@angular/core';`,
+        `import { Foo } from 'foo';`,
+        ``,
+        `@Directive()`,
+        `abstract class MyDir {`,
+        `  constructor(private foo: Foo) {}`,
+        `}`,
+      ].join('\n');
+
+      writeFile('/dir.ts', initialContent);
+
+      await runInternalMigration();
+
+      expect(tree.readContent('/dir.ts')).toBe(initialContent);
+    });
   });
 });

--- a/packages/core/schematics/test/inject_migration_spec.ts
+++ b/packages/core/schematics/test/inject_migration_spec.ts
@@ -2082,5 +2082,128 @@ describe('inject migration', () => {
 
       expect(tree.readContent('/dir.ts')).toBe(initialContent);
     });
+
+    it('should combine the members in their initialization order, if they only have references to each other or constructor parameters', async () => {
+      writeFile(
+        '/dir.ts',
+        [
+          `import { Directive, Injector } from '@angular/core';`,
+          `import { Service } from './service';`,
+          ``,
+          `@Directive()`,
+          `export class MyDir {`,
+          `  private serviceId: string;`,
+          `  private service: Service;`,
+          `  readonly greeting = 'hello';`,
+          `  private optionalProp?: number;`,
+          ``,
+          `  constructor(protected injector: Injector) {`,
+          `    this.service = this.injector.get(Injector);`,
+          `    this.serviceId = this.service.getId();`,
+          `  }`,
+          `}`,
+        ].join('\n'),
+      );
+
+      await runInternalMigration();
+
+      expect(tree.readContent('/dir.ts').split('\n')).toEqual([
+        `import { Directive, Injector, inject } from '@angular/core';`,
+        `import { Service } from './service';`,
+        ``,
+        `@Directive()`,
+        `export class MyDir {`,
+        `  private optionalProp?: number;`,
+        ``,
+        `  protected injector = inject(Injector);`,
+        `  private service: Service = this.injector.get(Injector);`,
+        `  private serviceId: string = this.service.getId();`,
+        ``,
+        `  readonly greeting = 'hello';`,
+        `}`,
+      ]);
+    });
+
+    it('should leave combined the members in their declaration order if at least one of them refers to a class member not part of the migration', async () => {
+      writeFile(
+        '/dir.ts',
+        [
+          `import { Directive, Injector } from '@angular/core';`,
+          `import { Service } from './service';`,
+          ``,
+          `@Directive()`,
+          `export class MyDir {`,
+          `  private serviceId: string;`,
+          `  private service: Service;`,
+          `  readonly name = 'Frodo';`,
+          `  private optionalProp?: number;`,
+          ``,
+          `  constructor(protected injector: Injector) {`,
+          `    this.service = this.injector.get(Injector);`,
+          `    this.serviceId = this.service.getId(this.name.toUpperCase());`,
+          `  }`,
+          `}`,
+        ].join('\n'),
+      );
+
+      await runInternalMigration();
+
+      expect(tree.readContent('/dir.ts').split('\n')).toEqual([
+        `import { Directive, Injector, inject } from '@angular/core';`,
+        `import { Service } from './service';`,
+        ``,
+        `@Directive()`,
+        `export class MyDir {`,
+        `  private optionalProp?: number;`,
+        ``,
+        `  protected injector = inject(Injector);`,
+        ``,
+        `  private serviceId: string = this.service.getId(this.name.toUpperCase());`,
+        `  private service: Service = this.injector.get(Injector);`,
+        `  readonly name = 'Frodo';`,
+        `}`,
+      ]);
+    });
+
+    it('should leave combined the members in their declaration order if none of them refer to each other', async () => {
+      writeFile(
+        '/dir.ts',
+        [
+          `import { Directive, Injector, ApplicationRef } from '@angular/core';`,
+          `import { Service } from './service';`,
+          ``,
+          `@Directive()`,
+          `export class MyDir {`,
+          `  private appRef: ApplicationRef;`,
+          `  private service: Service;`,
+          `  readonly greeting = 'hello';`,
+          `  private optionalProp?: number;`,
+          ``,
+          `  constructor(protected injector: Injector) {`,
+          `    this.service = this.injector.get(Injector);`,
+          `    this.appRef = this.injector.get(ApplicationRef);`,
+          `  }`,
+          `}`,
+        ].join('\n'),
+      );
+
+      await runInternalMigration();
+
+      expect(tree.readContent('/dir.ts').split('\n')).toEqual([
+        `import { Directive, Injector, ApplicationRef, inject } from '@angular/core';`,
+        `import { Service } from './service';`,
+        ``,
+        `@Directive()`,
+        `export class MyDir {`,
+        `  private optionalProp?: number;`,
+        ``,
+        `  protected injector = inject(Injector);`,
+        ``,
+        `  private appRef: ApplicationRef = this.injector.get(ApplicationRef);`,
+        `  private service: Service = this.injector.get(Injector);`,
+        `  readonly greeting = 'hello';`,
+        `}`,
+      ]);
+    });
   });
 });

--- a/packages/core/schematics/utils/change_tracker.ts
+++ b/packages/core/schematics/utils/change_tracker.ts
@@ -97,11 +97,14 @@ export class ChangeTracker {
   /**
    * Removes the text of an AST node from a file.
    * @param node Node whose text should be removed.
+   * @param useFullOffsets Whether to remove the node using its full offset (e.g. `getFullStart`
+   * rather than `fullStart`). This has the advantage of removing any comments that may be tied
+   * to the node, but can lead to too much code being deleted.
    */
-  removeNode(node: ts.Node): void {
+  removeNode(node: ts.Node, useFullOffsets = false): void {
     this._trackChange(node.getSourceFile(), {
-      start: node.getStart(),
-      removeLength: node.getWidth(),
+      start: useFullOffsets ? node.getFullStart() : node.getStart(),
+      removeLength: useFullOffsets ? node.getFullWidth() : node.getWidth(),
       text: '',
     });
   }


### PR DESCRIPTION
Includes another batch of fixes for the internal `inject` migration.

### refactor(migrations): internal inject migration applying some changes to abstract classes
We were filtering out abstract classes pretty late in the migration which led to the internal part of it to make some changes that aren't finalized later. These changes fix the issue by filtering out abstract classes during analysis.

### refactor(migrations): make it easier to delete nodes including comments 
We were repeating the logic that deletes a node together with all its comments in a few different places. These changes consolidate the logic under `ChangeTracker.removeNode`.

### refactor(migrations): attempt to correct initialization order in internal inject migration
Updates the internal part of the `inject` migration to attempt to correct some cases where the declaration order of properties doesn't match the initialization order.