### PR TITLE
docs: remove `standalone: true` across content

### DIFF
--- a/adev/src/content/api-examples/router/testing/test/router_testing_harness_examples.spec.ts
+++ b/adev/src/content/api-examples/router/testing/test/router_testing_harness_examples.spec.ts
@@ -15,7 +15,7 @@ import {RouterTestingHarness} from '@angular/router/testing';
 describe('navigate for test examples', () => {
   // #docregion RoutedComponent
   it('navigates to routed component', async () => {
-    @Component({standalone: true, template: 'hello {{name}}'})
+    @Component({template: 'hello {{name}}'})
     class TestCmp {
       name = 'world';
     }
@@ -32,9 +32,9 @@ describe('navigate for test examples', () => {
   // #enddocregion
 
   it('testing a guard', async () => {
-    @Component({standalone: true, template: ''})
+    @Component({template: ''})
     class AdminComponent {}
-    @Component({standalone: true, template: ''})
+    @Component({template: ''})
     class LoginComponent {}
 
     // #docregion Guard

--- a/adev/src/content/best-practices/style-guide.md
+++ b/adev/src/content/best-practices/style-guide.md
@@ -293,8 +293,8 @@ Provides a consistent way to quickly identify and reference pipes.
 
 | Symbol name                                                                                                                                                                          | File name |
 |:---                                                                                                                                                                                  |:---       |
-| <docs-code hideCopy language="typescript"> @Pipe({ standalone: true, name: 'ellipsis' }) <br>export class EllipsisPipe implements PipeTransform { } </docs-code> | ellipsis.pipe.ts  |
-| <docs-code hideCopy language="typescript"> @Pipe({ standalone: true, name: 'initCaps' }) <br>export class InitCapsPipe implements PipeTransform { } </docs-code> | init-caps.pipe.ts |
+| <docs-code hideCopy language="typescript"> @Pipe({ name: 'ellipsis' }) <br>export class EllipsisPipe implements PipeTransform { } </docs-code> | ellipsis.pipe.ts  |
+| <docs-code hideCopy language="typescript"> @Pipe({ name: 'initCaps' }) <br>export class InitCapsPipe implements PipeTransform { } </docs-code> | init-caps.pipe.ts |
 
 ### Unit test file names
 

--- a/adev/src/content/examples/accessibility/src/app/app.component.ts
+++ b/adev/src/content/examples/accessibility/src/app/app.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {ExampleProgressbarComponent} from './progress-bar.component';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],

--- a/adev/src/content/examples/accessibility/src/app/progress-bar.component.ts
+++ b/adev/src/content/examples/accessibility/src/app/progress-bar.component.ts
@@ -6,7 +6,6 @@ import {Component, Input} from '@angular/core';
  * Example progressbar component.
  */
 @Component({
-  standalone: true,
   selector: 'app-example-progressbar',
   template: '<div class="bar" [style.width.%]="value"></div>',
   styleUrls: ['./progress-bar.component.css'],

--- a/adev/src/content/examples/angular-compiler-options/src/app/app.component.ts
+++ b/adev/src/content/examples/angular-compiler-options/src/app/app.component.ts
@@ -1,7 +1,6 @@
 import {Component} from '@angular/core';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],

--- a/adev/src/content/examples/animations/src/app/about.component.ts
+++ b/adev/src/content/examples/animations/src/app/about.component.ts
@@ -1,7 +1,6 @@
 import {Component} from '@angular/core';
 
 @Component({
-  standalone: true,
   selector: 'app-about',
   templateUrl: './about.component.html',
   styleUrls: ['./about.component.css'],

--- a/adev/src/content/examples/animations/src/app/app.component.ts
+++ b/adev/src/content/examples/animations/src/app/app.component.ts
@@ -16,7 +16,6 @@ import {slideInAnimation} from './animations';
 
 // #docregion decorator, toggle-app-animations, define
 @Component({
-  standalone: true,
   selector: 'app-root',
   templateUrl: 'app.component.html',
   styleUrls: ['app.component.css'],

--- a/adev/src/content/examples/animations/src/app/hero-list-auto-page.component.ts
+++ b/adev/src/content/examples/animations/src/app/hero-list-auto-page.component.ts
@@ -3,7 +3,6 @@ import {HEROES} from './mock-heroes';
 import {HeroListAutoComponent} from './hero-list-auto.component';
 
 @Component({
-  standalone: true,
   selector: 'app-hero-list-auto-page',
   template: `
     <section>

--- a/adev/src/content/examples/animations/src/app/hero-list-auto.component.ts
+++ b/adev/src/content/examples/animations/src/app/hero-list-auto.component.ts
@@ -5,7 +5,6 @@ import {Hero} from './hero';
 import {NgFor} from '@angular/common';
 
 @Component({
-  standalone: true,
   selector: 'app-hero-list-auto',
   templateUrl: 'hero-list-auto.component.html',
   styleUrls: ['./hero-list-page.component.css'],

--- a/adev/src/content/examples/animations/src/app/hero-list-enter-leave-page.component.ts
+++ b/adev/src/content/examples/animations/src/app/hero-list-enter-leave-page.component.ts
@@ -3,7 +3,6 @@ import {HEROES} from './mock-heroes';
 import {HeroListEnterLeaveComponent} from './hero-list-enter-leave.component';
 
 @Component({
-  standalone: true,
   selector: 'app-hero-list-enter-leave-page',
   template: `
     <section>

--- a/adev/src/content/examples/animations/src/app/hero-list-enter-leave.component.ts
+++ b/adev/src/content/examples/animations/src/app/hero-list-enter-leave.component.ts
@@ -5,7 +5,6 @@ import {Hero} from './hero';
 import {NgFor} from '@angular/common';
 
 @Component({
-  standalone: true,
   selector: 'app-hero-list-enter-leave',
   template: `
     <ul class="heroes">

--- a/adev/src/content/examples/animations/src/app/hero-list-group-page.component.ts
+++ b/adev/src/content/examples/animations/src/app/hero-list-group-page.component.ts
@@ -3,7 +3,6 @@ import {HEROES} from './mock-heroes';
 import {HeroListGroupsComponent} from './hero-list-groups.component';
 
 @Component({
-  standalone: true,
   selector: 'app-hero-list-groups-page',
   template: `
     <section>

--- a/adev/src/content/examples/animations/src/app/hero-list-groups.component.ts
+++ b/adev/src/content/examples/animations/src/app/hero-list-groups.component.ts
@@ -5,7 +5,6 @@ import {Hero} from './hero';
 import {NgFor} from '@angular/common';
 
 @Component({
-  standalone: true,
   selector: 'app-hero-list-groups',
   template: `
     <ul class="heroes">

--- a/adev/src/content/examples/animations/src/app/hero-list-page.component.ts
+++ b/adev/src/content/examples/animations/src/app/hero-list-page.component.ts
@@ -9,7 +9,6 @@ import {NgFor} from '@angular/common';
 // #docregion filter-animations
 @Component({
   // #enddocregion filter-animations
-  standalone: true,
   imports: [NgFor],
   selector: 'app-hero-list-page',
   templateUrl: 'hero-list-page.component.html',

--- a/adev/src/content/examples/animations/src/app/home.component.ts
+++ b/adev/src/content/examples/animations/src/app/home.component.ts
@@ -1,7 +1,6 @@
 import {Component} from '@angular/core';
 
 @Component({
-  standalone: true,
   selector: 'app-home',
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.css'],

--- a/adev/src/content/examples/animations/src/app/insert-remove.component.ts
+++ b/adev/src/content/examples/animations/src/app/insert-remove.component.ts
@@ -4,7 +4,6 @@ import {trigger, transition, animate, style} from '@angular/animations';
 import {NgIf} from '@angular/common';
 
 @Component({
-  standalone: true,
   selector: 'app-insert-remove',
   imports: [NgIf],
   animations: [

--- a/adev/src/content/examples/animations/src/app/open-close-page.component.ts
+++ b/adev/src/content/examples/animations/src/app/open-close-page.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {OpenCloseComponent} from './open-close.component';
 
 @Component({
-  standalone: true,
   selector: 'app-open-close-page',
   template: `
     <section>

--- a/adev/src/content/examples/animations/src/app/open-close.component.1.ts
+++ b/adev/src/content/examples/animations/src/app/open-close.component.1.ts
@@ -10,7 +10,6 @@ import {
 } from '@angular/animations';
 
 @Component({
-  standalone: true,
   selector: 'app-open-close',
   animations: [
     // #docregion trigger

--- a/adev/src/content/examples/animations/src/app/open-close.component.2.ts
+++ b/adev/src/content/examples/animations/src/app/open-close.component.2.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {trigger, transition, state, animate, style} from '@angular/animations';
 
 @Component({
-  standalone: true,
   selector: 'app-open-close-boolean',
   // #docregion trigger-boolean
   animations: [

--- a/adev/src/content/examples/animations/src/app/open-close.component.3.ts
+++ b/adev/src/content/examples/animations/src/app/open-close.component.3.ts
@@ -5,7 +5,6 @@ import {transition, trigger, useAnimation, AnimationEvent} from '@angular/animat
 import {transitionAnimation} from './animations';
 
 @Component({
-  standalone: true,
   selector: 'app-open-close-reusable',
   animations: [
     trigger('openClose', [

--- a/adev/src/content/examples/animations/src/app/open-close.component.4.ts
+++ b/adev/src/content/examples/animations/src/app/open-close.component.4.ts
@@ -6,7 +6,6 @@ import {trigger, transition, state, animate, style} from '@angular/animations';
 // #docregion toggle-animation
 @Component({
   // #enddocregion toggle-animation
-  standalone: true,
   selector: 'app-open-close-toggle',
   templateUrl: 'open-close.component.4.html',
   styleUrls: ['open-close.component.css'],

--- a/adev/src/content/examples/animations/src/app/open-close.component.ts
+++ b/adev/src/content/examples/animations/src/app/open-close.component.ts
@@ -4,7 +4,6 @@ import {trigger, transition, state, animate, style, AnimationEvent} from '@angul
 
 // #docregion component, events1
 @Component({
-  standalone: true,
   selector: 'app-open-close',
   // #docregion trigger-wildcard1, trigger-transition
   animations: [

--- a/adev/src/content/examples/animations/src/app/querying.component.ts
+++ b/adev/src/content/examples/animations/src/app/querying.component.ts
@@ -14,7 +14,6 @@ import {HEROES} from './mock-heroes';
 import {NgIf} from '@angular/common';
 
 @Component({
-  standalone: true,
   selector: 'app-querying',
   template: `
     <nav>

--- a/adev/src/content/examples/animations/src/app/status-slider-page.component.ts
+++ b/adev/src/content/examples/animations/src/app/status-slider-page.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {StatusSliderComponent} from './status-slider.component';
 
 @Component({
-  standalone: true,
   selector: 'app-status-slider-page',
   template: `
     <section>

--- a/adev/src/content/examples/animations/src/app/status-slider.component.ts
+++ b/adev/src/content/examples/animations/src/app/status-slider.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {trigger, transition, state, animate, style, keyframes} from '@angular/animations';
 
 @Component({
-  standalone: true,
   selector: 'app-status-slider',
   templateUrl: 'status-slider.component.html',
   styleUrls: ['status-slider.component.css'],

--- a/adev/src/content/examples/animations/src/app/toggle-animations-page.component.ts
+++ b/adev/src/content/examples/animations/src/app/toggle-animations-page.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {OpenCloseChildComponent} from './open-close.component.4';
 
 @Component({
-  standalone: true,
   selector: 'app-toggle-animations-child-page',
   template: `
     <section>

--- a/adev/src/content/examples/attribute-directives/src/app/app.component.1.ts
+++ b/adev/src/content/examples/attribute-directives/src/app/app.component.1.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {HighlightDirective} from './highlight.directive';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   templateUrl: './app.component.1.html',
   imports: [HighlightDirective],

--- a/adev/src/content/examples/attribute-directives/src/app/app.component.ts
+++ b/adev/src/content/examples/attribute-directives/src/app/app.component.ts
@@ -3,7 +3,6 @@ import {Component} from '@angular/core';
 import {HighlightDirective} from './highlight.directive';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   templateUrl: './app.component.html',
   imports: [HighlightDirective],

--- a/adev/src/content/examples/attribute-directives/src/app/highlight.directive.0.ts
+++ b/adev/src/content/examples/attribute-directives/src/app/highlight.directive.0.ts
@@ -2,7 +2,6 @@
 import {Directive} from '@angular/core';
 
 @Directive({
-  standalone: true,
   selector: '[appHighlight]',
 })
 export class HighlightDirective {}

--- a/adev/src/content/examples/attribute-directives/src/app/highlight.directive.1.ts
+++ b/adev/src/content/examples/attribute-directives/src/app/highlight.directive.1.ts
@@ -2,7 +2,6 @@
 import {Directive, ElementRef} from '@angular/core';
 
 @Directive({
-  standalone: true,
   selector: '[appHighlight]',
 })
 export class HighlightDirective {

--- a/adev/src/content/examples/attribute-directives/src/app/highlight.directive.2.ts
+++ b/adev/src/content/examples/attribute-directives/src/app/highlight.directive.2.ts
@@ -6,7 +6,6 @@ import {Input} from '@angular/core';
 // #docregion
 
 @Directive({
-  standalone: true,
   selector: '[appHighlight]',
 })
 export class HighlightDirective {

--- a/adev/src/content/examples/attribute-directives/src/app/highlight.directive.3.ts
+++ b/adev/src/content/examples/attribute-directives/src/app/highlight.directive.3.ts
@@ -3,7 +3,6 @@ import {Directive, ElementRef, HostListener, Input} from '@angular/core';
 // #enddocregion imports
 
 @Directive({
-  standalone: true,
   selector: '[appHighlight]',
 })
 export class HighlightDirective {

--- a/adev/src/content/examples/attribute-directives/src/app/highlight.directive.ts
+++ b/adev/src/content/examples/attribute-directives/src/app/highlight.directive.ts
@@ -1,7 +1,6 @@
 import {Directive, ElementRef, HostListener, Input} from '@angular/core';
 
 @Directive({
-  standalone: true,
   selector: '[appHighlight]',
 })
 export class HighlightDirective {

--- a/adev/src/content/examples/built-in-directives/src/app/app.component.ts
+++ b/adev/src/content/examples/built-in-directives/src/app/app.component.ts
@@ -25,7 +25,6 @@ import {StoutItemComponent} from './item-switch.component';
 
 // #docregion import-ng-if, import-ng-for, import-ng-switch, import-ng-style, import-ng-class, import-forms-module
 @Component({
-  standalone: true,
   // #enddocregion import-ng-if, import-ng-for, import-ng-switch, import-ng-style, import-ng-class, import-forms-module
   selector: 'app-root',
   templateUrl: './app.component.html',

--- a/adev/src/content/examples/built-in-directives/src/app/item-detail/item-detail.component.ts
+++ b/adev/src/content/examples/built-in-directives/src/app/item-detail/item-detail.component.ts
@@ -3,7 +3,6 @@ import {Component, Input} from '@angular/core';
 import {Item} from '../item';
 
 @Component({
-  standalone: true,
   selector: 'app-item-detail',
   templateUrl: './item-detail.component.html',
   styleUrls: ['./item-detail.component.css'],

--- a/adev/src/content/examples/built-in-directives/src/app/item-switch.component.ts
+++ b/adev/src/content/examples/built-in-directives/src/app/item-switch.component.ts
@@ -2,7 +2,6 @@ import {Component, Input} from '@angular/core';
 import {Item} from './item';
 
 @Component({
-  standalone: true,
   selector: 'app-stout-item',
   template: "I'm a little {{item.name}}, short and stout!",
 })
@@ -14,7 +13,6 @@ export class StoutItemComponent {
 // #enddocregion input
 
 @Component({
-  standalone: true,
   selector: 'app-best-item',
   template: 'This is the brightest {{item.name}} in town.',
 })
@@ -23,7 +21,6 @@ export class BestItemComponent {
 }
 
 @Component({
-  standalone: true,
   selector: 'app-device-item',
   template: 'Which is the slimmest {{item.name}}?',
 })
@@ -32,7 +29,6 @@ export class DeviceItemComponent {
 }
 
 @Component({
-  standalone: true,
   selector: 'app-lost-item',
   template: 'Has anyone seen my {{item.name}}?',
 })
@@ -41,7 +37,6 @@ export class LostItemComponent {
 }
 
 @Component({
-  standalone: true,
   selector: 'app-unknown-item',
   template: '{{message}}',
 })

--- a/adev/src/content/examples/dependency-injection/src/app/app.component.1.ts
+++ b/adev/src/content/examples/dependency-injection/src/app/app.component.1.ts
@@ -4,7 +4,6 @@ import {CarComponent} from './car/car.component';
 import {HeroesComponent} from './heroes/heroes.component';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   template: `
     <h1>{{title}}</h1>

--- a/adev/src/content/examples/dependency-injection/src/app/app.component.2.ts
+++ b/adev/src/content/examples/dependency-injection/src/app/app.component.2.ts
@@ -5,7 +5,6 @@ import {CarComponent} from './car/car.component';
 import {HeroesComponent} from './heroes/heroes.component';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   template: `
     <h1>{{title}}</h1>

--- a/adev/src/content/examples/dependency-injection/src/app/app.component.ts
+++ b/adev/src/content/examples/dependency-injection/src/app/app.component.ts
@@ -11,7 +11,6 @@ import {TestComponent} from './test.component';
 import {NgIf} from '@angular/common';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   template: `
     <h1>{{title}}</h1>

--- a/adev/src/content/examples/dependency-injection/src/app/car/car.component.ts
+++ b/adev/src/content/examples/dependency-injection/src/app/car/car.component.ts
@@ -10,7 +10,6 @@ import {testCar, simpleCar, superCar} from './car-creations';
 import {useInjector} from './car-injector';
 
 @Component({
-  standalone: true,
   selector: 'app-car',
   template: `
   <h2>Cars</h2>

--- a/adev/src/content/examples/dependency-injection/src/app/heroes/hero-list.component.1.ts
+++ b/adev/src/content/examples/dependency-injection/src/app/heroes/hero-list.component.1.ts
@@ -3,7 +3,6 @@ import {Component} from '@angular/core';
 import {HEROES} from './mock-heroes';
 
 @Component({
-  standalone: true,
   selector: 'app-hero-list',
   template: `
     @for (hero of heroes; track hero) {

--- a/adev/src/content/examples/dependency-injection/src/app/heroes/hero-list.component.2.ts
+++ b/adev/src/content/examples/dependency-injection/src/app/heroes/hero-list.component.2.ts
@@ -13,7 +13,6 @@ import { HeroService } from './hero.service';
 // #docregion
 
 @Component({
-  standalone: true,
   selector: 'app-hero-list',
   template: `
     @for (hero of heroes; track hero) {

--- a/adev/src/content/examples/dependency-injection/src/app/heroes/hero-list.component.ts
+++ b/adev/src/content/examples/dependency-injection/src/app/heroes/hero-list.component.ts
@@ -5,7 +5,6 @@ import {HeroService} from './hero.service';
 import {NgFor} from '@angular/common';
 
 @Component({
-  standalone: true,
   selector: 'app-hero-list',
   template: `
     @for (hero of heroes; track hero) {

--- a/adev/src/content/examples/dependency-injection/src/app/heroes/heroes-tsp.component.ts
+++ b/adev/src/content/examples/dependency-injection/src/app/heroes/heroes-tsp.component.ts
@@ -8,7 +8,6 @@ import {HeroListComponent} from './hero-list.component';
  * TSP stands for Tree-Shakeable Provider.
  */
 @Component({
-  standalone: true,
   selector: 'app-heroes-tsp',
   template: `
     <h2>Heroes</h2>

--- a/adev/src/content/examples/dependency-injection/src/app/heroes/heroes.component.1.ts
+++ b/adev/src/content/examples/dependency-injection/src/app/heroes/heroes.component.1.ts
@@ -4,7 +4,6 @@ import {HeroService} from './hero.service';
 import {HeroListComponent} from './hero-list.component';
 
 @Component({
-  standalone: true,
   selector: 'app-heroes',
   providers: [HeroService],
   template: `

--- a/adev/src/content/examples/dependency-injection/src/app/heroes/heroes.component.ts
+++ b/adev/src/content/examples/dependency-injection/src/app/heroes/heroes.component.ts
@@ -4,7 +4,6 @@ import {heroServiceProvider} from './hero.service.provider';
 import {HeroListComponent} from './hero-list.component';
 
 @Component({
-  standalone: true,
   selector: 'app-heroes',
   providers: [heroServiceProvider],
   template: `

--- a/adev/src/content/examples/dependency-injection/src/app/injector.component.ts
+++ b/adev/src/content/examples/dependency-injection/src/app/injector.component.ts
@@ -9,7 +9,6 @@ import {heroServiceProvider} from './heroes/hero.service.provider';
 import {Logger} from './logger.service';
 
 @Component({
-  standalone: true,
   selector: 'app-injectors',
   template: `
   <h2>Other Injections</h2>

--- a/adev/src/content/examples/dependency-injection/src/app/providers.component.ts
+++ b/adev/src/content/examples/dependency-injection/src/app/providers.component.ts
@@ -14,7 +14,6 @@ import {UserService} from './user.service';
 const template = '{{log}}';
 
 @Component({
-  standalone: true,
   selector: 'provider-1',
   template,
   // #docregion providers-logger
@@ -32,7 +31,6 @@ export class Provider1Component {
 //////////////////////////////////////////
 
 @Component({
-  standalone: true,
   selector: 'provider-3',
   template,
   providers:
@@ -52,7 +50,6 @@ export class Provider3Component {
 export class BetterLogger extends Logger {}
 
 @Component({
-  standalone: true,
   selector: 'provider-4',
   template,
   providers:
@@ -85,7 +82,6 @@ export class EvenBetterLogger extends Logger {
 // #enddocregion EvenBetterLogger
 
 @Component({
-  standalone: true,
   selector: 'provider-5',
   template,
   providers:
@@ -113,7 +109,6 @@ export class OldLogger {
 }
 
 @Component({
-  standalone: true,
   selector: 'provider-6a',
   template,
   providers: [
@@ -136,7 +131,6 @@ export class Provider6aComponent {
 }
 
 @Component({
-  standalone: true,
   selector: 'provider-6b',
   template,
   providers:
@@ -170,7 +164,6 @@ export const SilentLogger = {
 };
 
 @Component({
-  standalone: true,
   selector: 'provider-7',
   template,
   providers: [{provide: Logger, useValue: SilentLogger}],
@@ -186,7 +179,6 @@ export class Provider7Component {
 /////////////////
 
 @Component({
-  standalone: true,
   selector: 'provider-8',
   template,
   providers: [heroServiceProvider, Logger, UserService],
@@ -201,7 +193,6 @@ export class Provider8Component {
 /////////////////
 
 @Component({
-  standalone: true,
   selector: 'provider-9',
   template,
   /*
@@ -237,7 +228,6 @@ import {Optional} from '@angular/core';
 const someMessage = 'Hello from the injected logger';
 
 @Component({
-  standalone: true,
   selector: 'provider-10',
   template,
   providers: [{provide: Logger, useValue: null}],
@@ -258,7 +248,6 @@ export class Provider10Component implements OnInit {
 /////////////////
 
 @Component({
-  standalone: true,
   selector: 'app-providers',
   template: `
   <h2>Provider variations</h2>

--- a/adev/src/content/examples/dependency-injection/src/app/test.component.ts
+++ b/adev/src/content/examples/dependency-injection/src/app/test.component.ts
@@ -8,7 +8,6 @@ import {HeroService} from './heroes/hero.service';
 import {HeroListComponent} from './heroes/hero-list.component';
 
 @Component({
-  standalone: true,
   selector: 'app-tests',
   template: `
     <h2>Tests</h2>

--- a/adev/src/content/examples/dynamic-form/src/app/app.component.ts
+++ b/adev/src/content/examples/dynamic-form/src/app/app.component.ts
@@ -9,7 +9,6 @@ import {QuestionBase} from './question-base';
 import {Observable} from 'rxjs';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   template: `
     <div>

--- a/adev/src/content/examples/dynamic-form/src/app/dynamic-form-question.component.ts
+++ b/adev/src/content/examples/dynamic-form/src/app/dynamic-form-question.component.ts
@@ -6,7 +6,6 @@ import {CommonModule} from '@angular/common';
 import {QuestionBase} from './question-base';
 
 @Component({
-  standalone: true,
   selector: 'app-question',
   templateUrl: './dynamic-form-question.component.html',
   imports: [CommonModule, ReactiveFormsModule],

--- a/adev/src/content/examples/dynamic-form/src/app/dynamic-form.component.ts
+++ b/adev/src/content/examples/dynamic-form/src/app/dynamic-form.component.ts
@@ -9,7 +9,6 @@ import {QuestionBase} from './question-base';
 import {QuestionControlService} from './question-control.service';
 
 @Component({
-  standalone: true,
   selector: 'app-dynamic-form',
   templateUrl: './dynamic-form.component.html',
   providers: [QuestionControlService],

--- a/adev/src/content/examples/elements/src/app/app.component.ts
+++ b/adev/src/content/examples/elements/src/app/app.component.ts
@@ -4,7 +4,6 @@ import {PopupComponent} from './popup.component';
 import {PopupService} from './popup.service';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   template: `
     <input #input value="Message" />

--- a/adev/src/content/examples/elements/src/app/popup.component.ts
+++ b/adev/src/content/examples/elements/src/app/popup.component.ts
@@ -3,7 +3,6 @@ import {Component, EventEmitter, HostBinding, Input, Output} from '@angular/core
 import {animate, state, style, transition, trigger} from '@angular/animations';
 
 @Component({
-  standalone: true,
   selector: 'my-popup',
   template: `
     <span>Popup: {{ message }}</span>

--- a/adev/src/content/examples/errors/cyclic-imports/child.component.ts
+++ b/adev/src/content/examples/errors/cyclic-imports/child.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {ParentComponent} from './parent.component';
 
 @Component({
-  standalone: true,
   selector: 'app-child',
   template: 'The child!',
 })

--- a/adev/src/content/examples/errors/cyclic-imports/parent.component.ts
+++ b/adev/src/content/examples/errors/cyclic-imports/parent.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {ChildComponent} from './child.component';
 
 @Component({
-  standalone: true,
   selector: 'app-parent',
   imports: [ChildComponent],
   template: '<app-child/>',

--- a/adev/src/content/examples/i18n/src/app/app.component.ts
+++ b/adev/src/content/examples/i18n/src/app/app.component.ts
@@ -3,7 +3,6 @@ import {Component, computed, signal} from '@angular/core';
 import {$localize} from '@angular/localize/init';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   templateUrl: './app.component.html',
 })

--- a/adev/src/content/examples/inputs-outputs/src/app/aliasing.component.ts
+++ b/adev/src/content/examples/inputs-outputs/src/app/aliasing.component.ts
@@ -5,7 +5,6 @@
 import {Component, EventEmitter, Input, Output} from '@angular/core';
 
 @Component({
-  standalone: true,
   selector: 'app-aliasing',
   template: `
     <p>Save for later item: {{input1}}</p>

--- a/adev/src/content/examples/inputs-outputs/src/app/app.component.ts
+++ b/adev/src/content/examples/inputs-outputs/src/app/app.component.ts
@@ -10,7 +10,6 @@ import {ItemDetailMetadataComponent} from './item-details-metadata.component';
 import {ItemOutputComponent} from './item-output.component';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   templateUrl: './app.component.html',
   imports: [

--- a/adev/src/content/examples/inputs-outputs/src/app/in-the-metadata.component.ts
+++ b/adev/src/content/examples/inputs-outputs/src/app/in-the-metadata.component.ts
@@ -2,7 +2,6 @@
 import {Component, EventEmitter} from '@angular/core';
 
 @Component({
-  standalone: true,
   selector: 'app-in-the-metadata',
   template: `
   <p>Latest clearance item: {{clearanceItem}}</p>

--- a/adev/src/content/examples/inputs-outputs/src/app/input-output.component.ts
+++ b/adev/src/content/examples/inputs-outputs/src/app/input-output.component.ts
@@ -1,7 +1,6 @@
 import {Component, Input, Output, EventEmitter} from '@angular/core';
 
 @Component({
-  standalone: true,
   selector: 'app-input-output',
   template: `
   <p [style.text-decoration]="lineThrough">Item: {{item}}</p>

--- a/adev/src/content/examples/inputs-outputs/src/app/item-detail.component.ts
+++ b/adev/src/content/examples/inputs-outputs/src/app/item-detail.component.ts
@@ -4,7 +4,6 @@ import {Component, Input} from '@angular/core'; // First, import Input
 // #enddocregion use-input
 
 @Component({
-  standalone: true,
   selector: 'app-item-detail',
   templateUrl: './item-detail.component.html',
 })

--- a/adev/src/content/examples/inputs-outputs/src/app/item-details-metadata.component.ts
+++ b/adev/src/content/examples/inputs-outputs/src/app/item-details-metadata.component.ts
@@ -6,7 +6,6 @@ import {Component, Input} from '@angular/core'; // First, import Input
 import {booleanAttribute} from '@angular/core'; // First, import booleanAttribute
 // #enddocregion use-input-metadata-boolean-transform
 @Component({
-  standalone: true,
   selector: 'app-item-detail-metadata',
   template: `
   <h2>Child component with &commat;Input() metadata configurations</h2>

--- a/adev/src/content/examples/inputs-outputs/src/app/item-output.component.ts
+++ b/adev/src/content/examples/inputs-outputs/src/app/item-output.component.ts
@@ -1,7 +1,6 @@
 import {Component, Output, EventEmitter} from '@angular/core';
 
 @Component({
-  standalone: true,
   selector: 'app-item-output',
   templateUrl: './item-output.component.html',
 })

--- a/adev/src/content/examples/pipes/src/app/app.component.ts
+++ b/adev/src/content/examples/pipes/src/app/app.component.ts
@@ -10,7 +10,6 @@ import {JsonPipeComponent} from './json-pipe.component';
 import {PowerBoosterComponent} from './power-booster.component';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   templateUrl: './app.component.html',
   imports: [

--- a/adev/src/content/examples/pipes/src/app/birthday-formatting.component.ts
+++ b/adev/src/content/examples/pipes/src/app/birthday-formatting.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {DatePipe} from '@angular/common';
 
 @Component({
-  standalone: true,
   selector: 'app-birthday-formatting',
   templateUrl: './birthday-formatting.component.html',
   imports: [DatePipe],

--- a/adev/src/content/examples/pipes/src/app/birthday-pipe-chaining.component.ts
+++ b/adev/src/content/examples/pipes/src/app/birthday-pipe-chaining.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {DatePipe, UpperCasePipe} from '@angular/common';
 
 @Component({
-  standalone: true,
   selector: 'app-birthday-pipe-chaining',
   templateUrl: './birthday-pipe-chaining.component.html',
   imports: [DatePipe, UpperCasePipe],

--- a/adev/src/content/examples/pipes/src/app/birthday.component.ts
+++ b/adev/src/content/examples/pipes/src/app/birthday.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {DatePipe} from '@angular/common';
 
 @Component({
-  standalone: true,
   selector: 'app-birthday',
   templateUrl: './birthday.component.html',
   imports: [DatePipe],

--- a/adev/src/content/examples/pipes/src/app/exponential-strength.pipe.ts
+++ b/adev/src/content/examples/pipes/src/app/exponential-strength.pipe.ts
@@ -10,7 +10,6 @@ import {Pipe, PipeTransform} from '@angular/core';
  */
 // #docregion pipe-class
 @Pipe({
-  standalone: true,
   name: 'exponentialStrength',
 })
 export class ExponentialStrengthPipe implements PipeTransform {

--- a/adev/src/content/examples/pipes/src/app/flying-heroes.component.ts
+++ b/adev/src/content/examples/pipes/src/app/flying-heroes.component.ts
@@ -8,7 +8,6 @@ import {FlyingHeroesPipe, FlyingHeroesImpurePipe} from './flying-heroes.pipe';
 import {HEROES} from './heroes';
 
 @Component({
-  standalone: true,
   selector: 'app-flying-heroes',
   templateUrl: './flying-heroes.component.html',
   imports: [CommonModule, FormsModule, FlyingHeroesPipe],
@@ -63,7 +62,6 @@ export class FlyingHeroesComponent {
 
 ////// Identical except for impure pipe //////
 @Component({
-  standalone: true,
   selector: 'app-flying-heroes-impure',
   templateUrl: './flying-heroes-impure.component.html',
   imports: [CommonModule, FormsModule, FlyingHeroesImpurePipe],

--- a/adev/src/content/examples/pipes/src/app/flying-heroes.pipe.ts
+++ b/adev/src/content/examples/pipes/src/app/flying-heroes.pipe.ts
@@ -5,7 +5,6 @@ import {Pipe, PipeTransform} from '@angular/core';
 import {Hero} from './heroes';
 
 @Pipe({
-  standalone: true,
   name: 'flyingHeroes',
 })
 export class FlyingHeroesPipe implements PipeTransform {
@@ -21,7 +20,6 @@ export class FlyingHeroesPipe implements PipeTransform {
 // #docregion impure
 // #docregion pipe-decorator
 @Pipe({
-  standalone: true,
   name: 'flyingHeroesImpure',
   pure: false,
 })

--- a/adev/src/content/examples/pipes/src/app/hero-async-message.component.ts
+++ b/adev/src/content/examples/pipes/src/app/hero-async-message.component.ts
@@ -5,7 +5,6 @@ import {Observable, interval} from 'rxjs';
 import {map, startWith, take} from 'rxjs/operators';
 
 @Component({
-  standalone: true,
   selector: 'app-hero-async-message',
   template: `
     <h2>Async Messages and AsyncPipe</h2>

--- a/adev/src/content/examples/pipes/src/app/json-pipe.component.ts
+++ b/adev/src/content/examples/pipes/src/app/json-pipe.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {JsonPipe} from '@angular/common';
 
 @Component({
-  standalone: true,
   selector: 'app-json-pipe',
   template: `{{ data | json }}`,
   imports: [JsonPipe],

--- a/adev/src/content/examples/pipes/src/app/power-booster.component.ts
+++ b/adev/src/content/examples/pipes/src/app/power-booster.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {ExponentialStrengthPipe} from './exponential-strength.pipe';
 
 @Component({
-  standalone: true,
   selector: 'app-power-booster',
   template: `
     <h2>Power Booster</h2>

--- a/adev/src/content/examples/pipes/src/app/precedence.component.ts
+++ b/adev/src/content/examples/pipes/src/app/precedence.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {UpperCasePipe} from '@angular/common';
 
 @Component({
-  standalone: true,
   selector: 'app-pipe-precedence',
   templateUrl: './precedence.component.html',
   imports: [UpperCasePipe],

--- a/adev/src/content/examples/resolution-modifiers/src/app/app.component.ts
+++ b/adev/src/content/examples/resolution-modifiers/src/app/app.component.ts
@@ -10,7 +10,6 @@ import {SelfNoDataComponent} from './self-no-data/self-no-data.component';
 import {SkipselfComponent} from './skipself/skipself.component';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],

--- a/adev/src/content/examples/resolution-modifiers/src/app/host-child/host-child.component.ts
+++ b/adev/src/content/examples/resolution-modifiers/src/app/host-child/host-child.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {FlowerService} from '../flower.service';
 
 @Component({
-  standalone: true,
   selector: 'app-host-child',
   templateUrl: './host-child.component.html',
   styleUrls: ['./host-child.component.css'],

--- a/adev/src/content/examples/resolution-modifiers/src/app/host-parent/host-parent.component.ts
+++ b/adev/src/content/examples/resolution-modifiers/src/app/host-parent/host-parent.component.ts
@@ -3,7 +3,6 @@ import {FlowerService} from '../flower.service';
 import {HostComponent} from '../host/host.component';
 
 @Component({
-  standalone: true,
   selector: 'app-host-parent',
   templateUrl: './host-parent.component.html',
   styleUrls: ['./host-parent.component.css'],

--- a/adev/src/content/examples/resolution-modifiers/src/app/host/host.component.ts
+++ b/adev/src/content/examples/resolution-modifiers/src/app/host/host.component.ts
@@ -4,7 +4,6 @@ import {HostChildComponent} from '../host-child/host-child.component';
 
 // #docregion host-component
 @Component({
-  standalone: true,
   selector: 'app-host',
   templateUrl: './host.component.html',
   styleUrls: ['./host.component.css'],

--- a/adev/src/content/examples/resolution-modifiers/src/app/optional/optional.component.ts
+++ b/adev/src/content/examples/resolution-modifiers/src/app/optional/optional.component.ts
@@ -2,7 +2,6 @@ import {Component, Optional} from '@angular/core';
 import {OptionalService} from '../optional.service';
 
 @Component({
-  standalone: true,
   selector: 'app-optional',
   templateUrl: './optional.component.html',
   styleUrls: ['./optional.component.css'],

--- a/adev/src/content/examples/resolution-modifiers/src/app/self-no-data/self-no-data.component.ts
+++ b/adev/src/content/examples/resolution-modifiers/src/app/self-no-data/self-no-data.component.ts
@@ -3,7 +3,6 @@ import {LeafService} from '../leaf.service';
 
 // #docregion self-no-data-component
 @Component({
-  standalone: true,
   selector: 'app-self-no-data',
   templateUrl: './self-no-data.component.html',
   styleUrls: ['./self-no-data.component.css'],

--- a/adev/src/content/examples/resolution-modifiers/src/app/self/self.component.ts
+++ b/adev/src/content/examples/resolution-modifiers/src/app/self/self.component.ts
@@ -3,7 +3,6 @@ import {FlowerService} from '../flower.service';
 
 // #docregion self-component
 @Component({
-  standalone: true,
   selector: 'app-self',
   templateUrl: './self.component.html',
   styleUrls: ['./self.component.css'],

--- a/adev/src/content/examples/resolution-modifiers/src/app/skipself/skipself.component.ts
+++ b/adev/src/content/examples/resolution-modifiers/src/app/skipself/skipself.component.ts
@@ -3,7 +3,6 @@ import {LeafService} from '../leaf.service';
 
 // #docregion skipself-component
 @Component({
-  standalone: true,
   selector: 'app-skipself',
   templateUrl: './skipself.component.html',
   styleUrls: ['./skipself.component.css'],

--- a/adev/src/content/examples/router-tutorial/src/app/app.component.ts
+++ b/adev/src/content/examples/router-tutorial/src/app/app.component.ts
@@ -6,7 +6,6 @@ import {HeroesListComponent} from './heroes-list/heroes-list.component';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [RouterOutlet, RouterLink, RouterLinkActive, CrisisListComponent, HeroesListComponent],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],

--- a/adev/src/content/examples/router-tutorial/src/app/crisis-list/crisis-list.component.ts
+++ b/adev/src/content/examples/router-tutorial/src/app/crisis-list/crisis-list.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 
 @Component({
   selector: 'app-crisis-list',
-  standalone: true,
   templateUrl: './crisis-list.component.html',
   styleUrls: ['./crisis-list.component.css'],
 })

--- a/adev/src/content/examples/router-tutorial/src/app/heroes-list/heroes-list.component.ts
+++ b/adev/src/content/examples/router-tutorial/src/app/heroes-list/heroes-list.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 
 @Component({
   selector: 'app-heroes-list',
-  standalone: true,
   templateUrl: './heroes-list.component.html',
   styleUrls: ['./heroes-list.component.css'],
 })

--- a/adev/src/content/examples/router-tutorial/src/app/page-not-found/page-not-found.component.ts
+++ b/adev/src/content/examples/router-tutorial/src/app/page-not-found/page-not-found.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 
 @Component({
   selector: 'app-page-not-found',
-  standalone: true,
   templateUrl: './page-not-found.component.html',
   styleUrls: ['./page-not-found.component.css'],
 })

--- a/adev/src/content/examples/routing-with-urlmatcher/src/app/app.component.ts
+++ b/adev/src/content/examples/routing-with-urlmatcher/src/app/app.component.ts
@@ -3,7 +3,6 @@ import {RouterLink, RouterOutlet} from '@angular/router';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [RouterOutlet, RouterLink],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],

--- a/adev/src/content/examples/routing-with-urlmatcher/src/app/profile/profile.component.ts
+++ b/adev/src/content/examples/routing-with-urlmatcher/src/app/profile/profile.component.ts
@@ -2,7 +2,6 @@ import {Component, Input} from '@angular/core';
 
 @Component({
   selector: 'app-profile',
-  standalone: true,
   templateUrl: './profile.component.html',
   styleUrls: ['./profile.component.css'],
 })

--- a/adev/src/content/examples/security/src/app/app.component.ts
+++ b/adev/src/content/examples/security/src/app/app.component.ts
@@ -4,7 +4,6 @@ import {BypassSecurityComponent} from './bypass-security.component';
 import {InnerHtmlBindingComponent} from './inner-html-binding.component';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   template: `
     <h1>Security</h1>

--- a/adev/src/content/examples/security/src/app/bypass-security.component.ts
+++ b/adev/src/content/examples/security/src/app/bypass-security.component.ts
@@ -4,7 +4,6 @@ import {Component} from '@angular/core';
 import {DomSanitizer, SafeResourceUrl, SafeUrl} from '@angular/platform-browser';
 
 @Component({
-  standalone: true,
   selector: 'app-bypass-security',
   templateUrl: './bypass-security.component.html',
 })

--- a/adev/src/content/examples/security/src/app/inner-html-binding.component.ts
+++ b/adev/src/content/examples/security/src/app/inner-html-binding.component.ts
@@ -2,7 +2,6 @@
 import {Component} from '@angular/core';
 
 @Component({
-  standalone: true,
   selector: 'app-inner-html-binding',
   templateUrl: './inner-html-binding.component.html',
 })

--- a/adev/src/content/examples/service-worker-getting-started/src/app/app.component.ts
+++ b/adev/src/content/examples/service-worker-getting-started/src/app/app.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {SwUpdate} from '@angular/service-worker';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   templateUrl: './app.component.html',
 })

--- a/adev/src/content/examples/ssr/src/app/app.component.ts
+++ b/adev/src/content/examples/ssr/src/app/app.component.ts
@@ -7,7 +7,6 @@ import {isPlatformBrowser} from '@angular/common';
 import {MessagesComponent} from './messages/messages.component';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   templateUrl: './app.component.html',
   imports: [RouterLink, RouterOutlet, MessagesComponent],

--- a/adev/src/content/examples/ssr/src/app/dashboard/dashboard.component.ts
+++ b/adev/src/content/examples/ssr/src/app/dashboard/dashboard.component.ts
@@ -7,7 +7,6 @@ import {HeroSearchComponent} from '../hero-search/hero-search.component';
 import {HeroService} from '../hero.service';
 
 @Component({
-  standalone: true,
   selector: 'app-dashboard',
   templateUrl: './dashboard.component.html',
   imports: [NgFor, RouterLink, HeroSearchComponent],

--- a/adev/src/content/examples/ssr/src/app/hero-detail/hero-detail.component.ts
+++ b/adev/src/content/examples/ssr/src/app/hero-detail/hero-detail.component.ts
@@ -7,7 +7,6 @@ import {Hero} from '../hero';
 import {HeroService} from '../hero.service';
 
 @Component({
-  standalone: true,
   selector: 'app-hero-detail',
   templateUrl: './hero-detail.component.html',
   imports: [FormsModule, NgIf, UpperCasePipe],

--- a/adev/src/content/examples/ssr/src/app/hero-search/hero-search.component.ts
+++ b/adev/src/content/examples/ssr/src/app/hero-search/hero-search.component.ts
@@ -10,7 +10,6 @@ import {Hero} from '../hero';
 import {HeroService} from '../hero.service';
 
 @Component({
-  standalone: true,
   selector: 'app-hero-search',
   templateUrl: './hero-search.component.html',
   imports: [AsyncPipe, NgFor, RouterLink],

--- a/adev/src/content/examples/ssr/src/app/heroes/heroes.component.ts
+++ b/adev/src/content/examples/ssr/src/app/heroes/heroes.component.ts
@@ -6,7 +6,6 @@ import {Hero} from '../hero';
 import {HeroService} from '../hero.service';
 
 @Component({
-  standalone: true,
   selector: 'app-heroes',
   templateUrl: './heroes.component.html',
   imports: [NgFor, RouterLink],

--- a/adev/src/content/examples/ssr/src/app/messages/messages.component.ts
+++ b/adev/src/content/examples/ssr/src/app/messages/messages.component.ts
@@ -4,7 +4,6 @@ import {NgFor, NgIf} from '@angular/common';
 import {MessageService} from '../message.service';
 
 @Component({
-  standalone: true,
   selector: 'app-messages',
   templateUrl: './messages.component.html',
   imports: [NgFor, NgIf],

--- a/adev/src/content/examples/structural-directives/src/app/app.component.ts
+++ b/adev/src/content/examples/structural-directives/src/app/app.component.ts
@@ -10,7 +10,6 @@ import {TrigonometryDirective} from './trigonometry.directive';
 import {Hero, heroes} from './hero';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],

--- a/adev/src/content/examples/structural-directives/src/app/hero-switch.components.ts
+++ b/adev/src/content/examples/structural-directives/src/app/hero-switch.components.ts
@@ -3,7 +3,6 @@ import {Component, Input} from '@angular/core';
 import {Hero} from './hero';
 
 @Component({
-  standalone: true,
   selector: 'app-happy-hero',
   template: 'Wow. You like {{hero.name}}. What a happy hero ... just like you.',
 })
@@ -12,7 +11,6 @@ export class HappyHeroComponent {
 }
 
 @Component({
-  standalone: true,
   selector: 'app-sad-hero',
   template: 'You like {{hero.name}}? Such a sad hero. Are you sad too?',
 })
@@ -21,7 +19,6 @@ export class SadHeroComponent {
 }
 
 @Component({
-  standalone: true,
   selector: 'app-confused-hero',
   template: 'Are you as confused as {{hero.name}}?',
 })
@@ -30,7 +27,6 @@ export class ConfusedHeroComponent {
 }
 
 @Component({
-  standalone: true,
   selector: 'app-unknown-hero',
   template: '{{message}}',
 })

--- a/adev/src/content/examples/structural-directives/src/app/hero.component.ts
+++ b/adev/src/content/examples/structural-directives/src/app/hero.component.ts
@@ -7,7 +7,6 @@ import {LoadingState} from './loading-state';
 import {Hero, heroes} from './hero';
 
 @Component({
-  standalone: true,
   selector: 'app-hero',
   template: `
     <button (click)="onLoadHero()">Load Hero</button>

--- a/adev/src/content/examples/structural-directives/src/app/if-loaded.directive.ts
+++ b/adev/src/content/examples/structural-directives/src/app/if-loaded.directive.ts
@@ -3,7 +3,6 @@ import {Directive, Input, TemplateRef, ViewContainerRef} from '@angular/core';
 import {Loaded, LoadingState} from './loading-state';
 
 @Directive({
-  standalone: true,
   selector: '[appIfLoaded]',
 })
 export class IfLoadedDirective<T> {

--- a/adev/src/content/examples/structural-directives/src/app/trigonometry.directive.ts
+++ b/adev/src/content/examples/structural-directives/src/app/trigonometry.directive.ts
@@ -1,7 +1,6 @@
 import {Directive, Input, TemplateRef, ViewContainerRef} from '@angular/core';
 
 @Directive({
-  standalone: true,
   selector: '[appTrigonometry]',
 })
 export class TrigonometryDirective {

--- a/adev/src/content/examples/structural-directives/src/app/unless.directive.ts
+++ b/adev/src/content/examples/structural-directives/src/app/unless.directive.ts
@@ -25,7 +25,6 @@ import {Directive, Input, TemplateRef, ViewContainerRef} from '@angular/core';
  */
 // #docregion skeleton
 @Directive({
-  standalone: true,
   selector: '[appUnless]',
 })
 export class UnlessDirective {

--- a/adev/src/content/examples/styleguide/src/02-07/app/heroes/hero.component.avoid.ts
+++ b/adev/src/content/examples/styleguide/src/02-07/app/heroes/hero.component.avoid.ts
@@ -5,7 +5,6 @@ import {Component} from '@angular/core';
 
 // HeroComponent is in the Tour of Heroes feature
 @Component({
-  standalone: true,
   selector: 'hero',
   template: '',
 })

--- a/adev/src/content/examples/styleguide/src/02-07/app/heroes/hero.component.ts
+++ b/adev/src/content/examples/styleguide/src/02-07/app/heroes/hero.component.ts
@@ -7,7 +7,6 @@ import {Component} from '@angular/core';
   // #enddocregion example
   template: '<div>hero component</div>',
   // #docregion example
-  standalone: true,
   selector: 'toh-hero',
 })
 export class HeroComponent {}

--- a/adev/src/content/examples/styleguide/src/02-07/app/users/users.component.avoid.ts
+++ b/adev/src/content/examples/styleguide/src/02-07/app/users/users.component.avoid.ts
@@ -5,7 +5,6 @@ import {Component} from '@angular/core';
 
 // UsersComponent is in an Admin feature
 @Component({
-  standalone: true,
   selector: 'users',
   template: '',
 })

--- a/adev/src/content/examples/styleguide/src/02-07/app/users/users.component.ts
+++ b/adev/src/content/examples/styleguide/src/02-07/app/users/users.component.ts
@@ -7,7 +7,6 @@ import {Component} from '@angular/core';
   // #enddocregion example
   template: '<div>users component</div>',
   // #docregion example
-  standalone: true,
   selector: 'admin-users',
 })
 export class UsersComponent {}

--- a/adev/src/content/examples/styleguide/src/02-08/app/shared/validate.directive.avoid.ts
+++ b/adev/src/content/examples/styleguide/src/02-08/app/shared/validate.directive.avoid.ts
@@ -4,7 +4,6 @@ import {Directive} from '@angular/core';
 /* avoid */
 
 @Directive({
-  standalone: true,
   selector: '[validate]',
 })
 export class ValidateDirective {}

--- a/adev/src/content/examples/styleguide/src/02-08/app/shared/validate.directive.ts
+++ b/adev/src/content/examples/styleguide/src/02-08/app/shared/validate.directive.ts
@@ -3,7 +3,6 @@ import {Directive} from '@angular/core';
 
 // #docregion example
 @Directive({
-  standalone: true,
   selector: '[tohValidate]',
 })
 export class ValidateDirective {}

--- a/adev/src/content/examples/styleguide/src/05-02/app/heroes/shared/hero-button/hero-button.component.avoid.ts
+++ b/adev/src/content/examples/styleguide/src/05-02/app/heroes/shared/hero-button/hero-button.component.avoid.ts
@@ -4,7 +4,6 @@ import {Component} from '@angular/core';
 /* avoid */
 
 @Component({
-  standalone: true,
   selector: 'tohHeroButton',
   templateUrl: './hero-button.component.html',
 })

--- a/adev/src/content/examples/styleguide/src/05-02/app/heroes/shared/hero-button/hero-button.component.ts
+++ b/adev/src/content/examples/styleguide/src/05-02/app/heroes/shared/hero-button/hero-button.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 
 // #docregion example
 @Component({
-  standalone: true,
   selector: 'toh-hero-button',
   templateUrl: './hero-button.component.html',
 })

--- a/adev/src/content/examples/styleguide/src/05-03/app/heroes/shared/hero-button/hero-button.component.avoid.ts
+++ b/adev/src/content/examples/styleguide/src/05-03/app/heroes/shared/hero-button/hero-button.component.avoid.ts
@@ -3,7 +3,6 @@ import {Component} from '@angular/core';
 /* avoid */
 
 @Component({
-  standalone: true,
   selector: '[tohHeroButton]',
   templateUrl: './hero-button.component.html',
 })

--- a/adev/src/content/examples/styleguide/src/05-03/app/heroes/shared/hero-button/hero-button.component.ts
+++ b/adev/src/content/examples/styleguide/src/05-03/app/heroes/shared/hero-button/hero-button.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 
 // #docregion example
 @Component({
-  standalone: true,
   selector: 'toh-hero-button',
   templateUrl: './hero-button.component.html',
 })

--- a/adev/src/content/examples/styleguide/src/05-04/app/app.component.ts
+++ b/adev/src/content/examples/styleguide/src/05-04/app/app.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {HeroesComponent} from './heroes';
 
 @Component({
-  standalone: true,
   selector: 'sg-app',
   template: '<toh-heroes></toh-heroes>',
   imports: [HeroesComponent],

--- a/adev/src/content/examples/styleguide/src/05-04/app/heroes/heroes.component.avoid.ts
+++ b/adev/src/content/examples/styleguide/src/05-04/app/heroes/heroes.component.avoid.ts
@@ -8,7 +8,6 @@ import {AsyncPipe, NgFor, NgIf, UpperCasePipe} from '@angular/common';
 /* avoid */
 
 @Component({
-  standalone: true,
   selector: 'toh-heroes',
   template: `
     <div>

--- a/adev/src/content/examples/styleguide/src/05-04/app/heroes/heroes.component.ts
+++ b/adev/src/content/examples/styleguide/src/05-04/app/heroes/heroes.component.ts
@@ -6,7 +6,6 @@ import {AsyncPipe, NgFor, NgIf, UpperCasePipe} from '@angular/common';
 
 // #docregion example
 @Component({
-  standalone: true,
   selector: 'toh-heroes',
   templateUrl: './heroes.component.html',
   styleUrls: ['./heroes.component.css'],

--- a/adev/src/content/examples/styleguide/src/05-12/app/app.component.ts
+++ b/adev/src/content/examples/styleguide/src/05-12/app/app.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {HeroButtonComponent} from './heroes/shared/hero-button/hero-button.component';
 
 @Component({
-  standalone: true,
   selector: 'sg-app',
   template: '<toh-hero-button label="OK"></toh-hero-button>',
   imports: [HeroButtonComponent],

--- a/adev/src/content/examples/styleguide/src/05-12/app/heroes/shared/hero-button/hero-button.component.avoid.ts
+++ b/adev/src/content/examples/styleguide/src/05-12/app/heroes/shared/hero-button/hero-button.component.avoid.ts
@@ -4,7 +4,6 @@ import {Component, EventEmitter} from '@angular/core';
 /* avoid */
 
 @Component({
-  standalone: true,
   selector: 'toh-hero-button',
   template: `<button type="button"></button>`,
   inputs: ['label'],

--- a/adev/src/content/examples/styleguide/src/05-12/app/heroes/shared/hero-button/hero-button.component.ts
+++ b/adev/src/content/examples/styleguide/src/05-12/app/heroes/shared/hero-button/hero-button.component.ts
@@ -3,7 +3,6 @@ import {Component, EventEmitter, Input, Output} from '@angular/core';
 
 // #docregion example
 @Component({
-  standalone: true,
   selector: 'toh-hero-button',
   template: `<button type="button">{{label}}</button>`,
 })

--- a/adev/src/content/examples/styleguide/src/05-13/app/heroes/shared/hero-button/hero-button.component.avoid.ts
+++ b/adev/src/content/examples/styleguide/src/05-13/app/heroes/shared/hero-button/hero-button.component.avoid.ts
@@ -3,7 +3,6 @@ import {Component, EventEmitter, Input, Output} from '@angular/core';
 /* avoid pointless aliasing */
 
 @Component({
-  standalone: true,
   selector: 'toh-hero-button',
   template: `<button type="button">{{label}}</button>`,
 })

--- a/adev/src/content/examples/styleguide/src/05-13/app/heroes/shared/hero-button/hero-button.component.ts
+++ b/adev/src/content/examples/styleguide/src/05-13/app/heroes/shared/hero-button/hero-button.component.ts
@@ -3,7 +3,6 @@ import {Component, EventEmitter, Input, Output} from '@angular/core';
 
 // #docregion example
 @Component({
-  standalone: true,
   selector: 'toh-hero-button',
   template: `<button type="button" >{{label}}</button>`,
 })

--- a/adev/src/content/examples/styleguide/src/05-13/app/heroes/shared/hero-highlight.directive.ts
+++ b/adev/src/content/examples/styleguide/src/05-13/app/heroes/shared/hero-highlight.directive.ts
@@ -3,7 +3,6 @@ import {Directive, ElementRef, Input, OnChanges} from '@angular/core';
 
 // eslint-disable-next-line @angular-eslint/directive-selector
 @Directive({
-  standalone: true,
   selector: '[heroHighlight]',
 })
 export class HeroHighlightDirective implements OnChanges {

--- a/adev/src/content/examples/styleguide/src/05-15/app/heroes/hero-list/hero-list.component.avoid.ts
+++ b/adev/src/content/examples/styleguide/src/05-15/app/heroes/hero-list/hero-list.component.avoid.ts
@@ -12,7 +12,6 @@ import {Hero} from '../shared/hero.model';
 const heroesUrl = 'http://angular.io';
 
 @Component({
-  standalone: true,
   selector: 'toh-hero-list',
   template: `...`,
 })

--- a/adev/src/content/examples/styleguide/src/05-15/app/heroes/hero-list/hero-list.component.ts
+++ b/adev/src/content/examples/styleguide/src/05-15/app/heroes/hero-list/hero-list.component.ts
@@ -4,7 +4,6 @@ import {Component, OnInit} from '@angular/core';
 import {Hero, HeroService} from '../shared';
 
 @Component({
-  standalone: true,
   selector: 'toh-hero-list',
   template: `...`,
 })

--- a/adev/src/content/examples/styleguide/src/05-16/app/heroes/hero.component.avoid.ts
+++ b/adev/src/content/examples/styleguide/src/05-16/app/heroes/hero.component.avoid.ts
@@ -4,7 +4,6 @@ import {Component, EventEmitter, Output} from '@angular/core';
 /* avoid */
 
 @Component({
-  standalone: true,
   selector: 'toh-hero',
   template: `...`,
 })

--- a/adev/src/content/examples/styleguide/src/05-16/app/heroes/hero.component.ts
+++ b/adev/src/content/examples/styleguide/src/05-16/app/heroes/hero.component.ts
@@ -2,7 +2,6 @@
 import {Component, EventEmitter, Output} from '@angular/core';
 
 @Component({
-  standalone: true,
   selector: 'toh-hero',
   template: `...`,
 })

--- a/adev/src/content/examples/styleguide/src/05-17/app/heroes/hero-list/hero-list.component.avoid.ts
+++ b/adev/src/content/examples/styleguide/src/05-17/app/heroes/hero-list/hero-list.component.avoid.ts
@@ -9,7 +9,6 @@ import {HeroComponent} from '../hero/hero.component';
 /* avoid */
 
 @Component({
-  standalone: true,
   selector: 'toh-hero-list',
   template: `
     <section>

--- a/adev/src/content/examples/styleguide/src/05-17/app/heroes/hero-list/hero-list.component.ts
+++ b/adev/src/content/examples/styleguide/src/05-17/app/heroes/hero-list/hero-list.component.ts
@@ -7,7 +7,6 @@ import {NgFor} from '@angular/common';
 
 // #docregion example
 @Component({
-  standalone: true,
   selector: 'toh-hero-list',
   template: `
     <section>

--- a/adev/src/content/examples/styleguide/src/05-17/app/heroes/hero/hero.component.ts
+++ b/adev/src/content/examples/styleguide/src/05-17/app/heroes/hero/hero.component.ts
@@ -3,7 +3,6 @@ import {Component, Input} from '@angular/core';
 import {Hero} from '../shared/hero.model';
 
 @Component({
-  standalone: true,
   selector: 'toh-hero',
   template: `...`,
 })

--- a/adev/src/content/examples/styleguide/src/05-18/app/heroes/hero/hero.component.avoid.ts
+++ b/adev/src/content/examples/styleguide/src/05-18/app/heroes/hero/hero.component.avoid.ts
@@ -2,7 +2,6 @@ import {Component, Input} from '@angular/core';
 
 // #docregion example
 @Component({
-  standalone: true,
   selector: 'toh-hero',
   template: `...`,
 })

--- a/adev/src/content/examples/styleguide/src/05-18/app/heroes/hero/hero.component.optional.ts
+++ b/adev/src/content/examples/styleguide/src/05-18/app/heroes/hero/hero.component.optional.ts
@@ -2,7 +2,6 @@ import {Component, Input} from '@angular/core';
 
 // #docregion example
 @Component({
-  standalone: true,
   selector: 'toh-hero',
   template: `...`,
 })

--- a/adev/src/content/examples/styleguide/src/05-18/app/heroes/hero/hero.component.ts
+++ b/adev/src/content/examples/styleguide/src/05-18/app/heroes/hero/hero.component.ts
@@ -2,7 +2,6 @@ import {Component, Input} from '@angular/core';
 
 // #docregion example
 @Component({
-  standalone: true,
   selector: 'toh-hero',
   template: `...`,
 })

--- a/adev/src/content/examples/styleguide/src/06-01/app/shared/highlight.directive.ts
+++ b/adev/src/content/examples/styleguide/src/06-01/app/shared/highlight.directive.ts
@@ -3,7 +3,6 @@ import {Directive, HostListener} from '@angular/core';
 
 // #docregion example
 @Directive({
-  standalone: true,
   selector: '[tohHighlight]',
 })
 export class HighlightDirective {

--- a/adev/src/content/examples/styleguide/src/06-03/app/shared/validator.directive.ts
+++ b/adev/src/content/examples/styleguide/src/06-03/app/shared/validator.directive.ts
@@ -2,7 +2,6 @@
 import {Directive, HostBinding, HostListener} from '@angular/core';
 
 @Directive({
-  standalone: true,
   selector: '[tohValidator]',
 })
 export class ValidatorDirective {

--- a/adev/src/content/examples/styleguide/src/06-03/app/shared/validator2.directive.ts
+++ b/adev/src/content/examples/styleguide/src/06-03/app/shared/validator2.directive.ts
@@ -3,7 +3,6 @@
 import {Directive} from '@angular/core';
 
 @Directive({
-  standalone: true,
   selector: '[tohValidator2]',
   host: {
     '[attr.role]': 'role',

--- a/adev/src/content/examples/styleguide/src/09-01/app/heroes/shared/hero-button/hero-button.component.avoid.ts
+++ b/adev/src/content/examples/styleguide/src/09-01/app/heroes/shared/hero-button/hero-button.component.avoid.ts
@@ -4,7 +4,6 @@ import {Component} from '@angular/core';
 /* avoid */
 
 @Component({
-  standalone: true,
   selector: 'toh-hero-button',
   template: `<button type="button">OK</button>`,
 })

--- a/adev/src/content/examples/styleguide/src/09-01/app/heroes/shared/hero-button/hero-button.component.ts
+++ b/adev/src/content/examples/styleguide/src/09-01/app/heroes/shared/hero-button/hero-button.component.ts
@@ -3,7 +3,6 @@ import {Component, OnInit} from '@angular/core';
 
 // #docregion example
 @Component({
-  standalone: true,
   selector: 'toh-hero-button',
   template: `<button type="button">OK</button>`,
 })

--- a/adev/src/content/examples/testing/src/app/about/about.component.ts
+++ b/adev/src/content/examples/testing/src/app/about/about.component.ts
@@ -5,7 +5,6 @@ import {HighlightDirective} from '../shared/highlight.directive';
 import {TwainComponent} from '../twain/twain.component';
 
 @Component({
-  standalone: true,
   template: `
     <h2 highlight="skyblue">About</h2>
     <h3>Quote of the day:</h3>

--- a/adev/src/content/examples/testing/src/app/app-initial.component.ts
+++ b/adev/src/content/examples/testing/src/app/app-initial.component.ts
@@ -3,7 +3,6 @@
 import {Component} from '@angular/core';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   template: '<h1>Welcome to {{title}}!</h1>',
 })

--- a/adev/src/content/examples/testing/src/app/app.component.spec.ts
+++ b/adev/src/content/examples/testing/src/app/app.component.spec.ts
@@ -9,13 +9,13 @@ import {appConfig} from './app.config';
 import {UserService} from './model';
 
 // #docregion component-stubs
-@Component({standalone: true, selector: 'app-banner', template: ''})
+@Component({selector: 'app-banner', template: ''})
 class BannerStubComponent {}
 
-@Component({standalone: true, selector: 'router-outlet', template: ''})
+@Component({selector: 'router-outlet', template: ''})
 class RouterOutletStubComponent {}
 
-@Component({standalone: true, selector: 'app-welcome', template: ''})
+@Component({selector: 'app-welcome', template: ''})
 class WelcomeStubComponent {}
 // #enddocregion component-stubs
 

--- a/adev/src/content/examples/testing/src/app/app.component.ts
+++ b/adev/src/content/examples/testing/src/app/app.component.ts
@@ -6,7 +6,6 @@ import {BannerComponent} from './banner/banner.component';
 import {WelcomeComponent} from './welcome/welcome.component';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   templateUrl: './app.component.html',
   imports: [BannerComponent, WelcomeComponent, RouterOutlet, RouterLink],

--- a/adev/src/content/examples/testing/src/app/banner/banner-external.component.ts
+++ b/adev/src/content/examples/testing/src/app/banner/banner-external.component.ts
@@ -4,7 +4,6 @@ import {Component} from '@angular/core';
 
 // #docregion metadata
 @Component({
-  standalone: true,
   selector: 'app-banner',
   templateUrl: './banner-external.component.html',
   styleUrls: ['./banner-external.component.css'],

--- a/adev/src/content/examples/testing/src/app/banner/banner-initial.component.ts
+++ b/adev/src/content/examples/testing/src/app/banner/banner-initial.component.ts
@@ -3,7 +3,6 @@
 import {Component} from '@angular/core';
 
 @Component({
-  standalone: true,
   selector: 'app-banner',
   template: '<p>banner works!</p>',
   styles: [],

--- a/adev/src/content/examples/testing/src/app/banner/banner.component.ts
+++ b/adev/src/content/examples/testing/src/app/banner/banner.component.ts
@@ -2,7 +2,6 @@ import {Component, signal} from '@angular/core';
 
 // #docregion component
 @Component({
-  standalone: true,
   selector: 'app-banner',
   template: '<h1>{{title()}}</h1>',
   styles: ['h1 { color: green; font-size: 350%}'],

--- a/adev/src/content/examples/testing/src/app/dashboard/dashboard-hero.component.spec.ts
+++ b/adev/src/content/examples/testing/src/app/dashboard/dashboard-hero.component.spec.ts
@@ -144,7 +144,6 @@ import {Component} from '@angular/core';
 
 // #docregion test-host
 @Component({
-  standalone: true,
   imports: [DashboardHeroComponent],
   template: ` <dashboard-hero [hero]="hero" (selected)="onSelected($event)"> </dashboard-hero>`,
 })

--- a/adev/src/content/examples/testing/src/app/dashboard/dashboard-hero.component.ts
+++ b/adev/src/content/examples/testing/src/app/dashboard/dashboard-hero.component.ts
@@ -6,7 +6,6 @@ import {Hero} from '../model/hero';
 
 // #docregion component
 @Component({
-  standalone: true,
   selector: 'dashboard-hero',
   template: `
     <button type="button" (click)="click()" class="hero">

--- a/adev/src/content/examples/testing/src/app/dashboard/dashboard.component.ts
+++ b/adev/src/content/examples/testing/src/app/dashboard/dashboard.component.ts
@@ -9,7 +9,6 @@ import {sharedImports} from '../shared/shared';
 import {DashboardHeroComponent} from './dashboard-hero.component';
 
 @Component({
-  standalone: true,
   selector: 'app-dashboard',
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.css'],

--- a/adev/src/content/examples/testing/src/app/demo/demo.testbed.spec.ts
+++ b/adev/src/content/examples/testing/src/app/demo/demo.testbed.spec.ts
@@ -452,7 +452,6 @@ describe('demo (with TestBed):', () => {
     it("injected provider should not be same as component's provider", () => {
       // TestComponent is parent of TestProvidersComponent
       @Component({
-        standalone: true,
         template: '<my-service-comp></my-service-comp>',
         imports: [TestProvidersComponent],
       })
@@ -704,21 +703,18 @@ describe('demo (with TestBed):', () => {
 ////////// Fakes ///////////
 
 @Component({
-  standalone: true,
   selector: 'child-1',
   template: 'Fake Child',
 })
 class FakeChildComponent {}
 
 @Component({
-  standalone: true,
   selector: 'grandchild-1',
   template: 'Fake Grandchild',
 })
 class FakeGrandchildComponent {}
 
 @Component({
-  standalone: true,
   selector: 'child-1',
   imports: [FakeGrandchildComponent],
   template: 'Fake Child(<grandchild-1></grandchild-1>)',

--- a/adev/src/content/examples/testing/src/app/demo/demo.ts
+++ b/adev/src/content/examples/testing/src/app/demo/demo.ts
@@ -69,7 +69,7 @@ export class MasterService {
 /*
  * Reverse the input string.
  */
-@Pipe({name: 'reverse', standalone: true})
+@Pipe({name: 'reverse'})
 export class ReversePipe implements PipeTransform {
   transform(s: string) {
     let r = '';
@@ -82,7 +82,6 @@ export class ReversePipe implements PipeTransform {
 
 //////////// Components /////////////
 @Component({
-  standalone: true,
   selector: 'bank-account',
   template: ` Bank Name: {{ bank }} Account Id: {{ id }} `,
 })
@@ -98,7 +97,6 @@ export class BankAccountComponent {
 
 /** A component with attributes, styles, classes, and property setting */
 @Component({
-  standalone: true,
   selector: 'bank-account-parent',
   template: `
     <bank-account
@@ -121,7 +119,6 @@ export class BankAccountParentComponent {
 
 // #docregion LightswitchComp
 @Component({
-  standalone: true,
   selector: 'lightswitch-comp',
   template: ` <button type="button" (click)="clicked()">Click me!</button>
     <span>{{ message }}</span>`,
@@ -138,7 +135,6 @@ export class LightswitchComponent {
 // #enddocregion LightswitchComp
 
 @Component({
-  standalone: true,
   selector: 'child-1',
   template: '<span>Child-1({{text}})</span>',
 })
@@ -147,7 +143,6 @@ export class Child1Component {
 }
 
 @Component({
-  standalone: true,
   selector: 'child-2',
   template: '<div>Child-2({{text}})</div>',
 })
@@ -156,7 +151,6 @@ export class Child2Component {
 }
 
 @Component({
-  standalone: true,
   selector: 'child-3',
   template: '<div>Child-3({{text}})</div>',
 })
@@ -165,7 +159,6 @@ export class Child3Component {
 }
 
 @Component({
-  standalone: true,
   selector: 'input-comp',
   template: '<input [(ngModel)]="name">',
   imports: [FormsModule],
@@ -190,7 +183,7 @@ export class InputComponent {
 // }
 
 // As the styleguide recommends
-@Directive({standalone: true, selector: 'input[value]'})
+@Directive({selector: 'input[value]'})
 export class InputValueBinderDirective {
   @HostBinding() @Input() value: any;
 
@@ -203,7 +196,6 @@ export class InputValueBinderDirective {
 }
 
 @Component({
-  standalone: true,
   selector: 'input-value-comp',
   template: ` Name: <input [value]="name" /> {{ name }} `,
 })
@@ -212,7 +204,6 @@ export class InputValueBinderComponent {
 }
 
 @Component({
-  standalone: true,
   selector: 'parent-comp',
   imports: [Child1Component],
   template: 'Parent(<child-1></child-1>)',
@@ -220,7 +211,6 @@ export class InputValueBinderComponent {
 export class ParentComponent {}
 
 @Component({
-  standalone: true,
   selector: 'io-comp',
   template: '<button type="button" class="hero" (click)="click()">Original {{hero.name}}</button>',
 })
@@ -233,7 +223,6 @@ export class IoComponent {
 }
 
 @Component({
-  standalone: true,
   selector: 'io-parent-comp',
   template: `
     @if (!selectedHero) {
@@ -257,7 +246,6 @@ export class IoParentComponent {
 }
 
 @Component({
-  standalone: true,
   selector: 'my-if-comp',
   template: 'MyIf(@if (showMore) {<span>More</span>})',
   imports: [sharedImports],
@@ -267,7 +255,6 @@ export class MyIfComponent {
 }
 
 @Component({
-  standalone: true,
   selector: 'my-service-comp',
   template: 'injected value: {{valueService.value}}',
   providers: [ValueService],
@@ -277,7 +264,6 @@ export class TestProvidersComponent {
 }
 
 @Component({
-  standalone: true,
   selector: 'my-service-comp',
   template: 'injected value: {{valueService.value}}',
   viewProviders: [ValueService],
@@ -287,7 +273,6 @@ export class TestViewProvidersComponent {
 }
 
 @Component({
-  standalone: true,
   selector: 'external-template-comp',
   templateUrl: './demo-external-template.html',
 })
@@ -304,7 +289,6 @@ export class ExternalTemplateComponent implements OnInit {
 }
 
 @Component({
-  standalone: true,
   selector: 'comp-w-ext-comp',
   imports: [ExternalTemplateComponent],
   template: `
@@ -314,7 +298,7 @@ export class ExternalTemplateComponent implements OnInit {
 })
 export class InnerCompWithExternalTemplateComponent {}
 
-@Component({standalone: true, selector: 'needs-content', template: '<ng-content></ng-content>'})
+@Component({selector: 'needs-content', template: '<ng-content></ng-content>'})
 export class NeedsContentComponent {
   // children with #content local variable
   @ContentChildren('content') children: any;
@@ -322,7 +306,6 @@ export class NeedsContentComponent {
 
 ///////// MyIfChildComp ////////
 @Component({
-  standalone: true,
   selector: 'my-if-child-1',
   template: ` <h4>MyIfChildComp</h4>
     <div>
@@ -381,7 +364,6 @@ export class MyIfChildComponent implements OnInit, OnChanges, OnDestroy {
 ///////// MyIfParentComp ////////
 
 @Component({
-  standalone: true,
   selector: 'my-if-parent-comp',
   template: `
     <h3>MyIfParentComp</h3>
@@ -416,7 +398,6 @@ export class MyIfParentComponent implements OnInit {
 }
 
 @Component({
-  standalone: true,
   selector: 'reverse-pipe-comp',
   template: `
     <input [(ngModel)]="text" />
@@ -429,14 +410,12 @@ export class ReversePipeComponent {
 }
 
 @Component({
-  standalone: true,
   imports: [NeedsContentComponent],
   template: '<div>Replace Me</div>',
 })
 export class ShellComponent {}
 
 @Component({
-  standalone: true,
   selector: 'demo-comp',
   template: `
     <h1>Specs Demo</h1>

--- a/adev/src/content/examples/testing/src/app/hero/hero-detail.component.ts
+++ b/adev/src/content/examples/testing/src/app/hero/hero-detail.component.ts
@@ -9,7 +9,6 @@ import {HeroDetailService} from './hero-detail.service';
 
 // #docregion prototype
 @Component({
-  standalone: true,
   selector: 'app-hero-detail',
   templateUrl: './hero-detail.component.html',
   styleUrls: ['./hero-detail.component.css'],

--- a/adev/src/content/examples/testing/src/app/hero/hero-list.component.ts
+++ b/adev/src/content/examples/testing/src/app/hero/hero-list.component.ts
@@ -9,7 +9,6 @@ import {HeroService} from '../model/hero.service';
 import {sharedImports} from '../shared/shared';
 
 @Component({
-  standalone: true,
   selector: 'app-heroes',
   templateUrl: './hero-list.component.html',
   styleUrls: ['./hero-list.component.css'],

--- a/adev/src/content/examples/testing/src/app/shared/canvas.component.ts
+++ b/adev/src/content/examples/testing/src/app/shared/canvas.component.ts
@@ -9,7 +9,6 @@ import 'zone.js/plugins/zone-patch-canvas';
 import {Component, AfterViewInit, ViewChild, ElementRef} from '@angular/core';
 
 @Component({
-  standalone: true,
   selector: 'sample-canvas',
   template: '<canvas #sampleCanvas width="200" height="200"></canvas>',
 })

--- a/adev/src/content/examples/testing/src/app/shared/highlight.directive.spec.ts
+++ b/adev/src/content/examples/testing/src/app/shared/highlight.directive.spec.ts
@@ -6,7 +6,6 @@ import {HighlightDirective} from './highlight.directive';
 
 // #docregion test-component
 @Component({
-  standalone: true,
   template: ` <h2 highlight="yellow">Something Yellow</h2>
     <h2 highlight>The Default (Gray)</h2>
     <h2>No Highlight</h2>

--- a/adev/src/content/examples/testing/src/app/shared/highlight.directive.ts
+++ b/adev/src/content/examples/testing/src/app/shared/highlight.directive.ts
@@ -2,7 +2,7 @@
 // #docregion
 import {Directive, ElementRef, Input, OnChanges} from '@angular/core';
 
-@Directive({standalone: true, selector: '[highlight]'})
+@Directive({selector: '[highlight]'})
 /**
  * Set backgroundColor for the attached element to highlight color
  * and set the element's customProperty to true

--- a/adev/src/content/examples/testing/src/app/shared/title-case.pipe.ts
+++ b/adev/src/content/examples/testing/src/app/shared/title-case.pipe.ts
@@ -1,7 +1,7 @@
 // #docregion
 import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({name: 'titlecase', standalone: true, pure: true})
+@Pipe({name: 'titlecase', pure: true})
 /** Transform to Title Case: uppercase the first letter of the words in a string. */
 export class TitleCasePipe implements PipeTransform {
   transform(input: string): string {

--- a/adev/src/content/examples/testing/src/app/twain/twain.component.ts
+++ b/adev/src/content/examples/testing/src/app/twain/twain.component.ts
@@ -9,7 +9,6 @@ import {catchError, startWith} from 'rxjs/operators';
 import {TwainService} from './twain.service';
 
 @Component({
-  standalone: true,
   selector: 'twain-quote',
   // #docregion template
   template: ` <p class="twain">

--- a/adev/src/content/examples/testing/src/app/welcome/welcome.component.ts
+++ b/adev/src/content/examples/testing/src/app/welcome/welcome.component.ts
@@ -3,7 +3,6 @@ import {Component, OnInit, signal} from '@angular/core';
 import {UserService} from '../model/user.service';
 
 @Component({
-  standalone: true,
   selector: 'app-welcome',
   template: '<h3 class="welcome"><i>{{welcome()}}</i></h3>',
 })

--- a/adev/src/content/guide/di/dependency-injection.md
+++ b/adev/src/content/guide/di/dependency-injection.md
@@ -50,9 +50,8 @@ In this case the `HeroService` becomes available to all instances of this compon
 
 For example:
 
-<docs-code language="typescript" highlight="[5]">
+<docs-code language="typescript" highlight="[4]">
 @Component({
-  standalone: true,
   selector: 'hero-list',
   template: '...',
   providers: [HeroService]

--- a/adev/src/content/guide/di/hierarchical-dependency-injection.md
+++ b/adev/src/content/guide/di/hierarchical-dependency-injection.md
@@ -816,9 +816,8 @@ Because the injector has only to look at the `ElementInjector` of the `<app-chil
 As in the `FlowerService` example, if you add `@SkipSelf()` to the constructor for the `AnimalService`, the injector won't look in the  `ElementInjector` of the current `<app-child>` for the `AnimalService`.
 Instead, the injector will begin at the `<app-root>` `ElementInjector`.
 
-<docs-code language="typescript" highlight="[6]">
+<docs-code language="typescript" highlight="[5]">
 @Component({
-  standalone: true,
   selector: 'app-child',
   …
   viewProviders: [
@@ -853,9 +852,8 @@ If you just use `@Host()` for the injection of `AnimalService`, the result is do
 The `ChildComponent` configures the `viewProviders` so that the dog emoji is provided as `AnimalService` value.
 You can also see `@Host()` in the constructor:
 
-<docs-code language="typescript" highlight="[[6],[10]]">
+<docs-code language="typescript" highlight="[[5],[9]]">
 @Component({
-  standalone: true
   selector: 'app-child',
   …
   viewProviders: [
@@ -886,9 +884,8 @@ export class ChildComponent {
 
 Add a `viewProviders` array with a third animal, hedgehog <code>&#x1F994;</code>, to the `app.component.ts` `@Component()` metadata:
 
-<docs-code language="typescript" highlight="[7]">
+<docs-code language="typescript" highlight="[6]">
 @Component({
-  standalone: true,
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: [ './app.component.css' ],

--- a/adev/src/content/guide/directives/directive-composition-api.md
+++ b/adev/src/content/guide/directives/directive-composition-api.md
@@ -16,7 +16,6 @@ works similarly to applying the `MenuBehavior` to the `<admin-menu>` element in 
 
 ```typescript
 @Component({
-  standalone: true,
   selector: 'admin-menu',
   template: 'admin-menu.html',
   hostDirectives: [MenuBehavior],
@@ -32,7 +31,7 @@ and outputs are not exposed as part of the component's public API. See
 **Angular applies host directives statically at compile time.** You cannot dynamically add
 directives at runtime.
 
-**Directives used in `hostDirectives` must be `standalone: true`.**
+**Directives used in `hostDirectives` may not specify `standalone: false`.**
 
 **Angular ignores the `selector` of directives applied in the `hostDirectives` property.**
 
@@ -44,7 +43,6 @@ in your component's API by expanding the entry in `hostDirectives`:
 
 ```typescript
 @Component({
-  standalone: true,
   selector: 'admin-menu',
   template: 'admin-menu.html',
   hostDirectives: [{
@@ -69,7 +67,6 @@ component:
 
 ```typescript
 @Component({
-  standalone: true,
   selector: 'admin-menu',
   template: 'admin-menu.html',
   hostDirectives: [{
@@ -108,14 +105,12 @@ export class Tooltip { }
 
 // MenuWithTooltip can compose behaviors from multiple other directives
 @Directive({
-  standalone: true,
   hostDirectives: [Tooltip, Menu],
 })
 export class MenuWithTooltip { }
 
 // CustomWidget can apply the already-composed behaviors from MenuWithTooltip
 @Directive({
-  standalone: true,
   hostDirectives: [MenuWithTooltip],
 })
 export class SpecializedMenuWithTooltip { }
@@ -132,7 +127,6 @@ The following example shows minimal use of a host directive:
 
 ```typescript
 @Component({
-  standalone: true,
   selector: 'admin-menu',
   template: 'admin-menu.html',
   hostDirectives: [MenuBehavior],
@@ -160,13 +154,11 @@ example.
 export class Tooltip { }
 
 @Directive({
-  standalone: true,
   hostDirectives: [Tooltip],
 })
 export class CustomTooltip { }
 
 @Directive({
-  standalone: true,
   hostDirectives: [CustomTooltip],
 })
 export class EvenMoreCustomTooltip { }

--- a/adev/src/content/guide/directives/structural-directives.md
+++ b/adev/src/content/guide/directives/structural-directives.md
@@ -79,7 +79,6 @@ Import `TemplateRef`, and `ViewContainerRef`. Inject `TemplateRef` and `ViewCont
 import {Directive, TemplateRef, ViewContainerRef} from '@angular/core';
 
 @Directive({
-  standalone: true,
   selector: '[select]',
 })
 export class SelectDirective {

--- a/adev/src/content/guide/http/making-requests.md
+++ b/adev/src/content/guide/http/making-requests.md
@@ -247,7 +247,6 @@ Within a component, you can combine `@if` with the `async` pipe to render the UI
 <docs-code language="ts">
 import { AsyncPipe } from '@angular/common';
 @Component({
-  standalone: true,
   imports: [AsyncPipe],
   template: `
     @if (user$ | async; as user) {

--- a/adev/src/content/guide/pipes/template.md
+++ b/adev/src/content/guide/pipes/template.md
@@ -14,7 +14,6 @@ import { Component } from '@angular/core';
 import { DatePipe } from '@angular/common';
 
 @Component({
-  standalone: true,
   templateUrl: './app.component.html',
   imports: [DatePipe],
 })

--- a/adev/src/content/guide/pipes/transform-data.md
+++ b/adev/src/content/guide/pipes/transform-data.md
@@ -19,7 +19,6 @@ import { Pipe } from '@angular/core';
 
 @Pipe({
   name: 'greet',
-  standalone: true,
 })
 export class GreetPipe {}
 ```
@@ -35,7 +34,6 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
   name: 'greet',
-  standalone: true,
 })
 export class GreetPipe implements PipeTransform {
   transform(value: string, param1: boolean, param2: boolean): string {

--- a/adev/src/content/guide/routing/common-router-tasks.md
+++ b/adev/src/content/guide/routing/common-router-tasks.md
@@ -110,7 +110,6 @@ You also need to add the `RouterLink`, `RouterLinkActive`, and `RouterOutlet` to
 ```ts
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [CommonModule, RouterOutlet, RouterLink, RouterLinkActive],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']

--- a/adev/src/content/guide/templates/ng-content.md
+++ b/adev/src/content/guide/templates/ng-content.md
@@ -10,7 +10,6 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'button[baseButton]',
-  standalone: true,
   template: `
       <ng-content />
   `,
@@ -25,7 +24,6 @@ import { BaseButton } from './base-button/base-button.component.ts';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [BaseButton],
   template: `
     <button baseButton>

--- a/adev/src/content/guide/templates/pipes.md
+++ b/adev/src/content/guide/templates/pipes.md
@@ -14,7 +14,6 @@ import { CurrencyPipe, DatePipe, TitleCasePipe } from '@angular/common';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [CurrencyPipe, DatePipe, TitleCasePipe],
   template: `
     <main>
@@ -113,7 +112,6 @@ import { CurrencyPipe} from '@angular/common';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [CurrencyPipe],
   template: `
     <main>
@@ -184,7 +182,6 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
   name: 'kebabCase',
-  standalone: true,
 })
 export class KebabCasePipe implements PipeTransform {
   transform(value: string): string {
@@ -202,15 +199,11 @@ import { Pipe } from '@angular/core';
 
 @Pipe({
   name: 'myCustomTransformation',
-  standalone: true
 })
 export class MyCustomTransformationPipe {}
 ```
 
-The `@Pipe` decorator requires two configuration options:
-
-- `name`: The pipe name that will be used in a template
-- `standalone: true` - Ensures the pipe can be used in standalone applications
+The `@Pipe` decorator requires a `name` that controls how the pipe is used in a template.
 
 ### Naming convention for custom pipes
 
@@ -228,7 +221,6 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
   name: 'myCustomTransformation',
-  standalone: true
 })
 export class MyCustomTransformationPipe implements PipeTransform {}
 ```
@@ -244,7 +236,6 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
   name: 'myCustomTransformation',
-  standalone: true
 })
 export class MyCustomTransformationPipe implements PipeTransform {
   transform(value: string): string {
@@ -262,7 +253,6 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
   name: 'myCustomTransformation',
-  standalone: true
 })
 export class MyCustomTransformationPipe implements PipeTransform {
   transform(value: string, format: string): string {
@@ -289,7 +279,6 @@ import { Pipe, PipeTransform } from '@angular/core';
 @Pipe({
   name: 'featuredItemsImpure',
   pure: false,
-  standalone: true
 })
 export class FeaturedItemsImpurePipe implements PipeTransform {
   transform(value: string, format: string): string {

--- a/adev/src/content/guide/templates/two-way-binding.md
+++ b/adev/src/content/guide/templates/two-way-binding.md
@@ -17,7 +17,6 @@ import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 @Component({
-  standalone: true,
   imports: [FormsModule],
   template: `
     <main>
@@ -54,7 +53,6 @@ import { CounterComponent } from './counter/counter.component';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [CounterComponent],
   template: `
     <main>
@@ -74,7 +72,6 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 @Component({
   selector: 'app-counter',
-  standalone: true,
   template: `
     <button (click)="updateCount(-1)">-</button>
     <span>{{ count }}</span>
@@ -134,7 +131,6 @@ import { CounterComponent } from './counter/counter.component';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [CounterComponent],
   template: `
     <main>

--- a/adev/src/content/reference/errors/NG0302.md
+++ b/adev/src/content/reference/errors/NG0302.md
@@ -9,8 +9,7 @@ The [pipe](guide/templates/pipes) referenced in the template has not been named 
 To use the pipe:
 
 - Ensure the name used in a template matches the name defined in the pipe decorator.
-- Either mark it as standalone by adding the `standalone: true` flag to the pipe's decorator or declare it as a part of an `NgModule` by adding to that module's declarations array.
-- Import it in the standalone components and/or the `NgModules` where it is needed.
+- Add the pipe to your component's `imports` array or, if the pipe sets `standalone: false`, add the `NgModule` to which the pipe belongs.
 
 ## Debugging the error
 

--- a/adev/src/content/reference/errors/NG0500.md
+++ b/adev/src/content/reference/errors/NG0500.md
@@ -10,7 +10,6 @@ The following example will trigger the error.
 
 ```typescript
 @Component({
-  standalone: true,
   selector: 'app-example',
   template: '<div><span>world</span></div>',
 })

--- a/adev/src/content/reference/errors/NG0503.md
+++ b/adev/src/content/reference/errors/NG0503.md
@@ -8,7 +8,6 @@ The following examples will trigger the error.
 
 ```typescript
 @Component({
-  standalone: true,
   selector: 'dynamic',
   template: `
   <ng-content />
@@ -18,7 +17,6 @@ class DynamicComponent {
 }
 
 @Component({
-  standalone: true,
   selector: 'app',
   template: `<div #target></div>`,
 })

--- a/adev/src/content/reference/errors/NG0504.md
+++ b/adev/src/content/reference/errors/NG0504.md
@@ -12,7 +12,6 @@ In this example, the `ngSkipHydration` attribute is applied to a `<div>` using h
 
 ```typescript
 @Directive({
-  standalone: true,
   selector: '[dir]',
   host: {ngSkipHydration: 'true'},
 })
@@ -20,7 +19,6 @@ class Dir {
 }
 
 @Component({
-  standalone: true,
   selector: 'app',
   imports: [Dir],
   template: `
@@ -38,7 +36,6 @@ Since the `<div>` doesn't act as a component host node, Angular will throw an er
 
 ```typescript
 @Component({
-  standalone: true,
   selector: 'app',
   template: `
     <div ngSkipHydration></div>

--- a/adev/src/content/reference/errors/NG0506.md
+++ b/adev/src/content/reference/errors/NG0506.md
@@ -22,7 +22,6 @@ If one of these functions is called during the initialization phase of the appli
 
 ```typescript
 @Component({
-  standalone: true,
   selector: 'app',
   template: ``,
 })

--- a/adev/src/content/reference/extended-diagnostics/NG8103.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8103.md
@@ -9,7 +9,6 @@ individually or by importing the `CommonModule`.
 import {Component} from '@angular/core';
 
 @Component({
-  standalone: true,
   // Template uses `*ngIf`, but no corresponding directive imported.
   imports: [],
   template: `<div *ngIf="visible">Hi</div>`,
@@ -34,7 +33,6 @@ import {Component} from '@angular/core';
 import {NgIf} from '@angular/common';
 
 @Component({
-  standalone: true,
   imports: [NgIf],
   template: `<div *ngIf="visible">Hi</div>`,
 })
@@ -50,7 +48,6 @@ import {Component} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 @Component({
-  standalone: true,
   imports: [CommonModule],
   template: `<div *ngIf="visible">Hi</div>`,
 })

--- a/adev/src/content/tutorials/deferrable-views/intro/src/app/app.component.ts
+++ b/adev/src/content/tutorials/deferrable-views/intro/src/app/app.component.ts
@@ -5,6 +5,5 @@ import {Component} from '@angular/core';
   template: `
     Welcome to Angular!
   `,
-  standalone: true,
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/deferrable-views/steps/1-what-are-deferrable-views/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/deferrable-views/steps/1-what-are-deferrable-views/answer/src/app/app.component.ts
@@ -22,7 +22,6 @@ import {ArticleCommentsComponent} from './article-comments.component';
 
     </div>
   `,
-  standalone: true,
   imports: [ArticleCommentsComponent],
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/deferrable-views/steps/1-what-are-deferrable-views/answer/src/app/article-comments.component.ts
+++ b/adev/src/content/tutorials/deferrable-views/steps/1-what-are-deferrable-views/answer/src/app/article-comments.component.ts
@@ -24,6 +24,5 @@ import {Component} from '@angular/core';
     }
   `,
   ],
-  standalone: true,
 })
 export class ArticleCommentsComponent {}

--- a/adev/src/content/tutorials/deferrable-views/steps/1-what-are-deferrable-views/src/app/app.component.ts
+++ b/adev/src/content/tutorials/deferrable-views/steps/1-what-are-deferrable-views/src/app/app.component.ts
@@ -20,7 +20,6 @@ import {ArticleCommentsComponent} from './article-comments.component';
 
     </div>
   `,
-  standalone: true,
   imports: [ArticleCommentsComponent],
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/deferrable-views/steps/1-what-are-deferrable-views/src/app/article-comments.component.ts
+++ b/adev/src/content/tutorials/deferrable-views/steps/1-what-are-deferrable-views/src/app/article-comments.component.ts
@@ -24,6 +24,5 @@ import {Component} from '@angular/core';
     }
   `,
   ],
-  standalone: true,
 })
 export class ArticleCommentsComponent {}

--- a/adev/src/content/tutorials/deferrable-views/steps/2-loading-error-placeholder/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/deferrable-views/steps/2-loading-error-placeholder/answer/src/app/app.component.ts
@@ -28,7 +28,6 @@ import {ArticleCommentsComponent} from './article-comments.component';
 
     </div>
   `,
-  standalone: true,
   imports: [ArticleCommentsComponent],
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/deferrable-views/steps/2-loading-error-placeholder/answer/src/app/article-comments.component.ts
+++ b/adev/src/content/tutorials/deferrable-views/steps/2-loading-error-placeholder/answer/src/app/article-comments.component.ts
@@ -24,6 +24,5 @@ import {Component} from '@angular/core';
     }
   `,
   ],
-  standalone: true,
 })
 export class ArticleCommentsComponent {}

--- a/adev/src/content/tutorials/deferrable-views/steps/2-loading-error-placeholder/src/app/app.component.ts
+++ b/adev/src/content/tutorials/deferrable-views/steps/2-loading-error-placeholder/src/app/app.component.ts
@@ -22,7 +22,6 @@ import {ArticleCommentsComponent} from './article-comments.component';
 
     </div>
   `,
-  standalone: true,
   imports: [ArticleCommentsComponent],
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/deferrable-views/steps/2-loading-error-placeholder/src/app/article-comments.component.ts
+++ b/adev/src/content/tutorials/deferrable-views/steps/2-loading-error-placeholder/src/app/article-comments.component.ts
@@ -24,6 +24,5 @@ import {Component} from '@angular/core';
     }
   `,
   ],
-  standalone: true,
 })
 export class ArticleCommentsComponent {}

--- a/adev/src/content/tutorials/deferrable-views/steps/3-defer-triggers/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/deferrable-views/steps/3-defer-triggers/answer/src/app/app.component.ts
@@ -30,7 +30,6 @@ import {ArticleCommentsComponent} from './article-comments.component';
 
     </div>
   `,
-  standalone: true,
   imports: [ArticleCommentsComponent],
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/deferrable-views/steps/3-defer-triggers/answer/src/app/article-comments.component.ts
+++ b/adev/src/content/tutorials/deferrable-views/steps/3-defer-triggers/answer/src/app/article-comments.component.ts
@@ -24,6 +24,5 @@ import {Component} from '@angular/core';
     }
   `,
   ],
-  standalone: true,
 })
 export class ArticleCommentsComponent {}

--- a/adev/src/content/tutorials/deferrable-views/steps/3-defer-triggers/src/app/app.component.ts
+++ b/adev/src/content/tutorials/deferrable-views/steps/3-defer-triggers/src/app/app.component.ts
@@ -28,7 +28,6 @@ import {ArticleCommentsComponent} from './article-comments.component';
 
     </div>
   `,
-  standalone: true,
   imports: [ArticleCommentsComponent],
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/deferrable-views/steps/3-defer-triggers/src/app/article-comments.component.ts
+++ b/adev/src/content/tutorials/deferrable-views/steps/3-defer-triggers/src/app/article-comments.component.ts
@@ -24,6 +24,5 @@ import {Component} from '@angular/core';
     }
   `,
   ],
-  standalone: true,
 })
 export class ArticleCommentsComponent {}

--- a/adev/src/content/tutorials/first-app/steps/01-hello-world/src/app/app.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/01-hello-world/src/app/app.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [],
   template: `
     <h1>Default</h1>

--- a/adev/src/content/tutorials/first-app/steps/02-HomeComponent/src/app/app.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/02-HomeComponent/src/app/app.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [],
   template: `
     <h1>Hello world!</h1>

--- a/adev/src/content/tutorials/first-app/steps/03-HousingLocation/src/app/app.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/03-HousingLocation/src/app/app.component.ts
@@ -3,7 +3,6 @@ import {HomeComponent} from './home/home.component';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [HomeComponent],
   template: `
     <main>

--- a/adev/src/content/tutorials/first-app/steps/03-HousingLocation/src/app/home/home.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/03-HousingLocation/src/app/home/home.component.ts
@@ -3,7 +3,6 @@ import {CommonModule} from '@angular/common';
 
 @Component({
   selector: 'app-home',
-  standalone: true,
   imports: [CommonModule],
   template: `
     <section>

--- a/adev/src/content/tutorials/first-app/steps/04-interfaces/src/app/app.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/04-interfaces/src/app/app.component.ts
@@ -3,7 +3,6 @@ import {HomeComponent} from './home/home.component';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [HomeComponent],
   template: `
     <main>

--- a/adev/src/content/tutorials/first-app/steps/04-interfaces/src/app/home/home.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/04-interfaces/src/app/home/home.component.ts
@@ -3,7 +3,6 @@ import {CommonModule} from '@angular/common';
 import {HousingLocationComponent} from '../housing-location/housing-location.component';
 @Component({
   selector: 'app-home',
-  standalone: true,
   imports: [CommonModule, HousingLocationComponent],
   template: `
     <section>

--- a/adev/src/content/tutorials/first-app/steps/04-interfaces/src/app/housing-location/housing-location.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/04-interfaces/src/app/housing-location/housing-location.component.ts
@@ -3,7 +3,6 @@ import {CommonModule} from '@angular/common';
 
 @Component({
   selector: 'app-housing-location',
-  standalone: true,
   imports: [CommonModule],
   template: `
     <p>housing-location works!</p>

--- a/adev/src/content/tutorials/first-app/steps/05-inputs/src/app/app.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/05-inputs/src/app/app.component.ts
@@ -3,7 +3,6 @@ import {HomeComponent} from './home/home.component';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [HomeComponent],
   template: `
     <main>

--- a/adev/src/content/tutorials/first-app/steps/05-inputs/src/app/home/home.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/05-inputs/src/app/home/home.component.ts
@@ -5,7 +5,6 @@ import {HousingLocation} from '../housinglocation';
 
 @Component({
   selector: 'app-home',
-  standalone: true,
   imports: [CommonModule, HousingLocationComponent],
   template: `
     <section>

--- a/adev/src/content/tutorials/first-app/steps/05-inputs/src/app/housing-location/housing-location.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/05-inputs/src/app/housing-location/housing-location.component.ts
@@ -3,7 +3,6 @@ import {CommonModule} from '@angular/common';
 
 @Component({
   selector: 'app-housing-location',
-  standalone: true,
   imports: [CommonModule],
   template: `
     <p>housing-location works!</p>

--- a/adev/src/content/tutorials/first-app/steps/06-property-binding/src/app/app.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/06-property-binding/src/app/app.component.ts
@@ -3,7 +3,6 @@ import {HomeComponent} from './home/home.component';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [HomeComponent],
   template: `
     <main>

--- a/adev/src/content/tutorials/first-app/steps/06-property-binding/src/app/home/home.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/06-property-binding/src/app/home/home.component.ts
@@ -5,7 +5,6 @@ import {HousingLocation} from '../housinglocation';
 
 @Component({
   selector: 'app-home',
-  standalone: true,
   imports: [CommonModule, HousingLocationComponent],
   template: `
     <section>

--- a/adev/src/content/tutorials/first-app/steps/06-property-binding/src/app/housing-location/housing-location.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/06-property-binding/src/app/housing-location/housing-location.component.ts
@@ -3,7 +3,6 @@ import {CommonModule} from '@angular/common';
 import {HousingLocation} from '../housinglocation';
 @Component({
   selector: 'app-housing-location',
-  standalone: true,
   imports: [CommonModule],
   template: `
     <p>housing-location works!</p>

--- a/adev/src/content/tutorials/first-app/steps/07-dynamic-template-values/src/app/app.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/07-dynamic-template-values/src/app/app.component.ts
@@ -3,7 +3,6 @@ import {HomeComponent} from './home/home.component';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [HomeComponent],
   template: `
     <main>

--- a/adev/src/content/tutorials/first-app/steps/07-dynamic-template-values/src/app/home/home.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/07-dynamic-template-values/src/app/home/home.component.ts
@@ -5,7 +5,6 @@ import {HousingLocation} from '../housinglocation';
 
 @Component({
   selector: 'app-home',
-  standalone: true,
   imports: [CommonModule, HousingLocationComponent],
   template: `
     <section>

--- a/adev/src/content/tutorials/first-app/steps/07-dynamic-template-values/src/app/housing-location/housing-location.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/07-dynamic-template-values/src/app/housing-location/housing-location.component.ts
@@ -4,7 +4,6 @@ import {HousingLocation} from '../housinglocation';
 
 @Component({
   selector: 'app-housing-location',
-  standalone: true,
   imports: [CommonModule],
   template: `
     <p>housing-location works!</p>

--- a/adev/src/content/tutorials/first-app/steps/08-ngFor/src/app/app.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/08-ngFor/src/app/app.component.ts
@@ -3,7 +3,6 @@ import {HomeComponent} from './home/home.component';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [HomeComponent],
   template: `
     <main>

--- a/adev/src/content/tutorials/first-app/steps/08-ngFor/src/app/home/home.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/08-ngFor/src/app/home/home.component.ts
@@ -5,7 +5,6 @@ import {HousingLocation} from '../housinglocation';
 
 @Component({
   selector: 'app-home',
-  standalone: true,
   imports: [CommonModule, HousingLocationComponent],
   template: `
     <section>

--- a/adev/src/content/tutorials/first-app/steps/08-ngFor/src/app/housing-location/housing-location.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/08-ngFor/src/app/housing-location/housing-location.component.ts
@@ -4,7 +4,6 @@ import {HousingLocation} from '../housinglocation';
 
 @Component({
   selector: 'app-housing-location',
-  standalone: true,
   imports: [CommonModule],
   template: `
     <section class="listing">

--- a/adev/src/content/tutorials/first-app/steps/09-services/src/app/app.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/09-services/src/app/app.component.ts
@@ -3,7 +3,6 @@ import {HomeComponent} from './home/home.component';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [HomeComponent],
   template: `
     <main>

--- a/adev/src/content/tutorials/first-app/steps/09-services/src/app/home/home.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/09-services/src/app/home/home.component.ts
@@ -5,7 +5,6 @@ import {HousingLocation} from '../housinglocation';
 
 @Component({
   selector: 'app-home',
-  standalone: true,
   imports: [CommonModule, HousingLocationComponent],
   template: `
     <section>

--- a/adev/src/content/tutorials/first-app/steps/09-services/src/app/housing-location/housing-location.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/09-services/src/app/housing-location/housing-location.component.ts
@@ -4,7 +4,6 @@ import {HousingLocation} from '../housinglocation';
 
 @Component({
   selector: 'app-housing-location',
-  standalone: true,
   imports: [CommonModule],
   template: `
     <section class="listing">

--- a/adev/src/content/tutorials/first-app/steps/10-routing/src/app/app.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/10-routing/src/app/app.component.ts
@@ -3,7 +3,6 @@ import {HomeComponent} from './home/home.component';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [HomeComponent],
   template: `
     <main>

--- a/adev/src/content/tutorials/first-app/steps/10-routing/src/app/home/home.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/10-routing/src/app/home/home.component.ts
@@ -5,7 +5,6 @@ import {HousingLocation} from '../housinglocation';
 import {HousingService} from '../housing.service';
 @Component({
   selector: 'app-home',
-  standalone: true,
   imports: [CommonModule, HousingLocationComponent],
   template: `
     <section>

--- a/adev/src/content/tutorials/first-app/steps/10-routing/src/app/housing-location/housing-location.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/10-routing/src/app/housing-location/housing-location.component.ts
@@ -4,7 +4,6 @@ import {HousingLocation} from '../housinglocation';
 
 @Component({
   selector: 'app-housing-location',
-  standalone: true,
   imports: [CommonModule],
   template: `
     <section class="listing">

--- a/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/app.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/app.component.ts
@@ -3,7 +3,6 @@ import {HomeComponent} from './home/home.component';
 import {RouterModule} from '@angular/router';
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [HomeComponent, RouterModule],
   template: `
     <main>

--- a/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/details/details.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/details/details.component.ts
@@ -3,7 +3,6 @@ import {CommonModule} from '@angular/common';
 
 @Component({
   selector: 'app-details',
-  standalone: true,
   imports: [CommonModule],
   template: `
     <p>details works!</p>

--- a/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/home/home.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/home/home.component.ts
@@ -6,7 +6,6 @@ import {HousingService} from '../housing.service';
 
 @Component({
   selector: 'app-home',
-  standalone: true,
   imports: [CommonModule, HousingLocationComponent],
   template: `
     <section>

--- a/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/housing-location/housing-location.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/housing-location/housing-location.component.ts
@@ -5,7 +5,6 @@ import {RouterModule} from '@angular/router';
 
 @Component({
   selector: 'app-housing-location',
-  standalone: true,
   imports: [CommonModule, RouterModule],
   template: `
     <section class="listing">

--- a/adev/src/content/tutorials/first-app/steps/12-forms/src/app/app.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/12-forms/src/app/app.component.ts
@@ -4,7 +4,6 @@ import {RouterLink, RouterOutlet} from '@angular/router';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [HomeComponent, RouterLink, RouterOutlet],
   template: `
     <main>

--- a/adev/src/content/tutorials/first-app/steps/12-forms/src/app/details/details.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/12-forms/src/app/details/details.component.ts
@@ -6,7 +6,6 @@ import {HousingLocation} from '../housinglocation';
 
 @Component({
   selector: 'app-details',
-  standalone: true,
   imports: [CommonModule],
   template: `
     <article>

--- a/adev/src/content/tutorials/first-app/steps/12-forms/src/app/home/home.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/12-forms/src/app/home/home.component.ts
@@ -6,7 +6,6 @@ import {HousingService} from '../housing.service';
 
 @Component({
   selector: 'app-home',
-  standalone: true,
   imports: [CommonModule, HousingLocationComponent],
   template: `
     <section>

--- a/adev/src/content/tutorials/first-app/steps/12-forms/src/app/housing-location/housing-location.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/12-forms/src/app/housing-location/housing-location.component.ts
@@ -5,7 +5,6 @@ import {RouterModule} from '@angular/router';
 
 @Component({
   selector: 'app-housing-location',
-  standalone: true,
   imports: [CommonModule, RouterModule],
   template: `
     <section class="listing">

--- a/adev/src/content/tutorials/first-app/steps/13-search/src/app/app.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/13-search/src/app/app.component.ts
@@ -4,7 +4,6 @@ import {RouterLink, RouterOutlet} from '@angular/router';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [HomeComponent, RouterLink, RouterOutlet],
   template: `
     <main>

--- a/adev/src/content/tutorials/first-app/steps/13-search/src/app/details/details.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/13-search/src/app/details/details.component.ts
@@ -6,7 +6,6 @@ import {HousingLocation} from '../housinglocation';
 import {FormControl, FormGroup, ReactiveFormsModule} from '@angular/forms';
 @Component({
   selector: 'app-details',
-  standalone: true,
   imports: [CommonModule, ReactiveFormsModule],
   template: `
     <article>

--- a/adev/src/content/tutorials/first-app/steps/13-search/src/app/home/home.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/13-search/src/app/home/home.component.ts
@@ -6,7 +6,6 @@ import {HousingService} from '../housing.service';
 
 @Component({
   selector: 'app-home',
-  standalone: true,
   imports: [CommonModule, HousingLocationComponent],
   template: `
     <section>

--- a/adev/src/content/tutorials/first-app/steps/13-search/src/app/housing-location/housing-location.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/13-search/src/app/housing-location/housing-location.component.ts
@@ -5,7 +5,6 @@ import {RouterModule} from '@angular/router';
 
 @Component({
   selector: 'app-housing-location',
-  standalone: true,
   imports: [CommonModule, RouterModule],
   template: `
     <section class="listing">

--- a/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/app.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/app.component.ts
@@ -4,7 +4,6 @@ import {RouterLink, RouterOutlet} from '@angular/router';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [HomeComponent, RouterLink, RouterOutlet],
   template: `
     <main>

--- a/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/details/details.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/details/details.component.ts
@@ -7,7 +7,6 @@ import {FormControl, FormGroup, ReactiveFormsModule} from '@angular/forms';
 
 @Component({
   selector: 'app-details',
-  standalone: true,
   imports: [CommonModule, ReactiveFormsModule],
   template: `
     <article>

--- a/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/home/home.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/home/home.component.ts
@@ -6,7 +6,6 @@ import {HousingService} from '../housing.service';
 
 @Component({
   selector: 'app-home',
-  standalone: true,
   imports: [CommonModule, HousingLocationComponent],
   template: `
     <section>

--- a/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/housing-location/housing-location.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/housing-location/housing-location.component.ts
@@ -5,7 +5,6 @@ import {RouterModule} from '@angular/router';
 
 @Component({
   selector: 'app-housing-location',
-  standalone: true,
   imports: [CommonModule, RouterModule],
   template: `
     <section class="listing">

--- a/adev/src/content/tutorials/first-app/steps/14-http/src/app/app.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src/app/app.component.ts
@@ -4,7 +4,6 @@ import {RouterLink, RouterOutlet} from '@angular/router';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [HomeComponent, RouterLink, RouterOutlet],
   template: `
     <main>

--- a/adev/src/content/tutorials/first-app/steps/14-http/src/app/details/details.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src/app/details/details.component.ts
@@ -7,7 +7,6 @@ import {FormControl, FormGroup, ReactiveFormsModule} from '@angular/forms';
 
 @Component({
   selector: 'app-details',
-  standalone: true,
   imports: [CommonModule, ReactiveFormsModule],
   template: `
     <article>

--- a/adev/src/content/tutorials/first-app/steps/14-http/src/app/home/home.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src/app/home/home.component.ts
@@ -6,7 +6,6 @@ import {HousingService} from '../housing.service';
 
 @Component({
   selector: 'app-home',
-  standalone: true,
   imports: [CommonModule, HousingLocationComponent],
   template: `
     <section>

--- a/adev/src/content/tutorials/first-app/steps/14-http/src/app/housing-location/housing-location.component.ts
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src/app/housing-location/housing-location.component.ts
@@ -5,7 +5,6 @@ import {RouterModule} from '@angular/router';
 
 @Component({
   selector: 'app-housing-location',
-  standalone: true,
   imports: [CommonModule, RouterModule],
   template: `
     <section class="listing">

--- a/adev/src/content/tutorials/homepage/src/main.ts
+++ b/adev/src/content/tutorials/homepage/src/main.ts
@@ -4,7 +4,6 @@ import {bootstrapApplication} from '@angular/platform-browser';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   template: `
     <label for="name">Name:</label>
     <input type="text" id="name" [(ngModel)]="name" placeholder="Enter a name here" />

--- a/adev/src/content/tutorials/learn-angular/intro/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/intro/src/app/app.component.ts
@@ -5,6 +5,5 @@ import {Component} from '@angular/core';
   template: `
     Welcome to Angular!
   `,
-  standalone: true,
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/1-components-in-angular/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/1-components-in-angular/answer/src/app/app.component.ts
@@ -10,6 +10,5 @@ import {Component} from '@angular/core';
       color: #a144eb;
     }
   `,
-  standalone: true,
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/1-components-in-angular/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/1-components-in-angular/src/app/app.component.ts
@@ -10,6 +10,5 @@ import {Component} from '@angular/core';
       color: blue;
     }
   `,
-  standalone: true,
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/10-deferrable-views/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/10-deferrable-views/answer/src/app/app.component.ts
@@ -62,7 +62,6 @@ import {CommentsComponent} from './comments.component';
       }
     </div>
   `,
-  standalone: true,
   imports: [CommentsComponent],
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/10-deferrable-views/answer/src/app/comments.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/10-deferrable-views/answer/src/app/comments.component.ts
@@ -9,6 +9,5 @@ import {Component} from '@angular/core';
       <li>I agree with the other comments!</li>
     </ul>
   `,
-  standalone: true,
 })
 export class CommentsComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/10-deferrable-views/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/10-deferrable-views/src/app/app.component.ts
@@ -10,7 +10,6 @@ import {CommentsComponent} from './comments.component';
       <comments />
     </div>
   `,
-  standalone: true,
   imports: [CommentsComponent],
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/10-deferrable-views/src/app/comments.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/10-deferrable-views/src/app/comments.component.ts
@@ -9,6 +9,5 @@ import {Component} from '@angular/core';
       <li>I agree with the other comments!</li>
     </ul>
   `,
-  standalone: true,
 })
 export class CommentsComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/11-optimizing-images/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/11-optimizing-images/README.md
@@ -16,7 +16,6 @@ In order to leverage the `NgOptimizedImage` directive, first import it from the 
 import { NgOptimizedImage } from '@angular/common';
 
 @Component({
-  standalone: true,
   imports: [NgOptimizedImage],
   ...
 })
@@ -32,7 +31,6 @@ To enable the `NgOptimizedImage` directive, swap out the `src` attribute for `ng
 import { NgOptimizedImage } from '@angular/common';
 
 @Component({
-  standalone: true,
   template: `
     ...
     <li>

--- a/adev/src/content/tutorials/learn-angular/steps/11-optimizing-images/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/11-optimizing-images/answer/src/app/app.component.ts
@@ -6,7 +6,6 @@ import {UserComponent} from './user.component';
   template: `
     <app-user />
   `,
-  standalone: true,
   imports: [UserComponent],
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/11-optimizing-images/answer/src/app/user.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/11-optimizing-images/answer/src/app/user.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {NgOptimizedImage} from '@angular/common';
 
 @Component({
-  standalone: true,
   selector: 'app-user',
   template: `
     <p>Username: {{ username }}</p>

--- a/adev/src/content/tutorials/learn-angular/steps/11-optimizing-images/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/11-optimizing-images/src/app/app.component.ts
@@ -6,7 +6,6 @@ import {UserComponent} from './user.component';
   template: `
     <app-user />
   `,
-  standalone: true,
   imports: [UserComponent],
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/11-optimizing-images/src/app/user.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/11-optimizing-images/src/app/user.component.ts
@@ -1,7 +1,6 @@
 import {Component} from '@angular/core';
 
 @Component({
-  standalone: true,
   selector: 'app-user',
   template: `
     <p>Username: {{ username }}</p>

--- a/adev/src/content/tutorials/learn-angular/steps/12-enable-routing/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/12-enable-routing/README.md
@@ -62,7 +62,6 @@ import {RouterOutlet} from '@angular/router';
     </nav>
     <router-outlet />
   `,
-  standalone: true,
   imports: [RouterOutlet],
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/12-enable-routing/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/12-enable-routing/answer/src/app/app.component.ts
@@ -11,7 +11,6 @@ import {RouterOutlet} from '@angular/router';
     </nav>
     <router-outlet />
   `,
-  standalone: true,
   imports: [RouterOutlet],
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/12-enable-routing/answer/src/app/home/home.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/12-enable-routing/answer/src/app/home/home.component.ts
@@ -5,6 +5,5 @@ import {Component} from '@angular/core';
   template: `
     <div>Home Page</div>
   `,
-  standalone: true,
 })
 export class HomeComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/12-enable-routing/answer/src/app/user/user.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/12-enable-routing/answer/src/app/user/user.component.ts
@@ -5,7 +5,6 @@ import {Component} from '@angular/core';
   template: `
     <div>Username: {{ username }}</div>
   `,
-  standalone: true,
 })
 export class UserComponent {
   username = 'youngTech';

--- a/adev/src/content/tutorials/learn-angular/steps/12-enable-routing/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/12-enable-routing/src/app/app.component.ts
@@ -10,7 +10,6 @@ import {RouterOutlet} from '@angular/router';
       <a href="/user">User</a>
     </nav>
   `,
-  standalone: true,
   imports: [RouterOutlet],
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/12-enable-routing/src/app/home/home.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/12-enable-routing/src/app/home/home.component.ts
@@ -5,6 +5,5 @@ import {Component} from '@angular/core';
   template: `
     <div>Home Page</div>
   `,
-  standalone: true,
 })
 export class HomeComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/12-enable-routing/src/app/user/user.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/12-enable-routing/src/app/user/user.component.ts
@@ -5,7 +5,6 @@ import {Component} from '@angular/core';
   template: `
     <div>Username: {{ username }}</div>
   `,
-  standalone: true,
 })
 export class UserComponent {
   username = 'youngTech';

--- a/adev/src/content/tutorials/learn-angular/steps/13-define-a-route/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/13-define-a-route/answer/src/app/app.component.ts
@@ -11,7 +11,6 @@ import {RouterOutlet} from '@angular/router';
     </nav>
     <router-outlet></router-outlet>
   `,
-  standalone: true,
   imports: [RouterOutlet],
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/13-define-a-route/answer/src/app/home/home.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/13-define-a-route/answer/src/app/home/home.component.ts
@@ -5,6 +5,5 @@ import {Component} from '@angular/core';
   template: `
     <div>Home Page</div>
   `,
-  standalone: true,
 })
 export class HomeComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/13-define-a-route/answer/src/app/user/user.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/13-define-a-route/answer/src/app/user/user.component.ts
@@ -5,7 +5,6 @@ import {Component} from '@angular/core';
   template: `
     <div>Username: {{ username }}</div>
   `,
-  standalone: true,
 })
 export class UserComponent {
   username = 'youngTech';

--- a/adev/src/content/tutorials/learn-angular/steps/13-define-a-route/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/13-define-a-route/src/app/app.component.ts
@@ -11,7 +11,6 @@ import {RouterOutlet} from '@angular/router';
     </nav>
     <router-outlet></router-outlet>
   `,
-  standalone: true,
   imports: [RouterOutlet],
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/13-define-a-route/src/app/home/home.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/13-define-a-route/src/app/home/home.component.ts
@@ -5,6 +5,5 @@ import {Component} from '@angular/core';
   template: `
     <div>Home Page</div>
   `,
-  standalone: true,
 })
 export class HomeComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/13-define-a-route/src/app/user/user.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/13-define-a-route/src/app/user/user.component.ts
@@ -5,7 +5,6 @@ import {Component} from '@angular/core';
   template: `
     <div>Username: {{ username }}</div>
   `,
-  standalone: true,
 })
 export class UserComponent {
   username = 'youngTech';

--- a/adev/src/content/tutorials/learn-angular/steps/14-routerLink/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/14-routerLink/README.md
@@ -17,7 +17,6 @@ In `app.component.ts` add the `RouterLink` directive import to the existing impo
 import { RouterLink, RouterOutlet } from '@angular/router';
 
 @Component({
-  standalone: true,
   imports: [RouterLink, RouterOutlet],
   ...
 })
@@ -34,7 +33,6 @@ import { RouterLink, RouterOutlet } from '@angular/router';
 
 @Component({
   ...
-  standalone: true,
   template: `
     ...
     <a routerLink="/">Home</a>

--- a/adev/src/content/tutorials/learn-angular/steps/14-routerLink/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/14-routerLink/answer/src/app/app.component.ts
@@ -11,7 +11,6 @@ import {RouterOutlet, RouterLink} from '@angular/router';
     </nav>
     <router-outlet />
   `,
-  standalone: true,
   imports: [RouterOutlet, RouterLink],
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/14-routerLink/answer/src/app/home/home.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/14-routerLink/answer/src/app/home/home.component.ts
@@ -5,6 +5,5 @@ import {Component} from '@angular/core';
   template: `
     <div>Home Page</div>
   `,
-  standalone: true,
 })
 export class HomeComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/14-routerLink/answer/src/app/user/user.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/14-routerLink/answer/src/app/user/user.component.ts
@@ -5,7 +5,6 @@ import {Component} from '@angular/core';
   template: `
     <div>Username: {{ username }}</div>
   `,
-  standalone: true,
 })
 export class UserComponent {
   username = 'youngTech';

--- a/adev/src/content/tutorials/learn-angular/steps/14-routerLink/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/14-routerLink/src/app/app.component.ts
@@ -11,7 +11,6 @@ import {RouterOutlet} from '@angular/router';
     </nav>
     <router-outlet />
   `,
-  standalone: true,
   imports: [RouterOutlet],
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/14-routerLink/src/app/home/home.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/14-routerLink/src/app/home/home.component.ts
@@ -5,6 +5,5 @@ import {Component} from '@angular/core';
   template: `
     <div>Home Page</div>
   `,
-  standalone: true,
 })
 export class HomeComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/14-routerLink/src/app/user/user.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/14-routerLink/src/app/user/user.component.ts
@@ -5,7 +5,6 @@ import {Component} from '@angular/core';
   template: `
     <div>Username: {{ username }}</div>
   `,
-  standalone: true,
 })
 export class UserComponent {
   username = 'youngTech';

--- a/adev/src/content/tutorials/learn-angular/steps/15-forms/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/15-forms/README.md
@@ -35,7 +35,6 @@ import {FormsModule} from '@angular/forms';
 
 @Component({
   ...
-  standalone: true,
   imports: [FormsModule],
 })
 export class UserComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/15-forms/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/15-forms/answer/src/app/app.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {UserComponent} from './user.component';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   template: `
     <app-user />

--- a/adev/src/content/tutorials/learn-angular/steps/15-forms/answer/src/app/user.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/15-forms/answer/src/app/user.component.ts
@@ -11,7 +11,6 @@ import {FormsModule} from '@angular/forms';
       <input id="framework" type="text" [(ngModel)]="favoriteFramework" />
     </label>
   `,
-  standalone: true,
   imports: [FormsModule],
 })
 export class UserComponent {

--- a/adev/src/content/tutorials/learn-angular/steps/15-forms/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/15-forms/src/app/app.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {UserComponent} from './user.component';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   template: `
     <app-user />

--- a/adev/src/content/tutorials/learn-angular/steps/15-forms/src/app/user.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/15-forms/src/app/user.component.ts
@@ -7,7 +7,6 @@ import {Component} from '@angular/core';
     <p>{{ username }}'s favorite framework: {{ favoriteFramework }}</p>
     <label for="framework">Favorite Framework:</label>
   `,
-  standalone: true,
   imports: [],
 })
 export class UserComponent {

--- a/adev/src/content/tutorials/learn-angular/steps/16-form-control-values/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/16-form-control-values/answer/src/app/app.component.ts
@@ -6,7 +6,6 @@ import {UserComponent} from './user.component';
   template: `
     <app-user />
   `,
-  standalone: true,
   imports: [UserComponent],
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/16-form-control-values/answer/src/app/user.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/16-form-control-values/answer/src/app/user.component.ts
@@ -12,7 +12,6 @@ import {FormsModule} from '@angular/forms';
     </label>
     <button (click)="showFramework()">Show Framework</button>
   `,
-  standalone: true,
   imports: [FormsModule],
 })
 export class UserComponent {

--- a/adev/src/content/tutorials/learn-angular/steps/16-form-control-values/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/16-form-control-values/src/app/app.component.ts
@@ -6,7 +6,6 @@ import {UserComponent} from './user.component';
   template: `
     <app-user />
   `,
-  standalone: true,
   imports: [UserComponent],
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/16-form-control-values/src/app/user.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/16-form-control-values/src/app/user.component.ts
@@ -12,7 +12,6 @@ import {FormsModule} from '@angular/forms';
     </label>
     <button (click)="showFramework()">Show Framework</button>
   `,
-  standalone: true,
   imports: [FormsModule],
 })
 export class UserComponent {

--- a/adev/src/content/tutorials/learn-angular/steps/17-reactive-forms/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/17-reactive-forms/README.md
@@ -17,7 +17,6 @@ import { ReactiveFormsModule } from '@angular/forms';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   template: `
     <form>
       <label>Name

--- a/adev/src/content/tutorials/learn-angular/steps/17-reactive-forms/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/17-reactive-forms/answer/src/app/app.component.ts
@@ -15,7 +15,6 @@ import {ReactiveFormsModule} from '@angular/forms';
     <p>Name: {{ profileForm.value.name }}</p>
     <p>Email: {{ profileForm.value.email }}</p>
   `,
-  standalone: true,
   imports: [ReactiveFormsModule],
 })
 export class AppComponent {

--- a/adev/src/content/tutorials/learn-angular/steps/17-reactive-forms/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/17-reactive-forms/src/app/app.component.ts
@@ -15,7 +15,6 @@ import {Component} from '@angular/core';
       <button type="submit">Submit</button>
     </form>
   `,
-  standalone: true,
   imports: [],
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/18-forms-validation/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/18-forms-validation/answer/src/app/app.component.ts
@@ -11,7 +11,6 @@ import {ReactiveFormsModule, Validators} from '@angular/forms';
       <button type="submit" [disabled]="!profileForm.valid">Submit</button>
     </form>
   `,
-  standalone: true,
   imports: [ReactiveFormsModule],
 })
 export class AppComponent {

--- a/adev/src/content/tutorials/learn-angular/steps/18-forms-validation/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/18-forms-validation/src/app/app.component.ts
@@ -11,7 +11,6 @@ import {ReactiveFormsModule} from '@angular/forms';
       <button type="submit">Submit</button>
     </form>
   `,
-  standalone: true,
   imports: [ReactiveFormsModule],
 })
 export class AppComponent {

--- a/adev/src/content/tutorials/learn-angular/steps/19-creating-an-injectable-service/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/19-creating-an-injectable-service/answer/src/app/app.component.ts
@@ -4,7 +4,6 @@ import {CarService} from './car.service';
 @Component({
   selector: 'app-root',
   template: '<p> {{ carService.getCars() }} </p>',
-  standalone: true,
 })
 export class AppComponent {
   carService = inject(CarService);

--- a/adev/src/content/tutorials/learn-angular/steps/19-creating-an-injectable-service/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/19-creating-an-injectable-service/src/app/app.component.ts
@@ -4,7 +4,6 @@ import {CarService} from './car.service';
 @Component({
   selector: 'app-root',
   template: '<p> {{ carService.getCars() }} </p>',
-  standalone: true,
 })
 export class AppComponent {
   carService = inject(CarService);

--- a/adev/src/content/tutorials/learn-angular/steps/2-updating-the-component-class/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/2-updating-the-component-class/answer/src/app/app.component.ts
@@ -5,7 +5,6 @@ import {Component} from '@angular/core';
   template: `
     Hello {{ city }}, {{ 1 + 1 }}
   `,
-  standalone: true,
 })
 export class AppComponent {
   city = 'San Francisco';

--- a/adev/src/content/tutorials/learn-angular/steps/2-updating-the-component-class/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/2-updating-the-component-class/src/app/app.component.ts
@@ -5,6 +5,5 @@ import {Component} from '@angular/core';
   template: `
     Hello
   `,
-  standalone: true,
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/20-inject-based-di/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/20-inject-based-di/answer/src/app/app.component.ts
@@ -6,7 +6,6 @@ import {CarService} from './car.service';
   template: `
     <p>Car Listing: {{ display }}</p>
   `,
-  standalone: true,
 })
 export class AppComponent {
   display = '';

--- a/adev/src/content/tutorials/learn-angular/steps/20-inject-based-di/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/20-inject-based-di/src/app/app.component.ts
@@ -4,7 +4,6 @@ import {CarService} from './car.service';
 @Component({
   selector: 'app-root',
   template: ``,
-  standalone: true,
 })
 export class AppComponent {
   display = '';

--- a/adev/src/content/tutorials/learn-angular/steps/21-constructor-based-di/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/21-constructor-based-di/answer/src/app/app.component.ts
@@ -6,7 +6,6 @@ import {CarService} from './car.service';
   template: `
     <p>Car Listing: {{ display }}</p>
   `,
-  standalone: true,
 })
 export class AppComponent {
   display = '';

--- a/adev/src/content/tutorials/learn-angular/steps/21-constructor-based-di/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/21-constructor-based-di/src/app/app.component.ts
@@ -6,7 +6,6 @@ import {CarService} from './car.service';
   template: `
     <p>Car Listing: {{ display }}</p>
   `,
-  standalone: true,
 })
 export class AppComponent {
   display = '';

--- a/adev/src/content/tutorials/learn-angular/steps/22-pipes/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/22-pipes/answer/src/app/app.component.ts
@@ -6,7 +6,6 @@ import {LowerCasePipe} from '@angular/common';
   template: `
     {{ username | lowercase }}
   `,
-  standalone: true,
   imports: [LowerCasePipe],
 })
 export class AppComponent {

--- a/adev/src/content/tutorials/learn-angular/steps/22-pipes/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/22-pipes/src/app/app.component.ts
@@ -5,7 +5,6 @@ import {Component} from '@angular/core';
   template: `
     {{ username }}
   `,
-  standalone: true,
   imports: [],
 })
 export class AppComponent {

--- a/adev/src/content/tutorials/learn-angular/steps/23-pipes-format-data/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/23-pipes-format-data/answer/src/app/app.component.ts
@@ -10,7 +10,6 @@ import {DecimalPipe, DatePipe, CurrencyPipe} from '@angular/common';
       <li>Currency with "currency" {{ cost | currency }}</li>
     </ul>
   `,
-  standalone: true,
   imports: [DecimalPipe, DatePipe, CurrencyPipe],
 })
 export class AppComponent {

--- a/adev/src/content/tutorials/learn-angular/steps/23-pipes-format-data/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/23-pipes-format-data/src/app/app.component.ts
@@ -10,7 +10,6 @@ import {DecimalPipe, DatePipe, CurrencyPipe} from '@angular/common';
       <li>Currency with "currency" {{ cost }}</li>
     </ul>
   `,
-  standalone: true,
   imports: [DecimalPipe, DatePipe, CurrencyPipe],
 })
 export class AppComponent {

--- a/adev/src/content/tutorials/learn-angular/steps/24-create-a-pipe/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/24-create-a-pipe/README.md
@@ -12,7 +12,6 @@ A pipe is a TypeScript class with a `@Pipe` decorator. Here's an example:
 import {Pipe, PipeTransform} from '@angular/core';
 
 @Pipe({
-  standalone: true,
   name: 'star',
 })
 export class StarPipe implements PipeTransform {
@@ -37,7 +36,6 @@ In `reverse.pipe.ts` add the `@Pipe` decorator to the `ReversePipe` class and pr
 
 ```ts
 @Pipe({
-    standalone: true,
     name: 'reverse'
 })
 ```

--- a/adev/src/content/tutorials/learn-angular/steps/24-create-a-pipe/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/24-create-a-pipe/answer/src/app/app.component.ts
@@ -6,7 +6,6 @@ import {ReversePipe} from './reverse.pipe';
   template: `
     Reverse Machine: {{ word | reverse }}
   `,
-  standalone: true,
   imports: [ReversePipe],
 })
 export class AppComponent {

--- a/adev/src/content/tutorials/learn-angular/steps/24-create-a-pipe/answer/src/app/reverse.pipe.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/24-create-a-pipe/answer/src/app/reverse.pipe.ts
@@ -2,7 +2,6 @@ import {Pipe, PipeTransform} from '@angular/core';
 
 @Pipe({
   name: 'reverse',
-  standalone: true,
 })
 export class ReversePipe implements PipeTransform {
   transform(value: string): string {

--- a/adev/src/content/tutorials/learn-angular/steps/24-create-a-pipe/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/24-create-a-pipe/src/app/app.component.ts
@@ -6,7 +6,6 @@ import {ReversePipe} from './reverse.pipe';
   template: `
     Reverse Machine: {{ word }}
   `,
-  standalone: true,
   imports: [],
 })
 export class AppComponent {

--- a/adev/src/content/tutorials/learn-angular/steps/3-composing-components/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/3-composing-components/answer/src/app/app.component.ts
@@ -5,7 +5,6 @@ import {Component} from '@angular/core';
   template: `
     Username: {{ username }}
   `,
-  standalone: true,
 })
 export class UserComponent {
   username = 'youngTech';
@@ -18,7 +17,6 @@ export class UserComponent {
       <app-user />
     </section>
   `,
-  standalone: true,
   imports: [UserComponent],
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/3-composing-components/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/3-composing-components/src/app/app.component.ts
@@ -5,7 +5,6 @@ import {Component} from '@angular/core';
   template: `
     Username: {{ username }}
   `,
-  standalone: true,
 })
 export class UserComponent {
   username = 'youngTech';
@@ -14,7 +13,6 @@ export class UserComponent {
 @Component({
   selector: 'app-root',
   template: ``,
-  standalone: true,
   imports: [],
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/4-control-flow-if/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/4-control-flow-if/answer/src/app/app.component.ts
@@ -9,7 +9,6 @@ import {Component} from '@angular/core';
     <span>No, the server is not running</span>
     }
   `,
-  standalone: true,
 })
 export class AppComponent {
   isServerRunning = true;

--- a/adev/src/content/tutorials/learn-angular/steps/4-control-flow-if/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/4-control-flow-if/src/app/app.component.ts
@@ -5,7 +5,6 @@ import {Component} from '@angular/core';
   template: `
     <span>Yes, the server is running</span>
   `,
-  standalone: true,
 })
 export class AppComponent {
   // add the boolean property here

--- a/adev/src/content/tutorials/learn-angular/steps/5-control-flow-for/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/5-control-flow-for/answer/src/app/app.component.ts
@@ -7,7 +7,6 @@ import {Component} from '@angular/core';
     <p>{{ user.name }}</p>
     }
   `,
-  standalone: true,
 })
 export class AppComponent {
   users = [

--- a/adev/src/content/tutorials/learn-angular/steps/5-control-flow-for/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/5-control-flow-for/src/app/app.component.ts
@@ -3,6 +3,5 @@ import {Component} from '@angular/core';
 @Component({
   selector: 'app-root',
   template: ``,
-  standalone: true,
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/6-property-binding/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/6-property-binding/answer/src/app/app.component.ts
@@ -6,7 +6,6 @@ import {Component} from '@angular/core';
   template: `
     <div [contentEditable]="isEditable"></div>
   `,
-  standalone: true,
 })
 export class AppComponent {
   isEditable = true;

--- a/adev/src/content/tutorials/learn-angular/steps/6-property-binding/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/6-property-binding/src/app/app.component.ts
@@ -6,6 +6,5 @@ import {Component} from '@angular/core';
   template: `
     <div contentEditable="false"></div>
   `,
-  standalone: true,
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/7-event-handling/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/7-event-handling/answer/src/app/app.component.ts
@@ -8,7 +8,6 @@ import {Component} from '@angular/core';
       {{ message }}
     </section>
   `,
-  standalone: true,
 })
 export class AppComponent {
   message = '';

--- a/adev/src/content/tutorials/learn-angular/steps/7-event-handling/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/7-event-handling/src/app/app.component.ts
@@ -8,7 +8,6 @@ import {Component} from '@angular/core';
       {{ message }}
     </section>
   `,
-  standalone: true,
 })
 export class AppComponent {
   message = '';

--- a/adev/src/content/tutorials/learn-angular/steps/8-input/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/8-input/answer/src/app/app.component.ts
@@ -6,7 +6,6 @@ import {UserComponent} from './user.component';
   template: `
     <app-user name="Simran" />
   `,
-  standalone: true,
   imports: [UserComponent],
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/8-input/answer/src/app/user.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/8-input/answer/src/app/user.component.ts
@@ -5,7 +5,6 @@ import {Component, Input} from '@angular/core';
   template: `
     <p>The user's name is {{ name }}</p>
   `,
-  standalone: true,
 })
 export class UserComponent {
   @Input() name = '';

--- a/adev/src/content/tutorials/learn-angular/steps/8-input/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/8-input/src/app/app.component.ts
@@ -6,7 +6,6 @@ import {UserComponent} from './user.component';
   template: `
     <app-user />
   `,
-  standalone: true,
   imports: [UserComponent],
 })
 export class AppComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/8-input/src/app/user.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/8-input/src/app/user.component.ts
@@ -5,6 +5,5 @@ import {Component, Input} from '@angular/core';
   template: `
     <p>The user's name is</p>
   `,
-  standalone: true,
 })
 export class UserComponent {}

--- a/adev/src/content/tutorials/learn-angular/steps/9-output/answer/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/9-output/answer/src/app/app.component.ts
@@ -7,7 +7,6 @@ import {ChildComponent} from './child.component';
     <app-child (addItemEvent)="addItem($event)" />
     <p>🐢 all the way down {{ items.length }}</p>
   `,
-  standalone: true,
   imports: [ChildComponent],
 })
 export class AppComponent {

--- a/adev/src/content/tutorials/learn-angular/steps/9-output/answer/src/app/child.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/9-output/answer/src/app/child.component.ts
@@ -6,7 +6,6 @@ import {Component, Output, EventEmitter} from '@angular/core';
   template: `
     <button class="btn" (click)="addItem()">Add Item</button>
   `,
-  standalone: true,
 })
 export class ChildComponent {
   @Output() addItemEvent = new EventEmitter<string>();

--- a/adev/src/content/tutorials/learn-angular/steps/9-output/src/app/app.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/9-output/src/app/app.component.ts
@@ -7,7 +7,6 @@ import {ChildComponent} from './child.component';
     <app-child />
     <p>🐢 all the way down {{ items.length }}</p>
   `,
-  standalone: true,
   imports: [ChildComponent],
 })
 export class AppComponent {

--- a/adev/src/content/tutorials/learn-angular/steps/9-output/src/app/child.component.ts
+++ b/adev/src/content/tutorials/learn-angular/steps/9-output/src/app/child.component.ts
@@ -6,7 +6,6 @@ import {Component, Output, EventEmitter} from '@angular/core';
   template: `
     <button class="btn" (click)="addItem()">Add Item</button>
   `,
-  standalone: true,
 })
 export class ChildComponent {
   addItem() {}

--- a/adev/src/content/tutorials/playground/0-hello-world/src/main.ts
+++ b/adev/src/content/tutorials/playground/0-hello-world/src/main.ts
@@ -3,7 +3,6 @@ import {bootstrapApplication} from '@angular/platform-browser';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   template: `
     Hello world!
   `,

--- a/adev/src/content/tutorials/playground/1-signals/src/main.ts
+++ b/adev/src/content/tutorials/playground/1-signals/src/main.ts
@@ -3,7 +3,6 @@ import {bootstrapApplication} from '@angular/platform-browser';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   template: `
     <h2>Cookie recipe</h2>
 

--- a/adev/src/content/tutorials/playground/2-control-flow/src/main.ts
+++ b/adev/src/content/tutorials/playground/2-control-flow/src/main.ts
@@ -3,7 +3,6 @@ import {bootstrapApplication} from '@angular/platform-browser';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   template: `
     <h2>Todos</h2>
     <input #text />

--- a/adev/src/content/tutorials/playground/3-minigame/src/main.ts
+++ b/adev/src/content/tutorials/playground/3-minigame/src/main.ts
@@ -52,7 +52,6 @@ function getResultQuote(accuracy: number) {
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [CommonModule, MatSlideToggleModule, A11yModule],
   styleUrl: 'game.css',
   templateUrl: 'game.html',


### PR DESCRIPTION
This change removes `standalone: true` from documentation and examples now that it is the default.