### PR TITLE
docs: fix grammatical error in template binding documentation

### DIFF
--- a/adev/src/content/guide/templates/binding.md
+++ b/adev/src/content/guide/templates/binding.md
@@ -172,7 +172,7 @@ In the example above, Angular renders the `ul` element with all three CSS classe
 
 Angular does not guarantee any specific order of CSS classes on rendered elements.
 
-When binding `class` to an array or an object, Angular compares the previous value to the current value with the triple-equals operator (`===`). You must create a new object or array instance when you modify these values in order to Angular to apply any updates.
+When binding `class` to an array or an object, Angular compares the previous value to the current value with the triple-equals operator (`===`). You must create a new object or array instance when you modify these values in order for Angular to apply any updates.
 
 If an element has multiple bindings for the same CSS class, Angular resolves collisions by following its style precedence order.
 


### PR DESCRIPTION
This update corrects a grammatical error in the "CSS style properties" section of the template binding documentation. The sentence "You must create a new object instance when you modify these values in order to Angular to apply any updates" was updated to read correctly as "You must create a new object instance when you modify these values in order for Angular to apply any updates." This clarification helps improve readability and ensures the documentation communicates instructions accurately for readers.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
