### PR TITLE
Language service fixes

### DIFF
--- a/packages/language-service/src/codefixes/code_fixes.ts
+++ b/packages/language-service/src/codefixes/code_fixes.ts
@@ -46,7 +46,7 @@ export class CodeFixes {
    */
   getCodeFixesAtPosition(
     fileName: string,
-    templateInfo: TemplateInfo,
+    templateInfo: TemplateInfo | null,
     compiler: NgCompiler,
     start: number,
     end: number,

--- a/packages/language-service/src/codefixes/fix_invalid_banana_in_box.ts
+++ b/packages/language-service/src/codefixes/fix_invalid_banana_in_box.ts
@@ -21,7 +21,8 @@ import {CodeActionMeta, FixIdForCodeFixesAll} from './utils';
 export const fixInvalidBananaInBoxMeta: CodeActionMeta = {
   errorCodes: [ngErrorCode(ErrorCode.INVALID_BANANA_IN_BOX)],
   getCodeActions({start, fileName, templateInfo}) {
-    const boundEvent = getTheBoundEventAtPosition(templateInfo, start);
+    const boundEvent =
+      templateInfo === null ? null : getTheBoundEventAtPosition(templateInfo, start);
     if (boundEvent === null) {
       return [];
     }

--- a/packages/language-service/src/codefixes/fix_missing_import.ts
+++ b/packages/language-service/src/codefixes/fix_missing_import.ts
@@ -47,19 +47,13 @@ export const missingImportMeta: CodeActionMeta = {
   },
 };
 
-function getCodeActions({
-  templateInfo,
-  start,
-  compiler,
-  formatOptions,
-  preferences,
-  errorCode,
-  tsLs,
-}: CodeActionContext) {
+function getCodeActions({templateInfo, start, compiler}: CodeActionContext) {
+  if (templateInfo === null) {
+    return [];
+  }
+
   let codeActions: ts.CodeFixAction[] = [];
   const checker = compiler.getTemplateTypeChecker();
-  const tsChecker = compiler.programDriver.getProgram().getTypeChecker();
-
   const target = getTargetAtPosition(templateInfo.template, start);
   if (target === null) {
     return [];

--- a/packages/language-service/src/codefixes/fix_missing_member.ts
+++ b/packages/language-service/src/codefixes/fix_missing_member.ts
@@ -8,11 +8,7 @@
 
 import tss from 'typescript';
 
-import {
-  getTargetAtPosition,
-  getTcbNodesOfTemplateAtPosition,
-  TargetNodeKind,
-} from '../template_target';
+import {getTcbNodesOfTemplateAtPosition} from '../template_target';
 import {getTemplateInfoAtPosition} from '../utils';
 
 import {CodeActionMeta, convertFileTextChangeInTcb, FixIdForCodeFixesAll} from './utils';
@@ -37,7 +33,8 @@ export const missingMemberMeta: CodeActionMeta = {
     errorCode,
     tsLs,
   }) {
-    const tcbNodesInfo = getTcbNodesOfTemplateAtPosition(templateInfo, start, compiler);
+    const tcbNodesInfo =
+      templateInfo === null ? null : getTcbNodesOfTemplateAtPosition(templateInfo, start, compiler);
     if (tcbNodesInfo === null) {
       return [];
     }

--- a/packages/language-service/src/codefixes/utils.ts
+++ b/packages/language-service/src/codefixes/utils.ts
@@ -20,7 +20,7 @@ import {TemplateInfo} from '../utils';
  * context will be provided to the `CodeActionMeta` which could handle the `errorCode`.
  */
 export interface CodeActionContext {
-  templateInfo: TemplateInfo;
+  templateInfo: TemplateInfo | null;
   fileName: string;
   compiler: NgCompiler;
   start: number;

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -404,17 +404,13 @@ export class LanguageService {
           return [];
         }
 
-        const templateInfo = getTemplateInfoAtPosition(fileName, start, compiler);
-        if (templateInfo === undefined) {
-          return [];
-        }
         const diags = this.getSemanticDiagnostics(fileName);
         if (diags.length === 0) {
           return [];
         }
         return this.codeFixes.getCodeFixesAtPosition(
           fileName,
-          templateInfo,
+          getTemplateInfoAtPosition(fileName, start, compiler) ?? null,
           compiler,
           start,
           end,


### PR DESCRIPTION
Includes the following fixes for the language service:

### fix(language-service): allow fixes to run without template info 
Currently the code fixes won't run if the template information can't be resolved on the diagnostic node. This is incorrect for diagnostics that are reported within `.ts` files. These changes make the `templateInfo` nullable and leave the early exit up to the individual fixes.

### fix(language-service): add fix for individual unused imports 
Fixes that `getCodeActions` wasn't implemented for the unused imports fixer which meant that it wouldn't show up in the most common cases.