### PR TITLE
refactor(compiler-cli): fix instanceof for error not working

### DIFF
--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -533,7 +533,16 @@ export function reflectIdentifierOfDeclaration(decl: ts.Declaration): ts.Identif
   return null;
 }
 
-export class TypeEntityToDeclarationError extends Error {}
+export class TypeEntityToDeclarationError extends Error {
+  constructor(message: string) {
+    super(message);
+
+    // Extending `Error` ends up breaking some internal tests. This appears to be a known issue
+    // when extending errors in TS and the workaround is to explicitly set the prototype.
+    // https://stackoverflow.com/questions/41102060/typescript-extending-error-class
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
 
 /**
  * @throws {TypeEntityToDeclarationError} if the type cannot be converted


### PR DESCRIPTION
We recently introduced a custom error to allow us to catch certain types of errors. Unfortunately it doesn't work as expected in G3 because the Node execution seems to run with ES5.