### PR TITLE
fix(core): Ensure that a destroyed `effect` never runs

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -20,7 +20,7 @@
   },
   "forms": {
     "uncompressed": {
-      "main": 176726,
+      "main": 181773,
       "polyfills": 33772
     }
   },

--- a/packages/core/src/render3/reactivity/effect.ts
+++ b/packages/core/src/render3/reactivity/effect.ts
@@ -312,6 +312,7 @@ export const ROOT_EFFECT_NODE: Omit<RootEffectNode, 'fn' | 'scheduler' | 'notifi
       consumerDestroy(this);
       this.onDestroyFn();
       this.maybeCleanup();
+      this.scheduler.remove(this);
     },
   }))();
 

--- a/packages/core/src/render3/reactivity/root_effect_scheduler.ts
+++ b/packages/core/src/render3/reactivity/root_effect_scheduler.ts
@@ -36,6 +36,9 @@ export abstract class EffectScheduler {
    */
   abstract flush(): void;
 
+  /** Remove a scheduled effect */
+  abstract remove(e: SchedulableEffect): void;
+
   /** @nocollapse */
   static ɵprov = /** @pureOrBreakMyCode */ /* @__PURE__ */ ɵɵdefineInjectable({
     token: EffectScheduler,
@@ -54,6 +57,17 @@ export class ZoneAwareEffectScheduler implements EffectScheduler {
 
   schedule(handle: SchedulableEffect): void {
     this.enqueue(handle);
+  }
+
+  remove(handle: SchedulableEffect): void {
+    const zone = handle.zone as Zone | null;
+    const queue = this.queues.get(zone)!;
+    if (!queue.has(handle)) {
+      return;
+    }
+
+    queue.delete(handle);
+    this.queuedEffectCount--;
   }
 
   private enqueue(handle: SchedulableEffect): void {


### PR DESCRIPTION
Prior to this change, a scheduled root effect, even if destroyed instantly, would still run at least once.

This commit fixes this.

fixes #59410
