### PR TITLE
docs: remove dev preview warning for rxjs-interop in output page

### DIFF
--- a/adev/src/content/ecosystem/rxjs-interop/output-interop.md
+++ b/adev/src/content/ecosystem/rxjs-interop/output-interop.md
@@ -1,7 +1,5 @@
 # RxJS interop with component and directive outputs
 
-IMPORTANT: The RxJS Interop package is available for [developer preview](reference/releases#developer-preview). It's ready for you to try, but it might change before it is stable.
-
 Tip: This guide assumes you're familiar with [component and directive outputs](guide/components/outputs).
 
 The `@angular/rxjs-interop` package offers two APIs related to component and directive outputs.


### PR DESCRIPTION
`outputFromObservable` and `outputToObservable` from `@angular/core/rxjs-interop` were recently promoted to `@publicApi`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

A warning says that the relevant two RXJS interop functions are in developer preview - this is no longer the case.

Issue Number: N/A


## What is the new behavior?

Removed the developer preview warning.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

N/A