### PR TITLE
refactor(core): Make wording of effect-allowSignalWrites deprecation warning more accurate

### DIFF
--- a/packages/core/src/render3/reactivity/effect.ts
+++ b/packages/core/src/render3/reactivity/effect.ts
@@ -169,7 +169,7 @@ export function effect(
 
   if (ngDevMode && options?.allowSignalWrites !== undefined) {
     console.warn(
-      `The 'allowSignalWrites' flag is deprecated & longer required for effect() (writes are allowed by default)`,
+      `The 'allowSignalWrites' flag is deprecated and no longer impacts effect() (writes are always allowed)`,
     );
   }
 


### PR DESCRIPTION
The previous warning contained a typo and also somewhat implied that allowSignalWrites did something. However, setting allowSignalWrites to false has no impact at all in Angular 19.

Closes #58790

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #58790


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
```typescript
@Component({
  selector: 'app-root',
  template: "{{someSignal()}}",
  standalone: true,
})
export class AppComponent {

  someSignal = signal("test");

  constructor() {
    effect(() => {
      this.someSignal.set("Hello World");
    }, {allowSignalWrites: false});
  }
}
```

This will show "Hello World", so the new warning seems more appropriate.