### PR TITLE
docs(core): signal has to be called

### DIFF
--- a/adev/src/content/guide/signals/linked-signal.md
+++ b/adev/src/content/guide/signals/linked-signal.md
@@ -45,7 +45,7 @@ const shippingOptions = signal(['Ground', 'Air', 'Sea']);
 const selectedOption = linkedSignal(() => shippingOptions()[0]);
 console.log(selectedOption()); // 'Ground'
 
-selectedOption.set(shippingOptions[2]);
+selectedOption.set(shippingOptions()[2]);
 console.log(selectedOption()); // 'Sea'
 
 shippingOptions.set(['Email', 'Will Call', 'Postal service']);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, this code throws the following error: `TS7053: Element implicitly has an 'any' type because expression of type '2' can't be used to index type 'WritableSignal<string[]>'. Property '2' does not exist on type 'WritableSignal<string[]>'.` This occurs because we are not retrieving the values from the shippingOptions signal but are instead attempting to access index 2 directly.

Issue Number: N/A


## What is the new behavior?
We call the signal to retrieve the values from it.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
