### PR TITLE
fix(core): correctly perform lazy routes migration for components wit…

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/index.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/index.ts
@@ -10,6 +10,7 @@
 
 export {
   forwardRefResolver,
+  findAngularDecorator,
   getAngularDecorators,
   isAngularDecorator,
   NoopReferencesRegistry,

--- a/packages/core/schematics/ng-generate/route-lazy-loading/BUILD.bazel
+++ b/packages/core/schematics/ng-generate/route-lazy-loading/BUILD.bazel
@@ -20,6 +20,8 @@ ts_library(
     deps = [
         "//packages/compiler-cli",
         "//packages/compiler-cli/private",
+        "//packages/compiler-cli/src/ngtsc/annotations",
+        "//packages/compiler-cli/src/ngtsc/reflection",
         "//packages/core/schematics/utils",
         "@npm//@angular-devkit/schematics",
         "@npm//@types/node",


### PR DESCRIPTION
…h additional decorators

This fixes an issue where the lazy-routes migration would crash for component classes a decorator without arguments in front of the `@Component` decorator (in particular, it needed to be the first decorator).

Fixes #58793