### PR TITLE
fix(migrations): include the output migration in the defaults of the signal migration

### DIFF
--- a/packages/core/schematics/ng-generate/signals/schema.json
+++ b/packages/core/schematics/ng-generate/signals/schema.json
@@ -8,6 +8,7 @@
       "type": "array",
       "default": [
         "inputs",
+        "outputs",
         "queries"
       ],
       "items": {


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Running `ng g @angular/core:signals` prompts for the question on which migration to run and offers 3 options (inputs, outputs, queries). Running with `--defaults` skips the prompts, but only runs 2 of them. 

## What is the new behavior?

This fixes it by including the `outputs` migration in the default ones.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
