### PR TITLE
docs(docs-infra): fix the global layout of the site

### DIFF
--- a/adev/shared-docs/components/table-of-contents/table-of-contents.component.scss
+++ b/adev/shared-docs/components/table-of-contents/table-of-contents.component.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   position: fixed;
-  right: 16px;
+  right: 1rem;
   top: 0;
   height: fit-content;
   width: 14rem;

--- a/adev/shared-docs/components/table-of-contents/table-of-contents.component.scss
+++ b/adev/shared-docs/components/table-of-contents/table-of-contents.component.scss
@@ -6,7 +6,7 @@
   top: 0;
   height: fit-content;
   width: 14rem;
-  padding-inline: 1rem;
+  padding-right: 2rem;
   max-height: 100vh;
   overflow-y: scroll;
   box-sizing: border-box;

--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.scss
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.scss
@@ -1,5 +1,6 @@
 @use '../../../styles/links' as links;
 @use '../../../styles/anchor' as anchor;
+@use '../../../styles/media-queries' as mq;
 
 :host {
   --translate-y: clamp(5px, 0.25em, 7px);
@@ -8,18 +9,23 @@
 .docs-viewer {
   display: flex;
   flex-direction: column;
-  padding: var(--layout-padding);
+  padding: 0px;
   box-sizing: border-box;
 
   @media only screen and (max-width: 1430px) {
     container: docs-content / inline-size;
   }
 
+  @include mq.for-big-desktop-up{
+    max-width: var(--page-width);
+  }
+
   // check if TOC component present in the page and has more than one elenment
   &.docs-with-TOC:has(docs-table-of-contents ul > li:nth-child(2)) {
     @media only screen and (min-width: 1430px) {
       // take the available space except a reserved area for TOC
-      max-width: calc(100% - 17rem);
+      margin-left: -16rem;
+      width: calc(100% - 16rem);
     }
   }
 

--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.scss
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.scss
@@ -9,19 +9,17 @@
   display: flex;
   flex-direction: column;
   padding: var(--layout-padding);
-  max-width: var(--page-width);
-  width: 100%;
   box-sizing: border-box;
 
   @media only screen and (max-width: 1430px) {
     container: docs-content / inline-size;
   }
 
-  // If rendered on the docs page, accommodate width for TOC
-  docs-docs & {
-    @media only screen and (min-width: 1430px) and (max-width: 1550px) {
-      width: calc(100% - 195px - var(--layout-padding));
-      max-width: var(--page-width);
+  // check if TOC component present in the page and has more than one elenment
+  &.docs-with-TOC:has(docs-table-of-contents ul > li:nth-child(2)) {
+    @media only screen and (min-width: 1430px) {
+      // take the available space except a reserved area for TOC
+      max-width: calc(100% - 17rem);
     }
   }
 

--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
@@ -58,6 +58,7 @@ export const GITHUB_CONTENT_URL = 'https://github.com/angular/angular/blob/main/
   encapsulation: ViewEncapsulation.None,
   host: {
     '[class.docs-animate-content]': 'animateContent',
+    '[class.docs-with-TOC]': 'hasToc',
   },
 })
 export class DocViewer implements OnChanges {

--- a/adev/shared-docs/styles/docs/_decorative-header.scss
+++ b/adev/shared-docs/styles/docs/_decorative-header.scss
@@ -6,7 +6,6 @@
   .docs-decorative-header {
     border-radius: 0.625rem;
     background: var(--septenary-contrast);
-    max-width: var(--page-width);
     overflow: hidden;
     display: flex;
     position: relative;

--- a/adev/src/app/features/docs/docs.component.scss
+++ b/adev/src/app/features/docs/docs.component.scss
@@ -4,6 +4,12 @@
       animation: fade-in 500ms;
     }
   }
+  padding: var(--layout-padding);
+  
+  @media only screen and (min-width: 1430px) {
+    display: flex;
+    justify-content: center;
+  }
 }
 
 @keyframes fade-in {

--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
@@ -19,6 +19,13 @@
     transition: background-color 0.3s ease;
   }
 
+  & > *{
+    padding-inline: 0px;
+    @include mq.for-big-desktop-up{
+      width: var(--page-width);
+    }
+  }
+  
   h1 {
     font-size: 1.5rem;
   }

--- a/adev/src/app/features/references/api-reference-list/api-reference-list.component.scss
+++ b/adev/src/app/features/references/api-reference-list/api-reference-list.component.scss
@@ -1,6 +1,5 @@
 :host {
   padding: var(--layout-padding);
-  max-width: var(--page-width);
   display: block;
 
   container: api-ref-page / inline-size;

--- a/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.scss
+++ b/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.scss
@@ -19,3 +19,19 @@
   @include ref.reference-common();
   @include ref.cli-reference();
 }
+
+:host{
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: center;
+  padding: var(--layout-padding);
+
+  & > *{
+    width: 100%;
+    
+    @include mq.for-desktop-up{
+      padding-inline: 0px;
+      width: var(--page-width);
+    }
+  }
+}

--- a/adev/src/app/features/tutorial/tutorial.component.scss
+++ b/adev/src/app/features/tutorial/tutorial.component.scss
@@ -67,7 +67,6 @@ $column-width: calc(50% - #{$resizer-width} - var(--layout-padding));
 }
 
 .docs-tutorial-content {
-  max-width: var(--page-width);
   min-width: 300px;
   width: 100%;
   box-sizing: content-box;

--- a/adev/src/app/features/update/update.component.scss
+++ b/adev/src/app/features/update/update.component.scss
@@ -1,6 +1,23 @@
-.page {
+@use '@angular/docs/styles/media-queries' as mq;
+
+::ng-deep adev-update-guide{
+  display: flex;
+  flex-flow: column;
+  align-items: center;
   padding: var(--layout-padding);
   container: update-guide-page / inline-size;
+}
+.page {
+  max-width: var(--page-width);
+  & > *{
+    @include mq.for-big-desktop-up{
+      padding-inline: 0px;
+    }
+  }
+
+  @include mq.for-tablet-landscape-down{
+    width: 100%;
+  }
 }
 
 h3,

--- a/adev/src/app/features/update/update.component.scss
+++ b/adev/src/app/features/update/update.component.scss
@@ -1,6 +1,5 @@
 .page {
   padding: var(--layout-padding);
-  max-width: var(--page-width);
   container: update-guide-page / inline-size;
 }
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Fixes https://github.com/angular/angular/issues/52648
Issue Number: https://github.com/angular/angular/issues/52648

Currently we are not taking the full available space for the main content of the page 

![image](https://github.com/user-attachments/assets/ca328662-01af-4df7-91e6-906b1f2aa03b)
![image](https://github.com/user-attachments/assets/b9c8c72a-69cb-4b96-8b37-d4373cd65b84)
![image](https://github.com/user-attachments/assets/e69ece51-5d51-4f03-954d-f8c234adf068)
![image](https://github.com/user-attachments/assets/ef7d5466-2a71-4f44-b733-349d641f24bc)



## What is the new behavior?
Take the full width of the page unless needed 

![image](https://github.com/user-attachments/assets/47657273-6aad-4d10-8a7a-aa190c1962d9)
![image](https://github.com/user-attachments/assets/a09a285a-17f7-45e6-9648-42e8ba697d2e)
![image](https://github.com/user-attachments/assets/5759d8b4-56e3-41a1-9cdf-e61620cd5205)
![image](https://github.com/user-attachments/assets/3aa80e5c-8660-411f-9588-873f471b8dfa)



## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
