### PR TITLE
refactor(migrations): speed up code refactoring action for queries

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -150,7 +150,7 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
   ) {}
 
   getTemplate(component: ts.ClassDeclaration, optimizeFor?: OptimizeFor): TmplAstNode[] | null {
-    const {data} = this.getLatestComponentState(component);
+    const {data} = this.getLatestComponentState(component, optimizeFor);
     if (data === null) {
       return null;
     }

--- a/packages/core/schematics/migrations/signal-queries-migration/migration.ts
+++ b/packages/core/schematics/migrations/signal-queries-migration/migration.ts
@@ -104,6 +104,8 @@ export class SignalQueriesMigration extends TsurgeComplexMigration<
 
     // Pre-Analyze the program and get access to the template type checker.
     const {templateTypeChecker} = info.ngCompiler['ensureAnalyzed']();
+    // Generate all type check blocks.
+    templateTypeChecker.generateAllTypeCheckBlocks();
 
     const {sourceFiles, program} = info;
     const checker = program.getTypeChecker();
@@ -205,8 +207,7 @@ export class SignalQueriesMigration extends TsurgeComplexMigration<
         // Ignore references to non-query class fields.
         if (
           this.config.assumeNonBatch &&
-          descriptor !== null &&
-          !filteredQueriesForCompilationUnit.has(descriptor.key)
+          (descriptor === null || !filteredQueriesForCompilationUnit.has(descriptor.key))
         ) {
           return null;
         }
@@ -448,8 +449,6 @@ export class SignalQueriesMigration extends TsurgeComplexMigration<
       ts.forEachChild(node, queryWholeProgramVisitor);
     };
 
-    this.config.reportProgressFn?.(40, 'Tracking query declarations..');
-
     for (const sf of info.fullProgramSourceFiles) {
       ts.forEachChild(sf, queryWholeProgramVisitor);
     }
@@ -493,14 +492,14 @@ export class SignalQueriesMigration extends TsurgeComplexMigration<
       isClassWithKnownFields: (clazz) => knownQueries.getQueryFieldsOfClass(clazz) !== undefined,
     });
 
-    this.config.reportProgressFn?.(70, 'Checking inheritance..');
+    this.config.reportProgressFn?.(80, 'Checking inheritance..');
     groupedAstVisitor.execute();
 
     if (this.config.bestEffortMode) {
       filterBestEffortIncompatibilities(knownQueries);
     }
 
-    this.config.reportProgressFn?.(80, 'Migrating queries..');
+    this.config.reportProgressFn?.(90, 'Migrating queries..');
 
     // Migrate declarations.
     for (const extractedQuery of sourceQueries) {


### PR DESCRIPTION
We were not properly passing around the TCB full program optimization, so TCB generation was done per individual file. This significantly slowed down reference resolution.