### PR TITLE
Update templates.md to actually use isAccountDisabled()

### DIFF
--- a/adev/src/content/introduction/essentials/templates.md
+++ b/adev/src/content/introduction/essentials/templates.md
@@ -47,7 +47,7 @@ Angular supports binding dynamic values into DOM properties with square brackets
 @Component({
   /*...*/
   // Set the `disabled` property of the button based on the value of `isAccountDisabled`.
-  template: `<button [disabled]="isValidUserId()">Save changes</button>`,
+  template: `<button [disabled]="isAccountDisabled()">Save changes</button>`,
 })
 export class UserProfile {
   isValidUserId = signal(false);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Ref: documentation page at https://angular.dev/essentials/templates
Currently the disabled property of the button is bound to isValidUserid()
// Set the `disabled` property of the button based on the value of `isAccountDisabled`.
  template: `<button [disabled]="isValidUserId()">Save changes</button>`,

Issue Number: N/A


## What is the new behavior?
Correctly binds the disabled property of the button to isAccountDisabled()

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
