### PR TITLE
Add internal-only debugging attributes

### DIFF
--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
@@ -237,6 +237,7 @@ export class PartialComponentLinkerVersion1<TStatement, TExpression>
         : ChangeDetectionStrategy.Default,
       animations: metaObj.has('animations') ? metaObj.getOpaque('animations') : null,
       relativeContextFilePath: this.sourceUrl,
+      relativeTemplatePath: null,
       i18nUseExternalIds: false,
       declarations,
     };

--- a/packages/compiler-cli/src/ngtsc/annotations/common/src/debug_info.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/src/debug_info.ts
@@ -24,7 +24,7 @@ export function extractClassDebugInfo(
   }
 
   const srcFile = clazz.getSourceFile();
-  const srcFileMaybeRelativePath = getProjectRelativePath(srcFile, rootDirs, compilerHost);
+  const srcFileMaybeRelativePath = getProjectRelativePath(srcFile.fileName, rootDirs, compilerHost);
 
   return {
     type: new WrappedNodeExpr(clazz.name),

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -181,6 +181,7 @@ import {
 import {getTemplateDiagnostics} from '../../../typecheck';
 import {JitDeclarationRegistry} from '../../common/src/jit_declaration_registry';
 import {extractHmrMetatadata, getHmrUpdateDeclaration} from '../../../hmr';
+import {getProjectRelativePath} from '../../../util/src/path';
 
 const EMPTY_ARRAY: any[] = [];
 
@@ -714,6 +715,11 @@ export class ComponentDecoratorHandler
           path: absoluteFrom(template.declaration.resolvedTemplateUrl),
           expression: template.sourceMapping.node,
         };
+    const relativeTemplatePath = getProjectRelativePath(
+      templateResource.path ?? ts.getOriginalNode(node).getSourceFile().fileName,
+      this.rootDirs,
+      this.compilerHost,
+    );
 
     // Figure out the set of styles. The ordering here is important: external resources (styleUrls)
     // precede inline styles, and styles defined in the template override styles defined in the
@@ -868,6 +874,7 @@ export class ComponentDecoratorHandler
           i18nUseExternalIds: this.i18nUseExternalIds,
           relativeContextFilePath,
           rawImports: rawImports !== null ? new o.WrappedNodeExpr(rawImports) : undefined,
+          relativeTemplatePath,
         },
         typeCheckMeta: extractDirectiveTypeCheckMeta(node, inputs, this.reflector),
         classMetadata: this.includeClassMetadata

