### PR TITLE
refactor(core): incremental hydration TODO cleanup

### DIFF
--- a/packages/core/src/hydration/annotate.ts
+++ b/packages/core/src/hydration/annotate.ts
@@ -303,7 +303,6 @@ export function annotateForHydration(appRef: ApplicationRef, doc: Document) {
 
   if (deferBlocks.size > 0) {
     const blocks: {[key: string]: SerializedDeferBlock} = {};
-    // TODO(incremental-hydration): we should probably have an object here instead of a Map?
     for (const [id, info] of deferBlocks.entries()) {
       blocks[id] = info;
     }
@@ -447,11 +446,10 @@ function serializeLContainer(
       }
 
       if (!isHydrateNeverBlock) {
-        // TODO(incremental-hydration): avoid copying of an object here
-        serializedView = {
-          ...serializedView,
-          ...serializeLView(lContainer[i] as LView, parentDeferBlockId, context),
-        };
+        Object.assign(
+          serializedView,
+          serializeLView(lContainer[i] as LView, parentDeferBlockId, context),
+        );
       }
     }
 


### PR DESCRIPTION
This adds a few helper functions and ensures we call complete fns when error state is rendered. It also eliminates serialized views from being copied.



## PR Type
What kind of change does this PR introduce?


- [x] Refactoring (no functional changes, no api changes)




## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

