### PR TITLE
feat(core): add utility for resolving defer block information to ng global

### DIFF
--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -48,6 +48,7 @@ import {
   getTDeferBlockDetails,
   setLDeferBlockDetails,
   setTDeferBlockDetails,
+  trackTriggerForDebugging,
 } from './utils';
 import {DEHYDRATED_BLOCK_REGISTRY, DehydratedBlockRegistry} from './registry';
 import {assertIncrementalHydrationIsConfigured, assertSsrIdDefined} from '../hydration/utils';
@@ -119,6 +120,7 @@ export function ɵɵdefer(
       loadingPromise: null,
       providers: null,
       hydrateTriggers: null,
+      debug: null,
       flags: flags ?? TDeferDetailsFlags.Default,
     };
     enableTimerScheduling?.(tView, tDetails, placeholderConfigIndex, loadingConfigIndex);
@@ -187,6 +189,10 @@ export function ɵɵdeferWhen(rawValue: unknown) {
   const lView = getLView();
   const tNode = getSelectedTNode();
 
+  if (ngDevMode) {
+    trackTriggerForDebugging(lView[TVIEW], tNode, 'when <expression>');
+  }
+
   if (!shouldAttachTrigger(TriggerType.Regular, lView, tNode)) return;
 
   const bindingIndex = nextBindingIndex();
@@ -220,6 +226,10 @@ export function ɵɵdeferPrefetchWhen(rawValue: unknown) {
   const lView = getLView();
   const tNode = getSelectedTNode();
 
+  if (ngDevMode) {
+    trackTriggerForDebugging(lView[TVIEW], tNode, 'prefetch when <expression>');
+  }
+
   if (!shouldAttachTrigger(TriggerType.Prefetch, lView, tNode)) return;
 
   const bindingIndex = nextBindingIndex();
@@ -248,6 +258,10 @@ export function ɵɵdeferPrefetchWhen(rawValue: unknown) {
 export function ɵɵdeferHydrateWhen(rawValue: unknown) {
   const lView = getLView();
   const tNode = getSelectedTNode();
+
+  if (ngDevMode) {
+    trackTriggerForDebugging(lView[TVIEW], tNode, 'hydrate when <expression>');
+  }
 
   if (!shouldAttachTrigger(TriggerType.Hydrate, lView, tNode)) return;
 
@@ -291,6 +305,10 @@ export function ɵɵdeferHydrateNever() {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
 
+  if (ngDevMode) {
+    trackTriggerForDebugging(lView[TVIEW], tNode, 'hydrate never');
+  }
+
   if (!shouldAttachTrigger(TriggerType.Hydrate, lView, tNode)) return;
 
   const hydrateTriggers = getHydrateTriggers(getTView(), tNode);
@@ -310,6 +328,10 @@ export function ɵɵdeferOnIdle() {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
 
+  if (ngDevMode) {
+    trackTriggerForDebugging(lView[TVIEW], tNode, 'on idle');
+  }
+
   if (!shouldAttachTrigger(TriggerType.Regular, lView, tNode)) return;
 
   scheduleDelayedTrigger(onIdle);
@@ -323,6 +345,10 @@ export function ɵɵdeferPrefetchOnIdle() {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
 
+  if (ngDevMode) {
+    trackTriggerForDebugging(lView[TVIEW], tNode, 'prefetch on idle');
+  }
+
   if (!shouldAttachTrigger(TriggerType.Prefetch, lView, tNode)) return;
 
   scheduleDelayedPrefetching(onIdle, DeferBlockTrigger.Idle);
@@ -335,6 +361,10 @@ export function ɵɵdeferPrefetchOnIdle() {
 export function ɵɵdeferHydrateOnIdle() {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
+
+  if (ngDevMode) {
+    trackTriggerForDebugging(lView[TVIEW], tNode, 'hydrate on idle');
+  }
 
   if (!shouldAttachTrigger(TriggerType.Hydrate, lView, tNode)) return;
 
@@ -357,6 +387,10 @@ export function ɵɵdeferOnImmediate() {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
 
+  if (ngDevMode) {
+    trackTriggerForDebugging(lView[TVIEW], tNode, 'on immediate');
+  }
+
   if (!shouldAttachTrigger(TriggerType.Regular, lView, tNode)) return;
 
   // Render placeholder block only if loading template is not present and we're on
@@ -377,6 +411,10 @@ export function ɵɵdeferPrefetchOnImmediate() {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
 
+  if (ngDevMode) {
+    trackTriggerForDebugging(lView[TVIEW], tNode, 'prefetch on immediate');
+  }
+
   if (!shouldAttachTrigger(TriggerType.Prefetch, lView, tNode)) return;
 
   const tView = lView[TVIEW];
@@ -394,6 +432,10 @@ export function ɵɵdeferPrefetchOnImmediate() {
 export function ɵɵdeferHydrateOnImmediate() {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
+
+  if (ngDevMode) {
+    trackTriggerForDebugging(lView[TVIEW], tNode, 'hydrate on immediate');
+  }
 
   if (!shouldAttachTrigger(TriggerType.Hydrate, lView, tNode)) return;
 
@@ -419,6 +461,10 @@ export function ɵɵdeferOnTimer(delay: number) {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
 
+  if (ngDevMode) {
+    trackTriggerForDebugging(lView[TVIEW], tNode, `on timer(${delay}ms)`);
+  }
+
   if (!shouldAttachTrigger(TriggerType.Regular, lView, tNode)) return;
 
   scheduleDelayedTrigger(onTimer(delay));
@@ -433,6 +479,10 @@ export function ɵɵdeferPrefetchOnTimer(delay: number) {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
 
+  if (ngDevMode) {
+    trackTriggerForDebugging(lView[TVIEW], tNode, `prefetch on timer(${delay}ms)`);
+  }
+
   if (!shouldAttachTrigger(TriggerType.Prefetch, lView, tNode)) return;
 
   scheduleDelayedPrefetching(onTimer(delay), DeferBlockTrigger.Timer);
@@ -446,6 +496,10 @@ export function ɵɵdeferPrefetchOnTimer(delay: number) {
 export function ɵɵdeferHydrateOnTimer(delay: number) {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
+
+  if (ngDevMode) {
+    trackTriggerForDebugging(lView[TVIEW], tNode, `hydrate on timer(${delay}ms)`);
+  }
 
   if (!shouldAttachTrigger(TriggerType.Hydrate, lView, tNode)) return;
 
@@ -469,6 +523,14 @@ export function ɵɵdeferHydrateOnTimer(delay: number) {
 export function ɵɵdeferOnHover(triggerIndex: number, walkUpTimes?: number) {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
+
+  if (ngDevMode) {
+    trackTriggerForDebugging(
+      lView[TVIEW],
+      tNode,
+      `on hover${walkUpTimes === -1 ? '' : '(<target>)'}`,
+    );
+  }
 
   if (!shouldAttachTrigger(TriggerType.Regular, lView, tNode)) return;
 
@@ -498,6 +560,14 @@ export function ɵɵdeferPrefetchOnHover(triggerIndex: number, walkUpTimes?: num
   const lView = getLView();
   const tNode = getCurrentTNode()!;
 
+  if (ngDevMode) {
+    trackTriggerForDebugging(
+      lView[TVIEW],
+      tNode,
+      `prefetch on hover${walkUpTimes === -1 ? '' : '(<target>)'}`,
+    );
+  }
+
   if (!shouldAttachTrigger(TriggerType.Prefetch, lView, tNode)) return;
 
   const tView = lView[TVIEW];
@@ -524,6 +594,10 @@ export function ɵɵdeferHydrateOnHover() {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
 
+  if (ngDevMode) {
+    trackTriggerForDebugging(lView[TVIEW], tNode, 'hydrate on hover');
+  }
+
   if (!shouldAttachTrigger(TriggerType.Hydrate, lView, tNode)) return;
 
   const hydrateTriggers = getHydrateTriggers(getTView(), tNode);
@@ -546,6 +620,14 @@ export function ɵɵdeferHydrateOnHover() {
 export function ɵɵdeferOnInteraction(triggerIndex: number, walkUpTimes?: number) {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
+
+  if (ngDevMode) {
+    trackTriggerForDebugging(
+      lView[TVIEW],
+      tNode,
+      `on interaction${walkUpTimes === -1 ? '' : '(<target>)'}`,
+    );
+  }
 
   if (!shouldAttachTrigger(TriggerType.Regular, lView, tNode)) return;
 
@@ -575,6 +657,14 @@ export function ɵɵdeferPrefetchOnInteraction(triggerIndex: number, walkUpTimes
   const lView = getLView();
   const tNode = getCurrentTNode()!;
 
+  if (ngDevMode) {
+    trackTriggerForDebugging(
+      lView[TVIEW],
+      tNode,
+      `prefetch on interaction${walkUpTimes === -1 ? '' : '(<target>)'}`,
+    );
+  }
+
   if (!shouldAttachTrigger(TriggerType.Prefetch, lView, tNode)) return;
 
   const tView = lView[TVIEW];
@@ -601,6 +691,10 @@ export function ɵɵdeferHydrateOnInteraction() {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
 
+  if (ngDevMode) {
+    trackTriggerForDebugging(lView[TVIEW], tNode, 'hydrate on interaction');
+  }
+
   if (!shouldAttachTrigger(TriggerType.Hydrate, lView, tNode)) return;
 
   const hydrateTriggers = getHydrateTriggers(getTView(), tNode);
@@ -623,6 +717,14 @@ export function ɵɵdeferHydrateOnInteraction() {
 export function ɵɵdeferOnViewport(triggerIndex: number, walkUpTimes?: number) {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
+
+  if (ngDevMode) {
+    trackTriggerForDebugging(
+      lView[TVIEW],
+      tNode,
+      `on viewport${walkUpTimes === -1 ? '' : '(<target>)'}`,
+    );
+  }
 
   if (!shouldAttachTrigger(TriggerType.Regular, lView, tNode)) return;
 
@@ -652,6 +754,14 @@ export function ɵɵdeferPrefetchOnViewport(triggerIndex: number, walkUpTimes?: 
   const lView = getLView();
   const tNode = getCurrentTNode()!;
 
+  if (ngDevMode) {
+    trackTriggerForDebugging(
+      lView[TVIEW],
+      tNode,
+      `prefetch on viewport${walkUpTimes === -1 ? '' : '(<target>)'}`,
+    );
+  }
+
   if (!shouldAttachTrigger(TriggerType.Prefetch, lView, tNode)) return;
 
   const tView = lView[TVIEW];
@@ -677,6 +787,10 @@ export function ɵɵdeferPrefetchOnViewport(triggerIndex: number, walkUpTimes?: 
 export function ɵɵdeferHydrateOnViewport() {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
+
+  if (ngDevMode) {
+    trackTriggerForDebugging(lView[TVIEW], tNode, 'hydrate on viewport');
+  }
 
   if (!shouldAttachTrigger(TriggerType.Hydrate, lView, tNode)) return;
 

--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -119,7 +119,6 @@ export function ɵɵdefer(
       loadingPromise: null,
       providers: null,
       hydrateTriggers: null,
-      prefetchTriggers: null,
       flags: flags ?? TDeferDetailsFlags.Default,
     };
     enableTimerScheduling?.(tView, tDetails, placeholderConfigIndex, loadingConfigIndex);

--- a/packages/core/src/defer/interfaces.ts
+++ b/packages/core/src/defer/interfaces.ts
@@ -141,11 +141,6 @@ export interface TDeferBlockDetails {
   hydrateTriggers: Map<DeferBlockTrigger, HydrateTriggerDetails | null> | null;
 
   /**
-   * List of prefetch triggers for a given block
-   */
-  prefetchTriggers: Set<DeferBlockTrigger> | null;
-
-  /**
    * Defer block flags, which should be used for all
    * instances of a given defer block (the flags that should be
    * placed into the `TDeferDetails` at runtime).

--- a/packages/core/src/defer/interfaces.ts
+++ b/packages/core/src/defer/interfaces.ts
@@ -146,6 +146,14 @@ export interface TDeferBlockDetails {
    * placed into the `TDeferDetails` at runtime).
    */
   flags: TDeferDetailsFlags;
+
+  /**
+   * Tracks debugging information about the deferred block.
+   */
+  debug: {
+    /** Text representations of the block's triggers. */
+    triggers?: Set<string>;
+  } | null;
 }
 
 /**

--- a/packages/core/src/defer/utils.ts
+++ b/packages/core/src/defer/utils.ts
@@ -181,3 +181,16 @@ export function isDeferBlock(tView: TView, tNode: TNode): boolean {
   }
   return !!tDetails && isTDeferBlockDetails(tDetails);
 }
+
+/**
+ * Tracks debugging information about a trigger.
+ * @param tView TView in which the trigger is declared.
+ * @param tNode TNode on which the trigger is declared.
+ * @param textRepresentation Text representation of the trigger to be used for debugging purposes.
+ */
+export function trackTriggerForDebugging(tView: TView, tNode: TNode, textRepresentation: string) {
+  const tDetails = getTDeferBlockDetails(tView, tNode);
+  tDetails.debug ??= {};
+  tDetails.debug.triggers ??= new Set();
+  tDetails.debug.triggers.add(textRepresentation);
+}

--- a/packages/core/src/render3/util/defer.ts
+++ b/packages/core/src/render3/util/defer.ts
@@ -1,0 +1,205 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {DeferBlockDetails, getDeferBlocks as getDeferBlocksInternal} from '../../defer/discovery';
+import {
+  DEFER_BLOCK_STATE,
+  DeferBlockInternalState,
+  DeferBlockState,
+  DeferBlockTrigger,
+  LDeferBlockDetails,
+  LOADING_AFTER_SLOT,
+  MINIMUM_SLOT,
+  SSR_UNIQUE_ID,
+  TDeferBlockDetails,
+} from '../../defer/interfaces';
+import {DEHYDRATED_BLOCK_REGISTRY, DehydratedBlockRegistry} from '../../defer/registry';
+import {getLDeferBlockDetails} from '../../defer/utils';
+import {assertLView} from '../assert';
+import {collectNativeNodes} from '../collect_native_nodes';
+import {getLContext} from '../context_discovery';
+import {CONTAINER_HEADER_OFFSET} from '../interfaces/container';
+import {INJECTOR, LView, TVIEW} from '../interfaces/view';
+import {getNativeByTNode} from './view_utils';
+
+/** Retrieved information about a `@defer` block. */
+interface DeferBlockData {
+  /** Current state of the block. */
+  state: 'placeholder' | 'loading' | 'complete' | 'error' | 'initial';
+
+  /** Hydration state of the block. */
+  incrementalHydrationState: 'not-configured' | 'hydrated' | 'dehydrated';
+
+  /** Wherther the block has a connected `@error` block. */
+  hasErrorBlock: boolean;
+
+  /** Information about the connected `@loading` block. */
+  loadingBlock: {
+    /** Whether the block is defined. */
+    exists: boolean;
+
+    /** Minimum amount of milliseconds that the block should be shown. */
+    minimumTime: number | null;
+
+    /** Amount of time after which the block should be shown. */
+    afterTime: number | null;
+  };
+
+  /** Information about the connected `@placeholder` block. */
+  placeholderBlock: {
+    /** Whether the block is defined. */
+    exists: boolean;
+
+    /** Minimum amount of time that block should be shown. */
+    minimumTime: number | null;
+  };
+
+  /** Stringified version of the block's triggers. */
+  triggers: string[];
+
+  /** Element root nodes that are currently being shown in the block. */
+  rootNodes: Node[];
+}
+
+/**
+ * Gets all of the `@defer` blocks that are present inside the specified DOM node.
+ * @param node Node in which to look for `@defer` blocks.
+ *
+ * @publicApi
+ */
+export function getDeferBlocks(node: Node): DeferBlockData[] {
+  const results: DeferBlockData[] = [];
+  const lView = getLContext(node)?.lView;
+
+  if (lView) {
+    findDeferBlocks(node, lView, results);
+  }
+
+  return results;
+}
+
+/**
+ * Finds all the `@defer` blocks inside a specific node and view.
+ * @param node Node in which to search for blocks.
+ * @param lView View within the node in which to search for blocks.
+ * @param results Array to which to add blocks once they're found.
+ */
+function findDeferBlocks(node: Node, lView: LView, results: DeferBlockData[]) {
+  const registry = lView[INJECTOR].get(DEHYDRATED_BLOCK_REGISTRY, null, {optional: true});
+  const blocks: DeferBlockDetails[] = [];
+  getDeferBlocksInternal(lView, blocks);
+
+  for (const details of blocks) {
+    const native = getNativeByTNode(details.tNode, details.lView);
+    const lDetails = getLDeferBlockDetails(details.lView, details.tNode);
+
+    // The LView from `getLContext` might be the view the element is placed in.
+    // Filter out defer blocks that aren't inside the specified root node.
+    if (!node.contains(native as Node)) {
+      continue;
+    }
+
+    const tDetails = details.tDetails;
+    const renderedLView = getRendererLView(details);
+    const rootNodes: Node[] = [];
+
+    if (renderedLView !== null) {
+      collectNativeNodes(
+        renderedLView[TVIEW],
+        renderedLView,
+        renderedLView[TVIEW].firstChild,
+        rootNodes,
+      );
+    }
+
+    const data: DeferBlockData = {
+      state: stringifyState(lDetails[DEFER_BLOCK_STATE]),
+      incrementalHydrationState: inferHydrationState(tDetails, lDetails, registry),
+      hasErrorBlock: tDetails.errorTmplIndex !== null,
+      loadingBlock: {
+        exists: tDetails.loadingTmplIndex !== null,
+        minimumTime: tDetails.loadingBlockConfig?.[MINIMUM_SLOT] ?? null,
+        afterTime: tDetails.loadingBlockConfig?.[LOADING_AFTER_SLOT] ?? null,
+      },
+      placeholderBlock: {
+        exists: tDetails.placeholderTmplIndex !== null,
+        minimumTime: tDetails.placeholderBlockConfig?.[MINIMUM_SLOT] ?? null,
+      },
+      triggers: tDetails.debug?.triggers ? Array.from(tDetails.debug.triggers).sort() : [],
+      rootNodes,
+    };
+
+    results.push(data);
+
+    // `getDeferBlocks` does not resolve nested defer blocks so we have to recurse manually.
+    if (renderedLView !== null) {
+      findDeferBlocks(node, renderedLView, results);
+    }
+  }
+}
+
+/**
+ * Turns the `DeferBlockState` into a string which is more readable than the enum form.
+ *
+ * @param lDetails Information about the
+ * @returns
+ */
+function stringifyState(state: DeferBlockState | DeferBlockInternalState): DeferBlockData['state'] {
+  switch (state) {
+    case DeferBlockState.Complete:
+      return 'complete';
+    case DeferBlockState.Loading:
+      return 'loading';
+    case DeferBlockState.Placeholder:
+      return 'placeholder';
+    case DeferBlockState.Error:
+      return 'error';
+    case DeferBlockInternalState.Initial:
+      return 'initial';
+    default:
+      throw new Error(`Unrecognized state ${state}`);
+  }
+}
+
+/**
+ * Infers the hydration state of a specific defer block.
+ * @param tDetails Static defer block information.
+ * @param lDetails Instance defer block information.
+ * @param registry Registry coordinating the hydration of defer blocks.
+ */
+function inferHydrationState(
+  tDetails: TDeferBlockDetails,
+  lDetails: LDeferBlockDetails,
+  registry: DehydratedBlockRegistry | null,
+): DeferBlockData['incrementalHydrationState'] {
+  if (
+    registry === null ||
+    lDetails[SSR_UNIQUE_ID] === null ||
+    tDetails.hydrateTriggers === null ||
+    tDetails.hydrateTriggers.has(DeferBlockTrigger.Never)
+  ) {
+    return 'not-configured';
+  }
+  return registry.has(lDetails[SSR_UNIQUE_ID]) ? 'dehydrated' : 'hydrated';
+}
+
+/**
+ * Gets the current LView that is rendered out in a defer block.
+ * @param details Instance information about the block.
+ */
+function getRendererLView(details: DeferBlockDetails): LView | null {
+  // Defer block containers can only ever contain one view.
+  // If they're empty, it means that nothing is rendered.
+  if (details.lContainer.length <= CONTAINER_HEADER_OFFSET) {
+    return null;
+  }
+
+  const lView = details.lContainer[CONTAINER_HEADER_OFFSET];
+  ngDevMode && assertLView(lView);
+  return lView;
+}

--- a/packages/core/src/render3/util/global_utils.ts
+++ b/packages/core/src/render3/util/global_utils.ts
@@ -12,6 +12,7 @@ import {setProfiler} from '../profiler';
 import {isSignal} from '../reactivity/api';
 
 import {applyChanges} from './change_detection_utils';
+import {getDeferBlocks} from './defer';
 import {
   getComponent,
   getContext,
@@ -67,6 +68,7 @@ const globalUtilsFunctions = {
   'ɵgetInjectorMetadata': getInjectorMetadata,
   'ɵsetProfiler': setProfiler,
   'ɵgetSignalGraph': getSignalGraph,
+  'ɵgetDeferBlocks': getDeferBlocks,
 
   'getDirectiveMetadata': getDirectiveMetadata,
   'getComponent': getComponent,

--- a/packages/core/test/acceptance/defer_utils_spec.ts
+++ b/packages/core/test/acceptance/defer_utils_spec.ts
@@ -1,0 +1,318 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+import {Component} from '@angular/core';
+import {DeferBlockBehavior, DeferBlockState, TestBed} from '@angular/core/testing';
+
+import {getDeferBlocks} from '../../src/render3/util/defer';
+
+describe('@defer debugging utilities', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      deferBlockBehavior: DeferBlockBehavior.Manual,
+    });
+  });
+
+  it('should get current state of a defer block', async () => {
+    @Component({
+      template: `
+        <section>
+          @defer (when false) {
+            Loaded
+          } @placeholder {
+            Placeholder
+          } @loading {
+            Loading
+          }
+        </section>
+      `,
+    })
+    class App {}
+
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    const [block] = await fixture.getDeferBlocks();
+
+    await block.render(DeferBlockState.Placeholder);
+    expect(getDeferBlocks(fixture.nativeElement)[0].state).toBe('placeholder');
+
+    await block.render(DeferBlockState.Loading);
+    expect(getDeferBlocks(fixture.nativeElement)[0].state).toBe('loading');
+
+    await block.render(DeferBlockState.Complete);
+    expect(getDeferBlocks(fixture.nativeElement)[0].state).toBe('complete');
+  });
+
+  it('should expose which blocks are connected to the defer block', () => {
+    @Component({
+      template: `
+        @defer (when false) {
+          No connected
+        }
+
+        @defer (when false) {
+          Has loading
+        } @loading (minimum 2s; after 1s) {
+          Loading
+        }
+
+        @defer (when false) {
+          Has all
+        } @placeholder (minimum 500) {
+          Placeholder
+        } @loading {
+          Loading
+        } @error {
+          Error
+        }
+      `,
+    })
+    class App {}
+
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    const blocks = getDeferBlocks(fixture.nativeElement);
+    expect(blocks.length).toBe(3);
+    expect(blocks[0]).toEqual(
+      jasmine.objectContaining({
+        loadingBlock: {exists: false, minimumTime: null, afterTime: null},
+        placeholderBlock: {exists: false, minimumTime: null},
+        hasErrorBlock: false,
+      }),
+    );
+    expect(blocks[1]).toEqual(
+      jasmine.objectContaining({
+        loadingBlock: {exists: true, minimumTime: 2000, afterTime: 1000},
+        placeholderBlock: {exists: false, minimumTime: null},
+        hasErrorBlock: false,
+      }),
+    );
+    expect(blocks[2]).toEqual(
+      jasmine.objectContaining({
+        loadingBlock: {exists: true, minimumTime: null, afterTime: null},
+        placeholderBlock: {exists: true, minimumTime: 500},
+        hasErrorBlock: true,
+      }),
+    );
+  });
+
+  it('should expose the triggers that were registered on the defer block', async () => {
+    @Component({
+      template: `
+        <section>
+          @defer (when false; on timer(500); on interaction) {
+            Loaded
+          } @placeholder {
+            <button>Load</button>
+          }
+        </section>
+      `,
+    })
+    class App {}
+
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    const blocks = getDeferBlocks(fixture.nativeElement);
+    expect(blocks.length).toBe(1);
+    expect(blocks[0].triggers).toEqual(['on interaction', 'on timer(500ms)', 'when <expression>']);
+  });
+
+  it('should return deferred blocks only under the specified DOM node', async () => {
+    @Component({
+      template: `
+        <section>
+          <div>
+            <header>
+              @defer (when false) {
+                Loaded
+              } @placeholder {
+                Placeholder
+              }
+            </header>
+          </div>
+
+          @defer (when false) {
+            Loaded
+          } @placeholder {
+            Placeholder
+          }
+        </section>
+
+        <button>Hello</button>
+      `,
+    })
+    class App {}
+
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    const blocks = await fixture.getDeferBlocks();
+
+    // Render out one of the blocks so we can distinguish them.
+    await blocks[1].render(DeferBlockState.Complete);
+
+    const section = fixture.nativeElement.querySelector('section');
+    const header = section.querySelector('header');
+    const button = fixture.nativeElement.querySelector('button');
+
+    expect(getDeferBlocks(section)).toEqual([
+      jasmine.objectContaining({state: 'placeholder'}),
+      jasmine.objectContaining({state: 'complete'}),
+    ]);
+    expect(getDeferBlocks(header)).toEqual([jasmine.objectContaining({state: 'placeholder'})]);
+    expect(getDeferBlocks(button)).toEqual([]);
+  });
+
+  it('should be able to resolve defer blocks inside embedded views', () => {
+    @Component({
+      template: `
+        <section>
+          @if (true) {
+            <div>
+              @switch (1) {
+                @case (1) {
+                  @if (true) {
+                    @defer (when false) {
+                      Loaded
+                    } @placeholder {
+                      Placeholder
+                    }
+                  }
+                }
+              }
+            </div>
+          }
+        </section>
+      `,
+    })
+    class App {}
+
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    expect(getDeferBlocks(fixture.nativeElement)).toEqual([
+      jasmine.objectContaining({state: 'placeholder'}),
+    ]);
+  });
+
+  it('should be able to resolve a defer block nested inside of another defer block', async () => {
+    @Component({
+      template: `
+        <section>
+          @defer (when false) {
+            Loaded root
+
+            @defer (when false) {
+              Loaded inner
+            } @placeholder {
+              Placeholder inner
+            }
+          } @placeholder {
+            Placeholder root
+          }
+        </section>
+      `,
+    })
+    class App {}
+
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    const [root] = await fixture.getDeferBlocks();
+
+    expect(getDeferBlocks(fixture.nativeElement)).toEqual([
+      jasmine.objectContaining({state: 'placeholder'}),
+    ]);
+
+    await root.render(DeferBlockState.Complete);
+    fixture.detectChanges();
+
+    expect(getDeferBlocks(fixture.nativeElement)).toEqual([
+      jasmine.objectContaining({state: 'complete'}),
+      jasmine.objectContaining({state: 'placeholder'}),
+    ]);
+  });
+
+  it('should return the root nodes of the currently-rendered block', async () => {
+    @Component({
+      template: `
+        Before
+        @defer (when false) {
+          <button>One</button>
+          Loaded
+          <span>Two</span>
+        } @placeholder {
+          Placeholder text
+        }
+        After
+      `,
+    })
+    class App {}
+
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    let results = getDeferBlocks(fixture.nativeElement);
+    expect(results.length).toBe(1);
+    expect(results[0].state).toBe('placeholder');
+    expect(stringifyNodes(results[0].rootNodes)).toEqual(['Text(Placeholder text)']);
+
+    const [block] = await fixture.getDeferBlocks();
+    await block.render(DeferBlockState.Complete);
+
+    results = getDeferBlocks(fixture.nativeElement);
+    expect(results.length).toBe(1);
+    expect(results[0].state).toBe('complete');
+    expect(stringifyNodes(results[0].rootNodes)).toEqual([
+      'Element(button, One)',
+      'Text(Loaded)',
+      'Element(span, Two)',
+    ]);
+  });
+
+  it('should skip over TNodes that do not correspond to DOM nodes', async () => {
+    @Component({
+      template: `
+        Before
+        @defer (when false) {
+          Loaded
+        } @placeholder {
+          @let one = 1;
+          One is {{one}}
+          @let two = one + 1;
+          Two is {{two}}
+        }
+        After
+      `,
+    })
+    class App {}
+
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    let results = getDeferBlocks(fixture.nativeElement);
+    expect(results.length).toBe(1);
+    expect(results[0].state).toBe('placeholder');
+    expect(stringifyNodes(results[0].rootNodes)).toEqual(['Text(One is 1)', 'Text(Two is 2)']);
+
+    const [block] = await fixture.getDeferBlocks();
+    await block.render(DeferBlockState.Complete);
+  });
+
+  function stringifyNodes(nodes: Node[]): string[] {
+    return nodes.map((node) => {
+      switch (node.nodeType) {
+        case document.COMMENT_NODE:
+          return `Comment(${node.textContent?.trim()})`;
+        case document.ELEMENT_NODE:
+          return `Element(${node.nodeName.toLowerCase()}, ${node.textContent?.trim()})`;
+        case document.TEXT_NODE:
+          return `Text(${node.textContent?.trim()})`;
+        default:
+          throw new Error('Unsupported node. Function may need to be updated.');
+      }
+    });
+  }
+});

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -448,6 +448,7 @@
   "init_def_getters",
   "init_default_iterable_differ",
   "init_default_keyvalue_differ",
+  "init_defer",
   "init_defer_component",
   "init_definition",
   "init_definition_factory",

--- a/packages/core/test/render3/global_utils_spec.ts
+++ b/packages/core/test/render3/global_utils_spec.ts
@@ -6,8 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {setProfiler} from '@angular/core/src/render3/profiler';
-
 import {applyChanges} from '../../src/render3/util/change_detection_utils';
 import {
   getComponent,
@@ -26,6 +24,8 @@ import {
   publishDefaultGlobalUtils,
   publishGlobalUtil,
 } from '../../src/render3/util/global_utils';
+import {setProfiler} from '../../src/render3/profiler';
+import {getDeferBlocks} from '../../src/render3/util/defer';
 import {global} from '../../src/util/global';
 
 type GlobalUtilFunctions = keyof GlobalDevModeUtils['ng'];
@@ -87,6 +87,10 @@ describe('global utils', () => {
 
     it('should publish ɵsetProfiler', () => {
       assertPublished('ɵsetProfiler', setProfiler);
+    });
+
+    it('should publish ɵgetDeferBlocks', () => {
+      assertPublished('ɵgetDeferBlocks', getDeferBlocks);
     });
   });
 });


### PR DESCRIPTION
Adds the `getDeferBlocks` function to the global `ng` namespace which returns information about all `@defer` blocks inside of a DOM node. This information can be useful either directly in the browser console or to implement future functionality in the dev tools.

Also includes the following supporting changes:

### refactor(core): remove unused field 
Removes the `prefetchTriggers` field from the `TDeferBlockDetails` since we weren't reading or writing to it anywhere.

### refactor(core): track debugging information about deferred triggers 
Adds a field on the `TDeferBlockDetails` where we can track debugging information about the defer block. Also uses it to store text representation of the different triggers which can be shown to the dev tools.