### PR TITLE
refactor(core): prevent duplicating LView destroyed checks

### DIFF
--- a/packages/core/src/render3/instructions/change_detection.ts
+++ b/packages/core/src/render3/instructions/change_detection.ts
@@ -69,6 +69,7 @@ import {
   refreshContentQueries,
 } from './shared';
 import {runEffectsInView} from '../reactivity/view_effect_runner';
+import {isDestroyed} from '../interfaces/type_checks';
 
 /**
  * The maximum number of times the change detection traversal will rerun before throwing an error.
@@ -193,8 +194,10 @@ export function refreshView<T>(
   context: T,
 ) {
   ngDevMode && assertEqual(isCreationMode(lView), false, 'Should be run in update mode');
+
+  if (isDestroyed(lView)) return;
+
   const flags = lView[FLAGS];
-  if ((flags & LViewFlags.Destroyed) === LViewFlags.Destroyed) return;
 
   // Check no changes mode is a dev only mode used to verify that bindings have not changed
   // since they were assigned. We do not want to execute lifecycle hooks in that mode.

--- a/packages/core/src/render3/interfaces/type_checks.ts
+++ b/packages/core/src/render3/interfaces/type_checks.ts
@@ -57,5 +57,6 @@ export function hasI18n(lView: LView): boolean {
 }
 
 export function isDestroyed(lView: LView): boolean {
+  // Determines whether a given LView is marked as destroyed.
   return (lView[FLAGS] & LViewFlags.Destroyed) === LViewFlags.Destroyed;
 }

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -6,11 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  consumerDestroy,
-  getActiveConsumer,
-  setActiveConsumer,
-} from '@angular/core/primitives/signals';
+import {consumerDestroy, setActiveConsumer} from '@angular/core/primitives/signals';
 
 import {NotificationSource} from '../change_detection/scheduling/zoneless_scheduling';
 import {hasInSkipHydrationBlockFlag} from '../hydration/skip_hydration';
@@ -55,8 +51,8 @@ import {
   TProjectionNode,
 } from './interfaces/node';
 import {Renderer} from './interfaces/renderer';
-import {RComment, RElement, RNode, RTemplate, RText} from './interfaces/renderer_dom';
-import {isLContainer, isLView} from './interfaces/type_checks';
+import {RComment, RElement, RNode, RText} from './interfaces/renderer_dom';
+import {isDestroyed, isLContainer, isLView} from './interfaces/type_checks';
 import {
   CHILD_HEAD,
   CLEANUP,
@@ -445,15 +441,17 @@ export function detachView(lContainer: LContainer, removeIndex: number): LView |
  * @param lView The view to be destroyed.
  */
 export function destroyLView(tView: TView, lView: LView) {
-  if (!(lView[FLAGS] & LViewFlags.Destroyed)) {
-    const renderer = lView[RENDERER];
-
-    if (renderer.destroyNode) {
-      applyView(tView, lView, renderer, WalkTNodeTreeAction.Destroy, null, null);
-    }
-
-    destroyViewTree(lView);
+  if (isDestroyed(lView)) {
+    return;
   }
+
+  const renderer = lView[RENDERER];
+
+  if (renderer.destroyNode) {
+    applyView(tView, lView, renderer, WalkTNodeTreeAction.Destroy, null, null);
+  }
+
+  destroyViewTree(lView);
 }
 
 /**
@@ -465,7 +463,7 @@ export function destroyLView(tView: TView, lView: LView) {
  * @param lView The LView to clean up
  */
 function cleanUpView(tView: TView, lView: LView): void {
-  if (lView[FLAGS] & LViewFlags.Destroyed) {
+  if (isDestroyed(lView)) {
     return;
   }
 

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -19,7 +19,7 @@ import {assertLView, assertTNode, assertTNodeForLView} from '../assert';
 import {LContainer, TYPE} from '../interfaces/container';
 import {TConstants, TNode} from '../interfaces/node';
 import {RNode} from '../interfaces/renderer_dom';
-import {isLContainer, isLView} from '../interfaces/type_checks';
+import {isDestroyed, isLContainer, isLView} from '../interfaces/type_checks';
 import {
   DECLARATION_VIEW,
   ENVIRONMENT,
@@ -271,7 +271,7 @@ export function markAncestorsForTraversal(lView: LView) {
  * Stores a LView-specific destroy callback.
  */
 export function storeLViewOnDestroy(lView: LView, onDestroyCallback: () => void) {
-  if ((lView[FLAGS] & LViewFlags.Destroyed) === LViewFlags.Destroyed) {
+  if (isDestroyed(lView)) {
     throw new RuntimeError(
       RuntimeErrorCode.VIEW_ALREADY_DESTROYED,
       ngDevMode && 'View has already been destroyed.',

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -18,7 +18,7 @@ import {collectNativeNodes} from './collect_native_nodes';
 import {checkNoChangesInternal, detectChangesInternal} from './instructions/change_detection';
 import {markViewDirty} from './instructions/mark_view_dirty';
 import {CONTAINER_HEADER_OFFSET, VIEW_REFS} from './interfaces/container';
-import {isLContainer, isRootView} from './interfaces/type_checks';
+import {isDestroyed, isLContainer, isRootView} from './interfaces/type_checks';
 import {
   CONTEXT,
   DECLARATION_LCONTAINER,
@@ -116,7 +116,7 @@ export class ViewRef<T> implements EmbeddedViewRef<T>, ChangeDetectorRefInterfac
   }
 
   get destroyed(): boolean {
-    return (this._lView[FLAGS] & LViewFlags.Destroyed) === LViewFlags.Destroyed;
+    return isDestroyed(this._lView);
   }
 
   destroy(): void {

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -370,6 +370,7 @@
   "isContentQueryHost",
   "isCssClassMatching",
   "isCurrentTNodeParent",
+  "isDestroyed",
   "isElementNode",
   "isEnvironmentProviders",
   "isFunction",

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -394,6 +394,7 @@
   "isContentQueryHost",
   "isCssClassMatching",
   "isCurrentTNodeParent",
+  "isDestroyed",
   "isElementNode",
   "isEnvironmentProviders",
   "isFunction",

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -316,6 +316,7 @@
   "isContentQueryHost",
   "isCssClassMatching",
   "isCurrentTNodeParent",
+  "isDestroyed",
   "isEnvironmentProviders",
   "isFunction",
   "isInlineTemplate",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -763,6 +763,7 @@
   "isContentQueryHost",
   "isCssClassMatching",
   "isCurrentTNodeParent",
+  "isDestroyed",
   "isDirectiveHost",
   "isEnvironmentProviders",
   "isFunction",

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -459,6 +459,7 @@
   "isContentQueryHost",
   "isCssClassMatching",
   "isCurrentTNodeParent",
+  "isDestroyed",
   "isDirectiveHost",
   "isEmptyInputValue",
   "isEnvironmentProviders",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -445,6 +445,7 @@
   "isContentQueryHost",
   "isCssClassMatching",
   "isCurrentTNodeParent",
+  "isDestroyed",
   "isDirectiveHost",
   "isEnvironmentProviders",
   "isFormControlState",

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -247,6 +247,7 @@
   "isAngularZoneProperty",
   "isApplicationBootstrapConfig",
   "isComponentDef",
+  "isDestroyed",
   "isEnvironmentProviders",
   "isFunction",
   "isInlineTemplate",

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -325,6 +325,7 @@
   "isAsyncIterable",
   "isComponentDef",
   "isComponentHost",
+  "isDestroyed",
   "isDetachedByI18n",
   "isDisconnectedNode",
   "isEnvironmentProviders",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -535,6 +535,7 @@
   "isContentQueryHost",
   "isCssClassMatching",
   "isCurrentTNodeParent",
+  "isDestroyed",
   "isDirectiveHost",
   "isEmptyError",
   "isEnvironmentProviders",

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -276,6 +276,7 @@
   "isAngularZoneProperty",
   "isApplicationBootstrapConfig",
   "isComponentDef",
+  "isDestroyed",
   "isEnvironmentProviders",
   "isFunction",
   "isInlineTemplate",

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -376,6 +376,7 @@
   "isContentQueryHost",
   "isCssClassMatching",
   "isCurrentTNodeParent",
+  "isDestroyed",
   "isDirectiveHost",
   "isEnvironmentProviders",
   "isFunction",


### PR DESCRIPTION
The `type_checks` module already exposes a utility function that checks whether `LView` is marked as destroyed. There is no need to check flags in other places, as we can reuse the helper function.