### PR TITLE
refactor(compiler): incorrect spelling in for loop parse error message

### DIFF
--- a/packages/compiler/src/render3/r3_control_flow.ts
+++ b/packages/compiler/src/render3/r3_control_flow.ts
@@ -386,7 +386,7 @@ function parseForLoopParameters(
     }
 
     errors.push(
-      new ParseError(param.sourceSpan, `Unrecognized @for loop paramater "${param.expression}"`),
+      new ParseError(param.sourceSpan, `Unrecognized @for loop parameter "${param.expression}"`),
     );
   }
 
@@ -614,7 +614,7 @@ function parseConditionalBlockParameters(
       errors.push(
         new ParseError(
           param.sourceSpan,
-          `Unrecognized conditional paramater "${param.expression}"`,
+          `Unrecognized conditional parameter "${param.expression}"`,
         ),
       );
     } else if (block.name !== 'if') {

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -1979,7 +1979,7 @@ describe('R3 template transform', () => {
 
       it('should report unrecognized for loop parameters', () => {
         expect(() => parse(`@for (a of b; foo bar) {hello}`)).toThrowError(
-          /Unrecognized @for loop paramater "foo bar"/,
+          /Unrecognized @for loop parameter "foo bar"/,
         );
       });
 
@@ -2257,7 +2257,7 @@ describe('R3 template transform', () => {
           parse(`
           @if (foo; bar) {hello}
         `),
-        ).toThrowError(/Unrecognized conditional paramater "bar"/);
+        ).toThrowError(/Unrecognized conditional parameter "bar"/);
       });
 
       it('should report an unknown parameter in an else if block', () => {
@@ -2265,7 +2265,7 @@ describe('R3 template transform', () => {
           parse(`
           @if (foo) {hello} @else if (bar; baz) {goodbye}
         `),
-        ).toThrowError(/Unrecognized conditional paramater "baz"/);
+        ).toThrowError(/Unrecognized conditional parameter "baz"/);
       });
 
       it('should report an if block that has multiple `as` expressions', () => {


### PR DESCRIPTION
Fixes incorrect spelling in compiler message `Unrecognized @for loop paramater "${param.expression}`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?


- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

Updates compiler error message.

## What is the current behavior?

When the compiler detects an unrecognized `@for` loop parameter, it indicates this with a message that is incorrectly spelled: `Unrecognized @for loop paramater "${param.expression}`.

Issue Number: N/A


## What is the new behavior?

The spelling is corrected.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
