### PR TITLE
docs(changelog): removed repetitive point from CHANGELOG.md of 18.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -956,10 +956,6 @@ Blog post: https://blog.angular.dev/meet-angular-v19-7b29dfd05b84
   be marked dirty for their host bindings to refresh. Previously, the host
   bindings were refreshed for all root views without respecting the
   `OnPush` change detection strategy.
-- `OnPush` views at the root of the application need to
-  be marked dirty for their host bindings to refresh. Previously, the host
-  bindings were refreshed for all root views without respecting the
-  `OnPush` change detection strategy.
 - The `ComponentFixture` `autoDetect` feature will no
   longer refresh the component's host view when the component is `OnPush`
   and not marked dirty. This exposes existing issues in components which


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
CHANGELOG.md has repetitive point mentioned as breaking changes mentioned under 18.0.0 (2024-05-22)

core
- OnPush views at the root of the application need to be marked dirty for their host bindings to refresh. Previously, the host bindings were refreshed for all root views without respecting the OnPush change detection strategy.
- OnPush views at the root of the application need to be marked dirty for their host bindings to refresh. Previously, the host bindings were refreshed for all root views without respecting the OnPush change detection strategy.

Issue Number: N/A


## What is the new behavior?
With this PR, repetitive point has been removed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
