### PR TITLE
docs(docs-infra): update default generic values and add constraints for type parameters in functions

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/entities.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/entities.ts
@@ -94,7 +94,9 @@ export interface ConstantEntry extends DocEntry {
 }
 
 /** Documentation entity for a type alias. */
-export type TypeAliasEntry = ConstantEntry;
+export interface TypeAliasEntry extends ConstantEntry {
+  generics: GenericEntry[];
+}
 
 /** Documentation entity for a TypeScript class. */
 export interface ClassEntry extends DocEntry {

--- a/adev/shared-docs/pipeline/api-gen/rendering/test/transforms/code-transforms.spec.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/test/transforms/code-transforms.spec.ts
@@ -1,0 +1,59 @@
+import {makeGenericsText} from '../../transforms/code-transforms';
+
+describe('makeGenericsText', () => {
+  it('should return an empty string if no generics are provided', () => {
+    expect(makeGenericsText(undefined)).toBe('');
+    expect(makeGenericsText([])).toBe('');
+  });
+
+  it('should return a single generic type without constraints or default', () => {
+    const generics = [{name: 'T', constraint: undefined, default: undefined}];
+    expect(makeGenericsText(generics)).toBe('<T>');
+  });
+
+  it('should handle a single generic type with a constraint', () => {
+    const generics = [{name: 'T', constraint: 'string', default: undefined}];
+    expect(makeGenericsText(generics)).toBe('<T extends string>');
+  });
+
+  it('should handle a single generic type with a default value', () => {
+    const generics = [{name: 'T', default: 'number', constraint: undefined}];
+    expect(makeGenericsText(generics)).toBe('<T = number>');
+  });
+
+  it('should handle a single generic type with both constraint and default value', () => {
+    const generics = [{name: 'T', constraint: 'string', default: 'number'}];
+    expect(makeGenericsText(generics)).toBe('<T extends string = number>');
+  });
+
+  it('should handle multiple generic types without constraints or defaults', () => {
+    const generics = [
+      {name: 'T', constraint: undefined, default: undefined},
+      {name: 'U', constraint: undefined, default: undefined},
+    ];
+    expect(makeGenericsText(generics)).toBe('<T, U>');
+  });
+
+  it('should handle multiple generic types with constraints and defaults', () => {
+    const generics = [
+      {name: 'T', constraint: 'string', default: 'number'},
+      {name: 'U', constraint: 'boolean', default: undefined},
+      {name: 'V', default: 'any', constraint: undefined},
+    ];
+    expect(makeGenericsText(generics)).toBe(
+      '<T extends string = number, U extends boolean, V = any>',
+    );
+  });
+
+  it('should handle complex generics with mixed constraints and defaults', () => {
+    const generics = [
+      {name: 'A', constraint: 'string', default: undefined},
+      {name: 'B', constraint: undefined, default: undefined},
+      {name: 'C', default: 'number', constraint: undefined},
+      {name: 'D', constraint: 'boolean', default: 'true'},
+    ];
+    expect(makeGenericsText(generics)).toBe(
+      '<A extends string, B, C = number, D extends boolean = true>',
+    );
+  });
+});

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/code-transforms.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/code-transforms.ts
@@ -243,7 +243,8 @@ export function mapDocEntryToCode(entry: DocEntry): CodeTableOfContentsData {
   }
 
   if (isTypeAliasEntry(entry)) {
-    const contents = `type ${entry.name} = ${entry.type}`;
+    const generics = makeGenericsText(entry.generics);
+    const contents = `type ${entry.name}${generics} = ${entry.type}`;
 
     if (isDeprecated) {
       const numberOfLinesOfCode = getNumberOfLinesOfCode(contents);
@@ -446,7 +447,6 @@ function appendPrefixAndSuffix(entry: DocEntry, codeTocData: CodeTableOfContents
 
   if (isClassEntry(entry) || isInterfaceEntry(entry)) {
     const generics = makeGenericsText(entry.generics);
-
     const extendsStr = entry.extends ? ` extends ${entry.extends}` : '';
     // TODO: remove the ? when we distinguish Class & Decorator entries
     const implementsStr =

--- a/packages/compiler-cli/src/ngtsc/docs/src/entities.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/entities.ts
@@ -100,14 +100,16 @@ export interface ConstantEntry extends DocEntry {
 }
 
 /** Documentation entity for a type alias. */
-export type TypeAliasEntry = ConstantEntry;
+export interface TypeAliasEntry extends ConstantEntry {
+  generics: GenericEntry[];
+}
 
 /** Documentation entity for a TypeScript class. */
 export interface ClassEntry extends DocEntry {
   isAbstract: boolean;
   members: MemberEntry[];
-  generics: GenericEntry[];
   extends?: string;
+  generics: GenericEntry[];
   implements: string[];
 }
 

--- a/packages/compiler-cli/src/ngtsc/docs/src/type_alias_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/type_alias_extractor.ts
@@ -9,6 +9,7 @@ import ts from 'typescript';
 
 import {EntryType} from './entities';
 import {extractJsDocDescription, extractJsDocTags, extractRawJsDoc} from './jsdoc_extractor';
+import {extractGenerics} from './generics_extractor';
 
 /** Extract the documentation entry for a type alias. */
 export function extractTypeAlias(declaration: ts.TypeAliasDeclaration) {
@@ -20,6 +21,7 @@ export function extractTypeAlias(declaration: ts.TypeAliasDeclaration) {
     name: declaration.name.getText(),
     type: declaration.type.getText(),
     entryType: EntryType.TypeAlias,
+    generics: extractGenerics(declaration),
     rawComment: extractRawJsDoc(declaration),
     description: extractJsDocDescription(declaration),
     jsdocTags: extractJsDocTags(declaration),

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/type_alias_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/type_alias_doc_extraction_spec.ts
@@ -63,5 +63,26 @@ runInEachFileSystem(() => {
           age: number;
         }`);
     });
+
+    it('should extract type aliases based with generics', () => {
+      env.write(
+        'index.ts',
+        `
+          type Foo<T> = undefined;
+          export type Bar<T extends string> = Foo<T>;
+        `,
+      );
+
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
+      expect(docs.length).toBe(1);
+
+      const typeAliasEntry = docs[0] as TypeAliasEntry;
+      expect(typeAliasEntry.name).toBe('Bar');
+      expect(typeAliasEntry.entryType).toBe(EntryType.TypeAlias);
+      expect(typeAliasEntry.type).toBe('Foo<T>');
+      expect(typeAliasEntry.generics).toEqual([
+        {name: 'T', constraint: 'string', default: undefined},
+      ]);
+    });
   });
 });


### PR DESCRIPTION

Before
```typescript
createNodeRequestHandler(
  handler: T
): T;
```

```typescript
class NgIf<T> {
  @Input() set ngIf(value: T);
  @Input() set ngIfThen(value: TemplateRef<NgIfContext<T>> | null);
  @Input() set ngIfElse(value: TemplateRef<NgIfContext<T>> | null);
  static ngTemplateGuard_ngIf: "binding";
  static ngTemplateContextGuard<T>(dir: NgIf<T>, ctx: any): boolean;
}
```

Now
```typescript
createNodeRequestHandler<T extends NodeRequestHandlerFunction>(
  handler: T
): T;
```

```typescript
class NgIf<T = unknown> {
  @Input() set ngIf(value: T);
  @Input() set ngIfThen(value: TemplateRef<NgIfContext<T>> | null);
  @Input() set ngIfElse(value: TemplateRef<NgIfContext<T>> | null);
  static ngTemplateGuard_ngIf: "binding";
  static ngTemplateContextGuard<T>(dir: NgIf<T>, ctx: any): boolean;
}
```
