### PR TITLE
fix(core): correctly clear template HMR internal renderer cache

### DIFF
--- a/packages/core/src/render3/hmr.ts
+++ b/packages/core/src/render3/hmr.ts
@@ -123,9 +123,9 @@ function recreateMatchingLViews(def: ComponentDef<unknown>, rootLView: LView): v
  * @param def A ComponentDef instance.
  */
 function clearRendererCache(factory: RendererFactory, def: ComponentDef<unknown>) {
-  // Cast to `any` to read a private field.
+  // Cast to read a private field.
   // NOTE: This must be kept synchronized with the renderer factory implementation in platform-browser.
-  (factory as any).rendererByCompId?.remove(def.id);
+  (factory as {rendererByCompId?: Map<string, unknown>}).rendererByCompId?.delete(def.id);
 }
 
 /**


### PR DESCRIPTION
The internal renderer cache within the renderer factory was not being correctly cleared due to a type-casting error. This prevented template HMR from correctly updating the component. A more explicitly cast has now been used to mitigate this problem.
Component template HMR is currently considered experimental.