### PR TITLE
ci: update renovate `postUpgradeTasks` executionMode to `branch`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,7 @@
       "yarn ng-dev misc update-generated-files"
     ],
     "fileFilters": [".github/actions/deploy-docs-site/**/*", "packages/**/*"],
-    "executionMode": "update"
+    "executionMode": "branch"
   },
   "ignoreDeps": [
     "@types/node",


### PR DESCRIPTION
This change modifies the execution level of `postUpgradeTasks` in Renovate. By setting `executionMode` to `branch`, the task will run once per branch, rather than for each dependency update. This helps streamline tasks across dependencies by consolidating them at the branch level.
