### PR TITLE
refactor: make LView[Injector] non nullable

### DIFF
--- a/packages/core/src/defer/dom_triggers.ts
+++ b/packages/core/src/defer/dom_triggers.ts
@@ -278,7 +278,7 @@ export function registerDomTrigger(
   callback: VoidFunction,
   type: TriggerType,
 ) {
-  const injector = initialLView[INJECTOR]!;
+  const injector = initialLView[INJECTOR];
   const zone = injector.get(NgZone);
   function pollDomTrigger() {
     // If the initial view was destroyed, we don't need to do anything.

--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -100,7 +100,7 @@ export function ɵɵdefer(
   const tView = getTView();
   const adjustedIndex = index + HEADER_OFFSET;
   const tNode = declareTemplate(lView, tView, index, null, 0, 0);
-  const injector = lView[INJECTOR]!;
+  const injector = lView[INJECTOR];
 
   if (tView.firstCreatePass) {
     performanceMarkFeature('NgDefer');
@@ -199,7 +199,7 @@ export function ɵɵdeferWhen(rawValue: unknown) {
         value === true &&
         (renderedState === DeferBlockInternalState.Initial ||
           renderedState === DeferBlockState.Placeholder) &&
-        shouldTriggerWhenOnClient(lView[INJECTOR]!, lDetails, tDetails)
+        shouldTriggerWhenOnClient(lView[INJECTOR], lDetails, tDetails)
       ) {
         triggerDeferBlock(lView, tNode);
       }
@@ -257,7 +257,7 @@ export function ɵɵdeferHydrateWhen(rawValue: unknown) {
   hydrateTriggers.set(DeferBlockTrigger.When, null);
 
   if (bindingUpdated(lView, bindingIndex, rawValue)) {
-    const injector = lView[INJECTOR]!;
+    const injector = lView[INJECTOR];
     if (typeof ngServerMode !== 'undefined' && ngServerMode) {
       // We are on the server and SSR for defer blocks is enabled.
       triggerDeferBlock(lView, tNode);
@@ -343,7 +343,7 @@ export function ɵɵdeferOnImmediate() {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
   const tView = lView[TVIEW];
-  const injector = lView[INJECTOR]!;
+  const injector = lView[INJECTOR];
   const tDetails = getTDeferBlockDetails(tView, tNode);
   const lDetails = getLDeferBlockDetails(lView, tNode);
 
@@ -383,7 +383,7 @@ export function ɵɵdeferHydrateOnImmediate() {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
   if (shouldActivateHydrateTrigger(lView, tNode)) {
-    const injector = lView[INJECTOR]!;
+    const injector = lView[INJECTOR];
     const hydrateTriggers = getHydrateTriggers(getTView(), tNode);
     hydrateTriggers.set(DeferBlockTrigger.Immediate, null);
 
@@ -448,7 +448,7 @@ export function ɵɵdeferOnHover(triggerIndex: number, walkUpTimes?: number) {
   const lDetails = getLDeferBlockDetails(lView, tNode);
   const tDetails = getTDeferBlockDetails(lView[TVIEW], tNode);
   renderPlaceholder(lView, tNode);
-  if (shouldTriggerWhenOnClient(lView[INJECTOR]!, lDetails, tDetails)) {
+  if (shouldTriggerWhenOnClient(lView[INJECTOR], lDetails, tDetails)) {
     registerDomTrigger(
       lView,
       tNode,
@@ -520,7 +520,7 @@ export function ɵɵdeferOnInteraction(triggerIndex: number, walkUpTimes?: numbe
   const lDetails = getLDeferBlockDetails(lView, tNode);
   const tDetails = getTDeferBlockDetails(lView[TVIEW], tNode);
   renderPlaceholder(lView, tNode);
-  if (shouldTriggerWhenOnClient(lView[INJECTOR]!, lDetails, tDetails)) {
+  if (shouldTriggerWhenOnClient(lView[INJECTOR], lDetails, tDetails)) {
     registerDomTrigger(
       lView,
       tNode,
@@ -592,7 +592,7 @@ export function ɵɵdeferOnViewport(triggerIndex: number, walkUpTimes?: number) 
   const lDetails = getLDeferBlockDetails(lView, tNode);
   const tDetails = getTDeferBlockDetails(lView[TVIEW], tNode);
   renderPlaceholder(lView, tNode);
-  if (shouldTriggerWhenOnClient(lView[INJECTOR]!, lDetails, tDetails)) {
+  if (shouldTriggerWhenOnClient(lView[INJECTOR], lDetails, tDetails)) {
     registerDomTrigger(
       lView,
       tNode,
@@ -642,7 +642,7 @@ export function ɵɵdeferHydrateOnViewport() {
   if (shouldActivateHydrateTrigger(lView, tNode)) {
     const hydrateTriggers = getHydrateTriggers(getTView(), tNode);
     hydrateTriggers.set(DeferBlockTrigger.Viewport, null);
-    const injector = lView[INJECTOR]!;
+    const injector = lView[INJECTOR];
 
     if (typeof ngServerMode !== 'undefined' && ngServerMode) {
       // We are on the server and SSR for defer blocks is enabled.

--- a/packages/core/src/defer/rendering.ts
+++ b/packages/core/src/defer/rendering.ts
@@ -276,7 +276,7 @@ function applyDeferBlockState(
       const tDetails = getTDeferBlockDetails(hostTView, tNode);
       const providers = tDetails.providers;
       if (providers && providers.length > 0) {
-        injector = createDeferBlockInjector(hostLView[INJECTOR]!, tDetails, providers);
+        injector = createDeferBlockInjector(hostLView[INJECTOR], tDetails, providers);
       }
     }
 
@@ -400,7 +400,7 @@ function scheduleDeferBlockUpdate(
       renderDeferBlockState(nextState, tNode, lContainer);
     }
   };
-  return scheduleTimerTrigger(timeout, callback, hostLView[INJECTOR]!);
+  return scheduleTimerTrigger(timeout, callback, hostLView[INJECTOR]);
 }
 
 /**

--- a/packages/core/src/defer/triggering.ts
+++ b/packages/core/src/defer/triggering.ts
@@ -72,13 +72,13 @@ export function scheduleDelayedTrigger(
 ) {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
-  const injector = lView[INJECTOR]!;
+  const injector = lView[INJECTOR];
   const lDetails = getLDeferBlockDetails(lView, tNode);
   const tDetails = getTDeferBlockDetails(lView[TVIEW], tNode);
 
   renderPlaceholder(lView, tNode);
 
-  if (shouldTriggerWhenOnClient(lView[INJECTOR]!, lDetails, tDetails)) {
+  if (shouldTriggerWhenOnClient(lView[INJECTOR], lDetails, tDetails)) {
     // Only trigger the scheduled trigger on the browser
     // since we don't want to delay the server response.
     const cleanupFn = scheduleFn(() => triggerDeferBlock(lView, tNode), injector);
@@ -100,7 +100,7 @@ export function scheduleDelayedPrefetching(
   }
 
   const lView = getLView();
-  const injector = lView[INJECTOR]!;
+  const injector = lView[INJECTOR];
 
   // Only trigger the scheduled trigger on the browser
   // since we don't want to delay the server response.
@@ -132,7 +132,7 @@ export function scheduleDelayedHydrating(
 
   // Only trigger the scheduled trigger on the browser
   // since we don't want to delay the server response.
-  const injector = lView[INJECTOR]!;
+  const injector = lView[INJECTOR];
   const lDetails = getLDeferBlockDetails(lView, tNode);
   const ssrUniqueId = lDetails[SSR_UNIQUE_ID]!;
   ngDevMode && assertSsrIdDefined(ssrUniqueId);
@@ -152,7 +152,7 @@ export function scheduleDelayedHydrating(
  */
 export function triggerPrefetching(tDetails: TDeferBlockDetails, lView: LView, tNode: TNode) {
   const tDeferBlockDetails = getTDeferBlockDetails(lView[TVIEW], tNode);
-  if (lView[INJECTOR] && shouldTriggerDeferBlock(lView[INJECTOR]!, tDeferBlockDetails)) {
+  if (lView[INJECTOR] && shouldTriggerDeferBlock(lView[INJECTOR], tDeferBlockDetails)) {
     triggerResourceLoading(tDetails, lView, tNode);
   }
 }
@@ -168,7 +168,7 @@ export function triggerResourceLoading(
   lView: LView,
   tNode: TNode,
 ): Promise<unknown> {
-  const injector = lView[INJECTOR]!;
+  const injector = lView[INJECTOR];
   const tView = lView[TVIEW];
 
   if (tDetails.loadingState !== DeferDependenciesLoadingState.NOT_STARTED) {
@@ -295,7 +295,7 @@ export function triggerResourceLoading(
 export function triggerDeferBlock(lView: LView, tNode: TNode) {
   const tView = lView[TVIEW];
   const lContainer = lView[tNode.index];
-  const injector = lView[INJECTOR]!;
+  const injector = lView[INJECTOR];
   ngDevMode && assertLContainer(lContainer);
 
   const lDetails = getLDeferBlockDetails(lView, tNode);
@@ -478,7 +478,7 @@ function onDeferBlockCompletion(lDetails: LDeferBlockDetails, callback: VoidFunc
  */
 export function shouldActivateHydrateTrigger(lView: LView, tNode: TNode): boolean {
   const lDetails = getLDeferBlockDetails(lView, tNode);
-  const injector = lView[INJECTOR]!;
+  const injector = lView[INJECTOR];
   // TODO(incremental-hydration): ideally, this check should only happen once and then stored on
   // LDeferBlockDetails as a flag. This would make subsequent lookups very cheap.
   return (

--- a/packages/core/src/hydration/annotate.ts
+++ b/packages/core/src/hydration/annotate.ts
@@ -357,7 +357,7 @@ function serializeLContainer(
         // The `+1` is to capture the `<app-root />` element.
         numRootNodes = calcNumRootNodesInLContainer(childLView) + 1;
 
-        annotateLContainerForHydration(childLView, context, lView[INJECTOR]!);
+        annotateLContainerForHydration(childLView, context, lView[INJECTOR]);
 
         const componentLView = unwrapLView(childLView[HOST]) as LView<unknown>;
 

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -531,7 +531,7 @@ function createRootComponentView(
   // and passed to the component LView.
   let hydrationInfo: DehydratedView | null = null;
   if (hostRNode !== null) {
-    hydrationInfo = retrieveHydrationInfo(hostRNode, rootView[INJECTOR]!);
+    hydrationInfo = retrieveHydrationInfo(hostRNode, rootView[INJECTOR]);
   }
   const viewRenderer = environment.rendererFactory.createRenderer(hostRNode, rootComponentDef);
   const componentView = createLView(

--- a/packages/core/src/render3/instructions/render.ts
+++ b/packages/core/src/render3/instructions/render.ts
@@ -35,7 +35,7 @@ export function renderComponent(hostLView: LView, componentHostIdx: number) {
   const hostRNode = componentView[HOST];
   // Populate an LView with hydration info retrieved from the DOM via TransferState.
   if (hostRNode !== null && componentView[HYDRATION] === null) {
-    componentView[HYDRATION] = retrieveHydrationInfo(hostRNode, componentView[INJECTOR]!);
+    componentView[HYDRATION] = retrieveHydrationInfo(hostRNode, componentView[INJECTOR]);
   }
 
   renderView(componentTView, componentView, componentView[CONTEXT]);

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -190,8 +190,8 @@ export interface LView<T = unknown> extends Array<any> {
    */
   [CONTEXT]: T;
 
-  /** An optional Module Injector to be used as fall back after Element Injectors are consulted. */
-  readonly [INJECTOR]: Injector | null;
+  /** A Module Injector to be used as fall back after Element Injectors are consulted. */
+  readonly [INJECTOR]: Injector;
 
   /**
    * Contextual data that is shared across multiple instances of `LView` in the same application.


### PR DESCRIPTION
Currently, the LView[INJECTOR] typings include null, when in practice we don't have cases when that may happen. That requires using non-null assertions in the code. 

This PR makes LView[INJECTOR] nonnullable and drops all the assertions