### PR TITLE
feat(migrations): add schematic to clean up unused imports

### DIFF
--- a/packages/compiler-cli/index.ts
+++ b/packages/compiler-cli/index.ts
@@ -42,6 +42,6 @@ export * from './src/ngtsc/docs/src/entities';
 export * from './src/ngtsc/docs';
 
 // Exposed for usage in 1P Angular plugin.
-export {isLocalCompilationDiagnostics} from './src/ngtsc/diagnostics';
+export {isLocalCompilationDiagnostics, ErrorCode, ngErrorCode} from './src/ngtsc/diagnostics';
 
 setFileSystem(new NodeJSFileSystem());

--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//tools:defaults.bzl", "pkg_npm")
 load("@npm//@bazel/rollup:index.bzl", "rollup_bundle")
+load("//tools:defaults.bzl", "pkg_npm")
 
 exports_files([
     "tsconfig.json",
@@ -13,6 +13,7 @@ pkg_npm(
         "collection.json",
         "migrations.json",
         "package.json",
+        "//packages/core/schematics/ng-generate/cleanup-unused-imports:static_files",
         "//packages/core/schematics/ng-generate/control-flow-migration:static_files",
         "//packages/core/schematics/ng-generate/inject-migration:static_files",
         "//packages/core/schematics/ng-generate/output-migration:static_files",
@@ -37,6 +38,7 @@ rollup_bundle(
         "//packages/core/schematics/ng-generate/inject-migration:index.ts": "inject-migration",
         "//packages/core/schematics/ng-generate/route-lazy-loading:index.ts": "route-lazy-loading",
         "//packages/core/schematics/ng-generate/standalone-migration:index.ts": "standalone-migration",
+        "//packages/core/schematics/ng-generate/cleanup-unused-imports:index.ts": "cleanup-unused-imports",
         "//packages/core/schematics/ng-generate/signals:index.ts": "signals",
         "//packages/core/schematics/ng-generate/signal-input-migration:index.ts": "signal-input-migration",
         "//packages/core/schematics/ng-generate/signal-queries-migration:index.ts": "signal-queries-migration",
@@ -56,6 +58,7 @@ rollup_bundle(
         "//packages/core/schematics/migrations/explicit-standalone-flag",
         "//packages/core/schematics/migrations/pending-tasks",
         "//packages/core/schematics/migrations/provide-initializer",
+        "//packages/core/schematics/ng-generate/cleanup-unused-imports",
         "//packages/core/schematics/ng-generate/control-flow-migration",
         "//packages/core/schematics/ng-generate/inject-migration",
         "//packages/core/schematics/ng-generate/output-migration",

--- a/packages/core/schematics/collection.json
+++ b/packages/core/schematics/collection.json
@@ -46,6 +46,11 @@
       "description": "Combines all signals-related migrations into a single migration",
       "factory": "./bundles/signals#migrate",
       "schema": "./ng-generate/signals/schema.json"
+    },
+    "cleanup-unused-imports": {
+      "description": "Removes unused imports from standalone components.",
+      "factory": "./bundles/cleanup-unused-imports#migrate",
+      "schema": "./ng-generate/cleanup-unused-imports/schema.json"
     }
   }
 }

--- a/packages/core/schematics/ng-generate/cleanup-unused-imports/BUILD.bazel
+++ b/packages/core/schematics/ng-generate/cleanup-unused-imports/BUILD.bazel
@@ -1,0 +1,32 @@
+load("//tools:defaults.bzl", "ts_library")
+
+package(
+    default_visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/migrations/google3:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+)
+
+filegroup(
+    name = "static_files",
+    srcs = ["schema.json"],
+)
+
+ts_library(
+    name = "cleanup-unused-imports",
+    srcs = glob(["**/*.ts"]),
+    tsconfig = "//packages/core/schematics:tsconfig.json",
+    deps = [
+        "//packages/compiler-cli",
+        "//packages/compiler-cli/private",
+        "//packages/compiler-cli/src/ngtsc/core:api",
+        "//packages/compiler-cli/src/ngtsc/file_system",
+        "//packages/core/schematics/utils",
+        "//packages/core/schematics/utils/tsurge",
+        "//packages/core/schematics/utils/tsurge/helpers/angular_devkit",
+        "@npm//@angular-devkit/schematics",
+        "@npm//@types/node",
+        "@npm//typescript",
+    ],
+)

--- a/packages/core/schematics/ng-generate/cleanup-unused-imports/README.md
+++ b/packages/core/schematics/ng-generate/cleanup-unused-imports/README.md
@@ -1,0 +1,30 @@
+## Cleanup unused imports migration
+Automated migration that removes all unused standalone imports across the entire project. It can be
+run using:
+
+```bash
+ng generate @angular/core:cleanup-unused-imports
+```
+
+**Before:**
+```typescript
+import { Component } from '@angular/core';
+import { UnusedDirective } from './unused';
+
+@Component({
+  template: 'Hello',
+  imports: [UnusedDirective],
+})
+export class MyComp {}
+```
+
+**After:**
+```typescript
+import { Component } from '@angular/core';
+
+@Component({
+  template: 'Hello',
+  imports: [],
+})
+export class MyComp {}
+```

--- a/packages/core/schematics/ng-generate/cleanup-unused-imports/index.ts
+++ b/packages/core/schematics/ng-generate/cleanup-unused-imports/index.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Rule, SchematicsException} from '@angular-devkit/schematics';
+
+import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
+import {DevkitMigrationFilesystem} from '../../utils/tsurge/helpers/angular_devkit/devkit_filesystem';
+import {groupReplacementsByFile} from '../../utils/tsurge/helpers/group_replacements';
+import {setFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {ProjectRootRelativePath, TextUpdate} from '../../utils/tsurge';
+import {synchronouslyCombineUnitData} from '../../utils/tsurge/helpers/combine_units';
+import {CompilationUnitData, UnusedImportsMigration} from './unused_imports_migration';
+
+export function migrate(): Rule {
+  return async (tree, context) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
+
+    if (!buildPaths.length && !testPaths.length) {
+      throw new SchematicsException(
+        'Could not find any tsconfig file. Cannot clean up unused imports.',
+      );
+    }
+
+    const fs = new DevkitMigrationFilesystem(tree);
+    setFileSystem(fs);
+
+    const migration = new UnusedImportsMigration();
+    const unitResults: CompilationUnitData[] = [];
+    const programInfos = [...buildPaths, ...testPaths].map((tsconfigPath) => {
+      context.logger.info(`Preparing analysis for ${tsconfigPath}`);
+
+      const baseInfo = migration.createProgram(tsconfigPath, fs);
+      const info = migration.prepareProgram(baseInfo);
+
+      return {info, tsconfigPath};
+    });
+
+    for (const {info, tsconfigPath} of programInfos) {
+      context.logger.info(`Scanning for unused imports using ${tsconfigPath}`);
+      unitResults.push(await migration.analyze(info));
+    }
+
+    const combined = await synchronouslyCombineUnitData(migration, unitResults);
+    if (combined === null) {
+      context.logger.error('Schematic failed unexpectedly with no analysis data');
+      return;
+    }
+
+    const globalMeta = await migration.globalMeta(combined);
+    const replacementsPerFile: Map<ProjectRootRelativePath, TextUpdate[]> = new Map();
+    const {replacements} = await migration.migrate(globalMeta);
+    const changesPerFile = groupReplacementsByFile(replacements);
+
+    for (const [file, changes] of changesPerFile) {
+      if (!replacementsPerFile.has(file)) {
+        replacementsPerFile.set(file, changes);
+      }
+    }
+
+    for (const [file, changes] of replacementsPerFile) {
+      const recorder = tree.beginUpdate(file);
+      for (const c of changes) {
+        recorder
+          .remove(c.data.position, c.data.end - c.data.position)
+          .insertLeft(c.data.position, c.data.toInsert);
+      }
+      tree.commitUpdate(recorder);
+    }
+
+    const {
+      counters: {removedImports, changedFiles},
+    } = await migration.stats(globalMeta);
+    let statsMessage: string;
+
+    if (removedImports === 0) {
+      statsMessage = 'Schematic could not find unused imports in the project';
+    } else {
+      statsMessage =
+        `Removed ${removedImports} import${removedImports !== 1 ? 's' : ''} ` +
+        `in ${changedFiles} file${changedFiles !== 1 ? 's' : ''}`;
+    }
+
+    context.logger.info('');
+    context.logger.info(statsMessage);
+  };
+}

--- a/packages/core/schematics/ng-generate/cleanup-unused-imports/schema.json
+++ b/packages/core/schematics/ng-generate/cleanup-unused-imports/schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "AngularCleanupUnusedImportsMigration",
+  "title": "Angular Cleanup Unused Imports Schema",
+  "type": "object",
+  "properties": {}
+}

