### PR TITLE
refactor(devtools): add missing imports

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.ts
@@ -35,6 +35,7 @@ import {IndexedNode} from './index-forest';
 import {MatIcon} from '@angular/material/icon';
 import {FilterComponent} from './filter/filter.component';
 import {MatTooltip} from '@angular/material/tooltip';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'ng-directive-forest',

--- a/devtools/projects/ng-devtools/src/lib/devtools_spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component} from '@angular/core';
+import {Component, signal} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {FrameManager} from './frame_manager';
 import {DevToolsComponent} from './devtools.component';


### PR DESCRIPTION
Some of the devtools commits were merged into v19
(probably shouldn't have) and were missing imports. This commit adds missing imports to re-enable tests.
