### PR TITLE
docs(core): add descriptive usage line for projectableNodes param in …

### DIFF
--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -69,7 +69,10 @@ import {assertComponentDef} from './errors';
  *  * `elementInjector` (optional): An `ElementInjector` instance, see additional info about it
  * [here](guide/di/hierarchical-dependency-injection#elementinjector).
  *  * `projectableNodes` (optional): A list of DOM nodes that should be projected through
- *                      [`<ng-content>`](api/core/ng-content) of the new component instance.
+ * [`<ng-content>`](api/core/ng-content) of the new component instance, e.g.,
+ * `[[element1, element2]]`: projects `element1` and `element2` into the same `<ng-content>`.
+ * `[[element1, element2], [element3]]`: projects `element1` and `element2` into one `<ng-content>`,
+ * and `element3` into a separate `<ng-content>`.
  * @returns ComponentRef instance that represents a given Component.
  *
  * @publicApi


### PR DESCRIPTION
# Add descriptive usage for projectableNodes in createComponent docs

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Clear documentation is missing on the projectableNodes  parameter of the createComponent function.
Fixes #57601 

## What is the new behavior?
Added clear documentation for the usage of the projectableNodes  parameter of the createComponent function.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
