### PR TITLE
fix(docs-infra): update search provider link

### DIFF
--- a/adev/shared-docs/components/search-dialog/search-dialog.component.html
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.html
@@ -70,7 +70,8 @@
 
     <div class="docs-algolia">
       <span>Search by</span>
-      <a href="https://www.algolia.com/developers/" target="_blank" rel="noopener">
+      <a target="_blank" rel="noopener"
+         href="https://www.algolia.com/developers/?utm_source=angular.dev&utm_medium=referral&utm_content=powered_by&utm_campaign=docsearch">
         <docs-algolia-icon />
       </a>
     </div>


### PR DESCRIPTION
Update the link used to reference algolia as the search provider on our documentation site. Adds a few URL parameters for algolia to map back to our usage.