### PR TITLE
docs: add doc page about unused imports schematic

### DIFF
--- a/adev/src/app/sub-navigation-data.ts
+++ b/adev/src/app/sub-navigation-data.ts
@@ -1459,6 +1459,11 @@ const REFERENCE_SUB_NAVIGATION_DATA: NavigationItem[] = [
         path: 'reference/migrations/signal-queries',
         contentPath: 'reference/migrations/signal-queries',
       },
+      {
+        label: 'Clean up unused imports',
+        path: 'reference/migrations/cleanup-unused-imports',
+        contentPath: 'reference/migrations/cleanup-unused-imports',
+      },
     ],
   },
 ];

--- a/adev/src/content/reference/migrations/cleanup-unused-imports.md
+++ b/adev/src/content/reference/migrations/cleanup-unused-imports.md
@@ -1,0 +1,38 @@
+# Clean up unused imports
+
+As of version 19, Angular reports when a component's `imports` array contains symbols that aren't used in its template.
+
+Running this schematic will clean up all unused imports within the project.
+
+Run the schematic using the following command:
+
+<docs-code language="shell">
+
+ng generate @angular/core:cleanup-unused-imports
+
+</docs-code>
+
+#### Before
+
+<docs-code language="typescript">
+import { Component } from '@angular/core';
+import { UnusedDirective } from './unused';
+
+@Component({
+  template: 'Hello',
+  imports: [UnusedDirective],
+})
+export class MyComp {}
+</docs-code>
+
+#### After
+
+<docs-code language="typescript">
+import { Component } from '@angular/core';
+
+@Component({
+  template: 'Hello',
+  imports: [],
+})
+export class MyComp {}
+</docs-code>

--- a/adev/src/content/reference/migrations/overview.md
+++ b/adev/src/content/reference/migrations/overview.md
@@ -24,4 +24,7 @@ Learn about how you can migrate your existing angular project to the latest feat
   <docs-card title="Queries as signal" link="Migrate now" href="reference/migrations/signal-queries">
     Convert existing decorator query fields to the improved signal queries API. The API is now production ready.
   </docs-card>
+  <docs-card title="Cleanup unused imports" link="Try it not" href="reference/migrations/cleanup-unused-imports">
+    Clean up unused imports in your project.
+  </docs-card>
 </docs-card-container>


### PR DESCRIPTION
Adds a docs for the new `ng generate @angular/core:cleanup-unused-imports` schematic.
