### PR TITLE
docs: remove data attributes from api-item-label

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/header-api.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/header-api.tsx
@@ -36,11 +36,7 @@ export function HeaderApi(props: {entry: DocEntryRenderable; showFullDescription
       <div className={HEADER_ENTRY_TITLE}>
         <div>
           <h1>{entry.name}</h1>
-          <div
-            className={HEADER_ENTRY_LABEL}
-            data-mode={'full'}
-            data-type={entry.entryType.toLowerCase()}
-          >
+          <div className={`${HEADER_ENTRY_LABEL} type-${entry.entryType.toLowerCase()} full`}>
             {getEntryTypeDisplayName(entry.entryType)}
           </div>
           {entry.isDeprecated && (

--- a/adev/shared-docs/styles/_api-item-label.scss
+++ b/adev/shared-docs/styles/_api-item-label.scss
@@ -14,12 +14,12 @@
       background-color 0.3s ease;
     text-transform: capitalize;
 
-    &[data-mode='short'] {
+    &:not(.full) {
       height: 22px;
       width: 22px;
     }
 
-    &[data-mode='full'] {
+    &.full {
       font-size: 0.75rem;
       padding: 0.25rem 0.5rem;
     }
@@ -44,58 +44,58 @@
       background: color-mix(in srgb, var(--label-theme) 10%, white);
     }
 
-    &[data-type='undecorated_class'],
-    &[data-type='class'] {
+    &.type-undecorated_class,
+    &.type-class {
       --label-theme: var(--symbolic-purple);
     }
 
-    &[data-type='constant'],
-    &[data-type='const'] {
+    &.type-constant,
+    &.type-const {
       --label-theme: var(--symbolic-gray);
     }
 
-    &[data-type='decorator'] {
+    &.type-decorator {
       --label-theme: var(--symbolic-blue);
     }
 
-    &[data-type='directive'] {
+    &.type-directive {
       --label-theme: var(--symbolic-pink);
     }
 
-    &[data-type='element'] {
+    &.type-element {
       --label-theme: var(--symbolic-orange);
     }
 
-    &[data-type='enum'] {
+    &.type-enum {
       --label-theme: var(--symbolic-yellow);
     }
 
-    &[data-type='function'] {
+    &.type-function {
       --label-theme: var(--symbolic-green);
     }
 
-    &[data-type='interface'] {
+    &.type-interface {
       --label-theme: var(--symbolic-cyan);
     }
 
-    &[data-type='pipe'] {
+    &.type-pipe {
       --label-theme: var(--symbolic-teal);
     }
 
-    &[data-type='ng_module'] {
+    &.type-ng_module {
       --label-theme: var(--symbolic-brown);
     }
 
-    &[data-type='type_alias'] {
+    &.type-type_alias {
       --label-theme: var(--symbolic-lime);
     }
 
-    &[data-type='block'] {
+    &.type-block {
       --label-theme: var(--vivid-pink);
     }
 
-    &[data-type='developer_preview'],
-    &[data-type='deprecated'] {
+    &.type-developer_preview,
+    &.type-deprecated {
       --label-theme: var(--hot-red);
     }
   }

--- a/adev/src/app/features/references/api-item-label/api-item-label.component.html
+++ b/adev/src/app/features/references/api-item-label/api-item-label.component.html
@@ -1,1 +1,0 @@
-{{ type() | adevApiLabel: mode() }}

--- a/adev/src/app/features/references/api-item-label/api-item-label.component.spec.ts
+++ b/adev/src/app/features/references/api-item-label/api-item-label.component.spec.ts
@@ -33,19 +33,8 @@ describe('ApiItemLabel', () => {
     expect(label).toBe('C');
   });
 
-  it('should display full label for Class when labelMode equals full', () => {
+  it('should display short label for Class', () => {
     fixture.componentRef.setInput('type', ApiItemType.CLASS);
-    fixture.componentRef.setInput('mode', 'full');
-    fixture.detectChanges();
-
-    const label = fixture.nativeElement.innerText;
-
-    expect(label).toBe('Class');
-  });
-
-  it('should display short label for Class when labelMode equals short', () => {
-    fixture.componentRef.setInput('type', ApiItemType.CLASS);
-    fixture.componentRef.setInput('mode', 'short');
     fixture.detectChanges();
 
     const label = fixture.nativeElement.innerText;

--- a/adev/src/app/features/references/api-item-label/api-item-label.component.ts
+++ b/adev/src/app/features/references/api-item-label/api-item-label.component.ts
@@ -6,21 +6,21 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, computed, input} from '@angular/core';
 import {ApiItemType} from '../interfaces/api-item-type';
-import {ApiLabel} from '../pipes/api-label.pipe';
+import {ApiLabel, shortLabelsMap} from '../pipes/api-label.pipe';
 
 @Component({
   selector: 'docs-api-item-label',
-  templateUrl: './api-item-label.component.html',
+  template: `{{ label() }}`,
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
-    '[attr.data-type]': 'type()',
-    '[attr.data-mode]': 'mode()',
+    '[class]': `clazz()`,
   },
   imports: [ApiLabel],
 })
 export default class ApiItemLabel {
   readonly type = input.required<ApiItemType>();
-  readonly mode = input.required<'short' | 'full'>();
+  readonly label = computed(() => shortLabelsMap[this.type()]);
+  readonly clazz = computed(() => `type-${this.type()}`);
 }

--- a/adev/src/app/features/references/pipes/api-label.pipe.ts
+++ b/adev/src/app/features/references/pipes/api-label.pipe.ts
@@ -14,39 +14,39 @@ import {ApiItemType} from '../interfaces/api-item-type';
   name: 'adevApiLabel',
 })
 export class ApiLabel implements PipeTransform {
-  private readonly shortLabelsMap: Record<ApiItemType, string> = {
-    [ApiItemType.BLOCK]: 'B',
-    [ApiItemType.CLASS]: 'C',
-    [ApiItemType.CONST]: 'K',
-    [ApiItemType.DECORATOR]: '@',
-    [ApiItemType.DIRECTIVE]: 'D',
-    [ApiItemType.ELEMENT]: 'El',
-    [ApiItemType.ENUM]: 'E',
-    [ApiItemType.FUNCTION]: 'F',
-    [ApiItemType.INTERFACE]: 'I',
-    [ApiItemType.PIPE]: 'P',
-    [ApiItemType.NG_MODULE]: 'M',
-    [ApiItemType.TYPE_ALIAS]: 'T',
-    [ApiItemType.INITIALIZER_API_FUNCTION]: 'IA',
-  };
-
-  private readonly fullLabelsMap: Record<ApiItemType, string> = {
-    [ApiItemType.BLOCK]: 'Block',
-    [ApiItemType.CLASS]: 'Class',
-    [ApiItemType.CONST]: 'Const',
-    [ApiItemType.DECORATOR]: 'Decorator',
-    [ApiItemType.DIRECTIVE]: 'Directive',
-    [ApiItemType.ELEMENT]: 'Element',
-    [ApiItemType.ENUM]: 'Enum',
-    [ApiItemType.FUNCTION]: 'Function',
-    [ApiItemType.INTERFACE]: 'Interface',
-    [ApiItemType.PIPE]: 'Pipe',
-    [ApiItemType.NG_MODULE]: 'Module',
-    [ApiItemType.TYPE_ALIAS]: 'Type Alias',
-    [ApiItemType.INITIALIZER_API_FUNCTION]: 'Initializer API',
-  };
-
   transform(value: ApiItemType, labelType: 'short' | 'full'): string {
-    return labelType === 'full' ? this.fullLabelsMap[value] : this.shortLabelsMap[value];
+    return labelType === 'full' ? fullLabelsMap[value] : shortLabelsMap[value];
   }
 }
+
+export const shortLabelsMap: Record<ApiItemType, string> = {
+  [ApiItemType.BLOCK]: 'B',
+  [ApiItemType.CLASS]: 'C',
+  [ApiItemType.CONST]: 'K',
+  [ApiItemType.DECORATOR]: '@',
+  [ApiItemType.DIRECTIVE]: 'D',
+  [ApiItemType.ELEMENT]: 'El',
+  [ApiItemType.ENUM]: 'E',
+  [ApiItemType.FUNCTION]: 'F',
+  [ApiItemType.INTERFACE]: 'I',
+  [ApiItemType.PIPE]: 'P',
+  [ApiItemType.NG_MODULE]: 'M',
+  [ApiItemType.TYPE_ALIAS]: 'T',
+  [ApiItemType.INITIALIZER_API_FUNCTION]: 'IA',
+};
+
+export const fullLabelsMap: Record<ApiItemType, string> = {
+  [ApiItemType.BLOCK]: 'Block',
+  [ApiItemType.CLASS]: 'Class',
+  [ApiItemType.CONST]: 'Const',
+  [ApiItemType.DECORATOR]: 'Decorator',
+  [ApiItemType.DIRECTIVE]: 'Directive',
+  [ApiItemType.ELEMENT]: 'Element',
+  [ApiItemType.ENUM]: 'Enum',
+  [ApiItemType.FUNCTION]: 'Function',
+  [ApiItemType.INTERFACE]: 'Interface',
+  [ApiItemType.PIPE]: 'Pipe',
+  [ApiItemType.NG_MODULE]: 'Module',
+  [ApiItemType.TYPE_ALIAS]: 'Type Alias',
+  [ApiItemType.INITIALIZER_API_FUNCTION]: 'Initializer API',
+};


### PR DESCRIPTION
Perf measurments have revealed that `data-*` attributes are slower to set than classes.

#59264
