### PR TITLE
refactor(docs-infra): use input bindings in docs component

### DIFF
--- a/adev/src/app/features/docs/docs.component.html
+++ b/adev/src/app/features/docs/docs.component.html
@@ -1,7 +1,8 @@
-@if (documentContent()) {
+@let docContent = this.docContent();
+@if (docContent) {
   <docs-viewer
     class="docs-viewer"
-    [docContent]="documentContent()!.contents"
+    [docContent]="docContent.contents"
     [hasToc]="true"
   />
 }

--- a/adev/src/app/features/docs/docs.component.ts
+++ b/adev/src/app/features/docs/docs.component.ts
@@ -7,10 +7,7 @@
  */
 
 import {DocContent, DocViewer} from '@angular/docs';
-import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
-import {toSignal} from '@angular/core/rxjs-interop';
-import {ActivatedRoute} from '@angular/router';
-import {map} from 'rxjs/operators';
+import {ChangeDetectionStrategy, Component, input} from '@angular/core';
 
 @Component({
   selector: 'docs-docs',
@@ -21,14 +18,9 @@ import {map} from 'rxjs/operators';
   templateUrl: './docs.component.html',
 })
 export default class DocsComponent {
-  private readonly activatedRoute = inject(ActivatedRoute);
-
   // Based on current route, proper static content for doc page is fetched.
   // In case when exists example-viewer placeholders, then ExampleViewer
   // components are going to be rendered.
-  private readonly documentContent$ = this.activatedRoute.data.pipe(
-    map((data) => data['docContent'] as DocContent),
-  );
 
-  documentContent = toSignal(this.documentContent$);
+  docContent = input<DocContent>();
 }


### PR DESCRIPTION
Use reactive inputs instead of manually getting data from the currently activated route.
