### PR TITLE
refactor(core): mark linkedSignal as developer preview

### DIFF
--- a/adev/src/content/guide/signals/linked-signal.md
+++ b/adev/src/content/guide/signals/linked-signal.md
@@ -1,6 +1,6 @@
 # `linkedSignal`
 
-IMPORTANT: `linkedSignal` is [experimental](reference/releases#experimental). It's ready for you to try, but it might change before it is stable.
+IMPORTANT: `linkedSignal` is [developer preview](reference/releases#developer-preview). It's ready for you to try, but it might change before it is stable.
 
 You can use the `signal` function to hold some state in your Angular code. Sometimes, this state depends on some _other_ state. For example, imagine a component that lets the user select a shipping method for an order:
 

--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1123,12 +1123,12 @@ export class KeyValueDiffers {
     static ɵprov: unknown;
 }
 
-// @public (undocumented)
+// @public
 export function linkedSignal<D>(computation: () => D, options?: {
     equal?: ValueEqualityFn<NoInfer<D>>;
 }): WritableSignal<D>;
 
-// @public (undocumented)
+// @public
 export function linkedSignal<S, D>(options: {
     source: () => S;
     computation: (source: NoInfer<S>, previous?: {

--- a/packages/core/src/render3/reactivity/linked_signal.ts
+++ b/packages/core/src/render3/reactivity/linked_signal.ts
@@ -105,12 +105,21 @@ function createLinkedSignal<S, D>(node: LinkedSignalNode<S, D>): WritableSignal<
 }
 
 /**
- * @experimental
+ * Creates a writable signals whose value is initialized and reset by the linked, reactive computation.
+ *
+ * @developerPreview
  */
 export function linkedSignal<D>(
   computation: () => D,
   options?: {equal?: ValueEqualityFn<NoInfer<D>>},
 ): WritableSignal<D>;
+
+/**
+ * Creates a writable signals whose value is initialized and reset by the linked, reactive computation.
+ * This is an advanced API form where the computation has access to the previous value of the signal and the computation result.
+ *
+ * @developerPreview
+ */
 export function linkedSignal<S, D>(options: {
   source: () => S;
   computation: (source: NoInfer<S>, previous?: {source: NoInfer<S>; value: NoInfer<D>}) => D;


### PR DESCRIPTION
This commit bumps up the stability status of the linkedSignal to developer preview - clearly expressing our higher confidence in this API.
