### PR TITLE
refactor(docs-infra): cleanup after render sequence in `ReferenceScrollHandler`

### DIFF
--- a/adev/src/app/app-scroller.ts
+++ b/adev/src/app/app-scroller.ts
@@ -12,6 +12,7 @@ import {
   ApplicationRef,
   afterNextRender,
   EnvironmentInjector,
+  Injector,
 } from '@angular/core';
 import {Scroll, Router} from '@angular/router';
 import {filter, firstValueFrom, map, switchMap, tap} from 'rxjs';
@@ -62,7 +63,7 @@ export class AppScroller {
       });
   }
 
-  scroll() {
+  scroll(injector?: Injector) {
     if (!this._lastScrollEvent || !this.canScroll) {
       return;
     }
@@ -83,7 +84,9 @@ export class AppScroller {
           }
         },
       },
-      {injector: this.injector},
+      // Use the component injector when provided so that the manager can
+      // deregister the sequence once the component is destroyed.
+      {injector: injector ?? this.injector},
     );
     this.cancelScroll = () => {
       ref.destroy();

--- a/adev/src/app/features/references/services/reference-scroll-handler.service.ts
+++ b/adev/src/app/features/references/services/reference-scroll-handler.service.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT, isPlatformBrowser} from '@angular/common';
-import {DestroyRef, Injectable, PLATFORM_ID, inject} from '@angular/core';
+import {DestroyRef, Injectable, Injector, PLATFORM_ID, inject} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {fromEvent} from 'rxjs';
 import {MEMBER_ID_ATTRIBUTE} from '../constants/api-reference-prerender.constants';
@@ -22,6 +22,7 @@ const SCROLL_MARGIN_TOP = 100;
 export class ReferenceScrollHandler {
   private readonly destroyRef = inject(DestroyRef);
   private readonly document = inject(DOCUMENT);
+  private readonly injector = inject(Injector);
   private readonly window = inject(WINDOW);
   private readonly router = inject(Router);
   private readonly appScroller = inject(AppScroller);
@@ -43,7 +44,7 @@ export class ReferenceScrollHandler {
         // If there is no fragment or the scroll event has a position (traversing through history),
         // allow the scroller to handler scrolling instead of going to the fragment
         if (!fragment || this.appScroller.lastScrollEvent?.position) {
-          this.appScroller.scroll();
+          this.appScroller.scroll(this.injector);
           return;
         }
 


### PR DESCRIPTION
In this commit, we're replacing the provided injector in `afterNextRender` with a node injector
because it was previously mistakenly passing an `EnvironmentInjector` in the `ReferenceScrollHandler`.