### PR TITLE
fix(compiler): fix pseudo-selector parsing issues

### DIFF
--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -743,7 +743,7 @@ export class ShadowCss {
             },
           );
         })
-        .replace(_polyfillHostRe, replaceBy + ' ');
+        .replace(_polyfillHostRe, replaceBy);
     }
 
     return scopeSelector + ' ' + selector;
@@ -765,7 +765,7 @@ export class ShadowCss {
     const isRe = /\[is=([^\]]*)\]/g;
     scopeSelector = scopeSelector.replace(isRe, (_: string, ...parts: string[]) => parts[0]);
 
-    const attrName = '[' + scopeSelector + ']';
+    const attrName = `[${scopeSelector}]`;
 
     const _scopeSelectorPart = (p: string) => {
       let scopedP = p.trim();
@@ -776,7 +776,7 @@ export class ShadowCss {
 
       if (p.includes(_polyfillHostNoCombinator)) {
         scopedP = this._applySimpleSelectorScope(p, scopeSelector, hostSelector);
-        if (_polyfillHostNoCombinatorWithinPseudoFunction.test(p)) {
+        if (!p.match(_polyfillHostNoCombinatorOutsidePseudoFunction)) {
           const [_, before, colon, after] = scopedP.match(/([^:]*)(:*)(.*)/)!;
           scopedP = before + attrName + colon + after;
         }
@@ -979,10 +979,11 @@ const _cssColonHostContextReGlobal = new RegExp(
 );
 const _cssColonHostContextRe = new RegExp(_polyfillHostContext + _parenSuffix, 'im');
 const _polyfillHostNoCombinator = _polyfillHost + '-no-combinator';
-const _polyfillHostNoCombinatorWithinPseudoFunction = new RegExp(
-  `:.*\\(.*${_polyfillHostNoCombinator}.*\\)`,
+const _polyfillHostNoCombinatorOutsidePseudoFunction = new RegExp(
+  `${_polyfillHostNoCombinator}(?![^(]*\\))`,
+  'g',
 );
-const _polyfillHostNoCombinatorRe = /-shadowcsshost-no-combinator([^\s]*)/;
+const _polyfillHostNoCombinatorRe = /-shadowcsshost-no-combinator([^\s,]*)/;
 const _polyfillHostNoCombinatorReGlobal = new RegExp(_polyfillHostNoCombinatorRe, 'g');
 const _shadowDOMSelectorsRe = [
   /::shadow/g,

--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -779,14 +779,14 @@ export class ShadowCss {
       if (p.includes(_polyfillHostNoCombinator)) {
         scopedP = this._applySimpleSelectorScope(p, scopeSelector, hostSelector);
         if (!p.match(_polyfillHostNoCombinatorOutsidePseudoFunction)) {
-          const [_, before, colon, after] = scopedP.match(/([^:]*)(:*)(.*)/)!;
+          const [_, before, colon, after] = scopedP.match(/([^:]*)(:*)([\s\S]*)/)!;
           scopedP = before + attrName + colon + after;
         }
       } else {
         // remove :host since it should be unnecessary
         const t = p.replace(_polyfillHostRe, '');
         if (t.length > 0) {
-          const matches = t.match(/([^:]*)(:*)(.*)/);
+          const matches = t.match(/([^:]*)(:*)([\s\S]*)/);
           if (matches) {
             scopedP = matches[1] + attrName + matches[2] + matches[3];
           }

--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -734,16 +734,18 @@ export class ShadowCss {
     _polyfillHostRe.lastIndex = 0;
     if (_polyfillHostRe.test(selector)) {
       const replaceBy = `[${hostSelector}]`;
-      return selector
-        .replace(_polyfillHostNoCombinatorReGlobal, (_hnc, selector) => {
+      let result = selector;
+      while (result.match(_polyfillHostNoCombinatorRe)) {
+        result = result.replace(_polyfillHostNoCombinatorRe, (_hnc, selector) => {
           return selector.replace(
             /([^:\)]*)(:*)(.*)/,
             (_: string, before: string, colon: string, after: string) => {
               return before + replaceBy + colon + after;
             },
           );
-        })
-        .replace(_polyfillHostRe, replaceBy);
+        });
+      }
+      return result.replace(_polyfillHostRe, replaceBy);
     }
 
     return scopeSelector + ' ' + selector;
@@ -1021,7 +1023,6 @@ const _polyfillHostNoCombinatorOutsidePseudoFunction = new RegExp(
   'g',
 );
 const _polyfillHostNoCombinatorRe = /-shadowcsshost-no-combinator([^\s,]*)/;
-const _polyfillHostNoCombinatorReGlobal = new RegExp(_polyfillHostNoCombinatorRe, 'g');
 const _shadowDOMSelectorsRe = [
   /::shadow/g,
   /::content/g,

--- a/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
+++ b/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
@@ -83,6 +83,21 @@ describe('ShadowCss, :host and :host-context', () => {
       expect(shim(':host(:not(p)):before {}', 'contenta', 'a-host')).toEqualCss(
         '[a-host]:not(p):before {}',
       );
+      expect(shim(':host:not(:host.foo) {}', 'contenta', 'a-host')).toEqualCss(
+        '[a-host]:not([a-host].foo) {}',
+      );
+      expect(shim(':host:not(.foo:host) {}', 'contenta', 'a-host')).toEqualCss(
+        '[a-host]:not(.foo[a-host]) {}',
+      );
+      expect(shim(':host:not(:host.foo, :host.bar) {}', 'contenta', 'a-host')).toEqualCss(
+        '[a-host]:not([a-host].foo, .bar[a-host]) {}',
+      );
+      expect(shim(':host:not(:host.foo, .bar :host) {}', 'contenta', 'a-host')).toEqualCss(
+        '[a-host]:not([a-host].foo, .bar [a-host]) {}',
+      );
+      expect(shim(':host:not(.foo, .bar) {}', 'contenta', 'a-host')).toEqualCss(
+        '[a-host]:not(.foo, .bar) {}',
+      );
     });
 
     // see b/63672152

--- a/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
+++ b/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
@@ -255,6 +255,18 @@ describe('ShadowCss, :host and :host-context', () => {
       );
     });
 
+    it('should handle no selector :host', () => {
+      // The second selector below should have a `[a-host]` attribute selector
+      // attached to `.one`, current `:host-context` unwrapping logic doesn't
+      // work correctly on prefixed selectors, see #58345.
+      expect(shim(':host:host-context(.one) {}', 'contenta', 'a-host')).toEqualCss(
+        '.one[a-host][a-host], .one [a-host] {}',
+      );
+      expect(shim(':host-context(.one) :host {}', 'contenta', 'a-host')).toEqualCss(
+        '.one [a-host] {}',
+      );
+    });
+
     it('should handle selectors on different elements', () => {
       expect(shim(':host-context(div) :host(.x) > .y {}', 'contenta', 'a-host')).toEqualCss(
         'div .x[a-host] > .y[contenta] {}',

--- a/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
+++ b/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
@@ -119,6 +119,17 @@ describe('ShadowCss, :host and :host-context', () => {
         'cmp [a-host] child {}',
       );
     });
+
+    it('should support newlines in the same selector and content ', () => {
+      const selector = `.foo:not(
+        :host) {
+          background-color:
+            green;
+      }`;
+      expect(shim(selector, 'contenta', 'a-host')).toEqualCss(
+        '.foo[contenta]:not( [a-host]) { background-color:green;}',
+      );
+    });
   });
 
   describe(':host-context', () => {

--- a/packages/compiler/test/shadow_css/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css/shadow_css_spec.ts
@@ -93,22 +93,12 @@ describe('ShadowCss', () => {
       'div[contenta]:where(.one) {}',
     );
     expect(shim('div:where() {}', 'contenta', 'hosta')).toEqualCss('div[contenta]:where() {}');
-    // See `xit('should parse concatenated pseudo selectors'`
     expect(shim(':where(a):where(b) {}', 'contenta', 'hosta')).toEqualCss(
-      ':where(a)[contenta]:where(b) {}',
+      ':where(a[contenta]):where(b[contenta]) {}',
     );
     expect(shim('*:where(.one) {}', 'contenta', 'hosta')).toEqualCss('*[contenta]:where(.one) {}');
     expect(shim('*:where(.one) ::ng-deep .foo {}', 'contenta', 'hosta')).toEqualCss(
       '*[contenta]:where(.one) .foo {}',
-    );
-  });
-
-  xit('should parse concatenated pseudo selectors', () => {
-    // Current logic leads to a result with an outer scope
-    // It could be changed, to not increase specificity
-    // Requires a more complex parsing
-    expect(shim(':where(a):where(b) {}', 'contenta', 'hosta')).toEqualCss(
-      ':where(a[contenta]):where(b[contenta]) {}',
     );
   });
 
@@ -200,6 +190,18 @@ describe('ShadowCss', () => {
     ).toEqualCss(
       ':where(:where(a[contenta]:has(.foo), b[contenta]) :is(.one[contenta], .two[contenta]:where(.foo > .bar))) {}',
     );
+    expect(shim(':where(.two):first-child {}', 'contenta', 'hosta')).toEqualCss(
+      '[contenta]:where(.two):first-child {}',
+    );
+    expect(shim(':first-child:where(.two) {}', 'contenta', 'hosta')).toEqualCss(
+      '[contenta]:first-child:where(.two) {}',
+    );
+    expect(shim(':where(.two):nth-child(3) {}', 'contenta', 'hosta')).toEqualCss(
+      '[contenta]:where(.two):nth-child(3) {}',
+    );
+    expect(shim('table :where(td, th):hover { color: lime; }', 'contenta', 'hosta')).toEqualCss(
+      'table[contenta] [contenta]:where(td, th):hover { color:lime;}',
+    );
 
     // complex selectors
     expect(shim(':host:is([foo],[foo-2])>div.example-2 {}', 'contenta', 'a-host')).toEqualCss(
@@ -272,6 +274,18 @@ describe('ShadowCss', () => {
     expect(shim('.one :where(:host, .two) {}', 'contenta', 'hosta')).toEqualCss(
       '.one :where([hosta], .two[contenta]) {}',
     );
+    expect(shim(':is(.foo):is(:host):is(.two) {}', 'contenta', 'hosta')).toEqualCss(
+      ':is(.foo):is([hosta]):is(.two[contenta]) {}',
+    );
+    expect(shim(':where(.one, :host .two):first-letter {}', 'contenta', 'hosta')).toEqualCss(
+      '[contenta]:where(.one, [hosta] .two):first-letter {}',
+    );
+    expect(shim(':first-child:where(.one, :host .two) {}', 'contenta', 'hosta')).toEqualCss(
+      '[contenta]:first-child:where(.one, [hosta] .two) {}',
+    );
+    expect(
+      shim(':where(.one, :host .two):nth-child(3):is(.foo, a:where(.bar)) {}', 'contenta', 'hosta'),
+    ).toEqualCss('[contenta]:where(.one, [hosta] .two):nth-child(3):is(.foo, a:where(.bar)) {}');
   });
 
   it('should handle escaped selector with space (if followed by a hex char)', () => {

--- a/packages/compiler/test/shadow_css/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css/shadow_css_spec.ts
@@ -229,6 +229,24 @@ describe('ShadowCss', () => {
     expect(shim(':has(a) :has(b) {}', 'contenta', 'hosta')).toEqualCss(
       '[contenta]:has(a) [contenta]:has(b) {}',
     );
+    expect(shim(':has(a, b) {}', 'contenta', 'hosta')).toEqualCss('[contenta]:has(a, b) {}');
+    expect(shim(':has(a, b:where(.foo), :is(.bar)) {}', 'contenta', 'hosta')).toEqualCss(
+      '[contenta]:has(a, b:where(.foo), :is(.bar)) {}',
+    );
+    expect(
+      shim(':has(a, b:where(.foo), :is(.bar):first-child):first-letter {}', 'contenta', 'hosta'),
+    ).toEqualCss('[contenta]:has(a, b:where(.foo), :is(.bar):first-child):first-letter {}');
+    expect(
+      shim(':where(a, b:where(.foo), :has(.bar):first-child) {}', 'contenta', 'hosta'),
+    ).toEqualCss(
+      ':where(a[contenta], b[contenta]:where(.foo), [contenta]:has(.bar):first-child) {}',
+    );
+    expect(shim(':has(.one :host, .two) {}', 'contenta', 'hosta')).toEqualCss(
+      '[contenta]:has(.one [hosta], .two) {}',
+    );
+    expect(shim(':has(.one, :host) {}', 'contenta', 'hosta')).toEqualCss(
+      '[contenta]:has(.one, [hosta]) {}',
+    );
   });
 
   it('should handle :host inclusions inside pseudo-selectors selectors', () => {

--- a/packages/compiler/test/shadow_css/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css/shadow_css_spec.ts
@@ -47,6 +47,17 @@ describe('ShadowCss', () => {
     expect(shim(css, 'contenta')).toEqualCss(expected);
   });
 
+  it('should support newlines in the same selector and content ', () => {
+    const selector = `.foo:not(
+      .bar) {
+        background-color:
+          green;
+    }`;
+    expect(shim(selector, 'contenta', 'a-host')).toEqualCss(
+      '.foo[contenta]:not( .bar) { background-color:green;}',
+    );
+  });
+
   it('should handle complicated selectors', () => {
     expect(shim('one::before {}', 'contenta')).toEqualCss('one[contenta]::before {}');
     expect(shim('one two {}', 'contenta')).toEqualCss('one[contenta] two[contenta] {}');


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #58226


## What is the new behavior?
`:where` and `:is` with attached selectors of other types are parsed as all other selectors. If selectors consist only of those two than each of them is scoped separately (recursively) and result is returned back

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No (some selectors may be evaluated differently)


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
