### PR TITLE
fix(core): correct type narrowing on Signal<T>

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -10,6 +10,7 @@ import { SIGNAL } from '@angular/core/primitives/signals';
 import { SignalNode } from '@angular/core/primitives/signals';
 import { Subject } from 'rxjs';
 import { Subscription } from 'rxjs';
+import { ɵTYPE_MARKER } from '@angular/core/primitives/signals';
 
 // @public
 export interface AbstractType<T> extends Function {
@@ -1679,9 +1680,14 @@ export interface SelfDecorator {
 export function setTestabilityGetter(getter: GetTestability): void;
 
 // @public
-export type Signal<T> = (() => T) & {
+export interface Signal<T> {
+    // (undocumented)
+    (): SignalType<this>;
+    // (undocumented)
+    [ɵTYPE_MARKER]: T;
+    // (undocumented)
     [SIGNAL]: unknown;
-};
+}
 
 // @public
 export function signal<T>(initialValue: T, options?: CreateSignalOptions<T>): WritableSignal<T>;
@@ -1987,9 +1993,9 @@ export interface WritableResource<T> extends Resource<T> {
 export interface WritableSignal<T> extends Signal<T> {
     // (undocumented)
     [ɵWRITABLE_SIGNAL]: T;
-    asReadonly(): Signal<T>;
-    set(value: T): void;
-    update(updateFn: (value: T) => T): void;
+    asReadonly(): Signal<SignalType<this>>;
+    set(value: SignalType<this>): void;
+    update(updateFn: (value: SignalType<this>) => SignalType<this>): void;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1680,14 +1680,9 @@ export interface SelfDecorator {
 export function setTestabilityGetter(getter: GetTestability): void;
 
 // @public
-export interface Signal<T> {
-    // (undocumented)
-    (): SignalType<this>;
-    // (undocumented)
-    [ɵTYPE_MARKER]: T;
-    // (undocumented)
+export type Signal<T> = SignalFn<T> & {
     [SIGNAL]: unknown;
-}
+};
 
 // @public
 export function signal<T>(initialValue: T, options?: CreateSignalOptions<T>): WritableSignal<T>;

--- a/packages/core/primitives/signals/index.ts
+++ b/packages/core/primitives/signals/index.ts
@@ -39,6 +39,7 @@ export {
   setPostSignalSetFn,
   signalSetFn,
   signalUpdateFn,
+  ɵTYPE_MARKER,
 } from './src/signal';
 export {Watch, WatchCleanupFn, WatchCleanupRegisterFn, createWatch} from './src/watch';
 export {setAlternateWeakRefImpl} from './src/weak_ref';

--- a/packages/core/primitives/signals/src/signal.ts
+++ b/packages/core/primitives/signals/src/signal.ts
@@ -35,7 +35,21 @@ export interface SignalNode<T> extends ReactiveNode {
   equal: ValueEqualityFn<T>;
 }
 
-export type SignalBaseGetter<T> = (() => T) & {readonly [SIGNAL]: unknown};
+/**
+ * Symbol used to store the type of the Signal outside of a function type.
+ *
+ * Since TypeScript considers an intersection of two functions to be an overloaded function
+ * with both definitions allowed, we store the type of the Signal in a property, which is then
+ * referenced by the function call definition. This allows us to have proper type narrowing in
+ * cases like WritableResource#hasValue.
+ */
+export const ɵTYPE_MARKER = /* @__PURE__ */ Symbol('TYPE_MARKER');
+
+export interface SignalBaseGetter<T> {
+  (): this[typeof ɵTYPE_MARKER];
+  [ɵTYPE_MARKER]: T;
+  [SIGNAL]: unknown;
+}
 
 // Note: Closure *requires* this to be an `interface` and not a type, which is why the
 // `SignalBaseGetter` type exists to provide the correct shape.

--- a/packages/core/src/authoring/model/model_signal.ts
+++ b/packages/core/src/authoring/model/model_signal.ts
@@ -6,7 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {producerAccessed, SIGNAL, signalSetFn} from '@angular/core/primitives/signals';
+import {
+  producerAccessed,
+  SIGNAL,
+  signalSetFn,
+  ɵTYPE_MARKER,
+} from '@angular/core/primitives/signals';
 
 import {RuntimeError, RuntimeErrorCode} from '../../errors';
 import {Signal} from '../../render3/reactivity/api';
@@ -103,6 +108,7 @@ export function createModelSignal<T>(initialValue: T, opts?: ModelOptions): Mode
       | typeof ɵINPUT_SIGNAL_BRAND_READ_TYPE
       | typeof ɵINPUT_SIGNAL_BRAND_WRITE_TYPE
       | typeof ɵWRITABLE_SIGNAL
+      | typeof ɵTYPE_MARKER
     >;
 }
 

--- a/packages/core/src/render3/reactivity/api.ts
+++ b/packages/core/src/render3/reactivity/api.ts
@@ -6,7 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {SIGNAL} from '@angular/core/primitives/signals';
+import {SIGNAL, ɵTYPE_MARKER} from '@angular/core/primitives/signals';
+
+/** Extracts the inner type of a Signal. */
+export type SignalType<T extends Signal<unknown>> = T[typeof ɵTYPE_MARKER];
 
 /**
  * A reactive value which notifies consumers of any changes.
@@ -16,9 +19,11 @@ import {SIGNAL} from '@angular/core/primitives/signals';
  *
  * Ordinary values can be turned into `Signal`s with the `signal` function.
  */
-export type Signal<T> = (() => T) & {
+export interface Signal<T> {
+  (): SignalType<this>;
+  [ɵTYPE_MARKER]: T;
   [SIGNAL]: unknown;
-};
+}
 
 /**
  * Checks if the given `value` is a reactive `Signal`.

--- a/packages/core/src/render3/reactivity/api.ts
+++ b/packages/core/src/render3/reactivity/api.ts
@@ -9,7 +9,13 @@
 import {SIGNAL, ɵTYPE_MARKER} from '@angular/core/primitives/signals';
 
 /** Extracts the inner type of a Signal. */
-export type SignalType<T extends Signal<unknown>> = T[typeof ɵTYPE_MARKER];
+export type SignalType<T extends SignalFn<unknown>> = T[typeof ɵTYPE_MARKER];
+
+/** Function type definition for a `Signal`. */
+export interface SignalFn<T> {
+  (): SignalType<this>;
+  [ɵTYPE_MARKER]: T;
+}
 
 /**
  * A reactive value which notifies consumers of any changes.
@@ -19,11 +25,7 @@ export type SignalType<T extends Signal<unknown>> = T[typeof ɵTYPE_MARKER];
  *
  * Ordinary values can be turned into `Signal`s with the `signal` function.
  */
-export interface Signal<T> {
-  (): SignalType<this>;
-  [ɵTYPE_MARKER]: T;
-  [SIGNAL]: unknown;
-}
+export type Signal<T> = SignalFn<T> & { [SIGNAL]: unknown; };
 
 /**
  * Checks if the given `value` is a reactive `Signal`.

--- a/packages/core/src/render3/reactivity/computed.ts
+++ b/packages/core/src/render3/reactivity/computed.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {createComputed, SIGNAL} from '@angular/core/primitives/signals';
+import {createComputed, SIGNAL, ɵTYPE_MARKER} from '@angular/core/primitives/signals';
 
 import {performanceMarkFeature} from '../../util/performance';
 
@@ -42,5 +42,5 @@ export function computed<T>(computation: () => T, options?: CreateComputedOption
     getter[SIGNAL].debugName = options?.debugName;
   }
 
-  return getter;
+  return getter as typeof getter & Pick<Signal<T>, typeof ɵTYPE_MARKER>;
 }

--- a/packages/core/src/render3/reactivity/signal.ts
+++ b/packages/core/src/render3/reactivity/signal.ts
@@ -17,7 +17,7 @@ import {
 
 import {performanceMarkFeature} from '../../util/performance';
 
-import {isSignal, Signal, ValueEqualityFn} from './api';
+import {isSignal, Signal, ValueEqualityFn, SignalType} from './api';
 
 /** Symbol used distinguish `WritableSignal` from other non-writable signals and functions. */
 export const ɵWRITABLE_SIGNAL = /* @__PURE__ */ Symbol('WRITABLE_SIGNAL');
@@ -31,20 +31,20 @@ export interface WritableSignal<T> extends Signal<T> {
   /**
    * Directly set the signal to a new value, and notify any dependents.
    */
-  set(value: T): void;
+  set(value: SignalType<this>): void;
 
   /**
    * Update the value of the signal based on its current value, and
    * notify any dependents.
    */
-  update(updateFn: (value: T) => T): void;
+  update(updateFn: (value: SignalType<this>) => SignalType<this>): void;
 
   /**
    * Returns a readonly version of this signal. Readonly signals can be accessed to read their value
    * but can't be changed using set or update methods. The readonly signals do _not_ have
    * any built-in mechanism that would prevent deep-mutation of their value.
    */
-  asReadonly(): Signal<T>;
+  asReadonly(): Signal<SignalType<this>>;
 }
 
 /**


### PR DESCRIPTION
TypeScript considers an intersection of two function types to be an overloaded function containing both signatures. The implication of this is that `Signal<T|undefined> & Signal<T>` is just
`Signal<T|undefined>`, instead of `Signal<T>` as would be expected.

This PR introduces a new symbol that holds the type information for `Signal`, so that intersection types will calculate the type intersection correctly, allowing for `WritableResource#hasValue` to correctly narrow the type of `WritableResource#value`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
