### PR TITLE
refactor(core): change `Restriction` to symbol

### DIFF
--- a/goldens/public-api/core/primitives/event-dispatch/index.api.md
+++ b/goldens/public-api/core/primitives/event-dispatch/index.api.md
@@ -30,11 +30,11 @@ export class EventContract implements UnrenamedEventContract {
     constructor(containerManager: EventContractContainerManager);
     addEvent(eventType: string, prefixedEventType?: string, passive?: boolean): void;
     cleanUp(): void;
-    ecrd(dispatcher: Dispatcher, restriction: Restriction): void;
+    ecrd(dispatcher: Dispatcher, restriction: typeof RESTRICTION): void;
     handler(eventType: string): EventHandler | undefined;
     // (undocumented)
     static MOUSE_SPECIAL_SUPPORT: boolean;
-    registerDispatcher(dispatcher: Dispatcher, restriction: Restriction): void;
+    registerDispatcher(dispatcher: Dispatcher, restriction: typeof RESTRICTION): void;
     replayEarlyEventInfos(earlyEventInfos: EventInfo[]): void;
     replayEarlyEvents(earlyJsactionData?: EarlyJsactionData | undefined): void;
 }
@@ -118,7 +118,7 @@ export const isCaptureEventType: (eventType: string) => boolean;
 export const isEarlyEventType: (eventType: string) => boolean;
 
 // @public
-export function registerAppScopedDispatcher(restriction: Restriction, appId: string, dispatcher: (eventInfo: EventInfo) => void, dataContainer?: EarlyJsactionDataContainer): void;
+export function registerAppScopedDispatcher(restriction: typeof RESTRICTION, appId: string, dispatcher: (eventInfo: EventInfo) => void, dataContainer?: EarlyJsactionDataContainer): void;
 
 // @public
 export function registerDispatcher(eventContract: UnrenamedEventContract, dispatcher: EventDispatcher): void;

