### PR TITLE
fix(compiler-cli): account for multiple generated namespace imports in HMR

### DIFF
--- a/packages/compiler-cli/src/ngtsc/hmr/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/hmr/src/metadata.ts
@@ -10,7 +10,7 @@ import {R3CompiledExpression, R3HmrMetadata, outputAst as o} from '@angular/comp
 import {DeclarationNode, ReflectionHost} from '../../reflection';
 import {getProjectRelativePath} from '../../util/src/path';
 import {CompileResult} from '../../transform';
-import {extractHmrLocals} from './extract_locals';
+import {extractHmrDependencies} from './extract_dependencies';
 import ts from 'typescript';
 
 /**
@@ -43,12 +43,13 @@ export function extractHmrMetatadata(
     getProjectRelativePath(sourceFile, rootDirs, compilerHost) ||
     compilerHost.getCanonicalFileName(sourceFile.fileName);
 
+  const dependencies = extractHmrDependencies(clazz, definition, factory, classMetadata, debugInfo);
   const meta: R3HmrMetadata = {
     type: new o.WrappedNodeExpr(clazz.name),
     className: clazz.name.text,
     filePath,
-    locals: extractHmrLocals(clazz, definition, factory, classMetadata, debugInfo),
-    coreName: '__ngCore__',
+    localDependencies: dependencies.local,
+    namespaceDependencies: dependencies.external,
   };
 
   return meta;

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -177,6 +177,7 @@ export {
   compileHmrInitializer,
   compileHmrUpdateCallback,
   R3HmrMetadata,
+  R3HmrNamespaceDependency,
 } from './render3/r3_hmr_compiler';
 export {
   compileFactoryFunction,

--- a/packages/core/src/render3/hmr.ts
+++ b/packages/core/src/render3/hmr.ts
@@ -46,14 +46,14 @@ import {RendererFactory} from './interfaces/renderer';
  * Replaces the metadata of a component type and re-renders all live instances of the component.
  * @param type Class whose metadata will be replaced.
  * @param applyMetadata Callback that will apply a new set of metadata on the `type` when invoked.
- * @param environment Core runtime environment to use when applying the HMR update.
+ * @param environment Syntehtic namespace imports that need to be passed along to the callback.
  * @param locals Local symbols from the source location that have to be exposed to the callback.
  * @codeGenApi
  */
 export function ɵɵreplaceMetadata(
   type: Type<unknown>,
-  applyMetadata: (...args: [Type<unknown>, Record<string, unknown>, ...unknown[]]) => void,
-  environment: Record<string, unknown>,
+  applyMetadata: (...args: [Type<unknown>, unknown[], ...unknown[]]) => void,
+  namespaces: unknown[],
   locals: unknown[],
 ) {
   ngDevMode && assertComponentDef(type);
@@ -64,7 +64,7 @@ export function ɵɵreplaceMetadata(
   // can be functions for embedded views, the variables for the constant pool and `setClassMetadata`
   // calls. The callback allows us to keep them isolate from the rest of the app and to invoke
   // them at the right time.
-  applyMetadata.apply(null, [type, environment, ...locals]);
+  applyMetadata.apply(null, [type, namespaces, ...locals]);
 
   // If a `tView` hasn't been created yet, it means that this component hasn't been instantianted
   // before. In this case there's nothing left for us to do aside from patching it in.

--- a/packages/core/test/acceptance/hmr_spec.ts
+++ b/packages/core/test/acceptance/hmr_spec.ts
@@ -1967,7 +1967,7 @@ describe('hot module replacement', () => {
         (type as any)[ɵNG_COMP_DEF] = null;
         compileComponent(type, metadata);
       },
-      angularCoreEnv,
+      [angularCoreEnv],
       [],
     );
   }


### PR DESCRIPTION
The current HMR compiler assumes that there will only be one namespace import in the generated code (`@angular/core`). This is incorrect, because the compiler may need to generate additional imports in some cases (e.g. importing directives through a module). These changes adjust the compiler to capture all the namespaces in an array and pass them along.

Fixes #58915.
