### PR TITLE
fix(compiler-cli): preserve defer block dependencies during HMR when class metadata is disabled

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -272,7 +272,7 @@ export class ComponentDecoratorHandler
 
     // Dependencies can't be deferred during HMR, because the HMR update module can't have
     // dynamic imports and its dependencies need to be passed in directly. If dependencies
-    // are deferred, their imports will be deleted so we won't may lose the reference to them.
+    // are deferred, their imports will be deleted so we may lose the reference to them.
     this.canDeferDeps = !enableHmr;
   }
 
@@ -1617,10 +1617,11 @@ export class ComponentDecoratorHandler
     const perComponentDeferredDeps = this.canDeferDeps
       ? this.resolveAllDeferredDependencies(resolution)
       : null;
+    const defer = this.compileDeferBlocks(resolution);
     const meta: R3ComponentMetadata<R3TemplateDependency> = {
       ...analysis.meta,
       ...resolution,
-      defer: this.compileDeferBlocks(resolution),
+      defer,
     };
     const fac = compileNgFactoryDefField(toFactoryMetadata(meta, FactoryTarget.Component));
 
@@ -1646,6 +1647,7 @@ export class ComponentDecoratorHandler
           this.rootDirs,
           def,
           fac,
+          defer,
           classMetadata,
           debugInfo,
         )
@@ -1687,10 +1689,11 @@ export class ComponentDecoratorHandler
     const perComponentDeferredDeps = this.canDeferDeps
       ? this.resolveAllDeferredDependencies(resolution)
       : null;
+    const defer = this.compileDeferBlocks(resolution);
     const meta: R3ComponentMetadata<R3TemplateDependencyMetadata> = {
       ...analysis.meta,
       ...resolution,
-      defer: this.compileDeferBlocks(resolution),
+      defer,
     };
     const fac = compileDeclareFactory(toFactoryMetadata(meta, FactoryTarget.Component));
     const inputTransformFields = compileInputTransformFields(analysis.inputs);
@@ -1710,6 +1713,7 @@ export class ComponentDecoratorHandler
           this.rootDirs,
           def,
           fac,
+          defer,
           classMetadata,
           null,
         )
@@ -1741,10 +1745,11 @@ export class ComponentDecoratorHandler
     // doesn't have information on which dependencies belong to which defer blocks.
     const deferrableTypes = this.canDeferDeps ? analysis.explicitlyDeferredTypes : null;
 
+    const defer = this.compileDeferBlocks(resolution);
     const meta = {
       ...analysis.meta,
       ...resolution,
-      defer: this.compileDeferBlocks(resolution),
+      defer,
     } as R3ComponentMetadata<R3TemplateDependency>;
 
     if (deferrableTypes !== null) {
@@ -1770,6 +1775,7 @@ export class ComponentDecoratorHandler
           this.rootDirs,
           def,
           fac,
+          defer,
           classMetadata,
           debugInfo,
         )
@@ -1801,10 +1807,11 @@ export class ComponentDecoratorHandler
 
     // Create a brand-new constant pool since there shouldn't be any constant sharing.
     const pool = new ConstantPool();
+    const defer = this.compileDeferBlocks(resolution);
     const meta: R3ComponentMetadata<R3TemplateDependency> = {
       ...analysis.meta,
       ...resolution,
-      defer: this.compileDeferBlocks(resolution),
+      defer,
     };
     const fac = compileNgFactoryDefField(toFactoryMetadata(meta, FactoryTarget.Component));
     const def = compileComponentFromMetadata(meta, pool, makeBindingParser());
@@ -1824,6 +1831,7 @@ export class ComponentDecoratorHandler
           this.rootDirs,
           def,
           fac,
+          defer,
           classMetadata,
           debugInfo,
         )

--- a/packages/compiler-cli/src/ngtsc/hmr/src/extract_dependencies.ts
+++ b/packages/compiler-cli/src/ngtsc/hmr/src/extract_dependencies.ts
@@ -6,7 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {R3CompiledExpression, R3HmrNamespaceDependency, outputAst as o} from '@angular/compiler';
+import {
+  DeferBlockDepsEmitMode,
+  R3CompiledExpression,
+  R3ComponentDeferMetadata,
+  R3HmrNamespaceDependency,
+  outputAst as o,
+} from '@angular/compiler';
 import {DeclarationNode} from '../../reflection';
 import {CompileResult} from '../../transform';
 import ts from 'typescript';
