### PR TITLE
refactor(core): drop `DEFER_BLOCK_DEPENDENCY_INTERCEPTOR` in production

### DIFF
--- a/packages/core/src/defer/rendering.ts
+++ b/packages/core/src/defer/rendering.ts
@@ -66,7 +66,9 @@ import {
  * This token is only injected in devMode
  */
 export const DEFER_BLOCK_DEPENDENCY_INTERCEPTOR =
-  new InjectionToken<DeferBlockDependencyInterceptor>('DEFER_BLOCK_DEPENDENCY_INTERCEPTOR');
+  /* @__PURE__ */ new InjectionToken<DeferBlockDependencyInterceptor>(
+    'DEFER_BLOCK_DEPENDENCY_INTERCEPTOR',
+  );
 
 /**
  * **INTERNAL**, token used for configuring defer block behavior.


### PR DESCRIPTION
`new` expressions are not dropped by default because they are considered side-effectful, even if they are not referenced anywhere in production mode.