### PR TITLE
docs: add anti-patterns and notes about 3rd party scripts

### DIFF
--- a/adev/src/content/guide/hydration.md
+++ b/adev/src/content/guide/hydration.md
@@ -99,10 +99,11 @@ As an example, here are some of the most common cases of this issue.
 
 - `<table>` without a `<tbody>`
 - `<div>` inside a `<p>`
-- `<a>` inside an `<h1>`
 - `<a>` inside another `<a>`
 
 If you are uncertain about whether your HTML is valid, you can use a [syntax validator](https://validator.w3.org/) to check it.
+
+Note: While the HTML standard does not require the `<tbody>` element inside tables, modern browsers automatically create a `<tbody>` element in tables that do not declare one. Because of this inconsistency, always explicitly declare a `<tbody>` element in tables to avoid hydration errors.
 
 ### Preserve Whitespaces Configuration
 
@@ -150,6 +151,10 @@ The `ngSkipHydration` attribute can only be used on component host nodes. Angula
 
 Keep in mind that adding the `ngSkipHydration` attribute to your root application component would effectively disable hydration for your entire application. Be careful and thoughtful about using this attribute. It is intended as a last resort workaround. Components that break hydration should be considered bugs that need to be fixed.
 
+## Hydration Timing and Application Stability
+
+Application stability is an important part of the hydration process. Hydration and any post-hydration processes only occur once the application has reported stability. There are a number of ways that stability can be delayed. Examples include setting timeouts and intervals, unresolved promises, and pending microtasks. In those cases, you may encounter the [Application remains unstable](errors/NG0506) error, which indicates that your app has not yet reached the stable state after 10 seconds. If you're finding that your application is not hydrating right away, take a look at what is impacting application stability and refactor to avoid causing these delays.
+
 ## I18N
 
 HELPFUL: Support for internationalization with hydration is currently in [developer preview](/reference/releases#developer-preview). By default, Angular will skip hydration for components that use i18n blocks, effectively re-rendering those components from scratch.
@@ -169,9 +174,16 @@ bootstrapApplication(AppComponent, {
 });
 ```
 
+## Consistent rendering across server-side and client-side
+Avoid introducing `@if` blocks and other conditionals that display different content when server-side rendering than client-side rendering, such as using an `@if` block with Angular's `isPlatformBrowser` function. These rendering differences cause layout shifts, negatively impacting end-user experience and core web vitals.
+
 ## Third Party Libraries with DOM Manipulation
 
 There are a number of third party libraries that depend on DOM manipulation to be able to render. D3 charts is a prime example. These libraries worked without hydration, but they may cause DOM mismatch errors when hydration is enabled. For now, if you encounter DOM mismatch errors using one of these libraries, you can add the `ngSkipHydration` attribute to the component that renders using that library.
+
+## Third Party Scripts with DOM Manipulation
+
+Many third party scripts, such as ad trackers and analytics, modify the DOM before hydration can occur. These scripts may cause hydration errors because the page no longer matches the structure expected by Angular. Prefer deferring this type of script until after hydration whenever possible. Consider using [`AfterNextRender`](api/core/afterNextRender) to delay the script until post-hydration processes have occured.
 
 ## Incremental Hydration
 


### PR DESCRIPTION
Some users are confused by the requirements of hydration around DOM manipulation, and this adds some clarity around those requirements.


- [x] Documentation content changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
