### PR TITLE
docs(docs-infra): add support for `@remarks`

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/jsdoc-transforms.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/jsdoc-transforms.ts
@@ -33,6 +33,7 @@ import {getLinkToModule} from './url-transforms';
 import {addApiLinksToHtml} from './code-transforms';
 import {getCurrentSymbol, getModuleName, logUnknownSymbol} from '../symbol-context';
 
+export const JS_DOC_REMARKS_TAG = 'remarks';
 export const JS_DOC_USAGE_NOTES_TAG = 'usageNotes';
 export const JS_DOC_SEE_TAG = 'see';
 export const JS_DOC_DESCRIPTION_TAG = 'description';
@@ -96,7 +97,9 @@ export function addHtmlAdditionalLinks<T extends HasJsDocTags & HasModuleName>(
 }
 
 export function addHtmlUsageNotes<T extends HasJsDocTags>(entry: T): T & HasHtmlUsageNotes {
-  const usageNotesTag = entry.jsdocTags.find((tag) => tag.name === JS_DOC_USAGE_NOTES_TAG);
+  const usageNotesTag = entry.jsdocTags.find(
+    ({name}) => name === JS_DOC_USAGE_NOTES_TAG || name === JS_DOC_REMARKS_TAG,
+  );
   const htmlUsageNotes = usageNotesTag
     ? (marked.parse(
         convertJsDocExampleToHtmlExample(wrapExampleHtmlElementsWithCode(usageNotesTag.comment)),


### PR DESCRIPTION
In TSDoc, we currently handle the `@usageNotes` annotation, but this is not a standard TSDoc tag. Instead, the `@remarks` annotation is the correct standard, which is used in the Angular CLI repo and on the SSR package.

This change ensures that `@remarks` is treated the same as `@usageNotes` during the transform process.
