### PR TITLE
docs: Rework "Programmatically rendering components" section with @defer mention

### DIFF
--- a/adev/src/content/guide/components/programmatic-rendering.md
+++ b/adev/src/content/guide/components/programmatic-rendering.md
@@ -3,8 +3,7 @@
 Tip: This guide assumes you've already read the [Essentials Guide](essentials). Read that first if you're new to Angular.
 
 In addition to using a component directly in a template, you can also dynamically render components.
-There are two main ways to dynamically render a component: in a template with `NgComponentOutlet`,
-or in your TypeScript code with `ViewContainerRef`.
+The main way to dynamically render a component: in a template with `NgComponentOutlet`.
 
 ## Using NgComponentOutlet
 
@@ -36,66 +35,9 @@ export class CustomDialog {
 See the [NgComponentOutlet API reference](api/common/NgComponentOutlet) for more information on the
 directive's capabilities.
 
-## Using ViewContainerRef
-
-A **view container** is a node in Angular's component tree that can contain content. Any component
-or directive can inject `ViewContainerRef` to get a reference to a view container corresponding to
-that component or directive's location in the DOM.
-
-You can use the `createComponent`method on `ViewContainerRef` to dynamically create and render a
-component. When you create a new component with a `ViewContainerRef`, Angular appends it into the
-DOM as the next sibling of the component or directive that injected the `ViewContainerRef`.
-
-```angular-ts
-@Component({
-  selector: 'leaf-content',
-  template: `
-    This is the leaf content
-  `,
-})
-export class LeafContent {}
-
-@Component({
-  selector: 'outer-container',
-  template: `
-    <p>This is the start of the outer container</p>
-    <inner-item />
-    <p>This is the end of the outer container</p>
-  `,
-})
-export class OuterContainer {}
-
-@Component({
-  selector: 'inner-item',
-  template: `
-    <button (click)="loadContent()">Load content</button>
-  `,
-})
-export class InnerItem {
-  constructor(private viewContainer: ViewContainerRef) {}
-
-  loadContent() {
-    this.viewContainer.createComponent(LeafContent);
-  }
-}
-```
-
-In the example above, clicking the "Load content" button results in the following DOM structure
-
-```angular-html
-<outer-container>
-  <p>This is the start of the outer container</p>
-  <inner-item>
-    <button>Load content</button>
-  </inner-item>
-  <leaf-content>This is the leaf content</leaf-content>
-  <p>This is the end of the outer container</p>
-</outer-container>
-```
-
 ## Lazy-loading components
 
-You can use both of the approaches described above, `NgComponentOutlet` and `ViewContainerRef`, to
+You can use conjunction between `NgComponentOutlet` and deferred loading with `@defer`, to
 render components that are lazy-loaded with a standard
 JavaScript [dynamic import](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/import).
 
@@ -109,10 +51,15 @@ JavaScript [dynamic import](https://developer.mozilla.org/docs/Web/JavaScript/Re
     </section>
     <section>
       <h2>Advanced settings</h2>
-      <button (click)="loadAdvanced()" *ngIf="!advancedSettings">
-        Load advanced settings
-      </button>
-      <ng-container *ngComponentOutlet="advancedSettings" />
+      @defer (on interaction) {
+        <ng-container *ngComponentOutlet="advancedSettings"></ng-container>
+      } @placeholder {
+        <button (click)="loadAdvanced()">Load advanced settings</button>
+      } @loading {
+        <p>Loading advanced settings...</p>
+      } @error {
+        <p>Failed to load advanced settings.</p>
+      }
     </section>
   `
 })

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -60,6 +60,57 @@ import {assertComponentDef} from './errors';
  * componentRef.changeDetectorRef.detectChanges();
  * ```
  *
+ * You can use the `createComponent`method to dynamically create and render a
+ * component. When you create a new component with a `ViewContainerRef`, Angular appends it into the
+ * DOM as the next sibling of the component or directive that injected the `ViewContainerRef`.
+ *
+ * ```angular-ts
+ * @Component({
+ *   selector: 'leaf-content',
+ *   template: `
+ *     This is the leaf content
+ *   `,
+ * })
+ * export class LeafContent {}
+ *
+ * @Component({
+ *   selector: 'outer-container',
+ *   template: `
+ *     <p>This is the start of the outer container</p>
+ *     <inner-item />
+ *     <p>This is the end of the outer container</p>
+ *   `,
+ * })
+ * export class OuterContainer {}
+ *
+ * @Component({
+ *   selector: 'inner-item',
+ *   template: `
+ *     <button (click)="loadContent()">Load content</button>
+ *   `,
+ * })
+ * export class InnerItem {
+ *   constructor(private viewContainer: ViewContainerRef) {}
+ *
+ *   loadContent() {
+ *     this.viewContainer.createComponent(LeafContent);
+ *   }
+ * }
+ * ```
+ *
+ * In the example above, clicking the "Load content" button results in the following DOM structure
+ *
+ * ```angular-html
+ * <outer-container>
+ *   <p>This is the start of the outer container</p>
+ *   <inner-item>
+ *     <button>Load content</button>
+ *   </inner-item>
+ *   <leaf-content>This is the leaf content</leaf-content>
+ *   <p>This is the end of the outer container</p>
+ * </outer-container>
+ * ```
+ *
  * @param component Component class reference.
  * @param options Set of options to use:
  *  * `environmentInjector`: An `EnvironmentInjector` instance to be used for the component.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently in "Programmatically rendering components" section mentioned two ways of management of rendering:
- using `NgComponentOutlet`
- using `ViewContainerRef`

Issue Number: #56782 


## What is the new behavior?
Section was reworked using `@defer` to present Lazy(Defer) loading implementation.
"using `ViewContainerRef`" part was moved to the "Usage notes" of the ViewContainerRef.createComponent function itself

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
- As it was mentioned that proposal with moving "using `ViewContainerRef`" part to "Usage notes" is `under triage` let me know if it is needed to be dropped there or `ViewContainerRef` remain in section.
- If `ViewContainerRef` would be better to drop of, let me know if needed to put a reference to ViewContainerRef.createComponent function documentation somewhere in "Programmatically rendering components" section