### PR TITLE
ci: restrict file updates to a specified file location for post-task saves

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,11 @@
   "lockFileMaintenance": {"enabled": true},
   "labels": ["target: patch", "area: build & ci", "action: merge"],
   "postUpgradeTasks": {
-    "commands": ["yarn install", "yarn ng-dev misc update-generated-files"],
+    "commands": [
+      "yarn install --frozen-lockfile --non-interactive",
+      "yarn ng-dev misc update-generated-files"
+    ],
+    "fileFilters": [".github/actions/deploy-docs-site/**/*", "packages/**/*"],
     "executionMode": "update"
   },
   "ignoreDeps": [


### PR DESCRIPTION
This is aiming to resolve issues with Renovate when executing `yarn ng-dev misc update-generated-files`
