### PR TITLE
docs: update titles for resource and linkedSignal

### DIFF
--- a/adev/src/app/sub-navigation-data.ts
+++ b/adev/src/app/sub-navigation-data.ts
@@ -90,12 +90,12 @@ const DOCS_SUB_NAVIGATION_DATA: NavigationItem[] = [
             contentPath: 'guide/signals/overview',
           },
           {
-            label: 'linkedSignal',
+            label: 'Dependent state with linkedSignal',
             path: 'guide/signals/linked-signal',
             contentPath: 'guide/signals/linked-signal',
           },
           {
-            label: 'Resource',
+            label: 'Async reactivity with resources',
             path: 'guide/signals/resource',
             contentPath: 'guide/signals/resource',
           },

--- a/adev/src/content/guide/signals/linked-signal.md
+++ b/adev/src/content/guide/signals/linked-signal.md
@@ -1,4 +1,4 @@
-# `linkedSignal`
+# Dependent state with `linkedSignal`
 
 IMPORTANT: `linkedSignal` is [developer preview](reference/releases#developer-preview). It's ready for you to try, but it might change before it is stable.
 

--- a/adev/src/content/guide/signals/resource.md
+++ b/adev/src/content/guide/signals/resource.md
@@ -4,7 +4,7 @@ IMPORTANT: `resource` is [experimental](reference/releases#experimental). It's r
 
 Most signal APIs are synchronous— `signal`, `computed`, `input`, etc. However, applications often need to deal with data that is available asynchronously. A `Resource` gives you a way to incorporate async data into your application's signal-based code.
 
-You can use a `Resource` to perform any kind of async operation, but the most common use-case for `Resource` is fetching data from a server. The following creates a resource to fetch some user data.
+You can use a `Resource` to perform any kind of async operation, but the most common use-case for `Resource` is fetching data from a server. The following example creates a resource to fetch some user data.
 
 The easiest way to create a `Resource` is the `resource` function.
 
@@ -47,6 +47,9 @@ The `ResourceLoaderParams` object contains three properties: `request`, `previou
 | `previous`    | An object with a `status` property, containing the previous `ResourceStatus`.                                                                    |
 | `abortSignal` | An [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). See [Aborting requests](#aborting-requests) below for details. |
 
+
+If the `request` computation returns `undefined`, the loader function does not run and the resource and the resource status becomes `Idle`.
+
 ### Aborting requests
 
 A resource aborts an outstanding request if the `request` computation changes while the resource is loading.
@@ -84,10 +87,6 @@ const userResource = resource({
 
 userResource.reload();
 ```
-
-### `undefined` requests
-
-A request value of `undefined` prevents the resource from running its loader, and will put the resource into an `Idle` state.
 
 ## Resource status
 


### PR DESCRIPTION
This change updates the navigation titles for linkedSignal and resource to follow the pattern of `"<accomplish X> with <feature Y>"`. Also makes a few minor updates to the body of the resource topic.