### PR TITLE
fix(core): fix type inference for Resource#hasValue.

### DIFF
--- a/packages/core/src/resource/api.ts
+++ b/packages/core/src/resource/api.ts
@@ -91,7 +91,7 @@ export interface Resource<T> {
    *
    * This function is reactive.
    */
-  hasValue(): this is Resource<T> & {value: Signal<T>};
+  hasValue(): this is ValuedResource<T>;
 
   /**
    * Instructs the resource to re-load any asynchronous dependency it may have.
@@ -105,6 +105,15 @@ export interface Resource<T> {
 }
 
 /**
+ * A `Resource` with a valid current value.
+ *
+ * @experimental
+ */
+export interface ValuedResource<T> extends Resource<T> {
+  readonly value: Signal<T>;
+}
+
+/**
  * A `Resource` with a mutable value.
  *
  * Overwriting the value of a resource sets it to the 'local' state.
@@ -113,7 +122,7 @@ export interface Resource<T> {
  */
 export interface WritableResource<T> extends Resource<T> {
   readonly value: WritableSignal<T | undefined>;
-  hasValue(): this is WritableResource<T> & {value: WritableSignal<T>};
+  hasValue(): this is ValuedWritableResource<T>;
 
   /**
    * Convenience wrapper for `value.set`.
@@ -125,6 +134,15 @@ export interface WritableResource<T> extends Resource<T> {
    */
   update(updater: (value: T | undefined) => T | undefined): void;
   asReadonly(): Resource<T>;
+}
+
+/**
+ * A `Resource` with a mutable value that is currently valid.
+ *
+ * @experimental
+ */
+export interface ValuedWritableResource<T> extends Resource<T> {
+  readonly value: WritableSignal<T>;
 }
 
 /**

--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -15,6 +15,7 @@ import {
   ResourceOptions,
   ResourceStatus,
   WritableResource,
+  ValuedWritableResource,
   ResourceLoader,
   Resource,
   ResourceRef,
@@ -90,7 +91,7 @@ abstract class BaseWritableResource<T> implements WritableResource<T> {
     () => this.status() === ResourceStatus.Loading || this.status() === ResourceStatus.Reloading,
   );
 
-  hasValue(): this is WritableResource<T> & {value: WritableSignal<T>} {
+  hasValue(): this is ValuedWritableResource<T> {
     return (
       this.status() === ResourceStatus.Resolved ||
       this.status() === ResourceStatus.Local ||

--- a/packages/core/test/authoring/BUILD.bazel
+++ b/packages/core/test/authoring/BUILD.bazel
@@ -4,6 +4,7 @@ ts_library(
     name = "signal_authoring_signature_test_lib",
     testonly = True,
     srcs = [
+        "resource_signature_test.ts",
         "signal_input_signature_test.ts",
         "signal_model_signature_test.ts",
         "signal_queries_signature_test.ts",

--- a/packages/core/test/authoring/resource_signature_test.ts
+++ b/packages/core/test/authoring/resource_signature_test.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+/**
+ * @fileoverview
+ * This file contains various signal `resource()` patterns and ensures
+ * the resulting types match our expectations (via comments asserting the `.d.ts`).
+ */
+
+import {resource} from '@angular/core';
+// import preserved to simplify `.d.ts` emit and simplify the `type_tester` logic.
+// tslint:disable-next-line no-duplicate-imports
+import {ResourceRef} from '@angular/core';
+
+export class ResourceSignatureTest {
+  /** ResourceRef<string> */
+  noRequest = resource({
+    loader: () => new Promise<string>(() => {}),
+  });
+
+  /** number | undefined */
+  inferredValue = (() => {
+    const res = resource({
+      loader: () => new Promise<number>(() => {}),
+    });
+    return res.value();
+  })();
+
+  /** number */
+  inferredValueAfterCallingHasValue = (() => {
+    const res = resource({
+      loader: () => new Promise<number>(() => {}),
+    });
+    if (res.hasValue()) {
+      return res.value();
+    }
+    throw new Error('error thrown to stop type inference from this branch');
+  })();
+}

--- a/packages/core/test/authoring/type_tester.ts
+++ b/packages/core/test/authoring/type_tester.ts
@@ -20,6 +20,7 @@ const TESTS = new Map<string, (value: string) => string>([
   ['signal_queries_signature_test', (v) => `Signal<${v}>`],
   ['signal_model_signature_test', (v) => `ModelSignal<${v}>`],
   ['unwrap_writable_signal_signature_test', (v) => v],
+  ['resource_signature_test', (v) => v],
 ]);
 
 const containingDir = path.dirname(url.fileURLToPath(import.meta.url));


### PR DESCRIPTION
TypeScript considers an intersection of two function types to be an overloaded function containing both signatures. The implication of this is that `Signal<T|undefined> & Signal<T>` is just `Signal<T|undefined>`, instead of `Signal<T>` as would be expected. This results in `Resource#hasValue` not correctly narrowing the type of `#value`.

This adds an additional two interfaces representing Resources that are known to have a set value, which avoids the function intersection issue.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

