### PR TITLE
docs(docs-infra): fix missing code examples in the API reference

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/extraction/BUILD.bazel
+++ b/adev/shared-docs/pipeline/api-gen/extraction/BUILD.bazel
@@ -1,17 +1,16 @@
 load("@angular//tools/esm-interop:index.bzl", "nodejs_binary")
-load("@npm//@angular/build-tooling/bazel/esbuild:index.bzl", "esbuild")
 load("@npm//@angular/build-tooling/bazel:defaults.bzl", "ts_library")
+load("@npm//@angular/build-tooling/bazel/esbuild:index.bzl", "esbuild_esm_bundle")
 
 package(default_visibility = ["//adev/shared-docs/pipeline/api-gen:__subpackages__"])
 
-esbuild(
+esbuild_esm_bundle(
     name = "bin",
     entry_point = ":index.ts",
     external = [
         "@angular/compiler-cli",
         "typescript",
     ],
-    format = "esm",
     output = "bin.mjs",
     platform = "node",
     target = "es2022",

--- a/adev/shared-docs/pipeline/api-gen/extraction/BUILD.bazel
+++ b/adev/shared-docs/pipeline/api-gen/extraction/BUILD.bazel
@@ -23,7 +23,12 @@ esbuild_esm_bundle(
 
 ts_library(
     name = "extract_api_to_json_lib",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = [
+            "**/*.spec.ts",
+        ],
+    ),
     devmode_module = "commonjs",
     tsconfig = "//adev:tsconfig.json",
     deps = [

--- a/adev/shared-docs/pipeline/api-gen/extraction/index.ts
+++ b/adev/shared-docs/pipeline/api-gen/extraction/index.ts
@@ -59,7 +59,16 @@ function main() {
   };
 
   const compilerHost = createCompilerHost({options: compilerOptions});
-  const program: NgtscProgram = new NgtscProgram(srcs.split(','), compilerOptions, compilerHost);
+  const files = srcs.split(',');
+
+  // Code examples should not be fed to the compiler.
+  const filesWithoutExamples = files.filter((path) => !path.startsWith('packages/examples'));
+
+  const program: NgtscProgram = new NgtscProgram(
+    filesWithoutExamples,
+    compilerOptions,
+    compilerHost,
+  );
 
   const extraEntries: DocEntry[] = (extraEntriesSrcs ?? '')
     .split(',')

--- a/adev/shared-docs/pipeline/api-gen/extraction/index.ts
+++ b/adev/shared-docs/pipeline/api-gen/extraction/index.ts
@@ -11,6 +11,7 @@ import {
   ClassEntry,
 } from '@angular/compiler-cli';
 import ts from 'typescript';
+import {EXAMPLES_PATH, interpolateCodeExamples} from './interpolate_code_examples';
 
 function main() {
   const [paramFilePath] = process.argv.slice(2);
@@ -58,12 +59,9 @@ function main() {
     experimentalDecorators: true,
   };
 
-  const compilerHost = createCompilerHost({options: compilerOptions});
-  const files = srcs.split(',');
-
   // Code examples should not be fed to the compiler.
-  const filesWithoutExamples = files.filter((path) => !path.startsWith('packages/examples'));
-
+  const filesWithoutExamples = srcs.split(',').filter((src) => !src.startsWith(EXAMPLES_PATH));
+  const compilerHost = createCompilerHost({options: compilerOptions});
   const program: NgtscProgram = new NgtscProgram(
     filesWithoutExamples,
     compilerOptions,
@@ -80,6 +78,8 @@ function main() {
   const apiDoc = program.getApiDocumentation(entryPointExecRootRelativePath, privateModules);
   const extractedEntries = apiDoc.entries;
   const combinedEntries = extractedEntries.concat(extraEntries);
+
+  interpolateCodeExamples(combinedEntries);
 
   const normalized = moduleName.replace('@', '').replace(/[\/]/g, '_');
 

--- a/adev/shared-docs/pipeline/api-gen/extraction/interpolate_code_examples.ts
+++ b/adev/shared-docs/pipeline/api-gen/extraction/interpolate_code_examples.ts
@@ -1,0 +1,141 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {DocEntry} from '@angular/compiler-cli';
+import {readFileSync} from 'fs';
+import {basename, dirname, resolve} from 'path';
+
+export const EXAMPLES_PATH = 'packages/examples';
+const REGION_START_MARKER = '#docregion';
+const REGION_END_MARKER = '#enddocregion';
+
+const examplesFilesCache = new Map<string, string>();
+
+type FileType = 'ts' | 'js' | 'html';
+
+/**
+ * Interpolate code examples in the `DocEntry`-ies JSDocs content and raw comments in place.
+ *
+ * @param entries Target `DocEntry`-ies array that has its examples substituted with the actual TS code.
+ * @param examplesFiles A set with all examples files sources.
+ */
+export function interpolateCodeExamples(entries: DocEntry[]): void {
+  for (const entry of entries) {
+    entry.rawComment = replaceExample(entry.rawComment);
+
+    for (const jsdocTag of entry.jsdocTags) {
+      jsdocTag.comment = replaceExample(jsdocTag.comment);
+    }
+  }
+}
+
+function replaceExample(text: string): string {
+  const examplesTagRegex = /{@example (\S+) region=(['"])([^'"]+)\2\s*}/g;
+
+  return text.replace(examplesTagRegex, (_: string, path: string, __: string, region: string) => {
+    const contents = getExampleFileContents(path);
+    const fileType = path.split('.').pop() as FileType;
+    const example = extractExampleFromContents(contents, region, fileType);
+
+    if (!example) {
+      throw new Error(`Missing code example for ${path}#${region}`);
+    }
+
+    return '```typescript\n' + example + '\n```';
+  });
+}
+
+function getExampleFileContents(path: string): string {
+  let contents = examplesFilesCache.get(path);
+  if (!contents) {
+    const src = `${EXAMPLES_PATH}/${path}`;
+    const fullPath = resolve(dirname(src), basename(src));
+    contents = readFileSync(fullPath, {encoding: 'utf8'});
+    examplesFilesCache.set(path, contents);
+  }
+  return contents;
+}
+
+function trimLeftoverCommentsFromExample(example: string, fileType: FileType): string {
+  switch (fileType) {
+    case 'ts':
+    case 'js':
+      // We can have only a trailing TS comment leftover
+      return example.replace(/\/\/\s*$/, '');
+    case 'html':
+      return example.replace(/(^\s*-->)|(<!--\s*$)/, '');
+    default:
+      return example;
+  }
+}
+
+/** Extract a `#docregion` example from file contents (represented as a string) by a provided `region`. */
+function extractExampleFromContents(contents: string, region: string, fileType: FileType): string {
+  let startIdx = -1;
+  let endIdx = -1;
+
+  let markerBuffer = '';
+  let regionBuffer = '';
+  let isInRegion = false;
+
+  // Iterate over the contents string and determine the start and end indices.
+  for (let i = 0; i < contents.length; i++) {
+    const char = contents[i];
+
+    // Build the marker string
+    if (char === REGION_START_MARKER[0]) {
+      markerBuffer = char;
+    } else if (markerBuffer) {
+      markerBuffer += char;
+    }
+
+    // Check if the marker corresponds to the start or the end region markers
+    if (markerBuffer === REGION_START_MARKER) {
+      isInRegion = true;
+      markerBuffer = '';
+      startIdx = -1;
+
+      // We need to skip the region checks in this case.
+      continue;
+    } else if (markerBuffer === REGION_END_MARKER) {
+      isInRegion = false;
+      markerBuffer = '';
+
+      // If the startIdx is set, this means that
+      // we've successfully found the region start marker
+      // and we can break from the loop with the respective
+      // end index.
+      if (startIdx > -1) {
+        endIdx = i - REGION_END_MARKER.length;
+        break;
+      }
+    }
+
+    // Build the region string
+    if (isInRegion && !/\s/.test(char) && startIdx === -1) {
+      regionBuffer += char;
+    } else if (isInRegion) {
+      // If the region string matches the argument,
+      // we can safely set the start index.
+      if (regionBuffer === region) {
+        startIdx = i + 1;
+      }
+      regionBuffer = '';
+    }
+  }
+
+  // If any of the indices are missing, we cannot determine the borders
+  // or the region. Therefore, we return an empty string.
+  if (startIdx === -1 || endIdx === -1) {
+    return '';
+  }
+
+  const example = contents.substring(startIdx, endIdx);
+
+  return trimLeftoverCommentsFromExample(example, fileType);
+}

--- a/adev/shared-docs/pipeline/api-gen/extraction/interpolate_code_examples.ts
+++ b/adev/shared-docs/pipeline/api-gen/extraction/interpolate_code_examples.ts
@@ -86,7 +86,7 @@ function getExample(path: string, region: string): string {
 }
 
 /**
- * Extract a `#docregion` example from file contents (represented as a string) by a provided `region`.
+ * Extract `#docregion` examples from file contents represented as a string.
  *
  * @param contents File contents represented as a string
  * @param fileType File type

--- a/adev/shared-docs/pipeline/api-gen/extraction/interpolate_code_examples.ts
+++ b/adev/shared-docs/pipeline/api-gen/extraction/interpolate_code_examples.ts
@@ -28,9 +28,9 @@ type FileType = 'ts' | 'js' | 'html';
 type RegionStartToken = {name: string; startIdx: number};
 
 const MD_CTYPE_MAP: {[key in FileType]: string} = {
-  'ts': 'typescript',
+  'ts': 'angular-ts',
   'js': 'javascript',
-  'html': 'html',
+  'html': 'angular-html',
 };
 
 /**

--- a/adev/shared-docs/pipeline/api-gen/extraction/test/BUILD.bazel
+++ b/adev/shared-docs/pipeline/api-gen/extraction/test/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//adev/shared-docs/pipeline/api-gen/extraction:extract_api_to_json.bzl", "extract_api_to_json")
+load("//tools:defaults.bzl", "jasmine_node_test", "ts_library")
 
 package(default_visibility = ["//adev/shared-docs/pipeline/api-gen:__subpackages__"])
 
@@ -38,4 +39,19 @@ extract_api_to_json(
 filegroup(
     name = "source_files",
     srcs = ["fake-source.ts"],
+)
+
+ts_library(
+    name = "unit_test_lib",
+    testonly = True,
+    srcs = glob(["*.spec.ts"]),
+    deps = [
+        "//adev/shared-docs/pipeline/api-gen/extraction:extract_api_to_json_lib",
+        "@angular//packages/compiler-cli",
+    ],
+)
+
+jasmine_node_test(
+    name = "unit_tests",
+    deps = [":unit_test_lib"],
 )

--- a/adev/shared-docs/pipeline/api-gen/extraction/test/BUILD.bazel
+++ b/adev/shared-docs/pipeline/api-gen/extraction/test/BUILD.bazel
@@ -44,7 +44,10 @@ filegroup(
 ts_library(
     name = "unit_test_lib",
     testonly = True,
-    srcs = glob(["*.spec.ts"]),
+    srcs =
+        glob(["*.spec.ts"]) + [
+            "fake-examples.ts",
+        ],
     deps = [
         "//adev/shared-docs/pipeline/api-gen/extraction:extract_api_to_json_lib",
         "@angular//packages/compiler-cli",

--- a/adev/shared-docs/pipeline/api-gen/extraction/test/fake-examples.ts
+++ b/adev/shared-docs/pipeline/api-gen/extraction/test/fake-examples.ts
@@ -1,3 +1,11 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
 const JSDOCS_RAWCONTENT_FILE = `
 // #docregion class
 class Foo {}

--- a/adev/shared-docs/pipeline/api-gen/extraction/test/fake-examples.ts
+++ b/adev/shared-docs/pipeline/api-gen/extraction/test/fake-examples.ts
@@ -1,0 +1,146 @@
+const JSDOCS_RAWCONTENT_FILE = `
+// #docregion class
+class Foo {}
+// #enddocregion
+
+// #docregion function
+function bar() {}
+// #enddocregion
+`;
+
+const SINGLE_EXAMPLE_FILE = `
+import {foo} from 'bar';
+
+// #docregion foo
+foo('Hello world!');
+// #enddocregion
+`;
+
+const MULTIPLE_EXAMPLES_FILE = `
+import {foo} from 'bar';
+
+// #docregion example-1
+foo(null);
+// #enddocregion
+
+foo('');
+
+// #docregion example-2
+type Test = 'a' | 'b';
+// #enddocregion
+`;
+
+const NESTED_EXAMPLES_FILE = `
+import {foo} from 'bar';
+
+// #docregion out
+function baz() {
+  // #docregion in
+  const leet = 1337;
+  // #enddocregion
+}
+// #enddocregion
+`;
+
+const REGIONS_EXAMPLE_FILE = `
+import {foo} from 'bar';
+
+// #docregion fn
+function baz() {
+// #enddocregion
+  const leet = 1337;
+
+  if (true) {
+    console.log(leet);
+  }
+
+// #docregion fn
+}
+// #enddocregion
+`;
+
+const OVERLAP_PARAM_EXAMPLE_FILE = `
+// #docregion 1st
+import {foo} from 'bar';
+
+// #docregion 2nd
+class Baz {
+  constructor () {}
+  // #enddocregion 1st
+
+  example () {}
+}
+// #enddocregion 2nd
+`;
+
+const COMPLEX_EXAMPLE_FILE = `
+import {foo} from 'bar';
+// #docregion ex-1
+import {baz} from 'foo';
+// #enddocregion
+
+// #docregion ex-2
+function test() {}
+// #enddocregion
+
+// #docregion ex-3
+function test2() {
+  // #docregion ex-4
+  const leet = 1337;
+  // #enddocregion
+}
+// #enddocregion
+
+// #docregion ex-2
+baz();
+// #enddocregion
+
+// #docregion ex-5
+const A = 'a';
+// #docregion ex-6
+const B = 'b';
+// #enddocregion ex-5
+const C = 'c';
+// #enddocregion ex-6
+`;
+
+const HTML_EXAMPLE_FILE = `
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Angular</title>
+  </head>
+  <body>
+    <!-- #docregion tags -->
+    <i>Foo</i>
+    <!-- #enddocregion -->
+    <strong>Bar</strong>
+    <!-- #docregion tags -->
+    <p>Baz</p>
+    <!-- #enddocregion -->
+  </body>
+</html>
+`;
+
+export const mockReadFileSync = (path: string): string => {
+  switch (path.split('/').pop()) {
+    case 'jsdocs_raw.ts':
+      return JSDOCS_RAWCONTENT_FILE;
+    case 'single.ts':
+      return SINGLE_EXAMPLE_FILE;
+    case 'multi.ts':
+      return MULTIPLE_EXAMPLES_FILE;
+    case 'nested.ts':
+      return NESTED_EXAMPLES_FILE;
+    case 'regions.ts':
+      return REGIONS_EXAMPLE_FILE;
+    case 'overlap.ts':
+      return OVERLAP_PARAM_EXAMPLE_FILE;
+    case 'complex.ts':
+      return COMPLEX_EXAMPLE_FILE;
+    case 'index.html':
+      return HTML_EXAMPLE_FILE;
+  }
+  return '';
+};

--- a/adev/shared-docs/pipeline/api-gen/extraction/test/interpolate_code_examples.spec.ts
+++ b/adev/shared-docs/pipeline/api-gen/extraction/test/interpolate_code_examples.spec.ts
@@ -1,32 +1,32 @@
 import fs from 'fs';
 import {interpolateCodeExamples} from '../interpolate_code_examples';
 import {DocEntry} from '@angular/compiler-cli';
-
-const DUMMY_EXAMPLE_FILE = `
-#docregion class
-class Foo {}
-#enddocregion
-
-#docregion function
-function bar() {}
-#enddocregion
-`;
+import {mockReadFileSync} from './fake-examples';
 
 const tsMdBlock = (code: string) => '```typescript\n' + code + '\n```';
+const htmlMdBlock = (code: string) => '```html\n' + code + '\n```';
+
+const entriesBuilder = (comment: string): DocEntry[] => [
+  {jsdocTags: [], rawComment: comment} as unknown as DocEntry,
+];
+
+const getComment = (entries: DocEntry[]) => entries[0].rawComment;
 
 describe('interpolate_code_examples', () => {
-  it('should interpolate both JSDoc tags comments and raw comment', () => {
-    spyOn(fs, 'readFileSync').and.returnValue(DUMMY_EXAMPLE_FILE);
+  beforeAll(() => {
+    spyOn(fs, 'readFileSync').and.callFake(mockReadFileSync as any);
+  });
 
+  it('should interpolate both JSDoc tags comments and raw comment', () => {
     const entries: Partial<DocEntry>[] = [
       {
         jsdocTags: [
           {
             name: '',
-            comment: `{@example dummy/path/file.ts region='class'}`,
+            comment: `{@example dummy/jsdocs_raw.ts region='class'}`,
           },
         ],
-        rawComment: `{@example dummy/path/file.ts region='function'}`,
+        rawComment: `{@example dummy/jsdocs_raw.ts region='function'}`,
       },
     ];
 
@@ -36,5 +36,102 @@ describe('interpolate_code_examples', () => {
 
     expect(jsdocTags![0].comment).toEqual(tsMdBlock('class Foo {}'));
     expect(rawComment).toEqual(tsMdBlock('function bar() {}'));
+  });
+
+  it('should interpolate a single example', () => {
+    const entries = entriesBuilder(`Code: {@example dummy/single.ts region='foo'}`);
+
+    interpolateCodeExamples(entries);
+
+    expect(getComment(entries)).toEqual('Code: ' + tsMdBlock("foo('Hello world!');"));
+  });
+
+  it('should interpolate multiple examples', () => {
+    const entries = entriesBuilder(
+      `First: {@example dummy/multi.ts region='example-1'} Second: {@example dummy/multi.ts region='example-2'}`,
+    );
+
+    interpolateCodeExamples(entries);
+
+    expect(getComment(entries)).toEqual(
+      `First: ${tsMdBlock('foo(null);')} Second: ${tsMdBlock("type Test = 'a' | 'b';")}`,
+    );
+  });
+
+  it('should interpolate nested examples', () => {
+    const entries = entriesBuilder(
+      `Outer: {@example dummy/nested.ts region='out'} Inner: {@example dummy/nested.ts region='in'}`,
+    );
+
+    interpolateCodeExamples(entries);
+
+    const outer = `function baz() {
+  const leet = 1337;
+}`;
+
+    expect(getComment(entries)).toEqual(
+      `Outer: ${tsMdBlock(outer)} Inner: ${tsMdBlock('const leet = 1337;')}`,
+    );
+  });
+
+  it('should interpolate a single example with multiple regions', () => {
+    const entries = entriesBuilder(`Code: {@example dummy/regions.ts region='fn'}`);
+
+    interpolateCodeExamples(entries);
+
+    expect(getComment(entries)).toEqual('Code: ' + tsMdBlock('function baz() {\n}'));
+  });
+
+  it('should support examples defined by overlapping regions', () => {
+    const entries = entriesBuilder(
+      `1st: {@example dummy/overlap.ts region='1st'} 2nd: {@example dummy/overlap.ts region='2nd'}`,
+    );
+
+    interpolateCodeExamples(entries);
+
+    const first = `import {foo} from 'bar';
+
+class Baz {
+  constructor () {}`;
+
+    const second = `class Baz {
+  constructor () {}
+
+  example () {}
+}`;
+
+    expect(getComment(entries)).toEqual(`1st: ${tsMdBlock(first)} 2nd: ${tsMdBlock(second)}`);
+  });
+
+  it('should support multiple region combinations simultaneously', () => {
+    const targetStr = `1: {@example dummy/complex.ts region='ex-1'}
+2: {@example dummy/complex.ts region='ex-2'}
+3: {@example dummy/complex.ts region='ex-3'}
+4: {@example dummy/complex.ts region='ex-4'}
+5: {@example dummy/complex.ts region='ex-5'}
+6: {@example dummy/complex.ts region='ex-6'}`;
+
+    const entries = entriesBuilder(targetStr);
+
+    interpolateCodeExamples(entries);
+
+    const output = `1: ${tsMdBlock("import {baz} from 'foo';")}
+2: ${tsMdBlock('function test() {}\nbaz();')}
+3: ${tsMdBlock(`function test2() {
+  const leet = 1337;
+}`)}
+4: ${tsMdBlock('const leet = 1337;')}
+5: ${tsMdBlock("const A = 'a';\nconst B = 'b';")}
+6: ${tsMdBlock("const B = 'b';\nconst C = 'c';")}`;
+
+    expect(getComment(entries)).toEqual(output);
+  });
+
+  it('should support HTML files', () => {
+    const entries = entriesBuilder(`HTML: {@example dummy/index.html region='tags'}`);
+
+    interpolateCodeExamples(entries);
+
+    expect(getComment(entries)).toEqual(`HTML: ${htmlMdBlock('    <i>Foo</i>\n    <p>Baz</p>')}`);
   });
 });

--- a/adev/shared-docs/pipeline/api-gen/extraction/test/interpolate_code_examples.spec.ts
+++ b/adev/shared-docs/pipeline/api-gen/extraction/test/interpolate_code_examples.spec.ts
@@ -11,8 +11,8 @@ import {interpolateCodeExamples} from '../interpolate_code_examples';
 import {DocEntry} from '@angular/compiler-cli';
 import {mockReadFileSync} from './fake-examples';
 
-const tsMdBlock = (code: string) => '```typescript\n' + code + '\n```';
-const htmlMdBlock = (code: string) => '```html\n' + code + '\n```';
+const tsMdBlock = (code: string) => '```angular-ts\n' + code + '\n```';
+const htmlMdBlock = (code: string) => '```angular-html\n' + code + '\n```';
 
 const entriesBuilder = (comment: string): DocEntry[] => [
   {jsdocTags: [], rawComment: comment} as unknown as DocEntry,

--- a/adev/shared-docs/pipeline/api-gen/extraction/test/interpolate_code_examples.spec.ts
+++ b/adev/shared-docs/pipeline/api-gen/extraction/test/interpolate_code_examples.spec.ts
@@ -1,3 +1,11 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
 import fs from 'fs';
 import {interpolateCodeExamples} from '../interpolate_code_examples';
 import {DocEntry} from '@angular/compiler-cli';

--- a/adev/shared-docs/pipeline/api-gen/extraction/test/interpolate_code_examples.spec.ts
+++ b/adev/shared-docs/pipeline/api-gen/extraction/test/interpolate_code_examples.spec.ts
@@ -1,0 +1,40 @@
+import fs from 'fs';
+import {interpolateCodeExamples} from '../interpolate_code_examples';
+import {DocEntry} from '@angular/compiler-cli';
+
+const DUMMY_EXAMPLE_FILE = `
+#docregion class
+class Foo {}
+#enddocregion
+
+#docregion function
+function bar() {}
+#enddocregion
+`;
+
+const tsMdBlock = (code: string) => '```typescript\n' + code + '\n```';
+
+describe('interpolate_code_examples', () => {
+  it('should interpolate both JSDoc tags comments and raw comment', () => {
+    spyOn(fs, 'readFileSync').and.returnValue(DUMMY_EXAMPLE_FILE);
+
+    const entries: Partial<DocEntry>[] = [
+      {
+        jsdocTags: [
+          {
+            name: '',
+            comment: `{@example dummy/path/file.ts region='class'}`,
+          },
+        ],
+        rawComment: `{@example dummy/path/file.ts region='function'}`,
+      },
+    ];
+
+    interpolateCodeExamples(entries as DocEntry[]);
+
+    const {jsdocTags, rawComment} = entries[0];
+
+    expect(jsdocTags![0].comment).toEqual(tsMdBlock('class Foo {}'));
+    expect(rawComment).toEqual(tsMdBlock('function bar() {}'));
+  });
+});

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/jsdoc-transforms.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/jsdoc-transforms.ts
@@ -101,9 +101,7 @@ export function addHtmlUsageNotes<T extends HasJsDocTags>(entry: T): T & HasHtml
     ({name}) => name === JS_DOC_USAGE_NOTES_TAG || name === JS_DOC_REMARKS_TAG,
   );
   const htmlUsageNotes = usageNotesTag
-    ? (marked.parse(
-        convertJsDocExampleToHtmlExample(wrapExampleHtmlElementsWithCode(usageNotesTag.comment)),
-      ) as string)
+    ? (marked.parse(wrapExampleHtmlElementsWithCode(usageNotesTag.comment)) as string)
     : '';
 
   const transformedHtml = addApiLinksToHtml(htmlUsageNotes);
@@ -176,17 +174,6 @@ function wrapExampleHtmlElementsWithCode(text: string) {
   return text
     .replace(/'<input>'/g, `<code><input></code>`)
     .replace(/'<img>'/g, `<code><img></code>`);
-}
-
-function convertJsDocExampleToHtmlExample(text: string): string {
-  const codeExampleAtRule = /{@example (\S+) region=(['"])([^'"]+)\2\s*}/g;
-
-  return text.replace(
-    codeExampleAtRule,
-    (_: string, path: string, separator: string, region: string) => {
-      return `<code-example path="${path}" region="${region}" />`;
-    },
-  );
 }
 
 /**

--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//tools:defaults.bzl", "ts_config", "ts_library")
 load("//:packages.bzl", "DOCS_ENTRYPOINTS")
 load("//adev/shared-docs/pipeline/api-gen/manifest:generate_api_manifest.bzl", "generate_api_manifest")
+load("//tools:defaults.bzl", "ts_config", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -60,6 +60,7 @@ filegroup(
         "//packages/core/src/interface:files_for_docgen",
         "//packages/core/src/reflection:files_for_docgen",
         "//packages/core/src/util:files_for_docgen",
+        "//packages/examples:files_for_docgen",
         "//packages/platform-browser:files_for_docgen",
         "//packages/platform-browser-dynamic:files_for_docgen",
         "//packages/zone.js/lib:zone_d_ts",

--- a/packages/common/src/location/location.ts
+++ b/packages/common/src/location/location.ts
@@ -43,8 +43,7 @@ export interface PopStateEvent {
  *
  * ### Example
  *
- * <code-example path='common/location/ts/path_location_component.ts'
- * region='LocationComponent'></code-example>
+ * {@example common/location/ts/path_location_component.ts region='LocationComponent'}
  *
  * @publicApi
  */

--- a/packages/common/src/pipes/case_conversion_pipes.ts
+++ b/packages/common/src/pipes/case_conversion_pipes.ts
@@ -20,7 +20,7 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  * The following example defines a view that allows the user to enter
  * text, and then uses the pipe to convert the input text to all lower case.
  *
- * <code-example path="common/pipes/ts/lowerupper_pipe.ts" region='LowerUpperPipe'></code-example>
+ * {@example common/pipes/ts/lowerupper_pipe.ts region='LowerUpperPipe'}
  *
  * @ngModule CommonModule
  * @publicApi
@@ -69,7 +69,7 @@ const unicodeWordMatch =
  * @usageNotes
  * The following example shows the result of transforming various strings into title case.
  *
- * <code-example path="common/pipes/ts/titlecase_pipe.ts" region='TitleCasePipe'></code-example>
+ * {@example common/pipes/ts/titlecase_pipe.ts region='TitleCasePipe'}
  *
  * @ngModule CommonModule
  * @publicApi

--- a/packages/common/src/pipes/number_pipe.ts
+++ b/packages/common/src/pipes/number_pipe.ts
@@ -72,7 +72,7 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  * according to various format specifications,
  * where the caller's default locale is `en-US`.
  *
- * <code-example path="common/pipes/ts/number_pipe.ts" region='NumberPipe'></code-example>
+ * {@example common/pipes/ts/number_pipe.ts region='NumberPipe'}
  *
  * @publicApi
  */
@@ -131,7 +131,7 @@ export class DecimalPipe implements PipeTransform {
  * into text strings, according to various format specifications,
  * where the caller's default locale is `en-US`.
  *
- * <code-example path="common/pipes/ts/percent_pipe.ts" region='PercentPipe'></code-example>
+ * {@example common/pipes/ts/percent_pipe.ts region='PercentPipe'}
  *
  * @publicApi
  */
@@ -198,7 +198,7 @@ export class PercentPipe implements PipeTransform {
  * into text strings, according to various format specifications,
  * where the caller's default locale is `en-US`.
  *
- * <code-example path="common/pipes/ts/currency_pipe.ts" region='CurrencyPipe'></code-example>
+ * {@example common/pipes/ts/currency_pipe.ts region='CurrencyPipe'}
  *
  * @publicApi
  */

--- a/packages/core/src/change_detection/change_detector_ref.ts
+++ b/packages/core/src/change_detection/change_detector_ref.ts
@@ -35,8 +35,7 @@ import {ViewRef} from '../render3/view_ref';
  * (`CheckOnce`, rather than the default `CheckAlways`), then forces a second check
  * after an interval.
  *
- * <code-example path="core/ts/change_detect/change-detection.ts"
- * region="mark-for-check"></code-example>
+ * {@example core/ts/change_detect/change-detection.ts region='mark-for-check'}
  *
  * ### Detach change detector to limit how often check occurs
  *
@@ -46,7 +45,7 @@ import {ViewRef} from '../render3/view_ref';
  * less often than the changes actually occur. To do that, we detach
  * the component's change detector and perform an explicit local check every five seconds.
  *
- * <code-example path="core/ts/change_detect/change-detection.ts" region="detach"></code-example>
+ * {@example core/ts/change_detect/change-detection.ts region='detach'}
  *
  *
  * ### Reattaching a detached component
@@ -56,7 +55,7 @@ import {ViewRef} from '../render3/view_ref';
  * when the `live` property is set to false, and reattaches it when the property
  * becomes true.
  *
- * <code-example path="core/ts/change_detect/change-detection.ts" region="reattach"></code-example>
+ * {@example core/ts/change_detect/change-detection.ts region='reattach'}
  *
  * @publicApi
  */

--- a/packages/core/src/di/injectable.ts
+++ b/packages/core/src/di/injectable.ts
@@ -56,7 +56,7 @@ export interface InjectableDecorator {
    * The following example shows how a service class is properly
    *  marked so that a supporting service can be injected upon creation.
    *
-   * <code-example path="core/di/ts/metadata_spec.ts" region="Injectable"></code-example>
+   * {@example core/di/ts/metadata_spec.ts region='Injectable'}
    *
    */
   (): TypeDecorator;

--- a/packages/core/src/di/injection_token.ts
+++ b/packages/core/src/di/injection_token.ts
@@ -30,8 +30,7 @@ import {ɵɵdefineInjectable} from './interface/defs';
  *
  * </div>
  *
- * <code-example format="typescript" language="typescript" path="injection-token/src/main.ts"
- * region="InjectionToken"></code-example>
+ * {@example injection-token/src/main.ts region='InjectionToken'}
  *
  * When creating an `InjectionToken`, you can optionally specify a factory function which returns
  * (possibly by creating) a default value of the parameterized type `T`. This sets up the

--- a/packages/core/src/di/metadata.ts
+++ b/packages/core/src/di/metadata.ts
@@ -28,8 +28,7 @@ export interface InjectDecorator {
    * When `@Inject()` is not present, the injector uses the type annotation of the
    * parameter as the provider.
    *
-   * <code-example path="core/di/ts/metadata_spec.ts" region="InjectWithoutDecorator">
-   * </code-example>
+   * {@example core/di/ts/metadata_spec.ts region='InjectWithoutDecorator'}
    *
    * @see [Dependency Injection Guide](guide/di/dependency-injection
    *
@@ -81,8 +80,7 @@ export interface OptionalDecorator {
    *
    * The following code allows the possibility of a `null` result:
    *
-   * <code-example path="core/di/ts/metadata_spec.ts" region="Optional">
-   * </code-example>
+   * {@example core/di/ts/metadata_spec.ts region='Optional'}
    *
    * @see [Dependency Injection Guide](guide/di/dependency-injection.
    */
@@ -127,8 +125,7 @@ export interface SelfDecorator {
    * by the local injector when instantiating the class itself, but not
    * when instantiating a child.
    *
-   * <code-example path="core/di/ts/metadata_spec.ts" region="Self">
-   * </code-example>
+   * {@example core/di/ts/metadata_spec.ts region='Self'}
    *
    * @see {@link SkipSelf}
    * @see {@link Optional}
@@ -173,8 +170,7 @@ export interface SkipSelfDecorator {
    * In the following example, the dependency can be resolved when
    * instantiating a child, but not when instantiating the class itself.
    *
-   * <code-example path="core/di/ts/metadata_spec.ts" region="SkipSelf">
-   * </code-example>
+   * {@example core/di/ts/metadata_spec.ts region='SkipSelf'}
    *
    * @see [Dependency Injection guide](guide/di/di-in-action#skip).
    * @see {@link Self}
@@ -218,8 +214,7 @@ export interface HostDecorator {
    *
    * The following shows use with the `@Optional` decorator, and allows for a `null` result.
    *
-   * <code-example path="core/di/ts/metadata_spec.ts" region="Host">
-   * </code-example>
+   * {@example core/di/ts/metadata_spec.ts region='Host'}
    *
    * For an extended example, see ["Dependency Injection
    * Guide"](guide/di/di-in-action#optional).

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -418,7 +418,7 @@ export interface ComponentDecorator {
    * The following example creates a component with two data-bound properties,
    * specified by the `inputs` value.
    *
-   * <code-example path="core/ts/metadata/directives.ts" region="component-input"></code-example>
+   * {@example core/ts/metadata/directives.ts region='component-input'}
    *
    *
    * ### Setting component outputs

--- a/packages/examples/BUILD.bazel
+++ b/packages/examples/BUILD.bazel
@@ -13,6 +13,7 @@ filegroup(
         "//packages/examples/core/di/ts/forward_ref:files_for_docgen",
         "//packages/examples/core/testing/ts:files_for_docgen",
         "//packages/examples/forms:files_for_docgen",
+        "//packages/examples/injection-token:files_for_docgen",
         "//packages/examples/platform-browser:files_for_docgen",
         "//packages/examples/router:files_for_docgen",
         "//packages/examples/router/activated-route:files_for_docgen",

--- a/packages/examples/BUILD.bazel
+++ b/packages/examples/BUILD.bazel
@@ -1,4 +1,28 @@
+package(default_visibility = ["//visibility:public"])
+
 exports_files([
     "index.html",
     "tsconfig-e2e.json",
 ])
+
+filegroup(
+    name = "files_for_docgen",
+    srcs = [
+        "//packages/examples/common:files_for_docgen",
+        "//packages/examples/core:files_for_docgen",
+        "//packages/examples/core/di/ts/forward_ref:files_for_docgen",
+        "//packages/examples/core/testing/ts:files_for_docgen",
+        "//packages/examples/forms:files_for_docgen",
+        "//packages/examples/platform-browser:files_for_docgen",
+        "//packages/examples/router:files_for_docgen",
+        "//packages/examples/router/activated-route:files_for_docgen",
+        "//packages/examples/router/testing:files_for_docgen",
+        "//packages/examples/service-worker/push:files_for_docgen",
+        "//packages/examples/service-worker/registration-options:files_for_docgen",
+        "//packages/examples/test-utils:files_for_docgen",
+        "//packages/examples/upgrade/static/ts/full:files_for_docgen",
+        "//packages/examples/upgrade/static/ts/lite:files_for_docgen",
+        "//packages/examples/upgrade/static/ts/lite-multi:files_for_docgen",
+        "//packages/examples/upgrade/static/ts/lite-multi-shared:files_for_docgen",
+    ],
+)

--- a/packages/examples/injection-token/BUILD.bazel
+++ b/packages/examples/injection-token/BUILD.bazel
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "files_for_docgen",
+    srcs = glob([
+        "**/*.ts",
+    ]),
+)

--- a/packages/examples/injection-token/src/main.ts
+++ b/packages/examples/injection-token/src/main.ts
@@ -1,0 +1,26 @@
+// TODO: Add unit tests for this file.
+/* eslint-disable @angular-eslint/no-output-native */
+// #docregion
+import {Injector, InjectionToken} from '@angular/core';
+
+interface MyInterface {
+  someProperty: string;
+}
+
+// #docregion InjectionToken
+
+const TOKEN = new InjectionToken<MyInterface>('SomeToken');
+
+// Setting up the provider using the same token instance
+const providers = [
+  {provide: TOKEN, useValue: {someProperty: 'exampleValue'}}, // Mock value for MyInterface
+];
+
+// Creating the injector with the provider
+const injector = Injector.create({providers});
+
+// Retrieving the value using the same token instance
+const myInterface = injector.get(TOKEN);
+// myInterface is inferred to be MyInterface.
+
+// #enddocregion InjectionToken

--- a/packages/examples/injection-token/src/main.ts
+++ b/packages/examples/injection-token/src/main.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
 // TODO: Add unit tests for this file.
 /* eslint-disable @angular-eslint/no-output-native */
 // #docregion

--- a/packages/forms/src/form_builder.ts
+++ b/packages/forms/src/form_builder.ts
@@ -325,8 +325,7 @@ export class FormBuilder {
    *
    * The following example returns a control with an initial value in a disabled state.
    *
-   * <code-example path="forms/ts/formBuilder/form_builder_example.ts" region="disabled-control">
-   * </code-example>
+   * {@example forms/ts/formBuilder/form_builder_example.ts region='disabled-control'}
    */
   control<T>(
     formState: T | FormControlState<T>,

--- a/packages/upgrade/static/testing/src/create_angular_testing_module.ts
+++ b/packages/upgrade/static/testing/src/create_angular_testing_module.ts
@@ -39,7 +39,7 @@ export class AngularTestingModule {
  * The `Ng2AppModule` is the Angular part of our hybrid application and the `ng1AppModule` is the
  * AngularJS part.
  *
- * <code-example path="upgrade/static/ts/full/module.spec.ts" region="angular-setup"></code-example>
+ * {@example upgrade/static/ts/full/module.spec.ts region='angular-setup'}
  *
  * Once this is done we can get hold of services via the Angular `Injector` as normal.
  * Services that are (or have dependencies on) an upgraded AngularJS service, will be instantiated
@@ -48,7 +48,7 @@ export class AngularTestingModule {
  * In the following code snippet, `HeroesService` is an Angular service that depends upon an
  * AngularJS service, `titleCase`.
  *
- * <code-example path="upgrade/static/ts/full/module.spec.ts" region="angular-spec"></code-example>
+ * {@example upgrade/static/ts/full/module.spec.ts region='angular-spec'}
  *
  * <div class="alert is-important">
  *

--- a/packages/upgrade/static/testing/src/create_angularjs_testing_module.ts
+++ b/packages/upgrade/static/testing/src/create_angularjs_testing_module.ts
@@ -28,8 +28,7 @@ import {UpgradeAppType} from '../../../src/common/src/util';
  * The AngularJS `ng1AppModule`, which is the AngularJS part of our hybrid application and the
  * `Ng2AppModule`, which is the Angular part.
  *
- * <code-example path="upgrade/static/ts/full/module.spec.ts"
- * region="angularjs-setup"></code-example>
+ * {@example upgrade/static/ts/full/module.spec.ts region='angularjs-setup'}
  *
  * Once this is done we can get hold of services via the AngularJS `$injector` as normal.
  * Services that are (or have dependencies on) a downgraded Angular service, will be instantiated as
@@ -38,8 +37,7 @@ import {UpgradeAppType} from '../../../src/common/src/util';
  * In the following code snippet, `heroesService` is a downgraded Angular service that we are
  * accessing from AngularJS.
  *
- * <code-example path="upgrade/static/ts/full/module.spec.ts"
- * region="angularjs-spec"></code-example>
+ * {@example upgrade/static/ts/full/module.spec.ts region='angularjs-spec'}
  *
  * <div class="alert is-important">
  *


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular/issues/56321


## What is the new behavior?

The new examples extraction and interpolation mechanism is integrated into the API gen JSON extraction phase since I thought that it makes most sense given the JSON files could be potentially consumed by other services and having the examples already inlined is desired. Let me know, if that's good. Currently, all `{@example}`-s are being targeted by the script and then replaced with the respective code example wrapped in a Markdown code block.

The extractor/parser supports various `#docregion` use variations that can be checked in the unit tests. It is still possible that I missed a use case but these are based on the different examples that I explored during the implementation.

It is _**important**_ to note that there are about half a dozen examples that are still missing because of the `<code-example>` usage. Some of the instances have already been replaced with `{@example}` – those that have only a `region` parameter (https://github.com/angular/angular/pull/59004/commits/a63b52477af5f3d3adf0b3a8bec2a91db99ca6e2). The remaining instances are left because they contain a `header` param. All that being said, I want to start a discussion in that regard – should we get rid of `<code-example>` completely in favor of `{@example}` or vice versa? Obviously, there are other details that have to be taken into account like whether the output of this interpolation mechanism should produce Markdown or HTML but this is something that can be decided as a secondary thing.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No