### PR TITLE
refactor(router): remove unused default error handler function

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -58,10 +58,6 @@ import {validateConfig} from './utils/config';
 import {afterNextNavigation} from './utils/navigations';
 import {standardizeConfig} from './components/empty_outlet';
 
-function defaultErrorHandler(error: any): never {
-  throw error;
-}
-
 /**
  * The equivalent `IsActiveMatchOptions` options for `Router.isActive` is called with `true`
  * (exact = true).


### PR DESCRIPTION
with v19 the `defaultErrorHandler` has become unused, so could be removed

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Unused defaultErrorHandler function


## What is the new behavior?
old unused function has been removed

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