--- a/packages/core/primitives/event-dispatch/src/bootstrap_app_scoped.ts
+++ b/packages/core/primitives/event-dispatch/src/bootstrap_app_scoped.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Restriction} from './restriction';
 import {
   EarlyJsactionDataContainer,
   addEvents,
@@ -16,6 +15,7 @@ import {
   removeAllEventListeners,
 } from './earlyeventcontract';
 import {EventInfo} from './event_info';
+import {RESTRICTION} from './restriction';
 
 /**
  * Creates an `EarlyJsactionData`, adds events to it, and populates it on a nested object on
@@ -50,7 +50,7 @@ export function getAppScopedQueuedEventInfos(
  * window.
  */
 export function registerAppScopedDispatcher(
-  restriction: Restriction,
+  restriction: typeof RESTRICTION,
   appId: string,
   dispatcher: (eventInfo: EventInfo) => void,
   dataContainer: EarlyJsactionDataContainer = window,

--- a/packages/core/primitives/event-dispatch/src/bootstrap_global.ts
+++ b/packages/core/primitives/event-dispatch/src/bootstrap_global.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Restriction} from './restriction';
 import {
   addEvents,
   createEarlyJsactionData,
@@ -15,6 +14,7 @@ import {
   removeAllEventListeners,
 } from './earlyeventcontract';
 import {EventInfo} from './event_info';
+import {RESTRICTION} from './restriction';
 
 /** Creates an `EarlyJsactionData`, adds events to it, and populates it on the window. */
 export function bootstrapGlobalEarlyEventContract(
@@ -34,7 +34,7 @@ export function getGlobalQueuedEventInfos() {
 
 /** Registers a dispatcher function on the `EarlyJsactionData` present on the window. */
 export function registerGlobalDispatcher(
-  restriction: Restriction,
+  restriction: typeof RESTRICTION,
   dispatcher: (eventInfo: EventInfo) => void,
 ) {
   registerDispatcher(window._ejsa, dispatcher);

--- a/packages/core/primitives/event-dispatch/src/dispatcher.ts
+++ b/packages/core/primitives/event-dispatch/src/dispatcher.ts
@@ -8,7 +8,7 @@
 
 import {EventInfo, EventInfoWrapper} from './event_info';
 import {EventType} from './event_type';
-import {Restriction} from './restriction';
+import {RESTRICTION} from './restriction';
 import {UnrenamedEventContract} from './eventcontract';
 import * as eventLib from './event';
 import {ActionResolver} from './action_resolver';
@@ -146,5 +146,5 @@ function shouldPreventDefaultBeforeDispatching(
 export function registerDispatcher(eventContract: UnrenamedEventContract, dispatcher: Dispatcher) {
   eventContract.ecrd((eventInfo: EventInfo) => {
     dispatcher.dispatch(eventInfo);
-  }, Restriction.I_AM_THE_JSACTION_FRAMEWORK);
+  }, RESTRICTION);
 }

--- a/packages/core/primitives/event-dispatch/src/event_dispatcher.ts
+++ b/packages/core/primitives/event-dispatch/src/event_dispatcher.ts
@@ -11,7 +11,7 @@ import {Dispatcher} from './dispatcher';
 import {EventInfo, EventInfoWrapper} from './event_info';
 import {isCaptureEventType} from './event_type';
 import {UnrenamedEventContract} from './eventcontract';
-import {Restriction} from './restriction';
+import {RESTRICTION} from './restriction';
 
 /**
  * A replayer is a function that is called when there are queued events, from the `EventContract`.
@@ -184,5 +184,5 @@ export function registerDispatcher(
 ) {
   eventContract.ecrd((eventInfo: EventInfo) => {
     dispatcher.dispatch(eventInfo);
-  }, Restriction.I_AM_THE_JSACTION_FRAMEWORK);
+  }, RESTRICTION);
 }

--- a/packages/core/primitives/event-dispatch/src/eventcontract.ts
+++ b/packages/core/primitives/event-dispatch/src/eventcontract.ts
@@ -30,24 +30,20 @@
  * possible and thus its dependencies to a minimum.
  */
 
-import {
-  EarlyJsactionData,
-  EarlyJsactionDataContainer,
-  removeAllEventListeners,
-} from './earlyeventcontract';
+import {EarlyJsactionData, removeAllEventListeners} from './earlyeventcontract';
 import * as eventLib from './event';
 import {EventContractContainerManager} from './event_contract_container';
 import {MOUSE_SPECIAL_SUPPORT} from './event_contract_defines';
 import * as eventInfoLib from './event_info';
 import {MOUSE_SPECIAL_EVENT_TYPES} from './event_type';
-import {Restriction} from './restriction';
+import {RESTRICTION} from './restriction';
 
 /**
  * The API of an EventContract that is safe to call from any compilation unit.
  */
 export declare interface UnrenamedEventContract {
   // Alias for Jsction EventContract registerDispatcher.
-  ecrd(dispatcher: Dispatcher, restriction: Restriction): void;
+  ecrd(dispatcher: Dispatcher, restriction: typeof RESTRICTION): void;
 }
 
 /** A function that is called to handle events captured by the EventContract. */
@@ -271,7 +267,7 @@ export class EventContract implements UnrenamedEventContract {
    * @param dispatcher The dispatcher function.
    * @param restriction
    */
-  registerDispatcher(dispatcher: Dispatcher, restriction: Restriction) {
+  registerDispatcher(dispatcher: Dispatcher, restriction: typeof RESTRICTION) {
     this.ecrd(dispatcher, restriction);
   }
 
@@ -280,7 +276,7 @@ export class EventContract implements UnrenamedEventContract {
    * split the `EventContract` and `Dispatcher` code into different compilation
    * units.
    */
-  ecrd(dispatcher: Dispatcher, restriction: Restriction) {
+  ecrd(dispatcher: Dispatcher, restriction: typeof RESTRICTION) {
     this.dispatcher = dispatcher;
 
     if (this.queuedEventInfos?.length) {

--- a/packages/core/primitives/event-dispatch/src/restriction.ts
+++ b/packages/core/primitives/event-dispatch/src/restriction.ts
@@ -7,9 +7,12 @@
  */
 
 /**
- * @fileoverview An enum to control who can call certain jsaction APIs.
+ * @fileoverview Provides a unique symbol used for internal access control to jsaction APIs.
+ *
+ * This avoids using an `enum` or `const enum` to reduce bundle size and avoid issues
+ * with single-file compilation. Using a plain `const` with a `unique symbol` ensures
+ * type safety without runtime overhead.
  */
-
-export enum Restriction {
-  I_AM_THE_JSACTION_FRAMEWORK,
-}
+export const RESTRICTION: unique symbol = /* @__PURE__ */ Symbol(
+  'core.primitives.event-dispatch.src.restriction.RESTRICTION',
+);

--- a/packages/core/primitives/event-dispatch/test/eventcontract_test.ts
+++ b/packages/core/primitives/event-dispatch/test/eventcontract_test.ts
@@ -18,7 +18,7 @@ import {
 import {EventInfoWrapper} from '../src/event_info';
 import {EventType} from '../src/event_type';
 import {Dispatcher, EventContract} from '../src/eventcontract';
-import {Restriction} from '../src/restriction';
+import {RESTRICTION} from '../src/restriction';
 
 import {safeElement, testonlyHtml} from './html';
 
@@ -97,7 +97,7 @@ function createEventContract({
     }
   }
   if (dispatcher) {
-    eventContract.registerDispatcher(dispatcher, Restriction.I_AM_THE_JSACTION_FRAMEWORK);
+    eventContract.registerDispatcher(dispatcher, RESTRICTION);
   }
   return eventContract;
 }
@@ -248,7 +248,7 @@ describe('EventContract', () => {
     const clickEvent = dispatchMouseEvent(targetElement);
 
     const dispatcher = createDispatcherSpy();
-    eventContract.registerDispatcher(dispatcher, Restriction.I_AM_THE_JSACTION_FRAMEWORK);
+    eventContract.registerDispatcher(dispatcher, RESTRICTION);
 
     expect(dispatcher).toHaveBeenCalledTimes(1);
 


### PR DESCRIPTION
Prior to this commit, the compiler produced:

```js
var Restriction;
(function (Restriction) {
    Restriction[Restriction["I_AM_THE_JSACTION_FRAMEWORK"] = 0] = "I_AM_THE_JSACTION_FRAMEWORK";
})(Restriction || (Restriction = {}));
```

Changing to plain const produces lower code overhead and eliminates extra bytes.