### PR TITLE
docs(docs-infra): change API reference list items order to top-down

### DIFF
--- a/adev/shared-docs/styles/_api-item-label.scss
+++ b/adev/shared-docs/styles/_api-item-label.scss
@@ -17,6 +17,7 @@
     &:not(.full) {
       height: 22px;
       width: 22px;
+      flex: 0 0 22px;
     }
 
     &.full {

--- a/adev/src/app/features/references/api-items-section/api-items-section.component.html
+++ b/adev/src/app/features/references/api-items-section/api-items-section.component.html
@@ -26,7 +26,7 @@
           class="docs-api-item-label"
           aria-hidden="true"
         />
-        <span class="adev-item-title">{{ apiItem.title }}</span>
+        <span class="adev-item-title" [attr.title]="apiItem.title">{{ apiItem.title }}</span>
       </a>
       @if (apiItem.isDeprecated) {
         <span class="docs-deprecated"> &lt;!&gt; </span>

--- a/adev/src/app/features/references/api-items-section/api-items-section.component.scss
+++ b/adev/src/app/features/references/api-items-section/api-items-section.component.scss
@@ -28,33 +28,39 @@
 }
 
 .adev-api-items-section-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  column-count: 3;
+  column-gap: 0.5rem;
   padding: 0;
 
   @container api-ref-page (max-width: 798px) {
-    grid-template-columns: 1fr 1fr;
+    column-count: 2;
   }
   @container api-ref-page (max-width: 600px) {
-    grid-template-columns: 1fr;
+    column-count: 1;
   }
 
   li {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     border-inline-start: 1px solid var(--senary-contrast);
     padding: 0.3rem;
     padding-inline-start: 0.75rem;
     font-size: 0.875rem;
+    text-overflow: ellipsis;
+    box-sizing: border-box;
+    width: 100%;
 
     a {
       color: var(--quaternary-contrast);
       display: flex;
       align-items: center;
+      overflow: hidden;
+      padding-block: 2px;
     }
 
     .adev-item-title {
-      margin-block-start: 3px;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     &:hover {

--- a/adev/src/app/features/references/api-reference-list/api-reference-list.component.scss
+++ b/adev/src/app/features/references/api-reference-list/api-reference-list.component.scss
@@ -79,6 +79,10 @@
           border: 1px solid var(--quinary-contrast);
           color: var(--primary-contrast);
         }
+
+        .docs-api-item-label-full {
+          white-space: nowrap;
+        }
       }
     }
 
@@ -100,7 +104,7 @@
     }
   }
 
-  .docs-api-item-label-full {
-    white-space: nowrap;
+  adev-api-items-section {
+    width: 100%;
   }
 }


### PR DESCRIPTION
Change the order from left-right to top-down (columns) and additionally make columns equal width.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The list items in the API reference list groups have left-right alphabetical order while the vertical borders imply that the order should be top-down instead.


## What is the new behavior?

The order is changed to top-down. Additionally, the column width is now equal which made it necessary to truncate the text.

<img width="829" alt="Screenshot 2024-11-14 at 15 19 13" src="https://github.com/user-attachments/assets/24b0f9fe-9081-404c-96e9-e6f1534a4b62">


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
