### PR TITLE
docs: correct link to Dependency Injection guide in NgModule overview

### DIFF
--- a/adev/src/content/guide/ngmodules/overview.md
+++ b/adev/src/content/guide/ngmodules/overview.md
@@ -107,7 +107,7 @@ export class CustomMenuModule { }
 
 ## `NgModule` providers
 
-Tip: See the [Dependency Injection guide](guides/di) for information on dependency injection and providers.
+Tip: See the [Dependency Injection guide](guide/di) for information on dependency injection and providers.
 
 An `NgModule` can specify `providers` for injected dependencies. These providers are available to:
 * Any standalone component, directive, or pipe that imports the NgModule, and


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
When you click on this link:
![image](https://github.com/user-attachments/assets/6a1d93b7-f29d-49fc-8195-ff52a8f317b6)

You are routed to a page that doesn't exist:
![image](https://github.com/user-attachments/assets/bcfd0f0a-e7fe-491b-a0e9-5227eb792ce4)

Issue Number: #59139


## What is the new behavior?
By adjusting the link for the DI docs, we get redirected to the correct place:
![image](https://github.com/user-attachments/assets/f3662f0d-b731-44b0-8d2d-f92bf7af7b42)


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
