### PR TITLE
fix(bazel): support setting `type: module` in source `package.json`

### DIFF
--- a/packages/bazel/src/ng_package/packager.ts
+++ b/packages/bazel/src/ng_package/packager.ts
@@ -306,7 +306,7 @@ function main(args: string[]): void {
    * the module conditional exports and the ESM module type.
    */
   function updatePrimaryPackageJson(packageJson: Readonly<PackageJson>): PackageJson {
-    if (packageJson.type !== 'module') {
+    if (packageJson.type !== undefined && packageJson.type !== 'module') {
       throw Error(
         'The primary "package.json" file of the package sets the "type" field ' +
           'that is controlled by the packager. Please unset it or set `type` to `module`.',

--- a/packages/bazel/src/ng_package/packager.ts
+++ b/packages/bazel/src/ng_package/packager.ts
@@ -306,10 +306,10 @@ function main(args: string[]): void {
    * the module conditional exports and the ESM module type.
    */
   function updatePrimaryPackageJson(packageJson: Readonly<PackageJson>): PackageJson {
-    if (packageJson.type !== undefined) {
+    if (packageJson.type !== 'module') {
       throw Error(
         'The primary "package.json" file of the package sets the "type" field ' +
-          'that is controlled by the packager. Please unset it.',
+          'that is controlled by the packager. Please unset it or set `type` to `module`.',
       );
     }
 


### PR DESCRIPTION
This is helpful as it allows us to set `type: module` in the checked-in package files, useful for the hybrid mode of `rules_js` and `rules_nodejs`, where the package.json files can control the execution format.