### PR TITLE
build: publish `angular-in-memory-web-api@0.19.0` for v19 compatibility

### DIFF
--- a/packages/misc/angular-in-memory-web-api/package.json
+++ b/packages/misc/angular-in-memory-web-api/package.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-in-memory-web-api",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "An in-memory web api for Angular demos and tests",
   "author": "angular",
   "license": "MIT",
   "peerDependencies": {
-    "@angular/core": "^18.0.0",
-    "@angular/common": "^18.0.0",
+    "@angular/core": "^19.0.0",
+    "@angular/common": "^19.0.0",
     "rxjs": "^6.5.3 || ^7.4.0"
   },
   "dependencies": {


### PR DESCRIPTION
We re-publish this package with new peer dependencies for v19 compatibility.