### PR TITLE
docs: fix @let roadmap tile.

### DIFF
--- a/adev/src/content/reference/roadmap.md
+++ b/adev/src/content/reference/roadmap.md
@@ -154,7 +154,7 @@ This section represents explorations and prototyping of potential future project
   <docs-card title="Streamline standalone imports with Language Service" link="Completed in Q4 2024" href="">
   As part of this initiative, the language service automatically imports components and pipes in standalone and NgModule-based apps. Additionally, we've added a template diagnostic to highlight unused imports in standalone components, which should help make application bundles smaller.
   </docs-card>
-  <docs-card title="Local template variables" link="Completed in Q3 2024" href="https://github.com/angular/angular/issues/15280">
+  <docs-card title="Local template variables" link="Completed in Q3 2024">
   We've released the support for local template variables in Angular, see [`@let` docs](https://angular.dev/api/core/@let) for additional information.
   </docs-card>
   <docs-card title="Expand the customizability of Angular Material" link="Completed in Q2 2024" href="https://material.angular.io/guide/theming">


### PR DESCRIPTION
Prior to this change, we generated an invalid HTML with nested anchor elements. Those are not valid and are recovered by the browser by closing one early which messed the layout.

fixes #58884
