### PR TITLE
fix(router): avoid component ID collisions with user code

### DIFF
--- a/packages/router/src/components/empty_outlet.ts
+++ b/packages/router/src/components/empty_outlet.ts
@@ -23,8 +23,10 @@ export {ɵEmptyOutletComponent as EmptyOutletComponent};
  * to this `EmptyOutletComponent`.
  */
 @Component({
-  template: `<router-outlet></router-outlet>`,
+  template: `<router-outlet/>`,
   imports: [RouterOutlet],
+  // Used to avoid component ID collisions with user code.
+  exportAs: 'emptyRouterOutlet',
 })
 export class ɵEmptyOutletComponent {}
 


### PR DESCRIPTION
Currently the `ɵEmptyOutletComponent` is very prone to generating ID collision warnings with user code, because it only has one child and no other metadata. This shows up some of our tests as well. While users can resolve it on their end, it can be confusing since they won't have any references to `ɵEmptyOutletComponent` in their own code.

These changes add an `exportAs` to it to make its component ID unique. This doesn't affect the public API of the component since users can't use it directly anyways.