### PR TITLE
docs(docs-infra): replace newline with <br>

### DIFF
--- a/adev/src/content/guide/di/dependency-injection.md
+++ b/adev/src/content/guide/di/dependency-injection.md
@@ -127,7 +127,7 @@ serviceC[Service C]
 serviceD[Service D]
 end
 direction TB
-componentConstructor["Component\nconstructor(HeroService)"]
+componentConstructor["Component <br> constructor(HeroService)"]
 heroService-->componentConstructor
 style componentConstructor text-align: left
 ```


### PR DESCRIPTION
On the [link](https://angular.dev/guide/di/dependency-injection). The graph below "new line" is not working.
Component\nconstructor(HeroService)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
On the [link](https://angular.dev/guide/di/dependency-injection). The graph below "new line" is not working.
![image](https://github.com/user-attachments/assets/30f31849-59e2-48c0-ac06-83acaf25a589)

Issue Number: N/A


## What is the new behavior?
By the [mermaid docs](https://mermaid.js.org/syntax/flowchart.html#markdown-strings), to make a new line, need to add `<br> `tag.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
