### PR TITLE
fix(platform-server): Warn user when transfer state happens more than…

### DIFF
--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -85,6 +85,7 @@ function createMyServerApp(standalone: boolean) {
     template: `Works!`,
   })
   class MyServerApp {}
+
   return MyServerApp;
 }
 
@@ -115,6 +116,7 @@ function createAppWithPendingTask(standalone: boolean) {
       });
     }
   }
+
   return PendingTasksApp;
 }
 
@@ -178,7 +180,12 @@ function asyncRejectRenderHook() {
 }
 
 const RenderHookProviders = [
-  {provide: BEFORE_APP_SERIALIZED, useFactory: getTitleRenderHook, multi: true, deps: [DOCUMENT]},
+  {
+    provide: BEFORE_APP_SERIALIZED,
+    useFactory: getTitleRenderHook,
+    multi: true,
+    deps: [DOCUMENT],
+  },
 ];
 
 @NgModule({
@@ -189,9 +196,19 @@ const RenderHookProviders = [
 class RenderHookModule {}
 
 const MultiRenderHookProviders = [
-  {provide: BEFORE_APP_SERIALIZED, useFactory: getTitleRenderHook, multi: true, deps: [DOCUMENT]},
+  {
+    provide: BEFORE_APP_SERIALIZED,
+    useFactory: getTitleRenderHook,
+    multi: true,
+    deps: [DOCUMENT],
+  },
   {provide: BEFORE_APP_SERIALIZED, useValue: exceptionRenderHook, multi: true},
-  {provide: BEFORE_APP_SERIALIZED, useFactory: getMetaRenderHook, multi: true, deps: [DOCUMENT]},
+  {
+    provide: BEFORE_APP_SERIALIZED,
+    useFactory: getMetaRenderHook,
+    multi: true,
+    deps: [DOCUMENT],
+  },
 ];
 
 @NgModule({
@@ -218,14 +235,23 @@ const AsyncRenderHookProviders = [
 class AsyncRenderHookModule {}
 
 const AsyncMultiRenderHookProviders = [
-  {provide: BEFORE_APP_SERIALIZED, useFactory: getMetaRenderHook, multi: true, deps: [DOCUMENT]},
+  {
+    provide: BEFORE_APP_SERIALIZED,
+    useFactory: getMetaRenderHook,
+    multi: true,
+    deps: [DOCUMENT],
+  },
   {
     provide: BEFORE_APP_SERIALIZED,
     useFactory: getAsyncTitleRenderHook,
     multi: true,
     deps: [DOCUMENT],
   },
-  {provide: BEFORE_APP_SERIALIZED, useFactory: asyncRejectRenderHook, multi: true},
+  {
+    provide: BEFORE_APP_SERIALIZED,
+    useFactory: asyncRejectRenderHook,
+    multi: true,
+  },
 ];
 
 @NgModule({
@@ -242,7 +268,11 @@ class AsyncMultiRenderHookModule {}
 })
 class MyServerApp2 {}
 
-@NgModule({declarations: [MyServerApp2], imports: [ServerModule], bootstrap: [MyServerApp2]})
+@NgModule({
+  declarations: [MyServerApp2],
+  imports: [ServerModule],
+  bootstrap: [MyServerApp2],
+})
 class ExampleModule2 {}
 
 @Component({
@@ -252,12 +282,17 @@ class ExampleModule2 {}
 })
 class TitleApp {
   constructor(private title: Title) {}
+
   ngOnInit() {
     this.title.setTitle('Test App Title');
   }
 }
 
-@NgModule({declarations: [TitleApp], imports: [ServerModule], bootstrap: [TitleApp]})
+@NgModule({
+  declarations: [TitleApp],
+  imports: [ServerModule],
+  bootstrap: [TitleApp],
+})
 class TitleAppModule {}
 
 function createMyAsyncServerApp(standalone: boolean) {
@@ -284,6 +319,7 @@ function createMyAsyncServerApp(standalone: boolean) {
       );
     }
   }
+
   return MyAsyncServerApp;
 }
 
@@ -304,6 +340,7 @@ function createSVGComponent(standalone: boolean) {
     standalone,
   })
   class SVGComponent {}
+
   return SVGComponent;
 }
 
@@ -322,10 +359,10 @@ function createMyAnimationApp(standalone: boolean) {
     standalone,
     selector: 'app',
     template: `
-  <div [@myAnimation]="state">
-    <svg *ngIf="true"></svg>
-    {{text}}
-  </div>`,
+      <div [@myAnimation]="state">
+        <svg *ngIf="true"></svg>
+        {{text}}
+      </div>`,
     animations: [
       trigger('myAnimation', [
         state('void', style({'opacity': '0'})),
@@ -343,10 +380,12 @@ function createMyAnimationApp(standalone: boolean) {
   })
   class MyAnimationApp {
     state = 'active';
+
     constructor(private builder: AnimationBuilder) {}
 
     text = 'Works!';
   }
+
   return MyAnimationApp;
 }
 
@@ -364,10 +403,12 @@ function createMyStylesApp(standalone: boolean) {
   @Component({
     standalone,
     selector: 'app',
-    template: `<div>Works!</div>`,
+    template: `
+      <div>Works!</div>`,
     styles: ['div {color: blue; } :host { color: red; }'],
   })
   class MyStylesApp {}
+
   return MyStylesApp;
 }
 
@@ -385,14 +426,17 @@ function createMyTransferStateApp(standalone: boolean) {
   @Component({
     standalone,
     selector: 'app',
-    template: `<div>Works!</div>`,
+    template: `
+      <div>Works!</div>`,
   })
   class MyStylesApp {
     state = coreInject(TransferState);
+
     constructor() {
       this.state.set(makeStateKey<string>('some-key'), 'some-value');
     }
   }
+
   return MyStylesApp;
 }
 
@@ -405,6 +449,14 @@ const MyTransferStateAppStandalone = getStandaloneBootstrapFn(createMyTransferSt
   bootstrap: [MyTransferStateApp],
 })
 class MyTransferStateModule {}
+
+@NgModule({
+  declarations: [MyTransferStateApp],
+  imports: [BrowserModule, ServerModule],
+  providers: [provideServerRendering()],
+  bootstrap: [MyTransferStateApp],
+})
+class DoubleTransferStateModule {}
 
 @NgModule({
   bootstrap: [MyServerApp],
@@ -424,7 +476,13 @@ export class MyHttpInterceptor implements HttpInterceptor {
 @NgModule({
   bootstrap: [MyServerApp],
   imports: [MyServerAppModule, ServerModule, HttpClientModule, HttpClientTestingModule],
-  providers: [{provide: HTTP_INTERCEPTORS, multi: true, useClass: MyHttpInterceptor}],
+  providers: [
+    {
+      provide: HTTP_INTERCEPTORS,
+      multi: true,
+      useClass: MyHttpInterceptor,
+    },
+  ],
 })
 export class HttpInterceptorExampleModule {}
 
@@ -435,7 +493,11 @@ export class HttpInterceptorExampleModule {}
 })
 class ImageApp {}
 
-@NgModule({declarations: [ImageApp], imports: [ServerModule], bootstrap: [ImageApp]})
+@NgModule({
+  declarations: [ImageApp],
+  imports: [ServerModule],
+  bootstrap: [ImageApp],
+})
 class ImageExampleModule {}
 
 function createShadowDomEncapsulationApp(standalone: boolean) {
@@ -447,6 +509,7 @@ function createShadowDomEncapsulationApp(standalone: boolean) {
     styles: [':host { color: red; }'],
   })
   class ShadowDomEncapsulationApp {}
+
   return ShadowDomEncapsulationApp;
 }
 
@@ -479,6 +542,7 @@ function createFalseAttributesComponents(standalone: boolean) {
     imports: standalone ? [MyChildComponent] : [],
   })
   class MyHostComponent {}
+
   return [MyHostComponent, MyChildComponent];
 }
 
@@ -503,6 +567,7 @@ function createMyInputComponent(standalone: boolean) {
   class MyInputComponent {
     @Input() name = '';
   }
+
   return MyInputComponent;
 }
 
@@ -524,8 +589,10 @@ function createHTMLTypesApp(standalone: boolean) {
   })
   class HTMLTypesApp {
     html = '<b>foo</b> bar';
+
     constructor(@Inject(DOCUMENT) doc: Document) {}
   }
+
   return HTMLTypesApp;
 }
 
@@ -548,6 +615,7 @@ function createMyHiddenComponent(standalone: boolean) {
   class MyHiddenComponent {
     @Input() name = '';
   }
+
   return MyHiddenComponent;
 }
 
@@ -682,7 +750,10 @@ class HiddenModule {}
         const platform = platformServer([
           {
             provide: INITIAL_CONFIG,
-            useValue: {document: '<app></app>', url: 'http://test.com/deep/path?query#hash'},
+            useValue: {
+              document: '<app></app>',
+              url: 'http://test.com/deep/path?query#hash',
+            },
           },
         ]);
 
@@ -698,7 +769,10 @@ class HiddenModule {}
         const platform = platformServer([
           {
             provide: INITIAL_CONFIG,
-            useValue: {document: '<app></app>', url: 'http://test.com:80/deep/path?query#hash'},
+            useValue: {
+              document: '<app></app>',
+              url: 'http://test.com:80/deep/path?query#hash',
+            },
           },
         ]);
 
@@ -717,7 +791,10 @@ class HiddenModule {}
         const platform = platformServer([
           {
             provide: INITIAL_CONFIG,
-            useValue: {document: '<app></app>', url: 'http://test.com/deep/path'},
+            useValue: {
+              document: '<app></app>',
+              url: 'http://test.com/deep/path',
+            },
           },
         ]);
 
@@ -777,7 +854,12 @@ class HiddenModule {}
       });
 
       it('using long form should work', async () => {
-        const platform = platformServer([{provide: INITIAL_CONFIG, useValue: {document: doc}}]);
+        const platform = platformServer([
+          {
+            provide: INITIAL_CONFIG,
+            useValue: {document: doc},
+          },
+        ]);
 
         const moduleRef = await platform.bootstrapModule(AsyncServerModule);
         const applicationRef = moduleRef.injector.get(ApplicationRef);
@@ -881,8 +963,14 @@ class HiddenModule {}
             },
           ];
           const bootstrap = isStandalone
-            ? renderApplication(MyStylesAppStandalone, {...options, platformProviders: providers})
-            : renderModule(ExampleStylesModule, {...options, extraProviders: providers});
+            ? renderApplication(MyStylesAppStandalone, {
+                ...options,
+                platformProviders: providers,
+              })
+            : renderModule(ExampleStylesModule, {
+                ...options,
+                extraProviders: providers,
+              });
           const output = await bootstrap;
           expect(output).toMatch(
             /<app _nghost-ng-c\d+="" ng-version="0.0.0-PLACEHOLDER" ng-server-context="ssg">/,
@@ -900,8 +988,14 @@ class HiddenModule {}
             },
           ];
           const bootstrap = isStandalone
-            ? renderApplication(MyStylesAppStandalone, {...options, platformProviders: providers})
-            : renderModule(ExampleStylesModule, {...options, extraProviders: providers});
+            ? renderApplication(MyStylesAppStandalone, {
+                ...options,
+                platformProviders: providers,
+              })
+            : renderModule(ExampleStylesModule, {
+                ...options,
+                extraProviders: providers,
+              });
           // All symbols other than [a-zA-Z0-9\-] are removed
           const output = await bootstrap;
           expect(output).toMatch(/ng-server-context="Someextrachars----"/);
@@ -934,8 +1028,14 @@ class HiddenModule {}
             },
           ];
           const bootstrap = isStandalone
-            ? renderApplication(MyStylesAppStandalone, {...options, platformProviders: providers})
-            : renderModule(ExampleStylesModule, {...options, extraProviders: providers});
+            ? renderApplication(MyStylesAppStandalone, {
+                ...options,
+                platformProviders: providers,
+              })
+            : renderModule(ExampleStylesModule, {
+                ...options,
+                extraProviders: providers,
+              });
           // All symbols other than [a-zA-Z0-9\-] are removed,
           // the `other` is used as the default.
           const output = await bootstrap;
@@ -1273,9 +1373,9 @@ class HiddenModule {}
           standalone: false,
           selector: 'app',
           template: `
-          Works!
-          <router-outlet />
-        `,
+            Works!
+            <router-outlet/>
+          `,
         })
         class MyServerApp {}
 
@@ -1340,6 +1440,45 @@ class HiddenModule {}
         });
       });
 
