### PR TITLE
fix(compiler-cli): preserve non-null assertions in event side of two-way bindings

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -721,6 +721,25 @@ describe('type check blocks', () => {
     expect(block).toContain('_t2 = $event;');
   });
 
+  it('should handle a two-way binding to a non-null-asserted expression', () => {
+    const TEMPLATE = `<div twoWay [(input)]="value!"></div>`;
+    const DIRECTIVES: TestDeclaration[] = [
+      {
+        type: 'directive',
+        name: 'TwoWay',
+        selector: '[twoWay]',
+        inputs: {input: 'input'},
+        outputs: {inputChange: 'inputChange'},
+      },
+    ];
+    const block = tcb(TEMPLATE, DIRECTIVES);
+
+    expect(block).toContain('var _t1 = null! as i0.TwoWay;');
+    expect(block).toContain('_t1.input = i1.ɵunwrapWritableSignal(((((this).value))!));');
+    expect(block).toContain('var _t2 = i1.ɵunwrapWritableSignal((((this).value))!);');
+    expect(block).toContain('_t2 = $event!;');
+  });
+
   it('should handle a two-way binding to an input/output pair of a generic directive', () => {
     const TEMPLATE = `<div twoWay [(input)]="value"></div>`;
     const DIRECTIVES: TestDeclaration[] = [

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -685,6 +685,33 @@ runInEachFileSystem(() => {
       expect(diags[0].messageText).toBe(`Type 'number' is not assignable to type 'string'.`);
     });
 
+    it('should apply non-null assertions both to the property and event sides of two-way bindings', () => {
+      env.tsconfig({strictTemplates: true, _checkTwoWayBoundEvents: true});
+      env.write(
+        'test.ts',
+        `
+          import {Component, Directive, Input, Output, EventEmitter} from '@angular/core';
+
+          @Directive({selector: '[dir]'})
+          export class Dir {
+            @Input() value: number | null;
+            @Output() valueChange = new EventEmitter<number | null>();
+          }
+
+          @Component({
+            template: '<div dir [(value)]="value!"></div>',
+            imports: [Dir],
+          })
+          export class App {
+            value = 123;
+          }
+        `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(0);
+    });
+
     it('should check the fallback content of ng-content', () => {
       env.write(
         'test.ts',


### PR DESCRIPTION
Follow-up to #59002. If a two-way binding is non-null asserted, only the property side was getting the assertion since the `$event` is synthetic. In practice this means that there's no way to non-null assert a two-way binding. These changes fix the issue by checking if the handler is asserted and applying it to the `$event` assignment.
