### PR TITLE
fix(platform-browser): collect external component styles from server rendering

### DIFF
--- a/packages/platform-browser/test/dom/shared_styles_host_spec.ts
+++ b/packages/platform-browser/test/dom/shared_styles_host_spec.ts
@@ -61,6 +61,18 @@ describe('SharedStylesHost', () => {
       ssh.addHost(someHost);
       expect(someHost.innerHTML).toEqual('<style nonce="{% nonce %}">a {};</style>');
     });
+
+    it(`should reuse SSR generated element`, () => {
+      const style = doc.createElement('style');
+      style.setAttribute('ng-app-id', 'app-id');
+      style.textContent = 'a {};';
+      doc.head.appendChild(style);
+
+      ssh = new SharedStylesHost(doc, 'app-id');
+      ssh.addStyles(['a {};']);
+      expect(doc.head.innerHTML).toContain('<style ng-style-reused="">a {};</style>');
+      expect(doc.head.innerHTML).not.toContain('ng-app-id');
+    });
   });
 
   describe('external', () => {
@@ -113,6 +125,21 @@ describe('SharedStylesHost', () => {
       expect(someHost.innerHTML).toEqual(
         '<link rel="stylesheet" href="component-1.css?ngcomp=ng-app-c123456789">',
       );
+    });
+
+    it(`should reuse SSR generated element`, () => {
+      const link = doc.createElement('link');
+      link.setAttribute('rel', 'stylesheet');
+      link.setAttribute('href', 'component-1.css');
+      link.setAttribute('ng-app-id', 'app-id');
+      doc.head.appendChild(link);
+
+      ssh = new SharedStylesHost(doc, 'app-id');
+      ssh.addStyles([], ['component-1.css']);
+      expect(doc.head.innerHTML).toContain(
+        '<link rel="stylesheet" href="component-1.css" ng-style-reused="">',
+      );
+      expect(doc.head.innerHTML).not.toContain('ng-app-id');
     });
   });
 });


### PR DESCRIPTION
SSR generated component styles used in development environments will add external styles via link elements to the HTML. However, the runtime would previously not collect these link elements for reuse with rendered components. This would result in two copies of the link elements present in the DOM. In isolation this is not problematic as it is only present in development mode. Unfortunately, the Vite-based CSS HMR functionality used by the Angular CLI only updates the first stylesheet it finds and leaves other instances of the stylesheet in place. This behavior causes the styles to be left in an inconsistent state. This could be considered a defect within Vite as it should update all relevant styles to maintain consistency but ideally there should not be two instances in the Angular SSR case. To avoid the Vite issue, the runtime will now collect SSR generated external styles and reuse them.