### PR TITLE
refactor(migrations): skip TS version check in tsurge

### DIFF
--- a/packages/core/schematics/utils/tsurge/helpers/ts_program.ts
+++ b/packages/core/schematics/utils/tsurge/helpers/ts_program.ts
@@ -17,6 +17,8 @@ export const defaultMigrationTsOptions: Partial<ts.CompilerOptions> = {
   skipLibCheck: true,
   skipDefaultLibCheck: true,
   noEmit: true,
+  // Does not apply to g3 and externally is enforced when the app is built by the compiler.
+  disableTypeScriptVersionCheck: true,
 };
 
 /**


### PR DESCRIPTION
Skips the TS version check in tsurge since it's blocking some internal changes and generally isn't necessary since the app will be checked when it's built anyways.