### PR TITLE
test(platform-server): fix issue with `ngServerMode` when focusing `fit` tests

### DIFF
--- a/packages/platform-server/test/dom_utils.ts
+++ b/packages/platform-server/test/dom_utils.ts
@@ -88,10 +88,10 @@ export function resetTViewsFor(...types: Type<unknown>[]) {
 export function hydrate(
   doc: Document,
   component: Type<unknown>,
-  options?: {
+  options: {
     envProviders?: Provider[];
-    hydrationFeatures?: HydrationFeature<HydrationFeatureKind>[];
-  },
+    hydrationFeatures?: () => HydrationFeature<HydrationFeatureKind>[];
+  } = {},
 ) {
   function _document(): any {
     ɵsetDocument(doc);
@@ -99,13 +99,13 @@ export function hydrate(
     return doc;
   }
 
-  const envProviders = options?.envProviders ?? [];
-  const hydrationFeatures = options?.hydrationFeatures ?? [];
+  const {envProviders = [], hydrationFeatures = () => []} = options;
+
   const providers = [
     ...envProviders,
     {provide: PLATFORM_ID, useValue: 'browser'},
     {provide: DOCUMENT, useFactory: _document, deps: []},
-    provideClientHydration(...hydrationFeatures),
+    provideClientHydration(...hydrationFeatures()),
   ];
 
   return bootstrapApplication(component, {providers});
@@ -158,7 +158,7 @@ export async function prepareEnvironmentAndHydrate(
   component: Type<unknown>,
   options?: {
     envProviders?: Provider[];
-    hydrationFeatures?: HydrationFeature<HydrationFeatureKind>[];
+    hydrationFeatures?: () => HydrationFeature<HydrationFeatureKind>[];
   },
 ): Promise<ApplicationRef> {
   prepareEnvironment(doc, html);

--- a/packages/platform-server/test/event_replay_spec.ts
+++ b/packages/platform-server/test/event_replay_spec.ts
@@ -136,7 +136,7 @@ describe('event replay', () => {
     const btn = doc.getElementById('btn')!;
     btn.click();
     const appRef = await hydrate(doc, AppComponent, {
-      hydrationFeatures: [withEventReplay()],
+      hydrationFeatures: () => [withEventReplay()],
     });
     appRef.tick();
     expect(onClickSpy).toHaveBeenCalled();
@@ -186,7 +186,7 @@ describe('event replay', () => {
     inner.click();
     await hydrate(doc, AppComponent, {
       envProviders: [{provide: PLATFORM_ID, useValue: 'browser'}],
-      hydrationFeatures: [withEventReplay()],
+      hydrationFeatures: () => [withEventReplay()],
     });
     expect(outerOnClickSpy).toHaveBeenCalledBefore(innerOnClickSpy);
   });
@@ -215,7 +215,7 @@ describe('event replay', () => {
     expect((el.firstChild as Element).hasAttribute('jsaction')).toBeTrue();
     resetTViewsFor(SimpleComponent);
     await hydrate(doc, SimpleComponent, {
-      hydrationFeatures: [withEventReplay()],
+      hydrationFeatures: () => [withEventReplay()],
     });
     expect(el.hasAttribute('jsaction')).toBeFalse();
     expect((el.firstChild as Element).hasAttribute('jsaction')).toBeFalse();
@@ -268,7 +268,7 @@ describe('event replay', () => {
       bottomEl.click();
       await hydrate(doc, SimpleComponent, {
         envProviders: [{provide: PLATFORM_ID, useValue: 'browser'}],
-        hydrationFeatures: [withEventReplay()],
+        hydrationFeatures: () => [withEventReplay()],
       });
       expect(onClickSpy).toHaveBeenCalledTimes(2);
       onClickSpy.calls.reset();
@@ -301,7 +301,7 @@ describe('event replay', () => {
       const bottomEl = doc.getElementById('bottom')!;
       bottomEl.click();
       await hydrate(doc, SimpleComponent, {
-        hydrationFeatures: [withEventReplay()],
+        hydrationFeatures: () => [withEventReplay()],
       });
       expect(onClickSpy).toHaveBeenCalledTimes(1);
       onClickSpy.calls.reset();
@@ -339,7 +339,7 @@ describe('event replay', () => {
       bottomEl.click();
       await hydrate(doc, SimpleComponent, {
         envProviders: [{provide: PLATFORM_ID, useValue: 'browser'}],
-        hydrationFeatures: [withEventReplay()],
+        hydrationFeatures: () => [withEventReplay()],
       });
       const replayedEvent = currentEvent;
       expect(replayedEvent.target).not.toBeNull();
@@ -394,7 +394,7 @@ describe('event replay', () => {
           // that has no events, but enables Event Replay feature.
           withStrictErrorHandler(),
         ],
-        hydrationFeatures: [withEventReplay()],
+        hydrationFeatures: () => [withEventReplay()],
       });
     });
 

--- a/packages/platform-server/test/full_app_hydration_spec.ts
+++ b/packages/platform-server/test/full_app_hydration_spec.ts
@@ -50,7 +50,7 @@ import {
 import {NoopNgZone} from '@angular/core/src/zone/ng_zone';
 import {TestBed} from '@angular/core/testing';
 import {clearTranslations, loadTranslations} from '@angular/localize';
-import {HydrationFeature, withI18nSupport} from '@angular/platform-browser';
+import {withI18nSupport} from '@angular/platform-browser';
 import {provideRouter, RouterOutlet, Routes} from '@angular/router';
 
 import {
@@ -1791,7 +1791,7 @@ describe('platform-server full application hydration integration', () => {
             vcr = inject(ViewContainerRef);
           }
 
-          const hydrationFeatures = [] as unknown as HydrationFeature<any>[];
+          const hydrationFeatures = () => [];
           const html = await ssr(SimpleComponent, {hydrationFeatures});
 
           const ssrContents = getAppContents(html);
@@ -1812,7 +1812,7 @@ describe('platform-server full application hydration integration', () => {
           })
           class SimpleComponent {}
 
-          const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+          const hydrationFeatures = () => [withI18nSupport()];
           const html = await ssr(SimpleComponent, {hydrationFeatures});
           const ssrContents = getAppContents(html);
           expect(ssrContents).toContain('<app ngh');
@@ -1831,7 +1831,7 @@ describe('platform-server full application hydration integration', () => {
           })
           class SimpleComponent {}
 
-          const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+          const hydrationFeatures = () => [withI18nSupport()];
           const html = await ssr(SimpleComponent, {hydrationFeatures});
           const ssrContents = getAppContents(html);
           expect(ssrContents).toContain('<app ngh');
@@ -1847,7 +1847,7 @@ describe('platform-server full application hydration integration', () => {
           })
           class SimpleComponent {}
 
-          const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+          const hydrationFeatures = () => [withI18nSupport()];
           const html = await ssr(SimpleComponent, {hydrationFeatures});
           const ssrContents = getAppContents(html);
           expect(ssrContents).toContain('<app ngh');
@@ -1864,7 +1864,7 @@ describe('platform-server full application hydration integration', () => {
           })
           class SimpleComponent {}
 
-          const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+          const hydrationFeatures = () => [withI18nSupport()];
           const html = await ssr(SimpleComponent, {hydrationFeatures});
           const ssrContents = getAppContents(html);
           expect(ssrContents).toContain('<app ngh');
@@ -1883,7 +1883,7 @@ describe('platform-server full application hydration integration', () => {
           })
           class SimpleComponent {}
 
-          const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+          const hydrationFeatures = () => [withI18nSupport()];
           const html = await ssr(SimpleComponent, {hydrationFeatures});
           const ssrContents = getAppContents(html);
           expect(ssrContents).toContain('<app ngh');
@@ -1920,7 +1920,7 @@ describe('platform-server full application hydration integration', () => {
           })
           class SimpleComponent {}
 
-          const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+          const hydrationFeatures = () => [withI18nSupport()];
           const html = await ssr(SimpleComponent, {hydrationFeatures});
           const ssrContents = getAppContents(html);
           expect(ssrContents).toContain('<app ngh');
@@ -1967,7 +1967,7 @@ describe('platform-server full application hydration integration', () => {
           })
           class SimpleComponent {}
 
-          const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+          const hydrationFeatures = () => [withI18nSupport()];
           const html = await ssr(SimpleComponent, {hydrationFeatures});
 
           const ssrContents = getAppContents(html);
@@ -2014,7 +2014,7 @@ describe('platform-server full application hydration integration', () => {
           })
           class SimpleComponent {}
 
-          const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+          const hydrationFeatures = () => [withI18nSupport()];
           const html = await ssr(SimpleComponent, {hydrationFeatures});
           const ssrContents = getAppContents(html);
           expect(ssrContents).toContain('<app ngh');
@@ -2060,7 +2060,7 @@ describe('platform-server full application hydration integration', () => {
             count = 0;
           }
 
-          const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+          const hydrationFeatures = () => [withI18nSupport()];
           const html = await ssr(SimpleComponent, {hydrationFeatures});
           const ssrContents = getAppContents(html);
           expect(ssrContents).toContain('<app ngh');
@@ -2114,7 +2114,7 @@ describe('platform-server full application hydration integration', () => {
           })
           class SimpleComponent {}
 
-          const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+          const hydrationFeatures = () => [withI18nSupport()];
           const html = await ssr(SimpleComponent, {hydrationFeatures});
           const ssrContents = getAppContents(html);
           expect(ssrContents).toContain('<app ngh');
@@ -2153,7 +2153,7 @@ describe('platform-server full application hydration integration', () => {
           })
           class SimpleComponent {}
 
-          const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+          const hydrationFeatures = () => [withI18nSupport()];
           const html = await ssr(SimpleComponent, {hydrationFeatures});
           const ssrContents = getAppContents(html);
           expect(ssrContents).toContain('<app ngh');
@@ -2196,7 +2196,7 @@ describe('platform-server full application hydration integration', () => {
           })
           class SimpleComponent {}
 
-          const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+          const hydrationFeatures = () => [withI18nSupport()];
           const html = await ssr(SimpleComponent, {hydrationFeatures});
           const ssrContents = getAppContents(html);
           expect(ssrContents).toContain('<app ngh');
@@ -2239,7 +2239,7 @@ describe('platform-server full application hydration integration', () => {
           })
           class SimpleComponent {}
 
-          const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+          const hydrationFeatures = () => [withI18nSupport()];
           const html = await ssr(SimpleComponent, {hydrationFeatures});
           const ssrContents = getAppContents(html);
           expect(ssrContents).toContain('<app ngh');
@@ -2282,7 +2282,7 @@ describe('platform-server full application hydration integration', () => {
             }
           }
 
-          const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+          const hydrationFeatures = () => [withI18nSupport()];
           const html = await ssr(SimpleComponent, {hydrationFeatures});
           const ssrContents = getAppContents(html);
           expect(ssrContents).toContain('<app ngh');
@@ -2320,7 +2320,7 @@ describe('platform-server full application hydration integration', () => {
           })
           class SimpleComponent {}
 
-          const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+          const hydrationFeatures = () => [withI18nSupport()];
           const html = await ssr(SimpleComponent, {hydrationFeatures});
           const ssrContents = getAppContents(html);
           expect(ssrContents).toContain('<app ngh');
@@ -2356,7 +2356,7 @@ describe('platform-server full application hydration integration', () => {
             case = 0;
           }
 
-          const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+          const hydrationFeatures = () => [withI18nSupport()];
           const html = await ssr(SimpleComponent, {hydrationFeatures});
           const ssrContents = getAppContents(html);
           expect(ssrContents).toContain('<app ngh');
@@ -2389,7 +2389,7 @@ describe('platform-server full application hydration integration', () => {
           })
           class SimpleComponent {}
 
-          const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+          const hydrationFeatures = () => [withI18nSupport()];
           const html = await ssr(SimpleComponent, {hydrationFeatures});
           const ssrContents = getAppContents(html);
           expect(ssrContents).toContain('<app ngh');
@@ -2420,7 +2420,7 @@ describe('platform-server full application hydration integration', () => {
             isServer = isPlatformServer(inject(PLATFORM_ID)) + '';
           }
 
-          const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+          const hydrationFeatures = () => [withI18nSupport()];
           const html = await ssr(SimpleComponent, {hydrationFeatures});
           let ssrContents = getAppContents(html);
           expect(ssrContents).toContain('<app ngh');
@@ -2463,7 +2463,7 @@ describe('platform-server full application hydration integration', () => {
             secondCase = 1;
           }
 
-          const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+          const hydrationFeatures = () => [withI18nSupport()];
           const html = await ssr(SimpleComponent, {hydrationFeatures});
           const ssrContents = getAppContents(html);
           expect(ssrContents).toContain('<app ngh');
@@ -2508,7 +2508,7 @@ describe('platform-server full application hydration integration', () => {
           })
           class AppComponent {}
 
-          const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+          const hydrationFeatures = () => [withI18nSupport()];
           const html = await ssr(AppComponent, {hydrationFeatures});
           const ssrContents = getAppContents(html);
           expect(ssrContents).toContain('<app ngh');
@@ -2546,7 +2546,7 @@ describe('platform-server full application hydration integration', () => {
           })
           class SimpleComponent {}
 
-          const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+          const hydrationFeatures = () => [withI18nSupport()];
           const html = await ssr(SimpleComponent, {hydrationFeatures});
           const ssrContents = getAppContents(html);
           expect(ssrContents).toContain('<app ngh');
@@ -2584,7 +2584,7 @@ describe('platform-server full application hydration integration', () => {
             items = [1, 2, 3];
           }
 
-          const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+          const hydrationFeatures = () => [withI18nSupport()];
           const html = await ssr(SimpleComponent, {hydrationFeatures});
           const ssrContents = getAppContents(html);
           expect(ssrContents).toContain('<app ngh');
@@ -2623,7 +2623,7 @@ describe('platform-server full application hydration integration', () => {
             items = [1, 2, 3];
           }
 
-          const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+          const hydrationFeatures = () => [withI18nSupport()];
           const html = await ssr(SimpleComponent, {hydrationFeatures});
           const ssrContents = getAppContents(html);
           expect(ssrContents).toContain('<app ngh');
@@ -2670,7 +2670,7 @@ describe('platform-server full application hydration integration', () => {
             })
             class SimpleComponent {}
 
-            const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+            const hydrationFeatures = () => [withI18nSupport()];
             const html = await ssr(SimpleComponent, {hydrationFeatures});
             const ssrContents = getAppContents(html);
             expect(ssrContents).toContain('<app ngh');
@@ -2716,7 +2716,7 @@ describe('platform-server full application hydration integration', () => {
             })
             class SimpleComponent {}
 
-            const hydrationFeatures = [withI18nSupport()] as unknown as HydrationFeature<any>[];
+            const hydrationFeatures = () => [withI18nSupport()];
             const html = await ssr(SimpleComponent, {hydrationFeatures});
             const ssrContents = getAppContents(html);
             expect(ssrContents).toContain('<app ngh');

--- a/packages/platform-server/test/hydration_utils.ts
+++ b/packages/platform-server/test/hydration_utils.ts
@@ -234,21 +234,19 @@ export function withDebugConsole() {
  */
 export async function ssr(
   component: Type<unknown>,
-  options?: {
+  options: {
     doc?: string;
     envProviders?: Provider[];
-    hydrationFeatures?: HydrationFeature<HydrationFeatureKind>[];
+    hydrationFeatures?: () => HydrationFeature<HydrationFeatureKind>[];
     enableHydration?: boolean;
-  },
+  } = {},
 ): Promise<string> {
   const defaultHtml = DEFAULT_DOCUMENT;
-  const enableHydration = options?.enableHydration ?? true;
-  const envProviders = options?.envProviders ?? [];
-  const hydrationFeatures = options?.hydrationFeatures ?? [];
+  const {enableHydration = true, envProviders = [], hydrationFeatures = () => []} = options;
   const providers = [
     ...envProviders,
     provideServerRendering(),
-    enableHydration ? provideClientHydration(...hydrationFeatures) : [],
+    enableHydration ? provideClientHydration(...hydrationFeatures()) : [],
   ];
 
   const bootstrap = () => bootstrapApplication(component, {providers});

--- a/packages/platform-server/test/incremental_hydration_spec.ts
+++ b/packages/platform-server/test/incremental_hydration_spec.ts
@@ -17,7 +17,7 @@ import {
   ɵwhenStable as whenStable,
 } from '@angular/core';
 
-import {getAppContents, hydrate, prepareEnvironmentAndHydrate, resetTViewsFor} from './dom_utils';
+import {getAppContents, prepareEnvironmentAndHydrate, resetTViewsFor} from './dom_utils';
 import {getComponentRef, ssr, timeout} from './hydration_utils';
 import {getDocument} from '@angular/core/src/render3/interfaces/document';
 import {isPlatformServer} from '@angular/common';
@@ -103,7 +103,7 @@ describe('platform-server partial hydration integration', () => {
 
       const appId = 'custom-app-id';
       const providers = [{provide: APP_ID, useValue: appId}];
-      const hydrationFeatures = [withIncrementalHydration(), withEventReplay()];
+      const hydrationFeatures = () => [withIncrementalHydration(), withEventReplay()];
 
       const html = await ssr(SimpleComponent, {envProviders: providers, hydrationFeatures});
       const ssrContents = getAppContents(html);
@@ -154,9 +154,13 @@ describe('platform-server partial hydration integration', () => {
 
       const appId = 'custom-app-id';
       const providers = [{provide: APP_ID, useValue: appId}];
-      const hydrationFeatures = [withIncrementalHydration()];
+      const hydrationFeatures = () => [withIncrementalHydration()];
 
-      const html = await ssr(SimpleComponent, {envProviders: providers, hydrationFeatures});
+      const html = await ssr(SimpleComponent, {
+        envProviders: providers,
+        hydrationFeatures,
+      });
+
       const ssrContents = getAppContents(html);
 
       // Assert that we have `jsaction` annotations and
@@ -268,7 +272,7 @@ describe('platform-server partial hydration integration', () => {
 
       const appId = 'custom-app-id';
       const providers = [{provide: APP_ID, useValue: appId}];
-      const hydrationFeatures = [withIncrementalHydration()];
+      const hydrationFeatures = () => [withIncrementalHydration()];
 
       const html = await ssr(SimpleComponent, {envProviders: providers, hydrationFeatures});
       const ssrContents = getAppContents(html);
@@ -379,7 +383,7 @@ describe('platform-server partial hydration integration', () => {
 
       const appId = 'custom-app-id';
       const providers = [{provide: APP_ID, useValue: appId}];
-      const hydrationFeatures = [withIncrementalHydration()];
+      const hydrationFeatures = () => [withIncrementalHydration()];
 
       const html = await ssr(SimpleComponent, {envProviders: providers, hydrationFeatures});
       const ssrContents = getAppContents(html);
@@ -492,7 +496,7 @@ describe('platform-server partial hydration integration', () => {
 
         const appId = 'custom-app-id';
         const providers = [{provide: APP_ID, useValue: appId}];
-        const hydrationFeatures = [withIncrementalHydration()];
+        const hydrationFeatures = () => [withIncrementalHydration()];
 
         const html = await ssr(SimpleComponent, {envProviders: providers, hydrationFeatures});
         const ssrContents = getAppContents(html);
@@ -560,7 +564,7 @@ describe('platform-server partial hydration integration', () => {
 
         const appId = 'custom-app-id';
         const providers = [{provide: APP_ID, useValue: appId}];
-        const hydrationFeatures = [withIncrementalHydration()];
+        const hydrationFeatures = () => [withIncrementalHydration()];
 
         const html = await ssr(SimpleComponent, {envProviders: providers, hydrationFeatures});
         const ssrContents = getAppContents(html);
@@ -631,7 +635,7 @@ describe('platform-server partial hydration integration', () => {
 
         const appId = 'custom-app-id';
         const providers = [{provide: APP_ID, useValue: appId}];
-        const hydrationFeatures = [withIncrementalHydration()];
+        const hydrationFeatures = () => [withIncrementalHydration()];
 
         const html = await ssr(SimpleComponent, {envProviders: providers, hydrationFeatures});
         const ssrContents = getAppContents(html);
@@ -704,7 +708,7 @@ describe('platform-server partial hydration integration', () => {
 
         const appId = 'custom-app-id';
         const providers = [{provide: APP_ID, useValue: appId}];
-        const hydrationFeatures = [withIncrementalHydration()];
+        const hydrationFeatures = () => [withIncrementalHydration()];
 
         const html = await ssr(SimpleComponent, {envProviders: providers, hydrationFeatures});
         const ssrContents = getAppContents(html);
@@ -871,7 +875,7 @@ describe('platform-server partial hydration integration', () => {
 
         const appId = 'custom-app-id';
         const providers = [{provide: APP_ID, useValue: appId}];
-        const hydrationFeatures = [withIncrementalHydration()];
+        const hydrationFeatures = () => [withIncrementalHydration()];
 
         const html = await ssr(SimpleComponent, {envProviders: providers, hydrationFeatures});
         const ssrContents = getAppContents(html);
@@ -956,7 +960,7 @@ describe('platform-server partial hydration integration', () => {
 
       const appId = 'custom-app-id';
       const providers = [{provide: APP_ID, useValue: appId}];
-      const hydrationFeatures = [withIncrementalHydration()];
+      const hydrationFeatures = () => [withIncrementalHydration()];
 
       const html = await ssr(SimpleComponent, {envProviders: providers, hydrationFeatures});
       const ssrContents = getAppContents(html);
@@ -1083,7 +1087,7 @@ describe('platform-server partial hydration integration', () => {
 
         const appId = 'custom-app-id';
         const providers = [{provide: APP_ID, useValue: appId}];
-        const hydrationFeatures = [withIncrementalHydration()];
+        const hydrationFeatures = () => [withIncrementalHydration()];
 
         const html = await ssr(SimpleComponent, {envProviders: providers, hydrationFeatures});
         const ssrContents = getAppContents(html);
@@ -1155,7 +1159,7 @@ describe('platform-server partial hydration integration', () => {
 
       const appId = 'custom-app-id';
       const providers = [{provide: APP_ID, useValue: appId}];
-      const hydrationFeatures = [withIncrementalHydration()];
+      const hydrationFeatures = () => [withIncrementalHydration()];
 
       const html = await ssr(SimpleComponent, {envProviders: providers, hydrationFeatures});
       const ssrContents = getAppContents(html);
@@ -1227,7 +1231,7 @@ describe('platform-server partial hydration integration', () => {
 
       const appId = 'custom-app-id';
       const providers = [{provide: APP_ID, useValue: appId}];
-      const hydrationFeatures = [withIncrementalHydration()];
+      const hydrationFeatures = () => [withIncrementalHydration()];
 
       const html = await ssr(SimpleComponent, {envProviders: providers, hydrationFeatures});
       const ssrContents = getAppContents(html);
@@ -1292,7 +1296,7 @@ describe('platform-server partial hydration integration', () => {
 
       const appId = 'custom-app-id';
       const providers = [{provide: APP_ID, useValue: appId}];
-      const hydrationFeatures = [withIncrementalHydration()];
+      const hydrationFeatures = () => [withIncrementalHydration()];
 
       const html = await ssr(SimpleComponent, {envProviders: providers, hydrationFeatures});
       const ssrContents = getAppContents(html);
@@ -1381,7 +1385,7 @@ describe('platform-server partial hydration integration', () => {
 
       const appId = 'custom-app-id';
       const providers = [{provide: APP_ID, useValue: appId}];
-      const hydrationFeatures = [withIncrementalHydration()];
+      const hydrationFeatures = () => [withIncrementalHydration()];
 
       const html = await ssr(SimpleComponent, {envProviders: providers, hydrationFeatures});
       const ssrContents = getAppContents(html);
@@ -1464,7 +1468,7 @@ describe('platform-server partial hydration integration', () => {
 
       const appId = 'custom-app-id';
       const providers = [{provide: APP_ID, useValue: appId}];
-      const hydrationFeatures = [withIncrementalHydration()];
+      const hydrationFeatures = () => [withIncrementalHydration()];
 
       const html = await ssr(SimpleComponent, {envProviders: providers, hydrationFeatures});
       const ssrContents = getAppContents(html);


### PR DESCRIPTION
This commit addresses a problem with tests that use the `fit` function to focus on individual test cases. While these tests run successfully in the full suite, they fail when focused individually using `fit`.

The issue lies in the behavior of `withEventReply` and other hydration-related functions (i.e., `provideX`, `withX`). These functions return platform-specific providers based on the `ngServerMode` setting, causing inconsistencies between server and browser environments. As a result, provider instances cannot be reused across server and browser applications.

**Example of problematic code:**
```ts
const hydrationFeatures = [withEventReply()];
const html = await ssr(SimpleComponent, { hydrationFeatures });
// Expected behavior ...

const appRef = await prepareEnvironmentAndHydrate(doc, html, SimpleComponent, {
  hydrationFeatures,
});
// Expected behavior ...
```

**Solution:**
To address this, we define `hydrationFeatures` as a function instead of a static array. This ensures that a new instance of `withEventReply` is created separately for each environment, eliminating platform-specific mismatches between server and browser contexts:

```typescript
const hydrationFeatures = () => [withEventReply()];  // Define as a function
const html = await ssr(SimpleComponent, { hydrationFeatures: hydrationFeatures() });
// Expected behavior ...

const appRef = await prepareEnvironmentAndHydrate(doc, html, SimpleComponent, {
  hydrationFeatures: hydrationFeatures(),
});
// Expected behavior ...
```
