### PR TITLE
docs: fix link to API entry `AngularAppEngine`

### DIFF
--- a/adev/src/content/guide/hybrid-rendering.md
+++ b/adev/src/content/guide/hybrid-rendering.md
@@ -271,7 +271,7 @@ IMPORTANT: The above tokens will be `null` in the following scenarios:
 
 ## Configuring a non-Node.js Server
 
-The `@angular/ssr` provides essential APIs for server-side rendering your Angular application on platforms other than Node.js. It leverages the standard [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) and [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) objects from the Web API, enabling you to integrate Angular SSR into various server environments. For detailed information and examples, refer to the [`@angular/ssr` API reference](api/ssr/node/AngularAppEngine).
+The `@angular/ssr` provides essential APIs for server-side rendering your Angular application on platforms other than Node.js. It leverages the standard [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) and [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) objects from the Web API, enabling you to integrate Angular SSR into various server environments. For detailed information and examples, refer to the [`@angular/ssr` API reference](api/ssr/AngularAppEngine).
 
 ```typescript
 // server.ts


### PR DESCRIPTION
fixes #59342
