### PR TITLE
build: update `yarn` to `1.22.22`

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -2,4 +2,4 @@
 # yarn lockfile v1
 
 
-yarn-path ".yarn/releases/yarn-1.22.19.cjs"
+yarn-path ".yarn/releases/yarn-1.22.22.cjs"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -64,8 +64,8 @@ config_setting(
 
 nodejs_binary(
     name = "yarn_vendored",
-    data = [".yarn/releases/yarn-1.22.19.cjs"],
-    entry_point = ".yarn/releases/yarn-1.22.19.cjs",
+    data = [".yarn/releases/yarn-1.22.22.cjs"],
+    entry_point = ".yarn/releases/yarn-1.22.22.cjs",
     visibility = [
         "//integration:__subpackages__",
         "//modules/ssr-benchmarks:__subpackages__",

--- a/yarn.bzl
+++ b/yarn.bzl
@@ -1,2 +1,2 @@
-YARN_PATH = ".yarn/releases/yarn-1.22.19.cjs"
+YARN_PATH = ".yarn/releases/yarn-1.22.22.cjs"
 YARN_LABEL = "//:" + YARN_PATH


### PR DESCRIPTION
Trying to get around a problem is causing renovate to keep trying updating this file.

