### PR TITLE
perf(core): optimize multiple sequential reads of the same signal

### DIFF
--- a/packages/core/primitives/signals/src/graph.ts
+++ b/packages/core/primitives/signals/src/graph.ts
@@ -226,11 +226,17 @@ export function producerAccessed(node: ReactiveNode): void {
   }
 
   activeConsumer.consumerOnSignalRead(node);
+  assertConsumerNode(activeConsumer);
+
+  // Check if this producer is the tail dependency of `activeConsumer`. This is a cheap optimization
+  // for cases when the same signal is read back-to-back.
+  let idx = activeConsumer.producerNode.length - 1;
+  if (idx >= 0 && activeConsumer.producerNode[idx] === node) {
+    return;
+  }
 
   // This producer is the `idx`th dependency of `activeConsumer`.
-  const idx = activeConsumer.nextProducerIndex++;
-
-  assertConsumerNode(activeConsumer);
+  idx = activeConsumer.nextProducerIndex++;
 
   if (idx < activeConsumer.producerNode.length && activeConsumer.producerNode[idx] !== node) {
     // There's been a change in producers since the last execution of `activeConsumer`.

--- a/packages/core/test/signals/signal_spec.ts
+++ b/packages/core/test/signals/signal_spec.ts
@@ -163,6 +163,19 @@ describe('signals', () => {
       expect(derived()).toBe(2);
       expect(computations).toBe(2);
     });
+
+    it('should coalesce back-to-back reads of the same signal', () => {
+      const source = signal(1);
+      const derived = computed(() => source() + source() + source());
+      const derivedNode = derived[SIGNAL] as ReactiveNode;
+
+      expect(derived()).toBe(3);
+      expect(derivedNode.producerNode?.length).toBe(1);
+
+      source.set(2);
+      expect(derived()).toBe(6);
+      expect(derivedNode.producerNode?.length).toBe(1);
+    });
   });
 
   describe('post-signal-set functions', () => {


### PR DESCRIPTION
This commit adds an optimization to the signals graph to avoid adding multiple producer records to a consumer when the same signal is read several times in a row. This can happen when state is stored in a larger signal which is repeatedly read to access different individual properties.