### PR TITLE
docs: release notes for the v19.0.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<a name="19.0.3"></a>
+# 19.0.3 (2024-12-04)
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="19.1.0-next.1"></a>
 # 19.1.0-next.1 (2024-12-04)
 ### compiler-cli


### PR DESCRIPTION
Cherry-picks the changelog from the "19.0.x" branch to the next branch (main).