### PR TITLE
refactor(compiler-cli): parse `angularCompilerOptions` from bazel options as a fallback

### DIFF
--- a/packages/compiler-cli/src/perform_compile.ts
+++ b/packages/compiler-cli/src/perform_compile.ts
@@ -93,9 +93,16 @@ export function readConfiguration(
         return parentOptions;
       }
 
+      // Note: In Google, `angularCompilerOptions` are stored in `bazelOptions`.
+      // This function typically doesn't run for actual Angular compilations, but
+      // tooling like Tsurge, or schematics may leverage this helper, so we account
+      // for this here.
+      const angularCompilerOptions =
+        config.angularCompilerOptions ?? config.bazelOptions?.angularCompilerOptions;
+
       // we are only interested into merging 'angularCompilerOptions' as
       // other options like 'compilerOptions' are merged by TS
-      let existingNgCompilerOptions = {...config.angularCompilerOptions, ...parentOptions};
+      let existingNgCompilerOptions = {...angularCompilerOptions, ...parentOptions};
       if (!config.extends) {
         return existingNgCompilerOptions;
       }


### PR DESCRIPTION
This commit is only useful to Google. It fixes that some code relies on `readConfiguration`, but doesn't properly parse Angular compiler options as those are part of `bazelOptions.angularCompilerOptions` if the 1P-generated tsconfig's are used.