### PR TITLE
docs(docs-infra): remove sorting from API manager

### DIFF
--- a/adev/src/app/features/references/api-reference-list/api-reference-manager.service.ts
+++ b/adev/src/app/features/references/api-reference-list/api-reference-manager.service.ts
@@ -28,17 +28,15 @@ export class ApiReferenceManager {
       groups.push({
         title: module.moduleLabel.replace('@angular/', ''),
         id: module.normalizedModuleName,
-        items: module.entries
-          .map((api) => {
-            const url = getApiUrl(module, api.name);
-            return {
-              itemType: api.type,
-              title: api.name,
-              isDeprecated: !!api.isDeprecated,
-              url,
-            };
-          })
-          .sort((a, b) => a.title.localeCompare(b.title)),
+        items: module.entries.map((api) => {
+          const url = getApiUrl(module, api.name);
+          return {
+            itemType: api.type,
+            title: api.name,
+            isDeprecated: !!api.isDeprecated,
+            url,
+          };
+        }),
       });
     }
 


### PR DESCRIPTION
fixes #59423

The entries were already sorted (fixed by a previous change)

From:
<img width="447" alt="Screenshot 2025-01-11 at 02 37 45" src="https://github.com/user-attachments/assets/a8c521cf-5eaf-424d-b484-69a08b0e0614" />

To: 
<img width="454" alt="Screenshot 2025-01-11 at 02 38 15" src="https://github.com/user-attachments/assets/eec4a30b-0309-4dcb-8402-7c3d62c48376" />
