### PR TITLE
refactor(docs-infra):  extract `NodeRuntimeSandbox` lazy-loading into separate function

### DIFF
--- a/adev/src/app/editor/download-manager.service.ts
+++ b/adev/src/app/editor/download-manager.service.ts
@@ -9,7 +9,8 @@
 import {DOCUMENT, isPlatformBrowser} from '@angular/common';
 import {EnvironmentInjector, Injectable, PLATFORM_ID, inject} from '@angular/core';
 import {generateZip} from '@angular/docs';
-import {injectAsync} from '../core/services/inject-async';
+
+import {injectNodeRuntimeSandbox} from './inject-node-runtime-sandbox';
 
 @Injectable({
   providedIn: 'root',
@@ -23,9 +24,7 @@ export class DownloadManager {
    * Generate ZIP with the current state of the solution in the EmbeddedEditor
    */
   async downloadCurrentStateOfTheSolution(name: string) {
-    const nodeRuntimeSandbox = await injectAsync(this.environmentInjector, () =>
-      import('./node-runtime-sandbox.service').then((c) => c.NodeRuntimeSandbox),
-    );
+    const nodeRuntimeSandbox = await injectNodeRuntimeSandbox(this.environmentInjector);
 
     const files = await nodeRuntimeSandbox.getSolutionFiles();
     const content = await generateZip(files);

--- a/adev/src/app/editor/idx-launcher.service.ts
+++ b/adev/src/app/editor/idx-launcher.service.ts
@@ -7,8 +7,9 @@
  */
 
 import {EnvironmentInjector, Injectable, inject} from '@angular/core';
-import {injectAsync} from '../core/services/inject-async';
 import * as IDX from 'open-in-idx';
+
+import {injectNodeRuntimeSandbox} from './inject-node-runtime-sandbox';
 
 @Injectable({
   providedIn: 'root',
@@ -17,9 +18,7 @@ export class IDXLauncher {
   private readonly environmentInjector = inject(EnvironmentInjector);
 
   async openCurrentSolutionInIDX(): Promise<void> {
-    const nodeRuntimeSandbox = await injectAsync(this.environmentInjector, () =>
-      import('./node-runtime-sandbox.service').then((c) => c.NodeRuntimeSandbox),
-    );
+    const nodeRuntimeSandbox = await injectNodeRuntimeSandbox(this.environmentInjector);
 
     const runtimeFiles = await nodeRuntimeSandbox.getSolutionFiles();
     const workspaceFiles: Record<string, string> = {};

--- a/adev/src/app/editor/index.ts
+++ b/adev/src/app/editor/index.ts
@@ -9,8 +9,7 @@
 export {EmbeddedTutorialManager} from './embedded-tutorial-manager.service';
 export {LoadingStep} from './enums/loading-steps';
 export {NodeRuntimeState} from './node-runtime-state.service';
-
-export {NodeRuntimeSandbox} from './node-runtime-sandbox.service';
+export {injectNodeRuntimeSandbox} from './inject-node-runtime-sandbox';
 
 export {EmbeddedEditor, EMBEDDED_EDITOR_SELECTOR} from './embedded-editor.component';
 

--- a/adev/src/app/editor/inject-node-runtime-sandbox.ts
+++ b/adev/src/app/editor/inject-node-runtime-sandbox.ts
@@ -1,0 +1,17 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {EnvironmentInjector} from '@angular/core';
+
+import {injectAsync} from '../core/services/inject-async';
+
+export function injectNodeRuntimeSandbox(injector: EnvironmentInjector) {
+  return injectAsync(injector, () =>
+    import('./node-runtime-sandbox.service').then((c) => c.NodeRuntimeSandbox),
+  );
+}

--- a/adev/src/app/editor/preview/preview.component.ts
+++ b/adev/src/app/editor/preview/preview.component.ts
@@ -6,13 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  inject,
-  computed,
-} from '@angular/core';
+import {ChangeDetectionStrategy, Component, inject, computed} from '@angular/core';
 import {DomSanitizer} from '@angular/platform-browser';
 import {toSignal} from '@angular/core/rxjs-interop';
 
@@ -30,7 +24,6 @@ import {PreviewError} from './preview-error.component';
   imports: [PreviewError],
 })
 export class Preview {
-  private readonly changeDetectorRef = inject(ChangeDetectorRef);
   private readonly domSanitizer = inject(DomSanitizer);
   private readonly nodeRuntimeSandbox = inject(NodeRuntimeSandbox);
   private readonly nodeRuntimeState = inject(NodeRuntimeState);

--- a/adev/src/app/editor/stackblitz-opener.service.ts
+++ b/adev/src/app/editor/stackblitz-opener.service.ts
@@ -8,7 +8,8 @@
 
 import {EnvironmentInjector, Injectable, inject} from '@angular/core';
 import sdk, {Project, ProjectFiles} from '@stackblitz/sdk';
-import {injectAsync} from '../core/services/inject-async';
+
+import {injectNodeRuntimeSandbox} from './inject-node-runtime-sandbox';
 
 @Injectable({
   providedIn: 'root',
@@ -22,9 +23,7 @@ export class StackBlitzOpener {
   async openCurrentSolutionInStackBlitz(
     projectMetadata: Pick<Project, 'title' | 'description'>,
   ): Promise<void> {
-    const nodeRuntimeSandbox = await injectAsync(this.environmentInjector, () =>
-      import('./node-runtime-sandbox.service').then((c) => c.NodeRuntimeSandbox),
-    );
+    const nodeRuntimeSandbox = await injectNodeRuntimeSandbox(this.environmentInjector);
 
     const runtimeFiles = await nodeRuntimeSandbox.getSolutionFiles();
 

--- a/adev/src/app/features/home/components/home-editor.component.ts
+++ b/adev/src/app/features/home/components/home-editor.component.ts
@@ -19,8 +19,11 @@ import {
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {forkJoin, switchMap} from 'rxjs';
 
-import {injectAsync} from '../../../core/services/inject-async';
-import {EmbeddedEditor, injectEmbeddedTutorialManager} from '../../../editor';
+import {
+  EmbeddedEditor,
+  injectEmbeddedTutorialManager,
+  injectNodeRuntimeSandbox,
+} from '../../../editor';
 
 @Component({
   selector: 'adev-code-editor',
@@ -46,9 +49,7 @@ export class CodeEditorComponent implements OnInit {
     // and completed, which can lead to a memory leak if the user navigates away from
     // this component to another page.
     forkJoin([
-      injectAsync(this.environmentInjector, () =>
-        import('../../../editor/index').then((c) => c.NodeRuntimeSandbox),
-      ),
+      injectNodeRuntimeSandbox(this.environmentInjector),
       injectEmbeddedTutorialManager(this.environmentInjector),
     ])
       .pipe(

--- a/adev/src/app/features/playground/playground.component.spec.ts
+++ b/adev/src/app/features/playground/playground.component.spec.ts
@@ -9,7 +9,8 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {WINDOW} from '@angular/docs';
 
-import {NodeRuntimeSandbox, EmbeddedTutorialManager} from '../../editor';
+import {EmbeddedTutorialManager} from '../../editor';
+import {NodeRuntimeSandbox} from '../../editor/node-runtime-sandbox.service';
 
 import TutorialPlayground from './playground.component';
 

--- a/adev/src/app/features/playground/playground.component.ts
+++ b/adev/src/app/features/playground/playground.component.ts
@@ -24,7 +24,8 @@ import {IconComponent, PlaygroundTemplate} from '@angular/docs';
 import {forkJoin, switchMap, tap} from 'rxjs';
 
 import {injectAsync} from '../../core/services/inject-async';
-import type {EmbeddedTutorialManager, NodeRuntimeSandbox} from '../../editor/index';
+import {injectNodeRuntimeSandbox} from '../../editor/index';
+import type {NodeRuntimeSandbox} from '../../editor/node-runtime-sandbox.service';
 
 import PLAYGROUND_ROUTE_DATA_JSON from '../../../../src/assets/tutorials/playground/routes.json';
 
@@ -62,9 +63,7 @@ export default class PlaygroundComponent implements AfterViewInit {
     // and completed, which can lead to a memory leak if the user navigates away from
     // the playground component to another page.
     forkJoin({
-      nodeRuntimeSandbox: injectAsync(this.environmentInjector, () =>
-        import('../../editor/index').then((c) => c.NodeRuntimeSandbox),
-      ),
+      nodeRuntimeSandbox: injectNodeRuntimeSandbox(this.environmentInjector),
       embeddedEditorComponent: import('../../editor/index').then((c) => c.EmbeddedEditor),
     })
       .pipe(

--- a/adev/src/app/features/tutorial/tutorial.component.spec.ts
+++ b/adev/src/app/features/tutorial/tutorial.component.spec.ts
@@ -14,12 +14,8 @@ import {provideNoopAnimations} from '@angular/platform-browser/animations';
 import {provideRouter} from '@angular/router';
 import {of} from 'rxjs';
 
-import {
-  EMBEDDED_EDITOR_SELECTOR,
-  EmbeddedEditor,
-  EmbeddedTutorialManager,
-  NodeRuntimeSandbox,
-} from '../../editor';
+import {EMBEDDED_EDITOR_SELECTOR, EmbeddedEditor, EmbeddedTutorialManager} from '../../editor';
+import {NodeRuntimeSandbox} from '../../editor/node-runtime-sandbox.service';
 
 import {mockAsyncProvider} from '../../core/services/inject-async';
 import Tutorial from './tutorial.component';

--- a/adev/src/app/features/tutorial/tutorial.component.ts
+++ b/adev/src/app/features/tutorial/tutorial.component.ts
@@ -40,12 +40,12 @@ import {from} from 'rxjs';
 import {filter} from 'rxjs/operators';
 
 import {PagePrefix} from '../../core/enums/pages';
-import {injectAsync} from '../../core/services/inject-async';
 import {
   EmbeddedTutorialManager,
   LoadingStep,
   NodeRuntimeState,
   EmbeddedEditor,
+  injectNodeRuntimeSandbox,
 } from '../../editor/index';
 import {SplitResizerHandler} from './split-resizer-handler.service';
 
@@ -151,9 +151,7 @@ export default class Tutorial {
 
     this.embeddedTutorialManager.revealAnswer();
 
-    const nodeRuntimeSandbox = await injectAsync(this.environmentInjector, () =>
-      import('../../editor/index').then((s) => s.NodeRuntimeSandbox),
-    );
+    const nodeRuntimeSandbox = await injectNodeRuntimeSandbox(this.environmentInjector);
 
     await Promise.all(
       Object.entries(this.embeddedTutorialManager.answerFiles()).map(([path, contents]) =>
@@ -169,9 +167,7 @@ export default class Tutorial {
 
     this.embeddedTutorialManager.resetRevealAnswer();
 
-    const nodeRuntimeSandbox = await injectAsync(this.environmentInjector, () =>
-      import('../../editor/index').then((s) => s.NodeRuntimeSandbox),
-    );
+    const nodeRuntimeSandbox = await injectNodeRuntimeSandbox(this.environmentInjector);
 
     await Promise.all(
       Object.entries(this.embeddedTutorialManager.tutorialFiles()).map(([path, contents]) =>
@@ -258,9 +254,7 @@ export default class Tutorial {
   }
 
   private async loadEmbeddedEditor() {
-    const nodeRuntimeSandbox = await injectAsync(this.environmentInjector, () =>
-      import('../../editor/index').then((s) => s.NodeRuntimeSandbox),
-    );
+    const nodeRuntimeSandbox = await injectNodeRuntimeSandbox(this.environmentInjector);
 
     this.canRevealAnswer = computed(() => this.nodeRuntimeState.loadingStep() > LoadingStep.BOOT);
 


### PR DESCRIPTION
In this commit, we extract `NodeRuntimeSandbox` lazy-loading into a separate function (because it's duplicated).