### PR TITLE
ci: run Renovate post tasks sequentially

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "devtools:test": "bazelisk test --//devtools/projects/shell-browser/src:flag_browser=chrome -- //devtools/...",
     "docs": "[[ -n $CI ]] && echo 'Cannot run this yarn script on CI' && exit 1 || yarn ibazel run //adev:serve",
     "docs:build": "[[ -n $CI ]] && echo 'Cannot run this yarn script on CI' && exit 1 || yarn bazel build //adev:build",
-    "benchmarks": "tsx --tsconfig=scripts/tsconfig.json scripts/benchmarks/index.mts"
+    "benchmarks": "tsx --tsconfig=scripts/tsconfig.json scripts/benchmarks/index.mts",
+    "renovate-update-generated-files": "yarn install --frozen-lockfile --non-interactive && yarn ng-dev misc update-generated-files"
   },
   "// 1": "dependencies are used locally and by bazel",
   "dependencies": {

--- a/renovate.json
+++ b/renovate.json
@@ -16,8 +16,7 @@
   "labels": ["target: patch", "area: build & ci", "action: merge"],
   "postUpgradeTasks": {
     "commands": [
-      "yarn install --frozen-lockfile --non-interactive",
-      "yarn ng-dev misc update-generated-files"
+      "yarn renovate-update-generated-files"
     ],
     "fileFilters": [".github/actions/deploy-docs-site/**/*", "packages/**/*"],
     "executionMode": "branch"


### PR DESCRIPTION
Due to a bug in Renovate (see: https://github.com/sarunint/renovate/blob/276a01fdd743d270fd2662cabb3b0e1e465aec83/lib/util/exec/common.ts#L50-L53), post tasks are incorrectly running in parallel. This causes 'yarn install' to overlap with 'yarn ng-dev misc update-generated-files', resulting in incomplete installs before file updates start.

