### PR TITLE
docs: fix all brokens links on the API pages

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/symbol-context.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/symbol-context.ts
@@ -38,8 +38,6 @@ export function getCurrentSymbol(): string | undefined {
   return currentSymbol;
 }
 
-export function logUnknownSymbol(link: string, symbol: string): void {
-  console.warn(
-    `WARNING: {@link ${link}} is invalid, ${symbol} or ${currentSymbol}.${symbol} is unknown in this context`,
-  );
+export function unknownSymbolMessage(link: string, symbol: string): string {
+  return `WARNING: {@link ${link}} is invalid, ${symbol} or ${currentSymbol}.${symbol} is unknown in this context`;
 }

--- a/adev/shared-docs/pipeline/api-gen/rendering/test/marked.spec.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/test/marked.spec.ts
@@ -34,6 +34,13 @@ describe('markdown to html', () => {
     const symbols = new Map<string, string>([
       ['AfterRenderPhase', 'core'],
       ['afterRender', 'core'],
+      ['EmbeddedViewRef', 'core'],
+      ['ChangeDetectionStrategy', 'core'],
+      ['ChangeDetectorRef', 'core'],
+      ['withNoHttpTransferCache', 'platform-browser'],
+      ['withHttpTransferCacheOptions', 'platform-browser'],
+      ['withI18nSupport', 'platform-browser'],
+      ['withEventReplay', 'platform-browser'],
     ]);
     setSymbols(symbols);
     for (const entry of entryJson.entries) {

--- a/adev/shared-docs/pipeline/api-gen/rendering/test/renderable.spec.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/test/renderable.spec.ts
@@ -12,6 +12,7 @@ import {getRenderable} from '../processing';
 import {DocEntryRenderable} from '../entities/renderables';
 import {initHighlighter} from '../shiki/shiki';
 import {configureMarkedGlobally} from '../marked/configuration';
+import {setSymbols} from '../symbol-context';
 
 // Note: The tests will probably break if the schema of the api extraction changes.
 // All entries in the fake-entries are extracted from Angular's api.
@@ -28,6 +29,19 @@ describe('renderable', () => {
       encoding: 'utf-8',
     });
     const entryJson = JSON.parse(entryContent) as any;
+    const symbols = new Map<string, string>([
+      ['AfterRenderPhase', 'core'],
+      ['afterRender', 'core'],
+      ['EmbeddedViewRef', 'core'],
+      ['ChangeDetectionStrategy', 'core'],
+      ['ChangeDetectorRef', 'core'],
+      ['withNoHttpTransferCache', 'platform-browser'],
+      ['withHttpTransferCacheOptions', 'platform-browser'],
+      ['withI18nSupport', 'platform-browser'],
+      ['withEventReplay', 'platform-browser'],
+    ]);
+    setSymbols(symbols);
+
     for (const entry of entryJson.entries) {
       const renderableJson = getRenderable(entry, '@angular/fakeentry') as DocEntryRenderable;
       entries.set(entry['name'], renderableJson);

--- a/adev/shared-docs/pipeline/api-gen/rendering/test/transforms/jsdoc-transforms.spec.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/test/transforms/jsdoc-transforms.spec.ts
@@ -72,10 +72,6 @@ describe('jsdoc transforms', () => {
         },
         {
           name: 'see',
-          comment: '{@link cli/build ng build}',
-        },
-        {
-          name: 'see',
           comment: '{@link /ecosystem/rxjs-interop/output-interop Output Interop}',
         },
       ],
@@ -135,16 +131,24 @@ describe('jsdoc transforms', () => {
       url: '/cli/build',
     });
 
-    // TODO: in the future when all links are valid we would throw an error instead when not starting with a slash
-    // Links should be absolute within adev (to support both next & stable site)
     expect(entry.additionalLinks[11]).toEqual({
-      label: 'ng build',
-      url: 'cli/build',
-    });
-
-    expect(entry.additionalLinks[12]).toEqual({
       label: 'Output Interop',
       url: '/ecosystem/rxjs-interop/output-interop',
     });
+  });
+
+  it('should throw on invalid relatie @link', () => {
+    const entryFn = () =>
+      addHtmlAdditionalLinks({
+        jsdocTags: [
+          {
+            name: 'see',
+            comment: '{@link cli/build ng build}',
+          },
+        ],
+        moduleName: 'test',
+      });
+
+    expect(entryFn).toThrowError(/Forbidden relative link: cli\/build ng build/);
   });
 });

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/jsdoc-transforms.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/jsdoc-transforms.ts
@@ -31,7 +31,7 @@ import {
 
 import {getLinkToModule} from './url-transforms';
 import {addApiLinksToHtml} from './code-transforms';
-import {getCurrentSymbol, getModuleName, logUnknownSymbol} from '../symbol-context';
+import {getCurrentSymbol, getModuleName, unknownSymbolMessage} from '../symbol-context';
 
 export const JS_DOC_REMARKS_TAG = 'remarks';
 export const JS_DOC_USAGE_NOTES_TAG = 'usageNotes';
@@ -186,6 +186,12 @@ function parseAtLink(link: string): {label: string; url: string} {
   if (rawSymbol.startsWith('#')) {
     rawSymbol = rawSymbol.substring(1);
   } else if (rawSymbol.includes('/')) {
+    if (!rawSymbol.startsWith('/') && !rawSymbol.startsWith('http')) {
+      throw Error(
+        `Forbidden relative link: ${link}. Links should be absolute and start with a slash`,
+      );
+    }
+
     return {
       url: rawSymbol,
       label: description ?? rawSymbol.split('/').pop()!,
@@ -204,11 +210,9 @@ function parseAtLink(link: string): {label: string; url: string} {
     moduleName = getModuleName(`${currentSymbol}.${symbol}`);
 
     if (!moduleName || !currentSymbol) {
-      // TODO: remove the links that generate this error
-      // TODO: throw an error when there are no more warning generated
-      logUnknownSymbol(link, symbol);
-      return {label, url: '#'};
+      throw unknownSymbolMessage(link, symbol);
     }
+
     subSymbol = symbol;
     symbol = currentSymbol;
   }

--- a/packages/animations/src/animation_metadata.ts
+++ b/packages/animations/src/animation_metadata.ts
@@ -54,7 +54,7 @@ export declare type AnimateTimings = {
  *
  * - `transition()`
  * - `sequence()`
- * - `{@link animations/group group()}`
+ * - [`group()`](/api/animations/group)
  * - `query()`
  * - `animation()`
  * - `useAnimation()`
@@ -118,7 +118,7 @@ export enum AnimationMetadataType {
   Sequence = 2,
   /**
    * Contains a set of animation steps.
-   * See `{@link animations/group group()}`
+   * See [`group()`](/api/animations/group)
    */
   Group = 3,
   /**
@@ -403,7 +403,7 @@ export interface AnimationSequenceMetadata extends AnimationMetadata {
 
 /**
  * Encapsulates an animation group.
- * Instantiated and returned by the `group()` function.
+ * Instantiated and returned by the [`group()`](/api/animations/group) function.
  *
  * @publicApi
  */
@@ -636,7 +636,7 @@ export function trigger(name: string, definitions: AnimationMetadata[]): Animati
  * @returns An object that encapsulates the animation step.
  *
  * @usageNotes
- * Call within an animation `sequence()`, `{@link animations/group group()}`, or
+ * Call within an animation `sequence()`, [`group()`](/api/animations/group), or
  * `transition()` call to specify an animation step
  * that applies given style data to the parent animation for a given amount of time.
  *
@@ -740,10 +740,10 @@ export function group(
  * @usageNotes
  * When you pass an array of steps to a
  * `transition()` call, the steps run sequentially by default.
- * Compare this to the `{@link animations/group group()}` call, which runs animation steps in
+ * Compare this to the [`group()`](/api/animations/group) call, which runs animation steps in
  *parallel.
  *
- * When a sequence is used within a `{@link animations/group group()}` or a `transition()` call,
+ * When a sequence is used within a [`group()`](/api/animations/group) or a `transition()` call,
  * execution continues to the next instruction only after each of the inner animation
  * steps have completed.
  *

--- a/packages/animations/src/animation_metadata.ts
+++ b/packages/animations/src/animation_metadata.ts
@@ -54,7 +54,7 @@ export declare type AnimateTimings = {
  *
  * - `transition()`
  * - `sequence()`
- * - [`group()`](/api/animations/group)
+ * - `{@link /api/animations/group group()}`
  * - `query()`
  * - `animation()`
  * - `useAnimation()`
@@ -118,7 +118,7 @@ export enum AnimationMetadataType {
   Sequence = 2,
   /**
    * Contains a set of animation steps.
-   * See [`group()`](/api/animations/group)
+   * See `{@link /api/animations/group group()}`
    */
   Group = 3,
   /**
@@ -403,7 +403,7 @@ export interface AnimationSequenceMetadata extends AnimationMetadata {
 
 /**
  * Encapsulates an animation group.
- * Instantiated and returned by the [`group()`](/api/animations/group) function.
+ * Instantiated and returned by the `group()` function.
  *
  * @publicApi
  */
@@ -636,7 +636,7 @@ export function trigger(name: string, definitions: AnimationMetadata[]): Animati
  * @returns An object that encapsulates the animation step.
  *
  * @usageNotes
- * Call within an animation `sequence()`, [`group()`](/api/animations/group), or
+ * Call within an animation `sequence()`, {@link /api/animations/group group}, or
  * `transition()` call to specify an animation step
  * that applies given style data to the parent animation for a given amount of time.
  *
@@ -740,10 +740,10 @@ export function group(
  * @usageNotes
  * When you pass an array of steps to a
  * `transition()` call, the steps run sequentially by default.
- * Compare this to the [`group()`](/api/animations/group) call, which runs animation steps in
+ * Compare this to the  {@link /api/animations/group group} call, which runs animation steps in
  *parallel.
  *
- * When a sequence is used within a [`group()`](/api/animations/group) or a `transition()` call,
+ * When a sequence is used within a  {@link /api/animations/group group} or a `transition()` call,
  * execution continues to the next instruction only after each of the inner animation
  * steps have completed.
  *

--- a/packages/animations/src/animation_metadata.ts
+++ b/packages/animations/src/animation_metadata.ts
@@ -636,7 +636,7 @@ export function trigger(name: string, definitions: AnimationMetadata[]): Animati
  * @returns An object that encapsulates the animation step.
  *
  * @usageNotes
- * Call within an animation `sequence()`, {@link /api/animations/group group}, or
+ * Call within an animation `sequence()`, [`group()`](/api/animations/group), or
  * `transition()` call to specify an animation step
  * that applies given style data to the parent animation for a given amount of time.
  *
@@ -740,10 +740,10 @@ export function group(
  * @usageNotes
  * When you pass an array of steps to a
  * `transition()` call, the steps run sequentially by default.
- * Compare this to the  {@link /api/animations/group group} call, which runs animation steps in
+ * Compare this to the  [`group()`](/api/animations/group) call, which runs animation steps in
  *parallel.
  *
- * When a sequence is used within a  {@link /api/animations/group group} or a `transition()` call,
+ * When a sequence is used within a [`group()`](/api/animations/group) or a `transition()` call,
  * execution continues to the next instruction only after each of the inner animation
  * steps have completed.
  *

--- a/packages/animations/src/animation_metadata.ts
+++ b/packages/animations/src/animation_metadata.ts
@@ -636,7 +636,7 @@ export function trigger(name: string, definitions: AnimationMetadata[]): Animati
  * @returns An object that encapsulates the animation step.
  *
  * @usageNotes
- * Call within an animation `sequence()`, [`group()`](/api/animations/group), or
+ * Call within an animation `sequence()`, {@link /api/animations/group group()}, or
  * `transition()` call to specify an animation step
  * that applies given style data to the parent animation for a given amount of time.
  *
@@ -740,10 +740,10 @@ export function group(
  * @usageNotes
  * When you pass an array of steps to a
  * `transition()` call, the steps run sequentially by default.
- * Compare this to the  [`group()`](/api/animations/group) call, which runs animation steps in
+ * Compare this to the  {@link /api/animations/group group()} call, which runs animation steps in
  *parallel.
  *
- * When a sequence is used within a [`group()`](/api/animations/group) or a `transition()` call,
+ * When a sequence is used within a  {@link /api/animations/group group()} or a `transition()` call,
  * execution continues to the next instruction only after each of the inner animation
  * steps have completed.
  *

--- a/packages/common/src/directives/ng_component_outlet.ts
+++ b/packages/common/src/directives/ng_component_outlet.ts
@@ -23,7 +23,7 @@ import {
 } from '@angular/core';
 
 /**
- * Instantiates a {@link Component} type and inserts its Host View into the current View.
+ * Instantiates a [`Component`](/api/core/Component) type and inserts its Host View into the current View.
  * `NgComponentOutlet` provides a declarative approach for dynamic component creation.
  *
  * `NgComponentOutlet` requires a component type, if a falsy value is set the view will clear and

--- a/packages/common/src/directives/ng_component_outlet.ts
+++ b/packages/common/src/directives/ng_component_outlet.ts
@@ -23,7 +23,7 @@ import {
 } from '@angular/core';
 
 /**
- * Instantiates a [`Component`](/api/core/Component) type and inserts its Host View into the current View.
+ * Instantiates a {@link /api/core/Component Component} type and inserts its Host View into the current View.
  * `NgComponentOutlet` provides a declarative approach for dynamic component creation.
  *
  * `NgComponentOutlet` requires a component type, if a falsy value is set the view will clear and

--- a/packages/common/src/location/platform_location.ts
+++ b/packages/common/src/location/platform_location.ts
@@ -26,8 +26,8 @@ import {DOCUMENT} from '../dom_tokens';
  * when they need to interact with the DOM APIs like pushState, popState, etc.
  *
  * {@link LocationStrategy} in turn is used by the {@link Location} service which is used directly
- * by the {@link Router} in order to navigate between routes. Since all interactions between {@link
- * Router} /
+ * by the [`Router`](/api/router/Router) in order to navigate between routes. Since all interactions between
+ * [`Router`](/api/router/Router) /
  * {@link Location} / {@link LocationStrategy} and DOM APIs flow through the `PlatformLocation`
  * class, they are all platform-agnostic.
  *

--- a/packages/common/src/location/platform_location.ts
+++ b/packages/common/src/location/platform_location.ts
@@ -26,8 +26,8 @@ import {DOCUMENT} from '../dom_tokens';
  * when they need to interact with the DOM APIs like pushState, popState, etc.
  *
  * {@link LocationStrategy} in turn is used by the {@link Location} service which is used directly
- * by the [`Router`](/api/router/Router) in order to navigate between routes. Since all interactions between
- * [`Router`](/api/router/Router) /
+ * by the {@link /api/router/Router Router} in order to navigate between routes. Since all interactions between
+ * {@link /api/router/Router Router} /
  * {@link Location} / {@link LocationStrategy} and DOM APIs flow through the `PlatformLocation`
  * class, they are all platform-agnostic.
  *

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/jsdoc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/jsdoc_extraction_spec.ts
@@ -244,7 +244,7 @@ runInEachFileSystem(() => {
 
         /**
          * Future version.
-         * @see {@link Component}
+         * @see [Component](/api/core/Component)
          */
         export const NEW_VERSION = '99.0.0';
       `,
@@ -257,7 +257,7 @@ runInEachFileSystem(() => {
       expect(docs[0].jsdocTags.length).toBe(1);
       expect(docs[0].jsdocTags[0]).toEqual({
         name: 'see',
-        comment: '{@link Component}',
+        comment: '[Component](/api/core/Component)',
       });
     });
 

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/jsdoc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/jsdoc_extraction_spec.ts
@@ -244,7 +244,7 @@ runInEachFileSystem(() => {
 
         /**
          * Future version.
-         * @see [Component](/api/core/Component)
+         * @see {@link Component}
          */
         export const NEW_VERSION = '99.0.0';
       `,
@@ -257,7 +257,7 @@ runInEachFileSystem(() => {
       expect(docs[0].jsdocTags.length).toBe(1);
       expect(docs[0].jsdocTags[0]).toEqual({
         name: 'see',
-        comment: '[Component](/api/core/Component)',
+        comment: '{@link Component}',
       });
     });
 

--- a/packages/core/src/change_detection/constants.ts
+++ b/packages/core/src/change_detection/constants.ts
@@ -10,8 +10,8 @@
  * The strategy that the default change detector uses to detect changes.
  * When set, takes effect the next time change detection is triggered.
  *
- * @see [Change detection usage](/api/core/ChangeDetectorRef?tab=usage-notes)
- * @see [Skipping component subtrees](/best-practices/skipping-subtrees)
+ * @see {@link /api/core/ChangeDetectorRef?tab=usage-notes Change detection usage}
+ * @see {@link /best-practices/skipping-subtrees Skipping component subtrees}
  *
  * @publicApi
  */

--- a/packages/core/src/change_detection/differs/iterable_differs.ts
+++ b/packages/core/src/change_detection/differs/iterable_differs.ts
@@ -20,7 +20,7 @@ import {DefaultIterableDifferFactory} from '../differs/default_iterable_differ';
 export type NgIterable<T> = Array<T> | Iterable<T>;
 
 /**
- * A strategy for tracking changes over time to an iterable. Used by {@link NgForOf} to
+ * A strategy for tracking changes over time to an iterable. Used by [`NgForOf`](/api/common/NgForOf) to
  * respond to changes in an iterable by effecting equivalent changes in the DOM.
  *
  * @publicApi

--- a/packages/core/src/change_detection/differs/iterable_differs.ts
+++ b/packages/core/src/change_detection/differs/iterable_differs.ts
@@ -20,7 +20,7 @@ import {DefaultIterableDifferFactory} from '../differs/default_iterable_differ';
 export type NgIterable<T> = Array<T> | Iterable<T>;
 
 /**
- * A strategy for tracking changes over time to an iterable. Used by [`NgForOf`](/api/common/NgForOf) to
+ * A strategy for tracking changes over time to an iterable. Used by {@link /api/common/NgForOf NgForOf} to
  * respond to changes in an iterable by effecting equivalent changes in the DOM.
  *
  * @publicApi

--- a/packages/core/src/change_detection/scheduling/ng_zone_scheduling.ts
+++ b/packages/core/src/change_detection/scheduling/ng_zone_scheduling.ts
@@ -153,7 +153,7 @@ export function internalProvideZoneChangeDetection({
  * ```
  *
  * @publicApi
- * @see {@link bootstrapApplication}
+ * @see {@link /api/core/bootstrapApplication bootstrapApplication}
  * @see {@link NgZoneOptions}
  */
 export function provideZoneChangeDetection(options?: NgZoneOptions): EnvironmentProviders {

--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
@@ -369,7 +369,7 @@ export class ChangeDetectionSchedulerImpl implements ChangeDetectionScheduler {
  *
  * @publicApi
  * @experimental
- * @see [bootstrapApplication](/api/platform-browser/bootstrapApplication)
+ * @see {@link /api/platform-browser/bootstrapApplication bootstrapApplication}
  */
 export function provideExperimentalZonelessChangeDetection(): EnvironmentProviders {
   performanceMarkFeature('NgZoneless');

--- a/packages/core/src/linker/view_ref.ts
+++ b/packages/core/src/linker/view_ref.ts
@@ -11,7 +11,7 @@ import {ChangeDetectorRef} from '../change_detection/change_detector_ref';
 /**
  * Represents an Angular view.
  *
- * @see [Change detection usage](/api/core/ChangeDetectorRef?tab=usage-notes)
+ * @see {@link /api/core/ChangeDetectorRef?tab=usage-notes Change detection usage}
  *
  * @publicApi
  */

--- a/packages/core/src/metadata/view.ts
+++ b/packages/core/src/metadata/view.ts
@@ -7,7 +7,7 @@
  */
 
 /**
- * Defines the CSS styles encapsulation policies for the {@link Component} decorator's
+ * Defines the CSS styles encapsulation policies for the [`Component`](/api/core/Component) decorator's
  * `encapsulation` option.
  *
  * See {@link Component#encapsulation encapsulation}.

--- a/packages/core/src/metadata/view.ts
+++ b/packages/core/src/metadata/view.ts
@@ -7,7 +7,7 @@
  */
 
 /**
- * Defines the CSS styles encapsulation policies for the [`Component`](/api/core/Component) decorator's
+ * Defines the CSS styles encapsulation policies for the {@link /api/core/Component Component} decorator's
  * `encapsulation` option.
  *
  * See {@link Component#encapsulation encapsulation}.

--- a/packages/core/src/render/api_flags.ts
+++ b/packages/core/src/render/api_flags.ts
@@ -41,8 +41,7 @@ export interface RendererType2 {
   data: {[kind: string]: any};
 
   /**
-   * A function added by the {@link ɵɵExternalStylesFeature} and used by the framework to create
-   * the list of external runtime style URLs.
+   * A function used by the framework to create the list of external runtime style URLs.
    */
   getExternalStyles?: ((encapsulationId?: string) => string[]) | null;
 }

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -286,7 +286,7 @@ interface ComponentDefinition<T> extends Omit<DirectiveDefinition<T>, 'features'
   features?: ComponentDefFeature[];
 
   /**
-   * Defines template and style encapsulation options available for Component's {@link Component}.
+   * Defines template and style encapsulation options available for Component's [`Component`](/api/core/Component).
    */
   encapsulation?: ViewEncapsulation;
 

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -286,7 +286,7 @@ interface ComponentDefinition<T> extends Omit<DirectiveDefinition<T>, 'features'
   features?: ComponentDefFeature[];
 
   /**
-   * Defines template and style encapsulation options available for Component's [`Component`](/api/core/Component).
+   * Defines template and style encapsulation options available for Component's {@link /api/core/Component Component}.
    */
   encapsulation?: ViewEncapsulation;
 

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -402,8 +402,7 @@ export interface ComponentDef<T> extends DirectiveDef<T> {
     | null;
 
   /**
-   * A function added by the {@link ɵɵExternalStylesFeature} and used by the framework to create
-   * the list of external runtime style URLs.
+   * A function used by the framework to create the list of external runtime style URLs.
    */
   getExternalStyles: ((encapsulationId?: string) => string[]) | null;
 

--- a/packages/core/src/render3/reactivity/asserts.ts
+++ b/packages/core/src/render3/reactivity/asserts.ts
@@ -12,7 +12,7 @@ import {RuntimeError, RuntimeErrorCode} from '../../errors';
 
 /**
  * Asserts that the current stack frame is not within a reactive context. Useful
- * to disallow certain code from running inside a reactive context (see {@link toSignal}).
+ * to disallow certain code from running inside a reactive context (see [`toSignal`](/api/core/rxjs/toSignal)).
  *
  * @param debugFn a reference to the function making the assertion (used for the error message).
  *

--- a/packages/core/src/render3/reactivity/asserts.ts
+++ b/packages/core/src/render3/reactivity/asserts.ts
@@ -12,7 +12,7 @@ import {RuntimeError, RuntimeErrorCode} from '../../errors';
 
 /**
  * Asserts that the current stack frame is not within a reactive context. Useful
- * to disallow certain code from running inside a reactive context (see [`toSignal`](/api/core/rxjs/toSignal)).
+ * to disallow certain code from running inside a reactive context (see {@link /api/core/rxjs/toSignal toSignal})
  *
  * @param debugFn a reference to the function making the assertion (used for the error message).
  *

--- a/packages/core/src/render3/util/change_detection_utils.ts
+++ b/packages/core/src/render3/util/change_detection_utils.ts
@@ -19,7 +19,7 @@ import {getRootComponents} from './discovery_utils';
  * Marks a component for check (in case of OnPush components) and synchronously
  * performs change detection on the application this component belongs to.
  *
- * @param component Component to {@link ChangeDetectorRef#markForCheck mark for check}.
+ * @param component Component to [`mark for check`](/api/core/ChangeDetectorRef#markForCheck).
  *
  * @publicApi
  */

--- a/packages/core/src/render3/util/change_detection_utils.ts
+++ b/packages/core/src/render3/util/change_detection_utils.ts
@@ -19,7 +19,7 @@ import {getRootComponents} from './discovery_utils';
  * Marks a component for check (in case of OnPush components) and synchronously
  * performs change detection on the application this component belongs to.
  *
- * @param component Component to [`mark for check`](/api/core/ChangeDetectorRef#markForCheck).
+ * @param component Component to {@link /api/core/ChangeDetectorRef#markForCheck mark for check}
  *
  * @publicApi
  */

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -185,7 +185,7 @@ export class ViewRef<T> implements EmbeddedViewRef<T>, ChangeDetectorRefInterfac
    *
    * Detached views will not be checked during change detection runs until they are
    * re-attached, even if they are dirty. `detach` can be used in combination with
-   * {@link ChangeDetectorRef#detectChanges} to implement local change
+   * [`detectChanges`](/api/core/ChangeDetectorRef#detectChanges) to implement local change
    * detection checks.
    *
    * <!-- TODO: Add a link to a chapter on detach/reattach/local digest -->

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -185,7 +185,7 @@ export class ViewRef<T> implements EmbeddedViewRef<T>, ChangeDetectorRefInterfac
    *
    * Detached views will not be checked during change detection runs until they are
    * re-attached, even if they are dirty. `detach` can be used in combination with
-   * {@link ChangeDetectorRef#detectChanges} to implement local change to implement local change
+   * {@link ChangeDetectorRef#detectChanges} to implement local change
    * detection checks.
    *
    * <!-- TODO: Add a link to a chapter on detach/reattach/local digest -->

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -185,7 +185,7 @@ export class ViewRef<T> implements EmbeddedViewRef<T>, ChangeDetectorRefInterfac
    *
    * Detached views will not be checked during change detection runs until they are
    * re-attached, even if they are dirty. `detach` can be used in combination with
-   * [`detectChanges`](/api/core/ChangeDetectorRef#detectChanges) to implement local change
+   * {@link ChangeDetectorRef#detectChanges} to implement local change to implement local change
    * detection checks.
    *
    * <!-- TODO: Add a link to a chapter on detach/reattach/local digest -->

--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -175,7 +175,7 @@ export class Validators {
    * @returns A validator function that returns an error map with the
    * `min` property if the validation check fails, otherwise `null`.
    *
-   * @see {@link updateValueAndValidity()}
+   * @see {@link /api/forms/AbstractControl#updateValueAndValidity updateValueAndValidity}
    *
    */
   static min(min: number): ValidatorFn {
@@ -199,7 +199,7 @@ export class Validators {
    * @returns A validator function that returns an error map with the
    * `max` property if the validation check fails, otherwise `null`.
    *
-   * @see {@link updateValueAndValidity()}
+   * @see {@link /api/forms/AbstractControl#updateValueAndValidity updateValueAndValidity}
    *
    */
   static max(max: number): ValidatorFn {
@@ -223,7 +223,7 @@ export class Validators {
    * @returns An error map with the `required` property
    * if the validation check fails, otherwise `null`.
    *
-   * @see {@link updateValueAndValidity()}
+   * @see {@link /api/forms/AbstractControl#updateValueAndValidity updateValueAndValidity}
    *
    */
   static required(control: AbstractControl): ValidationErrors | null {
@@ -248,7 +248,7 @@ export class Validators {
    * @returns An error map that contains the `required` property
    * set to `true` if the validation check fails, otherwise `null`.
    *
-   * @see {@link updateValueAndValidity()}
+   * @see {@link /api/forms/AbstractControl#updateValueAndValidity updateValueAndValidity}
    *
    */
   static requiredTrue(control: AbstractControl): ValidationErrors | null {
@@ -288,7 +288,7 @@ export class Validators {
    * @returns An error map with the `email` property
    * if the validation check fails, otherwise `null`.
    *
-   * @see {@link updateValueAndValidity()}
+   * @see {@link /api/forms/AbstractControl#updateValueAndValidity updateValueAndValidity}
    *
    */
   static email(control: AbstractControl): ValidationErrors | null {
@@ -323,7 +323,7 @@ export class Validators {
    * @returns A validator function that returns an error map with the
    * `minlength` property if the validation check fails, otherwise `null`.
    *
-   * @see {@link updateValueAndValidity()}
+   * @see {@link /api/forms/AbstractControl#updateValueAndValidity updateValueAndValidity}
    *
    */
   static minLength(minLength: number): ValidatorFn {
@@ -355,7 +355,7 @@ export class Validators {
    * @returns A validator function that returns an error map with the
    * `maxlength` property if the validation check fails, otherwise `null`.
    *
-   * @see {@link updateValueAndValidity()}
+   * @see {@link /api/forms/AbstractControl#updateValueAndValidity updateValueAndValidity}
    *
    */
   static maxLength(maxLength: number): ValidatorFn {
@@ -408,7 +408,7 @@ export class Validators {
    * @returns A validator function that returns an error map with the
    * `pattern` property if the validation check fails, otherwise `null`.
    *
-   * @see {@link updateValueAndValidity()}
+   * @see {@link /api/forms/AbstractControl#updateValueAndValidity updateValueAndValidity}
    *
    */
   static pattern(pattern: string | RegExp): ValidatorFn {
@@ -419,7 +419,7 @@ export class Validators {
    * @description
    * Validator that performs no operation.
    *
-   * @see {@link updateValueAndValidity()}
+   * @see {@link /api/forms/AbstractControl#updateValueAndValidity updateValueAndValidity}
    *
    */
   static nullValidator(control: AbstractControl): ValidationErrors | null {
@@ -434,7 +434,7 @@ export class Validators {
    * @returns A validator function that returns an error map with the
    * merged error maps of the validators if the validation check fails, otherwise `null`.
    *
-   * @see {@link updateValueAndValidity()}
+   * @see {@link /api/forms/AbstractControl#updateValueAndValidity updateValueAndValidity}
    *
    */
   static compose(validators: null): null;
@@ -451,7 +451,7 @@ export class Validators {
    * @returns A validator function that returns an error map with the
    * merged error objects of the async validators if the validation check fails, otherwise `null`.
    *
-   * @see {@link updateValueAndValidity()}
+   * @see {@link /api/forms/AbstractControl#updateValueAndValidity updateValueAndValidity}
    *
    */
   static composeAsync(validators: (AsyncValidatorFn | null)[]): AsyncValidatorFn | null {

--- a/packages/localize/src/translate.ts
+++ b/packages/localize/src/translate.ts
@@ -58,7 +58,7 @@ declare const $localize: LocalizeFn & {TRANSLATIONS: Record<MessageId, ParsedTra
  * These messages are processed and added to a lookup based on their `MessageId`.
  *
  * @see {@link clearTranslations} for removing translations loaded using this function.
- * @see [$localize](api/localize/init/$localize) for tagging messages as needing to be translated.
+ * @see {@link /api/localize/init/$localize $localize} for tagging messages as needing to be translated.
  * @publicApi
  */
 export function loadTranslations(translations: Record<MessageId, TargetMessage>) {
@@ -80,7 +80,7 @@ export function loadTranslations(translations: Record<MessageId, TargetMessage>)
  * All translations that had been loading into memory using `loadTranslations()` will be removed.
  *
  * @see {@link loadTranslations} for loading translations at runtime.
- * @see [$localize](api/localize/init/$localize) for tagging messages as needing to be translated.
+ * @see {@link /api/localize/init/$localize $localize} for tagging messages as needing to be translated.
  *
  * @publicApi
  */

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -59,7 +59,7 @@ export type OnSameUrlNavigation = 'reload' | 'ignore';
  * @see {@link CanActivateChildFn}
  * @see {@link CanDeactivateFn}
  * @see {@link ResolveFn}
- * @see {@link core/inject}
+ * @see {@link /api/core/inject inject}
  * @publicApi
  */
 export type DeprecatedGuard = ProviderToken<any> | any;

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -747,7 +747,7 @@ export type ViewTransitionsFeature = RouterFeature<RouterFeatureKind.ViewTransit
  * Default values can be provided with a resolver on the route to ensure the value is always present
  * or an input and use an input transform in the component.
  *
- * @see [Input Transforms](/guide/components/inputs#input-transforms)
+ * @see {@link /guide/components/inputs#input-transforms Input Transforms}
  * @returns A set of providers for use with `provideRouter`.
  */
 export function withComponentInputBinding(): ComponentInputBindingFeature {

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -622,7 +622,7 @@ export type RouterHashLocationFeature = RouterFeature<RouterFeatureKind.RouterHa
  * ```
  *
  * @see {@link provideRouter}
- * @see {@link HashLocationStrategy}
+ * @see {@link /api/common/HashLocationStrategy HashLocationStrategy}
  *
  * @returns A set of providers for use with `provideRouter`.
  *
@@ -672,7 +672,7 @@ export type NavigationErrorHandlerFeature =
  * ```
  *
  * @see {@link NavigationError}
- * @see {@link core/inject}
+ * @see {@link /api/core/inject inject}
  * @see {@link runInInjectionContext}
  *
  * @returns A set of providers for use with `provideRouter`.
@@ -747,7 +747,7 @@ export type ViewTransitionsFeature = RouterFeature<RouterFeatureKind.ViewTransit
  * Default values can be provided with a resolver on the route to ensure the value is always present
  * or an input and use an input transform in the component.
  *
- * @see {@link guide/components/inputs#input-transforms input transforms}
+ * @see [Input Transforms](/guide/components/inputs#input-transforms)
  * @returns A set of providers for use with `provideRouter`.
  */
 export function withComponentInputBinding(): ComponentInputBindingFeature {

--- a/packages/router/src/router_config.ts
+++ b/packages/router/src/router_config.ts
@@ -26,7 +26,7 @@ import {OnSameUrlNavigation, QueryParamsHandling, RedirectCommand} from './model
  * more control over when the router starts its initial navigation due to some complex
  * initialization logic.
  *
- * @see {@link forRoot()}
+ * @see {@link /api/router/routerModule#forRoot forRoot}
  *
  * @publicApi
  */
@@ -179,7 +179,7 @@ export interface InMemoryScrollingOptions {
  * A set of configuration options for a router module, provided in the
  * `forRoot()` method.
  *
- * @see {@link forRoot()}
+ * @see {@link /api/router/routerModule#forRoot forRoot}
  *
  *
  * @publicApi

--- a/packages/router/upgrade/src/upgrade.ts
+++ b/packages/router/upgrade/src/upgrade.ts
@@ -57,8 +57,8 @@ export function locationSyncBootstrapListener(ngUpgrade: UpgradeModule) {
  *
  * @param ngUpgrade The upgrade NgModule.
  * @param urlType The location strategy.
- * @see {@link HashLocationStrategy}
- * @see {@link PathLocationStrategy}
+ * @see {@link /api/common/HashLocationStrategy HashLocationStrategy}
+ * @see {@link /api/common/PathLocationStrategy PathLocationStrategy}
  *
  * @publicApi
  */

--- a/packages/service-worker/src/low_level.ts
+++ b/packages/service-worker/src/low_level.ts
@@ -15,7 +15,7 @@ export const ERR_SW_NOT_SUPPORTED = 'Service workers are disabled or not support
  * An event emitted when the service worker has checked the version of the app on the server and it
  * didn't find a new version that it doesn't have already downloaded.
  *
- * @see {@link ecosystem/service-workers/communications Service worker communication guide}
+ * @see [Service Worker Communication Guide](/ecosystem/service-workers/communications)
  *
  * @publicApi
  */
@@ -28,7 +28,7 @@ export interface NoNewVersionDetectedEvent {
  * An event emitted when the service worker has detected a new version of the app on the server and
  * is about to start downloading it.
  *
- * @see {@link ecosystem/service-workers/communications Service worker communication guide}
+ * @see [Service Worker Communication Guide](/ecosystem/service-workers/communications)
  *
  * @publicApi
  */
@@ -41,7 +41,7 @@ export interface VersionDetectedEvent {
  * An event emitted when the installation of a new version failed.
  * It may be used for logging/monitoring purposes.
  *
- * @see {@link ecosystem/service-workers/communications Service worker communication guide}
+ * @see [Service Worker Communication Guide](/ecosystem/service-workers/communications)
  *
  * @publicApi
  */
@@ -54,7 +54,7 @@ export interface VersionInstallationFailedEvent {
 /**
  * An event emitted when a new version of the app is available.
  *
- * @see {@link ecosystem/service-workers/communications Service worker communication guide}
+ * @see [Service Worker Communication Guide](/ecosystem/service-workers/communications)
  *
  * @publicApi
  */
@@ -85,7 +85,7 @@ export type VersionEvent =
  * service worker cache has been partially cleaned by the browser, removing some files of a previous
  * app version but not all.
  *
- * @see {@link ecosystem/service-workers/communications Service worker communication guide}
+ * @see [Service Worker Communication Guide](/ecosystem/service-workers/communications)
  *
  * @publicApi
  */

--- a/packages/service-worker/src/low_level.ts
+++ b/packages/service-worker/src/low_level.ts
@@ -15,7 +15,8 @@ export const ERR_SW_NOT_SUPPORTED = 'Service workers are disabled or not support
  * An event emitted when the service worker has checked the version of the app on the server and it
  * didn't find a new version that it doesn't have already downloaded.
  *
- * @see [Service Worker Communication Guide](/ecosystem/service-workers/communications)
+ * @see {@link /ecosystem/service-workers/communications Service Worker Communication Guide}
+
  *
  * @publicApi
  */
@@ -28,7 +29,8 @@ export interface NoNewVersionDetectedEvent {
  * An event emitted when the service worker has detected a new version of the app on the server and
  * is about to start downloading it.
  *
- * @see [Service Worker Communication Guide](/ecosystem/service-workers/communications)
+ * @see {@link /ecosystem/service-workers/communications Service Worker Communication Guide}
+
  *
  * @publicApi
  */
@@ -41,8 +43,8 @@ export interface VersionDetectedEvent {
  * An event emitted when the installation of a new version failed.
  * It may be used for logging/monitoring purposes.
  *
- * @see [Service Worker Communication Guide](/ecosystem/service-workers/communications)
- *
+ * @see {@link /ecosystem/service-workers/communications Service Worker Communication Guide}
+ *a
  * @publicApi
  */
 export interface VersionInstallationFailedEvent {
@@ -54,7 +56,8 @@ export interface VersionInstallationFailedEvent {
 /**
  * An event emitted when a new version of the app is available.
  *
- * @see [Service Worker Communication Guide](/ecosystem/service-workers/communications)
+ * @see {@link /ecosystem/service-workers/communications Service Worker Communication Guide}
+
  *
  * @publicApi
  */
@@ -85,7 +88,8 @@ export type VersionEvent =
  * service worker cache has been partially cleaned by the browser, removing some files of a previous
  * app version but not all.
  *
- * @see [Service Worker Communication Guide](/ecosystem/service-workers/communications)
+ * @see {@link /ecosystem/service-workers/communications Service Worker Communication Guide}
+
  *
  * @publicApi
  */

--- a/packages/service-worker/src/update.ts
+++ b/packages/service-worker/src/update.ts
@@ -20,7 +20,7 @@ import {
  * Subscribe to update notifications from the Service Worker, trigger update
  * checks, and forcibly activate updates.
  *
- * @see {@link ecosystem/service-workers/communications Service worker communication guide}
+ * @see [Service Worker Communication Guide](/ecosystem/service-workers/communications)
  *
  * @publicApi
  */

--- a/packages/service-worker/src/update.ts
+++ b/packages/service-worker/src/update.ts
@@ -20,7 +20,7 @@ import {
  * Subscribe to update notifications from the Service Worker, trigger update
  * checks, and forcibly activate updates.
  *
- * @see [Service Worker Communication Guide](/ecosystem/service-workers/communications)
+ * @see {@link /ecosystem/service-workers/communications Service Worker Communication Guide}
  *
  * @publicApi
  */

--- a/packages/upgrade/src/common/src/downgrade_component.ts
+++ b/packages/upgrade/src/common/src/downgrade_component.ts
@@ -78,7 +78,7 @@ import {
  *   <br />
  *   (This option is only necessary when using `downgradeModule()` to downgrade more than one
  *   Angular module.)
- * - `propagateDigest?: boolean`: Whether to perform {@link ChangeDetectorRef#detectChanges} on the
+ * - `propagateDigest?: boolean`: Whether to perform [`detectChanges`](/api/core/ChangeDetectorRef#detectChanges) on the
  * component on every
  *   [$digest](https://docs.angularjs.org/api/ng/type/$rootScope.Scope#$digest). If set to `false`,
  *   change detection will still be performed when any of the component's inputs changes.

--- a/packages/upgrade/src/common/src/downgrade_component.ts
+++ b/packages/upgrade/src/common/src/downgrade_component.ts
@@ -78,10 +78,9 @@ import {
  *   <br />
  *   (This option is only necessary when using `downgradeModule()` to downgrade more than one
  *   Angular module.)
- * - `propagateDigest?: boolean`: Whether to perform [`detectChanges`](/api/core/ChangeDetectorRef#detectChanges) on the
- * component on every
- *   [$digest](https://docs.angularjs.org/api/ng/type/$rootScope.Scope#$digest). If set to `false`,
- *   change detection will still be performed when any of the component's inputs changes.
+ * - `propagateDigest?: boolean`: Whether to perform {@link /api/core/ChangeDetectorRef#detectChanges detectChanges} on the
+ * component on every {@link https://docs.angularjs.org/api/ng/type/$rootScope.Scope#$digest $digest}.
+ *   If set to `false`, change detection will still be performed when any of the component's inputs changes.
  *   (Default: true)
  *
  * @returns a factory function that can be used to register the component in an

--- a/packages/upgrade/static/src/downgrade_module.ts
+++ b/packages/upgrade/static/src/downgrade_module.ts
@@ -128,7 +128,7 @@ let moduleUid = 0;
  *   {@link PlatformRef#bootstrapmodulefactory `bootstrapModuleFactory()`} to bootstrap the
  *   downgraded modules, each one is considered a "root" module. As a consequence, a new instance
  *   will be created for every injectable provided in `"root"` (via
- *   {@link Injectable#providedIn `providedIn`}).
+ *   [`providedIn`](/api/core/Injectable#providedIn)).
  *   If this is not your intention, you can have a shared module (that will act as act as the "root"
  *   module) and create all downgraded modules using that module's injector:
  *
@@ -244,7 +244,7 @@ export function downgradeModule<T>(
  *   {@link PlatformRef#bootstrapmodulefactory `bootstrapModuleFactory()`} to bootstrap the
  *   downgraded modules, each one is considered a "root" module. As a consequence, a new instance
  *   will be created for every injectable provided in `"root"` (via
- *   {@link Injectable#providedIn `providedIn`}).
+ *   [`providedIn`](/api/core/Injectable#providedIn)).
  *   If this is not your intention, you can have a shared module (that will act as act as the "root"
  *   module) and create all downgraded modules using that module's injector:
  *
@@ -361,7 +361,7 @@ export function downgradeModule<T>(moduleOrBootstrapFn: NgModuleFactory<T>): str
  *   {@link PlatformRef#bootstrapmodulefactory `bootstrapModuleFactory()`} to bootstrap the
  *   downgraded modules, each one is considered a "root" module. As a consequence, a new instance
  *   will be created for every injectable provided in `"root"` (via
- *   {@link Injectable#providedIn `providedIn`}).
+ *   [`providedIn`](/api/core/Injectable#providedIn)).
  *   If this is not your intention, you can have a shared module (that will act as act as the "root"
  *   module) and create all downgraded modules using that module's injector:
  *

--- a/packages/upgrade/static/src/downgrade_module.ts
+++ b/packages/upgrade/static/src/downgrade_module.ts
@@ -128,7 +128,7 @@ let moduleUid = 0;
  *   {@link PlatformRef#bootstrapmodulefactory `bootstrapModuleFactory()`} to bootstrap the
  *   downgraded modules, each one is considered a "root" module. As a consequence, a new instance
  *   will be created for every injectable provided in `"root"` (via
- *   [`providedIn`](/api/core/Injectable#providedIn)).
+ *   {@link /api/core/Injectable#providedIn providedIn}
  *   If this is not your intention, you can have a shared module (that will act as act as the "root"
  *   module) and create all downgraded modules using that module's injector:
  *
@@ -244,7 +244,7 @@ export function downgradeModule<T>(
  *   {@link PlatformRef#bootstrapmodulefactory `bootstrapModuleFactory()`} to bootstrap the
  *   downgraded modules, each one is considered a "root" module. As a consequence, a new instance
  *   will be created for every injectable provided in `"root"` (via
- *   [`providedIn`](/api/core/Injectable#providedIn)).
+ *   {@link /api/core/Injectable#providedIn providedIn}
  *   If this is not your intention, you can have a shared module (that will act as act as the "root"
  *   module) and create all downgraded modules using that module's injector:
  *
@@ -361,7 +361,7 @@ export function downgradeModule<T>(moduleOrBootstrapFn: NgModuleFactory<T>): str
  *   {@link PlatformRef#bootstrapmodulefactory `bootstrapModuleFactory()`} to bootstrap the
  *   downgraded modules, each one is considered a "root" module. As a consequence, a new instance
  *   will be created for every injectable provided in `"root"` (via
- *   [`providedIn`](/api/core/Injectable#providedIn)).
+ *   {@link /api/core/Injectable#providedIn providedIn}
  *   If this is not your intention, you can have a shared module (that will act as act as the "root"
  *   module) and create all downgraded modules using that module's injector:
  *


### PR DESCRIPTION
This PR fix is for the broken links on the API
pages mentioned in issue #57591. The fix works 
by replacing automatic linking with markdown links
for respective warning packages.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #57591


## What is the new behavior?
No more broken link warnings.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
NA
