### PR TITLE
feat(compiler): Add support for bigint in templates

### DIFF
--- a/integration/nodenext_resolution/tsconfig.json
+++ b/integration/nodenext_resolution/tsconfig.json
@@ -15,7 +15,8 @@
       "dom",
       "es2015.collection",
       "es2015.iterable",
-      "es2015.promise"
+      "es2015.promise",
+      "es2020",
     ],
     "types": [],
   },

--- a/integration/typings_test_rxjs7/tsconfig.json
+++ b/integration/typings_test_rxjs7/tsconfig.json
@@ -15,7 +15,8 @@
       "dom",
       "es2015.collection",
       "es2015.iterable",
-      "es2015.promise"
+      "es2015.promise",
+      "es2020",
     ],
     "types": [],
   },

--- a/integration/typings_test_ts55/tsconfig.json
+++ b/integration/typings_test_ts55/tsconfig.json
@@ -15,7 +15,8 @@
       "dom",
       "es2015.collection",
       "es2015.iterable",
-      "es2015.promise"
+      "es2015.promise",
+      "es2020",
     ],
     "types": [],
   },

--- a/integration/typings_test_ts56/tsconfig.json
+++ b/integration/typings_test_ts56/tsconfig.json
@@ -15,7 +15,8 @@
       "dom",
       "es2015.collection",
       "es2015.iterable",
-      "es2015.promise"
+      "es2015.promise",
+      "es2020",
     ],
     "types": [],
   },

--- a/packages/compiler-cli/linker/babel/src/ast/babel_ast_factory.ts
+++ b/packages/compiler-cli/linker/babel/src/ast/babel_ast_factory.ts
@@ -127,11 +127,13 @@ export class BabelAstFactory implements AstFactory<t.Statement, t.Expression> {
     );
   }
 
