### PR TITLE
refactor(common): tree-shake fetch backend

### DIFF
--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {inject, Injectable, NgZone} from '@angular/core';
+import {inject, Injectable, InjectionToken, NgZone} from '@angular/core';
 import {Observable, Observer} from 'rxjs';
 
 import {HttpBackend} from './backend';
@@ -38,6 +38,14 @@ function getResponseUrl(response: Response): string | null {
   const xRequestUrl = REQUEST_URL_HEADER.toLocaleLowerCase();
   return response.headers.get(xRequestUrl);
 }
+
+/**
+ * An internal injection token to reference `FetchBackend` implementation
+ * in a tree-shakable way.
+ */
+export const FETCH_BACKEND = new InjectionToken<FetchBackend>(
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'FETCH_BACKEND' : '',
+);
 
 /**
  * Uses `fetch` to send requests to a backend server.

--- a/packages/common/http/src/provider.ts
+++ b/packages/common/http/src/provider.ts
@@ -16,7 +16,7 @@ import {
 
 import {HttpBackend, HttpHandler} from './backend';
 import {HttpClient} from './client';
-import {FetchBackend} from './fetch';
+import {FETCH_BACKEND, FetchBackend} from './fetch';
 import {
   HTTP_INTERCEPTOR_FNS,
   HttpInterceptorFn,
@@ -128,7 +128,7 @@ export function provideHttpClient(
     {
       provide: HttpBackend,
       useFactory: () => {
-        return inject(FetchBackend, {optional: true}) ?? inject(HttpXhrBackend);
+        return inject(FETCH_BACKEND, {optional: true}) ?? inject(HttpXhrBackend);
       },
     },
     {
@@ -305,6 +305,7 @@ export function withRequestsMadeViaParent(): HttpFeature<HttpFeatureKind.Request
 export function withFetch(): HttpFeature<HttpFeatureKind.Fetch> {
   return makeHttpFeature(HttpFeatureKind.Fetch, [
     FetchBackend,
+    {provide: FETCH_BACKEND, useExisting: FetchBackend},
     {provide: HttpBackend, useExisting: FetchBackend},
   ]);
 }


### PR DESCRIPTION
This commit updates the code of the HTTP code to make the `FetchBackend` class tree-shakable. The class is only needed when `withFetch()` is called and it should not be included into bundles that do not use that feature.