### PR TITLE
fix(router): complete router `events` on dispose

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -377,6 +377,12 @@ export class Router {
 
   /** Disposes of the router. */
   dispose(): void {
+    // We call `unsubscribe()` to release observers, as users may forget to
+    // unsubscribe manually when subscribing to `router.events`. We do not call
+    // `complete()` because it is unsafe; if someone subscribes using the `first`
+    // operator and the observable completes before emitting a value,
+    // RxJS will throw an error.
+    this._events.unsubscribe();
     this.navigationTransitions.complete();
     if (this.nonRouterCurrentEntryChangeSubscription) {
       this.nonRouterCurrentEntryChangeSubscription.unsubscribe();


### PR DESCRIPTION
In this commit, we manually complete the `events` subject to remove all active observers and enable granular garbage collection, as users may forget to unsubscribe manually when subscribing to `router.events`.