### PR TITLE
fix(docs-infra): fix cards not shown if we hit the API page without API tab active

### DIFF
--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.ts
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.ts
@@ -110,9 +110,7 @@ export default class ApiReferenceDetailsPage {
     this.appScroller.disableScrolling = true;
     afterNextRender({
       write: () => {
-        if (this.isApiTabActive()) {
-          this.scrollHandler.updateMembersMarginTop(API_REFERENCE_TAB_BODY_CLASS_NAME);
-        }
+        this.scrollHandler.updateMembersMarginTop(API_REFERENCE_TAB_BODY_CLASS_NAME);
       },
     });
   }


### PR DESCRIPTION
Since we are only updating the members margin at the constructing phase, we should not disable this operation if user hit the page with tabs different than API active, otherwise if user switched to the API page he won't see the cards since members margin equals zero and docs viewer won't be shown

Resolves #58882

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #58882


## What is the new behavior?
User can hit the API ref page with any tab active and switches back to the API tab seeing the members cards

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
