### PR TITLE
refactor(migrations): use import manager in provide-initializer

### DIFF
--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -12,7 +12,7 @@
     },
     "provide-initializer": {
       "version": "19.0.0",
-      "description": "Replaces `APP_INITIALIZER`, 'ENVIRONMENT_INITIALIZER' & 'PLATFORM_INITIALIZER' respectively with `provideAppInitializer`, `provideEnvironmentInitializer` & `providePlatormInitializer`.",
+      "description": "Replaces `APP_INITIALIZER`, `ENVIRONMENT_INITIALIZER` & `PLATFORM_INITIALIZER` respectively with `provideAppInitializer`, `provideEnvironmentInitializer` & `providePlatformInitializer`.",
       "factory": "./bundles/provide-initializer#migrate",
       "optional": true
     }

--- a/packages/core/schematics/test/provide_initializer_spec.ts
+++ b/packages/core/schematics/test/provide_initializer_spec.ts
@@ -46,6 +46,24 @@ describe('Provide initializer migration', () => {
     expect(content).toContain(`import { input, provideAppInitializer } from '@angular/core';`);
   });
 
+  it('should not duplicate imported symbols with several APP_INITIALIZER', async () => {
+    const content = await migrateCode(`
+      import { APP_INITIALIZER, input } from '@angular/core';
+
+      const providers = [{
+        provide: APP_INITIALIZER,
+        useValue: () => { console.log('hello'); },
+        multi: true,
+      },{
+        provide: APP_INITIALIZER,
+        useValue: () => { console.log('world'); },
+        multi: true,
+      }];
+    `);
+
+    expect(content).toContain(`import { input, provideAppInitializer } from '@angular/core';`);
+  });
+
   it('should reuse provideAppInitializer if already imported', async () => {
     const content = await migrateCode(`
       import { APP_INITIALIZER, input, provideAppInitializer } from '@angular/core';
@@ -75,6 +93,7 @@ describe('Provide initializer migration', () => {
       `const providers = [provideAppInitializer(async () => { await Promise.resolve(); return 42; })]`,
     );
   });
+
   it('should transform APP_INITIALIZER + useValue symbol into provideAppInitializer', async () => {
     const content = await migrateCode(`
       import { APP_INITIALIZER } from '@angular/core';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The manual replacement logic had a flaw and was inserting the imports several times.

For example:

```ts
import { APP_INITIALIZER, ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
import { InitService } from './init.service';

export const appConfig: ApplicationConfig = {
  providers: [provideZoneChangeDetection({ eventCoalescing: true }),
    {
      provide: APP_INITIALIZER,
      useFactory: (initService: InitService) => initService.init(),
      deps: [InitService],
      multi: true
    },
    {
      provide: APP_INITIALIZER,
      useFactory: (initService: InitService) => initService.init(),
      deps: [InitService],
      multi: true
    }
  ]
};
```

produced:

```ts
import { ApplicationConfig, provideZoneChangeDetection, inject, provideAppInitializer }{ ApplicationConfig, provideZoneChangeDetection, inject, provideAppInitializer } from '@angular/core';
import { InitService } from './init.service';

export const appConfig: ApplicationConfig = {
  providers: [provideZoneChangeDetection({ eventCoalescing: true }),
    provideAppInitializer(() => { return ((initService: InitService) => initService.init())(inject(InitService)); }),
    provideAppInitializer(() => { return ((initService: InitService) => initService.init())(inject(InitService)); })
  ]
};
```

## What is the new behavior?

It now produces proper imports:

```ts
import { ApplicationConfig, provideZoneChangeDetection, inject, provideAppInitializer } from '@angular/core';
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
