### PR TITLE
fix(compiler-cli): incorrectly checking event side of two-way bindings when narrowed

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -3091,8 +3091,7 @@ function tcbCreateEventHandler(
   scope: Scope,
   eventType: EventParamType | ts.TypeNode,
 ): ts.Expression {
-  const handler = tcbEventHandlerExpression(event.handler, tcb, scope);
-  const statements: ts.Statement[] = [];
+  let handler = tcbEventHandlerExpression(event.handler, tcb, scope);
 
   // TODO(crisbeto): remove the `checkTwoWayBoundEvents` check in v20.
   if (event.type === ParsedEventType.TwoWay && tcb.env.config.checkTwoWayBoundEvents) {
@@ -3100,22 +3099,14 @@ function tcbCreateEventHandler(
     // signal value of the expression and then we assign `$event` to it. Note that in most cases
     // this will already be covered by the corresponding input binding, however it allows us to
     // handle the case where the input has a wider type than the output (see #58971).
-    const target = tcb.allocateId();
-    const assignment = ts.factory.createBinaryExpression(
-      target,
-      ts.SyntaxKind.EqualsToken,
+    const assignRef = tcb.env.referenceExternalSymbol(
+      R3Identifiers.assignTwoWayBinding.moduleName,
+      R3Identifiers.assignTwoWayBinding.name,
+    );
+    handler = ts.factory.createCallExpression(assignRef, undefined, [
+      handler,
       ts.factory.createIdentifier(EVENT_PARAMETER),
-    );
-
-    statements.push(
-      tsCreateVariable(
-        target,
-        tcb.env.config.allowSignalsInTwoWayBindings ? unwrapWritableSignal(handler, tcb) : handler,
-      ),
-      ts.factory.createExpressionStatement(assignment),
-    );
-  } else {
-    statements.push(ts.factory.createExpressionStatement(handler));
+    ]);
   }
 
   let eventParamType: ts.TypeNode | undefined;
@@ -3131,7 +3122,7 @@ function tcbCreateEventHandler(
   // repeated within the handler function for their narrowing to be in effect within the handler.
   const guards = scope.guards();
 
-  let body = ts.factory.createBlock(statements);
+  let body = ts.factory.createBlock([ts.factory.createExpressionStatement(handler)]);
   if (guards !== null) {
     // Wrap the body in an `if` statement containing all guards that have to be applied.
     body = ts.factory.createBlock([ts.factory.createIfStatement(guards, body)]);

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/model_signal_diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/model_signal_diagnostics_spec.ts
@@ -383,7 +383,7 @@ runInEachFileSystem(() => {
         template: `<div dir [(gen)]="genVal" [(other)]="otherVal">`,
         expected: [
           `TestComponent.html(1, 29): Type 'string' is not assignable to type 'boolean'.`,
-          `TestComponent.html(1, 27): Type 'boolean' is not assignable to type 'string'.`,
+          `TestComponent.html(1, 27): Argument of type 'boolean' is not assignable to parameter of type 'string'.`,
         ],
       },
       {
@@ -410,7 +410,7 @@ runInEachFileSystem(() => {
         `,
         expected: [
           `TestComponent.html(1, 12): Type 'boolean' is not assignable to type 'string'.`,
-          `TestComponent.html(1, 10): Type 'string' is not assignable to type 'boolean'.`,
+          `TestComponent.html(1, 10): Argument of type 'string' is not assignable to parameter of type 'boolean'.`,
         ],
       },
       {
@@ -434,7 +434,7 @@ runInEachFileSystem(() => {
         `,
         expected: [
           `TestComponent.html(1, 29): Type 'string' is not assignable to type 'boolean'.`,
-          `TestComponent.html(1, 27): Type 'boolean' is not assignable to type 'string'.`,
+          `TestComponent.html(1, 27): Argument of type 'boolean' is not assignable to parameter of type 'string'.`,
         ],
       },
       {
@@ -461,7 +461,7 @@ runInEachFileSystem(() => {
         `,
         expected: [
           `TestComponent.html(1, 29): Type 'string' is not assignable to type 'boolean'.`,
-          `TestComponent.html(1, 27): Type 'boolean' is not assignable to type 'string'.`,
+          `TestComponent.html(1, 27): Argument of type 'boolean' is not assignable to parameter of type 'string'.`,
         ],
       },
       {
@@ -597,7 +597,7 @@ runInEachFileSystem(() => {
         component: `bla = true;`,
         expected: [
           `TestComponent.html(1, 12): Type 'boolean' is not assignable to type 'string'.`,
-          `TestComponent.html(1, 10): Type 'string' is not assignable to type 'boolean'.`,
+          `TestComponent.html(1, 10): Argument of type 'string' is not assignable to parameter of type 'boolean'.`,
         ],
       },
       {
@@ -669,7 +669,7 @@ runInEachFileSystem(() => {
         component: `val!: WritableSignal<string>;`,
         expected: [
           `TestComponent.html(1, 12): Type 'string' is not assignable to type 'boolean'.`,
-          `TestComponent.html(1, 10): Type 'boolean' is not assignable to type 'string'.`,
+          `TestComponent.html(1, 10): Argument of type 'boolean' is not assignable to parameter of type 'string'.`,
         ],
       },
       {
@@ -680,7 +680,7 @@ runInEachFileSystem(() => {
         component: `val!: InputSignal<boolean>;`,
         expected: [
           `TestComponent.html(1, 10): Type 'InputSignal<boolean>' is not assignable to type 'boolean'.`,
-          `TestComponent.html(1, 10): Type 'boolean' is not assignable to type 'InputSignal<boolean>'.`,
+          `TestComponent.html(1, 10): Argument of type 'boolean' is not assignable to parameter of type 'InputSignal<boolean>'.`,
         ],
       },
       {
@@ -702,7 +702,7 @@ runInEachFileSystem(() => {
             `TestComponent.html(1, 12): Type '(v: string) => number' is not assignable to type '(v: number) => number`,
           ),
           jasmine.stringContaining(
-            `TestComponent.html(1, 10): Type '(v: number) => number' is not assignable to type '(v: string) => number`,
+            `TestComponent.html(1, 10): Argument of type '(v: number) => number' is not assignable to parameter of type '(v: string) => number`,
           ),
         ],
       },

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/output_function_diagnostics.spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/output_function_diagnostics.spec.ts
@@ -33,7 +33,7 @@ runInEachFileSystem(() => {
         component: `bla = true;`,
         expected: [
           `TestComponent.html(1, 12): Type 'boolean' is not assignable to type 'string'.`,
-          `TestComponent.html(1, 10): Type 'string' is not assignable to type 'boolean'.`,
+          `TestComponent.html(1, 10): Argument of type 'string' is not assignable to parameter of type 'boolean'.`,
         ],
       },
       {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -717,8 +717,7 @@ describe('type check blocks', () => {
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).toContain('var _t1 = null! as i0.TwoWay;');
     expect(block).toContain('_t1.input = i1.ɵunwrapWritableSignal((((this).value)));');
-    expect(block).toContain('var _t2 = i1.ɵunwrapWritableSignal(((this).value));');
-    expect(block).toContain('_t2 = $event;');
+    expect(block).toContain('i1.ɵassignTwoWayBinding(((this).value), $event);');
   });
 
   it('should handle a two-way binding to an input/output pair of a generic directive', () => {
@@ -741,8 +740,7 @@ describe('type check blocks', () => {
       'var _t1 = _ctor1({ "input": (i1.ɵunwrapWritableSignal(((this).value))) });',
     );
     expect(block).toContain('_t1.input = i1.ɵunwrapWritableSignal((((this).value)));');
-    expect(block).toContain('var _t2 = i1.ɵunwrapWritableSignal(((this).value));');
-    expect(block).toContain('_t2 = $event;');
+    expect(block).toContain('i1.ɵassignTwoWayBinding(((this).value), $event);');
   });
 
   it('should handle a two-way binding to a model()', () => {
@@ -769,8 +767,7 @@ describe('type check blocks', () => {
     expect(block).toContain(
       '_t1.input[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((this).value)));',
     );
-    expect(block).toContain('var _t2 = i1.ɵunwrapWritableSignal(((this).value));');
-    expect(block).toContain('_t2 = $event;');
+    expect(block).toContain('i1.ɵassignTwoWayBinding(((this).value), $event);');
   });
 
   it('should handle a two-way binding to an input with a transform', () => {
@@ -812,8 +809,7 @@ describe('type check blocks', () => {
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).toContain('var _t1 = null! as boolean | string;');
     expect(block).toContain('_t1 = i1.ɵunwrapWritableSignal((((this).value)));');
-    expect(block).toContain('var _t3 = i1.ɵunwrapWritableSignal(((this).value));');
-    expect(block).toContain('_t3 = $event;');
+    expect(block).toContain('i1.ɵassignTwoWayBinding(((this).value), $event);');
   });
 
   describe('experimental DOM checking via lib.dom.d.ts', () => {

--- a/packages/compiler-cli/test/ngtsc/authoring_inputs_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/authoring_inputs_spec.ts
@@ -258,7 +258,9 @@ runInEachFileSystem(() => {
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(2);
       expect(diags[0].messageText).toBe(`Type 'number' is not assignable to type 'string'.`);
-      expect(diags[1].messageText).toBe(`Type 'string' is not assignable to type 'number'.`);
+      expect(diags[1].messageText).toBe(
+        `Argument of type 'string' is not assignable to parameter of type 'number'.`,
+      );
     });
 
     describe('type checking', () => {

--- a/packages/compiler-cli/test/ngtsc/authoring_models_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/authoring_models_spec.ts
@@ -300,7 +300,9 @@ runInEachFileSystem(() => {
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
         expect(diags[0].messageText).toBe(`Type 'boolean' is not assignable to type 'number'.`);
-        expect(diags[1].messageText).toBe(`Type 'number' is not assignable to type 'boolean'.`);
+        expect(diags[1].messageText).toBe(
+          `Argument of type 'number' is not assignable to parameter of type 'boolean'.`,
+        );
       });
 
       it('should check a signal value bound to a model input via a two-way binding', () => {
@@ -331,7 +333,9 @@ runInEachFileSystem(() => {
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
         expect(diags[0].messageText).toBe(`Type 'boolean' is not assignable to type 'number'.`);
-        expect(diags[1].messageText).toBe(`Type 'number' is not assignable to type 'boolean'.`);
+        expect(diags[1].messageText).toBe(
+          `Argument of type 'number' is not assignable to parameter of type 'boolean'.`,
+        );
       });
 
       it('should check two-way binding of a signal to a decorator-based input/output pair', () => {
@@ -363,7 +367,9 @@ runInEachFileSystem(() => {
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
         expect(diags[0].messageText).toBe(`Type 'boolean' is not assignable to type 'number'.`);
-        expect(diags[1].messageText).toBe(`Type 'number' is not assignable to type 'boolean'.`);
+        expect(diags[1].messageText).toBe(
+          `Argument of type 'number' is not assignable to parameter of type 'boolean'.`,
+        );
       });
 
       it('should not allow a non-writable signal to be assigned to a model', () => {
@@ -397,7 +403,7 @@ runInEachFileSystem(() => {
           `Type 'InputSignal<number>' is not assignable to type 'number'.`,
         );
         expect(diags[1].messageText).toBe(
-          `Type 'number' is not assignable to type 'InputSignal<number>'.`,
+          `Argument of type 'number' is not assignable to parameter of type 'InputSignal<number>'.`,
         );
       });
 
@@ -527,7 +533,7 @@ runInEachFileSystem(() => {
         );
         expect(diags[1].messageText).toEqual(
           jasmine.objectContaining({
-            messageText: `Type '{ id: string; }' is not assignable to type '{ id: number; }'.`,
+            messageText: `Argument of type '{ id: string; }' is not assignable to parameter of type '{ id: number; }'.`,
           }),
         );
       });
@@ -566,7 +572,7 @@ runInEachFileSystem(() => {
         );
         expect(diags[1].messageText).toEqual(
           jasmine.objectContaining({
-            messageText: `Type '{ id: string; }' is not assignable to type '{ id: number; }'.`,
+            messageText: `Argument of type '{ id: string; }' is not assignable to parameter of type '{ id: number; }'.`,
           }),
         );
       });

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -576,7 +576,7 @@ runInEachFileSystem(() => {
       );
       expect(diags[1].messageText).toEqual(
         jasmine.objectContaining({
-          messageText: `Type '{ id: string; }' is not assignable to type '{ id: number; }'.`,
+          messageText: `Argument of type '{ id: string; }' is not assignable to parameter of type '{ id: number; }'.`,
         }),
       );
     });
@@ -652,7 +652,7 @@ runInEachFileSystem(() => {
       );
       expect(diags[1].messageText).toEqual(
         jasmine.objectContaining({
-          messageText: `Type 'TestFn' is not assignable to type '(val: string) => number'.`,
+          messageText: `Argument of type 'TestFn' is not assignable to parameter of type '(val: string) => number'.`,
         }),
       );
     });
@@ -682,7 +682,63 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(`Type 'number' is not assignable to type 'string'.`);
+      expect(diags[0].messageText).toBe(
+        `Argument of type 'number' is not assignable to parameter of type 'string'.`,
+      );
+    });
+
+    it('should type check a two-way binding to a narrowed value', () => {
+      env.tsconfig({strictTemplates: true, _checkTwoWayBoundEvents: true});
+      env.write(
+        'test.ts',
+        `
+          import {Component, Directive, Input, Output, EventEmitter} from '@angular/core';
+
+          @Directive({selector: '[dir]'})
+          export class Dir {
+            @Input() value: boolean;
+            @Output() valueChange = new EventEmitter<boolean>();
+          }
+
+          @Component({
+            template: '@if (value) {<div dir [(value)]="value"></div>}',
+            imports: [Dir],
+          })
+          export class App {
+            value = false;
+          }
+        `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(0);
+    });
+
+    it('should type check a two-way binding to a narrowed property', () => {
+      env.tsconfig({strictTemplates: true, _checkTwoWayBoundEvents: true});
+      env.write(
+        'test.ts',
+        `
+          import {Component, Directive, Input, Output, EventEmitter} from '@angular/core';
+
+          @Directive({selector: '[dir]'})
+          export class Dir {
+            @Input() value: boolean;
+            @Output() valueChange = new EventEmitter<boolean>();
+          }
+
+          @Component({
+            template: '@if (value) {<div dir [(value)]="value.field"></div>}',
+            imports: [Dir],
+          })
+          export class App {
+            value = {field: true} as {field: boolean} | null;
+          }
+        `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(0);
     });
 
     it('should check the fallback content of ng-content', () => {

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -595,4 +595,5 @@ export class Identifiers {
   static InputSignalBrandWriteType = {name: 'ɵINPUT_SIGNAL_BRAND_WRITE_TYPE', moduleName: CORE};
   static UnwrapDirectiveSignalInputs = {name: 'ɵUnwrapDirectiveSignalInputs', moduleName: CORE};
   static unwrapWritableSignal = {name: 'ɵunwrapWritableSignal', moduleName: CORE};
+  static assignTwoWayBinding = {name: 'ɵassignTwoWayBinding', moduleName: CORE};
 }

--- a/packages/core/src/core_reactivity_export_internal.ts
+++ b/packages/core/src/core_reactivity_export_internal.ts
@@ -15,6 +15,7 @@ export {
   signal,
   WritableSignal,
   ɵunwrapWritableSignal,
+  ɵassignTwoWayBinding,
 } from './render3/reactivity/signal';
 export {linkedSignal} from './render3/reactivity/linked_signal';
 export {untracked} from './render3/reactivity/untracked';

--- a/packages/core/src/render3/reactivity/signal.ts
+++ b/packages/core/src/render3/reactivity/signal.ts
@@ -58,6 +58,12 @@ export function ɵunwrapWritableSignal<T>(value: T | {[ɵWRITABLE_SIGNAL]: T}): 
 }
 
 /**
+ * Utility function used during type checking to write to a two-way binding that may or may
+ * not be a writable signal.
+ */
+export function ɵassignTwoWayBinding<T>(target: T | {[ɵWRITABLE_SIGNAL]: T}, value: T): void {}
+
+/**
  * Options passed to the `signal` creation function.
  */
 export interface CreateSignalOptions<T> {

--- a/packages/core/test/render3/jit_environment_spec.ts
+++ b/packages/core/test/render3/jit_environment_spec.ts
@@ -35,6 +35,7 @@ const AOT_ONLY = new Set<string>([
   'ɵINPUT_SIGNAL_BRAND_WRITE_TYPE',
   'ɵUnwrapDirectiveSignalInputs',
   'ɵunwrapWritableSignal',
+  'ɵassignTwoWayBinding',
 ]);
 
 /**


### PR DESCRIPTION
After #59002, we started producing code like the following for the event side of two-way bindings:

```
someOutput.subscribe($event => {
  var _t1 = unwrapSignalValue(this.someField);
  _t1 = $event;
});
```

The problem with this approach is that if `someField` is narrowed, the type of `_t1` will be narrowed as well which will make `$event` unassignable. This came up when trying to roll out the changes from the previous PR internally.

These changes rework the approach by generating a function call instead. Now the TCB looks as follows:

```
someOutput.subscribe($event => {
  assignTwoWayBinding(this.someField, $event);
});
```