### PR TITLE
docs: fix mermaid polygon node text visibility in dark mode

### DIFF
--- a/adev/shared-docs/styles/docs/_mermaid.scss
+++ b/adev/shared-docs/styles/docs/_mermaid.scss
@@ -58,7 +58,7 @@
     fill: var(--page-background) !important;
   }
 
-  .nodeLabel {
+  .nodeLabel:not(.node:has(polygon) .nodeLabel) {
     fill: var(--primary-contrast) !important;
     color: var(--primary-contrast) !important;
   }


### PR DESCRIPTION
Fix visibility issue with text inside polygon nodes in mermaid diagrams when using dark mode theme to ensure proper contrast and readability

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Mermaid diagram polygon node text is not visible when using dark mode theme. (white text on light yellow background)
<img width="207" alt="image" src="https://github.com/user-attachments/assets/5091c815-321d-490c-a584-915b89c2ddc0" />


Issue Number: #59128


## What is the new behavior?
The text inside mermaid diagram polygon nodes is now visible in dark mode.
<img width="171" alt="image" src="https://github.com/user-attachments/assets/8f1e5589-7c3f-4fd5-9918-6c70a6c0a9df" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

All the texts inside nodes have the class "nodeLabel" that makes the text dark on light mode and light on dark mode.
I excluded the texts inside polygons from behaving the same way as the others, and that fixes the problem.

However, what triggers me, is that the current background color of the polygon is #fff4dd which is the default color of mermaid polygons. Yet there is this css code that is supposed to style polygons , but it does not select the polygons correctly !
```css
.eventNode {
  polygon {
    fill: var(--hot-pink) !important;
    filter: none;
    stroke: var(--hot-pink) !important;
  }
}
```