### PR TITLE
fix(docs-infra): retain `function` keyword in API definitions

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/shiki/shiki.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/shiki/shiki.ts
@@ -21,11 +21,7 @@ export async function initHighlighter() {
   });
 }
 
-export function codeToHtml(
-  code: string,
-  language: string | undefined,
-  options?: {removeFunctionKeyword?: boolean},
-): string {
+export function codeToHtml(code: string, language: string | undefined): string {
   const html = highlighter.codeToHtml(code, {
     lang: language ?? 'text',
     themes: {
@@ -36,9 +32,6 @@ export function codeToHtml(
     defaultColor: false,
   });
 
-  if (options?.removeFunctionKeyword) {
-    return replaceKeywordFromShikiHtml('function', html);
-  }
   return html;
 }
 

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/function-reference.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/function-reference.tsx
@@ -43,7 +43,6 @@ export const signatureCard = (
                 // Always omit types in signature headers, to keep them short.
                 true,
               )}
-              removeFunctionKeyword={true}
             />
           </code>
         ) : (

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/highlight-ts.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/highlight-ts.tsx
@@ -11,10 +11,8 @@ import {RawHtml} from './raw-html';
 import {codeToHtml} from '../shiki/shiki';
 
 /** Component to render a header of the CLI page. */
-export function HighlightTypeScript(props: {code: string; removeFunctionKeyword?: boolean}) {
-  const result = codeToHtml(props.code, 'typescript', {
-    removeFunctionKeyword: props.removeFunctionKeyword,
-  });
+export function HighlightTypeScript(props: {code: string; }) {
+  const result = codeToHtml(props.code, 'typescript');
 
   return <RawHtml value={result} />;
 }

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/code-transforms.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/code-transforms.ts
@@ -66,9 +66,7 @@ export function addRenderableCodeToc<T extends DocEntry & HasModuleName>(
   const metadata = mapDocEntryToCode(entry);
   appendPrefixAndSuffix(entry, metadata);
 
-  let codeWithSyntaxHighlighting = codeToHtml(metadata.contents, 'typescript', {
-    removeFunctionKeyword: true,
-  });
+  let codeWithSyntaxHighlighting = codeToHtml(metadata.contents, 'typescript');
 
   if (isDecoratorEntry(entry)) {
     // Shiki requires a keyword for correct formating of Decorators


### PR DESCRIPTION
**Before:**
```ts
animate(
  timings: string | number,
  styles?: AnimationStyleMetadata | AnimationKeyframesSequenceMetadata | null
): AnimationAnimateMetadata;
```

**Now:**
```ts
function animate(
  timings: string | number,
  styles?: AnimationStyleMetadata | AnimationKeyframesSequenceMetadata | null
): AnimationAnimateMetadata;
```