### PR TITLE
fix(platform-browser): styles not replaced during HMR when using animations renderer

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -47,7 +47,7 @@
   },
   "defer": {
     "uncompressed": {
-      "main": 12094,
+      "main": 12709,
       "polyfills": 33807,
       "defer.component": 345
     }

--- a/packages/animations/browser/src/render/animation_renderer.ts
+++ b/packages/animations/browser/src/render/animation_renderer.ts
@@ -132,4 +132,12 @@ export class AnimationRendererFactory implements RendererFactory2 {
   whenRenderingDone(): Promise<any> {
     return this.engine.whenRenderingDone();
   }
+
+  /**
+   * Used during HMR to clear any cached data about a component.
+   * @param componentId ID of the component that is being replaced.
+   */
+  protected componentReplaced(componentId: string) {
+    (this.delegate as {componentReplaced?: (id: string) => void}).componentReplaced?.(componentId);
+  }
 }

--- a/packages/core/src/render3/hmr.ts
+++ b/packages/core/src/render3/hmr.ts
@@ -124,8 +124,9 @@ function recreateMatchingLViews(def: ComponentDef<unknown>, rootLView: LView): v
  */
 function clearRendererCache(factory: RendererFactory, def: ComponentDef<unknown>) {
   // Cast to read a private field.
-  // NOTE: This must be kept synchronized with the renderer factory implementation in platform-browser.
-  (factory as {rendererByCompId?: Map<string, unknown>}).rendererByCompId?.delete(def.id);
+  // NOTE: This must be kept synchronized with the renderer factory implementation in
+  // platform-browser and platform-browser/animations.
+  (factory as {componentReplaced?: (id: string) => void}).componentReplaced?.(def.id);
 }
 
 /**

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -195,6 +195,14 @@ export class DomRendererFactory2 implements RendererFactory2, OnDestroy {
   ngOnDestroy() {
     this.rendererByCompId.clear();
   }
+
+  /**
+   * Used during HMR to clear any cached data about a component.
+   * @param componentId ID of the component that is being replaced.
+   */
+  protected componentReplaced(componentId: string) {
+    this.rendererByCompId.delete(componentId);
+  }
 }
 
 class DefaultDomRenderer2 implements Renderer2 {


### PR DESCRIPTION
When we replace a component during HMR, we clear it from the cache of the renderer factory, however when using animations, there's an animation-specific renderer factory that wraps the base DOM one and was preventing the cache from being cleared.

These changes rework the logic that clear the cache to go through a method so we can forward the call to the delegated factory.
