### PR TITLE
refactor(core): remove outdated comment.

### DIFF
--- a/packages/core/src/render3/def_getters.ts
+++ b/packages/core/src/render3/def_getters.ts
@@ -50,6 +50,5 @@ export function getPipeDef<T>(type: any): PipeDef<T> | null {
  */
 export function isStandalone(type: Type<unknown>): boolean {
   const def = getComponentDef(type) || getDirectiveDef(type) || getPipeDef(type);
-  // TODO: standalone as default value (invert the condition)
-  return def !== null ? def.standalone : false;
+  return def !== null && def.standalone;
 }


### PR DESCRIPTION
Should have been done by #58238, but was probably missed in a rebase.

fixes #59397
