### PR TITLE
refactor(core): add `REQUEST`, `RESPONSE_INIT` and `REQUEST_CONTEXT` tokens

### DIFF
--- a/adev/src/assets/BUILD.bazel
+++ b/adev/src/assets/BUILD.bazel
@@ -71,7 +71,6 @@ copy_to_directory(
         "//packages/service-worker:service-worker_docs",
         "//packages/ssr:ssr_docs",
         "//packages/ssr:ssr_node_docs",
-        "//packages/ssr:ssr_tokens_docs",
         "//packages/upgrade:upgrade_docs",
         "//packages/upgrade/static:upgrade_static_docs",
         "//packages/upgrade/static/testing:upgrade_static_testing_docs",

--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1563,6 +1563,12 @@ export interface RendererType2 {
 }
 
 // @public
+export const REQUEST: InjectionToken<Request | null>;
+
+// @public
+export const REQUEST_CONTEXT: InjectionToken<unknown>;
+
+// @public
 export function resolveForwardRef<T>(type: T): T;
 
 // @public
@@ -1617,6 +1623,9 @@ export enum ResourceStatus {
     Reloading = 3,
     Resolved = 4
 }
+
+// @public
+export const RESPONSE_INIT: InjectionToken<ResponseInit | null>;
 
 // @public
 export function runInInjectionContext<ReturnT>(injector: Injector, fn: () => ReturnT): ReturnT;

--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -101,7 +101,6 @@ generate_api_manifest(
         "//packages/service-worker:service-worker_docs_extraction",
         "//packages/ssr:ssr_docs_extraction",
         "//packages/ssr:ssr_node_docs_extraction",
-        "//packages/ssr:ssr_tokens_docs_extraction",
         "//packages/upgrade:upgrade_docs_extraction",
         "//packages/upgrade/static:upgrade_static_docs_extraction",
         "//packages/upgrade/static/testing:upgrade_static_testing_docs_extraction",

--- a/packages/core/src/application/platform_tokens.ts
+++ b/packages/core/src/application/platform_tokens.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {InjectionToken} from '../di/injection_token';
+
+/**
+ * Injection token representing the current HTTP request object.
+ *
+ * Use this token to access the current request when handling server-side
+ * rendering (SSR).
+ *
+ * @remarks
+ * This token may be `null` in the following scenarios:
+ *
+ * * During the build processes.
+ * * When the application is rendered in the browser (client-side rendering).
+ * * When performing static site generation (SSG).
+ * * During route extraction in development (at the time of the request).
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Request | `Request` on MDN}
+ *
+ * @developerPreview
+ */
+export const REQUEST = new InjectionToken<Request | null>('REQUEST', {
+  providedIn: 'platform',
+  factory: () => null,
+});
+
+/**
+ * Injection token for response initialization options.
+ *
+ * Use this token to provide response options for configuring or initializing
+ * HTTP responses in server-side rendering or API endpoints.
+ *
+ * @remarks
+ * This token may be `null` in the following scenarios:
+ *
+ * * During the build processes.
+ * * When the application is rendered in the browser (client-side rendering).
+ * * When performing static site generation (SSG).
+ * * During route extraction in development (at the time of the request).
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Response/Response | `ResponseInit` on MDN}
+ *
+ * @developerPreview
+ */
+export const RESPONSE_INIT = new InjectionToken<ResponseInit | null>('RESPONSE_INIT', {
+  providedIn: 'platform',
+  factory: () => null,
+});
+
+/**
+ * Injection token for additional request context.
+ *
+ * Use this token to pass custom metadata or context related to the current request in server-side rendering.
+ *
+ * @remarks
+ * This token is only available during server-side rendering and will be `null` in other contexts.
+ *
+ * @developerPreview
+ */
+export const REQUEST_CONTEXT = new InjectionToken<unknown>('REQUEST_CONTEXT', {
+  providedIn: 'platform',
+  factory: () => null,
+});

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -115,6 +115,7 @@ export {
 export {ApplicationConfig, mergeApplicationConfig} from './application/application_config';
 export {makeStateKey, StateKey, TransferState} from './transfer_state';
 export {booleanAttribute, numberAttribute} from './util/coercion';
+export {REQUEST, REQUEST_CONTEXT, RESPONSE_INIT} from './application/platform_tokens';
 
 import {global} from './util/global';
 if (typeof ngDevMode !== 'undefined' && ngDevMode) {

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -1887,6 +1887,9 @@
     "name": "init_platform_ref"
   },
   {
+    "name": "init_platform_tokens"
+  },
+  {
     "name": "init_profiler"
   },
   {

--- a/packages/ssr/BUILD.bazel
+++ b/packages/ssr/BUILD.bazel
@@ -22,13 +22,3 @@ generate_api_docs(
     entry_point = "@npm//:node_modules/@angular/ssr/node/index.d.ts",
     module_name = "@angular/ssr/node",
 )
-
-generate_api_docs(
-    name = "ssr_tokens_docs",
-    srcs = [
-        "//packages:common_files_and_deps_for_docs",
-        "@npm//@angular/ssr",
-    ],
-    entry_point = "@npm//:node_modules/@angular/ssr/tokens/index.d.ts",
-    module_name = "@angular/ssr/tokens",
-)


### PR DESCRIPTION
This commit introduces the `REQUEST`, `RESPONSE_INIT` and `REQUEST_CONTEXT` tokens, which will replace similar ones from https://github.com/angular/angular-cli/blob/28503186230b5e22b84499641d56c9c981fdab1d/packages/angular/ssr/tokens/src/tokens.ts, so those tokens would be imported in application code via `@angular/core` package.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No