### PR TITLE
fix(compiler-cli): consider pre-release versions when detecting feature support

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -469,7 +469,7 @@ export class NgCompiler {
     // version of the compiler against an older version of Angular.
     this.implicitStandaloneValue =
       this.angularCoreVersion === null ||
-      coreVersionSupportsFeature(this.angularCoreVersion, '>= 19.0.0-0');
+      coreVersionSupportsFeature(this.angularCoreVersion, '>= 19.0.0');
     this.enableHmr = !!options['_enableHmr'];
     this.constructionDiagnostics.push(
       ...this.adapter.constructionDiagnostics,
@@ -1036,7 +1036,7 @@ export class NgCompiler {
     let allowSignalsInTwoWayBindings =
       coreHasSymbol(this.inputProgram, R3Identifiers.unwrapWritableSignal) ??
       (this.angularCoreVersion === null ||
-        coreVersionSupportsFeature(this.angularCoreVersion, '>= 17.2.0-0'));
+        coreVersionSupportsFeature(this.angularCoreVersion, '>= 17.2.0'));
 
     // First select a type-checking configuration, based on whether full template type-checking is
     // requested.

--- a/packages/compiler-cli/src/ngtsc/core/src/feature_detection.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/feature_detection.ts
@@ -23,5 +23,5 @@ export function coreVersionSupportsFeature(coreVersion: string, minVersion: stri
     return true;
   }
 
-  return semver.satisfies(coreVersion, minVersion);
+  return semver.satisfies(coreVersion, minVersion, {includePrerelease: true});
 }

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -11002,6 +11002,45 @@ runInEachFileSystem((os: string) => {
         );
       });
 
+      it('should consider declarations as standalone by default in v19 pre-release versions', () => {
+        env.tsconfig({
+          _angularCoreVersion: '19.1.0-next.0',
+        });
+
+        env.write(
+          '/test.ts',
+          `
+            import {Directive, Component, Pipe, NgModule} from '@angular/core';
+
+            @Directive()
+            export class TestDir {}
+
+            @Component({template: ''})
+            export class TestComp {}
+
+            @Pipe({name: 'test'})
+            export class TestPipe {}
+
+            @NgModule({
+              declarations: [TestDir, TestComp, TestPipe]
+            })
+            export class TestModule {}
+          `,
+        );
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(3);
+        expect(diags[0].messageText).toContain(
+          'Directive TestDir is standalone, and cannot be declared in an NgModule.',
+        );
+        expect(diags[1].messageText).toContain(
+          'Component TestComp is standalone, and cannot be declared in an NgModule.',
+        );
+        expect(diags[2].messageText).toContain(
+          'Pipe TestPipe is standalone, and cannot be declared in an NgModule.',
+        );
+      });
+
       it('should disable standalone by default on versions older than 19', () => {
         env.tsconfig({
           _angularCoreVersion: '18.2.10',


### PR DESCRIPTION
Fixes that the logic which checks whether a feature is supported didn't account for pre-releases.

Fixes https://github.com/angular/vscode-ng-language-service/issues/2123.
