### PR TITLE
docs: update i18n deployment docs to use subPath option

### DIFF
--- a/adev/src/content/examples/i18n/angular.json
+++ b/adev/src/content/examples/i18n/angular.json
@@ -3,29 +3,29 @@
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
   "newProjectRoot": "projects",
-  // #docregion locale-config, i18n-baseHref
+  // #docregion locale-config, i18n-subPath
   "projects": {
     "angular.io-example": {
-      // #enddocregion locale-config, i18n-baseHref
+      // #enddocregion locale-config, i18n-subPath
       "projectType": "application",
       "root": "",
       "sourceRoot": "src",
       "prefix": "app",
-      // #docregion locale-config, i18n-baseHref
+      // #docregion locale-config, i18n-subPath
       "i18n": {
         "sourceLocale": "en-US",
         "locales": {
           "fr": {
             "translation": "src/locale/messages.fr.xlf",
             // #enddocregion locale-config
-            "baseHref": ""
+            "subPath": ""
             // #docregion locale-config
           }
         }
       },
       // #docregion build-production-french
       "architect": {
-        // #enddocregion locale-config, i18n-baseHref
+        // #enddocregion locale-config, i18n-subPath
         // #docregion build-localize-true, build-single-locale, missing-translation-error
         "build": {
           // #enddocregion build-single-locale
@@ -132,12 +132,12 @@
             }
           }
         }
-        // #docregion locale-config, build-single-locale, build-production-french, i18n-baseHref
+        // #docregion locale-config, build-single-locale, build-production-french, i18n-subPath
       }
       // #enddocregion build-single-locale, build-production-french
     }
   }
-  // #enddocregion i18n-baseHref
-  // #docregion i18n-baseHref
+  // #enddocregion i18n-subPath
+  // #docregion i18n-subPath
 }
-// #enddocregion locale-config, i18n-baseHref
+// #enddocregion locale-config, i18n-subPath

--- a/adev/src/content/examples/i18n/doc-files/apache2.conf
+++ b/adev/src/content/examples/i18n/doc-files/apache2.conf
@@ -1,22 +1,32 @@
-# #docregion
+# docregion
 <VirtualHost *:80>
     ServerName localhost
     DocumentRoot /www/data
+
     <Directory "/www/data">
+        # Enable rewrite engine for URL manipulation
         RewriteEngine on
         RewriteBase /
+
+        # Serve 'index.html' for root-level access
         RewriteRule ^../index\.html$ - [L]
 
+        # If the requested file or directory does not exist, redirect to 'index.html'
         RewriteCond %{REQUEST_FILENAME} !-f
         RewriteCond %{REQUEST_FILENAME} !-d
         RewriteRule (..) $1/index.html [L]
 
+        # Language-based redirection based on HTTP Accept-Language header
+
+        # Redirect German users to the '/de/' directory
         RewriteCond %{HTTP:Accept-Language} ^de [NC]
         RewriteRule ^$ /de/ [R]
 
+        # Redirect English-speaking users to the '/en/' directory
         RewriteCond %{HTTP:Accept-Language} ^en [NC]
         RewriteRule ^$ /en/ [R]
 
+        # Redirect users with unsupported languages (not 'en' or 'de') to the '/fr/' directory
         RewriteCond %{HTTP:Accept-Language} !^en [NC]
         RewriteCond %{HTTP:Accept-Language} !^de [NC]
         RewriteRule ^$ /fr/ [R]

--- a/adev/src/content/examples/i18n/doc-files/nginx.conf
+++ b/adev/src/content/examples/i18n/doc-files/nginx.conf
@@ -5,7 +5,7 @@ http {
     map $http_accept_language $accept_language {
         ~*^de de;
         ~*^fr fr;
-        ~*^en en;
+        ~*^en "";
     }
     # ...
 }
@@ -25,7 +25,10 @@ server {
 
     # Everything under the Angular application is always redirected to Angular in the
     # correct language
-    location ~ ^/(fr|de|en) {
+    location ~ ^/(fr|de|$) {
+        if ($accept_language = "") {
+            try_files $uri /index.html?$args;
+        }
         try_files $uri /$1/index.html?$args;
     }
     # ...

--- a/adev/src/content/guide/i18n/deploy.md
+++ b/adev/src/content/guide/i18n/deploy.md
@@ -5,13 +5,11 @@ For example, your French version is located in the `myapp/fr` directory and the 
 
 The HTML `base` tag with the `href` attribute specifies the base URI, or URL, for relative links.
 If you set the `"localize"` option in [`angular.json`][GuideWorkspaceConfig] workspace build configuration file to `true` or to an array of locale IDs, the CLI adjusts the base `href` for each version of the application.
-To adjust the base `href` for each version of the application, the CLI adds the locale to the configured `"baseHref"`.
-Specify the `"baseHref"` for each locale in your [`angular.json`][GuideWorkspaceConfig] workspace build configuration file.
-The following example displays `"baseHref"` set to an empty string.
+To adjust the base `href` for each version of the application, the CLI adds the locale to the configured `"subPath"`.
+Specify the `"subPath"` for each locale in your [`angular.json`][GuideWorkspaceConfig] workspace build configuration file.
+The following example displays `"subPath"` set to an empty string.
 
-<docs-code header="angular.json" path="adev/src/content/examples/i18n/angular.json" visibleRegion="i18n-baseHref"/>
-
-Also, to declare the base `href` at compile time, use the CLI `--baseHref` option with [`ng build`][CliBuild].
+<docs-code header="angular.json" path="adev/src/content/examples/i18n/angular.json" visibleRegion="i18n-subPath"/>
 
 ## Configure a server
 
@@ -21,7 +19,9 @@ If the user has not defined a preferred language, or if the preferred language i
 To change the language, change your current location to another subdirectory.
 The change of subdirectory often occurs using a menu implemented in the application.
 
-HELPFUL: For more information on how to deploy apps to a remote server, see [Deployment][GuideDeployment].
+For more information on how to deploy apps to a remote server, see [Deployment][GuideDeployment].
+
+IMPORTANT: If you are using [Hybrid rendering](guide/hybrid-rendering) with `outputMode` set to `server`, Angular automatically handles redirection dynamically based on the `Accept-Language` HTTP header. This simplifies deployment by eliminating the need for manual server or configuration adjustments.
 
 ### Nginx example
 


### PR DESCRIPTION
This option replaces the baseHref option.
