### PR TITLE
fix(compiler): allow $any in two-way bindings

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -927,6 +927,24 @@ describe('type check blocks', () => {
       );
     });
 
+    it('should handle $any cast in a two-way binding', () => {
+      const TEMPLATE = `<div twoWay [(input)]="$any(value)"></div>`;
+      const DIRECTIVES: TestDeclaration[] = [
+        {
+          type: 'directive',
+          name: 'TwoWay',
+          selector: '[twoWay]',
+          inputs: {input: 'input'},
+          outputs: {inputChange: 'inputChange'},
+        },
+      ];
+      const block = tcb(TEMPLATE, DIRECTIVES);
+      expect(block).toContain('var _t1 = null! as i0.TwoWay;');
+      expect(block).toContain('_t1.input = i1.ɵunwrapWritableSignal(((((this).value) as any)));');
+      expect(block).toContain('var _t2 = i1.ɵunwrapWritableSignal((((this).value) as any));');
+      expect(block).toContain('_t2 = $event;');
+    });
+
     it('should detect writes to template variables', () => {
       const TEMPLATE = `<ng-template let-v><div (event)="v = 3"></div></ng-template>`;
       const block = tcb(TEMPLATE);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/GOLDEN_PARTIAL.js
@@ -1016,3 +1016,50 @@ export declare class TestCmp {
     static ɵcmp: i0.ɵɵComponentDeclaration<TestCmp, "ng-component", never, {}, {}, never, never, true, never>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: two_way_to_any.js
+ ****************************************************************************************************/
+import { Component, Directive, model } from '@angular/core';
+import * as i0 from "@angular/core";
+export class NgModelDirective {
+    constructor() {
+        this.ngModel = model('');
+    }
+}
+NgModelDirective.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: NgModelDirective, deps: [], target: i0.ɵɵFactoryTarget.Directive });
+NgModelDirective.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "17.1.0", version: "0.0.0-PLACEHOLDER", type: NgModelDirective, isStandalone: true, selector: "[ngModel]", inputs: { ngModel: { classPropertyName: "ngModel", publicName: "ngModel", isSignal: true, isRequired: false, transformFunction: null } }, outputs: { ngModel: "ngModelChange" }, ngImport: i0 });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: NgModelDirective, decorators: [{
+            type: Directive,
+            args: [{ selector: '[ngModel]' }]
+        }] });
+export class TestCmp {
+    constructor() {
+        this.value = 123;
+    }
+}
+TestCmp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestCmp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+TestCmp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: TestCmp, isStandalone: true, selector: "test-cmp", ngImport: i0, template: '<input [(ngModel)]="$any(value)">', isInline: true, dependencies: [{ kind: "directive", type: NgModelDirective, selector: "[ngModel]", inputs: ["ngModel"], outputs: ["ngModelChange"] }] });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestCmp, decorators: [{
+            type: Component,
+            args: [{
+                    selector: 'test-cmp',
+                    template: '<input [(ngModel)]="$any(value)">',
+                    imports: [NgModelDirective],
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: two_way_to_any.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class NgModelDirective {
+    ngModel: import("@angular/core").ModelSignal<string>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<NgModelDirective, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<NgModelDirective, "[ngModel]", never, { "ngModel": { "alias": "ngModel"; "required": false; "isSignal": true; }; }, { "ngModel": "ngModelChange"; }, never, never, true, never>;
+}
+export declare class TestCmp {
+    value: number;
+    static ɵfac: i0.ɵɵFactoryDeclaration<TestCmp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<TestCmp, "test-cmp", never, {}, {}, never, never, true, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/TEST_CASES.json
@@ -370,6 +370,23 @@
           "failureMessage": "Incorrect template"
         }
       ]
+    },
+    {
+      "description": "should generate a two-way binding to a $any expression",
+      "inputFiles": [
+        "two_way_to_any.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "two_way_to_any_template.js",
+              "generated": "two_way_to_any.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/two_way_to_any.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/two_way_to_any.ts
@@ -1,0 +1,15 @@
+import {Component, Directive, model} from '@angular/core';
+
+@Directive({selector: '[ngModel]'})
+export class NgModelDirective {
+  ngModel = model('');
+}
+
+@Component({
+  selector: 'test-cmp',
+  template: '<input [(ngModel)]="$any(value)">',
+  imports: [NgModelDirective],
+})
+export class TestCmp {
+  value = 123;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/two_way_to_any_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/two_way_to_any_template.js
@@ -1,0 +1,13 @@
+function TestCmp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵelementStart(0, "input", 0);
+    $r3$.ɵɵtwoWayListener("ngModelChange", function TestCmp_Template_input_ngModelChange_0_listener($event) {
+      $r3$.ɵɵtwoWayBindingSet(ctx.value, $event) || (ctx.value = $event);
+      return $event;
+    });
+    $r3$.ɵɵelementEnd();
+  }
+  if (rf & 2) {
+    $r3$.ɵɵtwoWayProperty("ngModel", ctx.value);
+  }
+}

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -657,6 +657,34 @@ runInEachFileSystem(() => {
       );
     });
 
+    it('should be able to cast to any in a two-way binding', () => {
+      env.tsconfig({strictTemplates: true, _checkTwoWayBoundEvents: true});
+      env.write(
+        'test.ts',
+        `
+        import {Component, Directive, Input, Output, EventEmitter} from '@angular/core';
+
+        @Directive({selector: '[dir]', standalone: true})
+        export class Dir {
+          @Input() val!: number;
+          @Output() valChange = new EventEmitter<number>();
+        }
+
+        @Component({
+          template: '<input dir [(val)]="$any(invalidType)">',
+          standalone: true,
+          imports: [Dir],
+        })
+        export class FooCmp {
+          invalidType = 'hello';
+        }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(0);
+    });
+
     it('should type check a two-way binding to input/output pair where the input has a wider type than the output', () => {
       env.tsconfig({strictTemplates: true, _checkTwoWayBoundEvents: true});
       env.write(

--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -11,12 +11,12 @@ import {
   AbsoluteSourceSpan,
   AST,
   ASTWithSource,
-  Binary,
   BindingPipe,
   BindingType,
   BoundElementProperty,
-  Conditional,
+  Call,
   EmptyExpr,
+  ImplicitReceiver,
   KeyedRead,
   NonNullAssert,
   ParsedEvent,
@@ -25,10 +25,10 @@ import {
   ParsedPropertyType,
   ParsedVariable,
   ParserError,
-  PrefixNot,
   PropertyRead,
   RecursiveAstVisitor,
   TemplateBinding,
+  ThisReceiver,
   VariableBinding,
 } from '../expression_parser/ast';
 import {Parser} from '../expression_parser/parser';
@@ -809,6 +809,17 @@ export class BindingParser {
 
     if (ast instanceof NonNullAssert) {
       return this._isAllowedAssignmentEvent(ast.expression);
+    }
+
+    if (
+      ast instanceof Call &&
+      ast.args.length === 1 &&
+      ast.receiver instanceof PropertyRead &&
+      ast.receiver.name === '$any' &&
+      ast.receiver.receiver instanceof ImplicitReceiver &&
+      !(ast.receiver.receiver instanceof ThisReceiver)
+    ) {
+      return this._isAllowedAssignmentEvent(ast.args[0]);
     }
 
     if (ast instanceof PropertyRead || ast instanceof KeyedRead) {

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -491,6 +491,14 @@ describe('R3 template transform', () => {
       ]);
     });
 
+    it('should parse $any in a two-way binding', () => {
+      expectFromHtml('<div [(prop)]="$any(v)"></div>').toEqual([
+        ['Element', 'div'],
+        ['BoundAttribute', BindingType.TwoWay, 'prop', '$any(v)'],
+        ['BoundEvent', ParsedEventType.TwoWay, 'propChange', null, '$any(v)'],
+      ]);
+    });
+
     it('should parse bound events and properties via bindon-', () => {
       expectFromHtml('<div bindon-prop="v"></div>').toEqual([
         ['Element', 'div'],
@@ -553,6 +561,9 @@ describe('R3 template transform', () => {
         '!a',
         '!!a',
         'a ? b : c',
+        '$any(a || b)',
+        'this.$any(a)',
+        '$any(a, b)',
       ];
 
       for (const expression of unsupportedExpressions) {


### PR DESCRIPTION
Some time ago we narrowed down the expressions we support in two-way bindings, because in most cases any apart from property reads doesn't make sense. This ended up preventing users from using `$any` in the binding since it's considered a function call.

These changes update the validation logic to allow `$any`.

Fixes #51165.