### PR TITLE
refactor(docs-infra): migrate adev to signal-based inputs

### DIFF
--- a/adev/shared-docs/components/navigation-list/navigation-list.component.ts
+++ b/adev/shared-docs/components/navigation-list/navigation-list.component.ts
@@ -10,9 +10,9 @@ import {
   ChangeDetectionStrategy,
   Component,
   EventEmitter,
-  Input,
   Output,
   inject,
+  input,
 } from '@angular/core';
 import {NavigationItem} from '../../interfaces/index';
 import {NavigationState} from '../../services/index';
@@ -30,11 +30,11 @@ import {IsActiveNavigationItem} from '../../pipes/is-active-navigation-item.pipe
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class NavigationList {
-  @Input({required: true}) navigationItems: NavigationItem[] = [];
-  @Input() displayItemsToLevel: number = 2;
-  @Input() collapsableLevel: number | undefined = undefined;
-  @Input() expandableLevel: number = 2;
-  @Input() isDropdownView = false;
+  readonly navigationItems = input.required<NavigationItem[]>();
+  readonly displayItemsToLevel = input<number>(2);
+  readonly collapsableLevel = input<number>();
+  readonly expandableLevel = input<number>(2);
+  readonly isDropdownView = input(false);
 
   @Output() linkClicked = new EventEmitter<void>();
 
@@ -46,8 +46,8 @@ export class NavigationList {
   toggle(item: NavigationItem): void {
     if (
       item.level === 1 &&
-      item.level !== this.expandableLevel &&
-      item.level !== this.collapsableLevel
+      item.level !== this.expandableLevel() &&
+      item.level !== this.collapsableLevel()
     ) {
       return;
     }

--- a/adev/shared-docs/components/select/select.component.ts
+++ b/adev/shared-docs/components/select/select.component.ts
@@ -7,7 +7,7 @@
  */
 
 import {ControlValueAccessor, NG_VALUE_ACCESSOR, FormsModule} from '@angular/forms';
-import {ChangeDetectionStrategy, Component, Input, forwardRef, signal} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, forwardRef, signal, input} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 type SelectOptionValue = string | number | boolean;
@@ -36,9 +36,9 @@ export interface SelectOption {
   },
 })
 export class Select implements ControlValueAccessor {
-  @Input({required: true, alias: 'selectId'}) id!: string;
-  @Input({required: true}) name!: string;
-  @Input({required: true}) options!: SelectOption[];
+  readonly id = input.required<string>({alias: 'selectId'});
+  readonly name = input.required<string>();
+  readonly options = input.required<SelectOption[]>();
   @Input() disabled = false;
 
   // Implemented as part of ControlValueAccessor.

--- a/adev/shared-docs/components/slide-toggle/slide-toggle.component.ts
+++ b/adev/shared-docs/components/slide-toggle/slide-toggle.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, Input, forwardRef, signal} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, forwardRef, signal, input} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 
@@ -26,8 +26,8 @@ import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
   ],
 })
 export class SlideToggle implements ControlValueAccessor {
-  @Input({required: true}) buttonId!: string;
-  @Input({required: true}) label!: string;
+  readonly buttonId = input.required<string>();
+  readonly label = input.required<string>();
   @Input() disabled = false;
 
   // Implemented as part of ControlValueAccessor.

--- a/adev/shared-docs/components/table-of-contents/table-of-contents.component.ts
+++ b/adev/shared-docs/components/table-of-contents/table-of-contents.component.ts
@@ -10,9 +10,9 @@ import {
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
-  Input,
   computed,
   inject,
+  input,
 } from '@angular/core';
 import {RouterLink} from '@angular/router';
 import {TableOfContentsLevel} from '../../interfaces/index';
@@ -30,7 +30,7 @@ import {IconComponent} from '../icon/icon.component';
 })
 export class TableOfContents {
   // Element that contains the content from which the Table of Contents is built
-  @Input({required: true}) contentSourceElement!: HTMLElement;
+  readonly contentSourceElement = input.required<HTMLElement>();
 
   private readonly scrollSpy = inject(TableOfContentsScrollSpy);
   private readonly tableOfContentsLoader = inject(TableOfContentsLoader);
@@ -43,8 +43,9 @@ export class TableOfContents {
   TableOfContentsLevel = TableOfContentsLevel;
 
   ngAfterViewInit() {
-    this.tableOfContentsLoader.buildTableOfContent(this.contentSourceElement);
-    this.scrollSpy.startListeningToScroll(this.contentSourceElement, this.destroyRef);
+    const contentSourceElement = this.contentSourceElement();
+    this.tableOfContentsLoader.buildTableOfContent(contentSourceElement);
+    this.scrollSpy.startListeningToScroll(contentSourceElement, this.destroyRef);
   }
 
   scrollToTop(): void {

--- a/adev/shared-docs/components/text-field/text-field.component.ts
+++ b/adev/shared-docs/components/text-field/text-field.component.ts
@@ -15,6 +15,7 @@ import {
   afterNextRender,
   forwardRef,
   signal,
+  input,
 } from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR} from '@angular/forms';
@@ -41,11 +42,11 @@ import {IconComponent} from '../icon/icon.component';
 export class TextField implements ControlValueAccessor {
   @ViewChild('inputRef') private input?: ElementRef<HTMLInputElement>;
 
-  @Input() name: string | null = null;
-  @Input() placeholder: string | null = null;
+  readonly name = input<string | null>(null);
+  readonly placeholder = input<string | null>(null);
   @Input() disabled = false;
-  @Input() hideIcon = false;
-  @Input() autofocus = false;
+  readonly hideIcon = input(false);
+  readonly autofocus = input(false);
 
   // Implemented as part of ControlValueAccessor.
   private onChange: (value: string) => void = (_: string) => {};
@@ -55,7 +56,7 @@ export class TextField implements ControlValueAccessor {
 
   constructor() {
     afterNextRender(() => {
-      if (this.autofocus) {
+      if (this.autofocus()) {
         this.input?.nativeElement.focus();
       }
     });

--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
@@ -18,7 +18,6 @@ import {
   EnvironmentInjector,
   inject,
   Injector,
-  Input,
   OnChanges,
   PLATFORM_ID,
   SimpleChanges,
@@ -28,6 +27,7 @@ import {
   ɵPendingTasks as PendingTasks,
   EventEmitter,
   Output,
+  input,
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {TOC_SKIP_CONTENT_MARKER, NavigationState} from '../../../services/index';
@@ -66,8 +66,8 @@ export const GITHUB_CONTENT_URL =
   },
 })
 export class DocViewer implements OnChanges {
-  @Input() docContent?: string;
-  @Input() hasToc = false;
+  readonly docContent = input<string>();
+  readonly hasToc = input(false);
   @Output() contentLoaded = new EventEmitter<void>();
 
   private readonly destroyRef = inject(DestroyRef);
@@ -92,7 +92,7 @@ export class DocViewer implements OnChanges {
   async ngOnChanges(changes: SimpleChanges): Promise<void> {
     const taskId = this.pendingTasks.add();
     if ('docContent' in changes) {
-      await this.renderContentsAndRunClientSetup(this.docContent!);
+      await this.renderContentsAndRunClientSetup(this.docContent()!);
     }
     this.pendingTasks.remove(taskId);
   }
@@ -166,7 +166,7 @@ export class DocViewer implements OnChanges {
   }
 
   private renderTableOfContents(element: HTMLElement): void {
-    if (!this.hasToc) {
+    if (!this.hasToc()) {
       return;
     }
 

--- a/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.ts
+++ b/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.ts
@@ -19,6 +19,7 @@ import {
   signal,
   ElementRef,
   forwardRef,
+  input,
 } from '@angular/core';
 import {CommonModule, DOCUMENT} from '@angular/common';
 import {MatTabGroup, MatTabsModule} from '@angular/material/tabs';
@@ -53,8 +54,8 @@ export class ExampleViewer {
     this.exampleMetadata.set(value);
   }
 
-  @Input() githubUrl: string | null = null;
-  @Input() stackblitzUrl: string | null = null;
+  readonly githubUrl = input<string | null>(null);
+  readonly stackblitzUrl = input<string | null>(null);
   @ViewChild('codeTabs') matTabGroup?: MatTabGroup;
 
   private readonly changeDetector = inject(ChangeDetectorRef);

--- a/adev/shared-docs/directives/click-outside/click-outside.directive.ts
+++ b/adev/shared-docs/directives/click-outside/click-outside.directive.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {Directive, ElementRef, EventEmitter, Input, Output, inject} from '@angular/core';
+import {Directive, ElementRef, EventEmitter, Output, inject, input} from '@angular/core';
 
 @Directive({
   selector: '[docsClickOutside]',
@@ -17,7 +17,7 @@ import {Directive, ElementRef, EventEmitter, Input, Output, inject} from '@angul
   },
 })
 export class ClickOutside {
-  @Input('docsClickOutsideIgnore') public ignoredElementsIds: string[] = [];
+  public readonly ignoredElementsIds = input<string[]>([], {alias: 'docsClickOutsideIgnore'});
   @Output('docsClickOutside') public clickOutside = new EventEmitter<void>();
 
   private readonly document = inject(DOCUMENT);
@@ -33,11 +33,12 @@ export class ClickOutside {
   }
 
   private wasClickedOnIgnoredElement($event: PointerEvent): boolean {
-    if (this.ignoredElementsIds.length === 0) {
+    const ignoredElementsIds = this.ignoredElementsIds();
+    if (ignoredElementsIds.length === 0) {
       return false;
     }
 
-    return this.ignoredElementsIds.some((elementId) => {
+    return ignoredElementsIds.some((elementId) => {
       const element = this.document.getElementById(elementId);
       const target = $event.target as Node;
       const contains = element?.contains(target);

--- a/adev/shared-docs/directives/search-item/search-item.directive.ts
+++ b/adev/shared-docs/directives/search-item/search-item.directive.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Directive, ElementRef, Input, inject, signal} from '@angular/core';
+import {Directive, ElementRef, inject, signal, input} from '@angular/core';
 import {Highlightable} from '@angular/cdk/a11y';
 import {SearchResult} from '../../interfaces/search-results';
 
@@ -18,8 +18,8 @@ import {SearchResult} from '../../interfaces/search-results';
   },
 })
 export class SearchItem implements Highlightable {
-  @Input() item?: SearchResult;
-  @Input() disabled = false;
+  readonly item = input<SearchResult>();
+  readonly disabled = input(false);
 
   private readonly elementRef = inject(ElementRef<HTMLLIElement>);
 
@@ -38,10 +38,11 @@ export class SearchItem implements Highlightable {
   }
 
   getLabel(): string {
-    if (!this.item?.hierarchy) {
+    const item = this.item();
+    if (!item?.hierarchy) {
       return '';
     }
-    const {hierarchy} = this.item;
+    const {hierarchy} = item;
     return `${hierarchy.lvl0}${hierarchy.lvl1}${hierarchy.lvl2}`;
   }
 

--- a/adev/src/app/features/home/components/home-editor.component.ts
+++ b/adev/src/app/features/home/components/home-editor.component.ts
@@ -12,8 +12,8 @@ import {
   Component,
   EnvironmentInjector,
   inject,
-  Input,
   OnInit,
+  input,
 } from '@angular/core';
 
 import {injectAsync} from '../../../core/services/inject-async';
@@ -33,7 +33,7 @@ export class CodeEditorComponent implements OnInit {
   private readonly environmentInjector = inject(EnvironmentInjector);
   private readonly embeddedTutorialManager = inject(EmbeddedTutorialManager);
 
-  @Input({required: true}) tutorialFiles!: string;
+  readonly tutorialFiles = input.required<string>();
 
   ngOnInit(): void {
     this.loadEmbeddedEditor();
@@ -44,7 +44,7 @@ export class CodeEditorComponent implements OnInit {
       import('../../../editor/index').then((c) => c.NodeRuntimeSandbox),
     );
 
-    await this.embeddedTutorialManager.fetchAndSetTutorialFiles(this.tutorialFiles);
+    await this.embeddedTutorialManager.fetchAndSetTutorialFiles(this.tutorialFiles());
 
     this.cdRef.markForCheck();
 

--- a/adev/src/app/features/tutorial/tutorial.component.spec.ts
+++ b/adev/src/app/features/tutorial/tutorial.component.spec.ts
@@ -8,7 +8,7 @@
 
 import {DOCS_VIEWER_SELECTOR, DocViewer, WINDOW} from '@angular/docs';
 
-import {Component, Input, signal} from '@angular/core';
+import {Component, signal, input} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {RouterTestingModule} from '@angular/router/testing';
@@ -38,7 +38,7 @@ class FakeEmbeddedEditor {}
   standalone: true,
 })
 class FakeDocViewer {
-  @Input('documentFilePath') documentFilePath: string | undefined;
+  readonly documentFilePath = input<string>();
 }
 
 // TODO: export this class, it's a helpful mock we could you on other tests.


### PR DESCRIPTION
This change is the result of running the automated input migration on adev (with the safe flags).
