### PR TITLE
docs(docs-infra): fix scrolling issues in the API reference

### DIFF
--- a/adev/src/app/app-scroller.ts
+++ b/adev/src/app/app-scroller.ts
@@ -22,10 +22,11 @@ export class AppScroller {
   private readonly viewportScroller = inject(ViewportScroller);
   private readonly appRef = inject(ApplicationRef);
   private readonly injector = inject(EnvironmentInjector);
-  disableScrolling = false;
+
   private _lastScrollEvent?: Scroll;
   private canScroll = false;
   private cancelScroll?: () => void;
+
   get lastScrollEvent(): Scroll | undefined {
     return this._lastScrollEvent;
   }
@@ -40,7 +41,6 @@ export class AppScroller {
           this.canScroll = true;
           this._lastScrollEvent = e;
         }),
-        filter(() => !this.disableScrolling),
         filter(() => {
           const info = this.router.lastSuccessfulNavigation?.extras.info as Record<
             'disableScrolling',

--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.ts
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.ts
@@ -21,7 +21,6 @@ import {
   API_TAB_CLASS_NAME,
   API_REFERENCE_TAB_URL_ATTRIBUTE,
 } from '../constants/api-reference-prerender.constants';
-import {AppScroller} from '../../../app-scroller';
 
 @Component({
   selector: 'adev-reference-page',
@@ -36,7 +35,6 @@ export default class ApiReferenceDetailsPage {
   private readonly document = inject(DOCUMENT);
   private readonly router = inject(Router);
   private readonly scrollHandler = inject(ReferenceScrollHandler);
-  private readonly appScroller = inject(AppScroller);
 
   docContent = input<DocContent | undefined>();
   tab = input<string | undefined>();
@@ -95,14 +93,6 @@ export default class ApiReferenceDetailsPage {
     const activeTabTitle = this.tabs()[this.selectedTabIndex()]?.title;
     return activeTabTitle === API_REFERENCE_TAB_API_LABEL || activeTabTitle === 'CLI';
   });
-
-  constructor() {
-    this.appScroller.disableScrolling = true;
-  }
-
-  ngOnDestroy() {
-    this.appScroller.disableScrolling = false;
-  }
 
   membersCardsLoaded(): void {
     this.scrollHandler.setupListeners(API_TAB_CLASS_NAME);

--- a/adev/src/app/features/references/api-reference-list/api-reference-list.component.html
+++ b/adev/src/app/features/references/api-reference-list/api-reference-list.component.html
@@ -4,7 +4,12 @@
 
 <div class="adev-reference-list-filter">
   <div class="adev-reference-list-query-filter">
-    <docs-text-field name="query" placeholder="Filter" [(ngModel)]="query" />
+    <docs-text-field
+      name="query"
+      placeholder="Filter"
+      [(ngModel)]="query"
+      (ngModelChange)="syncUrlWithFilters()"
+    />
 
     <docs-slide-toggle
       buttonId="includeDeprecated"

--- a/adev/src/app/features/references/api-reference-list/api-reference-list.component.spec.ts
+++ b/adev/src/app/features/references/api-reference-list/api-reference-list.component.spec.ts
@@ -8,13 +8,15 @@
 
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
-import ApiReferenceList, {ALL_STATUSES_KEY} from './api-reference-list.component';
+import ApiReferenceList, {ALL_TYPES_KEY} from './api-reference-list.component';
 import {ApiReferenceManager} from './api-reference-manager.service';
 import {signal} from '@angular/core';
 import {ApiItemType} from '../interfaces/api-item-type';
 import {RouterTestingHarness} from '@angular/router/testing';
 import {provideRouter} from '@angular/router';
 import {Location} from '@angular/common';
+import {By} from '@angular/platform-browser';
+import {TextField} from '@angular/docs';
 
 describe('ApiReferenceList', () => {
   let component: ApiReferenceList;
@@ -103,7 +105,7 @@ describe('ApiReferenceList', () => {
   });
 
   it('should set selected type when provided type is different than selected', async () => {
-    expect(component.type()).toBe(ALL_STATUSES_KEY);
+    expect(component.type()).toBe(ALL_TYPES_KEY);
     component.filterByItemType(ApiItemType.BLOCK);
     await RouterTestingHarness.create(`/api?type=${ApiItemType.BLOCK}`);
     expect(component.type()).toBe(ApiItemType.BLOCK);
@@ -116,12 +118,15 @@ describe('ApiReferenceList', () => {
 
     component.filterByItemType(ApiItemType.BLOCK);
     harness.navigateByUrl(`/api`);
-    expect(component.type()).toBe(ALL_STATUSES_KEY);
+    expect(component.type()).toBe(ALL_TYPES_KEY);
   });
 
-  it('should set the value of the queryParam equal to the query value', async () => {
+  it('should set the value of the queryParam equal to the query text field', async () => {
     const location = TestBed.inject(Location);
-    component.query.set('item1');
+
+    const textField = fixture.debugElement.query(By.directive(TextField));
+    (textField.componentInstance as TextField).setValue('item1');
+
     await fixture.whenStable();
     expect(location.path()).toBe(`?query=item1&type=All`);
   });
@@ -129,7 +134,8 @@ describe('ApiReferenceList', () => {
   it('should keep the values of existing queryParams and set new queryParam equal to the type', async () => {
     const location = TestBed.inject(Location);
 
-    component.query.set('item1');
+    const textField = fixture.debugElement.query(By.directive(TextField));
+    (textField.componentInstance as TextField).setValue('item1');
     await fixture.whenStable();
     expect(location.path()).toBe(`?query=item1&type=All`);
 

--- a/adev/src/app/features/references/services/reference-scroll-handler.service.ts
+++ b/adev/src/app/features/references/services/reference-scroll-handler.service.ts
@@ -41,7 +41,7 @@ export class ReferenceScrollHandler {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((fragment) => {
         // If there is no fragment or the scroll event has a position (traversing through history),
-        // allow the scroller to handler scrolling instead of going to the fragment
+        // allow the scroller to handle scrolling instead of going to the fragment
         if (!fragment || this.appScroller.lastScrollEvent?.position) {
           this.appScroller.scroll();
           return;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

1. When navigating to the API details page, the page is scrolled down, if the API item link is located down the API list (i.e. the scroll is preserved; it shouldn't be).
2. The API list page scroll position is not preserved. 

## What is the new behavior?

It seems that some of the changes in the last few months resulted in some scrolling regressions, so I pinpointed the culprits and introduced some bug fixes. Some of the functionality rendered redundant, so it was dropped.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No