### PR TITLE
refactor(core): remove dependency on rxjs' `BehaviorSubject`.

### DIFF
--- a/packages/core/rxjs-interop/test/pending_until_event_spec.ts
+++ b/packages/core/rxjs-interop/test/pending_until_event_spec.ts
@@ -36,10 +36,10 @@ describe('pendingUntilEvent', () => {
   it('should not block stability until subscription', async () => {
     const originalSource = new BehaviorSubject(0);
     const delayedSource = originalSource.pipe(delay(5), pendingUntilEvent(injector));
-    expect(taskService.hasPendingTasks.value).toEqual(false);
+    expect(taskService.hasPendingTasks).toEqual(false);
 
     const emitPromise = firstValueFrom(delayedSource);
-    expect(taskService.hasPendingTasks.value).toEqual(true);
+    expect(taskService.hasPendingTasks).toEqual(true);
 
     await expectAsync(emitPromise).toBeResolvedTo(0);
     await expectAsync(appRef.whenStable()).toBeResolved();
@@ -49,10 +49,10 @@ describe('pendingUntilEvent', () => {
     const source = of(1).pipe(pendingUntilEvent(injector));
 
     // stable before subscription
-    expect(taskService.hasPendingTasks.value).toEqual(false);
+    expect(taskService.hasPendingTasks).toEqual(false);
     source.subscribe(() => {
       // unstable within synchronous subscription body
-      expect(taskService.hasPendingTasks.value).toBe(true);
+      expect(taskService.hasPendingTasks).toBe(true);
     });
     // stable after above synchronous subscription execution
     await expectAsync(appRef.whenStable()).toBeResolved();
@@ -60,12 +60,12 @@ describe('pendingUntilEvent', () => {
 
   it('only blocks stability until first emit', async () => {
     const intervalSource = interval(5).pipe(pendingUntilEvent(injector));
-    expect(taskService.hasPendingTasks.value).toEqual(false);
+    expect(taskService.hasPendingTasks).toEqual(false);
 
     await new Promise<void>(async (resolve) => {
       const subscription = intervalSource.subscribe(async (v) => {
         if (v === 0) {
-          expect(taskService.hasPendingTasks.value).toBe(true);
+          expect(taskService.hasPendingTasks).toBe(true);
         } else {
           await expectAsync(appRef.whenStable()).toBeResolved();
         }
@@ -74,14 +74,14 @@ describe('pendingUntilEvent', () => {
           resolve();
         }
       });
-      expect(taskService.hasPendingTasks.value).toBe(true);
+      expect(taskService.hasPendingTasks).toBe(true);
     });
   });
 
   it('should unblock stability on complete (but no emit)', async () => {
     const sub = new Subject();
     sub.asObservable().pipe(pendingUntilEvent(injector)).subscribe();
-    expect(taskService.hasPendingTasks.value).toBe(true);
+    expect(taskService.hasPendingTasks).toBe(true);
     sub.complete();
     await expectAsync(appRef.whenStable()).toBeResolved();
   });
@@ -89,7 +89,7 @@ describe('pendingUntilEvent', () => {
   it('should unblock stability on unsubscribe before emit', async () => {
     const sub = new Subject();
     const subscription = sub.asObservable().pipe(pendingUntilEvent(injector)).subscribe();
-    expect(taskService.hasPendingTasks.value).toBe(true);
+    expect(taskService.hasPendingTasks).toBe(true);
     subscription.unsubscribe();
     await expectAsync(appRef.whenStable()).toBeResolved();
   });
@@ -107,12 +107,12 @@ describe('pendingUntilEvent', () => {
       .pipe(
         finalize(() => {
           finalizeExecuted = true;
-          expect(taskService.hasPendingTasks.value).toBe(true);
+          expect(taskService.hasPendingTasks).toBe(true);
         }),
         pendingUntilEvent(injector),
       )
       .subscribe();
-    expect(taskService.hasPendingTasks.value).toBe(true);
+    expect(taskService.hasPendingTasks).toBe(true);
     subscription.unsubscribe();
     await expectAsync(appRef.whenStable()).toBeResolved();
     expect(finalizeExecuted).toBe(true);
@@ -121,7 +121,7 @@ describe('pendingUntilEvent', () => {
   it('should not throw if application is destroyed before emit', async () => {
     const sub = new Subject<void>();
     sub.asObservable().pipe(pendingUntilEvent(injector)).subscribe();
-    expect(taskService.hasPendingTasks.value).toBe(true);
+    expect(taskService.hasPendingTasks).toBe(true);
     TestBed.resetTestingModule();
     await expectAsync(appRef.whenStable()).toBeResolved();
     sub.next();
@@ -137,7 +137,7 @@ describe('pendingUntilEvent', () => {
         catchError(() => EMPTY),
       )
       .subscribe();
-    expect(taskService.hasPendingTasks.value).toBe(true);
+    expect(taskService.hasPendingTasks).toBe(true);
     sub.error(new Error('error in pipe'));
     await expectAsync(appRef.whenStable()).toBeResolved();
     sub.next();
@@ -162,7 +162,7 @@ describe('pendingUntilEvent', () => {
           throw new Error('oh noes');
         },
       });
-    expect(taskService.hasPendingTasks.value).toBe(true);
+    expect(taskService.hasPendingTasks).toBe(true);
     const errorPromise = nextUncaughtError();
     sub.next();
     await expectAsync(errorPromise).toBeResolved();
@@ -225,13 +225,13 @@ describe('pendingUntilEvent', () => {
     const observable = sub.asObservable().pipe(delay(5), pendingUntilEvent(injector));
 
     observable.subscribe();
-    expect(taskService.hasPendingTasks.value).toBe(true);
+    expect(taskService.hasPendingTasks).toBe(true);
     sub.next();
     observable.subscribe();
     // first subscription unblocks
     await new Promise((r) => setTimeout(r, 5));
     // still pending because the other subscribed after the emit
-    expect(taskService.hasPendingTasks.value).toBe(true);
+    expect(taskService.hasPendingTasks).toBe(true);
 
     sub.next();
     await new Promise((r) => setTimeout(r, 3));
@@ -240,7 +240,7 @@ describe('pendingUntilEvent', () => {
     // second subscription unblocks
     await new Promise((r) => setTimeout(r, 2));
     // still pending because third subscription delay not finished
-    expect(taskService.hasPendingTasks.value).toBe(true);
+    expect(taskService.hasPendingTasks).toBe(true);
 
     // finishes third subscription
     await new Promise((r) => setTimeout(r, 3));

--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -14,7 +14,7 @@ import {
   setThrowInvalidWriteToSignalError,
 } from '@angular/core/primitives/signals';
 import {Observable, Subject, Subscription} from 'rxjs';
-import {map} from 'rxjs/operators';
+import {map, startWith} from 'rxjs/operators';
 
 import {ZONELESS_ENABLED} from '../change_detection/scheduling/zoneless_scheduling';
 import {Console} from '../console';
@@ -369,9 +369,9 @@ export class ApplicationRef {
   /**
    * Returns an Observable that indicates when the application is stable or unstable.
    */
-  public readonly isStable: Observable<boolean> = inject(PendingTasksInternal).hasPendingTasks.pipe(
-    map((pending) => !pending),
-  );
+  public readonly isStable: Observable<boolean> = inject(PendingTasksInternal)
+    .pendingTasksObservable()
+    .pipe(map((pending) => !pending));
 
   constructor() {
     // Inject the tracing service to initialize it.

--- a/packages/core/test/acceptance/pending_tasks_spec.ts
+++ b/packages/core/test/acceptance/pending_tasks_spec.ts
@@ -8,8 +8,7 @@
 
 import {ApplicationRef, PendingTasks} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {EMPTY, firstValueFrom, of} from 'rxjs';
-import {filter, map, take, withLatestFrom} from 'rxjs/operators';
+import {firstValueFrom} from 'rxjs';
 
 import {PendingTasksInternal} from '../../src/pending_tasks';
 
@@ -23,32 +22,32 @@ describe('PendingTasks', () => {
     pendingTasks.remove(taskA);
     pendingTasks.remove(taskB);
     pendingTasks.remove(taskC);
-    expect(await hasPendingTasks(pendingTasks)).toBeFalse();
+    expect(pendingTasks.hasPendingTasks).toBeFalse();
   });
 
   it('should allow calls to remove the same task multiple times', async () => {
     const pendingTasks = TestBed.inject(PendingTasksInternal);
-    expect(await hasPendingTasks(pendingTasks)).toBeFalse();
+    expect(pendingTasks.hasPendingTasks).toBeFalse();
 
     const taskA = pendingTasks.add();
-    expect(await hasPendingTasks(pendingTasks)).toBeTrue();
+    expect(pendingTasks.hasPendingTasks).toBeTrue();
 
     pendingTasks.remove(taskA);
     pendingTasks.remove(taskA);
     pendingTasks.remove(taskA);
 
-    expect(await hasPendingTasks(pendingTasks)).toBeFalse();
+    expect(pendingTasks.hasPendingTasks).toBeFalse();
   });
 
   it('should be tolerant to removal of non-existent ids', async () => {
     const pendingTasks = TestBed.inject(PendingTasksInternal);
-    expect(await hasPendingTasks(pendingTasks)).toBeFalse();
+    expect(pendingTasks.hasPendingTasks).toBeFalse();
 
     pendingTasks.remove(Math.random());
     pendingTasks.remove(Math.random());
     pendingTasks.remove(Math.random());
 
-    expect(await hasPendingTasks(pendingTasks)).toBeFalse();
+    expect(pendingTasks.hasPendingTasks).toBeFalse();
   });
 
   it('contributes to applicationRef stableness', async () => {
@@ -131,13 +130,4 @@ describe('public PendingTasks', () => {
 
 function applicationRefIsStable(applicationRef: ApplicationRef) {
   return firstValueFrom(applicationRef.isStable);
-}
-
-function hasPendingTasks(pendingTasks: PendingTasksInternal): Promise<boolean> {
-  return of(EMPTY)
-    .pipe(
-      withLatestFrom(pendingTasks.hasPendingTasks),
-      map(([_, hasPendingTasks]) => hasPendingTasks),
-    )
-    .toPromise() as Promise<boolean>;
 }

--- a/packages/core/testing/src/component_fixture.ts
+++ b/packages/core/testing/src/component_fixture.ts
@@ -201,7 +201,7 @@ export class ComponentFixture<T> {
    * yet.
    */
   isStable(): boolean {
-    return !this.pendingTasks.hasPendingTasks.value;
+    return !this.pendingTasks.hasPendingTasks;
   }
 
   /**


### PR DESCRIPTION
The allows us to pull less symbols from RxJS in a bare minimum project.
