### PR TITLE
refactor(router): replace `mapTo` since deprecated

### DIFF
--- a/packages/router/src/operators/resolve_data.ts
+++ b/packages/router/src/operators/resolve_data.ts
@@ -8,7 +8,7 @@
 
 import {EnvironmentInjector, ProviderToken, runInInjectionContext} from '@angular/core';
 import {EMPTY, from, MonoTypeOperatorFunction, Observable, of, throwError} from 'rxjs';
-import {catchError, concatMap, first, map, mapTo, mergeMap, takeLast, tap} from 'rxjs/operators';
+import {catchError, concatMap, first, map, mergeMap, takeLast, tap} from 'rxjs/operators';
 
 import {RedirectCommand, ResolveData} from '../models';
 import type {NavigationTransition} from '../navigation_transition';
@@ -122,7 +122,7 @@ function resolveNode(
       ),
     ),
     takeLast(1),
-    mapTo(data),
+    map(() => data),
     catchError((e: unknown) => (isEmptyError(e as Error) ? EMPTY : throwError(e))),
   );
 }


### PR DESCRIPTION
Replaces `mapTo` with `map` because, in RxJS, `mapTo` is deprecated and internally uses `map`.