### PR TITLE
Fixes for edge cases in inject migration

### DIFF
--- a/packages/core/schematics/ng-generate/inject-migration/migration.ts
+++ b/packages/core/schematics/ng-generate/inject-migration/migration.ts
@@ -259,7 +259,15 @@ function migrateClass(
 
   if (prependToClass.length > 0) {
     if (removedMembers.size === node.members.length) {
-      tracker.insertText(sourceFile, constructor.getEnd() + 1, `${prependToClass.join('\n')}\n`);
+      tracker.insertText(
+        sourceFile,
+        // If all members were deleted, insert after the last one.
+        // This allows us to preserve the indentation.
+        node.members.length > 0
+          ? node.members[node.members.length - 1].getEnd() + 1
+          : node.getEnd() - 1,
+        `${prependToClass.join('\n')}\n`,
+      );
     } else {
       // Insert the new properties after the first member that hasn't been deleted.
       tracker.insertText(

--- a/packages/core/schematics/ng-generate/inject-migration/migration.ts
+++ b/packages/core/schematics/ng-generate/inject-migration/migration.ts
@@ -553,14 +553,10 @@ function migrateInjectDecorator(
       }
     }
   } else if (
-    // Pass the type for cases like `@Inject(FOO_TOKEN) foo: Foo`, because:
-    // 1. It guarantees that the type stays the same as before.
-    // 2. Avoids leaving unused imports behind.
-    // We only do this for type references since the `@Inject` pattern above is fairly common and
-    // apps don't necessarily type their injection tokens correctly, whereas doing it for literal
-    // types will add a lot of noise to the generated code.
     type &&
     (ts.isTypeReferenceNode(type) ||
+      ts.isTypeLiteralNode(type) ||
+      ts.isTupleTypeNode(type) ||
       (ts.isUnionTypeNode(type) && type.types.some(ts.isTypeReferenceNode)))
   ) {
     typeArguments = [type];

--- a/packages/core/schematics/ng-generate/inject-migration/migration.ts
+++ b/packages/core/schematics/ng-generate/inject-migration/migration.ts
@@ -230,8 +230,8 @@ function migrateClass(
     const nextStatement = getNextPreservedStatement(superCall, removedStatements);
     tracker.insertText(
       sourceFile,
-      nextStatement ? nextStatement.getFullStart() : superCall.getEnd() + 1,
-      `\n${afterSuper.join('\n')}\n`,
+      nextStatement ? nextStatement.getFullStart() : constructor.getEnd() - 1,
+      `\n${afterSuper.join('\n')}\n` + (nextStatement ? '' : memberIndentation),
     );
   }
 

--- a/packages/core/schematics/test/inject_migration_spec.ts
+++ b/packages/core/schematics/test/inject_migration_spec.ts
@@ -1341,6 +1341,24 @@ describe('inject migration', () => {
     ]);
   });
 
+  it('should not migrate class that has un-injectable parameters', async () => {
+    const initialText = [
+      `import { Directive, Inject } from '@angular/core';`,
+      `import { FOO_TOKEN, Foo } from 'foo';`,
+      ``,
+      `@Directive()`,
+      `class MyDir {`,
+      `  constructor(readonly injectable: Foo, private notInjectable: string) {}`,
+      `}`,
+    ].join('\n');
+
+    writeFile('/dir.ts', initialText);
+
+    await runMigration();
+
+    expect(tree.readContent('/dir.ts')).toBe(initialText);
+  });
+
   it('should unwrap forwardRef with an implicit return', async () => {
     writeFile(
       '/dir.ts',

--- a/packages/core/schematics/test/inject_migration_spec.ts
+++ b/packages/core/schematics/test/inject_migration_spec.ts
@@ -1282,6 +1282,65 @@ describe('inject migration', () => {
     ]);
   });
 
+  it('should preserve type literals in @Inject parameter', async () => {
+    writeFile(
+      '/dir.ts',
+      [
+        `import { Directive, Inject } from '@angular/core';`,
+        `import { FOO_TOKEN } from 'foo';`,
+        ``,
+        `@Directive()`,
+        `class MyDir {`,
+        `  constructor(@Inject(FOO_TOKEN) private foo: {id: number}) {}`,
+        `}`,
+      ].join('\n'),
+    );
+
+    await runMigration();
+
+    expect(tree.readContent('/dir.ts').split('\n')).toEqual([
+      `import { Directive, inject } from '@angular/core';`,
+      `import { FOO_TOKEN } from 'foo';`,
+      ``,
+      `@Directive()`,
+      `class MyDir {`,
+      `  private foo = inject<{`,
+      `    id: number;`,
+      `}>(FOO_TOKEN);`,
+      `}`,
+    ]);
+  });
+
+  it('should preserve tuple types in @Inject parameter', async () => {
+    writeFile(
+      '/dir.ts',
+      [
+        `import { Directive, Inject } from '@angular/core';`,
+        `import { FOO_TOKEN } from 'foo';`,
+        ``,
+        `@Directive()`,
+        `class MyDir {`,
+        `  constructor(@Inject(FOO_TOKEN) private foo: [a: number, b: number]) {}`,
+        `}`,
+      ].join('\n'),
+    );
+
+    await runMigration();
+
+    expect(tree.readContent('/dir.ts').split('\n')).toEqual([
+      `import { Directive, inject } from '@angular/core';`,
+      `import { FOO_TOKEN } from 'foo';`,
+      ``,
+      `@Directive()`,
+      `class MyDir {`,
+      `  private foo = inject<[`,
+      `    a: number,`,
+      `    b: number`,
+      `]>(FOO_TOKEN);`,
+      `}`,
+    ]);
+  });
+
   it('should unwrap forwardRef with an implicit return', async () => {
     writeFile(
       '/dir.ts',


### PR DESCRIPTION
Includes the following fixes for some edge cases in the `inject` migration:

### fix(migrations): class content being deleted in some edge cases 
Fixes that the inject migration was deleting the class' content if a property exists after the constructor that is being rewritten.

### fix(migrations): correctly strip away parameters surrounded by comments in inject migration
Fixes that the inject migration was sometimes producing invalid code if there are comments around the parameters.

### fix(migrations): inject migration aggressively removing imports 
Fixes that the inject migration would remove imports even if they're still used by classes that aren't being migrated.

### fix(migrations): preserve type literals and tuples in inject migrations 
Updates the inject migration to preserve type literals and tuple types, based on some internal feedback.

### fix(migrations): don't migrate classes with parameters that can't be injected
Updates the inject migrations to skip over classes that have uninjectable class parameters.

### fix(migrations): inject migration dropping code if everything except super is removed
Fixes that in some cases the internal version of the migration was dropping code when all the statements after the `super` call are deleted.