+      describe('detecting state being transferred twice', () => {
+        it(`shows a warning when server providers has been provided twice`, async () => {
+          const consoleSpy = spyOn(console, 'warn');
+          const options = {document: '<app></app>'};
+          const bootstrap = renderModule(DoubleTransferStateModule, options);
+
+          // Note: script#ng-state repeated twice below.
+          // It's a warning in v19
+          // And might become an error in v20.
+          const expectedOutput =
+            '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER" ng-server-context="other"><div>Works!</div></app>' +
+            '<script id="ng-state" type="application/json">{"some-key":"some-value"}</script><script id="ng-state" type="application/json">{"some-key":"some-value"}</script></body></html>';
+          const output = await bootstrap;
+          expect(output).toEqual(expectedOutput);
+          expect(consoleSpy).toHaveBeenCalledWith(
+            jasmine.stringMatching('Angular detected an incompatible configuration'),
+          );
+          expect(consoleSpy).toHaveBeenCalledWith(
+            jasmine.stringMatching(
+              `This can happen if the server providers have been provided more than once using different mechanisms.`,
+            ),
+          );
+        });
+
+        it(`should not show a warning when server providers were provided once`, async () => {
+          const consoleSpy = spyOn(console, 'warn');
+          const options = {document: '<app></app>'};
+          const bootstrap = renderModule(MyTransferStateModule, options);
+          const expectedOutput =
+            '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER" ng-server-context="other"><div>Works!</div></app>' +
+            '<script id="ng-state" type="application/json">{"some-key":"some-value"}</script></body></html>';
+          const output = await bootstrap;
+          expect(output).toEqual(expectedOutput);
+          expect(consoleSpy).not.toHaveBeenCalledWith(
+            jasmine.stringMatching('Angular detected an incompatible configuration'),
+          );
+        });
+      });
+
       describe(`given 'url' is provided in 'INITIAL_CONFIG'`, () => {
         let mock: HttpTestingController;
         let ref: NgModuleRef<HttpInterceptorExampleModule>;
@@ -1349,7 +1488,10 @@ class HiddenModule {}
           const platform = platformServer([
             {
               provide: INITIAL_CONFIG,
-              useValue: {document: '<app></app>', url: 'http://localhost:4000/foo'},
+              useValue: {
+                document: '<app></app>',
+                url: 'http://localhost:4000/foo',
+              },
             },
           ]);
 


### PR DESCRIPTION
… once

This can happen if server providers are provided more than twice. We detect it on the state transfer phase by flagging app id as transferred in a set.
