### PR TITLE
docs: Fix Dependency Injection Readme guide link

### DIFF
--- a/adev/src/content/guide/ngmodules/overview.md
+++ b/adev/src/content/guide/ngmodules/overview.md
@@ -107,7 +107,7 @@ export class CustomMenuModule { }
 
 ## `NgModule` providers
 
-Tip: See the [Dependency Injection guide](guides/di) for information on dependency injection and providers.
+Tip: See the [Dependency Injection guide](guide/di) for information on dependency injection and providers.
 
 An `NgModule` can specify `providers` for injected dependencies. These providers are available to:
 * Any standalone component, directive, or pipe that imports the NgModule, and


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [X ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently when you click on "Dependency Injection guide" on this [page](https://angular.dev/guide/ngmodules/overview#ngmodule-providers), it routes you to `https://angular.dev/guides/di ` instead of `https://angular.dev/guide/di` which is the correct page


Issue Number: https://github.com/angular/angular/issues/59139


## What is the new behavior?
It correctly routes to the right page/route - https://angular.dev/guide/di


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
