### PR TITLE
fix(core): Explicitly manage TracingSnapshot lifecycle and dispose of it once it's been used.

### DIFF
--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -604,6 +604,7 @@ export class ApplicationRef {
       // if one exists. Snapshots may be reference counted by the implementation so
       // we want to ensure that if we request a snapshot that we use it.
       snapshot.run(TracingAction.CHANGE_DETECTION, this._tick);
+      snapshot.dispose();
       return;
     }
 

--- a/packages/core/src/application/tracing.ts
+++ b/packages/core/src/application/tracing.ts
@@ -17,6 +17,9 @@ export enum TracingAction {
 /** A single tracing snapshot. */
 export interface TracingSnapshot {
   run<T>(action: TracingAction, fn: () => T): T;
+
+  /** Disposes of the tracing snapshot. Must be run exactly once per TracingSnapshot. */
+  dispose(): void;
 }
 
 /**
@@ -39,6 +42,10 @@ export interface TracingService<T extends TracingSnapshot> {
    * used when additional work is performed that was scheduled in this context.
    *
    * @param linkedSnapshot Optional snapshot to use link to the current context.
+   * The caller is no longer responsible for calling dispose on the linkedSnapshot.
+   *
+   * @return The tracing snapshot. The caller is responsible for diposing of the
+   * snapshot.
    */
   snapshot(linkedSnapshot: T | null): T;
 }

--- a/packages/core/src/render3/after_render/manager.ts
+++ b/packages/core/src/render3/after_render/manager.ts
@@ -187,6 +187,7 @@ export class AfterRenderSequence implements AfterRenderRef {
     // associates the initial run of the hook with the context that created it.
     // Follow-up runs are independent of that initial context and have different
     // triggers.
+    this.snapshot?.dispose();
     this.snapshot = null;
   }
 

--- a/packages/core/test/acceptance/tracing_spec.ts
+++ b/packages/core/test/acceptance/tracing_spec.ts
@@ -27,6 +27,7 @@ describe('TracingService', () => {
         actions.push(action);
         return fn();
       },
+      dispose() {},
     };
     mockTracingService = {
       snapshot: jasmine.createSpy('snapshot').and.returnValue(fakeSnapshot),


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X ] Tests for the changes have been added (for bug fixes / features)
- [ X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

Fix for tracing service to explicitly manage lifecycle


<!-- Please check the one that applies to this PR using "x". -->

- [X ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently our experimental implementation of this service fails because it attempts to run snapshots that have been previously resumed. Need to explicitly manage releasing ref counts and enable snapshots to be used multiple times.


Issue Number: N/A


## What is the new behavior?

Have Angular explicitly call dispose to release resources (refcounts) by the tracing.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
