### PR TITLE
refactor(docs-infra): improve API reference page loading time and drop blocking time

### DIFF
--- a/adev/src/app/features/references/api-reference-list/api-reference-list.component.ts
+++ b/adev/src/app/features/references/api-reference-list/api-reference-list.component.ts
@@ -16,7 +16,7 @@ import {
   model,
   signal,
   viewChild,
-  afterRenderEffect,
+  afterNextRender,
 } from '@angular/core';
 import ApiItemsSection from '../api-items-section/api-items-section.component';
 import {FormsModule} from '@angular/forms';
@@ -57,14 +57,14 @@ export default class ApiReferenceList {
   filterInput = viewChild.required(TextField, {read: ElementRef});
 
   constructor() {
-    afterRenderEffect({
-      write: () => {
-        // Lord forgive me for I have sinned
-        // Use the CVA to focus when https://github.com/angular/angular/issues/31133 is implemented
-        if (matchMedia('(hover: hover) and (pointer:fine)').matches) {
+    afterNextRender(() => {
+      // Lord forgive me for I have sinned
+      // Use the CVA to focus when https://github.com/angular/angular/issues/31133 is implemented
+      if (matchMedia('(hover: hover) and (pointer:fine)').matches) {
+        scheduleOnIdle(() => {
           this.filterInput().nativeElement.querySelector('input').focus();
-        }
-      },
+        });
+      }
     });
 
     effect(() => {
@@ -106,5 +106,18 @@ export default class ApiReferenceList {
 
   filterByItemType(itemType: ApiItemType): void {
     this.type.update((currentType) => (currentType === itemType ? ALL_STATUSES_KEY : itemType));
+  }
+}
+
+/**
+ * Schedules a function to be run in a new macrotask.
+ * This is needed because the `requestIdleCallback` API is not available in all browsers.
+ * @param fn
+ */
+function scheduleOnIdle(fn: () => void): void {
+  if (typeof requestIdleCallback !== 'undefined') {
+    requestIdleCallback(fn);
+  } else {
+    setTimeout(fn, 0);
   }
 }


### PR DESCRIPTION
By scheduling the focus of the input, we can drop the blocking time that is caused by the blocking task of rendering.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit


## PR Type
What kind of change does this PR introduce?

- [x] angular.dev application / infrastructure changes


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently we use focus immediately using afterRenderEffect, but we don't have any signals inside the body of the fn, so we can convert that to be afterNextRender, and also in order for it to not be part of the current task, we can schedule it for later using requestIdleCallback. 

![CleanShot 2024-11-26 at 19 19 22](https://github.com/user-attachments/assets/aa0ca49b-94be-4392-9fc1-01677e855b78)
The blocking task is ~854ms which is too much! 

![CleanShot 2024-11-26 at 19 00 28](https://github.com/user-attachments/assets/73b096b4-ccd1-48d5-a977-2132fa405b38)

## What is the new behavior?
![CleanShot 2024-11-26 at 19 15 29](https://github.com/user-attachments/assets/483a715b-27eb-4ce9-8a69-3732b16b34d7)

The `focus` call should take only a couple of ms instead of +200ms.

This makes the initial page load task to be faster. 
![CleanShot 2024-11-26 at 19 18 33](https://github.com/user-attachments/assets/9338b933-327f-4bc5-9e59-8ad2dd676222)

## Does this PR introduce a breaking change?
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
