### PR TITLE
fix(core): fixes issues with control flow and incremental hydration

### DIFF
--- a/packages/core/src/defer/registry.ts
+++ b/packages/core/src/defer/registry.ts
@@ -35,9 +35,11 @@ export class DehydratedBlockRegistry {
   private cleanupFns = new Map<string, Function[]>();
   private jsActionMap: Map<string, Set<Element>> = inject(JSACTION_BLOCK_ELEMENT_MAP);
   private contract: EventContractDetails = inject(JSACTION_EVENT_CONTRACT);
+
   add(blockId: string, info: DehydratedDeferBlock) {
     this.registry.set(blockId, info);
   }
+
   get(blockId: string): DehydratedDeferBlock | null {
     return this.registry.get(blockId) ?? null;
   }

--- a/packages/core/src/defer/triggering.ts
+++ b/packages/core/src/defer/triggering.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {afterNextRender} from '../render3/after_render/hooks';
 import {Injector} from '../di';
 import {internalImportProvidersFrom} from '../di/provider_collection';
 import {RuntimeError, RuntimeErrorCode} from '../errors';
@@ -43,7 +44,7 @@ import {
   TDeferBlockDetails,
   TriggerType,
 } from './interfaces';
-import {DEHYDRATED_BLOCK_REGISTRY} from './registry';
+import {DEHYDRATED_BLOCK_REGISTRY, DehydratedBlockRegistry} from './registry';
 import {
   DEFER_BLOCK_CONFIG,
   DEFER_BLOCK_DEPENDENCY_INTERCEPTOR,
@@ -350,12 +351,43 @@ export async function triggerHydrationFromBlockName(
  * Triggers the resource loading for a defer block and passes back a promise
  * to handle cleanup on completion
  */
-export function triggerAndWaitForCompletion(deferBlock: DehydratedDeferBlock): Promise<void> {
-  const lDetails = getLDeferBlockDetails(deferBlock.lView, deferBlock.tNode);
-  const promise = new Promise<void>((resolve) => {
-    onDeferBlockCompletion(lDetails, resolve);
+export function triggerAndWaitForCompletion(
+  dehydratedBlockId: string,
+  dehydratedBlockRegistry: DehydratedBlockRegistry,
+  injector: Injector,
+): Promise<void> {
+  // TODO(incremental-hydration): This is a temporary fix to resolve control flow
+  // cases where nested defer blocks are inside control flow. We wait for each nested
+  // defer block to load and render before triggering the next one in a sequence. This is
+  // needed to ensure that corresponding LViews & LContainers are available for a block
+  // before we trigger it. We need to investigate how to get rid of the `afterNextRender`
+  // calls (in the nearest future) and do loading of all dependencies of nested defer blocks
+  // in parallel (later).
+
+  let resolve: VoidFunction;
+  const promise = new Promise<void>((resolveFn) => {
+    resolve = resolveFn;
   });
-  triggerDeferBlock(deferBlock.lView, deferBlock.tNode);
+
+  afterNextRender(
+    () => {
+      const deferBlock = dehydratedBlockRegistry.get(dehydratedBlockId);
+      // Since we trigger hydration for nested defer blocks in a sequence (parent -> child),
+      // there is a chance that a defer block may not be present at hydration time. For example,
+      // when a nested block was in an `@if` condition, which has changed.
+      // TODO(incremental-hydration): add tests to verify the behavior mentioned above.
+      if (deferBlock !== null) {
+        const {tNode, lView} = deferBlock;
+        const lDetails = getLDeferBlockDetails(lView, tNode);
+        onDeferBlockCompletion(lDetails, resolve);
+        triggerDeferBlock(lView, tNode);
+        // TODO(incremental-hydration): handle the cleanup for cases when
+        // defer block is no longer present during hydration (e.g. `@if` condition
+        // has changed during hydration/rendering).
+      }
+    },
+    {injector},
+  );
   return promise;
 }
 
@@ -397,12 +429,9 @@ async function triggerBlockTreeHydrationByName(
 
   // Step 3: hydrate each block in the queue. It will be in descending order from the top down.
   for (const dehydratedBlockId of hydrationQueue) {
-    // The registry will have the item in the queue after each loop.
-    const deferBlock = dehydratedBlockRegistry.get(dehydratedBlockId)!;
-
     // Step 4: Run the actual trigger function to fetch dependencies.
     // Triggering a block adds any of its child defer blocks to the registry.
-    await triggerAndWaitForCompletion(deferBlock);
+    await triggerAndWaitForCompletion(dehydratedBlockId, dehydratedBlockRegistry, injector);
   }
 
   const hydratedBlocks = new Set<string>(hydrationQueue);


### PR DESCRIPTION
If a defer block is nested inside control flow while also being nested underneath a defer block all using incremental hydration, timing issues prevented the child nodes from being properly hydrated. This ensures hydration happens on next render.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


