### PR TITLE
refactor(migrations): improve control flow analysis for loops in signal migration

### DIFF
--- a/packages/core/schematics/migrations/signal-migration/src/passes/10_apply_import_manager.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/10_apply_import_manager.ts
@@ -10,7 +10,6 @@ import {ImportManager} from '@angular/compiler-cli/src/ngtsc/translator';
 import ts from 'typescript';
 import {applyImportManagerChanges} from '../../../../utils/tsurge/helpers/apply_import_manager';
 import {MigrationResult} from '../result';
-import {AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {ProgramInfo} from '../../../../utils/tsurge';
 
 /**

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/flow_cases.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/flow_cases.ts
@@ -1,0 +1,13 @@
+// tslint:disable
+
+import {Input} from '@angular/core';
+
+class Test {
+  @Input() maxCellsPerRow = 5;
+
+  private test(arr: string[]) {
+    for (let i = 0; i < arr.length; i += this.maxCellsPerRow) {
+      console.log(this.maxCellsPerRow);
+    }
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/flow_cases.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/flow_cases.ts
@@ -4,10 +4,14 @@ import {Input} from '@angular/core';
 
 class Test {
   @Input() maxCellsPerRow = 5;
+  @Input() maxCellsPerRow2 = 5;
 
   private test(arr: string[]) {
     for (let i = 0; i < arr.length; i += this.maxCellsPerRow) {
       console.log(this.maxCellsPerRow);
     }
   }
+
+  protected readonly test2 = this.maxCellsPerRow ? this.maxCellsPerRow === 3 : false;
+  protected readonly test3 = this.maxCellsPerRow2 === 3 ? true : false;
 }

--- a/packages/core/schematics/migrations/signal-migration/test/golden.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden.txt
@@ -368,6 +368,22 @@ import {Component, input} from '@angular/core';
 export class WithTemplate {
   readonly test = input(true);
 }
+@@@@@@ flow_cases.ts @@@@@@
+
+// tslint:disable
+
+import {input} from '@angular/core';
+
+class Test {
+  readonly maxCellsPerRow = input(5);
+
+  private test(arr: string[]) {
+    const maxCellsPerRow = this.maxCellsPerRow();
+    for (let i = 0; i < arr.length; i += maxCellsPerRow) {
+      console.log(maxCellsPerRow);
+    }
+  }
+}
 @@@@@@ getters.ts @@@@@@
 
 // tslint:disable

--- a/packages/core/schematics/migrations/signal-migration/test/golden.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden.txt
@@ -376,6 +376,7 @@ import {input} from '@angular/core';
 
 class Test {
   readonly maxCellsPerRow = input(5);
+  readonly maxCellsPerRow2 = input(5);
 
   private test(arr: string[]) {
     const maxCellsPerRow = this.maxCellsPerRow();
@@ -383,6 +384,10 @@ class Test {
       console.log(maxCellsPerRow);
     }
   }
+
+  private readonly maxCellsPerRowValue = this.maxCellsPerRow();
+  protected readonly test2 = this.maxCellsPerRowValue ? this.maxCellsPerRowValue === 3 : false;
+  protected readonly test3 = this.maxCellsPerRow2() === 3 ? true : false;
 }
 @@@@@@ getters.ts @@@@@@
 

--- a/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
@@ -352,6 +352,7 @@ import {input} from '@angular/core';
 
 class Test {
   readonly maxCellsPerRow = input(5);
+  readonly maxCellsPerRow2 = input(5);
 
   private test(arr: string[]) {
     const maxCellsPerRow = this.maxCellsPerRow();
@@ -359,6 +360,10 @@ class Test {
       console.log(maxCellsPerRow);
     }
   }
+
+  private readonly maxCellsPerRowValue = this.maxCellsPerRow();
+  protected readonly test2 = this.maxCellsPerRowValue ? this.maxCellsPerRowValue === 3 : false;
+  protected readonly test3 = this.maxCellsPerRow2() === 3 ? true : false;
 }
 @@@@@@ getters.ts @@@@@@
 

--- a/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
@@ -344,6 +344,22 @@ import {Component, input} from '@angular/core';
 export class WithTemplate {
   readonly test = input(true);
 }
+@@@@@@ flow_cases.ts @@@@@@
+
+// tslint:disable
+
+import {input} from '@angular/core';
+
+class Test {
+  readonly maxCellsPerRow = input(5);
+
+  private test(arr: string[]) {
+    const maxCellsPerRow = this.maxCellsPerRow();
+    for (let i = 0; i < arr.length; i += maxCellsPerRow) {
+      console.log(maxCellsPerRow);
+    }
+  }
+}
 @@@@@@ getters.ts @@@@@@
 
 // tslint:disable


### PR DESCRIPTION
Currently whenever we would come across a code snippet like this, where `maxCellsPerRow` is an input, the control flow analysis would fall apart because the first occurrence of the node points to a control flow node that is offset-wise "after" the first occurrence. This commit makes the logic more robust.