### PR TITLE
Replace leftover modules with exports in tests

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
@@ -169,7 +169,7 @@ export interface TemplateTypeChecker {
    */
   getPotentialImportsFor(
     toImport: Reference<ClassDeclaration>,
-    inComponent: ts.ClassDeclaration,
+    inContext: ts.Node,
     importMode: PotentialImportMode,
   ): ReadonlyArray<PotentialImport>;
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -846,7 +846,7 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
   private emit(
     kind: PotentialImportKind,
     refTo: Reference<ClassDeclaration>,
-    inContext: ts.ClassDeclaration,
+    inContext: ts.Node,
   ): PotentialImport | null {
     const emittedRef = this.refEmitter.emit(refTo, inContext.getSourceFile());
     if (emittedRef.kind === ReferenceEmitKind.Failed) {
@@ -889,7 +889,7 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
 
   getPotentialImportsFor(
     toImport: Reference<ClassDeclaration>,
-    inContext: ts.ClassDeclaration,
+    inContext: ts.Node,
     importMode: PotentialImportMode,
   ): ReadonlyArray<PotentialImport> {
     const imports: PotentialImport[] = [];

--- a/packages/core/schematics/ng-generate/standalone-migration/standalone-bootstrap.ts
+++ b/packages/core/schematics/ng-generate/standalone-migration/standalone-bootstrap.ts
@@ -16,7 +16,7 @@ import {getAngularDecorators} from '../../utils/ng_decorators';
 import {closestNode} from '../../utils/typescript/nodes';
 
 import {
-  ComponentImportsRemapper,
+  DeclarationImportsRemapper,
   convertNgModuleDeclarationToStandalone,
   extractDeclarationsFromModule,
   findTestObjectsToMigrate,
@@ -59,7 +59,7 @@ export function toStandaloneBootstrap(
   printer: ts.Printer,
   importRemapper?: ImportRemapper,
   referenceLookupExcludedFiles?: RegExp,
-  componentImportRemapper?: ComponentImportsRemapper,
+  declarationImportRemapper?: DeclarationImportsRemapper,
 ) {
   const tracker = new ChangeTracker(printer, importRemapper);
   const typeChecker = program.getTsProgram().getTypeChecker();
@@ -121,7 +121,7 @@ export function toStandaloneBootstrap(
       allDeclarations,
       tracker,
       templateTypeChecker,
-      componentImportRemapper,
+      declarationImportRemapper,
     );
   }
 


### PR DESCRIPTION
Includes the following changes in an attempt to keep more tests working in the standalone migration:

### refactor(compiler-cli): broaden type of getPotentialImportsFor 
Currently the `getPotentialImportsFor` only accepts a `ClassDeclaration` as the context for generating an import, but that's not necessary because it doesn't require any class-specific information. These changes expand it to any `Node` so that it can be used when generating imports in testing declarations.

### fix(migrations): replace removed NgModules in tests with their exports 
In #57684 the standalone migration was changed so that it replaces any leftover modules with their `exports`, in an attempt to preserve more working code. These changes expand that logic to also cover tests since it's somewhat common internally to only import a component's module without having any references to the component.

Note that tests are a bit of a special case, because we don't have access to the template type checker, so instead we copy over all of the `exports` of that module.