### PR TITLE
docs: update standalone migration guide

### DIFF
--- a/adev/src/content/reference/migrations/standalone.md
+++ b/adev/src/content/reference/migrations/standalone.md
@@ -63,7 +63,7 @@ You should run these migrations in the order given.
 
 ### Convert declarations to standalone
 
-In this mode, the migration converts all components, directives and pipes to standalone by setting `standalone: true` and adding dependencies to their `imports` array.
+In this mode, the migration converts all components, directives and pipes to standalone by removing `standalone: false` and adding dependencies to their `imports` array.
 
 HELPFUL: The schematic ignores NgModules which bootstrap a component during this step because they are likely root modules used by `bootstrapModule` rather than the standalone-compatible `bootstrapApplication`. The schematic converts these declarations automatically as a part of the ["Switch to standalone bootstrapping API"](#switch-to-standalone-bootstrapping-api) step.
 
@@ -84,6 +84,7 @@ export class SharedModule {}
 @Component({
   selector: 'greeter',
   template: '<div *ngIf="showGreeting">Hello</div>',
+  standalone: false,
 })
 export class GreeterComponent {
   showGreeting = true;
@@ -106,7 +107,6 @@ export class SharedModule {}
 @Component({
   selector: 'greeter',
   template: '<div *ngIf="showGreeting">Hello</div>',
-  standalone: true,
   imports: [NgIf]
 })
 export class GreeterComponent {
@@ -150,7 +150,7 @@ export class ImporterModule {}
 
 ### Switch to standalone bootstrapping API
 
-This step converts any usages of  `bootstrapModule` to the new, standalone-based `bootstrapApplication`. It also switches the root component to `standalone: true` and deletes the root NgModule. If the root module has any `providers` or `imports`, the migration attempts to copy as much of this configuration as possible into the new bootstrap call.
+This step converts any usages of  `bootstrapModule` to the new, standalone-based `bootstrapApplication`. It also removes `standalone: false` from the root component and deletes the root NgModule. If the root module has any `providers` or `imports`, the migration attempts to copy as much of this configuration as possible into the new bootstrap call.
 
 **Before:**
 
@@ -168,7 +168,11 @@ export class AppModule {}
 
 ```typescript
 // ./app/app.component.ts
-@Component({ selector: 'app', template: 'hello' })
+@Component({
+  selector: 'app',
+  template: 'hello',
+  standalone: false,
+})
 export class AppComponent {}
 ```
 
@@ -189,7 +193,10 @@ platformBrowser().bootstrapModule(AppModule).catch(e => console.error(e));
 
 ```typescript
 // ./app/app.component.ts
-@Component({ selector: 'app', template: 'hello', standalone: true })
+@Component({
+  selector: 'app',
+  template: 'hello'
+})
 export class AppComponent {}
 ```
 


### PR DESCRIPTION
Updates the guide for the standalone migration to account for standalone being the default.
