### PR TITLE
feat(core): add change detection tracing service

### DIFF
--- a/adev/src/app/app.config.ts
+++ b/adev/src/app/app.config.ts
@@ -15,6 +15,7 @@ import {
   inject,
   provideExperimentalZonelessChangeDetection,
   provideEnvironmentInitializer,
+  provideChangeDetectionTracingService,
 } from '@angular/core';
 import {
   DOCS_CONTENT_LOADER,
@@ -50,6 +51,11 @@ import {AppScroller} from './app-scroller';
 
 export const appConfig: ApplicationConfig = {
   providers: [
+    // More than 10 change detections in 1 second triggers a warning.
+    provideChangeDetectionTracingService({
+      msThresholdWindow: 1000,
+      cdThreshold: 10,
+    }),
     provideRouter(
       routes,
       withInMemoryScrolling(),

--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1430,6 +1430,12 @@ export type Predicate<T> = (value: T) => boolean;
 export function provideAppInitializer(initializerFn: () => Observable<unknown> | Promise<unknown> | void): EnvironmentProviders;
 
 // @public
+export function provideChangeDetectionTracingService(options?: {
+    msThresholdWindow: number;
+    cdThreshold: number;
+}): Provider[];
+
+// @public
 export function provideEnvironmentInitializer(initializerFn: () => void): EnvironmentProviders;
 
 // @public

--- a/packages/core/src/application/cd-tracing.ts
+++ b/packages/core/src/application/cd-tracing.ts
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Console} from '../console';
+import {inject, InjectionToken, Provider} from '../di';
+import {NgZone} from '../zone';
+import {TracingAction, TracingService, TracingSnapshot} from './tracing';
+
+interface CDTracingOptions {
+  msThresholdWindow: number;
+  cdThreshold: number;
+}
+
+const CD_TRACING_OPTIONS = new InjectionToken<CDTracingOptions>('CD_TRACING_OPTIONS');
+
+/**
+ * A change detection tracing service that logs a warning if the number of change detections
+ * exceeds a threshold. This is useful for debugging performance issues.
+ */
+class CDTracingService implements TracingService<TracingSnapshot> {
+  private ngZone = inject(NgZone);
+  private console = inject(Console);
+  private options = inject(CD_TRACING_OPTIONS);
+
+  private cds: {timestamp: number}[] = [];
+
+  constructor() {
+    this.ngZone.runOutsideAngular(() => {
+      setInterval(() => {
+        if (this.cds.length > this.options.cdThreshold) {
+          this.console.warn(
+            `You have [${this.cds.length}] change detections in [${this.options.msThresholdWindow / 1000} seconds]!`,
+          );
+          this.cds = [];
+        }
+      }, this.options.msThresholdWindow);
+    });
+  }
+
+  snapshot(linkedSnapshot: TracingSnapshot | null): TracingSnapshot {
+    return {
+      run: (action: TracingAction, fn: () => any) => {
+        if (action === TracingAction.CHANGE_DETECTION) {
+          this.cds.push({
+            timestamp: Date.now(),
+          });
+        }
+        return fn();
+      },
+    };
+  }
+}
+
+/**
+ * Configures the change detection tracing service.
+ *
+ * @usageNotes
+ *
+ * The following example illustrates how to configure the change detection tracing service.
+ * ```
+ * bootstrapApplication(App, {
+ *   providers: [
+ *     provideChangeDetectionTracingService(),
+ *   ],
+ * });
+ * ```
+ *
+ * @publicApi
+ */
+export function provideChangeDetectionTracingService(
+  options = {
+    msThresholdWindow: 1000,
+    cdThreshold: 10,
+  },
+) {
+  return [
+    {
+      provide: CD_TRACING_OPTIONS,
+      useValue: {
+        msThresholdWindow: options.msThresholdWindow,
+        cdThreshold: options.cdThreshold,
+      },
+    },
+    {
+      provide: TracingService,
+      useClass: CDTracingService,
+    },
+  ] as Provider[];
+}

--- a/packages/core/src/application/cd-tracing.ts
+++ b/packages/core/src/application/cd-tracing.ts
@@ -8,7 +8,6 @@
 
 import {Console} from '../console';
 import {inject, InjectionToken, Provider} from '../di';
-import {NgZone} from '../zone';
 import {TracingAction, TracingService, TracingSnapshot} from './tracing';
 
 interface CDTracingOptions {
@@ -16,48 +15,77 @@ interface CDTracingOptions {
   cdThreshold: number;
 }
 
-const CD_TRACING_OPTIONS = new InjectionToken<CDTracingOptions>('CD_TRACING_OPTIONS');
+const CD_TRACING_OPTIONS = new InjectionToken<CDTracingOptions>(
+  ngDevMode ? 'CD_TRACING_OPTIONS' : '',
+);
 
 /**
  * A change detection tracing service that logs a warning if the number of change detections
  * exceeds a threshold. This is useful for debugging performance issues.
  */
 class CDTracingService implements TracingService<TracingSnapshot> {
-  private ngZone = inject(NgZone);
   private console = inject(Console);
   private options = inject(CD_TRACING_OPTIONS);
 
-  private cds: {timestamp: number}[] = [];
+  private cdList: {timestamp: number}[] = [];
+  private readonly listMaxSize = this.options.cdThreshold * 3;
+  private warningTimeout: ReturnType<typeof setTimeout> | null = null;
 
   constructor() {
-    this.ngZone.runOutsideAngular(() => {
-      setInterval(() => {
-        if (this.cds.length > this.options.cdThreshold) {
-          this.console.warn(
-            `You have [${this.cds.length}] change detections in [${this.options.msThresholdWindow / 1000} seconds]!`,
-          );
-          this.cds = [];
-        }
-      }, this.options.msThresholdWindow);
-    });
+    if (!ngDevMode) {
+      this.console.warn(
+        `Warning: You're running the change detection tracing service in production mode!`,
+      );
+    }
   }
 
   snapshot(linkedSnapshot: TracingSnapshot | null): TracingSnapshot {
     return {
       run: (action: TracingAction, fn: () => any) => {
         if (action === TracingAction.CHANGE_DETECTION) {
-          this.cds.push({
-            timestamp: Date.now(),
-          });
+          this.addTimestamp();
         }
         return fn();
       },
     };
   }
+
+  private addTimestamp() {
+    const now = Date.now();
+
+    // removing timestamps that are older than the threshold window
+    while (this.cdList[0] && this.cdList[0].timestamp + this.options.msThresholdWindow < now) {
+      this.cdList.shift();
+    }
+
+    this.cdList.push({timestamp: now});
+
+    // We're over the threshold but still within the window. Schedule a warning if not already
+    if (this.cdList.length > this.options.cdThreshold && this.warningTimeout === null) {
+      const timeRemaining = this.options.msThresholdWindow - (now - this.cdList[0].timestamp);
+      this.warningTimeout = setTimeout(() => this.checkCdCount(), timeRemaining);
+    }
+  }
+
+  private checkCdCount() {
+    this.warningTimeout = null;
+
+    const count =
+      this.cdList.length === this.listMaxSize ? `${this.listMaxSize}+` : `${this.cdList.length}`;
+    this.console.warn(
+      `You had [${count}] change detections in [${this.options.msThresholdWindow / 1000} seconds]!`,
+    );
+
+    // Reset the list to start tracking a new window.
+    this.cdList.length = 0;
+  }
 }
 
 /**
  * Configures the change detection tracing service.
+ *
+ * The change detection tracing service logs a warning if the number of change detections
+ * exceeds a threshold. This is useful for debugging performance issues.
  *
  * @usageNotes
  *
@@ -77,7 +105,7 @@ export function provideChangeDetectionTracingService(
     msThresholdWindow: 1000,
     cdThreshold: 10,
   },
-) {
+): Provider[] {
   return [
     {
       provide: CD_TRACING_OPTIONS,
@@ -90,5 +118,5 @@ export function provideChangeDetectionTracingService(
       provide: TracingService,
       useClass: CDTracingService,
     },
-  ] as Provider[];
+  ];
 }

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -116,6 +116,7 @@ export {ApplicationConfig, mergeApplicationConfig} from './application/applicati
 export {makeStateKey, StateKey, TransferState} from './transfer_state';
 export {booleanAttribute, numberAttribute} from './util/coercion';
 export {REQUEST, REQUEST_CONTEXT, RESPONSE_INIT} from './application/platform_tokens';
+export {provideChangeDetectionTracingService} from './application/cd-tracing';
 
 import {global} from './util/global';
 if (typeof ngDevMode !== 'undefined' && ngDevMode) {

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -1194,6 +1194,9 @@
     "name": "init_callback_scheduler"
   },
   {
+    "name": "init_cd_tracing"
+  },
+  {
     "name": "init_chained_injector"
   },
   {


### PR DESCRIPTION
This will warn users when they are rendering too much based on the config they provide. Linked to #58540

It works somehow like this: 

```ts
// More than 10 change detections in 1 second triggers a warning.
provideChangeDetectionTracingService({
  msThresholdWindow: 1000,
  cdThreshold: 10,
}),
```

![CleanShot 2024-11-26 at 23 22 50](https://github.com/user-attachments/assets/2cabb8d1-2c87-47d4-8a1f-d311f7254ebc)
