### PR TITLE
refactor(core): move logic out of shared instructions code

### DIFF
--- a/packages/core/src/authoring/queries.ts
+++ b/packages/core/src/authoring/queries.ts
@@ -12,7 +12,7 @@ import {
   createMultiResultQuerySignalFn,
   createSingleResultOptionalQuerySignalFn,
   createSingleResultRequiredQuerySignalFn,
-} from '../render3/query_reactive';
+} from '../render3/queries/query_reactive';
 import {Signal} from '../render3/reactivity/api';
 
 function viewChildFn<LocatorT, ReadT>(

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -43,7 +43,6 @@ import {
   addToEndOfViewTree,
   createLView,
   createTView,
-  executeContentQueries,
   getInitialLViewFlagsFromDef,
   getOrCreateComponentTView,
   getOrCreateTNode,
@@ -91,6 +90,7 @@ import {ChainedInjector} from './chained_injector';
 import {unregisterLView} from './interfaces/lview_tracking';
 import {profiler} from './profiler';
 import {ProfilerEvent} from './profiler_types';
+import {executeContentQueries} from './queries/query_execution';
 
 export class ComponentFactoryResolver extends AbstractComponentFactoryResolver {
   /**

--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -48,6 +48,7 @@ import {
   createElementNode,
   setupStaticAttributes,
 } from '../node_manipulation';
+import {executeContentQueries} from '../queries/query_execution';
 import {
   decreaseElementDepthCount,
   enterSkipHydrationBlock,
@@ -74,7 +75,6 @@ import {validateElementIsKnown} from './element_validation';
 import {setDirectiveInputsWhichShadowsStyling} from './property';
 import {
   createDirectivesInstances,
-  executeContentQueries,
   getOrCreateTNode,
   resolveDirectives,
   saveResolvedLocalsInData,

--- a/packages/core/src/render3/instructions/element_container.ts
+++ b/packages/core/src/render3/instructions/element_container.ts
@@ -24,6 +24,7 @@ import {isContentQueryHost, isDirectiveHost} from '../interfaces/type_checks';
 import {HEADER_OFFSET, HYDRATION, LView, RENDERER, TView} from '../interfaces/view';
 import {assertTNodeType} from '../node_assert';
 import {appendChild, createCommentNode} from '../node_manipulation';
+import {executeContentQueries} from '../queries/query_execution';
 import {
   getBindingIndex,
   getCurrentTNode,
@@ -41,7 +42,6 @@ import {getConstant} from '../util/view_utils';
 
 import {
   createDirectivesInstances,
-  executeContentQueries,
   getOrCreateTNode,
   resolveDirectives,
   saveResolvedLocalsInData,

--- a/packages/core/src/render3/instructions/listener.ts
+++ b/packages/core/src/render3/instructions/listener.ts
@@ -19,15 +19,16 @@ import {assertTNodeType} from '../node_assert';
 import {profiler} from '../profiler';
 import {ProfilerEvent} from '../profiler_types';
 import {getCurrentDirectiveDef, getCurrentTNode, getLView, getTView} from '../state';
-import {getComponentLViewByIndex, getNativeByTNode, unwrapRNode} from '../util/view_utils';
-
-import {markViewDirty} from './mark_view_dirty';
 import {
+  getComponentLViewByIndex,
+  getNativeByTNode,
   getOrCreateLViewCleanup,
   getOrCreateTViewCleanup,
-  handleError,
-  loadComponentRenderer,
-} from './shared';
+  unwrapRNode,
+} from '../util/view_utils';
+
+import {markViewDirty} from './mark_view_dirty';
+import {handleError, loadComponentRenderer} from './shared';
 
 /**
  * Contains a reference to a function that disables event replay feature

--- a/packages/core/src/render3/instructions/queries.ts
+++ b/packages/core/src/render3/instructions/queries.ts
@@ -16,7 +16,7 @@ import {
   getQueryResults,
   getTQuery,
   loadQueryInternal,
-} from '../query';
+} from '../queries/query';
 import {getCurrentQueryIndex, getLView, getTView, setCurrentQueryIndex} from '../state';
 import {isCreationMode} from '../util/view_utils';
 

--- a/packages/core/src/render3/instructions/queries_signals.ts
+++ b/packages/core/src/render3/instructions/queries_signals.ts
@@ -8,8 +8,8 @@
 
 import {ProviderToken} from '../../di/provider_token';
 import {QueryFlags} from '../interfaces/query';
-import {createContentQuery, createViewQuery} from '../query';
-import {bindQueryToSignal} from '../query_reactive';
+import {createContentQuery, createViewQuery} from '../queries/query';
+import {bindQueryToSignal} from '../queries/query_reactive';
 import {Signal} from '../reactivity/api';
 import {getCurrentQueryIndex, setCurrentQueryIndex} from '../state';
 

--- a/packages/core/src/render3/instructions/render.ts
+++ b/packages/core/src/render3/instructions/render.ts
@@ -23,10 +23,11 @@ import {
 } from '../interfaces/view';
 import {profiler} from '../profiler';
 import {ProfilerEvent} from '../profiler_types';
+import {executeViewQueryFn, refreshContentQueries} from '../queries/query_execution';
 import {enterView, leaveView} from '../state';
 import {getComponentLViewByIndex, isCreationMode} from '../util/view_utils';
 
-import {executeTemplate, executeViewQueryFn, refreshContentQueries} from './shared';
+import {executeTemplate} from './shared';
 
 export function renderComponent(hostLView: LView, componentHostIdx: number) {
   ngDevMode && assertEqual(isCreationMode(hostLView), true, 'Should be run in creation mode');

--- a/packages/core/src/render3/instructions/text_interpolation.ts
+++ b/packages/core/src/render3/instructions/text_interpolation.ts
@@ -5,8 +5,13 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
+import {assertDefined, assertIndexInRange, assertNotSame, assertString} from '../../util/assert';
+import {RText} from '../interfaces/renderer_dom';
+import {LView, RENDERER} from '../interfaces/view';
+import {updateTextNode} from '../node_manipulation';
 import {getLView, getSelectedIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
+import {getNativeByIndex} from '../util/view_utils';
 
 import {
   interpolation1,
@@ -19,7 +24,6 @@ import {
   interpolation8,
   interpolationV,
 } from './interpolation';
-import {textBindingInternal} from './shared';
 
 /**
  *
@@ -448,4 +452,16 @@ export function ɵɵtextInterpolateV(values: any[]): typeof ɵɵtextInterpolateV
     textBindingInternal(lView, getSelectedIndex(), interpolated as string);
   }
   return ɵɵtextInterpolateV;
+}
+
+/**
+ * Updates a text binding at a given index in a given LView.
+ */
+function textBindingInternal(lView: LView, index: number, value: string): void {
+  ngDevMode && assertString(value, 'Value should be a string');
+  ngDevMode && assertNotSame(value, NO_CHANGE as any, 'value should not be NO_CHANGE');
+  ngDevMode && assertIndexInRange(lView, index);
+  const element = getNativeByIndex(index, lView) as any as RText;
+  ngDevMode && assertDefined(element, 'native element should exist');
+  updateTextNode(lView[RENDERER], element, value);
 }

--- a/packages/core/src/render3/queries/query.ts
+++ b/packages/core/src/render3/queries/query.ts
@@ -9,29 +9,29 @@
 // We are temporarily importing the existing viewEngine_from core so we can be sure we are
 // correctly implementing its interfaces for backwards compatibility.
 
-import {ProviderToken} from '../di/provider_token';
-import {createElementRef, ElementRef as ViewEngine_ElementRef} from '../linker/element_ref';
-import {QueryList} from '../linker/query_list';
-import {createTemplateRef, TemplateRef as ViewEngine_TemplateRef} from '../linker/template_ref';
-import {createContainerRef, ViewContainerRef} from '../linker/view_container_ref';
-import {assertDefined, assertIndexInRange, assertNumber, throwError} from '../util/assert';
-import {stringify} from '../util/stringify';
+import {ProviderToken} from '../../di/provider_token';
+import {createElementRef, ElementRef as ViewEngine_ElementRef} from '../../linker/element_ref';
+import {QueryList} from '../../linker/query_list';
+import {createTemplateRef, TemplateRef as ViewEngine_TemplateRef} from '../../linker/template_ref';
+import {createContainerRef, ViewContainerRef} from '../../linker/view_container_ref';
+import {assertDefined, assertIndexInRange, assertNumber, throwError} from '../../util/assert';
+import {stringify} from '../../util/stringify';
 
-import {assertFirstCreatePass, assertLContainer} from './assert';
-import {getNodeInjectable, locateDirectiveOrProvider} from './di';
-import {storeCleanupWithContext} from './instructions/shared';
-import {CONTAINER_HEADER_OFFSET, LContainer, MOVED_VIEWS} from './interfaces/container';
+import {assertFirstCreatePass, assertLContainer} from '../assert';
+import {getNodeInjectable, locateDirectiveOrProvider} from '../di';
+import {CONTAINER_HEADER_OFFSET, LContainer, MOVED_VIEWS} from '../interfaces/container';
 import {
   TContainerNode,
   TElementContainerNode,
   TElementNode,
   TNode,
   TNodeType,
-} from './interfaces/node';
-import {LQueries, LQuery, QueryFlags, TQueries, TQuery, TQueryMetadata} from './interfaces/query';
-import {DECLARATION_LCONTAINER, LView, PARENT, QUERIES, TVIEW, TView} from './interfaces/view';
-import {assertTNodeType} from './node_assert';
-import {getCurrentTNode, getLView, getTView} from './state';
+} from '../interfaces/node';
+import {LQueries, LQuery, QueryFlags, TQueries, TQuery, TQueryMetadata} from '../interfaces/query';
+import {DECLARATION_LCONTAINER, LView, PARENT, QUERIES, TVIEW, TView} from '../interfaces/view';
+import {assertTNodeType} from '../node_assert';
+import {getCurrentTNode, getLView, getTView} from '../state';
+import {storeCleanupWithContext} from '../util/view_utils';
 
 class LQuery_<T> implements LQuery<T> {
   matches: (T | null)[] | null = null;

--- a/packages/core/src/render3/queries/query_execution.ts
+++ b/packages/core/src/render3/queries/query_execution.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {setActiveConsumer} from '@angular/core/primitives/signals';
+import {LView, TView} from '../interfaces/view';
+import {DirectiveDef, RenderFlags, ViewQueriesFunction} from '../interfaces/definition';
+import {assertDefined} from '../../util/assert';
+import {setCurrentQueryIndex} from '../state';
+import {TNode} from '../interfaces/node';
+import {isContentQueryHost} from '../interfaces/type_checks';
+
+/** Refreshes all content queries declared by directives in a given view */
+export function refreshContentQueries(tView: TView, lView: LView): void {
+  const contentQueries = tView.contentQueries;
+  if (contentQueries !== null) {
+    const prevConsumer = setActiveConsumer(null);
+    try {
+      for (let i = 0; i < contentQueries.length; i += 2) {
+        const queryStartIdx = contentQueries[i];
+        const directiveDefIdx = contentQueries[i + 1];
+        if (directiveDefIdx !== -1) {
+          const directiveDef = tView.data[directiveDefIdx] as DirectiveDef<any>;
+          ngDevMode && assertDefined(directiveDef, 'DirectiveDef not found.');
+          ngDevMode &&
+            assertDefined(directiveDef.contentQueries, 'contentQueries function should be defined');
+          setCurrentQueryIndex(queryStartIdx);
+          directiveDef.contentQueries!(RenderFlags.Update, lView[directiveDefIdx], directiveDefIdx);
+        }
+      }
+    } finally {
+      setActiveConsumer(prevConsumer);
+    }
+  }
+}
+
+export function executeViewQueryFn<T>(
+  flags: RenderFlags,
+  viewQueryFn: ViewQueriesFunction<T>,
+  component: T,
+): void {
+  ngDevMode && assertDefined(viewQueryFn, 'View queries function to execute must be defined.');
+  setCurrentQueryIndex(0);
+  const prevConsumer = setActiveConsumer(null);
+  try {
+    viewQueryFn(flags, component);
+  } finally {
+    setActiveConsumer(prevConsumer);
+  }
+}
+
+export function executeContentQueries(tView: TView, tNode: TNode, lView: LView) {
+  if (isContentQueryHost(tNode)) {
+    const prevConsumer = setActiveConsumer(null);
+    try {
+      const start = tNode.directiveStart;
+      const end = tNode.directiveEnd;
+      for (let directiveIndex = start; directiveIndex < end; directiveIndex++) {
+        const def = tView.data[directiveIndex] as DirectiveDef<any>;
+        if (def.contentQueries) {
+          const directiveInstance = lView[directiveIndex];
+          ngDevMode &&
+            assertDefined(
+              directiveIndex,
+              'Incorrect reference to a directive defining a content query',
+            );
+          def.contentQueries(RenderFlags.Create, directiveInstance, directiveIndex);
+        }
+      }
+    } finally {
+      setActiveConsumer(prevConsumer);
+    }
+  }
+}

--- a/packages/core/src/render3/queries/query_reactive.ts
+++ b/packages/core/src/render3/queries/query_reactive.ts
@@ -8,16 +8,16 @@
 
 import {ComputedNode, createComputed, SIGNAL} from '@angular/core/primitives/signals';
 
-import {RuntimeError, RuntimeErrorCode} from '../errors';
-import {unwrapElementRef} from '../linker/element_ref';
-import {QueryList} from '../linker/query_list';
-import {EMPTY_ARRAY} from '../util/empty';
+import {RuntimeError, RuntimeErrorCode} from '../../errors';
+import {unwrapElementRef} from '../../linker/element_ref';
+import {QueryList} from '../../linker/query_list';
+import {EMPTY_ARRAY} from '../../util/empty';
 
-import {FLAGS, LView, LViewFlags} from './interfaces/view';
+import {FLAGS, LView, LViewFlags} from '../interfaces/view';
+import {Signal} from '../reactivity/api';
+import {signal, WritableSignal} from '../reactivity/signal';
+import {getLView} from '../state';
 import {getQueryResults, loadQueryInternal} from './query';
-import {Signal} from './reactivity/api';
-import {signal, WritableSignal} from './reactivity/signal';
-import {getLView} from './state';
 
 interface QuerySignalNode<T> extends ComputedNode<T | ReadonlyArray<T>> {
   _lView?: LView;

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -21,6 +21,7 @@ import {TConstants, TNode} from '../interfaces/node';
 import {RNode} from '../interfaces/renderer_dom';
 import {isDestroyed, isLContainer, isLView} from '../interfaces/type_checks';
 import {
+  CLEANUP,
   DECLARATION_VIEW,
   ENVIRONMENT,
   FLAGS,
@@ -304,4 +305,50 @@ export function getLViewParent(lView: LView): LView | null {
   ngDevMode && assertLView(lView);
   const parent = lView[PARENT];
   return isLContainer(parent) ? parent[PARENT] : parent;
+}
+
+export function getOrCreateLViewCleanup(view: LView): any[] {
+  // top level variables should not be exported for performance reasons (PERF_NOTES.md)
+  return (view[CLEANUP] ??= []);
+}
+
+export function getOrCreateTViewCleanup(tView: TView): any[] {
+  return (tView.cleanup ??= []);
+}
+
+/**
+ * Saves context for this cleanup function in LView.cleanupInstances.
+ *
+ * On the first template pass, saves in TView:
+ * - Cleanup function
+ * - Index of context we just saved in LView.cleanupInstances
+ */
+export function storeCleanupWithContext(
+  tView: TView,
+  lView: LView,
+  context: any,
+  cleanupFn: Function,
+): void {
+  const lCleanup = getOrCreateLViewCleanup(lView);
+
+  // Historically the `storeCleanupWithContext` was used to register both framework-level and
+  // user-defined cleanup callbacks, but over time those two types of cleanups were separated.
+  // This dev mode checks assures that user-level cleanup callbacks are _not_ stored in data
+  // structures reserved for framework-specific hooks.
+  ngDevMode &&
+    assertDefined(
+      context,
+      'Cleanup context is mandatory when registering framework-level destroy hooks',
+    );
+  lCleanup.push(context);
+
+  if (tView.firstCreatePass) {
+    getOrCreateTViewCleanup(tView).push(cleanupFn, lCleanup.length - 1);
+  } else {
+    // Make sure that no new framework-level cleanup functions are registered after the first
+    // template pass is done (and TView data structures are meant to fully constructed).
+    if (ngDevMode) {
+      Object.freeze(getOrCreateTViewCleanup(tView));
+    }
+  }
 }

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -651,6 +651,7 @@
   "init_queries2",
   "init_queries_signals",
   "init_query",
+  "init_query_execution",
   "init_query_list",
   "init_query_reactive",
   "init_r3_injector",


### PR DESCRIPTION
This is first of a series of refactorings that moves code around such that logic from the shared instruction file is dispatched to the relevant functional parts.
