### PR TITLE
refactor(core): introduce `TracingService` for snapshot-based tracing

### DIFF
--- a/packages/core/src/application/tracing.ts
+++ b/packages/core/src/application/tracing.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {InjectionToken} from '../di/injection_token';
+
+/**
+ * Injection token for a `TracingService`, optionally provided.
+ */
+export const TracingService = new InjectionToken<TracingService<unknown>>('');
+
+/**
+ * Tracing mechanism which can associate causes (snapshots) with runs of subsequent operations.
+ *
+ * Not defined by Angular directly, but defined in contexts where tracing is desired.
+ */
+export interface TracingService<TSnapshot> {
+  /**
+   * Take a snapshot of the current context which will be stored by Angular and used when additional
+   * work is performed that was scheduled in this context.
+   */
+  snapshot(): TSnapshot;
+
+  /**
+   * Invoke `fn` within the given tracing snapshot, which may be `undefined`.
+   *
+   * This _must_ return the result of the function invocation.
+   */
+  run<T>(fn: () => T, snapshot: TSnapshot | undefined): T;
+}

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -17,6 +17,7 @@ export {
   IMAGE_CONFIG_DEFAULTS as ɵIMAGE_CONFIG_DEFAULTS,
   ImageConfig as ɵImageConfig,
 } from './application/application_tokens';
+export {TracingService as ɵTracingService} from './application/tracing';
 export {internalCreateApplication as ɵinternalCreateApplication} from './application/create_application';
 export {
   defaultIterableDiffers as ɵdefaultIterableDiffers,

--- a/packages/core/src/render3/after_render/hooks.ts
+++ b/packages/core/src/render3/after_render/hooks.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {TracingService} from '../../application/tracing';
 import {assertInInjectionContext} from '../../di';
 import {Injector} from '../../di/injector';
 import {inject} from '../../di/injector_compatibility';
@@ -454,6 +455,8 @@ function afterRenderImpl(
   // tree-shaken if `afterRender` and `afterNextRender` aren't used.
   manager.impl ??= injector.get(AfterRenderImpl);
 
+  const tracing = injector.get(TracingService, null, {optional: true});
+
   const hooks = options?.phase ?? AfterRenderPhase.MixedReadWrite;
   const destroyRef = options?.manualCleanup !== true ? injector.get(DestroyRef) : null;
   const sequence = new AfterRenderSequence(
@@ -461,6 +464,7 @@ function afterRenderImpl(
     getHooks(callbackOrSpec, hooks),
     once,
     destroyRef,
+    tracing?.snapshot(),
   );
   manager.impl.register(sequence);
   return sequence;

--- a/packages/core/src/render3/after_render/manager.ts
+++ b/packages/core/src/render3/after_render/manager.ts
@@ -16,6 +16,7 @@ import {
   NotificationSource,
 } from '../../change_detection/scheduling/zoneless_scheduling';
 import {type DestroyRef} from '../../linker/destroy_ref';
+import {TracingService} from '../../application/tracing';
 
 export class AfterRenderManager {
   impl: AfterRenderImpl | null = null;
@@ -44,6 +45,7 @@ export class AfterRenderImpl {
   private readonly ngZone = inject(NgZone);
   private readonly scheduler = inject(ChangeDetectionScheduler);
   private readonly errorHandler = inject(ErrorHandler, {optional: true});
+  private readonly tracing = inject(TracingService, {optional: true});
 
   /** Current set of active sequences. */
   private readonly sequences = new Set<AfterRenderSequence>();
@@ -68,7 +70,10 @@ export class AfterRenderImpl {
 
         try {
           sequence.pipelinedValue = this.ngZone.runOutsideAngular(() =>
-            sequence.hooks[phase]!(sequence.pipelinedValue),
+            this.maybeTrace(
+              () => sequence.hooks[phase]!(sequence.pipelinedValue),
+              sequence.snapshot,
+            ),
           );
         } catch (err) {
           sequence.erroredOrDestroyed = true;
@@ -124,6 +129,11 @@ export class AfterRenderImpl {
     }
   }
 
+  protected maybeTrace<T>(fn: () => T, snapshot: unknown): T {
+    // Only trace the execution if the snapshot is defined.
+    return this.tracing && snapshot ? this.tracing.run(fn, snapshot) : fn();
+  }
+
   /** @nocollapse */
   static ɵprov = /** @pureOrBreakMyCode */ /* @__PURE__ */ ɵɵdefineInjectable({
     token: AfterRenderImpl,
@@ -160,6 +170,7 @@ export class AfterRenderSequence implements AfterRenderRef {
     readonly hooks: AfterRenderHooks,
     public once: boolean,
     destroyRef: DestroyRef | null,
+    public snapshot: unknown,
   ) {
     this.unregisterOnDestroy = destroyRef?.onDestroy(() => this.destroy());
   }
@@ -167,6 +178,11 @@ export class AfterRenderSequence implements AfterRenderRef {
   afterRun(): void {
     this.erroredOrDestroyed = false;
     this.pipelinedValue = undefined;
+
+    // Clear the tracing snapshot after the initial run. This snapshot only associates the initial
+    // run of the hook with the context that created it. Follow-up runs are independent of that
+    // initial context and have different triggers.
+    this.snapshot = undefined;
   }
 
   destroy(): void {


### PR DESCRIPTION
This commit introduces a private API, the `TracingService` DI token. By providing this token, Angular can be configured to capture tracing snapshots for certain operations such as change detection notifications, and to run downstream operations within the context of those snapshots. `TracingService` abstracts this context propagation and makes it pluggable.