### PR TITLE
refactor(forms): drop `CALL_SET_DISABLED_STATE` name in production

### DIFF
--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -31,10 +31,13 @@ import {AsyncValidatorFn, Validator, ValidatorFn} from './validators';
  *
  * @see {@link FormsModule#withconfig}
  */
-export const CALL_SET_DISABLED_STATE = new InjectionToken('CallSetDisabledState', {
-  providedIn: 'root',
-  factory: () => setDisabledStateDefault,
-});
+export const CALL_SET_DISABLED_STATE = new InjectionToken(
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'CallSetDisabledState' : '',
+  {
+    providedIn: 'root',
+    factory: () => setDisabledStateDefault,
+  },
+);
 
 /**
  * The type for CALL_SET_DISABLED_STATE. If `always`, then ControlValueAccessor will always call


### PR DESCRIPTION
In this commit, we drop the `CALL_SET_DISABLED_STATE` injection token name in production.