### PR TITLE
docs(docs-infra): removed confusing extra single quote

### DIFF
--- a/adev/src/content/tools/cli/build-system-migration.md
+++ b/adev/src/content/tools/cli/build-system-migration.md
@@ -283,7 +283,7 @@ An example is as follows:
       ...
       "define": {
           "SOME_NUMBER": "5",
-          "ANOTHER": "''this is a string literal, note the extra single quotes'",
+          "ANOTHER": "'this is a string literal, note the extra single quotes'",
           "REFERENCE": "globalThis.someValue.noteTheAbsentSingleQuotes"
       }
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
```json
      "define": {
          "SOME_NUMBER": "5",
-          "ANOTHER": "''this is a string literal, note the extra single quotes'",
          "REFERENCE": "globalThis.someValue.noteTheAbsentSingleQuotes"
      }
```
Issue Number: N/A


## What is the new behavior?
```json
      "define": {
          "SOME_NUMBER": "5",
+          "ANOTHER": "'this is a string literal, note the extra single quotes'",
          "REFERENCE": "globalThis.someValue.noteTheAbsentSingleQuotes"
      }
```


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

