### PR TITLE
docs(docs-infra): remove costly `localeCompare`

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/manifest/generate_manifest.ts
+++ b/adev/shared-docs/pipeline/api-gen/manifest/generate_manifest.ts
@@ -78,6 +78,11 @@ export function generateManifest(apiCollections: EntryCollection[]): Manifest {
     }
   }
 
+  // We sort the API entries alphabetically by name to ensure a stable order in the manifest.
+  manifest.forEach((entry) => {
+    entry.entries.sort((entry1, entry2) => entry1.name.localeCompare(entry2.name));
+  });
+
   manifest.sort((entry1, entry2) => {
     // Ensure that labels that start with a `code` tag like `window.ng` are last
     if (entry1.moduleLabel.startsWith('<')) {

--- a/adev/shared-docs/pipeline/api-gen/manifest/test/manifest.spec.ts
+++ b/adev/shared-docs/pipeline/api-gen/manifest/test/manifest.spec.ts
@@ -6,19 +6,20 @@ describe('api manifest generation', () => {
   it('should generate a manifest from multiple collections', () => {
     const manifest: Manifest = generateManifest([
       {
-        moduleName: '@angular/core',
-        entries: [entry({name: 'PI', entryType: EntryType.Constant})],
-        normalizedModuleName: 'angular_core',
-        moduleLabel: 'core',
-      },
-      {
         moduleName: '@angular/router',
         entries: [entry({name: 'Router', entryType: EntryType.UndecoratedClass})],
         normalizedModuleName: 'angular_router',
         moduleLabel: 'router',
       },
+      {
+        moduleName: '@angular/core',
+        entries: [entry({name: 'PI', entryType: EntryType.Constant})],
+        normalizedModuleName: 'angular_core',
+        moduleLabel: 'core',
+      },
     ]);
 
+    // The test also makes sure that we sort modules by name.
     expect(manifest).toEqual([
       {
         moduleName: '@angular/core',

--- a/adev/shared-docs/pipeline/api-gen/manifest/test/manifest.spec.ts
+++ b/adev/shared-docs/pipeline/api-gen/manifest/test/manifest.spec.ts
@@ -17,15 +17,28 @@ describe('api manifest generation', () => {
         normalizedModuleName: 'angular_core',
         moduleLabel: 'core',
       },
+      {
+        moduleName: '@angular/core',
+        entries: [entry({name: 'foo', entryType: EntryType.Constant})],
+        normalizedModuleName: 'angular_core',
+        moduleLabel: 'core',
+      },
     ]);
 
-    // The test also makes sure that we sort modules by name.
+    // The test also makes sure that we sort modules & entries by name.
     expect(manifest).toEqual([
       {
         moduleName: '@angular/core',
         moduleLabel: 'core',
         normalizedModuleName: 'angular_core',
         entries: [
+          {
+            name: 'foo',
+            type: EntryType.Constant,
+            isDeprecated: false,
+            isDeveloperPreview: false,
+            isExperimental: false,
+          },
           {
             name: 'PI',
             type: EntryType.Constant,

--- a/adev/src/app/features/references/helpers/manifest.helper.ts
+++ b/adev/src/app/features/references/helpers/manifest.helper.ts
@@ -43,12 +43,10 @@ export function getApiNavigationItems(): NavigationItem[] {
   for (const packageEntry of manifest) {
     const packageNavigationItem: NavigationItem = {
       label: packageEntry.moduleLabel,
-      children: packageEntry.entries
-        .map((api) => ({
-          path: getApiUrl(packageEntry, api.name),
-          label: api.name,
-        }))
-        .sort((a, b) => a.label.localeCompare(b.label)),
+      children: packageEntry.entries.map((api) => ({
+        path: getApiUrl(packageEntry, api.name),
+        label: api.name,
+      })),
     };
 
     apiNavigationItems.push(packageNavigationItem);


### PR DESCRIPTION
This function wasn't necessary, the items were already sorted.

fixes #59069d
