### PR TITLE
feat(forms): add phoneNumber validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,8 @@
     "webtreemap": "^2.0.1",
     "ws": "^8.15.0",
     "xhr2": "0.2.1",
-    "yargs": "^17.2.1"
+    "yargs": "^17.2.1",
+    "libphonenumber-js": "~1.11.14"
   },
   "// 2": "devDependencies are not used under Bazel. Many can be removed after test.sh is deleted.",
   "devDependencies": {

--- a/packages/forms/src/model/phone_number.ts
+++ b/packages/forms/src/model/phone_number.ts
@@ -1,0 +1,32 @@
+/* eslint-disable @typescript-eslint/typedef */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const PhoneNumberType = {
+  MOBILE: 'MOBILE',
+  FIXED_LINE: 'FIXED_LINE',
+  PREMIUM_RATE: 'PREMIUM_RATE',
+  TOLL_FREE: 'TOLL_FREE',
+  SHARED_COST: 'SHARED_COST',
+  VOIP: 'VOIP',
+  PERSONAL_NUMBER: 'PERSONAL_NUMBER',
+  PAGER: 'PAGER',
+  UAN: 'UAN',
+  VOICEMAIL: 'VOICEMAIL',
+} as const;
+export type PhoneNumberType =
+  (typeof PhoneNumberType)[keyof typeof PhoneNumberType];
+/*
+  types of all possible return values of the .getType() in the phone number libphonenumber-js/max library
+*/
+
+export const allPhoneNumberTypes: Array<PhoneNumberType> = [
+  'MOBILE',
+  'FIXED_LINE',
+  'PREMIUM_RATE',
+  'TOLL_FREE',
+  'SHARED_COST',
+  'VOIP',
+  'PERSONAL_NUMBER',
+  'PAGER',
+  'UAN',
+  'VOICEMAIL',
+];

--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -853,6 +853,7 @@ export function isPhoneNumberValidator(
           }
         : null;
     } catch (error) {
+      // if the `error` exists always return an object of an invalid number 
       return {
         phoneNumber: {
           invalidPhoneNumber: true,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
there is no way for a formControl to validate a phoneNumber and check the number type being 'MOBILE' , 'FIXED_LINE' etc...

Issue Number: N/A


## What is the new behavior?
added the follow validator for use in formControls
`const control = new FormControl({number: '1234567890', countryCode: 'US'}, Validators.phoneNumber([PhoneNumberType.MOBILE, PhoneNumberType.FIXED_LINE]));`


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
it only needs to download `libphonenumber-js` library as a dependency so that the new validator works

## Other information
The new feature is a new optional Validator that has it's own types file and new functions so it shouldn't affect any existing formControl behavior.