### PR TITLE
refactor(core): extract `dirty` and `markForRefresh` from the private ViewRef.

### DIFF
--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -282,7 +282,11 @@ export {compilePipe as ɵcompilePipe} from './render3/jit/pipe';
 export {isNgModule as ɵisNgModule} from './render3/jit/util';
 export {Profiler as ɵProfiler, ProfilerEvent as ɵProfilerEvent} from './render3/profiler_types';
 export {GlobalDevModeUtils as ɵGlobalDevModeUtils} from './render3/util/global_utils';
-export {ViewRef as ɵViewRef} from './render3/view_ref';
+export {
+  ViewRef as ɵViewRef,
+  isViewDirty as ɵisViewDirty,
+  markForRefresh as ɵmarkForRefresh,
+} from './render3/view_ref';
 export {
   bypassSanitizationTrustHtml as ɵbypassSanitizationTrustHtml,
   bypassSanitizationTrustResourceUrl as ɵbypassSanitizationTrustResourceUrl,

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -26,7 +26,6 @@ import {
   LView,
   LViewFlags,
   PARENT,
-  REACTIVE_TEMPLATE_CONSUMER,
   TVIEW,
 } from './interfaces/view';
 import {
@@ -41,6 +40,7 @@ import {
   markViewForRefresh,
   storeLViewOnDestroy,
   updateAncestorTraversalFlagsOnAttach,
+  requiresRefreshOrTraversal,
 } from './util/view_utils';
 
 // Needed due to tsickle downleveling where multiple `implements` with classes creates
@@ -84,18 +84,6 @@ export class ViewRef<T> implements EmbeddedViewRef<T>, ChangeDetectorRefInterfac
 
   get context(): T {
     return this._lView[CONTEXT] as unknown as T;
-  }
-
-  /**
-   * Reports whether the given view is considered dirty according to the different marking mechanisms.
-   */
-  get dirty(): boolean {
-    return (
-      !!(
-        this._lView[FLAGS] &
-        (LViewFlags.Dirty | LViewFlags.RefreshView | LViewFlags.HasChildViewsToRefresh)
-      ) || !!this._lView[REACTIVE_TEMPLATE_CONSUMER]?.dirty
-    );
   }
 
   /**
@@ -180,10 +168,6 @@ export class ViewRef<T> implements EmbeddedViewRef<T>, ChangeDetectorRefInterfac
    */
   markForCheck(): void {
     markViewDirty(this._cdRefInjectingView || this._lView, NotificationSource.MarkForCheck);
-  }
-
-  markForRefresh(): void {
-    markViewForRefresh(this._cdRefInjectingView || this._lView);
   }
 
   /**
@@ -386,4 +370,15 @@ export class ViewRef<T> implements EmbeddedViewRef<T>, ChangeDetectorRefInterfac
     }
     updateAncestorTraversalFlagsOnAttach(this._lView);
   }
+}
+
+/**
+ * Reports whether the given view is considered dirty according to the different marking mechanisms.
+ */
+export function isViewDirty(view: ViewRef<unknown>): boolean {
+  return requiresRefreshOrTraversal(view._lView) || !!(view._lView[FLAGS] & LViewFlags.Dirty);
+}
+
+export function markForRefresh(view: ViewRef<unknown>): void {
+  markViewForRefresh(view['_cdRefInjectingView'] || view._lView);
 }

--- a/packages/elements/src/component-factory-strategy.ts
+++ b/packages/elements/src/component-factory-strategy.ts
@@ -18,6 +18,8 @@ import {
   ɵChangeDetectionScheduler as ChangeDetectionScheduler,
   ɵNotificationSource as NotificationSource,
   ɵViewRef as ViewRef,
+  ɵisViewDirty as isViewDirty,
+  ɵmarkForRefresh as markForRefresh,
   OutputRef,
 } from '@angular/core';
 import {merge, Observable, ReplaySubject} from 'rxjs';
@@ -174,12 +176,12 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
       this.componentRef!.setInput(this.inputMap.get(property) ?? property, value);
 
       // `setInput` won't mark the view dirty if the input didn't change from its previous value.
-      if ((this.componentRef!.hostView as ViewRef<unknown>).dirty) {
+      if (isViewDirty(this.componentRef!.hostView as ViewRef<unknown>)) {
         // `setInput` will have marked the view dirty already, but also mark it for refresh. This
         // guarantees the view will be checked even if the input is being set from within change
         // detection. This provides backwards compatibility, since we used to unconditionally
         // schedule change detection in addition to the current zone run.
-        (this.componentRef!.changeDetectorRef as ViewRef<unknown>).markForRefresh();
+        markForRefresh(this.componentRef!.changeDetectorRef as ViewRef<unknown>);
 
         // Notifying the scheduler with `NotificationSource.CustomElement` causes a `tick()` to be
         // scheduled unconditionally, even if the scheduler is otherwise disabled.


### PR DESCRIPTION
This allows better tree shaking when not using the `element` package.

