### PR TITLE
fix(elements): allow custom elements to be detached and reattached

### DIFF
--- a/packages/elements/src/component-factory-strategy.ts
+++ b/packages/elements/src/component-factory-strategy.ts
@@ -14,6 +14,7 @@ import {
   ComponentFactory,
   ComponentFactoryResolver,
   ComponentRef,
+  EmbeddedViewRef,
   EventEmitter,
   Injector,
   NgZone,
@@ -143,11 +144,48 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
       // Schedule the component to be destroyed after a small timeout in case it is being
       // moved elsewhere in the DOM
       this.scheduledDestroyFn = scheduler.schedule(() => {
+        this.scheduledDestroyFn = null;
         if (this.componentRef !== null) {
+          // Save old position of the element node, to maintain it attached even
+          // after the this.componentRef.destroy, that detach it from parent
+          const attachInfo = this.getElementAttachPoint();
+          // Prepare back properties from componentRef to `initialInputValues`
+          this.resetProperties();
           this.componentRef.destroy();
           this.componentRef = null;
+          // Reattach the destroyed empty html element to the parent
+          if (attachInfo) {
+            const {parent, viewNode, beforeOf} = attachInfo;
+            parent.insertBefore(viewNode, beforeOf);
+          }
         }
       }, DESTROY_DELAY);
+    });
+  }
+
+  /**
+   * Get the current attach point of the custom element and his position
+   */
+  private getElementAttachPoint():
+    | {parent: HTMLElement; viewNode: HTMLElement; beforeOf: ChildNode}
+    | undefined {
+    const hostView = this.componentRef!.hostView as EmbeddedViewRef<unknown>;
+    const viewNode = hostView?.rootNodes?.[0] as HTMLElement;
+    const parent = viewNode?.parentElement!;
+    if (!parent) {
+      return;
+    }
+    const index = parent && Array.from(parent.childNodes).indexOf(viewNode);
+    const beforeOf = parent && parent.childNodes.item(index + 1);
+    return {parent, viewNode, beforeOf};
+  }
+
+  /**
+   * Copy back live properties from the componentRef (about to be destroyed) to initialInputValues for future reattach
+   */
+  private resetProperties() {
+    this.componentFactory.inputs.forEach((input) => {
+      this.initialInputValues.set(input.propName, this.componentRef!.instance[input.propName]);
     });
   }
 

--- a/packages/elements/src/component-factory-strategy.ts
+++ b/packages/elements/src/component-factory-strategy.ts
@@ -25,6 +25,7 @@ import {
   ɵisViewDirty as isViewDirty,
   ɵmarkForRefresh as markForRefresh,
   OutputRef,
+  isSignal,
 } from '@angular/core';
 import {merge, Observable, ReplaySubject} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
@@ -185,7 +186,9 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
    */
   private resetProperties() {
     this.componentFactory.inputs.forEach((input) => {
-      this.initialInputValues.set(input.propName, this.componentRef!.instance[input.propName]);
+      let inputValue = this.getInputValue(input.propName);
+      inputValue = input.isSignal && isSignal(inputValue) ? inputValue() : inputValue;
+      this.initialInputValues.set(input.propName, inputValue);
     });
   }
 

