### PR TITLE
refactor(router): change `NavigationResult` to `const enum`

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -135,7 +135,6 @@
   "NavigationCancellationCode",
   "NavigationEnd",
   "NavigationError",
-  "NavigationResult",
   "NavigationSkipped",
   "NavigationSkippedCode",
   "NavigationStart",

--- a/packages/router/src/utils/navigations.ts
+++ b/packages/router/src/utils/navigations.ts
@@ -18,7 +18,7 @@ import {
   NavigationSkipped,
 } from '../events';
 
-enum NavigationResult {
+const enum NavigationResult {
   COMPLETE,
   FAILED,
   REDIRECTING,


### PR DESCRIPTION
Prior to this commit, the compiler produced:

```js
NavigationResult = (function (NavigationResult2) {
  return (
    (NavigationResult2[(NavigationResult2.COMPLETE = 0)] = "COMPLETE"),
    (NavigationResult2[(NavigationResult2.FAILED = 1)] = "FAILED"),
    (NavigationResult2[(NavigationResult2.REDIRECTING = 2)] = "REDIRECTING"),
    NavigationResult2
  );
})(NavigationResult || {});
```

Changing to `const enum` allows it to be entirely dropped and inline values.

Note: this enum is not a part of the public API.