### PR TITLE
docs: update `linkedSignal`.

### DIFF
--- a/adev/src/content/guide/signals/linked-signal.md
+++ b/adev/src/content/guide/signals/linked-signal.md
@@ -90,19 +90,17 @@ The `computation` is a function that receives the new value of `source` and a `p
 `linkedSignal` updates to the result of the computation every time its linked state changes. By default, Angular uses referential equality to determine if the linked state has changed. You can alternatively provide a custom equality function.
 
 ```typescript
-const activeUser = signal({id: 123, name: 'Morgan'});
-const email = linkedSignal(() => `${activeUser().name}@example.com`, {
+const activeUser = signal({id: 123, name: 'Morgan', isAdmin: true});
+const email = linkedSignal(() => ({id:`${activeUser().name}@example.com`}), {
   // Consider the user as the same if it's the same `id`.
   equal: (a, b) => a.id === b.id,
 });
-
 // Or, if separating `source` and `computation`
 const alternateEmail = linkedSignal({
   source: activeUser,
-  computation: user => `${user.name}@example.com`,
+  computation: user => ({id:`${user.name}@example.com`}),
   equal: (a, b) => a.id === b.id,
 });
-
 // This update to `activeUser` does not cause `email` or `alternateEmail`
 // to update because the `id` is the same.
 activeUser.set({id: 123, name: 'Morgan', isAdmin: false});

--- a/packages/core/src/render3/reactivity/linked_signal.ts
+++ b/packages/core/src/render3/reactivity/linked_signal.ts
@@ -118,6 +118,8 @@ export function linkedSignal<D>(
  * Creates a writable signals whose value is initialized and reset by the linked, reactive computation.
  * This is an advanced API form where the computation has access to the previous value of the signal and the computation result.
  *
+ * Note: The computation is reactive, meaning the linked signal will automatically update whenever any of the signals used within the computation change.
+ *
  * @developerPreview
  */
 export function linkedSignal<S, D>(options: {
@@ -125,6 +127,7 @@ export function linkedSignal<S, D>(options: {
   computation: (source: NoInfer<S>, previous?: {source: NoInfer<S>; value: NoInfer<D>}) => D;
   equal?: ValueEqualityFn<NoInfer<D>>;
 }): WritableSignal<D>;
+
 export function linkedSignal<S, D>(
   optionsOrComputation:
     | {


### PR DESCRIPTION
The commit adds the mention that it is intentionnal that the computation is reactive even if there is an explicit `source`.

fixes #59094
