### PR TITLE
fix(compiler): fix object literal parsing

### DIFF
--- a/packages/compiler/src/chars.ts
+++ b/packages/compiler/src/chars.ts
@@ -102,3 +102,11 @@ export function isOctalDigit(code: number): boolean {
 export function isQuote(code: number): boolean {
   return code === $SQ || code === $DQ || code === $BT;
 }
+
+export function isLeftBrace(code: number): boolean {
+  return code === $LBRACE;
+}
+
+export function isRightBrace(code: number): boolean {
+  return code === $RBRACE;
+}

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -458,7 +458,10 @@ export class Parser {
    */
   private _getInterpolationEndIndex(input: string, expressionEnd: string, start: number): number {
     for (const charIndex of this._forEachUnquotedChar(input, start)) {
-      if (input.startsWith(expressionEnd, charIndex)) {
+      if (
+        input.startsWith(expressionEnd, charIndex) &&
+        !input.startsWith(expressionEnd, charIndex + 1)
+      ) {
         return charIndex;
       }
 

--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -1016,6 +1016,7 @@ class _Tokenizer {
     // Find the end of the interpolation, ignoring content inside quotes.
     const expressionStart = this._cursor.clone();
     let inQuote: number | null = null;
+    let leftBraces: number = 0;
     let inComment = false;
     while (
       this._cursor.peek() !== chars.$EOF &&
@@ -1033,7 +1034,7 @@ class _Tokenizer {
         return;
       }
 
-      if (inQuote === null) {
+      if (inQuote === null && leftBraces === 0) {
         if (this._attemptStr(this._interpolationConfig.end)) {
           // We are not in a string, and we hit the end interpolation marker
           parts.push(this._getProcessedChars(expressionStart, current));
@@ -1054,9 +1055,15 @@ class _Tokenizer {
       } else if (char === inQuote) {
         // Exiting the current quoted string
         inQuote = null;
+      } else if (chars.isRightBrace(char) && leftBraces !== 0) {
+        // Exiting the current brace
+        leftBraces--;
       } else if (!inComment && inQuote === null && chars.isQuote(char)) {
         // Entering a new quoted string
         inQuote = char;
+      } else if (!inComment && inQuote === null && chars.isLeftBrace(char)) {
+        // Entering a new brace
+        leftBraces++;
       }
     }
 

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -1043,6 +1043,16 @@ describe('parser', () => {
       checkInterpolation(`{{ 'foo' +\n 'bar' +\r 'baz' }}`, `{{ "foo" + "bar" + "baz" }}`);
     });
 
+    it('should parse object literals', () => {
+      checkInterpolation(`{{{foo:'bar'}}}`, `{{ {foo: "bar"} }}`);
+    });
+
+    it('should parse object with nested objects', () => {
+      checkInterpolation(`{{{foo:{bar:true}}}}`, `{{ {foo: {bar: true}} }}`);
+
+      checkInterpolation(`{{{foo:{bar:{baz:true}}}}}`, `{{ {foo: {bar: {baz: true}}} }}`);
+    });
+
     it('should support custom interpolation', () => {
       const parser = new Parser(new Lexer());
       const ast = parser.parseInterpolation('{% a %}', '', 0, null, {start: '{%', end: '%}'})!


### PR DESCRIPTION
This change allows interpolate object literals with the following syntax: {{{foo:'bar'}}}

Fixes: #9571

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #9571


## What is the new behavior?

Possibility of interpolate object literals with the following syntax: {{{foo:'bar'}}}


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
