### PR TITLE
fix(compiler-cli): check event side of two-way bindings

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
@@ -120,6 +120,12 @@ export interface InternalOptions {
    * @internal
    */
   _enableHmr?: boolean;
+
+  // TODO(crisbeto): this is a temporary flag that will be removed in v20.
+  /**
+   * Whether to check the event side of two-way bindings.
+   */
+  _checkTwoWayBoundEvents?: boolean;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -1027,6 +1027,7 @@ export class NgCompiler {
     const strictTemplates = !!this.options.strictTemplates;
 
     const useInlineTypeConstructors = this.programDriver.supportsInlineOperations;
+    const checkTwoWayBoundEvents = this.options['_checkTwoWayBoundEvents'] ?? false;
 
     // Check whether the loaded version of `@angular/core` in the `ts.Program` supports unwrapping
     // writable signals for type-checking. If this check fails to find a suitable .d.ts file, fall
@@ -1080,6 +1081,7 @@ export class NgCompiler {
         unusedStandaloneImports:
           this.options.extendedDiagnostics?.defaultCategory || DiagnosticCategoryLabel.Warning,
         allowSignalsInTwoWayBindings,
+        checkTwoWayBoundEvents,
       };
     } else {
       typeCheckingConfig = {
@@ -1114,6 +1116,7 @@ export class NgCompiler {
         unusedStandaloneImports:
           this.options.extendedDiagnostics?.defaultCategory || DiagnosticCategoryLabel.Warning,
         allowSignalsInTwoWayBindings,
+        checkTwoWayBoundEvents,
       };
     }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
@@ -357,6 +357,11 @@ export interface TypeCheckingConfig {
    * Whether to descend into the bodies of control flow blocks (`@if`, `@switch` and `@for`).
    */
   checkControlFlowBodies: boolean;
+
+  /**
+   * Whether the event side of a two-way binding should be type checked.
+   */
+  checkTwoWayBoundEvents: boolean;
 }
 
 export type TemplateSourceMapping =

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -3094,7 +3094,8 @@ function tcbCreateEventHandler(
   const handler = tcbEventHandlerExpression(event.handler, tcb, scope);
   const statements: ts.Statement[] = [];
 
-  if (event.type === ParsedEventType.TwoWay) {
+  // TODO(crisbeto): remove the `checkTwoWayBoundEvents` check in v20.
+  if (event.type === ParsedEventType.TwoWay && tcb.env.config.checkTwoWayBoundEvents) {
     // If we're dealing with a two-way event, we create a variable initialized to the unwrapped
     // signal value of the expression and then we assign `$event` to it. Note that in most cases
     // this will already be covered by the corresponding input binding, however it allows us to

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -1407,7 +1407,7 @@ export class TcbDirectiveOutputsOp extends TcbOp {
 
       if (this.tcb.env.config.checkTypeOfOutputEvents && output.name.endsWith('Change')) {
         const inputName = output.name.slice(0, -6);
-        isSplitTwoWayBinding(inputName, output, this.node.inputs, this.tcb);
+        checkSplitTwoWayBinding(inputName, output, this.node.inputs, this.tcb);
       }
       // TODO(alxhub): consider supporting multiple fields with the same property name for outputs.
       const field = outputs.getByBindingPropertyName(output.name)![0].classPropertyName;
@@ -1481,7 +1481,7 @@ class TcbUnclaimedOutputsOp extends TcbOp {
 
       if (this.tcb.env.config.checkTypeOfOutputEvents && output.name.endsWith('Change')) {
         const inputName = output.name.slice(0, -6);
-        if (isSplitTwoWayBinding(inputName, output, this.element.inputs, this.tcb)) {
+        if (checkSplitTwoWayBinding(inputName, output, this.element.inputs, this.tcb)) {
           // Skip this event handler as the error was already handled.
           continue;
         }
@@ -3142,7 +3142,7 @@ function tcbEventHandlerExpression(ast: AST, tcb: Context, scope: Scope): ts.Exp
   return translator.translate(ast);
 }
 
-function isSplitTwoWayBinding(
+function checkSplitTwoWayBinding(
   inputName: string,
   output: TmplAstBoundEvent,
   inputs: TmplAstBoundAttribute[],

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/model_signal_diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/model_signal_diagnostics_spec.ts
@@ -381,7 +381,10 @@ runInEachFileSystem(() => {
           otherVal!: string;
         `,
         template: `<div dir [(gen)]="genVal" [(other)]="otherVal">`,
-        expected: [`TestComponent.html(1, 29): Type 'string' is not assignable to type 'boolean'.`],
+        expected: [
+          `TestComponent.html(1, 29): Type 'string' is not assignable to type 'boolean'.`,
+          `TestComponent.html(1, 27): Type 'boolean' is not assignable to type 'string'.`,
+        ],
       },
       {
         id: 'generic inference and two-way binding to directive, mix of zone input and model',
@@ -405,7 +408,10 @@ runInEachFileSystem(() => {
           genVal!: boolean;
           otherVal!: string;
         `,
-        expected: [`TestComponent.html(1, 12): Type 'boolean' is not assignable to type 'string'.`],
+        expected: [
+          `TestComponent.html(1, 12): Type 'boolean' is not assignable to type 'string'.`,
+          `TestComponent.html(1, 10): Type 'string' is not assignable to type 'boolean'.`,
+        ],
       },
       {
         id: 'generic inference and two-way binding to directive (with `extends boolean`), all model inputs',
@@ -426,7 +432,10 @@ runInEachFileSystem(() => {
           genVal!: boolean;
           otherVal!: string;
         `,
-        expected: [`TestComponent.html(1, 29): Type 'string' is not assignable to type 'boolean'.`],
+        expected: [
+          `TestComponent.html(1, 29): Type 'string' is not assignable to type 'boolean'.`,
+          `TestComponent.html(1, 27): Type 'boolean' is not assignable to type 'string'.`,
+        ],
       },
       {
         id: 'generic inference and two-way binding to directive (with `extends boolean`), mix of zone inputs and model',
@@ -450,7 +459,10 @@ runInEachFileSystem(() => {
           genVal!: boolean;
           otherVal!: string;
         `,
-        expected: [`TestComponent.html(1, 29): Type 'string' is not assignable to type 'boolean'.`],
+        expected: [
+          `TestComponent.html(1, 29): Type 'string' is not assignable to type 'boolean'.`,
+          `TestComponent.html(1, 27): Type 'boolean' is not assignable to type 'string'.`,
+        ],
       },
       {
         id: 'generic multi-inference and two-way bindings to directive, all model inputs',
@@ -583,7 +595,10 @@ runInEachFileSystem(() => {
         outputs: {valueChange: {type: 'ModelSignal<string>'}},
         template: `<div dir [(value)]="bla">`,
         component: `bla = true;`,
-        expected: [`TestComponent.html(1, 12): Type 'boolean' is not assignable to type 'string'.`],
+        expected: [
+          `TestComponent.html(1, 12): Type 'boolean' is not assignable to type 'string'.`,
+          `TestComponent.html(1, 10): Type 'string' is not assignable to type 'boolean'.`,
+        ],
       },
       {
         id: 'two-way binding to primitive, valid',
@@ -652,7 +667,10 @@ runInEachFileSystem(() => {
         outputs: {valueChange: {type: 'ModelSignal<boolean>'}},
         template: `<div dir [(value)]="val">`,
         component: `val!: WritableSignal<string>;`,
-        expected: [`TestComponent.html(1, 12): Type 'string' is not assignable to type 'boolean'.`],
+        expected: [
+          `TestComponent.html(1, 12): Type 'string' is not assignable to type 'boolean'.`,
+          `TestComponent.html(1, 10): Type 'boolean' is not assignable to type 'string'.`,
+        ],
       },
       {
         id: 'non-writable signal binding',
@@ -662,6 +680,7 @@ runInEachFileSystem(() => {
         component: `val!: InputSignal<boolean>;`,
         expected: [
           `TestComponent.html(1, 10): Type 'InputSignal<boolean>' is not assignable to type 'boolean'.`,
+          `TestComponent.html(1, 10): Type 'boolean' is not assignable to type 'InputSignal<boolean>'.`,
         ],
       },
       {
@@ -681,6 +700,9 @@ runInEachFileSystem(() => {
         expected: [
           jasmine.stringContaining(
             `TestComponent.html(1, 12): Type '(v: string) => number' is not assignable to type '(v: number) => number`,
+          ),
+          jasmine.stringContaining(
+            `TestComponent.html(1, 10): Type '(v: number) => number' is not assignable to type '(v: string) => number`,
           ),
         ],
       },

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/output_function_diagnostics.spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/output_function_diagnostics.spec.ts
@@ -31,7 +31,10 @@ runInEachFileSystem(() => {
         outputs: {'valueChange': {type: 'OutputEmitterRef<string>'}},
         template: `<div dir [(value)]="bla">`,
         component: `bla = true;`,
-        expected: [`TestComponent.html(1, 12): Type 'boolean' is not assignable to type 'string'.`],
+        expected: [
+          `TestComponent.html(1, 12): Type 'boolean' is not assignable to type 'string'.`,
+          `TestComponent.html(1, 10): Type 'string' is not assignable to type 'boolean'.`,
+        ],
       },
       {
         id: 'two way data binding, valid',

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -717,6 +717,8 @@ describe('type check blocks', () => {
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).toContain('var _t1 = null! as i0.TwoWay;');
     expect(block).toContain('_t1.input = i1.ɵunwrapWritableSignal((((this).value)));');
+    expect(block).toContain('var _t2 = i1.ɵunwrapWritableSignal(((this).value));');
+    expect(block).toContain('_t2 = $event;');
   });
 
   it('should handle a two-way binding to an input/output pair of a generic directive', () => {
@@ -739,6 +741,8 @@ describe('type check blocks', () => {
       'var _t1 = _ctor1({ "input": (i1.ɵunwrapWritableSignal(((this).value))) });',
     );
     expect(block).toContain('_t1.input = i1.ɵunwrapWritableSignal((((this).value)));');
+    expect(block).toContain('var _t2 = i1.ɵunwrapWritableSignal(((this).value));');
+    expect(block).toContain('_t2 = $event;');
   });
 
   it('should handle a two-way binding to a model()', () => {
@@ -765,6 +769,8 @@ describe('type check blocks', () => {
     expect(block).toContain(
       '_t1.input[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((this).value)));',
     );
+    expect(block).toContain('var _t2 = i1.ɵunwrapWritableSignal(((this).value));');
+    expect(block).toContain('_t2 = $event;');
   });
 
   it('should handle a two-way binding to an input with a transform', () => {
@@ -806,6 +812,8 @@ describe('type check blocks', () => {
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).toContain('var _t1 = null! as boolean | string;');
     expect(block).toContain('_t1 = i1.ɵunwrapWritableSignal((((this).value)));');
+    expect(block).toContain('var _t3 = i1.ɵunwrapWritableSignal(((this).value));');
+    expect(block).toContain('_t3 = $event;');
   });
 
   describe('experimental DOM checking via lib.dom.d.ts', () => {
@@ -1733,15 +1741,15 @@ describe('type check blocks', () => {
 
       const result = tcb(TEMPLATE);
 
-      expect(result).toContain(`if ((((this).expr)) === (0)) (this).zero();`);
+      expect(result).toContain(`if ((((this).expr)) === (0)) { (this).zero(); }`);
       expect(result).toContain(
-        `if (!((((this).expr)) === (0)) && (((this).expr)) === (1)) (this).one();`,
+        `if (!((((this).expr)) === (0)) && (((this).expr)) === (1)) { (this).one(); }`,
       );
       expect(result).toContain(
-        `if (!((((this).expr)) === (0)) && !((((this).expr)) === (1)) && (((this).expr)) === (2)) (this).two();`,
+        `if (!((((this).expr)) === (0)) && !((((this).expr)) === (1)) && (((this).expr)) === (2)) { (this).two(); }`,
       );
       expect(result).toContain(
-        `if (!((((this).expr)) === (0)) && !((((this).expr)) === (1)) && !((((this).expr)) === (2))) (this).otherwise();`,
+        `if (!((((this).expr)) === (0)) && !((((this).expr)) === (1)) && !((((this).expr)) === (2))) { (this).otherwise(); }`,
       );
     });
 
@@ -1830,9 +1838,11 @@ describe('type check blocks', () => {
 
       const result = tcb(TEMPLATE);
 
-      expect(result).toContain(`if (((this).expr) === 1) (this).one();`);
-      expect(result).toContain(`if (((this).expr) === 2) (this).two();`);
-      expect(result).toContain(`if (((this).expr) !== 1 && ((this).expr) !== 2) (this).default();`);
+      expect(result).toContain(`if (((this).expr) === 1) { (this).one(); }`);
+      expect(result).toContain(`if (((this).expr) === 2) { (this).two(); }`);
+      expect(result).toContain(
+        `if (((this).expr) !== 1 && ((this).expr) !== 2) { (this).default(); }`,
+      );
     });
 
     it('should generate a switch block inside a template', () => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -981,6 +981,7 @@ describe('type check blocks', () => {
       controlFlowPreventingContentProjection: 'warning',
       unusedStandaloneImports: 'warning',
       allowSignalsInTwoWayBindings: true,
+      checkTwoWayBoundEvents: true,
     };
 
     describe('config.applyTemplateContextGuards', () => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -284,6 +284,7 @@ export const ALL_ENABLED_CONFIG: Readonly<TypeCheckingConfig> = {
   controlFlowPreventingContentProjection: 'warning',
   unusedStandaloneImports: 'warning',
   allowSignalsInTwoWayBindings: true,
+  checkTwoWayBoundEvents: true,
 };
 
 // Remove 'ref' from TypeCheckableDirectiveMeta and add a 'selector' instead.
@@ -423,6 +424,7 @@ export function tcb(
     useInlineTypeConstructors: true,
     suggestionsForSuboptimalTypeInference: false,
     allowSignalsInTwoWayBindings: true,
+    checkTwoWayBoundEvents: true,
     ...config,
   };
   options = options || {

--- a/packages/compiler-cli/test/ngtsc/authoring_inputs_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/authoring_inputs_spec.ts
@@ -21,7 +21,7 @@ runInEachFileSystem(() => {
 
     beforeEach(() => {
       env = NgtscTestEnvironment.setup(testFiles);
-      env.tsconfig({strictTemplates: true});
+      env.tsconfig({strictTemplates: true, _checkTwoWayBoundEvents: true});
     });
 
     it('should handle a basic, primitive valued input', () => {

--- a/packages/compiler-cli/test/ngtsc/authoring_inputs_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/authoring_inputs_spec.ts
@@ -256,8 +256,9 @@ runInEachFileSystem(() => {
       );
 
       const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
+      expect(diags.length).toBe(2);
       expect(diags[0].messageText).toBe(`Type 'number' is not assignable to type 'string'.`);
+      expect(diags[1].messageText).toBe(`Type 'string' is not assignable to type 'number'.`);
     });
 
     describe('type checking', () => {

--- a/packages/compiler-cli/test/ngtsc/authoring_models_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/authoring_models_spec.ts
@@ -21,7 +21,7 @@ runInEachFileSystem(() => {
 
     beforeEach(() => {
       env = NgtscTestEnvironment.setup(testFiles);
-      env.tsconfig({strictTemplates: true});
+      env.tsconfig({strictTemplates: true, _checkTwoWayBoundEvents: true});
     });
 
     it('should declare an input/output pair for a field initialized to a model()', () => {

--- a/packages/compiler-cli/test/ngtsc/authoring_models_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/authoring_models_spec.ts
@@ -298,8 +298,9 @@ runInEachFileSystem(() => {
         );
 
         const diags = env.driveDiagnostics();
-        expect(diags.length).toBe(1);
+        expect(diags.length).toBe(2);
         expect(diags[0].messageText).toBe(`Type 'boolean' is not assignable to type 'number'.`);
+        expect(diags[1].messageText).toBe(`Type 'number' is not assignable to type 'boolean'.`);
       });
 
       it('should check a signal value bound to a model input via a two-way binding', () => {
@@ -328,8 +329,9 @@ runInEachFileSystem(() => {
         );
 
         const diags = env.driveDiagnostics();
-        expect(diags.length).toBe(1);
+        expect(diags.length).toBe(2);
         expect(diags[0].messageText).toBe(`Type 'boolean' is not assignable to type 'number'.`);
+        expect(diags[1].messageText).toBe(`Type 'number' is not assignable to type 'boolean'.`);
       });
 
       it('should check two-way binding of a signal to a decorator-based input/output pair', () => {
@@ -359,8 +361,9 @@ runInEachFileSystem(() => {
         );
 
         const diags = env.driveDiagnostics();
-        expect(diags.length).toBe(1);
+        expect(diags.length).toBe(2);
         expect(diags[0].messageText).toBe(`Type 'boolean' is not assignable to type 'number'.`);
+        expect(diags[1].messageText).toBe(`Type 'number' is not assignable to type 'boolean'.`);
       });
 
       it('should not allow a non-writable signal to be assigned to a model', () => {
@@ -389,9 +392,12 @@ runInEachFileSystem(() => {
         );
 
         const diags = env.driveDiagnostics();
-        expect(diags.length).toBe(1);
+        expect(diags.length).toBe(2);
         expect(diags[0].messageText).toBe(
           `Type 'InputSignal<number>' is not assignable to type 'number'.`,
+        );
+        expect(diags[1].messageText).toBe(
+          `Type 'number' is not assignable to type 'InputSignal<number>'.`,
         );
       });
 
@@ -513,10 +519,15 @@ runInEachFileSystem(() => {
         );
 
         const diags = env.driveDiagnostics();
-        expect(diags.length).toBe(1);
+        expect(diags.length).toBe(2);
         expect(diags[0].messageText).toEqual(
           jasmine.objectContaining({
             messageText: `Type '{ id: number; }' is not assignable to type '{ id: string; }'.`,
+          }),
+        );
+        expect(diags[1].messageText).toEqual(
+          jasmine.objectContaining({
+            messageText: `Type '{ id: string; }' is not assignable to type '{ id: number; }'.`,
           }),
         );
       });
@@ -547,10 +558,15 @@ runInEachFileSystem(() => {
         );
 
         const diags = env.driveDiagnostics();
-        expect(diags.length).toBe(1);
+        expect(diags.length).toBe(2);
         expect(diags[0].messageText).toEqual(
           jasmine.objectContaining({
             messageText: `Type '{ id: number; }' is not assignable to type '{ id: string; }'.`,
+          }),
+        );
+        expect(diags[1].messageText).toEqual(
+          jasmine.objectContaining({
+            messageText: `Type '{ id: string; }' is not assignable to type '{ id: number; }'.`,
           }),
         );
       });

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -568,10 +568,15 @@ runInEachFileSystem(() => {
       );
 
       const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
+      expect(diags.length).toBe(2);
       expect(diags[0].messageText).toEqual(
         jasmine.objectContaining({
           messageText: `Type '{ id: number; }' is not assignable to type '{ id: string; }'.`,
+        }),
+      );
+      expect(diags[1].messageText).toEqual(
+        jasmine.objectContaining({
+          messageText: `Type '{ id: string; }' is not assignable to type '{ id: number; }'.`,
         }),
       );
     });
@@ -603,7 +608,7 @@ runInEachFileSystem(() => {
               imports: [Dir],
             })
             export class FooCmp {
-              nullableType = null;
+              nullableType: string | null = null;
             }
           `,
       );
@@ -639,12 +644,45 @@ runInEachFileSystem(() => {
       );
 
       const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
+      expect(diags.length).toBe(2);
       expect(diags[0].messageText).toEqual(
         jasmine.objectContaining({
           messageText: `Type '(val: string) => number' is not assignable to type 'TestFn'.`,
         }),
       );
+      expect(diags[1].messageText).toEqual(
+        jasmine.objectContaining({
+          messageText: `Type 'TestFn' is not assignable to type '(val: string) => number'.`,
+        }),
+      );
+    });
+
+    it('should type check a two-way binding to input/output pair where the input has a wider type than the output', () => {
+      env.tsconfig({strictTemplates: true});
+      env.write(
+        'test.ts',
+        `
+          import {Component, Directive, Input, Output, EventEmitter} from '@angular/core';
+
+          @Directive({selector: '[dir]'})
+          export class Dir {
+            @Input() value: string | number;
+            @Output() valueChange = new EventEmitter<number>();
+          }
+
+          @Component({
+            template: '<div dir [(value)]="value"></div>',
+            imports: [Dir],
+          })
+          export class App {
+            value = 'hello';
+          }
+        `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(`Type 'number' is not assignable to type 'string'.`);
     });
 
     it('should check the fallback content of ng-content', () => {

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -544,7 +544,7 @@ runInEachFileSystem(() => {
     });
 
     it('should type check a two-way binding to a generic property', () => {
-      env.tsconfig({strictTemplates: true});
+      env.tsconfig({strictTemplates: true, _checkTwoWayBoundEvents: true});
       env.write(
         'test.ts',
         `
@@ -582,7 +582,7 @@ runInEachFileSystem(() => {
     });
 
     it('should use the setter type when assigning using a two-way binding to an input with different getter and setter types', () => {
-      env.tsconfig({strictTemplates: true});
+      env.tsconfig({strictTemplates: true, _checkTwoWayBoundEvents: true});
       env.write(
         'test.ts',
         `
@@ -618,7 +618,7 @@ runInEachFileSystem(() => {
     });
 
     it('should type check a two-way binding to a function value', () => {
-      env.tsconfig({strictTemplates: true});
+      env.tsconfig({strictTemplates: true, _checkTwoWayBoundEvents: true});
       env.write(
         'test.ts',
         `
@@ -658,7 +658,7 @@ runInEachFileSystem(() => {
     });
 
     it('should type check a two-way binding to input/output pair where the input has a wider type than the output', () => {
-      env.tsconfig({strictTemplates: true});
+      env.tsconfig({strictTemplates: true, _checkTwoWayBoundEvents: true});
       env.write(
         'test.ts',
         `
@@ -3007,7 +3007,7 @@ runInEachFileSystem(() => {
       });
 
       it('should type check a two-way binding to an input with a transform', () => {
-        env.tsconfig({strictTemplates: true});
+        env.tsconfig({strictTemplates: true, _checkTwoWayBoundEvents: true});
         env.write(
           'test.ts',
           `

--- a/packages/language-service/test/quick_info_spec.ts
+++ b/packages/language-service/test/quick_info_spec.ts
@@ -62,6 +62,7 @@ function quickInfoSkeleton(): {[fileName: string]: string} {
           setTitle(newTitle: string) {}
           trackByFn!: any;
           name!: any;
+          signalValue: string|undefined;
           someObject = {
             someProp: 'prop',
             someSignal: signal<number>(0),
@@ -267,7 +268,7 @@ describe('quick info', () => {
 
         it('should work for signal-based two-way binding providers', () => {
           expectQuickInfo({
-            templateOverride: `<test-comp signal-model [(signa¦lModel)]="title"></test-comp>`,
+            templateOverride: `<test-comp signal-model [(signa¦lModel)]="signalValue"></test-comp>`,
             expectedSpanText: 'signalModel',
             expectedDisplayString:
               '(property) SignalModel.signalModel: ModelSignal<string | undefined>',

--- a/packages/language-service/test/references_and_rename_spec.ts
+++ b/packages/language-service/test/references_and_rename_spec.ts
@@ -507,7 +507,7 @@ describe('find references and rename locations', () => {
             import {Directive} from '@angular/core';
 
             @Directive({
-              selector: '[dir]', 
+              selector: '[dir]',
               exportAs: 'myDir',
               standalone: false,
             })
@@ -734,7 +734,7 @@ describe('find references and rename locations', () => {
           constructor(readonly $implicit: T, readonly identifier: string) {}
         }
 
-        @Directive({ 
+        @Directive({
           selector: '[example]',
           standalone: false,
         })
@@ -751,7 +751,7 @@ describe('find references and rename locations', () => {
 
         @Component({
           template: '<div *example="state; let id = identifier">{{id}}</div>',
-          standalone: false,  
+          standalone: false,
         })
         export class AppCmp {
           state = {};
@@ -793,7 +793,7 @@ describe('find references and rename locations', () => {
 
             @Component({
               template: '<div *ngFor="let hero of heroes">{{hero.name}}</div>',
-              standalone: false,  
+              standalone: false,
             })
             export class AppCmp {
               heroes: Array<{name: string}> = [];
@@ -865,7 +865,7 @@ describe('find references and rename locations', () => {
     const prefixPipe = `
         import {Pipe, PipeTransform} from '@angular/core';
 
-        @Pipe({ 
+        @Pipe({
           name: 'prefixPipe',
           standalone: false,
         })
@@ -964,7 +964,7 @@ describe('find references and rename locations', () => {
           '/base_pipe.ts': `
         import {Pipe, PipeTransform} from '@angular/core';
 
-        @Pipe({ 
+        @Pipe({
           name: 'basePipe',
           standalone: false,
         })
@@ -1553,7 +1553,7 @@ describe('find references and rename locations', () => {
           standalone: false,
         })
         export class AppCmp {
-          title = 'title';
+          title = 'title' as string | undefined;
         }`,
     };
 
@@ -1577,7 +1577,7 @@ describe('find references and rename locations', () => {
       import {Directive} from '@angular/core';
 
       @Directive({
-        selector: '[dir]', 
+        selector: '[dir]',
         standalone: false,
       })
       export class Dir {}`,
@@ -1728,7 +1728,7 @@ describe('find references and rename locations', () => {
       import {Component} from '@angular/core';
 
       @Component({
-        selector: 'my-comp', 
+        selector: 'my-comp',
         template: '',
         standalone: false,
       })
@@ -1780,7 +1780,7 @@ describe('find references and rename locations', () => {
       import {Component} from '@angular/core';
 
       @Component({
-        selector: 'my-comp', template: '', 
+        selector: 'my-comp', template: '',
         standalone: false,
       })
       export class MyComp {}`;
@@ -1866,7 +1866,7 @@ describe('find references and rename locations', () => {
             import {Component} from '@angular/core';
 
             @Component({
-              selector: 'my-comp', 
+              selector: 'my-comp',
               template: '',
               standalone: false,
             })
@@ -1888,7 +1888,7 @@ describe('find references and rename locations', () => {
             import {Component, Input} from '@angular/core';
 
             @Component({
-              selector: 'my-comp', 
+              selector: 'my-comp',
               template: '',
               standalone: false,
             })
@@ -1912,7 +1912,7 @@ describe('find references and rename locations', () => {
             import {Component} from '@angular/core';
 
             @Component({
-              selector: 'my-comp', 
+              selector: 'my-comp',
               template: '{{ myObj["myProp"] }}',
               standalone: false,
             })
@@ -1948,7 +1948,7 @@ describe('find references and rename locations', () => {
         'dir.ts': `
         import {Directive, Input} from '@angular/core';
         @Directive({
-          selector: '[dir]', 
+          selector: '[dir]',
           standalone: false,
         })
         export class MyDir {
@@ -1958,7 +1958,7 @@ describe('find references and rename locations', () => {
             import {Component, Input} from '@angular/core';
 
             @Component({
-              selector: 'my-comp', 
+              selector: 'my-comp',
               template: '<div dir="something"></div>',
               standalone: false,
             })

--- a/packages/language-service/test/type_definitions_spec.ts
+++ b/packages/language-service/test/type_definitions_spec.ts
@@ -182,7 +182,7 @@ describe('type definitions', () => {
         })
         export class AppCmp {
           noop() {}
-          value = 'hello';
+          value = 'hello' as string | undefined;
         }
       `,
       'app.html': `Will be overridden`,


### PR DESCRIPTION
In the past two-way bindings used to be interpreted as `foo = $event` at the parser level. In https://github.com/angular/angular/pull/54065 it was changed to preserve the actual expression, because it was problematic for supporting two-way binding to signals. This unintentionally ended up causing the TCB to two-way bindings to look something like `someOutput.subscribe($event => expr);` which does nothing. It largely hasn't been a problem, because the input side of two-way bindings was still being checked, except for the case where the input side of the two-way binding has a wider type than the output side.

These changes re-add type checking for the output side by generating the following TCB instead:

```
someOutput.subscribe($event => {
  var _t1 = unwrapSignalValue(this.someField);
  _t1 = $event;
});
```