### PR TITLE
feat(compiler): Add support for multiple conditions for cases in switch control flow

### DIFF
--- a/adev/src/content/guide/templates/control-flow.md
+++ b/adev/src/content/guide/templates/control-flow.md
@@ -103,7 +103,7 @@ While the `@if` block is great for most scenarios, the `@switch` block provides 
 
 ```angular-html
 @switch (userPermissions) {
-  @case ('admin') {
+  @case ('admin'; 'super-admin') {
     <app-admin-dashboard />
   }
   @case ('reviewer') {
@@ -118,7 +118,9 @@ While the `@if` block is great for most scenarios, the `@switch` block provides 
 }
 ```
 
-The value of the conditional expression is compared to the case expression using the triple-equals (`===`) operator.
+The value of the conditional expression is compared to the case expressions using the triple-equals (`===`) operator.
+
+You may provide multiple case expressions in a single `@case` block by separating each case by `;`.
 
 **`@switch` does not have a fallthrough**, so you do not need an equivalent to a `break` or `return` statement in the block.
 

--- a/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
@@ -327,7 +327,7 @@ class TemplateVisitor extends TmplAstRecursiveVisitor {
   }
 
   override visitSwitchBlockCase(block: TmplAstSwitchBlockCase) {
-    block.expression && this.visitExpression(block.expression);
+    block.expressions && block.expressions.forEach((expr) => this.visitExpression(expr));
     this.visitAll(block.children);
   }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/api/api.ts
@@ -261,7 +261,7 @@ class TemplateVisitor<Code extends ErrorCode>
   }
 
   visitSwitchBlockCase(block: TmplAstSwitchBlockCase): void {
-    block.expression && this.visitAst(block.expression);
+    block.expressions && block.expressions.forEach((expr) => this.visitAst(expr));
     this.visitAllNodes(block.children);
   }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1860,6 +1860,29 @@ describe('type check blocks', () => {
       );
     });
 
+    it('should generate a switch block with multiple cases', () => {
+      const TEMPLATE = `
+        @switch (expr) {
+          @case (1) {
+            {{one()}}
+          }
+          @case (2; 3) {
+            {{twoOrThree()}}
+          }
+          @default {
+            {{default()}}
+          }
+        }
+      `;
+
+      expect(tcb(TEMPLATE)).toContain(
+        'switch (((this).expr)) { ' +
+          'case 1: "" + ((this).one()); break; ' +
+          'case 2: case 3: "" + ((this).twoOrThree()); break; ' +
+          'default: "" + ((this).default()); break; }',
+      );
+    });
+
     it('should handle an empty switch block', () => {
       expect(tcb('@switch (expr) {}')).toContain('if (true) { switch (((this).expr)) { } }');
     });

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
@@ -335,6 +335,68 @@ export declare class MyApp {
 }
 
 /****************************************************************************************************
+ * PARTIAL FILE: switch_with_multi_case.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+        this.value = () => 1;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: false, selector: "ng-component", ngImport: i0, template: `
+    <div>
+      {{message}}
+      @switch (value()) {
+        @case (0; 1; 2) {
+          case 0, 1, or 2
+        }
+        @case (3) {
+          case 3
+        }
+        @case (4) {
+          case 4
+        }
+      }
+    </div>
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <div>
+      {{message}}
+      @switch (value()) {
+        @case (0; 1; 2) {
+          case 0, 1, or 2
+        }
+        @case (3) {
+          case 3
+        }
+        @case (4) {
+          case 4
+        }
+      }
+    </div>
+  `,
+                    standalone: false
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: switch_with_multi_case.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    message: string;
+    value: () => number;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+
+/****************************************************************************************************
  * PARTIAL FILE: basic_if.js
  ****************************************************************************************************/
 import { Component } from '@angular/core';

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
@@ -77,6 +77,21 @@
       ]
     },
     {
+      "description": "should generate code for switch blocks containing a case with multiple guards",
+      "inputFiles": ["switch_with_multi_case.ts"],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "switch_with_multi_case_template.js",
+              "generated": "switch_with_multi_case.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ]
+    },
+    {
       "description": "should generate a basic if block",
       "inputFiles": ["basic_if.ts"],
       "expectations": [

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_with_multi_case.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_with_multi_case.ts
@@ -1,0 +1,25 @@
+import {Component} from '@angular/core';
+
+@Component({
+    template: `
+    <div>
+      {{message}}
+      @switch (value()) {
+        @case (0; 1; 2) {
+          case 0, 1, or 2
+        }
+        @case (3) {
+          case 3
+        }
+        @case (4) {
+          case 4
+        }
+      }
+    </div>
+  `,
+    standalone: false
+})
+export class MyApp {
+  message = 'hello';
+  value = () => 1;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_with_multi_case_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_with_multi_case_template.js
@@ -1,0 +1,33 @@
+function MyApp_Case_2_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " case 0, 1, or 2 ");
+  }
+}
+
+function MyApp_Case_3_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " case 3 ");
+  }
+}
+
+function MyApp_Case_4_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " case 4 ");
+  }
+}
+…
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵelementStart(0, "div");
+    $r3$.ɵɵtext(1);
+    $r3$.ɵɵtemplate(2, MyApp_Case_2_Template, 1, 0)(3, MyApp_Case_3_Template, 1, 0)(4, MyApp_Case_4_Template, 1, 0);
+    $r3$.ɵɵelementEnd();
+  }
+  if (rf & 2) {
+    let $MyApp_contFlowTmp$;
+    $r3$.ɵɵadvance();
+    $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
+    $r3$.ɵɵadvance();
+    $r3$.ɵɵconditional(($MyApp_contFlowTmp$ = ctx.value()) === 0 ? 2 : $MyApp_contFlowTmp$ === 1 ? 2 : $MyApp_contFlowTmp$ === 2 ? 2 : $MyApp_contFlowTmp$ === 3 ? 3 : $MyApp_contFlowTmp$ === 4 ? 4 : -1);
+  }
+}

