### PR TITLE
fix(compiler-cli): account for more expression types when determining HMR dependencies

### DIFF
--- a/packages/compiler-cli/test/ngtsc/hmr_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/hmr_spec.ts
@@ -349,5 +349,32 @@ runInEachFileSystem(() => {
       const hmrContents = env.driveHmr('test.ts', 'Foo');
       expect(hmrContents).toBe(null);
     });
+
+    it('should capture shorthand property assignment dependencies', () => {
+      enableHmr();
+      env.write(
+        'test.ts',
+        `
+          import {Component} from '@angular/core';
+
+          const providers: any[] = [];
+
+          @Component({template: '', providers})
+          export class Cmp {}
+        `,
+      );
+
+      env.driveMain();
+
+      const jsContents = env.getContents('test.js');
+      const hmrContents = env.driveHmr('test.ts', 'Cmp');
+
+      expect(jsContents).toContain(
+        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [providers, Component]));',
+      );
+      expect(hmrContents).toContain(
+        'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, providers, Component) {',
+      );
+    });
   });
 });


### PR DESCRIPTION
During the HMR dependency analysis we need to check if an identifier is top-level or not. We do this by looking at each identifier and its parent, however we didn't account for some cases. These changes expand our logic to cover more of the common node types.

Related to https://github.com/angular/angular/issues/59310#issuecomment-2563963501.