### PR TITLE
docs(docs-infra): fix visually-hidden elements style

### DIFF
--- a/adev/shared-docs/styles/global-styles.scss
+++ b/adev/shared-docs/styles/global-styles.scss
@@ -62,7 +62,6 @@ $theme: mat.m2-define-light-theme(
 );
 
 // Include material core styles.
-@include mat.core();
 @include cdk.a11y-visually-hidden();
 @include mat.tabs-theme($theme);
 @include mat.button-toggle-theme($theme);

--- a/adev/shared-docs/styles/global-styles.scss
+++ b/adev/shared-docs/styles/global-styles.scss
@@ -1,5 +1,6 @@
 // TODO: Continue organizing and refactoring this file
 @use '@angular/material' as mat;
+@use '@angular/cdk';
 
 // Using disable-next-line to avoid stylelint errors - these imports are necessary
 // TODO: Is there another way to prevent these linting errors?
@@ -62,6 +63,7 @@ $theme: mat.m2-define-light-theme(
 
 // Include material core styles.
 @include mat.core();
+@include cdk.a11y-visually-hidden();
 @include mat.tabs-theme($theme);
 @include mat.button-toggle-theme($theme);
 @include mat.tooltip-theme($theme);


### PR DESCRIPTION
import visually-hidden styles from CDK as the new version of Angular material no more does that inside the deprecated core mixin 

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
![image](https://github.com/user-attachments/assets/f0722242-a01e-4943-bbc5-e7319e09f224)


## What is the new behavior?
![image](https://github.com/user-attachments/assets/179c86ca-e905-4c56-bc4b-4a10a3369539)


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
