### PR TITLE
Backport: feat(compiler): add support for the typeof keyword in template expressions #58183 

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -25,6 +25,7 @@ import {
   LiteralPrimitive,
   NonNullAssert,
   PrefixNot,
+  TypeofExpression,
   PropertyRead,
   PropertyWrite,
   SafeCall,
@@ -271,6 +272,13 @@ class AstTranslator implements AstVisitor {
   visitPrefixNot(ast: PrefixNot): ts.Expression {
     const expression = wrapForDiagnostics(this.translate(ast.expression));
     const node = ts.factory.createLogicalNot(expression);
+    addParseSpanInfo(node, ast.sourceSpan);
+    return node;
+  }
+
+  visitTypeofExpresion(ast: TypeofExpression): ts.Expression {
+    const expression = wrapForDiagnostics(this.translate(ast.expression));
+    const node = ts.factory.createTypeOfExpression(expression);
     addParseSpanInfo(node, ast.sourceSpan);
     return node;
   }
@@ -539,6 +547,9 @@ class VeSafeLhsInferenceBugDetector implements AstVisitor {
     return true;
   }
   visitPrefixNot(ast: PrefixNot): boolean {
+    return ast.expression.visit(this);
+  }
+  visitTypeofExpresion(ast: PrefixNot): boolean {
     return ast.expression.visit(this);
   }
   visitNonNullAssert(ast: PrefixNot): boolean {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -61,6 +61,14 @@ describe('type check blocks', () => {
     );
   });
 
+  it('should handle typeof expressions', () => {
+    expect(tcb('{{typeof a}}')).toContain('typeof (((this).a))');
+    expect(tcb('{{!(typeof a)}}')).toContain('!(typeof (((this).a)))');
+    expect(tcb('{{!(typeof a === "object")}}')).toContain(
+      '!((typeof (((this).a))) === ("object"))',
+    );
+  });
+
   it('should handle attribute values for directive inputs', () => {
     const TEMPLATE = `<div dir inputA="value"></div>`;
     const DIRECTIVES: TestDeclaration[] = [

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/GOLDEN_PARTIAL.js
@@ -66,16 +66,23 @@ export declare class TodoModule {
 /****************************************************************************************************
  * PARTIAL FILE: operators.js
  ****************************************************************************************************/
-import { Component, NgModule } from '@angular/core';
+import { Component, NgModule, Pipe } from '@angular/core';
 import * as i0 from "@angular/core";
 export class MyApp {
+    constructor() {
+        this.foo = { bar: 'baz' };
+    }
 }
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     {{ 1 + 2 }}
 	{{ (1 % 2) + 3 / 4 * 5 }}
 	{{ +1 }}
-`, isInline: true });
+  {{ typeof {} === 'object' }}
+  {{ !(typeof {} === 'object') }}
+  {{ typeof foo?.bar === 'string' }}
+  {{ typeof foo?.bar | identity }}
+`, isInline: true, dependencies: [{ kind: "pipe", type: i0.forwardRef(() => IdentityPipe), name: "identity" }] });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
             type: Component,
             args: [{
@@ -83,17 +90,30 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
     {{ 1 + 2 }}
 	{{ (1 % 2) + 3 / 4 * 5 }}
 	{{ +1 }}
+  {{ typeof {} === 'object' }}
+  {{ !(typeof {} === 'object') }}
+  {{ typeof foo?.bar === 'string' }}
+  {{ typeof foo?.bar | identity }}
 `
                 }]
+        }] });
+export class IdentityPipe {
+    transform(value) { return value; }
+}
+IdentityPipe.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: IdentityPipe, deps: [], target: i0.ɵɵFactoryTarget.Pipe });
+IdentityPipe.ɵpipe = i0.ɵɵngDeclarePipe({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: IdentityPipe, name: "identity" });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: IdentityPipe, decorators: [{
+            type: Pipe,
+            args: [{ name: 'identity' }]
         }] });
 export class MyModule {
 }
 MyModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
-MyModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, declarations: [MyApp] });
+MyModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, declarations: [MyApp, IdentityPipe] });
 MyModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, decorators: [{
             type: NgModule,
-            args: [{ declarations: [MyApp] }]
+            args: [{ declarations: [MyApp, IdentityPipe] }]
         }] });
 
 /****************************************************************************************************
@@ -101,12 +121,20 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
  ****************************************************************************************************/
 import * as i0 from "@angular/core";
 export declare class MyApp {
+    foo: {
+        bar?: string;
+    };
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
 }
+export declare class IdentityPipe {
+    transform(value: any): any;
+    static ɵfac: i0.ɵɵFactoryDeclaration<IdentityPipe, never>;
+    static ɵpipe: i0.ɵɵPipeDeclaration<IdentityPipe, "identity", false>;
+}
 export declare class MyModule {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyModule, never>;
-    static ɵmod: i0.ɵɵNgModuleDeclaration<MyModule, [typeof MyApp], never, never>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MyModule, [typeof MyApp, typeof IdentityPipe], never, never>;
     static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
 }
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/operators.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/operators.ts
@@ -1,15 +1,25 @@
-import {Component, NgModule} from '@angular/core';
+import {Component, NgModule, Pipe} from '@angular/core';
 
 @Component({
   template: `
     {{ 1 + 2 }}
 	{{ (1 % 2) + 3 / 4 * 5 }}
 	{{ +1 }}
+  {{ typeof {} === 'object' }}
+  {{ !(typeof {} === 'object') }}
+  {{ typeof foo?.bar === 'string' }}
+  {{ typeof foo?.bar | identity }}
 `
 })
 export class MyApp {
+    foo: {bar?: string} = {bar: 'baz'};
 }
 
-@NgModule({declarations: [MyApp]})
+@Pipe ({name: 'identity'})
+export class IdentityPipe {
+    transform(value: any) { return value; }
+}
+
+@NgModule({declarations: [MyApp, IdentityPipe]})
 export class MyModule {
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/operators_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/operators_template.js
@@ -1,8 +1,17 @@
 template: function MyApp_Template(rf, $ctx$) {
 	if (rf & 1) {
 	  $i0$.ɵɵtext(0);
+	  i0.ɵɵpipe(1, "identity");
 	} if (rf & 2) {
-	  i0.ɵɵtextInterpolate3(" ", 1 + 2, " ", 1 % 2 + 3 / 4 * 5, " ", +1, "\n");
+	  i0.ɵɵtextInterpolate7(" ", 
+		1 + 2, " ", 
+		1 % 2 + 3 / 4 * 5, " ", 
+		+1, " ", 
+		typeof i0.ɵɵpureFunction0(9, _c0) === "object", " ", 
+		!(typeof i0.ɵɵpureFunction0(10, _c0) === "object"), " ", 
+		typeof (ctx.foo == null ? null : ctx.foo.bar) === "string", " ", 
+		i0.ɵɵpipeBind1(1, 7, typeof (ctx.foo == null ? null : ctx.foo.bar)), "\n"
+	  );	
 	}
   }
   

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -663,6 +663,47 @@ runInEachFileSystem(() => {
       expect(diags[0].messageText).toContain(`Property 'input' does not exist on type 'TestCmp'.`);
     });
 
+    it('should error on non valid typeof expressions', () => {
+      env.write(
+        'test.ts',
+        `
+        import {Component} from '@angular/core';
+
+        @Component({
+          standalone: true,
+          template: \` {{typeof {} === 'foobar'}} \`,
+        })
+        class TestCmp {
+        }
+        `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toContain(`This comparison appears to be unintentional`);
+    });
+
+    it('should error on misused logical not in typeof expressions', () => {
+      env.write(
+        'test.ts',
+        `
+        import {Component} from '@angular/core';
+
+        @Component({
+          standalone: true,
+          // should be !(typeof {} === 'object')
+          template: \` {{!typeof {} === 'object'}} \`,
+        })
+        class TestCmp {
+        }
+        `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toContain(`This comparison appears to be unintentional`);
+    });
+
     describe('strictInputTypes', () => {
       beforeEach(() => {
         env.write(

--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -373,6 +373,19 @@ export class PrefixNot extends AST {
   }
 }
 
+export class TypeofExpression extends AST {
+  constructor(
+    span: ParseSpan,
+    sourceSpan: AbsoluteSourceSpan,
+    public expression: AST,
+  ) {
+    super(span, sourceSpan);
+  }
+  override visit(visitor: AstVisitor, context: any = null): any {
+    return visitor.visitTypeofExpresion(this, context);
+  }
+}
+
 export class NonNullAssert extends AST {
   constructor(
     span: ParseSpan,
@@ -534,6 +547,7 @@ export interface AstVisitor {
   visitLiteralPrimitive(ast: LiteralPrimitive, context: any): any;
   visitPipe(ast: BindingPipe, context: any): any;
   visitPrefixNot(ast: PrefixNot, context: any): any;
+  visitTypeofExpresion(ast: TypeofExpression, context: any): any;
   visitNonNullAssert(ast: NonNullAssert, context: any): any;
   visitPropertyRead(ast: PropertyRead, context: any): any;
   visitPropertyWrite(ast: PropertyWrite, context: any): any;
@@ -599,6 +613,9 @@ export class RecursiveAstVisitor implements AstVisitor {
   }
   visitLiteralPrimitive(ast: LiteralPrimitive, context: any): any {}
   visitPrefixNot(ast: PrefixNot, context: any): any {
+    this.visit(ast.expression, context);
+  }
+  visitTypeofExpresion(ast: TypeofExpression, context: any) {
     this.visit(ast.expression, context);
   }
   visitNonNullAssert(ast: NonNullAssert, context: any): any {
@@ -713,6 +730,10 @@ export class AstTransformer implements AstVisitor {
 
   visitPrefixNot(ast: PrefixNot, context: any): AST {
     return new PrefixNot(ast.span, ast.sourceSpan, ast.expression.visit(this));
+  }
+
+  visitTypeofExpresion(ast: TypeofExpression, context: any): AST {
+    return new TypeofExpression(ast.span, ast.sourceSpan, ast.expression.visit(this));
   }
 
   visitNonNullAssert(ast: NonNullAssert, context: any): AST {
@@ -887,6 +908,14 @@ export class AstMemoryEfficientTransformer implements AstVisitor {
     const expression = ast.expression.visit(this);
     if (expression !== ast.expression) {
       return new PrefixNot(ast.span, ast.sourceSpan, expression);
+    }
+    return ast;
+  }
+
+  visitTypeofExpresion(ast: TypeofExpression, context: any): AST {
+    const expression = ast.expression.visit(this);
+    if (expression !== ast.expression) {
+      return new TypeofExpression(ast.span, ast.sourceSpan, expression);
     }
     return ast;
   }

--- a/packages/compiler/src/expression_parser/lexer.ts
+++ b/packages/compiler/src/expression_parser/lexer.ts
@@ -19,7 +19,19 @@ export enum TokenType {
   Error,
 }
 
-const KEYWORDS = ['var', 'let', 'as', 'null', 'undefined', 'true', 'false', 'if', 'else', 'this'];
+const KEYWORDS = [
+  'var',
+  'let',
+  'as',
+  'null',
+  'undefined',
+  'true',
+  'false',
+  'if',
+  'else',
+  'this',
+  'typeof',
+];
 
 export class Lexer {
   tokenize(text: string): Token[] {
@@ -97,6 +109,10 @@ export class Token {
 
   isKeywordThis(): boolean {
     return this.type == TokenType.Keyword && this.strValue == 'this';
+  }
+
+  isKeywordTypeof(): boolean {
+    return this.type === TokenType.Keyword && this.strValue === 'typeof';
   }
 
   isError(): boolean {
@@ -434,18 +450,6 @@ function isIdentifierStart(code: number): boolean {
     code == chars.$_ ||
     code == chars.$$
   );
-}
-
-export function isIdentifier(input: string): boolean {
-  if (input.length == 0) return false;
-  const scanner = new _Scanner(input);
-  if (!isIdentifierStart(scanner.peek)) return false;
-  scanner.advance();
-  while (scanner.peek !== chars.$EOF) {
-    if (!isIdentifierPart(scanner.peek)) return false;
-    scanner.advance();
-  }
-  return true;
 }
 
 function isIdentifierPart(code: number): boolean {

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -37,6 +37,7 @@ import {
   ParserError,
   ParseSpan,
   PrefixNot,
+  TypeofExpression,
   PropertyRead,
   PropertyWrite,
   RecursiveAstVisitor,
@@ -960,6 +961,11 @@ class _ParseAST {
           result = this.parsePrefix();
           return new PrefixNot(this.span(start), this.sourceSpan(start), result);
       }
+    } else if (this.next.isKeywordTypeof()) {
+      this.advance();
+      const start = this.inputIndex;
+      let result = this.parsePrefix();
+      return new TypeofExpression(this.span(start), this.sourceSpan(start), result);
     }
     return this.parseCallChain();
   }

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -1118,6 +1118,8 @@ function convertAst(
       convertAst(ast.expression, job, baseSourceSpan),
       convertSourceSpan(ast.span, baseSourceSpan),
     );
+  } else if (ast instanceof e.TypeofExpression) {
+    return o.typeofExpr(convertAst(ast.expression, job, baseSourceSpan));
   } else {
     throw new Error(
       `Unhandled expression type "${ast.constructor.name}" in file "${baseSourceSpan?.start.file.url}"`,

--- a/packages/compiler/test/expression_parser/lexer_spec.ts
+++ b/packages/compiler/test/expression_parser/lexer_spec.ts
@@ -185,6 +185,12 @@ describe('lexer', () => {
       expect(tokens[0].isKeywordUndefined()).toBe(true);
     });
 
+    it('should tokenize typeof', () => {
+      const tokens: Token[] = lex('typeof');
+      expectKeywordToken(tokens[0], 0, 6, 'typeof');
+      expect(tokens[0].isKeywordTypeof()).toBe(true);
+    });
+
     it('should ignore whitespace', () => {
       const tokens: Token[] = lex('a \t \n \r b');
       expectIdentifierToken(tokens[0], 0, 1, 'a');

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -98,6 +98,11 @@ describe('parser', () => {
       checkAction('null ?? undefined ?? 0');
     });
 
+    it('should parse typeof expression', () => {
+      checkAction(`typeof {} === "object"`);
+      checkAction('(!(typeof {} === "number"))', '!typeof {} === "number"');
+    });
+
     it('should parse grouped expressions', () => {
       checkAction('(1 + 2) * 3', '1 + 2 * 3');
     });

--- a/packages/compiler/test/expression_parser/utils/unparser.ts
+++ b/packages/compiler/test/expression_parser/utils/unparser.ts
@@ -24,6 +24,7 @@ import {
   LiteralPrimitive,
   NonNullAssert,
   PrefixNot,
+  TypeofExpression,
   PropertyRead,
   PropertyWrite,
   RecursiveAstVisitor,
@@ -189,6 +190,11 @@ class Unparser implements AstVisitor {
 
   visitPrefixNot(ast: PrefixNot, context: any) {
     this._expression += '!';
+    this._visit(ast.expression);
+  }
+
+  visitTypeofExpresion(ast: TypeofExpression, context: any) {
+    this._expression += 'typeof ';
     this._visit(ast.expression);
   }
 

--- a/packages/compiler/test/expression_parser/utils/validator.ts
+++ b/packages/compiler/test/expression_parser/utils/validator.ts
@@ -22,6 +22,7 @@ import {
   LiteralPrimitive,
   ParseSpan,
   PrefixNot,
+  TypeofExpression,
   PropertyRead,
   PropertyWrite,
   RecursiveAstVisitor,
@@ -110,6 +111,10 @@ class ASTValidator extends RecursiveAstVisitor {
 
   override visitPrefixNot(ast: PrefixNot, context: any): any {
     this.validate(ast, () => super.visitPrefixNot(ast, context));
+  }
+
+  override visitTypeofExpresion(ast: TypeofExpression, context: any): any {
+    this.validate(ast, () => super.visitTypeofExpresion(ast, context));
   }
 
   override visitPropertyRead(ast: PropertyRead, context: any): any {

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -87,6 +87,10 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
     this.recordAst(ast);
     super.visitPrefixNot(ast, null);
   }
+  override visitTypeofExpresion(ast: e.TypeofExpression) {
+    this.recordAst(ast);
+    super.visitTypeofExpresion(ast, null);
+  }
   override visitPropertyRead(ast: e.PropertyRead) {
     this.recordAst(ast);
     super.visitPropertyRead(ast, null);

--- a/packages/core/test/acceptance/control_flow_if_spec.ts
+++ b/packages/core/test/acceptance/control_flow_if_spec.ts
@@ -277,6 +277,30 @@ describe('control flow - if', () => {
     expect(fixture.nativeElement.textContent).toBe('Something');
   });
 
+  it('should support a condition with the a typeof expression', () => {
+    @Component({
+      standalone: true,
+      template: `
+          @if (typeof value === 'string') {
+            {{value.length}}
+          } @else {
+            {{value}}
+          }
+        `,
+    })
+    class TestComponent {
+      value: string | number = 'string';
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent.trim()).toBe('6');
+
+    fixture.componentInstance.value = 42;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent.trim()).toBe('42');
+  });
+
   describe('content projection', () => {
     it('should project an @if with a single root node into the root node slot', () => {
       @Component({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

This is just a backport of #58183 to v18

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Currently `typeof` is not usable on angular <v19.

Issue Number: #58183


## What is the new behavior?

This is not a breaking change, so allow it in v18 too.
Many projects can't make major updates quickly

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Do you make/accept backports of this kind?