### PR TITLE
refactor(core): remove an unused field and invoke `setActiveConsumer` at the right time

### DIFF
--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -301,8 +301,6 @@ export function optionsReducer<T extends Object>(dst: T, objs: T | T[]): T {
 @Injectable({providedIn: 'root'})
 export class ApplicationRef {
   /** @internal */
-  private _bootstrapListeners: ((compRef: ComponentRef<any>) => void)[] = [];
-  /** @internal */
   _runningTick: boolean = false;
   private _destroyed = false;
   private _destroyListeners: Array<() => void> = [];
@@ -792,7 +790,7 @@ export class ApplicationRef {
           '`multi: true` provider.',
       );
     }
-    [...this._bootstrapListeners, ...listeners].forEach((listener) => listener(componentRef));
+    listeners.forEach((listener) => listener(componentRef));
   }
 
   /** @internal */
@@ -811,7 +809,6 @@ export class ApplicationRef {
 
       // Release all references.
       this._views = [];
-      this._bootstrapListeners = [];
       this._destroyListeners = [];
     }
   }

--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -262,6 +262,7 @@ export function ɵɵdeferHydrateWhen(rawValue: unknown) {
       // We are on the server and SSR for defer blocks is enabled.
       triggerDeferBlock(lView, tNode);
     } else {
+      const prevConsumer = setActiveConsumer(null);
       try {
         const value = Boolean(rawValue); // handle truthy or falsy values
         if (value === true) {
@@ -274,7 +275,6 @@ export function ɵɵdeferHydrateWhen(rawValue: unknown) {
           triggerHydrationFromBlockName(injector, ssrUniqueId);
         }
       } finally {
-        const prevConsumer = setActiveConsumer(null);
         setActiveConsumer(prevConsumer);
       }
     }


### PR DESCRIPTION
This PR contains a couple minor commits:

**refactor(core): remove unused field in `ApplicationRef` class**

This commit removes an unused field in the `ApplicationRef` class. Most likely the usage of the field was removed earlier.

**refactor(core): invoke `setActiveConsumer` in `ɵɵdeferHydrateWhen` at the right time**

This commit updates the code of the `ɵɵdeferHydrateWhen` function to invoke the `setActiveConsumer` function at the right time (currently, we invoke it in the `finally` block, which is too late).