### PR TITLE
docs: Fix more typos in the guide

### DIFF
--- a/adev/src/content/guide/signals/resource.md
+++ b/adev/src/content/guide/signals/resource.md
@@ -94,7 +94,7 @@ The resource object has several signal properties for reading the status of the 
 
 | Property    | Description                                                                                                     |
 | ----------- | --------------------------------------------------------------------------------------------------------------- |
-| `value`     | The most recent value of the resource, or `undefined` if no value has been recieved.                            |
+| `value`     | The most recent value of the resource, or `undefined` if no value has been received.                            |
 | `hasValue`  | Whether the resource has a value.                                                                               |
 | `error`     | The most recent error encountered while running the resource's loader, or `undefined` if no error has occurred. |
 | `isLoading` | Whether the resource loader is currently running.                                                               |

--- a/adev/src/content/guide/ssr.md
+++ b/adev/src/content/guide/ssr.md
@@ -41,7 +41,7 @@ To verify that the application is server-side rendered, run it locally with `ng 
 
 ## Configure server-side rendering
 
-Note: In Angular v17 and later, `server.ts` is no longer used by `ng serve`. The dev server will use `main.server.ts` directly to perfom server side rendering.
+Note: In Angular v17 and later, `server.ts` is no longer used by `ng serve`. The dev server will use `main.server.ts` directly to perform server side rendering.
 
 The `server.ts` file configures a Node.js Express server and Angular server-side rendering. `CommonEngine` is used to render an Angular application.
 

--- a/adev/src/content/guide/templates/overview.md
+++ b/adev/src/content/guide/templates/overview.md
@@ -44,5 +44,5 @@ You might also be interested in the following:
 | [Grouping elements with ng-container](guide/templates/ng-container)         | Group multiple elements together or mark a location for rendering.                      |
 | [Variables in templates](guide/templates/variables)                         | Learn about variable declarations.                                                      |
 | [Deferred loading with @defer](guide/templates/defer)                       | Create deferrable views with `@defer`.                                                  |
-| [Expression syntax](guide/templates/expression-syntax)                      | Learn similarities and differences betwene Angular expressions and standard JavaScript. |
+| [Expression syntax](guide/templates/expression-syntax)                      | Learn similarities and differences between Angular expressions and standard JavaScript. |
 | [Whitespace in templates](guide/templates/whitespace)                       | Learn how Angular handles whitespace.                                                   |


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

Fix more spelling mistakes. After I found 2 mistakes. I looked for more!

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Multiple spelling mistakes. I also found several `re-use` and `re-usable` being used. Yes, that can be used indeed, but officially it's actually just "reuse" and "reusable".


## What is the new behavior?

Fix typos except for re-use and re-usable. Unless you want me to change that as well.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

