### PR TITLE
fix(core): Ensure resource sets an error

### DIFF
--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -115,8 +115,9 @@ abstract class BaseWritableResource<T> implements WritableResource<T> {
    * Put the resource into the error state.
    */
   protected setErrorState(err: unknown): void {
-    this.status.set(ResourceStatus.Error);
     this.value.set(undefined);
+    // The previous line will set the status to `Local`, so we need to update it.
+    this.status.set(ResourceStatus.Error);
     this.error.set(err);
   }
 


### PR DESCRIPTION
Before this commit, a resource with a previous value wouldn't set the error state correctly.
This commit fixes this. A resource will set its status to error even when there was a previous valid value. 
