### PR TITLE
refactor(http): Don't log fetch warning in tests.

### DIFF
--- a/packages/common/http/src/interceptor.ts
+++ b/packages/common/http/src/interceptor.ts
@@ -276,7 +276,14 @@ export class HttpInterceptorHandler extends HttpHandler {
     // a warning otherwise.
     if ((typeof ngDevMode === 'undefined' || ngDevMode) && !fetchBackendWarningDisplayed) {
       const isServer = isPlatformServer(injector.get(PLATFORM_ID));
-      if (isServer && !(this.backend instanceof FetchBackend)) {
+
+      // This flag is necessary because provideHttpClientTesting() overrides the backend
+      // even if `withFetch()` is used within the test. When the testing HTTP backend is provided,
+      // no HTTP calls are actually performed during the test, so producing a warning would be
+      // misleading.
+      const isTestingBackend = (this.backend as any).isTestingBackend;
+
+      if (isServer && !(this.backend instanceof FetchBackend) && !isTestingBackend) {
         fetchBackendWarningDisplayed = true;
         injector
           .get(Console)

--- a/packages/common/http/testing/src/backend.ts
+++ b/packages/common/http/testing/src/backend.ts
@@ -32,6 +32,11 @@ export class HttpClientTestingBackend implements HttpBackend, HttpTestingControl
   private open: TestRequest[] = [];
 
   /**
+   * Used when checking if we need to throw the NOT_USING_FETCH_BACKEND_IN_SSR error
+   */
+  private isTestingBackend = true;
+
+  /**
    * Handle an incoming request by queueing it in the list of open requests.
    */
   handle(req: HttpRequest<any>): Observable<HttpEvent<any>> {


### PR DESCRIPTION
Prior to this commit, we were logging the `NOT_USING_FETCH_BACKEND_IN_SSR` error when `provideHttpTestingClient` and `PLATFORM_ID` were provided.

fixes #59028
