### PR TITLE
ci: add myself to the `renovate-changes` PullApprove group

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -684,6 +684,8 @@ groups:
     conditions:
       - author in ["angular-robot"]
     reviewers:
+      users:
+        - ~alan-agius4
       teams:
         - framework-team
 


### PR DESCRIPTION
I frequently need to ping others to approve Renovate PRs, so this should streamline the process.

