### PR TITLE
refactor(router): drop forRoot guard in production

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -861,11 +861,11 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
 
 // @public
 export class RouterModule {
-    constructor(guard: any);
+    constructor();
     static forChild(routes: Routes): ModuleWithProviders<RouterModule>;
     static forRoot(routes: Routes, config?: ExtraOptions): ModuleWithProviders<RouterModule>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<RouterModule, [{ optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<RouterModule, never>;
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<RouterModule>;
     // (undocumented)

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -63,9 +63,7 @@ const ROUTER_DIRECTIVES = [RouterOutlet, RouterLink, RouterLinkActive, EmptyOutl
  * @docsNotRequired
  */
 export const ROUTER_FORROOT_GUARD = new InjectionToken<void>(
-  typeof ngDevMode === 'undefined' || ngDevMode
-    ? 'router duplicate forRoot guard'
-    : 'ROUTER_FORROOT_GUARD',
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'router duplicate forRoot guard' : '',
 );
 
 // TODO(atscott): All of these except `ActivatedRoute` are `providedIn: 'root'`. They are only kept
@@ -112,7 +110,11 @@ export const ROUTER_PROVIDERS: Provider[] = [
   exports: ROUTER_DIRECTIVES,
 })
 export class RouterModule {
-  constructor(@Optional() @Inject(ROUTER_FORROOT_GUARD) guard: any) {}
+  constructor() {
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      inject(ROUTER_FORROOT_GUARD, {optional: true});
+    }
+  }
 
   /**
    * Creates and configures a module with all the router providers and directives.
@@ -143,11 +145,13 @@ export class RouterModule {
             : []
           : [],
         {provide: ROUTES, multi: true, useValue: routes},
-        {
-          provide: ROUTER_FORROOT_GUARD,
-          useFactory: provideForRootGuard,
-          deps: [[Router, new Optional(), new SkipSelf()]],
-        },
+        typeof ngDevMode === 'undefined' || ngDevMode
+          ? {
+              provide: ROUTER_FORROOT_GUARD,
+              useFactory: provideForRootGuard,
+              deps: [[Router, new Optional(), new SkipSelf()]],
+            }
+          : [],
         config?.errorHandler
           ? {
               provide: NAVIGATION_ERROR_HANDLER,
@@ -224,7 +228,7 @@ function providePathLocationStrategy(): Provider {
 }
 
 export function provideForRootGuard(router: Router): any {
-  if ((typeof ngDevMode === 'undefined' || ngDevMode) && router) {
+  if (router) {
     throw new RuntimeError(
       RuntimeErrorCode.FOR_ROOT_CALLED_TWICE,
       `The Router was provided more than once. This can happen if 'forRoot' is used outside of the root injector.` +


### PR DESCRIPTION
In this commit, we switch from decorators (which also produce redundant metadata, such as in the `declareFactory` instruction) to the `inject` function to drop the `ROUTER_FORROOT_GUARD` token in production. This token factory function is only in development mode but is still referenced in the constructor due to the `@Inject(ROUTER_FORROOT_GUARD)` decorator.