### PR TITLE
refactor(language-service): reuse code fixes map for has fix check

### DIFF
--- a/packages/language-service/src/codefixes/code_fixes.ts
+++ b/packages/language-service/src/codefixes/code_fixes.ts
@@ -14,7 +14,7 @@ import {TemplateInfo} from '../utils';
 import {CodeActionMeta, FixIdForCodeFixesAll, isFixAllAvailable} from './utils';
 
 export class CodeFixes {
-  private errorCodeToFixes: Map<number, CodeActionMeta[]> = new Map();
+  private errorCodeToFixes = new Map<number, CodeActionMeta[]>();
   private fixIdToRegistration = new Map<FixIdForCodeFixesAll, CodeActionMeta>();
 
   constructor(
@@ -38,6 +38,10 @@ export class CodeFixes {
         this.fixIdToRegistration.set(fixId, meta);
       }
     }
+  }
+
+  hasFixForCode(code: number): boolean {
+    return this.errorCodeToFixes.has(code);
   }
 
   /**

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -385,7 +385,7 @@ export class LanguageService {
    * Related context: https://github.com/angular/vscode-ng-language-service/pull/2050#discussion_r1673079263
    */
   hasCodeFixesForErrorCode(errorCode: number): boolean {
-    return this.codeFixes.codeActionMetas.some((m) => m.errorCodes.includes(errorCode));
+    return this.codeFixes.hasFixForCode(errorCode);
   }
 
   getCodeFixesAtPosition(


### PR DESCRIPTION
The error codes that have fixes are present in a Map instance and can be directly leveraged to determine if an error code can be fixed. This avoids multiple levels of iteration that would otherwise be needed.