### PR TITLE
refactor(forms): work around another TypeScript 5.7 issue

### DIFF
--- a/goldens/public-api/forms/index.api.md
+++ b/goldens/public-api/forms/index.api.md
@@ -308,7 +308,7 @@ export class FormBuilder {
     control<T>(formState: T | FormControlState<T>, opts: FormControlOptions, asyncValidator: AsyncValidatorFn | AsyncValidatorFn[]): FormControl<T | null>;
     // (undocumented)
     control<T>(formState: T | FormControlState<T>, validatorOrOpts?: ValidatorFn | ValidatorFn[] | FormControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): FormControl<T | null>;
-    group<T extends {}>(controls: T, options?: AbstractControlOptions | null): ɵNullableFormGroup<T>;
+    group<T extends {}>(controls: T, options?: AbstractControlOptions | null): FormGroup<ɵNullableFormControls<T>>;
     // @deprecated
     group(controls: {
         [key: string]: any;
@@ -766,7 +766,7 @@ export class NgSelectOption implements OnDestroy {
 export abstract class NonNullableFormBuilder {
     abstract array<T>(controls: Array<T>, validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): FormArray<ɵElement<T, never>>;
     abstract control<T>(formState: T | FormControlState<T>, validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): FormControl<T>;
-    abstract group<T extends {}>(controls: T, options?: AbstractControlOptions | null): ɵNonNullableFormGroup<T>;
+    abstract group<T extends {}>(controls: T, options?: AbstractControlOptions | null): FormGroup<ɵNonNullableFormControls<T>>;
     abstract record<T>(controls: {
         [key: string]: T;
     }, options?: AbstractControlOptions | null): FormRecord<ɵElement<T, never>>;

--- a/packages/forms/src/form_builder.ts
+++ b/packages/forms/src/form_builder.ts
@@ -56,11 +56,11 @@ interface PermissiveAbstractControlOptions extends Omit<AbstractControlOptions, 
 // Note: these two types have been extracted into type aliases to work around a .d.ts generation
 // issue in TypeScript 5.7. See: https://github.com/Microsoft/TypeScript/issues/60506. The types
 // have to be exported for the workaround to work.
-/** Group of nullable form controls. */
-export type ɵNullableFormGroup<T> = FormGroup<{[K in keyof T]: ɵElement<T[K], null>}>;
+/** A map of nullable form controls. */
+export type ɵNullableFormControls<T> = {[K in keyof T]: ɵElement<T[K], null>};
 
-/** Group of non-nullable form controls. */
-export type ɵNonNullableFormGroup<T> = FormGroup<{[K in keyof T]: ɵElement<T[K], never>}>;
+/** A map of non-nullable form controls. */
+export type ɵNonNullableFormControls<T> = {[K in keyof T]: ɵElement<T[K], never>};
 
 /**
  * ControlConfig<T> is a tuple containing a value of type T, plus optional validators and async
@@ -203,7 +203,10 @@ export class FormBuilder {
    * * `updateOn`: The event upon which the control should be updated (options: 'change' | 'blur'
    * | submit').
    */
-  group<T extends {}>(controls: T, options?: AbstractControlOptions | null): ɵNullableFormGroup<T>;
+  group<T extends {}>(
+    controls: T,
+    options?: AbstractControlOptions | null,
+  ): FormGroup<ɵNullableFormControls<T>>;
 
   /**
    * @description
@@ -424,7 +427,7 @@ export abstract class NonNullableFormBuilder {
   abstract group<T extends {}>(
     controls: T,
     options?: AbstractControlOptions | null,
-  ): ɵNonNullableFormGroup<T>;
+  ): FormGroup<ɵNonNullableFormControls<T>>;
 
   /**
    * Similar to `FormBuilder#record`, except any implicitly constructed `FormControl`


### PR DESCRIPTION
Reworks the changes from #58731, because they didn't cover all use cases.