--- a/packages/compiler-cli/src/ngtsc/hmr/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/hmr/src/metadata.ts
@@ -40,7 +40,7 @@ export function extractHmrMetatadata(
 
   const sourceFile = clazz.getSourceFile();
   const filePath =
-    getProjectRelativePath(sourceFile, rootDirs, compilerHost) ||
+    getProjectRelativePath(sourceFile.fileName, rootDirs, compilerHost) ||
     compilerHost.getCanonicalFileName(sourceFile.fileName);
 
   const dependencies = extractHmrDependencies(clazz, definition, factory, classMetadata, debugInfo);

--- a/packages/compiler-cli/src/ngtsc/util/src/path.ts
+++ b/packages/compiler-cli/src/ngtsc/util/src/path.ts
@@ -20,14 +20,14 @@ export function normalizeSeparators(path: string): string {
 }
 
 /**
- * Attempts to generate a project-relative path
- * @param sourceFile
- * @param rootDirs
- * @param compilerHost
+ * Attempts to generate a project-relative path for a file.
+ * @param fileName Absolute path to the file.
+ * @param rootDirs Root directories of the project.
+ * @param compilerHost Host used to resolve file names.
  * @returns
  */
 export function getProjectRelativePath(
-  sourceFile: ts.SourceFile,
+  fileName: string,
   rootDirs: readonly string[],
   compilerHost: Pick<ts.CompilerHost, 'getCanonicalFileName'>,
 ): string | null {
@@ -35,7 +35,7 @@ export function getProjectRelativePath(
   // because the root directories might've been passed through it already while the source files
   // definitely have not. This can break the relative return value, because in some platforms
   // getCanonicalFileName lowercases the path.
-  const filePath = compilerHost.getCanonicalFileName(sourceFile.fileName);
+  const filePath = compilerHost.getCanonicalFileName(fileName);
 
   for (const rootDir of rootDirs) {
     const rel = relative(compilerHost.getCanonicalFileName(rootDir), filePath);

--- a/packages/compiler-cli/test/ngtsc/attach_source_location_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/attach_source_location_spec.ts
@@ -1,0 +1,140 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+import {NgtscTestEnvironment} from './env';
+import {setEnableTemplateSourceLocations} from '@angular/compiler/src/render3/view/config';
+
+const testFiles = loadStandardTestFiles({fakeCommon: true});
+
+runInEachFileSystem(() => {
+  describe('source location instruction generation', () => {
+    let env!: NgtscTestEnvironment;
+
+    beforeEach(() => {
+      setEnableTemplateSourceLocations(true);
+      env = NgtscTestEnvironment.setup(testFiles);
+      env.tsconfig();
+    });
+
+    afterEach(() => {
+      setEnableTemplateSourceLocations(false);
+    });
+
+    it('should attach the source location in an inline template', () => {
+      env.write(
+        `test.ts`,
+        `
+          import {Component} from '@angular/core';
+
+          @Component({
+            template: \`
+              <div><span>
+                <strong>Hello</strong>
+              </span></div>
+            \`,
+          })
+          class Comp {}
+         `,
+      );
+      env.driveMain();
+      const content = env.getContents('test.js');
+      expect(content).toContain('ɵɵelementStart(0, "div")(1, "span")(2, "strong");');
+      expect(content).toContain(
+        'ɵɵattachSourceLocations("test.ts", [[0, 114, 5, 14], [1, 119, 5, 19], [2, 142, 6, 16]]);',
+      );
+    });
+
+    it('should attach the source location in an external template', () => {
+      env.write(
+        'test.html',
+        `
+        <div><span>
+          <strong>Hello</strong>
+        </span></div>
+      `,
+      );
+
+      env.write(
+        `test.ts`,
+        `
+          import {Component} from '@angular/core';
+
+          @Component({templateUrl: './test.html'})
+          class Comp {}
+        `,
+      );
+      env.driveMain();
+      const content = env.getContents('test.js');
+      expect(content).toContain('ɵɵelementStart(0, "div")(1, "span")(2, "strong");');
+      expect(content).toContain(
+        'ɵɵattachSourceLocations("test.html", [[0, 9, 1, 8], [1, 14, 1, 13], [2, 31, 2, 10]]);',
+      );
+    });
+
+    it('should attach the source location to structural directives', () => {
+      env.write(
+        `test.ts`,
+        `
+          import {Component} from '@angular/core';
+          import {CommonModule} from '@angular/common';
+
+          @Component({
+            imports: [CommonModule],
+            template: \`
+              <div *ngIf="true">
+                <span></span>
+              </div>
+            \`,
+          })
+          class Comp {}
+        `,
+      );
+      env.driveMain();
+      const content = env.getContents('test.js');
+      expect(content).toContain('ɵɵtemplate(0,');
+      expect(content).toContain('ɵɵelementStart(0, "div");');
+      expect(content).toContain('ɵɵelement(1, "span");');
+      expect(content).toContain(
+        'ɵɵattachSourceLocations("test.ts", [[0, 207, 7, 14], [1, 242, 8, 16]]);',
+      );
+    });
+
+    it('should not attach the source location to ng-container', () => {
+      env.write(
+        `test.ts`,
+        `
+          import {Component} from '@angular/core';
+
+          @Component({
+            template: \`
+              <ng-container>
+                <div>
+                  <ng-container>
+                    <span></span>
+                  </ng-container>
+                </div>
+              </ng-container>
+            \`,
+          })
+          class Comp {}
+        `,
+      );
+      env.driveMain();
+      const content = env.getContents('test.js');
+      expect(content).toContain('ɵɵelementContainerStart(0);');
+      expect(content).toContain('ɵɵelementStart(1, "div");');
+      expect(content).toContain('ɵɵelementContainerStart(2);');
+      expect(content).toContain('ɵɵelement(3, "span");');
+      expect(content).toContain(
+        'ɵɵattachSourceLocations("test.ts", [[1, 145, 6, 16], [3, 204, 8, 20]]);',
+      );
+    });
+  });
+});

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -321,6 +321,7 @@ export class CompilerFacadeImpl implements CompilerFacade {
         facade.viewProviders != null ? new WrappedNodeExpr(facade.viewProviders) : null,
       relativeContextFilePath: '',
       i18nUseExternalIds: true,
+      relativeTemplatePath: null,
     };
     const jitExpressionSourceMap = `ng:///${facade.name}.js`;
     return this.compileComponentFromMeta(angularCoreEnv, jitExpressionSourceMap, meta);
@@ -673,6 +674,7 @@ function convertDeclareComponentFacadeToMetadata(
     declarationListEmitMode: DeclarationListEmitMode.ClosureResolved,
     relativeContextFilePath: '',
     i18nUseExternalIds: true,
+    relativeTemplatePath: null,
   };
 }
 

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -527,6 +527,11 @@ export class Identifiers {
   static storeLet: o.ExternalReference = {name: 'ɵɵstoreLet', moduleName: CORE};
   static readContextLet: o.ExternalReference = {name: 'ɵɵreadContextLet', moduleName: CORE};
 
+  static attachSourceLocations: o.ExternalReference = {
+    name: 'ɵɵattachSourceLocations',
+    moduleName: CORE,
+  };
+
   static NgOnChangesFeature: o.ExternalReference = {name: 'ɵɵNgOnChangesFeature', moduleName: CORE};
 
   static InheritDefinitionFeature: o.ExternalReference = {

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -289,6 +289,12 @@ export interface R3ComponentMetadata<DeclarationT extends R3TemplateDependency>
   changeDetection: ChangeDetectionStrategy | o.Expression | null;
 
   /**
+   * Relative path to the component's template from the root of the project.
+   * Used to generate debugging information.
+   */
+  relativeTemplatePath: string | null;
+
+  /**
    * The imports expression as appears on the component decorate for standalone component. This
    * field is currently needed only for local compilation, and so in other compilation modes it may
    * not be set. If component has empty array imports then this field is not set.

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -23,13 +23,12 @@ import {
   DeclarationListEmitMode,
   DeferBlockDepsEmitMode,
   R3ComponentMetadata,
-  R3DeferPerBlockDependency,
-  R3DeferPerComponentDependency,
   R3DeferResolverFunctionMetadata,
   R3DirectiveMetadata,
   R3HostMetadata,
   R3TemplateDependency,
 } from './api';
+import {getTemplateSourceLocationsEnabled} from './config';
 import {createContentQueriesFunction, createViewQueriesFunction} from './query_generation';
 import {makeBindingParser} from './template';
 import {asLiteral, conditionallyCreateDirectiveBindingLiteral, DefinitionMap} from './util';
@@ -235,6 +234,7 @@ export function compileComponentFromMetadata(
     meta.defer,
     allDeferrableDepsFn,
     meta.relativeTemplatePath,
+    getTemplateSourceLocationsEnabled(),
   );
 
   // Then the IR is transformed to prepare it for cod egeneration.

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -234,6 +234,7 @@ export function compileComponentFromMetadata(
     meta.i18nUseExternalIds,
     meta.defer,
     allDeferrableDepsFn,
+    meta.relativeTemplatePath,
   );
 
   // Then the IR is transformed to prepare it for cod egeneration.

--- a/packages/compiler/src/render3/view/config.ts
+++ b/packages/compiler/src/render3/view/config.ts
@@ -1,0 +1,28 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+/**
+ * Whether to produce instructions that will attach the source location to each DOM node.
+ *
+ * !!!Important!!! at the time of writing this flag isn't exposed externally, but internal debug
+ * tools enable it via a local change. Any modifications to this flag need to update the
+ * internal tooling as well.
+ */
+let ENABLE_TEMPLATE_SOURCE_LOCATIONS = false;
+
+/**
+ * Utility function to enable source locations. Intended to be used **only** inside unit tests.
+ */
+export function setEnableTemplateSourceLocations(value: boolean): void {
+  ENABLE_TEMPLATE_SOURCE_LOCATIONS = value;
+}
+
+/** Gets whether template source locations are enabled. */
+export function getTemplateSourceLocationsEnabled(): boolean {
+  return ENABLE_TEMPLATE_SOURCE_LOCATIONS;
+}

--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -264,6 +264,11 @@ export enum OpKind {
    * A creation op that corresponds to i18n attributes on an element.
    */
   I18nAttributes,
+
+  /**
+   * Creation op that attaches the location at which an element was defined in a template to it.
+   */
+  SourceLocation,
 }
 
 /**

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -1219,6 +1219,7 @@ export function transformExpressionsInOp(
     case OpKind.I18nAttributes:
     case OpKind.IcuPlaceholder:
     case OpKind.DeclareLet:
+    case OpKind.SourceLocation:
       // These operations contain no expressions.
       break;
     default:

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -70,7 +70,8 @@ export type CreateOp =
   | IcuPlaceholderOp
   | I18nContextOp
   | I18nAttributesOp
-  | DeclareLetOp;
+  | DeclareLetOp
+  | SourceLocationOp;
 
 /**
  * An operation representing the creation of an element or container.
@@ -1550,6 +1551,36 @@ export function createI18nAttributesOp(
     i18nAttributesConfig: null,
     ...NEW_OP,
     ...TRAIT_CONSUMES_SLOT,
+  };
+}
+
+/** Describes a location at which an element is defined within a template. */
+export interface ElementSourceLocation {
+  targetSlot: SlotHandle;
+  offset: number;
+  line: number;
+  column: number;
+}
+
+/**
+ * Op that attaches the location at which each element is defined within the source template.
+ */
+export interface SourceLocationOp extends Op<CreateOp> {
+  kind: OpKind.SourceLocation;
+  templatePath: string;
+  locations: ElementSourceLocation[];
+}
+
+/** Create a `SourceLocationOp`. */
+export function createSourceLocationOp(
+  templatePath: string,
+  locations: ElementSourceLocation[],
+): SourceLocationOp {
+  return {
+    kind: OpKind.SourceLocation,
+    templatePath,
+    locations,
+    ...NEW_OP,
   };
 }
 

--- a/packages/compiler/src/template/pipeline/src/compilation.ts
+++ b/packages/compiler/src/template/pipeline/src/compilation.ts
@@ -73,6 +73,7 @@ export class ComponentCompilationJob extends CompilationJob {
     readonly i18nUseExternalIds: boolean,
     readonly deferMeta: R3ComponentDeferMetadata,
     readonly allDeferrableDepsFn: o.ReadVarExpr | null,
+    readonly relativeTemplatePath: string | null,
   ) {
     super(componentName, pool, compatibility);
     this.root = new ViewCompilationUnit(this, this.allocateXrefId(), null);

--- a/packages/compiler/src/template/pipeline/src/compilation.ts
+++ b/packages/compiler/src/template/pipeline/src/compilation.ts
@@ -74,6 +74,7 @@ export class ComponentCompilationJob extends CompilationJob {
     readonly deferMeta: R3ComponentDeferMetadata,
     readonly allDeferrableDepsFn: o.ReadVarExpr | null,
     readonly relativeTemplatePath: string | null,
+    readonly enableDebugLocations: boolean,
   ) {
     super(componentName, pool, compatibility);
     this.root = new ViewCompilationUnit(this, this.allocateXrefId(), null);

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -83,6 +83,7 @@ import {wrapI18nIcus} from './phases/wrap_icus';
 import {optimizeStoreLet} from './phases/store_let_optimization';
 import {removeIllegalLetReferences} from './phases/remove_illegal_let_references';
 import {generateLocalLetReferences} from './phases/generate_local_let_references';
+import {attachSourceLocations} from './phases/attach_source_locations';
 
 type Phase =
   | {
@@ -159,6 +160,7 @@ const phases: Phase[] = [
   {kind: Kind.Tmpl, fn: mergeNextContextExpressions},
   {kind: Kind.Tmpl, fn: generateNgContainerOps},
   {kind: Kind.Tmpl, fn: collapseEmptyInstructions},
+  {kind: Kind.Tmpl, fn: attachSourceLocations},
   {kind: Kind.Tmpl, fn: disableBindings},
   {kind: Kind.Both, fn: extractPureFunctions},
   {kind: Kind.Both, fn: reify},

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -58,6 +58,7 @@ export function ingestComponent(
   i18nUseExternalIds: boolean,
   deferMeta: R3ComponentDeferMetadata,
   allDeferrableDepsFn: o.ReadVarExpr | null,
+  relativeTemplatePath: string | null,
 ): ComponentCompilationJob {
   const job = new ComponentCompilationJob(
     componentName,
@@ -67,6 +68,7 @@ export function ingestComponent(
     i18nUseExternalIds,
     deferMeta,
     allDeferrableDepsFn,
+    relativeTemplatePath,
   );
   ingestNodes(job.root, template);
   return job;

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -59,6 +59,7 @@ export function ingestComponent(
   deferMeta: R3ComponentDeferMetadata,
   allDeferrableDepsFn: o.ReadVarExpr | null,
   relativeTemplatePath: string | null,
+  enableDebugLocations: boolean,
 ): ComponentCompilationJob {
   const job = new ComponentCompilationJob(
     componentName,
@@ -69,6 +70,7 @@ export function ingestComponent(
     deferMeta,
     allDeferrableDepsFn,
     relativeTemplatePath,
+    enableDebugLocations,
   );
   ingestNodes(job.root, template);
   return job;

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -723,6 +723,13 @@ export function pureFunction(
   );
 }
 
+export function attachSourceLocation(
+  templatePath: string,
+  locations: o.LiteralArrayExpr,
+): ir.CreateOp {
+  return call(Identifiers.attachSourceLocations, [o.literal(templatePath), locations], null);
+}
+
 /**
  * Collates the string an expression arguments for an interpolation instruction.
  */

--- a/packages/compiler/src/template/pipeline/src/phases/attach_source_locations.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/attach_source_locations.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import * as ir from '../../ir';
+import type {ComponentCompilationJob} from '../compilation';
+
+/**
+ * Locates all of the elements defined in a creation block and outputs an op
+ * that will expose their definition location in the DOM.
+ */
+export function attachSourceLocations(job: ComponentCompilationJob): void {
+  if (!job.enableDebugLocations || job.relativeTemplatePath === null) {
+    return;
+  }
+
+  for (const unit of job.units) {
+    const locations: ir.ElementSourceLocation[] = [];
+
+    for (const op of unit.create) {
+      if (op.kind === ir.OpKind.ElementStart || op.kind === ir.OpKind.Element) {
+        const start = op.startSourceSpan.start;
+        locations.push({
+          targetSlot: op.handle,
+          offset: start.offset,
+          line: start.line,
+          column: start.col,
+        });
+      }
+    }
+
+    if (locations.length > 0) {
+      unit.create.push(ir.createSourceLocationOp(job.relativeTemplatePath, locations));
+    }
+  }
+}

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -402,6 +402,23 @@ function reifyCreateOperations(unit: CompilationUnit, ops: ir.OpList<ir.CreateOp
           ),
         );
         break;
+      case ir.OpKind.SourceLocation:
+        const locationsLiteral = o.literalArr(
+          op.locations.map(({targetSlot, offset, line, column}) => {
+            if (targetSlot.slot === null) {
+              throw new Error('No slot was assigned for source location');
+            }
+            return o.literalArr([
+              o.literal(targetSlot.slot),
+              o.literal(offset),
+              o.literal(line),
+              o.literal(column),
+            ]);
+          }),
+        );
+
+        ir.OpList.replace(op, ng.attachSourceLocation(op.templatePath, locationsLiteral));
+        break;
       case ir.OpKind.Statement:
         // Pass statement operations directly through.
         break;

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -249,6 +249,7 @@ export {
   ɵɵstoreLet,
   ɵɵreadContextLet,
   ɵɵreplaceMetadata,
+  ɵɵattachSourceLocations,
 } from './render3/index';
 export {CONTAINER_HEADER_OFFSET as ɵCONTAINER_HEADER_OFFSET} from './render3/interfaces/container';
 export {LContext as ɵLContext} from './render3/interfaces/context';

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -179,6 +179,7 @@ export {
   ɵɵdeclareLet,
   ɵɵstoreLet,
   ɵɵreadContextLet,
+  ɵɵattachSourceLocations,
 } from './instructions/all';
 export {
   ɵɵdeferEnableTimerScheduling,

--- a/packages/core/src/render3/instructions/all.ts
+++ b/packages/core/src/render3/instructions/all.ts
@@ -63,3 +63,4 @@ export * from './text';
 export * from './text_interpolation';
 export * from './two_way';
 export * from './let_declaration';
+export * from './attach_source_locations';

--- a/packages/core/src/render3/instructions/attach_source_locations.ts
+++ b/packages/core/src/render3/instructions/attach_source_locations.ts
@@ -1,0 +1,47 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {TNodeType} from '../interfaces/node';
+import {RElement} from '../interfaces/renderer_dom';
+import {HEADER_OFFSET, RENDERER} from '../interfaces/view';
+import {assertTNodeType} from '../node_assert';
+import {getLView, getTView} from '../state';
+import {getNativeByIndex, getTNode} from '../util/view_utils';
+
+/**
+ * Sets the location within the source template at which
+ * each element in the current view was defined.
+ *
+ * @param index Index at which the DOM node was created.
+ * @param templatePath Path to the template at which the node was defined.
+ * @param locations Element locations to which to attach the source location.
+ *
+ * @codeGenApi
+ */
+export function ɵɵattachSourceLocations(
+  templatePath: string,
+  locations: [index: number, offset: number, line: number, column: number][],
+) {
+  const tView = getTView();
+  const lView = getLView();
+  const renderer = lView[RENDERER];
+  const attributeName = 'data-ng-source-location';
+
+  for (const [index, offset, line, column] of locations) {
+    const tNode = getTNode(tView, index + HEADER_OFFSET);
+    // The compiler shouldn't generate the instruction for non-element nodes, but assert just in case.
+    ngDevMode && assertTNodeType(tNode, TNodeType.Element);
+    const node = getNativeByIndex(index + HEADER_OFFSET, lView) as RElement;
+
+    // Set the attribute directly in the DOM so it doesn't participate in directive matching.
+    if (!node.hasAttribute(attributeName)) {
+      const attributeValue = `${templatePath}@o:${offset},l:${line},c:${column}`;
+      renderer.setAttribute(node, attributeName, attributeValue);
+    }
+  }
+}

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -198,6 +198,7 @@ export const angularCoreEnv: {[name: string]: unknown} = (() => ({
   'ɵɵdeclareLet': r3.ɵɵdeclareLet,
   'ɵɵstoreLet': r3.ɵɵstoreLet,
   'ɵɵreadContextLet': r3.ɵɵreadContextLet,
+  'ɵɵattachSourceLocations': r3.ɵɵattachSourceLocations,
 
   'ɵɵsanitizeHtml': sanitization.ɵɵsanitizeHtml,
   'ɵɵsanitizeStyle': sanitization.ɵɵsanitizeStyle,

--- a/packages/core/test/acceptance/attach_source_locations_spec.ts
+++ b/packages/core/test/acceptance/attach_source_locations_spec.ts
@@ -1,0 +1,156 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {TestBed} from '@angular/core/testing';
+import {
+  RenderFlags,
+  ɵɵadvance,
+  ɵɵattachSourceLocations,
+  ɵɵconditional,
+  ɵɵdefineComponent,
+  ɵɵelement,
+  ɵɵelementEnd,
+  ɵɵelementStart,
+  ɵɵtemplate,
+  ɵɵtext,
+} from '@angular/core/src/render3';
+import {Directive} from '@angular/core';
+
+// The `ɵɵattachSourceLocation` calls are produced only in
+// AoT so these tests need to "be compiled manually".
+describe('attaching source locations', () => {
+  it('should attach the source location to DOM nodes', () => {
+    // @Component({
+    //   selector: 'comp',
+    //   template: \`
+    //     <div>
+    //       <span>
+    //         @if (true) {
+    //           <strong>Hello</strong>
+    //         }
+    //       </span>
+    //     </div>
+    //   \`,
+    // })
+    // class Comp {}
+    function conditionalTemplate(rf: number) {
+      if (rf & RenderFlags.Create) {
+        ɵɵelementStart(0, 'strong');
+        ɵɵtext(1, 'Hello');
+        ɵɵelementEnd();
+        ɵɵattachSourceLocations('test.ts', [[0, 240, 9, 22]]);
+      }
+    }
+
+    class Comp {
+      static ɵfac = () => new Comp();
+      static ɵcmp = ɵɵdefineComponent({
+        type: Comp,
+        selectors: [['comp']],
+        decls: 3,
+        vars: 1,
+        template: (rf) => {
+          if (rf & RenderFlags.Create) {
+            ɵɵelementStart(0, 'div')(1, 'span');
+            ɵɵtemplate(2, conditionalTemplate, 2, 0, 'strong');
+            ɵɵelementEnd()();
+            ɵɵattachSourceLocations('test.ts', [
+              [0, 154, 6, 16],
+              [1, 178, 7, 18],
+            ]);
+          }
+          if (rf & 2) {
+            ɵɵadvance(2);
+            ɵɵconditional(true ? 2 : -1);
+          }
+        },
+        encapsulation: 2,
+      });
+    }
+
+    const fixture = TestBed.createComponent(Comp);
+    fixture.detectChanges();
+    const content = fixture.nativeElement.innerHTML;
+    expect(content).toContain('<div data-ng-source-location="test.ts@o:154,l:6,c:16">');
+    expect(content).toContain('<span data-ng-source-location="test.ts@o:178,l:7,c:18">');
+    expect(content).toContain('<strong data-ng-source-location="test.ts@o:240,l:9,c:22">');
+  });
+
+  it('should not match directives on the data-ng-source-location attribute', () => {
+    let isUsed = false;
+
+    @Directive({selector: '[data-ng-source-location]'})
+    class Dir {
+      constructor() {
+        isUsed = true;
+      }
+    }
+
+    // @Component({
+    //   selector: 'comp',
+    //   template: '<div></div>',
+    //   imports: [Dir],
+    // })
+    // class Comp {}
+    class Comp {
+      static ɵfac = () => new Comp();
+      static ɵcmp = ɵɵdefineComponent({
+        type: Comp,
+        selectors: [['comp']],
+        dependencies: [Dir],
+        decls: 1,
+        vars: 0,
+        template: (rf) => {
+          if (rf & 1) {
+            ɵɵelement(0, 'div');
+            ɵɵattachSourceLocations('test.ts', [[0, 231, 8, 23]]);
+          }
+        },
+        encapsulation: 2,
+      });
+    }
+
+    const fixture = TestBed.createComponent(Comp);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.innerHTML).toContain(
+      '<div data-ng-source-location="test.ts@o:231,l:8,c:23">',
+    );
+    expect(isUsed).toBe(false);
+  });
+
+  it('should not overwrite a pre-existing data-ng-source-location attribute', () => {
+    // @Component({
+    //   selector: 'comp',
+    //   template: '<div data-ng-source-location="pre-existing"></div>',
+    // })
+    // class Comp {}
+    class Comp {
+      static ɵfac = () => new Comp();
+      static ɵcmp = ɵɵdefineComponent({
+        type: Comp,
+        selectors: [['comp']],
+        decls: 1,
+        vars: 0,
+        consts: [['data-ng-source-location', 'pre-existing']],
+        template: (rf) => {
+          if (rf & 1) {
+            ɵɵelement(0, 'div', 0);
+            ɵɵattachSourceLocations('test.ts', [[0, 140, 5, 23]]);
+          }
+        },
+        encapsulation: 2,
+      });
+    }
+
+    const fixture = TestBed.createComponent(Comp);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.innerHTML).toContain(
+      '<div data-ng-source-location="pre-existing">',
+    );
+  });
+});

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -1161,6 +1161,9 @@
     "name": "init_async_stack_tagging"
   },
   {
+    "name": "init_attach_source_locations"
+  },
+  {
     "name": "init_attribute"
   },
   {


### PR DESCRIPTION
Adds some logic to include the original template location on each DOM node. Currently there's no way to enable this, apart from making a local change to the compiler. The main usage is aimed at internal tools, but we may consider exposing this in dev mode in the future.

Fixes #42530.