--- a/packages/elements/test/reconnect_spec.ts
+++ b/packages/elements/test/reconnect_spec.ts
@@ -24,28 +24,22 @@ const tick = (ms: number) => {
 describe('Reconnect', () => {
   let testContainer: HTMLDivElement;
 
-  beforeAll((done) => {
+  beforeAll(async () => {
     testContainer = document.createElement('div');
     document.body.appendChild(testContainer);
-    destroyPlatform();
-    platformBrowser()
-      .bootstrapModule(TestModule)
-      .then((ref) => {
-        const injector = ref.injector;
-        const cfr: ComponentFactoryResolver = injector.get(ComponentFactoryResolver);
+    const ref = await platformBrowser().bootstrapModule(TestModule);
+    const injector = ref.injector;
+    const cfr: ComponentFactoryResolver = injector.get(ComponentFactoryResolver);
 
-        testElements.forEach((comp) => {
-          const compFactory = cfr.resolveComponentFactory(comp);
-          customElements.define(compFactory.selector, createCustomElement(comp, {injector}));
-        });
-      })
-      .then(done, done.fail);
+    testElements.forEach((comp) => {
+      const compFactory = cfr.resolveComponentFactory(comp);
+      customElements.define(compFactory.selector, createCustomElement(comp, {injector}));
+    });
   });
 
   afterAll(() => {
     destroyPlatform();
     testContainer.remove();
-    (testContainer as any) = null;
   });
 
   it('should be able to rebuild and reconnect after direct disconnection from parent', async () => {

--- a/packages/elements/test/reconnect_spec.ts
+++ b/packages/elements/test/reconnect_spec.ts
@@ -1,0 +1,196 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  Component,
+  ComponentFactoryResolver,
+  destroyPlatform,
+  Input,
+  NgModule,
+  ViewEncapsulation,
+} from '@angular/core';
+import {BrowserModule, platformBrowser} from '@angular/platform-browser';
+import {createCustomElement} from '../src/create-custom-element';
+
+const tick = (ms: number) => {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+};
+
+describe('Reconnect', () => {
+  let testContainer: HTMLDivElement;
+
+  beforeAll((done) => {
+    testContainer = document.createElement('div');
+    document.body.appendChild(testContainer);
+    destroyPlatform();
+    platformBrowser()
+      .bootstrapModule(TestModule)
+      .then((ref) => {
+        const injector = ref.injector;
+        const cfr: ComponentFactoryResolver = injector.get(ComponentFactoryResolver);
+
+        testElements.forEach((comp) => {
+          const compFactory = cfr.resolveComponentFactory(comp);
+          customElements.define(compFactory.selector, createCustomElement(comp, {injector}));
+        });
+      })
+      .then(done, done.fail);
+  });
+
+  afterAll(() => {
+    destroyPlatform();
+    testContainer.remove();
+    (testContainer as any) = null;
+  });
+
+  it('should be able to rebuild and reconnect after direct disconnection from parent', async () => {
+    // Create and attach it
+    const tpl = `<reconnect-el test-attr="a"></reconnect-el>`;
+    testContainer.innerHTML = tpl;
+    // Check that the Angular element was created and attributes are bound
+    expect(testContainer.querySelector('.test-attr-outlet')!.textContent).toBe('a');
+    // Check that the Angular element was bound to properties too
+    const testEl = testContainer.querySelector<Element & ReconnectTestComponentEl>('reconnect-el')!;
+    testEl.testProp = 'b';
+    // Wait change to be propagated
+    await tick(10);
+    expect(testContainer.querySelector('.test-prop-outlet')!.textContent).toBe('b');
+    // Now detach the element from the container
+    testContainer.removeChild(testEl);
+    // Wait for detach timer
+    await tick(10);
+    // Check that the web-element is orphan and the Angular Component is destroyed
+    expect(testEl.parentElement).toBeFalsy();
+    // Check property values to be maintained
+    expect(testEl.testProp).toBe('b');
+
+    // Now reattach root to testContainer
+    testContainer.appendChild(testEl);
+    // Check for re-render, but with the same instance of web-element
+    expect(
+      testContainer.querySelectorAll<Element & ReconnectTestComponentEl>('reconnect-el').length,
+    ).toBe(1);
+    expect(
+      testContainer.querySelectorAll<Element & ReconnectTestComponentEl>('.reconnect-el').length,
+    ).toBe(1);
+    expect(testContainer.querySelectorAll('.test-attr-outlet').length).toBe(1);
+    expect(testContainer.querySelectorAll('.test-prop-outlet').length).toBe(1);
+    expect(testContainer.querySelector('.test-attr-outlet')!.textContent).toBe('a');
+    expect(testContainer.querySelector('.test-prop-outlet')!.textContent).toBe('b');
+  });
+
+  it('should be able to rebuild and reconnect after indirect disconnection via parent node', async () => {
+    const tpl = `<div class="root"><reconnect-el test-attr="a"></reconnect-el></div>`;
+    testContainer.innerHTML = tpl;
+    const root = testContainer.querySelector<HTMLDivElement>('.root')!;
+    // Check that the Angular element was created and attributes are bound
+    expect(testContainer.querySelector('.test-attr-outlet')!.textContent).toBe('a');
+    // Check that the Angular element was bound to properties too
+    const testEl = testContainer.querySelector<Element & ReconnectTestComponentEl>('reconnect-el')!;
+    testEl.testProp = 'b';
+    // Wait change to be propagated
+    await tick(10);
+    expect(testContainer.querySelector('.test-prop-outlet')!.textContent).toBe('b');
+
+    // Now detach the root from the DOM
+    testContainer.removeChild(root);
+    // Wait for detach timer
+    await tick(10);
+    // Check that the web-element is still under root, but the Angular Component is destroyed
+    expect(testEl.parentElement).toBe(root);
+    // Check property values to be maintained
+    expect(testEl.testProp).toBe('b');
+
+    // Now reattach root to testContainer
+    testContainer.appendChild(root);
+    // Check for re-render, but with the same instance of web-element
+    expect(testContainer.querySelector<Element & ReconnectTestComponentEl>('reconnect-el')).toBe(
+      testEl,
+    );
+    expect(
+      testContainer.querySelectorAll<Element & ReconnectTestComponentEl>('reconnect-el').length,
+    ).toBe(1);
+    expect(
+      testContainer.querySelectorAll<Element & ReconnectTestComponentEl>('.reconnect-el').length,
+    ).toBe(1);
+    expect(testContainer.querySelectorAll('.test-attr-outlet').length).toBe(1);
+    expect(testContainer.querySelectorAll('.test-prop-outlet').length).toBe(1);
+    expect(testContainer.querySelector('.test-attr-outlet')!.textContent).toBe('a');
+    expect(testContainer.querySelector('.test-prop-outlet')!.textContent).toBe('b');
+  });
+
+  it('should be able to rebuild and reconnect after indirect disconnection via parent node, with slots', async () => {
+    const tpl = `<div class="root"><reconnect-slotted-el><span class="projected"></span></reconnect-slotted-el></div>`;
+    testContainer.innerHTML = tpl;
+    const root = testContainer.querySelector<HTMLDivElement>('.root')!;
+    const testEl = testContainer.querySelector('reconnect-slotted-el')!;
+
+    // Check that the Angular element was created and slots are projected
+    {
+      const content = testContainer.querySelector('span.projected')!;
+      const slot = testEl.shadowRoot!.querySelector('slot') as HTMLSlotElement;
+      const assignedNodes = slot.assignedNodes();
+      expect(assignedNodes[0]).toBe(content);
+    }
+
+    // Now detach the root from the DOM
+    testContainer.removeChild(root);
+    // Wait for detach timer
+    await tick(10);
+
+    // Check that the web-element is still under root, but the Angular Component is destroyed
+    expect(testEl.parentElement).toBe(root);
+
+    // Now reattach root to testContainer
+    testContainer.appendChild(root);
+    // Check for re-render, but with the same instance of web-element
+    expect(testContainer.querySelectorAll('reconnect-slotted-el').length).toBe(1);
+    expect(testEl.shadowRoot!.querySelectorAll('.reconnect-slotted-el').length).toBe(1);
+
+    // Check that the Angular element was re-created and slots are still projected
+    {
+      const content = testContainer.querySelector('span.projected')!;
+      const slot = testEl.shadowRoot!.querySelector('slot') as HTMLSlotElement;
+      const assignedNodes = slot.assignedNodes();
+      expect(assignedNodes[0]).toBe(content);
+    }
+  });
+});
+
+interface ReconnectTestComponentEl {
+  testProp: string;
+}
+
+@Component({
+  selector: 'reconnect-el',
+  template:
+    '<div class="reconnect-el"><p class="test-prop-outlet">{{testProp}}</p><p class="test-attr-outlet">{{testAttr}}</p></div>',
+  standalone: false,
+})
+class ReconnectTestComponent implements ReconnectTestComponentEl {
+  @Input() testAttr: string = '';
+  @Input() testProp: string = '';
+  constructor() {}
+}
+
+@Component({
+  selector: 'reconnect-slotted-el',
+  template: '<div class="reconnect-slotted-el"><slot></slot></div>',
+  encapsulation: ViewEncapsulation.ShadowDom,
+  standalone: false,
+})
+class ReconnectSlottedTestComponent {
+  constructor() {}
+}
+
+const testElements = [ReconnectTestComponent, ReconnectSlottedTestComponent];
+
+@NgModule({imports: [BrowserModule], declarations: testElements})
+class TestModule {
+  ngDoBootstrap() {}
+}

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -522,7 +522,14 @@ class ShadowDomRenderer extends DefaultDomRenderer2 {
     private sharedStylesHost?: SharedStylesHost,
   ) {
     super(eventManager, doc, ngZone, platformIsServer, tracingService);
-    this.shadowRoot = (hostEl as any).attachShadow({mode: 'open'});
+    this.shadowRoot = (hostEl as Element).shadowRoot;
+    if (!this.shadowRoot) {
+      this.shadowRoot = (hostEl as Element).attachShadow({mode: 'open'});
+    } else {
+      // In case of custom elements, it is possible that the host element was already initialized during the
+      // element life-cycle (after a disconnect/reconnect)
+      this.shadowRoot.innerHTML = '';
+    }
 
     // SharedStylesHost is used to add styles to the shadow root by ShadowDom.
     // This is optional as it is not used by IsolatedShadowDom.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The commit fixes the issue #38778, allowing a HTML custom element defined via `angular/elements` to be disconnected from the DOM for indefinite time and then re-connected without breaking it.

The current behavior (correctly) destroys the Angular component after 10ms of grace time after receiving the disconnected event. This event can be called if the element is directly disconnected from his parent, or even when a larger DOM tree is disconnected and "parked" in memory for future reattach.

Since the mission of the Angular custom element support is to adhere to the W3C standards and write completely reusable Angular component for interoperability with other frameworks, it can be expected that detached DOM structures that contains a Angular element would be working even after reattaching the tree later on.

Destroying the Angular component when the HTML element is disconnected is correct, since it correctly frees all the resources and allow GC reclaiming of the orphan node.

However the current behavior of the `componentRef.destroy()` is to detach the Element node from his parent. This causes the issue, since the whole tree - when re-connected back later on - won't contain the custom element anymore, causing the issue.

Simply letting the `NgElementImpl` instance to remain attached to his parent mainly fixes the issue of the missing connected callback not called.

Rather than trying to allow a "non-detaching" version of `destroy()`, the proposed fix simply reattach the HTML Custom Element instance back to the DOM in the original position immediately after the `componentRef.destroy()`. This limits the fix to the `elements` package only. I'm not sure if there are some internal utilities to save/restore a node position in the DOM tree, so I used low-level DOM calls to do that.

```ts
          // Save old position of the element node, to maintain it attached even
          // after the this.componentRef.destroy, that detach it from parent
          const attachInfo = this.getElementAttachPoint();

          this.componentRef.destroy();
          this.componentRef = null;

          // Reattach the destroyed empty html element to the parent
          if (attachInfo) {
            const { parent, viewNode, beforeOf } = attachInfo;
            parent.insertBefore(viewNode, beforeOf);
         }          
```

When the node will receive the "connected" event again later, the Angular component should be able to be recreated again from scratch, using the element properties and attributes, exactly like it was the first initialization. The extensive unit test suite already in `elements` is clear about the intent of element reuse, so the fix looks legit.

However, an additional fix is required to let the custom element to not lose the property values. The hosting framework will probably expect the custom element properties to remain in sync, considering the HTML Element implementation as a black box. This is something probably not fully documented in the W3C specs, but when disconnected a custom element should ideally retain his public property values like any other `HTMLElement` instance.

For that, I added a function to copy back input property values from the Component instance to `initialInputValues` immediately before the destruction. I foresee some possible issue about the inputs that uses the `transform` callback.

```ts
  private resetProperties() {
    this.componentFactory.inputs.forEach(input => {
      this.initialInputValues.set(input.propName, this.componentRef!.instance[input.propName]);
    })
  }
```

I don't see any inverted transform function available for inputs, so if we want 100% be sure that the properties are stored back properly the only working solution is to keep the  `initialInputValues` set always in sync with the passed values (the risk in that case is to use more memory for properties that are supposed to only store volatile data decoded on-the-fly by the input).

Last line changed is in `platform-browser`, unfortunately, since the `ShadowDomRendered` must cope with the Element reuse in case of later reconnection. It seems that the W3C specs don't allow `shadowRoot` to be destroyed and then recreated, so the `attachShadow` would raise an exception if called on a element with already a shadow root present. 

The proposed fix there requires a clear of the node content in case of reuse, otherwise duplicated nodes can be created (at least this happened in my tests).

```ts
    if (!this.shadowRoot) {
      this.shadowRoot = (hostEl as Element).attachShadow({mode: 'open'});
    } else {
      // In case of custom elements, it is possible that the host element was already initialized during the
      // element life-cycle (after a disconnect/reconnect)
      this.shadowRoot.innerHTML = "";
    }
```

I've added an additional integration test `reconnect_spec.ts` to test the following cases:

* Direct disconnect/reconnect of the custom element node
* Indirect disconnect/reconnect via disconnection from parent node
* Test of components with shadow DOM and slots.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
- [x] Not sure

I don't know how many Angular features can break this fix, since a complete coverage for Angular components should be tested in the `elements` module.

However I don't expect regressions, since the current issue doesn't allow the nodes to be reused at all at the moment.

## Different fix approaches

In order to avoid potential regressions due to the change, the fix could be introduced in different ways:

### Setting

It should be possible to enable/disable such behavior via some setting exposed in the `NgElementConfig`. This would require some little documentation of the current behavior and the new one, to allow backward compatibility.

### Inheritance

The current public `NgElementStrategy` interface is more or less enough to implement an alternative version of `ComponentNgElementStrategy` with the fix, directly in the app.
However this requires ~500 LOC to be copy/pasted in the app, and this is obviously subject to future fixes/evolutions, due to fact that these classes are mainly the core of `angular/elements`.

A viable intermediate solution is to expose the `ComponentNgElementStrategy` in public API as default implementation, to allow:

* override of the destroy behavior
* or exposing flags.

However this solution will require - again - quite extensive documentation of the current internal behavior.

Thanks, L


