### PR TITLE
refactor(compiler): remove allowInvalidAssignmentEvents flag

### DIFF
--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -130,14 +130,6 @@ export interface ParseTemplateOptions {
 
   /** Whether the `@let` syntax is enabled. */
   enableLetSyntax?: boolean;
-
-  // TODO(crisbeto): delete this option when the migration is deleted.
-  /**
-   * Whether the parser should allow invalid two-way bindings.
-   *
-   * This option is only present to support an automated migration away from the invalid syntax.
-   */
-  allowInvalidAssignmentEvents?: boolean;
 }
 
 /**
@@ -152,13 +144,8 @@ export function parseTemplate(
   templateUrl: string,
   options: ParseTemplateOptions = {},
 ): ParsedTemplate {
-  const {
-    interpolationConfig,
-    preserveWhitespaces,
-    enableI18nLegacyMessageIdFormat,
-    allowInvalidAssignmentEvents,
-  } = options;
-  const bindingParser = makeBindingParser(interpolationConfig, allowInvalidAssignmentEvents);
+  const {interpolationConfig, preserveWhitespaces, enableI18nLegacyMessageIdFormat} = options;
+  const bindingParser = makeBindingParser(interpolationConfig);
   const htmlParser = new HtmlParser();
   const parseResult = htmlParser.parse(template, templateUrl, {
     leadingTriviaChars: LEADING_TRIVIA_CHARS,
@@ -302,15 +289,8 @@ const elementRegistry = new DomElementSchemaRegistry();
  */
 export function makeBindingParser(
   interpolationConfig: InterpolationConfig = DEFAULT_INTERPOLATION_CONFIG,
-  allowInvalidAssignmentEvents = false,
 ): BindingParser {
-  return new BindingParser(
-    new Parser(new Lexer()),
-    interpolationConfig,
-    elementRegistry,
-    [],
-    allowInvalidAssignmentEvents,
-  );
+  return new BindingParser(new Parser(new Lexer()), interpolationConfig, elementRegistry, []);
 }
 
 /**

--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -64,7 +64,6 @@ export class BindingParser {
     private _interpolationConfig: InterpolationConfig,
     private _schemaRegistry: ElementSchemaRegistry,
     public errors: ParseError[],
-    private _allowInvalidAssignmentEvents = false,
   ) {}
 
   get interpolationConfig(): InterpolationConfig {
@@ -816,20 +815,7 @@ export class BindingParser {
       return true;
     }
 
-    // TODO(crisbeto): this logic is only here to support the automated migration away
-    // from invalid bindings. It should be removed once the migration is deleted.
-    if (!this._allowInvalidAssignmentEvents) {
-      return false;
-    }
-
-    if (ast instanceof Binary) {
-      return (
-        (ast.operation === '&&' || ast.operation === '||' || ast.operation === '??') &&
-        (ast.right instanceof PropertyRead || ast.right instanceof KeyedRead)
-      );
-    }
-
-    return ast instanceof Conditional || ast instanceof PrefixNot;
+    return false;
   }
 }
 


### PR DESCRIPTION
Deletes the `allowInvalidAssignmentEvents` which was added to facilitate a migration away from invalid two-way bindings. Since the migration doesn't exist anymore, we don't need the flag either.