### PR TITLE
feat(core): extend the set of profiler events

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/hooks/profiler/native.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/hooks/profiler/native.ts
@@ -74,6 +74,96 @@ export class NgProfiler extends Profiler {
     });
   }
 
+  [ɵProfilerEvent.BootstrapApplicationStart](_directive: any, _hookOrListener: any): void {
+    // todo: implement
+    return;
+  }
+
+  [ɵProfilerEvent.BootstrapApplicationEnd](_directive: any, _hookOrListener: any): void {
+    // todo: implement
+    return;
+  }
+
+  [ɵProfilerEvent.BootstrapComponentStart](_directive: any, _hookOrListener: any): void {
+    // todo: implement
+    return;
+  }
+
+  [ɵProfilerEvent.BootstrapComponentEnd](_directive: any, _hookOrListener: any): void {
+    // todo: implement
+    return;
+  }
+
+  [ɵProfilerEvent.ChangeDetectionStart](_directive: any, _hookOrListener: any): void {
+    // todo: implement
+    return;
+  }
+
+  [ɵProfilerEvent.ChangeDetectionEnd](_directive: any, _hookOrListener: any): void {
+    // todo: implement
+    return;
+  }
+
+  [ɵProfilerEvent.ChangeDetectionSyncStart](_directive: any, _hookOrListener: any): void {
+    // todo: implement
+    return;
+  }
+
+  [ɵProfilerEvent.ChangeDetectionSyncEnd](_directive: any, _hookOrListener: any): void {
+    // todo: implement
+    return;
+  }
+
+  [ɵProfilerEvent.AfterRenderHooksStart](_directive: any, _hookOrListener: any): void {
+    // todo: implement
+    return;
+  }
+
+  [ɵProfilerEvent.AfterRenderHooksEnd](_directive: any, _hookOrListener: any): void {
+    // todo: implement
+    return;
+  }
+
+  [ɵProfilerEvent.ComponentStart](_directive: any, _hookOrListener: any): void {
+    // todo: implement
+    return;
+  }
+
+  [ɵProfilerEvent.ComponentEnd](_directive: any, _hookOrListener: any): void {
+    // todo: implement
+    return;
+  }
+
+  [ɵProfilerEvent.DeferBlockStateStart](_directive: any, _hookOrListener: any): void {
+    // todo: implement
+    return;
+  }
+
+  [ɵProfilerEvent.DeferBlockStateEnd](_directive: any, _hookOrListener: any): void {
+    // todo: implement
+    return;
+  }
+
+  [ɵProfilerEvent.DynamicComponentStart](_directive: any, _hookOrListener: any): void {
+    // todo: implement
+    return;
+  }
+
+  [ɵProfilerEvent.DynamicComponentEnd](_directive: any, _hookOrListener: any): void {
+    // todo: implement
+    return;
+  }
+
+  [ɵProfilerEvent.HostBindingsUpdateStart](_directive: any, _hookOrListener: any): void {
+    // todo: implement
+    return;
+  }
+
+  [ɵProfilerEvent.HostBindingsUpdateEnd](_directive: any, _hookOrListener: any): void {
+    // todo: implement
+    return;
+  }
+
   [ɵProfilerEvent.TemplateCreateStart](_directive: any, _hookOrListener: any): void {
     // todo: implement
     return;

--- a/packages/core/src/render3/profiler_types.ts
+++ b/packages/core/src/render3/profiler_types.ts
@@ -62,6 +62,98 @@ export const enum ProfilerEvent {
    * an event or an output.
    */
   OutputEnd,
+
+  /**
+   * Corresponds to the point in time just before application bootstrap.
+   */
+  BootstrapApplicationStart,
+
+  /**
+   * Corresponds to the point in time after application bootstrap.
+   */
+  BootstrapApplicationEnd,
+
+  /**
+   * Corresponds to the point in time just before root component bootstrap.
+   */
+  BootstrapComponentStart,
+
+  /**
+   * Corresponds to the point in time after root component bootstrap.
+   */
+  BootstrapComponentEnd,
+
+  /**
+   * Corresponds to the point in time just before Angular starts a change detection tick.
+   */
+  ChangeDetectionStart,
+
+  /**
+   * Corresponds to the point in time after Angular ended a change detection tick.
+   */
+  ChangeDetectionEnd,
+
+  /**
+   * Corresponds to the point in time just before Angular starts a new synchronization pass of change detection tick.
+   */
+  ChangeDetectionSyncStart,
+
+  /**
+   * Corresponds to the point in time after Angular ended a synchronization pass.
+   */
+  ChangeDetectionSyncEnd,
+
+  /**
+   * Corresponds to the point in time just before Angular executes after render hooks.
+   */
+  AfterRenderHooksStart,
+
+  /**
+   * Corresponds to the point in time after Angular executed after render hooks.
+   */
+  AfterRenderHooksEnd,
+
+  /**
+   * Corresponds to the point in time just before Angular starts processing a component (create or update).
+   */
+  ComponentStart,
+
+  /**
+   * Corresponds to the point in time after Angular finished processing a component.
+   */
+  ComponentEnd,
+
+  /**
+   * Corresponds to the point in time just before a defer block transitions between states.
+   */
+  DeferBlockStateStart,
+
+  /**
+   * Corresponds to the point in time after a defer block transitioned between states.
+   */
+  DeferBlockStateEnd,
+
+  /**
+   * Corresponds to the point in time just before a component instance is created dynamically.
+   */
+  DynamicComponentStart,
+
+  /**
+   * Corresponds to the point in time after a a component instance is created dynamically.
+   */
+  DynamicComponentEnd,
+
+  /**
+   * Corresponds to the point in time before the runtime has called the host bindings function
+   * of a directive.
+   */
+  HostBindingsUpdateStart,
+
+  /**
+   * Corresponds to the point in time after the runtime has called the host bindings function
+   * of a directive.
+   */
+  HostBindingsUpdateEnd,
 }
 
 /**


### PR DESCRIPTION
This commit extends the set of events understood by the profiler integrated with the Angular time. The set got extended to account for the recently added functionality and mark entry point to the code execution points.

The new set of events can be visualised by the Angular DevTools or other profiler integrations.
