### PR TITLE
docs: Fix Code of Conduct Readme link

### DIFF
--- a/adev/README.md
+++ b/adev/README.md
@@ -36,7 +36,7 @@ And if you're new, check out one of our issues labeled as <kbd>[help wanted](htt
 
 ### Code of Conduct
 
-Help us keep Angular open and inclusive. Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+Help us keep Angular open and inclusive. Please read and follow our [Code of Conduct](/CODE_OF_CONDUCT.md).
 
 ## FAQs
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?


- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently when you click on "Code of Conduct" on this [page](https://github.com/angular/angular/blob/main/adev/README.md), it routes you to https://github.com/angular/angular/blob/main/adev/CODE_OF_CONDUCT.md instead of https://github.com/angular/angular/blob/main/CODE_OF_CONDUCT.md which is the correct page


## What is the new behavior?
It correctly routes to the right page/route - https://github.com/angular/angular/blob/main/CODE_OF_CONDUCT.md

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