@@ -16,6 +22,7 @@ import ts from 'typescript';
  * @param sourceFile File in which the file is being compiled.
  * @param definition Compiled component definition.
  * @param factory Compiled component factory.
+ * @param deferBlockMetadata Metadata about the defer blocks in the component.
  * @param classMetadata Compiled `setClassMetadata` expression, if any.
  * @param debugInfo Compiled `setClassDebugInfo` expression, if any.
  */
@@ -23,6 +30,7 @@ export function extractHmrDependencies(
   node: DeclarationNode,
   definition: R3CompiledExpression,
   factory: CompileResult,
+  deferBlockMetadata: R3ComponentDeferMetadata,
   classMetadata: o.Statement | null,
   debugInfo: o.Statement | null,
 ): {local: string[]; external: R3HmrNamespaceDependency[]} {
@@ -30,7 +38,7 @@ export function extractHmrDependencies(
   const visitor = new PotentialTopLevelReadsVisitor();
   const sourceFile = node.getSourceFile();
 
-  // Visit all of the compiled expression to look for potential
+  // Visit all of the compiled expressions to look for potential
   // local references that would have to be retained.
   definition.expression.visitExpression(visitor, null);
   definition.statements.forEach((statement) => statement.visitStatement(visitor, null));
@@ -38,6 +46,12 @@ export function extractHmrDependencies(
   factory.statements.forEach((statement) => statement.visitStatement(visitor, null));
   classMetadata?.visitStatement(visitor, null);
   debugInfo?.visitStatement(visitor, null);
+
+  if (deferBlockMetadata.mode === DeferBlockDepsEmitMode.PerBlock) {
+    deferBlockMetadata.blocks.forEach((loader) => loader?.visitExpression(visitor, null));
+  } else {
+    deferBlockMetadata.dependenciesFn?.visitExpression(visitor, null);
+  }
 
   // Filter out only the references to defined top-level symbols. This allows us to ignore local
   // variables inside of functions. Note that we filter out the class name since it is always

--- a/packages/compiler-cli/src/ngtsc/hmr/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/hmr/src/metadata.ts
@@ -6,7 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {R3CompiledExpression, R3HmrMetadata, outputAst as o} from '@angular/compiler';
+import {
+  R3CompiledExpression,
+  R3ComponentDeferMetadata,
+  R3HmrMetadata,
+  outputAst as o,
+} from '@angular/compiler';
 import {DeclarationNode, ReflectionHost} from '../../reflection';
 import {getProjectRelativePath} from '../../util/src/path';
 import {CompileResult} from '../../transform';
@@ -21,6 +26,7 @@ import ts from 'typescript';
  * @param rootDirs Root directories configured by the user.
  * @param definition Analyzed component definition.
  * @param factory Analyzed component factory.
+ * @param deferBlockMetadata Metadata about the defer blocks in the component.
  * @param classMetadata Analyzed `setClassMetadata` expression, if any.
  * @param debugInfo Analyzed `setClassDebugInfo` expression, if any.
  */
@@ -31,6 +37,7 @@ export function extractHmrMetatadata(
   rootDirs: readonly string[],
   definition: R3CompiledExpression,
   factory: CompileResult,
+  deferBlockMetadata: R3ComponentDeferMetadata,
   classMetadata: o.Statement | null,
   debugInfo: o.Statement | null,
 ): R3HmrMetadata | null {
@@ -43,7 +50,14 @@ export function extractHmrMetatadata(
     getProjectRelativePath(sourceFile.fileName, rootDirs, compilerHost) ||
     compilerHost.getCanonicalFileName(sourceFile.fileName);
 
-  const dependencies = extractHmrDependencies(clazz, definition, factory, classMetadata, debugInfo);
+  const dependencies = extractHmrDependencies(
+    clazz,
+    definition,
+    factory,
+    deferBlockMetadata,
+    classMetadata,
+    debugInfo,
+  );
   const meta: R3HmrMetadata = {
     type: new o.WrappedNodeExpr(clazz.name),
     className: clazz.name.text,


### PR DESCRIPTION
Fixes that the compiler wasn't capturing defer block dependencies correctly when `supportTestBed` is disabled. We had tests for this, but we didn't notice the issue because the dependencies ended up being captured because of the `setClassMetadata` calls. Once they're disabled, the dependencies stopped being recorded.

Fixes #59310.
