### PR TITLE
fix(platform-server): remove peer dependency on animations

### DIFF
--- a/packages/platform-server/BUILD.bazel
+++ b/packages/platform-server/BUILD.bazel
@@ -15,7 +15,6 @@ ng_module(
     ),
     deps = [
         ":bundled_domino_lib",
-        "//packages/animations/browser",
         "//packages/common",
         "//packages/common/http",
         "//packages/compiler",

--- a/packages/platform-server/package.json
+++ b/packages/platform-server/package.json
@@ -8,7 +8,6 @@
     "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
   },
   "peerDependencies": {
-    "@angular/animations": "0.0.0-PLACEHOLDER",
     "@angular/common": "0.0.0-PLACEHOLDER",
     "@angular/compiler": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-PLACEHOLDER",


### PR DESCRIPTION
The `@angular/platform-server` package had a peer dependency on `@angular/animations` which wasn't being used anywhere.
