### PR TITLE
fix(core): correctly infer the `request` type.

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1627,7 +1627,7 @@ export interface ResourceLoaderParams<R> {
         status: ResourceStatus;
     };
     // (undocumented)
-    request: Exclude<NoInfer<R>, undefined>;
+    request: NoInfer<Exclude<R, undefined>>;
 }
 
 // @public (undocumented)

--- a/packages/core/src/resource/api.ts
+++ b/packages/core/src/resource/api.ts
@@ -148,7 +148,7 @@ export interface ResourceRef<T> extends WritableResource<T> {
  * @experimental
  */
 export interface ResourceLoaderParams<R> {
-  request: Exclude<NoInfer<R>, undefined>;
+  request: NoInfer<Exclude<R, undefined>>;
   abortSignal: AbortSignal;
   previous: {
     status: ResourceStatus;

--- a/packages/core/test/resource/resource_spec.ts
+++ b/packages/core/test/resource/resource_spec.ts
@@ -12,6 +12,7 @@ import {
   EnvironmentInjector,
   Injector,
   resource,
+  ResourceRef,
   ResourceStatus,
   signal,
 } from '../../src/core';
@@ -718,6 +719,20 @@ describe('resource', () => {
     expect(echoResource.value()).toBe(null);
     expect(echoResource.error()).toBe(undefined);
     expect(aborted).toEqual([{counter: 0}, {counter: 0}]);
+  });
+
+  it('should infer request type correctly', () => {
+    // This is a typing test
+    const array = signal<number[] | undefined>([3]);
+    const res = resource({
+      request: () => array(),
+      loader: async ({request}) => {
+        // We check the undefined is correctly removed from the type
+        const arr: number[] = request;
+        return Promise.resolve(arr);
+      },
+      injector: TestBed.inject(Injector),
+    });
   });
 });
 


### PR DESCRIPTION
Prior to this fix, in some case `undefined` wasn't removed from request type.

fixes #58871
