### PR TITLE
fix(core): cancel in-progress request when same value is assigned

### DIFF
--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -221,7 +221,11 @@ class ResourceImpl<T, R> extends BaseWritableResource<T> implements ResourceRef<
     }
 
     const current = untracked(this.value);
-    if (this.equal ? this.equal(current, value) : current === value) {
+
+    if (
+      untracked(this.status) === ResourceStatus.Local &&
+      (this.equal ? this.equal(current, value) : current === value)
+    ) {
       return;
     }
 


### PR DESCRIPTION
Fixes that `resource` wasn't cancelling its in-progress request if the same value as the current one is assigned.

Fixes #59272.
