### PR TITLE
fix(migrations): flip the default standalone flag in route-lazy-loadi…

### DIFF
--- a/packages/core/schematics/ng-generate/route-lazy-loading/util.ts
+++ b/packages/core/schematics/ng-generate/route-lazy-loading/util.ts
@@ -23,7 +23,11 @@ export function isStandaloneComponent(node: ts.ClassDeclaration): boolean {
     const arg = decorator.expression.arguments[0];
     if (ts.isObjectLiteralExpression(arg)) {
       const property = findLiteralProperty(arg, 'standalone') as ts.PropertyAssignment;
-      return property ? property.initializer.getText() === 'true' : false;
+      if (property) {
+        return property.initializer.getText() === 'true';
+      } else {
+        return true; // standalone is true by default in v19
+      }
     }
   }
 

--- a/packages/core/schematics/test/standalone_routes_spec.ts
+++ b/packages/core/schematics/test/standalone_routes_spec.ts
@@ -335,11 +335,13 @@ describe('route lazy loading migration', () => {
       import {NgModule} from '@angular/core';
       import {provideRoutes} from '@angular/router';
       import {TestComponent} from './test';
+      import {StandaloneByDefaultComponent} from './standalone-by-default';
       import {NotStandaloneComponent} from './not-standalone';
 
       const routes = [
         {path: 'test', component: TestComponent},
         {path: 'test1', component: NotStandaloneComponent},
+        {path: 'test2', component: StandaloneByDefaultComponent},
       ];
 
       @NgModule({
@@ -359,10 +361,19 @@ describe('route lazy loading migration', () => {
     );
 
     writeFile(
+      'standalone-by-default.ts',
+      `
+      import {Component} from '@angular/core';
+      @Component({template: 'hello'})
+      export class StandaloneByDefaultComponent {}
+    `,
+    );
+
+    writeFile(
       'not-standalone.ts',
       `
       import {Component, NgModule} from '@angular/core';
-      @Component({template: 'hello'})
+      @Component({template: 'hello', standalone: false})
       export class NotStandaloneComponent {}
 
       @NgModule({declarations: [NotStandaloneComponent], exports: [NotStandaloneComponent]})
@@ -381,6 +392,7 @@ describe('route lazy loading migration', () => {
         const routes = [
           {path: 'test', loadComponent: () => import('./test').then(m => m.TestComponent)},
           {path: 'test1', component: NotStandaloneComponent},
+          {path: 'test2', loadComponent: () => import('./standalone-by-default').then(m => m.StandaloneByDefaultComponent)},
         ];
 
         @NgModule({


### PR DESCRIPTION
…ng migration

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #58473


## What is the new behavior?
Now the migration will work fine even when the standalone flag is not there at all (v19 defaults to true)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No



