### PR TITLE
refactor(platform-server): reduce timeout used in tests

### DIFF
--- a/packages/platform-server/test/incremental_hydration_spec.ts
+++ b/packages/platform-server/test/incremental_hydration_spec.ts
@@ -65,8 +65,8 @@ function dynamicImportOf<T>(type: T, timeout = 0): Promise<T> {
  * Helper function to await all pending dynamic imports
  * emulated using `dynamicImportOf` function.
  */
-function allPendingDynamicImports() {
-  return dynamicImportOf(null, 101);
+function allPendingDynamicImports(timeout?: number) {
+  return dynamicImportOf(null, timeout ?? 10);
 }
 
 describe('platform-server partial hydration integration', () => {
@@ -2364,10 +2364,12 @@ describe('platform-server partial hydration integration', () => {
         location = inject(Location);
       }
 
+      const dynamicImportTimeout = 5; // ms
+
       const deferDepsInterceptor = {
         intercept() {
           return () => {
-            return [dynamicImportOf(DeferredCmp, 100)];
+            return [dynamicImportOf(DeferredCmp, dynamicImportTimeout)];
           };
         },
       };
@@ -2397,10 +2399,12 @@ describe('platform-server partial hydration integration', () => {
 
       const routeLink = doc.getElementById('route-link')!;
       routeLink.click();
-      await allPendingDynamicImports();
+      // Wait a bit longer than a timeout used to emulate a dynamic import.
+      await allPendingDynamicImports(dynamicImportTimeout * 2);
       appRef.tick();
 
-      await allPendingDynamicImports();
+      // Wait a bit longer than a timeout used to emulate a dynamic import.
+      await allPendingDynamicImports(dynamicImportTimeout * 2);
       await appRef.whenStable();
 
       expect(location.path()).toBe('/other/thing/stuff');


### PR DESCRIPTION
This commit updates the timeout used in the incremental hydration tests from `101` -> `10` ms, which allows to speed up tests by ~20% (12.5 -> 10 seconds locally).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No