### PR TITLE
fix(bazel): allow strictStandalone to be passed through tsconfig

### DIFF
--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -93,6 +93,7 @@ export async function runOneBuild(
     'generateExtraImportsInLocalMode',
     '_enableLetSyntax',
     '_enableHmr',
+    'strictStandalone',
   ]);
 
   const userOverrides = Object.entries(userOptions)


### PR DESCRIPTION
Allows users to pass the `strictStandalone` compiler option through the tsconfig.