### PR TITLE
docs(docs-infra): make font styles consistent in the API code ToC

### DIFF
--- a/adev/shared-docs/styles/docs/_code.scss
+++ b/adev/shared-docs/styles/docs/_code.scss
@@ -2,6 +2,8 @@
 
 /* stylelint-disable */
 
+$code-font-size: 0.875rem;
+
 @mixin docs-code-block {
   // code across docs, inline, blocks, shell, example viewer, etc.
   code {
@@ -106,7 +108,7 @@
     code {
       display: flex;
       flex-direction: column;
-      font-size: 0.875rem;
+      font-size: $code-font-size;
       counter-reset: line;
     }
   }
@@ -222,7 +224,7 @@
       background-clip: text;
       -webkit-background-clip: text;
       color: transparent;
-      font-size: 0.875rem;
+      font-size: $code-font-size;
       font-style: normal;
       font-weight: 400;
       line-height: 1.4rem;
@@ -296,7 +298,7 @@
     padding-inline-start: 0.75rem;
     padding-inline-end: 0.5rem;
     color: var(--quaternary-contrast);
-    font-size: 0.875rem;
+    font-size: $code-font-size;
     text-align: right;
   }
 
@@ -322,8 +324,13 @@
     min-height: 1.375em;
     padding-inline: 1rem;
     color: var(--tertiary-contrast);
-
     display: block;
+    font-size: $code-font-size;
+    font-family: var(--code-font);
+    font-weight: 400;
+    text-align: left;
+    padding-block: 0.25rem;
+
     &.hidden {
       display: none;
     }

--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
@@ -97,13 +97,6 @@
 
       button {
         transition: background-color 0.3s ease;
-        font-family: monospace;
-
-        &.line {
-          font-weight: 400;
-          text-align: left;
-          padding-block: 0.25rem;
-        }
 
         &.shiki-ln-line-highlighted {
           background-color: var(--senary-contrast);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Since code lines are wrapped in `<button>`-s, the native font styles override the parent's one which results in the font-family and font-size (esp. Safari) difference.

<img width="774" alt="Screenshot 2024-12-05 at 16 33 48" src="https://github.com/user-attachments/assets/d6d581f6-6c54-4d0c-947b-d832331aaba6">

## What is the new behavior?

This is a bug fix of the described issue.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
