### PR TITLE
refactor(compiler): remove compatibility mode

### DIFF
--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -23,8 +23,6 @@ import {
   DeclarationListEmitMode,
   DeferBlockDepsEmitMode,
   R3ComponentMetadata,
-  R3DeferPerBlockDependency,
-  R3DeferPerComponentDependency,
   R3DeferResolverFunctionMetadata,
   R3DirectiveMetadata,
   R3HostMetadata,

--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -437,16 +437,6 @@ export enum SemanticVariableKind {
 }
 
 /**
- * Whether to compile in compatibilty mode. In compatibility mode, the template pipeline will
- * attempt to match the output of `TemplateDefinitionBuilder` as exactly as possible, at the cost
- * of producing quirky or larger code in some cases.
- */
-export enum CompatibilityMode {
-  Normal,
-  TemplateDefinitionBuilder,
-}
-
-/**
  * Enumeration of the types of attributes which can be applied to an element.
  */
 export enum BindingKind {

--- a/packages/compiler/src/template/pipeline/src/compilation.ts
+++ b/packages/compiler/src/template/pipeline/src/compilation.ts
@@ -25,7 +25,6 @@ export abstract class CompilationJob {
   constructor(
     readonly componentName: string,
     readonly pool: ConstantPool,
-    readonly compatibility: ir.CompatibilityMode,
   ) {}
 
   kind: CompilationJobKind = CompilationJobKind.Both;
@@ -68,13 +67,12 @@ export class ComponentCompilationJob extends CompilationJob {
   constructor(
     componentName: string,
     pool: ConstantPool,
-    compatibility: ir.CompatibilityMode,
     readonly relativeContextFilePath: string,
     readonly i18nUseExternalIds: boolean,
     readonly deferMeta: R3ComponentDeferMetadata,
     readonly allDeferrableDepsFn: o.ReadVarExpr | null,
   ) {
-    super(componentName, pool, compatibility);
+    super(componentName, pool);
     this.root = new ViewCompilationUnit(this, this.allocateXrefId(), null);
     this.views.set(this.root.xref, this.root);
   }
@@ -231,8 +229,8 @@ export class ViewCompilationUnit extends CompilationUnit {
  * Compilation-in-progress of a host binding, which contains a single unit for that host binding.
  */
 export class HostBindingCompilationJob extends CompilationJob {
-  constructor(componentName: string, pool: ConstantPool, compatibility: ir.CompatibilityMode) {
-    super(componentName, pool, compatibility);
+  constructor(componentName: string, pool: ConstantPool) {
+    super(componentName, pool);
     this.root = new HostBindingCompilationUnit(this);
   }
 

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -29,8 +29,6 @@ import {
 } from './compilation';
 import {BINARY_OPERATORS, namespaceForKey, prefixWithNamespace} from './conversion';
 
-const compatibilityMode = ir.CompatibilityMode.TemplateDefinitionBuilder;
-
 // Schema containing DOM elements and their properties.
 const domSchema = new DomElementSchemaRegistry();
 
@@ -62,7 +60,6 @@ export function ingestComponent(
   const job = new ComponentCompilationJob(
     componentName,
     constantPool,
-    compatibilityMode,
     relativeContextFilePath,
     i18nUseExternalIds,
     deferMeta,
@@ -89,7 +86,7 @@ export function ingestHostBinding(
   bindingParser: BindingParser,
   constantPool: ConstantPool,
 ): HostBindingCompilationJob {
-  const job = new HostBindingCompilationJob(input.componentName, constantPool, compatibilityMode);
+  const job = new HostBindingCompilationJob(input.componentName, constantPool);
   for (const property of input.properties ?? []) {
     let bindingKind = ir.BindingKind.Property;
     // TODO: this should really be handled in the parser.
@@ -451,9 +448,9 @@ function ingestBoundText(
   const textXref = unit.job.allocateXrefId();
   unit.create.push(ir.createTextOp(textXref, '', icuPlaceholder, text.sourceSpan));
   // TemplateDefinitionBuilder does not generate source maps for sub-expressions inside an
-  // interpolation. We copy that behavior in compatibility mode.
+  // interpolation. We copy that behavior.
   // TODO: is it actually correct to generate these extra maps in modern mode?
-  const baseSourceSpan = unit.job.compatibility ? null : text.sourceSpan;
+  const baseSourceSpan = true ? null : text.sourceSpan;
   unit.update.push(
     ir.createInterpolateTextOp(
       textXref,

--- a/packages/compiler/src/template/pipeline/src/phases/attribute_extraction.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/attribute_extraction.ts
@@ -74,10 +74,7 @@ export function extractAttributes(job: CompilationJob): void {
           // The old compiler treated empty style bindings as regular bindings for the purpose of
           // directive matching. That behavior is incorrect, but we emulate it in compatibility
           // mode.
-          if (
-            unit.job.compatibility === ir.CompatibilityMode.TemplateDefinitionBuilder &&
-            op.expression instanceof ir.EmptyExpr
-          ) {
+          if (op.expression instanceof ir.EmptyExpr) {
             ir.OpList.insertBefore<ir.CreateOp>(
               ir.createExtractedAttributeOp(
                 op.target,
@@ -106,14 +103,9 @@ export function extractAttributes(job: CompilationJob): void {
               SecurityContext.NONE,
             );
             if (job.kind === CompilationJobKind.Host) {
-              if (job.compatibility) {
-                // TemplateDefinitionBuilder does not extract listener bindings to the const array
-                // (which is honestly pretty inconsistent).
-                break;
-              }
-              // This attribute will apply to the enclosing host binding compilation unit, so order
-              // doesn't matter.
-              unit.create.push(extractedAttributeOp);
+              // TemplateDefinitionBuilder does not extract listener bindings to the const array
+              // (which is honestly pretty inconsistent).
+              break;
             } else {
               ir.OpList.insertBefore<ir.CreateOp>(
                 extractedAttributeOp,
@@ -173,11 +165,9 @@ function extractAttributeOp(
   }
 
   let extractable = op.isTextAttribute || op.expression.isConstant();
-  if (unit.job.compatibility === ir.CompatibilityMode.TemplateDefinitionBuilder) {
-    // TemplateDefinitionBuilder only extracts text attributes. It does not extract attriibute
-    // bindings, even if they are constants.
-    extractable &&= op.isTextAttribute;
-  }
+  // TemplateDefinitionBuilder only extracts text attributes. It does not extract attriibute
+  // bindings, even if they are constants.
+  extractable &&= op.isTextAttribute;
 
   if (extractable) {
     const extractedAttributeOp = ir.createExtractedAttributeOp(

--- a/packages/compiler/src/template/pipeline/src/phases/const_collection.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/const_collection.ts
@@ -27,8 +27,7 @@ export function collectElementConsts(job: CompilationJob): void {
   for (const unit of job.units) {
     for (const op of unit.create) {
       if (op.kind === ir.OpKind.ExtractedAttribute) {
-        const attributes =
-          allElementAttributes.get(op.target) || new ElementAttributes(job.compatibility);
+        const attributes = allElementAttributes.get(op.target) || new ElementAttributes();
         allElementAttributes.set(op.target, attributes);
         attributes.add(op.bindingKind, op.name, op.expression, op.namespace, op.trustedValueFn);
         ir.OpList.remove<ir.CreateOp>(op);
@@ -138,7 +137,7 @@ class ElementAttributes {
     return this.byKind.get(ir.BindingKind.I18n) ?? FLYWEIGHT_ARRAY;
   }
 
-  constructor(private compatibility: ir.CompatibilityMode) {}
+  constructor() {}
 
   private isKnown(kind: ir.BindingKind, name: string) {
     const nameToValue = this.known.get(kind) ?? new Set<string>();
@@ -161,10 +160,9 @@ class ElementAttributes {
     // array. This seems inefficient, we can probably keep just the first one or the last value
     // (whichever actually gets applied when multiple values are listed for the same attribute).
     const allowDuplicates =
-      this.compatibility === ir.CompatibilityMode.TemplateDefinitionBuilder &&
-      (kind === ir.BindingKind.Attribute ||
-        kind === ir.BindingKind.ClassName ||
-        kind === ir.BindingKind.StyleProperty);
+      kind === ir.BindingKind.Attribute ||
+      kind === ir.BindingKind.ClassName ||
+      kind === ir.BindingKind.StyleProperty;
     if (!allowDuplicates && this.isKnown(kind, name)) {
       return;
     }

--- a/packages/compiler/src/template/pipeline/src/phases/deduplicate_text_bindings.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/deduplicate_text_bindings.ts
@@ -19,19 +19,17 @@ export function deduplicateTextBindings(job: CompilationJob): void {
       if (op.kind === ir.OpKind.Binding && op.isTextAttribute) {
         const seenForElement = seen.get(op.target) || new Set();
         if (seenForElement.has(op.name)) {
-          if (job.compatibility === ir.CompatibilityMode.TemplateDefinitionBuilder) {
-            // For most duplicated attributes, TemplateDefinitionBuilder lists all of the values in
-            // the consts array. However, for style and class attributes it only keeps the last one.
-            // We replicate that behavior here since it has actual consequences for apps with
-            // duplicate class or style attrs.
-            if (op.name === 'style' || op.name === 'class') {
-              ir.OpList.remove<ir.UpdateOp>(op);
-            }
-          } else {
-            // TODO: Determine the correct behavior. It would probably make sense to merge multiple
-            // style and class attributes. Alternatively we could just throw an error, as HTML
-            // doesn't permit duplicate attributes.
+          // For most duplicated attributes, TemplateDefinitionBuilder lists all of the values in
+          // the consts array. However, for style and class attributes it only keeps the last one.
+          // We replicate that behavior here since it has actual consequences for apps with
+          // duplicate class or style attrs.
+          if (op.name === 'style' || op.name === 'class') {
+            ir.OpList.remove<ir.UpdateOp>(op);
           }
+
+          // TODO: Determine the correct behavior. It would probably make sense to merge multiple
+          // style and class attributes. Alternatively we could just throw an error, as HTML
+          // doesn't permit duplicate attributes.
         }
         seenForElement.add(op.name);
         seen.set(op.target, seenForElement);

--- a/packages/compiler/src/template/pipeline/src/phases/expand_safe_reads.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/expand_safe_reads.ts
@@ -103,9 +103,7 @@ function eliminateTemporaryAssignments(
         // temporary variables to themselves. This happens because some subexpression that the
         // temporary refers to, possibly through nested temporaries, has a function call. We copy that
         // behavior here.
-        return ctx.job.compatibility === ir.CompatibilityMode.TemplateDefinitionBuilder
-          ? new ir.AssignTemporaryExpr(read, read.xref)
-          : read;
+        return new ir.AssignTemporaryExpr(read, read.xref);
       }
       return e;
     },

--- a/packages/compiler/src/template/pipeline/src/phases/generate_projection_def.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/generate_projection_def.ts
@@ -18,8 +18,9 @@ import {literalOrArrayLiteral} from '../conversion';
  * root view.
  */
 export function generateProjectionDefs(job: ComponentCompilationJob): void {
-  // TODO: Why does TemplateDefinitionBuilder force a shared constant?
-  const share = job.compatibility === ir.CompatibilityMode.TemplateDefinitionBuilder;
+  // TODO: to maintain the compatibility with TemplateDefinitionBuilder we set it to true
+  // But why does TemplateDefinitionBuilder force a shared constant?
+  const share = true;
 
   // Collect all selectors from this component, and its nested views. Also, assign each projection a
   // unique ascending projection slot index.

--- a/packages/compiler/src/template/pipeline/src/phases/pipe_creation.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/pipe_creation.ts
@@ -37,19 +37,11 @@ function processPipeBindingsInView(unit: CompilationUnit): void {
         throw new Error(`AssertionError: pipe bindings should not appear in child expressions`);
       }
 
-      if (unit.job.compatibility) {
-        // TODO: We can delete this cast and check once compatibility mode is removed.
-        const slotHandle = (updateOp as any).target;
-        if (slotHandle == undefined) {
-          throw new Error(`AssertionError: expected slot handle to be assigned for pipe creation`);
-        }
-        addPipeToCreationBlock(unit, (updateOp as any).target, expr);
-      } else {
-        // When not in compatibility mode, we just add the pipe to the end of the create block. This
-        // is not only simpler and faster, but allows more chaining opportunities for other
-        // instructions.
-        unit.create.push(ir.createPipeOp(expr.target, expr.targetSlot, expr.name));
+      const slotHandle = (updateOp as any).target;
+      if (slotHandle == undefined) {
+        throw new Error(`AssertionError: expected slot handle to be assigned for pipe creation`);
       }
+      addPipeToCreationBlock(unit, (updateOp as any).target, expr);
     });
   }
 }

--- a/packages/compiler/src/template/pipeline/src/phases/variable_optimization.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/variable_optimization.ts
@@ -39,12 +39,12 @@ export function optimizeVariables(job: CompilationJob): void {
       }
     }
 
-    optimizeVariablesInOpList(unit.create, job.compatibility);
-    optimizeVariablesInOpList(unit.update, job.compatibility);
+    optimizeVariablesInOpList(unit.create);
+    optimizeVariablesInOpList(unit.update);
 
     for (const op of unit.create) {
       if (op.kind === ir.OpKind.Listener || op.kind === ir.OpKind.TwoWayListener) {
-        optimizeVariablesInOpList(op.handlerOps, job.compatibility);
+        optimizeVariablesInOpList(op.handlerOps);
       }
     }
   }
@@ -138,10 +138,7 @@ function inlineAlwaysInlineVariables(ops: ir.OpList<ir.CreateOp | ir.UpdateOp>):
 /**
  * Process a list of operations and optimize variables within that list.
  */
-function optimizeVariablesInOpList(
-  ops: ir.OpList<ir.CreateOp | ir.UpdateOp>,
-  compatibility: ir.CompatibilityMode,
-): void {
+function optimizeVariablesInOpList(ops: ir.OpList<ir.CreateOp | ir.UpdateOp>): void {
   const varDecls = new Map<ir.XrefId, ir.VariableOp<ir.CreateOp | ir.UpdateOp>>();
   const varUsages = new Map<ir.XrefId, number>();
 
@@ -263,10 +260,7 @@ function optimizeVariablesInOpList(
 
       // Is the variable used in this operation?
       if (opInfo.variablesUsed.has(candidate)) {
-        if (
-          compatibility === ir.CompatibilityMode.TemplateDefinitionBuilder &&
-          !allowConservativeInlining(decl, targetOp)
-        ) {
+        if (!allowConservativeInlining(decl, targetOp)) {
           // We're in conservative mode, and this variable is not eligible for inlining into the
           // target operation in this mode.
           break;


### PR DESCRIPTION
The normal mode was unused, compatibility became de the de-facto behavior to maintain the exisiting behavior.
