### PR TITLE
fix: typing of QueryList.changes is now more strict

### DIFF
--- a/packages/core/src/linker/query_list.ts
+++ b/packages/core/src/linker/query_list.ts
@@ -57,7 +57,7 @@ export class QueryList<T> implements Iterable<T> {
   /**
    * Returns `Observable` of `QueryList` notifying the subscriber of changes.
    */
-  get changes(): Observable<any> {
+  get changes(): Observable<QueryList<T>> {
     return (this._changes ??= new Subject());
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

Previously, `.changes` was an `any` type, making the following code error out with `implicit any`s when using strict mode:

```typescript
@Component({
	selector: "my-app",
	standalone: true,
	imports: [MyComponentComponent, NgIf, FormsModule],
	template: `
		<p>The console should output the combination of all values below</p>
		<input type="checkbox" [(ngModel)]="bool" />
		<div *ngIf="bool">
			<my-custom-component></my-custom-component>
		</div>
		<my-custom-component></my-custom-component>
	`,
})
export class AppComponent implements AfterViewInit {
	@ViewChildren(MyComponentComponent)
	myComponents!: QueryList<MyComponentComponent>;

	bool = false;

	ngAfterViewInit() {
		this.myComponents.changes.subscribe((compsQueryList) => {
			const componentsNum = compsQueryList.reduce((prev, comp) => {
				return prev + comp.numberProp;
			}, 0);
			console.log(componentsNum); // This would output the combined number from all of the component's `numberProp` field. This would run any time Angular saw a difference in the values
		});
	}
}
```

This PR fixes this issue by making `changes` an `Observable<QueryList<T>>` type 

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

This is technically a change to the typings, so I'd consider it a breaking change, even though it doesn't change the behavior.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
