### PR TITLE
refactor(common): deprecate `ngStyle` and `ngClass`

### DIFF
--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -472,7 +472,7 @@ export class LowerCasePipe implements PipeTransform {
     static ɵpipe: i0.ɵɵPipeDeclaration<LowerCasePipe, "lowercase", true>;
 }
 
-// @public
+// @public @deprecated
 export class NgClass implements DoCheck {
     constructor(_ngEl: ElementRef, _renderer: Renderer2);
     // (undocumented)
@@ -666,7 +666,7 @@ export class NgPluralCase {
     static ɵfac: i0.ɵɵFactoryDeclaration<NgPluralCase, [{ attribute: "ngPluralCase"; }, null, null, { host: true; }]>;
 }
 
-// @public
+// @public @deprecated
 export class NgStyle implements DoCheck {
     constructor(_ngEl: ElementRef, _differs: KeyValueDiffers, _renderer: Renderer2);
     // (undocumented)

--- a/packages/common/src/directives/ng_class.ts
+++ b/packages/common/src/directives/ng_class.ts
@@ -10,8 +10,6 @@ import {
   DoCheck,
   ElementRef,
   Input,
-  IterableDiffers,
-  KeyValueDiffers,
   Renderer2,
   ɵstringify as stringify,
 } from '@angular/core';
@@ -63,6 +61,8 @@ interface CssClassState {
  * - `Array` - the CSS classes declared as Array elements are added,
  * - `Object` - keys are CSS classes that get added when the expression given in the value
  *              evaluates to a truthy value, otherwise they are removed.
+ *
+ * @deprecated  Use class bindings with the [class] or [class.prop] syntax.
  *
  * @publicApi
  */

--- a/packages/common/src/directives/ng_style.ts
+++ b/packages/common/src/directives/ng_style.ts
@@ -51,6 +51,8 @@ import {
  * is assigned to the given style property.
  * If the result of evaluation is null, the corresponding style is removed.
  *
+ * @deprecated Use style bindings with the [style] or [style.prop] syntax.
+ *
  * @publicApi
  */
 @Directive({


### PR DESCRIPTION
The overhead of those directives (additional bundle size, distinct import) doesn't outweighs the few additional cases it supports compared to compiler provided `class` and `style` bindings.

DEPRECATE: Both `ngStyle` and `ngClass` directives are deprecated, use the their direct bindings instead.

Also, documentation the migration for this will address #40623. 

---- 
Note: 
The native bindings support almost the same usecases at the exception of 2 :

* They don't support `Set`
* They don't support keys with multiple styles/classes separated with spaces.
* Unit suffix for `style` (eg `myStyles = { 'width.px': 100}`) wouldn't be supported either. 

The recommendation is to drop those space-separated-keys into separate ones and replace Sets with arrays. 