### PR TITLE
refactor(common): tree-shake transfer cache interceptor stuff

### DIFF
--- a/packages/common/http/src/transfer_cache.ts
+++ b/packages/common/http/src/transfer_cache.ts
@@ -12,7 +12,6 @@ import {
   inject,
   InjectionToken,
   makeStateKey,
-  PLATFORM_ID,
   Provider,
   StateKey,
   TransferState,
@@ -21,7 +20,6 @@ import {
   ɵtruncateMiddle as truncateMiddle,
   ɵRuntimeError as RuntimeError,
 } from '@angular/core';
-import {isPlatformServer} from '@angular/common';
 import {Observable, of} from 'rxjs';
 import {tap} from 'rxjs/operators';
 
@@ -149,8 +147,8 @@ export function transferCacheInterceptorFn(
   const originMap: Record<string, string> | null = inject(HTTP_TRANSFER_CACHE_ORIGIN_MAP, {
     optional: true,
   });
-  const isServer = isPlatformServer(inject(PLATFORM_ID));
-  if (originMap && !isServer) {
+
+  if (typeof ngServerMode !== 'undefined' && !ngServerMode && originMap) {
     throw new RuntimeError(
       RuntimeErrorCode.HTTP_ORIGIN_MAP_USED_IN_CLIENT,
       ngDevMode &&
@@ -160,7 +158,10 @@ export function transferCacheInterceptorFn(
     );
   }
 
-  const requestUrl = isServer && originMap ? mapRequestOriginUrl(req.url, originMap) : req.url;
+  const requestUrl =
+    typeof ngServerMode !== 'undefined' && ngServerMode && originMap
+      ? mapRequestOriginUrl(req.url, originMap)
+      : req.url;
 
   const storeKey = makeCacheKey(req, requestUrl);
   const response = transferState.get(storeKey, null);
@@ -217,7 +218,7 @@ export function transferCacheInterceptorFn(
   // Request not found in cache. Make the request and cache it if on the server.
   return next(req).pipe(
     tap((event: HttpEvent<unknown>) => {
-      if (event instanceof HttpResponse && isServer) {
+      if (event instanceof HttpResponse && typeof ngServerMode !== 'undefined' && ngServerMode) {
         transferState.set<TransferHttpResponse>(storeKey, {
           [BODY]: event.body,
           [HEADERS]: getFilteredHeaders(event.headers, headersToInclude),

--- a/packages/common/http/test/transfer_cache_spec.ts
+++ b/packages/common/http/test/transfer_cache_spec.ts
@@ -88,6 +88,14 @@ describe('TransferCache', () => {
       return response;
     }
 
+    beforeEach(() => {
+      globalThis['ngServerMode'] = true;
+    });
+
+    afterEach(() => {
+      globalThis['ngServerMode'] = undefined;
+    });
+
     beforeEach(
       withBody('<test-app-http></test-app-http>', () => {
         TestBed.resetTestingModule();
@@ -323,6 +331,14 @@ describe('TransferCache', () => {
     });
 
     describe('caching in browser context', () => {
+      beforeEach(() => {
+        globalThis['ngServerMode'] = false;
+      });
+
+      afterEach(() => {
+        globalThis['ngServerMode'] = undefined;
+      });
+
       beforeEach(
         withBody('<test-app-http></test-app-http>', () => {
           TestBed.resetTestingModule();

--- a/packages/platform-browser/test/hydration_spec.ts
+++ b/packages/platform-browser/test/hydration_spec.ts
@@ -53,6 +53,14 @@ describe('provideClientHydration', () => {
     override isStable = new BehaviorSubject<boolean>(false);
   }
 
+  beforeEach(() => {
+    globalThis['ngServerMode'] = true;
+  });
+
+  afterEach(() => {
+    globalThis['ngServerMode'] = undefined;
+  });
+
   describe('default', () => {
     beforeEach(
       withBody(


### PR DESCRIPTION
In this commit, we replace `isPlatformServer` runtime call with the `ngServerMode` in the `transferCacheInterceptorFn` in order to make the functionality tree-shakable between client and server bundles.