### PR TITLE
refactor(docs-infra): migrate to output

### DIFF
--- a/adev/shared-docs/components/navigation-list/navigation-list.component.ts
+++ b/adev/shared-docs/components/navigation-list/navigation-list.component.ts
@@ -6,14 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  Input,
-  Output,
-  inject,
-} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, inject, output} from '@angular/core';
 import {NavigationItem} from '../../interfaces/index';
 import {NavigationState} from '../../services/index';
 import {RouterLink, RouterLinkActive} from '@angular/router';
@@ -36,7 +29,7 @@ export class NavigationList {
   @Input() expandableLevel: number = 2;
   @Input() isDropdownView = false;
 
-  @Output() linkClicked = new EventEmitter<void>();
+  readonly linkClicked = output<void>();
 
   private readonly navigationState = inject(NavigationState);
 

--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
@@ -26,8 +26,7 @@ import {
   ViewContainerRef,
   ViewEncapsulation,
   ɵPendingTasks as PendingTasks,
-  EventEmitter,
-  Output,
+  output,
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {TOC_SKIP_CONTENT_MARKER, NavigationState} from '../../../services/index';
@@ -68,7 +67,7 @@ export const GITHUB_CONTENT_URL =
 export class DocViewer implements OnChanges {
   @Input() docContent?: string;
   @Input() hasToc = false;
-  @Output() contentLoaded = new EventEmitter<void>();
+  readonly contentLoaded = output<void>();
 
   private readonly destroyRef = inject(DestroyRef);
   private readonly document = inject(DOCUMENT);
@@ -134,7 +133,7 @@ export class DocViewer implements OnChanges {
     // Render ToC
     this.renderTableOfContents(contentContainer);
 
-    this.contentLoaded.next();
+    this.contentLoaded.emit();
   }
 
   /**

--- a/adev/shared-docs/directives/click-outside/click-outside.directive.ts
+++ b/adev/shared-docs/directives/click-outside/click-outside.directive.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {Directive, ElementRef, EventEmitter, Input, Output, inject} from '@angular/core';
+import {Directive, ElementRef, Input, inject, output} from '@angular/core';
 
 @Directive({
   selector: '[docsClickOutside]',
@@ -18,7 +18,7 @@ import {Directive, ElementRef, EventEmitter, Input, Output, inject} from '@angul
 })
 export class ClickOutside {
   @Input('docsClickOutsideIgnore') public ignoredElementsIds: string[] = [];
-  @Output('docsClickOutside') public clickOutside = new EventEmitter<void>();
+  public readonly clickOutside = output<void>({alias: 'docsClickOutside'});
 
   private readonly document = inject(DOCUMENT);
   private readonly elementRef = inject(ElementRef<HTMLElement>);


### PR DESCRIPTION
This change contains result of the automated migration of the decorator based @Output to the function equivalent.

Generated by running `ng generate @angular/core:output-migration`