### PR TITLE
fix(animations): `provideAnimations()` & `provideNoopAnimations()` re…

### DIFF
--- a/goldens/public-api/platform-browser/animations/index.api.md
+++ b/goldens/public-api/platform-browser/animations/index.api.md
@@ -5,10 +5,10 @@
 ```ts
 
 import { ANIMATION_MODULE_TYPE } from '@angular/core';
+import { EnvironmentProviders } from '@angular/core';
 import * as i0 from '@angular/core';
 import * as i1 from '@angular/platform-browser';
 import { ModuleWithProviders } from '@angular/core';
-import { Provider } from '@angular/core';
 
 export { ANIMATION_MODULE_TYPE }
 
@@ -39,10 +39,10 @@ export class NoopAnimationsModule {
 }
 
 // @public
-export function provideAnimations(): Provider[];
+export function provideAnimations(): EnvironmentProviders;
 
 // @public
-export function provideNoopAnimations(): Provider[];
+export function provideNoopAnimations(): EnvironmentProviders;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/core/test/bundling/animations-standalone/index.ts
+++ b/packages/core/test/bundling/animations-standalone/index.ts
@@ -34,4 +34,6 @@ class AnimationsComponent {
 })
 class RootComponent {}
 
-(window as any).waitForApp = bootstrapApplication(RootComponent, {providers: provideAnimations()});
+(window as any).waitForApp = bootstrapApplication(RootComponent, {
+  providers: [provideAnimations()],
+});

--- a/packages/platform-browser/animations/src/module.ts
+++ b/packages/platform-browser/animations/src/module.ts
@@ -6,9 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import {
+  EnvironmentProviders,
   ModuleWithProviders,
   NgModule,
-  Provider,
+  makeEnvironmentProviders,
   ɵperformanceMarkFeature as performanceMarkFeature,
 } from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
@@ -87,11 +88,11 @@ export class BrowserAnimationsModule {
  *
  * @publicApi
  */
-export function provideAnimations(): Provider[] {
+export function provideAnimations(): EnvironmentProviders {
   performanceMarkFeature('NgEagerAnimations');
   // Return a copy to prevent changes to the original array in case any in-place
   // alterations are performed to the `provideAnimations` call results in app code.
-  return [...BROWSER_ANIMATIONS_PROVIDERS];
+  return makeEnvironmentProviders([...BROWSER_ANIMATIONS_PROVIDERS]);
 }
 
 /**
@@ -125,8 +126,8 @@ export class NoopAnimationsModule {}
  *
  * @publicApi
  */
-export function provideNoopAnimations(): Provider[] {
+export function provideNoopAnimations(): EnvironmentProviders {
   // Return a copy to prevent changes to the original array in case any in-place
   // alterations are performed to the `provideNoopAnimations` call results in app code.
-  return [...BROWSER_NOOP_ANIMATIONS_PROVIDERS];
+  return makeEnvironmentProviders([...BROWSER_NOOP_ANIMATIONS_PROVIDERS]);
 }

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -915,6 +915,22 @@ describe('providePlatformInitializer', () => {
      */
     return createOrReusePlatformInjector(providers as any);
   }
+
+  it('should not be importable in standalone components', () => {
+    @Component({
+      imports: [
+        // @ts-expect-error
+        provideAnimations(),
+
+        // @ts-expect-error
+        provideNoopAnimations(),
+      ],
+    })
+    class TestComponent {}
+
+    // This should still be fine
+    bootstrapApplication(TestComponent, {providers: [provideAnimations()]});
+  });
 });
 
 /**


### PR DESCRIPTION
…turn `EnvironmentProvider`

This prevent developers from importing `provideAnimations` in standalone components. `provideAnimationsAsync()` already has the correct return type.

fixes #59044
