### PR TITLE
refactor(migrations): useFactory in provide-initializer migration

### DIFF
--- a/packages/core/schematics/migrations/provide-initializer/utils.ts
+++ b/packages/core/schematics/migrations/provide-initializer/utils.ts
@@ -167,7 +167,7 @@ function tryParseProviderExpression(node: ts.Node): ProviderInfo | undefined {
     return {
       ...info,
       importInject: deps.length > 0,
-      initializerCode: `() => { return (${useFactory.getText()})(${args.join(', ')}); }`,
+      initializerCode: `(${useFactory.getText()})(${args.join(', ')})`,
     };
   }
 

--- a/packages/core/schematics/test/provide_initializer_spec.ts
+++ b/packages/core/schematics/test/provide_initializer_spec.ts
@@ -105,10 +105,10 @@ describe('Provide initializer migration', () => {
       }];
     `);
 
-    expect(content).toContain(`const providers = [provideAppInitializer(() => { return (() => {
+    expect(content).toContain(`const providers = [provideAppInitializer((() => {
           const service = inject(Service);
           return () => service.init();
-        })(); })];`);
+        })())];`);
   });
 
   it('should transform APP_INITIALIZER + useExisting into provideAppInitializer', async () => {
@@ -144,9 +144,9 @@ describe('Provide initializer migration', () => {
 
     expect(content).toContain(`import { inject, provideAppInitializer } from '@angular/core';`);
     expect(content).toContain(
-      `const providers = [provideAppInitializer(() => { return ((a: ServiceA, b: ServiceB) => {
+      `const providers = [provideAppInitializer(((a: ServiceA, b: ServiceB) => {
           return () => a.init();
-        })(inject(ServiceA), inject(ServiceB)); })];`,
+        })(inject(ServiceA), inject(ServiceB)))];`,
     );
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The following provider:

```ts
{
  provide: APP_INITIALIZER,
  useFactory: (initService: InitService) => {
    return () => initService.init()
  },
  deps: [InitService],
  multi: true
}
```

was migrated in:

```ts
provideAppInitializer(() => { return ((initService: InitService) => {
  return () => initService.init()
})(inject(InitService)); })
```

This doesn't compile because there is an extra function:

```
✘ [ERROR] TS2345: Argument of type '() => () => void' is not assignable to parameter of type '() => void | Observable<unknown> | Promise<unknown>'.
  Type '() => void' is not assignable to type 'void | Observable<unknown> | Promise<unknown>'. [plugin angular-compiler]

    src/app/app.config.ts:7:26:
      7 │ ...ovideAppInitializer(() => { return ((initService: InitService) => {
```

## What is the new behavior?

It now migrates the provider in:

```ts
provideAppInitializer(((initService: InitService) => {
  return () => initService.init()
})(inject(InitService)))
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
