### PR TITLE
docs: update front page banner to link to the blog

### DIFF
--- a/adev/src/app/features/home/home.component.html
+++ b/adev/src/app/features/home/home.component.html
@@ -2,9 +2,9 @@
   <div class="adev-top">
     <div class="adev-top-content">
       <!-- Banner(s) can be edited here! -->
-      <a href="https://goo.gle/angular-v19" class="adev-banner" target="_blank">
+      <a href="https://blog.angular.dev/meet-angular-v19-7b29dfd05b84" class="adev-banner" target="_blank">
         <h1 tabindex="-1">Angular v19 is here!</h1>
-        <p class="adev-banner-cta">Watch the all-new developer event now.</p>
+        <p class="adev-banner-cta">Read about our newest release.</p>
       </a>
     </div>
   </div>


### PR DESCRIPTION
The blog post now has the release event embedded.
Link to the blog for a more comprehensive overview