### PR TITLE
docs(docs-infra): Fix Card's Styles in focus and overflow states

### DIFF
--- a/adev/shared-docs/styles/docs/_code.scss
+++ b/adev/shared-docs/styles/docs/_code.scss
@@ -276,6 +276,12 @@
       overflow-x: auto;
       display: flex;
       flex-direction: column;
+      align-items: start;
+    }
+
+    pre > * {
+      min-width: 100%;
+      width: auto;
     }
   }
 

--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
@@ -272,7 +272,7 @@
     header {
       display: flex;
       flex-direction: column;
-      border-radius: 0.25rem;
+      border-radius: 0.25rem 0.25rem 0 0;
       background-color: var(--octonary-contrast);
       position: relative;
       z-index: 10;


### PR DESCRIPTION

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

1. Overflow state
![image](https://github.com/user-attachments/assets/d2d577b2-238f-45c8-ab74-1c96d74b1871)

       the custom scroll styles aren't applied because the overflow happens on a different element + 
       The items inside the example's container don't take the full width 


2. Focus state 
![Screenshot 2024-11-16 235129-copy](https://github.com/user-attachments/assets/ed824ed8-67bf-4a18-af20-f7e9c98b5a81)





## What is the new behavior?

1. Overflow state
![image](https://github.com/user-attachments/assets/cf8d443d-1ca0-4c43-b8a1-d019da4f969b)

2. Focus state 
![Screenshot 2024-11-16 235045](https://github.com/user-attachments/assets/4e80acd0-7f4b-4ab7-967d-b902c7c45444)




## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
