### PR TITLE
docs(docs-infra): handle the long API names in the API cards

### DIFF
--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
@@ -304,6 +304,9 @@
         font-size: 1.25rem;
         letter-spacing: -0.025rem;
         margin: 0;
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
 
       code,


### PR DESCRIPTION
I've added elipsis to address any overflow occurs in the card's header.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
![image](https://github.com/user-attachments/assets/94ec5d05-1542-4b36-b094-527d779c059f)


## What is the new behavior?
![image](https://github.com/user-attachments/assets/fcd8405c-5c0f-4c75-a02d-f83c6771a851)




