### PR TITLE
refactor(platform-browser): remove `Console` from Hammer gestures

### DIFF
--- a/packages/platform-browser/src/dom/events/hammer_gestures.ts
+++ b/packages/platform-browser/src/dom/events/hammer_gestures.ts
@@ -11,9 +11,9 @@ import {
   Inject,
   Injectable,
   InjectionToken,
+  Injector,
   NgModule,
   Optional,
-  Provider,
   ɵConsole as Console,
 } from '@angular/core';
 
@@ -174,7 +174,7 @@ export class HammerGesturesPlugin extends EventManagerPlugin {
   constructor(
     @Inject(DOCUMENT) doc: any,
     @Inject(HAMMER_GESTURE_CONFIG) private _config: HammerGestureConfig,
-    private console: Console,
+    private _injector: Injector,
     @Optional() @Inject(HAMMER_LOADER) private loader?: HammerLoader | null,
   ) {
     super(doc);
@@ -187,7 +187,10 @@ export class HammerGesturesPlugin extends EventManagerPlugin {
 
     if (!(window as any).Hammer && !this.loader) {
       if (typeof ngDevMode === 'undefined' || ngDevMode) {
-        this.console.warn(
+        // Get a `Console` through an injector to tree-shake the
+        // class when it is unused in production.
+        const _console = this._injector.get(Console);
+        _console.warn(
           `The "${eventName}" event cannot be bound because Hammer.JS is not ` +
             `loaded and no custom loader has been specified.`,
         );
@@ -219,9 +222,8 @@ export class HammerGesturesPlugin extends EventManagerPlugin {
           // If Hammer isn't actually loaded when the custom loader resolves, give up.
           if (!(window as any).Hammer) {
             if (typeof ngDevMode === 'undefined' || ngDevMode) {
-              this.console.warn(
-                `The custom HAMMER_LOADER completed, but Hammer.JS is not present.`,
-              );
+              const _console = this._injector.get(Console);
+              _console.warn(`The custom HAMMER_LOADER completed, but Hammer.JS is not present.`);
             }
             deregister = () => {};
             return;
@@ -235,7 +237,8 @@ export class HammerGesturesPlugin extends EventManagerPlugin {
           }
         }).catch(() => {
           if (typeof ngDevMode === 'undefined' || ngDevMode) {
-            this.console.warn(
+            const _console = this._injector.get(Console);
+            _console.warn(
               `The "${eventName}" event cannot be bound because the custom ` +
                 `Hammer.JS loader failed.`,
             );
@@ -293,7 +296,7 @@ export class HammerGesturesPlugin extends EventManagerPlugin {
       provide: EVENT_MANAGER_PLUGINS,
       useClass: HammerGesturesPlugin,
       multi: true,
-      deps: [DOCUMENT, HAMMER_GESTURE_CONFIG, Console, [new Optional(), HAMMER_LOADER]],
+      deps: [DOCUMENT, HAMMER_GESTURE_CONFIG, Injector, [new Optional(), HAMMER_LOADER]],
     },
     {provide: HAMMER_GESTURE_CONFIG, useClass: HammerGestureConfig, deps: []},
   ],

--- a/packages/platform-browser/test/dom/events/hammer_gestures_spec.ts
+++ b/packages/platform-browser/test/dom/events/hammer_gestures_spec.ts
@@ -15,7 +15,6 @@ import {
 
 describe('HammerGesturesPlugin', () => {
   let plugin: HammerGesturesPlugin;
-  let fakeConsole: any;
 
   if (isNode) {
     // Jasmine will throw if there are no tests.
@@ -23,18 +22,15 @@ describe('HammerGesturesPlugin', () => {
     return;
   }
 
-  beforeEach(() => {
-    fakeConsole = {warn: jasmine.createSpy('console.warn')};
-  });
-
   describe('with no custom loader', () => {
     beforeEach(() => {
-      plugin = new HammerGesturesPlugin(document, new HammerGestureConfig(), fakeConsole);
+      plugin = new HammerGesturesPlugin(document, new HammerGestureConfig(), TestBed);
     });
 
     it('should warn user and do nothing when Hammer.js not loaded', () => {
+      const warnSpy = spyOn(console, 'warn');
       expect(plugin.supports('swipe')).toBe(false);
-      expect(fakeConsole.warn).toHaveBeenCalledWith(
+      expect(warnSpy).toHaveBeenCalledWith(
         `The "swipe" event cannot be bound because Hammer.JS is not ` +
           `loaded and no custom loader has been specified.`,
       );
@@ -90,7 +86,7 @@ describe('HammerGesturesPlugin', () => {
       const hammerConfig = new HammerGestureConfig();
       spyOn(hammerConfig, 'buildHammer').and.returnValue(fakeHammerInstance);
 
-      plugin = new HammerGesturesPlugin(document, hammerConfig, fakeConsole, loader);
+      plugin = new HammerGesturesPlugin(document, hammerConfig, TestBed, loader);
 
       // Use a fake EventManager that has access to the NgZone.
       plugin.manager = {getZone: () => ngZone} as EventManager;
@@ -114,8 +110,9 @@ describe('HammerGesturesPlugin', () => {
     });
 
     it('should not log a warning when HammerJS is not loaded', () => {
+      const warnSpy = spyOn(console, 'warn');
       plugin.addEventListener(someElement, 'swipe', () => {});
-      expect(fakeConsole.warn).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
     });
 
     it('should defer registering an event until Hammer is loaded', fakeAsync(() => {
@@ -152,21 +149,25 @@ describe('HammerGesturesPlugin', () => {
     }));
 
     it('should log a warning when the loader fails', fakeAsync(() => {
+      const warnSpy = spyOn(console, 'warn');
+
       plugin.addEventListener(someElement, 'swipe', () => {});
       failLoader();
       tick();
 
-      expect(fakeConsole.warn).toHaveBeenCalledWith(
+      expect(warnSpy).toHaveBeenCalledWith(
         `The "swipe" event cannot be bound because the custom Hammer.JS loader failed.`,
       );
     }));
 
     it('should load a warning if the loader resolves and Hammer is not present', fakeAsync(() => {
+      const warnSpy = spyOn(console, 'warn');
+
       plugin.addEventListener(someElement, 'swipe', () => {});
       resolveLoader();
       tick();
 
-      expect(fakeConsole.warn).toHaveBeenCalledWith(
+      expect(warnSpy).toHaveBeenCalledWith(
         `The custom HAMMER_LOADER completed, but Hammer.JS is not present.`,
       );
     }));


### PR DESCRIPTION
Injecting the `Console` is redundant because it directly calls the global `console` object. There is no reason to reference this class in Hammer gestures, as it is only used in development mode. We can safely call the `console` object directly.