### PR TITLE
fix(core): Prevents race condition of cleanup for incremental hydration

### DIFF
--- a/packages/core/src/defer/registry.ts
+++ b/packages/core/src/defer/registry.ts
@@ -85,7 +85,7 @@ export class DehydratedBlockRegistry {
   }
 
   // Blocks that are being hydrated.
-  hydrating = new Set<string>();
+  hydrating = new Map<string, PromiseWithResolvers<void>>();
 
   /** @nocollapse */
   static ɵprov = /** @pureOrBreakMyCode */ /* @__PURE__ */ ɵɵdefineInjectable({

--- a/packages/core/src/defer/rendering.ts
+++ b/packages/core/src/defer/rendering.ts
@@ -320,13 +320,6 @@ function applyDeferBlockState(
       lDetails[ON_COMPLETE_FNS] = null;
     }
   }
-
-  if (newState === DeferBlockState.Complete && Array.isArray(lDetails[ON_COMPLETE_FNS])) {
-    for (const callback of lDetails[ON_COMPLETE_FNS]) {
-      callback();
-    }
-    lDetails[ON_COMPLETE_FNS] = null;
-  }
 }
 
 /**

--- a/packages/core/src/hydration/cleanup.ts
+++ b/packages/core/src/hydration/cleanup.ts
@@ -6,10 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ApplicationRef, whenStable} from '../application/application_ref';
+import {ApplicationRef} from '../application/application_ref';
 import {DehydratedDeferBlock} from '../defer/interfaces';
-import {DEHYDRATED_BLOCK_REGISTRY} from '../defer/registry';
-import {Injector} from '../di';
+import {DehydratedBlockRegistry} from '../defer/registry';
 import {
   CONTAINER_HEADER_OFFSET,
   DEHYDRATED_VIEWS,
@@ -138,20 +137,15 @@ export function cleanupDehydratedViews(appRef: ApplicationRef) {
  * hydrated. This removes all the jsaction attributes, timers, observers,
  * dehydrated views and containers
  */
-export async function cleanupDeferBlock(
+export function cleanupHydratedDeferBlocks(
   deferBlock: DehydratedDeferBlock | null,
-  hydratedBlocks: Set<string>,
-  injector: Injector,
-): Promise<void> {
+  hydratedBlocks: string[],
+  registry: DehydratedBlockRegistry,
+  appRef: ApplicationRef,
+): void {
   if (deferBlock !== null) {
-    // hydratedBlocks is a set, and needs to be converted to an array
-    // for removing listeners
-    const registry = injector.get(DEHYDRATED_BLOCK_REGISTRY);
-    registry.cleanup([...hydratedBlocks]);
+    registry.cleanup(hydratedBlocks);
     cleanupLContainer(deferBlock.lContainer);
-    cleanupDehydratedViews(injector.get(ApplicationRef));
+    cleanupDehydratedViews(appRef);
   }
-  // we need to wait for app stability here so we don't continue before
-  // the hydration process has finished, which could result in problems
-  return whenStable(injector.get(ApplicationRef));
 }

--- a/packages/core/src/hydration/event_replay.ts
+++ b/packages/core/src/hydration/event_replay.ts
@@ -250,24 +250,25 @@ export function invokeRegisteredReplayListeners(
   }
 }
 
-export async function hydrateAndInvokeBlockListeners(
+function hydrateAndInvokeBlockListeners(
   blockName: string,
   injector: Injector,
   event: Event,
   currentTarget: Element,
 ) {
   blockEventQueue.push({event, currentTarget});
-  await triggerHydrationFromBlockName(injector, blockName, replayQueuedBlockEvents);
+  triggerHydrationFromBlockName(injector, blockName, replayQueuedBlockEvents);
 }
 
-function replayQueuedBlockEvents(hydratedBlocks: Set<string>) {
+function replayQueuedBlockEvents(hydratedBlocks: string[]) {
   // clone the queue
   const queue = [...blockEventQueue];
+  const hydrated = new Set<string>(hydratedBlocks);
   // empty it
   blockEventQueue = [];
   for (let {event, currentTarget} of queue) {
     const blockName = currentTarget.getAttribute(DEFER_BLOCK_SSR_ID_ATTRIBUTE)!;
-    if (hydratedBlocks.has(blockName)) {
+    if (hydrated.has(blockName)) {
       invokeListeners(event, currentTarget);
     } else {
       // requeue events that weren't yet hydrated

--- a/packages/core/src/util/promise_with_resolvers.ts
+++ b/packages/core/src/util/promise_with_resolvers.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+/**
+ * TODO(incremental-hydration): Remove this file entirely once PromiseWithResolvers lands in stable
+ * node / TS.
+ */
+interface PromiseWithResolvers<T> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: any) => void;
+}
+
+interface PromiseConstructor {
+  /**
+   * Creates a new Promise and returns it in an object, along with its resolve and reject functions.
+   * @returns An object with the properties `promise`, `resolve`, and `reject`.
+   *
+   * ```ts
+   * const { promise, resolve, reject } = Promise.withResolvers<T>();
+   * ```
+   */
+  withResolvers<T>(): PromiseWithResolvers<T>;
+}


### PR DESCRIPTION
When hydrating a tree of blocks, this prevents cleanup from firing more than once per tree. It also ensures the cleanup happens after hydration has finished.

fixes #58690

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix




## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

