### PR TITLE
docs: update contributing guidelines to reference TypeScript style guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,7 +205,7 @@ To ensure consistency throughout the source code, keep these rules in mind as yo
 
 * All features or bug fixes **must be tested** by one or more specs (unit-tests).
 * All public API methods **must be documented**.
-* We follow [Google's JavaScript Style Guide][js-style-guide], but wrap all code at **100 characters**.
+* We follow [Google's TypeScript Style Guide][ts-style-guide], but wrap all code at **100 characters**.
 
    An automated formatter is available, see [DEVELOPER.md](contributing-docs/building-and-testing-angular.md#formatting-your-source-code).
 
@@ -396,4 +396,4 @@ The following documents can help you sort out issues with GitHub accounts and mu
 [github]: https://github.com/angular/angular
 [discord]: https://discord.gg/angular
 [individual-cla]: https://cla.developers.google.com/about/google-individual
-[js-style-guide]: https://google.github.io/styleguide/jsguide.html
+[ts-style-guide]: https://google.github.io/styleguide/tsguide.html


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently the docs are pointing to the JavaScript style guide, but we get this message:
<img width="840" alt="image" src="https://github.com/user-attachments/assets/4409b2de-0183-451a-9369-5ed906e393c4" />

## What is the new behavior?
Points to the TypeScript style guide.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No