### PR TITLE
refactor: standardize the way we detect ngDevMode

### DIFF
--- a/packages/animations/browser/src/dsl/animation_ast_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_ast_builder.ts
@@ -141,7 +141,7 @@ export class AnimationAstBuilderVisitor implements AnimationDslVisitor {
       visitDslNode(this, normalizeAnimationEntry(metadata), context)
     );
 
-    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       if (context.unsupportedCSSPropertiesFound.size) {
         pushUnrecognizedPropertiesWarning(warnings, [
           ...context.unsupportedCSSPropertiesFound.keys(),
@@ -387,7 +387,7 @@ export class AnimationAstBuilderVisitor implements AnimationDslVisitor {
       if (typeof tuple === 'string') return;
 
       tuple.forEach((value, prop) => {
-        if (typeof ngDevMode === 'undefined' || ngDevMode) {
+        if (typeof ngDevMode !== 'undefined' && ngDevMode) {
           if (!this._driver.validateStyleProperty(prop)) {
             tuple.delete(prop);
             context.unsupportedCSSPropertiesFound.add(prop);

--- a/packages/animations/browser/src/dsl/animation_transition_factory.ts
+++ b/packages/animations/browser/src/dsl/animation_transition_factory.ts
@@ -128,7 +128,7 @@ export class AnimationTransitionFactory {
       }
     });
 
-    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       checkNonAnimatableInTimelines(timelines, this._triggerName, driver);
     }
 

--- a/packages/animations/browser/src/render/web_animations/web_animations_driver.ts
+++ b/packages/animations/browser/src/render/web_animations/web_animations_driver.ts
@@ -29,7 +29,7 @@ import {WebAnimationsPlayer} from './web_animations_player';
 export class WebAnimationsDriver implements AnimationDriver {
   validateStyleProperty(prop: string): boolean {
     // Perform actual validation in dev mode only, in prod mode this check is a noop.
-    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       return validateStyleProperty(prop);
     }
     return true;
@@ -37,7 +37,7 @@ export class WebAnimationsDriver implements AnimationDriver {
 
   validateAnimatableStyleProperty(prop: string): boolean {
     // Perform actual validation in dev mode only, in prod mode this check is a noop.
-    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       const cssProp = camelCaseToDashCase(prop);
       return validateWebAnimatableStyleProperty(cssProp);
     }

--- a/packages/animations/browser/src/warning_helpers.ts
+++ b/packages/animations/browser/src/warning_helpers.ts
@@ -15,12 +15,14 @@ function createListOfWarnings(warnings: string[]): string {
 }
 
 export function warnValidation(warnings: string[]): void {
-  (typeof ngDevMode === 'undefined' || ngDevMode) &&
+  typeof ngDevMode !== 'undefined' &&
+    ngDevMode &&
     console.warn(`animation validation warnings:${createListOfWarnings(warnings)}`);
 }
 
 export function warnTriggerBuild(name: string, warnings: string[]): void {
-  (typeof ngDevMode === 'undefined' || ngDevMode) &&
+  typeof ngDevMode !== 'undefined' &&
+    ngDevMode &&
     console.warn(
       `The animation trigger "${name}" has built with the following warnings:${createListOfWarnings(
         warnings,
@@ -29,12 +31,14 @@ export function warnTriggerBuild(name: string, warnings: string[]): void {
 }
 
 export function warnRegister(warnings: string[]): void {
-  (typeof ngDevMode === 'undefined' || ngDevMode) &&
+  typeof ngDevMode !== 'undefined' &&
+    ngDevMode &&
     console.warn(`Animation built with the following warnings:${createListOfWarnings(warnings)}`);
 }
 
 export function triggerParsingWarnings(name: string, warnings: string[]): void {
-  (typeof ngDevMode === 'undefined' || ngDevMode) &&
+  typeof ngDevMode !== 'undefined' &&
+    ngDevMode &&
     console.warn(
       `Animation parsing for the ${name} trigger presents the following warnings:${createListOfWarnings(
         warnings,

--- a/packages/animations/src/animation_builder.ts
+++ b/packages/animations/src/animation_builder.ts
@@ -121,7 +121,8 @@ export class BrowserAnimationBuilder extends AnimationBuilder {
 
       throw new RuntimeError(
         RuntimeErrorCode.BROWSER_ANIMATION_BUILDER_INJECTED_WITHOUT_ANIMATIONS,
-        (typeof ngDevMode === 'undefined' || ngDevMode) &&
+        typeof ngDevMode !== 'undefined' &&
+          ngDevMode &&
           'Angular detected that the `AnimationBuilder` was injected, but animation support was not enabled. ' +
             'Please make sure that you enable animations in your application by calling `provideAnimations()` or `provideAnimationsAsync()` function.',
       );

--- a/packages/common/http/src/headers.ts
+++ b/packages/common/http/src/headers.ts
@@ -68,7 +68,7 @@ export class HttpHeaders {
       });
     } else {
       this.lazyInit = () => {
-        if (typeof ngDevMode === 'undefined' || ngDevMode) {
+        if (typeof ngDevMode !== 'undefined' && ngDevMode) {
           assertValidHeaders(headers);
         }
         this.headers = new Map<string, string[]>();

--- a/packages/common/http/src/interceptor.ts
+++ b/packages/common/http/src/interceptor.ts
@@ -274,7 +274,7 @@ export class HttpInterceptorHandler extends HttpHandler {
     // We strongly recommend using fetch backend for HTTP calls when SSR is used
     // for an application. The logic below checks if that's the case and produces
     // a warning otherwise.
-    if ((typeof ngDevMode === 'undefined' || ngDevMode) && !fetchBackendWarningDisplayed) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode && !fetchBackendWarningDisplayed) {
       const isServer = isPlatformServer(injector.get(PLATFORM_ID));
 
       // This flag is necessary because provideHttpClientTesting() overrides the backend

--- a/packages/common/http/src/transfer_cache.ts
+++ b/packages/common/http/src/transfer_cache.ts
@@ -196,7 +196,7 @@ export function transferCacheInterceptorFn(
     // That HttpTransferCache alters the headers
     // The warning will be logged a single time by HttpHeaders instance
     let headers = new HttpHeaders(httpHeaders);
-    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       // Append extra logic in dev mode to produce a warning when a header
       // that was not transferred to the client is accessed in the code via `get`
       // and `has` calls.
@@ -401,7 +401,7 @@ function mapRequestOriginUrl(url: string, originMap: Record<string, string>): st
     return url;
   }
 
-  if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
     verifyMappedOrigin(mappedOrigin);
   }
 

--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -66,7 +66,8 @@ export class HttpXhrBackend implements HttpBackend {
     if (req.method === 'JSONP') {
       throw new RuntimeError(
         RuntimeErrorCode.MISSING_JSONP_MODULE,
-        (typeof ngDevMode === 'undefined' || ngDevMode) &&
+        typeof ngDevMode !== 'undefined' &&
+          ngDevMode &&
           `Cannot make a JSONP request without JSONP support. To fix the problem, either add the \`withJsonpSupport()\` call (if \`provideHttpClient()\` is used) or import the \`HttpClientJsonpModule\` in the root NgModule.`,
       );
     }

--- a/packages/common/src/directives/ng_for_of.ts
+++ b/packages/common/src/directives/ng_for_of.ts
@@ -198,7 +198,7 @@ export class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> implements DoCh
    */
   @Input()
   set ngForTrackBy(fn: TrackByFunction<T>) {
-    if ((typeof ngDevMode === 'undefined' || ngDevMode) && fn != null && typeof fn !== 'function') {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode && fn != null && typeof fn !== 'function') {
       console.warn(
         `trackBy must be a function, but received ${JSON.stringify(fn)}. ` +
           `See https://angular.io/api/common/NgForOf#change-propagation for more information.`,
@@ -249,7 +249,7 @@ export class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> implements DoCh
       // React on ngForOf changes only once all inputs have been initialized
       const value = this._ngForOf;
       if (!this._differ && value) {
-        if (typeof ngDevMode === 'undefined' || ngDevMode) {
+        if (typeof ngDevMode !== 'undefined' && ngDevMode) {
           try {
             // CAUTION: this logic is duplicated for production mode below, as the try-catch
             // is only present in development builds.

--- a/packages/common/src/directives/ng_switch.ts
+++ b/packages/common/src/directives/ng_switch.ts
@@ -212,7 +212,7 @@ export class NgSwitchCase implements DoCheck {
     templateRef: TemplateRef<Object>,
     @Optional() @Host() private ngSwitch: NgSwitch,
   ) {
-    if ((typeof ngDevMode === 'undefined' || ngDevMode) && !ngSwitch) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode && !ngSwitch) {
       throwNgSwitchProviderNotFoundError('ngSwitchCase', 'NgSwitchCase');
     }
 
@@ -252,7 +252,7 @@ export class NgSwitchDefault {
     templateRef: TemplateRef<Object>,
     @Optional() @Host() ngSwitch: NgSwitch,
   ) {
-    if ((typeof ngDevMode === 'undefined' || ngDevMode) && !ngSwitch) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode && !ngSwitch) {
       throwNgSwitchProviderNotFoundError('ngSwitchDefault', 'NgSwitchDefault');
     }
 

--- a/packages/common/src/pipes/number_pipe.ts
+++ b/packages/common/src/pipes/number_pipe.ts
@@ -274,7 +274,7 @@ export class CurrencyPipe implements PipeTransform {
     locale ||= this._locale;
 
     if (typeof display === 'boolean') {
-      if ((typeof ngDevMode === 'undefined' || ngDevMode) && <any>console && <any>console.warn) {
+      if (typeof ngDevMode !== 'undefined' && ngDevMode && <any>console && <any>console.warn) {
         console.warn(
           `Warning: the currency pipe has been changed in Angular v5. The symbolDisplay option (third parameter) is now a string instead of a boolean. The accepted values are "code", "symbol" or "symbol-narrow".`,
         );

--- a/packages/core/rxjs-interop/src/to_signal.ts
+++ b/packages/core/rxjs-interop/src/to_signal.ts
@@ -186,7 +186,8 @@ export function toSignal<T, U = undefined>(
   if (options?.requireSync && state().kind === StateKind.NoValue) {
     throw new ɵRuntimeError(
       ɵRuntimeErrorCode.REQUIRE_SYNC_WITHOUT_SYNC_EMIT,
-      (typeof ngDevMode === 'undefined' || ngDevMode) &&
+      typeof ngDevMode !== 'undefined' &&
+        ngDevMode &&
         '`toSignal()` called with `requireSync` but `Observable` did not emit synchronously.',
     );
   }
@@ -208,7 +209,8 @@ export function toSignal<T, U = undefined>(
           // This shouldn't really happen because the error is thrown on creation.
           throw new ɵRuntimeError(
             ɵRuntimeErrorCode.REQUIRE_SYNC_WITHOUT_SYNC_EMIT,
-            (typeof ngDevMode === 'undefined' || ngDevMode) &&
+            typeof ngDevMode !== 'undefined' &&
+              ngDevMode &&
               '`toSignal()` called with `requireSync` but `Observable` did not emit synchronously.',
           );
       }

--- a/packages/core/src/application/application_init.ts
+++ b/packages/core/src/application/application_init.ts
@@ -224,7 +224,7 @@ export class ApplicationInitStatus {
   private readonly injector = inject(Injector);
 
   constructor() {
-    if ((typeof ngDevMode === 'undefined' || ngDevMode) && !Array.isArray(this.appInits)) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode && !Array.isArray(this.appInits)) {
       throw new RuntimeError(
         RuntimeErrorCode.INVALID_MULTI_PROVIDER,
         'Unexpected type of the `APP_INITIALIZER` token value ' +

--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -531,14 +531,15 @@ export class ApplicationRef {
     componentOrFactory: ComponentFactory<C> | Type<C>,
     rootSelectorOrNode?: string | any,
   ): ComponentRef<C> {
-    (typeof ngDevMode === 'undefined' || ngDevMode) && this.warnIfDestroyed();
+    typeof ngDevMode !== 'undefined' && ngDevMode && this.warnIfDestroyed();
     const isComponentFactory = componentOrFactory instanceof ComponentFactory;
     const initStatus = this._injector.get(ApplicationInitStatus);
 
     if (!initStatus.done) {
       const standalone = !isComponentFactory && isStandalone(componentOrFactory);
       const errorMessage =
-        (typeof ngDevMode === 'undefined' || ngDevMode) &&
+        typeof ngDevMode !== 'undefined' &&
+        ngDevMode &&
         'Cannot bootstrap as there are still asynchronous initializers running.' +
           (standalone
             ? ''
@@ -572,7 +573,7 @@ export class ApplicationRef {
     });
 
     this._loadComponent(compRef);
-    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       const _console = this._injector.get(Console);
       _console.log(`Angular is running in development mode.`);
     }
@@ -610,7 +611,7 @@ export class ApplicationRef {
       return;
     }
 
-    (typeof ngDevMode === 'undefined' || ngDevMode) && this.warnIfDestroyed();
+    typeof ngDevMode !== 'undefined' && ngDevMode && this.warnIfDestroyed();
     if (this._runningTick) {
       throw new RuntimeError(
         RuntimeErrorCode.RECURSIVE_APPLICATION_REF_TICK,
@@ -623,7 +624,7 @@ export class ApplicationRef {
       this._runningTick = true;
       this.synchronize();
 
-      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      if (typeof ngDevMode !== 'undefined' && ngDevMode) {
         for (let view of this.allViews) {
           view.checkNoChanges();
         }
@@ -656,7 +657,7 @@ export class ApplicationRef {
       this.synchronizeOnce();
     }
 
-    if ((typeof ngDevMode === 'undefined' || ngDevMode) && runs >= MAXIMUM_REFRESH_RERUNS) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode && runs >= MAXIMUM_REFRESH_RERUNS) {
       throw new RuntimeError(
         RuntimeErrorCode.INFINITE_CHANGE_DETECTION,
         ngDevMode &&
@@ -768,7 +769,7 @@ export class ApplicationRef {
    * This will throw if the view is already attached to a ViewContainer.
    */
   attachView(viewRef: ViewRef): void {
-    (typeof ngDevMode === 'undefined' || ngDevMode) && this.warnIfDestroyed();
+    typeof ngDevMode !== 'undefined' && ngDevMode && this.warnIfDestroyed();
     const view = viewRef as InternalViewRef<unknown>;
     this._views.push(view);
     view.attachToAppRef(this);
@@ -778,7 +779,7 @@ export class ApplicationRef {
    * Detaches a view from dirty checking again.
    */
   detachView(viewRef: ViewRef): void {
-    (typeof ngDevMode === 'undefined' || ngDevMode) && this.warnIfDestroyed();
+    typeof ngDevMode !== 'undefined' && ngDevMode && this.warnIfDestroyed();
     const view = viewRef as InternalViewRef<unknown>;
     remove(this._views, view);
     view.detachFromAppRef();
@@ -829,7 +830,7 @@ export class ApplicationRef {
    * @returns A function which unregisters a listener.
    */
   onDestroy(callback: () => void): VoidFunction {
-    (typeof ngDevMode === 'undefined' || ngDevMode) && this.warnIfDestroyed();
+    typeof ngDevMode !== 'undefined' && ngDevMode && this.warnIfDestroyed();
     this._destroyListeners.push(callback);
     return () => remove(this._destroyListeners, callback);
   }
@@ -865,7 +866,7 @@ export class ApplicationRef {
   }
 
   private warnIfDestroyed() {
-    if ((typeof ngDevMode === 'undefined' || ngDevMode) && this._destroyed) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode && this._destroyed) {
       console.warn(
         formatRuntimeError(
           RuntimeErrorCode.APPLICATION_REF_ALREADY_DESTROYED,

--- a/packages/core/src/application/create_application.ts
+++ b/packages/core/src/application/create_application.ts
@@ -40,7 +40,7 @@ export function internalCreateApplication(config: {
   try {
     const {rootComponent, appProviders, platformProviders} = config;
 
-    if ((typeof ngDevMode === 'undefined' || ngDevMode) && rootComponent !== undefined) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode && rootComponent !== undefined) {
       assertStandaloneComponentType(rootComponent);
     }
 
@@ -56,7 +56,7 @@ export function internalCreateApplication(config: {
     const adapter = new EnvironmentNgModuleRefAdapter({
       providers: allAppProviders,
       parent: platformInjector as EnvironmentInjector,
-      debugName: typeof ngDevMode === 'undefined' || ngDevMode ? 'Environment Injector' : '',
+      debugName: typeof ngDevMode !== 'undefined' && ngDevMode ? 'Environment Injector' : '',
       // We skip environment initializers because we need to run them inside the NgZone, which
       // happens after we get the NgZone instance from the Injector.
       runEnvironmentInitializers: false,

--- a/packages/core/src/change_detection/scheduling/exhaustive_check_no_changes.ts
+++ b/packages/core/src/change_detection/scheduling/exhaustive_check_no_changes.ts
@@ -44,7 +44,7 @@ export function provideExperimentalCheckNoChangesForDebug(options: {
   useNgZoneOnStable?: boolean;
   exhaustive?: boolean;
 }) {
-  if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
     if (options.interval === undefined && !options.useNgZoneOnStable) {
       throw new Error('Must provide one of `useNgZoneOnStable` or `interval`');
     }

--- a/packages/core/src/change_detection/scheduling/ng_zone_scheduling.ts
+++ b/packages/core/src/change_detection/scheduling/ng_zone_scheduling.ts
@@ -70,7 +70,7 @@ export class NgZoneChangeDetectionScheduler {
  * with the bootstrapModule API.
  */
 export const PROVIDED_NG_ZONE = new InjectionToken<boolean>(
-  typeof ngDevMode === 'undefined' || ngDevMode ? 'provideZoneChangeDetection token' : '',
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'provideZoneChangeDetection token' : '',
   {factory: () => false},
 );
 
@@ -95,7 +95,8 @@ export function internalProvideZoneChangeDetection({
           optional: true,
         });
         if (
-          (typeof ngDevMode === 'undefined' || ngDevMode) &&
+          typeof ngDevMode !== 'undefined' &&
+          ngDevMode &&
           ngZoneChangeDetectionScheduler === null
         ) {
           throw new RuntimeError(

--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling.ts
@@ -66,21 +66,21 @@ export abstract class ChangeDetectionScheduler {
 
 /** Token used to indicate if zoneless was enabled via provideZonelessChangeDetection(). */
 export const ZONELESS_ENABLED = new InjectionToken<boolean>(
-  typeof ngDevMode === 'undefined' || ngDevMode ? 'Zoneless enabled' : '',
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'Zoneless enabled' : '',
   {providedIn: 'root', factory: () => false},
 );
 
 /** Token used to indicate `provideExperimentalZonelessChangeDetection` was used. */
 export const PROVIDED_ZONELESS = new InjectionToken<boolean>(
-  typeof ngDevMode === 'undefined' || ngDevMode ? 'Zoneless provided' : '',
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'Zoneless provided' : '',
   {providedIn: 'root', factory: () => false},
 );
 
 export const ZONELESS_SCHEDULER_DISABLED = new InjectionToken<boolean>(
-  typeof ngDevMode === 'undefined' || ngDevMode ? 'scheduler disabled' : '',
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'scheduler disabled' : '',
 );
 
 // TODO(atscott): Remove in v19. Scheduler should be done with runOutsideAngular.
 export const SCHEDULE_IN_ROOT_ZONE = new InjectionToken<boolean>(
-  typeof ngDevMode === 'undefined' || ngDevMode ? 'run changes outside zone in root' : '',
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'run changes outside zone in root' : '',
 );

--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
@@ -203,7 +203,7 @@ export class ChangeDetectionSchedulerImpl implements ChangeDetectionScheduler {
       return;
     }
 
-    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       if (this.useMicrotaskScheduler) {
         trackMicrotaskNotificationForDebugging();
       } else {
@@ -381,7 +381,7 @@ export class ChangeDetectionSchedulerImpl implements ChangeDetectionScheduler {
 export function provideExperimentalZonelessChangeDetection(): EnvironmentProviders {
   performanceMarkFeature('NgZoneless');
 
-  if ((typeof ngDevMode === 'undefined' || ngDevMode) && typeof Zone !== 'undefined' && Zone) {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode && typeof Zone !== 'undefined' && Zone) {
     const message = formatRuntimeError(
       RuntimeErrorCode.UNEXPECTED_ZONEJS_PRESENT_IN_ZONELESS_MODE,
       `The application is using zoneless change detection, but is still loading Zone.js. ` +
@@ -396,7 +396,7 @@ export function provideExperimentalZonelessChangeDetection(): EnvironmentProvide
     {provide: NgZone, useClass: NoopNgZone},
     {provide: ZONELESS_ENABLED, useValue: true},
     {provide: SCHEDULE_IN_ROOT_ZONE, useValue: false},
-    typeof ngDevMode === 'undefined' || ngDevMode
+    typeof ngDevMode !== 'undefined' && ngDevMode
       ? [{provide: PROVIDED_ZONELESS, useValue: true}]
       : [],
   ]);

--- a/packages/core/src/compiler/compiler_facade.ts
+++ b/packages/core/src/compiler/compiler_facade.ts
@@ -26,7 +26,7 @@ export function getCompilerFacade(request: JitCompilerUsageRequest): CompilerFac
     return globalNg.ɵcompilerFacade;
   }
 
-  if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
     // Log the type as an error so that a developer can easily navigate to the type from the
     // console.
     console.error(`JIT compilation failed for ${request.kind}`, request.type);

--- a/packages/core/src/di/injection_token.ts
+++ b/packages/core/src/di/injection_token.ts
@@ -80,7 +80,8 @@ export class InjectionToken<T> {
   ) {
     this.ɵprov = undefined;
     if (typeof options == 'number') {
-      (typeof ngDevMode === 'undefined' || ngDevMode) &&
+      typeof ngDevMode !== 'undefined' &&
+        ngDevMode &&
         assertLessThan(options, 0, 'Only negative numbers are supported here');
       // This is a special hack to assign __NG_ELEMENT_ID__ to this instance.
       // See `InjectorMarkers`

--- a/packages/core/src/di/provider_collection.ts
+++ b/packages/core/src/di/provider_collection.ts
@@ -161,7 +161,7 @@ export function internalImportProvidersFrom(
   };
 
   deepForEach(sources, (source) => {
-    if ((typeof ngDevMode === 'undefined' || ngDevMode) && checkForStandaloneCmp) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode && checkForStandaloneCmp) {
       const cmpDef = getComponentDef(source);
       if (cmpDef?.standalone) {
         throw new RuntimeError(

--- a/packages/core/src/error_handler.ts
+++ b/packages/core/src/error_handler.ts
@@ -58,7 +58,7 @@ export class ErrorHandler {
  * is calling `ErrorHandler.handleError` outside of the Angular zone.
  */
 export const INTERNAL_APPLICATION_ERROR_HANDLER = new InjectionToken<(e: any) => void>(
-  typeof ngDevMode === 'undefined' || ngDevMode ? 'internal error handler' : '',
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'internal error handler' : '',
   {
     providedIn: 'root',
     factory: () => {

--- a/packages/core/src/platform/bootstrap.ts
+++ b/packages/core/src/platform/bootstrap.ts
@@ -66,7 +66,7 @@ export function bootstrap<M>(
       config.moduleRef.resolveInjectorInitializers();
     }
     const exceptionHandler = envInjector.get(ErrorHandler, null);
-    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       if (exceptionHandler === null) {
         const errorMessage = isApplicationBootstrapConfig(config)
           ? 'No `ErrorHandler` found in the Dependency Injection tree.'
@@ -125,7 +125,7 @@ export function bootstrap<M>(
         // If the `LOCALE_ID` provider is defined at bootstrap then we set the value for ivy
         const localeId = envInjector.get(LOCALE_ID, DEFAULT_LOCALE_ID);
         setLocaleId(localeId || DEFAULT_LOCALE_ID);
-        if (typeof ngDevMode === 'undefined' || ngDevMode) {
+        if (typeof ngDevMode !== 'undefined' && ngDevMode) {
           const imagePerformanceService = envInjector.get(ImagePerformanceWarning);
           imagePerformanceService.start();
         }

--- a/packages/core/src/platform/platform.ts
+++ b/packages/core/src/platform/platform.ts
@@ -120,7 +120,8 @@ export function assertPlatform(requiredToken: any): PlatformRef {
   }
 
   if (
-    (typeof ngDevMode === 'undefined' || ngDevMode) &&
+    typeof ngDevMode !== 'undefined' &&
+    ngDevMode &&
     !platform.injector.get(requiredToken, null)
   ) {
     throw new RuntimeError(

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -727,7 +727,7 @@ function getComponentId<T>(componentDef: ComponentDef<T>): string {
     !!componentDef.viewQuery,
   ];
 
-  if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
     // If client and server bundles were produced with different minification configurations,
     // the serializable contents of the function body would be different on the client and on
     // the server. Ensure that we do not accidentally use functions in component id computation.
@@ -750,7 +750,7 @@ function getComponentId<T>(componentDef: ComponentDef<T>): string {
 
   const compId = 'c' + hash;
 
-  if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
     if (GENERATED_COMP_IDS.has(compId)) {
       const previousCompDefType = GENERATED_COMP_IDS.get(compId)!;
       if (previousCompDefType !== componentDef.type) {

--- a/packages/core/src/render3/features/host_directives_feature.ts
+++ b/packages/core/src/render3/features/host_directives_feature.ts
@@ -87,7 +87,7 @@ function trackHostDirectiveDef(
 ) {
   const hostDirectiveDef = getDirectiveDef(def.directive)!;
 
-  if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
     validateHostDirective(def, hostDirectiveDef);
   }
 
@@ -163,7 +163,8 @@ function patchDeclaredInputs(
       // `validateMappings`. If we somehow did, it would lead to `ngOnChanges` being invoked
       // with the wrong name so we have a non-user-friendly assertion here just in case.
       if (
-        (typeof ngDevMode === 'undefined' || ngDevMode) &&
+        typeof ngDevMode !== 'undefined' &&
+        ngDevMode &&
         declaredInputs.hasOwnProperty(remappedPublicName)
       ) {
         assertEqual(

--- a/packages/core/src/render3/interfaces/document.ts
+++ b/packages/core/src/render3/interfaces/document.ts
@@ -52,7 +52,8 @@ export function getDocument(): Document {
 
   throw new RuntimeError(
     RuntimeErrorCode.MISSING_DOCUMENT,
-    (typeof ngDevMode === 'undefined' || ngDevMode) &&
+    typeof ngDevMode !== 'undefined' &&
+      ngDevMode &&
       `The document object is not available in this context. Make sure the DOCUMENT injection token is provided.`,
   );
 

--- a/packages/core/src/render3/tokens.ts
+++ b/packages/core/src/render3/tokens.ts
@@ -13,4 +13,4 @@ export interface NO_CHANGE {
 
 /** A special value which designates that a value has not changed. */
 export const NO_CHANGE: NO_CHANGE =
-  typeof ngDevMode === 'undefined' || ngDevMode ? {__brand__: 'NO_CHANGE'} : ({} as NO_CHANGE);
+  typeof ngDevMode !== 'undefined' && ngDevMode ? {__brand__: 'NO_CHANGE'} : ({} as NO_CHANGE);

--- a/packages/core/src/sanitization/html_sanitizer.ts
+++ b/packages/core/src/sanitization/html_sanitizer.ts
@@ -325,7 +325,7 @@ export function _sanitizeHtml(defaultDoc: any, unsafeHtmlInput: string): Trusted
     const safeHtml = sanitizer.sanitizeChildren(
       (getTemplateContent(inertBodyElement!) as Element) || inertBodyElement,
     );
-    if ((typeof ngDevMode === 'undefined' || ngDevMode) && sanitizer.sanitizedSomething) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode && sanitizer.sanitizedSomething) {
       console.warn(`WARNING: sanitizing HTML stripped some content, see ${XSS_SECURITY_URL}`);
     }
 

--- a/packages/core/src/sanitization/url_sanitizer.ts
+++ b/packages/core/src/sanitization/url_sanitizer.ts
@@ -40,7 +40,7 @@ export function _sanitizeUrl(url: string): string {
   url = String(url);
   if (url.match(SAFE_URL_PATTERN)) return url;
 
-  if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
     console.warn(`WARNING: sanitizing unsafe URL value ${url} (see ${XSS_SECURITY_URL})`);
   }
 

--- a/packages/forms/src/directives/ng_model.ts
+++ b/packages/forms/src/directives/ng_model.ts
@@ -340,7 +340,7 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
   }
 
   private _checkParentType(): void {
-    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       if (
         !(this._parent instanceof NgModelGroup) &&
         this._parent instanceof AbstractFormGroupDirective
@@ -355,7 +355,7 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
   private _checkName(): void {
     if (this.options && this.options.name) this.name = this.options.name;
 
-    if (!this._isStandalone() && !this.name && (typeof ngDevMode === 'undefined' || ngDevMode)) {
+    if (!this._isStandalone() && !this.name && typeof ngDevMode !== 'undefined' && ngDevMode) {
       throw missingNameException();
     }
   }

--- a/packages/forms/src/directives/ng_model_group.ts
+++ b/packages/forms/src/directives/ng_model_group.ts
@@ -91,7 +91,8 @@ export class NgModelGroup extends AbstractFormGroupDirective implements OnInit, 
     if (
       !(this._parent instanceof NgModelGroup) &&
       !(this._parent instanceof NgForm) &&
-      (typeof ngDevMode === 'undefined' || ngDevMode)
+      typeof ngDevMode !== 'undefined' &&
+      ngDevMode
     ) {
       throw modelGroupParentException();
     }

--- a/packages/forms/src/directives/radio_control_value_accessor.ts
+++ b/packages/forms/src/directives/radio_control_value_accessor.ts
@@ -261,7 +261,8 @@ export class RadioControlValueAccessor
       this.name &&
       this.formControlName &&
       this.name !== this.formControlName &&
-      (typeof ngDevMode === 'undefined' || ngDevMode)
+      typeof ngDevMode !== 'undefined' &&
+      ngDevMode
     ) {
       throwNameError();
     }

--- a/packages/forms/src/directives/reactive_directives/form_control_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_directive.ts
@@ -97,7 +97,7 @@ export class FormControlDirective extends NgControl implements OnChanges, OnDest
    */
   @Input('disabled')
   set isDisabled(isDisabled: boolean) {
-    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       console.warn(disabledAttrWarning);
     }
   }
@@ -159,7 +159,7 @@ export class FormControlDirective extends NgControl implements OnChanges, OnDest
       this.form.updateValueAndValidity({emitEvent: false});
     }
     if (isPropertyUpdated(changes, this.viewModel)) {
-      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      if (typeof ngDevMode !== 'undefined' && ngDevMode) {
         _ngModelWarning('formControl', FormControlDirective, this, this._ngModelWarningConfig);
       }
       this.form.setValue(this.model);

--- a/packages/forms/src/directives/reactive_directives/form_control_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_name.ts
@@ -116,7 +116,7 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
    */
   @Input('disabled')
   set isDisabled(isDisabled: boolean) {
-    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       console.warn(disabledAttrWarning);
     }
   }
@@ -170,7 +170,7 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
   ngOnChanges(changes: SimpleChanges) {
     if (!this._added) this._setUpControl();
     if (isPropertyUpdated(changes, this.viewModel)) {
-      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      if (typeof ngDevMode !== 'undefined' && ngDevMode) {
         _ngModelWarning('formControlName', FormControlName, this, this._ngModelWarningConfig);
       }
       this.viewModel = this.model;
@@ -214,7 +214,7 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
   }
 
   private _checkParentType(): void {
-    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       if (
         !(this._parent instanceof FormGroupName) &&
         this._parent instanceof AbstractFormGroupDirective

--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -407,7 +407,7 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
   }
 
   private _checkFormPresent() {
-    if (!this.form && (typeof ngDevMode === 'undefined' || ngDevMode)) {
+    if (!this.form && typeof ngDevMode !== 'undefined' && ngDevMode) {
       throw missingFormException();
     }
   }

--- a/packages/forms/src/directives/reactive_directives/form_group_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_name.ts
@@ -115,7 +115,7 @@ export class FormGroupName extends AbstractFormGroupDirective implements OnInit,
 
   /** @internal */
   override _checkParentType(): void {
-    if (_hasInvalidParent(this._parent) && (typeof ngDevMode === 'undefined' || ngDevMode)) {
+    if (_hasInvalidParent(this._parent) && typeof ngDevMode !== 'undefined' && ngDevMode) {
       throw groupParentException();
     }
   }
@@ -230,7 +230,7 @@ export class FormArrayName extends ControlContainer implements OnInit, OnDestroy
   }
 
   private _checkParentType(): void {
-    if (_hasInvalidParent(this._parent) && (typeof ngDevMode === 'undefined' || ngDevMode)) {
+    if (_hasInvalidParent(this._parent) && typeof ngDevMode !== 'undefined' && ngDevMode) {
       throw arrayParentException();
     }
   }

--- a/packages/forms/src/directives/select_control_value_accessor.ts
+++ b/packages/forms/src/directives/select_control_value_accessor.ts
@@ -126,7 +126,7 @@ export class SelectControlValueAccessor
    */
   @Input()
   set compareWith(fn: (o1: any, o2: any) => boolean) {
-    if (typeof fn !== 'function' && (typeof ngDevMode === 'undefined' || ngDevMode)) {
+    if (typeof fn !== 'function' && typeof ngDevMode !== 'undefined' && ngDevMode) {
       throw new RuntimeError(
         RuntimeErrorCode.COMPAREWITH_NOT_A_FN,
         `compareWith must be a function, but received ${JSON.stringify(fn)}`,

--- a/packages/forms/src/directives/select_multiple_control_value_accessor.ts
+++ b/packages/forms/src/directives/select_multiple_control_value_accessor.ts
@@ -122,7 +122,7 @@ export class SelectMultipleControlValueAccessor
    */
   @Input()
   set compareWith(fn: (o1: any, o2: any) => boolean) {
-    if (typeof fn !== 'function' && (typeof ngDevMode === 'undefined' || ngDevMode)) {
+    if (typeof fn !== 'function' && typeof ngDevMode !== 'undefined' && ngDevMode) {
       throw new RuntimeError(
         RuntimeErrorCode.COMPAREWITH_NOT_A_FN,
         `compareWith must be a function, but received ${JSON.stringify(fn)}`,

--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -67,7 +67,7 @@ export function setUpControl(
   dir: NgControl,
   callSetDisabledState: SetDisabledStateOption = setDisabledStateDefault,
 ): void {
-  if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
     if (!control) _throwError(dir, 'Cannot find control with');
     if (!dir.valueAccessor) _throwMissingValueAccessorError(dir);
   }
@@ -108,7 +108,7 @@ export function cleanUpControl(
   validateControlPresenceOnChange: boolean = true,
 ): void {
   const noop = () => {
-    if (validateControlPresenceOnChange && (typeof ngDevMode === 'undefined' || ngDevMode)) {
+    if (validateControlPresenceOnChange && typeof ngDevMode !== 'undefined' && ngDevMode) {
       _noControlError(dir);
     }
   };
@@ -301,7 +301,7 @@ export function setUpFormContainer(
   control: FormGroup | FormArray,
   dir: AbstractFormGroupDirective | FormArrayName,
 ) {
-  if (control == null && (typeof ngDevMode === 'undefined' || ngDevMode))
+  if (control == null && typeof ngDevMode !== 'undefined' && ngDevMode)
     _throwError(dir, 'Cannot find control with');
   setUpValidators(control, dir);
 }
@@ -388,7 +388,7 @@ export function selectValueAccessor(
 ): ControlValueAccessor | null {
   if (!valueAccessors) return null;
 
-  if (!Array.isArray(valueAccessors) && (typeof ngDevMode === 'undefined' || ngDevMode))
+  if (!Array.isArray(valueAccessors) && typeof ngDevMode !== 'undefined' && ngDevMode)
     _throwInvalidValueAccessorError(dir);
 
   let defaultAccessor: ControlValueAccessor | undefined = undefined;
@@ -399,11 +399,11 @@ export function selectValueAccessor(
     if (v.constructor === DefaultValueAccessor) {
       defaultAccessor = v;
     } else if (isBuiltInAccessor(v)) {
-      if (builtinAccessor && (typeof ngDevMode === 'undefined' || ngDevMode))
+      if (builtinAccessor && typeof ngDevMode !== 'undefined' && ngDevMode)
         _throwError(dir, 'More than one built-in value accessor matches form control with');
       builtinAccessor = v;
     } else {
-      if (customAccessor && (typeof ngDevMode === 'undefined' || ngDevMode))
+      if (customAccessor && typeof ngDevMode !== 'undefined' && ngDevMode)
         _throwError(dir, 'More than one custom value accessor matches form control with');
       customAccessor = v;
     }
@@ -413,7 +413,7 @@ export function selectValueAccessor(
   if (builtinAccessor) return builtinAccessor;
   if (defaultAccessor) return defaultAccessor;
 
-  if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
     _throwError(dir, 'No valid value accessor for form control with');
   }
   return null;

--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -197,7 +197,7 @@ export function pickAsyncValidators(
   asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null,
   validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null,
 ): AsyncValidatorFn | AsyncValidatorFn[] | null {
-  if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
     if (isOptionsObj(validatorOrOpts) && asyncValidator) {
       console.warn(asyncValidatorsDroppedWithOptsWarning);
     }
@@ -257,13 +257,13 @@ export function assertControlPresent(parent: any, isGroup: boolean, key: string 
   if (!collection.length) {
     throw new RuntimeError(
       RuntimeErrorCode.NO_CONTROLS,
-      typeof ngDevMode === 'undefined' || ngDevMode ? noControlsError(isGroup) : '',
+      typeof ngDevMode !== 'undefined' && ngDevMode ? noControlsError(isGroup) : '',
     );
   }
   if (!controls[key]) {
     throw new RuntimeError(
       RuntimeErrorCode.MISSING_CONTROL,
-      typeof ngDevMode === 'undefined' || ngDevMode ? missingControlError(isGroup, key) : '',
+      typeof ngDevMode !== 'undefined' && ngDevMode ? missingControlError(isGroup, key) : '',
     );
   }
 }
@@ -273,7 +273,7 @@ export function assertAllValuesPresent(control: any, isGroup: boolean, value: an
     if (value[key] === undefined) {
       throw new RuntimeError(
         RuntimeErrorCode.MISSING_CONTROL_VALUE,
-        typeof ngDevMode === 'undefined' || ngDevMode ? missingControlValueError(isGroup, key) : '',
+        typeof ngDevMode !== 'undefined' && ngDevMode ? missingControlValueError(isGroup, key) : '',
       );
     }
   });

--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -197,7 +197,7 @@ export class FormGroup<
     asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null,
   ) {
     super(pickValidators(validatorOrOpts), pickAsyncValidators(asyncValidator, validatorOrOpts));
-    (typeof ngDevMode === 'undefined' || ngDevMode) && validateFormGroupControls(controls);
+    typeof ngDevMode !== 'undefined' && ngDevMode && validateFormGroupControls(controls);
     this.controls = controls;
     this._initObservables();
     this._setUpdateStrategy(validatorOrOpts);

--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -586,7 +586,7 @@ function isPresent(o: any): boolean {
 
 export function toObservable(value: any): Observable<any> {
   const obs = isPromise(value) ? from(value) : value;
-  if ((typeof ngDevMode === 'undefined' || ngDevMode) && !isSubscribable(obs)) {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode && !isSubscribable(obs)) {
     let errorMessage = `Expected async validator to return Promise or Observable.`;
     // A synchronous validator will return object or null.
     if (typeof value === 'object') {

--- a/packages/platform-browser/animations/async/src/async_animation_renderer.ts
+++ b/packages/platform-browser/animations/async/src/async_animation_renderer.ts
@@ -86,7 +86,8 @@ export class AsyncAnimationRendererFactory implements OnDestroy, RendererFactory
       .catch((e) => {
         throw new RuntimeError(
           RuntimeErrorCode.ANIMATION_RENDERER_ASYNC_LOADING_FAILURE,
-          (typeof ngDevMode === 'undefined' || ngDevMode) &&
+          typeof ngDevMode !== 'undefined' &&
+            ngDevMode &&
             'Async loading for animations package was ' +
               'enabled, but loading failed. Angular falls back to using regular rendering. ' +
               "No animations will be displayed and their styles won't be applied.",

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -209,7 +209,7 @@ export const platformBrowser: (extraProviders?: StaticProvider[]) => PlatformRef
  * `BrowserModule` providers without referencing the module itself.
  */
 const BROWSER_MODULE_PROVIDERS_MARKER = new InjectionToken(
-  typeof ngDevMode === 'undefined' || ngDevMode ? 'BrowserModule Providers Marker' : '',
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'BrowserModule Providers Marker' : '',
 );
 
 const TESTABILITY_PROVIDERS = [
@@ -245,7 +245,7 @@ const BROWSER_MODULE_PROVIDERS: Provider[] = [
   EventManager,
   {provide: RendererFactory2, useExisting: DomRendererFactory2},
   {provide: XhrFactory, useClass: BrowserXhr, deps: []},
-  typeof ngDevMode === 'undefined' || ngDevMode
+  typeof ngDevMode !== 'undefined' && ngDevMode
     ? {provide: BROWSER_MODULE_PROVIDERS_MARKER, useValue: true}
     : [],
 ];
@@ -270,7 +270,7 @@ export class BrowserModule {
     @Inject(BROWSER_MODULE_PROVIDERS_MARKER)
     providersAlreadyPresent: boolean | null,
   ) {
-    if ((typeof ngDevMode === 'undefined' || ngDevMode) && providersAlreadyPresent) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode && providersAlreadyPresent) {
       throw new RuntimeError(
         RuntimeErrorCode.BROWSER_MODULE_ALREADY_LOADED,
         `Providers from the \`BrowserModule\` have already been loaded. If you need access ` +

--- a/packages/platform-browser/src/browser/testability.ts
+++ b/packages/platform-browser/src/browser/testability.ts
@@ -24,7 +24,8 @@ export class BrowserGetTestability implements GetTestability {
       if (testability == null) {
         throw new RuntimeError(
           RuntimeErrorCode.TESTABILITY_NOT_FOUND,
-          (typeof ngDevMode === 'undefined' || ngDevMode) &&
+          typeof ngDevMode !== 'undefined' &&
+            ngDevMode &&
             'Could not find testability for element.',
         );
       }

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -265,7 +265,8 @@ class DefaultDomRenderer2 implements Renderer2 {
     if (!el) {
       throw new RuntimeError(
         RuntimeErrorCode.ROOT_NODE_NOT_FOUND,
-        (typeof ngDevMode === 'undefined' || ngDevMode) &&
+        typeof ngDevMode !== 'undefined' &&
+          ngDevMode &&
           `The selector "${selectorOrNode}" did not match any elements`,
       );
     }
@@ -340,7 +341,8 @@ class DefaultDomRenderer2 implements Renderer2 {
       return;
     }
 
-    (typeof ngDevMode === 'undefined' || ngDevMode) &&
+    typeof ngDevMode !== 'undefined' &&
+      ngDevMode &&
       this.throwOnSyntheticProps &&
       checkNoSyntheticProp(name, 'property');
     el[name] = value;
@@ -356,7 +358,8 @@ class DefaultDomRenderer2 implements Renderer2 {
     callback: (event: any) => boolean,
     options?: ListenerOptions,
   ): () => void {
-    (typeof ngDevMode === 'undefined' || ngDevMode) &&
+    typeof ngDevMode !== 'undefined' &&
+      ngDevMode &&
       this.throwOnSyntheticProps &&
       checkNoSyntheticProp(event, 'listener');
     if (typeof target === 'string') {

--- a/packages/platform-browser/src/dom/events/event_manager.ts
+++ b/packages/platform-browser/src/dom/events/event_manager.ts
@@ -89,7 +89,8 @@ export class EventManager {
     if (!plugin) {
       throw new RuntimeError(
         RuntimeErrorCode.NO_PLUGIN_FOR_EVENT,
-        (typeof ngDevMode === 'undefined' || ngDevMode) &&
+        typeof ngDevMode !== 'undefined' &&
+          ngDevMode &&
           `No event manager plugin found for event ${eventName}`,
       );
     }

--- a/packages/platform-browser/src/dom/events/hammer_gestures.ts
+++ b/packages/platform-browser/src/dom/events/hammer_gestures.ts
@@ -186,7 +186,7 @@ export class HammerGesturesPlugin extends EventManagerPlugin {
     }
 
     if (!(window as any).Hammer && !this.loader) {
-      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      if (typeof ngDevMode !== 'undefined' && ngDevMode) {
         this.console.warn(
           `The "${eventName}" event cannot be bound because Hammer.JS is not ` +
             `loaded and no custom loader has been specified.`,
@@ -218,7 +218,7 @@ export class HammerGesturesPlugin extends EventManagerPlugin {
         this._loaderPromise!.then(() => {
           // If Hammer isn't actually loaded when the custom loader resolves, give up.
           if (!(window as any).Hammer) {
-            if (typeof ngDevMode === 'undefined' || ngDevMode) {
+            if (typeof ngDevMode !== 'undefined' && ngDevMode) {
               this.console.warn(
                 `The custom HAMMER_LOADER completed, but Hammer.JS is not present.`,
               );
@@ -234,7 +234,7 @@ export class HammerGesturesPlugin extends EventManagerPlugin {
             deregister = this.addEventListener(element, eventName, handler);
           }
         }).catch(() => {
-          if (typeof ngDevMode === 'undefined' || ngDevMode) {
+          if (typeof ngDevMode !== 'undefined' && ngDevMode) {
             this.console.warn(
               `The "${eventName}" event cannot be bound because the custom ` +
                 `Hammer.JS loader failed.`,

--- a/packages/platform-browser/src/dom/shared_styles_host.ts
+++ b/packages/platform-browser/src/dom/shared_styles_host.ts
@@ -170,7 +170,7 @@ export class SharedStylesHost implements OnDestroy {
 
     // If existing, just increment the usage count
     if (record) {
-      if ((typeof ngDevMode === 'undefined' || ngDevMode) && record.usage === 0) {
+      if (typeof ngDevMode !== 'undefined' && ngDevMode && record.usage === 0) {
         // A usage count of zero indicates a preexisting server generated style.
         // This attribute is solely used for debugging purposes of SSR style reuse.
         record.elements.forEach((element) => element.setAttribute('ng-style-reused', ''));

--- a/packages/platform-browser/src/security/dom_sanitization_service.ts
+++ b/packages/platform-browser/src/security/dom_sanitization_service.ts
@@ -189,8 +189,7 @@ export class DomSanitizerImpl extends DomSanitizer {
         }
         throw new RuntimeError(
           RuntimeErrorCode.SANITIZATION_UNSAFE_SCRIPT,
-          (typeof ngDevMode === 'undefined' || ngDevMode) &&
-            'unsafe value used in a script context',
+          typeof ngDevMode !== 'undefined' && ngDevMode && 'unsafe value used in a script context',
         );
       case SecurityContext.URL:
         if (allowSanitizationBypassOrThrow(value, BypassType.Url)) {
@@ -203,13 +202,15 @@ export class DomSanitizerImpl extends DomSanitizer {
         }
         throw new RuntimeError(
           RuntimeErrorCode.SANITIZATION_UNSAFE_RESOURCE_URL,
-          (typeof ngDevMode === 'undefined' || ngDevMode) &&
+          typeof ngDevMode !== 'undefined' &&
+            ngDevMode &&
             `unsafe value used in a resource URL context (see ${XSS_SECURITY_URL})`,
         );
       default:
         throw new RuntimeError(
           RuntimeErrorCode.SANITIZATION_UNEXPECTED_CTX,
-          (typeof ngDevMode === 'undefined' || ngDevMode) &&
+          typeof ngDevMode !== 'undefined' &&
+            ngDevMode &&
             `Unexpected SecurityContext ${ctx} (see ${XSS_SECURITY_URL})`,
         );
     }

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -43,7 +43,8 @@ export function namedOutletsRedirect(redirectTo: string): Observable<any> {
   return throwError(
     new RuntimeError(
       RuntimeErrorCode.NAMED_OUTLET_REDIRECT,
-      (typeof ngDevMode === 'undefined' || ngDevMode) &&
+      typeof ngDevMode !== 'undefined' &&
+        ngDevMode &&
         `Only absolute redirects can have named outlets. redirectTo: '${redirectTo}'`,
     ),
   );
@@ -52,7 +53,8 @@ export function namedOutletsRedirect(redirectTo: string): Observable<any> {
 export function canLoadFails(route: Route): Observable<LoadedRouterConfig> {
   return throwError(
     navigationCancelingError(
-      (typeof ngDevMode === 'undefined' || ngDevMode) &&
+      typeof ngDevMode !== 'undefined' &&
+        ngDevMode &&
         `Cannot load children because the guard of the route "path: '${route.path}'" returned false`,
       NavigationCancellationCode.GuardRejected,
     ),
@@ -181,7 +183,8 @@ export class ApplyRedirects {
     if (!pos)
       throw new RuntimeError(
         RuntimeErrorCode.MISSING_REDIRECT,
-        (typeof ngDevMode === 'undefined' || ngDevMode) &&
+        typeof ngDevMode !== 'undefined' &&
+          ngDevMode &&
           `Cannot redirect to '${redirectTo}'. Cannot find '${redirectToUrlSegment.path}'.`,
       );
     return pos;

--- a/packages/router/src/create_url_tree.ts
+++ b/packages/router/src/create_url_tree.ts
@@ -197,7 +197,8 @@ class Navigation {
     if (isAbsolute && commands.length > 0 && isMatrixParams(commands[0])) {
       throw new RuntimeError(
         RuntimeErrorCode.ROOT_SEGMENT_MATRIX_PARAMS,
-        (typeof ngDevMode === 'undefined' || ngDevMode) &&
+        typeof ngDevMode !== 'undefined' &&
+          ngDevMode &&
           'Root segment cannot have matrix parameters',
       );
     }
@@ -206,8 +207,7 @@ class Navigation {
     if (cmdWithOutlet && cmdWithOutlet !== last(commands)) {
       throw new RuntimeError(
         RuntimeErrorCode.MISPLACED_OUTLETS_COMMAND,
-        (typeof ngDevMode === 'undefined' || ngDevMode) &&
-          '{outlets:{}} has to be the last command',
+        typeof ngDevMode !== 'undefined' && ngDevMode && '{outlets:{}} has to be the last command',
       );
     }
   }
@@ -316,7 +316,7 @@ function createPositionApplyingDoubleDots(
     if (!g) {
       throw new RuntimeError(
         RuntimeErrorCode.INVALID_DOUBLE_DOTS,
-        (typeof ngDevMode === 'undefined' || ngDevMode) && "Invalid number of '../'",
+        typeof ngDevMode !== 'undefined' && ngDevMode && "Invalid number of '../'",
       );
     }
     ci = g.segments.length;

--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -316,7 +316,7 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
     if (!this.activated)
       throw new RuntimeError(
         RuntimeErrorCode.OUTLET_NOT_ACTIVATED,
-        (typeof ngDevMode === 'undefined' || ngDevMode) && 'Outlet is not activated',
+        typeof ngDevMode !== 'undefined' && ngDevMode && 'Outlet is not activated',
       );
     return this.activated.instance;
   }
@@ -325,7 +325,7 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
     if (!this.activated)
       throw new RuntimeError(
         RuntimeErrorCode.OUTLET_NOT_ACTIVATED,
-        (typeof ngDevMode === 'undefined' || ngDevMode) && 'Outlet is not activated',
+        typeof ngDevMode !== 'undefined' && ngDevMode && 'Outlet is not activated',
       );
     return this._activatedRoute as ActivatedRoute;
   }
@@ -344,7 +344,7 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
     if (!this.activated)
       throw new RuntimeError(
         RuntimeErrorCode.OUTLET_NOT_ACTIVATED,
-        (typeof ngDevMode === 'undefined' || ngDevMode) && 'Outlet is not activated',
+        typeof ngDevMode !== 'undefined' && ngDevMode && 'Outlet is not activated',
       );
     this.location.detach();
     const cmp = this.activated;
@@ -379,7 +379,8 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
     if (this.isActivated) {
       throw new RuntimeError(
         RuntimeErrorCode.OUTLET_ALREADY_ACTIVATED,
-        (typeof ngDevMode === 'undefined' || ngDevMode) &&
+        typeof ngDevMode !== 'undefined' &&
+          ngDevMode &&
           'Cannot activate an already activated outlet',
       );
     }

--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -335,7 +335,7 @@ interface InternalRouterInterface {
 
 export const NAVIGATION_ERROR_HANDLER = new InjectionToken<
   (error: NavigationError) => unknown | RedirectCommand
->(typeof ngDevMode === 'undefined' || ngDevMode ? 'navigation error handler' : '');
+>(typeof ngDevMode !== 'undefined' && ngDevMode ? 'navigation error handler' : '');
 
 @Injectable({providedIn: 'root'})
 export class NavigationTransitions {
@@ -461,7 +461,7 @@ export class NavigationTransitions {
             // https://github.com/ReactiveX/rxjs/issues/7455
             if (this.navigationId > overallTransitionState.id) {
               const cancellationReason =
-                typeof ngDevMode === 'undefined' || ngDevMode
+                typeof ngDevMode !== 'undefined' && ngDevMode
                   ? `Navigation ID ${overallTransitionState.id} is not equal to the current navigation id ${this.navigationId}`
                   : '';
               this.cancelNavigationTransition(
@@ -496,7 +496,7 @@ export class NavigationTransitions {
             const onSameUrlNavigation = t.extras.onSameUrlNavigation ?? router.onSameUrlNavigation;
             if (!urlTransition && onSameUrlNavigation !== 'reload') {
               const reason =
-                typeof ngDevMode === 'undefined' || ngDevMode
+                typeof ngDevMode !== 'undefined' && ngDevMode
                   ? `Navigation to ${t.rawUrl} was ignored because it is the same as the current Router URL.`
                   : '';
               this.events.next(
@@ -594,7 +594,7 @@ export class NavigationTransitions {
                * from the current URL in the browser.
                */
               const reason =
-                typeof ngDevMode === 'undefined' || ngDevMode
+                typeof ngDevMode !== 'undefined' && ngDevMode
                   ? `Navigation was ignored because the UrlHandlingStrategy` +
                     ` indicated neither the current URL ${t.currentRawUrl} nor target URL ${t.rawUrl} should be processed.`
                   : '';
@@ -678,7 +678,7 @@ export class NavigationTransitions {
                         if (!dataResolved) {
                           this.cancelNavigationTransition(
                             t,
-                            typeof ngDevMode === 'undefined' || ngDevMode
+                            typeof ngDevMode !== 'undefined' && ngDevMode
                               ? `At least one route resolver didn't emit any value.`
                               : '',
                             NavigationCancellationCode.NoDataFromResolver,
@@ -814,7 +814,7 @@ export class NavigationTransitions {
              * navigation gets cancelled but not caught by other means. */
             if (!completed && !errored) {
               const cancelationReason =
-                typeof ngDevMode === 'undefined' || ngDevMode
+                typeof ngDevMode !== 'undefined' && ngDevMode
                   ? `Navigation ID ${overallTransitionState.id} is not equal to the current navigation id ${this.navigationId}`
                   : '';
               this.cancelNavigationTransition(

--- a/packages/router/src/operators/activate_routes.ts
+++ b/packages/router/src/operators/activate_routes.ts
@@ -235,7 +235,7 @@ export class ActivateRoutes {
         this.activateChildRoutes(futureNode, null, parentContexts);
       }
     }
-    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       const context = parentContexts.getOrCreateContext(future.outlet);
       const outlet = context.outlet;
       if (

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -89,7 +89,7 @@ import {
 export function provideRouter(routes: Routes, ...features: RouterFeatures[]): EnvironmentProviders {
   return makeEnvironmentProviders([
     {provide: ROUTES, multi: true, useValue: routes},
-    typeof ngDevMode === 'undefined' || ngDevMode
+    typeof ngDevMode !== 'undefined' && ngDevMode
       ? {provide: ROUTER_IS_PROVIDED, useValue: true}
       : [],
     {provide: ActivatedRoute, useFactory: rootRoute, deps: [Router]},
@@ -166,7 +166,7 @@ const routerIsProvidedDevModeCheck = {
 export function provideRoutes(routes: Routes): Provider[] {
   return [
     {provide: ROUTES, multi: true, useValue: routes},
-    typeof ngDevMode === 'undefined' || ngDevMode ? routerIsProvidedDevModeCheck : [],
+    typeof ngDevMode !== 'undefined' && ngDevMode ? routerIsProvidedDevModeCheck : [],
   ];
 }
 
@@ -256,7 +256,7 @@ export function getBootstrapListener() {
  * to the activation phase.
  */
 const BOOTSTRAP_DONE = new InjectionToken<Subject<void>>(
-  typeof ngDevMode === 'undefined' || ngDevMode ? 'bootstrap done indicator' : '',
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'bootstrap done indicator' : '',
   {
     factory: () => {
       return new Subject<void>();
@@ -289,7 +289,7 @@ const enum InitialNavigation {
 }
 
 const INITIAL_NAVIGATION = new InjectionToken<InitialNavigation>(
-  typeof ngDevMode === 'undefined' || ngDevMode ? 'initial navigation' : '',
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'initial navigation' : '',
   {providedIn: 'root', factory: () => InitialNavigation.EnabledNonBlocking},
 );
 
@@ -477,7 +477,7 @@ export type DebugTracingFeature = RouterFeature<RouterFeatureKind.DebugTracingFe
  */
 export function withDebugTracing(): DebugTracingFeature {
   let providers: Provider[] = [];
-  if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
     providers = [
       {
         provide: ENVIRONMENT_INITIALIZER,
@@ -503,7 +503,7 @@ export function withDebugTracing(): DebugTracingFeature {
 }
 
 const ROUTER_PRELOADER = new InjectionToken<RouterPreloader>(
-  typeof ngDevMode === 'undefined' || ngDevMode ? 'router preloader' : '',
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'router preloader' : '',
 );
 
 /**

--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -95,7 +95,7 @@ export class Recognizer {
   private noMatchError(e: NoMatch): RuntimeError<RuntimeErrorCode.NO_MATCH> {
     return new RuntimeError(
       RuntimeErrorCode.NO_MATCH,
-      typeof ngDevMode === 'undefined' || ngDevMode
+      typeof ngDevMode !== 'undefined' && ngDevMode
         ? `Cannot match any routes. URL Segment: '${e.segmentGroup}'`
         : `'${e.segmentGroup}'`,
     );
@@ -232,7 +232,7 @@ export class Recognizer {
         // multiple activated results for the same outlet. We should merge the children of
         // these results so the final return value is only one `TreeNode` per outlet.
         const mergedChildren = mergeEmptyPathMatches(children);
-        if (typeof ngDevMode === 'undefined' || ngDevMode) {
+        if (typeof ngDevMode !== 'undefined' && ngDevMode) {
           // This should really never happen - we are only taking the first match for each
           // outlet and merge the empty path matches.
           checkOutletNameUniqueness(mergedChildren);
@@ -591,7 +591,8 @@ function checkOutletNameUniqueness(nodes: TreeNode<ActivatedRouteSnapshot>[]): v
       const c = n.value.url.map((s) => s.toString()).join('/');
       throw new RuntimeError(
         RuntimeErrorCode.TWO_SEGMENTS_WITH_SAME_OUTLET,
-        (typeof ngDevMode === 'undefined' || ngDevMode) &&
+        typeof ngDevMode !== 'undefined' &&
+          ngDevMode &&
           `Two segments cannot have the same outlet name: '${p}' and '${c}'.`,
       );
     }

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -365,7 +365,7 @@ export class Router {
    * ```
    */
   resetConfig(config: Routes): void {
-    (typeof ngDevMode === 'undefined' || ngDevMode) && validateConfig(config);
+    typeof ngDevMode !== 'undefined' && ngDevMode && validateConfig(config);
     this.config = config.map(standardizeConfig);
     this.navigated = false;
   }
@@ -675,7 +675,8 @@ function validateCommands(commands: string[]): void {
     if (cmd == null) {
       throw new RuntimeError(
         RuntimeErrorCode.NULLISH_COMMAND,
-        (typeof ngDevMode === 'undefined' || ngDevMode) &&
+        typeof ngDevMode !== 'undefined' &&
+          ngDevMode &&
           `The requested path contains ${cmd} segment at index ${i}`,
       );
     }

--- a/packages/router/src/router_config.ts
+++ b/packages/router/src/router_config.ts
@@ -259,7 +259,7 @@ export interface ExtraOptions extends InMemoryScrollingOptions, RouterConfigOpti
  * @publicApi
  */
 export const ROUTER_CONFIGURATION = new InjectionToken<ExtraOptions>(
-  typeof ngDevMode === 'undefined' || ngDevMode ? 'router config' : '',
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'router config' : '',
   {
     providedIn: 'root',
     factory: () => ({}),

--- a/packages/router/src/router_config_loader.ts
+++ b/packages/router/src/router_config_loader.ts
@@ -62,7 +62,8 @@ export class RouterConfigLoader {
         if (this.onLoadEndListener) {
           this.onLoadEndListener(route);
         }
-        (typeof ngDevMode === 'undefined' || ngDevMode) &&
+        typeof ngDevMode !== 'undefined' &&
+          ngDevMode &&
           assertStandalone(route.path ?? '', component);
         route._loadedComponent = component;
       }),
@@ -153,7 +154,8 @@ export function loadChildren(
         rawRoutes = injector.get(ROUTES, [], {optional: true, self: true}).flat();
       }
       const routes = rawRoutes.map(standardizeConfig);
-      (typeof ngDevMode === 'undefined' || ngDevMode) &&
+      typeof ngDevMode !== 'undefined' &&
+        ngDevMode &&
         validateConfig(routes, route.path, requireStandaloneComponents);
       return {routes, injector};
     }),

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -63,7 +63,7 @@ const ROUTER_DIRECTIVES = [RouterOutlet, RouterLink, RouterLinkActive, EmptyOutl
  * @docsNotRequired
  */
 export const ROUTER_FORROOT_GUARD = new InjectionToken<void>(
-  typeof ngDevMode === 'undefined' || ngDevMode
+  typeof ngDevMode !== 'undefined' && ngDevMode
     ? 'router duplicate forRoot guard'
     : 'ROUTER_FORROOT_GUARD',
 );
@@ -81,7 +81,7 @@ export const ROUTER_PROVIDERS: Provider[] = [
   RouterConfigLoader,
   // Only used to warn when `provideRoutes` is used without `RouterModule` or `provideRouter`. Can
   // be removed when `provideRoutes` is removed.
-  typeof ngDevMode === 'undefined' || ngDevMode
+  typeof ngDevMode !== 'undefined' && ngDevMode
     ? {provide: ROUTER_IS_PROVIDED, useValue: true}
     : [],
 ];
@@ -137,7 +137,7 @@ export class RouterModule {
       ngModule: RouterModule,
       providers: [
         ROUTER_PROVIDERS,
-        typeof ngDevMode === 'undefined' || ngDevMode
+        typeof ngDevMode !== 'undefined' && ngDevMode
           ? config?.enableTracing
             ? withDebugTracing().ɵproviders
             : []
@@ -224,7 +224,7 @@ function providePathLocationStrategy(): Provider {
 }
 
 export function provideForRootGuard(router: Router): any {
-  if ((typeof ngDevMode === 'undefined' || ngDevMode) && router) {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode && router) {
     throw new RuntimeError(
       RuntimeErrorCode.FOR_ROOT_CALLED_TWICE,
       `The Router was provided more than once. This can happen if 'forRoot' is used outside of the root injector.` +
@@ -253,7 +253,7 @@ function provideInitialNavigation(config: Pick<ExtraOptions, 'initialNavigation'
  * @publicApi
  */
 export const ROUTER_INITIALIZER = new InjectionToken<(compRef: ComponentRef<any>) => void>(
-  typeof ngDevMode === 'undefined' || ngDevMode ? 'Router Initializer' : '',
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'Router Initializer' : '',
 );
 
 function provideRouterInitializer(): Provider[] {

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -218,7 +218,7 @@ export class UrlTree {
     /** The fragment of the URL */
     public fragment: string | null = null,
   ) {
-    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       if (root.segments.length > 0) {
         throw new RuntimeError(
           RuntimeErrorCode.INVALID_ROOT_URL_SEGMENT,
@@ -630,7 +630,8 @@ class UrlParser {
     if (path === '' && this.peekStartsWith(';')) {
       throw new RuntimeError(
         RuntimeErrorCode.EMPTY_PATH_WITH_PARAMS,
-        (typeof ngDevMode === 'undefined' || ngDevMode) &&
+        typeof ngDevMode !== 'undefined' &&
+          ngDevMode &&
           `Empty path url segment cannot have parameters: '${this.remaining}'.`,
       );
     }
@@ -713,7 +714,7 @@ class UrlParser {
       if (next !== '/' && next !== ')' && next !== ';') {
         throw new RuntimeError(
           RuntimeErrorCode.UNPARSABLE_URL,
-          (typeof ngDevMode === 'undefined' || ngDevMode) && `Cannot parse url '${this.url}'`,
+          typeof ngDevMode !== 'undefined' && ngDevMode && `Cannot parse url '${this.url}'`,
         );
       }
 
@@ -754,7 +755,7 @@ class UrlParser {
     if (!this.consumeOptional(str)) {
       throw new RuntimeError(
         RuntimeErrorCode.UNEXPECTED_VALUE_IN_URL,
-        (typeof ngDevMode === 'undefined' || ngDevMode) && `Expected "${str}".`,
+        typeof ngDevMode !== 'undefined' && ngDevMode && `Expected "${str}".`,
       );
     }
   }

--- a/packages/router/src/utils/config.ts
+++ b/packages/router/src/utils/config.ts
@@ -86,7 +86,7 @@ export function assertStandalone(fullPath: string, component: Type<unknown> | un
 }
 
 function validateNode(route: Route, fullPath: string, requireStandaloneComponents: boolean): void {
-  if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
     if (!route) {
       throw new RuntimeError(
         RuntimeErrorCode.INVALID_ROUTE_CONFIG,

--- a/packages/upgrade/src/dynamic/src/upgrade_adapter.ts
+++ b/packages/upgrade/src/dynamic/src/upgrade_adapter.ts
@@ -652,7 +652,7 @@ export class UpgradeAdapter {
                 let subscription = ngZone.onMicrotaskEmpty.subscribe({
                   next: () => {
                     if (rootScope.$$phase) {
-                      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+                      if (typeof ngDevMode !== 'undefined' && ngDevMode) {
                         console.warn(
                           'A digest was triggered while one was already in progress. This may mean that something is triggering digests outside the Angular zone.',
                         );

--- a/packages/upgrade/static/src/upgrade_module.ts
+++ b/packages/upgrade/static/src/upgrade_module.ts
@@ -298,7 +298,7 @@ export class UpgradeModule {
           setTimeout(() => {
             const subscription = this.ngZone.onMicrotaskEmpty.subscribe(() => {
               if ($rootScope.$$phase) {
-                if (typeof ngDevMode === 'undefined' || ngDevMode) {
+                if (typeof ngDevMode !== 'undefined' && ngDevMode) {
                   console.warn(
                     'A digest was triggered while one was already in progress. This may mean that something is triggering digests outside the Angular zone.',
                   );


### PR DESCRIPTION
Use  `typeof ngDevMode !== 'undefined' && ngDevMode` which is easier to understand than `typeof ngDevMode === 'undefined' || ngDevMode`.
 we also don't want the condition to be truthy if the` ngDdevMode` is undefined. 
 
`We're also keeping (ngDevMode === 'undefined' || ngDevMode)` for cases where we need to actually check if it's missing such as caling `initNgDevMode`
