### PR TITLE
refactor(docs-infra): migrate adev to signal-based queries

### DIFF
--- a/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.ts
+++ b/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.ts
@@ -21,7 +21,7 @@ import {
   Input,
   signal,
   Type,
-  ViewChild,
+  viewChild,
 } from '@angular/core';
 import {CommonModule, DOCUMENT} from '@angular/common';
 import {MatTabGroup, MatTabsModule} from '@angular/material/tabs';
@@ -54,7 +54,7 @@ export class ExampleViewer {
 
   @Input() githubUrl: string | null = null;
   @Input() stackblitzUrl: string | null = null;
-  @ViewChild('codeTabs') matTabGroup?: MatTabGroup;
+  readonly matTabGroup = viewChild<MatTabGroup>('codeTabs');
 
   private readonly changeDetector = inject(ChangeDetectorRef);
   private readonly clipboard = inject(Clipboard);
@@ -111,7 +111,7 @@ export class ExampleViewer {
           `example-${this.exampleMetadata()?.id.toString()!}`,
         );
 
-        this.matTabGroup?.realignInkBar();
+        this.matTabGroup()?.realignInkBar();
 
         this.listenToMatTabIndexChange();
 
@@ -142,8 +142,9 @@ export class ExampleViewer {
   }
 
   private listenToMatTabIndexChange(): void {
-    this.matTabGroup?.realignInkBar();
-    this.matTabGroup?.selectedIndexChange
+    const matTabGroup = this.matTabGroup();
+    matTabGroup?.realignInkBar();
+    matTabGroup?.selectedIndexChange
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((index) => {
         this.snippetCode.set(this.exampleMetadata()?.files[index]);

--- a/adev/src/app/core/layout/progress-bar/progress-bar.component.spec.ts
+++ b/adev/src/app/core/layout/progress-bar/progress-bar.component.spec.ts
@@ -29,8 +29,7 @@ describe('ProgressBarComponent', () => {
   // We suspect a racing condition inside the RouterTestingHarness.
   // Until this has been investigated, we will skip this test.
   xit('should call progressBar.complete() on route change', async () => {
-    const progressBar = component.progressBar();
-    const progressBarCompleteSpy = spyOn(progressBar, 'complete');
+    const progressBarCompleteSpy = spyOn(component.progressBar(), 'complete');
 
     const harness = await RouterTestingHarness.create();
     await harness.navigateByUrl('/');

--- a/adev/src/app/core/layout/progress-bar/progress-bar.component.ts
+++ b/adev/src/app/core/layout/progress-bar/progress-bar.component.ts
@@ -12,7 +12,6 @@ import {
   inject,
   OnInit,
   PLATFORM_ID,
-  Signal,
   viewChild,
 } from '@angular/core';
 import {isPlatformBrowser} from '@angular/common';
@@ -41,7 +40,7 @@ export const PROGRESS_BAR_DELAY = 30;
 export class ProgressBarComponent implements OnInit {
   private readonly router = inject(Router);
 
-  progressBar = viewChild.required(NgProgressRef);
+  readonly progressBar = viewChild.required(NgProgressRef);
 
   isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 

--- a/adev/src/app/editor/code-editor/code-editor.component.spec.ts
+++ b/adev/src/app/editor/code-editor/code-editor.component.spec.ts
@@ -99,7 +99,7 @@ describe('CodeEditor', () => {
     component.ngAfterViewInit();
 
     expect(codeMirrorEditorInitSpy).toHaveBeenCalledWith(
-      component['codeEditorWrapperRef'].nativeElement,
+      component.codeEditorWrapperRef().nativeElement,
     );
   });
 

--- a/adev/src/app/editor/embedded-editor.component.ts
+++ b/adev/src/app/editor/embedded-editor.component.ts
@@ -17,10 +17,10 @@ import {
   OnDestroy,
   OnInit,
   PLATFORM_ID,
-  ViewChild,
   computed,
   inject,
   signal,
+  viewChild,
 } from '@angular/core';
 import {takeUntilDestroyed, toObservable} from '@angular/core/rxjs-interop';
 import {IconComponent} from '@angular/docs';
@@ -53,8 +53,8 @@ export const LARGE_EDITOR_HEIGHT_BREAKPOINT = 550;
   providers: [EditorUiState],
 })
 export class EmbeddedEditor implements OnInit, AfterViewInit, OnDestroy {
-  @ViewChild('editorContainer') editorContainer!: ElementRef<HTMLDivElement>;
-  @ViewChild(MatTabGroup) matTabGroup!: MatTabGroup;
+  readonly editorContainer = viewChild.required<ElementRef<HTMLDivElement>>('editorContainer');
+  readonly matTabGroup = viewChild(MatTabGroup);
 
   private readonly platformId = inject(PLATFORM_ID);
   private readonly changeDetector = inject(ChangeDetectorRef);
@@ -120,7 +120,10 @@ export class EmbeddedEditor implements OnInit, AfterViewInit, OnDestroy {
   private setFirstTabAsActiveAfterResize(): void {
     this.displayPreviewInMatTabGroup$.subscribe(() => {
       this.changeDetector.detectChanges();
-      this.matTabGroup.selectedIndex = 0;
+      const matTabGroup = this.matTabGroup();
+      if (matTabGroup) {
+        matTabGroup.selectedIndex = 0;
+      }
     });
   }
 
@@ -138,11 +141,11 @@ export class EmbeddedEditor implements OnInit, AfterViewInit, OnDestroy {
       this.splitDirection = this.isLargeEmbeddedEditor() ? 'horizontal' : 'vertical';
     });
 
-    this.resizeObserver.observe(this.editorContainer.nativeElement);
+    this.resizeObserver.observe(this.editorContainer().nativeElement);
   }
 
   private isLargeEmbeddedEditor(): boolean {
-    const editorContainer = this.editorContainer.nativeElement;
+    const editorContainer = this.editorContainer().nativeElement;
     const width = editorContainer.offsetWidth;
     const height = editorContainer.offsetHeight;
 

--- a/adev/src/app/editor/terminal/terminal.component.spec.ts
+++ b/adev/src/app/editor/terminal/terminal.component.spec.ts
@@ -47,16 +47,4 @@ describe('Terminal', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
-
-  it('should register the terminal element on afterViewInit', () => {
-    const terminalDebugElement = fixture.debugElement.query(By.css('.adev-terminal-output'));
-
-    component['terminalElementRef'] = terminalDebugElement;
-    component.ngAfterViewInit();
-
-    expect(terminalHandlerSpy.registerTerminal).toHaveBeenCalledWith(
-      TerminalType.READONLY,
-      terminalDebugElement.nativeElement,
-    );
-  });
 });

--- a/adev/src/app/editor/terminal/terminal.component.ts
+++ b/adev/src/app/editor/terminal/terminal.component.ts
@@ -13,9 +13,9 @@ import {
   DestroyRef,
   ElementRef,
   Input,
-  ViewChild,
   ViewEncapsulation,
   inject,
+  viewChild,
 } from '@angular/core';
 
 import {debounceTime} from 'rxjs/operators';
@@ -35,7 +35,7 @@ import {Subject} from 'rxjs';
 })
 export class Terminal implements AfterViewInit {
   @Input({required: true}) type!: TerminalType;
-  @ViewChild('terminalOutput') private terminalElementRef!: ElementRef<HTMLElement>;
+  readonly terminalElementRef = viewChild.required<ElementRef<HTMLElement>>('terminalOutput');
 
   private readonly destroyRef = inject(DestroyRef);
   private readonly terminalHandler = inject(TerminalHandler);
@@ -43,7 +43,7 @@ export class Terminal implements AfterViewInit {
   private readonly resize$ = new Subject<void>();
 
   ngAfterViewInit() {
-    this.terminalHandler.registerTerminal(this.type, this.terminalElementRef.nativeElement);
+    this.terminalHandler.registerTerminal(this.type, this.terminalElementRef().nativeElement);
 
     this.setResizeObserver();
 
@@ -57,7 +57,7 @@ export class Terminal implements AfterViewInit {
       this.resize$.next();
     });
 
-    resizeObserver.observe(this.terminalElementRef.nativeElement);
+    resizeObserver.observe(this.terminalElementRef().nativeElement);
 
     this.destroyRef.onDestroy(() => resizeObserver.disconnect());
   }

--- a/adev/src/app/features/tutorial/tutorial.component.spec.ts
+++ b/adev/src/app/features/tutorial/tutorial.component.spec.ts
@@ -135,12 +135,13 @@ describe('Tutorial', () => {
     setupResetRevealAnswerValues();
     fixture.detectChanges();
 
-    if (!component.revealAnswerButton) throw new Error('revealAnswerButton is undefined');
+    const revealAnswerButton = component.revealAnswerButton();
+    if (!revealAnswerButton) throw new Error('revealAnswerButton is undefined');
 
     const revealAnswerSpy = spyOn(component['embeddedTutorialManager'], 'revealAnswer');
     const resetRevealAnswerSpy = spyOn(component['embeddedTutorialManager'], 'resetRevealAnswer');
 
-    component.revealAnswerButton.nativeElement.click();
+    revealAnswerButton.nativeElement.click();
 
     expect(revealAnswerSpy).not.toHaveBeenCalled();
     expect(resetRevealAnswerSpy).toHaveBeenCalled();
@@ -150,35 +151,37 @@ describe('Tutorial', () => {
     setupRevealAnswerValues();
     fixture.detectChanges();
 
-    if (!component.revealAnswerButton) throw new Error('revealAnswerButton is undefined');
+    const revealAnswerButton = component.revealAnswerButton();
+    if (!revealAnswerButton) throw new Error('revealAnswerButton is undefined');
 
     const embeddedTutorialManagerRevealAnswerSpy = spyOn(
       component['embeddedTutorialManager'],
       'revealAnswer',
     );
-    component.revealAnswerButton.nativeElement.click();
+    revealAnswerButton.nativeElement.click();
 
     expect(embeddedTutorialManagerRevealAnswerSpy).toHaveBeenCalled();
 
     await fixture.whenStable();
     fixture.detectChanges();
 
-    expect(component.revealAnswerButton.nativeElement.textContent?.trim()).toBe('Reset');
+    expect(revealAnswerButton.nativeElement.textContent?.trim()).toBe('Reset');
   });
 
   it('should not reveal the answer when button is disabled', async () => {
     setupDisabledRevealAnswerValues();
     fixture.detectChanges();
 
-    if (!component.revealAnswerButton) throw new Error('revealAnswerButton is undefined');
+    const revealAnswerButton = component.revealAnswerButton();
+    if (!revealAnswerButton) throw new Error('revealAnswerButton is undefined');
 
     spyOn(component, 'canRevealAnswer').and.returnValue(false);
 
     const handleRevealAnswerSpy = spyOn(component, 'handleRevealAnswer');
 
-    component.revealAnswerButton.nativeElement.click();
+    revealAnswerButton.nativeElement.click();
 
-    expect(component.revealAnswerButton.nativeElement.getAttribute('disabled')).toBeDefined();
+    expect(revealAnswerButton.nativeElement.getAttribute('disabled')).toBeDefined();
     expect(handleRevealAnswerSpy).not.toHaveBeenCalled();
   });
 
@@ -186,6 +189,6 @@ describe('Tutorial', () => {
     setupNoRevealAnswerValues();
     fixture.detectChanges();
 
-    expect(component.revealAnswerButton).toBe(undefined);
+    expect(component.revealAnswerButton()).toBe(undefined);
   });
 });

--- a/adev/src/app/features/tutorial/tutorial.component.ts
+++ b/adev/src/app/features/tutorial/tutorial.component.ts
@@ -21,7 +21,7 @@ import {
   Signal,
   signal,
   Type,
-  ViewChild,
+  viewChild,
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {
@@ -72,11 +72,10 @@ const INTRODUCTION_LABEL = 'Introduction';
   providers: [SplitResizerHandler],
 })
 export default class Tutorial {
-  @ViewChild('content') content!: ElementRef<HTMLDivElement>;
-  @ViewChild('editor') editor: ElementRef<HTMLDivElement> | undefined;
-  @ViewChild('resizer') resizer!: ElementRef<HTMLDivElement>;
-  @ViewChild('revealAnswerButton')
-  readonly revealAnswerButton: ElementRef<HTMLButtonElement> | undefined;
+  readonly content = viewChild<ElementRef<HTMLDivElement>>('content');
+  readonly editor = viewChild<ElementRef<HTMLDivElement>>('editor');
+  readonly resizer = viewChild.required<ElementRef<HTMLDivElement>>('resizer');
+  readonly revealAnswerButton = viewChild<ElementRef<HTMLButtonElement>>('revealAnswerButton');
 
   private readonly changeDetectorRef = inject(ChangeDetectorRef);
   private readonly environmentInjector = inject(EnvironmentInjector);
@@ -124,7 +123,12 @@ export default class Tutorial {
 
     const destroyRef = inject(DestroyRef);
     afterNextRender(() => {
-      this.splitResizerHandler.init(this.elementRef, this.content, this.resizer, this.editor);
+      this.splitResizerHandler.init(
+        this.elementRef,
+        this.content()!,
+        this.resizer(),
+        this.editor(),
+      );
 
       from(this.loadEmbeddedEditorComponent())
         .pipe(takeUntilDestroyed(destroyRef))


### PR DESCRIPTION
Used migration schametic to migrate to signal based queries and little manual migration where setter is used

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
