### PR TITLE
docs(docs-infra): fix the overscroll behavior of the search dialogue

### DIFF
--- a/adev/shared-docs/components/search-dialog/search-dialog.component.scss
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.scss
@@ -36,6 +36,7 @@ dialog {
   ul {
     max-height: 50vh;
     overflow-y: auto;
+    overscroll-behavior: contain;
     list-style-type: none;
     padding-inline: 0;
     padding-block-start: 1rem;


### PR DESCRIPTION
since the dialogue shows on top of other scrollable elements of the page, then the overscroll behavior should be contain for better UX.



## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Resloves: #58947

Issue Number: #58947


## What is the new behavior?
User can independently scroll in the search dialogue 

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
