### PR TITLE
ci: restore the local Yarn copy before executing `renovate-update-generated-files`

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "devtools:test": "bazelisk test --//devtools/projects/shell-browser/src:flag_browser=chrome -- //devtools/...",
     "docs": "[[ -n $CI ]] && echo 'Cannot run this yarn script on CI' && exit 1 || yarn ibazel run //adev:serve",
     "docs:build": "[[ -n $CI ]] && echo 'Cannot run this yarn script on CI' && exit 1 || yarn bazel build //adev:build",
-    "benchmarks": "tsx --tsconfig=scripts/tsconfig.json scripts/benchmarks/index.mts",
-    "renovate-update-generated-files": "yarn install --frozen-lockfile --non-interactive && yarn ng-dev misc update-generated-files"
+    "benchmarks": "tsx --tsconfig=scripts/tsconfig.json scripts/benchmarks/index.mts"
   },
   "// 1": "dependencies are used locally and by bazel",
   "dependencies": {

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,9 @@
   "labels": ["target: patch", "area: build & ci", "action: merge"],
   "postUpgradeTasks": {
     "commands": [
-      "yarn renovate-update-generated-files"
+      "git restore .yarn/releases/yarn-1.22.22.cjs",
+      "yarn install --frozen-lockfile --non-interactive",
+      "yarn ng-dev misc update-generated-files"
     ],
     "fileFilters": [".github/actions/deploy-docs-site/**/*", "packages/**/*"],
     "executionMode": "branch"


### PR DESCRIPTION


There is an unidentified issue causing the Yarn binary to be altered, resulting in packages not installing correctly and leading to failures in the process.
