### PR TITLE
Empty the circular dependencies golden

### DIFF
--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -1,27 +1,5 @@
 [
   [
-    "packages/core/src/metadata/directives.ts",
-    "packages/core/src/render3/jit/directive.ts"
-  ],
-  [
-    "packages/core/src/metadata/directives.ts",
-    "packages/core/src/render3/jit/directive.ts",
-    "packages/core/src/metadata/resource_loading.ts"
-  ],
-  [
-    "packages/core/src/metadata/directives.ts",
-    "packages/core/src/render3/jit/directive.ts",
-    "packages/core/src/render3/jit/module.ts"
-  ],
-  [
-    "packages/core/src/metadata/directives.ts",
-    "packages/core/src/render3/jit/pipe.ts"
-  ],
-  [
-    "packages/core/src/metadata/ng_module.ts",
-    "packages/core/src/render3/jit/module.ts"
-  ],
-  [
     "packages/core/src/render3/interfaces/container.ts",
     "packages/core/src/render3/interfaces/view.ts"
   ],

--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -1,9 +1,5 @@
 [
   [
-    "packages/core/src/di/injectable.ts",
-    "packages/core/src/di/jit/injectable.ts"
-  ],
-  [
     "packages/core/src/linker/component_factory_resolver.ts",
     "packages/core/src/linker/component_factory.ts",
     "packages/core/src/linker/ng_module_factory.ts"

--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -1,14 +1,5 @@
 [
   [
-    "packages/router/src/models.ts",
-    "packages/router/src/router_state.ts"
-  ],
-  [
-    "packages/router/src/models.ts",
-    "packages/router/src/url_tree.ts",
-    "packages/router/src/shared.ts"
-  ],
-  [
     "packages/router/src/navigation_transition.ts",
     "packages/router/src/operators/activate_routes.ts"
   ],
@@ -23,9 +14,5 @@
   [
     "packages/router/src/navigation_transition.ts",
     "packages/router/src/operators/resolve_data.ts"
-  ],
-  [
-    "packages/router/src/shared.ts",
-    "packages/router/src/url_tree.ts"
   ]
 ]

--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -1,18 +1,1 @@
-[
-  [
-    "packages/router/src/navigation_transition.ts",
-    "packages/router/src/operators/activate_routes.ts"
-  ],
-  [
-    "packages/router/src/navigation_transition.ts",
-    "packages/router/src/operators/check_guards.ts"
-  ],
-  [
-    "packages/router/src/navigation_transition.ts",
-    "packages/router/src/operators/recognize.ts"
-  ],
-  [
-    "packages/router/src/navigation_transition.ts",
-    "packages/router/src/operators/resolve_data.ts"
-  ]
-]
+[]

--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -1,9 +1,5 @@
 [
   [
-    "packages/router/src/directives/router_outlet.ts",
-    "packages/router/src/router_outlet_context.ts"
-  ],
-  [
     "packages/router/src/models.ts",
     "packages/router/src/router_state.ts"
   ],

--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -1,10 +1,5 @@
 [
   [
-    "packages/core/src/linker/component_factory_resolver.ts",
-    "packages/core/src/linker/component_factory.ts",
-    "packages/core/src/linker/ng_module_factory.ts"
-  ],
-  [
     "packages/core/src/metadata/directives.ts",
     "packages/core/src/render3/jit/directive.ts"
   ],

--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -1,9 +1,5 @@
 [
   [
-    "packages/core/src/render3/interfaces/container.ts",
-    "packages/core/src/render3/interfaces/view.ts"
-  ],
-  [
     "packages/router/src/directives/router_outlet.ts",
     "packages/router/src/router_outlet_context.ts"
   ],

--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -1,9 +1,5 @@
 [
   [
-    "packages/compiler-cli/src/ngtsc/partial_evaluator/src/interface.ts",
-    "packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts"
-  ],
-  [
     "packages/compiler/src/output/output_ast.ts",
     "packages/compiler/src/render3/view/i18n/meta.ts"
   ],

--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -1,9 +1,5 @@
 [
   [
-    "packages/core/src/change_detection/change_detector_ref.ts",
-    "packages/core/src/render3/view_ref.ts"
-  ],
-  [
     "packages/core/src/change_detection/differs/default_iterable_differ.ts",
     "packages/core/src/change_detection/differs/iterable_differs.ts"
   ],

--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -1,14 +1,5 @@
 [
   [
-    "packages/compiler/src/output/output_ast.ts",
-    "packages/compiler/src/render3/view/i18n/meta.ts"
-  ],
-  [
-    "packages/compiler/src/output/output_ast.ts",
-    "packages/compiler/src/render3/view/i18n/meta.ts",
-    "packages/compiler/src/render3/view/i18n/util.ts"
-  ],
-  [
     "packages/core/src/change_detection/change_detector_ref.ts",
     "packages/core/src/render3/view_ref.ts"
   ],

--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -1,13 +1,5 @@
 [
   [
-    "packages/core/src/change_detection/differs/default_iterable_differ.ts",
-    "packages/core/src/change_detection/differs/iterable_differs.ts"
-  ],
-  [
-    "packages/core/src/change_detection/differs/default_keyvalue_differ.ts",
-    "packages/core/src/change_detection/differs/keyvalue_differs.ts"
-  ],
-  [
     "packages/core/src/di/injectable.ts",
     "packages/core/src/di/jit/injectable.ts"
   ],

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
@@ -16,7 +16,7 @@ import {isDeclaration} from '../../util/src/typescript';
 
 import {ArrayConcatBuiltinFn, ArraySliceBuiltinFn, StringConcatBuiltinFn} from './builtin';
 import {DynamicValue} from './dynamic';
-import {ForeignFunctionResolver} from './interface';
+import type {ForeignFunctionResolver} from './interface';
 import {
   EnumValue,
   KnownFn,

--- a/packages/compiler/src/output/output_ast.ts
+++ b/packages/compiler/src/output/output_ast.ts
@@ -9,7 +9,7 @@
 import {computeMsgId} from '../i18n/digest';
 import {Message} from '../i18n/i18n_ast';
 import {ParseSourceSpan} from '../parse_util';
-import {I18nMeta} from '../render3/view/i18n/meta';
+import type {I18nMeta} from '../render3/view/i18n/meta';
 
 //// Types
 export enum TypeModifier {

--- a/packages/core/src/change_detection/differs/default_iterable_differ.ts
+++ b/packages/core/src/change_detection/differs/default_iterable_differ.ts
@@ -11,7 +11,7 @@ import {Writable} from '../../interface/type';
 import {isListLikeIterable, iterateListLike} from '../../util/iterable';
 import {stringify} from '../../util/stringify';
 
-import {
+import type {
   IterableChangeRecord,
   IterableChanges,
   IterableDiffer,

--- a/packages/core/src/change_detection/differs/default_keyvalue_differ.ts
+++ b/packages/core/src/change_detection/differs/default_keyvalue_differ.ts
@@ -10,7 +10,7 @@ import {RuntimeError, RuntimeErrorCode} from '../../errors';
 import {isJsObject} from '../../util/iterable';
 import {stringify} from '../../util/stringify';
 
-import {
+import type {
   KeyValueChangeRecord,
   KeyValueChanges,
   KeyValueDiffer,

--- a/packages/core/src/di/jit/injectable.ts
+++ b/packages/core/src/di/jit/injectable.ts
@@ -15,7 +15,7 @@ import {Type} from '../../interface/type';
 import {NG_FACTORY_DEF} from '../../render3/fields';
 import {getClosureSafeProperty} from '../../util/property';
 import {resolveForwardRef} from '../forward_ref';
-import {Injectable} from '../injectable';
+import type {Injectable} from '../injectable';
 import {NG_PROV_DEF} from '../interface/defs';
 import {
   ClassSansProvider,

--- a/packages/core/src/linker/component_factory.ts
+++ b/packages/core/src/linker/component_factory.ts
@@ -6,14 +6,14 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectorRef} from '../change_detection/change_detection';
-import {Injector} from '../di/injector';
-import {EnvironmentInjector} from '../di/r3_injector';
+import type {ChangeDetectorRef} from '../change_detection/change_detection';
+import type {Injector} from '../di/injector';
+import type {EnvironmentInjector} from '../di/r3_injector';
 import {Type} from '../interface/type';
 
-import {ElementRef} from './element_ref';
-import {NgModuleRef} from './ng_module_factory';
-import {ViewRef} from './view_ref';
+import type {ElementRef} from './element_ref';
+import type {NgModuleRef} from './ng_module_factory';
+import type {ViewRef} from './view_ref';
 
 /**
  * Represents a component created by a `ComponentFactory`.

--- a/packages/core/src/linker/component_factory_resolver.ts
+++ b/packages/core/src/linker/component_factory_resolver.ts
@@ -9,7 +9,7 @@
 import {Type} from '../interface/type';
 import {stringify} from '../util/stringify';
 
-import {ComponentFactory} from './component_factory';
+import type {ComponentFactory} from './component_factory';
 
 class _NullComponentFactoryResolver implements ComponentFactoryResolver {
   resolveComponentFactory<T>(component: {new (...args: any[]): T}): ComponentFactory<T> {

--- a/packages/core/src/metadata/resource_loading.ts
+++ b/packages/core/src/metadata/resource_loading.ts
@@ -8,7 +8,7 @@
 
 import {Type} from '../interface/type';
 
-import {Component} from './directives';
+import type {Component} from './directives';
 
 /**
  * Used to resolve resource URLs on `@Component` when used with JIT compilation.

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -13,11 +13,10 @@ import {ProviderToken} from '../../di/provider_token';
 import {DehydratedView} from '../../hydration/interfaces';
 import {SchemaMetadata} from '../../metadata/schema';
 import {Sanitizer} from '../../sanitization/sanitizer';
-import type {AfterRenderManager} from '../after_render/manager';
 import type {ReactiveLViewConsumer} from '../reactive_lview_consumer';
 import type {ViewEffectNode} from '../reactivity/effect';
 
-import {LContainer} from './container';
+import type {LContainer} from './container';
 import {
   ComponentDef,
   ComponentTemplate,

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -18,8 +18,8 @@ import {
 import {resolveForwardRef} from '../../di/forward_ref';
 import {getReflect, reflectDependencies} from '../../di/jit/util';
 import {Type} from '../../interface/type';
-import {Query} from '../../metadata/di';
-import {Component, Directive, Input} from '../../metadata/directives';
+import type {Query} from '../../metadata/di';
+import type {Component, Directive, Input} from '../../metadata/directives';
 import {
   componentNeedsResolution,
   maybeQueueResolutionOfComponentResources,

--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -13,13 +13,16 @@ import {
 } from '../../compiler/compiler_facade';
 import {resolveForwardRef} from '../../di/forward_ref';
 import {NG_INJ_DEF} from '../../di/interface/defs';
-import {ModuleWithProviders} from '../../di/interface/provider';
+import type {ModuleWithProviders} from '../../di/interface/provider';
 import {reflectDependencies} from '../../di/jit/util';
 import {Type} from '../../interface/type';
 import {registerNgModuleType} from '../../linker/ng_module_registration';
-import {Component} from '../../metadata/directives';
-import {NgModule} from '../../metadata/ng_module';
-import {NgModuleDef, NgModuleTransitiveScopes, NgModuleType} from '../../metadata/ng_module_def';
+import type {NgModule} from '../../metadata/ng_module';
+import type {
+  NgModuleDef,
+  NgModuleTransitiveScopes,
+  NgModuleType,
+} from '../../metadata/ng_module_def';
 import {deepForEach, flatten} from '../../util/array_utils';
 import {assertDefined} from '../../util/assert';
 import {EMPTY_ARRAY} from '../../util/empty';
@@ -33,7 +36,7 @@ import {
 } from '../def_getters';
 import {depsTracker, USE_RUNTIME_DEPS_TRACKER_FOR_JIT} from '../deps_tracker/deps_tracker';
 import {NG_COMP_DEF, NG_DIR_DEF, NG_FACTORY_DEF, NG_MOD_DEF, NG_PIPE_DEF} from '../fields';
-import {ComponentDef} from '../interfaces/definition';
+import type {ComponentDef} from '../interfaces/definition';
 import {maybeUnwrapFn} from '../util/misc_utils';
 import {stringifyForError} from '../util/stringify_utils';
 

--- a/packages/core/src/render3/jit/pipe.ts
+++ b/packages/core/src/render3/jit/pipe.ts
@@ -13,7 +13,7 @@ import {
 } from '../../compiler/compiler_facade';
 import {reflectDependencies} from '../../di/jit/util';
 import {Type} from '../../interface/type';
-import {Pipe} from '../../metadata/directives';
+import type {Pipe} from '../../metadata/directives';
 import {NG_FACTORY_DEF, NG_PIPE_DEF} from '../fields';
 
 import {angularCoreEnv} from './environment';

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectorRef} from '../change_detection/change_detector_ref';
+import type {ChangeDetectorRef} from '../change_detection/change_detector_ref';
 import {NotificationSource} from '../change_detection/scheduling/zoneless_scheduling';
 import type {ApplicationRef} from '../core';
 import {RuntimeError, RuntimeErrorCode} from '../errors';
-import {EmbeddedViewRef} from '../linker/view_ref';
+import type {EmbeddedViewRef} from '../linker/view_ref';
 import {removeFromArray} from '../util/array_utils';
 import {assertEqual} from '../util/assert';
 

--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -26,7 +26,6 @@ import {
   ɵRuntimeError as RuntimeError,
   Signal,
   input,
-  computed,
 } from '@angular/core';
 import {combineLatest, of, Subscription} from 'rxjs';
 import {switchMap} from 'rxjs/operators';

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -16,8 +16,8 @@ import {
 } from '@angular/core';
 import {Observable} from 'rxjs';
 
-import {ActivatedRouteSnapshot, RouterStateSnapshot} from './router_state';
-import {UrlSegment, UrlSegmentGroup, UrlTree} from './url_tree';
+import type {ActivatedRouteSnapshot, RouterStateSnapshot} from './router_state';
+import type {UrlSegment, UrlSegmentGroup, UrlTree} from './url_tree';
 
 /**
  * How to handle a navigation request to the current URL. One of:

--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -81,7 +81,7 @@ import {
   RouterState,
   RouterStateSnapshot,
 } from './router_state';
-import {Params} from './shared';
+import type {Params} from './shared';
 import {UrlHandlingStrategy} from './url_handling_strategy';
 import {isUrlTree, UrlSerializer, UrlTree} from './url_tree';
 import {Checks, getAllRouteGuards} from './utils/preactivation';

--- a/packages/router/src/operators/activate_routes.ts
+++ b/packages/router/src/operators/activate_routes.ts
@@ -10,11 +10,10 @@ import {MonoTypeOperatorFunction} from 'rxjs';
 import {map} from 'rxjs/operators';
 
 import {ActivationEnd, ChildActivationEnd, Event} from '../events';
-import {NavigationTransition} from '../navigation_transition';
-import {DetachedRouteHandleInternal, RouteReuseStrategy} from '../route_reuse_strategy';
-import {ChildrenOutletContexts} from '../router_outlet_context';
+import type {NavigationTransition} from '../navigation_transition';
+import type {DetachedRouteHandleInternal, RouteReuseStrategy} from '../route_reuse_strategy';
+import type {ChildrenOutletContexts} from '../router_outlet_context';
 import {ActivatedRoute, advanceActivatedRoute, RouterState} from '../router_state';
-import {getClosestRouteInjector} from '../utils/config';
 import {nodeChildrenAsMap, TreeNode} from '../utils/tree';
 
 let warnedAboutUnsupportedInputBinding = false;

--- a/packages/router/src/operators/check_guards.ts
+++ b/packages/router/src/operators/check_guards.ts
@@ -29,10 +29,10 @@ import {
   CanMatchFn,
   Route,
 } from '../models';
-import {navigationCancelingError, redirectingNavigationError} from '../navigation_canceling_error';
-import {NavigationTransition} from '../navigation_transition';
-import {ActivatedRouteSnapshot, RouterStateSnapshot} from '../router_state';
-import {isUrlTree, UrlSegment, UrlSerializer, UrlTree} from '../url_tree';
+import {redirectingNavigationError} from '../navigation_canceling_error';
+import type {NavigationTransition} from '../navigation_transition';
+import type {ActivatedRouteSnapshot, RouterStateSnapshot} from '../router_state';
+import {UrlSegment, UrlSerializer} from '../url_tree';
 import {wrapIntoObservable} from '../utils/collection';
 import {getClosestRouteInjector} from '../utils/config';
 import {

--- a/packages/router/src/operators/recognize.ts
+++ b/packages/router/src/operators/recognize.ts
@@ -10,11 +10,11 @@ import {EnvironmentInjector, Type} from '@angular/core';
 import {MonoTypeOperatorFunction} from 'rxjs';
 import {map, mergeMap} from 'rxjs/operators';
 
-import {Route} from '../models';
-import {NavigationTransition} from '../navigation_transition';
+import type {Route} from '../models';
+import type {NavigationTransition} from '../navigation_transition';
 import {recognize as recognizeFn} from '../recognize';
-import {RouterConfigLoader} from '../router_config_loader';
-import {UrlSerializer} from '../url_tree';
+import type {RouterConfigLoader} from '../router_config_loader';
+import type {UrlSerializer} from '../url_tree';
 
 export function recognize(
   injector: EnvironmentInjector,

--- a/packages/router/src/operators/resolve_data.ts
+++ b/packages/router/src/operators/resolve_data.ts
@@ -11,7 +11,7 @@ import {EMPTY, from, MonoTypeOperatorFunction, Observable, of, throwError} from 
 import {catchError, concatMap, first, map, mapTo, mergeMap, takeLast, tap} from 'rxjs/operators';
 
 import {RedirectCommand, ResolveData} from '../models';
-import {NavigationTransition} from '../navigation_transition';
+import type {NavigationTransition} from '../navigation_transition';
 import {
   ActivatedRouteSnapshot,
   getInherited,

--- a/packages/router/src/router_outlet_context.ts
+++ b/packages/router/src/router_outlet_context.ts
@@ -8,7 +8,7 @@
 
 import {ComponentRef, EnvironmentInjector, Injectable} from '@angular/core';
 
-import {RouterOutletContract} from './directives/router_outlet';
+import type {RouterOutletContract} from './directives/router_outlet';
 import {ActivatedRoute} from './router_state';
 import {getClosestRouteInjector} from './utils/config';
 

--- a/packages/router/src/shared.ts
+++ b/packages/router/src/shared.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Route, UrlMatchResult} from './models';
-import {UrlSegment, UrlSegmentGroup} from './url_tree';
+import type {Route, UrlMatchResult} from './models';
+import type {UrlSegment, UrlSegmentGroup} from './url_tree';
 
 /**
  * The primary routing outlet.


### PR DESCRIPTION
Collection of commits which use `import type` to remove every existing circular dependency exception.