### PR TITLE
build: simplify symbol tests format

### DIFF
--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -1,1499 +1,501 @@
 [
-  {
-    "name": "ANIMATION_MODULE_TYPE"
-  },
-  {
-    "name": "APP_BOOTSTRAP_LISTENER"
-  },
-  {
-    "name": "APP_ID"
-  },
-  {
-    "name": "APP_INITIALIZER"
-  },
-  {
-    "name": "AfterRenderManager"
-  },
-  {
-    "name": "AnimationAstBuilderContext"
-  },
-  {
-    "name": "AnimationAstBuilderVisitor"
-  },
-  {
-    "name": "AnimationDriver"
-  },
-  {
-    "name": "AnimationEngine"
-  },
-  {
-    "name": "AnimationGroupPlayer"
-  },
-  {
-    "name": "AnimationMetadataType"
-  },
-  {
-    "name": "AnimationRenderer"
-  },
-  {
-    "name": "AnimationRendererFactory"
-  },
-  {
-    "name": "AnimationStateStyles"
-  },
-  {
-    "name": "AnimationStyleNormalizer"
-  },
-  {
-    "name": "AnimationTimelineBuilderVisitor"
-  },
-  {
-    "name": "AnimationTimelineContext"
-  },
-  {
-    "name": "AnimationTransitionFactory"
-  },
-  {
-    "name": "AnimationTransitionNamespace"
-  },
-  {
-    "name": "AnimationTrigger"
-  },
-  {
-    "name": "AnimationsComponent"
-  },
-  {
-    "name": "AnonymousSubject"
-  },
-  {
-    "name": "ApplicationInitStatus"
-  },
-  {
-    "name": "ApplicationRef"
-  },
-  {
-    "name": "BROWSER_ANIMATIONS_PROVIDERS"
-  },
-  {
-    "name": "BROWSER_MODULE_PROVIDERS"
-  },
-  {
-    "name": "BaseAnimationRenderer"
-  },
-  {
-    "name": "BehaviorSubject"
-  },
-  {
-    "name": "BrowserDomAdapter"
-  },
-  {
-    "name": "BrowserXhr"
-  },
-  {
-    "name": "CIRCULAR"
-  },
-  {
-    "name": "COMPLETE_NOTIFICATION"
-  },
-  {
-    "name": "COMPONENT_REGEX"
-  },
-  {
-    "name": "CSP_NONCE"
-  },
-  {
-    "name": "ChainedInjector"
-  },
-  {
-    "name": "ChangeDetectionScheduler"
-  },
-  {
-    "name": "ChangeDetectionSchedulerImpl"
-  },
-  {
-    "name": "ChangeDetectionStrategy"
-  },
-  {
-    "name": "ComponentFactory"
-  },
-  {
-    "name": "ComponentFactory2"
-  },
-  {
-    "name": "ComponentFactoryResolver"
-  },
-  {
-    "name": "ComponentFactoryResolver2"
-  },
-  {
-    "name": "ComponentRef"
-  },
-  {
-    "name": "ComponentRef2"
-  },
-  {
-    "name": "ConsumerObserver"
-  },
-  {
-    "name": "DASH_CASE_REGEXP"
-  },
-  {
-    "name": "DEFAULT_APP_ID"
-  },
-  {
-    "name": "DEFAULT_NOOP_PREVIOUS_NODE"
-  },
-  {
-    "name": "DEFAULT_STATE_VALUE"
-  },
-  {
-    "name": "DIMENSIONAL_PROP_SET"
-  },
-  {
-    "name": "DOCUMENT"
-  },
-  {
-    "name": "DOCUMENT2"
-  },
-  {
-    "name": "DefaultDomRenderer2"
-  },
-  {
-    "name": "DestroyRef"
-  },
-  {
-    "name": "DomAdapter"
-  },
-  {
-    "name": "DomEventsPlugin"
-  },
-  {
-    "name": "DomRendererFactory2"
-  },
-  {
-    "name": "EMPTY_ARRAY"
-  },
-  {
-    "name": "EMPTY_INSTRUCTION_MAP"
-  },
-  {
-    "name": "EMPTY_OBJ"
-  },
-  {
-    "name": "EMPTY_OBJECT"
-  },
-  {
-    "name": "EMPTY_OBSERVER"
-  },
-  {
-    "name": "EMPTY_PAYLOAD"
-  },
-  {
-    "name": "EMPTY_PLAYER_ARRAY"
-  },
-  {
-    "name": "EMPTY_SUBSCRIPTION"
-  },
-  {
-    "name": "ENTER_TOKEN_REGEX"
-  },
-  {
-    "name": "ENVIRONMENT_INITIALIZER"
-  },
-  {
-    "name": "EVENT_MANAGER_PLUGINS"
-  },
-  {
-    "name": "EffectScheduler"
-  },
-  {
-    "name": "ElementInstructionMap"
-  },
-  {
-    "name": "ElementRef"
-  },
-  {
-    "name": "EmulatedEncapsulationDomRenderer2"
-  },
-  {
-    "name": "EnvironmentInjector"
-  },
-  {
-    "name": "EnvironmentNgModuleRefAdapter"
-  },
-  {
-    "name": "ErrorHandler"
-  },
-  {
-    "name": "EventEmitter"
-  },
-  {
-    "name": "EventManager"
-  },
-  {
-    "name": "EventManagerPlugin"
-  },
-  {
-    "name": "FALSE_BOOLEAN_VALUES"
-  },
-  {
-    "name": "GenericBrowserDomAdapter"
-  },
-  {
-    "name": "INJECTOR"
-  },
-  {
-    "name": "INJECTOR_DEF_TYPES"
-  },
-  {
-    "name": "INJECTOR_SCOPE"
-  },
-  {
-    "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
-  },
-  {
-    "name": "INTERNAL_BROWSER_PLATFORM_PROVIDERS"
-  },
-  {
-    "name": "InjectFlags"
-  },
-  {
-    "name": "InjectionToken"
-  },
-  {
-    "name": "Injector"
-  },
-  {
-    "name": "InputFlags"
-  },
-  {
-    "name": "KeyEventsPlugin"
-  },
-  {
-    "name": "LContainerFlags"
-  },
-  {
-    "name": "LEAVE_TOKEN_REGEX"
-  },
-  {
-    "name": "LOCALE_ID2"
-  },
-  {
-    "name": "LifecycleHooksFeature"
-  },
-  {
-    "name": "MODIFIER_KEYS"
-  },
-  {
-    "name": "MODIFIER_KEY_GETTERS"
-  },
-  {
-    "name": "NAMESPACE_URIS"
-  },
-  {
-    "name": "NEW_LINE"
-  },
-  {
-    "name": "NG_COMP_DEF"
-  },
-  {
-    "name": "NG_DIR_DEF"
-  },
-  {
-    "name": "NG_ELEMENT_ID"
-  },
-  {
-    "name": "NG_ENV_ID"
-  },
-  {
-    "name": "NG_FACTORY_DEF"
-  },
-  {
-    "name": "NG_INJECTABLE_DEF"
-  },
-  {
-    "name": "NG_INJECTOR_DEF"
-  },
-  {
-    "name": "NG_INJ_DEF"
-  },
-  {
-    "name": "NG_PIPE_DEF"
-  },
-  {
-    "name": "NG_PROV_DEF"
-  },
-  {
-    "name": "NOT_FOUND"
-  },
-  {
-    "name": "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR"
-  },
-  {
-    "name": "NOT_YET"
-  },
-  {
-    "name": "NO_CHANGE"
-  },
-  {
-    "name": "NULL_INJECTOR"
-  },
-  {
-    "name": "NULL_REMOVAL_STATE"
-  },
-  {
-    "name": "NULL_REMOVED_QUERIED_STATE"
-  },
-  {
-    "name": "NgModuleRef"
-  },
-  {
-    "name": "NgZone"
-  },
-  {
-    "name": "NgZoneChangeDetectionScheduler"
-  },
-  {
-    "name": "NodeInjector"
-  },
-  {
-    "name": "NodeInjectorDestroyRef"
-  },
-  {
-    "name": "NodeInjectorFactory"
-  },
-  {
-    "name": "NoneEncapsulationDomRenderer"
-  },
-  {
-    "name": "NoopAnimationDriver"
-  },
-  {
-    "name": "NoopAnimationPlayer"
-  },
-  {
-    "name": "NoopNgZone"
-  },
-  {
-    "name": "NullInjector"
-  },
-  {
-    "name": "ObjectUnsubscribedError"
-  },
-  {
-    "name": "Observable"
-  },
-  {
-    "name": "OperatorSubscriber"
-  },
-  {
-    "name": "PARAM_REGEX"
-  },
-  {
-    "name": "PLATFORM_DESTROY_LISTENERS"
-  },
-  {
-    "name": "PLATFORM_ID"
-  },
-  {
-    "name": "PLATFORM_INITIALIZER"
-  },
-  {
-    "name": "PRESERVE_HOST_CONTENT"
-  },
-  {
-    "name": "PendingTasksInternal"
-  },
-  {
-    "name": "R3Injector"
-  },
-  {
-    "name": "REACTIVE_LVIEW_CONSUMER_NODE"
-  },
-  {
-    "name": "REACTIVE_NODE"
-  },
-  {
-    "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
-  },
-  {
-    "name": "RendererFactory2"
-  },
-  {
-    "name": "RendererStyleFlags2"
-  },
-  {
-    "name": "RuntimeError"
-  },
-  {
-    "name": "SCHEDULE_IN_ROOT_ZONE"
-  },
-  {
-    "name": "SELF_TOKEN_REGEX"
-  },
-  {
-    "name": "SIGNAL"
-  },
-  {
-    "name": "SIMPLE_CHANGES_STORE"
-  },
-  {
-    "name": "SafeSubscriber"
-  },
-  {
-    "name": "Sanitizer"
-  },
-  {
-    "name": "ShadowDomRenderer"
-  },
-  {
-    "name": "SharedStylesHost"
-  },
-  {
-    "name": "SimpleChange"
-  },
-  {
-    "name": "SpecialCasedStyles"
-  },
-  {
-    "name": "StandaloneService"
-  },
-  {
-    "name": "StateValue"
-  },
-  {
-    "name": "SubTimelineBuilder"
-  },
-  {
-    "name": "Subject"
-  },
-  {
-    "name": "Subscriber"
-  },
-  {
-    "name": "Subscription"
-  },
-  {
-    "name": "TEMPORARY_CONSUMER_NODE"
-  },
-  {
-    "name": "TESTABILITY"
-  },
-  {
-    "name": "THROW_IF_NOT_FOUND"
-  },
-  {
-    "name": "TRACKED_LVIEWS"
-  },
-  {
-    "name": "TRUE_BOOLEAN_VALUES"
-  },
-  {
-    "name": "TimelineAnimationEngine"
-  },
-  {
-    "name": "TimelineBuilder"
-  },
-  {
-    "name": "TracingAction"
-  },
-  {
-    "name": "TracingService"
-  },
-  {
-    "name": "TransitionAnimationEngine"
-  },
-  {
-    "name": "TransitionAnimationPlayer"
-  },
-  {
-    "name": "USE_VALUE"
-  },
-  {
-    "name": "UnsubscriptionError"
-  },
-  {
-    "name": "ViewEncapsulation"
-  },
-  {
-    "name": "ViewRef"
-  },
-  {
-    "name": "WebAnimationsDriver"
-  },
-  {
-    "name": "WebAnimationsPlayer"
-  },
-  {
-    "name": "WebAnimationsStyleNormalizer"
-  },
-  {
-    "name": "ZONELESS_ENABLED"
-  },
-  {
-    "name": "ZONELESS_SCHEDULER_DISABLED"
-  },
-  {
-    "name": "ZoneAwareEffectScheduler"
-  },
-  {
-    "name": "ZoneStablePendingTask"
-  },
-  {
-    "name": "_CACHED_BODY"
-  },
-  {
-    "name": "_DOM"
-  },
-  {
-    "name": "_IS_WEBKIT"
-  },
-  {
-    "name": "_Injector"
-  },
-  {
-    "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__defProp"
-  },
-  {
-    "name": "__forward_ref__"
-  },
-  {
-    "name": "__publicField"
-  },
-  {
-    "name": "_applyRootElementTransformImpl"
-  },
-  {
-    "name": "_bind"
-  },
-  {
-    "name": "_convertTimeValueToMS"
-  },
-  {
-    "name": "_currentInjector"
-  },
-  {
-    "name": "_flattenGroupPlayersRecur"
-  },
-  {
-    "name": "_injectImplementation"
-  },
-  {
-    "name": "_isRefreshingViews"
-  },
-  {
-    "name": "_keyMap"
-  },
-  {
-    "name": "_locateOrCreateElementNode"
-  },
-  {
-    "name": "_platformInjector"
-  },
-  {
-    "name": "_wasLastNodeCreated"
-  },
-  {
-    "name": "activeConsumer"
-  },
-  {
-    "name": "addClass"
-  },
-  {
-    "name": "addPropertyBinding"
-  },
-  {
-    "name": "addToEndOfViewTree"
-  },
-  {
-    "name": "allocExpando"
-  },
-  {
-    "name": "allocLFrame"
-  },
-  {
-    "name": "angularZoneInstanceIdProperty"
-  },
-  {
-    "name": "animate"
-  },
-  {
-    "name": "appendChild"
-  },
-  {
-    "name": "applyNodes"
-  },
-  {
-    "name": "applyParamDefaults"
-  },
-  {
-    "name": "applyProjectionRecursive"
-  },
-  {
-    "name": "applyToElementOrContainer"
-  },
-  {
-    "name": "applyValueToInputField"
-  },
-  {
-    "name": "applyView"
-  },
-  {
-    "name": "arrRemove"
-  },
-  {
-    "name": "assertConsumerNode"
-  },
-  {
-    "name": "assertNotDestroyed"
-  },
-  {
-    "name": "attachPatchData"
-  },
-  {
-    "name": "balanceProperties"
-  },
-  {
-    "name": "baseElement"
-  },
-  {
-    "name": "bind"
-  },
-  {
-    "name": "bloomHasToken"
-  },
-  {
-    "name": "bootstrap"
-  },
-  {
-    "name": "buildAnimationAst"
-  },
-  {
-    "name": "buildAnimationTimelines"
-  },
-  {
-    "name": "buildRootMap"
-  },
-  {
-    "name": "callHook"
-  },
-  {
-    "name": "callHookInternal"
-  },
-  {
-    "name": "callHooks"
-  },
-  {
-    "name": "captureNodeBindings"
-  },
-  {
-    "name": "checkStable"
-  },
-  {
-    "name": "classIndexOf"
-  },
-  {
-    "name": "cleanUpView"
-  },
-  {
-    "name": "cloakAndComputeStyles"
-  },
-  {
-    "name": "cloakElement"
-  },
-  {
-    "name": "collectNativeNodes"
-  },
-  {
-    "name": "collectNativeNodesInLContainer"
-  },
-  {
-    "name": "computeStaticStyling"
-  },
-  {
-    "name": "computeStyle"
-  },
-  {
-    "name": "concatStringsWithSpace"
-  },
-  {
-    "name": "config"
-  },
-  {
-    "name": "configureViewWithDirective"
-  },
-  {
-    "name": "consumerBeforeComputation"
-  },
-  {
-    "name": "consumerDestroy"
-  },
-  {
-    "name": "consumerIsLive"
-  },
-  {
-    "name": "consumerPollProducersForChange"
-  },
-  {
-    "name": "containsElement"
-  },
-  {
-    "name": "context"
-  },
-  {
-    "name": "convertToBitFlags"
-  },
-  {
-    "name": "copyAnimationEvent"
-  },
-  {
-    "name": "createElementNode"
-  },
-  {
-    "name": "createElementRef"
-  },
-  {
-    "name": "createErrorClass"
-  },
-  {
-    "name": "createInjector"
-  },
-  {
-    "name": "createLFrame"
-  },
-  {
-    "name": "createLView"
-  },
-  {
-    "name": "createLinkElement"
-  },
-  {
-    "name": "createNodeInjector"
-  },
-  {
-    "name": "createNotification"
-  },
-  {
-    "name": "createStyleElement"
-  },
-  {
-    "name": "createTView"
-  },
-  {
-    "name": "createTimelineInstruction"
-  },
-  {
-    "name": "createTransitionInstruction"
-  },
-  {
-    "name": "dashCaseToCamelCase"
-  },
-  {
-    "name": "deepForEach"
-  },
-  {
-    "name": "deepForEachProvider"
-  },
-  {
-    "name": "detachMovedView"
-  },
-  {
-    "name": "detachViewFromDOM"
-  },
-  {
-    "name": "detectChangesInChildComponents"
-  },
-  {
-    "name": "detectChangesInComponent"
-  },
-  {
-    "name": "detectChangesInEmbeddedViews"
-  },
-  {
-    "name": "detectChangesInView"
-  },
-  {
-    "name": "detectChangesInViewIfAttached"
-  },
-  {
-    "name": "detectChangesInViewIfRequired"
-  },
-  {
-    "name": "detectChangesInternal"
-  },
-  {
-    "name": "diPublicInInjector"
-  },
-  {
-    "name": "documentElement"
-  },
-  {
-    "name": "enterDI"
-  },
-  {
-    "name": "enterView"
-  },
-  {
-    "name": "eraseStyles"
-  },
-  {
-    "name": "errorContext"
-  },
-  {
-    "name": "execFinalizer"
-  },
-  {
-    "name": "executeCheckHooks"
-  },
-  {
-    "name": "executeContentQueries"
-  },
-  {
-    "name": "executeInitAndCheckHooks"
-  },
-  {
-    "name": "executeTemplate"
-  },
-  {
-    "name": "executeViewQueryFn"
-  },
-  {
-    "name": "extractDefListOrFactory"
-  },
-  {
-    "name": "extractDirectiveDef"
-  },
-  {
-    "name": "extractStyleParams"
-  },
-  {
-    "name": "filterNonAnimatableStyles"
-  },
-  {
-    "name": "findAttrIndexInNode"
-  },
-  {
-    "name": "forEachSingleProvider"
-  },
-  {
-    "name": "forwardRef"
-  },
-  {
-    "name": "freeConsumers"
-  },
-  {
-    "name": "generateInitialInputs"
-  },
-  {
-    "name": "getBindingsEnabled"
-  },
-  {
-    "name": "getClosureSafeProperty"
-  },
-  {
-    "name": "getComponentDef"
-  },
-  {
-    "name": "getComponentLViewByIndex"
-  },
-  {
-    "name": "getConstant"
-  },
-  {
-    "name": "getCurrentTNode"
-  },
-  {
-    "name": "getCurrentTNodePlaceholderOk"
-  },
-  {
-    "name": "getDOM"
-  },
-  {
-    "name": "getDeclarationTNode"
-  },
-  {
-    "name": "getDirectiveDef"
-  },
-  {
-    "name": "getFactoryDef"
-  },
-  {
-    "name": "getFirstLContainer"
-  },
-  {
-    "name": "getInitialLViewFlagsFromDef"
-  },
-  {
-    "name": "getInjectImplementation"
-  },
-  {
-    "name": "getInjectableDef"
-  },
-  {
-    "name": "getInjectorDef"
-  },
-  {
-    "name": "getInjectorIndex"
-  },
-  {
-    "name": "getLView"
-  },
-  {
-    "name": "getLViewParent"
-  },
-  {
-    "name": "getNativeByTNode"
-  },
-  {
-    "name": "getNearestLContainer"
-  },
-  {
-    "name": "getNextLContainer"
-  },
-  {
-    "name": "getNodeInjectable"
-  },
-  {
-    "name": "getNullInjector"
-  },
-  {
-    "name": "getOrCreateComponentTView"
-  },
-  {
-    "name": "getOrCreateInjectable"
-  },
-  {
-    "name": "getOrCreateNodeInjectorForNode"
-  },
-  {
-    "name": "getOrCreateTNode"
-  },
-  {
-    "name": "getOrSetDefaultValue"
-  },
-  {
-    "name": "getOwnDefinition"
-  },
-  {
-    "name": "getParentElement"
-  },
-  {
-    "name": "getParentInjectorIndex"
-  },
-  {
-    "name": "getParentInjectorLocation"
-  },
-  {
-    "name": "getParentInjectorView"
-  },
-  {
-    "name": "getPipeDef"
-  },
-  {
-    "name": "getProjectionNodes"
-  },
-  {
-    "name": "getPromiseCtor"
-  },
-  {
-    "name": "getSimpleChangesStore"
-  },
-  {
-    "name": "getTNode"
-  },
-  {
-    "name": "getTNodeFromLView"
-  },
-  {
-    "name": "getTView"
-  },
-  {
-    "name": "handleStoppedNotification"
-  },
-  {
-    "name": "handleUnhandledError"
-  },
-  {
-    "name": "hasApplyArgsData"
-  },
-  {
-    "name": "hasTagAndTypeMatch"
-  },
-  {
-    "name": "icuContainerIterate"
-  },
-  {
-    "name": "identity"
-  },
-  {
-    "name": "importProvidersFrom"
-  },
-  {
-    "name": "includeViewProviders"
-  },
-  {
-    "name": "incrementInitPhaseFlags"
-  },
-  {
-    "name": "initializeDirectives"
-  },
-  {
-    "name": "inject"
-  },
-  {
-    "name": "injectArgs"
-  },
-  {
-    "name": "injectDestroyRef"
-  },
-  {
-    "name": "injectElementRef"
-  },
-  {
-    "name": "injectInjectorOnly"
-  },
-  {
-    "name": "injectRootLimpMode"
-  },
-  {
-    "name": "injectableDefOrInjectorDefFactory"
-  },
-  {
-    "name": "insertBloom"
-  },
-  {
-    "name": "instructionState"
-  },
-  {
-    "name": "internalImportProvidersFrom"
-  },
-  {
-    "name": "internalProvideZoneChangeDetection"
-  },
-  {
-    "name": "interpolateParams"
-  },
-  {
-    "name": "invalidTimingValue"
-  },
-  {
-    "name": "invokeDirectivesHostBindings"
-  },
-  {
-    "name": "invokeHostBindingsInCreationMode"
-  },
-  {
-    "name": "invokeQuery"
-  },
-  {
-    "name": "isAngularZoneProperty"
-  },
-  {
-    "name": "isApplicationBootstrapConfig"
-  },
-  {
-    "name": "isComponentDef"
-  },
-  {
-    "name": "isComponentHost"
-  },
-  {
-    "name": "isContentQueryHost"
-  },
-  {
-    "name": "isCssClassMatching"
-  },
-  {
-    "name": "isCurrentTNodeParent"
-  },
-  {
-    "name": "isElementNode"
-  },
-  {
-    "name": "isEnvironmentProviders"
-  },
-  {
-    "name": "isFunction"
-  },
-  {
-    "name": "isInlineTemplate"
-  },
-  {
-    "name": "isLContainer"
-  },
-  {
-    "name": "isLView"
-  },
-  {
-    "name": "isNodeMatchingSelector"
-  },
-  {
-    "name": "isNodeMatchingSelectorList"
-  },
-  {
-    "name": "isPlatformServer"
-  },
-  {
-    "name": "isPositive"
-  },
-  {
-    "name": "isPromise"
-  },
-  {
-    "name": "isRefreshingViews"
-  },
-  {
-    "name": "isRootView"
-  },
-  {
-    "name": "isSubscription"
-  },
-  {
-    "name": "isTemplateNode"
-  },
-  {
-    "name": "isTypeProvider"
-  },
-  {
-    "name": "isValueProvider"
-  },
-  {
-    "name": "leaveDI"
-  },
-  {
-    "name": "leaveView"
-  },
-  {
-    "name": "leaveViewLight"
-  },
-  {
-    "name": "listenOnPlayer"
-  },
-  {
-    "name": "lookupTokenUsingModuleInjector"
-  },
-  {
-    "name": "lookupTokenUsingNodeInjector"
-  },
-  {
-    "name": "makeAnimationEvent"
-  },
-  {
-    "name": "makeLambdaFromStates"
-  },
-  {
-    "name": "makeRecord"
-  },
-  {
-    "name": "makeTimingAst"
-  },
-  {
-    "name": "map"
-  },
-  {
-    "name": "markAncestorsForTraversal"
-  },
-  {
-    "name": "markAsComponentHost"
-  },
-  {
-    "name": "markViewDirty"
-  },
-  {
-    "name": "markViewForRefresh"
-  },
-  {
-    "name": "markedFeatures"
-  },
-  {
-    "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "mergeHostAttribute"
-  },
-  {
-    "name": "mergeHostAttrs"
-  },
-  {
-    "name": "nativeAppendChild"
-  },
-  {
-    "name": "nativeAppendOrInsertBefore"
-  },
-  {
-    "name": "nativeInsertBefore"
-  },
-  {
-    "name": "nextNgElementId"
-  },
-  {
-    "name": "ngOnChangesSetInput"
-  },
-  {
-    "name": "ngZoneInstanceId"
-  },
-  {
-    "name": "nonNull"
-  },
-  {
-    "name": "noop"
-  },
-  {
-    "name": "noop2"
-  },
-  {
-    "name": "normalizeAnimationEntry"
-  },
-  {
-    "name": "normalizeAnimationOptions"
-  },
-  {
-    "name": "normalizeKeyframes"
-  },
-  {
-    "name": "notFoundValueOrThrow"
-  },
-  {
-    "name": "observable"
-  },
-  {
-    "name": "onEnter"
-  },
-  {
-    "name": "onLeave"
-  },
-  {
-    "name": "optimizeGroupPlayer"
-  },
-  {
-    "name": "parseAndConvertBindingsForDefinition"
-  },
-  {
-    "name": "parseTimelineCommand"
-  },
-  {
-    "name": "performanceMarkFeature"
-  },
-  {
-    "name": "processInjectorTypesWithProviders"
-  },
-  {
-    "name": "producerMarkClean"
-  },
-  {
-    "name": "producerRemoveLiveConsumerAtIndex"
-  },
-  {
-    "name": "producerUpdateValueVersion"
-  },
-  {
-    "name": "refreshContentQueries"
-  },
-  {
-    "name": "refreshView"
-  },
-  {
-    "name": "registerPostOrderHooks"
-  },
-  {
-    "name": "rememberChangeHistoryAndInvokeOnChangesHook"
-  },
-  {
-    "name": "remove"
-  },
-  {
-    "name": "removeClass"
-  },
-  {
-    "name": "removeElements"
-  },
-  {
-    "name": "removeFromArray"
-  },
-  {
-    "name": "removeNodesAfterAnimationDone"
-  },
-  {
-    "name": "renderComponent"
-  },
-  {
-    "name": "renderView"
-  },
-  {
-    "name": "replacePostStylesAsPre"
-  },
-  {
-    "name": "requiresRefreshOrTraversal"
-  },
-  {
-    "name": "resetPreOrderHookFlags"
-  },
-  {
-    "name": "resolveForwardRef"
-  },
-  {
-    "name": "resolveTiming"
-  },
-  {
-    "name": "resolveTimingValue"
-  },
-  {
-    "name": "roundOffset"
-  },
-  {
-    "name": "runEffectsInView"
-  },
-  {
-    "name": "runInInjectionContext"
-  },
-  {
-    "name": "saveNameToExportMap"
-  },
-  {
-    "name": "scheduleCallbackWithMicrotask"
-  },
-  {
-    "name": "scheduleCallbackWithRafRace"
-  },
-  {
-    "name": "searchTokensOnInjector"
-  },
-  {
-    "name": "setActiveConsumer"
-  },
-  {
-    "name": "setBindingRootForHostBindings"
-  },
-  {
-    "name": "setCurrentDirectiveIndex"
-  },
-  {
-    "name": "setCurrentInjector"
-  },
-  {
-    "name": "setCurrentQueryIndex"
-  },
-  {
-    "name": "setCurrentTNode"
-  },
-  {
-    "name": "setDirectiveInputsWhichShadowsStyling"
-  },
-  {
-    "name": "setIncludeViewProviders"
-  },
-  {
-    "name": "setInjectImplementation"
-  },
-  {
-    "name": "setInputsForProperty"
-  },
-  {
-    "name": "setInputsFromAttrs"
-  },
-  {
-    "name": "setIsRefreshingViews"
-  },
-  {
-    "name": "setSelectedIndex"
-  },
-  {
-    "name": "setStyles"
-  },
-  {
-    "name": "setUpAttributes"
-  },
-  {
-    "name": "setupStaticAttributes"
-  },
-  {
-    "name": "shimStylesContent"
-  },
-  {
-    "name": "shouldSearchParent"
-  },
-  {
-    "name": "storeLViewOnDestroy"
-  },
-  {
-    "name": "stringify"
-  },
-  {
-    "name": "stringifyCSSSelector"
-  },
-  {
-    "name": "style"
-  },
-  {
-    "name": "throwProviderNotFoundError"
-  },
-  {
-    "name": "timeoutProvider"
-  },
-  {
-    "name": "toRefArray"
-  },
-  {
-    "name": "transition"
-  },
-  {
-    "name": "uniqueIdCounter"
-  },
-  {
-    "name": "unregisterLView"
-  },
-  {
-    "name": "unwrapRNode"
-  },
-  {
-    "name": "updateAncestorTraversalFlagsOnAttach"
-  },
-  {
-    "name": "updateMicroTaskStatus"
-  },
-  {
-    "name": "viewAttachedToChangeDetector"
-  },
-  {
-    "name": "viewShouldHaveReactiveConsumer"
-  },
-  {
-    "name": "visitDslNode"
-  },
-  {
-    "name": "walkProviderTree"
-  },
-  {
-    "name": "writeDirectClass"
-  },
-  {
-    "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "ɵɵdefineComponent"
-  },
-  {
-    "name": "ɵɵdefineInjectable"
-  },
-  {
-    "name": "ɵɵdirectiveInject"
-  },
-  {
-    "name": "ɵɵelement"
-  },
-  {
-    "name": "ɵɵelementEnd"
-  },
-  {
-    "name": "ɵɵelementStart"
-  },
-  {
-    "name": "ɵɵinject"
-  },
-  {
-    "name": "ɵɵproperty"
-  }
+  "ANIMATION_MODULE_TYPE",
+  "APP_BOOTSTRAP_LISTENER",
+  "APP_ID",
+  "APP_INITIALIZER",
+  "AfterRenderManager",
+  "AnimationAstBuilderContext",
+  "AnimationAstBuilderVisitor",
+  "AnimationDriver",
+  "AnimationEngine",
+  "AnimationGroupPlayer",
+  "AnimationMetadataType",
+  "AnimationRenderer",
+  "AnimationRendererFactory",
+  "AnimationStateStyles",
+  "AnimationStyleNormalizer",
+  "AnimationTimelineBuilderVisitor",
+  "AnimationTimelineContext",
+  "AnimationTransitionFactory",
+  "AnimationTransitionNamespace",
+  "AnimationTrigger",
+  "AnimationsComponent",
+  "AnonymousSubject",
+  "ApplicationInitStatus",
+  "ApplicationRef",
+  "BROWSER_ANIMATIONS_PROVIDERS",
+  "BROWSER_MODULE_PROVIDERS",
+  "BaseAnimationRenderer",
+  "BehaviorSubject",
+  "BrowserDomAdapter",
+  "BrowserXhr",
+  "CIRCULAR",
+  "COMPLETE_NOTIFICATION",
+  "COMPONENT_REGEX",
+  "CSP_NONCE",
+  "ChainedInjector",
+  "ChangeDetectionScheduler",
+  "ChangeDetectionSchedulerImpl",
+  "ChangeDetectionStrategy",
+  "ComponentFactory",
+  "ComponentFactory2",
+  "ComponentFactoryResolver",
+  "ComponentFactoryResolver2",
+  "ComponentRef",
+  "ComponentRef2",
+  "ConsumerObserver",
+  "DASH_CASE_REGEXP",
+  "DEFAULT_APP_ID",
+  "DEFAULT_NOOP_PREVIOUS_NODE",
+  "DEFAULT_STATE_VALUE",
+  "DIMENSIONAL_PROP_SET",
+  "DOCUMENT",
+  "DOCUMENT2",
+  "DefaultDomRenderer2",
+  "DestroyRef",
+  "DomAdapter",
+  "DomEventsPlugin",
+  "DomRendererFactory2",
+  "EMPTY_ARRAY",
+  "EMPTY_INSTRUCTION_MAP",
+  "EMPTY_OBJ",
+  "EMPTY_OBJECT",
+  "EMPTY_OBSERVER",
+  "EMPTY_PAYLOAD",
+  "EMPTY_PLAYER_ARRAY",
+  "EMPTY_SUBSCRIPTION",
+  "ENTER_TOKEN_REGEX",
+  "ENVIRONMENT_INITIALIZER",
+  "EVENT_MANAGER_PLUGINS",
+  "EffectScheduler",
+  "ElementInstructionMap",
+  "ElementRef",
+  "EmulatedEncapsulationDomRenderer2",
+  "EnvironmentInjector",
+  "EnvironmentNgModuleRefAdapter",
+  "ErrorHandler",
+  "EventEmitter",
+  "EventManager",
+  "EventManagerPlugin",
+  "FALSE_BOOLEAN_VALUES",
+  "GenericBrowserDomAdapter",
+  "INJECTOR",
+  "INJECTOR_DEF_TYPES",
+  "INJECTOR_SCOPE",
+  "INTERNAL_APPLICATION_ERROR_HANDLER",
+  "INTERNAL_BROWSER_PLATFORM_PROVIDERS",
+  "InjectFlags",
+  "InjectionToken",
+  "Injector",
+  "InputFlags",
+  "KeyEventsPlugin",
+  "LContainerFlags",
+  "LEAVE_TOKEN_REGEX",
+  "LOCALE_ID2",
+  "LifecycleHooksFeature",
+  "MODIFIER_KEYS",
+  "MODIFIER_KEY_GETTERS",
+  "NAMESPACE_URIS",
+  "NEW_LINE",
+  "NG_COMP_DEF",
+  "NG_DIR_DEF",
+  "NG_ELEMENT_ID",
+  "NG_ENV_ID",
+  "NG_FACTORY_DEF",
+  "NG_INJECTABLE_DEF",
+  "NG_INJECTOR_DEF",
+  "NG_INJ_DEF",
+  "NG_PIPE_DEF",
+  "NG_PROV_DEF",
+  "NOT_FOUND",
+  "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR",
+  "NOT_YET",
+  "NO_CHANGE",
+  "NULL_INJECTOR",
+  "NULL_REMOVAL_STATE",
+  "NULL_REMOVED_QUERIED_STATE",
+  "NgModuleRef",
+  "NgZone",
+  "NgZoneChangeDetectionScheduler",
+  "NodeInjector",
+  "NodeInjectorDestroyRef",
+  "NodeInjectorFactory",
+  "NoneEncapsulationDomRenderer",
+  "NoopAnimationDriver",
+  "NoopAnimationPlayer",
+  "NoopNgZone",
+  "NullInjector",
+  "ObjectUnsubscribedError",
+  "Observable",
+  "OperatorSubscriber",
+  "PARAM_REGEX",
+  "PLATFORM_DESTROY_LISTENERS",
+  "PLATFORM_ID",
+  "PLATFORM_INITIALIZER",
+  "PRESERVE_HOST_CONTENT",
+  "PendingTasksInternal",
+  "R3Injector",
+  "REACTIVE_LVIEW_CONSUMER_NODE",
+  "REACTIVE_NODE",
+  "REMOVE_STYLES_ON_COMPONENT_DESTROY",
+  "RendererFactory2",
+  "RendererStyleFlags2",
+  "RuntimeError",
+  "SCHEDULE_IN_ROOT_ZONE",
+  "SELF_TOKEN_REGEX",
+  "SIGNAL",
+  "SIMPLE_CHANGES_STORE",
+  "SafeSubscriber",
+  "Sanitizer",
+  "ShadowDomRenderer",
+  "SharedStylesHost",
+  "SimpleChange",
+  "SpecialCasedStyles",
+  "StandaloneService",
+  "StateValue",
+  "SubTimelineBuilder",
+  "Subject",
+  "Subscriber",
+  "Subscription",
+  "TEMPORARY_CONSUMER_NODE",
+  "TESTABILITY",
+  "THROW_IF_NOT_FOUND",
+  "TRACKED_LVIEWS",
+  "TRUE_BOOLEAN_VALUES",
+  "TimelineAnimationEngine",
+  "TimelineBuilder",
+  "TracingAction",
+  "TracingService",
+  "TransitionAnimationEngine",
+  "TransitionAnimationPlayer",
+  "USE_VALUE",
+  "UnsubscriptionError",
+  "ViewEncapsulation",
+  "ViewRef",
+  "WebAnimationsDriver",
+  "WebAnimationsPlayer",
+  "WebAnimationsStyleNormalizer",
+  "ZONELESS_ENABLED",
+  "ZONELESS_SCHEDULER_DISABLED",
+  "ZoneAwareEffectScheduler",
+  "ZoneStablePendingTask",
+  "_CACHED_BODY",
+  "_DOM",
+  "_IS_WEBKIT",
+  "_Injector",
+  "_NullComponentFactoryResolver",
+  "__defProp",
+  "__forward_ref__",
+  "__publicField",
+  "_applyRootElementTransformImpl",
+  "_bind",
+  "_convertTimeValueToMS",
+  "_currentInjector",
+  "_flattenGroupPlayersRecur",
+  "_injectImplementation",
+  "_isRefreshingViews",
+  "_keyMap",
+  "_locateOrCreateElementNode",
+  "_platformInjector",
+  "_wasLastNodeCreated",
+  "activeConsumer",
+  "addClass",
+  "addPropertyBinding",
+  "addToEndOfViewTree",
+  "allocExpando",
+  "allocLFrame",
+  "angularZoneInstanceIdProperty",
+  "animate",
+  "appendChild",
+  "applyNodes",
+  "applyParamDefaults",
+  "applyProjectionRecursive",
+  "applyToElementOrContainer",
+  "applyValueToInputField",
+  "applyView",
+  "arrRemove",
+  "assertConsumerNode",
+  "assertNotDestroyed",
+  "attachPatchData",
+  "balanceProperties",
+  "baseElement",
+  "bind",
+  "bloomHasToken",
+  "bootstrap",
+  "buildAnimationAst",
+  "buildAnimationTimelines",
+  "buildRootMap",
+  "callHook",
+  "callHookInternal",
+  "callHooks",
+  "captureNodeBindings",
+  "checkStable",
+  "classIndexOf",
+  "cleanUpView",
+  "cloakAndComputeStyles",
+  "cloakElement",
+  "collectNativeNodes",
+  "collectNativeNodesInLContainer",
+  "computeStaticStyling",
+  "computeStyle",
+  "concatStringsWithSpace",
+  "config",
+  "configureViewWithDirective",
+  "consumerBeforeComputation",
+  "consumerDestroy",
+  "consumerIsLive",
+  "consumerPollProducersForChange",
+  "containsElement",
+  "context",
+  "convertToBitFlags",
+  "copyAnimationEvent",
+  "createElementNode",
+  "createElementRef",
+  "createErrorClass",
+  "createInjector",
+  "createLFrame",
+  "createLView",
+  "createLinkElement",
+  "createNodeInjector",
+  "createNotification",
+  "createStyleElement",
+  "createTView",
+  "createTimelineInstruction",
+  "createTransitionInstruction",
+  "dashCaseToCamelCase",
+  "deepForEach",
+  "deepForEachProvider",
+  "detachMovedView",
+  "detachViewFromDOM",
+  "detectChangesInChildComponents",
+  "detectChangesInComponent",
+  "detectChangesInEmbeddedViews",
+  "detectChangesInView",
+  "detectChangesInViewIfAttached",
+  "detectChangesInViewIfRequired",
+  "detectChangesInternal",
+  "diPublicInInjector",
+  "documentElement",
+  "enterDI",
+  "enterView",
+  "eraseStyles",
+  "errorContext",
+  "execFinalizer",
+  "executeCheckHooks",
+  "executeContentQueries",
+  "executeInitAndCheckHooks",
+  "executeTemplate",
+  "executeViewQueryFn",
+  "extractDefListOrFactory",
+  "extractDirectiveDef",
+  "extractStyleParams",
+  "filterNonAnimatableStyles",
+  "findAttrIndexInNode",
+  "forEachSingleProvider",
+  "forwardRef",
+  "freeConsumers",
+  "generateInitialInputs",
+  "getBindingsEnabled",
+  "getClosureSafeProperty",
+  "getComponentDef",
+  "getComponentLViewByIndex",
+  "getConstant",
+  "getCurrentTNode",
+  "getCurrentTNodePlaceholderOk",
+  "getDOM",
+  "getDeclarationTNode",
+  "getDirectiveDef",
+  "getFactoryDef",
+  "getFirstLContainer",
+  "getInitialLViewFlagsFromDef",
+  "getInjectImplementation",
+  "getInjectableDef",
+  "getInjectorDef",
+  "getInjectorIndex",
+  "getLView",
+  "getLViewParent",
+  "getNativeByTNode",
+  "getNearestLContainer",
+  "getNextLContainer",
+  "getNodeInjectable",
+  "getNullInjector",
+  "getOrCreateComponentTView",
+  "getOrCreateInjectable",
+  "getOrCreateNodeInjectorForNode",
+  "getOrCreateTNode",
+  "getOrSetDefaultValue",
+  "getOwnDefinition",
+  "getParentElement",
+  "getParentInjectorIndex",
+  "getParentInjectorLocation",
+  "getParentInjectorView",
+  "getPipeDef",
+  "getProjectionNodes",
+  "getPromiseCtor",
+  "getSimpleChangesStore",
+  "getTNode",
+  "getTNodeFromLView",
+  "getTView",
+  "handleStoppedNotification",
+  "handleUnhandledError",
+  "hasApplyArgsData",
+  "hasTagAndTypeMatch",
+  "icuContainerIterate",
+  "identity",
+  "importProvidersFrom",
+  "includeViewProviders",
+  "incrementInitPhaseFlags",
+  "initializeDirectives",
+  "inject",
+  "injectArgs",
+  "injectDestroyRef",
+  "injectElementRef",
+  "injectInjectorOnly",
+  "injectRootLimpMode",
+  "injectableDefOrInjectorDefFactory",
+  "insertBloom",
+  "instructionState",
+  "internalImportProvidersFrom",
+  "internalProvideZoneChangeDetection",
+  "interpolateParams",
+  "invalidTimingValue",
+  "invokeDirectivesHostBindings",
+  "invokeHostBindingsInCreationMode",
+  "invokeQuery",
+  "isAngularZoneProperty",
+  "isApplicationBootstrapConfig",
+  "isComponentDef",
+  "isComponentHost",
+  "isContentQueryHost",
+  "isCssClassMatching",
+  "isCurrentTNodeParent",
+  "isElementNode",
+  "isEnvironmentProviders",
+  "isFunction",
+  "isInlineTemplate",
+  "isLContainer",
+  "isLView",
+  "isNodeMatchingSelector",
+  "isNodeMatchingSelectorList",
+  "isPlatformServer",
+  "isPositive",
+  "isPromise",
+  "isRefreshingViews",
+  "isRootView",
+  "isSubscription",
+  "isTemplateNode",
+  "isTypeProvider",
+  "isValueProvider",
+  "leaveDI",
+  "leaveView",
+  "leaveViewLight",
+  "listenOnPlayer",
+  "lookupTokenUsingModuleInjector",
+  "lookupTokenUsingNodeInjector",
+  "makeAnimationEvent",
+  "makeLambdaFromStates",
+  "makeRecord",
+  "makeTimingAst",
+  "map",
+  "markAncestorsForTraversal",
+  "markAsComponentHost",
+  "markViewDirty",
+  "markViewForRefresh",
+  "markedFeatures",
+  "maybeWrapInNotSelector",
+  "mergeHostAttribute",
+  "mergeHostAttrs",
+  "nativeAppendChild",
+  "nativeAppendOrInsertBefore",
+  "nativeInsertBefore",
+  "nextNgElementId",
+  "ngOnChangesSetInput",
+  "ngZoneInstanceId",
+  "nonNull",
+  "noop",
+  "noop2",
+  "normalizeAnimationEntry",
+  "normalizeAnimationOptions",
+  "normalizeKeyframes",
+  "notFoundValueOrThrow",
+  "observable",
+  "onEnter",
+  "onLeave",
+  "optimizeGroupPlayer",
+  "parseAndConvertBindingsForDefinition",
+  "parseTimelineCommand",
+  "performanceMarkFeature",
+  "processInjectorTypesWithProviders",
+  "producerMarkClean",
+  "producerRemoveLiveConsumerAtIndex",
+  "producerUpdateValueVersion",
+  "refreshContentQueries",
+  "refreshView",
+  "registerPostOrderHooks",
+  "rememberChangeHistoryAndInvokeOnChangesHook",
+  "remove",
+  "removeClass",
+  "removeElements",
+  "removeFromArray",
+  "removeNodesAfterAnimationDone",
+  "renderComponent",
+  "renderView",
+  "replacePostStylesAsPre",
+  "requiresRefreshOrTraversal",
+  "resetPreOrderHookFlags",
+  "resolveForwardRef",
+  "resolveTiming",
+  "resolveTimingValue",
+  "roundOffset",
+  "runEffectsInView",
+  "runInInjectionContext",
+  "saveNameToExportMap",
+  "scheduleCallbackWithMicrotask",
+  "scheduleCallbackWithRafRace",
+  "searchTokensOnInjector",
+  "setActiveConsumer",
+  "setBindingRootForHostBindings",
+  "setCurrentDirectiveIndex",
+  "setCurrentInjector",
+  "setCurrentQueryIndex",
+  "setCurrentTNode",
+  "setDirectiveInputsWhichShadowsStyling",
+  "setIncludeViewProviders",
+  "setInjectImplementation",
+  "setInputsForProperty",
+  "setInputsFromAttrs",
+  "setIsRefreshingViews",
+  "setSelectedIndex",
+  "setStyles",
+  "setUpAttributes",
+  "setupStaticAttributes",
+  "shimStylesContent",
+  "shouldSearchParent",
+  "storeLViewOnDestroy",
+  "stringify",
+  "stringifyCSSSelector",
+  "style",
+  "throwProviderNotFoundError",
+  "timeoutProvider",
+  "toRefArray",
+  "transition",
+  "uniqueIdCounter",
+  "unregisterLView",
+  "unwrapRNode",
+  "updateAncestorTraversalFlagsOnAttach",
+  "updateMicroTaskStatus",
+  "viewAttachedToChangeDetector",
+  "viewShouldHaveReactiveConsumer",
+  "visitDslNode",
+  "walkProviderTree",
+  "writeDirectClass",
+  "writeToDirectiveInput",
+  "ɵɵdefineComponent",
+  "ɵɵdefineInjectable",
+  "ɵɵdirectiveInject",
+  "ɵɵelement",
+  "ɵɵelementEnd",
+  "ɵɵelementStart",
+  "ɵɵinject",
+  "ɵɵproperty"
 ]

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -1,1586 +1,530 @@
 [
-  {
-    "name": "ALLOW_MULTIPLE_PLATFORMS"
-  },
-  {
-    "name": "ANIMATION_MODULE_TYPE"
-  },
-  {
-    "name": "APP_BOOTSTRAP_LISTENER"
-  },
-  {
-    "name": "APP_ID"
-  },
-  {
-    "name": "APP_INITIALIZER"
-  },
-  {
-    "name": "AfterRenderManager"
-  },
-  {
-    "name": "AnimationAstBuilderContext"
-  },
-  {
-    "name": "AnimationAstBuilderVisitor"
-  },
-  {
-    "name": "AnimationDriver"
-  },
-  {
-    "name": "AnimationEngine"
-  },
-  {
-    "name": "AnimationGroupPlayer"
-  },
-  {
-    "name": "AnimationMetadataType"
-  },
-  {
-    "name": "AnimationRenderer"
-  },
-  {
-    "name": "AnimationRendererFactory"
-  },
-  {
-    "name": "AnimationStateStyles"
-  },
-  {
-    "name": "AnimationStyleNormalizer"
-  },
-  {
-    "name": "AnimationTimelineBuilderVisitor"
-  },
-  {
-    "name": "AnimationTimelineContext"
-  },
-  {
-    "name": "AnimationTransitionFactory"
-  },
-  {
-    "name": "AnimationTransitionNamespace"
-  },
-  {
-    "name": "AnimationTrigger"
-  },
-  {
-    "name": "AnimationsComponent"
-  },
-  {
-    "name": "AnimationsExampleModule"
-  },
-  {
-    "name": "AnonymousSubject"
-  },
-  {
-    "name": "ApplicationInitStatus"
-  },
-  {
-    "name": "ApplicationModule"
-  },
-  {
-    "name": "ApplicationRef"
-  },
-  {
-    "name": "BROWSER_ANIMATIONS_PROVIDERS"
-  },
-  {
-    "name": "BROWSER_MODULE_PROVIDERS"
-  },
-  {
-    "name": "BROWSER_MODULE_PROVIDERS_MARKER"
-  },
-  {
-    "name": "BROWSER_NOOP_ANIMATIONS_PROVIDERS"
-  },
-  {
-    "name": "BaseAnimationRenderer"
-  },
-  {
-    "name": "BehaviorSubject"
-  },
-  {
-    "name": "BrowserAnimationsModule"
-  },
-  {
-    "name": "BrowserDomAdapter"
-  },
-  {
-    "name": "BrowserModule"
-  },
-  {
-    "name": "BrowserXhr"
-  },
-  {
-    "name": "CIRCULAR"
-  },
-  {
-    "name": "COMPLETE_NOTIFICATION"
-  },
-  {
-    "name": "COMPONENT_REGEX"
-  },
-  {
-    "name": "CSP_NONCE"
-  },
-  {
-    "name": "ChainedInjector"
-  },
-  {
-    "name": "ChangeDetectionScheduler"
-  },
-  {
-    "name": "ChangeDetectionSchedulerImpl"
-  },
-  {
-    "name": "ChangeDetectionStrategy"
-  },
-  {
-    "name": "CommonModule"
-  },
-  {
-    "name": "ComponentFactory"
-  },
-  {
-    "name": "ComponentFactory2"
-  },
-  {
-    "name": "ComponentFactoryResolver"
-  },
-  {
-    "name": "ComponentFactoryResolver2"
-  },
-  {
-    "name": "ComponentRef"
-  },
-  {
-    "name": "ComponentRef2"
-  },
-  {
-    "name": "ConsumerObserver"
-  },
-  {
-    "name": "DASH_CASE_REGEXP"
-  },
-  {
-    "name": "DEFAULT_APP_ID"
-  },
-  {
-    "name": "DEFAULT_NOOP_PREVIOUS_NODE"
-  },
-  {
-    "name": "DEFAULT_STATE_VALUE"
-  },
-  {
-    "name": "DIMENSIONAL_PROP_SET"
-  },
-  {
-    "name": "DOCUMENT"
-  },
-  {
-    "name": "DOCUMENT2"
-  },
-  {
-    "name": "DefaultDomRenderer2"
-  },
-  {
-    "name": "DestroyRef"
-  },
-  {
-    "name": "DomAdapter"
-  },
-  {
-    "name": "DomEventsPlugin"
-  },
-  {
-    "name": "DomRendererFactory2"
-  },
-  {
-    "name": "EMPTY_ARRAY"
-  },
-  {
-    "name": "EMPTY_INSTRUCTION_MAP"
-  },
-  {
-    "name": "EMPTY_OBJ"
-  },
-  {
-    "name": "EMPTY_OBJECT"
-  },
-  {
-    "name": "EMPTY_OBSERVER"
-  },
-  {
-    "name": "EMPTY_PAYLOAD"
-  },
-  {
-    "name": "EMPTY_PLAYER_ARRAY"
-  },
-  {
-    "name": "EMPTY_SUBSCRIPTION"
-  },
-  {
-    "name": "ENTER_TOKEN_REGEX"
-  },
-  {
-    "name": "ENVIRONMENT_INITIALIZER"
-  },
-  {
-    "name": "EVENT_MANAGER_PLUGINS"
-  },
-  {
-    "name": "EffectScheduler"
-  },
-  {
-    "name": "ElementInstructionMap"
-  },
-  {
-    "name": "ElementRef"
-  },
-  {
-    "name": "EmulatedEncapsulationDomRenderer2"
-  },
-  {
-    "name": "EnvironmentInjector"
-  },
-  {
-    "name": "EnvironmentNgModuleRefAdapter"
-  },
-  {
-    "name": "ErrorHandler"
-  },
-  {
-    "name": "EventEmitter"
-  },
-  {
-    "name": "EventManager"
-  },
-  {
-    "name": "EventManagerPlugin"
-  },
-  {
-    "name": "FALSE_BOOLEAN_VALUES"
-  },
-  {
-    "name": "GenericBrowserDomAdapter"
-  },
-  {
-    "name": "INJECTOR"
-  },
-  {
-    "name": "INJECTOR_DEF_TYPES"
-  },
-  {
-    "name": "INJECTOR_SCOPE"
-  },
-  {
-    "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
-  },
-  {
-    "name": "InjectFlags"
-  },
-  {
-    "name": "InjectionToken"
-  },
-  {
-    "name": "Injector"
-  },
-  {
-    "name": "InputFlags"
-  },
-  {
-    "name": "KeyEventsPlugin"
-  },
-  {
-    "name": "LContainerFlags"
-  },
-  {
-    "name": "LEAVE_TOKEN_REGEX"
-  },
-  {
-    "name": "LOCALE_ID2"
-  },
-  {
-    "name": "LifecycleHooksFeature"
-  },
-  {
-    "name": "MODIFIER_KEYS"
-  },
-  {
-    "name": "MODIFIER_KEY_GETTERS"
-  },
-  {
-    "name": "NAMESPACE_URIS"
-  },
-  {
-    "name": "NEW_LINE"
-  },
-  {
-    "name": "NG_COMP_DEF"
-  },
-  {
-    "name": "NG_DIR_DEF"
-  },
-  {
-    "name": "NG_ELEMENT_ID"
-  },
-  {
-    "name": "NG_ENV_ID"
-  },
-  {
-    "name": "NG_FACTORY_DEF"
-  },
-  {
-    "name": "NG_INJECTABLE_DEF"
-  },
-  {
-    "name": "NG_INJECTOR_DEF"
-  },
-  {
-    "name": "NG_INJ_DEF"
-  },
-  {
-    "name": "NG_MOD_DEF"
-  },
-  {
-    "name": "NG_PIPE_DEF"
-  },
-  {
-    "name": "NG_PROV_DEF"
-  },
-  {
-    "name": "NOT_FOUND"
-  },
-  {
-    "name": "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR"
-  },
-  {
-    "name": "NOT_YET"
-  },
-  {
-    "name": "NO_CHANGE"
-  },
-  {
-    "name": "NULL_INJECTOR"
-  },
-  {
-    "name": "NULL_REMOVAL_STATE"
-  },
-  {
-    "name": "NULL_REMOVED_QUERIED_STATE"
-  },
-  {
-    "name": "NgModuleFactory"
-  },
-  {
-    "name": "NgModuleFactory2"
-  },
-  {
-    "name": "NgModuleRef"
-  },
-  {
-    "name": "NgModuleRef2"
-  },
-  {
-    "name": "NgZone"
-  },
-  {
-    "name": "NgZoneChangeDetectionScheduler"
-  },
-  {
-    "name": "NodeInjector"
-  },
-  {
-    "name": "NodeInjectorDestroyRef"
-  },
-  {
-    "name": "NodeInjectorFactory"
-  },
-  {
-    "name": "NoneEncapsulationDomRenderer"
-  },
-  {
-    "name": "NoopAnimationDriver"
-  },
-  {
-    "name": "NoopAnimationPlayer"
-  },
-  {
-    "name": "NoopNgZone"
-  },
-  {
-    "name": "NullInjector"
-  },
-  {
-    "name": "ObjectUnsubscribedError"
-  },
-  {
-    "name": "Observable"
-  },
-  {
-    "name": "OperatorSubscriber"
-  },
-  {
-    "name": "PARAM_REGEX"
-  },
-  {
-    "name": "PLATFORM_DESTROY_LISTENERS"
-  },
-  {
-    "name": "PLATFORM_ID"
-  },
-  {
-    "name": "PLATFORM_INITIALIZER"
-  },
-  {
-    "name": "PRESERVE_HOST_CONTENT"
-  },
-  {
-    "name": "PendingTasksInternal"
-  },
-  {
-    "name": "PlatformRef"
-  },
-  {
-    "name": "R3Injector"
-  },
-  {
-    "name": "REACTIVE_LVIEW_CONSUMER_NODE"
-  },
-  {
-    "name": "REACTIVE_NODE"
-  },
-  {
-    "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
-  },
-  {
-    "name": "RendererFactory2"
-  },
-  {
-    "name": "RendererStyleFlags2"
-  },
-  {
-    "name": "RootComponent"
-  },
-  {
-    "name": "RuntimeError"
-  },
-  {
-    "name": "SCHEDULE_IN_ROOT_ZONE"
-  },
-  {
-    "name": "SELF_TOKEN_REGEX"
-  },
-  {
-    "name": "SHARED_ANIMATION_PROVIDERS"
-  },
-  {
-    "name": "SIGNAL"
-  },
-  {
-    "name": "SIMPLE_CHANGES_STORE"
-  },
-  {
-    "name": "SafeSubscriber"
-  },
-  {
-    "name": "Sanitizer"
-  },
-  {
-    "name": "ShadowDomRenderer"
-  },
-  {
-    "name": "SharedStylesHost"
-  },
-  {
-    "name": "SimpleChange"
-  },
-  {
-    "name": "SpecialCasedStyles"
-  },
-  {
-    "name": "StandaloneService"
-  },
-  {
-    "name": "StateValue"
-  },
-  {
-    "name": "SubTimelineBuilder"
-  },
-  {
-    "name": "Subject"
-  },
-  {
-    "name": "Subscriber"
-  },
-  {
-    "name": "Subscription"
-  },
-  {
-    "name": "TEMPORARY_CONSUMER_NODE"
-  },
-  {
-    "name": "TESTABILITY"
-  },
-  {
-    "name": "TESTABILITY_GETTER"
-  },
-  {
-    "name": "TESTABILITY_PROVIDERS"
-  },
-  {
-    "name": "THROW_IF_NOT_FOUND"
-  },
-  {
-    "name": "TRACKED_LVIEWS"
-  },
-  {
-    "name": "TRUE_BOOLEAN_VALUES"
-  },
-  {
-    "name": "Testability"
-  },
-  {
-    "name": "TestabilityRegistry"
-  },
-  {
-    "name": "TimelineAnimationEngine"
-  },
-  {
-    "name": "TimelineBuilder"
-  },
-  {
-    "name": "TracingAction"
-  },
-  {
-    "name": "TracingService"
-  },
-  {
-    "name": "TransitionAnimationEngine"
-  },
-  {
-    "name": "TransitionAnimationPlayer"
-  },
-  {
-    "name": "USE_VALUE"
-  },
-  {
-    "name": "UnsubscriptionError"
-  },
-  {
-    "name": "ViewEncapsulation"
-  },
-  {
-    "name": "ViewRef"
-  },
-  {
-    "name": "WebAnimationsDriver"
-  },
-  {
-    "name": "WebAnimationsPlayer"
-  },
-  {
-    "name": "WebAnimationsStyleNormalizer"
-  },
-  {
-    "name": "ZONELESS_ENABLED"
-  },
-  {
-    "name": "ZONELESS_SCHEDULER_DISABLED"
-  },
-  {
-    "name": "ZoneAwareEffectScheduler"
-  },
-  {
-    "name": "ZoneStablePendingTask"
-  },
-  {
-    "name": "_CACHED_BODY"
-  },
-  {
-    "name": "_DOM"
-  },
-  {
-    "name": "_IS_WEBKIT"
-  },
-  {
-    "name": "_Injector"
-  },
-  {
-    "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__defProp"
-  },
-  {
-    "name": "__forward_ref__"
-  },
-  {
-    "name": "__publicField"
-  },
-  {
-    "name": "_applyRootElementTransformImpl"
-  },
-  {
-    "name": "_bind"
-  },
-  {
-    "name": "_convertTimeValueToMS"
-  },
-  {
-    "name": "_currentInjector"
-  },
-  {
-    "name": "_flattenGroupPlayersRecur"
-  },
-  {
-    "name": "_global"
-  },
-  {
-    "name": "_injectImplementation"
-  },
-  {
-    "name": "_isRefreshingViews"
-  },
-  {
-    "name": "_keyMap"
-  },
-  {
-    "name": "_locateOrCreateElementNode"
-  },
-  {
-    "name": "_platformInjector"
-  },
-  {
-    "name": "_testabilityGetter"
-  },
-  {
-    "name": "_wasLastNodeCreated"
-  },
-  {
-    "name": "activeConsumer"
-  },
-  {
-    "name": "addClass"
-  },
-  {
-    "name": "addPropertyBinding"
-  },
-  {
-    "name": "addToEndOfViewTree"
-  },
-  {
-    "name": "allocExpando"
-  },
-  {
-    "name": "allocLFrame"
-  },
-  {
-    "name": "angularZoneInstanceIdProperty"
-  },
-  {
-    "name": "animate"
-  },
-  {
-    "name": "appendChild"
-  },
-  {
-    "name": "applyNodes"
-  },
-  {
-    "name": "applyParamDefaults"
-  },
-  {
-    "name": "applyProjectionRecursive"
-  },
-  {
-    "name": "applyToElementOrContainer"
-  },
-  {
-    "name": "applyValueToInputField"
-  },
-  {
-    "name": "applyView"
-  },
-  {
-    "name": "arrRemove"
-  },
-  {
-    "name": "assertConsumerNode"
-  },
-  {
-    "name": "assertNotDestroyed"
-  },
-  {
-    "name": "attachPatchData"
-  },
-  {
-    "name": "balanceProperties"
-  },
-  {
-    "name": "baseElement"
-  },
-  {
-    "name": "bind"
-  },
-  {
-    "name": "bloomHasToken"
-  },
-  {
-    "name": "bootstrap"
-  },
-  {
-    "name": "buildAnimationAst"
-  },
-  {
-    "name": "buildAnimationTimelines"
-  },
-  {
-    "name": "buildRootMap"
-  },
-  {
-    "name": "callHook"
-  },
-  {
-    "name": "callHookInternal"
-  },
-  {
-    "name": "callHooks"
-  },
-  {
-    "name": "captureNodeBindings"
-  },
-  {
-    "name": "checkStable"
-  },
-  {
-    "name": "classIndexOf"
-  },
-  {
-    "name": "cleanUpView"
-  },
-  {
-    "name": "cloakAndComputeStyles"
-  },
-  {
-    "name": "cloakElement"
-  },
-  {
-    "name": "collectNativeNodes"
-  },
-  {
-    "name": "collectNativeNodesInLContainer"
-  },
-  {
-    "name": "computeStaticStyling"
-  },
-  {
-    "name": "computeStyle"
-  },
-  {
-    "name": "concatStringsWithSpace"
-  },
-  {
-    "name": "config"
-  },
-  {
-    "name": "configureViewWithDirective"
-  },
-  {
-    "name": "consumerBeforeComputation"
-  },
-  {
-    "name": "consumerDestroy"
-  },
-  {
-    "name": "consumerIsLive"
-  },
-  {
-    "name": "consumerPollProducersForChange"
-  },
-  {
-    "name": "containsElement"
-  },
-  {
-    "name": "context"
-  },
-  {
-    "name": "convertToBitFlags"
-  },
-  {
-    "name": "copyAnimationEvent"
-  },
-  {
-    "name": "createElementNode"
-  },
-  {
-    "name": "createElementRef"
-  },
-  {
-    "name": "createErrorClass"
-  },
-  {
-    "name": "createInjector"
-  },
-  {
-    "name": "createInjectorWithoutInjectorInstances"
-  },
-  {
-    "name": "createLFrame"
-  },
-  {
-    "name": "createLView"
-  },
-  {
-    "name": "createLinkElement"
-  },
-  {
-    "name": "createNodeInjector"
-  },
-  {
-    "name": "createNotification"
-  },
-  {
-    "name": "createPlatformFactory"
-  },
-  {
-    "name": "createStyleElement"
-  },
-  {
-    "name": "createTView"
-  },
-  {
-    "name": "createTimelineInstruction"
-  },
-  {
-    "name": "createTransitionInstruction"
-  },
-  {
-    "name": "dashCaseToCamelCase"
-  },
-  {
-    "name": "deepForEach"
-  },
-  {
-    "name": "deepForEachProvider"
-  },
-  {
-    "name": "detachMovedView"
-  },
-  {
-    "name": "detachViewFromDOM"
-  },
-  {
-    "name": "detectChangesInChildComponents"
-  },
-  {
-    "name": "detectChangesInComponent"
-  },
-  {
-    "name": "detectChangesInEmbeddedViews"
-  },
-  {
-    "name": "detectChangesInView"
-  },
-  {
-    "name": "detectChangesInViewIfAttached"
-  },
-  {
-    "name": "detectChangesInViewIfRequired"
-  },
-  {
-    "name": "detectChangesInternal"
-  },
-  {
-    "name": "diPublicInInjector"
-  },
-  {
-    "name": "documentElement"
-  },
-  {
-    "name": "enterDI"
-  },
-  {
-    "name": "enterView"
-  },
-  {
-    "name": "eraseStyles"
-  },
-  {
-    "name": "errorContext"
-  },
-  {
-    "name": "execFinalizer"
-  },
-  {
-    "name": "executeCheckHooks"
-  },
-  {
-    "name": "executeContentQueries"
-  },
-  {
-    "name": "executeInitAndCheckHooks"
-  },
-  {
-    "name": "executeTemplate"
-  },
-  {
-    "name": "executeViewQueryFn"
-  },
-  {
-    "name": "extractDefListOrFactory"
-  },
-  {
-    "name": "extractDirectiveDef"
-  },
-  {
-    "name": "extractStyleParams"
-  },
-  {
-    "name": "filterNonAnimatableStyles"
-  },
-  {
-    "name": "findAttrIndexInNode"
-  },
-  {
-    "name": "forEachSingleProvider"
-  },
-  {
-    "name": "forwardRef"
-  },
-  {
-    "name": "freeConsumers"
-  },
-  {
-    "name": "generateInitialInputs"
-  },
-  {
-    "name": "getBindingsEnabled"
-  },
-  {
-    "name": "getClosureSafeProperty"
-  },
-  {
-    "name": "getComponentDef"
-  },
-  {
-    "name": "getComponentLViewByIndex"
-  },
-  {
-    "name": "getConstant"
-  },
-  {
-    "name": "getCurrentTNode"
-  },
-  {
-    "name": "getCurrentTNodePlaceholderOk"
-  },
-  {
-    "name": "getDOM"
-  },
-  {
-    "name": "getDeclarationTNode"
-  },
-  {
-    "name": "getDirectiveDef"
-  },
-  {
-    "name": "getFactoryDef"
-  },
-  {
-    "name": "getFirstLContainer"
-  },
-  {
-    "name": "getInitialLViewFlagsFromDef"
-  },
-  {
-    "name": "getInjectImplementation"
-  },
-  {
-    "name": "getInjectableDef"
-  },
-  {
-    "name": "getInjectorDef"
-  },
-  {
-    "name": "getInjectorIndex"
-  },
-  {
-    "name": "getLView"
-  },
-  {
-    "name": "getLViewParent"
-  },
-  {
-    "name": "getNativeByTNode"
-  },
-  {
-    "name": "getNearestLContainer"
-  },
-  {
-    "name": "getNextLContainer"
-  },
-  {
-    "name": "getNgZoneOptions"
-  },
-  {
-    "name": "getNodeInjectable"
-  },
-  {
-    "name": "getNullInjector"
-  },
-  {
-    "name": "getOrCreateComponentTView"
-  },
-  {
-    "name": "getOrCreateInjectable"
-  },
-  {
-    "name": "getOrCreateNodeInjectorForNode"
-  },
-  {
-    "name": "getOrCreateTNode"
-  },
-  {
-    "name": "getOrSetDefaultValue"
-  },
-  {
-    "name": "getOwnDefinition"
-  },
-  {
-    "name": "getParentElement"
-  },
-  {
-    "name": "getParentInjectorIndex"
-  },
-  {
-    "name": "getParentInjectorLocation"
-  },
-  {
-    "name": "getParentInjectorView"
-  },
-  {
-    "name": "getPipeDef"
-  },
-  {
-    "name": "getPlatform"
-  },
-  {
-    "name": "getProjectionNodes"
-  },
-  {
-    "name": "getPromiseCtor"
-  },
-  {
-    "name": "getSimpleChangesStore"
-  },
-  {
-    "name": "getTNode"
-  },
-  {
-    "name": "getTNodeFromLView"
-  },
-  {
-    "name": "getTView"
-  },
-  {
-    "name": "handleStoppedNotification"
-  },
-  {
-    "name": "handleUnhandledError"
-  },
-  {
-    "name": "hasApplyArgsData"
-  },
-  {
-    "name": "hasTagAndTypeMatch"
-  },
-  {
-    "name": "icuContainerIterate"
-  },
-  {
-    "name": "identity"
-  },
-  {
-    "name": "importProvidersFrom"
-  },
-  {
-    "name": "includeViewProviders"
-  },
-  {
-    "name": "incrementInitPhaseFlags"
-  },
-  {
-    "name": "initializeDirectives"
-  },
-  {
-    "name": "inject"
-  },
-  {
-    "name": "injectArgs"
-  },
-  {
-    "name": "injectDestroyRef"
-  },
-  {
-    "name": "injectElementRef"
-  },
-  {
-    "name": "injectInjectorOnly"
-  },
-  {
-    "name": "injectRootLimpMode"
-  },
-  {
-    "name": "injectableDefOrInjectorDefFactory"
-  },
-  {
-    "name": "insertBloom"
-  },
-  {
-    "name": "instructionState"
-  },
-  {
-    "name": "internalImportProvidersFrom"
-  },
-  {
-    "name": "internalProvideZoneChangeDetection"
-  },
-  {
-    "name": "interpolateParams"
-  },
-  {
-    "name": "invalidTimingValue"
-  },
-  {
-    "name": "invokeDirectivesHostBindings"
-  },
-  {
-    "name": "invokeHostBindingsInCreationMode"
-  },
-  {
-    "name": "invokeQuery"
-  },
-  {
-    "name": "isAngularZoneProperty"
-  },
-  {
-    "name": "isApplicationBootstrapConfig"
-  },
-  {
-    "name": "isComponentDef"
-  },
-  {
-    "name": "isComponentHost"
-  },
-  {
-    "name": "isContentQueryHost"
-  },
-  {
-    "name": "isCssClassMatching"
-  },
-  {
-    "name": "isCurrentTNodeParent"
-  },
-  {
-    "name": "isElementNode"
-  },
-  {
-    "name": "isEnvironmentProviders"
-  },
-  {
-    "name": "isFunction"
-  },
-  {
-    "name": "isInlineTemplate"
-  },
-  {
-    "name": "isLContainer"
-  },
-  {
-    "name": "isLView"
-  },
-  {
-    "name": "isNodeMatchingSelector"
-  },
-  {
-    "name": "isNodeMatchingSelectorList"
-  },
-  {
-    "name": "isPlatformServer"
-  },
-  {
-    "name": "isPositive"
-  },
-  {
-    "name": "isPromise"
-  },
-  {
-    "name": "isRefreshingViews"
-  },
-  {
-    "name": "isRootView"
-  },
-  {
-    "name": "isSubscription"
-  },
-  {
-    "name": "isTemplateNode"
-  },
-  {
-    "name": "isTypeProvider"
-  },
-  {
-    "name": "isValueProvider"
-  },
-  {
-    "name": "leaveDI"
-  },
-  {
-    "name": "leaveView"
-  },
-  {
-    "name": "leaveViewLight"
-  },
-  {
-    "name": "listenOnPlayer"
-  },
-  {
-    "name": "lookupTokenUsingModuleInjector"
-  },
-  {
-    "name": "lookupTokenUsingNodeInjector"
-  },
-  {
-    "name": "makeAnimationEvent"
-  },
-  {
-    "name": "makeLambdaFromStates"
-  },
-  {
-    "name": "makeRecord"
-  },
-  {
-    "name": "makeTimingAst"
-  },
-  {
-    "name": "map"
-  },
-  {
-    "name": "markAncestorsForTraversal"
-  },
-  {
-    "name": "markAsComponentHost"
-  },
-  {
-    "name": "markViewDirty"
-  },
-  {
-    "name": "markViewForRefresh"
-  },
-  {
-    "name": "markedFeatures"
-  },
-  {
-    "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "mergeHostAttribute"
-  },
-  {
-    "name": "mergeHostAttrs"
-  },
-  {
-    "name": "nativeAppendChild"
-  },
-  {
-    "name": "nativeAppendOrInsertBefore"
-  },
-  {
-    "name": "nativeInsertBefore"
-  },
-  {
-    "name": "nextNgElementId"
-  },
-  {
-    "name": "ngOnChangesSetInput"
-  },
-  {
-    "name": "ngZoneInstanceId"
-  },
-  {
-    "name": "noSideEffects"
-  },
-  {
-    "name": "nonNull"
-  },
-  {
-    "name": "noop"
-  },
-  {
-    "name": "noop2"
-  },
-  {
-    "name": "normalizeAnimationEntry"
-  },
-  {
-    "name": "normalizeAnimationOptions"
-  },
-  {
-    "name": "normalizeKeyframes"
-  },
-  {
-    "name": "notFoundValueOrThrow"
-  },
-  {
-    "name": "observable"
-  },
-  {
-    "name": "onEnter"
-  },
-  {
-    "name": "onLeave"
-  },
-  {
-    "name": "optimizeGroupPlayer"
-  },
-  {
-    "name": "optionsReducer"
-  },
-  {
-    "name": "parseAndConvertBindingsForDefinition"
-  },
-  {
-    "name": "parseTimelineCommand"
-  },
-  {
-    "name": "platformBrowser"
-  },
-  {
-    "name": "platformCore"
-  },
-  {
-    "name": "processInjectorTypesWithProviders"
-  },
-  {
-    "name": "producerMarkClean"
-  },
-  {
-    "name": "producerRemoveLiveConsumerAtIndex"
-  },
-  {
-    "name": "producerUpdateValueVersion"
-  },
-  {
-    "name": "refreshContentQueries"
-  },
-  {
-    "name": "refreshView"
-  },
-  {
-    "name": "registerPostOrderHooks"
-  },
-  {
-    "name": "rememberChangeHistoryAndInvokeOnChangesHook"
-  },
-  {
-    "name": "remove"
-  },
-  {
-    "name": "removeClass"
-  },
-  {
-    "name": "removeElements"
-  },
-  {
-    "name": "removeFromArray"
-  },
-  {
-    "name": "removeNodesAfterAnimationDone"
-  },
-  {
-    "name": "renderComponent"
-  },
-  {
-    "name": "renderView"
-  },
-  {
-    "name": "replacePostStylesAsPre"
-  },
-  {
-    "name": "requiresRefreshOrTraversal"
-  },
-  {
-    "name": "resetPreOrderHookFlags"
-  },
-  {
-    "name": "resolveForwardRef"
-  },
-  {
-    "name": "resolveTiming"
-  },
-  {
-    "name": "resolveTimingValue"
-  },
-  {
-    "name": "roundOffset"
-  },
-  {
-    "name": "runEffectsInView"
-  },
-  {
-    "name": "runInInjectionContext"
-  },
-  {
-    "name": "saveNameToExportMap"
-  },
-  {
-    "name": "scheduleCallbackWithMicrotask"
-  },
-  {
-    "name": "scheduleCallbackWithRafRace"
-  },
-  {
-    "name": "searchTokensOnInjector"
-  },
-  {
-    "name": "setActiveConsumer"
-  },
-  {
-    "name": "setBindingRootForHostBindings"
-  },
-  {
-    "name": "setCurrentDirectiveIndex"
-  },
-  {
-    "name": "setCurrentInjector"
-  },
-  {
-    "name": "setCurrentQueryIndex"
-  },
-  {
-    "name": "setCurrentTNode"
-  },
-  {
-    "name": "setDirectiveInputsWhichShadowsStyling"
-  },
-  {
-    "name": "setIncludeViewProviders"
-  },
-  {
-    "name": "setInjectImplementation"
-  },
-  {
-    "name": "setInputsForProperty"
-  },
-  {
-    "name": "setInputsFromAttrs"
-  },
-  {
-    "name": "setIsRefreshingViews"
-  },
-  {
-    "name": "setSelectedIndex"
-  },
-  {
-    "name": "setStyles"
-  },
-  {
-    "name": "setUpAttributes"
-  },
-  {
-    "name": "setupStaticAttributes"
-  },
-  {
-    "name": "shimStylesContent"
-  },
-  {
-    "name": "shouldSearchParent"
-  },
-  {
-    "name": "storeLViewOnDestroy"
-  },
-  {
-    "name": "stringify"
-  },
-  {
-    "name": "stringifyCSSSelector"
-  },
-  {
-    "name": "style"
-  },
-  {
-    "name": "throwProviderNotFoundError"
-  },
-  {
-    "name": "timeoutProvider"
-  },
-  {
-    "name": "toRefArray"
-  },
-  {
-    "name": "transition"
-  },
-  {
-    "name": "uniqueIdCounter"
-  },
-  {
-    "name": "unregisterLView"
-  },
-  {
-    "name": "unwrapRNode"
-  },
-  {
-    "name": "updateAncestorTraversalFlagsOnAttach"
-  },
-  {
-    "name": "updateMicroTaskStatus"
-  },
-  {
-    "name": "viewAttachedToChangeDetector"
-  },
-  {
-    "name": "viewShouldHaveReactiveConsumer"
-  },
-  {
-    "name": "visitDslNode"
-  },
-  {
-    "name": "walkProviderTree"
-  },
-  {
-    "name": "writeDirectClass"
-  },
-  {
-    "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "ɵɵdefineComponent"
-  },
-  {
-    "name": "ɵɵdefineInjectable"
-  },
-  {
-    "name": "ɵɵdefineInjector"
-  },
-  {
-    "name": "ɵɵdefineNgModule"
-  },
-  {
-    "name": "ɵɵdirectiveInject"
-  },
-  {
-    "name": "ɵɵelement"
-  },
-  {
-    "name": "ɵɵelementEnd"
-  },
-  {
-    "name": "ɵɵelementStart"
-  },
-  {
-    "name": "ɵɵinject"
-  },
-  {
-    "name": "ɵɵproperty"
-  }
+  "ALLOW_MULTIPLE_PLATFORMS",
+  "ANIMATION_MODULE_TYPE",
+  "APP_BOOTSTRAP_LISTENER",
+  "APP_ID",
+  "APP_INITIALIZER",
+  "AfterRenderManager",
+  "AnimationAstBuilderContext",
+  "AnimationAstBuilderVisitor",
+  "AnimationDriver",
+  "AnimationEngine",
+  "AnimationGroupPlayer",
+  "AnimationMetadataType",
+  "AnimationRenderer",
+  "AnimationRendererFactory",
+  "AnimationStateStyles",
+  "AnimationStyleNormalizer",
+  "AnimationTimelineBuilderVisitor",
+  "AnimationTimelineContext",
+  "AnimationTransitionFactory",
+  "AnimationTransitionNamespace",
+  "AnimationTrigger",
+  "AnimationsComponent",
+  "AnimationsExampleModule",
+  "AnonymousSubject",
+  "ApplicationInitStatus",
+  "ApplicationModule",
+  "ApplicationRef",
+  "BROWSER_ANIMATIONS_PROVIDERS",
+  "BROWSER_MODULE_PROVIDERS",
+  "BROWSER_MODULE_PROVIDERS_MARKER",
+  "BROWSER_NOOP_ANIMATIONS_PROVIDERS",
+  "BaseAnimationRenderer",
+  "BehaviorSubject",
+  "BrowserAnimationsModule",
+  "BrowserDomAdapter",
+  "BrowserModule",
+  "BrowserXhr",
+  "CIRCULAR",
+  "COMPLETE_NOTIFICATION",
+  "COMPONENT_REGEX",
+  "CSP_NONCE",
+  "ChainedInjector",
+  "ChangeDetectionScheduler",
+  "ChangeDetectionSchedulerImpl",
+  "ChangeDetectionStrategy",
+  "CommonModule",
+  "ComponentFactory",
+  "ComponentFactory2",
+  "ComponentFactoryResolver",
+  "ComponentFactoryResolver2",
+  "ComponentRef",
+  "ComponentRef2",
+  "ConsumerObserver",
+  "DASH_CASE_REGEXP",
+  "DEFAULT_APP_ID",
+  "DEFAULT_NOOP_PREVIOUS_NODE",
+  "DEFAULT_STATE_VALUE",
+  "DIMENSIONAL_PROP_SET",
+  "DOCUMENT",
+  "DOCUMENT2",
+  "DefaultDomRenderer2",
+  "DestroyRef",
+  "DomAdapter",
+  "DomEventsPlugin",
+  "DomRendererFactory2",
+  "EMPTY_ARRAY",
+  "EMPTY_INSTRUCTION_MAP",
+  "EMPTY_OBJ",
+  "EMPTY_OBJECT",
+  "EMPTY_OBSERVER",
+  "EMPTY_PAYLOAD",
+  "EMPTY_PLAYER_ARRAY",
+  "EMPTY_SUBSCRIPTION",
+  "ENTER_TOKEN_REGEX",
+  "ENVIRONMENT_INITIALIZER",
+  "EVENT_MANAGER_PLUGINS",
+  "EffectScheduler",
+  "ElementInstructionMap",
+  "ElementRef",
+  "EmulatedEncapsulationDomRenderer2",
+  "EnvironmentInjector",
+  "EnvironmentNgModuleRefAdapter",
+  "ErrorHandler",
+  "EventEmitter",
+  "EventManager",
+  "EventManagerPlugin",
+  "FALSE_BOOLEAN_VALUES",
+  "GenericBrowserDomAdapter",
+  "INJECTOR",
+  "INJECTOR_DEF_TYPES",
+  "INJECTOR_SCOPE",
+  "INTERNAL_APPLICATION_ERROR_HANDLER",
+  "InjectFlags",
+  "InjectionToken",
+  "Injector",
+  "InputFlags",
+  "KeyEventsPlugin",
+  "LContainerFlags",
+  "LEAVE_TOKEN_REGEX",
+  "LOCALE_ID2",
+  "LifecycleHooksFeature",
+  "MODIFIER_KEYS",
+  "MODIFIER_KEY_GETTERS",
+  "NAMESPACE_URIS",
+  "NEW_LINE",
+  "NG_COMP_DEF",
+  "NG_DIR_DEF",
+  "NG_ELEMENT_ID",
+  "NG_ENV_ID",
+  "NG_FACTORY_DEF",
+  "NG_INJECTABLE_DEF",
+  "NG_INJECTOR_DEF",
+  "NG_INJ_DEF",
+  "NG_MOD_DEF",
+  "NG_PIPE_DEF",
+  "NG_PROV_DEF",
+  "NOT_FOUND",
+  "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR",
+  "NOT_YET",
+  "NO_CHANGE",
+  "NULL_INJECTOR",
+  "NULL_REMOVAL_STATE",
+  "NULL_REMOVED_QUERIED_STATE",
+  "NgModuleFactory",
+  "NgModuleFactory2",
+  "NgModuleRef",
+  "NgModuleRef2",
+  "NgZone",
+  "NgZoneChangeDetectionScheduler",
+  "NodeInjector",
+  "NodeInjectorDestroyRef",
+  "NodeInjectorFactory",
+  "NoneEncapsulationDomRenderer",
+  "NoopAnimationDriver",
+  "NoopAnimationPlayer",
+  "NoopNgZone",
+  "NullInjector",
+  "ObjectUnsubscribedError",
+  "Observable",
+  "OperatorSubscriber",
+  "PARAM_REGEX",
+  "PLATFORM_DESTROY_LISTENERS",
+  "PLATFORM_ID",
+  "PLATFORM_INITIALIZER",
+  "PRESERVE_HOST_CONTENT",
+  "PendingTasksInternal",
+  "PlatformRef",
+  "R3Injector",
+  "REACTIVE_LVIEW_CONSUMER_NODE",
+  "REACTIVE_NODE",
+  "REMOVE_STYLES_ON_COMPONENT_DESTROY",
+  "RendererFactory2",
+  "RendererStyleFlags2",
+  "RootComponent",
+  "RuntimeError",
+  "SCHEDULE_IN_ROOT_ZONE",
+  "SELF_TOKEN_REGEX",
+  "SHARED_ANIMATION_PROVIDERS",
+  "SIGNAL",
+  "SIMPLE_CHANGES_STORE",
+  "SafeSubscriber",
+  "Sanitizer",
+  "ShadowDomRenderer",
+  "SharedStylesHost",
+  "SimpleChange",
+  "SpecialCasedStyles",
+  "StandaloneService",
+  "StateValue",
+  "SubTimelineBuilder",
+  "Subject",
+  "Subscriber",
+  "Subscription",
+  "TEMPORARY_CONSUMER_NODE",
+  "TESTABILITY",
+  "TESTABILITY_GETTER",
+  "TESTABILITY_PROVIDERS",
+  "THROW_IF_NOT_FOUND",
+  "TRACKED_LVIEWS",
+  "TRUE_BOOLEAN_VALUES",
+  "Testability",
+  "TestabilityRegistry",
+  "TimelineAnimationEngine",
+  "TimelineBuilder",
+  "TracingAction",
+  "TracingService",
+  "TransitionAnimationEngine",
+  "TransitionAnimationPlayer",
+  "USE_VALUE",
+  "UnsubscriptionError",
+  "ViewEncapsulation",
+  "ViewRef",
+  "WebAnimationsDriver",
+  "WebAnimationsPlayer",
+  "WebAnimationsStyleNormalizer",
+  "ZONELESS_ENABLED",
+  "ZONELESS_SCHEDULER_DISABLED",
+  "ZoneAwareEffectScheduler",
+  "ZoneStablePendingTask",
+  "_CACHED_BODY",
+  "_DOM",
+  "_IS_WEBKIT",
+  "_Injector",
+  "_NullComponentFactoryResolver",
+  "__defProp",
+  "__forward_ref__",
+  "__publicField",
+  "_applyRootElementTransformImpl",
+  "_bind",
+  "_convertTimeValueToMS",
+  "_currentInjector",
+  "_flattenGroupPlayersRecur",
+  "_global",
+  "_injectImplementation",
+  "_isRefreshingViews",
+  "_keyMap",
+  "_locateOrCreateElementNode",
+  "_platformInjector",
+  "_testabilityGetter",
+  "_wasLastNodeCreated",
+  "activeConsumer",
+  "addClass",
+  "addPropertyBinding",
+  "addToEndOfViewTree",
+  "allocExpando",
+  "allocLFrame",
+  "angularZoneInstanceIdProperty",
+  "animate",
+  "appendChild",
+  "applyNodes",
+  "applyParamDefaults",
+  "applyProjectionRecursive",
+  "applyToElementOrContainer",
+  "applyValueToInputField",
+  "applyView",
+  "arrRemove",
+  "assertConsumerNode",
+  "assertNotDestroyed",
+  "attachPatchData",
+  "balanceProperties",
+  "baseElement",
+  "bind",
+  "bloomHasToken",
+  "bootstrap",
+  "buildAnimationAst",
+  "buildAnimationTimelines",
+  "buildRootMap",
+  "callHook",
+  "callHookInternal",
+  "callHooks",
+  "captureNodeBindings",
+  "checkStable",
+  "classIndexOf",
+  "cleanUpView",
+  "cloakAndComputeStyles",
+  "cloakElement",
+  "collectNativeNodes",
+  "collectNativeNodesInLContainer",
+  "computeStaticStyling",
+  "computeStyle",
+  "concatStringsWithSpace",
+  "config",
+  "configureViewWithDirective",
+  "consumerBeforeComputation",
+  "consumerDestroy",
+  "consumerIsLive",
+  "consumerPollProducersForChange",
+  "containsElement",
+  "context",
+  "convertToBitFlags",
+  "copyAnimationEvent",
+  "createElementNode",
+  "createElementRef",
+  "createErrorClass",
+  "createInjector",
+  "createInjectorWithoutInjectorInstances",
+  "createLFrame",
+  "createLView",
+  "createLinkElement",
+  "createNodeInjector",
+  "createNotification",
+  "createPlatformFactory",
+  "createStyleElement",
+  "createTView",
+  "createTimelineInstruction",
+  "createTransitionInstruction",
+  "dashCaseToCamelCase",
+  "deepForEach",
+  "deepForEachProvider",
+  "detachMovedView",
+  "detachViewFromDOM",
+  "detectChangesInChildComponents",
+  "detectChangesInComponent",
+  "detectChangesInEmbeddedViews",
+  "detectChangesInView",
+  "detectChangesInViewIfAttached",
+  "detectChangesInViewIfRequired",
+  "detectChangesInternal",
+  "diPublicInInjector",
+  "documentElement",
+  "enterDI",
+  "enterView",
+  "eraseStyles",
+  "errorContext",
+  "execFinalizer",
+  "executeCheckHooks",
+  "executeContentQueries",
+  "executeInitAndCheckHooks",
+  "executeTemplate",
+  "executeViewQueryFn",
+  "extractDefListOrFactory",
+  "extractDirectiveDef",
+  "extractStyleParams",
+  "filterNonAnimatableStyles",
+  "findAttrIndexInNode",
+  "forEachSingleProvider",
+  "forwardRef",
+  "freeConsumers",
+  "generateInitialInputs",
+  "getBindingsEnabled",
+  "getClosureSafeProperty",
+  "getComponentDef",
+  "getComponentLViewByIndex",
+  "getConstant",
+  "getCurrentTNode",
+  "getCurrentTNodePlaceholderOk",
+  "getDOM",
+  "getDeclarationTNode",
+  "getDirectiveDef",
+  "getFactoryDef",
+  "getFirstLContainer",
+  "getInitialLViewFlagsFromDef",
+  "getInjectImplementation",
+  "getInjectableDef",
+  "getInjectorDef",
+  "getInjectorIndex",
+  "getLView",
+  "getLViewParent",
+  "getNativeByTNode",
+  "getNearestLContainer",
+  "getNextLContainer",
+  "getNgZoneOptions",
+  "getNodeInjectable",
+  "getNullInjector",
+  "getOrCreateComponentTView",
+  "getOrCreateInjectable",
+  "getOrCreateNodeInjectorForNode",
+  "getOrCreateTNode",
+  "getOrSetDefaultValue",
+  "getOwnDefinition",
+  "getParentElement",
+  "getParentInjectorIndex",
+  "getParentInjectorLocation",
+  "getParentInjectorView",
+  "getPipeDef",
+  "getPlatform",
+  "getProjectionNodes",
+  "getPromiseCtor",
+  "getSimpleChangesStore",
+  "getTNode",
+  "getTNodeFromLView",
+  "getTView",
+  "handleStoppedNotification",
+  "handleUnhandledError",
+  "hasApplyArgsData",
+  "hasTagAndTypeMatch",
+  "icuContainerIterate",
+  "identity",
+  "importProvidersFrom",
+  "includeViewProviders",
+  "incrementInitPhaseFlags",
+  "initializeDirectives",
+  "inject",
+  "injectArgs",
+  "injectDestroyRef",
+  "injectElementRef",
+  "injectInjectorOnly",
+  "injectRootLimpMode",
+  "injectableDefOrInjectorDefFactory",
+  "insertBloom",
+  "instructionState",
+  "internalImportProvidersFrom",
+  "internalProvideZoneChangeDetection",
+  "interpolateParams",
+  "invalidTimingValue",
+  "invokeDirectivesHostBindings",
+  "invokeHostBindingsInCreationMode",
+  "invokeQuery",
+  "isAngularZoneProperty",
+  "isApplicationBootstrapConfig",
+  "isComponentDef",
+  "isComponentHost",
+  "isContentQueryHost",
+  "isCssClassMatching",
+  "isCurrentTNodeParent",
+  "isElementNode",
+  "isEnvironmentProviders",
+  "isFunction",
+  "isInlineTemplate",
+  "isLContainer",
+  "isLView",
+  "isNodeMatchingSelector",
+  "isNodeMatchingSelectorList",
+  "isPlatformServer",
+  "isPositive",
+  "isPromise",
+  "isRefreshingViews",
+  "isRootView",
+  "isSubscription",
+  "isTemplateNode",
+  "isTypeProvider",
+  "isValueProvider",
+  "leaveDI",
+  "leaveView",
+  "leaveViewLight",
+  "listenOnPlayer",
+  "lookupTokenUsingModuleInjector",
+  "lookupTokenUsingNodeInjector",
+  "makeAnimationEvent",
+  "makeLambdaFromStates",
+  "makeRecord",
+  "makeTimingAst",
+  "map",
+  "markAncestorsForTraversal",
+  "markAsComponentHost",
+  "markViewDirty",
+  "markViewForRefresh",
+  "markedFeatures",
+  "maybeWrapInNotSelector",
+  "mergeHostAttribute",
+  "mergeHostAttrs",
+  "nativeAppendChild",
+  "nativeAppendOrInsertBefore",
+  "nativeInsertBefore",
+  "nextNgElementId",
+  "ngOnChangesSetInput",
+  "ngZoneInstanceId",
+  "noSideEffects",
+  "nonNull",
+  "noop",
+  "noop2",
+  "normalizeAnimationEntry",
+  "normalizeAnimationOptions",
+  "normalizeKeyframes",
+  "notFoundValueOrThrow",
+  "observable",
+  "onEnter",
+  "onLeave",
+  "optimizeGroupPlayer",
+  "optionsReducer",
+  "parseAndConvertBindingsForDefinition",
+  "parseTimelineCommand",
+  "platformBrowser",
+  "platformCore",
+  "processInjectorTypesWithProviders",
+  "producerMarkClean",
+  "producerRemoveLiveConsumerAtIndex",
+  "producerUpdateValueVersion",
+  "refreshContentQueries",
+  "refreshView",
+  "registerPostOrderHooks",
+  "rememberChangeHistoryAndInvokeOnChangesHook",
+  "remove",
+  "removeClass",
+  "removeElements",
+  "removeFromArray",
+  "removeNodesAfterAnimationDone",
+  "renderComponent",
+  "renderView",
+  "replacePostStylesAsPre",
+  "requiresRefreshOrTraversal",
+  "resetPreOrderHookFlags",
+  "resolveForwardRef",
+  "resolveTiming",
+  "resolveTimingValue",
+  "roundOffset",
+  "runEffectsInView",
+  "runInInjectionContext",
+  "saveNameToExportMap",
+  "scheduleCallbackWithMicrotask",
+  "scheduleCallbackWithRafRace",
+  "searchTokensOnInjector",
+  "setActiveConsumer",
+  "setBindingRootForHostBindings",
+  "setCurrentDirectiveIndex",
+  "setCurrentInjector",
+  "setCurrentQueryIndex",
+  "setCurrentTNode",
+  "setDirectiveInputsWhichShadowsStyling",
+  "setIncludeViewProviders",
+  "setInjectImplementation",
+  "setInputsForProperty",
+  "setInputsFromAttrs",
+  "setIsRefreshingViews",
+  "setSelectedIndex",
+  "setStyles",
+  "setUpAttributes",
+  "setupStaticAttributes",
+  "shimStylesContent",
+  "shouldSearchParent",
+  "storeLViewOnDestroy",
+  "stringify",
+  "stringifyCSSSelector",
+  "style",
+  "throwProviderNotFoundError",
+  "timeoutProvider",
+  "toRefArray",
+  "transition",
+  "uniqueIdCounter",
+  "unregisterLView",
+  "unwrapRNode",
+  "updateAncestorTraversalFlagsOnAttach",
+  "updateMicroTaskStatus",
+  "viewAttachedToChangeDetector",
+  "viewShouldHaveReactiveConsumer",
+  "visitDslNode",
+  "walkProviderTree",
+  "writeDirectClass",
+  "writeToDirectiveInput",
+  "ɵɵdefineComponent",
+  "ɵɵdefineInjectable",
+  "ɵɵdefineInjector",
+  "ɵɵdefineNgModule",
+  "ɵɵdirectiveInject",
+  "ɵɵelement",
+  "ɵɵelementEnd",
+  "ɵɵelementStart",
+  "ɵɵinject",
+  "ɵɵproperty"
 ]

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -1,1295 +1,433 @@
 [
-  {
-    "name": "ALLOW_MULTIPLE_PLATFORMS"
-  },
-  {
-    "name": "APP_BOOTSTRAP_LISTENER"
-  },
-  {
-    "name": "APP_ID"
-  },
-  {
-    "name": "APP_INITIALIZER"
-  },
-  {
-    "name": "AfterRenderManager"
-  },
-  {
-    "name": "AnonymousSubject"
-  },
-  {
-    "name": "ApplicationInitStatus"
-  },
-  {
-    "name": "ApplicationModule"
-  },
-  {
-    "name": "ApplicationRef"
-  },
-  {
-    "name": "BROWSER_MODULE_PROVIDERS"
-  },
-  {
-    "name": "BROWSER_MODULE_PROVIDERS_MARKER"
-  },
-  {
-    "name": "BehaviorSubject"
-  },
-  {
-    "name": "BrowserDomAdapter"
-  },
-  {
-    "name": "BrowserModule"
-  },
-  {
-    "name": "BrowserXhr"
-  },
-  {
-    "name": "CIRCULAR"
-  },
-  {
-    "name": "COMPLETE_NOTIFICATION"
-  },
-  {
-    "name": "COMPONENT_REGEX"
-  },
-  {
-    "name": "CSP_NONCE"
-  },
-  {
-    "name": "ChainedInjector"
-  },
-  {
-    "name": "ChangeDetectionScheduler"
-  },
-  {
-    "name": "ChangeDetectionSchedulerImpl"
-  },
-  {
-    "name": "ChangeDetectionStrategy"
-  },
-  {
-    "name": "CommonModule"
-  },
-  {
-    "name": "ComponentFactory"
-  },
-  {
-    "name": "ComponentFactory2"
-  },
-  {
-    "name": "ComponentFactoryResolver"
-  },
-  {
-    "name": "ComponentFactoryResolver2"
-  },
-  {
-    "name": "ComponentRef"
-  },
-  {
-    "name": "ComponentRef2"
-  },
-  {
-    "name": "ConsumerObserver"
-  },
-  {
-    "name": "DEFAULT_APP_ID"
-  },
-  {
-    "name": "DOCUMENT"
-  },
-  {
-    "name": "DOCUMENT2"
-  },
-  {
-    "name": "DefaultDomRenderer2"
-  },
-  {
-    "name": "DepComponent"
-  },
-  {
-    "name": "DestroyRef"
-  },
-  {
-    "name": "DomAdapter"
-  },
-  {
-    "name": "DomEventsPlugin"
-  },
-  {
-    "name": "DomRendererFactory2"
-  },
-  {
-    "name": "EMPTY_ARRAY"
-  },
-  {
-    "name": "EMPTY_OBJ"
-  },
-  {
-    "name": "EMPTY_OBSERVER"
-  },
-  {
-    "name": "EMPTY_PAYLOAD"
-  },
-  {
-    "name": "EMPTY_SUBSCRIPTION"
-  },
-  {
-    "name": "ENVIRONMENT_INITIALIZER"
-  },
-  {
-    "name": "EVENT_MANAGER_PLUGINS"
-  },
-  {
-    "name": "EffectScheduler"
-  },
-  {
-    "name": "ElementRef"
-  },
-  {
-    "name": "EmulatedEncapsulationDomRenderer2"
-  },
-  {
-    "name": "EnvironmentInjector"
-  },
-  {
-    "name": "EnvironmentNgModuleRefAdapter"
-  },
-  {
-    "name": "ErrorHandler"
-  },
-  {
-    "name": "EventEmitter"
-  },
-  {
-    "name": "EventManager"
-  },
-  {
-    "name": "EventManagerPlugin"
-  },
-  {
-    "name": "GenericBrowserDomAdapter"
-  },
-  {
-    "name": "INJECTOR"
-  },
-  {
-    "name": "INJECTOR_DEF_TYPES"
-  },
-  {
-    "name": "INJECTOR_SCOPE"
-  },
-  {
-    "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
-  },
-  {
-    "name": "InjectFlags"
-  },
-  {
-    "name": "InjectionToken"
-  },
-  {
-    "name": "Injector"
-  },
-  {
-    "name": "InputFlags"
-  },
-  {
-    "name": "KeyEventsPlugin"
-  },
-  {
-    "name": "LContainerFlags"
-  },
-  {
-    "name": "LOCALE_ID2"
-  },
-  {
-    "name": "LifecycleHooksFeature"
-  },
-  {
-    "name": "MODIFIER_KEYS"
-  },
-  {
-    "name": "MODIFIER_KEY_GETTERS"
-  },
-  {
-    "name": "Module"
-  },
-  {
-    "name": "NAMESPACE_URIS"
-  },
-  {
-    "name": "NEW_LINE"
-  },
-  {
-    "name": "NG_COMP_DEF"
-  },
-  {
-    "name": "NG_DIR_DEF"
-  },
-  {
-    "name": "NG_ELEMENT_ID"
-  },
-  {
-    "name": "NG_ENV_ID"
-  },
-  {
-    "name": "NG_FACTORY_DEF"
-  },
-  {
-    "name": "NG_INJECTABLE_DEF"
-  },
-  {
-    "name": "NG_INJECTOR_DEF"
-  },
-  {
-    "name": "NG_INJ_DEF"
-  },
-  {
-    "name": "NG_MOD_DEF"
-  },
-  {
-    "name": "NG_PIPE_DEF"
-  },
-  {
-    "name": "NG_PROV_DEF"
-  },
-  {
-    "name": "NOT_FOUND"
-  },
-  {
-    "name": "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR"
-  },
-  {
-    "name": "NOT_YET"
-  },
-  {
-    "name": "NO_CHANGE"
-  },
-  {
-    "name": "NULL_INJECTOR"
-  },
-  {
-    "name": "NgModuleFactory"
-  },
-  {
-    "name": "NgModuleFactory2"
-  },
-  {
-    "name": "NgModuleRef"
-  },
-  {
-    "name": "NgModuleRef2"
-  },
-  {
-    "name": "NgZone"
-  },
-  {
-    "name": "NgZoneChangeDetectionScheduler"
-  },
-  {
-    "name": "NodeInjector"
-  },
-  {
-    "name": "NodeInjectorDestroyRef"
-  },
-  {
-    "name": "NodeInjectorFactory"
-  },
-  {
-    "name": "NoneEncapsulationDomRenderer"
-  },
-  {
-    "name": "NoopNgZone"
-  },
-  {
-    "name": "NullInjector"
-  },
-  {
-    "name": "ObjectUnsubscribedError"
-  },
-  {
-    "name": "Observable"
-  },
-  {
-    "name": "OperatorSubscriber"
-  },
-  {
-    "name": "PLATFORM_DESTROY_LISTENERS"
-  },
-  {
-    "name": "PLATFORM_ID"
-  },
-  {
-    "name": "PLATFORM_INITIALIZER"
-  },
-  {
-    "name": "PRESERVE_HOST_CONTENT"
-  },
-  {
-    "name": "PendingTasksInternal"
-  },
-  {
-    "name": "PlatformRef"
-  },
-  {
-    "name": "R3Injector"
-  },
-  {
-    "name": "REACTIVE_LVIEW_CONSUMER_NODE"
-  },
-  {
-    "name": "REACTIVE_NODE"
-  },
-  {
-    "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
-  },
-  {
-    "name": "RendererFactory2"
-  },
-  {
-    "name": "RendererStyleFlags2"
-  },
-  {
-    "name": "RuntimeError"
-  },
-  {
-    "name": "SCHEDULE_IN_ROOT_ZONE"
-  },
-  {
-    "name": "SIGNAL"
-  },
-  {
-    "name": "SIMPLE_CHANGES_STORE"
-  },
-  {
-    "name": "SafeSubscriber"
-  },
-  {
-    "name": "Sanitizer"
-  },
-  {
-    "name": "ShadowDomRenderer"
-  },
-  {
-    "name": "SharedStylesHost"
-  },
-  {
-    "name": "SimpleChange"
-  },
-  {
-    "name": "StandaloneService"
-  },
-  {
-    "name": "Subject"
-  },
-  {
-    "name": "Subscriber"
-  },
-  {
-    "name": "Subscription"
-  },
-  {
-    "name": "TEMPORARY_CONSUMER_NODE"
-  },
-  {
-    "name": "TESTABILITY"
-  },
-  {
-    "name": "TESTABILITY_GETTER"
-  },
-  {
-    "name": "TESTABILITY_PROVIDERS"
-  },
-  {
-    "name": "THROW_IF_NOT_FOUND"
-  },
-  {
-    "name": "TRACKED_LVIEWS"
-  },
-  {
-    "name": "Testability"
-  },
-  {
-    "name": "TestabilityRegistry"
-  },
-  {
-    "name": "TracingAction"
-  },
-  {
-    "name": "TracingService"
-  },
-  {
-    "name": "TriggerComponent"
-  },
-  {
-    "name": "USE_VALUE"
-  },
-  {
-    "name": "UnsubscriptionError"
-  },
-  {
-    "name": "ViewEncapsulation"
-  },
-  {
-    "name": "ViewRef"
-  },
-  {
-    "name": "ZONELESS_ENABLED"
-  },
-  {
-    "name": "ZONELESS_SCHEDULER_DISABLED"
-  },
-  {
-    "name": "ZoneAwareEffectScheduler"
-  },
-  {
-    "name": "ZoneStablePendingTask"
-  },
-  {
-    "name": "_DOM"
-  },
-  {
-    "name": "_Injector"
-  },
-  {
-    "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__defProp"
-  },
-  {
-    "name": "__forward_ref__"
-  },
-  {
-    "name": "__publicField"
-  },
-  {
-    "name": "_applyRootElementTransformImpl"
-  },
-  {
-    "name": "_bind"
-  },
-  {
-    "name": "_currentInjector"
-  },
-  {
-    "name": "_global"
-  },
-  {
-    "name": "_injectImplementation"
-  },
-  {
-    "name": "_isRefreshingViews"
-  },
-  {
-    "name": "_keyMap"
-  },
-  {
-    "name": "_locateOrCreateElementNode"
-  },
-  {
-    "name": "_platformInjector"
-  },
-  {
-    "name": "_testabilityGetter"
-  },
-  {
-    "name": "_wasLastNodeCreated"
-  },
-  {
-    "name": "activeConsumer"
-  },
-  {
-    "name": "addPropertyBinding"
-  },
-  {
-    "name": "addToEndOfViewTree"
-  },
-  {
-    "name": "allocExpando"
-  },
-  {
-    "name": "allocLFrame"
-  },
-  {
-    "name": "angularZoneInstanceIdProperty"
-  },
-  {
-    "name": "appendChild"
-  },
-  {
-    "name": "applyNodes"
-  },
-  {
-    "name": "applyProjectionRecursive"
-  },
-  {
-    "name": "applyToElementOrContainer"
-  },
-  {
-    "name": "applyValueToInputField"
-  },
-  {
-    "name": "applyView"
-  },
-  {
-    "name": "arrRemove"
-  },
-  {
-    "name": "assertConsumerNode"
-  },
-  {
-    "name": "assertNotDestroyed"
-  },
-  {
-    "name": "attachPatchData"
-  },
-  {
-    "name": "baseElement"
-  },
-  {
-    "name": "bind"
-  },
-  {
-    "name": "bloomHasToken"
-  },
-  {
-    "name": "bootstrap"
-  },
-  {
-    "name": "callHook"
-  },
-  {
-    "name": "callHookInternal"
-  },
-  {
-    "name": "callHooks"
-  },
-  {
-    "name": "captureNodeBindings"
-  },
-  {
-    "name": "checkStable"
-  },
-  {
-    "name": "classIndexOf"
-  },
-  {
-    "name": "cleanUpView"
-  },
-  {
-    "name": "collectNativeNodes"
-  },
-  {
-    "name": "collectNativeNodesInLContainer"
-  },
-  {
-    "name": "computeStaticStyling"
-  },
-  {
-    "name": "concatStringsWithSpace"
-  },
-  {
-    "name": "config"
-  },
-  {
-    "name": "configureViewWithDirective"
-  },
-  {
-    "name": "consumerBeforeComputation"
-  },
-  {
-    "name": "consumerDestroy"
-  },
-  {
-    "name": "consumerIsLive"
-  },
-  {
-    "name": "consumerPollProducersForChange"
-  },
-  {
-    "name": "context"
-  },
-  {
-    "name": "convertToBitFlags"
-  },
-  {
-    "name": "createElementNode"
-  },
-  {
-    "name": "createElementRef"
-  },
-  {
-    "name": "createErrorClass"
-  },
-  {
-    "name": "createInjector"
-  },
-  {
-    "name": "createInjectorWithoutInjectorInstances"
-  },
-  {
-    "name": "createLFrame"
-  },
-  {
-    "name": "createLView"
-  },
-  {
-    "name": "createLinkElement"
-  },
-  {
-    "name": "createNodeInjector"
-  },
-  {
-    "name": "createNotification"
-  },
-  {
-    "name": "createPlatformFactory"
-  },
-  {
-    "name": "createStyleElement"
-  },
-  {
-    "name": "createTView"
-  },
-  {
-    "name": "deepForEach"
-  },
-  {
-    "name": "deepForEachProvider"
-  },
-  {
-    "name": "detachMovedView"
-  },
-  {
-    "name": "detachViewFromDOM"
-  },
-  {
-    "name": "detectChangesInChildComponents"
-  },
-  {
-    "name": "detectChangesInComponent"
-  },
-  {
-    "name": "detectChangesInEmbeddedViews"
-  },
-  {
-    "name": "detectChangesInView"
-  },
-  {
-    "name": "detectChangesInViewIfAttached"
-  },
-  {
-    "name": "detectChangesInViewIfRequired"
-  },
-  {
-    "name": "detectChangesInternal"
-  },
-  {
-    "name": "diPublicInInjector"
-  },
-  {
-    "name": "enterDI"
-  },
-  {
-    "name": "enterView"
-  },
-  {
-    "name": "errorContext"
-  },
-  {
-    "name": "execFinalizer"
-  },
-  {
-    "name": "executeCheckHooks"
-  },
-  {
-    "name": "executeContentQueries"
-  },
-  {
-    "name": "executeInitAndCheckHooks"
-  },
-  {
-    "name": "executeTemplate"
-  },
-  {
-    "name": "executeViewQueryFn"
-  },
-  {
-    "name": "extractDefListOrFactory"
-  },
-  {
-    "name": "extractDirectiveDef"
-  },
-  {
-    "name": "findAttrIndexInNode"
-  },
-  {
-    "name": "forEachSingleProvider"
-  },
-  {
-    "name": "forwardRef"
-  },
-  {
-    "name": "freeConsumers"
-  },
-  {
-    "name": "generateInitialInputs"
-  },
-  {
-    "name": "getBindingsEnabled"
-  },
-  {
-    "name": "getClosureSafeProperty"
-  },
-  {
-    "name": "getComponentDef"
-  },
-  {
-    "name": "getComponentLViewByIndex"
-  },
-  {
-    "name": "getConstant"
-  },
-  {
-    "name": "getCurrentTNode"
-  },
-  {
-    "name": "getCurrentTNodePlaceholderOk"
-  },
-  {
-    "name": "getDOM"
-  },
-  {
-    "name": "getDeclarationTNode"
-  },
-  {
-    "name": "getDirectiveDef"
-  },
-  {
-    "name": "getFactoryDef"
-  },
-  {
-    "name": "getFirstLContainer"
-  },
-  {
-    "name": "getInitialLViewFlagsFromDef"
-  },
-  {
-    "name": "getInjectImplementation"
-  },
-  {
-    "name": "getInjectableDef"
-  },
-  {
-    "name": "getInjectorDef"
-  },
-  {
-    "name": "getInjectorIndex"
-  },
-  {
-    "name": "getLView"
-  },
-  {
-    "name": "getLViewParent"
-  },
-  {
-    "name": "getNativeByTNode"
-  },
-  {
-    "name": "getNearestLContainer"
-  },
-  {
-    "name": "getNextLContainer"
-  },
-  {
-    "name": "getNgZoneOptions"
-  },
-  {
-    "name": "getNodeInjectable"
-  },
-  {
-    "name": "getNullInjector"
-  },
-  {
-    "name": "getOrCreateComponentTView"
-  },
-  {
-    "name": "getOrCreateInjectable"
-  },
-  {
-    "name": "getOrCreateNodeInjectorForNode"
-  },
-  {
-    "name": "getOrCreateTNode"
-  },
-  {
-    "name": "getOwnDefinition"
-  },
-  {
-    "name": "getParentInjectorIndex"
-  },
-  {
-    "name": "getParentInjectorLocation"
-  },
-  {
-    "name": "getParentInjectorView"
-  },
-  {
-    "name": "getPipeDef"
-  },
-  {
-    "name": "getPlatform"
-  },
-  {
-    "name": "getProjectionNodes"
-  },
-  {
-    "name": "getPromiseCtor"
-  },
-  {
-    "name": "getSimpleChangesStore"
-  },
-  {
-    "name": "getTNodeFromLView"
-  },
-  {
-    "name": "getTView"
-  },
-  {
-    "name": "handleStoppedNotification"
-  },
-  {
-    "name": "handleUnhandledError"
-  },
-  {
-    "name": "hasApplyArgsData"
-  },
-  {
-    "name": "hasTagAndTypeMatch"
-  },
-  {
-    "name": "icuContainerIterate"
-  },
-  {
-    "name": "identity"
-  },
-  {
-    "name": "importProvidersFrom"
-  },
-  {
-    "name": "includeViewProviders"
-  },
-  {
-    "name": "incrementInitPhaseFlags"
-  },
-  {
-    "name": "initializeDirectives"
-  },
-  {
-    "name": "inject"
-  },
-  {
-    "name": "injectArgs"
-  },
-  {
-    "name": "injectDestroyRef"
-  },
-  {
-    "name": "injectElementRef"
-  },
-  {
-    "name": "injectInjectorOnly"
-  },
-  {
-    "name": "injectRootLimpMode"
-  },
-  {
-    "name": "injectableDefOrInjectorDefFactory"
-  },
-  {
-    "name": "insertBloom"
-  },
-  {
-    "name": "instructionState"
-  },
-  {
-    "name": "internalImportProvidersFrom"
-  },
-  {
-    "name": "internalProvideZoneChangeDetection"
-  },
-  {
-    "name": "invokeDirectivesHostBindings"
-  },
-  {
-    "name": "invokeHostBindingsInCreationMode"
-  },
-  {
-    "name": "isAngularZoneProperty"
-  },
-  {
-    "name": "isApplicationBootstrapConfig"
-  },
-  {
-    "name": "isComponentDef"
-  },
-  {
-    "name": "isComponentHost"
-  },
-  {
-    "name": "isContentQueryHost"
-  },
-  {
-    "name": "isCssClassMatching"
-  },
-  {
-    "name": "isCurrentTNodeParent"
-  },
-  {
-    "name": "isEnvironmentProviders"
-  },
-  {
-    "name": "isFunction"
-  },
-  {
-    "name": "isInlineTemplate"
-  },
-  {
-    "name": "isLContainer"
-  },
-  {
-    "name": "isLView"
-  },
-  {
-    "name": "isNodeMatchingSelector"
-  },
-  {
-    "name": "isNodeMatchingSelectorList"
-  },
-  {
-    "name": "isPlatformServer"
-  },
-  {
-    "name": "isPositive"
-  },
-  {
-    "name": "isPromise"
-  },
-  {
-    "name": "isRefreshingViews"
-  },
-  {
-    "name": "isRootView"
-  },
-  {
-    "name": "isSubscription"
-  },
-  {
-    "name": "isTemplateNode"
-  },
-  {
-    "name": "isTypeProvider"
-  },
-  {
-    "name": "isValueProvider"
-  },
-  {
-    "name": "lastNodeWasCreated"
-  },
-  {
-    "name": "leaveDI"
-  },
-  {
-    "name": "leaveView"
-  },
-  {
-    "name": "leaveViewLight"
-  },
-  {
-    "name": "lookupTokenUsingModuleInjector"
-  },
-  {
-    "name": "lookupTokenUsingNodeInjector"
-  },
-  {
-    "name": "makeRecord"
-  },
-  {
-    "name": "map"
-  },
-  {
-    "name": "markAncestorsForTraversal"
-  },
-  {
-    "name": "markAsComponentHost"
-  },
-  {
-    "name": "markViewDirty"
-  },
-  {
-    "name": "markViewForRefresh"
-  },
-  {
-    "name": "markedFeatures"
-  },
-  {
-    "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "mergeHostAttribute"
-  },
-  {
-    "name": "mergeHostAttrs"
-  },
-  {
-    "name": "nativeAppendChild"
-  },
-  {
-    "name": "nativeAppendOrInsertBefore"
-  },
-  {
-    "name": "nativeInsertBefore"
-  },
-  {
-    "name": "nextNgElementId"
-  },
-  {
-    "name": "ngOnChangesSetInput"
-  },
-  {
-    "name": "ngZoneInstanceId"
-  },
-  {
-    "name": "noSideEffects"
-  },
-  {
-    "name": "nonNull"
-  },
-  {
-    "name": "noop"
-  },
-  {
-    "name": "noop2"
-  },
-  {
-    "name": "notFoundValueOrThrow"
-  },
-  {
-    "name": "observable"
-  },
-  {
-    "name": "onEnter"
-  },
-  {
-    "name": "onLeave"
-  },
-  {
-    "name": "optionsReducer"
-  },
-  {
-    "name": "parseAndConvertBindingsForDefinition"
-  },
-  {
-    "name": "platformBrowser"
-  },
-  {
-    "name": "platformCore"
-  },
-  {
-    "name": "processInjectorTypesWithProviders"
-  },
-  {
-    "name": "producerMarkClean"
-  },
-  {
-    "name": "producerRemoveLiveConsumerAtIndex"
-  },
-  {
-    "name": "producerUpdateValueVersion"
-  },
-  {
-    "name": "refreshContentQueries"
-  },
-  {
-    "name": "refreshView"
-  },
-  {
-    "name": "registerPostOrderHooks"
-  },
-  {
-    "name": "rememberChangeHistoryAndInvokeOnChangesHook"
-  },
-  {
-    "name": "remove"
-  },
-  {
-    "name": "removeElements"
-  },
-  {
-    "name": "removeFromArray"
-  },
-  {
-    "name": "renderComponent"
-  },
-  {
-    "name": "renderView"
-  },
-  {
-    "name": "requiresRefreshOrTraversal"
-  },
-  {
-    "name": "resetPreOrderHookFlags"
-  },
-  {
-    "name": "resolveForwardRef"
-  },
-  {
-    "name": "runEffectsInView"
-  },
-  {
-    "name": "runInInjectionContext"
-  },
-  {
-    "name": "saveNameToExportMap"
-  },
-  {
-    "name": "scheduleCallbackWithMicrotask"
-  },
-  {
-    "name": "scheduleCallbackWithRafRace"
-  },
-  {
-    "name": "searchTokensOnInjector"
-  },
-  {
-    "name": "setActiveConsumer"
-  },
-  {
-    "name": "setBindingRootForHostBindings"
-  },
-  {
-    "name": "setCurrentDirectiveIndex"
-  },
-  {
-    "name": "setCurrentInjector"
-  },
-  {
-    "name": "setCurrentQueryIndex"
-  },
-  {
-    "name": "setCurrentTNode"
-  },
-  {
-    "name": "setDirectiveInputsWhichShadowsStyling"
-  },
-  {
-    "name": "setIncludeViewProviders"
-  },
-  {
-    "name": "setInjectImplementation"
-  },
-  {
-    "name": "setInputsForProperty"
-  },
-  {
-    "name": "setInputsFromAttrs"
-  },
-  {
-    "name": "setIsRefreshingViews"
-  },
-  {
-    "name": "setSelectedIndex"
-  },
-  {
-    "name": "setUpAttributes"
-  },
-  {
-    "name": "setupStaticAttributes"
-  },
-  {
-    "name": "shimStylesContent"
-  },
-  {
-    "name": "shouldSearchParent"
-  },
-  {
-    "name": "storeLViewOnDestroy"
-  },
-  {
-    "name": "stringify"
-  },
-  {
-    "name": "stringifyCSSSelector"
-  },
-  {
-    "name": "throwProviderNotFoundError"
-  },
-  {
-    "name": "timeoutProvider"
-  },
-  {
-    "name": "toRefArray"
-  },
-  {
-    "name": "uniqueIdCounter"
-  },
-  {
-    "name": "unregisterLView"
-  },
-  {
-    "name": "unwrapRNode"
-  },
-  {
-    "name": "updateAncestorTraversalFlagsOnAttach"
-  },
-  {
-    "name": "updateMicroTaskStatus"
-  },
-  {
-    "name": "viewAttachedToChangeDetector"
-  },
-  {
-    "name": "viewShouldHaveReactiveConsumer"
-  },
-  {
-    "name": "walkProviderTree"
-  },
-  {
-    "name": "wasLastNodeCreated"
-  },
-  {
-    "name": "writeDirectClass"
-  },
-  {
-    "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "ɵɵdefineComponent"
-  },
-  {
-    "name": "ɵɵdefineInjectable"
-  },
-  {
-    "name": "ɵɵdefineInjector"
-  },
-  {
-    "name": "ɵɵdefineNgModule"
-  },
-  {
-    "name": "ɵɵdirectiveInject"
-  },
-  {
-    "name": "ɵɵelement"
-  },
-  {
-    "name": "ɵɵelementEnd"
-  },
-  {
-    "name": "ɵɵelementStart"
-  },
-  {
-    "name": "ɵɵinject"
-  }
+  "ALLOW_MULTIPLE_PLATFORMS",
+  "APP_BOOTSTRAP_LISTENER",
+  "APP_ID",
+  "APP_INITIALIZER",
+  "AfterRenderManager",
+  "AnonymousSubject",
+  "ApplicationInitStatus",
+  "ApplicationModule",
+  "ApplicationRef",
+  "BROWSER_MODULE_PROVIDERS",
+  "BROWSER_MODULE_PROVIDERS_MARKER",
+  "BehaviorSubject",
+  "BrowserDomAdapter",
+  "BrowserModule",
+  "BrowserXhr",
+  "CIRCULAR",
+  "COMPLETE_NOTIFICATION",
+  "COMPONENT_REGEX",
+  "CSP_NONCE",
+  "ChainedInjector",
+  "ChangeDetectionScheduler",
+  "ChangeDetectionSchedulerImpl",
+  "ChangeDetectionStrategy",
+  "CommonModule",
+  "ComponentFactory",
+  "ComponentFactory2",
+  "ComponentFactoryResolver",
+  "ComponentFactoryResolver2",
+  "ComponentRef",
+  "ComponentRef2",
+  "ConsumerObserver",
+  "DEFAULT_APP_ID",
+  "DOCUMENT",
+  "DOCUMENT2",
+  "DefaultDomRenderer2",
+  "DepComponent",
+  "DestroyRef",
+  "DomAdapter",
+  "DomEventsPlugin",
+  "DomRendererFactory2",
+  "EMPTY_ARRAY",
+  "EMPTY_OBJ",
+  "EMPTY_OBSERVER",
+  "EMPTY_PAYLOAD",
+  "EMPTY_SUBSCRIPTION",
+  "ENVIRONMENT_INITIALIZER",
+  "EVENT_MANAGER_PLUGINS",
+  "EffectScheduler",
+  "ElementRef",
+  "EmulatedEncapsulationDomRenderer2",
+  "EnvironmentInjector",
+  "EnvironmentNgModuleRefAdapter",
+  "ErrorHandler",
+  "EventEmitter",
+  "EventManager",
+  "EventManagerPlugin",
+  "GenericBrowserDomAdapter",
+  "INJECTOR",
+  "INJECTOR_DEF_TYPES",
+  "INJECTOR_SCOPE",
+  "INTERNAL_APPLICATION_ERROR_HANDLER",
+  "InjectFlags",
+  "InjectionToken",
+  "Injector",
+  "InputFlags",
+  "KeyEventsPlugin",
+  "LContainerFlags",
+  "LOCALE_ID2",
+  "LifecycleHooksFeature",
+  "MODIFIER_KEYS",
+  "MODIFIER_KEY_GETTERS",
+  "Module",
+  "NAMESPACE_URIS",
+  "NEW_LINE",
+  "NG_COMP_DEF",
+  "NG_DIR_DEF",
+  "NG_ELEMENT_ID",
+  "NG_ENV_ID",
+  "NG_FACTORY_DEF",
+  "NG_INJECTABLE_DEF",
+  "NG_INJECTOR_DEF",
+  "NG_INJ_DEF",
+  "NG_MOD_DEF",
+  "NG_PIPE_DEF",
+  "NG_PROV_DEF",
+  "NOT_FOUND",
+  "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR",
+  "NOT_YET",
+  "NO_CHANGE",
+  "NULL_INJECTOR",
+  "NgModuleFactory",
+  "NgModuleFactory2",
+  "NgModuleRef",
+  "NgModuleRef2",
+  "NgZone",
+  "NgZoneChangeDetectionScheduler",
+  "NodeInjector",
+  "NodeInjectorDestroyRef",
+  "NodeInjectorFactory",
+  "NoneEncapsulationDomRenderer",
+  "NoopNgZone",
+  "NullInjector",
+  "ObjectUnsubscribedError",
+  "Observable",
+  "OperatorSubscriber",
+  "PLATFORM_DESTROY_LISTENERS",
+  "PLATFORM_ID",
+  "PLATFORM_INITIALIZER",
+  "PRESERVE_HOST_CONTENT",
+  "PendingTasksInternal",
+  "PlatformRef",
+  "R3Injector",
+  "REACTIVE_LVIEW_CONSUMER_NODE",
+  "REACTIVE_NODE",
+  "REMOVE_STYLES_ON_COMPONENT_DESTROY",
+  "RendererFactory2",
+  "RendererStyleFlags2",
+  "RuntimeError",
+  "SCHEDULE_IN_ROOT_ZONE",
+  "SIGNAL",
+  "SIMPLE_CHANGES_STORE",
+  "SafeSubscriber",
+  "Sanitizer",
+  "ShadowDomRenderer",
+  "SharedStylesHost",
+  "SimpleChange",
+  "StandaloneService",
+  "Subject",
+  "Subscriber",
+  "Subscription",
+  "TEMPORARY_CONSUMER_NODE",
+  "TESTABILITY",
+  "TESTABILITY_GETTER",
+  "TESTABILITY_PROVIDERS",
+  "THROW_IF_NOT_FOUND",
+  "TRACKED_LVIEWS",
+  "Testability",
+  "TestabilityRegistry",
+  "TracingAction",
+  "TracingService",
+  "TriggerComponent",
+  "USE_VALUE",
+  "UnsubscriptionError",
+  "ViewEncapsulation",
+  "ViewRef",
+  "ZONELESS_ENABLED",
+  "ZONELESS_SCHEDULER_DISABLED",
+  "ZoneAwareEffectScheduler",
+  "ZoneStablePendingTask",
+  "_DOM",
+  "_Injector",
+  "_NullComponentFactoryResolver",
+  "__defProp",
+  "__forward_ref__",
+  "__publicField",
+  "_applyRootElementTransformImpl",
+  "_bind",
+  "_currentInjector",
+  "_global",
+  "_injectImplementation",
+  "_isRefreshingViews",
+  "_keyMap",
+  "_locateOrCreateElementNode",
+  "_platformInjector",
+  "_testabilityGetter",
+  "_wasLastNodeCreated",
+  "activeConsumer",
+  "addPropertyBinding",
+  "addToEndOfViewTree",
+  "allocExpando",
+  "allocLFrame",
+  "angularZoneInstanceIdProperty",
+  "appendChild",
+  "applyNodes",
+  "applyProjectionRecursive",
+  "applyToElementOrContainer",
+  "applyValueToInputField",
+  "applyView",
+  "arrRemove",
+  "assertConsumerNode",
+  "assertNotDestroyed",
+  "attachPatchData",
+  "baseElement",
+  "bind",
+  "bloomHasToken",
+  "bootstrap",
+  "callHook",
+  "callHookInternal",
+  "callHooks",
+  "captureNodeBindings",
+  "checkStable",
+  "classIndexOf",
+  "cleanUpView",
+  "collectNativeNodes",
+  "collectNativeNodesInLContainer",
+  "computeStaticStyling",
+  "concatStringsWithSpace",
+  "config",
+  "configureViewWithDirective",
+  "consumerBeforeComputation",
+  "consumerDestroy",
+  "consumerIsLive",
+  "consumerPollProducersForChange",
+  "context",
+  "convertToBitFlags",
+  "createElementNode",
+  "createElementRef",
+  "createErrorClass",
+  "createInjector",
+  "createInjectorWithoutInjectorInstances",
+  "createLFrame",
+  "createLView",
+  "createLinkElement",
+  "createNodeInjector",
+  "createNotification",
+  "createPlatformFactory",
+  "createStyleElement",
+  "createTView",
+  "deepForEach",
+  "deepForEachProvider",
+  "detachMovedView",
+  "detachViewFromDOM",
+  "detectChangesInChildComponents",
+  "detectChangesInComponent",
+  "detectChangesInEmbeddedViews",
+  "detectChangesInView",
+  "detectChangesInViewIfAttached",
+  "detectChangesInViewIfRequired",
+  "detectChangesInternal",
+  "diPublicInInjector",
+  "enterDI",
+  "enterView",
+  "errorContext",
+  "execFinalizer",
+  "executeCheckHooks",
+  "executeContentQueries",
+  "executeInitAndCheckHooks",
+  "executeTemplate",
+  "executeViewQueryFn",
+  "extractDefListOrFactory",
+  "extractDirectiveDef",
+  "findAttrIndexInNode",
+  "forEachSingleProvider",
+  "forwardRef",
+  "freeConsumers",
+  "generateInitialInputs",
+  "getBindingsEnabled",
+  "getClosureSafeProperty",
+  "getComponentDef",
+  "getComponentLViewByIndex",
+  "getConstant",
+  "getCurrentTNode",
+  "getCurrentTNodePlaceholderOk",
+  "getDOM",
+  "getDeclarationTNode",
+  "getDirectiveDef",
+  "getFactoryDef",
+  "getFirstLContainer",
+  "getInitialLViewFlagsFromDef",
+  "getInjectImplementation",
+  "getInjectableDef",
+  "getInjectorDef",
+  "getInjectorIndex",
+  "getLView",
+  "getLViewParent",
+  "getNativeByTNode",
+  "getNearestLContainer",
+  "getNextLContainer",
+  "getNgZoneOptions",
+  "getNodeInjectable",
+  "getNullInjector",
+  "getOrCreateComponentTView",
+  "getOrCreateInjectable",
+  "getOrCreateNodeInjectorForNode",
+  "getOrCreateTNode",
+  "getOwnDefinition",
+  "getParentInjectorIndex",
+  "getParentInjectorLocation",
+  "getParentInjectorView",
+  "getPipeDef",
+  "getPlatform",
+  "getProjectionNodes",
+  "getPromiseCtor",
+  "getSimpleChangesStore",
+  "getTNodeFromLView",
+  "getTView",
+  "handleStoppedNotification",
+  "handleUnhandledError",
+  "hasApplyArgsData",
+  "hasTagAndTypeMatch",
+  "icuContainerIterate",
+  "identity",
+  "importProvidersFrom",
+  "includeViewProviders",
+  "incrementInitPhaseFlags",
+  "initializeDirectives",
+  "inject",
+  "injectArgs",
+  "injectDestroyRef",
+  "injectElementRef",
+  "injectInjectorOnly",
+  "injectRootLimpMode",
+  "injectableDefOrInjectorDefFactory",
+  "insertBloom",
+  "instructionState",
+  "internalImportProvidersFrom",
+  "internalProvideZoneChangeDetection",
+  "invokeDirectivesHostBindings",
+  "invokeHostBindingsInCreationMode",
+  "isAngularZoneProperty",
+  "isApplicationBootstrapConfig",
+  "isComponentDef",
+  "isComponentHost",
+  "isContentQueryHost",
+  "isCssClassMatching",
+  "isCurrentTNodeParent",
+  "isEnvironmentProviders",
+  "isFunction",
+  "isInlineTemplate",
+  "isLContainer",
+  "isLView",
+  "isNodeMatchingSelector",
+  "isNodeMatchingSelectorList",
+  "isPlatformServer",
+  "isPositive",
+  "isPromise",
+  "isRefreshingViews",
+  "isRootView",
+  "isSubscription",
+  "isTemplateNode",
+  "isTypeProvider",
+  "isValueProvider",
+  "lastNodeWasCreated",
+  "leaveDI",
+  "leaveView",
+  "leaveViewLight",
+  "lookupTokenUsingModuleInjector",
+  "lookupTokenUsingNodeInjector",
+  "makeRecord",
+  "map",
+  "markAncestorsForTraversal",
+  "markAsComponentHost",
+  "markViewDirty",
+  "markViewForRefresh",
+  "markedFeatures",
+  "maybeWrapInNotSelector",
+  "mergeHostAttribute",
+  "mergeHostAttrs",
+  "nativeAppendChild",
+  "nativeAppendOrInsertBefore",
+  "nativeInsertBefore",
+  "nextNgElementId",
+  "ngOnChangesSetInput",
+  "ngZoneInstanceId",
+  "noSideEffects",
+  "nonNull",
+  "noop",
+  "noop2",
+  "notFoundValueOrThrow",
+  "observable",
+  "onEnter",
+  "onLeave",
+  "optionsReducer",
+  "parseAndConvertBindingsForDefinition",
+  "platformBrowser",
+  "platformCore",
+  "processInjectorTypesWithProviders",
+  "producerMarkClean",
+  "producerRemoveLiveConsumerAtIndex",
+  "producerUpdateValueVersion",
+  "refreshContentQueries",
+  "refreshView",
+  "registerPostOrderHooks",
+  "rememberChangeHistoryAndInvokeOnChangesHook",
+  "remove",
+  "removeElements",
+  "removeFromArray",
+  "renderComponent",
+  "renderView",
+  "requiresRefreshOrTraversal",
+  "resetPreOrderHookFlags",
+  "resolveForwardRef",
+  "runEffectsInView",
+  "runInInjectionContext",
+  "saveNameToExportMap",
+  "scheduleCallbackWithMicrotask",
+  "scheduleCallbackWithRafRace",
+  "searchTokensOnInjector",
+  "setActiveConsumer",
+  "setBindingRootForHostBindings",
+  "setCurrentDirectiveIndex",
+  "setCurrentInjector",
+  "setCurrentQueryIndex",
+  "setCurrentTNode",
+  "setDirectiveInputsWhichShadowsStyling",
+  "setIncludeViewProviders",
+  "setInjectImplementation",
+  "setInputsForProperty",
+  "setInputsFromAttrs",
+  "setIsRefreshingViews",
+  "setSelectedIndex",
+  "setUpAttributes",
+  "setupStaticAttributes",
+  "shimStylesContent",
+  "shouldSearchParent",
+  "storeLViewOnDestroy",
+  "stringify",
+  "stringifyCSSSelector",
+  "throwProviderNotFoundError",
+  "timeoutProvider",
+  "toRefArray",
+  "uniqueIdCounter",
+  "unregisterLView",
+  "unwrapRNode",
+  "updateAncestorTraversalFlagsOnAttach",
+  "updateMicroTaskStatus",
+  "viewAttachedToChangeDetector",
+  "viewShouldHaveReactiveConsumer",
+  "walkProviderTree",
+  "wasLastNodeCreated",
+  "writeDirectClass",
+  "writeToDirectiveInput",
+  "ɵɵdefineComponent",
+  "ɵɵdefineInjectable",
+  "ɵɵdefineInjector",
+  "ɵɵdefineNgModule",
+  "ɵɵdirectiveInject",
+  "ɵɵelement",
+  "ɵɵelementEnd",
+  "ɵɵelementStart",
+  "ɵɵinject"
 ]

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -1,2669 +1,891 @@
 [
-  {
-    "name": "APP_BOOTSTRAP_LISTENER"
-  },
-  {
-    "name": "APP_ID"
-  },
-  {
-    "name": "APP_INITIALIZER"
-  },
-  {
-    "name": "AfterRenderManager"
-  },
-  {
-    "name": "AnonymousSubject"
-  },
-  {
-    "name": "AppComponent_DeferError_5_Template"
-  },
-  {
-    "name": "AppComponent_DeferLoading_3_Template"
-  },
-  {
-    "name": "AppComponent_DeferPlaceholder_4_Template"
-  },
-  {
-    "name": "AppComponent_Defer_2_Template"
-  },
-  {
-    "name": "AppComponent_Defer_6_DepsFn"
-  },
-  {
-    "name": "ApplicationInitStatus"
-  },
-  {
-    "name": "ApplicationRef"
-  },
-  {
-    "name": "BLOOM_BUCKET_BITS"
-  },
-  {
-    "name": "BLOOM_MASK"
-  },
-  {
-    "name": "BROWSER_MODULE_PROVIDERS"
-  },
-  {
-    "name": "BehaviorSubject"
-  },
-  {
-    "name": "BrowserDomAdapter"
-  },
-  {
-    "name": "BrowserXhr"
-  },
-  {
-    "name": "CIRCULAR"
-  },
-  {
-    "name": "COMPLETE_NOTIFICATION"
-  },
-  {
-    "name": "COMPONENT_REGEX"
-  },
-  {
-    "name": "CONTAINER_HEADER_OFFSET"
-  },
-  {
-    "name": "CSP_NONCE"
-  },
-  {
-    "name": "CachedInjectorService"
-  },
-  {
-    "name": "ChainedInjector"
-  },
-  {
-    "name": "ChangeDetectionScheduler"
-  },
-  {
-    "name": "ChangeDetectionSchedulerImpl"
-  },
-  {
-    "name": "ChangeDetectionStrategy"
-  },
-  {
-    "name": "ComponentFactory"
-  },
-  {
-    "name": "ComponentFactory2"
-  },
-  {
-    "name": "ComponentFactoryResolver"
-  },
-  {
-    "name": "ComponentFactoryResolver2"
-  },
-  {
-    "name": "ComponentRef"
-  },
-  {
-    "name": "ComponentRef2"
-  },
-  {
-    "name": "ConsumerObserver"
-  },
-  {
-    "name": "DEFAULT_APP_ID"
-  },
-  {
-    "name": "DEFAULT_LOCALE_ID"
-  },
-  {
-    "name": "DEFER_BLOCK_CONFIG"
-  },
-  {
-    "name": "DEFER_BLOCK_ID"
-  },
-  {
-    "name": "DEFER_BLOCK_STATE"
-  },
-  {
-    "name": "DEFER_BLOCK_STATE2"
-  },
-  {
-    "name": "DEHYDRATED_BLOCK_REGISTRY"
-  },
-  {
-    "name": "DEHYDRATED_VIEWS"
-  },
-  {
-    "name": "DI_DECORATOR_FLAG"
-  },
-  {
-    "name": "DOCUMENT"
-  },
-  {
-    "name": "DOCUMENT2"
-  },
-  {
-    "name": "DefaultDomRenderer2"
-  },
-  {
-    "name": "DeferBlockBehavior"
-  },
-  {
-    "name": "DeferBlockInternalState"
-  },
-  {
-    "name": "DeferBlockState"
-  },
-  {
-    "name": "DeferComponent"
-  },
-  {
-    "name": "DeferDependenciesLoadingState"
-  },
-  {
-    "name": "DestroyRef"
-  },
-  {
-    "name": "DomAdapter"
-  },
-  {
-    "name": "DomEventsPlugin"
-  },
-  {
-    "name": "DomRendererFactory2"
-  },
-  {
-    "name": "EMPTY_ARRAY"
-  },
-  {
-    "name": "EMPTY_OBJ"
-  },
-  {
-    "name": "EMPTY_OBSERVER"
-  },
-  {
-    "name": "EMPTY_PAYLOAD"
-  },
-  {
-    "name": "EMPTY_SUBSCRIPTION"
-  },
-  {
-    "name": "ENVIRONMENT_INITIALIZER"
-  },
-  {
-    "name": "EVENT_MANAGER_PLUGINS"
-  },
-  {
-    "name": "EffectScheduler"
-  },
-  {
-    "name": "ElementRef"
-  },
-  {
-    "name": "EmulatedEncapsulationDomRenderer2"
-  },
-  {
-    "name": "EnvironmentInjector"
-  },
-  {
-    "name": "EnvironmentNgModuleRefAdapter"
-  },
-  {
-    "name": "ErrorHandler"
-  },
-  {
-    "name": "EventEmitter"
-  },
-  {
-    "name": "EventManager"
-  },
-  {
-    "name": "EventManagerPlugin"
-  },
-  {
-    "name": "GenericBrowserDomAdapter"
-  },
-  {
-    "name": "HYDRATE_TRIGGER_CLEANUP_FNS"
-  },
-  {
-    "name": "INJECTOR"
-  },
-  {
-    "name": "INJECTOR_DEF_TYPES"
-  },
-  {
-    "name": "INJECTOR_SCOPE"
-  },
-  {
-    "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
-  },
-  {
-    "name": "INTERNAL_BROWSER_PLATFORM_PROVIDERS"
-  },
-  {
-    "name": "IS_INCREMENTAL_HYDRATION_ENABLED"
-  },
-  {
-    "name": "InjectFlags"
-  },
-  {
-    "name": "InjectionToken"
-  },
-  {
-    "name": "Injector"
-  },
-  {
-    "name": "InputFlags"
-  },
-  {
-    "name": "KeyEventsPlugin"
-  },
-  {
-    "name": "LContainerFlags"
-  },
-  {
-    "name": "LOADING_AFTER_SLOT"
-  },
-  {
-    "name": "LOCALE_ID2"
-  },
-  {
-    "name": "LifecycleHooksFeature"
-  },
-  {
-    "name": "MATH_ML_NAMESPACE"
-  },
-  {
-    "name": "MAXIMUM_REFRESH_RERUNS"
-  },
-  {
-    "name": "MINIMUM_SLOT"
-  },
-  {
-    "name": "MODIFIER_KEYS"
-  },
-  {
-    "name": "MODIFIER_KEY_GETTERS"
-  },
-  {
-    "name": "MONKEY_PATCH_KEY_NAME"
-  },
-  {
-    "name": "MOVED_VIEWS"
-  },
-  {
-    "name": "NAMESPACE_URIS"
-  },
-  {
-    "name": "NATIVE"
-  },
-  {
-    "name": "NEW_LINE"
-  },
-  {
-    "name": "NEXT_DEFER_BLOCK_STATE"
-  },
-  {
-    "name": "NG_COMP_DEF"
-  },
-  {
-    "name": "NG_DIR_DEF"
-  },
-  {
-    "name": "NG_ELEMENT_ID"
-  },
-  {
-    "name": "NG_ENV_ID"
-  },
-  {
-    "name": "NG_FACTORY_DEF"
-  },
-  {
-    "name": "NG_INJECTABLE_DEF"
-  },
-  {
-    "name": "NG_INJECTOR_DEF"
-  },
-  {
-    "name": "NG_INJ_DEF"
-  },
-  {
-    "name": "NG_PIPE_DEF"
-  },
-  {
-    "name": "NG_PROV_DEF"
-  },
-  {
-    "name": "NG_TEMPLATE_SELECTOR"
-  },
-  {
-    "name": "NG_TEMP_TOKEN_PATH"
-  },
-  {
-    "name": "NG_TOKEN_PATH"
-  },
-  {
-    "name": "NOT_FOUND"
-  },
-  {
-    "name": "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR"
-  },
-  {
-    "name": "NOT_YET"
-  },
-  {
-    "name": "NO_CHANGE"
-  },
-  {
-    "name": "NO_NEW_LINE"
-  },
-  {
-    "name": "NO_PARENT_INJECTOR"
-  },
-  {
-    "name": "NULL_INJECTOR"
-  },
-  {
-    "name": "NgModuleRef"
-  },
-  {
-    "name": "NgZone"
-  },
-  {
-    "name": "NgZoneChangeDetectionScheduler"
-  },
-  {
-    "name": "NodeInjector"
-  },
-  {
-    "name": "NodeInjectorDestroyRef"
-  },
-  {
-    "name": "NodeInjectorFactory"
-  },
-  {
-    "name": "NoneEncapsulationDomRenderer"
-  },
-  {
-    "name": "NoopNgZone"
-  },
-  {
-    "name": "NullInjector"
-  },
-  {
-    "name": "ON_COMPLETE_FNS"
-  },
-  {
-    "name": "ObjectUnsubscribedError"
-  },
-  {
-    "name": "Observable"
-  },
-  {
-    "name": "OperatorSubscriber"
-  },
-  {
-    "name": "PLATFORM_DESTROY_LISTENERS"
-  },
-  {
-    "name": "PLATFORM_ID"
-  },
-  {
-    "name": "PLATFORM_INITIALIZER"
-  },
-  {
-    "name": "PREFETCH_TRIGGER_CLEANUP_FNS"
-  },
-  {
-    "name": "PRESERVE_HOST_CONTENT"
-  },
-  {
-    "name": "PRESERVE_HOST_CONTENT_DEFAULT"
-  },
-  {
-    "name": "PendingTasksInternal"
-  },
-  {
-    "name": "R3Injector"
-  },
-  {
-    "name": "REACTIVE_LVIEW_CONSUMER_NODE"
-  },
-  {
-    "name": "REACTIVE_NODE"
-  },
-  {
-    "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
-  },
-  {
-    "name": "RendererFactory2"
-  },
-  {
-    "name": "RendererStyleFlags2"
-  },
-  {
-    "name": "RuntimeError"
-  },
-  {
-    "name": "SCHEDULE_IN_ROOT_ZONE"
-  },
-  {
-    "name": "SIGNAL"
-  },
-  {
-    "name": "SIMPLE_CHANGES_STORE"
-  },
-  {
-    "name": "SOURCE"
-  },
-  {
-    "name": "SSR_BLOCK_STATE"
-  },
-  {
-    "name": "SSR_UNIQUE_ID"
-  },
-  {
-    "name": "SVG_NAMESPACE"
-  },
-  {
-    "name": "SafeSubscriber"
-  },
-  {
-    "name": "Sanitizer"
-  },
-  {
-    "name": "ShadowDomRenderer"
-  },
-  {
-    "name": "SharedStylesHost"
-  },
-  {
-    "name": "SimpleChange"
-  },
-  {
-    "name": "StandaloneService"
-  },
-  {
-    "name": "Subject"
-  },
-  {
-    "name": "Subscriber"
-  },
-  {
-    "name": "Subscription"
-  },
-  {
-    "name": "TEMPORARY_CONSUMER_NODE"
-  },
-  {
-    "name": "TESTABILITY"
-  },
-  {
-    "name": "THROW_IF_NOT_FOUND"
-  },
-  {
-    "name": "TRACKED_LVIEWS"
-  },
-  {
-    "name": "TRIGGER_CLEANUP_FNS"
-  },
-  {
-    "name": "TYPE"
-  },
-  {
-    "name": "TracingAction"
-  },
-  {
-    "name": "TracingService"
-  },
-  {
-    "name": "USE_VALUE"
-  },
-  {
-    "name": "UnsubscriptionError"
-  },
-  {
-    "name": "VIEW_REFS"
-  },
-  {
-    "name": "ViewEncapsulation"
-  },
-  {
-    "name": "ViewRef"
-  },
-  {
-    "name": "ZONELESS_ENABLED"
-  },
-  {
-    "name": "ZONELESS_SCHEDULER_DISABLED"
-  },
-  {
-    "name": "ZoneAwareEffectScheduler"
-  },
-  {
-    "name": "ZoneStablePendingTask"
-  },
-  {
-    "name": "_DOM"
-  },
-  {
-    "name": "_Injector"
-  },
-  {
-    "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__defProp"
-  },
-  {
-    "name": "__esm"
-  },
-  {
-    "name": "__forward_ref__"
-  },
-  {
-    "name": "__getOwnPropNames"
-  },
-  {
-    "name": "__publicField"
-  },
-  {
-    "name": "_applyRootElementTransformImpl"
-  },
-  {
-    "name": "_bind"
-  },
-  {
-    "name": "_currentInjector"
-  },
-  {
-    "name": "_getInsertInFrontOfRNodeWithI18n"
-  },
-  {
-    "name": "_icuContainerIterate"
-  },
-  {
-    "name": "_injectImplementation"
-  },
-  {
-    "name": "_isRefreshingViews"
-  },
-  {
-    "name": "_keyMap"
-  },
-  {
-    "name": "_locateOrCreateContainerAnchor"
-  },
-  {
-    "name": "_locateOrCreateElementNode"
-  },
-  {
-    "name": "_locateOrCreateTextNode"
-  },
-  {
-    "name": "_platformInjector"
-  },
-  {
-    "name": "_populateDehydratedViewsInLContainer"
-  },
-  {
-    "name": "_processI18nInsertBefore"
-  },
-  {
-    "name": "_retrieveHydrationInfoImpl"
-  },
-  {
-    "name": "_wasLastNodeCreated"
-  },
-  {
-    "name": "activeConsumer"
-  },
-  {
-    "name": "addDepsToRegistry"
-  },
-  {
-    "name": "addPropertyBinding"
-  },
-  {
-    "name": "addToEndOfViewTree"
-  },
-  {
-    "name": "allocExpando"
-  },
-  {
-    "name": "allocLFrame"
-  },
-  {
-    "name": "angularZoneInstanceIdProperty"
-  },
-  {
-    "name": "appendChild"
-  },
-  {
-    "name": "applyDeferBlockState"
-  },
-  {
-    "name": "applyDeferBlockStateWithSchedulingImpl"
-  },
-  {
-    "name": "applyNodes"
-  },
-  {
-    "name": "applyProjectionRecursive"
-  },
-  {
-    "name": "applyToElementOrContainer"
-  },
-  {
-    "name": "applyValueToInputField"
-  },
-  {
-    "name": "applyView"
-  },
-  {
-    "name": "arrRemove"
-  },
-  {
-    "name": "assertConsumerNode"
-  },
-  {
-    "name": "assertNotDestroyed"
-  },
-  {
-    "name": "attachPatchData"
-  },
-  {
-    "name": "baseElement"
-  },
-  {
-    "name": "bind"
-  },
-  {
-    "name": "bloomHasToken"
-  },
-  {
-    "name": "bootstrap"
-  },
-  {
-    "name": "callHook"
-  },
-  {
-    "name": "callHookInternal"
-  },
-  {
-    "name": "callHooks"
-  },
-  {
-    "name": "captureNodeBindings"
-  },
-  {
-    "name": "checkStable"
-  },
-  {
-    "name": "classIndexOf"
-  },
-  {
-    "name": "cleanUpView"
-  },
-  {
-    "name": "collectNativeNodes"
-  },
-  {
-    "name": "collectNativeNodesInLContainer"
-  },
-  {
-    "name": "computeStaticStyling"
-  },
-  {
-    "name": "concatStringsWithSpace"
-  },
-  {
-    "name": "config"
-  },
-  {
-    "name": "configureViewWithDirective"
-  },
-  {
-    "name": "consumerBeforeComputation"
-  },
-  {
-    "name": "consumerDestroy"
-  },
-  {
-    "name": "consumerIsLive"
-  },
-  {
-    "name": "consumerPollProducersForChange"
-  },
-  {
-    "name": "context"
-  },
-  {
-    "name": "convertToBitFlags"
-  },
-  {
-    "name": "createContainerAnchorImpl"
-  },
-  {
-    "name": "createDirectivesInstances"
-  },
-  {
-    "name": "createElementNode"
-  },
-  {
-    "name": "createElementRef"
-  },
-  {
-    "name": "createEnvironmentInjector"
-  },
-  {
-    "name": "createErrorClass"
-  },
-  {
-    "name": "createInjector"
-  },
-  {
-    "name": "createLFrame"
-  },
-  {
-    "name": "createLView"
-  },
-  {
-    "name": "createLinkElement"
-  },
-  {
-    "name": "createNodeInjector"
-  },
-  {
-    "name": "createNotification"
-  },
-  {
-    "name": "createStyleElement"
-  },
-  {
-    "name": "createTView"
-  },
-  {
-    "name": "declareTemplate"
-  },
-  {
-    "name": "deepForEach"
-  },
-  {
-    "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultErrorHandler"
-  },
-  {
-    "name": "defer_component_exports"
-  },
-  {
-    "name": "destroyLView"
-  },
-  {
-    "name": "detachMovedView"
-  },
-  {
-    "name": "detachView"
-  },
-  {
-    "name": "detachViewFromDOM"
-  },
-  {
-    "name": "detectChangesInChildComponents"
-  },
-  {
-    "name": "detectChangesInComponent"
-  },
-  {
-    "name": "detectChangesInEmbeddedViews"
-  },
-  {
-    "name": "detectChangesInView"
-  },
-  {
-    "name": "detectChangesInViewIfAttached"
-  },
-  {
-    "name": "detectChangesInViewIfRequired"
-  },
-  {
-    "name": "detectChangesInternal"
-  },
-  {
-    "name": "diPublicInInjector"
-  },
-  {
-    "name": "enterDI"
-  },
-  {
-    "name": "enterView"
-  },
-  {
-    "name": "epoch"
-  },
-  {
-    "name": "errorContext"
-  },
-  {
-    "name": "execFinalizer"
-  },
-  {
-    "name": "executeCheckHooks"
-  },
-  {
-    "name": "executeContentQueries"
-  },
-  {
-    "name": "executeInitAndCheckHooks"
-  },
-  {
-    "name": "executeTemplate"
-  },
-  {
-    "name": "executeViewQueryFn"
-  },
-  {
-    "name": "extractDefListOrFactory"
-  },
-  {
-    "name": "extractDirectiveDef"
-  },
-  {
-    "name": "findAttrIndexInNode"
-  },
-  {
-    "name": "forEachSingleProvider"
-  },
-  {
-    "name": "forwardRef"
-  },
-  {
-    "name": "freeConsumers"
-  },
-  {
-    "name": "generateInitialInputs"
-  },
-  {
-    "name": "getBeforeNodeForView"
-  },
-  {
-    "name": "getBindingsEnabled"
-  },
-  {
-    "name": "getCleanupFnKeyByType"
-  },
-  {
-    "name": "getClosureSafeProperty"
-  },
-  {
-    "name": "getComponentDef"
-  },
-  {
-    "name": "getComponentLViewByIndex"
-  },
-  {
-    "name": "getConstant"
-  },
-  {
-    "name": "getCurrentTNode"
-  },
-  {
-    "name": "getCurrentTNodePlaceholderOk"
-  },
-  {
-    "name": "getDOM"
-  },
-  {
-    "name": "getDeclarationTNode"
-  },
-  {
-    "name": "getDeferBlockDataIndex"
-  },
-  {
-    "name": "getDirectiveDef"
-  },
-  {
-    "name": "getFactoryDef"
-  },
-  {
-    "name": "getFirstLContainer"
-  },
-  {
-    "name": "getFirstNativeNode"
-  },
-  {
-    "name": "getInitialLViewFlagsFromDef"
-  },
-  {
-    "name": "getInjectImplementation"
-  },
-  {
-    "name": "getInjectableDef"
-  },
-  {
-    "name": "getInjectorDef"
-  },
-  {
-    "name": "getInjectorIndex"
-  },
-  {
-    "name": "getInsertInFrontOfRNodeWithNoI18n"
-  },
-  {
-    "name": "getLDeferBlockDetails"
-  },
-  {
-    "name": "getLView"
-  },
-  {
-    "name": "getLViewParent"
-  },
-  {
-    "name": "getMinimumDurationForState"
-  },
-  {
-    "name": "getNativeByTNode"
-  },
-  {
-    "name": "getNearestLContainer"
-  },
-  {
-    "name": "getNextLContainer"
-  },
-  {
-    "name": "getNodeInjectable"
-  },
-  {
-    "name": "getNullInjector"
-  },
-  {
-    "name": "getOrCreateComponentTView"
-  },
-  {
-    "name": "getOrCreateEnvironmentInjector"
-  },
-  {
-    "name": "getOrCreateInjectable"
-  },
-  {
-    "name": "getOrCreateNodeInjectorForNode"
-  },
-  {
-    "name": "getOrCreateTNode"
-  },
-  {
-    "name": "getOwnDefinition"
-  },
-  {
-    "name": "getParentInjectorIndex"
-  },
-  {
-    "name": "getParentInjectorLocation"
-  },
-  {
-    "name": "getParentInjectorView"
-  },
-  {
-    "name": "getPipeDef"
-  },
-  {
-    "name": "getProjectionNodes"
-  },
-  {
-    "name": "getPromiseCtor"
-  },
-  {
-    "name": "getSelectedIndex"
-  },
-  {
-    "name": "getSimpleChangesStore"
-  },
-  {
-    "name": "getTDeferBlockDetails"
-  },
-  {
-    "name": "getTNode"
-  },
-  {
-    "name": "getTNodeFromLView"
-  },
-  {
-    "name": "getTView"
-  },
-  {
-    "name": "handleError"
-  },
-  {
-    "name": "handleStoppedNotification"
-  },
-  {
-    "name": "handleUnhandledError"
-  },
-  {
-    "name": "hasApplyArgsData"
-  },
-  {
-    "name": "hasInSkipHydrationBlockFlag"
-  },
-  {
-    "name": "hasTagAndTypeMatch"
-  },
-  {
-    "name": "icuContainerIterate"
-  },
-  {
-    "name": "identity"
-  },
-  {
-    "name": "importProvidersFrom"
-  },
-  {
-    "name": "includeViewProviders"
-  },
-  {
-    "name": "incrementInitPhaseFlags"
-  },
-  {
-    "name": "init_BehaviorSubject"
-  },
-  {
-    "name": "init_NotificationFactories"
-  },
-  {
-    "name": "init_ObjectUnsubscribedError"
-  },
-  {
-    "name": "init_Observable"
-  },
-  {
-    "name": "init_OperatorSubscriber"
-  },
-  {
-    "name": "init_Subject"
-  },
-  {
-    "name": "init_Subscriber"
-  },
-  {
-    "name": "init_Subscription"
-  },
-  {
-    "name": "init_UnsubscriptionError"
-  },
-  {
-    "name": "init_action_resolver"
-  },
-  {
-    "name": "init_advance"
-  },
-  {
-    "name": "init_after_render_effect"
-  },
-  {
-    "name": "init_all"
-  },
-  {
-    "name": "init_annotate"
-  },
-  {
-    "name": "init_api"
-  },
-  {
-    "name": "init_api2"
-  },
-  {
-    "name": "init_api3"
-  },
-  {
-    "name": "init_api4"
-  },
-  {
-    "name": "init_api5"
-  },
-  {
-    "name": "init_api_flags"
-  },
-  {
-    "name": "init_application_config"
-  },
-  {
-    "name": "init_application_init"
-  },
-  {
-    "name": "init_application_module"
-  },
-  {
-    "name": "init_application_ngmodule_factory_compiler"
-  },
-  {
-    "name": "init_application_ref"
-  },
-  {
-    "name": "init_application_tokens"
-  },
-  {
-    "name": "init_apply_value_input_field"
-  },
-  {
-    "name": "init_arrRemove"
-  },
-  {
-    "name": "init_array_utils"
-  },
-  {
-    "name": "init_assert"
-  },
-  {
-    "name": "init_assert2"
-  },
-  {
-    "name": "init_asserts"
-  },
-  {
-    "name": "init_async_stack_tagging"
-  },
-  {
-    "name": "init_attach_source_locations"
-  },
-  {
-    "name": "init_attribute"
-  },
-  {
-    "name": "init_attribute2"
-  },
-  {
-    "name": "init_attribute_interpolation"
-  },
-  {
-    "name": "init_attrs_utils"
-  },
-  {
-    "name": "init_authoring"
-  },
-  {
-    "name": "init_bindings"
-  },
-  {
-    "name": "init_bootstrap"
-  },
-  {
-    "name": "init_bootstrap_app_scoped"
-  },
-  {
-    "name": "init_bypass"
-  },
-  {
-    "name": "init_cache"
-  },
-  {
-    "name": "init_cached_injector_service"
-  },
-  {
-    "name": "init_callback_scheduler"
-  },
-  {
-    "name": "init_chained_injector"
-  },
-  {
-    "name": "init_change_detection"
-  },
-  {
-    "name": "init_change_detection2"
-  },
-  {
-    "name": "init_change_detection3"
-  },
-  {
-    "name": "init_change_detection_utils"
-  },
-  {
-    "name": "init_change_detector_ref"
-  },
-  {
-    "name": "init_char"
-  },
-  {
-    "name": "init_class_differ"
-  },
-  {
-    "name": "init_class_map_interpolation"
-  },
-  {
-    "name": "init_cleanup"
-  },
-  {
-    "name": "init_cleanup2"
-  },
-  {
-    "name": "init_closure"
-  },
-  {
-    "name": "init_coercion"
-  },
-  {
-    "name": "init_collect_native_nodes"
-  },
-  {
-    "name": "init_comparison"
-  },
-  {
-    "name": "init_compiler"
-  },
-  {
-    "name": "init_compiler_facade"
-  },
-  {
-    "name": "init_compiler_facade_interface"
-  },
-  {
-    "name": "init_component"
-  },
-  {
-    "name": "init_component_factory"
-  },
-  {
-    "name": "init_component_factory_resolver"
-  },
-  {
-    "name": "init_component_instance"
-  },
-  {
-    "name": "init_component_ref"
-  },
-  {
-    "name": "init_compression"
-  },
-  {
-    "name": "init_computed"
-  },
-  {
-    "name": "init_computed2"
-  },
-  {
-    "name": "init_config"
-  },
-  {
-    "name": "init_console"
-  },
-  {
-    "name": "init_constants"
-  },
-  {
-    "name": "init_container"
-  },
-  {
-    "name": "init_context"
-  },
-  {
-    "name": "init_context_discovery"
-  },
-  {
-    "name": "init_contextual"
-  },
-  {
-    "name": "init_control_flow"
-  },
-  {
-    "name": "init_copy_definition_feature"
-  },
-  {
-    "name": "init_core"
-  },
-  {
-    "name": "init_core2"
-  },
-  {
-    "name": "init_core_private_export"
-  },
-  {
-    "name": "init_core_reactivity_export"
-  },
-  {
-    "name": "init_core_reactivity_export_internal"
-  },
-  {
-    "name": "init_core_render3_private_export"
-  },
-  {
-    "name": "init_createErrorClass"
-  },
-  {
-    "name": "init_create_application"
-  },
-  {
-    "name": "init_create_injector"
-  },
-  {
-    "name": "init_debug_node"
-  },
-  {
-    "name": "init_decorators"
-  },
-  {
-    "name": "init_def_getters"
-  },
-  {
-    "name": "init_default_iterable_differ"
-  },
-  {
-    "name": "init_default_keyvalue_differ"
-  },
-  {
-    "name": "init_defer_component"
-  },
-  {
-    "name": "init_definition"
-  },
-  {
-    "name": "init_definition_factory"
-  },
-  {
-    "name": "init_defs"
-  },
-  {
-    "name": "init_deps_tracker"
-  },
-  {
-    "name": "init_destroy_ref"
-  },
-  {
-    "name": "init_di"
-  },
-  {
-    "name": "init_di2"
-  },
-  {
-    "name": "init_di3"
-  },
-  {
-    "name": "init_di4"
-  },
-  {
-    "name": "init_di5"
-  },
-  {
-    "name": "init_di_attr"
-  },
-  {
-    "name": "init_di_setup"
-  },
-  {
-    "name": "init_directive"
-  },
-  {
-    "name": "init_directives"
-  },
-  {
-    "name": "init_discovery"
-  },
-  {
-    "name": "init_discovery_utils"
-  },
-  {
-    "name": "init_dispatcher"
-  },
-  {
-    "name": "init_document"
-  },
-  {
-    "name": "init_dom"
-  },
-  {
-    "name": "init_dom_triggers"
-  },
-  {
-    "name": "init_earlyeventcontract"
-  },
-  {
-    "name": "init_effect"
-  },
-  {
-    "name": "init_element"
-  },
-  {
-    "name": "init_element_container"
-  },
-  {
-    "name": "init_element_ref"
-  },
-  {
-    "name": "init_element_validation"
-  },
-  {
-    "name": "init_empty"
-  },
-  {
-    "name": "init_environment"
-  },
-  {
-    "name": "init_environment2"
-  },
-  {
-    "name": "init_equality"
-  },
-  {
-    "name": "init_errorContext"
-  },
-  {
-    "name": "init_error_details_base_url"
-  },
-  {
-    "name": "init_error_handler"
-  },
-  {
-    "name": "init_error_handling"
-  },
-  {
-    "name": "init_errors"
-  },
-  {
-    "name": "init_errors2"
-  },
-  {
-    "name": "init_errors3"
-  },
-  {
-    "name": "init_errors_di"
-  },
-  {
-    "name": "init_esm"
-  },
-  {
-    "name": "init_event"
-  },
-  {
-    "name": "init_event_contract_container"
-  },
-  {
-    "name": "init_event_contract_defines"
-  },
-  {
-    "name": "init_event_delegation_utils"
-  },
-  {
-    "name": "init_event_dispatch"
-  },
-  {
-    "name": "init_event_dispatcher"
-  },
-  {
-    "name": "init_event_emitter"
-  },
-  {
-    "name": "init_event_info"
-  },
-  {
-    "name": "init_event_replay"
-  },
-  {
-    "name": "init_event_type"
-  },
-  {
-    "name": "init_eventcontract"
-  },
-  {
-    "name": "init_exhaustive_check_no_changes"
-  },
-  {
-    "name": "init_external_styles_feature"
-  },
-  {
-    "name": "init_fields"
-  },
-  {
-    "name": "init_flags"
-  },
-  {
-    "name": "init_forward_ref"
-  },
-  {
-    "name": "init_framework_injector_profiler"
-  },
-  {
-    "name": "init_get_closest_component_name"
-  },
-  {
-    "name": "init_get_current_view"
-  },
-  {
-    "name": "init_global"
-  },
-  {
-    "name": "init_global_utils"
-  },
-  {
-    "name": "init_graph"
-  },
-  {
-    "name": "init_hmr"
-  },
-  {
-    "name": "init_hooks"
-  },
-  {
-    "name": "init_hooks2"
-  },
-  {
-    "name": "init_host_attribute_token"
-  },
-  {
-    "name": "init_host_directives_feature"
-  },
-  {
-    "name": "init_host_property"
-  },
-  {
-    "name": "init_host_tag_name_token"
-  },
-  {
-    "name": "init_html_sanitizer"
-  },
-  {
-    "name": "init_i18n"
-  },
-  {
-    "name": "init_i18n2"
-  },
-  {
-    "name": "init_i18n3"
-  },
-  {
-    "name": "init_i18n_apply"
-  },
-  {
-    "name": "init_i18n_debug"
-  },
-  {
-    "name": "init_i18n_icu_container_visitor"
-  },
-  {
-    "name": "init_i18n_insert_before_index"
-  },
-  {
-    "name": "init_i18n_locale_id"
-  },
-  {
-    "name": "init_i18n_parse"
-  },
-  {
-    "name": "init_i18n_postprocess"
-  },
-  {
-    "name": "init_i18n_tree_shaking"
-  },
-  {
-    "name": "init_i18n_util"
-  },
-  {
-    "name": "init_identity"
-  },
-  {
-    "name": "init_idle_scheduler"
-  },
-  {
-    "name": "init_iframe_attrs_validation"
-  },
-  {
-    "name": "init_image_performance_warning"
-  },
-  {
-    "name": "init_inert_body"
-  },
-  {
-    "name": "init_inherit_definition_feature"
-  },
-  {
-    "name": "init_initializer_token"
-  },
-  {
-    "name": "init_inject_switch"
-  },
-  {
-    "name": "init_injectable"
-  },
-  {
-    "name": "init_injectable2"
-  },
-  {
-    "name": "init_injection_token"
-  },
-  {
-    "name": "init_injector"
-  },
-  {
-    "name": "init_injector2"
-  },
-  {
-    "name": "init_injector3"
-  },
-  {
-    "name": "init_injector_compatibility"
-  },
-  {
-    "name": "init_injector_discovery_utils"
-  },
-  {
-    "name": "init_injector_profiler"
-  },
-  {
-    "name": "init_injector_token"
-  },
-  {
-    "name": "init_injector_utils"
-  },
-  {
-    "name": "init_input"
-  },
-  {
-    "name": "init_input_flags"
-  },
-  {
-    "name": "init_input_signal"
-  },
-  {
-    "name": "init_input_signal_node"
-  },
-  {
-    "name": "init_input_transforms_feature"
-  },
-  {
-    "name": "init_instructions"
-  },
-  {
-    "name": "init_interfaces"
-  },
-  {
-    "name": "init_interfaces2"
-  },
-  {
-    "name": "init_internal_tokens"
-  },
-  {
-    "name": "init_interpolation"
-  },
-  {
-    "name": "init_isFunction"
-  },
-  {
-    "name": "init_is_dev_mode"
-  },
-  {
-    "name": "init_iterable"
-  },
-  {
-    "name": "init_iterable_differs"
-  },
-  {
-    "name": "init_jit_options"
-  },
-  {
-    "name": "init_key_code"
-  },
-  {
-    "name": "init_keyvalue_differs"
-  },
-  {
-    "name": "init_lang"
-  },
-  {
-    "name": "init_let_declaration"
-  },
-  {
-    "name": "init_lift"
-  },
-  {
-    "name": "init_linked_signal"
-  },
-  {
-    "name": "init_linker"
-  },
-  {
-    "name": "init_list_reconciliation"
-  },
-  {
-    "name": "init_listener"
-  },
-  {
-    "name": "init_local_compilation"
-  },
-  {
-    "name": "init_locale_data_api"
-  },
-  {
-    "name": "init_locale_en"
-  },
-  {
-    "name": "init_localization"
-  },
-  {
-    "name": "init_lview_tracking"
-  },
-  {
-    "name": "init_manager"
-  },
-  {
-    "name": "init_map"
-  },
-  {
-    "name": "init_mark_view_dirty"
-  },
-  {
-    "name": "init_metadata"
-  },
-  {
-    "name": "init_metadata2"
-  },
-  {
-    "name": "init_metadata3"
-  },
-  {
-    "name": "init_metadata_attr"
-  },
-  {
-    "name": "init_microtask_effect"
-  },
-  {
-    "name": "init_misc_utils"
-  },
-  {
-    "name": "init_model"
-  },
-  {
-    "name": "init_model_signal"
-  },
-  {
-    "name": "init_module"
-  },
-  {
-    "name": "init_module_patch"
-  },
-  {
-    "name": "init_namespace"
-  },
-  {
-    "name": "init_namespaces"
-  },
-  {
-    "name": "init_next_context"
-  },
-  {
-    "name": "init_ng_dev_mode"
-  },
-  {
-    "name": "init_ng_i18n_closure_mode"
-  },
-  {
-    "name": "init_ng_jit_mode"
-  },
-  {
-    "name": "init_ng_module"
-  },
-  {
-    "name": "init_ng_module_factory"
-  },
-  {
-    "name": "init_ng_module_factory_loader"
-  },
-  {
-    "name": "init_ng_module_factory_loader_impl"
-  },
-  {
-    "name": "init_ng_module_ref"
-  },
-  {
-    "name": "init_ng_module_registration"
-  },
-  {
-    "name": "init_ng_onchanges_feature"
-  },
-  {
-    "name": "init_ng_reflect"
-  },
-  {
-    "name": "init_ng_server_mode"
-  },
-  {
-    "name": "init_ng_zone"
-  },
-  {
-    "name": "init_ng_zone_scheduling"
-  },
-  {
-    "name": "init_node"
-  },
-  {
-    "name": "init_node_assert"
-  },
-  {
-    "name": "init_node_lookup_utils"
-  },
-  {
-    "name": "init_node_manipulation"
-  },
-  {
-    "name": "init_node_manipulation_i18n"
-  },
-  {
-    "name": "init_node_selector_matcher"
-  },
-  {
-    "name": "init_noop"
-  },
-  {
-    "name": "init_noop2"
-  },
-  {
-    "name": "init_null_injector"
-  },
-  {
-    "name": "init_observable"
-  },
-  {
-    "name": "init_operators"
-  },
-  {
-    "name": "init_output"
-  },
-  {
-    "name": "init_output_emitter_ref"
-  },
-  {
-    "name": "init_partial"
-  },
-  {
-    "name": "init_patch"
-  },
-  {
-    "name": "init_pending_tasks"
-  },
-  {
-    "name": "init_performance"
-  },
-  {
-    "name": "init_pipe"
-  },
-  {
-    "name": "init_pipe2"
-  },
-  {
-    "name": "init_pipe3"
-  },
-  {
-    "name": "init_platform"
-  },
-  {
-    "name": "init_platform_core_providers"
-  },
-  {
-    "name": "init_platform_destroy_listeners"
-  },
-  {
-    "name": "init_platform_ref"
-  },
-  {
-    "name": "init_platform_tokens"
-  },
-  {
-    "name": "init_profiler"
-  },
-  {
-    "name": "init_profiler2"
-  },
-  {
-    "name": "init_projection"
-  },
-  {
-    "name": "init_property"
-  },
-  {
-    "name": "init_property2"
-  },
-  {
-    "name": "init_property3"
-  },
-  {
-    "name": "init_property_interpolation"
-  },
-  {
-    "name": "init_provider"
-  },
-  {
-    "name": "init_provider_collection"
-  },
-  {
-    "name": "init_provider_flags"
-  },
-  {
-    "name": "init_providers_feature"
-  },
-  {
-    "name": "init_public_api"
-  },
-  {
-    "name": "init_pure_function"
-  },
-  {
-    "name": "init_queries"
-  },
-  {
-    "name": "init_queries2"
-  },
-  {
-    "name": "init_queries_signals"
-  },
-  {
-    "name": "init_query"
-  },
-  {
-    "name": "init_query_list"
-  },
-  {
-    "name": "init_query_reactive"
-  },
-  {
-    "name": "init_r3_injector"
-  },
-  {
-    "name": "init_r3_symbols"
-  },
-  {
-    "name": "init_reactive_lview_consumer"
-  },
-  {
-    "name": "init_reflection_capabilities"
-  },
-  {
-    "name": "init_registry"
-  },
-  {
-    "name": "init_render"
-  },
-  {
-    "name": "init_render2"
-  },
-  {
-    "name": "init_render3"
-  },
-  {
-    "name": "init_rendering"
-  },
-  {
-    "name": "init_reportUnhandledError"
-  },
-  {
-    "name": "init_resource"
-  },
-  {
-    "name": "init_resource2"
-  },
-  {
-    "name": "init_resource_loading"
-  },
-  {
-    "name": "init_restriction"
-  },
-  {
-    "name": "init_root_effect_scheduler"
-  },
-  {
-    "name": "init_sanitization"
-  },
-  {
-    "name": "init_sanitizer"
-  },
-  {
-    "name": "init_schema"
-  },
-  {
-    "name": "init_scope"
-  },
-  {
-    "name": "init_scope2"
-  },
-  {
-    "name": "init_security"
-  },
-  {
-    "name": "init_set_debug_info"
-  },
-  {
-    "name": "init_shared"
-  },
-  {
-    "name": "init_signal"
-  },
-  {
-    "name": "init_signal2"
-  },
-  {
-    "name": "init_signal_debug"
-  },
-  {
-    "name": "init_signals"
-  },
-  {
-    "name": "init_simple_change"
-  },
-  {
-    "name": "init_skip_hydration"
-  },
-  {
-    "name": "init_standalone_service"
-  },
-  {
-    "name": "init_state"
-  },
-  {
-    "name": "init_static_styling"
-  },
-  {
-    "name": "init_storage"
-  },
-  {
-    "name": "init_stringify"
-  },
-  {
-    "name": "init_stringify_utils"
-  },
-  {
-    "name": "init_style_binding_list"
-  },
-  {
-    "name": "init_style_map_interpolation"
-  },
-  {
-    "name": "init_style_prop_interpolation"
-  },
-  {
-    "name": "init_styling"
-  },
-  {
-    "name": "init_styling2"
-  },
-  {
-    "name": "init_styling_parser"
-  },
-  {
-    "name": "init_template"
-  },
-  {
-    "name": "init_template_ref"
-  },
-  {
-    "name": "init_testability"
-  },
-  {
-    "name": "init_text"
-  },
-  {
-    "name": "init_text_interpolation"
-  },
-  {
-    "name": "init_timeoutProvider"
-  },
-  {
-    "name": "init_timer_scheduler"
-  },
-  {
-    "name": "init_tokens"
-  },
-  {
-    "name": "init_tokens2"
-  },
-  {
-    "name": "init_tokens3"
-  },
-  {
-    "name": "init_tracing"
-  },
-  {
-    "name": "init_transfer_state"
-  },
-  {
-    "name": "init_triggering"
-  },
-  {
-    "name": "init_trusted_types"
-  },
-  {
-    "name": "init_trusted_types_bypass"
-  },
-  {
-    "name": "init_two_way"
-  },
-  {
-    "name": "init_type"
-  },
-  {
-    "name": "init_type_checks"
-  },
-  {
-    "name": "init_types"
-  },
-  {
-    "name": "init_untracked"
-  },
-  {
-    "name": "init_url_sanitizer"
-  },
-  {
-    "name": "init_util"
-  },
-  {
-    "name": "init_util2"
-  },
-  {
-    "name": "init_utils"
-  },
-  {
-    "name": "init_utils2"
-  },
-  {
-    "name": "init_utils3"
-  },
-  {
-    "name": "init_version"
-  },
-  {
-    "name": "init_view"
-  },
-  {
-    "name": "init_view2"
-  },
-  {
-    "name": "init_view_container_ref"
-  },
-  {
-    "name": "init_view_context"
-  },
-  {
-    "name": "init_view_effect_runner"
-  },
-  {
-    "name": "init_view_engine_compatibility_prebound"
-  },
-  {
-    "name": "init_view_manipulation"
-  },
-  {
-    "name": "init_view_ref"
-  },
-  {
-    "name": "init_view_ref2"
-  },
-  {
-    "name": "init_view_traversal_utils"
-  },
-  {
-    "name": "init_view_utils"
-  },
-  {
-    "name": "init_views"
-  },
-  {
-    "name": "init_watch"
-  },
-  {
-    "name": "init_weak_ref"
-  },
-  {
-    "name": "init_write_to_directive_input"
-  },
-  {
-    "name": "init_zone"
-  },
-  {
-    "name": "init_zoneless_scheduling"
-  },
-  {
-    "name": "init_zoneless_scheduling_impl"
-  },
-  {
-    "name": "initializeDirectives"
-  },
-  {
-    "name": "inject"
-  },
-  {
-    "name": "injectArgs"
-  },
-  {
-    "name": "injectDestroyRef"
-  },
-  {
-    "name": "injectElementRef"
-  },
-  {
-    "name": "injectInjectorOnly"
-  },
-  {
-    "name": "injectRootLimpMode"
-  },
-  {
-    "name": "injectableDefOrInjectorDefFactory"
-  },
-  {
-    "name": "insertBloom"
-  },
-  {
-    "name": "instructionState"
-  },
-  {
-    "name": "internalImportProvidersFrom"
-  },
-  {
-    "name": "internalProvideZoneChangeDetection"
-  },
-  {
-    "name": "invokeAllTriggerCleanupFns"
-  },
-  {
-    "name": "invokeDirectivesHostBindings"
-  },
-  {
-    "name": "invokeHostBindingsInCreationMode"
-  },
-  {
-    "name": "invokeTriggerCleanupFns"
-  },
-  {
-    "name": "isAngularZoneProperty"
-  },
-  {
-    "name": "isApplicationBootstrapConfig"
-  },
-  {
-    "name": "isComponentDef"
-  },
-  {
-    "name": "isComponentHost"
-  },
-  {
-    "name": "isContentQueryHost"
-  },
-  {
-    "name": "isCssClassMatching"
-  },
-  {
-    "name": "isCurrentTNodeParent"
-  },
-  {
-    "name": "isDirectiveHost"
-  },
-  {
-    "name": "isEnvironmentProviders"
-  },
-  {
-    "name": "isFunction"
-  },
-  {
-    "name": "isInlineTemplate"
-  },
-  {
-    "name": "isLContainer"
-  },
-  {
-    "name": "isLView"
-  },
-  {
-    "name": "isNodeMatchingSelector"
-  },
-  {
-    "name": "isNodeMatchingSelectorList"
-  },
-  {
-    "name": "isPlatformServer"
-  },
-  {
-    "name": "isPositive"
-  },
-  {
-    "name": "isPromise"
-  },
-  {
-    "name": "isRefreshingViews"
-  },
-  {
-    "name": "isRootView"
-  },
-  {
-    "name": "isSubscription"
-  },
-  {
-    "name": "isTemplateNode"
-  },
-  {
-    "name": "isTypeProvider"
-  },
-  {
-    "name": "isValidStateChange"
-  },
-  {
-    "name": "isValueProvider"
-  },
-  {
-    "name": "lastNodeWasCreated"
-  },
-  {
-    "name": "leaveDI"
-  },
-  {
-    "name": "leaveView"
-  },
-  {
-    "name": "leaveViewLight"
-  },
-  {
-    "name": "lookupTokenUsingModuleInjector"
-  },
-  {
-    "name": "lookupTokenUsingNodeInjector"
-  },
-  {
-    "name": "makeRecord"
-  },
-  {
-    "name": "map"
-  },
-  {
-    "name": "markAncestorsForTraversal"
-  },
-  {
-    "name": "markAsComponentHost"
-  },
-  {
-    "name": "markViewDirty"
-  },
-  {
-    "name": "markViewForRefresh"
-  },
-  {
-    "name": "markedFeatures"
-  },
-  {
-    "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "mergeHostAttribute"
-  },
-  {
-    "name": "mergeHostAttrs"
-  },
-  {
-    "name": "nativeAppendChild"
-  },
-  {
-    "name": "nativeAppendOrInsertBefore"
-  },
-  {
-    "name": "nativeInsertBefore"
-  },
-  {
-    "name": "nextNgElementId"
-  },
-  {
-    "name": "ngOnChangesSetInput"
-  },
-  {
-    "name": "ngZoneInstanceId"
-  },
-  {
-    "name": "nonNull"
-  },
-  {
-    "name": "noop"
-  },
-  {
-    "name": "noop2"
-  },
-  {
-    "name": "notFoundValueOrThrow"
-  },
-  {
-    "name": "observable"
-  },
-  {
-    "name": "onEnter"
-  },
-  {
-    "name": "onLeave"
-  },
-  {
-    "name": "parseAndConvertBindingsForDefinition"
-  },
-  {
-    "name": "performanceMarkFeature"
-  },
-  {
-    "name": "populateDehydratedViewsInLContainer"
-  },
-  {
-    "name": "processInjectorTypesWithProviders"
-  },
-  {
-    "name": "producerMarkClean"
-  },
-  {
-    "name": "producerRemoveLiveConsumerAtIndex"
-  },
-  {
-    "name": "producerUpdateValueVersion"
-  },
-  {
-    "name": "profiler"
-  },
-  {
-    "name": "refreshContentQueries"
-  },
-  {
-    "name": "refreshView"
-  },
-  {
-    "name": "registerPostOrderHooks"
-  },
-  {
-    "name": "rememberChangeHistoryAndInvokeOnChangesHook"
-  },
-  {
-    "name": "remove"
-  },
-  {
-    "name": "removeElements"
-  },
-  {
-    "name": "removeFromArray"
-  },
-  {
-    "name": "removeLViewOnDestroy"
-  },
-  {
-    "name": "renderComponent"
-  },
-  {
-    "name": "renderDeferBlockState"
-  },
-  {
-    "name": "renderDeferStateAfterResourceLoading"
-  },
-  {
-    "name": "renderView"
-  },
-  {
-    "name": "requiresRefreshOrTraversal"
-  },
-  {
-    "name": "resetPreOrderHookFlags"
-  },
-  {
-    "name": "resolveDirectives"
-  },
-  {
-    "name": "resolveForwardRef"
-  },
-  {
-    "name": "retrieveHydrationInfo"
-  },
-  {
-    "name": "runEffectsInView"
-  },
-  {
-    "name": "runInInjectionContext"
-  },
-  {
-    "name": "saveNameToExportMap"
-  },
-  {
-    "name": "saveResolvedLocalsInData"
-  },
-  {
-    "name": "scheduleCallbackWithMicrotask"
-  },
-  {
-    "name": "scheduleCallbackWithRafRace"
-  },
-  {
-    "name": "searchTokensOnInjector"
-  },
-  {
-    "name": "selectIndexInternal"
-  },
-  {
-    "name": "setActiveConsumer"
-  },
-  {
-    "name": "setBindingRootForHostBindings"
-  },
-  {
-    "name": "setCurrentDirectiveIndex"
-  },
-  {
-    "name": "setCurrentInjector"
-  },
-  {
-    "name": "setCurrentQueryIndex"
-  },
-  {
-    "name": "setCurrentTNode"
-  },
-  {
-    "name": "setDirectiveInputsWhichShadowsStyling"
-  },
-  {
-    "name": "setIncludeViewProviders"
-  },
-  {
-    "name": "setInjectImplementation"
-  },
-  {
-    "name": "setInputsForProperty"
-  },
-  {
-    "name": "setInputsFromAttrs"
-  },
-  {
-    "name": "setIsRefreshingViews"
-  },
-  {
-    "name": "setSelectedIndex"
-  },
-  {
-    "name": "setUpAttributes"
-  },
-  {
-    "name": "setupStaticAttributes"
-  },
-  {
-    "name": "shimStylesContent"
-  },
-  {
-    "name": "shouldAttachRegularTrigger"
-  },
-  {
-    "name": "shouldSearchParent"
-  },
-  {
-    "name": "storeLViewOnDestroy"
-  },
-  {
-    "name": "stringify"
-  },
-  {
-    "name": "stringifyCSSSelector"
-  },
-  {
-    "name": "throwProviderNotFoundError"
-  },
-  {
-    "name": "timeoutProvider"
-  },
-  {
-    "name": "toRefArray"
-  },
-  {
-    "name": "trackMovedView"
-  },
-  {
-    "name": "triggerDeferBlock"
-  },
-  {
-    "name": "uniqueIdCounter"
-  },
-  {
-    "name": "unregisterLView"
-  },
-  {
-    "name": "unwrapRNode"
-  },
-  {
-    "name": "updateAncestorTraversalFlagsOnAttach"
-  },
-  {
-    "name": "updateMicroTaskStatus"
-  },
-  {
-    "name": "viewAttachedToChangeDetector"
-  },
-  {
-    "name": "viewShouldHaveReactiveConsumer"
-  },
-  {
-    "name": "walkProviderTree"
-  },
-  {
-    "name": "wasLastNodeCreated"
-  },
-  {
-    "name": "writeDirectClass"
-  },
-  {
-    "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "ɵɵdefer"
-  },
-  {
-    "name": "ɵɵdefineComponent"
-  },
-  {
-    "name": "ɵɵdefineInjectable"
-  },
-  {
-    "name": "ɵɵdirectiveInject"
-  },
-  {
-    "name": "ɵɵelement"
-  },
-  {
-    "name": "ɵɵelementEnd"
-  },
-  {
-    "name": "ɵɵelementStart"
-  },
-  {
-    "name": "ɵɵinject"
-  },
-  {
-    "name": "ɵɵtemplate"
-  },
-  {
-    "name": "ɵɵtext"
-  }
+  "APP_BOOTSTRAP_LISTENER",
+  "APP_ID",
+  "APP_INITIALIZER",
+  "AfterRenderManager",
+  "AnonymousSubject",
+  "AppComponent_DeferError_5_Template",
+  "AppComponent_DeferLoading_3_Template",
+  "AppComponent_DeferPlaceholder_4_Template",
+  "AppComponent_Defer_2_Template",
+  "AppComponent_Defer_6_DepsFn",
+  "ApplicationInitStatus",
+  "ApplicationRef",
+  "BLOOM_BUCKET_BITS",
+  "BLOOM_MASK",
+  "BROWSER_MODULE_PROVIDERS",
+  "BehaviorSubject",
+  "BrowserDomAdapter",
+  "BrowserXhr",
+  "CIRCULAR",
+  "COMPLETE_NOTIFICATION",
+  "COMPONENT_REGEX",
+  "CONTAINER_HEADER_OFFSET",
+  "CSP_NONCE",
+  "CachedInjectorService",
+  "ChainedInjector",
+  "ChangeDetectionScheduler",
+  "ChangeDetectionSchedulerImpl",
+  "ChangeDetectionStrategy",
+  "ComponentFactory",
+  "ComponentFactory2",
+  "ComponentFactoryResolver",
+  "ComponentFactoryResolver2",
+  "ComponentRef",
+  "ComponentRef2",
+  "ConsumerObserver",
+  "DEFAULT_APP_ID",
+  "DEFAULT_LOCALE_ID",
+  "DEFER_BLOCK_CONFIG",
+  "DEFER_BLOCK_ID",
+  "DEFER_BLOCK_STATE",
+  "DEFER_BLOCK_STATE2",
+  "DEHYDRATED_BLOCK_REGISTRY",
+  "DEHYDRATED_VIEWS",
+  "DI_DECORATOR_FLAG",
+  "DOCUMENT",
+  "DOCUMENT2",
+  "DefaultDomRenderer2",
+  "DeferBlockBehavior",
+  "DeferBlockInternalState",
+  "DeferBlockState",
+  "DeferComponent",
+  "DeferDependenciesLoadingState",
+  "DestroyRef",
+  "DomAdapter",
+  "DomEventsPlugin",
+  "DomRendererFactory2",
+  "EMPTY_ARRAY",
+  "EMPTY_OBJ",
+  "EMPTY_OBSERVER",
+  "EMPTY_PAYLOAD",
+  "EMPTY_SUBSCRIPTION",
+  "ENVIRONMENT_INITIALIZER",
+  "EVENT_MANAGER_PLUGINS",
+  "EffectScheduler",
+  "ElementRef",
+  "EmulatedEncapsulationDomRenderer2",
+  "EnvironmentInjector",
+  "EnvironmentNgModuleRefAdapter",
+  "ErrorHandler",
+  "EventEmitter",
+  "EventManager",
+  "EventManagerPlugin",
+  "GenericBrowserDomAdapter",
+  "HYDRATE_TRIGGER_CLEANUP_FNS",
+  "INJECTOR",
+  "INJECTOR_DEF_TYPES",
+  "INJECTOR_SCOPE",
+  "INTERNAL_APPLICATION_ERROR_HANDLER",
+  "INTERNAL_BROWSER_PLATFORM_PROVIDERS",
+  "IS_INCREMENTAL_HYDRATION_ENABLED",
+  "InjectFlags",
+  "InjectionToken",
+  "Injector",
+  "InputFlags",
+  "KeyEventsPlugin",
+  "LContainerFlags",
+  "LOADING_AFTER_SLOT",
+  "LOCALE_ID2",
+  "LifecycleHooksFeature",
+  "MATH_ML_NAMESPACE",
+  "MAXIMUM_REFRESH_RERUNS",
+  "MINIMUM_SLOT",
+  "MODIFIER_KEYS",
+  "MODIFIER_KEY_GETTERS",
+  "MONKEY_PATCH_KEY_NAME",
+  "MOVED_VIEWS",
+  "NAMESPACE_URIS",
+  "NATIVE",
+  "NEW_LINE",
+  "NEXT_DEFER_BLOCK_STATE",
+  "NG_COMP_DEF",
+  "NG_DIR_DEF",
+  "NG_ELEMENT_ID",
+  "NG_ENV_ID",
+  "NG_FACTORY_DEF",
+  "NG_INJECTABLE_DEF",
+  "NG_INJECTOR_DEF",
+  "NG_INJ_DEF",
+  "NG_PIPE_DEF",
+  "NG_PROV_DEF",
+  "NG_TEMPLATE_SELECTOR",
+  "NG_TEMP_TOKEN_PATH",
+  "NG_TOKEN_PATH",
+  "NOT_FOUND",
+  "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR",
+  "NOT_YET",
+  "NO_CHANGE",
+  "NO_NEW_LINE",
+  "NO_PARENT_INJECTOR",
+  "NULL_INJECTOR",
+  "NgModuleRef",
+  "NgZone",
+  "NgZoneChangeDetectionScheduler",
+  "NodeInjector",
+  "NodeInjectorDestroyRef",
+  "NodeInjectorFactory",
+  "NoneEncapsulationDomRenderer",
+  "NoopNgZone",
+  "NullInjector",
+  "ON_COMPLETE_FNS",
+  "ObjectUnsubscribedError",
+  "Observable",
+  "OperatorSubscriber",
+  "PLATFORM_DESTROY_LISTENERS",
+  "PLATFORM_ID",
+  "PLATFORM_INITIALIZER",
+  "PREFETCH_TRIGGER_CLEANUP_FNS",
+  "PRESERVE_HOST_CONTENT",
+  "PRESERVE_HOST_CONTENT_DEFAULT",
+  "PendingTasksInternal",
+  "R3Injector",
+  "REACTIVE_LVIEW_CONSUMER_NODE",
+  "REACTIVE_NODE",
+  "REMOVE_STYLES_ON_COMPONENT_DESTROY",
+  "RendererFactory2",
+  "RendererStyleFlags2",
+  "RuntimeError",
+  "SCHEDULE_IN_ROOT_ZONE",
+  "SIGNAL",
+  "SIMPLE_CHANGES_STORE",
+  "SOURCE",
+  "SSR_BLOCK_STATE",
+  "SSR_UNIQUE_ID",
+  "SVG_NAMESPACE",
+  "SafeSubscriber",
+  "Sanitizer",
+  "ShadowDomRenderer",
+  "SharedStylesHost",
+  "SimpleChange",
+  "StandaloneService",
+  "Subject",
+  "Subscriber",
+  "Subscription",
+  "TEMPORARY_CONSUMER_NODE",
+  "TESTABILITY",
+  "THROW_IF_NOT_FOUND",
+  "TRACKED_LVIEWS",
+  "TRIGGER_CLEANUP_FNS",
+  "TYPE",
+  "TracingAction",
+  "TracingService",
+  "USE_VALUE",
+  "UnsubscriptionError",
+  "VIEW_REFS",
+  "ViewEncapsulation",
+  "ViewRef",
+  "ZONELESS_ENABLED",
+  "ZONELESS_SCHEDULER_DISABLED",
+  "ZoneAwareEffectScheduler",
+  "ZoneStablePendingTask",
+  "_DOM",
+  "_Injector",
+  "_NullComponentFactoryResolver",
+  "__defProp",
+  "__esm",
+  "__forward_ref__",
+  "__getOwnPropNames",
+  "__publicField",
+  "_applyRootElementTransformImpl",
+  "_bind",
+  "_currentInjector",
+  "_getInsertInFrontOfRNodeWithI18n",
+  "_icuContainerIterate",
+  "_injectImplementation",
+  "_isRefreshingViews",
+  "_keyMap",
+  "_locateOrCreateContainerAnchor",
+  "_locateOrCreateElementNode",
+  "_locateOrCreateTextNode",
+  "_platformInjector",
+  "_populateDehydratedViewsInLContainer",
+  "_processI18nInsertBefore",
+  "_retrieveHydrationInfoImpl",
+  "_wasLastNodeCreated",
+  "activeConsumer",
+  "addDepsToRegistry",
+  "addPropertyBinding",
+  "addToEndOfViewTree",
+  "allocExpando",
+  "allocLFrame",
+  "angularZoneInstanceIdProperty",
+  "appendChild",
+  "applyDeferBlockState",
+  "applyDeferBlockStateWithSchedulingImpl",
+  "applyNodes",
+  "applyProjectionRecursive",
+  "applyToElementOrContainer",
+  "applyValueToInputField",
+  "applyView",
+  "arrRemove",
+  "assertConsumerNode",
+  "assertNotDestroyed",
+  "attachPatchData",
+  "baseElement",
+  "bind",
+  "bloomHasToken",
+  "bootstrap",
+  "callHook",
+  "callHookInternal",
+  "callHooks",
+  "captureNodeBindings",
+  "checkStable",
+  "classIndexOf",
+  "cleanUpView",
+  "collectNativeNodes",
+  "collectNativeNodesInLContainer",
+  "computeStaticStyling",
+  "concatStringsWithSpace",
+  "config",
+  "configureViewWithDirective",
+  "consumerBeforeComputation",
+  "consumerDestroy",
+  "consumerIsLive",
+  "consumerPollProducersForChange",
+  "context",
+  "convertToBitFlags",
+  "createContainerAnchorImpl",
+  "createDirectivesInstances",
+  "createElementNode",
+  "createElementRef",
+  "createEnvironmentInjector",
+  "createErrorClass",
+  "createInjector",
+  "createLFrame",
+  "createLView",
+  "createLinkElement",
+  "createNodeInjector",
+  "createNotification",
+  "createStyleElement",
+  "createTView",
+  "declareTemplate",
+  "deepForEach",
+  "deepForEachProvider",
+  "defaultErrorHandler",
+  "defer_component_exports",
+  "destroyLView",
+  "detachMovedView",
+  "detachView",
+  "detachViewFromDOM",
+  "detectChangesInChildComponents",
+  "detectChangesInComponent",
+  "detectChangesInEmbeddedViews",
+  "detectChangesInView",
+  "detectChangesInViewIfAttached",
+  "detectChangesInViewIfRequired",
+  "detectChangesInternal",
+  "diPublicInInjector",
+  "enterDI",
+  "enterView",
+  "epoch",
+  "errorContext",
+  "execFinalizer",
+  "executeCheckHooks",
+  "executeContentQueries",
+  "executeInitAndCheckHooks",
+  "executeTemplate",
+  "executeViewQueryFn",
+  "extractDefListOrFactory",
+  "extractDirectiveDef",
+  "findAttrIndexInNode",
+  "forEachSingleProvider",
+  "forwardRef",
+  "freeConsumers",
+  "generateInitialInputs",
+  "getBeforeNodeForView",
+  "getBindingsEnabled",
+  "getCleanupFnKeyByType",
+  "getClosureSafeProperty",
+  "getComponentDef",
+  "getComponentLViewByIndex",
+  "getConstant",
+  "getCurrentTNode",
+  "getCurrentTNodePlaceholderOk",
+  "getDOM",
+  "getDeclarationTNode",
+  "getDeferBlockDataIndex",
+  "getDirectiveDef",
+  "getFactoryDef",
+  "getFirstLContainer",
+  "getFirstNativeNode",
+  "getInitialLViewFlagsFromDef",
+  "getInjectImplementation",
+  "getInjectableDef",
+  "getInjectorDef",
+  "getInjectorIndex",
+  "getInsertInFrontOfRNodeWithNoI18n",
+  "getLDeferBlockDetails",
+  "getLView",
+  "getLViewParent",
+  "getMinimumDurationForState",
+  "getNativeByTNode",
+  "getNearestLContainer",
+  "getNextLContainer",
+  "getNodeInjectable",
+  "getNullInjector",
+  "getOrCreateComponentTView",
+  "getOrCreateEnvironmentInjector",
+  "getOrCreateInjectable",
+  "getOrCreateNodeInjectorForNode",
+  "getOrCreateTNode",
+  "getOwnDefinition",
+  "getParentInjectorIndex",
+  "getParentInjectorLocation",
+  "getParentInjectorView",
+  "getPipeDef",
+  "getProjectionNodes",
+  "getPromiseCtor",
+  "getSelectedIndex",
+  "getSimpleChangesStore",
+  "getTDeferBlockDetails",
+  "getTNode",
+  "getTNodeFromLView",
+  "getTView",
+  "handleError",
+  "handleStoppedNotification",
+  "handleUnhandledError",
+  "hasApplyArgsData",
+  "hasInSkipHydrationBlockFlag",
+  "hasTagAndTypeMatch",
+  "icuContainerIterate",
+  "identity",
+  "importProvidersFrom",
+  "includeViewProviders",
+  "incrementInitPhaseFlags",
+  "init_BehaviorSubject",
+  "init_NotificationFactories",
+  "init_ObjectUnsubscribedError",
+  "init_Observable",
+  "init_OperatorSubscriber",
+  "init_Subject",
+  "init_Subscriber",
+  "init_Subscription",
+  "init_UnsubscriptionError",
+  "init_action_resolver",
+  "init_advance",
+  "init_after_render_effect",
+  "init_all",
+  "init_annotate",
+  "init_api",
+  "init_api2",
+  "init_api3",
+  "init_api4",
+  "init_api5",
+  "init_api_flags",
+  "init_application_config",
+  "init_application_init",
+  "init_application_module",
+  "init_application_ngmodule_factory_compiler",
+  "init_application_ref",
+  "init_application_tokens",
+  "init_apply_value_input_field",
+  "init_arrRemove",
+  "init_array_utils",
+  "init_assert",
+  "init_assert2",
+  "init_asserts",
+  "init_async_stack_tagging",
+  "init_attach_source_locations",
+  "init_attribute",
+  "init_attribute2",
+  "init_attribute_interpolation",
+  "init_attrs_utils",
+  "init_authoring",
+  "init_bindings",
+  "init_bootstrap",
+  "init_bootstrap_app_scoped",
+  "init_bypass",
+  "init_cache",
+  "init_cached_injector_service",
+  "init_callback_scheduler",
+  "init_chained_injector",
+  "init_change_detection",
+  "init_change_detection2",
+  "init_change_detection3",
+  "init_change_detection_utils",
+  "init_change_detector_ref",
+  "init_char",
+  "init_class_differ",
+  "init_class_map_interpolation",
+  "init_cleanup",
+  "init_cleanup2",
+  "init_closure",
+  "init_coercion",
+  "init_collect_native_nodes",
+  "init_comparison",
+  "init_compiler",
+  "init_compiler_facade",
+  "init_compiler_facade_interface",
+  "init_component",
+  "init_component_factory",
+  "init_component_factory_resolver",
+  "init_component_instance",
+  "init_component_ref",
+  "init_compression",
+  "init_computed",
+  "init_computed2",
+  "init_config",
+  "init_console",
+  "init_constants",
+  "init_container",
+  "init_context",
+  "init_context_discovery",
+  "init_contextual",
+  "init_control_flow",
+  "init_copy_definition_feature",
+  "init_core",
+  "init_core2",
+  "init_core_private_export",
+  "init_core_reactivity_export",
+  "init_core_reactivity_export_internal",
+  "init_core_render3_private_export",
+  "init_createErrorClass",
+  "init_create_application",
+  "init_create_injector",
+  "init_debug_node",
+  "init_decorators",
+  "init_def_getters",
+  "init_default_iterable_differ",
+  "init_default_keyvalue_differ",
+  "init_defer_component",
+  "init_definition",
+  "init_definition_factory",
+  "init_defs",
+  "init_deps_tracker",
+  "init_destroy_ref",
+  "init_di",
+  "init_di2",
+  "init_di3",
+  "init_di4",
+  "init_di5",
+  "init_di_attr",
+  "init_di_setup",
+  "init_directive",
+  "init_directives",
+  "init_discovery",
+  "init_discovery_utils",
+  "init_dispatcher",
+  "init_document",
+  "init_dom",
+  "init_dom_triggers",
+  "init_earlyeventcontract",
+  "init_effect",
+  "init_element",
+  "init_element_container",
+  "init_element_ref",
+  "init_element_validation",
+  "init_empty",
+  "init_environment",
+  "init_environment2",
+  "init_equality",
+  "init_errorContext",
+  "init_error_details_base_url",
+  "init_error_handler",
+  "init_error_handling",
+  "init_errors",
+  "init_errors2",
+  "init_errors3",
+  "init_errors_di",
+  "init_esm",
+  "init_event",
+  "init_event_contract_container",
+  "init_event_contract_defines",
+  "init_event_delegation_utils",
+  "init_event_dispatch",
+  "init_event_dispatcher",
+  "init_event_emitter",
+  "init_event_info",
+  "init_event_replay",
+  "init_event_type",
+  "init_eventcontract",
+  "init_exhaustive_check_no_changes",
+  "init_external_styles_feature",
+  "init_fields",
+  "init_flags",
+  "init_forward_ref",
+  "init_framework_injector_profiler",
+  "init_get_closest_component_name",
+  "init_get_current_view",
+  "init_global",
+  "init_global_utils",
+  "init_graph",
+  "init_hmr",
+  "init_hooks",
+  "init_hooks2",
+  "init_host_attribute_token",
+  "init_host_directives_feature",
+  "init_host_property",
+  "init_host_tag_name_token",
+  "init_html_sanitizer",
+  "init_i18n",
+  "init_i18n2",
+  "init_i18n3",
+  "init_i18n_apply",
+  "init_i18n_debug",
+  "init_i18n_icu_container_visitor",
+  "init_i18n_insert_before_index",
+  "init_i18n_locale_id",
+  "init_i18n_parse",
+  "init_i18n_postprocess",
+  "init_i18n_tree_shaking",
+  "init_i18n_util",
+  "init_identity",
+  "init_idle_scheduler",
+  "init_iframe_attrs_validation",
+  "init_image_performance_warning",
+  "init_inert_body",
+  "init_inherit_definition_feature",
+  "init_initializer_token",
+  "init_inject_switch",
+  "init_injectable",
+  "init_injectable2",
+  "init_injection_token",
+  "init_injector",
+  "init_injector2",
+  "init_injector3",
+  "init_injector_compatibility",
+  "init_injector_discovery_utils",
+  "init_injector_profiler",
+  "init_injector_token",
+  "init_injector_utils",
+  "init_input",
+  "init_input_flags",
+  "init_input_signal",
+  "init_input_signal_node",
+  "init_input_transforms_feature",
+  "init_instructions",
+  "init_interfaces",
+  "init_interfaces2",
+  "init_internal_tokens",
+  "init_interpolation",
+  "init_isFunction",
+  "init_is_dev_mode",
+  "init_iterable",
+  "init_iterable_differs",
+  "init_jit_options",
+  "init_key_code",
+  "init_keyvalue_differs",
+  "init_lang",
+  "init_let_declaration",
+  "init_lift",
+  "init_linked_signal",
+  "init_linker",
+  "init_list_reconciliation",
+  "init_listener",
+  "init_local_compilation",
+  "init_locale_data_api",
+  "init_locale_en",
+  "init_localization",
+  "init_lview_tracking",
+  "init_manager",
+  "init_map",
+  "init_mark_view_dirty",
+  "init_metadata",
+  "init_metadata2",
+  "init_metadata3",
+  "init_metadata_attr",
+  "init_microtask_effect",
+  "init_misc_utils",
+  "init_model",
+  "init_model_signal",
+  "init_module",
+  "init_module_patch",
+  "init_namespace",
+  "init_namespaces",
+  "init_next_context",
+  "init_ng_dev_mode",
+  "init_ng_i18n_closure_mode",
+  "init_ng_jit_mode",
+  "init_ng_module",
+  "init_ng_module_factory",
+  "init_ng_module_factory_loader",
+  "init_ng_module_factory_loader_impl",
+  "init_ng_module_ref",
+  "init_ng_module_registration",
+  "init_ng_onchanges_feature",
+  "init_ng_reflect",
+  "init_ng_server_mode",
+  "init_ng_zone",
+  "init_ng_zone_scheduling",
+  "init_node",
+  "init_node_assert",
+  "init_node_lookup_utils",
+  "init_node_manipulation",
+  "init_node_manipulation_i18n",
+  "init_node_selector_matcher",
+  "init_noop",
+  "init_noop2",
+  "init_null_injector",
+  "init_observable",
+  "init_operators",
+  "init_output",
+  "init_output_emitter_ref",
+  "init_partial",
+  "init_patch",
+  "init_pending_tasks",
+  "init_performance",
+  "init_pipe",
+  "init_pipe2",
+  "init_pipe3",
+  "init_platform",
+  "init_platform_core_providers",
+  "init_platform_destroy_listeners",
+  "init_platform_ref",
+  "init_platform_tokens",
+  "init_profiler",
+  "init_profiler2",
+  "init_projection",
+  "init_property",
+  "init_property2",
+  "init_property3",
+  "init_property_interpolation",
+  "init_provider",
+  "init_provider_collection",
+  "init_provider_flags",
+  "init_providers_feature",
+  "init_public_api",
+  "init_pure_function",
+  "init_queries",
+  "init_queries2",
+  "init_queries_signals",
+  "init_query",
+  "init_query_list",
+  "init_query_reactive",
+  "init_r3_injector",
+  "init_r3_symbols",
+  "init_reactive_lview_consumer",
+  "init_reflection_capabilities",
+  "init_registry",
+  "init_render",
+  "init_render2",
+  "init_render3",
+  "init_rendering",
+  "init_reportUnhandledError",
+  "init_resource",
+  "init_resource2",
+  "init_resource_loading",
+  "init_restriction",
+  "init_root_effect_scheduler",
+  "init_sanitization",
+  "init_sanitizer",
+  "init_schema",
+  "init_scope",
+  "init_scope2",
+  "init_security",
+  "init_set_debug_info",
+  "init_shared",
+  "init_signal",
+  "init_signal2",
+  "init_signal_debug",
+  "init_signals",
+  "init_simple_change",
+  "init_skip_hydration",
+  "init_standalone_service",
+  "init_state",
+  "init_static_styling",
+  "init_storage",
+  "init_stringify",
+  "init_stringify_utils",
+  "init_style_binding_list",
+  "init_style_map_interpolation",
+  "init_style_prop_interpolation",
+  "init_styling",
+  "init_styling2",
+  "init_styling_parser",
+  "init_template",
+  "init_template_ref",
+  "init_testability",
+  "init_text",
+  "init_text_interpolation",
+  "init_timeoutProvider",
+  "init_timer_scheduler",
+  "init_tokens",
+  "init_tokens2",
+  "init_tokens3",
+  "init_tracing",
+  "init_transfer_state",
+  "init_triggering",
+  "init_trusted_types",
+  "init_trusted_types_bypass",
+  "init_two_way",
+  "init_type",
+  "init_type_checks",
+  "init_types",
+  "init_untracked",
+  "init_url_sanitizer",
+  "init_util",
+  "init_util2",
+  "init_utils",
+  "init_utils2",
+  "init_utils3",
+  "init_version",
+  "init_view",
+  "init_view2",
+  "init_view_container_ref",
+  "init_view_context",
+  "init_view_effect_runner",
+  "init_view_engine_compatibility_prebound",
+  "init_view_manipulation",
+  "init_view_ref",
+  "init_view_ref2",
+  "init_view_traversal_utils",
+  "init_view_utils",
+  "init_views",
+  "init_watch",
+  "init_weak_ref",
+  "init_write_to_directive_input",
+  "init_zone",
+  "init_zoneless_scheduling",
+  "init_zoneless_scheduling_impl",
+  "initializeDirectives",
+  "inject",
+  "injectArgs",
+  "injectDestroyRef",
+  "injectElementRef",
+  "injectInjectorOnly",
+  "injectRootLimpMode",
+  "injectableDefOrInjectorDefFactory",
+  "insertBloom",
+  "instructionState",
+  "internalImportProvidersFrom",
+  "internalProvideZoneChangeDetection",
+  "invokeAllTriggerCleanupFns",
+  "invokeDirectivesHostBindings",
+  "invokeHostBindingsInCreationMode",
+  "invokeTriggerCleanupFns",
+  "isAngularZoneProperty",
+  "isApplicationBootstrapConfig",
+  "isComponentDef",
+  "isComponentHost",
+  "isContentQueryHost",
+  "isCssClassMatching",
+  "isCurrentTNodeParent",
+  "isDirectiveHost",
+  "isEnvironmentProviders",
+  "isFunction",
+  "isInlineTemplate",
+  "isLContainer",
+  "isLView",
+  "isNodeMatchingSelector",
+  "isNodeMatchingSelectorList",
+  "isPlatformServer",
+  "isPositive",
+  "isPromise",
+  "isRefreshingViews",
+  "isRootView",
+  "isSubscription",
+  "isTemplateNode",
+  "isTypeProvider",
+  "isValidStateChange",
+  "isValueProvider",
+  "lastNodeWasCreated",
+  "leaveDI",
+  "leaveView",
+  "leaveViewLight",
+  "lookupTokenUsingModuleInjector",
+  "lookupTokenUsingNodeInjector",
+  "makeRecord",
+  "map",
+  "markAncestorsForTraversal",
+  "markAsComponentHost",
+  "markViewDirty",
+  "markViewForRefresh",
+  "markedFeatures",
+  "maybeWrapInNotSelector",
+  "mergeHostAttribute",
+  "mergeHostAttrs",
+  "nativeAppendChild",
+  "nativeAppendOrInsertBefore",
+  "nativeInsertBefore",
+  "nextNgElementId",
+  "ngOnChangesSetInput",
+  "ngZoneInstanceId",
+  "nonNull",
+  "noop",
+  "noop2",
+  "notFoundValueOrThrow",
+  "observable",
+  "onEnter",
+  "onLeave",
+  "parseAndConvertBindingsForDefinition",
+  "performanceMarkFeature",
+  "populateDehydratedViewsInLContainer",
+  "processInjectorTypesWithProviders",
+  "producerMarkClean",
+  "producerRemoveLiveConsumerAtIndex",
+  "producerUpdateValueVersion",
+  "profiler",
+  "refreshContentQueries",
+  "refreshView",
+  "registerPostOrderHooks",
+  "rememberChangeHistoryAndInvokeOnChangesHook",
+  "remove",
+  "removeElements",
+  "removeFromArray",
+  "removeLViewOnDestroy",
+  "renderComponent",
+  "renderDeferBlockState",
+  "renderDeferStateAfterResourceLoading",
+  "renderView",
+  "requiresRefreshOrTraversal",
+  "resetPreOrderHookFlags",
+  "resolveDirectives",
+  "resolveForwardRef",
+  "retrieveHydrationInfo",
+  "runEffectsInView",
+  "runInInjectionContext",
+  "saveNameToExportMap",
+  "saveResolvedLocalsInData",
+  "scheduleCallbackWithMicrotask",
+  "scheduleCallbackWithRafRace",
+  "searchTokensOnInjector",
+  "selectIndexInternal",
+  "setActiveConsumer",
+  "setBindingRootForHostBindings",
+  "setCurrentDirectiveIndex",
+  "setCurrentInjector",
+  "setCurrentQueryIndex",
+  "setCurrentTNode",
+  "setDirectiveInputsWhichShadowsStyling",
+  "setIncludeViewProviders",
+  "setInjectImplementation",
+  "setInputsForProperty",
+  "setInputsFromAttrs",
+  "setIsRefreshingViews",
+  "setSelectedIndex",
+  "setUpAttributes",
+  "setupStaticAttributes",
+  "shimStylesContent",
+  "shouldAttachRegularTrigger",
+  "shouldSearchParent",
+  "storeLViewOnDestroy",
+  "stringify",
+  "stringifyCSSSelector",
+  "throwProviderNotFoundError",
+  "timeoutProvider",
+  "toRefArray",
+  "trackMovedView",
+  "triggerDeferBlock",
+  "uniqueIdCounter",
+  "unregisterLView",
+  "unwrapRNode",
+  "updateAncestorTraversalFlagsOnAttach",
+  "updateMicroTaskStatus",
+  "viewAttachedToChangeDetector",
+  "viewShouldHaveReactiveConsumer",
+  "walkProviderTree",
+  "wasLastNodeCreated",
+  "writeDirectClass",
+  "writeToDirectiveInput",
+  "ɵɵdefer",
+  "ɵɵdefineComponent",
+  "ɵɵdefineInjectable",
+  "ɵɵdirectiveInject",
+  "ɵɵelement",
+  "ɵɵelementEnd",
+  "ɵɵelementStart",
+  "ɵɵinject",
+  "ɵɵtemplate",
+  "ɵɵtext"
 ]

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1,1976 +1,660 @@
 [
-  {
-    "name": "ALLOW_MULTIPLE_PLATFORMS"
-  },
-  {
-    "name": "APP_BOOTSTRAP_LISTENER"
-  },
-  {
-    "name": "APP_ID"
-  },
-  {
-    "name": "APP_INITIALIZER"
-  },
-  {
-    "name": "AbstractControl"
-  },
-  {
-    "name": "AbstractControlDirective"
-  },
-  {
-    "name": "AbstractControlStatus"
-  },
-  {
-    "name": "AbstractFormGroupDirective"
-  },
-  {
-    "name": "AfterRenderManager"
-  },
-  {
-    "name": "AnonymousSubject"
-  },
-  {
-    "name": "ApplicationInitStatus"
-  },
-  {
-    "name": "ApplicationModule"
-  },
-  {
-    "name": "ApplicationRef"
-  },
-  {
-    "name": "BROWSER_MODULE_PROVIDERS"
-  },
-  {
-    "name": "BROWSER_MODULE_PROVIDERS_MARKER"
-  },
-  {
-    "name": "BaseControlValueAccessor"
-  },
-  {
-    "name": "BehaviorSubject"
-  },
-  {
-    "name": "BrowserDomAdapter"
-  },
-  {
-    "name": "BrowserModule"
-  },
-  {
-    "name": "BrowserXhr"
-  },
-  {
-    "name": "BuiltInControlValueAccessor"
-  },
-  {
-    "name": "CALL_SET_DISABLED_STATE"
-  },
-  {
-    "name": "CHECKBOX_VALUE_ACCESSOR"
-  },
-  {
-    "name": "CIRCULAR"
-  },
-  {
-    "name": "COMPLETE_NOTIFICATION"
-  },
-  {
-    "name": "COMPONENT_REGEX"
-  },
-  {
-    "name": "COMPOSITION_BUFFER_MODE"
-  },
-  {
-    "name": "COMPUTED_NODE"
-  },
-  {
-    "name": "COMPUTING"
-  },
-  {
-    "name": "CSP_NONCE"
-  },
-  {
-    "name": "ChainedInjector"
-  },
-  {
-    "name": "ChangeDetectionScheduler"
-  },
-  {
-    "name": "ChangeDetectionSchedulerImpl"
-  },
-  {
-    "name": "ChangeDetectionStrategy"
-  },
-  {
-    "name": "CheckboxControlValueAccessor"
-  },
-  {
-    "name": "CommonModule"
-  },
-  {
-    "name": "ComponentFactory"
-  },
-  {
-    "name": "ComponentFactory2"
-  },
-  {
-    "name": "ComponentFactoryResolver"
-  },
-  {
-    "name": "ComponentFactoryResolver2"
-  },
-  {
-    "name": "ComponentRef"
-  },
-  {
-    "name": "ComponentRef2"
-  },
-  {
-    "name": "ConsumerObserver"
-  },
-  {
-    "name": "ControlContainer"
-  },
-  {
-    "name": "ControlEvent"
-  },
-  {
-    "name": "DEFAULT_APP_ID"
-  },
-  {
-    "name": "DEFAULT_VALUE_ACCESSOR"
-  },
-  {
-    "name": "DOCUMENT"
-  },
-  {
-    "name": "DOCUMENT2"
-  },
-  {
-    "name": "DefaultDomRenderer2"
-  },
-  {
-    "name": "DefaultIterableDiffer"
-  },
-  {
-    "name": "DefaultIterableDifferFactory"
-  },
-  {
-    "name": "DefaultValueAccessor"
-  },
-  {
-    "name": "DestroyRef"
-  },
-  {
-    "name": "DomAdapter"
-  },
-  {
-    "name": "DomEventsPlugin"
-  },
-  {
-    "name": "DomRendererFactory2"
-  },
-  {
-    "name": "EMAIL_REGEXP"
-  },
-  {
-    "name": "EMPTY_ARRAY"
-  },
-  {
-    "name": "EMPTY_OBJ"
-  },
-  {
-    "name": "EMPTY_OBSERVER"
-  },
-  {
-    "name": "EMPTY_PAYLOAD"
-  },
-  {
-    "name": "EMPTY_SUBSCRIPTION"
-  },
-  {
-    "name": "ENVIRONMENT_INITIALIZER"
-  },
-  {
-    "name": "ERRORED"
-  },
-  {
-    "name": "EVENT_MANAGER_PLUGINS"
-  },
-  {
-    "name": "EffectScheduler"
-  },
-  {
-    "name": "ElementRef"
-  },
-  {
-    "name": "EmulatedEncapsulationDomRenderer2"
-  },
-  {
-    "name": "EnvironmentInjector"
-  },
-  {
-    "name": "EnvironmentNgModuleRefAdapter"
-  },
-  {
-    "name": "ErrorHandler"
-  },
-  {
-    "name": "EventEmitter"
-  },
-  {
-    "name": "EventManager"
-  },
-  {
-    "name": "EventManagerPlugin"
-  },
-  {
-    "name": "FormArray"
-  },
-  {
-    "name": "FormArrayName"
-  },
-  {
-    "name": "FormBuilder"
-  },
-  {
-    "name": "FormControl"
-  },
-  {
-    "name": "FormControlName"
-  },
-  {
-    "name": "FormGroup"
-  },
-  {
-    "name": "FormGroupDirective"
-  },
-  {
-    "name": "FormGroupName"
-  },
-  {
-    "name": "FormRecord"
-  },
-  {
-    "name": "FormResetEvent"
-  },
-  {
-    "name": "FormSubmittedEvent"
-  },
-  {
-    "name": "FormsExampleModule"
-  },
-  {
-    "name": "GenericBrowserDomAdapter"
-  },
-  {
-    "name": "INJECTOR"
-  },
-  {
-    "name": "INJECTOR_DEF_TYPES"
-  },
-  {
-    "name": "INJECTOR_SCOPE"
-  },
-  {
-    "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
-  },
-  {
-    "name": "InjectFlags"
-  },
-  {
-    "name": "InjectionToken"
-  },
-  {
-    "name": "Injector"
-  },
-  {
-    "name": "InputFlags"
-  },
-  {
-    "name": "IterableChangeRecord_"
-  },
-  {
-    "name": "IterableDiffers"
-  },
-  {
-    "name": "KeyEventsPlugin"
-  },
-  {
-    "name": "LContainerFlags"
-  },
-  {
-    "name": "LOCALE_ID2"
-  },
-  {
-    "name": "LifecycleHooksFeature"
-  },
-  {
-    "name": "MODIFIER_KEYS"
-  },
-  {
-    "name": "MODIFIER_KEY_GETTERS"
-  },
-  {
-    "name": "NAMESPACE_URIS"
-  },
-  {
-    "name": "NEW_LINE"
-  },
-  {
-    "name": "NG_ASYNC_VALIDATORS"
-  },
-  {
-    "name": "NG_COMP_DEF"
-  },
-  {
-    "name": "NG_DIR_DEF"
-  },
-  {
-    "name": "NG_ELEMENT_ID"
-  },
-  {
-    "name": "NG_ENV_ID"
-  },
-  {
-    "name": "NG_FACTORY_DEF"
-  },
-  {
-    "name": "NG_INJECTABLE_DEF"
-  },
-  {
-    "name": "NG_INJECTOR_DEF"
-  },
-  {
-    "name": "NG_INJ_DEF"
-  },
-  {
-    "name": "NG_MODEL_WITH_FORM_CONTROL_WARNING"
-  },
-  {
-    "name": "NG_MOD_DEF"
-  },
-  {
-    "name": "NG_PIPE_DEF"
-  },
-  {
-    "name": "NG_PROV_DEF"
-  },
-  {
-    "name": "NG_VALIDATORS"
-  },
-  {
-    "name": "NG_VALUE_ACCESSOR"
-  },
-  {
-    "name": "NOT_FOUND"
-  },
-  {
-    "name": "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR"
-  },
-  {
-    "name": "NOT_YET"
-  },
-  {
-    "name": "NO_CHANGE"
-  },
-  {
-    "name": "NULL_INJECTOR"
-  },
-  {
-    "name": "NgControl"
-  },
-  {
-    "name": "NgControlStatus"
-  },
-  {
-    "name": "NgControlStatusGroup"
-  },
-  {
-    "name": "NgForOf"
-  },
-  {
-    "name": "NgForOfContext"
-  },
-  {
-    "name": "NgModuleFactory"
-  },
-  {
-    "name": "NgModuleFactory2"
-  },
-  {
-    "name": "NgModuleRef"
-  },
-  {
-    "name": "NgModuleRef2"
-  },
-  {
-    "name": "NgOnChangesFeatureImpl"
-  },
-  {
-    "name": "NgZone"
-  },
-  {
-    "name": "NgZoneChangeDetectionScheduler"
-  },
-  {
-    "name": "NodeInjector"
-  },
-  {
-    "name": "NodeInjectorDestroyRef"
-  },
-  {
-    "name": "NodeInjectorFactory"
-  },
-  {
-    "name": "NoneEncapsulationDomRenderer"
-  },
-  {
-    "name": "NoopNgZone"
-  },
-  {
-    "name": "NullInjector"
-  },
-  {
-    "name": "ObjectUnsubscribedError"
-  },
-  {
-    "name": "Observable"
-  },
-  {
-    "name": "OperatorSubscriber"
-  },
-  {
-    "name": "Optional"
-  },
-  {
-    "name": "PLATFORM_DESTROY_LISTENERS"
-  },
-  {
-    "name": "PLATFORM_ID"
-  },
-  {
-    "name": "PLATFORM_INITIALIZER"
-  },
-  {
-    "name": "PRESERVE_HOST_CONTENT"
-  },
-  {
-    "name": "PendingTasksInternal"
-  },
-  {
-    "name": "PlatformRef"
-  },
-  {
-    "name": "PristineChangeEvent"
-  },
-  {
-    "name": "R3Injector"
-  },
-  {
-    "name": "R3TemplateRef"
-  },
-  {
-    "name": "R3ViewContainerRef"
-  },
-  {
-    "name": "REACTIVE_LVIEW_CONSUMER_NODE"
-  },
-  {
-    "name": "REACTIVE_NODE"
-  },
-  {
-    "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
-  },
-  {
-    "name": "ReactiveFormsComponent"
-  },
-  {
-    "name": "ReactiveFormsComponent_div_14_Template"
-  },
-  {
-    "name": "ReactiveFormsModule"
-  },
-  {
-    "name": "Renderer2"
-  },
-  {
-    "name": "RendererFactory2"
-  },
-  {
-    "name": "RendererStyleFlags2"
-  },
-  {
-    "name": "RootComponent"
-  },
-  {
-    "name": "RuntimeError"
-  },
-  {
-    "name": "SCHEDULE_IN_ROOT_ZONE"
-  },
-  {
-    "name": "SIGNAL"
-  },
-  {
-    "name": "SIGNAL_NODE"
-  },
-  {
-    "name": "SIMPLE_CHANGES_STORE"
-  },
-  {
-    "name": "SafeSubscriber"
-  },
-  {
-    "name": "SafeValueImpl"
-  },
-  {
-    "name": "Sanitizer"
-  },
-  {
-    "name": "ShadowDomRenderer"
-  },
-  {
-    "name": "SharedStylesHost"
-  },
-  {
-    "name": "SimpleChange"
-  },
-  {
-    "name": "SkipSelf"
-  },
-  {
-    "name": "StandaloneService"
-  },
-  {
-    "name": "StatusChangeEvent"
-  },
-  {
-    "name": "Subject"
-  },
-  {
-    "name": "Subscriber"
-  },
-  {
-    "name": "Subscription"
-  },
-  {
-    "name": "TEMPORARY_CONSUMER_NODE"
-  },
-  {
-    "name": "TESTABILITY"
-  },
-  {
-    "name": "TESTABILITY_GETTER"
-  },
-  {
-    "name": "TESTABILITY_PROVIDERS"
-  },
-  {
-    "name": "THROW_IF_NOT_FOUND"
-  },
-  {
-    "name": "TRACKED_LVIEWS"
-  },
-  {
-    "name": "TemplateRef"
-  },
-  {
-    "name": "Testability"
-  },
-  {
-    "name": "TestabilityRegistry"
-  },
-  {
-    "name": "TouchedChangeEvent"
-  },
-  {
-    "name": "TracingAction"
-  },
-  {
-    "name": "TracingService"
-  },
-  {
-    "name": "UNSET"
-  },
-  {
-    "name": "USE_VALUE"
-  },
-  {
-    "name": "UnsubscriptionError"
-  },
-  {
-    "name": "VE_ViewContainerRef"
-  },
-  {
-    "name": "Validators"
-  },
-  {
-    "name": "ValueChangeEvent"
-  },
-  {
-    "name": "ViewContainerRef"
-  },
-  {
-    "name": "ViewEncapsulation"
-  },
-  {
-    "name": "ViewEngineTemplateRef"
-  },
-  {
-    "name": "ViewRef"
-  },
-  {
-    "name": "ZONELESS_ENABLED"
-  },
-  {
-    "name": "ZONELESS_SCHEDULER_DISABLED"
-  },
-  {
-    "name": "ZoneAwareEffectScheduler"
-  },
-  {
-    "name": "ZoneStablePendingTask"
-  },
-  {
-    "name": "_DOM"
-  },
-  {
-    "name": "_DuplicateItemRecordList"
-  },
-  {
-    "name": "_DuplicateMap"
-  },
-  {
-    "name": "_Injector"
-  },
-  {
-    "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__asyncValues"
-  },
-  {
-    "name": "__await"
-  },
-  {
-    "name": "__defProp"
-  },
-  {
-    "name": "__forward_ref__"
-  },
-  {
-    "name": "__publicField"
-  },
-  {
-    "name": "_applyRootElementTransformImpl"
-  },
-  {
-    "name": "_bind"
-  },
-  {
-    "name": "_currentInjector"
-  },
-  {
-    "name": "_global"
-  },
-  {
-    "name": "_hasInvalidParent"
-  },
-  {
-    "name": "_injectImplementation"
-  },
-  {
-    "name": "_isRefreshingViews"
-  },
-  {
-    "name": "_keyMap"
-  },
-  {
-    "name": "_locateOrCreateAnchorNode"
-  },
-  {
-    "name": "_locateOrCreateContainerAnchor"
-  },
-  {
-    "name": "_locateOrCreateElementNode"
-  },
-  {
-    "name": "_locateOrCreateTextNode"
-  },
-  {
-    "name": "_platformInjector"
-  },
-  {
-    "name": "_testabilityGetter"
-  },
-  {
-    "name": "_wasLastNodeCreated"
-  },
-  {
-    "name": "activeConsumer"
-  },
-  {
-    "name": "addPropertyBinding"
-  },
-  {
-    "name": "addToArray"
-  },
-  {
-    "name": "addToEndOfViewTree"
-  },
-  {
-    "name": "addValidators"
-  },
-  {
-    "name": "allocExpando"
-  },
-  {
-    "name": "allocLFrame"
-  },
-  {
-    "name": "angularZoneInstanceIdProperty"
-  },
-  {
-    "name": "appendChild"
-  },
-  {
-    "name": "applyNodes"
-  },
-  {
-    "name": "applyProjectionRecursive"
-  },
-  {
-    "name": "applyToElementOrContainer"
-  },
-  {
-    "name": "applyValueToInputField"
-  },
-  {
-    "name": "applyView"
-  },
-  {
-    "name": "applyViewChange"
-  },
-  {
-    "name": "arrRemove"
-  },
-  {
-    "name": "assertAllValuesPresent"
-  },
-  {
-    "name": "assertConsumerNode"
-  },
-  {
-    "name": "assertControlPresent"
-  },
-  {
-    "name": "assertNotDestroyed"
-  },
-  {
-    "name": "assertProducerNode"
-  },
-  {
-    "name": "attachInjectFlag"
-  },
-  {
-    "name": "attachPatchData"
-  },
-  {
-    "name": "baseElement"
-  },
-  {
-    "name": "bind"
-  },
-  {
-    "name": "bindingUpdated"
-  },
-  {
-    "name": "bloomHasToken"
-  },
-  {
-    "name": "bootstrap"
-  },
-  {
-    "name": "callHook"
-  },
-  {
-    "name": "callHookInternal"
-  },
-  {
-    "name": "callHooks"
-  },
-  {
-    "name": "captureNodeBindings"
-  },
-  {
-    "name": "checkStable"
-  },
-  {
-    "name": "classIndexOf"
-  },
-  {
-    "name": "cleanUpControl"
-  },
-  {
-    "name": "cleanUpValidators"
-  },
-  {
-    "name": "cleanUpView"
-  },
-  {
-    "name": "collectNativeNodes"
-  },
-  {
-    "name": "collectNativeNodesInLContainer"
-  },
-  {
-    "name": "collectStylingFromDirectives"
-  },
-  {
-    "name": "collectStylingFromTAttrs"
-  },
-  {
-    "name": "compose"
-  },
-  {
-    "name": "composeAsync"
-  },
-  {
-    "name": "composeAsyncValidators"
-  },
-  {
-    "name": "composeValidators"
-  },
-  {
-    "name": "computeStaticStyling"
-  },
-  {
-    "name": "computed"
-  },
-  {
-    "name": "concatStringsWithSpace"
-  },
-  {
-    "name": "config"
-  },
-  {
-    "name": "configureViewWithDirective"
-  },
-  {
-    "name": "consumerAfterComputation"
-  },
-  {
-    "name": "consumerBeforeComputation"
-  },
-  {
-    "name": "consumerDestroy"
-  },
-  {
-    "name": "consumerIsLive"
-  },
-  {
-    "name": "consumerMarkDirty"
-  },
-  {
-    "name": "consumerPollProducersForChange"
-  },
-  {
-    "name": "context"
-  },
-  {
-    "name": "controlNameBinding"
-  },
-  {
-    "name": "controlPath"
-  },
-  {
-    "name": "convertToBitFlags"
-  },
-  {
-    "name": "createDirectivesInstances"
-  },
-  {
-    "name": "createElementNode"
-  },
-  {
-    "name": "createElementRef"
-  },
-  {
-    "name": "createErrorClass"
-  },
-  {
-    "name": "createInjector"
-  },
-  {
-    "name": "createInjectorWithoutInjectorInstances"
-  },
-  {
-    "name": "createInvalidObservableTypeError"
-  },
-  {
-    "name": "createLContainer"
-  },
-  {
-    "name": "createLFrame"
-  },
-  {
-    "name": "createLView"
-  },
-  {
-    "name": "createLinkElement"
-  },
-  {
-    "name": "createNodeInjector"
-  },
-  {
-    "name": "createNotification"
-  },
-  {
-    "name": "createObject"
-  },
-  {
-    "name": "createOperatorSubscriber"
-  },
-  {
-    "name": "createPlatform"
-  },
-  {
-    "name": "createPlatformFactory"
-  },
-  {
-    "name": "createStyleElement"
-  },
-  {
-    "name": "createTView"
-  },
-  {
-    "name": "deepForEach"
-  },
-  {
-    "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultEquals"
-  },
-  {
-    "name": "defaultIterableDiffersFactory"
-  },
-  {
-    "name": "destroyLView"
-  },
-  {
-    "name": "detachMovedView"
-  },
-  {
-    "name": "detachView"
-  },
-  {
-    "name": "detachViewFromDOM"
-  },
-  {
-    "name": "detectChangesInChildComponents"
-  },
-  {
-    "name": "detectChangesInComponent"
-  },
-  {
-    "name": "detectChangesInEmbeddedViews"
-  },
-  {
-    "name": "detectChangesInView"
-  },
-  {
-    "name": "detectChangesInViewIfAttached"
-  },
-  {
-    "name": "detectChangesInViewIfRequired"
-  },
-  {
-    "name": "detectChangesInternal"
-  },
-  {
-    "name": "diPublicInInjector"
-  },
-  {
-    "name": "enterDI"
-  },
-  {
-    "name": "enterView"
-  },
-  {
-    "name": "epoch"
-  },
-  {
-    "name": "errorContext"
-  },
-  {
-    "name": "execFinalizer"
-  },
-  {
-    "name": "executeCheckHooks"
-  },
-  {
-    "name": "executeContentQueries"
-  },
-  {
-    "name": "executeInitAndCheckHooks"
-  },
-  {
-    "name": "executeListenerWithErrorHandling"
-  },
-  {
-    "name": "executeTemplate"
-  },
-  {
-    "name": "executeValidators"
-  },
-  {
-    "name": "executeViewQueryFn"
-  },
-  {
-    "name": "extractDefListOrFactory"
-  },
-  {
-    "name": "extractDirectiveDef"
-  },
-  {
-    "name": "fillProperties"
-  },
-  {
-    "name": "findAttrIndexInNode"
-  },
-  {
-    "name": "findStylingValue"
-  },
-  {
-    "name": "forEachSingleProvider"
-  },
-  {
-    "name": "forkJoin"
-  },
-  {
-    "name": "formArrayNameProvider"
-  },
-  {
-    "name": "formDirectiveProvider"
-  },
-  {
-    "name": "formGroupNameProvider"
-  },
-  {
-    "name": "forwardRef"
-  },
-  {
-    "name": "freeConsumers"
-  },
-  {
-    "name": "fromAsyncIterable"
-  },
-  {
-    "name": "generateInitialInputs"
-  },
-  {
-    "name": "getBeforeNodeForView"
-  },
-  {
-    "name": "getBindingsEnabled"
-  },
-  {
-    "name": "getClosureSafeProperty"
-  },
-  {
-    "name": "getComponentDef"
-  },
-  {
-    "name": "getComponentLViewByIndex"
-  },
-  {
-    "name": "getConstant"
-  },
-  {
-    "name": "getControlAsyncValidators"
-  },
-  {
-    "name": "getControlValidators"
-  },
-  {
-    "name": "getCurrentTNode"
-  },
-  {
-    "name": "getCurrentTNodePlaceholderOk"
-  },
-  {
-    "name": "getDOM"
-  },
-  {
-    "name": "getDeclarationTNode"
-  },
-  {
-    "name": "getDirectiveDef"
-  },
-  {
-    "name": "getFactoryDef"
-  },
-  {
-    "name": "getFactoryOf"
-  },
-  {
-    "name": "getFirstLContainer"
-  },
-  {
-    "name": "getFirstNativeNode"
-  },
-  {
-    "name": "getInitialLViewFlagsFromDef"
-  },
-  {
-    "name": "getInjectImplementation"
-  },
-  {
-    "name": "getInjectableDef"
-  },
-  {
-    "name": "getInjectorDef"
-  },
-  {
-    "name": "getInjectorIndex"
-  },
-  {
-    "name": "getLView"
-  },
-  {
-    "name": "getLViewParent"
-  },
-  {
-    "name": "getNativeByTNode"
-  },
-  {
-    "name": "getNearestLContainer"
-  },
-  {
-    "name": "getNextLContainer"
-  },
-  {
-    "name": "getNgDirectiveDef"
-  },
-  {
-    "name": "getNgZoneOptions"
-  },
-  {
-    "name": "getNodeInjectable"
-  },
-  {
-    "name": "getNullInjector"
-  },
-  {
-    "name": "getOrCreateComponentTView"
-  },
-  {
-    "name": "getOrCreateInjectable"
-  },
-  {
-    "name": "getOrCreateNodeInjectorForNode"
-  },
-  {
-    "name": "getOrCreateTNode"
-  },
-  {
-    "name": "getOrCreateViewRefs"
-  },
-  {
-    "name": "getOwnDefinition"
-  },
-  {
-    "name": "getParentInjectorIndex"
-  },
-  {
-    "name": "getParentInjectorLocation"
-  },
-  {
-    "name": "getParentInjectorView"
-  },
-  {
-    "name": "getPipeDef"
-  },
-  {
-    "name": "getPlatform"
-  },
-  {
-    "name": "getPreviousIndex"
-  },
-  {
-    "name": "getProjectionNodes"
-  },
-  {
-    "name": "getPromiseCtor"
-  },
-  {
-    "name": "getSelectedIndex"
-  },
-  {
-    "name": "getSimpleChangesStore"
-  },
-  {
-    "name": "getSymbolIterator"
-  },
-  {
-    "name": "getTNode"
-  },
-  {
-    "name": "getTNodeFromLView"
-  },
-  {
-    "name": "getTStylingRangeNext"
-  },
-  {
-    "name": "getTStylingRangePrev"
-  },
-  {
-    "name": "getTView"
-  },
-  {
-    "name": "getViewRefs"
-  },
-  {
-    "name": "handleError"
-  },
-  {
-    "name": "handleStoppedNotification"
-  },
-  {
-    "name": "handleUnhandledError"
-  },
-  {
-    "name": "hasApplyArgsData"
-  },
-  {
-    "name": "hasInSkipHydrationBlockFlag"
-  },
-  {
-    "name": "hasParentInjector"
-  },
-  {
-    "name": "hasTagAndTypeMatch"
-  },
-  {
-    "name": "hasValidLength"
-  },
-  {
-    "name": "hasValidator"
-  },
-  {
-    "name": "icuContainerIterate"
-  },
-  {
-    "name": "identity"
-  },
-  {
-    "name": "importProvidersFrom"
-  },
-  {
-    "name": "inNotificationPhase"
-  },
-  {
-    "name": "includeViewProviders"
-  },
-  {
-    "name": "incrementInitPhaseFlags"
-  },
-  {
-    "name": "indexOf"
-  },
-  {
-    "name": "inheritContentQueries"
-  },
-  {
-    "name": "inheritHostBindings"
-  },
-  {
-    "name": "inheritViewQuery"
-  },
-  {
-    "name": "initFeatures"
-  },
-  {
-    "name": "initializeDirectives"
-  },
-  {
-    "name": "inject"
-  },
-  {
-    "name": "injectArgs"
-  },
-  {
-    "name": "injectDestroyRef"
-  },
-  {
-    "name": "injectElementRef"
-  },
-  {
-    "name": "injectInjectorOnly"
-  },
-  {
-    "name": "injectRootLimpMode"
-  },
-  {
-    "name": "injectTemplateRef"
-  },
-  {
-    "name": "injectViewContainerRef"
-  },
-  {
-    "name": "injectableDefOrInjectorDefFactory"
-  },
-  {
-    "name": "innerFrom"
-  },
-  {
-    "name": "insertBloom"
-  },
-  {
-    "name": "instructionState"
-  },
-  {
-    "name": "internalImportProvidersFrom"
-  },
-  {
-    "name": "internalProvideZoneChangeDetection"
-  },
-  {
-    "name": "invokeDirectivesHostBindings"
-  },
-  {
-    "name": "invokeHostBindingsInCreationMode"
-  },
-  {
-    "name": "isAbstractControlOptions"
-  },
-  {
-    "name": "isAngularZoneProperty"
-  },
-  {
-    "name": "isApplicationBootstrapConfig"
-  },
-  {
-    "name": "isArrayLike"
-  },
-  {
-    "name": "isAsyncIterable"
-  },
-  {
-    "name": "isComponentDef"
-  },
-  {
-    "name": "isComponentHost"
-  },
-  {
-    "name": "isConsumerNode"
-  },
-  {
-    "name": "isContentQueryHost"
-  },
-  {
-    "name": "isCssClassMatching"
-  },
-  {
-    "name": "isCurrentTNodeParent"
-  },
-  {
-    "name": "isDirectiveHost"
-  },
-  {
-    "name": "isEmptyInputValue"
-  },
-  {
-    "name": "isEnvironmentProviders"
-  },
-  {
-    "name": "isFormControlState"
-  },
-  {
-    "name": "isForwardRef"
-  },
-  {
-    "name": "isFunction"
-  },
-  {
-    "name": "isInlineTemplate"
-  },
-  {
-    "name": "isInteropObservable"
-  },
-  {
-    "name": "isIterable"
-  },
-  {
-    "name": "isLContainer"
-  },
-  {
-    "name": "isLView"
-  },
-  {
-    "name": "isListLikeIterable"
-  },
-  {
-    "name": "isNodeMatchingSelector"
-  },
-  {
-    "name": "isNodeMatchingSelectorList"
-  },
-  {
-    "name": "isOptionsObj"
-  },
-  {
-    "name": "isPlatformServer"
-  },
-  {
-    "name": "isPositive"
-  },
-  {
-    "name": "isPresent"
-  },
-  {
-    "name": "isPromise"
-  },
-  {
-    "name": "isPromise2"
-  },
-  {
-    "name": "isReadableStreamLike"
-  },
-  {
-    "name": "isRefreshingViews"
-  },
-  {
-    "name": "isRootView"
-  },
-  {
-    "name": "isStylingMatch"
-  },
-  {
-    "name": "isStylingValuePresent"
-  },
-  {
-    "name": "isSubscription"
-  },
-  {
-    "name": "isTemplateNode"
-  },
-  {
-    "name": "isTypeProvider"
-  },
-  {
-    "name": "isValueProvider"
-  },
-  {
-    "name": "iterator"
-  },
-  {
-    "name": "keyValueArrayGet"
-  },
-  {
-    "name": "keyValueArrayIndexOf"
-  },
-  {
-    "name": "keyValueArraySet"
-  },
-  {
-    "name": "lastNodeWasCreated"
-  },
-  {
-    "name": "leaveDI"
-  },
-  {
-    "name": "leaveView"
-  },
-  {
-    "name": "leaveViewLight"
-  },
-  {
-    "name": "lookupTokenUsingModuleInjector"
-  },
-  {
-    "name": "lookupTokenUsingNodeInjector"
-  },
-  {
-    "name": "makeParamDecorator"
-  },
-  {
-    "name": "makeRecord"
-  },
-  {
-    "name": "makeValidatorsArray"
-  },
-  {
-    "name": "map"
-  },
-  {
-    "name": "markAncestorsForTraversal"
-  },
-  {
-    "name": "markAsComponentHost"
-  },
-  {
-    "name": "markDuplicates"
-  },
-  {
-    "name": "markViewDirty"
-  },
-  {
-    "name": "markViewForRefresh"
-  },
-  {
-    "name": "markedFeatures"
-  },
-  {
-    "name": "maybeUnwrapEmpty"
-  },
-  {
-    "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "mergeErrors"
-  },
-  {
-    "name": "mergeHostAttribute"
-  },
-  {
-    "name": "mergeHostAttrs"
-  },
-  {
-    "name": "mergeInputsWithTransforms"
-  },
-  {
-    "name": "mergeValidators"
-  },
-  {
-    "name": "multiFactoryAdd"
-  },
-  {
-    "name": "multiProvidersFactoryResolver"
-  },
-  {
-    "name": "multiResolve"
-  },
-  {
-    "name": "multiViewProvidersFactoryResolver"
-  },
-  {
-    "name": "nativeAppendChild"
-  },
-  {
-    "name": "nativeAppendOrInsertBefore"
-  },
-  {
-    "name": "nativeInsertBefore"
-  },
-  {
-    "name": "nativeParentNode"
-  },
-  {
-    "name": "nextNgElementId"
-  },
-  {
-    "name": "ngOnChangesSetInput"
-  },
-  {
-    "name": "ngZoneInstanceId"
-  },
-  {
-    "name": "noSideEffects"
-  },
-  {
-    "name": "nonNull"
-  },
-  {
-    "name": "noop"
-  },
-  {
-    "name": "noop2"
-  },
-  {
-    "name": "normalizeValidators"
-  },
-  {
-    "name": "notFoundValueOrThrow"
-  },
-  {
-    "name": "nullValidator"
-  },
-  {
-    "name": "observable"
-  },
-  {
-    "name": "onEnter"
-  },
-  {
-    "name": "onLeave"
-  },
-  {
-    "name": "operate"
-  },
-  {
-    "name": "optionsReducer"
-  },
-  {
-    "name": "parseAndConvertBindingsForDefinition"
-  },
-  {
-    "name": "performanceMarkFeature"
-  },
-  {
-    "name": "pickAsyncValidators"
-  },
-  {
-    "name": "pickValidators"
-  },
-  {
-    "name": "platformBrowser"
-  },
-  {
-    "name": "platformCore"
-  },
-  {
-    "name": "processInjectorTypesWithProviders"
-  },
-  {
-    "name": "producerAccessed"
-  },
-  {
-    "name": "producerAddLiveConsumer"
-  },
-  {
-    "name": "producerMarkClean"
-  },
-  {
-    "name": "producerNotifyConsumers"
-  },
-  {
-    "name": "producerRemoveLiveConsumerAtIndex"
-  },
-  {
-    "name": "producerUpdateValueVersion"
-  },
-  {
-    "name": "producerUpdatesAllowed"
-  },
-  {
-    "name": "providerToFactory"
-  },
-  {
-    "name": "readableStreamLikeToAsyncGenerator"
-  },
-  {
-    "name": "refreshContentQueries"
-  },
-  {
-    "name": "refreshView"
-  },
-  {
-    "name": "registerDestroyHooksIfSupported"
-  },
-  {
-    "name": "registerOnValidatorChange"
-  },
-  {
-    "name": "registerPostOrderHooks"
-  },
-  {
-    "name": "rememberChangeHistoryAndInvokeOnChangesHook"
-  },
-  {
-    "name": "remove"
-  },
-  {
-    "name": "removeElements"
-  },
-  {
-    "name": "removeFromArray"
-  },
-  {
-    "name": "removeListItem2"
-  },
-  {
-    "name": "removeValidators"
-  },
-  {
-    "name": "renderComponent"
-  },
-  {
-    "name": "renderView"
-  },
-  {
-    "name": "reportUnhandledError"
-  },
-  {
-    "name": "requiresRefreshOrTraversal"
-  },
-  {
-    "name": "resetPreOrderHookFlags"
-  },
-  {
-    "name": "resolveDirectives"
-  },
-  {
-    "name": "resolveForwardRef"
-  },
-  {
-    "name": "resolveProvider"
-  },
-  {
-    "name": "runEffectsInView"
-  },
-  {
-    "name": "runInInjectionContext"
-  },
-  {
-    "name": "saveNameToExportMap"
-  },
-  {
-    "name": "saveResolvedLocalsInData"
-  },
-  {
-    "name": "scheduleCallbackWithMicrotask"
-  },
-  {
-    "name": "scheduleCallbackWithRafRace"
-  },
-  {
-    "name": "searchTokensOnInjector"
-  },
-  {
-    "name": "selectIndexInternal"
-  },
-  {
-    "name": "setActiveConsumer"
-  },
-  {
-    "name": "setBindingRootForHostBindings"
-  },
-  {
-    "name": "setCurrentDirectiveIndex"
-  },
-  {
-    "name": "setCurrentInjector"
-  },
-  {
-    "name": "setCurrentQueryIndex"
-  },
-  {
-    "name": "setCurrentTNode"
-  },
-  {
-    "name": "setDirectiveInputsWhichShadowsStyling"
-  },
-  {
-    "name": "setDisabledStateDefault"
-  },
-  {
-    "name": "setIncludeViewProviders"
-  },
-  {
-    "name": "setInjectImplementation"
-  },
-  {
-    "name": "setInputsForProperty"
-  },
-  {
-    "name": "setInputsFromAttrs"
-  },
-  {
-    "name": "setIsRefreshingViews"
-  },
-  {
-    "name": "setSelectedIndex"
-  },
-  {
-    "name": "setTStylingRangeNext"
-  },
-  {
-    "name": "setTStylingRangeNextDuplicate"
-  },
-  {
-    "name": "setTStylingRangePrevDuplicate"
-  },
-  {
-    "name": "setUpAttributes"
-  },
-  {
-    "name": "setUpControl"
-  },
-  {
-    "name": "setUpValidators"
-  },
-  {
-    "name": "setupStaticAttributes"
-  },
-  {
-    "name": "shimStylesContent"
-  },
-  {
-    "name": "shouldAddViewToDom"
-  },
-  {
-    "name": "shouldSearchParent"
-  },
-  {
-    "name": "signal"
-  },
-  {
-    "name": "signalAsReadonlyFn"
-  },
-  {
-    "name": "signalSetFn"
-  },
-  {
-    "name": "storeLViewOnDestroy"
-  },
-  {
-    "name": "stringify"
-  },
-  {
-    "name": "stringifyCSSSelector"
-  },
-  {
-    "name": "throwInvalidWriteToSignalError"
-  },
-  {
-    "name": "throwInvalidWriteToSignalErrorFn"
-  },
-  {
-    "name": "throwProviderNotFoundError"
-  },
-  {
-    "name": "timeoutProvider"
-  },
-  {
-    "name": "toObservable"
-  },
-  {
-    "name": "toRefArray"
-  },
-  {
-    "name": "toTStylingRange"
-  },
-  {
-    "name": "trackByIdentity"
-  },
-  {
-    "name": "trackMovedView"
-  },
-  {
-    "name": "uniqueIdCounter"
-  },
-  {
-    "name": "unregisterLView"
-  },
-  {
-    "name": "untracked"
-  },
-  {
-    "name": "unwrapRNode"
-  },
-  {
-    "name": "updateAncestorTraversalFlagsOnAttach"
-  },
-  {
-    "name": "updateControl"
-  },
-  {
-    "name": "updateMicroTaskStatus"
-  },
-  {
-    "name": "viewAttachedToChangeDetector"
-  },
-  {
-    "name": "viewShouldHaveReactiveConsumer"
-  },
-  {
-    "name": "walkProviderTree"
-  },
-  {
-    "name": "wasLastNodeCreated"
-  },
-  {
-    "name": "wrapListener"
-  },
-  {
-    "name": "writeDirectClass"
-  },
-  {
-    "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}"
-  },
-  {
-    "name": "{isArray:isArray2}"
-  },
-  {
-    "name": "{isArray:isArray}"
-  },
-  {
-    "name": "ɵInternalFormsSharedModule"
-  },
-  {
-    "name": "ɵNgNoValidate"
-  },
-  {
-    "name": "ɵɵInheritDefinitionFeature"
-  },
-  {
-    "name": "ɵɵNgOnChangesFeature"
-  },
-  {
-    "name": "ɵɵProvidersFeature"
-  },
-  {
-    "name": "ɵɵclassProp"
-  },
-  {
-    "name": "ɵɵdefineComponent"
-  },
-  {
-    "name": "ɵɵdefineDirective"
-  },
-  {
-    "name": "ɵɵdefineInjectable"
-  },
-  {
-    "name": "ɵɵdefineInjector"
-  },
-  {
-    "name": "ɵɵdefineNgModule"
-  },
-  {
-    "name": "ɵɵdirectiveInject"
-  },
-  {
-    "name": "ɵɵelement"
-  },
-  {
-    "name": "ɵɵelementEnd"
-  },
-  {
-    "name": "ɵɵelementStart"
-  },
-  {
-    "name": "ɵɵgetInheritedFactory"
-  },
-  {
-    "name": "ɵɵinject"
-  },
-  {
-    "name": "ɵɵlistener"
-  },
-  {
-    "name": "ɵɵproperty"
-  },
-  {
-    "name": "ɵɵtemplate"
-  },
-  {
-    "name": "ɵɵtext"
-  }
+  "ALLOW_MULTIPLE_PLATFORMS",
+  "APP_BOOTSTRAP_LISTENER",
+  "APP_ID",
+  "APP_INITIALIZER",
+  "AbstractControl",
+  "AbstractControlDirective",
+  "AbstractControlStatus",
+  "AbstractFormGroupDirective",
+  "AfterRenderManager",
+  "AnonymousSubject",
+  "ApplicationInitStatus",
+  "ApplicationModule",
+  "ApplicationRef",
+  "BROWSER_MODULE_PROVIDERS",
+  "BROWSER_MODULE_PROVIDERS_MARKER",
+  "BaseControlValueAccessor",
+  "BehaviorSubject",
+  "BrowserDomAdapter",
+  "BrowserModule",
+  "BrowserXhr",
+  "BuiltInControlValueAccessor",
+  "CALL_SET_DISABLED_STATE",
+  "CHECKBOX_VALUE_ACCESSOR",
+  "CIRCULAR",
+  "COMPLETE_NOTIFICATION",
+  "COMPONENT_REGEX",
+  "COMPOSITION_BUFFER_MODE",
+  "COMPUTED_NODE",
+  "COMPUTING",
+  "CSP_NONCE",
+  "ChainedInjector",
+  "ChangeDetectionScheduler",
+  "ChangeDetectionSchedulerImpl",
+  "ChangeDetectionStrategy",
+  "CheckboxControlValueAccessor",
+  "CommonModule",
+  "ComponentFactory",
+  "ComponentFactory2",
+  "ComponentFactoryResolver",
+  "ComponentFactoryResolver2",
+  "ComponentRef",
+  "ComponentRef2",
+  "ConsumerObserver",
+  "ControlContainer",
+  "ControlEvent",
+  "DEFAULT_APP_ID",
+  "DEFAULT_VALUE_ACCESSOR",
+  "DOCUMENT",
+  "DOCUMENT2",
+  "DefaultDomRenderer2",
+  "DefaultIterableDiffer",
+  "DefaultIterableDifferFactory",
+  "DefaultValueAccessor",
+  "DestroyRef",
+  "DomAdapter",
+  "DomEventsPlugin",
+  "DomRendererFactory2",
+  "EMAIL_REGEXP",
+  "EMPTY_ARRAY",
+  "EMPTY_OBJ",
+  "EMPTY_OBSERVER",
+  "EMPTY_PAYLOAD",
+  "EMPTY_SUBSCRIPTION",
+  "ENVIRONMENT_INITIALIZER",
+  "ERRORED",
+  "EVENT_MANAGER_PLUGINS",
+  "EffectScheduler",
+  "ElementRef",
+  "EmulatedEncapsulationDomRenderer2",
+  "EnvironmentInjector",
+  "EnvironmentNgModuleRefAdapter",
+  "ErrorHandler",
+  "EventEmitter",
+  "EventManager",
+  "EventManagerPlugin",
+  "FormArray",
+  "FormArrayName",
+  "FormBuilder",
+  "FormControl",
+  "FormControlName",
+  "FormGroup",
+  "FormGroupDirective",
+  "FormGroupName",
+  "FormRecord",
+  "FormResetEvent",
+  "FormSubmittedEvent",
+  "FormsExampleModule",
+  "GenericBrowserDomAdapter",
+  "INJECTOR",
+  "INJECTOR_DEF_TYPES",
+  "INJECTOR_SCOPE",
+  "INTERNAL_APPLICATION_ERROR_HANDLER",
+  "InjectFlags",
+  "InjectionToken",
+  "Injector",
+  "InputFlags",
+  "IterableChangeRecord_",
+  "IterableDiffers",
+  "KeyEventsPlugin",
+  "LContainerFlags",
+  "LOCALE_ID2",
+  "LifecycleHooksFeature",
+  "MODIFIER_KEYS",
+  "MODIFIER_KEY_GETTERS",
+  "NAMESPACE_URIS",
+  "NEW_LINE",
+  "NG_ASYNC_VALIDATORS",
+  "NG_COMP_DEF",
+  "NG_DIR_DEF",
+  "NG_ELEMENT_ID",
+  "NG_ENV_ID",
+  "NG_FACTORY_DEF",
+  "NG_INJECTABLE_DEF",
+  "NG_INJECTOR_DEF",
+  "NG_INJ_DEF",
+  "NG_MODEL_WITH_FORM_CONTROL_WARNING",
+  "NG_MOD_DEF",
+  "NG_PIPE_DEF",
+  "NG_PROV_DEF",
+  "NG_VALIDATORS",
+  "NG_VALUE_ACCESSOR",
+  "NOT_FOUND",
+  "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR",
+  "NOT_YET",
+  "NO_CHANGE",
+  "NULL_INJECTOR",
+  "NgControl",
+  "NgControlStatus",
+  "NgControlStatusGroup",
+  "NgForOf",
+  "NgForOfContext",
+  "NgModuleFactory",
+  "NgModuleFactory2",
+  "NgModuleRef",
+  "NgModuleRef2",
+  "NgOnChangesFeatureImpl",
+  "NgZone",
+  "NgZoneChangeDetectionScheduler",
+  "NodeInjector",
+  "NodeInjectorDestroyRef",
+  "NodeInjectorFactory",
+  "NoneEncapsulationDomRenderer",
+  "NoopNgZone",
+  "NullInjector",
+  "ObjectUnsubscribedError",
+  "Observable",
+  "OperatorSubscriber",
+  "Optional",
+  "PLATFORM_DESTROY_LISTENERS",
+  "PLATFORM_ID",
+  "PLATFORM_INITIALIZER",
+  "PRESERVE_HOST_CONTENT",
+  "PendingTasksInternal",
+  "PlatformRef",
+  "PristineChangeEvent",
+  "R3Injector",
+  "R3TemplateRef",
+  "R3ViewContainerRef",
+  "REACTIVE_LVIEW_CONSUMER_NODE",
+  "REACTIVE_NODE",
+  "REMOVE_STYLES_ON_COMPONENT_DESTROY",
+  "ReactiveFormsComponent",
+  "ReactiveFormsComponent_div_14_Template",
+  "ReactiveFormsModule",
+  "Renderer2",
+  "RendererFactory2",
+  "RendererStyleFlags2",
+  "RootComponent",
+  "RuntimeError",
+  "SCHEDULE_IN_ROOT_ZONE",
+  "SIGNAL",
+  "SIGNAL_NODE",
+  "SIMPLE_CHANGES_STORE",
+  "SafeSubscriber",
+  "SafeValueImpl",
+  "Sanitizer",
+  "ShadowDomRenderer",
+  "SharedStylesHost",
+  "SimpleChange",
+  "SkipSelf",
+  "StandaloneService",
+  "StatusChangeEvent",
+  "Subject",
+  "Subscriber",
+  "Subscription",
+  "TEMPORARY_CONSUMER_NODE",
+  "TESTABILITY",
+  "TESTABILITY_GETTER",
+  "TESTABILITY_PROVIDERS",
+  "THROW_IF_NOT_FOUND",
+  "TRACKED_LVIEWS",
+  "TemplateRef",
+  "Testability",
+  "TestabilityRegistry",
+  "TouchedChangeEvent",
+  "TracingAction",
+  "TracingService",
+  "UNSET",
+  "USE_VALUE",
+  "UnsubscriptionError",
+  "VE_ViewContainerRef",
+  "Validators",
+  "ValueChangeEvent",
+  "ViewContainerRef",
+  "ViewEncapsulation",
+  "ViewEngineTemplateRef",
+  "ViewRef",
+  "ZONELESS_ENABLED",
+  "ZONELESS_SCHEDULER_DISABLED",
+  "ZoneAwareEffectScheduler",
+  "ZoneStablePendingTask",
+  "_DOM",
+  "_DuplicateItemRecordList",
+  "_DuplicateMap",
+  "_Injector",
+  "_NullComponentFactoryResolver",
+  "__asyncValues",
+  "__await",
+  "__defProp",
+  "__forward_ref__",
+  "__publicField",
+  "_applyRootElementTransformImpl",
+  "_bind",
+  "_currentInjector",
+  "_global",
+  "_hasInvalidParent",
+  "_injectImplementation",
+  "_isRefreshingViews",
+  "_keyMap",
+  "_locateOrCreateAnchorNode",
+  "_locateOrCreateContainerAnchor",
+  "_locateOrCreateElementNode",
+  "_locateOrCreateTextNode",
+  "_platformInjector",
+  "_testabilityGetter",
+  "_wasLastNodeCreated",
+  "activeConsumer",
+  "addPropertyBinding",
+  "addToArray",
+  "addToEndOfViewTree",
+  "addValidators",
+  "allocExpando",
+  "allocLFrame",
+  "angularZoneInstanceIdProperty",
+  "appendChild",
+  "applyNodes",
+  "applyProjectionRecursive",
+  "applyToElementOrContainer",
+  "applyValueToInputField",
+  "applyView",
+  "applyViewChange",
+  "arrRemove",
+  "assertAllValuesPresent",
+  "assertConsumerNode",
+  "assertControlPresent",
+  "assertNotDestroyed",
+  "assertProducerNode",
+  "attachInjectFlag",
+  "attachPatchData",
+  "baseElement",
+  "bind",
+  "bindingUpdated",
+  "bloomHasToken",
+  "bootstrap",
+  "callHook",
+  "callHookInternal",
+  "callHooks",
+  "captureNodeBindings",
+  "checkStable",
+  "classIndexOf",
+  "cleanUpControl",
+  "cleanUpValidators",
+  "cleanUpView",
+  "collectNativeNodes",
+  "collectNativeNodesInLContainer",
+  "collectStylingFromDirectives",
+  "collectStylingFromTAttrs",
+  "compose",
+  "composeAsync",
+  "composeAsyncValidators",
+  "composeValidators",
+  "computeStaticStyling",
+  "computed",
+  "concatStringsWithSpace",
+  "config",
+  "configureViewWithDirective",
+  "consumerAfterComputation",
+  "consumerBeforeComputation",
+  "consumerDestroy",
+  "consumerIsLive",
+  "consumerMarkDirty",
+  "consumerPollProducersForChange",
+  "context",
+  "controlNameBinding",
+  "controlPath",
+  "convertToBitFlags",
+  "createDirectivesInstances",
+  "createElementNode",
+  "createElementRef",
+  "createErrorClass",
+  "createInjector",
+  "createInjectorWithoutInjectorInstances",
+  "createInvalidObservableTypeError",
+  "createLContainer",
+  "createLFrame",
+  "createLView",
+  "createLinkElement",
+  "createNodeInjector",
+  "createNotification",
+  "createObject",
+  "createOperatorSubscriber",
+  "createPlatform",
+  "createPlatformFactory",
+  "createStyleElement",
+  "createTView",
+  "deepForEach",
+  "deepForEachProvider",
+  "defaultEquals",
+  "defaultIterableDiffersFactory",
+  "destroyLView",
+  "detachMovedView",
+  "detachView",
+  "detachViewFromDOM",
+  "detectChangesInChildComponents",
+  "detectChangesInComponent",
+  "detectChangesInEmbeddedViews",
+  "detectChangesInView",
+  "detectChangesInViewIfAttached",
+  "detectChangesInViewIfRequired",
+  "detectChangesInternal",
+  "diPublicInInjector",
+  "enterDI",
+  "enterView",
+  "epoch",
+  "errorContext",
+  "execFinalizer",
+  "executeCheckHooks",
+  "executeContentQueries",
+  "executeInitAndCheckHooks",
+  "executeListenerWithErrorHandling",
+  "executeTemplate",
+  "executeValidators",
+  "executeViewQueryFn",
+  "extractDefListOrFactory",
+  "extractDirectiveDef",
+  "fillProperties",
+  "findAttrIndexInNode",
+  "findStylingValue",
+  "forEachSingleProvider",
+  "forkJoin",
+  "formArrayNameProvider",
+  "formDirectiveProvider",
+  "formGroupNameProvider",
+  "forwardRef",
+  "freeConsumers",
+  "fromAsyncIterable",
+  "generateInitialInputs",
+  "getBeforeNodeForView",
+  "getBindingsEnabled",
+  "getClosureSafeProperty",
+  "getComponentDef",
+  "getComponentLViewByIndex",
+  "getConstant",
+  "getControlAsyncValidators",
+  "getControlValidators",
+  "getCurrentTNode",
+  "getCurrentTNodePlaceholderOk",
+  "getDOM",
+  "getDeclarationTNode",
+  "getDirectiveDef",
+  "getFactoryDef",
+  "getFactoryOf",
+  "getFirstLContainer",
+  "getFirstNativeNode",
+  "getInitialLViewFlagsFromDef",
+  "getInjectImplementation",
+  "getInjectableDef",
+  "getInjectorDef",
+  "getInjectorIndex",
+  "getLView",
+  "getLViewParent",
+  "getNativeByTNode",
+  "getNearestLContainer",
+  "getNextLContainer",
+  "getNgDirectiveDef",
+  "getNgZoneOptions",
+  "getNodeInjectable",
+  "getNullInjector",
+  "getOrCreateComponentTView",
+  "getOrCreateInjectable",
+  "getOrCreateNodeInjectorForNode",
+  "getOrCreateTNode",
+  "getOrCreateViewRefs",
+  "getOwnDefinition",
+  "getParentInjectorIndex",
+  "getParentInjectorLocation",
+  "getParentInjectorView",
+  "getPipeDef",
+  "getPlatform",
+  "getPreviousIndex",
+  "getProjectionNodes",
+  "getPromiseCtor",
+  "getSelectedIndex",
+  "getSimpleChangesStore",
+  "getSymbolIterator",
+  "getTNode",
+  "getTNodeFromLView",
+  "getTStylingRangeNext",
+  "getTStylingRangePrev",
+  "getTView",
+  "getViewRefs",
+  "handleError",
+  "handleStoppedNotification",
+  "handleUnhandledError",
+  "hasApplyArgsData",
+  "hasInSkipHydrationBlockFlag",
+  "hasParentInjector",
+  "hasTagAndTypeMatch",
+  "hasValidLength",
+  "hasValidator",
+  "icuContainerIterate",
+  "identity",
+  "importProvidersFrom",
+  "inNotificationPhase",
+  "includeViewProviders",
+  "incrementInitPhaseFlags",
+  "indexOf",
+  "inheritContentQueries",
+  "inheritHostBindings",
+  "inheritViewQuery",
+  "initFeatures",
+  "initializeDirectives",
+  "inject",
+  "injectArgs",
+  "injectDestroyRef",
+  "injectElementRef",
+  "injectInjectorOnly",
+  "injectRootLimpMode",
+  "injectTemplateRef",
+  "injectViewContainerRef",
+  "injectableDefOrInjectorDefFactory",
+  "innerFrom",
+  "insertBloom",
+  "instructionState",
+  "internalImportProvidersFrom",
+  "internalProvideZoneChangeDetection",
+  "invokeDirectivesHostBindings",
+  "invokeHostBindingsInCreationMode",
+  "isAbstractControlOptions",
+  "isAngularZoneProperty",
+  "isApplicationBootstrapConfig",
+  "isArrayLike",
+  "isAsyncIterable",
+  "isComponentDef",
+  "isComponentHost",
+  "isConsumerNode",
+  "isContentQueryHost",
+  "isCssClassMatching",
+  "isCurrentTNodeParent",
+  "isDirectiveHost",
+  "isEmptyInputValue",
+  "isEnvironmentProviders",
+  "isFormControlState",
+  "isForwardRef",
+  "isFunction",
+  "isInlineTemplate",
+  "isInteropObservable",
+  "isIterable",
+  "isLContainer",
+  "isLView",
+  "isListLikeIterable",
+  "isNodeMatchingSelector",
+  "isNodeMatchingSelectorList",
+  "isOptionsObj",
+  "isPlatformServer",
+  "isPositive",
+  "isPresent",
+  "isPromise",
+  "isPromise2",
+  "isReadableStreamLike",
+  "isRefreshingViews",
+  "isRootView",
+  "isStylingMatch",
+  "isStylingValuePresent",
+  "isSubscription",
+  "isTemplateNode",
+  "isTypeProvider",
+  "isValueProvider",
+  "iterator",
+  "keyValueArrayGet",
+  "keyValueArrayIndexOf",
+  "keyValueArraySet",
+  "lastNodeWasCreated",
+  "leaveDI",
+  "leaveView",
+  "leaveViewLight",
+  "lookupTokenUsingModuleInjector",
+  "lookupTokenUsingNodeInjector",
+  "makeParamDecorator",
+  "makeRecord",
+  "makeValidatorsArray",
+  "map",
+  "markAncestorsForTraversal",
+  "markAsComponentHost",
+  "markDuplicates",
+  "markViewDirty",
+  "markViewForRefresh",
+  "markedFeatures",
+  "maybeUnwrapEmpty",
+  "maybeWrapInNotSelector",
+  "mergeErrors",
+  "mergeHostAttribute",
+  "mergeHostAttrs",
+  "mergeInputsWithTransforms",
+  "mergeValidators",
+  "multiFactoryAdd",
+  "multiProvidersFactoryResolver",
+  "multiResolve",
+  "multiViewProvidersFactoryResolver",
+  "nativeAppendChild",
+  "nativeAppendOrInsertBefore",
+  "nativeInsertBefore",
+  "nativeParentNode",
+  "nextNgElementId",
+  "ngOnChangesSetInput",
+  "ngZoneInstanceId",
+  "noSideEffects",
+  "nonNull",
+  "noop",
+  "noop2",
+  "normalizeValidators",
+  "notFoundValueOrThrow",
+  "nullValidator",
+  "observable",
+  "onEnter",
+  "onLeave",
+  "operate",
+  "optionsReducer",
+  "parseAndConvertBindingsForDefinition",
+  "performanceMarkFeature",
+  "pickAsyncValidators",
+  "pickValidators",
+  "platformBrowser",
+  "platformCore",
+  "processInjectorTypesWithProviders",
+  "producerAccessed",
+  "producerAddLiveConsumer",
+  "producerMarkClean",
+  "producerNotifyConsumers",
+  "producerRemoveLiveConsumerAtIndex",
+  "producerUpdateValueVersion",
+  "producerUpdatesAllowed",
+  "providerToFactory",
+  "readableStreamLikeToAsyncGenerator",
+  "refreshContentQueries",
+  "refreshView",
+  "registerDestroyHooksIfSupported",
+  "registerOnValidatorChange",
+  "registerPostOrderHooks",
+  "rememberChangeHistoryAndInvokeOnChangesHook",
+  "remove",
+  "removeElements",
+  "removeFromArray",
+  "removeListItem2",
+  "removeValidators",
+  "renderComponent",
+  "renderView",
+  "reportUnhandledError",
+  "requiresRefreshOrTraversal",
+  "resetPreOrderHookFlags",
+  "resolveDirectives",
+  "resolveForwardRef",
+  "resolveProvider",
+  "runEffectsInView",
+  "runInInjectionContext",
+  "saveNameToExportMap",
+  "saveResolvedLocalsInData",
+  "scheduleCallbackWithMicrotask",
+  "scheduleCallbackWithRafRace",
+  "searchTokensOnInjector",
+  "selectIndexInternal",
+  "setActiveConsumer",
+  "setBindingRootForHostBindings",
+  "setCurrentDirectiveIndex",
+  "setCurrentInjector",
+  "setCurrentQueryIndex",
+  "setCurrentTNode",
+  "setDirectiveInputsWhichShadowsStyling",
+  "setDisabledStateDefault",
+  "setIncludeViewProviders",
+  "setInjectImplementation",
+  "setInputsForProperty",
+  "setInputsFromAttrs",
+  "setIsRefreshingViews",
+  "setSelectedIndex",
+  "setTStylingRangeNext",
+  "setTStylingRangeNextDuplicate",
+  "setTStylingRangePrevDuplicate",
+  "setUpAttributes",
+  "setUpControl",
+  "setUpValidators",
+  "setupStaticAttributes",
+  "shimStylesContent",
+  "shouldAddViewToDom",
+  "shouldSearchParent",
+  "signal",
+  "signalAsReadonlyFn",
+  "signalSetFn",
+  "storeLViewOnDestroy",
+  "stringify",
+  "stringifyCSSSelector",
+  "throwInvalidWriteToSignalError",
+  "throwInvalidWriteToSignalErrorFn",
+  "throwProviderNotFoundError",
+  "timeoutProvider",
+  "toObservable",
+  "toRefArray",
+  "toTStylingRange",
+  "trackByIdentity",
+  "trackMovedView",
+  "uniqueIdCounter",
+  "unregisterLView",
+  "untracked",
+  "unwrapRNode",
+  "updateAncestorTraversalFlagsOnAttach",
+  "updateControl",
+  "updateMicroTaskStatus",
+  "viewAttachedToChangeDetector",
+  "viewShouldHaveReactiveConsumer",
+  "walkProviderTree",
+  "wasLastNodeCreated",
+  "wrapListener",
+  "writeDirectClass",
+  "writeToDirectiveInput",
+  "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}",
+  "{isArray:isArray2}",
+  "{isArray:isArray}",
+  "ɵInternalFormsSharedModule",
+  "ɵNgNoValidate",
+  "ɵɵInheritDefinitionFeature",
+  "ɵɵNgOnChangesFeature",
+  "ɵɵProvidersFeature",
+  "ɵɵclassProp",
+  "ɵɵdefineComponent",
+  "ɵɵdefineDirective",
+  "ɵɵdefineInjectable",
+  "ɵɵdefineInjector",
+  "ɵɵdefineNgModule",
+  "ɵɵdirectiveInject",
+  "ɵɵelement",
+  "ɵɵelementEnd",
+  "ɵɵelementStart",
+  "ɵɵgetInheritedFactory",
+  "ɵɵinject",
+  "ɵɵlistener",
+  "ɵɵproperty",
+  "ɵɵtemplate",
+  "ɵɵtext"
 ]

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1,1970 +1,658 @@
 [
-  {
-    "name": "ALLOW_MULTIPLE_PLATFORMS"
-  },
-  {
-    "name": "APP_BOOTSTRAP_LISTENER"
-  },
-  {
-    "name": "APP_ID"
-  },
-  {
-    "name": "APP_INITIALIZER"
-  },
-  {
-    "name": "AbstractControl"
-  },
-  {
-    "name": "AbstractControlDirective"
-  },
-  {
-    "name": "AbstractControlStatus"
-  },
-  {
-    "name": "AbstractFormGroupDirective"
-  },
-  {
-    "name": "AbstractValidatorDirective"
-  },
-  {
-    "name": "AfterRenderManager"
-  },
-  {
-    "name": "AnonymousSubject"
-  },
-  {
-    "name": "ApplicationInitStatus"
-  },
-  {
-    "name": "ApplicationModule"
-  },
-  {
-    "name": "ApplicationRef"
-  },
-  {
-    "name": "BROWSER_MODULE_PROVIDERS"
-  },
-  {
-    "name": "BROWSER_MODULE_PROVIDERS_MARKER"
-  },
-  {
-    "name": "BaseControlValueAccessor"
-  },
-  {
-    "name": "BehaviorSubject"
-  },
-  {
-    "name": "BrowserDomAdapter"
-  },
-  {
-    "name": "BrowserModule"
-  },
-  {
-    "name": "BrowserXhr"
-  },
-  {
-    "name": "BuiltInControlValueAccessor"
-  },
-  {
-    "name": "CALL_SET_DISABLED_STATE"
-  },
-  {
-    "name": "CHECKBOX_VALUE_ACCESSOR"
-  },
-  {
-    "name": "CIRCULAR"
-  },
-  {
-    "name": "COMPLETE_NOTIFICATION"
-  },
-  {
-    "name": "COMPONENT_REGEX"
-  },
-  {
-    "name": "COMPOSITION_BUFFER_MODE"
-  },
-  {
-    "name": "COMPUTED_NODE"
-  },
-  {
-    "name": "COMPUTING"
-  },
-  {
-    "name": "CSP_NONCE"
-  },
-  {
-    "name": "ChainedInjector"
-  },
-  {
-    "name": "ChangeDetectionScheduler"
-  },
-  {
-    "name": "ChangeDetectionSchedulerImpl"
-  },
-  {
-    "name": "ChangeDetectionStrategy"
-  },
-  {
-    "name": "ChangeDetectorRef"
-  },
-  {
-    "name": "CheckboxControlValueAccessor"
-  },
-  {
-    "name": "CommonModule"
-  },
-  {
-    "name": "ComponentFactory"
-  },
-  {
-    "name": "ComponentFactory2"
-  },
-  {
-    "name": "ComponentFactoryResolver"
-  },
-  {
-    "name": "ComponentFactoryResolver2"
-  },
-  {
-    "name": "ComponentRef"
-  },
-  {
-    "name": "ComponentRef2"
-  },
-  {
-    "name": "ConsumerObserver"
-  },
-  {
-    "name": "ControlContainer"
-  },
-  {
-    "name": "ControlEvent"
-  },
-  {
-    "name": "DEFAULT_APP_ID"
-  },
-  {
-    "name": "DEFAULT_VALUE_ACCESSOR"
-  },
-  {
-    "name": "DOCUMENT"
-  },
-  {
-    "name": "DOCUMENT2"
-  },
-  {
-    "name": "DefaultDomRenderer2"
-  },
-  {
-    "name": "DefaultIterableDiffer"
-  },
-  {
-    "name": "DefaultIterableDifferFactory"
-  },
-  {
-    "name": "DefaultValueAccessor"
-  },
-  {
-    "name": "DestroyRef"
-  },
-  {
-    "name": "DomAdapter"
-  },
-  {
-    "name": "DomEventsPlugin"
-  },
-  {
-    "name": "DomRendererFactory2"
-  },
-  {
-    "name": "EMPTY_ARRAY"
-  },
-  {
-    "name": "EMPTY_OBJ"
-  },
-  {
-    "name": "EMPTY_OBSERVER"
-  },
-  {
-    "name": "EMPTY_PAYLOAD"
-  },
-  {
-    "name": "EMPTY_SUBSCRIPTION"
-  },
-  {
-    "name": "ENVIRONMENT_INITIALIZER"
-  },
-  {
-    "name": "ERRORED"
-  },
-  {
-    "name": "EVENT_MANAGER_PLUGINS"
-  },
-  {
-    "name": "EffectScheduler"
-  },
-  {
-    "name": "ElementRef"
-  },
-  {
-    "name": "EmulatedEncapsulationDomRenderer2"
-  },
-  {
-    "name": "EnvironmentInjector"
-  },
-  {
-    "name": "EnvironmentNgModuleRefAdapter"
-  },
-  {
-    "name": "ErrorHandler"
-  },
-  {
-    "name": "EventEmitter"
-  },
-  {
-    "name": "EventManager"
-  },
-  {
-    "name": "EventManagerPlugin"
-  },
-  {
-    "name": "FormControl"
-  },
-  {
-    "name": "FormGroup"
-  },
-  {
-    "name": "FormsExampleModule"
-  },
-  {
-    "name": "FormsModule"
-  },
-  {
-    "name": "GenericBrowserDomAdapter"
-  },
-  {
-    "name": "INJECTOR"
-  },
-  {
-    "name": "INJECTOR_DEF_TYPES"
-  },
-  {
-    "name": "INJECTOR_SCOPE"
-  },
-  {
-    "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
-  },
-  {
-    "name": "InjectFlags"
-  },
-  {
-    "name": "InjectionToken"
-  },
-  {
-    "name": "Injector"
-  },
-  {
-    "name": "InputFlags"
-  },
-  {
-    "name": "IterableChangeRecord_"
-  },
-  {
-    "name": "IterableDiffers"
-  },
-  {
-    "name": "KeyEventsPlugin"
-  },
-  {
-    "name": "LContainerFlags"
-  },
-  {
-    "name": "LOCALE_ID2"
-  },
-  {
-    "name": "LifecycleHooksFeature"
-  },
-  {
-    "name": "MODIFIER_KEYS"
-  },
-  {
-    "name": "MODIFIER_KEY_GETTERS"
-  },
-  {
-    "name": "NAMESPACE_URIS"
-  },
-  {
-    "name": "NEW_LINE"
-  },
-  {
-    "name": "NG_ASYNC_VALIDATORS"
-  },
-  {
-    "name": "NG_COMP_DEF"
-  },
-  {
-    "name": "NG_DIR_DEF"
-  },
-  {
-    "name": "NG_ELEMENT_ID"
-  },
-  {
-    "name": "NG_ENV_ID"
-  },
-  {
-    "name": "NG_FACTORY_DEF"
-  },
-  {
-    "name": "NG_INJECTABLE_DEF"
-  },
-  {
-    "name": "NG_INJECTOR_DEF"
-  },
-  {
-    "name": "NG_INJ_DEF"
-  },
-  {
-    "name": "NG_MOD_DEF"
-  },
-  {
-    "name": "NG_PIPE_DEF"
-  },
-  {
-    "name": "NG_PROV_DEF"
-  },
-  {
-    "name": "NG_VALIDATORS"
-  },
-  {
-    "name": "NG_VALUE_ACCESSOR"
-  },
-  {
-    "name": "NOT_FOUND"
-  },
-  {
-    "name": "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR"
-  },
-  {
-    "name": "NOT_YET"
-  },
-  {
-    "name": "NO_CHANGE"
-  },
-  {
-    "name": "NULL_INJECTOR"
-  },
-  {
-    "name": "NgControl"
-  },
-  {
-    "name": "NgControlStatus"
-  },
-  {
-    "name": "NgControlStatusGroup"
-  },
-  {
-    "name": "NgForOf"
-  },
-  {
-    "name": "NgForOfContext"
-  },
-  {
-    "name": "NgForm"
-  },
-  {
-    "name": "NgModel"
-  },
-  {
-    "name": "NgModelGroup"
-  },
-  {
-    "name": "NgModuleFactory"
-  },
-  {
-    "name": "NgModuleFactory2"
-  },
-  {
-    "name": "NgModuleRef"
-  },
-  {
-    "name": "NgModuleRef2"
-  },
-  {
-    "name": "NgOnChangesFeatureImpl"
-  },
-  {
-    "name": "NgZone"
-  },
-  {
-    "name": "NgZoneChangeDetectionScheduler"
-  },
-  {
-    "name": "NodeInjector"
-  },
-  {
-    "name": "NodeInjectorDestroyRef"
-  },
-  {
-    "name": "NodeInjectorFactory"
-  },
-  {
-    "name": "NoneEncapsulationDomRenderer"
-  },
-  {
-    "name": "NoopNgZone"
-  },
-  {
-    "name": "NullInjector"
-  },
-  {
-    "name": "ObjectUnsubscribedError"
-  },
-  {
-    "name": "Observable"
-  },
-  {
-    "name": "OperatorSubscriber"
-  },
-  {
-    "name": "Optional"
-  },
-  {
-    "name": "PLATFORM_DESTROY_LISTENERS"
-  },
-  {
-    "name": "PLATFORM_ID"
-  },
-  {
-    "name": "PLATFORM_INITIALIZER"
-  },
-  {
-    "name": "PRESERVE_HOST_CONTENT"
-  },
-  {
-    "name": "PendingTasksInternal"
-  },
-  {
-    "name": "PlatformRef"
-  },
-  {
-    "name": "PristineChangeEvent"
-  },
-  {
-    "name": "R3Injector"
-  },
-  {
-    "name": "R3TemplateRef"
-  },
-  {
-    "name": "R3ViewContainerRef"
-  },
-  {
-    "name": "REACTIVE_LVIEW_CONSUMER_NODE"
-  },
-  {
-    "name": "REACTIVE_NODE"
-  },
-  {
-    "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
-  },
-  {
-    "name": "REQUIRED_VALIDATOR"
-  },
-  {
-    "name": "Renderer2"
-  },
-  {
-    "name": "RendererFactory2"
-  },
-  {
-    "name": "RendererStyleFlags2"
-  },
-  {
-    "name": "RequiredValidator"
-  },
-  {
-    "name": "RootComponent"
-  },
-  {
-    "name": "RuntimeError"
-  },
-  {
-    "name": "SCHEDULE_IN_ROOT_ZONE"
-  },
-  {
-    "name": "SIGNAL"
-  },
-  {
-    "name": "SIGNAL_NODE"
-  },
-  {
-    "name": "SIMPLE_CHANGES_STORE"
-  },
-  {
-    "name": "SafeSubscriber"
-  },
-  {
-    "name": "SafeValueImpl"
-  },
-  {
-    "name": "Sanitizer"
-  },
-  {
-    "name": "ShadowDomRenderer"
-  },
-  {
-    "name": "SharedStylesHost"
-  },
-  {
-    "name": "SimpleChange"
-  },
-  {
-    "name": "SkipSelf"
-  },
-  {
-    "name": "StandaloneService"
-  },
-  {
-    "name": "StatusChangeEvent"
-  },
-  {
-    "name": "Subject"
-  },
-  {
-    "name": "Subscriber"
-  },
-  {
-    "name": "Subscription"
-  },
-  {
-    "name": "TEMPORARY_CONSUMER_NODE"
-  },
-  {
-    "name": "TESTABILITY"
-  },
-  {
-    "name": "TESTABILITY_GETTER"
-  },
-  {
-    "name": "TESTABILITY_PROVIDERS"
-  },
-  {
-    "name": "THROW_IF_NOT_FOUND"
-  },
-  {
-    "name": "TRACKED_LVIEWS"
-  },
-  {
-    "name": "TemplateFormsComponent"
-  },
-  {
-    "name": "TemplateFormsComponent_div_14_Template"
-  },
-  {
-    "name": "TemplateRef"
-  },
-  {
-    "name": "Testability"
-  },
-  {
-    "name": "TestabilityRegistry"
-  },
-  {
-    "name": "TouchedChangeEvent"
-  },
-  {
-    "name": "TracingAction"
-  },
-  {
-    "name": "TracingService"
-  },
-  {
-    "name": "UNSET"
-  },
-  {
-    "name": "USE_VALUE"
-  },
-  {
-    "name": "UnsubscriptionError"
-  },
-  {
-    "name": "VE_ViewContainerRef"
-  },
-  {
-    "name": "ValueChangeEvent"
-  },
-  {
-    "name": "ViewContainerRef"
-  },
-  {
-    "name": "ViewEncapsulation"
-  },
-  {
-    "name": "ViewEngineTemplateRef"
-  },
-  {
-    "name": "ViewRef"
-  },
-  {
-    "name": "ZONELESS_ENABLED"
-  },
-  {
-    "name": "ZONELESS_SCHEDULER_DISABLED"
-  },
-  {
-    "name": "ZoneAwareEffectScheduler"
-  },
-  {
-    "name": "ZoneStablePendingTask"
-  },
-  {
-    "name": "_DOM"
-  },
-  {
-    "name": "_DuplicateItemRecordList"
-  },
-  {
-    "name": "_DuplicateMap"
-  },
-  {
-    "name": "_Injector"
-  },
-  {
-    "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__asyncValues"
-  },
-  {
-    "name": "__await"
-  },
-  {
-    "name": "__defProp"
-  },
-  {
-    "name": "__forward_ref__"
-  },
-  {
-    "name": "__publicField"
-  },
-  {
-    "name": "_applyRootElementTransformImpl"
-  },
-  {
-    "name": "_bind"
-  },
-  {
-    "name": "_currentInjector"
-  },
-  {
-    "name": "_global"
-  },
-  {
-    "name": "_injectImplementation"
-  },
-  {
-    "name": "_isRefreshingViews"
-  },
-  {
-    "name": "_keyMap"
-  },
-  {
-    "name": "_locateOrCreateAnchorNode"
-  },
-  {
-    "name": "_locateOrCreateContainerAnchor"
-  },
-  {
-    "name": "_locateOrCreateElementNode"
-  },
-  {
-    "name": "_locateOrCreateTextNode"
-  },
-  {
-    "name": "_platformInjector"
-  },
-  {
-    "name": "_testabilityGetter"
-  },
-  {
-    "name": "_wasLastNodeCreated"
-  },
-  {
-    "name": "activeConsumer"
-  },
-  {
-    "name": "addPropertyBinding"
-  },
-  {
-    "name": "addToArray"
-  },
-  {
-    "name": "addToEndOfViewTree"
-  },
-  {
-    "name": "addValidators"
-  },
-  {
-    "name": "allocExpando"
-  },
-  {
-    "name": "allocLFrame"
-  },
-  {
-    "name": "angularZoneInstanceIdProperty"
-  },
-  {
-    "name": "appendChild"
-  },
-  {
-    "name": "applyNodes"
-  },
-  {
-    "name": "applyProjectionRecursive"
-  },
-  {
-    "name": "applyToElementOrContainer"
-  },
-  {
-    "name": "applyValueToInputField"
-  },
-  {
-    "name": "applyView"
-  },
-  {
-    "name": "applyViewChange"
-  },
-  {
-    "name": "arrRemove"
-  },
-  {
-    "name": "assertConsumerNode"
-  },
-  {
-    "name": "assertNotDestroyed"
-  },
-  {
-    "name": "assertProducerNode"
-  },
-  {
-    "name": "attachInjectFlag"
-  },
-  {
-    "name": "attachPatchData"
-  },
-  {
-    "name": "baseElement"
-  },
-  {
-    "name": "bind"
-  },
-  {
-    "name": "bindingUpdated"
-  },
-  {
-    "name": "bloomHasToken"
-  },
-  {
-    "name": "booleanAttribute"
-  },
-  {
-    "name": "bootstrap"
-  },
-  {
-    "name": "callHook"
-  },
-  {
-    "name": "callHookInternal"
-  },
-  {
-    "name": "callHooks"
-  },
-  {
-    "name": "captureNodeBindings"
-  },
-  {
-    "name": "checkStable"
-  },
-  {
-    "name": "classIndexOf"
-  },
-  {
-    "name": "cleanUpView"
-  },
-  {
-    "name": "collectNativeNodes"
-  },
-  {
-    "name": "collectNativeNodesInLContainer"
-  },
-  {
-    "name": "collectStylingFromDirectives"
-  },
-  {
-    "name": "collectStylingFromTAttrs"
-  },
-  {
-    "name": "composeAsyncValidators"
-  },
-  {
-    "name": "composeValidators"
-  },
-  {
-    "name": "computeStaticStyling"
-  },
-  {
-    "name": "computed"
-  },
-  {
-    "name": "concatStringsWithSpace"
-  },
-  {
-    "name": "config"
-  },
-  {
-    "name": "configureViewWithDirective"
-  },
-  {
-    "name": "consumerAfterComputation"
-  },
-  {
-    "name": "consumerBeforeComputation"
-  },
-  {
-    "name": "consumerDestroy"
-  },
-  {
-    "name": "consumerIsLive"
-  },
-  {
-    "name": "consumerMarkDirty"
-  },
-  {
-    "name": "consumerPollProducersForChange"
-  },
-  {
-    "name": "context"
-  },
-  {
-    "name": "controlPath"
-  },
-  {
-    "name": "convertToBitFlags"
-  },
-  {
-    "name": "createDirectivesInstances"
-  },
-  {
-    "name": "createElementNode"
-  },
-  {
-    "name": "createElementRef"
-  },
-  {
-    "name": "createErrorClass"
-  },
-  {
-    "name": "createInjector"
-  },
-  {
-    "name": "createInjectorWithoutInjectorInstances"
-  },
-  {
-    "name": "createInvalidObservableTypeError"
-  },
-  {
-    "name": "createLContainer"
-  },
-  {
-    "name": "createLFrame"
-  },
-  {
-    "name": "createLView"
-  },
-  {
-    "name": "createLinkElement"
-  },
-  {
-    "name": "createNodeInjector"
-  },
-  {
-    "name": "createNotification"
-  },
-  {
-    "name": "createObject"
-  },
-  {
-    "name": "createOperatorSubscriber"
-  },
-  {
-    "name": "createPlatform"
-  },
-  {
-    "name": "createPlatformFactory"
-  },
-  {
-    "name": "createStyleElement"
-  },
-  {
-    "name": "createTView"
-  },
-  {
-    "name": "deepForEach"
-  },
-  {
-    "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultEquals"
-  },
-  {
-    "name": "defaultIterableDiffersFactory"
-  },
-  {
-    "name": "destroyLView"
-  },
-  {
-    "name": "detachMovedView"
-  },
-  {
-    "name": "detachView"
-  },
-  {
-    "name": "detachViewFromDOM"
-  },
-  {
-    "name": "detectChangesInChildComponents"
-  },
-  {
-    "name": "detectChangesInComponent"
-  },
-  {
-    "name": "detectChangesInEmbeddedViews"
-  },
-  {
-    "name": "detectChangesInView"
-  },
-  {
-    "name": "detectChangesInViewIfAttached"
-  },
-  {
-    "name": "detectChangesInViewIfRequired"
-  },
-  {
-    "name": "detectChangesInternal"
-  },
-  {
-    "name": "diPublicInInjector"
-  },
-  {
-    "name": "elementPropertyInternal"
-  },
-  {
-    "name": "enterDI"
-  },
-  {
-    "name": "enterView"
-  },
-  {
-    "name": "epoch"
-  },
-  {
-    "name": "errorContext"
-  },
-  {
-    "name": "execFinalizer"
-  },
-  {
-    "name": "executeCheckHooks"
-  },
-  {
-    "name": "executeContentQueries"
-  },
-  {
-    "name": "executeInitAndCheckHooks"
-  },
-  {
-    "name": "executeListenerWithErrorHandling"
-  },
-  {
-    "name": "executeTemplate"
-  },
-  {
-    "name": "executeValidators"
-  },
-  {
-    "name": "executeViewQueryFn"
-  },
-  {
-    "name": "extractDefListOrFactory"
-  },
-  {
-    "name": "extractDirectiveDef"
-  },
-  {
-    "name": "fillProperties"
-  },
-  {
-    "name": "findAttrIndexInNode"
-  },
-  {
-    "name": "findStylingValue"
-  },
-  {
-    "name": "forEachSingleProvider"
-  },
-  {
-    "name": "forkJoin"
-  },
-  {
-    "name": "formControlBinding"
-  },
-  {
-    "name": "formDirectiveProvider"
-  },
-  {
-    "name": "forwardRef"
-  },
-  {
-    "name": "freeConsumers"
-  },
-  {
-    "name": "fromAsyncIterable"
-  },
-  {
-    "name": "generateInitialInputs"
-  },
-  {
-    "name": "getBeforeNodeForView"
-  },
-  {
-    "name": "getBindingsEnabled"
-  },
-  {
-    "name": "getClosureSafeProperty"
-  },
-  {
-    "name": "getComponentDef"
-  },
-  {
-    "name": "getComponentLViewByIndex"
-  },
-  {
-    "name": "getConstant"
-  },
-  {
-    "name": "getCurrentTNode"
-  },
-  {
-    "name": "getCurrentTNodePlaceholderOk"
-  },
-  {
-    "name": "getDOM"
-  },
-  {
-    "name": "getDeclarationTNode"
-  },
-  {
-    "name": "getDirectiveDef"
-  },
-  {
-    "name": "getFactoryDef"
-  },
-  {
-    "name": "getFactoryOf"
-  },
-  {
-    "name": "getFirstLContainer"
-  },
-  {
-    "name": "getFirstNativeNode"
-  },
-  {
-    "name": "getInitialLViewFlagsFromDef"
-  },
-  {
-    "name": "getInjectImplementation"
-  },
-  {
-    "name": "getInjectableDef"
-  },
-  {
-    "name": "getInjectorDef"
-  },
-  {
-    "name": "getInjectorIndex"
-  },
-  {
-    "name": "getLView"
-  },
-  {
-    "name": "getLViewParent"
-  },
-  {
-    "name": "getNativeByTNode"
-  },
-  {
-    "name": "getNearestLContainer"
-  },
-  {
-    "name": "getNextLContainer"
-  },
-  {
-    "name": "getNgDirectiveDef"
-  },
-  {
-    "name": "getNgZoneOptions"
-  },
-  {
-    "name": "getNodeInjectable"
-  },
-  {
-    "name": "getNullInjector"
-  },
-  {
-    "name": "getOrCreateComponentTView"
-  },
-  {
-    "name": "getOrCreateInjectable"
-  },
-  {
-    "name": "getOrCreateNodeInjectorForNode"
-  },
-  {
-    "name": "getOrCreateTNode"
-  },
-  {
-    "name": "getOrCreateViewRefs"
-  },
-  {
-    "name": "getOwnDefinition"
-  },
-  {
-    "name": "getParentInjectorIndex"
-  },
-  {
-    "name": "getParentInjectorLocation"
-  },
-  {
-    "name": "getParentInjectorView"
-  },
-  {
-    "name": "getPipeDef"
-  },
-  {
-    "name": "getPlatform"
-  },
-  {
-    "name": "getPreviousIndex"
-  },
-  {
-    "name": "getProjectionNodes"
-  },
-  {
-    "name": "getPromiseCtor"
-  },
-  {
-    "name": "getSelectedIndex"
-  },
-  {
-    "name": "getSelectedTNode"
-  },
-  {
-    "name": "getSimpleChangesStore"
-  },
-  {
-    "name": "getSymbolIterator"
-  },
-  {
-    "name": "getTNode"
-  },
-  {
-    "name": "getTNodeFromLView"
-  },
-  {
-    "name": "getTStylingRangeNext"
-  },
-  {
-    "name": "getTStylingRangePrev"
-  },
-  {
-    "name": "getTView"
-  },
-  {
-    "name": "getViewRefs"
-  },
-  {
-    "name": "handleError"
-  },
-  {
-    "name": "handleStoppedNotification"
-  },
-  {
-    "name": "handleUnhandledError"
-  },
-  {
-    "name": "hasApplyArgsData"
-  },
-  {
-    "name": "hasInSkipHydrationBlockFlag"
-  },
-  {
-    "name": "hasParentInjector"
-  },
-  {
-    "name": "hasTagAndTypeMatch"
-  },
-  {
-    "name": "hasValidator"
-  },
-  {
-    "name": "icuContainerIterate"
-  },
-  {
-    "name": "identity"
-  },
-  {
-    "name": "importProvidersFrom"
-  },
-  {
-    "name": "inNotificationPhase"
-  },
-  {
-    "name": "includeViewProviders"
-  },
-  {
-    "name": "incrementInitPhaseFlags"
-  },
-  {
-    "name": "indexOf"
-  },
-  {
-    "name": "inheritContentQueries"
-  },
-  {
-    "name": "inheritHostBindings"
-  },
-  {
-    "name": "inheritViewQuery"
-  },
-  {
-    "name": "initFeatures"
-  },
-  {
-    "name": "initializeDirectives"
-  },
-  {
-    "name": "inject"
-  },
-  {
-    "name": "injectArgs"
-  },
-  {
-    "name": "injectChangeDetectorRef"
-  },
-  {
-    "name": "injectDestroyRef"
-  },
-  {
-    "name": "injectElementRef"
-  },
-  {
-    "name": "injectInjectorOnly"
-  },
-  {
-    "name": "injectRootLimpMode"
-  },
-  {
-    "name": "injectTemplateRef"
-  },
-  {
-    "name": "injectViewContainerRef"
-  },
-  {
-    "name": "injectableDefOrInjectorDefFactory"
-  },
-  {
-    "name": "innerFrom"
-  },
-  {
-    "name": "insertBloom"
-  },
-  {
-    "name": "instructionState"
-  },
-  {
-    "name": "internalImportProvidersFrom"
-  },
-  {
-    "name": "internalProvideZoneChangeDetection"
-  },
-  {
-    "name": "invokeDirectivesHostBindings"
-  },
-  {
-    "name": "invokeHostBindingsInCreationMode"
-  },
-  {
-    "name": "isAngularZoneProperty"
-  },
-  {
-    "name": "isApplicationBootstrapConfig"
-  },
-  {
-    "name": "isArrayLike"
-  },
-  {
-    "name": "isAsyncIterable"
-  },
-  {
-    "name": "isComponentDef"
-  },
-  {
-    "name": "isComponentHost"
-  },
-  {
-    "name": "isConsumerNode"
-  },
-  {
-    "name": "isContentQueryHost"
-  },
-  {
-    "name": "isCssClassMatching"
-  },
-  {
-    "name": "isCurrentTNodeParent"
-  },
-  {
-    "name": "isDirectiveHost"
-  },
-  {
-    "name": "isEnvironmentProviders"
-  },
-  {
-    "name": "isFormControlState"
-  },
-  {
-    "name": "isForwardRef"
-  },
-  {
-    "name": "isFunction"
-  },
-  {
-    "name": "isInlineTemplate"
-  },
-  {
-    "name": "isInteropObservable"
-  },
-  {
-    "name": "isIterable"
-  },
-  {
-    "name": "isLContainer"
-  },
-  {
-    "name": "isLView"
-  },
-  {
-    "name": "isListLikeIterable"
-  },
-  {
-    "name": "isNodeMatchingSelector"
-  },
-  {
-    "name": "isNodeMatchingSelectorList"
-  },
-  {
-    "name": "isOptionsObj"
-  },
-  {
-    "name": "isPlatformServer"
-  },
-  {
-    "name": "isPositive"
-  },
-  {
-    "name": "isPresent"
-  },
-  {
-    "name": "isPromise"
-  },
-  {
-    "name": "isPromise2"
-  },
-  {
-    "name": "isReadableStreamLike"
-  },
-  {
-    "name": "isRefreshingViews"
-  },
-  {
-    "name": "isRootView"
-  },
-  {
-    "name": "isStylingMatch"
-  },
-  {
-    "name": "isStylingValuePresent"
-  },
-  {
-    "name": "isSubscription"
-  },
-  {
-    "name": "isTemplateNode"
-  },
-  {
-    "name": "isTypeProvider"
-  },
-  {
-    "name": "isValueProvider"
-  },
-  {
-    "name": "isWritableSignal"
-  },
-  {
-    "name": "iterator"
-  },
-  {
-    "name": "keyValueArrayGet"
-  },
-  {
-    "name": "keyValueArrayIndexOf"
-  },
-  {
-    "name": "keyValueArraySet"
-  },
-  {
-    "name": "lastNodeWasCreated"
-  },
-  {
-    "name": "leaveDI"
-  },
-  {
-    "name": "leaveView"
-  },
-  {
-    "name": "leaveViewLight"
-  },
-  {
-    "name": "listenerInternal"
-  },
-  {
-    "name": "lookupTokenUsingModuleInjector"
-  },
-  {
-    "name": "lookupTokenUsingNodeInjector"
-  },
-  {
-    "name": "makeParamDecorator"
-  },
-  {
-    "name": "makeRecord"
-  },
-  {
-    "name": "makeValidatorsArray"
-  },
-  {
-    "name": "map"
-  },
-  {
-    "name": "markAncestorsForTraversal"
-  },
-  {
-    "name": "markAsComponentHost"
-  },
-  {
-    "name": "markDuplicates"
-  },
-  {
-    "name": "markViewDirty"
-  },
-  {
-    "name": "markViewForRefresh"
-  },
-  {
-    "name": "markedFeatures"
-  },
-  {
-    "name": "maybeUnwrapEmpty"
-  },
-  {
-    "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "mergeErrors"
-  },
-  {
-    "name": "mergeHostAttribute"
-  },
-  {
-    "name": "mergeHostAttrs"
-  },
-  {
-    "name": "mergeInputsWithTransforms"
-  },
-  {
-    "name": "mergeValidators"
-  },
-  {
-    "name": "modelGroupProvider"
-  },
-  {
-    "name": "multiFactoryAdd"
-  },
-  {
-    "name": "multiProvidersFactoryResolver"
-  },
-  {
-    "name": "multiResolve"
-  },
-  {
-    "name": "multiViewProvidersFactoryResolver"
-  },
-  {
-    "name": "nativeAppendChild"
-  },
-  {
-    "name": "nativeAppendOrInsertBefore"
-  },
-  {
-    "name": "nativeInsertBefore"
-  },
-  {
-    "name": "nativeParentNode"
-  },
-  {
-    "name": "nextBindingIndex"
-  },
-  {
-    "name": "nextNgElementId"
-  },
-  {
-    "name": "ngOnChangesSetInput"
-  },
-  {
-    "name": "ngZoneInstanceId"
-  },
-  {
-    "name": "noSideEffects"
-  },
-  {
-    "name": "nonNull"
-  },
-  {
-    "name": "noop"
-  },
-  {
-    "name": "noop2"
-  },
-  {
-    "name": "normalizeValidators"
-  },
-  {
-    "name": "notFoundValueOrThrow"
-  },
-  {
-    "name": "nullValidator"
-  },
-  {
-    "name": "observable"
-  },
-  {
-    "name": "onEnter"
-  },
-  {
-    "name": "onLeave"
-  },
-  {
-    "name": "operate"
-  },
-  {
-    "name": "optionsReducer"
-  },
-  {
-    "name": "parseAndConvertBindingsForDefinition"
-  },
-  {
-    "name": "performanceMarkFeature"
-  },
-  {
-    "name": "pickAsyncValidators"
-  },
-  {
-    "name": "pickValidators"
-  },
-  {
-    "name": "platformBrowser"
-  },
-  {
-    "name": "platformCore"
-  },
-  {
-    "name": "processInjectorTypesWithProviders"
-  },
-  {
-    "name": "producerAccessed"
-  },
-  {
-    "name": "producerAddLiveConsumer"
-  },
-  {
-    "name": "producerMarkClean"
-  },
-  {
-    "name": "producerNotifyConsumers"
-  },
-  {
-    "name": "producerRemoveLiveConsumerAtIndex"
-  },
-  {
-    "name": "producerUpdateValueVersion"
-  },
-  {
-    "name": "producerUpdatesAllowed"
-  },
-  {
-    "name": "providerToFactory"
-  },
-  {
-    "name": "readableStreamLikeToAsyncGenerator"
-  },
-  {
-    "name": "refreshContentQueries"
-  },
-  {
-    "name": "refreshView"
-  },
-  {
-    "name": "registerDestroyHooksIfSupported"
-  },
-  {
-    "name": "registerOnValidatorChange"
-  },
-  {
-    "name": "registerPostOrderHooks"
-  },
-  {
-    "name": "rememberChangeHistoryAndInvokeOnChangesHook"
-  },
-  {
-    "name": "remove"
-  },
-  {
-    "name": "removeElements"
-  },
-  {
-    "name": "removeFromArray"
-  },
-  {
-    "name": "removeListItem"
-  },
-  {
-    "name": "removeValidators"
-  },
-  {
-    "name": "renderComponent"
-  },
-  {
-    "name": "renderStringify"
-  },
-  {
-    "name": "renderView"
-  },
-  {
-    "name": "reportUnhandledError"
-  },
-  {
-    "name": "requiredValidator"
-  },
-  {
-    "name": "requiresRefreshOrTraversal"
-  },
-  {
-    "name": "resetPreOrderHookFlags"
-  },
-  {
-    "name": "resolveDirectives"
-  },
-  {
-    "name": "resolveForwardRef"
-  },
-  {
-    "name": "resolveProvider"
-  },
-  {
-    "name": "resolvedPromise"
-  },
-  {
-    "name": "resolvedPromise2"
-  },
-  {
-    "name": "runEffectsInView"
-  },
-  {
-    "name": "runInInjectionContext"
-  },
-  {
-    "name": "saveNameToExportMap"
-  },
-  {
-    "name": "saveResolvedLocalsInData"
-  },
-  {
-    "name": "scheduleCallbackWithMicrotask"
-  },
-  {
-    "name": "scheduleCallbackWithRafRace"
-  },
-  {
-    "name": "searchTokensOnInjector"
-  },
-  {
-    "name": "selectIndexInternal"
-  },
-  {
-    "name": "setActiveConsumer"
-  },
-  {
-    "name": "setBindingRootForHostBindings"
-  },
-  {
-    "name": "setCurrentDirectiveIndex"
-  },
-  {
-    "name": "setCurrentInjector"
-  },
-  {
-    "name": "setCurrentQueryIndex"
-  },
-  {
-    "name": "setCurrentTNode"
-  },
-  {
-    "name": "setDirectiveInputsWhichShadowsStyling"
-  },
-  {
-    "name": "setDisabledStateDefault"
-  },
-  {
-    "name": "setIncludeViewProviders"
-  },
-  {
-    "name": "setInjectImplementation"
-  },
-  {
-    "name": "setInputsForProperty"
-  },
-  {
-    "name": "setInputsFromAttrs"
-  },
-  {
-    "name": "setIsRefreshingViews"
-  },
-  {
-    "name": "setSelectedIndex"
-  },
-  {
-    "name": "setTStylingRangeNext"
-  },
-  {
-    "name": "setTStylingRangeNextDuplicate"
-  },
-  {
-    "name": "setTStylingRangePrevDuplicate"
-  },
-  {
-    "name": "setUpAttributes"
-  },
-  {
-    "name": "setUpControl"
-  },
-  {
-    "name": "setUpValidators"
-  },
-  {
-    "name": "setupStaticAttributes"
-  },
-  {
-    "name": "shimStylesContent"
-  },
-  {
-    "name": "shouldAddViewToDom"
-  },
-  {
-    "name": "shouldSearchParent"
-  },
-  {
-    "name": "signal"
-  },
-  {
-    "name": "signalAsReadonlyFn"
-  },
-  {
-    "name": "signalSetFn"
-  },
-  {
-    "name": "storeLViewOnDestroy"
-  },
-  {
-    "name": "stringify"
-  },
-  {
-    "name": "stringifyCSSSelector"
-  },
-  {
-    "name": "throwInvalidWriteToSignalError"
-  },
-  {
-    "name": "throwInvalidWriteToSignalErrorFn"
-  },
-  {
-    "name": "throwProviderNotFoundError"
-  },
-  {
-    "name": "timeoutProvider"
-  },
-  {
-    "name": "toObservable"
-  },
-  {
-    "name": "toRefArray"
-  },
-  {
-    "name": "toTStylingRange"
-  },
-  {
-    "name": "trackByIdentity"
-  },
-  {
-    "name": "trackMovedView"
-  },
-  {
-    "name": "uniqueIdCounter"
-  },
-  {
-    "name": "unregisterLView"
-  },
-  {
-    "name": "untracked"
-  },
-  {
-    "name": "unwrapRNode"
-  },
-  {
-    "name": "updateAncestorTraversalFlagsOnAttach"
-  },
-  {
-    "name": "updateControl"
-  },
-  {
-    "name": "updateMicroTaskStatus"
-  },
-  {
-    "name": "viewAttachedToChangeDetector"
-  },
-  {
-    "name": "viewShouldHaveReactiveConsumer"
-  },
-  {
-    "name": "walkProviderTree"
-  },
-  {
-    "name": "wasLastNodeCreated"
-  },
-  {
-    "name": "wrapListener"
-  },
-  {
-    "name": "writeDirectClass"
-  },
-  {
-    "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}"
-  },
-  {
-    "name": "{isArray:isArray2}"
-  },
-  {
-    "name": "{isArray:isArray}"
-  },
-  {
-    "name": "ɵInternalFormsSharedModule"
-  },
-  {
-    "name": "ɵNgNoValidate"
-  },
-  {
-    "name": "ɵɵInheritDefinitionFeature"
-  },
-  {
-    "name": "ɵɵNgOnChangesFeature"
-  },
-  {
-    "name": "ɵɵProvidersFeature"
-  },
-  {
-    "name": "ɵɵadvance"
-  },
-  {
-    "name": "ɵɵattribute"
-  },
-  {
-    "name": "ɵɵclassProp"
-  },
-  {
-    "name": "ɵɵdefineComponent"
-  },
-  {
-    "name": "ɵɵdefineDirective"
-  },
-  {
-    "name": "ɵɵdefineInjectable"
-  },
-  {
-    "name": "ɵɵdefineInjector"
-  },
-  {
-    "name": "ɵɵdefineNgModule"
-  },
-  {
-    "name": "ɵɵdirectiveInject"
-  },
-  {
-    "name": "ɵɵelement"
-  },
-  {
-    "name": "ɵɵelementEnd"
-  },
-  {
-    "name": "ɵɵelementStart"
-  },
-  {
-    "name": "ɵɵgetInheritedFactory"
-  },
-  {
-    "name": "ɵɵinject"
-  },
-  {
-    "name": "ɵɵlistener"
-  },
-  {
-    "name": "ɵɵnextContext"
-  },
-  {
-    "name": "ɵɵproperty"
-  },
-  {
-    "name": "ɵɵtemplate"
-  },
-  {
-    "name": "ɵɵtext"
-  },
-  {
-    "name": "ɵɵtwoWayListener"
-  },
-  {
-    "name": "ɵɵtwoWayProperty"
-  }
+  "ALLOW_MULTIPLE_PLATFORMS",
+  "APP_BOOTSTRAP_LISTENER",
+  "APP_ID",
+  "APP_INITIALIZER",
+  "AbstractControl",
+  "AbstractControlDirective",
+  "AbstractControlStatus",
+  "AbstractFormGroupDirective",
+  "AbstractValidatorDirective",
+  "AfterRenderManager",
+  "AnonymousSubject",
+  "ApplicationInitStatus",
+  "ApplicationModule",
+  "ApplicationRef",
+  "BROWSER_MODULE_PROVIDERS",
+  "BROWSER_MODULE_PROVIDERS_MARKER",
+  "BaseControlValueAccessor",
+  "BehaviorSubject",
+  "BrowserDomAdapter",
+  "BrowserModule",
+  "BrowserXhr",
+  "BuiltInControlValueAccessor",
+  "CALL_SET_DISABLED_STATE",
+  "CHECKBOX_VALUE_ACCESSOR",
+  "CIRCULAR",
+  "COMPLETE_NOTIFICATION",
+  "COMPONENT_REGEX",
+  "COMPOSITION_BUFFER_MODE",
+  "COMPUTED_NODE",
+  "COMPUTING",
+  "CSP_NONCE",
+  "ChainedInjector",
+  "ChangeDetectionScheduler",
+  "ChangeDetectionSchedulerImpl",
+  "ChangeDetectionStrategy",
+  "ChangeDetectorRef",
+  "CheckboxControlValueAccessor",
+  "CommonModule",
+  "ComponentFactory",
+  "ComponentFactory2",
+  "ComponentFactoryResolver",
+  "ComponentFactoryResolver2",
+  "ComponentRef",
+  "ComponentRef2",
+  "ConsumerObserver",
+  "ControlContainer",
+  "ControlEvent",
+  "DEFAULT_APP_ID",
+  "DEFAULT_VALUE_ACCESSOR",
+  "DOCUMENT",
+  "DOCUMENT2",
+  "DefaultDomRenderer2",
+  "DefaultIterableDiffer",
+  "DefaultIterableDifferFactory",
+  "DefaultValueAccessor",
+  "DestroyRef",
+  "DomAdapter",
+  "DomEventsPlugin",
+  "DomRendererFactory2",
+  "EMPTY_ARRAY",
+  "EMPTY_OBJ",
+  "EMPTY_OBSERVER",
+  "EMPTY_PAYLOAD",
+  "EMPTY_SUBSCRIPTION",
+  "ENVIRONMENT_INITIALIZER",
+  "ERRORED",
+  "EVENT_MANAGER_PLUGINS",
+  "EffectScheduler",
+  "ElementRef",
+  "EmulatedEncapsulationDomRenderer2",
+  "EnvironmentInjector",
+  "EnvironmentNgModuleRefAdapter",
+  "ErrorHandler",
+  "EventEmitter",
+  "EventManager",
+  "EventManagerPlugin",
+  "FormControl",
+  "FormGroup",
+  "FormsExampleModule",
+  "FormsModule",
+  "GenericBrowserDomAdapter",
+  "INJECTOR",
+  "INJECTOR_DEF_TYPES",
+  "INJECTOR_SCOPE",
+  "INTERNAL_APPLICATION_ERROR_HANDLER",
+  "InjectFlags",
+  "InjectionToken",
+  "Injector",
+  "InputFlags",
+  "IterableChangeRecord_",
+  "IterableDiffers",
+  "KeyEventsPlugin",
+  "LContainerFlags",
+  "LOCALE_ID2",
+  "LifecycleHooksFeature",
+  "MODIFIER_KEYS",
+  "MODIFIER_KEY_GETTERS",
+  "NAMESPACE_URIS",
+  "NEW_LINE",
+  "NG_ASYNC_VALIDATORS",
+  "NG_COMP_DEF",
+  "NG_DIR_DEF",
+  "NG_ELEMENT_ID",
+  "NG_ENV_ID",
+  "NG_FACTORY_DEF",
+  "NG_INJECTABLE_DEF",
+  "NG_INJECTOR_DEF",
+  "NG_INJ_DEF",
+  "NG_MOD_DEF",
+  "NG_PIPE_DEF",
+  "NG_PROV_DEF",
+  "NG_VALIDATORS",
+  "NG_VALUE_ACCESSOR",
+  "NOT_FOUND",
+  "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR",
+  "NOT_YET",
+  "NO_CHANGE",
+  "NULL_INJECTOR",
+  "NgControl",
+  "NgControlStatus",
+  "NgControlStatusGroup",
+  "NgForOf",
+  "NgForOfContext",
+  "NgForm",
+  "NgModel",
+  "NgModelGroup",
+  "NgModuleFactory",
+  "NgModuleFactory2",
+  "NgModuleRef",
+  "NgModuleRef2",
+  "NgOnChangesFeatureImpl",
+  "NgZone",
+  "NgZoneChangeDetectionScheduler",
+  "NodeInjector",
+  "NodeInjectorDestroyRef",
+  "NodeInjectorFactory",
+  "NoneEncapsulationDomRenderer",
+  "NoopNgZone",
+  "NullInjector",
+  "ObjectUnsubscribedError",
+  "Observable",
+  "OperatorSubscriber",
+  "Optional",
+  "PLATFORM_DESTROY_LISTENERS",
+  "PLATFORM_ID",
+  "PLATFORM_INITIALIZER",
+  "PRESERVE_HOST_CONTENT",
+  "PendingTasksInternal",
+  "PlatformRef",
+  "PristineChangeEvent",
+  "R3Injector",
+  "R3TemplateRef",
+  "R3ViewContainerRef",
+  "REACTIVE_LVIEW_CONSUMER_NODE",
+  "REACTIVE_NODE",
+  "REMOVE_STYLES_ON_COMPONENT_DESTROY",
+  "REQUIRED_VALIDATOR",
+  "Renderer2",
+  "RendererFactory2",
+  "RendererStyleFlags2",
+  "RequiredValidator",
+  "RootComponent",
+  "RuntimeError",
+  "SCHEDULE_IN_ROOT_ZONE",
+  "SIGNAL",
+  "SIGNAL_NODE",
+  "SIMPLE_CHANGES_STORE",
+  "SafeSubscriber",
+  "SafeValueImpl",
+  "Sanitizer",
+  "ShadowDomRenderer",
+  "SharedStylesHost",
+  "SimpleChange",
+  "SkipSelf",
+  "StandaloneService",
+  "StatusChangeEvent",
+  "Subject",
+  "Subscriber",
+  "Subscription",
+  "TEMPORARY_CONSUMER_NODE",
+  "TESTABILITY",
+  "TESTABILITY_GETTER",
+  "TESTABILITY_PROVIDERS",
+  "THROW_IF_NOT_FOUND",
+  "TRACKED_LVIEWS",
+  "TemplateFormsComponent",
+  "TemplateFormsComponent_div_14_Template",
+  "TemplateRef",
+  "Testability",
+  "TestabilityRegistry",
+  "TouchedChangeEvent",
+  "TracingAction",
+  "TracingService",
+  "UNSET",
+  "USE_VALUE",
+  "UnsubscriptionError",
+  "VE_ViewContainerRef",
+  "ValueChangeEvent",
+  "ViewContainerRef",
+  "ViewEncapsulation",
+  "ViewEngineTemplateRef",
+  "ViewRef",
+  "ZONELESS_ENABLED",
+  "ZONELESS_SCHEDULER_DISABLED",
+  "ZoneAwareEffectScheduler",
+  "ZoneStablePendingTask",
+  "_DOM",
+  "_DuplicateItemRecordList",
+  "_DuplicateMap",
+  "_Injector",
+  "_NullComponentFactoryResolver",
+  "__asyncValues",
+  "__await",
+  "__defProp",
+  "__forward_ref__",
+  "__publicField",
+  "_applyRootElementTransformImpl",
+  "_bind",
+  "_currentInjector",
+  "_global",
+  "_injectImplementation",
+  "_isRefreshingViews",
+  "_keyMap",
+  "_locateOrCreateAnchorNode",
+  "_locateOrCreateContainerAnchor",
+  "_locateOrCreateElementNode",
+  "_locateOrCreateTextNode",
+  "_platformInjector",
+  "_testabilityGetter",
+  "_wasLastNodeCreated",
+  "activeConsumer",
+  "addPropertyBinding",
+  "addToArray",
+  "addToEndOfViewTree",
+  "addValidators",
+  "allocExpando",
+  "allocLFrame",
+  "angularZoneInstanceIdProperty",
+  "appendChild",
+  "applyNodes",
+  "applyProjectionRecursive",
+  "applyToElementOrContainer",
+  "applyValueToInputField",
+  "applyView",
+  "applyViewChange",
+  "arrRemove",
+  "assertConsumerNode",
+  "assertNotDestroyed",
+  "assertProducerNode",
+  "attachInjectFlag",
+  "attachPatchData",
+  "baseElement",
+  "bind",
+  "bindingUpdated",
+  "bloomHasToken",
+  "booleanAttribute",
+  "bootstrap",
+  "callHook",
+  "callHookInternal",
+  "callHooks",
+  "captureNodeBindings",
+  "checkStable",
+  "classIndexOf",
+  "cleanUpView",
+  "collectNativeNodes",
+  "collectNativeNodesInLContainer",
+  "collectStylingFromDirectives",
+  "collectStylingFromTAttrs",
+  "composeAsyncValidators",
+  "composeValidators",
+  "computeStaticStyling",
+  "computed",
+  "concatStringsWithSpace",
+  "config",
+  "configureViewWithDirective",
+  "consumerAfterComputation",
+  "consumerBeforeComputation",
+  "consumerDestroy",
+  "consumerIsLive",
+  "consumerMarkDirty",
+  "consumerPollProducersForChange",
+  "context",
+  "controlPath",
+  "convertToBitFlags",
+  "createDirectivesInstances",
+  "createElementNode",
+  "createElementRef",
+  "createErrorClass",
+  "createInjector",
+  "createInjectorWithoutInjectorInstances",
+  "createInvalidObservableTypeError",
+  "createLContainer",
+  "createLFrame",
+  "createLView",
+  "createLinkElement",
+  "createNodeInjector",
+  "createNotification",
+  "createObject",
+  "createOperatorSubscriber",
+  "createPlatform",
+  "createPlatformFactory",
+  "createStyleElement",
+  "createTView",
+  "deepForEach",
+  "deepForEachProvider",
+  "defaultEquals",
+  "defaultIterableDiffersFactory",
+  "destroyLView",
+  "detachMovedView",
+  "detachView",
+  "detachViewFromDOM",
+  "detectChangesInChildComponents",
+  "detectChangesInComponent",
+  "detectChangesInEmbeddedViews",
+  "detectChangesInView",
+  "detectChangesInViewIfAttached",
+  "detectChangesInViewIfRequired",
+  "detectChangesInternal",
+  "diPublicInInjector",
+  "elementPropertyInternal",
+  "enterDI",
+  "enterView",
+  "epoch",
+  "errorContext",
+  "execFinalizer",
+  "executeCheckHooks",
+  "executeContentQueries",
+  "executeInitAndCheckHooks",
+  "executeListenerWithErrorHandling",
+  "executeTemplate",
+  "executeValidators",
+  "executeViewQueryFn",
+  "extractDefListOrFactory",
+  "extractDirectiveDef",
+  "fillProperties",
+  "findAttrIndexInNode",
+  "findStylingValue",
+  "forEachSingleProvider",
+  "forkJoin",
+  "formControlBinding",
+  "formDirectiveProvider",
+  "forwardRef",
+  "freeConsumers",
+  "fromAsyncIterable",
+  "generateInitialInputs",
+  "getBeforeNodeForView",
+  "getBindingsEnabled",
+  "getClosureSafeProperty",
+  "getComponentDef",
+  "getComponentLViewByIndex",
+  "getConstant",
+  "getCurrentTNode",
+  "getCurrentTNodePlaceholderOk",
+  "getDOM",
+  "getDeclarationTNode",
+  "getDirectiveDef",
+  "getFactoryDef",
+  "getFactoryOf",
+  "getFirstLContainer",
+  "getFirstNativeNode",
+  "getInitialLViewFlagsFromDef",
+  "getInjectImplementation",
+  "getInjectableDef",
+  "getInjectorDef",
+  "getInjectorIndex",
+  "getLView",
+  "getLViewParent",
+  "getNativeByTNode",
+  "getNearestLContainer",
+  "getNextLContainer",
+  "getNgDirectiveDef",
+  "getNgZoneOptions",
+  "getNodeInjectable",
+  "getNullInjector",
+  "getOrCreateComponentTView",
+  "getOrCreateInjectable",
+  "getOrCreateNodeInjectorForNode",
+  "getOrCreateTNode",
+  "getOrCreateViewRefs",
+  "getOwnDefinition",
+  "getParentInjectorIndex",
+  "getParentInjectorLocation",
+  "getParentInjectorView",
+  "getPipeDef",
+  "getPlatform",
+  "getPreviousIndex",
+  "getProjectionNodes",
+  "getPromiseCtor",
+  "getSelectedIndex",
+  "getSelectedTNode",
+  "getSimpleChangesStore",
+  "getSymbolIterator",
+  "getTNode",
+  "getTNodeFromLView",
+  "getTStylingRangeNext",
+  "getTStylingRangePrev",
+  "getTView",
+  "getViewRefs",
+  "handleError",
+  "handleStoppedNotification",
+  "handleUnhandledError",
+  "hasApplyArgsData",
+  "hasInSkipHydrationBlockFlag",
+  "hasParentInjector",
+  "hasTagAndTypeMatch",
+  "hasValidator",
+  "icuContainerIterate",
+  "identity",
+  "importProvidersFrom",
+  "inNotificationPhase",
+  "includeViewProviders",
+  "incrementInitPhaseFlags",
+  "indexOf",
+  "inheritContentQueries",
+  "inheritHostBindings",
+  "inheritViewQuery",
+  "initFeatures",
+  "initializeDirectives",
+  "inject",
+  "injectArgs",
+  "injectChangeDetectorRef",
+  "injectDestroyRef",
+  "injectElementRef",
+  "injectInjectorOnly",
+  "injectRootLimpMode",
+  "injectTemplateRef",
+  "injectViewContainerRef",
+  "injectableDefOrInjectorDefFactory",
+  "innerFrom",
+  "insertBloom",
+  "instructionState",
+  "internalImportProvidersFrom",
+  "internalProvideZoneChangeDetection",
+  "invokeDirectivesHostBindings",
+  "invokeHostBindingsInCreationMode",
+  "isAngularZoneProperty",
+  "isApplicationBootstrapConfig",
+  "isArrayLike",
+  "isAsyncIterable",
+  "isComponentDef",
+  "isComponentHost",
+  "isConsumerNode",
+  "isContentQueryHost",
+  "isCssClassMatching",
+  "isCurrentTNodeParent",
+  "isDirectiveHost",
+  "isEnvironmentProviders",
+  "isFormControlState",
+  "isForwardRef",
+  "isFunction",
+  "isInlineTemplate",
+  "isInteropObservable",
+  "isIterable",
+  "isLContainer",
+  "isLView",
+  "isListLikeIterable",
+  "isNodeMatchingSelector",
+  "isNodeMatchingSelectorList",
+  "isOptionsObj",
+  "isPlatformServer",
+  "isPositive",
+  "isPresent",
+  "isPromise",
+  "isPromise2",
+  "isReadableStreamLike",
+  "isRefreshingViews",
+  "isRootView",
+  "isStylingMatch",
+  "isStylingValuePresent",
+  "isSubscription",
+  "isTemplateNode",
+  "isTypeProvider",
+  "isValueProvider",
+  "isWritableSignal",
+  "iterator",
+  "keyValueArrayGet",
+  "keyValueArrayIndexOf",
+  "keyValueArraySet",
+  "lastNodeWasCreated",
+  "leaveDI",
+  "leaveView",
+  "leaveViewLight",
+  "listenerInternal",
+  "lookupTokenUsingModuleInjector",
+  "lookupTokenUsingNodeInjector",
+  "makeParamDecorator",
+  "makeRecord",
+  "makeValidatorsArray",
+  "map",
+  "markAncestorsForTraversal",
+  "markAsComponentHost",
+  "markDuplicates",
+  "markViewDirty",
+  "markViewForRefresh",
+  "markedFeatures",
+  "maybeUnwrapEmpty",
+  "maybeWrapInNotSelector",
+  "mergeErrors",
+  "mergeHostAttribute",
+  "mergeHostAttrs",
+  "mergeInputsWithTransforms",
+  "mergeValidators",
+  "modelGroupProvider",
+  "multiFactoryAdd",
+  "multiProvidersFactoryResolver",
+  "multiResolve",
+  "multiViewProvidersFactoryResolver",
+  "nativeAppendChild",
+  "nativeAppendOrInsertBefore",
+  "nativeInsertBefore",
+  "nativeParentNode",
+  "nextBindingIndex",
+  "nextNgElementId",
+  "ngOnChangesSetInput",
+  "ngZoneInstanceId",
+  "noSideEffects",
+  "nonNull",
+  "noop",
+  "noop2",
+  "normalizeValidators",
+  "notFoundValueOrThrow",
+  "nullValidator",
+  "observable",
+  "onEnter",
+  "onLeave",
+  "operate",
+  "optionsReducer",
+  "parseAndConvertBindingsForDefinition",
+  "performanceMarkFeature",
+  "pickAsyncValidators",
+  "pickValidators",
+  "platformBrowser",
+  "platformCore",
+  "processInjectorTypesWithProviders",
+  "producerAccessed",
+  "producerAddLiveConsumer",
+  "producerMarkClean",
+  "producerNotifyConsumers",
+  "producerRemoveLiveConsumerAtIndex",
+  "producerUpdateValueVersion",
+  "producerUpdatesAllowed",
+  "providerToFactory",
+  "readableStreamLikeToAsyncGenerator",
+  "refreshContentQueries",
+  "refreshView",
+  "registerDestroyHooksIfSupported",
+  "registerOnValidatorChange",
+  "registerPostOrderHooks",
+  "rememberChangeHistoryAndInvokeOnChangesHook",
+  "remove",
+  "removeElements",
+  "removeFromArray",
+  "removeListItem",
+  "removeValidators",
+  "renderComponent",
+  "renderStringify",
+  "renderView",
+  "reportUnhandledError",
+  "requiredValidator",
+  "requiresRefreshOrTraversal",
+  "resetPreOrderHookFlags",
+  "resolveDirectives",
+  "resolveForwardRef",
+  "resolveProvider",
+  "resolvedPromise",
+  "resolvedPromise2",
+  "runEffectsInView",
+  "runInInjectionContext",
+  "saveNameToExportMap",
+  "saveResolvedLocalsInData",
+  "scheduleCallbackWithMicrotask",
+  "scheduleCallbackWithRafRace",
+  "searchTokensOnInjector",
+  "selectIndexInternal",
+  "setActiveConsumer",
+  "setBindingRootForHostBindings",
+  "setCurrentDirectiveIndex",
+  "setCurrentInjector",
+  "setCurrentQueryIndex",
+  "setCurrentTNode",
+  "setDirectiveInputsWhichShadowsStyling",
+  "setDisabledStateDefault",
+  "setIncludeViewProviders",
+  "setInjectImplementation",
+  "setInputsForProperty",
+  "setInputsFromAttrs",
+  "setIsRefreshingViews",
+  "setSelectedIndex",
+  "setTStylingRangeNext",
+  "setTStylingRangeNextDuplicate",
+  "setTStylingRangePrevDuplicate",
+  "setUpAttributes",
+  "setUpControl",
+  "setUpValidators",
+  "setupStaticAttributes",
+  "shimStylesContent",
+  "shouldAddViewToDom",
+  "shouldSearchParent",
+  "signal",
+  "signalAsReadonlyFn",
+  "signalSetFn",
+  "storeLViewOnDestroy",
+  "stringify",
+  "stringifyCSSSelector",
+  "throwInvalidWriteToSignalError",
+  "throwInvalidWriteToSignalErrorFn",
+  "throwProviderNotFoundError",
+  "timeoutProvider",
+  "toObservable",
+  "toRefArray",
+  "toTStylingRange",
+  "trackByIdentity",
+  "trackMovedView",
+  "uniqueIdCounter",
+  "unregisterLView",
+  "untracked",
+  "unwrapRNode",
+  "updateAncestorTraversalFlagsOnAttach",
+  "updateControl",
+  "updateMicroTaskStatus",
+  "viewAttachedToChangeDetector",
+  "viewShouldHaveReactiveConsumer",
+  "walkProviderTree",
+  "wasLastNodeCreated",
+  "wrapListener",
+  "writeDirectClass",
+  "writeToDirectiveInput",
+  "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}",
+  "{isArray:isArray2}",
+  "{isArray:isArray}",
+  "ɵInternalFormsSharedModule",
+  "ɵNgNoValidate",
+  "ɵɵInheritDefinitionFeature",
+  "ɵɵNgOnChangesFeature",
+  "ɵɵProvidersFeature",
+  "ɵɵadvance",
+  "ɵɵattribute",
+  "ɵɵclassProp",
+  "ɵɵdefineComponent",
+  "ɵɵdefineDirective",
+  "ɵɵdefineInjectable",
+  "ɵɵdefineInjector",
+  "ɵɵdefineNgModule",
+  "ɵɵdirectiveInject",
+  "ɵɵelement",
+  "ɵɵelementEnd",
+  "ɵɵelementStart",
+  "ɵɵgetInheritedFactory",
+  "ɵɵinject",
+  "ɵɵlistener",
+  "ɵɵnextContext",
+  "ɵɵproperty",
+  "ɵɵtemplate",
+  "ɵɵtext",
+  "ɵɵtwoWayListener",
+  "ɵɵtwoWayProperty"
 ]

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -1,1013 +1,339 @@
 [
-  {
-    "name": "ALLOW_MULTIPLE_PLATFORMS"
-  },
-  {
-    "name": "APP_BOOTSTRAP_LISTENER"
-  },
-  {
-    "name": "APP_INITIALIZER"
-  },
-  {
-    "name": "AfterRenderManager"
-  },
-  {
-    "name": "AnonymousSubject"
-  },
-  {
-    "name": "ApplicationInitStatus"
-  },
-  {
-    "name": "ApplicationRef"
-  },
-  {
-    "name": "BehaviorSubject"
-  },
-  {
-    "name": "BrowserDomAdapter"
-  },
-  {
-    "name": "CIRCULAR"
-  },
-  {
-    "name": "COMPLETE_NOTIFICATION"
-  },
-  {
-    "name": "ChainedInjector"
-  },
-  {
-    "name": "ChangeDetectionScheduler"
-  },
-  {
-    "name": "ChangeDetectionSchedulerImpl"
-  },
-  {
-    "name": "ComponentFactory"
-  },
-  {
-    "name": "ComponentFactory2"
-  },
-  {
-    "name": "ComponentFactoryResolver"
-  },
-  {
-    "name": "ComponentFactoryResolver2"
-  },
-  {
-    "name": "ComponentRef"
-  },
-  {
-    "name": "ComponentRef2"
-  },
-  {
-    "name": "ConsumerObserver"
-  },
-  {
-    "name": "DOCUMENT2"
-  },
-  {
-    "name": "DestroyRef"
-  },
-  {
-    "name": "DomAdapter"
-  },
-  {
-    "name": "EMPTY_ARRAY"
-  },
-  {
-    "name": "EMPTY_OBJ"
-  },
-  {
-    "name": "EMPTY_OBSERVER"
-  },
-  {
-    "name": "EMPTY_PAYLOAD"
-  },
-  {
-    "name": "EMPTY_SUBSCRIPTION"
-  },
-  {
-    "name": "ENVIRONMENT_INITIALIZER"
-  },
-  {
-    "name": "EffectScheduler"
-  },
-  {
-    "name": "ElementRef"
-  },
-  {
-    "name": "EnvironmentInjector"
-  },
-  {
-    "name": "ErrorHandler"
-  },
-  {
-    "name": "EventEmitter"
-  },
-  {
-    "name": "GenericBrowserDomAdapter"
-  },
-  {
-    "name": "HelloWorldModule"
-  },
-  {
-    "name": "INJECTOR"
-  },
-  {
-    "name": "INJECTOR_DEF_TYPES"
-  },
-  {
-    "name": "INJECTOR_SCOPE"
-  },
-  {
-    "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
-  },
-  {
-    "name": "InjectFlags"
-  },
-  {
-    "name": "InjectionToken"
-  },
-  {
-    "name": "Injector"
-  },
-  {
-    "name": "InputFlags"
-  },
-  {
-    "name": "LContainerFlags"
-  },
-  {
-    "name": "LOCALE_ID2"
-  },
-  {
-    "name": "LifecycleHooksFeature"
-  },
-  {
-    "name": "NEW_LINE"
-  },
-  {
-    "name": "NG_COMP_DEF"
-  },
-  {
-    "name": "NG_ELEMENT_ID"
-  },
-  {
-    "name": "NG_ENV_ID"
-  },
-  {
-    "name": "NG_FACTORY_DEF"
-  },
-  {
-    "name": "NG_INJECTABLE_DEF"
-  },
-  {
-    "name": "NG_INJECTOR_DEF"
-  },
-  {
-    "name": "NG_INJ_DEF"
-  },
-  {
-    "name": "NG_MOD_DEF"
-  },
-  {
-    "name": "NG_PROV_DEF"
-  },
-  {
-    "name": "NOT_FOUND"
-  },
-  {
-    "name": "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR"
-  },
-  {
-    "name": "NOT_YET"
-  },
-  {
-    "name": "NO_CHANGE"
-  },
-  {
-    "name": "NULL_INJECTOR"
-  },
-  {
-    "name": "NgModuleFactory"
-  },
-  {
-    "name": "NgModuleFactory2"
-  },
-  {
-    "name": "NgModuleRef"
-  },
-  {
-    "name": "NgModuleRef2"
-  },
-  {
-    "name": "NgZone"
-  },
-  {
-    "name": "NgZoneChangeDetectionScheduler"
-  },
-  {
-    "name": "NodeInjector"
-  },
-  {
-    "name": "NodeInjectorDestroyRef"
-  },
-  {
-    "name": "NodeInjectorFactory"
-  },
-  {
-    "name": "NoopNgZone"
-  },
-  {
-    "name": "NullInjector"
-  },
-  {
-    "name": "ObjectUnsubscribedError"
-  },
-  {
-    "name": "Observable"
-  },
-  {
-    "name": "OperatorSubscriber"
-  },
-  {
-    "name": "PLATFORM_DESTROY_LISTENERS"
-  },
-  {
-    "name": "PLATFORM_ID"
-  },
-  {
-    "name": "PLATFORM_INITIALIZER"
-  },
-  {
-    "name": "PRESERVE_HOST_CONTENT"
-  },
-  {
-    "name": "PendingTasksInternal"
-  },
-  {
-    "name": "PlatformRef"
-  },
-  {
-    "name": "R3Injector"
-  },
-  {
-    "name": "REACTIVE_LVIEW_CONSUMER_NODE"
-  },
-  {
-    "name": "REACTIVE_NODE"
-  },
-  {
-    "name": "RendererFactory2"
-  },
-  {
-    "name": "RuntimeError"
-  },
-  {
-    "name": "SCHEDULE_IN_ROOT_ZONE"
-  },
-  {
-    "name": "SIGNAL"
-  },
-  {
-    "name": "SIMPLE_CHANGES_STORE"
-  },
-  {
-    "name": "SafeSubscriber"
-  },
-  {
-    "name": "Sanitizer"
-  },
-  {
-    "name": "SimpleChange"
-  },
-  {
-    "name": "Subject"
-  },
-  {
-    "name": "Subscriber"
-  },
-  {
-    "name": "Subscription"
-  },
-  {
-    "name": "TEMPORARY_CONSUMER_NODE"
-  },
-  {
-    "name": "TESTABILITY"
-  },
-  {
-    "name": "THROW_IF_NOT_FOUND"
-  },
-  {
-    "name": "TRACKED_LVIEWS"
-  },
-  {
-    "name": "TracingAction"
-  },
-  {
-    "name": "TracingService"
-  },
-  {
-    "name": "USE_VALUE"
-  },
-  {
-    "name": "UnsubscriptionError"
-  },
-  {
-    "name": "ViewEncapsulation"
-  },
-  {
-    "name": "ViewRef"
-  },
-  {
-    "name": "ZONELESS_ENABLED"
-  },
-  {
-    "name": "ZONELESS_SCHEDULER_DISABLED"
-  },
-  {
-    "name": "ZoneAwareEffectScheduler"
-  },
-  {
-    "name": "ZoneStablePendingTask"
-  },
-  {
-    "name": "_DOM"
-  },
-  {
-    "name": "_Injector"
-  },
-  {
-    "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__defProp"
-  },
-  {
-    "name": "__forward_ref__"
-  },
-  {
-    "name": "__publicField"
-  },
-  {
-    "name": "_applyRootElementTransformImpl"
-  },
-  {
-    "name": "_bind"
-  },
-  {
-    "name": "_currentInjector"
-  },
-  {
-    "name": "_injectImplementation"
-  },
-  {
-    "name": "_isRefreshingViews"
-  },
-  {
-    "name": "_platformInjector"
-  },
-  {
-    "name": "activeConsumer"
-  },
-  {
-    "name": "addPropertyBinding"
-  },
-  {
-    "name": "allocExpando"
-  },
-  {
-    "name": "allocLFrame"
-  },
-  {
-    "name": "angularZoneInstanceIdProperty"
-  },
-  {
-    "name": "applyNodes"
-  },
-  {
-    "name": "applyProjectionRecursive"
-  },
-  {
-    "name": "applyToElementOrContainer"
-  },
-  {
-    "name": "applyValueToInputField"
-  },
-  {
-    "name": "applyView"
-  },
-  {
-    "name": "arrRemove"
-  },
-  {
-    "name": "assertConsumerNode"
-  },
-  {
-    "name": "assertNotDestroyed"
-  },
-  {
-    "name": "attachPatchData"
-  },
-  {
-    "name": "baseElement"
-  },
-  {
-    "name": "bind"
-  },
-  {
-    "name": "bloomHasToken"
-  },
-  {
-    "name": "bootstrap"
-  },
-  {
-    "name": "callHook"
-  },
-  {
-    "name": "callHookInternal"
-  },
-  {
-    "name": "callHooks"
-  },
-  {
-    "name": "captureNodeBindings"
-  },
-  {
-    "name": "checkStable"
-  },
-  {
-    "name": "cleanUpView"
-  },
-  {
-    "name": "collectNativeNodes"
-  },
-  {
-    "name": "collectNativeNodesInLContainer"
-  },
-  {
-    "name": "concatStringsWithSpace"
-  },
-  {
-    "name": "config"
-  },
-  {
-    "name": "configureViewWithDirective"
-  },
-  {
-    "name": "consumerBeforeComputation"
-  },
-  {
-    "name": "consumerDestroy"
-  },
-  {
-    "name": "consumerIsLive"
-  },
-  {
-    "name": "consumerPollProducersForChange"
-  },
-  {
-    "name": "context"
-  },
-  {
-    "name": "convertToBitFlags"
-  },
-  {
-    "name": "createElementRef"
-  },
-  {
-    "name": "createErrorClass"
-  },
-  {
-    "name": "createInjector"
-  },
-  {
-    "name": "createInjectorWithoutInjectorInstances"
-  },
-  {
-    "name": "createLFrame"
-  },
-  {
-    "name": "createLView"
-  },
-  {
-    "name": "createNodeInjector"
-  },
-  {
-    "name": "createNotification"
-  },
-  {
-    "name": "createPlatformFactory"
-  },
-  {
-    "name": "createTView"
-  },
-  {
-    "name": "deepForEach"
-  },
-  {
-    "name": "deepForEachProvider"
-  },
-  {
-    "name": "detachMovedView"
-  },
-  {
-    "name": "detachViewFromDOM"
-  },
-  {
-    "name": "detectChangesInChildComponents"
-  },
-  {
-    "name": "detectChangesInComponent"
-  },
-  {
-    "name": "detectChangesInEmbeddedViews"
-  },
-  {
-    "name": "detectChangesInView"
-  },
-  {
-    "name": "detectChangesInViewIfAttached"
-  },
-  {
-    "name": "detectChangesInViewIfRequired"
-  },
-  {
-    "name": "detectChangesInternal"
-  },
-  {
-    "name": "diPublicInInjector"
-  },
-  {
-    "name": "enterDI"
-  },
-  {
-    "name": "enterView"
-  },
-  {
-    "name": "errorContext"
-  },
-  {
-    "name": "execFinalizer"
-  },
-  {
-    "name": "executeCheckHooks"
-  },
-  {
-    "name": "executeInitAndCheckHooks"
-  },
-  {
-    "name": "executeTemplate"
-  },
-  {
-    "name": "executeViewQueryFn"
-  },
-  {
-    "name": "forEachSingleProvider"
-  },
-  {
-    "name": "forwardRef"
-  },
-  {
-    "name": "freeConsumers"
-  },
-  {
-    "name": "generateInitialInputs"
-  },
-  {
-    "name": "getClosureSafeProperty"
-  },
-  {
-    "name": "getComponentDef"
-  },
-  {
-    "name": "getComponentLViewByIndex"
-  },
-  {
-    "name": "getCurrentTNode"
-  },
-  {
-    "name": "getCurrentTNodePlaceholderOk"
-  },
-  {
-    "name": "getDeclarationTNode"
-  },
-  {
-    "name": "getFactoryDef"
-  },
-  {
-    "name": "getFirstLContainer"
-  },
-  {
-    "name": "getInjectImplementation"
-  },
-  {
-    "name": "getInjectableDef"
-  },
-  {
-    "name": "getInjectorDef"
-  },
-  {
-    "name": "getInjectorIndex"
-  },
-  {
-    "name": "getLView"
-  },
-  {
-    "name": "getLViewParent"
-  },
-  {
-    "name": "getNativeByTNode"
-  },
-  {
-    "name": "getNearestLContainer"
-  },
-  {
-    "name": "getNextLContainer"
-  },
-  {
-    "name": "getNgZoneOptions"
-  },
-  {
-    "name": "getNodeInjectable"
-  },
-  {
-    "name": "getNullInjector"
-  },
-  {
-    "name": "getOrCreateInjectable"
-  },
-  {
-    "name": "getOrCreateNodeInjectorForNode"
-  },
-  {
-    "name": "getOrCreateTNode"
-  },
-  {
-    "name": "getOwnDefinition"
-  },
-  {
-    "name": "getParentInjectorIndex"
-  },
-  {
-    "name": "getParentInjectorLocation"
-  },
-  {
-    "name": "getParentInjectorView"
-  },
-  {
-    "name": "getPlatform"
-  },
-  {
-    "name": "getProjectionNodes"
-  },
-  {
-    "name": "getPromiseCtor"
-  },
-  {
-    "name": "getSimpleChangesStore"
-  },
-  {
-    "name": "getTNodeFromLView"
-  },
-  {
-    "name": "handleStoppedNotification"
-  },
-  {
-    "name": "handleUnhandledError"
-  },
-  {
-    "name": "hasApplyArgsData"
-  },
-  {
-    "name": "icuContainerIterate"
-  },
-  {
-    "name": "identity"
-  },
-  {
-    "name": "importProvidersFrom"
-  },
-  {
-    "name": "includeViewProviders"
-  },
-  {
-    "name": "incrementInitPhaseFlags"
-  },
-  {
-    "name": "inject"
-  },
-  {
-    "name": "injectArgs"
-  },
-  {
-    "name": "injectDestroyRef"
-  },
-  {
-    "name": "injectElementRef"
-  },
-  {
-    "name": "injectInjectorOnly"
-  },
-  {
-    "name": "injectRootLimpMode"
-  },
-  {
-    "name": "injectableDefOrInjectorDefFactory"
-  },
-  {
-    "name": "insertBloom"
-  },
-  {
-    "name": "instructionState"
-  },
-  {
-    "name": "internalImportProvidersFrom"
-  },
-  {
-    "name": "internalProvideZoneChangeDetection"
-  },
-  {
-    "name": "invokeHostBindingsInCreationMode"
-  },
-  {
-    "name": "isAngularZoneProperty"
-  },
-  {
-    "name": "isApplicationBootstrapConfig"
-  },
-  {
-    "name": "isComponentDef"
-  },
-  {
-    "name": "isEnvironmentProviders"
-  },
-  {
-    "name": "isFunction"
-  },
-  {
-    "name": "isInlineTemplate"
-  },
-  {
-    "name": "isLContainer"
-  },
-  {
-    "name": "isLView"
-  },
-  {
-    "name": "isPositive"
-  },
-  {
-    "name": "isPromise"
-  },
-  {
-    "name": "isRefreshingViews"
-  },
-  {
-    "name": "isRootView"
-  },
-  {
-    "name": "isSubscription"
-  },
-  {
-    "name": "isTypeProvider"
-  },
-  {
-    "name": "isValueProvider"
-  },
-  {
-    "name": "leaveDI"
-  },
-  {
-    "name": "leaveView"
-  },
-  {
-    "name": "leaveViewLight"
-  },
-  {
-    "name": "lookupTokenUsingModuleInjector"
-  },
-  {
-    "name": "lookupTokenUsingNodeInjector"
-  },
-  {
-    "name": "makeRecord"
-  },
-  {
-    "name": "map"
-  },
-  {
-    "name": "markAncestorsForTraversal"
-  },
-  {
-    "name": "markViewDirty"
-  },
-  {
-    "name": "markViewForRefresh"
-  },
-  {
-    "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "mergeHostAttribute"
-  },
-  {
-    "name": "mergeHostAttrs"
-  },
-  {
-    "name": "nativeInsertBefore"
-  },
-  {
-    "name": "nextNgElementId"
-  },
-  {
-    "name": "ngOnChangesSetInput"
-  },
-  {
-    "name": "ngZoneInstanceId"
-  },
-  {
-    "name": "noop"
-  },
-  {
-    "name": "noop2"
-  },
-  {
-    "name": "notFoundValueOrThrow"
-  },
-  {
-    "name": "observable"
-  },
-  {
-    "name": "onEnter"
-  },
-  {
-    "name": "onLeave"
-  },
-  {
-    "name": "optionsReducer"
-  },
-  {
-    "name": "platformBrowser"
-  },
-  {
-    "name": "platformCore"
-  },
-  {
-    "name": "processInjectorTypesWithProviders"
-  },
-  {
-    "name": "producerMarkClean"
-  },
-  {
-    "name": "producerRemoveLiveConsumerAtIndex"
-  },
-  {
-    "name": "producerUpdateValueVersion"
-  },
-  {
-    "name": "refreshContentQueries"
-  },
-  {
-    "name": "refreshView"
-  },
-  {
-    "name": "rememberChangeHistoryAndInvokeOnChangesHook"
-  },
-  {
-    "name": "remove"
-  },
-  {
-    "name": "removeFromArray"
-  },
-  {
-    "name": "renderComponent"
-  },
-  {
-    "name": "renderView"
-  },
-  {
-    "name": "requiresRefreshOrTraversal"
-  },
-  {
-    "name": "resetPreOrderHookFlags"
-  },
-  {
-    "name": "resolveForwardRef"
-  },
-  {
-    "name": "runEffectsInView"
-  },
-  {
-    "name": "runInInjectionContext"
-  },
-  {
-    "name": "saveNameToExportMap"
-  },
-  {
-    "name": "scheduleCallbackWithMicrotask"
-  },
-  {
-    "name": "scheduleCallbackWithRafRace"
-  },
-  {
-    "name": "searchTokensOnInjector"
-  },
-  {
-    "name": "setActiveConsumer"
-  },
-  {
-    "name": "setBindingRootForHostBindings"
-  },
-  {
-    "name": "setCurrentDirectiveIndex"
-  },
-  {
-    "name": "setCurrentInjector"
-  },
-  {
-    "name": "setCurrentQueryIndex"
-  },
-  {
-    "name": "setIncludeViewProviders"
-  },
-  {
-    "name": "setInjectImplementation"
-  },
-  {
-    "name": "setIsRefreshingViews"
-  },
-  {
-    "name": "setSelectedIndex"
-  },
-  {
-    "name": "setUpAttributes"
-  },
-  {
-    "name": "shouldSearchParent"
-  },
-  {
-    "name": "storeLViewOnDestroy"
-  },
-  {
-    "name": "stringify"
-  },
-  {
-    "name": "stringifyCSSSelector"
-  },
-  {
-    "name": "throwProviderNotFoundError"
-  },
-  {
-    "name": "timeoutProvider"
-  },
-  {
-    "name": "toRefArray"
-  },
-  {
-    "name": "uniqueIdCounter"
-  },
-  {
-    "name": "unregisterLView"
-  },
-  {
-    "name": "unwrapRNode"
-  },
-  {
-    "name": "updateAncestorTraversalFlagsOnAttach"
-  },
-  {
-    "name": "updateMicroTaskStatus"
-  },
-  {
-    "name": "viewAttachedToChangeDetector"
-  },
-  {
-    "name": "viewShouldHaveReactiveConsumer"
-  },
-  {
-    "name": "walkProviderTree"
-  },
-  {
-    "name": "writeDirectClass"
-  },
-  {
-    "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "ɵɵdefineInjectable"
-  },
-  {
-    "name": "ɵɵdefineInjector"
-  },
-  {
-    "name": "ɵɵdefineNgModule"
-  },
-  {
-    "name": "ɵɵdirectiveInject"
-  },
-  {
-    "name": "ɵɵinject"
-  }
+  "ALLOW_MULTIPLE_PLATFORMS",
+  "APP_BOOTSTRAP_LISTENER",
+  "APP_INITIALIZER",
+  "AfterRenderManager",
+  "AnonymousSubject",
+  "ApplicationInitStatus",
+  "ApplicationRef",
+  "BehaviorSubject",
+  "BrowserDomAdapter",
+  "CIRCULAR",
+  "COMPLETE_NOTIFICATION",
+  "ChainedInjector",
+  "ChangeDetectionScheduler",
+  "ChangeDetectionSchedulerImpl",
+  "ComponentFactory",
+  "ComponentFactory2",
+  "ComponentFactoryResolver",
+  "ComponentFactoryResolver2",
+  "ComponentRef",
+  "ComponentRef2",
+  "ConsumerObserver",
+  "DOCUMENT2",
+  "DestroyRef",
+  "DomAdapter",
+  "EMPTY_ARRAY",
+  "EMPTY_OBJ",
+  "EMPTY_OBSERVER",
+  "EMPTY_PAYLOAD",
+  "EMPTY_SUBSCRIPTION",
+  "ENVIRONMENT_INITIALIZER",
+  "EffectScheduler",
+  "ElementRef",
+  "EnvironmentInjector",
+  "ErrorHandler",
+  "EventEmitter",
+  "GenericBrowserDomAdapter",
+  "HelloWorldModule",
+  "INJECTOR",
+  "INJECTOR_DEF_TYPES",
+  "INJECTOR_SCOPE",
+  "INTERNAL_APPLICATION_ERROR_HANDLER",
+  "InjectFlags",
+  "InjectionToken",
+  "Injector",
+  "InputFlags",
+  "LContainerFlags",
+  "LOCALE_ID2",
+  "LifecycleHooksFeature",
+  "NEW_LINE",
+  "NG_COMP_DEF",
+  "NG_ELEMENT_ID",
+  "NG_ENV_ID",
+  "NG_FACTORY_DEF",
+  "NG_INJECTABLE_DEF",
+  "NG_INJECTOR_DEF",
+  "NG_INJ_DEF",
+  "NG_MOD_DEF",
+  "NG_PROV_DEF",
+  "NOT_FOUND",
+  "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR",
+  "NOT_YET",
+  "NO_CHANGE",
+  "NULL_INJECTOR",
+  "NgModuleFactory",
+  "NgModuleFactory2",
+  "NgModuleRef",
+  "NgModuleRef2",
+  "NgZone",
+  "NgZoneChangeDetectionScheduler",
+  "NodeInjector",
+  "NodeInjectorDestroyRef",
+  "NodeInjectorFactory",
+  "NoopNgZone",
+  "NullInjector",
+  "ObjectUnsubscribedError",
+  "Observable",
+  "OperatorSubscriber",
+  "PLATFORM_DESTROY_LISTENERS",
+  "PLATFORM_ID",
+  "PLATFORM_INITIALIZER",
+  "PRESERVE_HOST_CONTENT",
+  "PendingTasksInternal",
+  "PlatformRef",
+  "R3Injector",
+  "REACTIVE_LVIEW_CONSUMER_NODE",
+  "REACTIVE_NODE",
+  "RendererFactory2",
+  "RuntimeError",
+  "SCHEDULE_IN_ROOT_ZONE",
+  "SIGNAL",
+  "SIMPLE_CHANGES_STORE",
+  "SafeSubscriber",
+  "Sanitizer",
+  "SimpleChange",
+  "Subject",
+  "Subscriber",
+  "Subscription",
+  "TEMPORARY_CONSUMER_NODE",
+  "TESTABILITY",
+  "THROW_IF_NOT_FOUND",
+  "TRACKED_LVIEWS",
+  "TracingAction",
+  "TracingService",
+  "USE_VALUE",
+  "UnsubscriptionError",
+  "ViewEncapsulation",
+  "ViewRef",
+  "ZONELESS_ENABLED",
+  "ZONELESS_SCHEDULER_DISABLED",
+  "ZoneAwareEffectScheduler",
+  "ZoneStablePendingTask",
+  "_DOM",
+  "_Injector",
+  "_NullComponentFactoryResolver",
+  "__defProp",
+  "__forward_ref__",
+  "__publicField",
+  "_applyRootElementTransformImpl",
+  "_bind",
+  "_currentInjector",
+  "_injectImplementation",
+  "_isRefreshingViews",
+  "_platformInjector",
+  "activeConsumer",
+  "addPropertyBinding",
+  "allocExpando",
+  "allocLFrame",
+  "angularZoneInstanceIdProperty",
+  "applyNodes",
+  "applyProjectionRecursive",
+  "applyToElementOrContainer",
+  "applyValueToInputField",
+  "applyView",
+  "arrRemove",
+  "assertConsumerNode",
+  "assertNotDestroyed",
+  "attachPatchData",
+  "baseElement",
+  "bind",
+  "bloomHasToken",
+  "bootstrap",
+  "callHook",
+  "callHookInternal",
+  "callHooks",
+  "captureNodeBindings",
+  "checkStable",
+  "cleanUpView",
+  "collectNativeNodes",
+  "collectNativeNodesInLContainer",
+  "concatStringsWithSpace",
+  "config",
+  "configureViewWithDirective",
+  "consumerBeforeComputation",
+  "consumerDestroy",
+  "consumerIsLive",
+  "consumerPollProducersForChange",
+  "context",
+  "convertToBitFlags",
+  "createElementRef",
+  "createErrorClass",
+  "createInjector",
+  "createInjectorWithoutInjectorInstances",
+  "createLFrame",
+  "createLView",
+  "createNodeInjector",
+  "createNotification",
+  "createPlatformFactory",
+  "createTView",
+  "deepForEach",
+  "deepForEachProvider",
+  "detachMovedView",
+  "detachViewFromDOM",
+  "detectChangesInChildComponents",
+  "detectChangesInComponent",
+  "detectChangesInEmbeddedViews",
+  "detectChangesInView",
+  "detectChangesInViewIfAttached",
+  "detectChangesInViewIfRequired",
+  "detectChangesInternal",
+  "diPublicInInjector",
+  "enterDI",
+  "enterView",
+  "errorContext",
+  "execFinalizer",
+  "executeCheckHooks",
+  "executeInitAndCheckHooks",
+  "executeTemplate",
+  "executeViewQueryFn",
+  "forEachSingleProvider",
+  "forwardRef",
+  "freeConsumers",
+  "generateInitialInputs",
+  "getClosureSafeProperty",
+  "getComponentDef",
+  "getComponentLViewByIndex",
+  "getCurrentTNode",
+  "getCurrentTNodePlaceholderOk",
+  "getDeclarationTNode",
+  "getFactoryDef",
+  "getFirstLContainer",
+  "getInjectImplementation",
+  "getInjectableDef",
+  "getInjectorDef",
+  "getInjectorIndex",
+  "getLView",
+  "getLViewParent",
+  "getNativeByTNode",
+  "getNearestLContainer",
+  "getNextLContainer",
+  "getNgZoneOptions",
+  "getNodeInjectable",
+  "getNullInjector",
+  "getOrCreateInjectable",
+  "getOrCreateNodeInjectorForNode",
+  "getOrCreateTNode",
+  "getOwnDefinition",
+  "getParentInjectorIndex",
+  "getParentInjectorLocation",
+  "getParentInjectorView",
+  "getPlatform",
+  "getProjectionNodes",
+  "getPromiseCtor",
+  "getSimpleChangesStore",
+  "getTNodeFromLView",
+  "handleStoppedNotification",
+  "handleUnhandledError",
+  "hasApplyArgsData",
+  "icuContainerIterate",
+  "identity",
+  "importProvidersFrom",
+  "includeViewProviders",
+  "incrementInitPhaseFlags",
+  "inject",
+  "injectArgs",
+  "injectDestroyRef",
+  "injectElementRef",
+  "injectInjectorOnly",
+  "injectRootLimpMode",
+  "injectableDefOrInjectorDefFactory",
+  "insertBloom",
+  "instructionState",
+  "internalImportProvidersFrom",
+  "internalProvideZoneChangeDetection",
+  "invokeHostBindingsInCreationMode",
+  "isAngularZoneProperty",
+  "isApplicationBootstrapConfig",
+  "isComponentDef",
+  "isEnvironmentProviders",
+  "isFunction",
+  "isInlineTemplate",
+  "isLContainer",
+  "isLView",
+  "isPositive",
+  "isPromise",
+  "isRefreshingViews",
+  "isRootView",
+  "isSubscription",
+  "isTypeProvider",
+  "isValueProvider",
+  "leaveDI",
+  "leaveView",
+  "leaveViewLight",
+  "lookupTokenUsingModuleInjector",
+  "lookupTokenUsingNodeInjector",
+  "makeRecord",
+  "map",
+  "markAncestorsForTraversal",
+  "markViewDirty",
+  "markViewForRefresh",
+  "maybeWrapInNotSelector",
+  "mergeHostAttribute",
+  "mergeHostAttrs",
+  "nativeInsertBefore",
+  "nextNgElementId",
+  "ngOnChangesSetInput",
+  "ngZoneInstanceId",
+  "noop",
+  "noop2",
+  "notFoundValueOrThrow",
+  "observable",
+  "onEnter",
+  "onLeave",
+  "optionsReducer",
+  "platformBrowser",
+  "platformCore",
+  "processInjectorTypesWithProviders",
+  "producerMarkClean",
+  "producerRemoveLiveConsumerAtIndex",
+  "producerUpdateValueVersion",
+  "refreshContentQueries",
+  "refreshView",
+  "rememberChangeHistoryAndInvokeOnChangesHook",
+  "remove",
+  "removeFromArray",
+  "renderComponent",
+  "renderView",
+  "requiresRefreshOrTraversal",
+  "resetPreOrderHookFlags",
+  "resolveForwardRef",
+  "runEffectsInView",
+  "runInInjectionContext",
+  "saveNameToExportMap",
+  "scheduleCallbackWithMicrotask",
+  "scheduleCallbackWithRafRace",
+  "searchTokensOnInjector",
+  "setActiveConsumer",
+  "setBindingRootForHostBindings",
+  "setCurrentDirectiveIndex",
+  "setCurrentInjector",
+  "setCurrentQueryIndex",
+  "setIncludeViewProviders",
+  "setInjectImplementation",
+  "setIsRefreshingViews",
+  "setSelectedIndex",
+  "setUpAttributes",
+  "shouldSearchParent",
+  "storeLViewOnDestroy",
+  "stringify",
+  "stringifyCSSSelector",
+  "throwProviderNotFoundError",
+  "timeoutProvider",
+  "toRefArray",
+  "uniqueIdCounter",
+  "unregisterLView",
+  "unwrapRNode",
+  "updateAncestorTraversalFlagsOnAttach",
+  "updateMicroTaskStatus",
+  "viewAttachedToChangeDetector",
+  "viewShouldHaveReactiveConsumer",
+  "walkProviderTree",
+  "writeDirectClass",
+  "writeToDirectiveInput",
+  "ɵɵdefineInjectable",
+  "ɵɵdefineInjector",
+  "ɵɵdefineNgModule",
+  "ɵɵdirectiveInject",
+  "ɵɵinject"
 ]

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -1,1358 +1,454 @@
 [
-  {
-    "name": "ALLOWED_METHODS"
-  },
-  {
-    "name": "APP_BOOTSTRAP_LISTENER"
-  },
-  {
-    "name": "APP_ID"
-  },
-  {
-    "name": "APP_INITIALIZER"
-  },
-  {
-    "name": "AfterRenderManager"
-  },
-  {
-    "name": "AnonymousSubject"
-  },
-  {
-    "name": "ApplicationInitStatus"
-  },
-  {
-    "name": "ApplicationRef"
-  },
-  {
-    "name": "BODY"
-  },
-  {
-    "name": "BROWSER_MODULE_PROVIDERS"
-  },
-  {
-    "name": "BehaviorSubject"
-  },
-  {
-    "name": "BrowserDomAdapter"
-  },
-  {
-    "name": "BrowserXhr"
-  },
-  {
-    "name": "CACHE_OPTIONS"
-  },
-  {
-    "name": "CIRCULAR"
-  },
-  {
-    "name": "COMPLETE_NOTIFICATION"
-  },
-  {
-    "name": "COMPONENT_REGEX"
-  },
-  {
-    "name": "CSP_NONCE"
-  },
-  {
-    "name": "ChainedInjector"
-  },
-  {
-    "name": "ChangeDetectionScheduler"
-  },
-  {
-    "name": "ChangeDetectionSchedulerImpl"
-  },
-  {
-    "name": "ChangeDetectionStrategy"
-  },
-  {
-    "name": "ComponentFactory"
-  },
-  {
-    "name": "ComponentFactory2"
-  },
-  {
-    "name": "ComponentFactoryResolver"
-  },
-  {
-    "name": "ComponentFactoryResolver2"
-  },
-  {
-    "name": "ComponentRef"
-  },
-  {
-    "name": "ComponentRef2"
-  },
-  {
-    "name": "ConsumerObserver"
-  },
-  {
-    "name": "DEFAULT_APP_ID"
-  },
-  {
-    "name": "DOCUMENT"
-  },
-  {
-    "name": "DOCUMENT2"
-  },
-  {
-    "name": "DefaultDomRenderer2"
-  },
-  {
-    "name": "DestroyRef"
-  },
-  {
-    "name": "DomAdapter"
-  },
-  {
-    "name": "DomEventsPlugin"
-  },
-  {
-    "name": "DomRendererFactory2"
-  },
-  {
-    "name": "EMPTY_ARRAY"
-  },
-  {
-    "name": "EMPTY_OBJ"
-  },
-  {
-    "name": "EMPTY_OBSERVER"
-  },
-  {
-    "name": "EMPTY_PAYLOAD"
-  },
-  {
-    "name": "EMPTY_SUBSCRIPTION"
-  },
-  {
-    "name": "ENVIRONMENT_INITIALIZER"
-  },
-  {
-    "name": "EVENT_MANAGER_PLUGINS"
-  },
-  {
-    "name": "EffectScheduler"
-  },
-  {
-    "name": "ElementRef"
-  },
-  {
-    "name": "EmulatedEncapsulationDomRenderer2"
-  },
-  {
-    "name": "EnvironmentInjector"
-  },
-  {
-    "name": "EnvironmentNgModuleRefAdapter"
-  },
-  {
-    "name": "ErrorHandler"
-  },
-  {
-    "name": "EventEmitter"
-  },
-  {
-    "name": "EventManager"
-  },
-  {
-    "name": "EventManagerPlugin"
-  },
-  {
-    "name": "GenericBrowserDomAdapter"
-  },
-  {
-    "name": "HEADERS"
-  },
-  {
-    "name": "HTTP_ROOT_INTERCEPTOR_FNS"
-  },
-  {
-    "name": "HTTP_TRANSFER_CACHE_ORIGIN_MAP"
-  },
-  {
-    "name": "HttpEventType"
-  },
-  {
-    "name": "HttpHeaders"
-  },
-  {
-    "name": "HttpResponse"
-  },
-  {
-    "name": "HttpResponseBase"
-  },
-  {
-    "name": "HydrationFeatureKind"
-  },
-  {
-    "name": "INJECTOR"
-  },
-  {
-    "name": "INJECTOR_DEF_TYPES"
-  },
-  {
-    "name": "INJECTOR_SCOPE"
-  },
-  {
-    "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
-  },
-  {
-    "name": "INTERNAL_BROWSER_PLATFORM_PROVIDERS"
-  },
-  {
-    "name": "IS_HYDRATION_DOM_REUSE_ENABLED"
-  },
-  {
-    "name": "InjectFlags"
-  },
-  {
-    "name": "InjectionToken"
-  },
-  {
-    "name": "Injector"
-  },
-  {
-    "name": "InputFlags"
-  },
-  {
-    "name": "KeyEventsPlugin"
-  },
-  {
-    "name": "LContainerFlags"
-  },
-  {
-    "name": "LOCALE_ID2"
-  },
-  {
-    "name": "LifecycleHooksFeature"
-  },
-  {
-    "name": "MODIFIER_KEYS"
-  },
-  {
-    "name": "MODIFIER_KEY_GETTERS"
-  },
-  {
-    "name": "NAMESPACE_URIS"
-  },
-  {
-    "name": "NEW_LINE"
-  },
-  {
-    "name": "NG_COMP_DEF"
-  },
-  {
-    "name": "NG_DIR_DEF"
-  },
-  {
-    "name": "NG_ELEMENT_ID"
-  },
-  {
-    "name": "NG_ENV_ID"
-  },
-  {
-    "name": "NG_FACTORY_DEF"
-  },
-  {
-    "name": "NG_INJECTABLE_DEF"
-  },
-  {
-    "name": "NG_INJECTOR_DEF"
-  },
-  {
-    "name": "NG_INJ_DEF"
-  },
-  {
-    "name": "NG_PIPE_DEF"
-  },
-  {
-    "name": "NG_PROV_DEF"
-  },
-  {
-    "name": "NOT_FOUND"
-  },
-  {
-    "name": "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR"
-  },
-  {
-    "name": "NOT_YET"
-  },
-  {
-    "name": "NO_CHANGE"
-  },
-  {
-    "name": "NULL_INJECTOR"
-  },
-  {
-    "name": "NgModuleRef"
-  },
-  {
-    "name": "NgZone"
-  },
-  {
-    "name": "NgZoneChangeDetectionScheduler"
-  },
-  {
-    "name": "NodeInjector"
-  },
-  {
-    "name": "NodeInjectorDestroyRef"
-  },
-  {
-    "name": "NodeInjectorFactory"
-  },
-  {
-    "name": "NodeNavigationStep"
-  },
-  {
-    "name": "NoneEncapsulationDomRenderer"
-  },
-  {
-    "name": "NoopNgZone"
-  },
-  {
-    "name": "NullInjector"
-  },
-  {
-    "name": "ObjectUnsubscribedError"
-  },
-  {
-    "name": "Observable"
-  },
-  {
-    "name": "OperatorSubscriber"
-  },
-  {
-    "name": "PLATFORM_DESTROY_LISTENERS"
-  },
-  {
-    "name": "PLATFORM_ID"
-  },
-  {
-    "name": "PLATFORM_INITIALIZER"
-  },
-  {
-    "name": "PRESERVE_HOST_CONTENT"
-  },
-  {
-    "name": "PendingTasksInternal"
-  },
-  {
-    "name": "R3Injector"
-  },
-  {
-    "name": "REACTIVE_LVIEW_CONSUMER_NODE"
-  },
-  {
-    "name": "REACTIVE_NODE"
-  },
-  {
-    "name": "REF_EXTRACTOR_REGEXP"
-  },
-  {
-    "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
-  },
-  {
-    "name": "REQ_URL"
-  },
-  {
-    "name": "RESPONSE_TYPE"
-  },
-  {
-    "name": "RendererFactory2"
-  },
-  {
-    "name": "RendererStyleFlags2"
-  },
-  {
-    "name": "RuntimeError"
-  },
-  {
-    "name": "SCHEDULE_IN_ROOT_ZONE"
-  },
-  {
-    "name": "SIGNAL"
-  },
-  {
-    "name": "SIMPLE_CHANGES_STORE"
-  },
-  {
-    "name": "STATUS"
-  },
-  {
-    "name": "STATUS_TEXT"
-  },
-  {
-    "name": "SafeSubscriber"
-  },
-  {
-    "name": "Sanitizer"
-  },
-  {
-    "name": "ShadowDomRenderer"
-  },
-  {
-    "name": "SharedStylesHost"
-  },
-  {
-    "name": "SimpleChange"
-  },
-  {
-    "name": "StandaloneService"
-  },
-  {
-    "name": "Subject"
-  },
-  {
-    "name": "Subscriber"
-  },
-  {
-    "name": "Subscription"
-  },
-  {
-    "name": "TEMPORARY_CONSUMER_NODE"
-  },
-  {
-    "name": "TESTABILITY"
-  },
-  {
-    "name": "THROW_IF_NOT_FOUND"
-  },
-  {
-    "name": "TRACKED_LVIEWS"
-  },
-  {
-    "name": "TracingAction"
-  },
-  {
-    "name": "TracingService"
-  },
-  {
-    "name": "TransferState"
-  },
-  {
-    "name": "USE_VALUE"
-  },
-  {
-    "name": "UnsubscriptionError"
-  },
-  {
-    "name": "ViewEncapsulation"
-  },
-  {
-    "name": "ViewRef"
-  },
-  {
-    "name": "ZONELESS_ENABLED"
-  },
-  {
-    "name": "ZONELESS_SCHEDULER_DISABLED"
-  },
-  {
-    "name": "ZoneAwareEffectScheduler"
-  },
-  {
-    "name": "ZoneStablePendingTask"
-  },
-  {
-    "name": "_DOM"
-  },
-  {
-    "name": "_Injector"
-  },
-  {
-    "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__asyncValues"
-  },
-  {
-    "name": "__await"
-  },
-  {
-    "name": "__defProp"
-  },
-  {
-    "name": "__forward_ref__"
-  },
-  {
-    "name": "__publicField"
-  },
-  {
-    "name": "_applyRootElementTransformImpl"
-  },
-  {
-    "name": "_bind"
-  },
-  {
-    "name": "_currentInjector"
-  },
-  {
-    "name": "_injectImplementation"
-  },
-  {
-    "name": "_isRefreshingViews"
-  },
-  {
-    "name": "_keyMap"
-  },
-  {
-    "name": "_locateOrCreateTextNode"
-  },
-  {
-    "name": "_platformInjector"
-  },
-  {
-    "name": "_retrieveHydrationInfoImpl"
-  },
-  {
-    "name": "_wasLastNodeCreated"
-  },
-  {
-    "name": "activeConsumer"
-  },
-  {
-    "name": "addPropertyBinding"
-  },
-  {
-    "name": "allocExpando"
-  },
-  {
-    "name": "allocLFrame"
-  },
-  {
-    "name": "angularZoneInstanceIdProperty"
-  },
-  {
-    "name": "appendChild"
-  },
-  {
-    "name": "applyNodes"
-  },
-  {
-    "name": "applyProjectionRecursive"
-  },
-  {
-    "name": "applyRootElementTransformImpl"
-  },
-  {
-    "name": "applyToElementOrContainer"
-  },
-  {
-    "name": "applyValueToInputField"
-  },
-  {
-    "name": "applyView"
-  },
-  {
-    "name": "arrRemove"
-  },
-  {
-    "name": "assertConsumerNode"
-  },
-  {
-    "name": "assertNotDestroyed"
-  },
-  {
-    "name": "attachPatchData"
-  },
-  {
-    "name": "baseElement"
-  },
-  {
-    "name": "bind"
-  },
-  {
-    "name": "bloomHasToken"
-  },
-  {
-    "name": "bootstrap"
-  },
-  {
-    "name": "calcSerializedContainerSize"
-  },
-  {
-    "name": "callHook"
-  },
-  {
-    "name": "callHookInternal"
-  },
-  {
-    "name": "callHooks"
-  },
-  {
-    "name": "captureNodeBindings"
-  },
-  {
-    "name": "checkStable"
-  },
-  {
-    "name": "cleanUpView"
-  },
-  {
-    "name": "cleanupDehydratedIcuData"
-  },
-  {
-    "name": "cleanupLContainer"
-  },
-  {
-    "name": "cleanupLView"
-  },
-  {
-    "name": "clearElementContents"
-  },
-  {
-    "name": "collectNativeNodes"
-  },
-  {
-    "name": "collectNativeNodesInLContainer"
-  },
-  {
-    "name": "concatStringsWithSpace"
-  },
-  {
-    "name": "config"
-  },
-  {
-    "name": "configureViewWithDirective"
-  },
-  {
-    "name": "consumerBeforeComputation"
-  },
-  {
-    "name": "consumerDestroy"
-  },
-  {
-    "name": "consumerIsLive"
-  },
-  {
-    "name": "consumerPollProducersForChange"
-  },
-  {
-    "name": "context"
-  },
-  {
-    "name": "convertToBitFlags"
-  },
-  {
-    "name": "createElementNode"
-  },
-  {
-    "name": "createElementRef"
-  },
-  {
-    "name": "createErrorClass"
-  },
-  {
-    "name": "createInjector"
-  },
-  {
-    "name": "createInvalidObservableTypeError"
-  },
-  {
-    "name": "createLFrame"
-  },
-  {
-    "name": "createLView"
-  },
-  {
-    "name": "createLinkElement"
-  },
-  {
-    "name": "createNodeInjector"
-  },
-  {
-    "name": "createNotification"
-  },
-  {
-    "name": "createOperatorSubscriber"
-  },
-  {
-    "name": "createStyleElement"
-  },
-  {
-    "name": "createTView"
-  },
-  {
-    "name": "createTextNode"
-  },
-  {
-    "name": "deepForEach"
-  },
-  {
-    "name": "deepForEachProvider"
-  },
-  {
-    "name": "detachMovedView"
-  },
-  {
-    "name": "detachViewFromDOM"
-  },
-  {
-    "name": "detectChangesInChildComponents"
-  },
-  {
-    "name": "detectChangesInComponent"
-  },
-  {
-    "name": "detectChangesInEmbeddedViews"
-  },
-  {
-    "name": "detectChangesInView"
-  },
-  {
-    "name": "detectChangesInViewIfAttached"
-  },
-  {
-    "name": "detectChangesInViewIfRequired"
-  },
-  {
-    "name": "detectChangesInternal"
-  },
-  {
-    "name": "diPublicInInjector"
-  },
-  {
-    "name": "enterDI"
-  },
-  {
-    "name": "enterView"
-  },
-  {
-    "name": "errorContext"
-  },
-  {
-    "name": "execFinalizer"
-  },
-  {
-    "name": "executeCheckHooks"
-  },
-  {
-    "name": "executeInitAndCheckHooks"
-  },
-  {
-    "name": "executeSchedule"
-  },
-  {
-    "name": "executeTemplate"
-  },
-  {
-    "name": "executeViewQueryFn"
-  },
-  {
-    "name": "extractDefListOrFactory"
-  },
-  {
-    "name": "extractDirectiveDef"
-  },
-  {
-    "name": "forEachSingleProvider"
-  },
-  {
-    "name": "forwardRef"
-  },
-  {
-    "name": "freeConsumers"
-  },
-  {
-    "name": "fromAsyncIterable"
-  },
-  {
-    "name": "generateInitialInputs"
-  },
-  {
-    "name": "getClosureSafeProperty"
-  },
-  {
-    "name": "getComponentDef"
-  },
-  {
-    "name": "getComponentLViewByIndex"
-  },
-  {
-    "name": "getCurrentTNode"
-  },
-  {
-    "name": "getCurrentTNodePlaceholderOk"
-  },
-  {
-    "name": "getDOM"
-  },
-  {
-    "name": "getDeclarationTNode"
-  },
-  {
-    "name": "getDirectiveDef"
-  },
-  {
-    "name": "getDocument"
-  },
-  {
-    "name": "getFactoryDef"
-  },
-  {
-    "name": "getFilteredHeaders"
-  },
-  {
-    "name": "getFirstLContainer"
-  },
-  {
-    "name": "getInjectImplementation"
-  },
-  {
-    "name": "getInjectableDef"
-  },
-  {
-    "name": "getInjectorDef"
-  },
-  {
-    "name": "getInjectorIndex"
-  },
-  {
-    "name": "getLNodeForHydration"
-  },
-  {
-    "name": "getLView"
-  },
-  {
-    "name": "getLViewParent"
-  },
-  {
-    "name": "getNativeByTNode"
-  },
-  {
-    "name": "getNearestLContainer"
-  },
-  {
-    "name": "getNextLContainer"
-  },
-  {
-    "name": "getNoOffsetIndex"
-  },
-  {
-    "name": "getNodeInjectable"
-  },
-  {
-    "name": "getNullInjector"
-  },
-  {
-    "name": "getOrCreateInjectable"
-  },
-  {
-    "name": "getOrCreateNodeInjectorForNode"
-  },
-  {
-    "name": "getOrCreateTNode"
-  },
-  {
-    "name": "getOwnDefinition"
-  },
-  {
-    "name": "getParentInjectorIndex"
-  },
-  {
-    "name": "getParentInjectorLocation"
-  },
-  {
-    "name": "getParentInjectorView"
-  },
-  {
-    "name": "getPipeDef"
-  },
-  {
-    "name": "getProjectionNodes"
-  },
-  {
-    "name": "getPromiseCtor"
-  },
-  {
-    "name": "getSegmentHead"
-  },
-  {
-    "name": "getSerializedContainerViews"
-  },
-  {
-    "name": "getSimpleChangesStore"
-  },
-  {
-    "name": "getSymbolIterator"
-  },
-  {
-    "name": "getTNodeFromLView"
-  },
-  {
-    "name": "handleStoppedNotification"
-  },
-  {
-    "name": "handleUnhandledError"
-  },
-  {
-    "name": "hasApplyArgsData"
-  },
-  {
-    "name": "hasInSkipHydrationBlockFlag"
-  },
-  {
-    "name": "hasSkipHydrationAttrOnRElement"
-  },
-  {
-    "name": "hasSkipHydrationAttrOnTNode"
-  },
-  {
-    "name": "icuContainerIterate"
-  },
-  {
-    "name": "identity"
-  },
-  {
-    "name": "importProvidersFrom"
-  },
-  {
-    "name": "includeViewProviders"
-  },
-  {
-    "name": "incrementInitPhaseFlags"
-  },
-  {
-    "name": "initTransferState"
-  },
-  {
-    "name": "inject"
-  },
-  {
-    "name": "injectArgs"
-  },
-  {
-    "name": "injectDestroyRef"
-  },
-  {
-    "name": "injectElementRef"
-  },
-  {
-    "name": "injectInjectorOnly"
-  },
-  {
-    "name": "injectRootLimpMode"
-  },
-  {
-    "name": "injectableDefOrInjectorDefFactory"
-  },
-  {
-    "name": "innerFrom"
-  },
-  {
-    "name": "insertBloom"
-  },
-  {
-    "name": "instructionState"
-  },
-  {
-    "name": "internalImportProvidersFrom"
-  },
-  {
-    "name": "internalProvideZoneChangeDetection"
-  },
-  {
-    "name": "invokeHostBindingsInCreationMode"
-  },
-  {
-    "name": "isAngularZoneProperty"
-  },
-  {
-    "name": "isApplicationBootstrapConfig"
-  },
-  {
-    "name": "isArrayLike"
-  },
-  {
-    "name": "isAsyncIterable"
-  },
-  {
-    "name": "isComponentDef"
-  },
-  {
-    "name": "isComponentHost"
-  },
-  {
-    "name": "isDetachedByI18n"
-  },
-  {
-    "name": "isDisconnectedNode"
-  },
-  {
-    "name": "isEnvironmentProviders"
-  },
-  {
-    "name": "isFunction"
-  },
-  {
-    "name": "isHydrationSupportEnabled"
-  },
-  {
-    "name": "isInSkipHydrationBlock"
-  },
-  {
-    "name": "isInlineTemplate"
-  },
-  {
-    "name": "isInteropObservable"
-  },
-  {
-    "name": "isIterable"
-  },
-  {
-    "name": "isLContainer"
-  },
-  {
-    "name": "isLView"
-  },
-  {
-    "name": "isPlatformServer"
-  },
-  {
-    "name": "isPositive"
-  },
-  {
-    "name": "isPromise"
-  },
-  {
-    "name": "isPromise2"
-  },
-  {
-    "name": "isReadableStreamLike"
-  },
-  {
-    "name": "isRefreshingViews"
-  },
-  {
-    "name": "isRootView"
-  },
-  {
-    "name": "isSubscription"
-  },
-  {
-    "name": "isTemplateNode"
-  },
-  {
-    "name": "isTypeProvider"
-  },
-  {
-    "name": "isValueProvider"
-  },
-  {
-    "name": "iterator"
-  },
-  {
-    "name": "lastNodeWasCreated"
-  },
-  {
-    "name": "leaveDI"
-  },
-  {
-    "name": "leaveView"
-  },
-  {
-    "name": "leaveViewLight"
-  },
-  {
-    "name": "locateNextRNode"
-  },
-  {
-    "name": "locateOrCreateTextNodeImpl"
-  },
-  {
-    "name": "lookupTokenUsingModuleInjector"
-  },
-  {
-    "name": "lookupTokenUsingNodeInjector"
-  },
-  {
-    "name": "makeEnvironmentProviders"
-  },
-  {
-    "name": "makeRecord"
-  },
-  {
-    "name": "markAncestorsForTraversal"
-  },
-  {
-    "name": "markViewDirty"
-  },
-  {
-    "name": "markViewForRefresh"
-  },
-  {
-    "name": "markedFeatures"
-  },
-  {
-    "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "mergeHostAttribute"
-  },
-  {
-    "name": "mergeHostAttrs"
-  },
-  {
-    "name": "nativeAppendChild"
-  },
-  {
-    "name": "nativeAppendOrInsertBefore"
-  },
-  {
-    "name": "nativeInsertBefore"
-  },
-  {
-    "name": "nativeRemoveNode"
-  },
-  {
-    "name": "nextNgElementId"
-  },
-  {
-    "name": "ngOnChangesSetInput"
-  },
-  {
-    "name": "ngZoneInstanceId"
-  },
-  {
-    "name": "nonNull"
-  },
-  {
-    "name": "noop"
-  },
-  {
-    "name": "noop2"
-  },
-  {
-    "name": "notFoundValueOrThrow"
-  },
-  {
-    "name": "observable"
-  },
-  {
-    "name": "observeOn"
-  },
-  {
-    "name": "of"
-  },
-  {
-    "name": "onEnter"
-  },
-  {
-    "name": "onLeave"
-  },
-  {
-    "name": "operate"
-  },
-  {
-    "name": "parseAndConvertBindingsForDefinition"
-  },
-  {
-    "name": "performanceMarkFeature"
-  },
-  {
-    "name": "populateDehydratedViewsInLContainerImpl"
-  },
-  {
-    "name": "processInjectorTypesWithProviders"
-  },
-  {
-    "name": "producerMarkClean"
-  },
-  {
-    "name": "producerRemoveLiveConsumerAtIndex"
-  },
-  {
-    "name": "producerUpdateValueVersion"
-  },
-  {
-    "name": "readableStreamLikeToAsyncGenerator"
-  },
-  {
-    "name": "refreshContentQueries"
-  },
-  {
-    "name": "refreshView"
-  },
-  {
-    "name": "rememberChangeHistoryAndInvokeOnChangesHook"
-  },
-  {
-    "name": "remove"
-  },
-  {
-    "name": "removeDehydratedView"
-  },
-  {
-    "name": "removeDehydratedViews"
-  },
-  {
-    "name": "removeElements"
-  },
-  {
-    "name": "removeFromArray"
-  },
-  {
-    "name": "renderComponent"
-  },
-  {
-    "name": "renderView"
-  },
-  {
-    "name": "reportUnhandledError"
-  },
-  {
-    "name": "requiresRefreshOrTraversal"
-  },
-  {
-    "name": "resetPreOrderHookFlags"
-  },
-  {
-    "name": "resolveForwardRef"
-  },
-  {
-    "name": "retrieveHydrationInfo"
-  },
-  {
-    "name": "retrieveHydrationInfoImpl"
-  },
-  {
-    "name": "runEffectsInView"
-  },
-  {
-    "name": "runInInjectionContext"
-  },
-  {
-    "name": "saveNameToExportMap"
-  },
-  {
-    "name": "scheduleAsyncIterable"
-  },
-  {
-    "name": "scheduleCallbackWithMicrotask"
-  },
-  {
-    "name": "scheduleCallbackWithRafRace"
-  },
-  {
-    "name": "searchTokensOnInjector"
-  },
-  {
-    "name": "setActiveConsumer"
-  },
-  {
-    "name": "setBindingRootForHostBindings"
-  },
-  {
-    "name": "setCurrentDirectiveIndex"
-  },
-  {
-    "name": "setCurrentInjector"
-  },
-  {
-    "name": "setCurrentQueryIndex"
-  },
-  {
-    "name": "setCurrentTNode"
-  },
-  {
-    "name": "setIncludeViewProviders"
-  },
-  {
-    "name": "setInjectImplementation"
-  },
-  {
-    "name": "setIsRefreshingViews"
-  },
-  {
-    "name": "setSegmentHead"
-  },
-  {
-    "name": "setSelectedIndex"
-  },
-  {
-    "name": "setUpAttributes"
-  },
-  {
-    "name": "shimStylesContent"
-  },
-  {
-    "name": "shouldSearchParent"
-  },
-  {
-    "name": "siblingAfter"
-  },
-  {
-    "name": "sortAndConcatParams"
-  },
-  {
-    "name": "storeLViewOnDestroy"
-  },
-  {
-    "name": "stringify"
-  },
-  {
-    "name": "stringifyCSSSelector"
-  },
-  {
-    "name": "subscribeOn"
-  },
-  {
-    "name": "throwProviderNotFoundError"
-  },
-  {
-    "name": "timeoutProvider"
-  },
-  {
-    "name": "toRefArray"
-  },
-  {
-    "name": "transferCacheInterceptorFn"
-  },
-  {
-    "name": "uniqueIdCounter"
-  },
-  {
-    "name": "unregisterLView"
-  },
-  {
-    "name": "unwrapRNode"
-  },
-  {
-    "name": "updateAncestorTraversalFlagsOnAttach"
-  },
-  {
-    "name": "updateMicroTaskStatus"
-  },
-  {
-    "name": "viewAttachedToChangeDetector"
-  },
-  {
-    "name": "viewShouldHaveReactiveConsumer"
-  },
-  {
-    "name": "walkProviderTree"
-  },
-  {
-    "name": "withDomHydration"
-  },
-  {
-    "name": "writeDirectClass"
-  },
-  {
-    "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "ɵɵdefineComponent"
-  },
-  {
-    "name": "ɵɵdefineInjectable"
-  },
-  {
-    "name": "ɵɵdirectiveInject"
-  },
-  {
-    "name": "ɵɵinject"
-  }
+  "ALLOWED_METHODS",
+  "APP_BOOTSTRAP_LISTENER",
+  "APP_ID",
+  "APP_INITIALIZER",
+  "AfterRenderManager",
+  "AnonymousSubject",
+  "ApplicationInitStatus",
+  "ApplicationRef",
+  "BODY",
+  "BROWSER_MODULE_PROVIDERS",
+  "BehaviorSubject",
+  "BrowserDomAdapter",
+  "BrowserXhr",
+  "CACHE_OPTIONS",
+  "CIRCULAR",
+  "COMPLETE_NOTIFICATION",
+  "COMPONENT_REGEX",
+  "CSP_NONCE",
+  "ChainedInjector",
+  "ChangeDetectionScheduler",
+  "ChangeDetectionSchedulerImpl",
+  "ChangeDetectionStrategy",
+  "ComponentFactory",
+  "ComponentFactory2",
+  "ComponentFactoryResolver",
+  "ComponentFactoryResolver2",
+  "ComponentRef",
+  "ComponentRef2",
+  "ConsumerObserver",
+  "DEFAULT_APP_ID",
+  "DOCUMENT",
+  "DOCUMENT2",
+  "DefaultDomRenderer2",
+  "DestroyRef",
+  "DomAdapter",
+  "DomEventsPlugin",
+  "DomRendererFactory2",
+  "EMPTY_ARRAY",
+  "EMPTY_OBJ",
+  "EMPTY_OBSERVER",
+  "EMPTY_PAYLOAD",
+  "EMPTY_SUBSCRIPTION",
+  "ENVIRONMENT_INITIALIZER",
+  "EVENT_MANAGER_PLUGINS",
+  "EffectScheduler",
+  "ElementRef",
+  "EmulatedEncapsulationDomRenderer2",
+  "EnvironmentInjector",
+  "EnvironmentNgModuleRefAdapter",
+  "ErrorHandler",
+  "EventEmitter",
+  "EventManager",
+  "EventManagerPlugin",
+  "GenericBrowserDomAdapter",
+  "HEADERS",
+  "HTTP_ROOT_INTERCEPTOR_FNS",
+  "HTTP_TRANSFER_CACHE_ORIGIN_MAP",
+  "HttpEventType",
+  "HttpHeaders",
+  "HttpResponse",
+  "HttpResponseBase",
+  "HydrationFeatureKind",
+  "INJECTOR",
+  "INJECTOR_DEF_TYPES",
+  "INJECTOR_SCOPE",
+  "INTERNAL_APPLICATION_ERROR_HANDLER",
+  "INTERNAL_BROWSER_PLATFORM_PROVIDERS",
+  "IS_HYDRATION_DOM_REUSE_ENABLED",
+  "InjectFlags",
+  "InjectionToken",
+  "Injector",
+  "InputFlags",
+  "KeyEventsPlugin",
+  "LContainerFlags",
+  "LOCALE_ID2",
+  "LifecycleHooksFeature",
+  "MODIFIER_KEYS",
+  "MODIFIER_KEY_GETTERS",
+  "NAMESPACE_URIS",
+  "NEW_LINE",
+  "NG_COMP_DEF",
+  "NG_DIR_DEF",
+  "NG_ELEMENT_ID",
+  "NG_ENV_ID",
+  "NG_FACTORY_DEF",
+  "NG_INJECTABLE_DEF",
+  "NG_INJECTOR_DEF",
+  "NG_INJ_DEF",
+  "NG_PIPE_DEF",
+  "NG_PROV_DEF",
+  "NOT_FOUND",
+  "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR",
+  "NOT_YET",
+  "NO_CHANGE",
+  "NULL_INJECTOR",
+  "NgModuleRef",
+  "NgZone",
+  "NgZoneChangeDetectionScheduler",
+  "NodeInjector",
+  "NodeInjectorDestroyRef",
+  "NodeInjectorFactory",
+  "NodeNavigationStep",
+  "NoneEncapsulationDomRenderer",
+  "NoopNgZone",
+  "NullInjector",
+  "ObjectUnsubscribedError",
+  "Observable",
+  "OperatorSubscriber",
+  "PLATFORM_DESTROY_LISTENERS",
+  "PLATFORM_ID",
+  "PLATFORM_INITIALIZER",
+  "PRESERVE_HOST_CONTENT",
+  "PendingTasksInternal",
+  "R3Injector",
+  "REACTIVE_LVIEW_CONSUMER_NODE",
+  "REACTIVE_NODE",
+  "REF_EXTRACTOR_REGEXP",
+  "REMOVE_STYLES_ON_COMPONENT_DESTROY",
+  "REQ_URL",
+  "RESPONSE_TYPE",
+  "RendererFactory2",
+  "RendererStyleFlags2",
+  "RuntimeError",
+  "SCHEDULE_IN_ROOT_ZONE",
+  "SIGNAL",
+  "SIMPLE_CHANGES_STORE",
+  "STATUS",
+  "STATUS_TEXT",
+  "SafeSubscriber",
+  "Sanitizer",
+  "ShadowDomRenderer",
+  "SharedStylesHost",
+  "SimpleChange",
+  "StandaloneService",
+  "Subject",
+  "Subscriber",
+  "Subscription",
+  "TEMPORARY_CONSUMER_NODE",
+  "TESTABILITY",
+  "THROW_IF_NOT_FOUND",
+  "TRACKED_LVIEWS",
+  "TracingAction",
+  "TracingService",
+  "TransferState",
+  "USE_VALUE",
+  "UnsubscriptionError",
+  "ViewEncapsulation",
+  "ViewRef",
+  "ZONELESS_ENABLED",
+  "ZONELESS_SCHEDULER_DISABLED",
+  "ZoneAwareEffectScheduler",
+  "ZoneStablePendingTask",
+  "_DOM",
+  "_Injector",
+  "_NullComponentFactoryResolver",
+  "__asyncValues",
+  "__await",
+  "__defProp",
+  "__forward_ref__",
+  "__publicField",
+  "_applyRootElementTransformImpl",
+  "_bind",
+  "_currentInjector",
+  "_injectImplementation",
+  "_isRefreshingViews",
+  "_keyMap",
+  "_locateOrCreateTextNode",
+  "_platformInjector",
+  "_retrieveHydrationInfoImpl",
+  "_wasLastNodeCreated",
+  "activeConsumer",
+  "addPropertyBinding",
+  "allocExpando",
+  "allocLFrame",
+  "angularZoneInstanceIdProperty",
+  "appendChild",
+  "applyNodes",
+  "applyProjectionRecursive",
+  "applyRootElementTransformImpl",
+  "applyToElementOrContainer",
+  "applyValueToInputField",
+  "applyView",
+  "arrRemove",
+  "assertConsumerNode",
+  "assertNotDestroyed",
+  "attachPatchData",
+  "baseElement",
+  "bind",
+  "bloomHasToken",
+  "bootstrap",
+  "calcSerializedContainerSize",
+  "callHook",
+  "callHookInternal",
+  "callHooks",
+  "captureNodeBindings",
+  "checkStable",
+  "cleanUpView",
+  "cleanupDehydratedIcuData",
+  "cleanupLContainer",
+  "cleanupLView",
+  "clearElementContents",
+  "collectNativeNodes",
+  "collectNativeNodesInLContainer",
+  "concatStringsWithSpace",
+  "config",
+  "configureViewWithDirective",
+  "consumerBeforeComputation",
+  "consumerDestroy",
+  "consumerIsLive",
+  "consumerPollProducersForChange",
+  "context",
+  "convertToBitFlags",
+  "createElementNode",
+  "createElementRef",
+  "createErrorClass",
+  "createInjector",
+  "createInvalidObservableTypeError",
+  "createLFrame",
+  "createLView",
+  "createLinkElement",
+  "createNodeInjector",
+  "createNotification",
+  "createOperatorSubscriber",
+  "createStyleElement",
+  "createTView",
+  "createTextNode",
+  "deepForEach",
+  "deepForEachProvider",
+  "detachMovedView",
+  "detachViewFromDOM",
+  "detectChangesInChildComponents",
+  "detectChangesInComponent",
+  "detectChangesInEmbeddedViews",
+  "detectChangesInView",
+  "detectChangesInViewIfAttached",
+  "detectChangesInViewIfRequired",
+  "detectChangesInternal",
+  "diPublicInInjector",
+  "enterDI",
+  "enterView",
+  "errorContext",
+  "execFinalizer",
+  "executeCheckHooks",
+  "executeInitAndCheckHooks",
+  "executeSchedule",
+  "executeTemplate",
+  "executeViewQueryFn",
+  "extractDefListOrFactory",
+  "extractDirectiveDef",
+  "forEachSingleProvider",
+  "forwardRef",
+  "freeConsumers",
+  "fromAsyncIterable",
+  "generateInitialInputs",
+  "getClosureSafeProperty",
+  "getComponentDef",
+  "getComponentLViewByIndex",
+  "getCurrentTNode",
+  "getCurrentTNodePlaceholderOk",
+  "getDOM",
+  "getDeclarationTNode",
+  "getDirectiveDef",
+  "getDocument",
+  "getFactoryDef",
+  "getFilteredHeaders",
+  "getFirstLContainer",
+  "getInjectImplementation",
+  "getInjectableDef",
+  "getInjectorDef",
+  "getInjectorIndex",
+  "getLNodeForHydration",
+  "getLView",
+  "getLViewParent",
+  "getNativeByTNode",
+  "getNearestLContainer",
+  "getNextLContainer",
+  "getNoOffsetIndex",
+  "getNodeInjectable",
+  "getNullInjector",
+  "getOrCreateInjectable",
+  "getOrCreateNodeInjectorForNode",
+  "getOrCreateTNode",
+  "getOwnDefinition",
+  "getParentInjectorIndex",
+  "getParentInjectorLocation",
+  "getParentInjectorView",
+  "getPipeDef",
+  "getProjectionNodes",
+  "getPromiseCtor",
+  "getSegmentHead",
+  "getSerializedContainerViews",
+  "getSimpleChangesStore",
+  "getSymbolIterator",
+  "getTNodeFromLView",
+  "handleStoppedNotification",
+  "handleUnhandledError",
+  "hasApplyArgsData",
+  "hasInSkipHydrationBlockFlag",
+  "hasSkipHydrationAttrOnRElement",
+  "hasSkipHydrationAttrOnTNode",
+  "icuContainerIterate",
+  "identity",
+  "importProvidersFrom",
+  "includeViewProviders",
+  "incrementInitPhaseFlags",
+  "initTransferState",
+  "inject",
+  "injectArgs",
+  "injectDestroyRef",
+  "injectElementRef",
+  "injectInjectorOnly",
+  "injectRootLimpMode",
+  "injectableDefOrInjectorDefFactory",
+  "innerFrom",
+  "insertBloom",
+  "instructionState",
+  "internalImportProvidersFrom",
+  "internalProvideZoneChangeDetection",
+  "invokeHostBindingsInCreationMode",
+  "isAngularZoneProperty",
+  "isApplicationBootstrapConfig",
+  "isArrayLike",
+  "isAsyncIterable",
+  "isComponentDef",
+  "isComponentHost",
+  "isDetachedByI18n",
+  "isDisconnectedNode",
+  "isEnvironmentProviders",
+  "isFunction",
+  "isHydrationSupportEnabled",
+  "isInSkipHydrationBlock",
+  "isInlineTemplate",
+  "isInteropObservable",
+  "isIterable",
+  "isLContainer",
+  "isLView",
+  "isPlatformServer",
+  "isPositive",
+  "isPromise",
+  "isPromise2",
+  "isReadableStreamLike",
+  "isRefreshingViews",
+  "isRootView",
+  "isSubscription",
+  "isTemplateNode",
+  "isTypeProvider",
+  "isValueProvider",
+  "iterator",
+  "lastNodeWasCreated",
+  "leaveDI",
+  "leaveView",
+  "leaveViewLight",
+  "locateNextRNode",
+  "locateOrCreateTextNodeImpl",
+  "lookupTokenUsingModuleInjector",
+  "lookupTokenUsingNodeInjector",
+  "makeEnvironmentProviders",
+  "makeRecord",
+  "markAncestorsForTraversal",
+  "markViewDirty",
+  "markViewForRefresh",
+  "markedFeatures",
+  "maybeWrapInNotSelector",
+  "mergeHostAttribute",
+  "mergeHostAttrs",
+  "nativeAppendChild",
+  "nativeAppendOrInsertBefore",
+  "nativeInsertBefore",
+  "nativeRemoveNode",
+  "nextNgElementId",
+  "ngOnChangesSetInput",
+  "ngZoneInstanceId",
+  "nonNull",
+  "noop",
+  "noop2",
+  "notFoundValueOrThrow",
+  "observable",
+  "observeOn",
+  "of",
+  "onEnter",
+  "onLeave",
+  "operate",
+  "parseAndConvertBindingsForDefinition",
+  "performanceMarkFeature",
+  "populateDehydratedViewsInLContainerImpl",
+  "processInjectorTypesWithProviders",
+  "producerMarkClean",
+  "producerRemoveLiveConsumerAtIndex",
+  "producerUpdateValueVersion",
+  "readableStreamLikeToAsyncGenerator",
+  "refreshContentQueries",
+  "refreshView",
+  "rememberChangeHistoryAndInvokeOnChangesHook",
+  "remove",
+  "removeDehydratedView",
+  "removeDehydratedViews",
+  "removeElements",
+  "removeFromArray",
+  "renderComponent",
+  "renderView",
+  "reportUnhandledError",
+  "requiresRefreshOrTraversal",
+  "resetPreOrderHookFlags",
+  "resolveForwardRef",
+  "retrieveHydrationInfo",
+  "retrieveHydrationInfoImpl",
+  "runEffectsInView",
+  "runInInjectionContext",
+  "saveNameToExportMap",
+  "scheduleAsyncIterable",
+  "scheduleCallbackWithMicrotask",
+  "scheduleCallbackWithRafRace",
+  "searchTokensOnInjector",
+  "setActiveConsumer",
+  "setBindingRootForHostBindings",
+  "setCurrentDirectiveIndex",
+  "setCurrentInjector",
+  "setCurrentQueryIndex",
+  "setCurrentTNode",
+  "setIncludeViewProviders",
+  "setInjectImplementation",
+  "setIsRefreshingViews",
+  "setSegmentHead",
+  "setSelectedIndex",
+  "setUpAttributes",
+  "shimStylesContent",
+  "shouldSearchParent",
+  "siblingAfter",
+  "sortAndConcatParams",
+  "storeLViewOnDestroy",
+  "stringify",
+  "stringifyCSSSelector",
+  "subscribeOn",
+  "throwProviderNotFoundError",
+  "timeoutProvider",
+  "toRefArray",
+  "transferCacheInterceptorFn",
+  "uniqueIdCounter",
+  "unregisterLView",
+  "unwrapRNode",
+  "updateAncestorTraversalFlagsOnAttach",
+  "updateMicroTaskStatus",
+  "viewAttachedToChangeDetector",
+  "viewShouldHaveReactiveConsumer",
+  "walkProviderTree",
+  "withDomHydration",
+  "writeDirectClass",
+  "writeToDirectiveInput",
+  "ɵɵdefineComponent",
+  "ɵɵdefineInjectable",
+  "ɵɵdirectiveInject",
+  "ɵɵinject"
 ]

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -1,209 +1,71 @@
 [
-  {
-    "name": "CIRCULAR"
-  },
-  {
-    "name": "EMPTY_ARRAY"
-  },
-  {
-    "name": "ENVIRONMENT_INITIALIZER"
-  },
-  {
-    "name": "EnvironmentInjector"
-  },
-  {
-    "name": "INJECTOR"
-  },
-  {
-    "name": "INJECTOR_DEF_TYPES"
-  },
-  {
-    "name": "INJECTOR_SCOPE"
-  },
-  {
-    "name": "InjectFlags"
-  },
-  {
-    "name": "InjectionToken"
-  },
-  {
-    "name": "NEW_LINE"
-  },
-  {
-    "name": "NG_COMP_DEF"
-  },
-  {
-    "name": "NG_ENV_ID"
-  },
-  {
-    "name": "NG_FACTORY_DEF"
-  },
-  {
-    "name": "NG_INJECTABLE_DEF"
-  },
-  {
-    "name": "NG_INJECTOR_DEF"
-  },
-  {
-    "name": "NG_INJ_DEF"
-  },
-  {
-    "name": "NG_PROV_DEF"
-  },
-  {
-    "name": "NOT_YET"
-  },
-  {
-    "name": "NULL_INJECTOR"
-  },
-  {
-    "name": "NullInjector"
-  },
-  {
-    "name": "R3Injector"
-  },
-  {
-    "name": "RuntimeError"
-  },
-  {
-    "name": "ScopedService"
-  },
-  {
-    "name": "Subscription"
-  },
-  {
-    "name": "THROW_IF_NOT_FOUND"
-  },
-  {
-    "name": "USE_VALUE"
-  },
-  {
-    "name": "UnsubscriptionError"
-  },
-  {
-    "name": "__defProp"
-  },
-  {
-    "name": "__forward_ref__"
-  },
-  {
-    "name": "__publicField"
-  },
-  {
-    "name": "_currentInjector"
-  },
-  {
-    "name": "_injectImplementation"
-  },
-  {
-    "name": "activeConsumer"
-  },
-  {
-    "name": "arrRemove"
-  },
-  {
-    "name": "assertNotDestroyed"
-  },
-  {
-    "name": "createErrorClass"
-  },
-  {
-    "name": "createInjector"
-  },
-  {
-    "name": "createLFrame"
-  },
-  {
-    "name": "deepForEach"
-  },
-  {
-    "name": "deepForEachProvider"
-  },
-  {
-    "name": "execFinalizer"
-  },
-  {
-    "name": "forEachSingleProvider"
-  },
-  {
-    "name": "forwardRef"
-  },
-  {
-    "name": "getClosureSafeProperty"
-  },
-  {
-    "name": "getFactoryDef"
-  },
-  {
-    "name": "getInjectableDef"
-  },
-  {
-    "name": "getInjectorDef"
-  },
-  {
-    "name": "getNullInjector"
-  },
-  {
-    "name": "getOwnDefinition"
-  },
-  {
-    "name": "importProvidersFrom"
-  },
-  {
-    "name": "injectArgs"
-  },
-  {
-    "name": "injectInjectorOnly"
-  },
-  {
-    "name": "injectableDefOrInjectorDefFactory"
-  },
-  {
-    "name": "instructionState"
-  },
-  {
-    "name": "internalImportProvidersFrom"
-  },
-  {
-    "name": "isEnvironmentProviders"
-  },
-  {
-    "name": "isFunction"
-  },
-  {
-    "name": "isTypeProvider"
-  },
-  {
-    "name": "isValueProvider"
-  },
-  {
-    "name": "makeRecord"
-  },
-  {
-    "name": "processInjectorTypesWithProviders"
-  },
-  {
-    "name": "resolveForwardRef"
-  },
-  {
-    "name": "setActiveConsumer"
-  },
-  {
-    "name": "setCurrentInjector"
-  },
-  {
-    "name": "setInjectImplementation"
-  },
-  {
-    "name": "stringify"
-  },
-  {
-    "name": "walkProviderTree"
-  },
-  {
-    "name": "ɵɵdefineInjectable"
-  },
-  {
-    "name": "ɵɵinject"
-  }
+  "CIRCULAR",
+  "EMPTY_ARRAY",
+  "ENVIRONMENT_INITIALIZER",
+  "EnvironmentInjector",
+  "INJECTOR",
+  "INJECTOR_DEF_TYPES",
+  "INJECTOR_SCOPE",
+  "InjectFlags",
+  "InjectionToken",
+  "NEW_LINE",
+  "NG_COMP_DEF",
+  "NG_ENV_ID",
+  "NG_FACTORY_DEF",
+  "NG_INJECTABLE_DEF",
+  "NG_INJECTOR_DEF",
+  "NG_INJ_DEF",
+  "NG_PROV_DEF",
+  "NOT_YET",
+  "NULL_INJECTOR",
+  "NullInjector",
+  "R3Injector",
+  "RuntimeError",
+  "ScopedService",
+  "Subscription",
+  "THROW_IF_NOT_FOUND",
+  "USE_VALUE",
+  "UnsubscriptionError",
+  "__defProp",
+  "__forward_ref__",
+  "__publicField",
+  "_currentInjector",
+  "_injectImplementation",
+  "activeConsumer",
+  "arrRemove",
+  "assertNotDestroyed",
+  "createErrorClass",
+  "createInjector",
+  "createLFrame",
+  "deepForEach",
+  "deepForEachProvider",
+  "execFinalizer",
+  "forEachSingleProvider",
+  "forwardRef",
+  "getClosureSafeProperty",
+  "getFactoryDef",
+  "getInjectableDef",
+  "getInjectorDef",
+  "getNullInjector",
+  "getOwnDefinition",
+  "importProvidersFrom",
+  "injectArgs",
+  "injectInjectorOnly",
+  "injectableDefOrInjectorDefFactory",
+  "instructionState",
+  "internalImportProvidersFrom",
+  "isEnvironmentProviders",
+  "isFunction",
+  "isTypeProvider",
+  "isValueProvider",
+  "makeRecord",
+  "processInjectorTypesWithProviders",
+  "resolveForwardRef",
+  "setActiveConsumer",
+  "setCurrentInjector",
+  "setInjectImplementation",
+  "stringify",
+  "walkProviderTree",
+  "ɵɵdefineInjectable",
+  "ɵɵinject"
 ]

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1,2246 +1,750 @@
 [
-  {
-    "name": "APP_BASE_HREF"
-  },
-  {
-    "name": "APP_BOOTSTRAP_LISTENER"
-  },
-  {
-    "name": "APP_ID"
-  },
-  {
-    "name": "APP_INITIALIZER"
-  },
-  {
-    "name": "AbsoluteRedirect"
-  },
-  {
-    "name": "ActivateRoutes"
-  },
-  {
-    "name": "ActivatedRoute"
-  },
-  {
-    "name": "ActivatedRouteSnapshot"
-  },
-  {
-    "name": "ActivationEnd"
-  },
-  {
-    "name": "ActivationStart"
-  },
-  {
-    "name": "AfterRenderManager"
-  },
-  {
-    "name": "AnonymousSubject"
-  },
-  {
-    "name": "ApplicationInitStatus"
-  },
-  {
-    "name": "ApplicationRef"
-  },
-  {
-    "name": "ApplyRedirects"
-  },
-  {
-    "name": "BOOTSTRAP_DONE"
-  },
-  {
-    "name": "BROWSER_MODULE_PROVIDERS"
-  },
-  {
-    "name": "BaseRouteReuseStrategy"
-  },
-  {
-    "name": "BeforeActivateRoutes"
-  },
-  {
-    "name": "BehaviorSubject"
-  },
-  {
-    "name": "BrowserDomAdapter"
-  },
-  {
-    "name": "BrowserPlatformLocation"
-  },
-  {
-    "name": "BrowserXhr"
-  },
-  {
-    "name": "CIRCULAR"
-  },
-  {
-    "name": "COMPLETE_NOTIFICATION"
-  },
-  {
-    "name": "COMPONENT_REGEX"
-  },
-  {
-    "name": "CREATE_VIEW_TRANSITION"
-  },
-  {
-    "name": "CSP_NONCE"
-  },
-  {
-    "name": "CanActivate"
-  },
-  {
-    "name": "CanDeactivate"
-  },
-  {
-    "name": "ChainedInjector"
-  },
-  {
-    "name": "ChangeDetectionScheduler"
-  },
-  {
-    "name": "ChangeDetectionSchedulerImpl"
-  },
-  {
-    "name": "ChangeDetectionStrategy"
-  },
-  {
-    "name": "ChangeDetectorRef"
-  },
-  {
-    "name": "ChildActivationEnd"
-  },
-  {
-    "name": "ChildActivationStart"
-  },
-  {
-    "name": "ChildrenOutletContexts"
-  },
-  {
-    "name": "Compiler"
-  },
-  {
-    "name": "ComponentFactory"
-  },
-  {
-    "name": "ComponentFactory2"
-  },
-  {
-    "name": "ComponentFactoryResolver"
-  },
-  {
-    "name": "ComponentFactoryResolver2"
-  },
-  {
-    "name": "ComponentRef"
-  },
-  {
-    "name": "ComponentRef2"
-  },
-  {
-    "name": "ConnectableObservable"
-  },
-  {
-    "name": "Console"
-  },
-  {
-    "name": "ConsumerObserver"
-  },
-  {
-    "name": "DEFAULT_APP_ID"
-  },
-  {
-    "name": "DEFAULT_SERIALIZER"
-  },
-  {
-    "name": "DOCUMENT"
-  },
-  {
-    "name": "DOCUMENT2"
-  },
-  {
-    "name": "DefaultDomRenderer2"
-  },
-  {
-    "name": "DefaultRouteReuseStrategy"
-  },
-  {
-    "name": "DefaultTitleStrategy"
-  },
-  {
-    "name": "DefaultUrlHandlingStrategy"
-  },
-  {
-    "name": "DefaultUrlSerializer"
-  },
-  {
-    "name": "DestroyRef"
-  },
-  {
-    "name": "DomAdapter"
-  },
-  {
-    "name": "DomEventsPlugin"
-  },
-  {
-    "name": "DomRendererFactory2"
-  },
-  {
-    "name": "EMPTY"
-  },
-  {
-    "name": "EMPTY_ARRAY"
-  },
-  {
-    "name": "EMPTY_OBJ"
-  },
-  {
-    "name": "EMPTY_OBSERVER"
-  },
-  {
-    "name": "EMPTY_PAYLOAD"
-  },
-  {
-    "name": "EMPTY_SUBSCRIPTION"
-  },
-  {
-    "name": "ENVIRONMENT_INITIALIZER"
-  },
-  {
-    "name": "EVENT_MANAGER_PLUGINS"
-  },
-  {
-    "name": "EffectScheduler"
-  },
-  {
-    "name": "ElementRef"
-  },
-  {
-    "name": "EmptyError"
-  },
-  {
-    "name": "EmulatedEncapsulationDomRenderer2"
-  },
-  {
-    "name": "EnvironmentInjector"
-  },
-  {
-    "name": "EnvironmentNgModuleRefAdapter"
-  },
-  {
-    "name": "ErrorHandler"
-  },
-  {
-    "name": "EventEmitter"
-  },
-  {
-    "name": "EventManager"
-  },
-  {
-    "name": "EventManagerPlugin"
-  },
-  {
-    "name": "EventType2"
-  },
-  {
-    "name": "GenericBrowserDomAdapter"
-  },
-  {
-    "name": "GuardsCheckEnd"
-  },
-  {
-    "name": "GuardsCheckStart"
-  },
-  {
-    "name": "HistoryStateManager"
-  },
-  {
-    "name": "INITIAL_NAVIGATION"
-  },
-  {
-    "name": "INITIAL_VALUE"
-  },
-  {
-    "name": "INJECTOR"
-  },
-  {
-    "name": "INJECTOR_DEF_TYPES"
-  },
-  {
-    "name": "INJECTOR_SCOPE"
-  },
-  {
-    "name": "INPUT_BINDER"
-  },
-  {
-    "name": "INPUT_SIGNAL_NODE"
-  },
-  {
-    "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
-  },
-  {
-    "name": "INTERNAL_BROWSER_PLATFORM_PROVIDERS"
-  },
-  {
-    "name": "InjectFlags"
-  },
-  {
-    "name": "InjectionToken"
-  },
-  {
-    "name": "Injector"
-  },
-  {
-    "name": "InputFlags"
-  },
-  {
-    "name": "ItemComponent"
-  },
-  {
-    "name": "KeyEventsPlugin"
-  },
-  {
-    "name": "LContainerFlags"
-  },
-  {
-    "name": "LOCALE_ID2"
-  },
-  {
-    "name": "LQueries_"
-  },
-  {
-    "name": "LQuery_"
-  },
-  {
-    "name": "LifecycleHooksFeature"
-  },
-  {
-    "name": "ListComponent"
-  },
-  {
-    "name": "Location"
-  },
-  {
-    "name": "LocationStrategy"
-  },
-  {
-    "name": "MATRIX_PARAM_SEGMENT_RE"
-  },
-  {
-    "name": "MODIFIER_KEYS"
-  },
-  {
-    "name": "MODIFIER_KEY_GETTERS"
-  },
-  {
-    "name": "ModuleWithComponentFactories"
-  },
-  {
-    "name": "NAMESPACE_URIS"
-  },
-  {
-    "name": "NAVIGATION_ERROR_HANDLER"
-  },
-  {
-    "name": "NEW_LINE"
-  },
-  {
-    "name": "NG_COMP_DEF"
-  },
-  {
-    "name": "NG_DIR_DEF"
-  },
-  {
-    "name": "NG_ELEMENT_ID"
-  },
-  {
-    "name": "NG_ENV_ID"
-  },
-  {
-    "name": "NG_FACTORY_DEF"
-  },
-  {
-    "name": "NG_INJECTABLE_DEF"
-  },
-  {
-    "name": "NG_INJECTOR_DEF"
-  },
-  {
-    "name": "NG_INJ_DEF"
-  },
-  {
-    "name": "NG_MOD_DEF"
-  },
-  {
-    "name": "NG_PIPE_DEF"
-  },
-  {
-    "name": "NG_PROV_DEF"
-  },
-  {
-    "name": "NOT_FOUND"
-  },
-  {
-    "name": "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR"
-  },
-  {
-    "name": "NOT_YET"
-  },
-  {
-    "name": "NO_CHANGE"
-  },
-  {
-    "name": "NULL_INJECTOR"
-  },
-  {
-    "name": "Navigation"
-  },
-  {
-    "name": "NavigationCancel"
-  },
-  {
-    "name": "NavigationCancellationCode"
-  },
-  {
-    "name": "NavigationEnd"
-  },
-  {
-    "name": "NavigationError"
-  },
-  {
-    "name": "NavigationResult"
-  },
-  {
-    "name": "NavigationSkipped"
-  },
-  {
-    "name": "NavigationSkippedCode"
-  },
-  {
-    "name": "NavigationStart"
-  },
-  {
-    "name": "NavigationTransitions"
-  },
-  {
-    "name": "NgModuleFactory"
-  },
-  {
-    "name": "NgModuleFactory2"
-  },
-  {
-    "name": "NgModuleRef"
-  },
-  {
-    "name": "NgModuleRef2"
-  },
-  {
-    "name": "NgOnChangesFeatureImpl"
-  },
-  {
-    "name": "NgZone"
-  },
-  {
-    "name": "NgZoneChangeDetectionScheduler"
-  },
-  {
-    "name": "NoLeftoversInUrl"
-  },
-  {
-    "name": "NoMatch"
-  },
-  {
-    "name": "NodeInjector"
-  },
-  {
-    "name": "NodeInjectorDestroyRef"
-  },
-  {
-    "name": "NodeInjectorFactory"
-  },
-  {
-    "name": "NoneEncapsulationDomRenderer"
-  },
-  {
-    "name": "NoopNgZone"
-  },
-  {
-    "name": "NullInjector"
-  },
-  {
-    "name": "ObjectUnsubscribedError"
-  },
-  {
-    "name": "Observable"
-  },
-  {
-    "name": "OperatorSubscriber"
-  },
-  {
-    "name": "OutletContext"
-  },
-  {
-    "name": "OutletInjector"
-  },
-  {
-    "name": "PLATFORM_DESTROY_LISTENERS"
-  },
-  {
-    "name": "PLATFORM_ID"
-  },
-  {
-    "name": "PLATFORM_INITIALIZER"
-  },
-  {
-    "name": "PRESERVE_HOST_CONTENT"
-  },
-  {
-    "name": "PRIMARY_OUTLET"
-  },
-  {
-    "name": "ParamsAsMap"
-  },
-  {
-    "name": "PathLocationStrategy"
-  },
-  {
-    "name": "PendingTasksInternal"
-  },
-  {
-    "name": "PlatformLocation"
-  },
-  {
-    "name": "Position"
-  },
-  {
-    "name": "QUERY_PARAM_RE"
-  },
-  {
-    "name": "QUERY_PARAM_VALUE_RE"
-  },
-  {
-    "name": "QueryList"
-  },
-  {
-    "name": "R3Injector"
-  },
-  {
-    "name": "R3TemplateRef"
-  },
-  {
-    "name": "R3ViewContainerRef"
-  },
-  {
-    "name": "REACTIVE_LVIEW_CONSUMER_NODE"
-  },
-  {
-    "name": "REACTIVE_NODE"
-  },
-  {
-    "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
-  },
-  {
-    "name": "REQUIRED_UNSET_VALUE"
-  },
-  {
-    "name": "ROUTER_CONFIGURATION"
-  },
-  {
-    "name": "ROUTER_OUTLET_DATA"
-  },
-  {
-    "name": "ROUTER_PRELOADER"
-  },
-  {
-    "name": "ROUTER_SCROLLER"
-  },
-  {
-    "name": "ROUTES"
-  },
-  {
-    "name": "Recognizer"
-  },
-  {
-    "name": "RedirectCommand"
-  },
-  {
-    "name": "RedirectRequest"
-  },
-  {
-    "name": "Renderer2"
-  },
-  {
-    "name": "RendererFactory2"
-  },
-  {
-    "name": "RendererStyleFlags2"
-  },
-  {
-    "name": "ResolveEnd"
-  },
-  {
-    "name": "ResolveStart"
-  },
-  {
-    "name": "RouteConfigLoadEnd"
-  },
-  {
-    "name": "RouteConfigLoadStart"
-  },
-  {
-    "name": "RouteReuseStrategy"
-  },
-  {
-    "name": "RouteTitleKey"
-  },
-  {
-    "name": "Router"
-  },
-  {
-    "name": "RouterConfigLoader"
-  },
-  {
-    "name": "RouterEvent"
-  },
-  {
-    "name": "RouterLink"
-  },
-  {
-    "name": "RouterLinkActive"
-  },
-  {
-    "name": "RouterOutlet"
-  },
-  {
-    "name": "RouterState"
-  },
-  {
-    "name": "RouterStateSnapshot"
-  },
-  {
-    "name": "RoutesRecognized"
-  },
-  {
-    "name": "RuntimeError"
-  },
-  {
-    "name": "SAFE_URL_PATTERN"
-  },
-  {
-    "name": "SCHEDULE_IN_ROOT_ZONE"
-  },
-  {
-    "name": "SEGMENT_RE"
-  },
-  {
-    "name": "SIGNAL"
-  },
-  {
-    "name": "SIGNAL_NODE"
-  },
-  {
-    "name": "SIMPLE_CHANGES_STORE"
-  },
-  {
-    "name": "SafeSubscriber"
-  },
-  {
-    "name": "SafeValueImpl"
-  },
-  {
-    "name": "Sanitizer"
-  },
-  {
-    "name": "SecurityContext"
-  },
-  {
-    "name": "ShadowDomRenderer"
-  },
-  {
-    "name": "SharedStylesHost"
-  },
-  {
-    "name": "SimpleChange"
-  },
-  {
-    "name": "StandaloneService"
-  },
-  {
-    "name": "StateManager"
-  },
-  {
-    "name": "Subject"
-  },
-  {
-    "name": "Subscriber"
-  },
-  {
-    "name": "Subscription"
-  },
-  {
-    "name": "TEMPORARY_CONSUMER_NODE"
-  },
-  {
-    "name": "TESTABILITY"
-  },
-  {
-    "name": "THROW_IF_NOT_FOUND"
-  },
-  {
-    "name": "TQueries_"
-  },
-  {
-    "name": "TQueryMetadata_"
-  },
-  {
-    "name": "TQuery_"
-  },
-  {
-    "name": "TRACKED_LVIEWS"
-  },
-  {
-    "name": "TemplateRef"
-  },
-  {
-    "name": "Title"
-  },
-  {
-    "name": "TitleStrategy"
-  },
-  {
-    "name": "TracingAction"
-  },
-  {
-    "name": "TracingService"
-  },
-  {
-    "name": "Tree"
-  },
-  {
-    "name": "TreeNode"
-  },
-  {
-    "name": "USE_VALUE"
-  },
-  {
-    "name": "UnsubscriptionError"
-  },
-  {
-    "name": "UrlHandlingStrategy"
-  },
-  {
-    "name": "UrlParser"
-  },
-  {
-    "name": "UrlSegment"
-  },
-  {
-    "name": "UrlSegmentGroup"
-  },
-  {
-    "name": "UrlSerializer"
-  },
-  {
-    "name": "UrlTree"
-  },
-  {
-    "name": "VE_ViewContainerRef"
-  },
-  {
-    "name": "ViewContainerRef"
-  },
-  {
-    "name": "ViewEncapsulation"
-  },
-  {
-    "name": "ViewEngineTemplateRef"
-  },
-  {
-    "name": "ViewRef"
-  },
-  {
-    "name": "ZONELESS_ENABLED"
-  },
-  {
-    "name": "ZONELESS_SCHEDULER_DISABLED"
-  },
-  {
-    "name": "ZoneAwareEffectScheduler"
-  },
-  {
-    "name": "ZoneStablePendingTask"
-  },
-  {
-    "name": "_DOM"
-  },
-  {
-    "name": "_Injector"
-  },
-  {
-    "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__asyncValues"
-  },
-  {
-    "name": "__await"
-  },
-  {
-    "name": "__defProp"
-  },
-  {
-    "name": "__forward_ref__"
-  },
-  {
-    "name": "__publicField"
-  },
-  {
-    "name": "_a"
-  },
-  {
-    "name": "_applyRootElementTransformImpl"
-  },
-  {
-    "name": "_bind"
-  },
-  {
-    "name": "_currentInjector"
-  },
-  {
-    "name": "_global"
-  },
-  {
-    "name": "_injectImplementation"
-  },
-  {
-    "name": "_isRefreshingViews"
-  },
-  {
-    "name": "_keyMap"
-  },
-  {
-    "name": "_locateOrCreateAnchorNode"
-  },
-  {
-    "name": "_locateOrCreateElementNode"
-  },
-  {
-    "name": "_locateOrCreateTextNode"
-  },
-  {
-    "name": "_platformInjector"
-  },
-  {
-    "name": "_stripIndexHtml"
-  },
-  {
-    "name": "_wasLastNodeCreated"
-  },
-  {
-    "name": "activeConsumer"
-  },
-  {
-    "name": "addEmptyPathsToChildrenIfNeeded"
-  },
-  {
-    "name": "addPropertyBinding"
-  },
-  {
-    "name": "addToArray"
-  },
-  {
-    "name": "addToEndOfViewTree"
-  },
-  {
-    "name": "advanceActivatedRoute"
-  },
-  {
-    "name": "allocExpando"
-  },
-  {
-    "name": "allocLFrame"
-  },
-  {
-    "name": "allowSanitizationBypassAndThrow"
-  },
-  {
-    "name": "angularZoneInstanceIdProperty"
-  },
-  {
-    "name": "appendChild"
-  },
-  {
-    "name": "applyNodes"
-  },
-  {
-    "name": "applyProjectionRecursive"
-  },
-  {
-    "name": "applyToElementOrContainer"
-  },
-  {
-    "name": "applyValueToInputField"
-  },
-  {
-    "name": "applyView"
-  },
-  {
-    "name": "arrRemove"
-  },
-  {
-    "name": "assertConsumerNode"
-  },
-  {
-    "name": "assertNotDestroyed"
-  },
-  {
-    "name": "assertProducerNode"
-  },
-  {
-    "name": "attachPatchData"
-  },
-  {
-    "name": "baseElement"
-  },
-  {
-    "name": "bind"
-  },
-  {
-    "name": "bindingUpdated"
-  },
-  {
-    "name": "bloomHasToken"
-  },
-  {
-    "name": "booleanAttribute"
-  },
-  {
-    "name": "bootstrap"
-  },
-  {
-    "name": "callHook"
-  },
-  {
-    "name": "callHookInternal"
-  },
-  {
-    "name": "callHooks"
-  },
-  {
-    "name": "captureNodeBindings"
-  },
-  {
-    "name": "catchError"
-  },
-  {
-    "name": "checkStable"
-  },
-  {
-    "name": "classIndexOf"
-  },
-  {
-    "name": "cleanUpView"
-  },
-  {
-    "name": "collectNativeNodes"
-  },
-  {
-    "name": "collectNativeNodesInLContainer"
-  },
-  {
-    "name": "collectQueryResults"
-  },
-  {
-    "name": "combineLatest"
-  },
-  {
-    "name": "compare"
-  },
-  {
-    "name": "computeStaticStyling"
-  },
-  {
-    "name": "concat"
-  },
-  {
-    "name": "concatMap"
-  },
-  {
-    "name": "concatStringsWithSpace"
-  },
-  {
-    "name": "config"
-  },
-  {
-    "name": "configureViewWithDirective"
-  },
-  {
-    "name": "consumerBeforeComputation"
-  },
-  {
-    "name": "consumerDestroy"
-  },
-  {
-    "name": "consumerIsLive"
-  },
-  {
-    "name": "consumerMarkDirty"
-  },
-  {
-    "name": "consumerPollProducersForChange"
-  },
-  {
-    "name": "containsSegmentGroup"
-  },
-  {
-    "name": "containsSegmentGroupHelper"
-  },
-  {
-    "name": "containsTree"
-  },
-  {
-    "name": "context"
-  },
-  {
-    "name": "convertToBitFlags"
-  },
-  {
-    "name": "convertToParamMap"
-  },
-  {
-    "name": "createChildrenForEmptyPaths"
-  },
-  {
-    "name": "createContainerRef"
-  },
-  {
-    "name": "createContentQuery"
-  },
-  {
-    "name": "createElementNode"
-  },
-  {
-    "name": "createElementRef"
-  },
-  {
-    "name": "createEmptyState"
-  },
-  {
-    "name": "createEnvironmentInjector"
-  },
-  {
-    "name": "createErrorClass"
-  },
-  {
-    "name": "createInjector"
-  },
-  {
-    "name": "createInjectorWithoutInjectorInstances"
-  },
-  {
-    "name": "createInputSignal"
-  },
-  {
-    "name": "createInvalidObservableTypeError"
-  },
-  {
-    "name": "createLFrame"
-  },
-  {
-    "name": "createLView"
-  },
-  {
-    "name": "createLinkElement"
-  },
-  {
-    "name": "createNewSegmentChildren"
-  },
-  {
-    "name": "createNewSegmentGroup"
-  },
-  {
-    "name": "createNode"
-  },
-  {
-    "name": "createNodeInjector"
-  },
-  {
-    "name": "createNotification"
-  },
-  {
-    "name": "createOperatorSubscriber"
-  },
-  {
-    "name": "createOrReusePlatformInjector"
-  },
-  {
-    "name": "createResultForNode"
-  },
-  {
-    "name": "createRoot"
-  },
-  {
-    "name": "createSegmentGroupFromRoute"
-  },
-  {
-    "name": "createStyleElement"
-  },
-  {
-    "name": "createTView"
-  },
-  {
-    "name": "createTemplateRef"
-  },
-  {
-    "name": "createUrlTreeFromSegmentGroup"
-  },
-  {
-    "name": "deactivateRouteAndItsChildren"
-  },
-  {
-    "name": "decode"
-  },
-  {
-    "name": "decodeQuery"
-  },
-  {
-    "name": "deepForEach"
-  },
-  {
-    "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultEquals"
-  },
-  {
-    "name": "defaultErrorFactory"
-  },
-  {
-    "name": "defaultIfEmpty"
-  },
-  {
-    "name": "defaultUrlMatcher"
-  },
-  {
-    "name": "defer"
-  },
-  {
-    "name": "destroyLView"
-  },
-  {
-    "name": "detachMovedView"
-  },
-  {
-    "name": "detachView"
-  },
-  {
-    "name": "detachViewFromDOM"
-  },
-  {
-    "name": "detectChangesInChildComponents"
-  },
-  {
-    "name": "detectChangesInComponent"
-  },
-  {
-    "name": "detectChangesInEmbeddedViews"
-  },
-  {
-    "name": "detectChangesInView"
-  },
-  {
-    "name": "detectChangesInViewIfAttached"
-  },
-  {
-    "name": "detectChangesInViewIfRequired"
-  },
-  {
-    "name": "detectChangesInternal"
-  },
-  {
-    "name": "diPublicInInjector"
-  },
-  {
-    "name": "emptyPathMatch"
-  },
-  {
-    "name": "encodeUriQuery"
-  },
-  {
-    "name": "encodeUriSegment"
-  },
-  {
-    "name": "encodeUriString"
-  },
-  {
-    "name": "enterDI"
-  },
-  {
-    "name": "enterView"
-  },
-  {
-    "name": "epoch"
-  },
-  {
-    "name": "equalArraysOrString"
-  },
-  {
-    "name": "equalParamsAndUrlSegments"
-  },
-  {
-    "name": "equalPath"
-  },
-  {
-    "name": "errorContext"
-  },
-  {
-    "name": "exactMatchOptions"
-  },
-  {
-    "name": "execFinalizer"
-  },
-  {
-    "name": "executeCheckHooks"
-  },
-  {
-    "name": "executeContentQueries"
-  },
-  {
-    "name": "executeInitAndCheckHooks"
-  },
-  {
-    "name": "executeListenerWithErrorHandling"
-  },
-  {
-    "name": "executeSchedule"
-  },
-  {
-    "name": "executeTemplate"
-  },
-  {
-    "name": "executeViewQueryFn"
-  },
-  {
-    "name": "extractDefListOrFactory"
-  },
-  {
-    "name": "extractDirectiveDef"
-  },
-  {
-    "name": "filter"
-  },
-  {
-    "name": "finalize"
-  },
-  {
-    "name": "findAttrIndexInNode"
-  },
-  {
-    "name": "findNode"
-  },
-  {
-    "name": "findPath"
-  },
-  {
-    "name": "first"
-  },
-  {
-    "name": "flattenRouteTree"
-  },
-  {
-    "name": "forEachSingleProvider"
-  },
-  {
-    "name": "forwardRef"
-  },
-  {
-    "name": "freeConsumers"
-  },
-  {
-    "name": "from"
-  },
-  {
-    "name": "fromAsyncIterable"
-  },
-  {
-    "name": "generateInitialInputs"
-  },
-  {
-    "name": "getAllRouteGuards"
-  },
-  {
-    "name": "getBeforeNodeForView"
-  },
-  {
-    "name": "getBindingsEnabled"
-  },
-  {
-    "name": "getBootstrapListener"
-  },
-  {
-    "name": "getChildRouteGuards"
-  },
-  {
-    "name": "getClosestRouteInjector"
-  },
-  {
-    "name": "getClosureSafeProperty"
-  },
-  {
-    "name": "getComponentDef"
-  },
-  {
-    "name": "getComponentLViewByIndex"
-  },
-  {
-    "name": "getConstant"
-  },
-  {
-    "name": "getCurrentQueryIndex"
-  },
-  {
-    "name": "getCurrentTNode"
-  },
-  {
-    "name": "getCurrentTNodePlaceholderOk"
-  },
-  {
-    "name": "getDOM"
-  },
-  {
-    "name": "getData"
-  },
-  {
-    "name": "getDataKeys"
-  },
-  {
-    "name": "getDeclarationTNode"
-  },
-  {
-    "name": "getDirectiveDef"
-  },
-  {
-    "name": "getFactoryDef"
-  },
-  {
-    "name": "getFactoryOf"
-  },
-  {
-    "name": "getFirstLContainer"
-  },
-  {
-    "name": "getFirstNativeNode"
-  },
-  {
-    "name": "getIdxOfMatchingSelector"
-  },
-  {
-    "name": "getInherited"
-  },
-  {
-    "name": "getInitialLViewFlagsFromDef"
-  },
-  {
-    "name": "getInjectImplementation"
-  },
-  {
-    "name": "getInjectableDef"
-  },
-  {
-    "name": "getInjectorDef"
-  },
-  {
-    "name": "getInjectorIndex"
-  },
-  {
-    "name": "getLView"
-  },
-  {
-    "name": "getLViewParent"
-  },
-  {
-    "name": "getNativeByTNode"
-  },
-  {
-    "name": "getNearestLContainer"
-  },
-  {
-    "name": "getNextLContainer"
-  },
-  {
-    "name": "getNgDirectiveDef"
-  },
-  {
-    "name": "getNgModuleDef"
-  },
-  {
-    "name": "getNodeInjectable"
-  },
-  {
-    "name": "getNullInjector"
-  },
-  {
-    "name": "getOrCreateComponentTView"
-  },
-  {
-    "name": "getOrCreateInjectable"
-  },
-  {
-    "name": "getOrCreateLViewCleanup"
-  },
-  {
-    "name": "getOrCreateNodeInjectorForNode"
-  },
-  {
-    "name": "getOrCreateTNode"
-  },
-  {
-    "name": "getOrCreateTViewCleanup"
-  },
-  {
-    "name": "getOrCreateViewRefs"
-  },
-  {
-    "name": "getOutlet"
-  },
-  {
-    "name": "getOwnDefinition"
-  },
-  {
-    "name": "getParentInjectorIndex"
-  },
-  {
-    "name": "getParentInjectorLocation"
-  },
-  {
-    "name": "getParentInjectorView"
-  },
-  {
-    "name": "getPipeDef"
-  },
-  {
-    "name": "getProjectionNodes"
-  },
-  {
-    "name": "getPromiseCtor"
-  },
-  {
-    "name": "getQueryResults"
-  },
-  {
-    "name": "getResolve"
-  },
-  {
-    "name": "getSanitizer"
-  },
-  {
-    "name": "getSelectedIndex"
-  },
-  {
-    "name": "getSimpleChangesStore"
-  },
-  {
-    "name": "getSymbolIterator"
-  },
-  {
-    "name": "getTNode"
-  },
-  {
-    "name": "getTNodeFromLView"
-  },
-  {
-    "name": "getTQuery"
-  },
-  {
-    "name": "getTView"
-  },
-  {
-    "name": "getTokenOrFunctionIdentity"
-  },
-  {
-    "name": "getViewRefs"
-  },
-  {
-    "name": "handleError"
-  },
-  {
-    "name": "handleStoppedNotification"
-  },
-  {
-    "name": "handleUnhandledError"
-  },
-  {
-    "name": "hasApplyArgsData"
-  },
-  {
-    "name": "hasEmptyPathConfig"
-  },
-  {
-    "name": "hasInSkipHydrationBlockFlag"
-  },
-  {
-    "name": "hasLift"
-  },
-  {
-    "name": "hasParentInjector"
-  },
-  {
-    "name": "hasStaticTitle"
-  },
-  {
-    "name": "hasTagAndTypeMatch"
-  },
-  {
-    "name": "icuContainerIterate"
-  },
-  {
-    "name": "identity"
-  },
-  {
-    "name": "importProvidersFrom"
-  },
-  {
-    "name": "inNotificationPhase"
-  },
-  {
-    "name": "includeViewProviders"
-  },
-  {
-    "name": "incrementInitPhaseFlags"
-  },
-  {
-    "name": "initFeatures"
-  },
-  {
-    "name": "initializeDirectives"
-  },
-  {
-    "name": "inject"
-  },
-  {
-    "name": "injectArgs"
-  },
-  {
-    "name": "injectChangeDetectorRef"
-  },
-  {
-    "name": "injectDestroyRef"
-  },
-  {
-    "name": "injectElementRef"
-  },
-  {
-    "name": "injectInjectorOnly"
-  },
-  {
-    "name": "injectRootLimpMode"
-  },
-  {
-    "name": "injectTemplateRef"
-  },
-  {
-    "name": "injectViewContainerRef"
-  },
-  {
-    "name": "injectableDefOrInjectorDefFactory"
-  },
-  {
-    "name": "innerFrom"
-  },
-  {
-    "name": "input"
-  },
-  {
-    "name": "inputFunction"
-  },
-  {
-    "name": "inputRequiredFunction"
-  },
-  {
-    "name": "insertBloom"
-  },
-  {
-    "name": "instructionState"
-  },
-  {
-    "name": "internalImportProvidersFrom"
-  },
-  {
-    "name": "internalProvideZoneChangeDetection"
-  },
-  {
-    "name": "invokeDirectivesHostBindings"
-  },
-  {
-    "name": "invokeHostBindingsInCreationMode"
-  },
-  {
-    "name": "isAngularZoneProperty"
-  },
-  {
-    "name": "isApplicationBootstrapConfig"
-  },
-  {
-    "name": "isArrayLike"
-  },
-  {
-    "name": "isAsyncIterable"
-  },
-  {
-    "name": "isCommandWithOutlets"
-  },
-  {
-    "name": "isComponentDef"
-  },
-  {
-    "name": "isComponentHost"
-  },
-  {
-    "name": "isConsumerNode"
-  },
-  {
-    "name": "isContentQueryHost"
-  },
-  {
-    "name": "isCssClassMatching"
-  },
-  {
-    "name": "isCurrentTNodeParent"
-  },
-  {
-    "name": "isDirectiveHost"
-  },
-  {
-    "name": "isEmptyError"
-  },
-  {
-    "name": "isEnvironmentProviders"
-  },
-  {
-    "name": "isForwardRef"
-  },
-  {
-    "name": "isFunction"
-  },
-  {
-    "name": "isFunction2"
-  },
-  {
-    "name": "isInlineTemplate"
-  },
-  {
-    "name": "isInteropObservable"
-  },
-  {
-    "name": "isIterable"
-  },
-  {
-    "name": "isLContainer"
-  },
-  {
-    "name": "isLView"
-  },
-  {
-    "name": "isMatrixParams"
-  },
-  {
-    "name": "isNameOnlyAttributeMarker"
-  },
-  {
-    "name": "isNavigationCancelingError"
-  },
-  {
-    "name": "isNodeMatchingSelector"
-  },
-  {
-    "name": "isNodeMatchingSelectorList"
-  },
-  {
-    "name": "isPlatformServer"
-  },
-  {
-    "name": "isPositive"
-  },
-  {
-    "name": "isPromise"
-  },
-  {
-    "name": "isPromise2"
-  },
-  {
-    "name": "isReadableStreamLike"
-  },
-  {
-    "name": "isRefreshingViews"
-  },
-  {
-    "name": "isRootView"
-  },
-  {
-    "name": "isSubscription"
-  },
-  {
-    "name": "isTemplateNode"
-  },
-  {
-    "name": "isTypeProvider"
-  },
-  {
-    "name": "isUrlTree"
-  },
-  {
-    "name": "isValueProvider"
-  },
-  {
-    "name": "iterator"
-  },
-  {
-    "name": "joinWithSlash"
-  },
-  {
-    "name": "last"
-  },
-  {
-    "name": "last3"
-  },
-  {
-    "name": "lastNodeWasCreated"
-  },
-  {
-    "name": "leaveDI"
-  },
-  {
-    "name": "leaveView"
-  },
-  {
-    "name": "leaveViewLight"
-  },
-  {
-    "name": "locateDirectiveOrProvider"
-  },
-  {
-    "name": "lookupTokenUsingModuleInjector"
-  },
-  {
-    "name": "lookupTokenUsingNodeInjector"
-  },
-  {
-    "name": "makeRecord"
-  },
-  {
-    "name": "map"
-  },
-  {
-    "name": "markAncestorsForTraversal"
-  },
-  {
-    "name": "markAsComponentHost"
-  },
-  {
-    "name": "markViewDirty"
-  },
-  {
-    "name": "markViewForRefresh"
-  },
-  {
-    "name": "markedFeatures"
-  },
-  {
-    "name": "match"
-  },
-  {
-    "name": "matchSegments"
-  },
-  {
-    "name": "matchWithChecks"
-  },
-  {
-    "name": "materializeViewResults"
-  },
-  {
-    "name": "matrixParamsMatch"
-  },
-  {
-    "name": "maybeSchedule"
-  },
-  {
-    "name": "maybeUnwrapDefaultExport"
-  },
-  {
-    "name": "maybeUnwrapFn"
-  },
-  {
-    "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "mergeAll"
-  },
-  {
-    "name": "mergeEmptyPathMatches"
-  },
-  {
-    "name": "mergeHostAttribute"
-  },
-  {
-    "name": "mergeHostAttrs"
-  },
-  {
-    "name": "mergeMap"
-  },
-  {
-    "name": "nativeAppendChild"
-  },
-  {
-    "name": "nativeAppendOrInsertBefore"
-  },
-  {
-    "name": "nativeInsertBefore"
-  },
-  {
-    "name": "nativeParentNode"
-  },
-  {
-    "name": "navigationCancelingError"
-  },
-  {
-    "name": "nextBindingIndex"
-  },
-  {
-    "name": "nextNgElementId"
-  },
-  {
-    "name": "ngOnChangesSetInput"
-  },
-  {
-    "name": "ngZoneInstanceId"
-  },
-  {
-    "name": "noMatch"
-  },
-  {
-    "name": "noMatch2"
-  },
-  {
-    "name": "noSideEffects"
-  },
-  {
-    "name": "nodeChildrenAsMap"
-  },
-  {
-    "name": "nonNull"
-  },
-  {
-    "name": "noop"
-  },
-  {
-    "name": "noop2"
-  },
-  {
-    "name": "normalizeQueryParams"
-  },
-  {
-    "name": "notFoundValueOrThrow"
-  },
-  {
-    "name": "observable"
-  },
-  {
-    "name": "observeOn"
-  },
-  {
-    "name": "of"
-  },
-  {
-    "name": "onEnter"
-  },
-  {
-    "name": "onLeave"
-  },
-  {
-    "name": "operate"
-  },
-  {
-    "name": "paramCompareMap"
-  },
-  {
-    "name": "parseAndConvertBindingsForDefinition"
-  },
-  {
-    "name": "pathCompareMap"
-  },
-  {
-    "name": "pipeFromArray"
-  },
-  {
-    "name": "policy"
-  },
-  {
-    "name": "popScheduler"
-  },
-  {
-    "name": "prioritizedGuardValue"
-  },
-  {
-    "name": "processInjectorTypesWithProviders"
-  },
-  {
-    "name": "producerAccessed"
-  },
-  {
-    "name": "producerAddLiveConsumer"
-  },
-  {
-    "name": "producerMarkClean"
-  },
-  {
-    "name": "producerNotifyConsumers"
-  },
-  {
-    "name": "producerRemoveLiveConsumerAtIndex"
-  },
-  {
-    "name": "producerUpdateValueVersion"
-  },
-  {
-    "name": "readableStreamLikeToAsyncGenerator"
-  },
-  {
-    "name": "redirectIfUrlTree"
-  },
-  {
-    "name": "redirectingNavigationError"
-  },
-  {
-    "name": "refCount"
-  },
-  {
-    "name": "refreshContentQueries"
-  },
-  {
-    "name": "refreshView"
-  },
-  {
-    "name": "registerPostOrderHooks"
-  },
-  {
-    "name": "rememberChangeHistoryAndInvokeOnChangesHook"
-  },
-  {
-    "name": "remove"
-  },
-  {
-    "name": "removeElements"
-  },
-  {
-    "name": "removeFromArray"
-  },
-  {
-    "name": "renderComponent"
-  },
-  {
-    "name": "renderStringify"
-  },
-  {
-    "name": "renderView"
-  },
-  {
-    "name": "replaceSegment"
-  },
-  {
-    "name": "reportUnhandledError"
-  },
-  {
-    "name": "requiresRefreshOrTraversal"
-  },
-  {
-    "name": "resetPreOrderHookFlags"
-  },
-  {
-    "name": "resolveForwardRef"
-  },
-  {
-    "name": "rootRoute"
-  },
-  {
-    "name": "routes"
-  },
-  {
-    "name": "runEffectsInView"
-  },
-  {
-    "name": "runInInjectionContext"
-  },
-  {
-    "name": "saveNameToExportMap"
-  },
-  {
-    "name": "scheduleAsyncIterable"
-  },
-  {
-    "name": "scheduleCallbackWithMicrotask"
-  },
-  {
-    "name": "scheduleCallbackWithRafRace"
-  },
-  {
-    "name": "searchTokensOnInjector"
-  },
-  {
-    "name": "serializeNode"
-  },
-  {
-    "name": "serializePath"
-  },
-  {
-    "name": "serializePaths"
-  },
-  {
-    "name": "serializeSegment"
-  },
-  {
-    "name": "setActiveConsumer"
-  },
-  {
-    "name": "setBindingRootForHostBindings"
-  },
-  {
-    "name": "setCurrentDirectiveIndex"
-  },
-  {
-    "name": "setCurrentInjector"
-  },
-  {
-    "name": "setCurrentQueryIndex"
-  },
-  {
-    "name": "setCurrentTNode"
-  },
-  {
-    "name": "setDirectiveInputsWhichShadowsStyling"
-  },
-  {
-    "name": "setIncludeViewProviders"
-  },
-  {
-    "name": "setInjectImplementation"
-  },
-  {
-    "name": "setInputsForProperty"
-  },
-  {
-    "name": "setInputsFromAttrs"
-  },
-  {
-    "name": "setIsRefreshingViews"
-  },
-  {
-    "name": "setRouterState"
-  },
-  {
-    "name": "setSelectedIndex"
-  },
-  {
-    "name": "setUpAttributes"
-  },
-  {
-    "name": "setupStaticAttributes"
-  },
-  {
-    "name": "shallowEqual"
-  },
-  {
-    "name": "shimStylesContent"
-  },
-  {
-    "name": "shouldAddViewToDom"
-  },
-  {
-    "name": "shouldSearchParent"
-  },
-  {
-    "name": "split"
-  },
-  {
-    "name": "squashSegmentGroup"
-  },
-  {
-    "name": "standardizeConfig"
-  },
-  {
-    "name": "storeLViewOnDestroy"
-  },
-  {
-    "name": "stringify"
-  },
-  {
-    "name": "stringify11"
-  },
-  {
-    "name": "stringifyCSSSelector"
-  },
-  {
-    "name": "stripTrailingSlash"
-  },
-  {
-    "name": "subscribeOn"
-  },
-  {
-    "name": "subsetMatchOptions"
-  },
-  {
-    "name": "switchMap"
-  },
-  {
-    "name": "switchTap"
-  },
-  {
-    "name": "symbolIterator"
-  },
-  {
-    "name": "take"
-  },
-  {
-    "name": "takeLast"
-  },
-  {
-    "name": "tap"
-  },
-  {
-    "name": "throwError2"
-  },
-  {
-    "name": "throwIfEmpty"
-  },
-  {
-    "name": "throwInvalidWriteToSignalErrorFn"
-  },
-  {
-    "name": "throwProviderNotFoundError"
-  },
-  {
-    "name": "timeoutProvider"
-  },
-  {
-    "name": "toRefArray"
-  },
-  {
-    "name": "trackMovedView"
-  },
-  {
-    "name": "tree"
-  },
-  {
-    "name": "trustedScriptURLFromStringBypass"
-  },
-  {
-    "name": "uniqueIdCounter"
-  },
-  {
-    "name": "unregisterLView"
-  },
-  {
-    "name": "unwrapElementRef"
-  },
-  {
-    "name": "unwrapRNode"
-  },
-  {
-    "name": "unwrapSafeValue"
-  },
-  {
-    "name": "updateAncestorTraversalFlagsOnAttach"
-  },
-  {
-    "name": "updateMicroTaskStatus"
-  },
-  {
-    "name": "updateSegmentGroup"
-  },
-  {
-    "name": "updateSegmentGroupChildren"
-  },
-  {
-    "name": "viewAttachedToChangeDetector"
-  },
-  {
-    "name": "viewShouldHaveReactiveConsumer"
-  },
-  {
-    "name": "walkProviderTree"
-  },
-  {
-    "name": "wasLastNodeCreated"
-  },
-  {
-    "name": "wrapIntoObservable"
-  },
-  {
-    "name": "wrapListener"
-  },
-  {
-    "name": "writeDirectClass"
-  },
-  {
-    "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}"
-  },
-  {
-    "name": "{isArray:isArray2}"
-  },
-  {
-    "name": "{isArray:isArray}"
-  },
-  {
-    "name": "ɵEmptyOutletComponent"
-  },
-  {
-    "name": "ɵɵInputTransformsFeature"
-  },
-  {
-    "name": "ɵɵNgOnChangesFeature"
-  },
-  {
-    "name": "ɵɵattribute"
-  },
-  {
-    "name": "ɵɵdefineComponent"
-  },
-  {
-    "name": "ɵɵdefineDirective"
-  },
-  {
-    "name": "ɵɵdefineInjectable"
-  },
-  {
-    "name": "ɵɵdirectiveInject"
-  },
-  {
-    "name": "ɵɵelement"
-  },
-  {
-    "name": "ɵɵelementEnd"
-  },
-  {
-    "name": "ɵɵelementStart"
-  },
-  {
-    "name": "ɵɵgetInheritedFactory"
-  },
-  {
-    "name": "ɵɵinject"
-  },
-  {
-    "name": "ɵɵlistener"
-  },
-  {
-    "name": "ɵɵsanitizeResourceUrl"
-  },
-  {
-    "name": "ɵɵsanitizeUrl"
-  },
-  {
-    "name": "ɵɵtext"
-  },
-  {
-    "name": "ɵɵtextInterpolate1"
-  }
+  "APP_BASE_HREF",
+  "APP_BOOTSTRAP_LISTENER",
+  "APP_ID",
+  "APP_INITIALIZER",
+  "AbsoluteRedirect",
+  "ActivateRoutes",
+  "ActivatedRoute",
+  "ActivatedRouteSnapshot",
+  "ActivationEnd",
+  "ActivationStart",
+  "AfterRenderManager",
+  "AnonymousSubject",
+  "ApplicationInitStatus",
+  "ApplicationRef",
+  "ApplyRedirects",
+  "BOOTSTRAP_DONE",
+  "BROWSER_MODULE_PROVIDERS",
+  "BaseRouteReuseStrategy",
+  "BeforeActivateRoutes",
+  "BehaviorSubject",
+  "BrowserDomAdapter",
+  "BrowserPlatformLocation",
+  "BrowserXhr",
+  "CIRCULAR",
+  "COMPLETE_NOTIFICATION",
+  "COMPONENT_REGEX",
+  "CREATE_VIEW_TRANSITION",
+  "CSP_NONCE",
+  "CanActivate",
+  "CanDeactivate",
+  "ChainedInjector",
+  "ChangeDetectionScheduler",
+  "ChangeDetectionSchedulerImpl",
+  "ChangeDetectionStrategy",
+  "ChangeDetectorRef",
+  "ChildActivationEnd",
+  "ChildActivationStart",
+  "ChildrenOutletContexts",
+  "Compiler",
+  "ComponentFactory",
+  "ComponentFactory2",
+  "ComponentFactoryResolver",
+  "ComponentFactoryResolver2",
+  "ComponentRef",
+  "ComponentRef2",
+  "ConnectableObservable",
+  "Console",
+  "ConsumerObserver",
+  "DEFAULT_APP_ID",
+  "DEFAULT_SERIALIZER",
+  "DOCUMENT",
+  "DOCUMENT2",
+  "DefaultDomRenderer2",
+  "DefaultRouteReuseStrategy",
+  "DefaultTitleStrategy",
+  "DefaultUrlHandlingStrategy",
+  "DefaultUrlSerializer",
+  "DestroyRef",
+  "DomAdapter",
+  "DomEventsPlugin",
+  "DomRendererFactory2",
+  "EMPTY",
+  "EMPTY_ARRAY",
+  "EMPTY_OBJ",
+  "EMPTY_OBSERVER",
+  "EMPTY_PAYLOAD",
+  "EMPTY_SUBSCRIPTION",
+  "ENVIRONMENT_INITIALIZER",
+  "EVENT_MANAGER_PLUGINS",
+  "EffectScheduler",
+  "ElementRef",
+  "EmptyError",
+  "EmulatedEncapsulationDomRenderer2",
+  "EnvironmentInjector",
+  "EnvironmentNgModuleRefAdapter",
+  "ErrorHandler",
+  "EventEmitter",
+  "EventManager",
+  "EventManagerPlugin",
+  "EventType2",
+  "GenericBrowserDomAdapter",
+  "GuardsCheckEnd",
+  "GuardsCheckStart",
+  "HistoryStateManager",
+  "INITIAL_NAVIGATION",
+  "INITIAL_VALUE",
+  "INJECTOR",
+  "INJECTOR_DEF_TYPES",
+  "INJECTOR_SCOPE",
+  "INPUT_BINDER",
+  "INPUT_SIGNAL_NODE",
+  "INTERNAL_APPLICATION_ERROR_HANDLER",
+  "INTERNAL_BROWSER_PLATFORM_PROVIDERS",
+  "InjectFlags",
+  "InjectionToken",
+  "Injector",
+  "InputFlags",
+  "ItemComponent",
+  "KeyEventsPlugin",
+  "LContainerFlags",
+  "LOCALE_ID2",
+  "LQueries_",
+  "LQuery_",
+  "LifecycleHooksFeature",
+  "ListComponent",
+  "Location",
+  "LocationStrategy",
+  "MATRIX_PARAM_SEGMENT_RE",
+  "MODIFIER_KEYS",
+  "MODIFIER_KEY_GETTERS",
+  "ModuleWithComponentFactories",
+  "NAMESPACE_URIS",
+  "NAVIGATION_ERROR_HANDLER",
+  "NEW_LINE",
+  "NG_COMP_DEF",
+  "NG_DIR_DEF",
+  "NG_ELEMENT_ID",
+  "NG_ENV_ID",
+  "NG_FACTORY_DEF",
+  "NG_INJECTABLE_DEF",
+  "NG_INJECTOR_DEF",
+  "NG_INJ_DEF",
+  "NG_MOD_DEF",
+  "NG_PIPE_DEF",
+  "NG_PROV_DEF",
+  "NOT_FOUND",
+  "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR",
+  "NOT_YET",
+  "NO_CHANGE",
+  "NULL_INJECTOR",
+  "Navigation",
+  "NavigationCancel",
+  "NavigationCancellationCode",
+  "NavigationEnd",
+  "NavigationError",
+  "NavigationResult",
+  "NavigationSkipped",
+  "NavigationSkippedCode",
+  "NavigationStart",
+  "NavigationTransitions",
+  "NgModuleFactory",
+  "NgModuleFactory2",
+  "NgModuleRef",
+  "NgModuleRef2",
+  "NgOnChangesFeatureImpl",
+  "NgZone",
+  "NgZoneChangeDetectionScheduler",
+  "NoLeftoversInUrl",
+  "NoMatch",
+  "NodeInjector",
+  "NodeInjectorDestroyRef",
+  "NodeInjectorFactory",
+  "NoneEncapsulationDomRenderer",
+  "NoopNgZone",
+  "NullInjector",
+  "ObjectUnsubscribedError",
+  "Observable",
+  "OperatorSubscriber",
+  "OutletContext",
+  "OutletInjector",
+  "PLATFORM_DESTROY_LISTENERS",
+  "PLATFORM_ID",
+  "PLATFORM_INITIALIZER",
+  "PRESERVE_HOST_CONTENT",
+  "PRIMARY_OUTLET",
+  "ParamsAsMap",
+  "PathLocationStrategy",
+  "PendingTasksInternal",
+  "PlatformLocation",
+  "Position",
+  "QUERY_PARAM_RE",
+  "QUERY_PARAM_VALUE_RE",
+  "QueryList",
+  "R3Injector",
+  "R3TemplateRef",
+  "R3ViewContainerRef",
+  "REACTIVE_LVIEW_CONSUMER_NODE",
+  "REACTIVE_NODE",
+  "REMOVE_STYLES_ON_COMPONENT_DESTROY",
+  "REQUIRED_UNSET_VALUE",
+  "ROUTER_CONFIGURATION",
+  "ROUTER_OUTLET_DATA",
+  "ROUTER_PRELOADER",
+  "ROUTER_SCROLLER",
+  "ROUTES",
+  "Recognizer",
+  "RedirectCommand",
+  "RedirectRequest",
+  "Renderer2",
+  "RendererFactory2",
+  "RendererStyleFlags2",
+  "ResolveEnd",
+  "ResolveStart",
+  "RouteConfigLoadEnd",
+  "RouteConfigLoadStart",
+  "RouteReuseStrategy",
+  "RouteTitleKey",
+  "Router",
+  "RouterConfigLoader",
+  "RouterEvent",
+  "RouterLink",
+  "RouterLinkActive",
+  "RouterOutlet",
+  "RouterState",
+  "RouterStateSnapshot",
+  "RoutesRecognized",
+  "RuntimeError",
+  "SAFE_URL_PATTERN",
+  "SCHEDULE_IN_ROOT_ZONE",
+  "SEGMENT_RE",
+  "SIGNAL",
+  "SIGNAL_NODE",
+  "SIMPLE_CHANGES_STORE",
+  "SafeSubscriber",
+  "SafeValueImpl",
+  "Sanitizer",
+  "SecurityContext",
+  "ShadowDomRenderer",
+  "SharedStylesHost",
+  "SimpleChange",
+  "StandaloneService",
+  "StateManager",
+  "Subject",
+  "Subscriber",
+  "Subscription",
+  "TEMPORARY_CONSUMER_NODE",
+  "TESTABILITY",
+  "THROW_IF_NOT_FOUND",
+  "TQueries_",
+  "TQueryMetadata_",
+  "TQuery_",
+  "TRACKED_LVIEWS",
+  "TemplateRef",
+  "Title",
+  "TitleStrategy",
+  "TracingAction",
+  "TracingService",
+  "Tree",
+  "TreeNode",
+  "USE_VALUE",
+  "UnsubscriptionError",
+  "UrlHandlingStrategy",
+  "UrlParser",
+  "UrlSegment",
+  "UrlSegmentGroup",
+  "UrlSerializer",
+  "UrlTree",
+  "VE_ViewContainerRef",
+  "ViewContainerRef",
+  "ViewEncapsulation",
+  "ViewEngineTemplateRef",
+  "ViewRef",
+  "ZONELESS_ENABLED",
+  "ZONELESS_SCHEDULER_DISABLED",
+  "ZoneAwareEffectScheduler",
+  "ZoneStablePendingTask",
+  "_DOM",
+  "_Injector",
+  "_NullComponentFactoryResolver",
+  "__asyncValues",
+  "__await",
+  "__defProp",
+  "__forward_ref__",
+  "__publicField",
+  "_a",
+  "_applyRootElementTransformImpl",
+  "_bind",
+  "_currentInjector",
+  "_global",
+  "_injectImplementation",
+  "_isRefreshingViews",
+  "_keyMap",
+  "_locateOrCreateAnchorNode",
+  "_locateOrCreateElementNode",
+  "_locateOrCreateTextNode",
+  "_platformInjector",
+  "_stripIndexHtml",
+  "_wasLastNodeCreated",
+  "activeConsumer",
+  "addEmptyPathsToChildrenIfNeeded",
+  "addPropertyBinding",
+  "addToArray",
+  "addToEndOfViewTree",
+  "advanceActivatedRoute",
+  "allocExpando",
+  "allocLFrame",
+  "allowSanitizationBypassAndThrow",
+  "angularZoneInstanceIdProperty",
+  "appendChild",
+  "applyNodes",
+  "applyProjectionRecursive",
+  "applyToElementOrContainer",
+  "applyValueToInputField",
+  "applyView",
+  "arrRemove",
+  "assertConsumerNode",
+  "assertNotDestroyed",
+  "assertProducerNode",
+  "attachPatchData",
+  "baseElement",
+  "bind",
+  "bindingUpdated",
+  "bloomHasToken",
+  "booleanAttribute",
+  "bootstrap",
+  "callHook",
+  "callHookInternal",
+  "callHooks",
+  "captureNodeBindings",
+  "catchError",
+  "checkStable",
+  "classIndexOf",
+  "cleanUpView",
+  "collectNativeNodes",
+  "collectNativeNodesInLContainer",
+  "collectQueryResults",
+  "combineLatest",
+  "compare",
+  "computeStaticStyling",
+  "concat",
+  "concatMap",
+  "concatStringsWithSpace",
+  "config",
+  "configureViewWithDirective",
+  "consumerBeforeComputation",
+  "consumerDestroy",
+  "consumerIsLive",
+  "consumerMarkDirty",
+  "consumerPollProducersForChange",
+  "containsSegmentGroup",
+  "containsSegmentGroupHelper",
+  "containsTree",
+  "context",
+  "convertToBitFlags",
+  "convertToParamMap",
+  "createChildrenForEmptyPaths",
+  "createContainerRef",
+  "createContentQuery",
+  "createElementNode",
+  "createElementRef",
+  "createEmptyState",
+  "createEnvironmentInjector",
+  "createErrorClass",
+  "createInjector",
+  "createInjectorWithoutInjectorInstances",
+  "createInputSignal",
+  "createInvalidObservableTypeError",
+  "createLFrame",
+  "createLView",
+  "createLinkElement",
+  "createNewSegmentChildren",
+  "createNewSegmentGroup",
+  "createNode",
+  "createNodeInjector",
+  "createNotification",
+  "createOperatorSubscriber",
+  "createOrReusePlatformInjector",
+  "createResultForNode",
+  "createRoot",
+  "createSegmentGroupFromRoute",
+  "createStyleElement",
+  "createTView",
+  "createTemplateRef",
+  "createUrlTreeFromSegmentGroup",
+  "deactivateRouteAndItsChildren",
+  "decode",
+  "decodeQuery",
+  "deepForEach",
+  "deepForEachProvider",
+  "defaultEquals",
+  "defaultErrorFactory",
+  "defaultIfEmpty",
+  "defaultUrlMatcher",
+  "defer",
+  "destroyLView",
+  "detachMovedView",
+  "detachView",
+  "detachViewFromDOM",
+  "detectChangesInChildComponents",
+  "detectChangesInComponent",
+  "detectChangesInEmbeddedViews",
+  "detectChangesInView",
+  "detectChangesInViewIfAttached",
+  "detectChangesInViewIfRequired",
+  "detectChangesInternal",
+  "diPublicInInjector",
+  "emptyPathMatch",
+  "encodeUriQuery",
+  "encodeUriSegment",
+  "encodeUriString",
+  "enterDI",
+  "enterView",
+  "epoch",
+  "equalArraysOrString",
+  "equalParamsAndUrlSegments",
+  "equalPath",
+  "errorContext",
+  "exactMatchOptions",
+  "execFinalizer",
+  "executeCheckHooks",
+  "executeContentQueries",
+  "executeInitAndCheckHooks",
+  "executeListenerWithErrorHandling",
+  "executeSchedule",
+  "executeTemplate",
+  "executeViewQueryFn",
+  "extractDefListOrFactory",
+  "extractDirectiveDef",
+  "filter",
+  "finalize",
+  "findAttrIndexInNode",
+  "findNode",
+  "findPath",
+  "first",
+  "flattenRouteTree",
+  "forEachSingleProvider",
+  "forwardRef",
+  "freeConsumers",
+  "from",
+  "fromAsyncIterable",
+  "generateInitialInputs",
+  "getAllRouteGuards",
+  "getBeforeNodeForView",
+  "getBindingsEnabled",
+  "getBootstrapListener",
+  "getChildRouteGuards",
+  "getClosestRouteInjector",
+  "getClosureSafeProperty",
+  "getComponentDef",
+  "getComponentLViewByIndex",
+  "getConstant",
+  "getCurrentQueryIndex",
+  "getCurrentTNode",
+  "getCurrentTNodePlaceholderOk",
+  "getDOM",
+  "getData",
+  "getDataKeys",
+  "getDeclarationTNode",
+  "getDirectiveDef",
+  "getFactoryDef",
+  "getFactoryOf",
+  "getFirstLContainer",
+  "getFirstNativeNode",
+  "getIdxOfMatchingSelector",
+  "getInherited",
+  "getInitialLViewFlagsFromDef",
+  "getInjectImplementation",
+  "getInjectableDef",
+  "getInjectorDef",
+  "getInjectorIndex",
+  "getLView",
+  "getLViewParent",
+  "getNativeByTNode",
+  "getNearestLContainer",
+  "getNextLContainer",
+  "getNgDirectiveDef",
+  "getNgModuleDef",
+  "getNodeInjectable",
+  "getNullInjector",
+  "getOrCreateComponentTView",
+  "getOrCreateInjectable",
+  "getOrCreateLViewCleanup",
+  "getOrCreateNodeInjectorForNode",
+  "getOrCreateTNode",
+  "getOrCreateTViewCleanup",
+  "getOrCreateViewRefs",
+  "getOutlet",
+  "getOwnDefinition",
+  "getParentInjectorIndex",
+  "getParentInjectorLocation",
+  "getParentInjectorView",
+  "getPipeDef",
+  "getProjectionNodes",
+  "getPromiseCtor",
+  "getQueryResults",
+  "getResolve",
+  "getSanitizer",
+  "getSelectedIndex",
+  "getSimpleChangesStore",
+  "getSymbolIterator",
+  "getTNode",
+  "getTNodeFromLView",
+  "getTQuery",
+  "getTView",
+  "getTokenOrFunctionIdentity",
+  "getViewRefs",
+  "handleError",
+  "handleStoppedNotification",
+  "handleUnhandledError",
+  "hasApplyArgsData",
+  "hasEmptyPathConfig",
+  "hasInSkipHydrationBlockFlag",
+  "hasLift",
+  "hasParentInjector",
+  "hasStaticTitle",
+  "hasTagAndTypeMatch",
+  "icuContainerIterate",
+  "identity",
+  "importProvidersFrom",
+  "inNotificationPhase",
+  "includeViewProviders",
+  "incrementInitPhaseFlags",
+  "initFeatures",
+  "initializeDirectives",
+  "inject",
+  "injectArgs",
+  "injectChangeDetectorRef",
+  "injectDestroyRef",
+  "injectElementRef",
+  "injectInjectorOnly",
+  "injectRootLimpMode",
+  "injectTemplateRef",
+  "injectViewContainerRef",
+  "injectableDefOrInjectorDefFactory",
+  "innerFrom",
+  "input",
+  "inputFunction",
+  "inputRequiredFunction",
+  "insertBloom",
+  "instructionState",
+  "internalImportProvidersFrom",
+  "internalProvideZoneChangeDetection",
+  "invokeDirectivesHostBindings",
+  "invokeHostBindingsInCreationMode",
+  "isAngularZoneProperty",
+  "isApplicationBootstrapConfig",
+  "isArrayLike",
+  "isAsyncIterable",
+  "isCommandWithOutlets",
+  "isComponentDef",
+  "isComponentHost",
+  "isConsumerNode",
+  "isContentQueryHost",
+  "isCssClassMatching",
+  "isCurrentTNodeParent",
+  "isDirectiveHost",
+  "isEmptyError",
+  "isEnvironmentProviders",
+  "isForwardRef",
+  "isFunction",
+  "isFunction2",
+  "isInlineTemplate",
+  "isInteropObservable",
+  "isIterable",
+  "isLContainer",
+  "isLView",
+  "isMatrixParams",
+  "isNameOnlyAttributeMarker",
+  "isNavigationCancelingError",
+  "isNodeMatchingSelector",
+  "isNodeMatchingSelectorList",
+  "isPlatformServer",
+  "isPositive",
+  "isPromise",
+  "isPromise2",
+  "isReadableStreamLike",
+  "isRefreshingViews",
+  "isRootView",
+  "isSubscription",
+  "isTemplateNode",
+  "isTypeProvider",
+  "isUrlTree",
+  "isValueProvider",
+  "iterator",
+  "joinWithSlash",
+  "last",
+  "last3",
+  "lastNodeWasCreated",
+  "leaveDI",
+  "leaveView",
+  "leaveViewLight",
+  "locateDirectiveOrProvider",
+  "lookupTokenUsingModuleInjector",
+  "lookupTokenUsingNodeInjector",
+  "makeRecord",
+  "map",
+  "markAncestorsForTraversal",
+  "markAsComponentHost",
+  "markViewDirty",
+  "markViewForRefresh",
+  "markedFeatures",
+  "match",
+  "matchSegments",
+  "matchWithChecks",
+  "materializeViewResults",
+  "matrixParamsMatch",
+  "maybeSchedule",
+  "maybeUnwrapDefaultExport",
+  "maybeUnwrapFn",
+  "maybeWrapInNotSelector",
+  "mergeAll",
+  "mergeEmptyPathMatches",
+  "mergeHostAttribute",
+  "mergeHostAttrs",
+  "mergeMap",
+  "nativeAppendChild",
+  "nativeAppendOrInsertBefore",
+  "nativeInsertBefore",
+  "nativeParentNode",
+  "navigationCancelingError",
+  "nextBindingIndex",
+  "nextNgElementId",
+  "ngOnChangesSetInput",
+  "ngZoneInstanceId",
+  "noMatch",
+  "noMatch2",
+  "noSideEffects",
+  "nodeChildrenAsMap",
+  "nonNull",
+  "noop",
+  "noop2",
+  "normalizeQueryParams",
+  "notFoundValueOrThrow",
+  "observable",
+  "observeOn",
+  "of",
+  "onEnter",
+  "onLeave",
+  "operate",
+  "paramCompareMap",
+  "parseAndConvertBindingsForDefinition",
+  "pathCompareMap",
+  "pipeFromArray",
+  "policy",
+  "popScheduler",
+  "prioritizedGuardValue",
+  "processInjectorTypesWithProviders",
+  "producerAccessed",
+  "producerAddLiveConsumer",
+  "producerMarkClean",
+  "producerNotifyConsumers",
+  "producerRemoveLiveConsumerAtIndex",
+  "producerUpdateValueVersion",
+  "readableStreamLikeToAsyncGenerator",
+  "redirectIfUrlTree",
+  "redirectingNavigationError",
+  "refCount",
+  "refreshContentQueries",
+  "refreshView",
+  "registerPostOrderHooks",
+  "rememberChangeHistoryAndInvokeOnChangesHook",
+  "remove",
+  "removeElements",
+  "removeFromArray",
+  "renderComponent",
+  "renderStringify",
+  "renderView",
+  "replaceSegment",
+  "reportUnhandledError",
+  "requiresRefreshOrTraversal",
+  "resetPreOrderHookFlags",
+  "resolveForwardRef",
+  "rootRoute",
+  "routes",
+  "runEffectsInView",
+  "runInInjectionContext",
+  "saveNameToExportMap",
+  "scheduleAsyncIterable",
+  "scheduleCallbackWithMicrotask",
+  "scheduleCallbackWithRafRace",
+  "searchTokensOnInjector",
+  "serializeNode",
+  "serializePath",
+  "serializePaths",
+  "serializeSegment",
+  "setActiveConsumer",
+  "setBindingRootForHostBindings",
+  "setCurrentDirectiveIndex",
+  "setCurrentInjector",
+  "setCurrentQueryIndex",
+  "setCurrentTNode",
+  "setDirectiveInputsWhichShadowsStyling",
+  "setIncludeViewProviders",
+  "setInjectImplementation",
+  "setInputsForProperty",
+  "setInputsFromAttrs",
+  "setIsRefreshingViews",
+  "setRouterState",
+  "setSelectedIndex",
+  "setUpAttributes",
+  "setupStaticAttributes",
+  "shallowEqual",
+  "shimStylesContent",
+  "shouldAddViewToDom",
+  "shouldSearchParent",
+  "split",
+  "squashSegmentGroup",
+  "standardizeConfig",
+  "storeLViewOnDestroy",
+  "stringify",
+  "stringify11",
+  "stringifyCSSSelector",
+  "stripTrailingSlash",
+  "subscribeOn",
+  "subsetMatchOptions",
+  "switchMap",
+  "switchTap",
+  "symbolIterator",
+  "take",
+  "takeLast",
+  "tap",
+  "throwError2",
+  "throwIfEmpty",
+  "throwInvalidWriteToSignalErrorFn",
+  "throwProviderNotFoundError",
+  "timeoutProvider",
+  "toRefArray",
+  "trackMovedView",
+  "tree",
+  "trustedScriptURLFromStringBypass",
+  "uniqueIdCounter",
+  "unregisterLView",
+  "unwrapElementRef",
+  "unwrapRNode",
+  "unwrapSafeValue",
+  "updateAncestorTraversalFlagsOnAttach",
+  "updateMicroTaskStatus",
+  "updateSegmentGroup",
+  "updateSegmentGroupChildren",
+  "viewAttachedToChangeDetector",
+  "viewShouldHaveReactiveConsumer",
+  "walkProviderTree",
+  "wasLastNodeCreated",
+  "wrapIntoObservable",
+  "wrapListener",
+  "writeDirectClass",
+  "writeToDirectiveInput",
+  "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}",
+  "{isArray:isArray2}",
+  "{isArray:isArray}",
+  "ɵEmptyOutletComponent",
+  "ɵɵInputTransformsFeature",
+  "ɵɵNgOnChangesFeature",
+  "ɵɵattribute",
+  "ɵɵdefineComponent",
+  "ɵɵdefineDirective",
+  "ɵɵdefineInjectable",
+  "ɵɵdirectiveInject",
+  "ɵɵelement",
+  "ɵɵelementEnd",
+  "ɵɵelementStart",
+  "ɵɵgetInheritedFactory",
+  "ɵɵinject",
+  "ɵɵlistener",
+  "ɵɵsanitizeResourceUrl",
+  "ɵɵsanitizeUrl",
+  "ɵɵtext",
+  "ɵɵtextInterpolate1"
 ]

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -1,1118 +1,374 @@
 [
-  {
-    "name": "APP_BOOTSTRAP_LISTENER"
-  },
-  {
-    "name": "APP_ID"
-  },
-  {
-    "name": "APP_INITIALIZER"
-  },
-  {
-    "name": "AfterRenderManager"
-  },
-  {
-    "name": "AnonymousSubject"
-  },
-  {
-    "name": "ApplicationInitStatus"
-  },
-  {
-    "name": "ApplicationRef"
-  },
-  {
-    "name": "BROWSER_MODULE_PROVIDERS"
-  },
-  {
-    "name": "BehaviorSubject"
-  },
-  {
-    "name": "BrowserDomAdapter"
-  },
-  {
-    "name": "BrowserXhr"
-  },
-  {
-    "name": "CIRCULAR"
-  },
-  {
-    "name": "COMPLETE_NOTIFICATION"
-  },
-  {
-    "name": "COMPONENT_REGEX"
-  },
-  {
-    "name": "CSP_NONCE"
-  },
-  {
-    "name": "ChainedInjector"
-  },
-  {
-    "name": "ChangeDetectionScheduler"
-  },
-  {
-    "name": "ChangeDetectionSchedulerImpl"
-  },
-  {
-    "name": "ChangeDetectionStrategy"
-  },
-  {
-    "name": "ComponentFactory"
-  },
-  {
-    "name": "ComponentFactory2"
-  },
-  {
-    "name": "ComponentFactoryResolver"
-  },
-  {
-    "name": "ComponentFactoryResolver2"
-  },
-  {
-    "name": "ComponentRef"
-  },
-  {
-    "name": "ComponentRef2"
-  },
-  {
-    "name": "ConsumerObserver"
-  },
-  {
-    "name": "DEFAULT_APP_ID"
-  },
-  {
-    "name": "DOCUMENT"
-  },
-  {
-    "name": "DOCUMENT2"
-  },
-  {
-    "name": "DefaultDomRenderer2"
-  },
-  {
-    "name": "DestroyRef"
-  },
-  {
-    "name": "DomAdapter"
-  },
-  {
-    "name": "DomEventsPlugin"
-  },
-  {
-    "name": "DomRendererFactory2"
-  },
-  {
-    "name": "EMPTY_ARRAY"
-  },
-  {
-    "name": "EMPTY_OBJ"
-  },
-  {
-    "name": "EMPTY_OBSERVER"
-  },
-  {
-    "name": "EMPTY_PAYLOAD"
-  },
-  {
-    "name": "EMPTY_SUBSCRIPTION"
-  },
-  {
-    "name": "ENVIRONMENT_INITIALIZER"
-  },
-  {
-    "name": "EVENT_MANAGER_PLUGINS"
-  },
-  {
-    "name": "EffectScheduler"
-  },
-  {
-    "name": "ElementRef"
-  },
-  {
-    "name": "EmulatedEncapsulationDomRenderer2"
-  },
-  {
-    "name": "EnvironmentInjector"
-  },
-  {
-    "name": "EnvironmentNgModuleRefAdapter"
-  },
-  {
-    "name": "ErrorHandler"
-  },
-  {
-    "name": "EventEmitter"
-  },
-  {
-    "name": "EventManager"
-  },
-  {
-    "name": "EventManagerPlugin"
-  },
-  {
-    "name": "GenericBrowserDomAdapter"
-  },
-  {
-    "name": "INJECTOR"
-  },
-  {
-    "name": "INJECTOR_DEF_TYPES"
-  },
-  {
-    "name": "INJECTOR_SCOPE"
-  },
-  {
-    "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
-  },
-  {
-    "name": "INTERNAL_BROWSER_PLATFORM_PROVIDERS"
-  },
-  {
-    "name": "InjectFlags"
-  },
-  {
-    "name": "InjectionToken"
-  },
-  {
-    "name": "Injector"
-  },
-  {
-    "name": "InputFlags"
-  },
-  {
-    "name": "KeyEventsPlugin"
-  },
-  {
-    "name": "LContainerFlags"
-  },
-  {
-    "name": "LOCALE_ID2"
-  },
-  {
-    "name": "LifecycleHooksFeature"
-  },
-  {
-    "name": "MODIFIER_KEYS"
-  },
-  {
-    "name": "MODIFIER_KEY_GETTERS"
-  },
-  {
-    "name": "NAMESPACE_URIS"
-  },
-  {
-    "name": "NEW_LINE"
-  },
-  {
-    "name": "NG_COMP_DEF"
-  },
-  {
-    "name": "NG_DIR_DEF"
-  },
-  {
-    "name": "NG_ELEMENT_ID"
-  },
-  {
-    "name": "NG_ENV_ID"
-  },
-  {
-    "name": "NG_FACTORY_DEF"
-  },
-  {
-    "name": "NG_INJECTABLE_DEF"
-  },
-  {
-    "name": "NG_INJECTOR_DEF"
-  },
-  {
-    "name": "NG_INJ_DEF"
-  },
-  {
-    "name": "NG_PIPE_DEF"
-  },
-  {
-    "name": "NG_PROV_DEF"
-  },
-  {
-    "name": "NOT_FOUND"
-  },
-  {
-    "name": "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR"
-  },
-  {
-    "name": "NOT_YET"
-  },
-  {
-    "name": "NO_CHANGE"
-  },
-  {
-    "name": "NULL_INJECTOR"
-  },
-  {
-    "name": "NgModuleRef"
-  },
-  {
-    "name": "NgZone"
-  },
-  {
-    "name": "NgZoneChangeDetectionScheduler"
-  },
-  {
-    "name": "NodeInjector"
-  },
-  {
-    "name": "NodeInjectorDestroyRef"
-  },
-  {
-    "name": "NodeInjectorFactory"
-  },
-  {
-    "name": "NoneEncapsulationDomRenderer"
-  },
-  {
-    "name": "NoopNgZone"
-  },
-  {
-    "name": "NullInjector"
-  },
-  {
-    "name": "ObjectUnsubscribedError"
-  },
-  {
-    "name": "Observable"
-  },
-  {
-    "name": "OperatorSubscriber"
-  },
-  {
-    "name": "PLATFORM_DESTROY_LISTENERS"
-  },
-  {
-    "name": "PLATFORM_ID"
-  },
-  {
-    "name": "PLATFORM_INITIALIZER"
-  },
-  {
-    "name": "PRESERVE_HOST_CONTENT"
-  },
-  {
-    "name": "PendingTasksInternal"
-  },
-  {
-    "name": "R3Injector"
-  },
-  {
-    "name": "REACTIVE_LVIEW_CONSUMER_NODE"
-  },
-  {
-    "name": "REACTIVE_NODE"
-  },
-  {
-    "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
-  },
-  {
-    "name": "RendererFactory2"
-  },
-  {
-    "name": "RendererStyleFlags2"
-  },
-  {
-    "name": "RuntimeError"
-  },
-  {
-    "name": "SCHEDULE_IN_ROOT_ZONE"
-  },
-  {
-    "name": "SIGNAL"
-  },
-  {
-    "name": "SIMPLE_CHANGES_STORE"
-  },
-  {
-    "name": "SafeSubscriber"
-  },
-  {
-    "name": "Sanitizer"
-  },
-  {
-    "name": "ShadowDomRenderer"
-  },
-  {
-    "name": "SharedStylesHost"
-  },
-  {
-    "name": "SimpleChange"
-  },
-  {
-    "name": "StandaloneService"
-  },
-  {
-    "name": "Subject"
-  },
-  {
-    "name": "Subscriber"
-  },
-  {
-    "name": "Subscription"
-  },
-  {
-    "name": "TEMPORARY_CONSUMER_NODE"
-  },
-  {
-    "name": "TESTABILITY"
-  },
-  {
-    "name": "THROW_IF_NOT_FOUND"
-  },
-  {
-    "name": "TRACKED_LVIEWS"
-  },
-  {
-    "name": "TracingAction"
-  },
-  {
-    "name": "TracingService"
-  },
-  {
-    "name": "USE_VALUE"
-  },
-  {
-    "name": "UnsubscriptionError"
-  },
-  {
-    "name": "ViewEncapsulation"
-  },
-  {
-    "name": "ViewRef"
-  },
-  {
-    "name": "ZONELESS_ENABLED"
-  },
-  {
-    "name": "ZONELESS_SCHEDULER_DISABLED"
-  },
-  {
-    "name": "ZoneAwareEffectScheduler"
-  },
-  {
-    "name": "ZoneStablePendingTask"
-  },
-  {
-    "name": "_DOM"
-  },
-  {
-    "name": "_Injector"
-  },
-  {
-    "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__defProp"
-  },
-  {
-    "name": "__forward_ref__"
-  },
-  {
-    "name": "__publicField"
-  },
-  {
-    "name": "_applyRootElementTransformImpl"
-  },
-  {
-    "name": "_bind"
-  },
-  {
-    "name": "_currentInjector"
-  },
-  {
-    "name": "_injectImplementation"
-  },
-  {
-    "name": "_isRefreshingViews"
-  },
-  {
-    "name": "_keyMap"
-  },
-  {
-    "name": "_locateOrCreateTextNode"
-  },
-  {
-    "name": "_platformInjector"
-  },
-  {
-    "name": "_wasLastNodeCreated"
-  },
-  {
-    "name": "activeConsumer"
-  },
-  {
-    "name": "addPropertyBinding"
-  },
-  {
-    "name": "allocExpando"
-  },
-  {
-    "name": "allocLFrame"
-  },
-  {
-    "name": "angularZoneInstanceIdProperty"
-  },
-  {
-    "name": "appendChild"
-  },
-  {
-    "name": "applyNodes"
-  },
-  {
-    "name": "applyProjectionRecursive"
-  },
-  {
-    "name": "applyToElementOrContainer"
-  },
-  {
-    "name": "applyValueToInputField"
-  },
-  {
-    "name": "applyView"
-  },
-  {
-    "name": "arrRemove"
-  },
-  {
-    "name": "assertConsumerNode"
-  },
-  {
-    "name": "assertNotDestroyed"
-  },
-  {
-    "name": "attachPatchData"
-  },
-  {
-    "name": "baseElement"
-  },
-  {
-    "name": "bind"
-  },
-  {
-    "name": "bloomHasToken"
-  },
-  {
-    "name": "bootstrap"
-  },
-  {
-    "name": "callHook"
-  },
-  {
-    "name": "callHookInternal"
-  },
-  {
-    "name": "callHooks"
-  },
-  {
-    "name": "captureNodeBindings"
-  },
-  {
-    "name": "checkStable"
-  },
-  {
-    "name": "cleanUpView"
-  },
-  {
-    "name": "collectNativeNodes"
-  },
-  {
-    "name": "collectNativeNodesInLContainer"
-  },
-  {
-    "name": "concatStringsWithSpace"
-  },
-  {
-    "name": "config"
-  },
-  {
-    "name": "configureViewWithDirective"
-  },
-  {
-    "name": "consumerBeforeComputation"
-  },
-  {
-    "name": "consumerDestroy"
-  },
-  {
-    "name": "consumerIsLive"
-  },
-  {
-    "name": "consumerPollProducersForChange"
-  },
-  {
-    "name": "context"
-  },
-  {
-    "name": "convertToBitFlags"
-  },
-  {
-    "name": "createElementRef"
-  },
-  {
-    "name": "createErrorClass"
-  },
-  {
-    "name": "createInjector"
-  },
-  {
-    "name": "createLFrame"
-  },
-  {
-    "name": "createLView"
-  },
-  {
-    "name": "createLinkElement"
-  },
-  {
-    "name": "createNodeInjector"
-  },
-  {
-    "name": "createNotification"
-  },
-  {
-    "name": "createStyleElement"
-  },
-  {
-    "name": "createTView"
-  },
-  {
-    "name": "deepForEach"
-  },
-  {
-    "name": "deepForEachProvider"
-  },
-  {
-    "name": "detachMovedView"
-  },
-  {
-    "name": "detachViewFromDOM"
-  },
-  {
-    "name": "detectChangesInChildComponents"
-  },
-  {
-    "name": "detectChangesInComponent"
-  },
-  {
-    "name": "detectChangesInEmbeddedViews"
-  },
-  {
-    "name": "detectChangesInView"
-  },
-  {
-    "name": "detectChangesInViewIfAttached"
-  },
-  {
-    "name": "detectChangesInViewIfRequired"
-  },
-  {
-    "name": "detectChangesInternal"
-  },
-  {
-    "name": "diPublicInInjector"
-  },
-  {
-    "name": "enterDI"
-  },
-  {
-    "name": "enterView"
-  },
-  {
-    "name": "errorContext"
-  },
-  {
-    "name": "execFinalizer"
-  },
-  {
-    "name": "executeCheckHooks"
-  },
-  {
-    "name": "executeInitAndCheckHooks"
-  },
-  {
-    "name": "executeTemplate"
-  },
-  {
-    "name": "executeViewQueryFn"
-  },
-  {
-    "name": "extractDefListOrFactory"
-  },
-  {
-    "name": "extractDirectiveDef"
-  },
-  {
-    "name": "forEachSingleProvider"
-  },
-  {
-    "name": "forwardRef"
-  },
-  {
-    "name": "freeConsumers"
-  },
-  {
-    "name": "generateInitialInputs"
-  },
-  {
-    "name": "getClosureSafeProperty"
-  },
-  {
-    "name": "getComponentDef"
-  },
-  {
-    "name": "getComponentLViewByIndex"
-  },
-  {
-    "name": "getCurrentTNode"
-  },
-  {
-    "name": "getCurrentTNodePlaceholderOk"
-  },
-  {
-    "name": "getDOM"
-  },
-  {
-    "name": "getDeclarationTNode"
-  },
-  {
-    "name": "getDirectiveDef"
-  },
-  {
-    "name": "getFactoryDef"
-  },
-  {
-    "name": "getFirstLContainer"
-  },
-  {
-    "name": "getInjectImplementation"
-  },
-  {
-    "name": "getInjectableDef"
-  },
-  {
-    "name": "getInjectorDef"
-  },
-  {
-    "name": "getInjectorIndex"
-  },
-  {
-    "name": "getLView"
-  },
-  {
-    "name": "getLViewParent"
-  },
-  {
-    "name": "getNativeByTNode"
-  },
-  {
-    "name": "getNearestLContainer"
-  },
-  {
-    "name": "getNextLContainer"
-  },
-  {
-    "name": "getNodeInjectable"
-  },
-  {
-    "name": "getNullInjector"
-  },
-  {
-    "name": "getOrCreateInjectable"
-  },
-  {
-    "name": "getOrCreateNodeInjectorForNode"
-  },
-  {
-    "name": "getOrCreateTNode"
-  },
-  {
-    "name": "getOwnDefinition"
-  },
-  {
-    "name": "getParentInjectorIndex"
-  },
-  {
-    "name": "getParentInjectorLocation"
-  },
-  {
-    "name": "getParentInjectorView"
-  },
-  {
-    "name": "getPipeDef"
-  },
-  {
-    "name": "getProjectionNodes"
-  },
-  {
-    "name": "getPromiseCtor"
-  },
-  {
-    "name": "getSimpleChangesStore"
-  },
-  {
-    "name": "getTNodeFromLView"
-  },
-  {
-    "name": "handleStoppedNotification"
-  },
-  {
-    "name": "handleUnhandledError"
-  },
-  {
-    "name": "hasApplyArgsData"
-  },
-  {
-    "name": "icuContainerIterate"
-  },
-  {
-    "name": "identity"
-  },
-  {
-    "name": "importProvidersFrom"
-  },
-  {
-    "name": "includeViewProviders"
-  },
-  {
-    "name": "incrementInitPhaseFlags"
-  },
-  {
-    "name": "inject"
-  },
-  {
-    "name": "injectArgs"
-  },
-  {
-    "name": "injectDestroyRef"
-  },
-  {
-    "name": "injectElementRef"
-  },
-  {
-    "name": "injectInjectorOnly"
-  },
-  {
-    "name": "injectRootLimpMode"
-  },
-  {
-    "name": "injectableDefOrInjectorDefFactory"
-  },
-  {
-    "name": "insertBloom"
-  },
-  {
-    "name": "instructionState"
-  },
-  {
-    "name": "internalImportProvidersFrom"
-  },
-  {
-    "name": "internalProvideZoneChangeDetection"
-  },
-  {
-    "name": "invokeHostBindingsInCreationMode"
-  },
-  {
-    "name": "isAngularZoneProperty"
-  },
-  {
-    "name": "isApplicationBootstrapConfig"
-  },
-  {
-    "name": "isComponentDef"
-  },
-  {
-    "name": "isEnvironmentProviders"
-  },
-  {
-    "name": "isFunction"
-  },
-  {
-    "name": "isInlineTemplate"
-  },
-  {
-    "name": "isLContainer"
-  },
-  {
-    "name": "isLView"
-  },
-  {
-    "name": "isPlatformServer"
-  },
-  {
-    "name": "isPositive"
-  },
-  {
-    "name": "isPromise"
-  },
-  {
-    "name": "isRefreshingViews"
-  },
-  {
-    "name": "isRootView"
-  },
-  {
-    "name": "isSubscription"
-  },
-  {
-    "name": "isTemplateNode"
-  },
-  {
-    "name": "isTypeProvider"
-  },
-  {
-    "name": "isValueProvider"
-  },
-  {
-    "name": "leaveDI"
-  },
-  {
-    "name": "leaveView"
-  },
-  {
-    "name": "leaveViewLight"
-  },
-  {
-    "name": "lookupTokenUsingModuleInjector"
-  },
-  {
-    "name": "lookupTokenUsingNodeInjector"
-  },
-  {
-    "name": "makeRecord"
-  },
-  {
-    "name": "map"
-  },
-  {
-    "name": "markAncestorsForTraversal"
-  },
-  {
-    "name": "markViewDirty"
-  },
-  {
-    "name": "markViewForRefresh"
-  },
-  {
-    "name": "markedFeatures"
-  },
-  {
-    "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "mergeHostAttribute"
-  },
-  {
-    "name": "mergeHostAttrs"
-  },
-  {
-    "name": "nativeAppendChild"
-  },
-  {
-    "name": "nativeAppendOrInsertBefore"
-  },
-  {
-    "name": "nativeInsertBefore"
-  },
-  {
-    "name": "nextNgElementId"
-  },
-  {
-    "name": "ngOnChangesSetInput"
-  },
-  {
-    "name": "ngZoneInstanceId"
-  },
-  {
-    "name": "nonNull"
-  },
-  {
-    "name": "noop"
-  },
-  {
-    "name": "noop2"
-  },
-  {
-    "name": "notFoundValueOrThrow"
-  },
-  {
-    "name": "observable"
-  },
-  {
-    "name": "onEnter"
-  },
-  {
-    "name": "onLeave"
-  },
-  {
-    "name": "parseAndConvertBindingsForDefinition"
-  },
-  {
-    "name": "processInjectorTypesWithProviders"
-  },
-  {
-    "name": "producerMarkClean"
-  },
-  {
-    "name": "producerRemoveLiveConsumerAtIndex"
-  },
-  {
-    "name": "producerUpdateValueVersion"
-  },
-  {
-    "name": "refreshContentQueries"
-  },
-  {
-    "name": "refreshView"
-  },
-  {
-    "name": "rememberChangeHistoryAndInvokeOnChangesHook"
-  },
-  {
-    "name": "remove"
-  },
-  {
-    "name": "removeElements"
-  },
-  {
-    "name": "removeFromArray"
-  },
-  {
-    "name": "renderComponent"
-  },
-  {
-    "name": "renderView"
-  },
-  {
-    "name": "requiresRefreshOrTraversal"
-  },
-  {
-    "name": "resetPreOrderHookFlags"
-  },
-  {
-    "name": "resolveForwardRef"
-  },
-  {
-    "name": "runEffectsInView"
-  },
-  {
-    "name": "runInInjectionContext"
-  },
-  {
-    "name": "saveNameToExportMap"
-  },
-  {
-    "name": "scheduleCallbackWithMicrotask"
-  },
-  {
-    "name": "scheduleCallbackWithRafRace"
-  },
-  {
-    "name": "searchTokensOnInjector"
-  },
-  {
-    "name": "setActiveConsumer"
-  },
-  {
-    "name": "setBindingRootForHostBindings"
-  },
-  {
-    "name": "setCurrentDirectiveIndex"
-  },
-  {
-    "name": "setCurrentInjector"
-  },
-  {
-    "name": "setCurrentQueryIndex"
-  },
-  {
-    "name": "setCurrentTNode"
-  },
-  {
-    "name": "setIncludeViewProviders"
-  },
-  {
-    "name": "setInjectImplementation"
-  },
-  {
-    "name": "setIsRefreshingViews"
-  },
-  {
-    "name": "setSelectedIndex"
-  },
-  {
-    "name": "setUpAttributes"
-  },
-  {
-    "name": "shimStylesContent"
-  },
-  {
-    "name": "shouldSearchParent"
-  },
-  {
-    "name": "storeLViewOnDestroy"
-  },
-  {
-    "name": "stringify"
-  },
-  {
-    "name": "stringifyCSSSelector"
-  },
-  {
-    "name": "throwProviderNotFoundError"
-  },
-  {
-    "name": "timeoutProvider"
-  },
-  {
-    "name": "toRefArray"
-  },
-  {
-    "name": "uniqueIdCounter"
-  },
-  {
-    "name": "unregisterLView"
-  },
-  {
-    "name": "unwrapRNode"
-  },
-  {
-    "name": "updateAncestorTraversalFlagsOnAttach"
-  },
-  {
-    "name": "updateMicroTaskStatus"
-  },
-  {
-    "name": "viewAttachedToChangeDetector"
-  },
-  {
-    "name": "viewShouldHaveReactiveConsumer"
-  },
-  {
-    "name": "walkProviderTree"
-  },
-  {
-    "name": "writeDirectClass"
-  },
-  {
-    "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "ɵɵdefineComponent"
-  },
-  {
-    "name": "ɵɵdefineInjectable"
-  },
-  {
-    "name": "ɵɵdirectiveInject"
-  },
-  {
-    "name": "ɵɵinject"
-  }
+  "APP_BOOTSTRAP_LISTENER",
+  "APP_ID",
+  "APP_INITIALIZER",
+  "AfterRenderManager",
+  "AnonymousSubject",
+  "ApplicationInitStatus",
+  "ApplicationRef",
+  "BROWSER_MODULE_PROVIDERS",
+  "BehaviorSubject",
+  "BrowserDomAdapter",
+  "BrowserXhr",
+  "CIRCULAR",
+  "COMPLETE_NOTIFICATION",
+  "COMPONENT_REGEX",
+  "CSP_NONCE",
+  "ChainedInjector",
+  "ChangeDetectionScheduler",
+  "ChangeDetectionSchedulerImpl",
+  "ChangeDetectionStrategy",
+  "ComponentFactory",
+  "ComponentFactory2",
+  "ComponentFactoryResolver",
+  "ComponentFactoryResolver2",
+  "ComponentRef",
+  "ComponentRef2",
+  "ConsumerObserver",
+  "DEFAULT_APP_ID",
+  "DOCUMENT",
+  "DOCUMENT2",
+  "DefaultDomRenderer2",
+  "DestroyRef",
+  "DomAdapter",
+  "DomEventsPlugin",
+  "DomRendererFactory2",
+  "EMPTY_ARRAY",
+  "EMPTY_OBJ",
+  "EMPTY_OBSERVER",
+  "EMPTY_PAYLOAD",
+  "EMPTY_SUBSCRIPTION",
+  "ENVIRONMENT_INITIALIZER",
+  "EVENT_MANAGER_PLUGINS",
+  "EffectScheduler",
+  "ElementRef",
+  "EmulatedEncapsulationDomRenderer2",
+  "EnvironmentInjector",
+  "EnvironmentNgModuleRefAdapter",
+  "ErrorHandler",
+  "EventEmitter",
+  "EventManager",
+  "EventManagerPlugin",
+  "GenericBrowserDomAdapter",
+  "INJECTOR",
+  "INJECTOR_DEF_TYPES",
+  "INJECTOR_SCOPE",
+  "INTERNAL_APPLICATION_ERROR_HANDLER",
+  "INTERNAL_BROWSER_PLATFORM_PROVIDERS",
+  "InjectFlags",
+  "InjectionToken",
+  "Injector",
+  "InputFlags",
+  "KeyEventsPlugin",
+  "LContainerFlags",
+  "LOCALE_ID2",
+  "LifecycleHooksFeature",
+  "MODIFIER_KEYS",
+  "MODIFIER_KEY_GETTERS",
+  "NAMESPACE_URIS",
+  "NEW_LINE",
+  "NG_COMP_DEF",
+  "NG_DIR_DEF",
+  "NG_ELEMENT_ID",
+  "NG_ENV_ID",
+  "NG_FACTORY_DEF",
+  "NG_INJECTABLE_DEF",
+  "NG_INJECTOR_DEF",
+  "NG_INJ_DEF",
+  "NG_PIPE_DEF",
+  "NG_PROV_DEF",
+  "NOT_FOUND",
+  "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR",
+  "NOT_YET",
+  "NO_CHANGE",
+  "NULL_INJECTOR",
+  "NgModuleRef",
+  "NgZone",
+  "NgZoneChangeDetectionScheduler",
+  "NodeInjector",
+  "NodeInjectorDestroyRef",
+  "NodeInjectorFactory",
+  "NoneEncapsulationDomRenderer",
+  "NoopNgZone",
+  "NullInjector",
+  "ObjectUnsubscribedError",
+  "Observable",
+  "OperatorSubscriber",
+  "PLATFORM_DESTROY_LISTENERS",
+  "PLATFORM_ID",
+  "PLATFORM_INITIALIZER",
+  "PRESERVE_HOST_CONTENT",
+  "PendingTasksInternal",
+  "R3Injector",
+  "REACTIVE_LVIEW_CONSUMER_NODE",
+  "REACTIVE_NODE",
+  "REMOVE_STYLES_ON_COMPONENT_DESTROY",
+  "RendererFactory2",
+  "RendererStyleFlags2",
+  "RuntimeError",
+  "SCHEDULE_IN_ROOT_ZONE",
+  "SIGNAL",
+  "SIMPLE_CHANGES_STORE",
+  "SafeSubscriber",
+  "Sanitizer",
+  "ShadowDomRenderer",
+  "SharedStylesHost",
+  "SimpleChange",
+  "StandaloneService",
+  "Subject",
+  "Subscriber",
+  "Subscription",
+  "TEMPORARY_CONSUMER_NODE",
+  "TESTABILITY",
+  "THROW_IF_NOT_FOUND",
+  "TRACKED_LVIEWS",
+  "TracingAction",
+  "TracingService",
+  "USE_VALUE",
+  "UnsubscriptionError",
+  "ViewEncapsulation",
+  "ViewRef",
+  "ZONELESS_ENABLED",
+  "ZONELESS_SCHEDULER_DISABLED",
+  "ZoneAwareEffectScheduler",
+  "ZoneStablePendingTask",
+  "_DOM",
+  "_Injector",
+  "_NullComponentFactoryResolver",
+  "__defProp",
+  "__forward_ref__",
+  "__publicField",
+  "_applyRootElementTransformImpl",
+  "_bind",
+  "_currentInjector",
+  "_injectImplementation",
+  "_isRefreshingViews",
+  "_keyMap",
+  "_locateOrCreateTextNode",
+  "_platformInjector",
+  "_wasLastNodeCreated",
+  "activeConsumer",
+  "addPropertyBinding",
+  "allocExpando",
+  "allocLFrame",
+  "angularZoneInstanceIdProperty",
+  "appendChild",
+  "applyNodes",
+  "applyProjectionRecursive",
+  "applyToElementOrContainer",
+  "applyValueToInputField",
+  "applyView",
+  "arrRemove",
+  "assertConsumerNode",
+  "assertNotDestroyed",
+  "attachPatchData",
+  "baseElement",
+  "bind",
+  "bloomHasToken",
+  "bootstrap",
+  "callHook",
+  "callHookInternal",
+  "callHooks",
+  "captureNodeBindings",
+  "checkStable",
+  "cleanUpView",
+  "collectNativeNodes",
+  "collectNativeNodesInLContainer",
+  "concatStringsWithSpace",
+  "config",
+  "configureViewWithDirective",
+  "consumerBeforeComputation",
+  "consumerDestroy",
+  "consumerIsLive",
+  "consumerPollProducersForChange",
+  "context",
+  "convertToBitFlags",
+  "createElementRef",
+  "createErrorClass",
+  "createInjector",
+  "createLFrame",
+  "createLView",
+  "createLinkElement",
+  "createNodeInjector",
+  "createNotification",
+  "createStyleElement",
+  "createTView",
+  "deepForEach",
+  "deepForEachProvider",
+  "detachMovedView",
+  "detachViewFromDOM",
+  "detectChangesInChildComponents",
+  "detectChangesInComponent",
+  "detectChangesInEmbeddedViews",
+  "detectChangesInView",
+  "detectChangesInViewIfAttached",
+  "detectChangesInViewIfRequired",
+  "detectChangesInternal",
+  "diPublicInInjector",
+  "enterDI",
+  "enterView",
+  "errorContext",
+  "execFinalizer",
+  "executeCheckHooks",
+  "executeInitAndCheckHooks",
+  "executeTemplate",
+  "executeViewQueryFn",
+  "extractDefListOrFactory",
+  "extractDirectiveDef",
+  "forEachSingleProvider",
+  "forwardRef",
+  "freeConsumers",
+  "generateInitialInputs",
+  "getClosureSafeProperty",
+  "getComponentDef",
+  "getComponentLViewByIndex",
+  "getCurrentTNode",
+  "getCurrentTNodePlaceholderOk",
+  "getDOM",
+  "getDeclarationTNode",
+  "getDirectiveDef",
+  "getFactoryDef",
+  "getFirstLContainer",
+  "getInjectImplementation",
+  "getInjectableDef",
+  "getInjectorDef",
+  "getInjectorIndex",
+  "getLView",
+  "getLViewParent",
+  "getNativeByTNode",
+  "getNearestLContainer",
+  "getNextLContainer",
+  "getNodeInjectable",
+  "getNullInjector",
+  "getOrCreateInjectable",
+  "getOrCreateNodeInjectorForNode",
+  "getOrCreateTNode",
+  "getOwnDefinition",
+  "getParentInjectorIndex",
+  "getParentInjectorLocation",
+  "getParentInjectorView",
+  "getPipeDef",
+  "getProjectionNodes",
+  "getPromiseCtor",
+  "getSimpleChangesStore",
+  "getTNodeFromLView",
+  "handleStoppedNotification",
+  "handleUnhandledError",
+  "hasApplyArgsData",
+  "icuContainerIterate",
+  "identity",
+  "importProvidersFrom",
+  "includeViewProviders",
+  "incrementInitPhaseFlags",
+  "inject",
+  "injectArgs",
+  "injectDestroyRef",
+  "injectElementRef",
+  "injectInjectorOnly",
+  "injectRootLimpMode",
+  "injectableDefOrInjectorDefFactory",
+  "insertBloom",
+  "instructionState",
+  "internalImportProvidersFrom",
+  "internalProvideZoneChangeDetection",
+  "invokeHostBindingsInCreationMode",
+  "isAngularZoneProperty",
+  "isApplicationBootstrapConfig",
+  "isComponentDef",
+  "isEnvironmentProviders",
+  "isFunction",
+  "isInlineTemplate",
+  "isLContainer",
+  "isLView",
+  "isPlatformServer",
+  "isPositive",
+  "isPromise",
+  "isRefreshingViews",
+  "isRootView",
+  "isSubscription",
+  "isTemplateNode",
+  "isTypeProvider",
+  "isValueProvider",
+  "leaveDI",
+  "leaveView",
+  "leaveViewLight",
+  "lookupTokenUsingModuleInjector",
+  "lookupTokenUsingNodeInjector",
+  "makeRecord",
+  "map",
+  "markAncestorsForTraversal",
+  "markViewDirty",
+  "markViewForRefresh",
+  "markedFeatures",
+  "maybeWrapInNotSelector",
+  "mergeHostAttribute",
+  "mergeHostAttrs",
+  "nativeAppendChild",
+  "nativeAppendOrInsertBefore",
+  "nativeInsertBefore",
+  "nextNgElementId",
+  "ngOnChangesSetInput",
+  "ngZoneInstanceId",
+  "nonNull",
+  "noop",
+  "noop2",
+  "notFoundValueOrThrow",
+  "observable",
+  "onEnter",
+  "onLeave",
+  "parseAndConvertBindingsForDefinition",
+  "processInjectorTypesWithProviders",
+  "producerMarkClean",
+  "producerRemoveLiveConsumerAtIndex",
+  "producerUpdateValueVersion",
+  "refreshContentQueries",
+  "refreshView",
+  "rememberChangeHistoryAndInvokeOnChangesHook",
+  "remove",
+  "removeElements",
+  "removeFromArray",
+  "renderComponent",
+  "renderView",
+  "requiresRefreshOrTraversal",
+  "resetPreOrderHookFlags",
+  "resolveForwardRef",
+  "runEffectsInView",
+  "runInInjectionContext",
+  "saveNameToExportMap",
+  "scheduleCallbackWithMicrotask",
+  "scheduleCallbackWithRafRace",
+  "searchTokensOnInjector",
+  "setActiveConsumer",
+  "setBindingRootForHostBindings",
+  "setCurrentDirectiveIndex",
+  "setCurrentInjector",
+  "setCurrentQueryIndex",
+  "setCurrentTNode",
+  "setIncludeViewProviders",
+  "setInjectImplementation",
+  "setIsRefreshingViews",
+  "setSelectedIndex",
+  "setUpAttributes",
+  "shimStylesContent",
+  "shouldSearchParent",
+  "storeLViewOnDestroy",
+  "stringify",
+  "stringifyCSSSelector",
+  "throwProviderNotFoundError",
+  "timeoutProvider",
+  "toRefArray",
+  "uniqueIdCounter",
+  "unregisterLView",
+  "unwrapRNode",
+  "updateAncestorTraversalFlagsOnAttach",
+  "updateMicroTaskStatus",
+  "viewAttachedToChangeDetector",
+  "viewShouldHaveReactiveConsumer",
+  "walkProviderTree",
+  "writeDirectClass",
+  "writeToDirectiveInput",
+  "ɵɵdefineComponent",
+  "ɵɵdefineInjectable",
+  "ɵɵdirectiveInject",
+  "ɵɵinject"
 ]

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1,1583 +1,529 @@
 [
-  {
-    "name": "ALLOW_MULTIPLE_PLATFORMS"
-  },
-  {
-    "name": "APP_BOOTSTRAP_LISTENER"
-  },
-  {
-    "name": "APP_ID"
-  },
-  {
-    "name": "APP_INITIALIZER"
-  },
-  {
-    "name": "AfterRenderManager"
-  },
-  {
-    "name": "AnonymousSubject"
-  },
-  {
-    "name": "ApplicationInitStatus"
-  },
-  {
-    "name": "ApplicationModule"
-  },
-  {
-    "name": "ApplicationRef"
-  },
-  {
-    "name": "BROWSER_MODULE_PROVIDERS"
-  },
-  {
-    "name": "BROWSER_MODULE_PROVIDERS_MARKER"
-  },
-  {
-    "name": "BehaviorSubject"
-  },
-  {
-    "name": "BrowserDomAdapter"
-  },
-  {
-    "name": "BrowserModule"
-  },
-  {
-    "name": "BrowserXhr"
-  },
-  {
-    "name": "CIRCULAR"
-  },
-  {
-    "name": "COMPLETE_NOTIFICATION"
-  },
-  {
-    "name": "COMPONENT_REGEX"
-  },
-  {
-    "name": "CSP_NONCE"
-  },
-  {
-    "name": "ChainedInjector"
-  },
-  {
-    "name": "ChangeDetectionScheduler"
-  },
-  {
-    "name": "ChangeDetectionSchedulerImpl"
-  },
-  {
-    "name": "ChangeDetectionStrategy"
-  },
-  {
-    "name": "CommonModule"
-  },
-  {
-    "name": "ComponentFactory"
-  },
-  {
-    "name": "ComponentFactory2"
-  },
-  {
-    "name": "ComponentFactoryResolver"
-  },
-  {
-    "name": "ComponentFactoryResolver2"
-  },
-  {
-    "name": "ComponentRef"
-  },
-  {
-    "name": "ComponentRef2"
-  },
-  {
-    "name": "ConsumerObserver"
-  },
-  {
-    "name": "DEFAULT_APP_ID"
-  },
-  {
-    "name": "DOCUMENT"
-  },
-  {
-    "name": "DOCUMENT2"
-  },
-  {
-    "name": "DefaultDomRenderer2"
-  },
-  {
-    "name": "DefaultIterableDiffer"
-  },
-  {
-    "name": "DefaultIterableDifferFactory"
-  },
-  {
-    "name": "DestroyRef"
-  },
-  {
-    "name": "DomAdapter"
-  },
-  {
-    "name": "DomEventsPlugin"
-  },
-  {
-    "name": "DomRendererFactory2"
-  },
-  {
-    "name": "EMPTY_ARRAY"
-  },
-  {
-    "name": "EMPTY_OBJ"
-  },
-  {
-    "name": "EMPTY_OBSERVER"
-  },
-  {
-    "name": "EMPTY_PAYLOAD"
-  },
-  {
-    "name": "EMPTY_SUBSCRIPTION"
-  },
-  {
-    "name": "ENVIRONMENT_INITIALIZER"
-  },
-  {
-    "name": "EVENT_MANAGER_PLUGINS"
-  },
-  {
-    "name": "EffectScheduler"
-  },
-  {
-    "name": "ElementRef"
-  },
-  {
-    "name": "EmulatedEncapsulationDomRenderer2"
-  },
-  {
-    "name": "EnvironmentInjector"
-  },
-  {
-    "name": "EnvironmentNgModuleRefAdapter"
-  },
-  {
-    "name": "ErrorHandler"
-  },
-  {
-    "name": "EventEmitter"
-  },
-  {
-    "name": "EventManager"
-  },
-  {
-    "name": "EventManagerPlugin"
-  },
-  {
-    "name": "GenericBrowserDomAdapter"
-  },
-  {
-    "name": "INJECTOR"
-  },
-  {
-    "name": "INJECTOR_DEF_TYPES"
-  },
-  {
-    "name": "INJECTOR_SCOPE"
-  },
-  {
-    "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
-  },
-  {
-    "name": "InjectFlags"
-  },
-  {
-    "name": "InjectionToken"
-  },
-  {
-    "name": "Injector"
-  },
-  {
-    "name": "InputFlags"
-  },
-  {
-    "name": "IterableChangeRecord_"
-  },
-  {
-    "name": "IterableDiffers"
-  },
-  {
-    "name": "KeyEventsPlugin"
-  },
-  {
-    "name": "LContainerFlags"
-  },
-  {
-    "name": "LOCALE_ID2"
-  },
-  {
-    "name": "LifecycleHooksFeature"
-  },
-  {
-    "name": "MODIFIER_KEYS"
-  },
-  {
-    "name": "MODIFIER_KEY_GETTERS"
-  },
-  {
-    "name": "NAMESPACE_URIS"
-  },
-  {
-    "name": "NEW_LINE"
-  },
-  {
-    "name": "NG_COMP_DEF"
-  },
-  {
-    "name": "NG_DIR_DEF"
-  },
-  {
-    "name": "NG_ELEMENT_ID"
-  },
-  {
-    "name": "NG_ENV_ID"
-  },
-  {
-    "name": "NG_FACTORY_DEF"
-  },
-  {
-    "name": "NG_INJECTABLE_DEF"
-  },
-  {
-    "name": "NG_INJECTOR_DEF"
-  },
-  {
-    "name": "NG_INJ_DEF"
-  },
-  {
-    "name": "NG_MOD_DEF"
-  },
-  {
-    "name": "NG_PIPE_DEF"
-  },
-  {
-    "name": "NG_PROV_DEF"
-  },
-  {
-    "name": "NOT_FOUND"
-  },
-  {
-    "name": "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR"
-  },
-  {
-    "name": "NOT_YET"
-  },
-  {
-    "name": "NO_CHANGE"
-  },
-  {
-    "name": "NULL_INJECTOR"
-  },
-  {
-    "name": "NgForOf"
-  },
-  {
-    "name": "NgForOfContext"
-  },
-  {
-    "name": "NgIf"
-  },
-  {
-    "name": "NgIfContext"
-  },
-  {
-    "name": "NgModuleFactory"
-  },
-  {
-    "name": "NgModuleFactory2"
-  },
-  {
-    "name": "NgModuleRef"
-  },
-  {
-    "name": "NgModuleRef2"
-  },
-  {
-    "name": "NgZone"
-  },
-  {
-    "name": "NgZoneChangeDetectionScheduler"
-  },
-  {
-    "name": "NodeInjector"
-  },
-  {
-    "name": "NodeInjectorDestroyRef"
-  },
-  {
-    "name": "NodeInjectorFactory"
-  },
-  {
-    "name": "NoneEncapsulationDomRenderer"
-  },
-  {
-    "name": "NoopNgZone"
-  },
-  {
-    "name": "NullInjector"
-  },
-  {
-    "name": "ObjectUnsubscribedError"
-  },
-  {
-    "name": "Observable"
-  },
-  {
-    "name": "OperatorSubscriber"
-  },
-  {
-    "name": "Optional"
-  },
-  {
-    "name": "PLATFORM_DESTROY_LISTENERS"
-  },
-  {
-    "name": "PLATFORM_ID"
-  },
-  {
-    "name": "PLATFORM_INITIALIZER"
-  },
-  {
-    "name": "PRESERVE_HOST_CONTENT"
-  },
-  {
-    "name": "PendingTasksInternal"
-  },
-  {
-    "name": "PlatformRef"
-  },
-  {
-    "name": "R3Injector"
-  },
-  {
-    "name": "R3TemplateRef"
-  },
-  {
-    "name": "R3ViewContainerRef"
-  },
-  {
-    "name": "REACTIVE_LVIEW_CONSUMER_NODE"
-  },
-  {
-    "name": "REACTIVE_NODE"
-  },
-  {
-    "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
-  },
-  {
-    "name": "RendererFactory2"
-  },
-  {
-    "name": "RendererStyleFlags2"
-  },
-  {
-    "name": "RuntimeError"
-  },
-  {
-    "name": "SCHEDULE_IN_ROOT_ZONE"
-  },
-  {
-    "name": "SIGNAL"
-  },
-  {
-    "name": "SIMPLE_CHANGES_STORE"
-  },
-  {
-    "name": "SafeSubscriber"
-  },
-  {
-    "name": "SafeValueImpl"
-  },
-  {
-    "name": "Sanitizer"
-  },
-  {
-    "name": "ShadowDomRenderer"
-  },
-  {
-    "name": "SharedStylesHost"
-  },
-  {
-    "name": "SimpleChange"
-  },
-  {
-    "name": "SkipSelf"
-  },
-  {
-    "name": "StandaloneService"
-  },
-  {
-    "name": "Subject"
-  },
-  {
-    "name": "Subscriber"
-  },
-  {
-    "name": "Subscription"
-  },
-  {
-    "name": "TEMPORARY_CONSUMER_NODE"
-  },
-  {
-    "name": "TESTABILITY"
-  },
-  {
-    "name": "TESTABILITY_GETTER"
-  },
-  {
-    "name": "TESTABILITY_PROVIDERS"
-  },
-  {
-    "name": "THROW_IF_NOT_FOUND"
-  },
-  {
-    "name": "TRACKED_LVIEWS"
-  },
-  {
-    "name": "TemplateRef"
-  },
-  {
-    "name": "Testability"
-  },
-  {
-    "name": "TestabilityRegistry"
-  },
-  {
-    "name": "ToDoAppComponent"
-  },
-  {
-    "name": "ToDoAppComponent_footer_6_Template"
-  },
-  {
-    "name": "ToDoAppComponent_footer_6_button_5_Template"
-  },
-  {
-    "name": "ToDoAppComponent_section_5_Template"
-  },
-  {
-    "name": "ToDoAppComponent_section_5_input_1_Template"
-  },
-  {
-    "name": "ToDoAppComponent_section_5_li_3_Template"
-  },
-  {
-    "name": "ToDoAppComponent_section_5_li_3_input_6_Template"
-  },
-  {
-    "name": "ToDoAppModule"
-  },
-  {
-    "name": "Todo"
-  },
-  {
-    "name": "TodoStore"
-  },
-  {
-    "name": "TracingAction"
-  },
-  {
-    "name": "TracingService"
-  },
-  {
-    "name": "USE_VALUE"
-  },
-  {
-    "name": "UnsubscriptionError"
-  },
-  {
-    "name": "VE_ViewContainerRef"
-  },
-  {
-    "name": "ViewContainerRef"
-  },
-  {
-    "name": "ViewEncapsulation"
-  },
-  {
-    "name": "ViewEngineTemplateRef"
-  },
-  {
-    "name": "ViewRef"
-  },
-  {
-    "name": "ZONELESS_ENABLED"
-  },
-  {
-    "name": "ZONELESS_SCHEDULER_DISABLED"
-  },
-  {
-    "name": "ZoneAwareEffectScheduler"
-  },
-  {
-    "name": "ZoneStablePendingTask"
-  },
-  {
-    "name": "_DOM"
-  },
-  {
-    "name": "_DuplicateItemRecordList"
-  },
-  {
-    "name": "_DuplicateMap"
-  },
-  {
-    "name": "_Injector"
-  },
-  {
-    "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__defProp"
-  },
-  {
-    "name": "__forward_ref__"
-  },
-  {
-    "name": "__publicField"
-  },
-  {
-    "name": "_applyRootElementTransformImpl"
-  },
-  {
-    "name": "_bind"
-  },
-  {
-    "name": "_currentInjector"
-  },
-  {
-    "name": "_global"
-  },
-  {
-    "name": "_injectImplementation"
-  },
-  {
-    "name": "_isRefreshingViews"
-  },
-  {
-    "name": "_keyMap"
-  },
-  {
-    "name": "_locateOrCreateAnchorNode"
-  },
-  {
-    "name": "_locateOrCreateContainerAnchor"
-  },
-  {
-    "name": "_locateOrCreateElementNode"
-  },
-  {
-    "name": "_locateOrCreateTextNode"
-  },
-  {
-    "name": "_platformInjector"
-  },
-  {
-    "name": "_testabilityGetter"
-  },
-  {
-    "name": "_wasLastNodeCreated"
-  },
-  {
-    "name": "activeConsumer"
-  },
-  {
-    "name": "addPropertyBinding"
-  },
-  {
-    "name": "addToArray"
-  },
-  {
-    "name": "addToEndOfViewTree"
-  },
-  {
-    "name": "allocExpando"
-  },
-  {
-    "name": "allocLFrame"
-  },
-  {
-    "name": "angularZoneInstanceIdProperty"
-  },
-  {
-    "name": "appendChild"
-  },
-  {
-    "name": "applyNodes"
-  },
-  {
-    "name": "applyProjectionRecursive"
-  },
-  {
-    "name": "applyToElementOrContainer"
-  },
-  {
-    "name": "applyValueToInputField"
-  },
-  {
-    "name": "applyView"
-  },
-  {
-    "name": "applyViewChange"
-  },
-  {
-    "name": "arrRemove"
-  },
-  {
-    "name": "assertConsumerNode"
-  },
-  {
-    "name": "assertNotDestroyed"
-  },
-  {
-    "name": "assertTemplate"
-  },
-  {
-    "name": "attachInjectFlag"
-  },
-  {
-    "name": "attachPatchData"
-  },
-  {
-    "name": "baseElement"
-  },
-  {
-    "name": "bind"
-  },
-  {
-    "name": "bindingUpdated"
-  },
-  {
-    "name": "bloomHasToken"
-  },
-  {
-    "name": "bootstrap"
-  },
-  {
-    "name": "callHook"
-  },
-  {
-    "name": "callHookInternal"
-  },
-  {
-    "name": "callHooks"
-  },
-  {
-    "name": "captureNodeBindings"
-  },
-  {
-    "name": "checkStable"
-  },
-  {
-    "name": "classIndexOf"
-  },
-  {
-    "name": "cleanUpView"
-  },
-  {
-    "name": "collectNativeNodes"
-  },
-  {
-    "name": "collectNativeNodesInLContainer"
-  },
-  {
-    "name": "collectStylingFromDirectives"
-  },
-  {
-    "name": "collectStylingFromTAttrs"
-  },
-  {
-    "name": "computeStaticStyling"
-  },
-  {
-    "name": "concatStringsWithSpace"
-  },
-  {
-    "name": "config"
-  },
-  {
-    "name": "configureViewWithDirective"
-  },
-  {
-    "name": "consumerBeforeComputation"
-  },
-  {
-    "name": "consumerDestroy"
-  },
-  {
-    "name": "consumerIsLive"
-  },
-  {
-    "name": "consumerPollProducersForChange"
-  },
-  {
-    "name": "context"
-  },
-  {
-    "name": "convertToBitFlags"
-  },
-  {
-    "name": "createDirectivesInstances"
-  },
-  {
-    "name": "createElementNode"
-  },
-  {
-    "name": "createElementRef"
-  },
-  {
-    "name": "createErrorClass"
-  },
-  {
-    "name": "createInjector"
-  },
-  {
-    "name": "createInjectorWithoutInjectorInstances"
-  },
-  {
-    "name": "createLContainer"
-  },
-  {
-    "name": "createLFrame"
-  },
-  {
-    "name": "createLView"
-  },
-  {
-    "name": "createLinkElement"
-  },
-  {
-    "name": "createNodeInjector"
-  },
-  {
-    "name": "createNotification"
-  },
-  {
-    "name": "createPlatformFactory"
-  },
-  {
-    "name": "createStyleElement"
-  },
-  {
-    "name": "createTView"
-  },
-  {
-    "name": "deepForEach"
-  },
-  {
-    "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultIterableDiffersFactory"
-  },
-  {
-    "name": "destroyLView"
-  },
-  {
-    "name": "detachMovedView"
-  },
-  {
-    "name": "detachView"
-  },
-  {
-    "name": "detachViewFromDOM"
-  },
-  {
-    "name": "detectChangesInChildComponents"
-  },
-  {
-    "name": "detectChangesInComponent"
-  },
-  {
-    "name": "detectChangesInEmbeddedViews"
-  },
-  {
-    "name": "detectChangesInView"
-  },
-  {
-    "name": "detectChangesInViewIfAttached"
-  },
-  {
-    "name": "detectChangesInViewIfRequired"
-  },
-  {
-    "name": "detectChangesInternal"
-  },
-  {
-    "name": "diPublicInInjector"
-  },
-  {
-    "name": "enterDI"
-  },
-  {
-    "name": "enterView"
-  },
-  {
-    "name": "errorContext"
-  },
-  {
-    "name": "execFinalizer"
-  },
-  {
-    "name": "executeCheckHooks"
-  },
-  {
-    "name": "executeContentQueries"
-  },
-  {
-    "name": "executeInitAndCheckHooks"
-  },
-  {
-    "name": "executeListenerWithErrorHandling"
-  },
-  {
-    "name": "executeTemplate"
-  },
-  {
-    "name": "executeViewQueryFn"
-  },
-  {
-    "name": "extractDefListOrFactory"
-  },
-  {
-    "name": "extractDirectiveDef"
-  },
-  {
-    "name": "findAttrIndexInNode"
-  },
-  {
-    "name": "findStylingValue"
-  },
-  {
-    "name": "forEachSingleProvider"
-  },
-  {
-    "name": "forwardRef"
-  },
-  {
-    "name": "freeConsumers"
-  },
-  {
-    "name": "generateInitialInputs"
-  },
-  {
-    "name": "getBeforeNodeForView"
-  },
-  {
-    "name": "getBindingsEnabled"
-  },
-  {
-    "name": "getClosureSafeProperty"
-  },
-  {
-    "name": "getComponentDef"
-  },
-  {
-    "name": "getComponentLViewByIndex"
-  },
-  {
-    "name": "getConstant"
-  },
-  {
-    "name": "getCurrentTNode"
-  },
-  {
-    "name": "getCurrentTNodePlaceholderOk"
-  },
-  {
-    "name": "getDOM"
-  },
-  {
-    "name": "getDeclarationTNode"
-  },
-  {
-    "name": "getDirectiveDef"
-  },
-  {
-    "name": "getFactoryDef"
-  },
-  {
-    "name": "getFirstLContainer"
-  },
-  {
-    "name": "getFirstNativeNode"
-  },
-  {
-    "name": "getInitialLViewFlagsFromDef"
-  },
-  {
-    "name": "getInjectImplementation"
-  },
-  {
-    "name": "getInjectableDef"
-  },
-  {
-    "name": "getInjectorDef"
-  },
-  {
-    "name": "getInjectorIndex"
-  },
-  {
-    "name": "getLView"
-  },
-  {
-    "name": "getLViewParent"
-  },
-  {
-    "name": "getNativeByIndex"
-  },
-  {
-    "name": "getNativeByTNode"
-  },
-  {
-    "name": "getNearestLContainer"
-  },
-  {
-    "name": "getNextLContainer"
-  },
-  {
-    "name": "getNgDirectiveDef"
-  },
-  {
-    "name": "getNgZoneOptions"
-  },
-  {
-    "name": "getNodeInjectable"
-  },
-  {
-    "name": "getNullInjector"
-  },
-  {
-    "name": "getOrCreateComponentTView"
-  },
-  {
-    "name": "getOrCreateInjectable"
-  },
-  {
-    "name": "getOrCreateNodeInjectorForNode"
-  },
-  {
-    "name": "getOrCreateTNode"
-  },
-  {
-    "name": "getOrCreateViewRefs"
-  },
-  {
-    "name": "getOwnDefinition"
-  },
-  {
-    "name": "getParentInjectorIndex"
-  },
-  {
-    "name": "getParentInjectorLocation"
-  },
-  {
-    "name": "getParentInjectorView"
-  },
-  {
-    "name": "getPipeDef"
-  },
-  {
-    "name": "getPlatform"
-  },
-  {
-    "name": "getPreviousIndex"
-  },
-  {
-    "name": "getProjectionNodes"
-  },
-  {
-    "name": "getPromiseCtor"
-  },
-  {
-    "name": "getSelectedIndex"
-  },
-  {
-    "name": "getSimpleChangesStore"
-  },
-  {
-    "name": "getTNode"
-  },
-  {
-    "name": "getTNodeFromLView"
-  },
-  {
-    "name": "getTStylingRangeNext"
-  },
-  {
-    "name": "getTStylingRangePrev"
-  },
-  {
-    "name": "getTView"
-  },
-  {
-    "name": "getViewRefs"
-  },
-  {
-    "name": "handleError"
-  },
-  {
-    "name": "handleStoppedNotification"
-  },
-  {
-    "name": "handleUnhandledError"
-  },
-  {
-    "name": "hasApplyArgsData"
-  },
-  {
-    "name": "hasInSkipHydrationBlockFlag"
-  },
-  {
-    "name": "hasParentInjector"
-  },
-  {
-    "name": "hasTagAndTypeMatch"
-  },
-  {
-    "name": "icuContainerIterate"
-  },
-  {
-    "name": "identity"
-  },
-  {
-    "name": "importProvidersFrom"
-  },
-  {
-    "name": "includeViewProviders"
-  },
-  {
-    "name": "incrementInitPhaseFlags"
-  },
-  {
-    "name": "initFeatures"
-  },
-  {
-    "name": "initializeDirectives"
-  },
-  {
-    "name": "inject"
-  },
-  {
-    "name": "injectArgs"
-  },
-  {
-    "name": "injectDestroyRef"
-  },
-  {
-    "name": "injectElementRef"
-  },
-  {
-    "name": "injectInjectorOnly"
-  },
-  {
-    "name": "injectRootLimpMode"
-  },
-  {
-    "name": "injectTemplateRef"
-  },
-  {
-    "name": "injectViewContainerRef"
-  },
-  {
-    "name": "injectableDefOrInjectorDefFactory"
-  },
-  {
-    "name": "insertBloom"
-  },
-  {
-    "name": "instructionState"
-  },
-  {
-    "name": "internalImportProvidersFrom"
-  },
-  {
-    "name": "internalProvideZoneChangeDetection"
-  },
-  {
-    "name": "invokeDirectivesHostBindings"
-  },
-  {
-    "name": "invokeHostBindingsInCreationMode"
-  },
-  {
-    "name": "isAngularZoneProperty"
-  },
-  {
-    "name": "isApplicationBootstrapConfig"
-  },
-  {
-    "name": "isComponentDef"
-  },
-  {
-    "name": "isComponentHost"
-  },
-  {
-    "name": "isContentQueryHost"
-  },
-  {
-    "name": "isCssClassMatching"
-  },
-  {
-    "name": "isCurrentTNodeParent"
-  },
-  {
-    "name": "isDirectiveHost"
-  },
-  {
-    "name": "isEnvironmentProviders"
-  },
-  {
-    "name": "isFunction"
-  },
-  {
-    "name": "isInlineTemplate"
-  },
-  {
-    "name": "isLContainer"
-  },
-  {
-    "name": "isLView"
-  },
-  {
-    "name": "isListLikeIterable"
-  },
-  {
-    "name": "isNodeMatchingSelector"
-  },
-  {
-    "name": "isNodeMatchingSelectorList"
-  },
-  {
-    "name": "isPlatformServer"
-  },
-  {
-    "name": "isPositive"
-  },
-  {
-    "name": "isPromise"
-  },
-  {
-    "name": "isRefreshingViews"
-  },
-  {
-    "name": "isRootView"
-  },
-  {
-    "name": "isStylingMatch"
-  },
-  {
-    "name": "isStylingValuePresent"
-  },
-  {
-    "name": "isSubscription"
-  },
-  {
-    "name": "isTemplateNode"
-  },
-  {
-    "name": "isTypeProvider"
-  },
-  {
-    "name": "isValueProvider"
-  },
-  {
-    "name": "keyValueArrayGet"
-  },
-  {
-    "name": "keyValueArrayIndexOf"
-  },
-  {
-    "name": "keyValueArraySet"
-  },
-  {
-    "name": "lastNodeWasCreated"
-  },
-  {
-    "name": "leaveDI"
-  },
-  {
-    "name": "leaveView"
-  },
-  {
-    "name": "leaveViewLight"
-  },
-  {
-    "name": "lookupTokenUsingModuleInjector"
-  },
-  {
-    "name": "lookupTokenUsingNodeInjector"
-  },
-  {
-    "name": "makeParamDecorator"
-  },
-  {
-    "name": "makeRecord"
-  },
-  {
-    "name": "map"
-  },
-  {
-    "name": "markAncestorsForTraversal"
-  },
-  {
-    "name": "markAsComponentHost"
-  },
-  {
-    "name": "markDuplicates"
-  },
-  {
-    "name": "markViewDirty"
-  },
-  {
-    "name": "markViewForRefresh"
-  },
-  {
-    "name": "markedFeatures"
-  },
-  {
-    "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "mergeHostAttribute"
-  },
-  {
-    "name": "mergeHostAttrs"
-  },
-  {
-    "name": "nativeAppendChild"
-  },
-  {
-    "name": "nativeAppendOrInsertBefore"
-  },
-  {
-    "name": "nativeInsertBefore"
-  },
-  {
-    "name": "nativeParentNode"
-  },
-  {
-    "name": "nextBindingIndex"
-  },
-  {
-    "name": "nextNgElementId"
-  },
-  {
-    "name": "ngOnChangesSetInput"
-  },
-  {
-    "name": "ngZoneInstanceId"
-  },
-  {
-    "name": "noSideEffects"
-  },
-  {
-    "name": "nonNull"
-  },
-  {
-    "name": "noop"
-  },
-  {
-    "name": "noop2"
-  },
-  {
-    "name": "notFoundValueOrThrow"
-  },
-  {
-    "name": "observable"
-  },
-  {
-    "name": "onEnter"
-  },
-  {
-    "name": "onLeave"
-  },
-  {
-    "name": "optionsReducer"
-  },
-  {
-    "name": "parseAndConvertBindingsForDefinition"
-  },
-  {
-    "name": "platformBrowser"
-  },
-  {
-    "name": "platformCore"
-  },
-  {
-    "name": "processInjectorTypesWithProviders"
-  },
-  {
-    "name": "producerMarkClean"
-  },
-  {
-    "name": "producerRemoveLiveConsumerAtIndex"
-  },
-  {
-    "name": "producerUpdateValueVersion"
-  },
-  {
-    "name": "refreshContentQueries"
-  },
-  {
-    "name": "refreshView"
-  },
-  {
-    "name": "registerPostOrderHooks"
-  },
-  {
-    "name": "rememberChangeHistoryAndInvokeOnChangesHook"
-  },
-  {
-    "name": "remove"
-  },
-  {
-    "name": "removeElements"
-  },
-  {
-    "name": "removeFromArray"
-  },
-  {
-    "name": "renderComponent"
-  },
-  {
-    "name": "renderStringify"
-  },
-  {
-    "name": "renderView"
-  },
-  {
-    "name": "requiresRefreshOrTraversal"
-  },
-  {
-    "name": "resetPreOrderHookFlags"
-  },
-  {
-    "name": "resolveDirectives"
-  },
-  {
-    "name": "resolveForwardRef"
-  },
-  {
-    "name": "runEffectsInView"
-  },
-  {
-    "name": "runInInjectionContext"
-  },
-  {
-    "name": "saveNameToExportMap"
-  },
-  {
-    "name": "saveResolvedLocalsInData"
-  },
-  {
-    "name": "scheduleCallbackWithMicrotask"
-  },
-  {
-    "name": "scheduleCallbackWithRafRace"
-  },
-  {
-    "name": "searchTokensOnInjector"
-  },
-  {
-    "name": "selectIndexInternal"
-  },
-  {
-    "name": "setActiveConsumer"
-  },
-  {
-    "name": "setBindingRootForHostBindings"
-  },
-  {
-    "name": "setCurrentDirectiveIndex"
-  },
-  {
-    "name": "setCurrentInjector"
-  },
-  {
-    "name": "setCurrentQueryIndex"
-  },
-  {
-    "name": "setCurrentTNode"
-  },
-  {
-    "name": "setDirectiveInputsWhichShadowsStyling"
-  },
-  {
-    "name": "setIncludeViewProviders"
-  },
-  {
-    "name": "setInjectImplementation"
-  },
-  {
-    "name": "setInputsForProperty"
-  },
-  {
-    "name": "setInputsFromAttrs"
-  },
-  {
-    "name": "setIsRefreshingViews"
-  },
-  {
-    "name": "setSelectedIndex"
-  },
-  {
-    "name": "setTStylingRangeNext"
-  },
-  {
-    "name": "setTStylingRangeNextDuplicate"
-  },
-  {
-    "name": "setTStylingRangePrevDuplicate"
-  },
-  {
-    "name": "setUpAttributes"
-  },
-  {
-    "name": "setupStaticAttributes"
-  },
-  {
-    "name": "shimStylesContent"
-  },
-  {
-    "name": "shouldAddViewToDom"
-  },
-  {
-    "name": "shouldSearchParent"
-  },
-  {
-    "name": "storeLViewOnDestroy"
-  },
-  {
-    "name": "stringify"
-  },
-  {
-    "name": "stringifyCSSSelector"
-  },
-  {
-    "name": "throwProviderNotFoundError"
-  },
-  {
-    "name": "timeoutProvider"
-  },
-  {
-    "name": "toRefArray"
-  },
-  {
-    "name": "toTStylingRange"
-  },
-  {
-    "name": "trackByIdentity"
-  },
-  {
-    "name": "trackMovedView"
-  },
-  {
-    "name": "uniqueIdCounter"
-  },
-  {
-    "name": "unregisterLView"
-  },
-  {
-    "name": "unwrapRNode"
-  },
-  {
-    "name": "updateAncestorTraversalFlagsOnAttach"
-  },
-  {
-    "name": "updateMicroTaskStatus"
-  },
-  {
-    "name": "viewAttachedToChangeDetector"
-  },
-  {
-    "name": "viewShouldHaveReactiveConsumer"
-  },
-  {
-    "name": "walkProviderTree"
-  },
-  {
-    "name": "wasLastNodeCreated"
-  },
-  {
-    "name": "wrapListener"
-  },
-  {
-    "name": "writeDirectClass"
-  },
-  {
-    "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "ɵɵadvance"
-  },
-  {
-    "name": "ɵɵclassProp"
-  },
-  {
-    "name": "ɵɵdefineComponent"
-  },
-  {
-    "name": "ɵɵdefineDirective"
-  },
-  {
-    "name": "ɵɵdefineInjectable"
-  },
-  {
-    "name": "ɵɵdefineInjector"
-  },
-  {
-    "name": "ɵɵdefineNgModule"
-  },
-  {
-    "name": "ɵɵdirectiveInject"
-  },
-  {
-    "name": "ɵɵelementEnd"
-  },
-  {
-    "name": "ɵɵelementStart"
-  },
-  {
-    "name": "ɵɵgetCurrentView"
-  },
-  {
-    "name": "ɵɵinject"
-  },
-  {
-    "name": "ɵɵlistener"
-  },
-  {
-    "name": "ɵɵnextContext"
-  },
-  {
-    "name": "ɵɵproperty"
-  },
-  {
-    "name": "ɵɵreference"
-  },
-  {
-    "name": "ɵɵresetView"
-  },
-  {
-    "name": "ɵɵrestoreView"
-  },
-  {
-    "name": "ɵɵtemplate"
-  },
-  {
-    "name": "ɵɵtext"
-  },
-  {
-    "name": "ɵɵtextInterpolate"
-  },
-  {
-    "name": "ɵɵtextInterpolate1"
-  }
+  "ALLOW_MULTIPLE_PLATFORMS",
+  "APP_BOOTSTRAP_LISTENER",
+  "APP_ID",
+  "APP_INITIALIZER",
+  "AfterRenderManager",
+  "AnonymousSubject",
+  "ApplicationInitStatus",
+  "ApplicationModule",
+  "ApplicationRef",
+  "BROWSER_MODULE_PROVIDERS",
+  "BROWSER_MODULE_PROVIDERS_MARKER",
+  "BehaviorSubject",
+  "BrowserDomAdapter",
+  "BrowserModule",
+  "BrowserXhr",
+  "CIRCULAR",
+  "COMPLETE_NOTIFICATION",
+  "COMPONENT_REGEX",
+  "CSP_NONCE",
+  "ChainedInjector",
+  "ChangeDetectionScheduler",
+  "ChangeDetectionSchedulerImpl",
+  "ChangeDetectionStrategy",
+  "CommonModule",
+  "ComponentFactory",
+  "ComponentFactory2",
+  "ComponentFactoryResolver",
+  "ComponentFactoryResolver2",
+  "ComponentRef",
+  "ComponentRef2",
+  "ConsumerObserver",
+  "DEFAULT_APP_ID",
+  "DOCUMENT",
+  "DOCUMENT2",
+  "DefaultDomRenderer2",
+  "DefaultIterableDiffer",
+  "DefaultIterableDifferFactory",
+  "DestroyRef",
+  "DomAdapter",
+  "DomEventsPlugin",
+  "DomRendererFactory2",
+  "EMPTY_ARRAY",
+  "EMPTY_OBJ",
+  "EMPTY_OBSERVER",
+  "EMPTY_PAYLOAD",
+  "EMPTY_SUBSCRIPTION",
+  "ENVIRONMENT_INITIALIZER",
+  "EVENT_MANAGER_PLUGINS",
+  "EffectScheduler",
+  "ElementRef",
+  "EmulatedEncapsulationDomRenderer2",
+  "EnvironmentInjector",
+  "EnvironmentNgModuleRefAdapter",
+  "ErrorHandler",
+  "EventEmitter",
+  "EventManager",
+  "EventManagerPlugin",
+  "GenericBrowserDomAdapter",
+  "INJECTOR",
+  "INJECTOR_DEF_TYPES",
+  "INJECTOR_SCOPE",
+  "INTERNAL_APPLICATION_ERROR_HANDLER",
+  "InjectFlags",
+  "InjectionToken",
+  "Injector",
+  "InputFlags",
+  "IterableChangeRecord_",
+  "IterableDiffers",
+  "KeyEventsPlugin",
+  "LContainerFlags",
+  "LOCALE_ID2",
+  "LifecycleHooksFeature",
+  "MODIFIER_KEYS",
+  "MODIFIER_KEY_GETTERS",
+  "NAMESPACE_URIS",
+  "NEW_LINE",
+  "NG_COMP_DEF",
+  "NG_DIR_DEF",
+  "NG_ELEMENT_ID",
+  "NG_ENV_ID",
+  "NG_FACTORY_DEF",
+  "NG_INJECTABLE_DEF",
+  "NG_INJECTOR_DEF",
+  "NG_INJ_DEF",
+  "NG_MOD_DEF",
+  "NG_PIPE_DEF",
+  "NG_PROV_DEF",
+  "NOT_FOUND",
+  "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR",
+  "NOT_YET",
+  "NO_CHANGE",
+  "NULL_INJECTOR",
+  "NgForOf",
+  "NgForOfContext",
+  "NgIf",
+  "NgIfContext",
+  "NgModuleFactory",
+  "NgModuleFactory2",
+  "NgModuleRef",
+  "NgModuleRef2",
+  "NgZone",
+  "NgZoneChangeDetectionScheduler",
+  "NodeInjector",
+  "NodeInjectorDestroyRef",
+  "NodeInjectorFactory",
+  "NoneEncapsulationDomRenderer",
+  "NoopNgZone",
+  "NullInjector",
+  "ObjectUnsubscribedError",
+  "Observable",
+  "OperatorSubscriber",
+  "Optional",
+  "PLATFORM_DESTROY_LISTENERS",
+  "PLATFORM_ID",
+  "PLATFORM_INITIALIZER",
+  "PRESERVE_HOST_CONTENT",
+  "PendingTasksInternal",
+  "PlatformRef",
+  "R3Injector",
+  "R3TemplateRef",
+  "R3ViewContainerRef",
+  "REACTIVE_LVIEW_CONSUMER_NODE",
+  "REACTIVE_NODE",
+  "REMOVE_STYLES_ON_COMPONENT_DESTROY",
+  "RendererFactory2",
+  "RendererStyleFlags2",
+  "RuntimeError",
+  "SCHEDULE_IN_ROOT_ZONE",
+  "SIGNAL",
+  "SIMPLE_CHANGES_STORE",
+  "SafeSubscriber",
+  "SafeValueImpl",
+  "Sanitizer",
+  "ShadowDomRenderer",
+  "SharedStylesHost",
+  "SimpleChange",
+  "SkipSelf",
+  "StandaloneService",
+  "Subject",
+  "Subscriber",
+  "Subscription",
+  "TEMPORARY_CONSUMER_NODE",
+  "TESTABILITY",
+  "TESTABILITY_GETTER",
+  "TESTABILITY_PROVIDERS",
+  "THROW_IF_NOT_FOUND",
+  "TRACKED_LVIEWS",
+  "TemplateRef",
+  "Testability",
+  "TestabilityRegistry",
+  "ToDoAppComponent",
+  "ToDoAppComponent_footer_6_Template",
+  "ToDoAppComponent_footer_6_button_5_Template",
+  "ToDoAppComponent_section_5_Template",
+  "ToDoAppComponent_section_5_input_1_Template",
+  "ToDoAppComponent_section_5_li_3_Template",
+  "ToDoAppComponent_section_5_li_3_input_6_Template",
+  "ToDoAppModule",
+  "Todo",
+  "TodoStore",
+  "TracingAction",
+  "TracingService",
+  "USE_VALUE",
+  "UnsubscriptionError",
+  "VE_ViewContainerRef",
+  "ViewContainerRef",
+  "ViewEncapsulation",
+  "ViewEngineTemplateRef",
+  "ViewRef",
+  "ZONELESS_ENABLED",
+  "ZONELESS_SCHEDULER_DISABLED",
+  "ZoneAwareEffectScheduler",
+  "ZoneStablePendingTask",
+  "_DOM",
+  "_DuplicateItemRecordList",
+  "_DuplicateMap",
+  "_Injector",
+  "_NullComponentFactoryResolver",
+  "__defProp",
+  "__forward_ref__",
+  "__publicField",
+  "_applyRootElementTransformImpl",
+  "_bind",
+  "_currentInjector",
+  "_global",
+  "_injectImplementation",
+  "_isRefreshingViews",
+  "_keyMap",
+  "_locateOrCreateAnchorNode",
+  "_locateOrCreateContainerAnchor",
+  "_locateOrCreateElementNode",
+  "_locateOrCreateTextNode",
+  "_platformInjector",
+  "_testabilityGetter",
+  "_wasLastNodeCreated",
+  "activeConsumer",
+  "addPropertyBinding",
+  "addToArray",
+  "addToEndOfViewTree",
+  "allocExpando",
+  "allocLFrame",
+  "angularZoneInstanceIdProperty",
+  "appendChild",
+  "applyNodes",
+  "applyProjectionRecursive",
+  "applyToElementOrContainer",
+  "applyValueToInputField",
+  "applyView",
+  "applyViewChange",
+  "arrRemove",
+  "assertConsumerNode",
+  "assertNotDestroyed",
+  "assertTemplate",
+  "attachInjectFlag",
+  "attachPatchData",
+  "baseElement",
+  "bind",
+  "bindingUpdated",
+  "bloomHasToken",
+  "bootstrap",
+  "callHook",
+  "callHookInternal",
+  "callHooks",
+  "captureNodeBindings",
+  "checkStable",
+  "classIndexOf",
+  "cleanUpView",
+  "collectNativeNodes",
+  "collectNativeNodesInLContainer",
+  "collectStylingFromDirectives",
+  "collectStylingFromTAttrs",
+  "computeStaticStyling",
+  "concatStringsWithSpace",
+  "config",
+  "configureViewWithDirective",
+  "consumerBeforeComputation",
+  "consumerDestroy",
+  "consumerIsLive",
+  "consumerPollProducersForChange",
+  "context",
+  "convertToBitFlags",
+  "createDirectivesInstances",
+  "createElementNode",
+  "createElementRef",
+  "createErrorClass",
+  "createInjector",
+  "createInjectorWithoutInjectorInstances",
+  "createLContainer",
+  "createLFrame",
+  "createLView",
+  "createLinkElement",
+  "createNodeInjector",
+  "createNotification",
+  "createPlatformFactory",
+  "createStyleElement",
+  "createTView",
+  "deepForEach",
+  "deepForEachProvider",
+  "defaultIterableDiffersFactory",
+  "destroyLView",
+  "detachMovedView",
+  "detachView",
+  "detachViewFromDOM",
+  "detectChangesInChildComponents",
+  "detectChangesInComponent",
+  "detectChangesInEmbeddedViews",
+  "detectChangesInView",
+  "detectChangesInViewIfAttached",
+  "detectChangesInViewIfRequired",
+  "detectChangesInternal",
+  "diPublicInInjector",
+  "enterDI",
+  "enterView",
+  "errorContext",
+  "execFinalizer",
+  "executeCheckHooks",
+  "executeContentQueries",
+  "executeInitAndCheckHooks",
+  "executeListenerWithErrorHandling",
+  "executeTemplate",
+  "executeViewQueryFn",
+  "extractDefListOrFactory",
+  "extractDirectiveDef",
+  "findAttrIndexInNode",
+  "findStylingValue",
+  "forEachSingleProvider",
+  "forwardRef",
+  "freeConsumers",
+  "generateInitialInputs",
+  "getBeforeNodeForView",
+  "getBindingsEnabled",
+  "getClosureSafeProperty",
+  "getComponentDef",
+  "getComponentLViewByIndex",
+  "getConstant",
+  "getCurrentTNode",
+  "getCurrentTNodePlaceholderOk",
+  "getDOM",
+  "getDeclarationTNode",
+  "getDirectiveDef",
+  "getFactoryDef",
+  "getFirstLContainer",
+  "getFirstNativeNode",
+  "getInitialLViewFlagsFromDef",
+  "getInjectImplementation",
+  "getInjectableDef",
+  "getInjectorDef",
+  "getInjectorIndex",
+  "getLView",
+  "getLViewParent",
+  "getNativeByIndex",
+  "getNativeByTNode",
+  "getNearestLContainer",
+  "getNextLContainer",
+  "getNgDirectiveDef",
+  "getNgZoneOptions",
+  "getNodeInjectable",
+  "getNullInjector",
+  "getOrCreateComponentTView",
+  "getOrCreateInjectable",
+  "getOrCreateNodeInjectorForNode",
+  "getOrCreateTNode",
+  "getOrCreateViewRefs",
+  "getOwnDefinition",
+  "getParentInjectorIndex",
+  "getParentInjectorLocation",
+  "getParentInjectorView",
+  "getPipeDef",
+  "getPlatform",
+  "getPreviousIndex",
+  "getProjectionNodes",
+  "getPromiseCtor",
+  "getSelectedIndex",
+  "getSimpleChangesStore",
+  "getTNode",
+  "getTNodeFromLView",
+  "getTStylingRangeNext",
+  "getTStylingRangePrev",
+  "getTView",
+  "getViewRefs",
+  "handleError",
+  "handleStoppedNotification",
+  "handleUnhandledError",
+  "hasApplyArgsData",
+  "hasInSkipHydrationBlockFlag",
+  "hasParentInjector",
+  "hasTagAndTypeMatch",
+  "icuContainerIterate",
+  "identity",
+  "importProvidersFrom",
+  "includeViewProviders",
+  "incrementInitPhaseFlags",
+  "initFeatures",
+  "initializeDirectives",
+  "inject",
+  "injectArgs",
+  "injectDestroyRef",
+  "injectElementRef",
+  "injectInjectorOnly",
+  "injectRootLimpMode",
+  "injectTemplateRef",
+  "injectViewContainerRef",
+  "injectableDefOrInjectorDefFactory",
+  "insertBloom",
+  "instructionState",
+  "internalImportProvidersFrom",
+  "internalProvideZoneChangeDetection",
+  "invokeDirectivesHostBindings",
+  "invokeHostBindingsInCreationMode",
+  "isAngularZoneProperty",
+  "isApplicationBootstrapConfig",
+  "isComponentDef",
+  "isComponentHost",
+  "isContentQueryHost",
+  "isCssClassMatching",
+  "isCurrentTNodeParent",
+  "isDirectiveHost",
+  "isEnvironmentProviders",
+  "isFunction",
+  "isInlineTemplate",
+  "isLContainer",
+  "isLView",
+  "isListLikeIterable",
+  "isNodeMatchingSelector",
+  "isNodeMatchingSelectorList",
+  "isPlatformServer",
+  "isPositive",
+  "isPromise",
+  "isRefreshingViews",
+  "isRootView",
+  "isStylingMatch",
+  "isStylingValuePresent",
+  "isSubscription",
+  "isTemplateNode",
+  "isTypeProvider",
+  "isValueProvider",
+  "keyValueArrayGet",
+  "keyValueArrayIndexOf",
+  "keyValueArraySet",
+  "lastNodeWasCreated",
+  "leaveDI",
+  "leaveView",
+  "leaveViewLight",
+  "lookupTokenUsingModuleInjector",
+  "lookupTokenUsingNodeInjector",
+  "makeParamDecorator",
+  "makeRecord",
+  "map",
+  "markAncestorsForTraversal",
+  "markAsComponentHost",
+  "markDuplicates",
+  "markViewDirty",
+  "markViewForRefresh",
+  "markedFeatures",
+  "maybeWrapInNotSelector",
+  "mergeHostAttribute",
+  "mergeHostAttrs",
+  "nativeAppendChild",
+  "nativeAppendOrInsertBefore",
+  "nativeInsertBefore",
+  "nativeParentNode",
+  "nextBindingIndex",
+  "nextNgElementId",
+  "ngOnChangesSetInput",
+  "ngZoneInstanceId",
+  "noSideEffects",
+  "nonNull",
+  "noop",
+  "noop2",
+  "notFoundValueOrThrow",
+  "observable",
+  "onEnter",
+  "onLeave",
+  "optionsReducer",
+  "parseAndConvertBindingsForDefinition",
+  "platformBrowser",
+  "platformCore",
+  "processInjectorTypesWithProviders",
+  "producerMarkClean",
+  "producerRemoveLiveConsumerAtIndex",
+  "producerUpdateValueVersion",
+  "refreshContentQueries",
+  "refreshView",
+  "registerPostOrderHooks",
+  "rememberChangeHistoryAndInvokeOnChangesHook",
+  "remove",
+  "removeElements",
+  "removeFromArray",
+  "renderComponent",
+  "renderStringify",
+  "renderView",
+  "requiresRefreshOrTraversal",
+  "resetPreOrderHookFlags",
+  "resolveDirectives",
+  "resolveForwardRef",
+  "runEffectsInView",
+  "runInInjectionContext",
+  "saveNameToExportMap",
+  "saveResolvedLocalsInData",
+  "scheduleCallbackWithMicrotask",
+  "scheduleCallbackWithRafRace",
+  "searchTokensOnInjector",
+  "selectIndexInternal",
+  "setActiveConsumer",
+  "setBindingRootForHostBindings",
+  "setCurrentDirectiveIndex",
+  "setCurrentInjector",
+  "setCurrentQueryIndex",
+  "setCurrentTNode",
+  "setDirectiveInputsWhichShadowsStyling",
+  "setIncludeViewProviders",
+  "setInjectImplementation",
+  "setInputsForProperty",
+  "setInputsFromAttrs",
+  "setIsRefreshingViews",
+  "setSelectedIndex",
+  "setTStylingRangeNext",
+  "setTStylingRangeNextDuplicate",
+  "setTStylingRangePrevDuplicate",
+  "setUpAttributes",
+  "setupStaticAttributes",
+  "shimStylesContent",
+  "shouldAddViewToDom",
+  "shouldSearchParent",
+  "storeLViewOnDestroy",
+  "stringify",
+  "stringifyCSSSelector",
+  "throwProviderNotFoundError",
+  "timeoutProvider",
+  "toRefArray",
+  "toTStylingRange",
+  "trackByIdentity",
+  "trackMovedView",
+  "uniqueIdCounter",
+  "unregisterLView",
+  "unwrapRNode",
+  "updateAncestorTraversalFlagsOnAttach",
+  "updateMicroTaskStatus",
+  "viewAttachedToChangeDetector",
+  "viewShouldHaveReactiveConsumer",
+  "walkProviderTree",
+  "wasLastNodeCreated",
+  "wrapListener",
+  "writeDirectClass",
+  "writeToDirectiveInput",
+  "ɵɵadvance",
+  "ɵɵclassProp",
+  "ɵɵdefineComponent",
+  "ɵɵdefineDirective",
+  "ɵɵdefineInjectable",
+  "ɵɵdefineInjector",
+  "ɵɵdefineNgModule",
+  "ɵɵdirectiveInject",
+  "ɵɵelementEnd",
+  "ɵɵelementStart",
+  "ɵɵgetCurrentView",
+  "ɵɵinject",
+  "ɵɵlistener",
+  "ɵɵnextContext",
+  "ɵɵproperty",
+  "ɵɵreference",
+  "ɵɵresetView",
+  "ɵɵrestoreView",
+  "ɵɵtemplate",
+  "ɵɵtext",
+  "ɵɵtextInterpolate",
+  "ɵɵtextInterpolate1"
 ]

--- a/tools/symbol-extractor/cli.ts
+++ b/tools/symbol-extractor/cli.ts
@@ -39,7 +39,7 @@ function main(argv: [string, string, string] | [string, string]): boolean {
     console.error('Updated gold file:', goldenFilePath);
     passed = true;
   } else {
-    passed = symbolExtractor.compareAndPrintError(goldenFilePath, goldenContent);
+    passed = symbolExtractor.compareAndPrintError(goldenContent);
     if (!passed) {
       console.error(`TEST FAILED!`);
       console.error(`  To update the golden file run: `);

--- a/tools/symbol-extractor/symbol_extractor_spec/iife_arrow_function.json
+++ b/tools/symbol-extractor/symbol_extractor_spec/iife_arrow_function.json
@@ -1,8 +1,4 @@
 [
-  {
-    "name": "Class"
-  },
-  {
-    "name": "fn"
-  }
+  "Class",
+  "fn"
 ]

--- a/tools/symbol-extractor/symbol_extractor_spec/simple.json
+++ b/tools/symbol-extractor/symbol_extractor_spec/simple.json
@@ -1,8 +1,4 @@
 [
-  {
-    "name": "Class"
-  },
-  {
-    "name": "fn"
-  }
+  "Class",
+  "fn"
 ]

--- a/tools/symbol-extractor/symbol_extractor_spec/two_symbols_per_var.json
+++ b/tools/symbol-extractor/symbol_extractor_spec/two_symbols_per_var.json
@@ -1,11 +1,5 @@
 [
-  {
-    "name": "A"
-  },
-  {
-    "name": "B"
-  },
-  {
-    "name": "no_initializer"
-  }
+  "A",
+  "B",
+  "no_initializer"
 ]


### PR DESCRIPTION
Switches the goldens for the symbol tests to be an array of strings, rather than an array of objects where each object only has a `name` property. This makes them more compact, easier to read and easier to avoid merge conflicts.
