### PR TITLE
refactor(animations): deprecate `BrowserAnimationsModule`

### DIFF
--- a/adev/src/content/examples/animations/src/app/app.module.1.ts
+++ b/adev/src/content/examples/animations/src/app/app.module.1.ts
@@ -1,10 +1,10 @@
 import {NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
-import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {provideAnimationsAsync} from '@angular/platform-browser/animations/async';
 
 @NgModule({
-  imports: [BrowserModule, BrowserAnimationsModule],
-  declarations: [],
+  imports: [BrowserModule],
+  providers: [provideAnimationsAsync()],
   bootstrap: [],
 })
 export class AppModule {}

--- a/adev/src/content/guide/animations/overview.md
+++ b/adev/src/content/guide/animations/overview.md
@@ -45,7 +45,7 @@ bootstrapApplication(AppComponent, {
   `provideAnimationsAsync` in the `bootstrapApplication` function call.
 </docs-callout>
 
-For `NgModule` based applications import `BrowserAnimationsModule`, which introduces the animation capabilities into your Angular root application module.
+For `NgModule` based applications add `provideAnimationsAsync` to the list of providers, which introduces the animation capabilities into your Angular root application module.
 
 <docs-code header="src/app/app.module.ts" path="adev/src/content/examples/animations/src/app/app.module.1.ts"/>
 </docs-step>

--- a/goldens/public-api/platform-browser/animations/index.api.md
+++ b/goldens/public-api/platform-browser/animations/index.api.md
@@ -12,7 +12,7 @@ import { Provider } from '@angular/core';
 
 export { ANIMATION_MODULE_TYPE }
 
-// @public
+// @public @deprecated
 export class BrowserAnimationsModule {
     static withConfig(config: BrowserAnimationsModuleConfig): ModuleWithProviders<BrowserAnimationsModule>;
     // (undocumented)
@@ -23,7 +23,7 @@ export class BrowserAnimationsModule {
     static ɵmod: i0.ɵɵNgModuleDeclaration<BrowserAnimationsModule, never, never, [typeof i1.BrowserModule]>;
 }
 
-// @public
+// @public @deprecated
 export interface BrowserAnimationsModuleConfig {
     disableAnimations?: boolean;
 }

--- a/packages/platform-browser/animations/src/module.ts
+++ b/packages/platform-browser/animations/src/module.ts
@@ -17,6 +17,9 @@ import {BROWSER_ANIMATIONS_PROVIDERS, BROWSER_NOOP_ANIMATIONS_PROVIDERS} from '.
 
 /**
  * Object used to configure the behavior of {@link BrowserAnimationsModule}
+ *
+ * @deprecated use the `provideNoopAnimations` provider function instead if you want to disable animations.
+ *
  * @publicApi
  */
 export interface BrowserAnimationsModuleConfig {
@@ -30,6 +33,9 @@ export interface BrowserAnimationsModuleConfig {
 /**
  * Exports `BrowserModule` with additional dependency-injection providers
  * for use with animations. See [Animations](guide/animations).
+ *
+ * @deprecated Use the `provideAnimations` or `provideAnimationsAsync` provider functions instead.
+ *
  * @publicApi
  */
 @NgModule({
@@ -96,6 +102,11 @@ export function provideAnimations(): Provider[] {
 
 /**
  * A null player that must be imported to allow disabling of animations.
+ *
+ * You can also use the `provideNoopAnimations` provider function to disable animations.
+ *
+ * @see  {@link provideNoopAnimations}
+ *
  * @publicApi
  */
 @NgModule({


### PR DESCRIPTION
The official recommendation is now to use one of the following provider functions :
* `provideAnimations`,
* `provideAnimationsAsync`
* `provideNoopAnimations` Depending on the wanted feature.

DEPRECATE: `BrowserAnimationsModule` & `BrowserAnimationsModuleConfig`
