### PR TITLE
refactor(migrations): typos in signal migration incompatibility reasons

### DIFF
--- a/packages/core/schematics/migrations/signal-migration/src/passes/problematic_patterns/incompatibility_human.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/problematic_patterns/incompatibility_human.ts
@@ -50,7 +50,7 @@ export function getMessageForFieldIncompatibility(
           `This ${fieldName.single} is used in combination with \`@HostBinding\` and ` +
           `migrating would break.`,
         extra:
-          `\`@HostBinding\` does not invoke the signal automatically and your code would. ` +
+          `\`@HostBinding\` does not invoke the signal automatically and your code would ` +
           `break after migration. Use \`host\` of \`@Directive\`/\`@Component\`for host bindings.`,
       };
     case FieldIncompatibilityReason.PotentiallyNarrowedInTemplateButNoSupportYet:
@@ -144,7 +144,7 @@ export function getMessageForClassIncompatibility(
       return {
         short:
           `Class of this ${fieldName.single} is manually instantiated. ` +
-          'This is discouraged and prevents migration',
+          'This is discouraged and prevents migration.',
         extra:
           `Signal ${fieldName.plural} require a DI injection context. Manually instantiating ` +
           'breaks this requirement in some cases, so the migration is skipped.',

--- a/packages/core/schematics/migrations/signal-migration/test/golden.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden.txt
@@ -827,7 +827,7 @@ import {Component, Input} from '@angular/core';
 export class ManualInstantiation {
   // TODO: Skipped for migration because:
   //  Class of this input is manually instantiated. This is discouraged and prevents
-  //  migration
+  //  migration.
   @Input() bla: string = '';
 }
 @@@@@@ modifier_tests.ts @@@@@@


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

A dot was appearing in the middle of the comment for `DerivedIsIncompatible`. While at it, a dot was missing in `ClassManuallyInstantiated`.

## What is the new behavior?

Fixes the typos.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
