### PR TITLE
fix(compiler-cli): error in unused standalone imports diagnostic

### DIFF
--- a/packages/compiler-cli/src/ngtsc/validation/src/rules/unused_standalone_imports_rule.ts
+++ b/packages/compiler-cli/src/ngtsc/validation/src/rules/unused_standalone_imports_rule.ts
@@ -172,7 +172,10 @@ export class UnusedStandaloneImportsRule implements SourceFileValidatorRule {
       if (ts.isVariableStatement(current)) {
         return !!current.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
       }
-      current = current.parent;
+
+      // `Node.parent` can be undefined, but the TS types don't reflect it.
+      // Coerce to null so the value is consitent with the type.
+      current = current.parent ?? null;
     }
 
     // Otherwise the reference likely comes from an imported


### PR DESCRIPTION
Fixes a null pointer error in the unused standalone imports diagnostic. It was caused by an inconsistency in TypeScript's built-in types.

Fixes #58872.
