### PR TITLE
fix(docs-infra): reduce `margin-block-start` from doc anchor headers

### DIFF
--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.scss
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.scss
@@ -36,7 +36,7 @@
   h5,
   h6 {
     .docs-anchor {
-      margin-block-start: 2.5rem;
+      margin-block-start: 0.75rem;
       display: inline-block;
       color: inherit;
 


### PR DESCRIPTION
This change reduces the spacing between headers, which is currently excessive.

**Before**
<img width="758" alt="Screenshot 2024-10-30 at 12 43 59" src="https://github.com/user-attachments/assets/edf35993-97cd-44e5-b11a-9d2fb572db43" style="width: 50%">
----
**Now**
<img width="874" alt="Screenshot 2024-10-30 at 19 06 50" src="https://github.com/user-attachments/assets/bf1afde1-6b45-4bfc-8a13-67e7793f1877">

