### PR TITLE
refactor(core): use `ApplicationRef.whenStable` instead of a custom util function

### DIFF
--- a/packages/common/http/src/transfer_cache.ts
+++ b/packages/common/http/src/transfer_cache.ts
@@ -19,7 +19,6 @@ import {
   ɵformatRuntimeError as formatRuntimeError,
   ɵperformanceMarkFeature as performanceMarkFeature,
   ɵtruncateMiddle as truncateMiddle,
-  ɵwhenStable as whenStable,
   ɵRuntimeError as RuntimeError,
 } from '@angular/core';
 import {isPlatformServer} from '@angular/common';
@@ -338,7 +337,7 @@ export function withHttpTransferCache(cacheOptions: HttpTransferCacheOptions): P
         const cacheState = inject(CACHE_OPTIONS);
 
         return () => {
-          whenStable(appRef).then(() => {
+          appRef.whenStable().then(() => {
             cacheState.isCacheActive = false;
           });
         };

--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -31,7 +31,6 @@ import {
   ɵunwrapSafeValue as unwrapSafeValue,
   ChangeDetectorRef,
   ApplicationRef,
-  ɵwhenStable as whenStable,
 } from '@angular/core';
 
 import {RuntimeErrorCode} from '../../errors';
@@ -1310,7 +1309,7 @@ function assertNoLoaderParamsWithoutLoader(dir: NgOptimizedImage, imageLoader: I
 async function assetPriorityCountBelowThreshold(appRef: ApplicationRef) {
   if (IMGS_WITH_PRIORITY_ATTR_COUNT === 0) {
     IMGS_WITH_PRIORITY_ATTR_COUNT++;
-    await whenStable(appRef);
+    await appRef.whenStable();
     if (IMGS_WITH_PRIORITY_ATTR_COUNT > PRIORITY_COUNT_THRESHOLD) {
       console.warn(
         formatRuntimeError(

--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -915,6 +915,10 @@ let whenStableStore: WeakMap<ApplicationRef, Promise<void>> | undefined;
 /**
  * Returns a Promise that resolves when the application becomes stable after this method is called
  * the first time.
+ *
+ * Note: this function is unused in the FW code, but it's still present since the CLI code relies
+ * on it currently (see https://github.com/angular/angular-cli/blob/20411f696eb52c500e096e3dfc5e195185794edc/packages/angular/ssr/src/routes/ng-routes.ts#L435).
+ * Remove this function once CLI code is updated to use `ApplicationRef.whenStable` instead.
  */
 export function whenStable(applicationRef: ApplicationRef): Promise<void> {
   whenStableStore ??= new WeakMap();

--- a/packages/core/src/hydration/api.ts
+++ b/packages/core/src/hydration/api.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {APP_BOOTSTRAP_LISTENER, ApplicationRef, whenStable} from '../application/application_ref';
+import {APP_BOOTSTRAP_LISTENER, ApplicationRef} from '../application/application_ref';
 import {Console} from '../console';
 import {
   ENVIRONMENT_INITIALIZER,
@@ -152,7 +152,7 @@ function printHydrationStats(injector: Injector) {
  * Returns a Promise that is resolved when an application becomes stable.
  */
 function whenStableWithTimeout(appRef: ApplicationRef, injector: Injector): Promise<void> {
-  const whenStablePromise = whenStable(appRef);
+  const whenStablePromise = appRef.whenStable();
   if (typeof ngDevMode !== 'undefined' && ngDevMode) {
     const timeoutTime = APPLICATION_IS_STABLE_TIMEOUT;
     const console = injector.get(Console);

--- a/packages/core/src/hydration/event_replay.ts
+++ b/packages/core/src/hydration/event_replay.ts
@@ -18,7 +18,7 @@ import {
   EventPhase,
 } from '@angular/core/primitives/event-dispatch';
 
-import {APP_BOOTSTRAP_LISTENER, ApplicationRef, whenStable} from '../application/application_ref';
+import {APP_BOOTSTRAP_LISTENER, ApplicationRef} from '../application/application_ref';
 import {ENVIRONMENT_INITIALIZER, Injector} from '../di';
 import {inject} from '../di/injector_compatibility';
 import {Provider} from '../di/interface/provider';
@@ -134,7 +134,7 @@ export function withEventReplay(): Provider[] {
             // Kick off event replay logic once hydration for the initial part
             // of the application is completed. This timing is similar to the unclaimed
             // dehydrated views cleanup timing.
-            whenStable(appRef).then(() => {
+            appRef.whenStable().then(() => {
               const eventContractDetails = injector.get(JSACTION_EVENT_CONTRACT);
               initEventReplay(eventContractDetails, injector);
               const jsActionMap = injector.get(JSACTION_BLOCK_ELEMENT_MAP);

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -135,9 +135,6 @@
     "name": "ElementRef"
   },
   {
-    "name": "EmptyError"
-  },
-  {
     "name": "EmulatedEncapsulationDomRenderer2"
   },
   {
@@ -679,9 +676,6 @@
   },
   {
     "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultErrorFactory"
   },
   {
     "name": "detachMovedView"
@@ -1299,9 +1293,6 @@
     "name": "subscribeOn"
   },
   {
-    "name": "throwIfEmpty"
-  },
-  {
     "name": "throwProviderNotFoundError"
   },
   {
@@ -1336,12 +1327,6 @@
   },
   {
     "name": "walkProviderTree"
-  },
-  {
-    "name": "whenStable"
-  },
-  {
-    "name": "whenStableStore"
   },
   {
     "name": "withDomHydration"

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -19,7 +19,6 @@ import {
   ɵannotateForHydration as annotateForHydration,
   ɵIS_HYDRATION_DOM_REUSE_ENABLED as IS_HYDRATION_DOM_REUSE_ENABLED,
   ɵSSR_CONTENT_INTEGRITY_MARKER as SSR_CONTENT_INTEGRITY_MARKER,
-  ɵwhenStable as whenStable,
   ɵstartMeasuring as startMeasuring,
   ɵstopMeasuring as stopMeasuring,
 } from '@angular/core';
@@ -178,8 +177,10 @@ function insertEventRecordScript(
 async function _render(platformRef: PlatformRef, applicationRef: ApplicationRef): Promise<string> {
   const measuringLabel = 'whenStable';
   startMeasuring(measuringLabel);
+
   // Block until application is stable.
-  await whenStable(applicationRef);
+  await applicationRef.whenStable();
+
   stopMeasuring(measuringLabel);
 
   const platformState = platformRef.injector.get(PlatformState);

--- a/packages/platform-server/test/full_app_hydration_spec.ts
+++ b/packages/platform-server/test/full_app_hydration_spec.ts
@@ -45,7 +45,6 @@ import {
   ViewChild,
   ViewContainerRef,
   ViewEncapsulation,
-  ɵwhenStable as whenStable,
 } from '@angular/core';
 import {NoopNgZone} from '@angular/core/src/zone/ng_zone';
 import {TestBed} from '@angular/core/testing';
@@ -110,6 +109,7 @@ describe('platform-server full application hydration integration', () => {
 
     beforeEach(() => {
       doc = TestBed.inject(DOCUMENT);
+      clearConsole(TestBed.inject(ApplicationRef));
     });
 
     afterEach(() => {
@@ -1301,7 +1301,7 @@ describe('platform-server full application hydration integration', () => {
             // because component host node also acted as a ViewContainerRef anchor,
             // thus there are elements after this node (as next siblings).
             const clientRootNode = compRef.location.nativeElement.parentNode;
-            await whenStable(appRef);
+            await appRef.whenStable();
 
             verifyAllChildNodesClaimedForHydration(clientRootNode);
             verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
@@ -1344,7 +1344,7 @@ describe('platform-server full application hydration integration', () => {
             // because component host node also acted as a ViewContainerRef anchor,
             // thus there are elements after this node (as next siblings).
             const clientRootNode = compRef.location.nativeElement.parentNode;
-            await whenStable(appRef);
+            await appRef.whenStable();
 
             verifyAllChildNodesClaimedForHydration(clientRootNode);
             verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
@@ -1457,7 +1457,7 @@ describe('platform-server full application hydration integration', () => {
             // because component host node also acted as a ViewContainerRef anchor,
             // thus there are elements after this node (as next siblings).
             const clientRootNode = compRef.location.nativeElement.parentNode;
-            await whenStable(appRef);
+            await appRef.whenStable();
 
             verifyAllChildNodesClaimedForHydration(clientRootNode);
             verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
@@ -1519,7 +1519,7 @@ describe('platform-server full application hydration integration', () => {
               // because component host node also acted as a ViewContainerRef anchor,
               // thus there are elements after this node (as next siblings).
               const clientRootNode = compRef.location.nativeElement.parentNode;
-              await whenStable(appRef);
+              await appRef.whenStable();
 
               verifyAllChildNodesClaimedForHydration(clientRootNode);
               verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
@@ -1580,7 +1580,7 @@ describe('platform-server full application hydration integration', () => {
               // because component host node also acted as a ViewContainerRef anchor,
               // thus there are elements after this node (as next siblings).
               const clientRootNode = compRef.location.nativeElement.parentNode;
-              await whenStable(appRef);
+              await appRef.whenStable();
 
               verifyAllChildNodesClaimedForHydration(clientRootNode);
               verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
@@ -2441,7 +2441,7 @@ describe('platform-server full application hydration integration', () => {
 
           const clientRootNode = compRef.location.nativeElement;
 
-          await whenStable(appRef);
+          await appRef.whenStable();
 
           const clientContents = stripExcessiveSpaces(
             stripUtilAttributes(clientRootNode.outerHTML, false),
@@ -3036,7 +3036,7 @@ describe('platform-server full application hydration integration', () => {
         const compRef = getComponentRef<SimpleComponent>(appRef);
         appRef.tick();
 
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         const clientRootNode = compRef.location.nativeElement;
 
@@ -3105,7 +3105,7 @@ describe('platform-server full application hydration integration', () => {
         const compRef = getComponentRef<SimpleComponent>(appRef);
         appRef.tick();
 
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         const clientRootNode = compRef.location.nativeElement;
         verifyAllNodesClaimedForHydration(clientRootNode);
@@ -3156,7 +3156,7 @@ describe('platform-server full application hydration integration', () => {
         const compRef = getComponentRef<SimpleComponent>(appRef);
         appRef.tick();
 
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         const clientRootNode = compRef.location.nativeElement;
         verifyAllNodesClaimedForHydration(clientRootNode);
@@ -3276,7 +3276,7 @@ describe('platform-server full application hydration integration', () => {
         const compRef = getComponentRef<SimpleComponent>(appRef);
         appRef.tick();
 
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         const clientRootNode = compRef.location.nativeElement;
 
@@ -3354,7 +3354,7 @@ describe('platform-server full application hydration integration', () => {
         const compRef = getComponentRef<SimpleComponent>(appRef);
         appRef.tick();
 
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         const clientRootNode = compRef.location.nativeElement;
 
@@ -4490,7 +4490,7 @@ describe('platform-server full application hydration integration', () => {
 
         const clientRootNode = compRef.location.nativeElement;
 
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         const clientContents = stripExcessiveSpaces(
           stripUtilAttributes(clientRootNode.outerHTML, false),
@@ -4537,7 +4537,7 @@ describe('platform-server full application hydration integration', () => {
 
         const clientRootNode = compRef.location.nativeElement;
 
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         const clientContents = stripExcessiveSpaces(
           stripUtilAttributes(clientRootNode.outerHTML, false),
@@ -4609,7 +4609,7 @@ describe('platform-server full application hydration integration', () => {
 
           const clientRootNode = compRef.location.nativeElement;
 
-          await whenStable(appRef);
+          await appRef.whenStable();
 
           const clientContents = stripExcessiveSpaces(
             stripUtilAttributes(clientRootNode.parentNode.outerHTML, false),
@@ -4670,7 +4670,7 @@ describe('platform-server full application hydration integration', () => {
 
         const clientRootNode = compRef.location.nativeElement;
 
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         const clientContents = stripExcessiveSpaces(
           stripUtilAttributes(clientRootNode.outerHTML, false),
@@ -4718,7 +4718,7 @@ describe('platform-server full application hydration integration', () => {
 
         const clientRootNode = compRef.location.nativeElement;
 
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         // Post-cleanup should *not* contain dehydrated views.
         const postCleanupContents = stripExcessiveSpaces(clientRootNode.outerHTML);
@@ -4792,7 +4792,7 @@ describe('platform-server full application hydration integration', () => {
 
         const clientRootNode = compRef.location.nativeElement;
 
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         const clientContents = stripExcessiveSpaces(
           stripUtilAttributes(clientRootNode.outerHTML, false),
@@ -4837,7 +4837,7 @@ describe('platform-server full application hydration integration', () => {
         expect(observedChildCountLog).toEqual([]);
 
         const appRef = await prepareEnvironmentAndHydrate(doc, html, SimpleComponent);
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         // afterRender should be triggered by:
         //   1.) Bootstrap
@@ -4891,7 +4891,7 @@ describe('platform-server full application hydration integration', () => {
         //   2.) Microtask empty event
         expect(observedChildCountLog).toEqual([2, 2]);
 
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         // afterRender should be triggered by:
         //   3.) Microtask empty event
@@ -7040,7 +7040,7 @@ describe('platform-server full application hydration integration', () => {
 
         const clientRootNode = compRef.location.nativeElement;
 
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         const clientContents = stripExcessiveSpaces(
           stripUtilAttributes(clientRootNode.outerHTML, false),
@@ -7122,7 +7122,7 @@ describe('platform-server full application hydration integration', () => {
         const compRef = getComponentRef<SimpleComponent>(appRef);
         appRef.tick();
 
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         const clientRootNode = compRef.location.nativeElement;
         verifyAllNodesClaimedForHydration(clientRootNode);
@@ -7180,7 +7180,7 @@ describe('platform-server full application hydration integration', () => {
 
         const clientRootNode = compRef.location.nativeElement;
 
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         const clientContents = stripExcessiveSpaces(
           stripUtilAttributes(clientRootNode.outerHTML, false),
@@ -7229,7 +7229,7 @@ describe('platform-server full application hydration integration', () => {
 
         const clientRootNode = compRef.location.nativeElement;
 
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         const clientContents = stripExcessiveSpaces(
           stripUtilAttributes(clientRootNode.outerHTML, false),
@@ -7350,7 +7350,7 @@ describe('platform-server full application hydration integration', () => {
           const compRef = getComponentRef<SimpleComponent>(appRef);
           appRef.tick();
 
-          await whenStable(appRef);
+          await appRef.whenStable();
 
           const clientRootNode = compRef.location.nativeElement;
 
@@ -7402,7 +7402,7 @@ describe('platform-server full application hydration integration', () => {
           const compRef = getComponentRef<SimpleComponent>(appRef);
           appRef.tick();
 
-          await whenStable(appRef);
+          await appRef.whenStable();
 
           const clientRootNode = compRef.location.nativeElement;
 
@@ -7450,7 +7450,7 @@ describe('platform-server full application hydration integration', () => {
         const compRef = getComponentRef<SimpleComponent>(appRef);
         appRef.tick();
 
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         const clientRootNode = compRef.location.nativeElement;
 
@@ -7505,7 +7505,7 @@ describe('platform-server full application hydration integration', () => {
         const compRef = getComponentRef<SimpleComponent>(appRef);
         appRef.tick();
 
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         const root: HTMLElement = compRef.location.nativeElement;
         const divs = root.querySelectorAll('div');
@@ -7969,7 +7969,70 @@ describe('platform-server full application hydration integration', () => {
 
         const clientRootNode = compRef.location.nativeElement;
 
-        await whenStable(appRef);
+        await appRef.whenStable();
+
+        verifyAllNodesClaimedForHydration(clientRootNode);
+        verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+      });
+
+      it('should wait for lazy routes before triggering post-hydration cleanup in zoneless mode', async () => {
+        const ngZone = TestBed.inject(NgZone);
+
+        @Component({
+          standalone: true,
+          selector: 'lazy',
+          template: `LazyCmp content`,
+        })
+        class LazyCmp {}
+
+        const routes: Routes = [
+          {
+            path: '',
+            loadComponent: () => {
+              return ngZone.runOutsideAngular(() => {
+                return new Promise((resolve) => {
+                  setTimeout(() => resolve(LazyCmp), 100);
+                });
+              });
+            },
+          },
+        ];
+
+        @Component({
+          standalone: true,
+          selector: 'app',
+          imports: [RouterOutlet],
+          template: `
+            Works!
+            <router-outlet />
+          `,
+        })
+        class SimpleComponent {}
+
+        const envProviders = [
+          provideExperimentalZonelessChangeDetection(),
+          {provide: PlatformLocation, useClass: MockPlatformLocation},
+          provideRouter(routes),
+        ] as unknown as Provider[];
+        const html = await ssr(SimpleComponent, {envProviders});
+        const ssrContents = getAppContents(html);
+
+        expect(ssrContents).toContain(`<app ${NGH_ATTR_NAME}`);
+
+        // Expect serialization to happen once a lazy-loaded route completes loading
+        // and a lazy component is rendered.
+        expect(ssrContents).toContain(`<lazy ${NGH_ATTR_NAME}="0">LazyCmp content</lazy>`);
+
+        resetTViewsFor(SimpleComponent, LazyCmp);
+
+        const appRef = await prepareEnvironmentAndHydrate(doc, html, SimpleComponent, {
+          envProviders,
+        });
+        const compRef = getComponentRef<SimpleComponent>(appRef);
+        appRef.tick();
+
+        const clientRootNode = compRef.location.nativeElement;
+        await appRef.whenStable();
 
         verifyAllNodesClaimedForHydration(clientRootNode);
         verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
@@ -8028,7 +8091,7 @@ describe('platform-server full application hydration integration', () => {
         const compRef = getComponentRef<SimpleComponent>(appRef);
         appRef.tick();
 
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         const clientRootNode = compRef.location.nativeElement;
 

--- a/packages/platform-server/test/incremental_hydration_spec.ts
+++ b/packages/platform-server/test/incremental_hydration_spec.ts
@@ -15,7 +15,6 @@ import {
   PLATFORM_ID,
   Provider,
   signal,
-  ɵwhenStable as whenStable,
   ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR,
 } from '@angular/core';
 
@@ -223,7 +222,7 @@ describe('platform-server partial hydration integration', () => {
       });
       const compRef = getComponentRef<SimpleComponent>(appRef);
       appRef.tick();
-      await whenStable(appRef);
+      await appRef.whenStable();
 
       const appHostNode = compRef.location.nativeElement;
 
@@ -338,7 +337,7 @@ describe('platform-server partial hydration integration', () => {
       });
       const compRef = getComponentRef<SimpleComponent>(appRef);
       appRef.tick();
-      await whenStable(appRef);
+      await appRef.whenStable();
 
       const appHostNode = compRef.location.nativeElement;
 
@@ -449,7 +448,7 @@ describe('platform-server partial hydration integration', () => {
       });
       const compRef = getComponentRef<SimpleComponent>(appRef);
       appRef.tick();
-      await whenStable(appRef);
+      await appRef.whenStable();
 
       const appHostNode = compRef.location.nativeElement;
 
@@ -549,7 +548,7 @@ describe('platform-server partial hydration integration', () => {
         });
         const compRef = getComponentRef<SimpleComponent>(appRef);
         appRef.tick();
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         const appHostNode = compRef.location.nativeElement;
 
@@ -617,7 +616,7 @@ describe('platform-server partial hydration integration', () => {
         });
         const compRef = getComponentRef<SimpleComponent>(appRef);
         appRef.tick();
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         const appHostNode = compRef.location.nativeElement;
 
@@ -688,7 +687,7 @@ describe('platform-server partial hydration integration', () => {
         });
         const compRef = getComponentRef<SimpleComponent>(appRef);
         appRef.tick();
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         const appHostNode = compRef.location.nativeElement;
 
@@ -761,7 +760,7 @@ describe('platform-server partial hydration integration', () => {
         });
         const compRef = getComponentRef<SimpleComponent>(appRef);
         appRef.tick();
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         const appHostNode = compRef.location.nativeElement;
 
@@ -928,7 +927,7 @@ describe('platform-server partial hydration integration', () => {
         });
         const compRef = getComponentRef<SimpleComponent>(appRef);
         appRef.tick();
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         const appHostNode = compRef.location.nativeElement;
         expect(appHostNode.outerHTML).toContain(
@@ -1011,7 +1010,7 @@ describe('platform-server partial hydration integration', () => {
       });
       const compRef = getComponentRef<SimpleComponent>(appRef);
       appRef.tick();
-      await whenStable(appRef);
+      await appRef.whenStable();
       appRef.tick();
 
       const appHostNode = compRef.location.nativeElement;
@@ -1141,7 +1140,7 @@ describe('platform-server partial hydration integration', () => {
         });
         const compRef = getComponentRef<SimpleComponent>(appRef);
         appRef.tick();
-        await whenStable(appRef);
+        await appRef.whenStable();
 
         const appHostNode = compRef.location.nativeElement;
 
@@ -1213,7 +1212,7 @@ describe('platform-server partial hydration integration', () => {
       });
       const compRef = getComponentRef<SimpleComponent>(appRef);
       appRef.tick();
-      await whenStable(appRef);
+      await appRef.whenStable();
 
       const appHostNode = compRef.location.nativeElement;
 
@@ -1285,7 +1284,7 @@ describe('platform-server partial hydration integration', () => {
       });
       const compRef = getComponentRef<SimpleComponent>(appRef);
       appRef.tick();
-      await whenStable(appRef);
+      await appRef.whenStable();
 
       const appHostNode = compRef.location.nativeElement;
 
@@ -1350,7 +1349,7 @@ describe('platform-server partial hydration integration', () => {
       });
       const compRef = getComponentRef<SimpleComponent>(appRef);
       appRef.tick();
-      await whenStable(appRef);
+      await appRef.whenStable();
 
       const appHostNode = compRef.location.nativeElement;
 
@@ -1533,7 +1532,7 @@ describe('platform-server partial hydration integration', () => {
       const registry = compRef.instance.registry;
       spyOn(registry, 'cleanup').and.callThrough();
       appRef.tick();
-      await whenStable(appRef);
+      await appRef.whenStable();
 
       const appHostNode = compRef.location.nativeElement;
 
@@ -1614,7 +1613,7 @@ describe('platform-server partial hydration integration', () => {
       spyOn(registry, 'cleanup').and.callThrough();
 
       appRef.tick();
-      await whenStable(appRef);
+      await appRef.whenStable();
       const appHostNode = compRef.location.nativeElement;
 
       expect(appHostNode.outerHTML).toContain(
@@ -1684,7 +1683,7 @@ describe('platform-server partial hydration integration', () => {
       });
       const compRef = getComponentRef<SimpleComponent>(appRef);
       appRef.tick();
-      await whenStable(appRef);
+      await appRef.whenStable();
 
       const registry = compRef.instance.registry;
       const jsActionMap = compRef.instance.jsActionMap;
@@ -1766,7 +1765,7 @@ describe('platform-server partial hydration integration', () => {
       });
       const compRef = getComponentRef<SimpleComponent>(appRef);
       appRef.tick();
-      await whenStable(appRef);
+      await appRef.whenStable();
 
       const registry = compRef.instance.registry;
       const jsActionMap = compRef.instance.jsActionMap;
@@ -1835,7 +1834,7 @@ describe('platform-server partial hydration integration', () => {
       });
       const compRef = getComponentRef<SimpleComponent>(appRef);
       appRef.tick();
-      await whenStable(appRef);
+      await appRef.whenStable();
 
       const registry = compRef.instance.registry;
       const jsActionMap = compRef.instance.jsActionMap;
@@ -1911,7 +1910,7 @@ describe('platform-server partial hydration integration', () => {
       });
       const compRef = getComponentRef<SimpleComponent>(appRef);
       appRef.tick();
-      await whenStable(appRef);
+      await appRef.whenStable();
       const contract = compRef.instance.contract;
       spyOn(contract.instance!, 'cleanUp').and.callThrough();
 

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -41,7 +41,6 @@ import {
   Type,
   ViewEncapsulation,
   ɵPendingTasks as PendingTasks,
-  ɵwhenStable as whenStable,
   APP_INITIALIZER,
   inject,
   getPlatform,
@@ -782,7 +781,7 @@ class HiddenModule {}
 
         const moduleRef = await platform.bootstrapModule(AsyncServerModule);
         const applicationRef = moduleRef.injector.get(ApplicationRef);
-        await whenStable(applicationRef);
+        await applicationRef.whenStable();
         // Note: the `ng-server-context` is not present in this output, since
         // `renderModule` or `renderApplication` functions are not used here.
         const expectedOutput =


### PR DESCRIPTION
This commit removes a custom `whenStable` util in favor of standard `ApplicationRef.whenStable` API.

There is also an important difference between the custom `whenStable` function and `ApplicationRef.whenStable` implementation: the `whenStable` was caching the "stable" promise on per-ApplicationRef basis, which resulted in unexpected behavior with zoneless, when some code ended up getting a stale resolved promise, when an application was not stable yet, this causing order of operations issues. This commit also has an extra test that covers that case.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No