### PR TITLE
ci: exclude `packages/ssr/BUILD.bazel` from requiring a G3 sync

### DIFF
--- a/.ng-dev/google-sync-config.json
+++ b/.ng-dev/google-sync-config.json
@@ -27,6 +27,7 @@
     "packages/localize/**",
     "packages/private/**",
     "packages/service-worker/**",
+    "packages/ssr/BUILD.bazel",
     "packages/common/locales/generate-locales-tool/**",
     "packages/common/locales/index.bzl",
     "packages/http/**",


### PR DESCRIPTION
Internal CL http://cl/693309493