### PR TITLE
ci: Update caretaker config for merge queue

### DIFF
--- a/.ng-dev/caretaker.mts
+++ b/.ng-dev/caretaker.mts
@@ -6,7 +6,7 @@ export const caretaker: CaretakerConfig = {
   githubQueries: [
     {
       name: 'Merge Queue',
-      query: `is:pr is:open status:success label:"action: merge"`,
+      query: `is:pr is:open label:"action: merge"`,
     },
     {
       name: 'Merge Assistance Queue',


### PR DESCRIPTION
This updates the caretaker query for merge queue
to remove status: success, since skipped workflows are considered failed by Github and omitted from
the query results.
