### PR TITLE
fix(compiler-cli): support nested component declaration

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/GOLDEN_PARTIAL.js
@@ -700,3 +700,36 @@ export declare class MainStandalone {
     static ɵcmp: i0.ɵɵComponentDeclaration<MainStandalone, "ng-component", never, {}, {}, never, never, true, never>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: nested_component_definition.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+class Outer {
+    constructor() {
+        class Inner {
+            static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Inner, deps: [], target: i0.ɵɵFactoryTarget.Component });
+            static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: Inner, isStandalone: true, selector: "ng-component", ngImport: i0, template: 'inner', isInline: true });
+        }
+        i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Inner, decorators: [{
+                    type: Component,
+                    args: [{
+                            template: 'inner',
+                        }]
+                }] });
+    }
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Outer, deps: [], target: i0.ɵɵFactoryTarget.Component });
+    static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: Outer, isStandalone: true, selector: "ng-component", ngImport: i0, template: 'outer', isInline: true });
+}
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Outer, decorators: [{
+            type: Component,
+            args: [{
+                    template: 'outer',
+                }]
+        }], ctorParameters: () => [] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: nested_component_definition.d.ts
+ ****************************************************************************************************/
+export {};
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/TEST_CASES.json
@@ -3,202 +3,143 @@
   "cases": [
     {
       "description": "should instantiate directives in a closure when they are forward referenced",
-      "inputFiles": [
-        "forward_referenced_directive.ts"
-      ],
+      "inputFiles": ["forward_referenced_directive.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid component definition",
-          "files": [
-            "forward_referenced_directive.js"
-          ]
+          "files": ["forward_referenced_directive.js"]
         }
       ]
     },
     {
       "description": "should instantiate pipes in a closure when they are forward referenced",
-      "inputFiles": [
-        "forward_referenced_pipe.ts"
-      ],
+      "inputFiles": ["forward_referenced_pipe.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid component definition",
-          "files": [
-            "forward_referenced_pipe.js"
-          ]
+          "files": ["forward_referenced_pipe.js"]
         }
       ]
     },
     {
       "description": "should split multiple `exportAs` values into an array",
-      "inputFiles": [
-        "export_as.ts"
-      ],
+      "inputFiles": ["export_as.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect SomeDirective.ɵdir",
-          "files": [
-            "export_as.js"
-          ]
+          "files": ["export_as.js"]
         }
       ]
     },
     {
       "description": "should not generate a selectors array if the directive does not have a selector",
-      "inputFiles": [
-        "no_selector.ts"
-      ],
+      "inputFiles": ["no_selector.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid directive definition",
-          "files": [
-            "no_selector.js"
-          ]
+          "files": ["no_selector.js"]
         }
       ]
     },
     {
       "description": "should generate a pure function for constant object literals",
-      "inputFiles": [
-        "constant_object_literals.ts"
-      ],
+      "inputFiles": ["constant_object_literals.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid component definition",
-          "files": [
-            "constant_object_literals.js"
-          ]
+          "files": ["constant_object_literals.js"]
         }
       ]
     },
     {
       "description": "should generate a pure function for constant array literals",
-      "inputFiles": [
-        "constant_array_literals.ts"
-      ],
+      "inputFiles": ["constant_array_literals.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid component definition",
-          "files": [
-            "constant_array_literals.js"
-          ]
+          "files": ["constant_array_literals.js"]
         }
       ]
     },
     {
       "description": "should not share pure functions between null and object literals",
-      "inputFiles": [
-        "object_literals_null_vs_empty.ts"
-      ],
+      "inputFiles": ["object_literals_null_vs_empty.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid component definition",
-          "files": [
-            "object_literals_null_vs_empty.js"
-          ]
+          "files": ["object_literals_null_vs_empty.js"]
         }
       ]
     },
     {
       "description": "should not share pure functions between null and array literals",
-      "inputFiles": [
-        "array_literals_null_vs_empty.ts"
-      ],
+      "inputFiles": ["array_literals_null_vs_empty.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid component definition",
-          "files": [
-            "array_literals_null_vs_empty.js"
-          ]
+          "files": ["array_literals_null_vs_empty.js"]
         }
       ]
     },
     {
       "description": "should not share pure functions between null and function calls",
-      "inputFiles": [
-        "object_literals_null_vs_function.ts"
-      ],
+      "inputFiles": ["object_literals_null_vs_function.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid component definition",
-          "files": [
-            "object_literals_null_vs_function.js"
-          ]
+          "files": ["object_literals_null_vs_function.js"]
         }
       ]
     },
     {
       "description": "should emit a valid setClassMetadata call in ES5 if a class with a custom decorator is referencing itself inside its own metadata",
-      "inputFiles": [
-        "custom_decorator_es5.ts"
-      ],
+      "inputFiles": ["custom_decorator_es5.ts"],
       "compilerOptions": {
         "target": "ES5"
       },
-      "compilationModeFilter": [
-        "full compile"
-      ],
+      "compilationModeFilter": ["full compile"],
       "expectations": [
         {
           "failureMessage": "Incorrect setClassMetadata call",
-          "files": [
-            "custom_decorator_es5.js"
-          ]
+          "files": ["custom_decorator_es5.js"]
         }
       ]
     },
     {
       "description": "should support empty property bindings on ng-template",
-      "inputFiles": [
-        "ng_template_empty_binding.ts"
-      ],
+      "inputFiles": ["ng_template_empty_binding.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "ng_template_empty_binding.js"
-          ]
+          "files": ["ng_template_empty_binding.js"]
         }
       ]
     },
     {
       "description": "should support inline non-literal templates",
-      "inputFiles": [
-        "non_literal_template.ts"
-      ]
+      "inputFiles": ["non_literal_template.ts"]
     },
     {
       "description": "should support inline non-literal templates using substitution",
-      "inputFiles": [
-        "non_literal_template_with_substitution.ts"
-      ]
+      "inputFiles": ["non_literal_template_with_substitution.ts"]
     },
     {
       "description": "should support inline non-literal templates using string concatenation",
-      "inputFiles": [
-        "non_literal_template_with_concatenation.ts"
-      ]
+      "inputFiles": ["non_literal_template_with_concatenation.ts"]
     },
     {
       "description": "should not use reexport names inside declarations when a direct export is available",
-      "inputFiles": [
-        "external_library.d.ts",
-        "library_exports.ts"
-      ],
+      "inputFiles": ["external_library.d.ts", "library_exports.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid list of directives",
-          "files": [
-            "library_exports.js"
-          ]
+          "files": ["library_exports.js"]
         }
       ],
       "compilerOptions": {
         "baseUrl": ".",
         "paths": {
-          "external_library": [
-            "./external_library"
-          ]
+          "external_library": ["./external_library"]
         }
       }
     },
