### PR TITLE
Add internal tracing API

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -134,6 +134,7 @@ export class ApplicationModule {
 
 // @public
 export class ApplicationRef {
+    constructor();
     attachView(viewRef: ViewRef): void;
     bootstrap<C>(component: Type<C>, rootSelectorOrNode?: string | any): ComponentRef<C>;
     // @deprecated

--- a/packages/core/src/application/tracing.ts
+++ b/packages/core/src/application/tracing.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {InjectionToken} from '../di/injection_token';
+
+/**
+ * Injection token for a `TracingService`, optionally provided.
+ */
+export const TracingService = new InjectionToken<TracingService<unknown>>('');
+
+/**
+ * Tracing mechanism which can associate causes (snapshots) with runs of subsequent operations.
+ *
+ * Not defined by Angular directly, but defined in contexts where tracing is desired.
+ */
+export interface TracingService<TSnapshot> {
+  /**
+   * Take a snapshot of the current context which will be stored by Angular and used when additional
+   * work is performed that was scheduled in this context.
+   */
+  snapshot(): TSnapshot;
+
+  /**
+   * Invoke `fn` within the given tracing snapshot, which may be `undefined`.
+   *
+   * This _must_ return the result of the function invocation.
+   */
+  run<T>(fn: () => T, snapshot: TSnapshot | undefined): T;
+}

--- a/packages/core/src/application/tracing.ts
+++ b/packages/core/src/application/tracing.ts
@@ -8,27 +8,37 @@
 
 import {InjectionToken} from '../di/injection_token';
 
+/** Actions that are supported by the tracing framework. */
+export enum TracingAction {
+  CHANGE_DETECTION,
+  AFTER_NEXT_RENDER,
+}
+
+/** A single tracing snapshot. */
+export interface TracingSnapshot {
+  run<T>(action: TracingAction, fn: () => T): T;
+}
+
 /**
  * Injection token for a `TracingService`, optionally provided.
  */
-export const TracingService = new InjectionToken<TracingService<unknown>>('');
+export const TracingService = new InjectionToken<TracingService<TracingSnapshot>>(
+  ngDevMode ? 'TracingService' : '',
+);
 
 /**
- * Tracing mechanism which can associate causes (snapshots) with runs of subsequent operations.
+ * Tracing mechanism which can associate causes (snapshots) with runs of
+ * subsequent operations.
  *
- * Not defined by Angular directly, but defined in contexts where tracing is desired.
+ * Not defined by Angular directly, but defined in contexts where tracing is
+ * desired.
  */
-export interface TracingService<TSnapshot> {
+export interface TracingService<T extends TracingSnapshot> {
   /**
-   * Take a snapshot of the current context which will be stored by Angular and used when additional
-   * work is performed that was scheduled in this context.
-   */
-  snapshot(): TSnapshot;
-
-  /**
-   * Invoke `fn` within the given tracing snapshot, which may be `undefined`.
+   * Take a snapshot of the current context which will be stored by Angular and
+   * used when additional work is performed that was scheduled in this context.
    *
-   * This _must_ return the result of the function invocation.
+   * @param linkedSnapshot Optional snapshot to use link to the current context.
    */
-  run<T>(fn: () => T, snapshot: TSnapshot | undefined): T;
+  snapshot(linkedSnapshot: T | null): T;
 }

--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
@@ -194,9 +194,10 @@ export class ChangeDetectionSchedulerImpl implements ChangeDetectionScheduler {
       }
     }
 
-    // If not already defined, attempt to capture a tracing snapshot of this notification so that
-    // the resulting CD run can be attributed to the context which produced the notification.
-    this.appRef.tracingSnapshot ??= this.tracing?.snapshot();
+    // If not already defined, attempt to capture a tracing snapshot of this
+    // notification so that the resulting CD run can be attributed to the
+    // context which produced the notification.
+    this.appRef.tracingSnapshot = this.tracing?.snapshot(this.appRef.tracingSnapshot) ?? null;
 
     if (!this.shouldScheduleTick(force)) {
       return;

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -17,6 +17,7 @@ export {
   IMAGE_CONFIG_DEFAULTS as ɵIMAGE_CONFIG_DEFAULTS,
   ImageConfig as ɵImageConfig,
 } from './application/application_tokens';
+export {TracingService as ɵTracingService} from './application/tracing';
 export {internalCreateApplication as ɵinternalCreateApplication} from './application/create_application';
 export {
   defaultIterableDiffers as ɵdefaultIterableDiffers,

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -17,7 +17,11 @@ export {
   IMAGE_CONFIG_DEFAULTS as ɵIMAGE_CONFIG_DEFAULTS,
   ImageConfig as ɵImageConfig,
 } from './application/application_tokens';
-export {TracingService as ɵTracingService} from './application/tracing';
+export {
+  TracingAction as ɵTracingAction,
+  TracingService as ɵTracingService,
+  TracingSnapshot as ɵTracingSnapshot,
+} from './application/tracing';
 export {internalCreateApplication as ɵinternalCreateApplication} from './application/create_application';
 export {
   defaultIterableDiffers as ɵdefaultIterableDiffers,

--- a/packages/core/src/render3/after_render/hooks.ts
+++ b/packages/core/src/render3/after_render/hooks.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {TracingService} from '../../application/tracing';
 import {assertInInjectionContext} from '../../di';
 import {Injector} from '../../di/injector';
 import {inject} from '../../di/injector_compatibility';
@@ -454,6 +455,8 @@ function afterRenderImpl(
   // tree-shaken if `afterRender` and `afterNextRender` aren't used.
   manager.impl ??= injector.get(AfterRenderImpl);
 
+  const tracing = injector.get(TracingService, null, {optional: true});
+
   const hooks = options?.phase ?? AfterRenderPhase.MixedReadWrite;
   const destroyRef = options?.manualCleanup !== true ? injector.get(DestroyRef) : null;
   const sequence = new AfterRenderSequence(
@@ -461,6 +464,7 @@ function afterRenderImpl(
     getHooks(callbackOrSpec, hooks),
     once,
     destroyRef,
+    tracing?.snapshot(),
   );
   manager.impl.register(sequence);
   return sequence;

--- a/packages/core/src/render3/after_render/hooks.ts
+++ b/packages/core/src/render3/after_render/hooks.ts
@@ -464,7 +464,7 @@ function afterRenderImpl(
     getHooks(callbackOrSpec, hooks),
     once,
     destroyRef,
-    tracing?.snapshot(),
+    tracing?.snapshot(null),
   );
   manager.impl.register(sequence);
   return sequence;

--- a/packages/core/src/render3/after_render/manager.ts
+++ b/packages/core/src/render3/after_render/manager.ts
@@ -16,6 +16,7 @@ import {
   NotificationSource,
 } from '../../change_detection/scheduling/zoneless_scheduling';
 import {type DestroyRef} from '../../linker/destroy_ref';
+import {TracingService} from '../../application/tracing';
 
 export class AfterRenderManager {
   impl: AfterRenderImpl | null = null;
@@ -44,6 +45,7 @@ export class AfterRenderImpl {
   private readonly ngZone = inject(NgZone);
   private readonly scheduler = inject(ChangeDetectionScheduler);
   private readonly errorHandler = inject(ErrorHandler, {optional: true});
+  private readonly tracing = inject(TracingService, {optional: true});
 
   /** Current set of active sequences. */
   private readonly sequences = new Set<AfterRenderSequence>();
@@ -68,7 +70,10 @@ export class AfterRenderImpl {
 
         try {
           sequence.pipelinedValue = this.ngZone.runOutsideAngular(() =>
-            sequence.hooks[phase]!(sequence.pipelinedValue),
+            this.maybeTrace(
+              () => sequence.hooks[phase]!(sequence.pipelinedValue),
+              sequence.snapshot,
+            ),
           );
         } catch (err) {
           sequence.erroredOrDestroyed = true;
@@ -124,6 +129,11 @@ export class AfterRenderImpl {
     }
   }
 
+  protected maybeTrace<T>(fn: () => T, snapshot: unknown): T {
+    // Only trace the execution if the snapshot is defined.
+    return this.tracing && snapshot ? this.tracing.run(fn, snapshot) : fn();
+  }
+
   /** @nocollapse */
   static ɵprov = /** @pureOrBreakMyCode */ /* @__PURE__ */ ɵɵdefineInjectable({
     token: AfterRenderImpl,
@@ -160,6 +170,7 @@ export class AfterRenderSequence implements AfterRenderRef {
     readonly hooks: AfterRenderHooks,
     public once: boolean,
     destroyRef: DestroyRef | null,
+    public snapshot: unknown,
   ) {
     this.unregisterOnDestroy = destroyRef?.onDestroy(() => this.destroy());
   }
@@ -167,6 +178,11 @@ export class AfterRenderSequence implements AfterRenderRef {
   afterRun(): void {
     this.erroredOrDestroyed = false;
     this.pipelinedValue = undefined;
+
+    // Clear the tracing snapshot after the initial run. This snapshot only associates the initial
+    // run of the hook with the context that created it. Follow-up runs are independent of that
+    // initial context and have different triggers.
+    this.snapshot = undefined;
   }
 
   destroy(): void {

--- a/packages/core/src/render3/reactivity/after_render_effect.ts
+++ b/packages/core/src/render3/reactivity/after_render_effect.ts
@@ -36,7 +36,7 @@ import {NOOP_AFTER_RENDER_REF, type AfterRenderOptions} from '../after_render/ho
 import {DestroyRef} from '../../linker/destroy_ref';
 import {assertNotInReactiveContext} from './asserts';
 import {assertInInjectionContext} from '../../di/contextual';
-import {TracingService} from '../../application/tracing';
+import {TracingService, TracingSnapshot} from '../../application/tracing';
 
 const NOT_SET = Symbol('NOT_SET');
 const EMPTY_CLEANUP_SET = new Set<() => void>();
@@ -176,7 +176,7 @@ class AfterRenderEffectSequence extends AfterRenderSequence {
     effectHooks: Array<AfterRenderPhaseEffectHook | undefined>,
     readonly scheduler: ChangeDetectionScheduler,
     destroyRef: DestroyRef,
-    snapshot: unknown,
+    snapshot: TracingSnapshot | null = null,
   ) {
     // Note that we also initialize the underlying `AfterRenderSequence` hooks to `undefined` and
     // populate them as we create reactive nodes below.
@@ -385,7 +385,7 @@ export function afterRenderEffect<E = never, W = never, M = never>(
     [spec.earlyRead, spec.write, spec.mixedReadWrite, spec.read] as AfterRenderPhaseEffectHook[],
     scheduler,
     injector.get(DestroyRef),
-    tracing?.snapshot(),
+    tracing?.snapshot(null),
   );
   manager.impl.register(sequence);
   return sequence;

--- a/packages/core/test/acceptance/tracing_spec.ts
+++ b/packages/core/test/acceptance/tracing_spec.ts
@@ -1,0 +1,74 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  Component,
+  ɵTracingService as TracingService,
+  ɵTracingSnapshot as TracingSnapshot,
+  ɵTracingAction as TracingAction,
+  afterRender,
+} from '@angular/core';
+import {fakeAsync, TestBed} from '@angular/core/testing';
+
+describe('TracingService', () => {
+  let actions: TracingAction[];
+  let fakeSnapshot: TracingSnapshot;
+  let mockTracingService: TracingService<TracingSnapshot>;
+
+  beforeEach(() => {
+    actions = [];
+    fakeSnapshot = {
+      run: function <T>(action: TracingAction, fn: () => T): T {
+        actions.push(action);
+        return fn();
+      },
+    };
+    mockTracingService = {
+      snapshot: jasmine.createSpy('snapshot').and.returnValue(fakeSnapshot),
+    };
+  });
+
+  it('should take a snapshot after change detection', () => {
+    TestBed.configureTestingModule({
+      providers: [{provide: TracingService, useValue: mockTracingService}],
+    });
+
+    @Component({template: ''})
+    class App {}
+
+    const fixture = TestBed.createComponent(App);
+    expect(mockTracingService.snapshot).not.toHaveBeenCalled();
+
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+    expect(mockTracingService.snapshot).toHaveBeenCalledTimes(1);
+    expect(actions).toEqual([TracingAction.CHANGE_DETECTION]);
+
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+    expect(mockTracingService.snapshot).toHaveBeenCalledTimes(2);
+    expect(actions).toEqual([TracingAction.CHANGE_DETECTION, TracingAction.CHANGE_DETECTION]);
+  });
+
+  it('should take a snapshot after `afterRender`', fakeAsync(() => {
+    TestBed.configureTestingModule({
+      providers: [{provide: TracingService, useValue: mockTracingService}],
+    });
+
+    @Component({template: ''})
+    class App {
+      constructor() {
+        afterRender(() => {});
+      }
+    }
+
+    TestBed.createComponent(App);
+    expect(mockTracingService.snapshot).toHaveBeenCalledTimes(2);
+    expect(actions).toEqual([TracingAction.CHANGE_DETECTION, TracingAction.AFTER_NEXT_RENDER]);
+  }));
+});

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -489,6 +489,12 @@
     "name": "TimelineBuilder"
   },
   {
+    "name": "TracingAction"
+  },
+  {
+    "name": "TracingService"
+  },
+  {
     "name": "TransitionAnimationEngine"
   },
   {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -549,6 +549,12 @@
     "name": "TimelineBuilder"
   },
   {
+    "name": "TracingAction"
+  },
+  {
+    "name": "TracingService"
+  },
+  {
     "name": "TransitionAnimationEngine"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -414,6 +414,12 @@
     "name": "TestabilityRegistry"
   },
   {
+    "name": "TracingAction"
+  },
+  {
+    "name": "TracingService"
+  },
+  {
     "name": "TriggerComponent"
   },
   {

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -504,6 +504,12 @@
     "name": "TYPE"
   },
   {
+    "name": "TracingAction"
+  },
+  {
+    "name": "TracingService"
+  },
+  {
     "name": "USE_VALUE"
   },
   {
@@ -2095,6 +2101,9 @@
   },
   {
     "name": "init_tokens3"
+  },
+  {
+    "name": "init_tracing"
   },
   {
     "name": "init_transfer_state"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -585,6 +585,12 @@
     "name": "TouchedChangeEvent"
   },
   {
+    "name": "TracingAction"
+  },
+  {
+    "name": "TracingService"
+  },
+  {
     "name": "UNSET"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -573,6 +573,12 @@
     "name": "TouchedChangeEvent"
   },
   {
+    "name": "TracingAction"
+  },
+  {
+    "name": "TracingService"
+  },
+  {
     "name": "UNSET"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -303,6 +303,12 @@
     "name": "TRACKED_LVIEWS"
   },
   {
+    "name": "TracingAction"
+  },
+  {
+    "name": "TracingService"
+  },
+  {
     "name": "USE_VALUE"
   },
   {

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -420,6 +420,12 @@
     "name": "TRACKED_LVIEWS"
   },
   {
+    "name": "TracingAction"
+  },
+  {
+    "name": "TracingService"
+  },
+  {
     "name": "TransferState"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -699,6 +699,12 @@
     "name": "TitleStrategy"
   },
   {
+    "name": "TracingAction"
+  },
+  {
+    "name": "TracingService"
+  },
+  {
     "name": "Tree"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -363,6 +363,12 @@
     "name": "TRACKED_LVIEWS"
   },
   {
+    "name": "TracingAction"
+  },
+  {
+    "name": "TracingService"
+  },
+  {
     "name": "USE_VALUE"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -480,6 +480,12 @@
     "name": "TodoStore"
   },
   {
+    "name": "TracingAction"
+  },
+  {
+    "name": "TracingService"
+  },
+  {
     "name": "USE_VALUE"
   },
   {


### PR DESCRIPTION
These changes pick up from #58613 and adjust the code to match the most recent requirements.

### refactor(core): introduce TracingService for snapshot-based tracing 
This commit introduces a private API, the `TracingService` DI token. By providing this token, Angular can be configured to capture tracing snapshots for certain operations such as change detection notifications, and to run downstream operations within the context of those snapshots. `TracingService` abstracts this context propagation and makes it pluggable.

### refactor(core): adjust tracing service 
Adjusts the tracing service based on internal requirements.