### PR TITLE
fix(compiler-cli): make the unused imports diagnostic easier to read 

### DIFF
--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -397,7 +397,7 @@ runInEachFileSystem(() => {
         export class TestCmp {}
 
         @Component({
-          template: '', 
+          template: '',
           selector: 'target-cmp',
           standalone: false,
         })
@@ -432,7 +432,7 @@ runInEachFileSystem(() => {
         export class TestCmp {}
 
         @Component({
-          template: '', 
+          template: '',
           selector: 'target-cmp',
           standalone: false,
         })
@@ -7711,9 +7711,7 @@ suppress
         expect(diags.length).toBe(1);
         expect(diags[0].messageText).toBe('Imports array contains unused imports');
         expect(diags[0].relatedInformation?.length).toBe(1);
-        expect(diags[0].relatedInformation![0].messageText).toBe(
-          'Directive "UnusedDir" is not used within the template',
-        );
+        expect(getSourceCodeForDiagnostic(diags[0].relatedInformation![0])).toBe('UnusedDir');
       });
 
       it('should report when a pipe is not used within a template', () => {
@@ -7770,9 +7768,7 @@ suppress
         expect(diags.length).toBe(1);
         expect(diags[0].messageText).toBe('Imports array contains unused imports');
         expect(diags[0].relatedInformation?.length).toBe(1);
-        expect(diags[0].relatedInformation?.[0].messageText).toBe(
-          'Pipe "UnusedPipe" is not used within the template',
-        );
+        expect(getSourceCodeForDiagnostic(diags[0].relatedInformation![0])).toBe('UnusedPipe');
       });
 
       it('should not report imports only used inside @defer blocks', () => {
@@ -7960,12 +7956,8 @@ suppress
         expect(diags.length).toBe(1);
         expect(diags[0].messageText).toBe('Imports array contains unused imports');
         expect(diags[0].relatedInformation?.length).toBe(2);
-        expect(diags[0].relatedInformation![0].messageText).toBe(
-          'Directive "NgFor" is not used within the template',
-        );
-        expect(diags[0].relatedInformation![1].messageText).toBe(
-          'Pipe "PercentPipe" is not used within the template',
-        );
+        expect(getSourceCodeForDiagnostic(diags[0].relatedInformation![0])).toBe('NgFor');
+        expect(getSourceCodeForDiagnostic(diags[0].relatedInformation![1])).toBe('PercentPipe');
       });
 
       it('should report unused imports coming from a nested array from the same file', () => {
@@ -8027,9 +8019,7 @@ suppress
         expect(diags.length).toBe(1);
         expect(diags[0].messageText).toBe('Imports array contains unused imports');
         expect(diags[0].relatedInformation?.length).toBe(1);
-        expect(diags[0].relatedInformation![0].messageText).toBe(
-          'Directive "UnusedDir" is not used within the template',
-        );
+        expect(getSourceCodeForDiagnostic(diags[0].relatedInformation![0])).toBe('UnusedDir');
       });
 
       it('should report unused imports coming from an array used as the `imports` initializer', () => {
@@ -8080,9 +8070,7 @@ suppress
         expect(diags.length).toBe(1);
         expect(diags[0].messageText).toBe('Imports array contains unused imports');
         expect(diags[0].relatedInformation?.length).toBe(1);
-        expect(diags[0].relatedInformation![0].messageText).toBe(
-          'Directive "UnusedDir" is not used within the template',
-        );
+        expect(getSourceCodeForDiagnostic(diags[0].relatedInformation![0])).toBe('UnusedDir');
       });
 
       it('should not report unused imports coming from an array through a spread expression from a different file', () => {


### PR DESCRIPTION
The unused imports diagnostic reports once on the entire initializer and then again once per unused imports. This ends up being a bit hard to follow, because in a lot of cases the code snippet looks identical.

These changes switch to highlighting the `imports:` part of the property declaration and only highlighting the unused imports without a message.

For reference, this is what the diagnostic looks like at the moment:
<img width="555" alt="image" src="https://github.com/user-attachments/assets/dc66b22d-0af4-4ddc-b352-9d5b7141e212">

And here's what it looks like after the changes:
<img width="555" alt="image" src="https://github.com/user-attachments/assets/97ff2b35-bdc5-4438-96b7-31182d25946b">
