### PR TITLE
fix(core): avoid triggering `on timer` and `on idle` on the server

### DIFF
--- a/packages/core/src/defer/triggering.ts
+++ b/packages/core/src/defer/triggering.ts
@@ -73,10 +73,16 @@ export function scheduleDelayedTrigger(
 ) {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
-  const injector = lView[INJECTOR];
-  const lDetails = getLDeferBlockDetails(lView, tNode);
 
   renderPlaceholder(lView, tNode);
+
+  // Exit early to avoid invoking `scheduleFn`, which would
+  // add `setTimeout` call and potentially delay serialization
+  // on the server unnecessarily.
+  if (!shouldTriggerDeferBlock(TriggerType.Regular, lView)) return;
+
+  const injector = lView[INJECTOR];
+  const lDetails = getLDeferBlockDetails(lView, tNode);
 
   const cleanupFn = scheduleFn(
     () => triggerDeferBlock(TriggerType.Regular, lView, tNode),


### PR DESCRIPTION
This commit updates defer block logic to avoid triggering `on idle` and `on timer` on the server for regular SSR mode (when incremental hydration is not enabled). Triggering the mentioned condition resulted in invoking `setTimeout` calls, which delayed serialization on the server during SSR (the process was waiting for the timeouts to clear).

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No