### PR TITLE
refactor(migrations): handle fake async catalyst

### DIFF
--- a/packages/core/schematics/ng-generate/standalone-migration/to-standalone.ts
+++ b/packages/core/schematics/ng-generate/standalone-migration/to-standalone.ts
@@ -602,7 +602,11 @@ function findNgModuleClassesToMigrate(sourceFile: ts.SourceFile, typeChecker: ts
 export function findTestObjectsToMigrate(sourceFile: ts.SourceFile, typeChecker: ts.TypeChecker) {
   const testObjects: ts.ObjectLiteralExpression[] = [];
   const testBedImport = getImportSpecifier(sourceFile, '@angular/core/testing', 'TestBed');
-  const catalystImport = getImportSpecifier(sourceFile, /testing\/catalyst$/, 'setupModule');
+  const catalystImport = getImportSpecifier(
+    sourceFile,
+    /testing\/catalyst(\/(fake_)?async)?$/,
+    'setupModule',
+  );
 
   if (testBedImport || catalystImport) {
     sourceFile.forEachChild(function walk(node) {


### PR DESCRIPTION
Fixes that the standalone migration wasn't handling the `fake_async` path for Catalyst.