### PR TITLE
docs: fix 404 link in roadmap

### DIFF
--- a/adev/src/content/reference/roadmap.md
+++ b/adev/src/content/reference/roadmap.md
@@ -37,7 +37,7 @@ Start developing with the latest Angular features from our roadmap. This list re
 * [Signal inputs](/guide/signals/inputs)
 * [Model inputs](/guide/signals/model)
 * [Signal queries](/guide/signals/queries)
-* [Function-based outputs](/guide/components/output-fn)
+* [Function-based outputs](/guide/components/outputs)
 
 ## Improving the Angular developer experience
 


### PR DESCRIPTION
https://angular.dev/guide/components/output-fn does not exist, change to https://angular.dev/guide/components/outputs

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

*Function-based outputs* under [Roadmap](https://angular.dev/roadmap#production-ready) links to a 404 page

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Link changed to [Custom events with outputs](https://angular.dev/guide/components/outputs)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
