### PR TITLE
Add "kind" field to non-primitive package signal nodes

### DIFF
--- a/packages/core/src/render3/reactive_lview_consumer.ts
+++ b/packages/core/src/render3/reactive_lview_consumer.ts
@@ -51,6 +51,7 @@ export function maybeReturnReactiveLViewConsumer(consumer: ReactiveLViewConsumer
 const REACTIVE_LVIEW_CONSUMER_NODE: Omit<ReactiveLViewConsumer, 'lView'> = {
   ...REACTIVE_NODE,
   consumerIsAlwaysLive: true,
+  kind: 'template',
   consumerMarkedDirty: (node: ReactiveLViewConsumer) => {
     markAncestorsForTraversal(node.lView!);
   },
@@ -80,6 +81,7 @@ export function getOrCreateTemporaryConsumer(lView: LView): ReactiveLViewConsume
 const TEMPORARY_CONSUMER_NODE = {
   ...REACTIVE_NODE,
   consumerIsAlwaysLive: true,
+  kind: 'template',
   consumerMarkedDirty: (node: ReactiveLViewConsumer) => {
     let parent = getLViewParent(node.lView!);
     while (parent && !viewShouldHaveReactiveConsumer(parent[TVIEW])) {

--- a/packages/core/src/render3/reactivity/effect.ts
+++ b/packages/core/src/render3/reactivity/effect.ts
@@ -245,6 +245,7 @@ export const BASE_EFFECT_NODE: Omit<EffectNode, 'fn' | 'destroy' | 'injector' | 
     hasRun: false,
     cleanupFns: undefined,
     zone: null,
+    kind: 'effect',
     onDestroyFn: noop,
     run(this: EffectNode): void {
       this.dirty = false;


### PR DESCRIPTION
Builds on [#58333](https://github.com/angular/angular/issues/58333) by assigning the kind field to reactive nodes that are not in the `core/primitives` package.

<s>Depends on / Blocked by #58333.</s>