@@ -209,12 +150,18 @@
         {
           "failureMessage": "Incorrect generated debug info statement",
           "files": ["debug_info.js"]
-        }        
+        }
       ],
-      "compilationModeFilter": [
-        "full compile",
-        "local compile",
-        "declaration-only emit"
+      "compilationModeFilter": ["full compile", "local compile", "declaration-only emit"]
+    },
+    {
+      "description": "should support nested component declarations",
+      "inputFiles": ["nested_component_definition.ts"],
+      "expectations": [
+        {
+          "failureMessage": "Invalid component definition",
+          "files": ["nested_component_definition.js"]
+        }
       ]
     }
   ]

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/nested_component_definition.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/nested_component_definition.js
@@ -1,0 +1,10 @@
+class Outer {
+  constructor() {
+    class Inner {
+      static ɵfac = …
+      static ɵcmp = …
+    }
+  }
+
+  …
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/nested_component_definition.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/nested_component_definition.ts
@@ -1,0 +1,13 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: 'outer',
+})
+class Outer {
+  constructor() {
+    @Component({
+      template: 'inner',
+    })
+    class Inner {}
+  }
+}


### PR DESCRIPTION
Example:
```ts
@Component(...)
class Outer {
  constructor() {
    @Component(...)
    class Inner {}
  }
}
```

Previous behavior was that IVy transformation was only applied to `Inner`, thus breaking `Outer` transformation.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