--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -231,7 +231,7 @@ class _Tokenizer {
           }
         } else if (
           this._tokenizeLet &&
-          // Use `peek` instead of `attempCharCode` since we
+          // Use `peek` instead of `attemptCharCode` since we
           // don't want to advance in case it's not `@let`.
           this._cursor.peek() === chars.$AT &&
           !this._inInterpolation &&

--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -420,7 +420,7 @@ export class SwitchBlock extends BlockNode implements Node {
 
 export class SwitchBlockCase extends BlockNode implements Node {
   constructor(
-    public expression: AST | null,
+    public expressions: AST[] | null,
     public children: Node[],
     sourceSpan: ParseSourceSpan,
     startSourceSpan: ParseSourceSpan,

--- a/packages/compiler/src/render3/r3_control_flow.ts
+++ b/packages/compiler/src/render3/r3_control_flow.ts
@@ -239,10 +239,18 @@ export function createSwitchBlock(
       continue;
     }
 
-    const expression =
-      node.name === 'case' ? parseBlockParameterToBinding(node.parameters[0], bindingParser) : null;
+    let expressions: ASTWithSource[] | null;
+
+    if (node.name === 'case') {
+      expressions = node.parameters.map((param) =>
+        parseBlockParameterToBinding(param, bindingParser),
+      );
+    } else {
+      expressions = null;
+    }
+
     const ast = new t.SwitchBlockCase(
-      expression,
+      expressions,
       html.visitAll(visitor, node.children, node.children),
       node.sourceSpan,
       node.startSourceSpan,
@@ -251,7 +259,7 @@ export function createSwitchBlock(
       node.i18n,
     );
 
-    if (expression === null) {
+    if (expressions === null) {
       defaultCase = ast;
     } else {
       cases.push(ast);
@@ -542,9 +550,9 @@ function validateSwitchBlock(ast: html.Block): ParseError[] {
         errors.push(new ParseError(node.startSourceSpan, '@default block cannot have parameters'));
       }
       hasDefault = true;
-    } else if (node.name === 'case' && node.parameters.length !== 1) {
+    } else if (node.name === 'case' && node.parameters.length === 0) {
       errors.push(
-        new ParseError(node.startSourceSpan, '@case block must have exactly one parameter'),
+        new ParseError(node.startSourceSpan, '@case block must have at least one parameter'),
       );
     }
   }

--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -838,7 +838,7 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
   }
 
   visitSwitchBlockCase(block: SwitchBlockCase) {
-    block.expression?.visit(this);
+    block.expressions?.forEach((expr) => expr.visit(this));
     this.ingestScopedNode(block);
   }
 

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -556,15 +556,19 @@ function ingestSwitchBlock(unit: ViewCompilationUnit, switchBlock: t.SwitchBlock
     if (firstXref === null) {
       firstXref = cView.xref;
     }
-    const caseExpr = switchCase.expression
-      ? convertAst(switchCase.expression, unit.job, switchBlock.startSourceSpan)
-      : null;
-    const conditionalCaseExpr = new ir.ConditionalCaseExpr(
-      caseExpr,
-      templateOp.xref,
-      templateOp.handle,
-    );
-    conditions.push(conditionalCaseExpr);
+    if (switchCase.expressions === null) {
+      conditions.push(new ir.ConditionalCaseExpr(null, templateOp.xref, templateOp.handle));
+    } else {
+      for (const expr of switchCase.expressions) {
+        const caseExpr = convertAst(expr, unit.job, switchBlock.startSourceSpan);
+        const conditionalCaseExpr = new ir.ConditionalCaseExpr(
+          caseExpr,
+          templateOp.xref,
+          templateOp.handle,
+        );
+        conditions.push(conditionalCaseExpr);
+      }
+    }
     ingestNodes(cView, switchCase.children);
   }
   unit.update.push(

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -182,7 +182,7 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
   }
 
   visitSwitchBlockCase(block: t.SwitchBlockCase) {
-    block.expression?.visit(this);
+    block.expressions?.forEach((expr) => expr.visit(this));
     t.visitAll(this, block.children);
   }
 

--- a/packages/core/schematics/migrations/signal-migration/src/passes/reference_resolution/template_reference_visitor.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/reference_resolution/template_reference_visitor.ts
@@ -187,11 +187,14 @@ export class TemplateReferenceVisitor<
   }
 
   override visitSwitchBlockCase(block: TmplAstSwitchBlockCase): void {
-    if (block.expression) {
-      const referencedFields = this.checkExpressionForReferencedFields(block, block.expression);
-      this.descendAndCheckForNarrowedSimilarReferences(referencedFields, () => {
-        super.visitSwitchBlockCase(block);
-      });
+    if (block.expressions) {
+      for (let i = 0; i < block.expressions.length; i++) {
+        const expression = block.expressions[i];
+        const referencedFields = this.checkExpressionForReferencedFields(block, expression);
+        this.descendAndCheckForNarrowedSimilarReferences(referencedFields, () => {
+          super.visitSwitchBlockCase(block);
+        });
+      }
     } else {
       super.visitSwitchBlockCase(block);
     }

--- a/packages/language-service/src/template_target.ts
+++ b/packages/language-service/src/template_target.ts
@@ -583,7 +583,7 @@ class TemplateTargetVisitor implements TmplAstVisitor {
   }
 
   visitSwitchBlockCase(block: TmplAstSwitchBlockCase) {
-    block.expression && this.visitBinding(block.expression);
+    block.expressions && block.expressions.forEach((expr) => this.visitBinding(expr));
     this.visitAll(block.children);
   }
 

--- a/tools/manual_api_docs/blocks/switch.md
+++ b/tools/manual_api_docs/blocks/switch.md
@@ -10,6 +10,9 @@ The `@switch` block is inspired by the JavaScript `switch` statement:
   @case (caseB) {
     Case B.
   }
+  @case (caseC; caseD) {
+    Case C or Case D.
+  }
   @default {
     Default case.
   }
@@ -19,8 +22,10 @@ The `@switch` block is inspired by the JavaScript `switch` statement:
 ## Description
 
 The `@switch` blocks displays content selected by one of the cases matching against the conditional
-expression. The value of the conditional expression is compared to the case expression using
+expression. The value of the conditional expression is compared to the case expressions using
 the `===` operator.
+
+You may provide multiple case expressions in a single `@case` block by separating each case by `;`.
 
 The `@default` block is optional and can be omitted. If no `@case` matches the expression and there
 is no `@default` block, nothing is shown.


### PR DESCRIPTION
Currently, the @switch/@case syntax is fairly limited, as cases may only have one guard. This often requires to either copy paste the body of the case-block or to refactor code to use @if / @else if syntax instead. This adds support for the highly requested feature of being able to define multiple guards to a single @case using the syntax @case(a; b; c)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
You can't have multiple conditions in a single case block.

Issue Number: #14659


## What is the new behavior?
Now you can

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I'm not certain if other tests are needed.

I made a few tests building this locally and this all works:
```
@Component({
  selector: 'app-root',
  standalone: true,
  template: `@switch (myVar) {
  @case (1; 2) {
    <div>{{myVar}}</div>
  }

  @default {
    <div>Default {{myVar}}</div>
  }
}
`,
  styleUrl: './app.component.scss'
})
export class AppComponent {
  myVar: number = 2; // replace by whatever you want

  public addOne() {
    this.myVar++;
  }
}
```

This does accurately not compile:
```
@Component({
  selector: 'app-root',
  standalone: true,
  template: `@switch (myVar) {
    @case (1) {
      <div>{{myVar}}</div>
    }

    @case (2; 3) {
      <div>{{myVar}}</div>
    }

    @default {
      <div>Default {{myVar}}</div>
    }
}
`,
  styleUrl: './app.component.scss'
})
export class AppComponent {
  myVar: 1 | 2 = 1;

  public addOne() {
    this.myVar++;
  }
}

```

```

Application bundle generation failed. [0.065 seconds]

X [ERROR] NG8: Type '3' is not comparable to type '1 | 2'. [plugin angular-compiler]

    src/app/app.component.ts:11:14:
      11 │     @case (2; 3) {
         ╵               ^



```