### PR TITLE
Add support for `globalThis` to access global scope in templates

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -2714,6 +2714,12 @@ class TcbExpressionTranslator {
       ast.receiver instanceof ImplicitReceiver &&
       !(ast.receiver instanceof ThisReceiver)
     ) {
+      // Resolves the special globalThis to access the global scope
+      if (ast.name === 'globalThis') {
+        const globalAccessExpr = ts.factory.createIdentifier('globalThis');
+        return globalAccessExpr;
+      }
+
       // Try to resolve a bound target for this expression. If no such target is available, then
       // the expression is referencing the top-level component context. In that case, `null` is
       // returned here to let it fall through resolution so it will be caught when the

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -703,6 +703,18 @@ describe('type check blocks', () => {
     expect(block).toContain('((((this).foo)).$any(((this).a)))');
   });
 
+  it('should handle $global access', () => {
+    const TEMPLATE = `{{globalThis.Math.random()}}`;
+    const block = tcb(TEMPLATE);
+    expect(block).toContain('((((globalThis).Math)).random())');
+  });
+
+  it('should handle globalThis accessed through `this`', () => {
+    const TEMPLATE = `{{this.globalThis.Math.random()}}`;
+    const block = tcb(TEMPLATE);
+    expect(block).toContain('((((((this).globalThis)).Math)).random())');
+  });
+
   it('should handle a two-way binding to an input/output pair', () => {
     const TEMPLATE = `<div twoWay [(input)]="value"></div>`;
     const DIRECTIVES: TestDeclaration[] = [

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/global_scope/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/global_scope/GOLDEN_PARTIAL.js
@@ -1,0 +1,45 @@
+/****************************************************************************************************
+ * PARTIAL FILE: basic_global.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+class Comp {
+}
+Comp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Comp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+Comp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: Comp, isStandalone: true, selector: "ng-component", ngImport: i0, template: '{{globalThis.Math.random()}}', isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Comp, decorators: [{
+            type: Component,
+            args: [{
+                    template: '{{globalThis.Math.random()}}',
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: basic_global.d.ts
+ ****************************************************************************************************/
+export {};
+
+/****************************************************************************************************
+ * PARTIAL FILE: this_globalThis_access.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+class Comp {
+    constructor() {
+        this.globalThis = globalThis;
+    }
+}
+Comp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Comp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+Comp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: Comp, isStandalone: true, selector: "ng-component", ngImport: i0, template: '{{this.globalThis.Math.random()}}', isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Comp, decorators: [{
+            type: Component,
+            args: [{
+                    template: '{{this.globalThis.Math.random()}}',
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: this_globalThis_access.d.ts
+ ****************************************************************************************************/
+export {};
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/global_scope/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/global_scope/TEST_CASES.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "../../test_case_schema.json",
+  "cases": [
+    {
+      "description": "should strip give access to the global scope",
+      "inputFiles": [
+        "basic_global.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "basic_global_template.js",
+              "generated": "basic_global.js"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "should preserve globalThis if it is accessed through `this`",
+      "inputFiles": [
+        "this_globalThis_access.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "this_globalThis_access_template.js",
+              "generated": "this_globalThis_access.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/global_scope/basic_global.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/global_scope/basic_global.ts
@@ -1,0 +1,7 @@
+import {Component} from '@angular/core';
+
+@Component({
+    template: '{{globalThis.Math.random()}}',
+})
+class Comp {
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/global_scope/basic_global_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/global_scope/basic_global_template.js
@@ -1,0 +1,1 @@
+globalThis.Math.random()

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/global_scope/this_globalThis_access.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/global_scope/this_globalThis_access.ts
@@ -1,0 +1,8 @@
+import {Component} from '@angular/core';
+
+@Component({
+    template: '{{this.globalThis.Math.random()}}',
+})
+class Comp {
+  globalThis = globalThis;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/global_scope/this_globalThis_access_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/global_scope/this_globalThis_access_template.js
@@ -1,0 +1,1 @@
+this.globalThis.Math.random()

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -5252,6 +5252,28 @@ runInEachFileSystem((os: string) => {
       );
     });
 
+    it('should handle globalThis used inside a listener', () => {
+      env.write(
+        'test.ts',
+        `
+        import {Component} from '@angular/core';
+
+        @Component({
+          selector: 'test-cmp',
+          template: '<div (click)="foo = globalThis.Math.random()"></div>',
+        })
+        export class TestCmp {
+          foo=0
+        }
+    `,
+      );
+
+      env.driveMain();
+      expect(env.getContents('test.js')).toContain(
+        `ɵɵlistener("click", function TestCmp_Template_div_click_0_listener() { return ctx.foo = globalThis.Math.random(); });`,
+      );
+    });
+
     it('should accept dynamic host attribute bindings', () => {
       env.write(
         'other.d.ts',

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -83,6 +83,7 @@ import {wrapI18nIcus} from './phases/wrap_icus';
 import {optimizeStoreLet} from './phases/store_let_optimization';
 import {removeIllegalLetReferences} from './phases/remove_illegal_let_references';
 import {generateLocalLetReferences} from './phases/generate_local_let_references';
+import {accessGlobalScope} from './phases/global_scope_access';
 
 type Phase =
   | {
@@ -128,6 +129,7 @@ const phases: Phase[] = [
   {kind: Kind.Tmpl, fn: generateVariables},
   {kind: Kind.Tmpl, fn: saveAndRestoreView},
   {kind: Kind.Both, fn: deleteAnyCasts},
+  {kind: Kind.Both, fn: accessGlobalScope},
   {kind: Kind.Both, fn: resolveDollarEvent},
   {kind: Kind.Tmpl, fn: generateTrackVariables},
   {kind: Kind.Tmpl, fn: removeIllegalLetReferences},

--- a/packages/compiler/src/template/pipeline/src/phases/global_scope_access.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/global_scope_access.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import * as o from '../../../../output/output_ast';
+import * as ir from '../../ir';
+import {CompilationJob} from '../compilation';
+
+/**
+ * Find any access to `globalThis` and replace them with `globalThis` to allow global scope access
+ */
+export function accessGlobalScope(job: CompilationJob): void {
+  for (const unit of job.units) {
+    for (const op of unit.ops()) {
+      ir.transformExpressionsInOp(op, replaceGlobalThis, ir.VisitorContextFlag.None);
+    }
+  }
+}
+
+function replaceGlobalThis(expr: o.Expression): o.Expression {
+  if (expr instanceof ir.LexicalReadExpr && expr.name === 'globalThis') {
+    return new o.ReadVarExpr('globalThis');
+  }
+  return expr;
+}

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -858,6 +858,33 @@ describe('acceptance integration tests', () => {
       fixture.detectChanges();
       expect(stripHtmlComments(compElement.innerHTML)).toEqual('');
     });
+
+    it('should support accessing the globalScope', () => {
+      @Component({
+        template: '<div>{{globalThis.Math.max(0, 5)}}</div>',
+      })
+      class App {}
+
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+      const appElement = fixture.nativeElement;
+
+      expect(stripHtmlComments(appElement.innerHTML)).toEqual('<div>5</div>');
+    });
+
+    it('should support accessing the globalScope on event callbacks', () => {
+      @Component({
+        template: '<button (click)="value = globalThis.Math.max(0, value)">click me</button>',
+      })
+      class App {
+        value = -5;
+      }
+
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+      fixture.nativeElement.querySelector('button')!.click();
+      expect(fixture.componentInstance.value).toBe(0);
+    });
   });
 
   describe('element bindings', () => {


### PR DESCRIPTION
feat(compiler): Add support for the `globalThis` keyword to access global scope in template expressions
Usage example: 
* `{{ globalThis.Math.min(0, myValue) }}`
* `<button (click)="myValue = globalThis.Math.max(someValue, 0)"></button>`