### PR TITLE
docs(common): fix syntax error in MyCustomTransformationPipe document…

### DIFF
--- a/adev/src/content/guide/templates/pipes.md
+++ b/adev/src/content/guide/templates/pipes.md
@@ -260,7 +260,7 @@ export class MyCustomTransformationPipe implements PipeTransform {
 
     if (format === 'uppercase') {
       return msg.toUpperCase()
-    else {
+    } else {
       return msg
     }
   }


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The MyCustomTransformationPipe class in documentation doesn't have the syntax for closing of if-else block. So, it'll throw error when someone uses the class.

Issue Number: N/A


## What is the new behavior?
By closing the if-else block properly in MyCustomTransformationPipe class, the functionality will work as expected. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
