### PR TITLE
fix(migrations): take care of tests that import both `HttpClientModule` & `HttpClientTestingModule`.

### DIFF
--- a/packages/core/schematics/test/http_providers_spec.ts
+++ b/packages/core/schematics/test/http_providers_spec.ts
@@ -475,4 +475,38 @@ describe('Http providers migration', () => {
     expect(content).not.toContain('HttpClientModule');
     expect(content).not.toContain('provideHttpClient');
   });
+
+  it('should migrate testing module with both modules imported', async () => {
+    writeFile(
+      '/index.ts',
+      `
+        import { HttpClientModule } from '@angular/common/http';
+        import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+        describe('AppComponent', () => {
+
+          beforeEach(async (): void => {
+            TestBed.configureTestingModule({
+              imports: [
+                HttpClientModule,
+                HttpClientTestingModule,
+              ],
+            })
+          });
+        });
+    `,
+    );
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).not.toContain('HttpClientModule');
+    expect(content).not.toContain('HttpClientTestingModule');
+
+    expect(content).toMatch(/import.*provideHttpClient.*withInterceptorsFromDi.*from/);
+    expect(content).toMatch(/import.*provideHttpClientTesting/);
+    expect(content).toContain(
+      `provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()`,
+    );
+  });
 });


### PR DESCRIPTION
While having both `HttpClientModule` & `HttpClientTestingModule` serves no real purpose (`HttpClientTestingModule` imports `HttpClientModule`), some code bases can have those 2 together and the migration can be quite breaking without this fix. 

fixes #58536
