### PR TITLE
refactor(language-service): suppress inline TCB required diagnostic for syncs

### DIFF
--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -60,6 +60,7 @@ const enableG3Suppression = false;
 // See `angular2/copy.bara.sky` for more information.
 const suppressDiagnosticsInG3: number[] = [
   parseInt(`-99${ErrorCode.COMPONENT_RESOURCE_NOT_FOUND}`),
+  parseInt(`-99${ErrorCode.INLINE_TCB_REQUIRED}`),
 ];
 
 export class LanguageService {


### PR DESCRIPTION
The NG8900 diagnostic is a non-actionable error code that does not affect the build result of a component.