### PR TITLE
docs(docs-infra): don't render visually hidden nav menu items in the NavigationList

### DIFF
--- a/adev/shared-docs/components/navigation-list/navigation-list.component.html
+++ b/adev/shared-docs/components/navigation-list/navigation-list.component.html
@@ -4,10 +4,7 @@
     [class.docs-navigation-list-dropdown]="isDropdownView()"
   >
     @for (item of navigationItems; track $index) {
-      <li
-        class="docs-faceted-list-item"
-        [class.docs-navigation-link-hidden]="displayItemsToLevel() && item.level > displayItemsToLevel()"
-      >
+      <li class="docs-faceted-list-item">
         @if (item.path) {
           @if (item.isExternal) {
             <a [href]="item.path" target="_blank">
@@ -67,7 +64,7 @@
             </button>
           }
         }
-        @if (item.children?.length > 0) {
+        @if (displayItemsToLevel() > item.level && item.children?.length > 0) {
           <ng-container *ngTemplateOutlet="navigationList; context: {$implicit: item.children}" />
         }
       </li>

--- a/adev/shared-docs/components/navigation-list/navigation-list.component.scss
+++ b/adev/shared-docs/components/navigation-list/navigation-list.component.scss
@@ -45,10 +45,6 @@
     border: 0;
   }
 
-  .docs-navigation-link-hidden {
-    display: none;
-  }
-
   .docs-nav-item-has-icon {
     &::after {
       // FIXME: for some reason this disappears when transformed
@@ -77,7 +73,9 @@
   font-family: var(--inter-font);
   line-height: 160%;
   letter-spacing: -0.00875rem;
-  transition: color 0.3s ease, background 0.3s ease;
+  transition:
+    color 0.3s ease,
+    background 0.3s ease;
   text-align: left; // forces left alignment of text in button
 
   &.docs-secondary-nav-button-active {

--- a/adev/shared-docs/components/navigation-list/navigation-list.component.spec.ts
+++ b/adev/shared-docs/components/navigation-list/navigation-list.component.spec.ts
@@ -11,7 +11,7 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {NavigationList} from './navigation-list.component';
 import {By} from '@angular/platform-browser';
 import {NavigationItem} from '../../interfaces';
-import {RouterTestingModule} from '@angular/router/testing';
+import {provideRouter} from '@angular/router';
 import {provideExperimentalZonelessChangeDetection, signal} from '@angular/core';
 import {NavigationState} from '../../services';
 
@@ -37,8 +37,9 @@ describe('NavigationList', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NavigationList, RouterTestingModule],
+      imports: [NavigationList],
       providers: [
+        provideRouter([]),
         {provide: NavigationState, useClass: FakeNavigationListState},
         provideExperimentalZonelessChangeDetection(),
       ],
@@ -121,24 +122,34 @@ describe('NavigationList', () => {
     expect(toggleItemSpy).toHaveBeenCalledOnceWith(itemToToggle);
   });
 
-  it('should display items to provided level', () => {
+  it('should display only items to provided level (Level 1)', () => {
     fixture.componentRef.setInput('navigationItems', [...navigationItems]);
     fixture.componentRef.setInput('displayItemsToLevel', 1);
     fixture.detectChanges(true);
 
-    const visibleItems = fixture.debugElement.queryAll(
-      By.css('li.docs-faceted-list-item:not(.docs-navigation-link-hidden)'),
-    );
-    const hiddenItems = fixture.debugElement.queryAll(
-      By.css('li.docs-faceted-list-item.docs-navigation-link-hidden'),
-    );
+    const items = fixture.debugElement.queryAll(By.css('li.docs-faceted-list-item'));
 
-    expect(visibleItems.length).toBe(2);
-    expect(visibleItems[0].nativeElement.innerText).toBe(navigationItems[0].label);
-    expect(visibleItems[1].nativeElement.innerText).toBe(navigationItems[1].label);
-    expect(hiddenItems.length).toBe(2);
-    expect(hiddenItems[0].nativeElement.innerText).toBe(navigationItems[1].children![0].label);
-    expect(hiddenItems[1].nativeElement.innerText).toBe(navigationItems[1].children![1].label);
+    expect(items.length).toBe(2);
+    expect(items[0].nativeElement.innerText).toBe(navigationItems[0].label);
+    expect(items[1].nativeElement.innerText).toBe(navigationItems[1].label);
+  });
+
+  it('should display all items (Level 2)', () => {
+    fixture.componentRef.setInput('navigationItems', [...navigationItems]);
+    fixture.componentRef.setInput('displayItemsToLevel', 2);
+    fixture.detectChanges(true);
+
+    const items = fixture.debugElement.queryAll(By.css('li.docs-faceted-list-item'));
+
+    expect(items.length).toBe(4);
+
+    expect(items[0].nativeElement.innerText).toBe(navigationItems[0].label);
+    expect(items[1].nativeElement.innerText.startsWith(navigationItems[1].label)).toBeTrue();
+
+    const secondItemChildren = navigationItems[1].children || [];
+
+    expect(items[2].nativeElement.innerText).toBe(secondItemChildren[0].label);
+    expect(items[3].nativeElement.innerText).toBe(secondItemChildren[1].label);
   });
 });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The DOM is cluttered with a lot of nav item UL-s, due to the usage of multiple `NavigationList` instances that are visually hidden from the end user but have all of their children recursively rendered.

Related to issue: https://github.com/angular/angular/issues/58878


## What is the new behavior?

Only the visible levels of the navigation menu are rendered. The rest of the children are omitted from the DOM. This should also reduce the size of the prerendered static HTML of the reference pages in a production build considering the lists represented the majority of the payload.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
