### PR TITLE
refactor(platform-browser): animation module is not optional.

### DIFF
--- a/packages/platform-browser/package.json
+++ b/packages/platform-browser/package.json
@@ -15,11 +15,6 @@
     "@angular/core": "0.0.0-PLACEHOLDER",
     "@angular/common": "0.0.0-PLACEHOLDER"
   },
-  "peerDependenciesMeta": {
-    "@angular/animations": {
-      "optional": true
-    }
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/angular/angular.git",


### PR DESCRIPTION
When `platform-server` pulls from `platform-browser/animations`, we need to make sure that animations are part of it.

fixes #59050
