### PR TITLE
docs: correctly display note about DI tokens  

### DIFF
--- a/adev/src/content/guide/hybrid-rendering.md
+++ b/adev/src/content/guide/hybrid-rendering.md
@@ -264,7 +264,6 @@ export class MyComponent {
 ```
 
 IMPORTANT: The above tokens will be `null` in the following scenarios:<br><br>
-
 - During the build processes.
 - When the application is rendered in the browser (client-side rendering).
 - When performing static site generation (SSG).


### PR DESCRIPTION
The breakline was breaking the note UI
