### PR TITLE
Revert "docs(docs-infra): add support for `@remarks` (#58523)"

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/jsdoc-transforms.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/jsdoc-transforms.ts
@@ -33,7 +33,6 @@ import {getLinkToModule} from './url-transforms';
 import {addApiLinksToHtml} from './code-transforms';
 import {getCurrentSymbol, getModuleName, logUnknownSymbol} from '../symbol-context';
 
-export const JS_DOC_REMARKS_TAG = 'remarks';
 export const JS_DOC_USAGE_NOTES_TAG = 'usageNotes';
 export const JS_DOC_SEE_TAG = 'see';
 export const JS_DOC_DESCRIPTION_TAG = 'description';
@@ -97,9 +96,7 @@ export function addHtmlAdditionalLinks<T extends HasJsDocTags & HasModuleName>(
 }
 
 export function addHtmlUsageNotes<T extends HasJsDocTags>(entry: T): T & HasHtmlUsageNotes {
-  const usageNotesTag = entry.jsdocTags.find(
-    ({name}) => name === JS_DOC_USAGE_NOTES_TAG || name === JS_DOC_REMARKS_TAG,
-  );
+  const usageNotesTag = entry.jsdocTags.find((tag) => tag.name === JS_DOC_USAGE_NOTES_TAG);
   const htmlUsageNotes = usageNotesTag
     ? (marked.parse(
         convertJsDocExampleToHtmlExample(wrapExampleHtmlElementsWithCode(usageNotesTag.comment)),


### PR DESCRIPTION
This reverts commit c5ce302e0b0667aa7522f80a741241a116abf168.

We are unsure why this is causing issues on CI, but since these is the location of the failure, we can revert it to see if that solves the issue for us.