### PR TITLE
fix(core): override inherited function properties

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1691,6 +1691,10 @@ export function setTestabilityGetter(getter: GetTestability): void;
 // @public
 export type Signal<T> = (() => T) & {
     [SIGNAL]: unknown;
+    readonly name: unknown;
+    readonly length: unknown;
+    readonly arguments: unknown;
+    readonly caller: unknown;
 };
 
 // @public

--- a/packages/core/primitives/signals/src/computed.ts
+++ b/packages/core/primitives/signals/src/computed.ts
@@ -45,6 +45,13 @@ export interface ComputedNode<T> extends ReactiveNode {
 
 export type ComputedGetter<T> = (() => T) & {
   [SIGNAL]: ComputedNode<T>;
+
+  // Hide properties inherited from Function.
+
+  readonly name: unknown;
+  readonly length: unknown;
+  readonly arguments: unknown;
+  readonly caller: unknown;
 };
 
 /**

--- a/packages/core/primitives/signals/src/signal.ts
+++ b/packages/core/primitives/signals/src/signal.ts
@@ -35,7 +35,16 @@ export interface SignalNode<T> extends ReactiveNode {
   equal: ValueEqualityFn<T>;
 }
 
-export type SignalBaseGetter<T> = (() => T) & {readonly [SIGNAL]: unknown};
+export type SignalBaseGetter<T> = (() => T) & {
+  readonly [SIGNAL]: unknown;
+
+  // Hide properties inherited from Function.
+
+  readonly name: unknown;
+  readonly length: unknown;
+  readonly arguments: unknown;
+  readonly caller: unknown;
+};
 
 // Note: Closure *requires* this to be an `interface` and not a type, which is why the
 // `SignalBaseGetter` type exists to provide the correct shape.

--- a/packages/core/src/render3/reactivity/api.ts
+++ b/packages/core/src/render3/reactivity/api.ts
@@ -18,6 +18,13 @@ import {SIGNAL} from '@angular/core/primitives/signals';
  */
 export type Signal<T> = (() => T) & {
   [SIGNAL]: unknown;
+
+  // Hide properties inherited from Function.
+
+  readonly name: unknown;
+  readonly length: unknown;
+  readonly arguments: unknown;
+  readonly caller: unknown;
 };
 
 /**

--- a/packages/core/src/render3/reactivity/linked_signal.ts
+++ b/packages/core/src/render3/reactivity/linked_signal.ts
@@ -58,6 +58,13 @@ interface LinkedSignalNode<S, D> extends ReactiveNode {
 
 export type LinkedSignalGetter<S, D> = (() => D) & {
   [SIGNAL]: LinkedSignalNode<S, D>;
+
+  // Hide properties inherited from Function.
+
+  readonly name: unknown;
+  readonly length: unknown;
+  readonly arguments: unknown;
+  readonly caller: unknown;
 };
 
 const identityFn = <T>(v: T) => v;


### PR DESCRIPTION
Since signals are functions, they inherit some properties like `length` and `name`. These can lead to issues in user code where somebody may write `someArraySignal.length` instead of `someArraySignal().length`.

These changes aim to mitigate the issue by overriding these properties to be `unknown`.

Fixes #59394.
