### PR TITLE
i created a fix for the note, what can ia dd itn the cmmt message Whe…

### DIFF
--- a/adev/src/content/guide/components/styling.md
+++ b/adev/src/content/guide/components/styling.md
@@ -24,6 +24,11 @@ You can also choose to write your styles in separate files:
 export class ProfilePhoto { }
 </docs-code>
 
+### Note
+
+The `styleUrl` property is supported in Angular 17 and later. For earlier versions of Angular, 
+use the `styleUrls` property to reference one or more external stylesheets.
+
 When Angular compiles your component, these styles are emitted with your component's JavaScript
 output. This means that component styles participate in the JavaScript module system. When you
 render an Angular component, the framework automatically includes its associated styles, even when


### PR DESCRIPTION
fix(docs): add clarification note for styleUrl in component styling
Added a note to the Styling Components guide explaining the distinction between styleUrl and styleUrls, along with the appropriate usage of styleUrl for single CSS file scenarios in Angular 17+.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The documentation does not provide clear guidance on the usage of styleUrl introduced in Angular 17, potentially causing confusion for developers.

Issue Number: https://github.com/angular/angular/issues/59262


## What is the new behavior?
The documentation now includes a note about styleUrl in the Styling Components section, clarifying its use and compatibility with Angular 17+.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Added a descriptive note to enhance developer understanding.
Verified the changes for alignment with Angular documentation standards.
