### PR TITLE
fix(compiler): fix `:host` parsing in pseudo-selectors

### DIFF
--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -743,7 +743,7 @@ export class ShadowCss {
             },
           );
         })
-        .replace(_polyfillHostRe, replaceBy + ' ');
+        .replace(_polyfillHostRe, replaceBy);
     }
 
     return scopeSelector + ' ' + selector;
@@ -765,7 +765,7 @@ export class ShadowCss {
     const isRe = /\[is=([^\]]*)\]/g;
     scopeSelector = scopeSelector.replace(isRe, (_: string, ...parts: string[]) => parts[0]);
 
-    const attrName = '[' + scopeSelector + ']';
+    const attrName = `[${scopeSelector}]`;
 
     const _scopeSelectorPart = (p: string) => {
       let scopedP = p.trim();
@@ -776,7 +776,7 @@ export class ShadowCss {
 
       if (p.includes(_polyfillHostNoCombinator)) {
         scopedP = this._applySimpleSelectorScope(p, scopeSelector, hostSelector);
-        if (_polyfillHostNoCombinatorWithinPseudoFunction.test(p)) {
+        if (!p.match(_polyfillHostNoCombinatorOutsidePseudoFunction)) {
           const [_, before, colon, after] = scopedP.match(/([^:]*)(:*)(.*)/)!;
           scopedP = before + attrName + colon + after;
         }
@@ -979,10 +979,11 @@ const _cssColonHostContextReGlobal = new RegExp(
 );
 const _cssColonHostContextRe = new RegExp(_polyfillHostContext + _parenSuffix, 'im');
 const _polyfillHostNoCombinator = _polyfillHost + '-no-combinator';
-const _polyfillHostNoCombinatorWithinPseudoFunction = new RegExp(
-  `:.*\\(.*${_polyfillHostNoCombinator}.*\\)`,
+const _polyfillHostNoCombinatorOutsidePseudoFunction = new RegExp(
+  `${_polyfillHostNoCombinator}(?![^(]*\\))`,
+  'g',
 );
-const _polyfillHostNoCombinatorRe = /-shadowcsshost-no-combinator([^\s]*)/;
+const _polyfillHostNoCombinatorRe = /-shadowcsshost-no-combinator([^\s,]*)/;
 const _polyfillHostNoCombinatorReGlobal = new RegExp(_polyfillHostNoCombinatorRe, 'g');
 const _shadowDOMSelectorsRe = [
   /::shadow/g,

--- a/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
+++ b/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
@@ -83,6 +83,21 @@ describe('ShadowCss, :host and :host-context', () => {
       expect(shim(':host(:not(p)):before {}', 'contenta', 'a-host')).toEqualCss(
         '[a-host]:not(p):before {}',
       );
+      expect(shim(':host:not(:host.foo) {}', 'contenta', 'a-host')).toEqualCss(
+        '[a-host]:not([a-host].foo) {}',
+      );
+      expect(shim(':host:not(.foo:host) {}', 'contenta', 'a-host')).toEqualCss(
+        '[a-host]:not(.foo[a-host]) {}',
+      );
+      expect(shim(':host:not(:host.foo, :host.bar) {}', 'contenta', 'a-host')).toEqualCss(
+        '[a-host]:not([a-host].foo, .bar[a-host]) {}',
+      );
+      expect(shim(':host:not(:host.foo, .bar :host) {}', 'contenta', 'a-host')).toEqualCss(
+        '[a-host]:not([a-host].foo, .bar [a-host]) {}',
+      );
+      expect(shim(':host:not(.foo, .bar) {}', 'contenta', 'a-host')).toEqualCss(
+        '[a-host]:not(.foo, .bar) {}',
+      );
     });
 
     // see b/63672152

--- a/packages/compiler/test/shadow_css/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css/shadow_css_spec.ts
@@ -229,6 +229,24 @@ describe('ShadowCss', () => {
     expect(shim(':has(a) :has(b) {}', 'contenta', 'hosta')).toEqualCss(
       '[contenta]:has(a) [contenta]:has(b) {}',
     );
+    expect(shim(':has(a, b) {}', 'contenta', 'hosta')).toEqualCss('[contenta]:has(a, b) {}');
+    expect(shim(':has(a, b:where(.foo), :is(.bar)) {}', 'contenta', 'hosta')).toEqualCss(
+      '[contenta]:has(a, b:where(.foo), :is(.bar)) {}',
+    );
+    expect(
+      shim(':has(a, b:where(.foo), :is(.bar):first-child):first-letter {}', 'contenta', 'hosta'),
+    ).toEqualCss('[contenta]:has(a, b:where(.foo), :is(.bar):first-child):first-letter {}');
+    expect(
+      shim(':where(a, b:where(.foo), :has(.bar):first-child) {}', 'contenta', 'hosta'),
+    ).toEqualCss(
+      ':where(a[contenta], b[contenta]:where(.foo), [contenta]:has(.bar):first-child) {}',
+    );
+    expect(shim(':has(.one :host, .two) {}', 'contenta', 'hosta')).toEqualCss(
+      '[contenta]:has(.one [hosta], .two) {}',
+    );
+    expect(shim(':has(.one, :host) {}', 'contenta', 'hosta')).toEqualCss(
+      '[contenta]:has(.one, [hosta]) {}',
+    );
   });
 
   it('should handle :host inclusions inside pseudo-selectors selectors', () => {


### PR DESCRIPTION
fix several use-cases where `:host` was used in or around pseudo-selectors
- `:host` followed by a comma inside pseudo-selectors
- `:host` outside of pseudo-selectors when another `:host` is present within see tests for examples

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Look for added tests. Mainly
- `:has(:host, .foo)` isn't parsed correctly (the comma after foo was recognized as a selector;
- `:host:has(.foo.host)` isn't scoped correctly (added `[content]` scoping).
Issue Number: #58226
Fixing issues outlined in this comment, doesn't solve all of the problems mentioned, splitting PR's as fixes seem not relevant.

## What is the new behavior?
Different `:host` combinations around pseudo-selectors are parsed correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No (unless a broken selector is fixed now, so styles would apply)


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This PR doesn't resolve the whole issue, but fixes a set of use-cases. 