### PR TITLE
refactor(common): prevent duplicating `X-Request-URL`

### DIFF
--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -11,7 +11,7 @@ import {Observable, Observer} from 'rxjs';
 
 import {HttpBackend} from './backend';
 import {HttpHeaders} from './headers';
-import {HttpRequest} from './request';
+import {HttpRequest, X_REQUEST_URL_HEADER} from './request';
 import {
   HTTP_STATUS_CODE_OK,
   HttpDownloadProgressEvent,
@@ -24,8 +24,6 @@ import {
 
 const XSSI_PREFIX = /^\)\]\}',?\n/;
 
-const REQUEST_URL_HEADER = `X-Request-URL`;
-
 /**
  * Determine an appropriate URL for the response, by checking either
  * response url or the X-Request-URL header.
@@ -35,7 +33,7 @@ function getResponseUrl(response: Response): string | null {
     return response.url;
   }
   // stored as lowercase in the map
-  const xRequestUrl = REQUEST_URL_HEADER.toLocaleLowerCase();
+  const xRequestUrl = X_REQUEST_URL_HEADER.toLocaleLowerCase();
   return response.headers.get(xRequestUrl);
 }
 

--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -78,6 +78,13 @@ function isUrlSearchParams(value: any): value is URLSearchParams {
 }
 
 /**
+ * `X-Request-URL` is a custom HTTP header used in older browser versions,
+ * including Firefox (< 32), Chrome (< 37), Safari (< 8), and Internet Explorer,
+ * to include the full URL of the request in cross-origin requests.
+ */
+export const X_REQUEST_URL_HEADER = 'X-Request-URL';
+
+/**
  * An outgoing HTTP request with an optional typed body.
  *
  * `HttpRequest` represents an outgoing request, including URL, method,

--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -14,7 +14,7 @@ import {switchMap} from 'rxjs/operators';
 import {HttpBackend} from './backend';
 import {RuntimeErrorCode} from './errors';
 import {HttpHeaders} from './headers';
-import {HttpRequest} from './request';
+import {HttpRequest, X_REQUEST_URL_HEADER} from './request';
 import {
   HTTP_STATUS_CODE_NO_CONTENT,
   HTTP_STATUS_CODE_OK,
@@ -30,6 +30,8 @@ import {
 
 const XSSI_PREFIX = /^\)\]\}',?\n/;
 
+const X_REQUEST_URL_REGEXP = RegExp(`^${X_REQUEST_URL_HEADER}:`, 'm');
+
 /**
  * Determine an appropriate URL for the response, by checking either
  * XMLHttpRequest.responseURL or the X-Request-URL header.
@@ -38,8 +40,8 @@ function getResponseUrl(xhr: any): string | null {
   if ('responseURL' in xhr && xhr.responseURL) {
     return xhr.responseURL;
   }
-  if (/^X-Request-URL:/m.test(xhr.getAllResponseHeaders())) {
-    return xhr.getResponseHeader('X-Request-URL');
+  if (X_REQUEST_URL_REGEXP.test(xhr.getAllResponseHeaders())) {
+    return xhr.getResponseHeader(X_REQUEST_URL_HEADER);
   }
   return null;
 }


### PR DESCRIPTION
The `X-Request-URL` string is duplicated in multiple places. It is worth moving it to a shared constant that would be minified to something like `var a="X-Request-URL"` and referenced in all the used places.