### PR TITLE
refactor(docs-infra): use interpolation instead of innerHTML for better perf

### DIFF
--- a/adev/shared-docs/components/navigation-list/navigation-list.component.html
+++ b/adev/shared-docs/components/navigation-list/navigation-list.component.html
@@ -29,7 +29,7 @@
               routerLinkActive="docs-faceted-list-item-active"
               (click)="emitClickOnLink()"
             >
-              <span [innerHtml]="item.label"></span>
+              <span>{{item.label}}</span>
               @if (item.children && !item.isExpanded) {
                 <docs-icon>chevron_right</docs-icon>
               }
@@ -39,7 +39,7 @@
           <!-- Nav Section Header -->
           @if (item.level !== collapsableLevel() && item.level !== expandableLevel()) {
             <div class="docs-secondary-nav-header">
-              <span [innerHtml]="item.label"></span>
+              <span>{{item.label}}</span>
             </div>
           }
 
@@ -50,7 +50,7 @@
             <button
               type="button"
               (click)="toggle(item)"
-              attr.aria-label="{{ item.isExpanded ? 'Collapse' : 'Expand' }} {{ item.label }}"
+              [attr.aria-label]="(item.isExpanded ? 'Collapse' : 'Expand') + ' ' + item.label"
               [attr.aria-expanded]="item.isExpanded"
               class="docs-secondary-nav-button"
               [class.docs-faceted-list-item-active]="item | isActiveNavigationItem: activeItem()"

--- a/adev/shared-docs/components/navigation-list/navigation-list.component.ts
+++ b/adev/shared-docs/components/navigation-list/navigation-list.component.ts
@@ -10,14 +10,14 @@ import {ChangeDetectionStrategy, Component, inject, input, output} from '@angula
 import {NavigationItem} from '../../interfaces/index';
 import {NavigationState} from '../../services/index';
 import {RouterLink, RouterLinkActive} from '@angular/router';
-import {CommonModule} from '@angular/common';
 import {IconComponent} from '../icon/icon.component';
 import {IsActiveNavigationItem} from '../../pipes/is-active-navigation-item.pipe';
+import {NgTemplateOutlet} from '@angular/common';
 
 @Component({
   selector: 'docs-navigation-list',
   standalone: true,
-  imports: [CommonModule, RouterLink, RouterLinkActive, IconComponent, IsActiveNavigationItem],
+  imports: [RouterLink, RouterLinkActive, IconComponent, IsActiveNavigationItem, NgTemplateOutlet],
   templateUrl: './navigation-list.component.html',
   styleUrls: ['./navigation-list.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/adev/src/app/features/references/api-items-section/api-items-section.component.html
+++ b/adev/src/app/features/references/api-items-section/api-items-section.component.html
@@ -1,14 +1,14 @@
 <header class="adev-api-items-section-header">
   <h3 [id]="group().id">
-    <!-- we use innerHtml because the title can be an html string-->
     <a
       routerLink="/api"
       [fragment]="group().id"
       queryParamsHandling="preserve"
       class="adev-api-anchor"
       tabindex="-1"
-      [innerHtml]="group().title"
-    ></a>
+    >
+      {{group().title}}
+    </a>
   </h3>
 </header>
 

--- a/packages/core/global/BUILD.bazel
+++ b/packages/core/global/BUILD.bazel
@@ -16,6 +16,6 @@ generate_api_docs(
         "//packages:common_files_and_deps_for_docs",
     ],
     entry_point = ":index.ts",
-    module_label = "<code>window.ng</code> globals",
+    module_label = "window.ng globals",
     module_name = "@angular/core/globals",
 )


### PR DESCRIPTION
Using innerHTML will cause the browser to parse the HTML and then create a DOM tree instead of just using the text content.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit

## PR Type
What kind of change does this PR introduce?

- [x] angular.dev application / infrastructure changes


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Both navigation list and api section component have usages of innerHTML which has worse perf than just using textContent when we want to show text on the page. 

- Api section
![CleanShot 2024-11-26 at 19 30 30](https://github.com/user-attachments/assets/c636c8d6-31e1-4086-bff3-a87b51c1693f)

- Navigation list
![CleanShot 2024-11-26 at 21 01 21](https://github.com/user-attachments/assets/c23f368a-fbe7-45b7-b661-cac3736e5264)

![CleanShot 2024-11-26 at 21 01 34](https://github.com/user-attachments/assets/05790bb8-100b-4939-bf7f-202d6d15fba3)


## What is the new behavior?
![CleanShot 2024-11-26 at 20 56 30](https://github.com/user-attachments/assets/be3aa0d5-5013-4c73-92ae-ddb4c87d3997)

No more parse HTML calls. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
The only occurence where we used html was the window.ng part, which I converted to be just a normal text in the bazel file. 