### PR TITLE
docs: fix external link in NG0100 error page

### DIFF
--- a/adev/src/content/reference/errors/NG0100.md
+++ b/adev/src/content/reference/errors/NG0100.md
@@ -16,4 +16,4 @@ Ensure that there are no changes to the bindings in the template after change de
 
 If you are binding to methods in the view, ensure that the invocation does not update any of the other bindings in the template.
 
-Read more about which solution is right for you in ['Everything you need to know about the "ExpressionChangedAfterItHasBeenCheckedError" error'](https://indepth.dev/posts/1001/everything-you-need-to-know-about-the-expressionchangedafterithasbeencheckederror-error) and why this is useful at ['Angular Debugging "Expression has changed after it was checked": Simple Explanation (and Fix)'](https://blog.angular-university.io/angular-debugging).
+Read more about which solution is right for you in ['Everything you need to know about the "ExpressionChangedAfterItHasBeenCheckedError" error'](https://angularindepth.com/posts/1001/everything-you-need-to-know-about-the-expressionchangedafterithasbeencheckederror-error) and why this is useful at ['Angular Debugging "Expression has changed after it was checked": Simple Explanation (and Fix)'](https://blog.angular-university.io/angular-debugging).


### PR DESCRIPTION
Fixes external link for 'Everything you need to know about the "ExpressionChangedAfterItHasBeenCheckedError" error' on the NG0100 error page. Domain has changed from indepth.dev to angularindepth.com

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes #58459 


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This PR links to https://angularindepth.com/posts/1001/everything-you-need-to-know-about-the-expressionchangedafterithasbeencheckederror-error
 
@JoostK I noticed on the issue you suggested linking to https://angular.love/everything-you-need-to-know-about-the-expressionchangedafterithasbeencheckederror-error but the overflow appears broken on that page and is cutting off content.

![image](https://github.com/user-attachments/assets/39432f38-a1ef-4794-9d24-79adf72c8bbc)

Let me know if that is acceptable.
