### PR TITLE
docs(fix): fix a typo in an example in Templates page

### DIFF
--- a/adev/src/content/introduction/essentials/templates.md
+++ b/adev/src/content/introduction/essentials/templates.md
@@ -23,7 +23,7 @@ export class TodoListItem {
 When Angular renders the component, you see:
 
 ```html
-<h1>Profile file pro_programmer_123</h1>
+<h1>Profile for pro_programmer_123</h1>
 ```
 
 Angular automatically keeps the binding up-to-date when the value of the signal changes. Building on
@@ -36,7 +36,7 @@ this.userName.set('cool_coder_789');
 The rendered page updates to reflect the new value:
 
 ```html
-<h1>Profile file cool_coder_789</h1>
+<h1>Profile for cool_coder_789</h1>
 ```
 
 ## Setting dynamic properties and attributes


### PR DESCRIPTION
docs(fix): fix a typo in an example in Templates page of Docs

Fix a typo in an example in Templates page in Essentials section of Angular Docs. Instead of "Profile file", the correct would be "Profile for", according to the example's template.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Fix a typo in an example in Templates page in Essentials section of Angular Docs. Instead of "Profile file", the correct would be "Profile for", according to the example's template.

Issue Number: N/A


## What is the new behavior?

N/A

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
