### PR TITLE
fix(forms): work around TypeScript 5.7 issue

### DIFF
--- a/goldens/public-api/forms/index.api.md
+++ b/goldens/public-api/forms/index.api.md
@@ -308,9 +308,7 @@ export class FormBuilder {
     control<T>(formState: T | FormControlState<T>, opts: FormControlOptions, asyncValidator: AsyncValidatorFn | AsyncValidatorFn[]): FormControl<T | null>;
     // (undocumented)
     control<T>(formState: T | FormControlState<T>, validatorOrOpts?: ValidatorFn | ValidatorFn[] | FormControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): FormControl<T | null>;
-    group<T extends {}>(controls: T, options?: AbstractControlOptions | null): FormGroup<{
-        [K in keyof T]: ɵElement<T[K], null>;
-    }>;
+    group<T extends {}>(controls: T, options?: AbstractControlOptions | null): ɵNullableFormGroup<T>;
     // @deprecated
     group(controls: {
         [key: string]: any;
@@ -768,9 +766,7 @@ export class NgSelectOption implements OnDestroy {
 export abstract class NonNullableFormBuilder {
     abstract array<T>(controls: Array<T>, validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): FormArray<ɵElement<T, never>>;
     abstract control<T>(formState: T | FormControlState<T>, validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): FormControl<T>;
-    abstract group<T extends {}>(controls: T, options?: AbstractControlOptions | null): FormGroup<{
-        [K in keyof T]: ɵElement<T[K], never>;
-    }>;
+    abstract group<T extends {}>(controls: T, options?: AbstractControlOptions | null): ɵNonNullableFormGroup<T>;
     abstract record<T>(controls: {
         [key: string]: T;
     }, options?: AbstractControlOptions | null): FormRecord<ɵElement<T, never>>;

--- a/packages/forms/src/form_builder.ts
+++ b/packages/forms/src/form_builder.ts
@@ -53,6 +53,15 @@ interface PermissiveAbstractControlOptions extends Omit<AbstractControlOptions, 
   updateOn?: string;
 }
 
+// Note: these two types have been extracted into type aliases to work around a .d.ts generation
+// issue in TypeScript 5.7. See: https://github.com/Microsoft/TypeScript/issues/60506. The types
+// have to be exported for the workaround to work.
+/** Group of nullable form controls. */
+export type ɵNullableFormGroup<T> = FormGroup<{[K in keyof T]: ɵElement<T[K], null>}>;
+
+/** Group of non-nullable form controls. */
+export type ɵNonNullableFormGroup<T> = FormGroup<{[K in keyof T]: ɵElement<T[K], never>}>;
+
 /**
  * ControlConfig<T> is a tuple containing a value of type T, plus optional validators and async
  * validators.
@@ -194,10 +203,7 @@ export class FormBuilder {
    * * `updateOn`: The event upon which the control should be updated (options: 'change' | 'blur'
    * | submit').
    */
-  group<T extends {}>(
-    controls: T,
-    options?: AbstractControlOptions | null,
-  ): FormGroup<{[K in keyof T]: ɵElement<T[K], null>}>;
+  group<T extends {}>(controls: T, options?: AbstractControlOptions | null): ɵNullableFormGroup<T>;
 
   /**
    * @description
@@ -418,7 +424,7 @@ export abstract class NonNullableFormBuilder {
   abstract group<T extends {}>(
     controls: T,
     options?: AbstractControlOptions | null,
-  ): FormGroup<{[K in keyof T]: ɵElement<T[K], never>}>;
+  ): ɵNonNullableFormGroup<T>;
 
   /**
    * Similar to `FormBuilder#record`, except any implicitly constructed `FormControl`


### PR DESCRIPTION
Adjusts the return type of `FormBuilder.group` to work around https://github.com/Microsoft/TypeScript/issues/60506.