### PR TITLE
docs(docs-infra): don't use `URL` to check for external links

### DIFF
--- a/adev/shared-docs/directives/external-link/external-link.directive.ts
+++ b/adev/shared-docs/directives/external-link/external-link.directive.ts
@@ -25,7 +25,6 @@ import {WINDOW} from '../../providers/index';
 export class ExternalLink implements OnInit {
   private readonly anchor: ElementRef<HTMLAnchorElement> = inject(ElementRef);
   private readonly platformId = inject(PLATFORM_ID);
-  private readonly window = inject(WINDOW);
 
   target?: '_blank' | '_self' | '_parent' | '_top' | '';
 
@@ -38,7 +37,7 @@ export class ExternalLink implements OnInit {
       return;
     }
 
-    if (isExternalLink(this.anchor.nativeElement.href, this.window.location.origin)) {
+    if (isExternalLink(this.anchor.nativeElement.href)) {
       this.target = '_blank';
     }
   }

--- a/adev/shared-docs/utils/navigation.utils.ts
+++ b/adev/shared-docs/utils/navigation.utils.ts
@@ -78,16 +78,18 @@ export const findNavigationItem = (
   return result;
 };
 
-export const isExternalLink = (link: string, windowOrigin: string) =>
-  new URL(link).origin !== windowOrigin;
+/**
+ * For perf reasons, we only don't rely on creating a new Url object and comparing the origins
+ */
+export function isExternalLink(link: string): boolean {
+  return link.startsWith('http://') || link.startsWith('https://');
+}
 
-export const markExternalLinks = (item: NavigationItem, origin: string): void => {
+export function markExternalLinks(item: NavigationItem): void {
   if (item.path) {
-    try {
-      item.isExternal = isExternalLink(item.path, origin);
-    } catch (err) {}
+    item.isExternal = isExternalLink(item.path);
   }
-};
+}
 
 export const mapNavigationItemsToRoutes = (
   navigationItems: NavigationItem[],

--- a/adev/src/app/core/layout/secondary-navigation/secondary-navigation.component.ts
+++ b/adev/src/app/core/layout/secondary-navigation/secondary-navigation.component.ts
@@ -63,7 +63,6 @@ export class SecondaryNavigation implements OnInit {
   private readonly navigationState = inject(NavigationState);
   private readonly platformId = inject(PLATFORM_ID);
   private readonly router = inject(Router);
-  private readonly window = inject(WINDOW);
 
   readonly isSecondaryNavVisible = this.navigationState.isMobileNavVisible;
   readonly primaryActiveRouteItem = this.navigationState.primaryActiveRouteItem;
@@ -84,10 +83,10 @@ export class SecondaryNavigation implements OnInit {
 
   private readonly routeMap: Record<string, NavigationItem[]> = {
     [PagePrefix.REFERENCE]: getNavigationItemsTree(SUB_NAVIGATION_DATA.reference, (tree) =>
-      markExternalLinks(tree, this.window.origin),
+      markExternalLinks(tree),
     ),
     [PagePrefix.DOCS]: getNavigationItemsTree(SUB_NAVIGATION_DATA.docs, (tree) =>
-      markExternalLinks(tree, this.window.origin),
+      markExternalLinks(tree),
     ),
   };
 


### PR DESCRIPTION
For perf reasons, it is more efficient to not rely on creating an `URL` object. Instead we check for the explicit protocol to detect external links.

This will also force us to use relative links, so archived versions & next versions navigate on the current version of the site.

fixes #58954