-  createLiteral(value: string | number | boolean | null | undefined): t.Expression {
+  createLiteral(value: string | number | bigint | boolean | null | undefined): t.Expression {
     if (typeof value === 'string') {
       return t.stringLiteral(value);
     } else if (typeof value === 'number') {
       return t.numericLiteral(value);
+    } else if (typeof value === 'bigint') {
+      return t.bigIntLiteral(value.toString());
     } else if (typeof value === 'boolean') {
       return t.booleanLiteral(value);
     } else if (value === undefined) {

--- a/packages/compiler-cli/src/ngtsc/translator/src/api/ast_factory.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/api/ast_factory.ts
@@ -165,7 +165,7 @@ export interface AstFactory<TStatement, TExpression> {
    *
    * @param value the value of the literal.
    */
-  createLiteral(value: string | number | boolean | null | undefined): TExpression;
+  createLiteral(value: string | number | bigint | boolean | null | undefined): TExpression;
 
   /**
    * Create an expression that is instantiating the `expression` as a class.

--- a/packages/compiler-cli/src/ngtsc/translator/src/ts_util.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/ts_util.ts
@@ -21,3 +21,19 @@ export function tsNumericExpression(value: number): ts.NumericLiteral | ts.Prefi
 
   return ts.factory.createNumericLiteral(value);
 }
+
+/**
+ * Creates a TypeScript node representing a numeric value.
+ */
+export function tsBigIntExpression(value: bigint): ts.BigIntLiteral | ts.PrefixUnaryExpression {
+  // As of TypeScript 5.3 negative numbers/bigint are represented as `prefixUnaryOperator` and passing a
+  // negative number (even as a string) into `createNumericLiteral` will result in an error.
+
+  // For the bigint to be printed as a literal, it needs to be suffixed with 'n'.
+  if (value < 0) {
+    const operand = ts.factory.createBigIntLiteral(`${-value}n`);
+    return ts.factory.createPrefixUnaryExpression(ts.SyntaxKind.MinusToken, operand);
+  }
+
+  return ts.factory.createBigIntLiteral(`${value}n`);
+}

--- a/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
@@ -20,7 +20,7 @@ import {AmbientImport, ReflectionHost} from '../../reflection';
 
 import {Context} from './context';
 import {ImportManager} from './import_manager/import_manager';
-import {tsNumericExpression} from './ts_util';
+import {tsNumericExpression, tsBigIntExpression} from './ts_util';
 import {TypeEmitter} from './type_emitter';
 
 export function translateType(
@@ -158,6 +158,8 @@ class TypeTranslatorVisitor implements o.ExpressionVisitor, o.TypeVisitor {
       );
     } else if (typeof ast.value === 'number') {
       return ts.factory.createLiteralTypeNode(tsNumericExpression(ast.value));
+    } else if (typeof ast.value === 'bigint') {
+      return ts.factory.createLiteralTypeNode(tsBigIntExpression(ast.value));
     } else {
       return ts.factory.createLiteralTypeNode(ts.factory.createStringLiteral(ast.value));
     }

--- a/packages/compiler-cli/src/ngtsc/translator/src/typescript_ast_factory.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/typescript_ast_factory.ts
@@ -17,7 +17,7 @@ import {
   UnaryOperator,
   VariableDeclarationType,
 } from './api/ast_factory';
-import {tsNumericExpression} from './ts_util';
+import {tsNumericExpression, tsBigIntExpression} from './ts_util';
 
 /**
  * Different optimizers use different annotations on a function or method call to indicate its pure
@@ -200,7 +200,7 @@ export class TypeScriptAstFactory implements AstFactory<ts.Statement, ts.Express
     return ts.factory.createIfStatement(condition, thenStatement, elseStatement ?? undefined);
   }
 
-  createLiteral(value: string | number | boolean | null | undefined): ts.Expression {
+  createLiteral(value: string | number | bigint | boolean | null | undefined): ts.Expression {
     if (value === undefined) {
       return ts.factory.createIdentifier('undefined');
     } else if (value === null) {
@@ -209,6 +209,8 @@ export class TypeScriptAstFactory implements AstFactory<ts.Statement, ts.Express
       return value ? ts.factory.createTrue() : ts.factory.createFalse();
     } else if (typeof value === 'number') {
       return tsNumericExpression(value);
+    } else if (typeof value === 'bigint') {
+      return tsBigIntExpression(value);
     } else {
       return ts.factory.createStringLiteral(value);
     }

--- a/packages/compiler-cli/src/ngtsc/translator/test/typescript_ast_factory_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/test/typescript_ast_factory_spec.ts
@@ -285,6 +285,20 @@ describe('TypeScriptAstFactory', () => {
       expect(generate(literal)).toEqual('NaN');
     });
 
+    it('should create a bigint literal', () => {
+      const {generate} = setupStatements();
+      const literal = factory.createLiteral(1234n);
+      expect(ts.isBigIntLiteral(literal)).toBe(true);
+      expect(generate(literal)).toEqual('1234n');
+    });
+
+    it('should create a negative bigint literal', () => {
+      const {generate} = setupStatements();
+      const literal = factory.createLiteral(-42n);
+      expect(ts.isPrefixUnaryExpression(literal)).toBe(true);
+      expect(generate(literal)).toEqual('-42n');
+    });
+
     it('should create a boolean literal', () => {
       const {generate} = setupStatements();
       const literal = factory.createLiteral(true);

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -39,7 +39,7 @@ import ts from 'typescript';
 import {TypeCheckingConfig} from '../api';
 
 import {addParseSpanInfo, wrapForDiagnostics, wrapForTypeChecker} from './diagnostics';
-import {tsCastToAny, tsNumericExpression} from './ts_util';
+import {tsBigIntExpression, tsCastToAny, tsNumericExpression} from './ts_util';
 
 /**
  * Expression that is cast to any. Currently represented as `0 as any`.
@@ -249,6 +249,8 @@ class AstTranslator implements AstVisitor {
       node = ts.factory.createStringLiteral(ast.value);
     } else if (typeof ast.value === 'number') {
       node = tsNumericExpression(ast.value);
+    } else if (typeof ast.value === 'bigint') {
+      node = tsBigIntExpression(ast.value);
     } else if (typeof ast.value === 'boolean') {
       node = ast.value ? ts.factory.createTrue() : ts.factory.createFalse();
     } else {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ts_util.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ts_util.ts
@@ -180,3 +180,19 @@ export function tsNumericExpression(value: number): ts.NumericLiteral | ts.Prefi
 
   return ts.factory.createNumericLiteral(value);
 }
+
+/**
+ * Creates a TypeScript node representing a numeric value.
+ */
+export function tsBigIntExpression(value: bigint): ts.BigIntLiteral | ts.PrefixUnaryExpression {
+  // As of TypeScript 5.3 negative numbers/bigint are represented as `prefixUnaryOperator` and passing a
+  // negative number (even as a string) into `createNumericLiteral` will result in an error.
+
+  // For the bigint to be printed as a literal, it needs to be suffixed with 'n'.
+  if (value < 0) {
+    const operand = ts.factory.createBigIntLiteral(`${-value}n`);
+    return ts.factory.createPrefixUnaryExpression(ts.SyntaxKind.MinusToken, operand);
+  }
+
+  return ts.factory.createBigIntLiteral(`${value}n`);
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/GOLDEN_PARTIAL.js
@@ -723,3 +723,37 @@ export declare class MyModule {
     static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: bigint.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.multiplier = 5n;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "my-app", ngImport: i0, template: `
+    <div>Total: {{ 1234n * multiplier }}</div>
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    selector: 'my-app',
+                    template: `
+    <div>Total: {{ 1234n * multiplier }}</div>
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: bigint.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    multiplier: bigint;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "my-app", never, {}, {}, never, never, true, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/TEST_CASES.json
@@ -290,6 +290,13 @@
           ]
         }
       ]
+    },
+    {
+      "description": "should support bigint literals",
+      "compilerOptions": {
+        "target": "ES2020"
+      },
+      "inputFiles": ["bigint.ts"]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/bigint.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/bigint.js
@@ -1,0 +1,7 @@
+template:  function MyApp_Template(rf, ctx) {
+  // ...
+  if (rf & 2) {
+    $r3$.ɵɵadvance();
+    $r3$.ɵɵtextInterpolate1("Total: ", 1234n * ctx.multiplier, "");
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/bigint.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/bigint.ts
@@ -1,0 +1,11 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-app',
+  template: `
+    <div>Total: {{ 1234n * multiplier }}</div>
+  `,
+})
+export class MyApp {
+  multiplier = 5n;
+}

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -89,7 +89,7 @@ export class NgtscTestEnvironment {
         "baseUrl": ".",
         "allowJs": true,
         "declaration": true,
-        "target": "es2015",
+        "target": "es2020",
         "newLine": "lf",
         "module": "es2015",
         "moduleResolution": "node",

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -741,6 +741,28 @@ runInEachFileSystem(() => {
       expect(diags[0].messageText).toContain(`This comparison appears to be unintentional`);
     });
 
+    it('should error on bigint misuse', () => {
+      env.write(
+        'test.ts',
+        `
+        import {Component} from '@angular/core';
+
+        @Component({
+          standalone: true,
+          template: \` {{ 1234n * 2}} \`,
+        })
+        class TestCmp {
+        }
+        `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toContain(
+        `Operator '*' cannot be applied to types 'bigint' and 'number'`,
+      );
+    });
+
     describe('strictInputTypes', () => {
       beforeEach(() => {
         env.write(

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -865,8 +865,8 @@ class _ParseAST {
     // '==','!=','===','!=='
     const start = this.inputIndex;
     let result = this.parseRelational();
-    while (this.next.type == TokenType.Operator) {
-      const operator = this.next.strValue;
+    while (this.next.typedValue.type == TokenType.Operator) {
+      const operator = this.next.typedValue.value;
       switch (operator) {
         case '==':
         case '===':
@@ -886,8 +886,8 @@ class _ParseAST {
     // '<', '>', '<=', '>='
     const start = this.inputIndex;
     let result = this.parseAdditive();
-    while (this.next.type == TokenType.Operator) {
-      const operator = this.next.strValue;
+    while (this.next.typedValue.type == TokenType.Operator) {
+      const operator = this.next.typedValue.value;
       switch (operator) {
         case '<':
         case '>':
@@ -907,8 +907,8 @@ class _ParseAST {
     // '+', '-'
     const start = this.inputIndex;
     let result = this.parseMultiplicative();
-    while (this.next.type == TokenType.Operator) {
-      const operator = this.next.strValue;
+    while (this.next.typedValue.type == TokenType.Operator) {
+      const operator = this.next.typedValue.value;
       switch (operator) {
         case '+':
         case '-':
@@ -926,8 +926,8 @@ class _ParseAST {
     // '*', '%', '/'
     const start = this.inputIndex;
     let result = this.parsePrefix();
-    while (this.next.type == TokenType.Operator) {
-      const operator = this.next.strValue;
+    while (this.next.typedValue.type == TokenType.Operator) {
+      const operator = this.next.typedValue.value;
       switch (operator) {
         case '*':
         case '%':
@@ -943,9 +943,9 @@ class _ParseAST {
   }
 
   private parsePrefix(): AST {
-    if (this.next.type == TokenType.Operator) {
+    if (this.next.typedValue.type == TokenType.Operator) {
       const start = this.inputIndex;
-      const operator = this.next.strValue;
+      const operator = this.next.typedValue.value;
       let result: AST;
       switch (operator) {
         case '+':
@@ -1034,7 +1034,11 @@ class _ParseAST {
         false,
       );
     } else if (this.next.isNumber()) {
-      const value = this.next.toNumber();
+      const value = this.next.typedValue.value;
+      this.advance();
+      return new LiteralPrimitive(this.span(start), this.sourceSpan(start), value);
+    } else if (this.next.isBigInt()) {
+      const value = this.next.typedValue.value;
       this.advance();
       return new LiteralPrimitive(this.span(start), this.sourceSpan(start), value);
     } else if (this.next.isString()) {

--- a/packages/compiler/src/expression_parser/serializer.ts
+++ b/packages/compiler/src/expression_parser/serializer.ts
@@ -79,6 +79,8 @@ class SerializeExpressionVisitor implements expr.AstVisitor {
       case 'number':
       case 'boolean':
         return ast.value.toString();
+      case 'bigint':
+        return `${ast.value.toString()}n`;
       case 'undefined':
         return 'undefined';
       case 'string':

--- a/packages/compiler/src/output/abstract_emitter.ts
+++ b/packages/compiler/src/output/abstract_emitter.ts
@@ -334,6 +334,9 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     const value = ast.value;
     if (typeof value === 'string') {
       ctx.print(ast, escapeIdentifier(value, this._escapeDollarInStrings));
+    } else if (typeof value === 'bigint') {
+      // We want to generate a bigint literal
+      ctx.print(ast, `${value}n`);
     } else {
       ctx.print(ast, `${value}`);
     }

--- a/packages/compiler/src/output/output_ast.ts
+++ b/packages/compiler/src/output/output_ast.ts
@@ -631,7 +631,7 @@ export class InstantiateExpr extends Expression {
 
 export class LiteralExpr extends Expression {
   constructor(
-    public value: number | string | boolean | null | undefined,
+    public value: number | string | boolean | bigint | null | undefined,
     type?: Type | null,
     sourceSpan?: ParseSourceSpan | null,
   ) {

--- a/packages/compiler/src/render3/r3_deferred_triggers.ts
+++ b/packages/compiler/src/render3/r3_deferred_triggers.ts
@@ -234,7 +234,7 @@ class OnTriggerParser {
     );
     const nameSpan = new ParseSourceSpan(
       triggerNameStartSpan,
-      triggerNameStartSpan.moveBy(identifier.strValue.length),
+      triggerNameStartSpan.moveBy((identifier.typedValue.value as string).length),
     );
     const endSpan = triggerNameStartSpan.moveBy(this.token().end - identifier.index);
 
@@ -382,8 +382,11 @@ class OnTriggerParser {
       // individual trigger (e.g. `on foo(a, b)`). To avoid tripping up the parser with commas that
       // are part of other sorts of syntax (object literals, arrays), we treat anything inside
       // a comma-delimited syntax block as plain text.
-      if (token.type === TokenType.Character && COMMA_DELIMITED_SYNTAX.has(token.numValue)) {
-        commaDelimStack.push(COMMA_DELIMITED_SYNTAX.get(token.numValue)!);
+      if (
+        token.typedValue.type === TokenType.Character &&
+        COMMA_DELIMITED_SYNTAX.has(token.typedValue.value)
+      ) {
+        commaDelimStack.push(COMMA_DELIMITED_SYNTAX.get(token.typedValue.value)!);
       }
 
       if (

--- a/packages/compiler/test/expression_parser/lexer_spec.ts
+++ b/packages/compiler/test/expression_parser/lexer_spec.ts
@@ -32,7 +32,13 @@ function expectOperatorToken(token: any, index: number, end: number, operator: s
 function expectNumberToken(token: any, index: number, end: number, n: number) {
   expectToken(token, index, end);
   expect(token.isNumber()).toBe(true);
-  expect(token.toNumber()).toEqual(n);
+  expect(token.typedValue.value).toEqual(n);
+}
+
+function expectBigIntToken(token: any, index: number, end: number, n: BigInt) {
+  expectToken(token, index, end);
+  expect(token.isBigInt()).toBe(true);
+  expect(token.typedValue.value).toEqual(n);
 }
 
 function expectStringToken(token: any, index: number, end: number, str: string) {
@@ -296,6 +302,19 @@ describe('lexer', () => {
       expectNumberToken(tokens[0], 0, 7, 0.5e-10);
       tokens = lex('0.5E+10');
       expectNumberToken(tokens[0], 0, 7, 0.5e10);
+    });
+
+    it('should tokenize bigint', () => {
+      expectBigIntToken(lex('1234n')[0], 0, 5, 1234n);
+    });
+
+    it('should return exception for invalid bigint', () => {
+      expectErrorToken(
+        lex('1.234n')[0],
+        5,
+        5,
+        'Lexer Error: Invalid bigint primitive value at column 5 in expression [1.234n]',
+      );
     });
 
     it('should return exception for invalid exponent', () => {

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -32,6 +32,10 @@ describe('parser', () => {
       checkAction('1');
     });
 
+    it('should parse bigints', () => {
+      checkAction('1234n');
+    });
+
     it('should parse strings', () => {
       checkAction("'1'", '"1"');
       checkAction('"1"');

--- a/packages/compiler/test/expression_parser/utils/unparser.ts
+++ b/packages/compiler/test/expression_parser/utils/unparser.ts
@@ -183,6 +183,8 @@ class Unparser implements AstVisitor {
   visitLiteralPrimitive(ast: LiteralPrimitive, context: any) {
     if (typeof ast.value === 'string') {
       this._expression += `"${ast.value.replace(Unparser._quoteRegExp, '"')}"`;
+    } else if (typeof ast.value === 'bigint') {
+      this._expression += `${ast.value}n`;
     } else {
       this._expression += `${ast.value}`;
     }

--- a/packages/core/test/acceptance/property_interpolation_spec.ts
+++ b/packages/core/test/acceptance/property_interpolation_spec.ts
@@ -171,6 +171,25 @@ describe('property interpolation', () => {
     );
   });
 
+  it('should handle interpolations with BigInt', () => {
+    @Component({
+      selector: 'app-comp',
+      template: `
+        <div (click)="val = 1234n">{{1234n}}</div>`,
+    })
+    class AppComp {
+      val: bigint | undefined;
+    }
+
+    const fixture = TestBed.createComponent(AppComp);
+    fixture.detectChanges();
+    const elt = fixture.debugElement.query(By.css('div')).nativeElement;
+    expect(elt.innerHTML).toEqual('1234');
+    elt.click();
+    expect(fixture.componentInstance.val).toEqual(1234n);
+    expect(typeof fixture.componentInstance.val).toEqual('bigint');
+  });
+
   it('should support the chained use cases of propertyInterpolate instructions', () => {
     // The below *just happens* to have two attributes in a row that have the same interpolation
     // count.

--- a/tools/legacy-saucelabs/build-saucelabs-test-bundle.mjs
+++ b/tools/legacy-saucelabs/build-saucelabs-test-bundle.mjs
@@ -49,7 +49,7 @@ async function main() {
     treeShaking: false,
     sourceRoot: projectDir,
     platform: 'browser',
-    target: 'es2015',
+    target: 'es2020',
     format: 'iife',
     outfile: outFile,
     sourcemap: true,


### PR DESCRIPTION
This commit adds the support for bigint literals (`1234n`) in angular templates. 

This goes toward supporting typescript expressions #43485