--- a/packages/core/schematics/ng-generate/cleanup-unused-imports/unused_imports_migration.ts
+++ b/packages/core/schematics/ng-generate/cleanup-unused-imports/unused_imports_migration.ts
@@ -1,0 +1,337 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import ts from 'typescript';
+import {
+  BaseProgramInfo,
+  confirmAsSerializable,
+  MigrationStats,
+  ProgramInfo,
+  projectFile,
+  Replacement,
+  Serializable,
+  TextUpdate,
+  TsurgeFunnelMigration,
+} from '../../utils/tsurge';
+import {ErrorCode, FileSystem, ngErrorCode} from '@angular/compiler-cli';
+import {DiagnosticCategoryLabel} from '@angular/compiler-cli/src/ngtsc/core/api';
+import {ImportManager} from '@angular/compiler-cli/private/migrations';
+import {applyImportManagerChanges} from '../../utils/tsurge/helpers/apply_import_manager';
+
+/** Data produced by the migration for each compilation unit. */
+export interface CompilationUnitData {
+  /** Text changes that should be performed. */
+  replacements: Replacement[];
+
+  /** Total number of imports that were removed. */
+  removedImports: number;
+
+  /** Total number of files that were changed. */
+  changedFiles: number;
+}
+
+/** Tracks the places from which to remove unused imports. */
+interface RemovalLocations {
+  /** Arrays whose entire contents should be cleared. */
+  fullRemovals: Set<ts.ArrayLiteralExpression>;
+
+  /** Arrays where only some elements need to be removed. */
+  partialRemovals: Map<ts.ArrayLiteralExpression, Set<ts.Expression>>;
+
+  /** Text of all identifiers that have been removed. */
+  allRemovedIdentifiers: Set<string>;
+}
+
+/** Tracks how identifiers are used across a single file. */
+interface UsageAnalysis {
+  /**
+   * Data about the symbols imported into the file. The key here is the module from which each
+   * symbol is imported. Each module contains a map between a local symbol name within the file
+   * and its original name.
+   */
+  importedSymbols: Map<string, Map<string, string>>;
+
+  /** Number of times each identifier string is seen within a file. */
+  identifierCounts: Map<string, number>;
+}
+
+/** Migration that cleans up unused imports from a project. */
+export class UnusedImportsMigration extends TsurgeFunnelMigration<
+  CompilationUnitData,
+  CompilationUnitData
+> {
+  private printer = ts.createPrinter();
+
+  override createProgram(tsconfigAbsPath: string, fs?: FileSystem): BaseProgramInfo {
+    return super.createProgram(tsconfigAbsPath, fs, {
+      extendedDiagnostics: {
+        checks: {
+          // Ensure that the diagnostic is enabled.
+          unusedStandaloneImports: DiagnosticCategoryLabel.Warning,
+        },
+      },
+    });
+  }
+
+  override async analyze(info: ProgramInfo): Promise<Serializable<CompilationUnitData>> {
+    const nodePositions = new Map<ts.SourceFile, Set<string>>();
+    const replacements: Replacement[] = [];
+    let removedImports = 0;
+    let changedFiles = 0;
+
+    info.ngCompiler?.getDiagnostics().forEach((diag) => {
+      if (
+        diag.file !== undefined &&
+        diag.start !== undefined &&
+        diag.length !== undefined &&
+        diag.code === ngErrorCode(ErrorCode.UNUSED_STANDALONE_IMPORTS)
+      ) {
+        if (!nodePositions.has(diag.file)) {
+          nodePositions.set(diag.file, new Set());
+        }
+        nodePositions.get(diag.file)!.add(this.getNodeKey(diag.start, diag.length));
+      }
+    });
+
+    nodePositions.forEach((locations, sourceFile) => {
+      const resolvedLocations = this.resolveRemovalLocations(sourceFile, locations);
+      const usageAnalysis = this.analyzeUsages(sourceFile, resolvedLocations);
+
+      if (resolvedLocations.allRemovedIdentifiers.size > 0) {
+        removedImports += resolvedLocations.allRemovedIdentifiers.size;
+        changedFiles++;
+      }
+
+      this.generateReplacements(sourceFile, resolvedLocations, usageAnalysis, info, replacements);
+    });
+
+    return confirmAsSerializable({replacements, removedImports, changedFiles});
+  }
+
+  override async migrate(globalData: CompilationUnitData) {
+    return confirmAsSerializable(globalData);
+  }
+
+  override async combine(
+    unitA: CompilationUnitData,
+    unitB: CompilationUnitData,
+  ): Promise<Serializable<CompilationUnitData>> {
+    return confirmAsSerializable({
+      replacements: [...unitA.replacements, ...unitB.replacements],
+      removedImports: unitA.removedImports + unitB.removedImports,
+      changedFiles: unitA.changedFiles + unitB.changedFiles,
+    });
+  }
+
+  override async globalMeta(
+    combinedData: CompilationUnitData,
+  ): Promise<Serializable<CompilationUnitData>> {
+    return confirmAsSerializable(combinedData);
+  }
+
+  override async stats(globalMetadata: CompilationUnitData): Promise<MigrationStats> {
+    return {
+      counters: {
+        removedImports: globalMetadata.removedImports,
+        changedFiles: globalMetadata.changedFiles,
+      },
+    };
+  }
+
+  /** Gets a key that can be used to look up a node based on its location. */
+  private getNodeKey(start: number, length: number): string {
+    return `${start}/${length}`;
+  }
+
+  /**
+   * Resolves a set of node locations to the actual AST nodes that need to be migrated.
+   * @param sourceFile File in which to resolve the locations.
+   * @param locations Location keys that should be resolved.
+   */
+  private resolveRemovalLocations(
+    sourceFile: ts.SourceFile,
+    locations: Set<string>,
+  ): RemovalLocations {
+    const result: RemovalLocations = {
+      fullRemovals: new Set(),
+      partialRemovals: new Map(),
+      allRemovedIdentifiers: new Set(),
+    };
+
+    const walk = (node: ts.Node) => {
+      if (!ts.isIdentifier(node)) {
+        node.forEachChild(walk);
+        return;
+      }
+
+      // The TS typings don't reflect that the parent can be undefined.
+      const parent = node.parent as ts.Node | undefined;
+
+      if (!parent) {
+        return;
+      }
+
+      if (locations.has(this.getNodeKey(node.getStart(), node.getWidth()))) {
+        // When the entire array needs to be cleared, the diagnostic is
+        // reported on the property assignment, rather than an array element.
+        if (
+          ts.isPropertyAssignment(parent) &&
+          parent.name === node &&
+          ts.isArrayLiteralExpression(parent.initializer)
+        ) {
+          result.fullRemovals.add(parent.initializer);
+          parent.initializer.elements.forEach((element) => {
+            if (ts.isIdentifier(element)) {
+              result.allRemovedIdentifiers.add(element.text);
+            }
+          });
+        } else if (ts.isArrayLiteralExpression(parent)) {
+          if (!result.partialRemovals.has(parent)) {
+            result.partialRemovals.set(parent, new Set());
+          }
+          result.partialRemovals.get(parent)!.add(node);
+          result.allRemovedIdentifiers.add(node.text);
+        }
+      }
+    };
+
+    walk(sourceFile);
+
+    return result;
+  }
+
+  /**
+   * Analyzes how identifiers are used across a file.
+   * @param sourceFile File to be analyzed.
+   * @param locations Locations that will be changed as a part of this migration.
+   */
+  private analyzeUsages(sourceFile: ts.SourceFile, locations: RemovalLocations): UsageAnalysis {
+    const {partialRemovals, fullRemovals} = locations;
+    const result: UsageAnalysis = {
+      importedSymbols: new Map(),
+      identifierCounts: new Map(),
+    };
+
+    const walk = (node: ts.Node) => {
+      if (
+        ts.isIdentifier(node) &&
+        node.parent &&
+        // Don't track individual identifiers marked for removal.
+        (!ts.isArrayLiteralExpression(node.parent) ||
+          !partialRemovals.has(node.parent) ||
+          !partialRemovals.get(node.parent)!.has(node))
+      ) {
+        result.identifierCounts.set(node.text, (result.identifierCounts.get(node.text) ?? 0) + 1);
+      }
+
+      // Don't track identifiers in array literals that are about to be removed.
+      if (ts.isArrayLiteralExpression(node) && fullRemovals.has(node)) {
+        return;
+      }
+
+      if (ts.isImportDeclaration(node)) {
+        const namedBindings = node.importClause?.namedBindings;
+        const moduleName = ts.isStringLiteral(node.moduleSpecifier)
+          ? node.moduleSpecifier.text
+          : null;
+
+        if (namedBindings && ts.isNamedImports(namedBindings) && moduleName !== null) {
+          namedBindings.elements.forEach((imp) => {
+            if (!result.importedSymbols.has(moduleName)) {
+              result.importedSymbols.set(moduleName, new Map());
+            }
+            const symbolName = (imp.propertyName || imp.name).text;
+            const localName = imp.name.text;
+            result.importedSymbols.get(moduleName)!.set(localName, symbolName);
+          });
+        }
+
+        // Don't track identifiers in imports.
+        return;
+      }
+
+      // Track identifiers in all other node kinds.
+      node.forEachChild(walk);
+    };
+
+    walk(sourceFile);
+
+    return result;
+  }
+
+  /**
+   * Generates text replacements based on the data produced by the migration.
+   * @param sourceFile File being migrated.
+   * @param removalLocations Data about nodes being removed.
+   * @param usages Data about identifier usage.
+   * @param info Information about the current program.
+   * @param replacements Array tracking all text replacements.
+   */
+  private generateReplacements(
+    sourceFile: ts.SourceFile,
+    removalLocations: RemovalLocations,
+    usages: UsageAnalysis,
+    info: ProgramInfo,
+    replacements: Replacement[],
+  ): void {
+    const {fullRemovals, partialRemovals, allRemovedIdentifiers} = removalLocations;
+    const {importedSymbols, identifierCounts} = usages;
+    const importManager = new ImportManager();
+
+    // Replace full arrays with empty ones. This allows preserves more of the user's formatting.
+    fullRemovals.forEach((node) => {
+      replacements.push(
+        new Replacement(
+          projectFile(sourceFile, info),
+          new TextUpdate({
+            position: node.getStart(),
+            end: node.getEnd(),
+            toInsert: '[]',
+          }),
+        ),
+      );
+    });
+
+    // Filter out the unused identifiers from an array.
+    partialRemovals.forEach((toRemove, node) => {
+      const newNode = ts.factory.updateArrayLiteralExpression(
+        node,
+        node.elements.filter((el) => !toRemove.has(el)),
+      );
+
+      replacements.push(
+        new Replacement(
+          projectFile(sourceFile, info),
+          new TextUpdate({
+            position: node.getStart(),
+            end: node.getEnd(),
+            toInsert: this.printer.printNode(ts.EmitHint.Unspecified, newNode, sourceFile),
+          }),
+        ),
+      );
+    });
+
+    // Attempt to clean up unused import declarations. Note that this isn't foolproof, because we
+    // do the matching based on identifier text, rather than going through the type checker which
+    // can be expensive. This should be enough for the vast majority of cases in this schematic
+    // since we're dealing exclusively with directive/pipe class names which tend to be very
+    // specific. In the worst case we may end up not removing an import declaration which would
+    // still be valid code that the user can clean up themselves.
+    importedSymbols.forEach((names, moduleName) => {
+      names.forEach((symbolName, localName) => {
+        // Note that in the `identifierCounts` lookup both zero and undefined
+        // are valid and mean that the identifiers isn't being used anymore.
+        if (allRemovedIdentifiers.has(localName) && !identifierCounts.get(localName)) {
+          importManager.removeImport(sourceFile, symbolName, moduleName);
+        }
+      });
+    });
+
+    applyImportManagerChanges(importManager, replacements, [sourceFile], info);
+  }
+}

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -21,6 +21,7 @@ jasmine_node_test(
         "//packages/core/schematics:bundles",
         "//packages/core/schematics:collection.json",
         "//packages/core/schematics:migrations.json",
+        "//packages/core/schematics/ng-generate/cleanup-unused-imports:static_files",
         "//packages/core/schematics/ng-generate/control-flow-migration:static_files",
         "//packages/core/schematics/ng-generate/inject-migration:static_files",
         "//packages/core/schematics/ng-generate/output-migration:static_files",

--- a/packages/core/schematics/test/cleanup_unused_imports_migration_spec.ts
+++ b/packages/core/schematics/test/cleanup_unused_imports_migration_spec.ts
@@ -1,0 +1,256 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {getSystemPath, normalize, virtualFs} from '@angular-devkit/core';
+import {TempScopedNodeJsSyncHost} from '@angular-devkit/core/node/testing';
+import {HostTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
+import {runfiles} from '@bazel/runfiles';
+import shx from 'shelljs';
+
+describe('cleanup unused imports schematic', () => {
+  let runner: SchematicTestRunner;
+  let host: TempScopedNodeJsSyncHost;
+  let tree: UnitTestTree;
+  let tmpDirPath: string;
+  let previousWorkingDir: string;
+
+  function writeFile(filePath: string, contents: string) {
+    host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
+  }
+
+  function runMigration() {
+    return runner.runSchematic('cleanup-unused-imports', {}, tree);
+  }
+
+  function stripWhitespace(content: string) {
+    return content.replace(/\s+/g, '');
+  }
+
+  beforeEach(() => {
+    runner = new SchematicTestRunner('test', runfiles.resolvePackageRelative('../collection.json'));
+    host = new TempScopedNodeJsSyncHost();
+    tree = new UnitTestTree(new HostTree(host));
+
+    writeFile(
+      '/tsconfig.json',
+      JSON.stringify({
+        compilerOptions: {
+          lib: ['es2015'],
+          strictNullChecks: true,
+        },
+      }),
+    );
+
+    writeFile(
+      '/angular.json',
+      JSON.stringify({
+        version: 1,
+        projects: {t: {root: '', architect: {build: {options: {tsConfig: './tsconfig.json'}}}}},
+      }),
+    );
+
+    previousWorkingDir = shx.pwd();
+    tmpDirPath = getSystemPath(host.root);
+
+    // Switch into the temporary directory path. This allows us to run
+    // the schematic against our custom unit test tree.
+    shx.cd(tmpDirPath);
+
+    writeFile(
+      'directives.ts',
+      `
+        import {Directive} from '@angular/core';
+
+        @Directive({selector: '[one]'})
+        export class One {}
+
+        @Directive({selector: '[two]'})
+        export class Two {}
+
+        @Directive({selector: '[three]'})
+        export class Three {}
+      `,
+    );
+  });
+
+  afterEach(() => {
+    shx.cd(previousWorkingDir);
+    shx.rm('-r', tmpDirPath);
+  });
+
+  it('should clean up an array where some imports are not used', async () => {
+    writeFile(
+      'comp.ts',
+      `
+        import {Component} from '@angular/core';
+        import {One, Two, Three} from './directives';
+
+        @Component({
+          imports: [Three, One, Two],
+          template: '<div one></div>',
+        })
+        export class Comp {}
+      `,
+    );
+
+    await runMigration();
+
+    expect(stripWhitespace(tree.readContent('comp.ts'))).toBe(
+      stripWhitespace(`
+        import {Component} from '@angular/core';
+        import {One} from './directives';
+
+        @Component({
+          imports: [One],
+          template: '<div one></div>',
+        })
+        export class Comp {}
+    `),
+    );
+  });
+
+  it('should clean up an array where all imports are not used', async () => {
+    writeFile(
+      'comp.ts',
+      `
+        import {Component} from '@angular/core';
+        import {One, Two, Three} from './directives';
+
+        @Component({
+          imports: [Three, One, Two],
+          template: '',
+        })
+        export class Comp {}
+      `,
+    );
+
+    await runMigration();
+
+    expect(stripWhitespace(tree.readContent('comp.ts'))).toBe(
+      stripWhitespace(`
+        import {Component} from '@angular/core';
+
+        @Component({
+          imports: [],
+          template: '',
+        })
+        export class Comp {}
+    `),
+    );
+  });
+
+  it('should clean up an array where aliased imports are not used', async () => {
+    writeFile(
+      'comp.ts',
+      `
+        import {Component} from '@angular/core';
+        import {One as OneAlias, Two as TwoAlias, Three as ThreeAlias} from './directives';
+
+        @Component({
+          imports: [ThreeAlias, OneAlias, TwoAlias],
+          template: '<div one></div>',
+        })
+        export class Comp {}
+      `,
+    );
+
+    await runMigration();
+
+    expect(stripWhitespace(tree.readContent('comp.ts'))).toBe(
+      stripWhitespace(`
+        import {Component} from '@angular/core';
+        import {One as OneAlias} from './directives';
+
+        @Component({
+          imports: [OneAlias],
+          template: '<div one></div>',
+        })
+        export class Comp {}
+    `),
+    );
+  });
+
+  it('should preserve import declaration if unused import is still used within the file', async () => {
+    writeFile(
+      'comp.ts',
+      `
+        import {Component} from '@angular/core';
+        import {One} from './directives';
+
+        @Component({
+          imports: [One],
+          template: '',
+        })
+        export class Comp {}
+
+        @Component({
+          imports: [One],
+          template: '<div one></div>',
+        })
+        export class OtherComp {}
+      `,
+    );
+
+    await runMigration();
+
+    expect(stripWhitespace(tree.readContent('comp.ts'))).toBe(
+      stripWhitespace(`
+        import {Component} from '@angular/core';
+        import {One} from './directives';
+
+        @Component({
+          imports: [],
+          template: '',
+        })
+        export class Comp {}
+
+        @Component({
+          imports: [One],
+          template: '<div one></div>',
+        })
+        export class OtherComp {}
+    `),
+    );
+  });
+
+  it('should not touch a file where all imports are used', async () => {
+    const initialContent = `
+      import {Component} from '@angular/core';
+      import {One, Two, Three} from './directives';
+
+      @Component({
+        imports: [Three, One, Two],
+        template: '<div one two three></div>',
+      })
+      export class Comp {}
+    `;
+
+    writeFile('comp.ts', initialContent);
+
+    await runMigration();
+
+    expect(tree.readContent('comp.ts')).toBe(initialContent);
+  });
+
+  it('should not touch unused import declarations that are not referenced in an `imports` array', async () => {
+    const initialContent = `
+      import {Component} from '@angular/core';
+      import {One, Two, Three} from './directives';
+
+      @Component({template: 'Hello'})
+      export class Comp {}
+    `;
+
+    writeFile('comp.ts', initialContent);
+
+    await runMigration();
+
+    expect(tree.readContent('comp.ts')).toBe(initialContent);
+  });
+});

--- a/packages/core/schematics/utils/tsurge/base_migration.ts
+++ b/packages/core/schematics/utils/tsurge/base_migration.ts
@@ -7,9 +7,10 @@
  */
 
 import {absoluteFrom, FileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {NgCompilerOptions} from '@angular/compiler-cli/src/ngtsc/core/api';
+import {getRootDirs} from '@angular/compiler-cli/src/ngtsc/util/src/typescript';
 import {isShim} from '@angular/compiler-cli/src/ngtsc/shims';
 import {BaseProgramInfo, ProgramInfo} from './program_info';
-import {getRootDirs} from '@angular/compiler-cli/src/ngtsc/util/src/typescript';
 import {Serializable} from './helpers/serializable';
 import {createBaseProgramInfo} from './helpers/create_program';
 
@@ -40,8 +41,12 @@ export abstract class TsurgeBaseMigration<UnitAnalysisMetadata, CombinedGlobalMe
    *  - In 3P: Ngtsc programs are being created.
    *  - In 1P: Ngtsc or TS programs are created based on the Blaze target.
    */
-  createProgram(tsconfigAbsPath: string, fs?: FileSystem): BaseProgramInfo {
-    return createBaseProgramInfo(tsconfigAbsPath, fs);
+  createProgram(
+    tsconfigAbsPath: string,
+    fs?: FileSystem,
+    optionOverrides?: NgCompilerOptions,
+  ): BaseProgramInfo {
+    return createBaseProgramInfo(tsconfigAbsPath, fs, optionOverrides);
   }
 
   // Optional function to prepare the base `ProgramInfo` even further,


### PR DESCRIPTION
In v19 we added a warning about unused standalone imports, however we didn't do anything about existing code which means that users have to clean it up manually. These changes add the `ng g @angular/core:cleanup-unused-imports` schematic which will remove the unused dependencies automatically.

There isn't any new detection code since all the manipulations are based on the produced diagnostics, but there's a bit of code to remove the import declarations from the file as well.

Fixes #58849.