### PR TITLE
fix(migrations): Mark hoisted properties as removed in inject migration

### DIFF
--- a/packages/core/schematics/ng-generate/inject-migration/migration.ts
+++ b/packages/core/schematics/ng-generate/inject-migration/migration.ts
@@ -814,6 +814,7 @@ function applyInternalOnlyChanges(
       memberIndentation + printer.printNode(ts.EmitHint.Unspecified, decl, decl.getSourceFile()),
     );
     tracker.removeNode(decl, true);
+    removedMembers.add(decl);
   });
 
   // If we added any hoisted properties, separate them visually with a new line.


### PR DESCRIPTION
Before, in a situation like shown in the test, all of the initializers would be dropped, as the code would try to insert it at the hoisted property which is going to be deleted.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Given this code:

```ts
import { Injectable } from '@angular/core';
import { ActivatedRoute } from '@angular/router';

@Injectable()
export class MyClass {
  uninitialized!: string;

  readonly a;
  readonly b;

  constructor(private readonly route: ActivatedRoute) {
    this.a = this.route.get();
    this.b = this.a.get();
  }
}
```

With the internal migration enabled, the new lines of code would be dropped and this would be the output:

```ts
import { Injectable, inject } from '@angular/core';
import { ActivatedRoute } from '@angular/router';

@Injectable()
export class MyClass {}
```

Issue Number: N/A


## What is the new behavior?

```ts
import { Injectable, inject } from '@angular/core';
import { ActivatedRoute } from '@angular/router';

@Injectable()
export class MyClass {
  uninitialized!: string;

  private readonly route = inject(ActivatedRoute);
  readonly a = this.route.get();
  readonly b = this.a.get();
}
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

The internal migration would result in failures with some files.
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
