### PR TITLE
docs(docs-infra): read jsdoctags from function overloads

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/manifest/test/manifest.spec.ts
+++ b/adev/shared-docs/pipeline/api-gen/manifest/test/manifest.spec.ts
@@ -1,5 +1,5 @@
 // @ts-ignore This compiles fine, but Webstorm doesn't like the ESM import in a CJS context.
-import {DocEntry, EntryType, JsDocTagEntry} from '@angular/compiler-cli';
+import {DocEntry, EntryType, FunctionEntry, JsDocTagEntry} from '@angular/compiler-cli';
 import {generateManifest, Manifest} from '../generate_manifest';
 
 describe('api manifest generation', () => {
@@ -178,44 +178,40 @@ describe('api manifest generation', () => {
     ]);
   });
 
-  it('should deduplicate function overloads', () => {
-    const manifest = generateManifest([
-      {
-        moduleName: '@angular/core',
-        entries: [
-          entry({name: 'save', entryType: EntryType.Function}),
-          entry({name: 'save', entryType: EntryType.Function}),
-        ],
-        normalizedModuleName: 'angular_core',
-        moduleLabel: 'core',
-      },
-    ]);
-
-    expect(manifest).toEqual([
-      {
-        moduleName: '@angular/core',
-        moduleLabel: 'core',
-        normalizedModuleName: 'angular_core',
-        entries: [
-          {
-            name: 'save',
-            type: EntryType.Function,
-            isDeprecated: false,
-            isDeveloperPreview: false,
-            isExperimental: false,
-          },
-        ],
-      },
-    ]);
-  });
-
   it('should not mark a function as deprecated if only one overload is deprecated', () => {
     const manifest = generateManifest([
       {
         moduleName: '@angular/core',
         entries: [
-          entry({name: 'save', entryType: EntryType.Function}),
-          entry({name: 'save', entryType: EntryType.Function, jsdocTags: jsdocTags('deprecated')}),
+          functionEntry({
+            name: 'save',
+            entryType: EntryType.Function,
+            jsdocTags: [],
+            signatures: [
+              {
+                name: 'save',
+                returnType: 'void',
+                jsdocTags: [],
+                description: '',
+                entryType: EntryType.Function,
+                params: [],
+                generics: [],
+                isNewType: false,
+                rawComment: '',
+              },
+              {
+                name: 'save',
+                returnType: 'void',
+                jsdocTags: jsdocTags('deprecated'),
+                description: '',
+                entryType: EntryType.Function,
+                params: [],
+                generics: [],
+                isNewType: false,
+                rawComment: '',
+              },
+            ],
+          }),
         ],
         normalizedModuleName: 'angular_core',
         moduleLabel: 'core',
@@ -245,8 +241,35 @@ describe('api manifest generation', () => {
       {
         moduleName: '@angular/core',
         entries: [
-          entry({name: 'save', entryType: EntryType.Function, jsdocTags: jsdocTags('deprecated')}),
-          entry({name: 'save', entryType: EntryType.Function, jsdocTags: jsdocTags('deprecated')}),
+          functionEntry({
+            name: 'save',
+            entryType: EntryType.Function,
+            jsdocTags: [],
+            signatures: [
+              {
+                name: 'save',
+                returnType: 'void',
+                jsdocTags: jsdocTags('deprecated'),
+                description: '',
+                entryType: EntryType.Function,
+                params: [],
+                generics: [],
+                isNewType: false,
+                rawComment: '',
+              },
+              {
+                name: 'save',
+                returnType: 'void',
+                jsdocTags: jsdocTags('deprecated'),
+                description: '',
+                entryType: EntryType.Function,
+                params: [],
+                generics: [],
+                isNewType: false,
+                rawComment: '',
+              },
+            ],
+          }),
         ],
         normalizedModuleName: 'angular_core',
         moduleLabel: 'core',
@@ -374,6 +397,15 @@ function entry(patch: Partial<DocEntry>): DocEntry {
     rawComment: '',
     ...patch,
   };
+}
+
+function functionEntry(patch: Partial<FunctionEntry>): FunctionEntry {
+  return entry({
+    entryType: EntryType.Function,
+    implementation: [],
+    signatures: [],
+    ...patch,
+  } as FunctionEntry) as FunctionEntry;
 }
 
 /** Creates a fake jsdoc tag entry list that contains a tag with the given name */

--- a/adev/shared-docs/pipeline/api-gen/rendering/test/fake-entries.json
+++ b/adev/shared-docs/pipeline/api-gen/rendering/test/fake-entries.json
@@ -669,6 +669,91 @@
         "startLine": 103,
         "endLine": 125
       }
+    },
+    {
+      "name": "linkedSignal",
+      "signatures": [
+        {
+          "name": "linkedSignal",
+          "entryType": "function",
+          "description": "Creates a writable signals whose value is initialized and reset by the linked, reactive computation.",
+          "generics": [{"name": "D"}],
+          "isNewType": false,
+          "jsdocTags": [{"name": "developerPreview", "comment": ""}],
+          "params": [
+            {
+              "name": "computation",
+              "description": "",
+              "type": "() => D",
+              "isOptional": false,
+              "isRestParam": false
+            },
+            {
+              "name": "options",
+              "description": "",
+              "type": "{ equal?: ValueEqualityFn<NoInfer<D>> | undefined; } | undefined",
+              "isOptional": true,
+              "isRestParam": false
+            }
+          ],
+          "rawComment": "/**\n * Creates a writable signals whose value is initialized and reset by the linked, reactive computation.\n *\n * @developerPreview\n */",
+          "returnType": "WritableSignal<D>"
+        },
+        {
+          "name": "linkedSignal",
+          "entryType": "function",
+          "description": "Creates a writable signals whose value is initialized and reset by the linked, reactive computation.\nThis is an advanced API form where the computation has access to the previous value of the signal and the computation result.",
+          "generics": [{"name": "S"}, {"name": "D"}],
+          "isNewType": false,
+          "jsdocTags": [{"name": "developerPreview", "comment": ""}],
+          "params": [
+            {
+              "name": "options",
+              "description": "",
+              "type": "{ source: () => S; computation: (source: NoInfer<S>, previous?: { source: NoInfer<S>; value: NoInfer<D>; } | undefined) => D; equal?: ValueEqualityFn<NoInfer<D>> | undefined; }",
+              "isOptional": false,
+              "isRestParam": false
+            }
+          ],
+          "rawComment": "/**\n * Creates a writable signals whose value is initialized and reset by the linked, reactive computation.\n * This is an advanced API form where the computation has access to the previous value of the signal and the computation result.\n *\n * @developerPreview\n */",
+          "returnType": "WritableSignal<D>"
+        }
+      ],
+      "implementation": {
+        "params": [
+          {
+            "name": "optionsOrComputation",
+            "description": "",
+            "type": "{ source: () => S; computation: ComputationFn<S, D>; equal?: ValueEqualityFn<D> | undefined; } | (() => D)",
+            "isOptional": false,
+            "isRestParam": false
+          },
+          {
+            "name": "options",
+            "description": "",
+            "type": "{ equal?: ValueEqualityFn<D> | undefined; } | undefined",
+            "isOptional": true,
+            "isRestParam": false
+          }
+        ],
+        "isNewType": false,
+        "returnType": "WritableSignal<D>",
+        "generics": [{"name": "S"}, {"name": "D"}],
+        "name": "linkedSignal",
+        "description": "",
+        "entryType": "function",
+        "jsdocTags": [],
+        "rawComment": ""
+      },
+      "entryType": "function",
+      "description": "",
+      "jsdocTags": [],
+      "rawComment": "",
+      "source": {
+        "filePath": "/packages/core/src/render3/reactivity/linked_signal.ts",
+        "startLine": 112,
+        "endLine": 115
+      }
     }
   ]
 }

--- a/adev/shared-docs/pipeline/api-gen/rendering/test/renderable.spec.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/test/renderable.spec.ts
@@ -1,0 +1,37 @@
+import {runfiles} from '@bazel/runfiles';
+import {readFile} from 'fs/promises';
+import {getRenderable} from '../processing';
+import {DocEntryRenderable} from '../entities/renderables';
+import {initHighlighter} from '../shiki/shiki';
+import {configureMarkedGlobally} from '../marked/configuration';
+
+// Note: The tests will probably break if the schema of the api extraction changes.
+// All entries in the fake-entries are extracted from Angular's api.
+// You can just generate them an copy/replace the items in the fake-entries file.
+
+describe('renderable', () => {
+  const entries = new Map<string, DocEntryRenderable>();
+
+  beforeAll(async () => {
+    await initHighlighter();
+    await configureMarkedGlobally();
+
+    const entryContent = await readFile(runfiles.resolvePackageRelative('fake-entries.json'), {
+      encoding: 'utf-8',
+    });
+    const entryJson = JSON.parse(entryContent) as any;
+    for (const entry of entryJson.entries) {
+      const renderableJson = getRenderable(entry, '@angular/fakeentry') as DocEntryRenderable;
+      entries.set(entry['name'], renderableJson);
+    }
+  });
+
+  it('should compute the flags correctly', () => {
+    // linkedSignal has the developerPreview tag on the overloads not on the main entry.
+    const linkedSignal = entries.get('linkedSignal');
+    expect(linkedSignal).toBeDefined();
+    expect(linkedSignal!.isDeprecated).toBe(false);
+    expect(linkedSignal!.isDeveloperPreview).toBe(true);
+    expect(linkedSignal!.isExperimental).toBe(false);
+  });
+});


### PR DESCRIPTION
Functions like `linkedSignal` have there `@developerPreview` tags on the overload signature. This commit adds the support for them.

fixes #58817
