### PR TITLE
docs: update location of `REQUEST`-related tokens in docs content

### DIFF
--- a/adev/src/content/guide/hybrid-rendering.md
+++ b/adev/src/content/guide/hybrid-rendering.md
@@ -242,15 +242,14 @@ export const serverRoutes: ServerRoute[] = [
 
 ## Accessing Request and Response via DI
 
-The `@angular/ssr/tokens` provides several tokens for interacting with the server-side rendering environment. These tokens give you access to crucial information and objects within your Angular application during SSR.
+The `@angular/core` package provides several tokens for interacting with the server-side rendering environment. These tokens give you access to crucial information and objects within your Angular application during SSR.
 
-- **[`REQUEST`](api/ssr/tokens/REQUEST 'API reference'):** Provides access to the current request object, which is of type [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) from the Web API. This allows you to access headers, cookies, and other request information.
-- **[`RESPONSE_INIT`](api/ssr/tokens/RESPONSE_INIT 'API reference'):** Provides access to the response initialization options, which is of type [`ResponseInit`](https://developer.mozilla.org/en-US/docs/Web/API/Response/Response#parameters) from the Web API. This allows you to set headers and the status code for the response dynamically. Use this token to set headers or status codes that need to be determined at runtime.
-- **[`REQUEST_CONTEXT`](api/ssr/tokens/REQUEST_CONTEXT 'API reference'):** Provides access to additional context related to the current request. This context can be passed as the second parameter of the [`handle`](api/ssr/AngularAppEngine#handle 'API reference') function. Typically, this is used to provide additional request-related information that is not part of the standard Web API.
+- **[`REQUEST`](api/core/REQUEST 'API reference'):** Provides access to the current request object, which is of type [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) from the Web API. This allows you to access headers, cookies, and other request information.
+- **[`RESPONSE_INIT`](api/core/RESPONSE_INIT 'API reference'):** Provides access to the response initialization options, which is of type [`ResponseInit`](https://developer.mozilla.org/en-US/docs/Web/API/Response/Response#parameters) from the Web API. This allows you to set headers and the status code for the response dynamically. Use this token to set headers or status codes that need to be determined at runtime.
+- **[`REQUEST_CONTEXT`](api/core/REQUEST_CONTEXT 'API reference'):** Provides access to additional context related to the current request. This context can be passed as the second parameter of the [`handle`](api/ssr/AngularAppEngine#handle 'API reference') function. Typically, this is used to provide additional request-related information that is not part of the standard Web API.
 
 ```angular-ts
-import { inject } from '@angular/core';
-import { REQUEST } from '@angular/ssr/tokens';
+import { inject, REQUEST } from '@angular/core';
 
 @Component({
   selector: 'app-my-component',


### PR DESCRIPTION
Since https://github.com/angular/angular/commit/a55341b1ab8d2bc4285a4cce59df7fc0b23c0125 commit, the `REQUEST`, `RESPONSE_INIT` and `REQUEST_CONTEXT` tokens became a part of the `@angular/core` pcakage. This commit updates the docs to mention `@angular/core` as a primary location of those tokens.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No