### PR TITLE
Revert "refactor(platform-server): reduce timeout used in tests (#59275)"

### DIFF
--- a/packages/platform-server/test/incremental_hydration_spec.ts
+++ b/packages/platform-server/test/incremental_hydration_spec.ts
@@ -65,8 +65,8 @@ function dynamicImportOf<T>(type: T, timeout = 0): Promise<T> {
  * Helper function to await all pending dynamic imports
  * emulated using `dynamicImportOf` function.
  */
-function allPendingDynamicImports(timeout?: number) {
-  return dynamicImportOf(null, timeout ?? 10);
+function allPendingDynamicImports() {
+  return dynamicImportOf(null, 101);
 }
 
 describe('platform-server partial hydration integration', () => {
@@ -2364,12 +2364,10 @@ describe('platform-server partial hydration integration', () => {
         location = inject(Location);
       }
 
-      const dynamicImportTimeout = 5; // ms
-
       const deferDepsInterceptor = {
         intercept() {
           return () => {
-            return [dynamicImportOf(DeferredCmp, dynamicImportTimeout)];
+            return [dynamicImportOf(DeferredCmp, 100)];
           };
         },
       };
@@ -2399,12 +2397,10 @@ describe('platform-server partial hydration integration', () => {
 
       const routeLink = doc.getElementById('route-link')!;
       routeLink.click();
-      // Wait a bit longer than a timeout used to emulate a dynamic import.
-      await allPendingDynamicImports(dynamicImportTimeout * 2);
+      await allPendingDynamicImports();
       appRef.tick();
 
-      // Wait a bit longer than a timeout used to emulate a dynamic import.
-      await allPendingDynamicImports(dynamicImportTimeout * 2);
+      await allPendingDynamicImports();
       await appRef.whenStable();
 
       expect(location.path()).toBe('/other/thing/stuff');


### PR DESCRIPTION
This reverts commit 19ec8266d1ef01ff59dfad55bc54e0f83bb87e67.

Reason for revert: it looks like the original change increases flakiness of a few tests on CI. Reverting the change to get back to a more stable state.