### PR TITLE
docs(docs-infra): prevent the host class from being replaced

### DIFF
--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.spec.ts
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.spec.ts
@@ -112,6 +112,13 @@ describe('DocViewer', () => {
 
     expect(exampleViewer).not.toBeNull();
     expect(exampleViewer.componentInstance.view()).toBe(CodeExampleViewMode.SNIPPET);
+
+    const checkIcon = fixture.debugElement.query(By.directive(IconComponent));
+    expect((checkIcon.nativeElement as HTMLElement).classList).toContain(
+      `material-symbols-outlined`,
+    );
+    expect((checkIcon.nativeElement as HTMLElement).classList).toContain(`docs-check`);
+    expect(checkIcon.nativeElement.innerHTML).toBe('check');
   });
 
   it('should display example viewer in multi file mode when user clicks expand', async () => {

--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
@@ -265,9 +265,12 @@ export class DocViewer implements OnChanges {
   }
 
   private loadIcons(element: HTMLElement): void {
-    element.querySelectorAll('docs-icon').forEach((iconsPlaceholder) => {
-      this.renderComponent(IconComponent, iconsPlaceholder as HTMLElement);
-    });
+    // We need to make sure that we don't reload the icons in loadCopySourceCodeButtons
+    element
+      .querySelectorAll('docs-icon:not([docs-copy-source-code] docs-icon)')
+      .forEach((iconsPlaceholder) => {
+        this.renderComponent(IconComponent, iconsPlaceholder as HTMLElement);
+      });
   }
 
   /**


### PR DESCRIPTION
fixes #59442

Usage: 
https://github.com/angular/angular/blob/a4164141a38e03becad32b9e71d1f4243cc06461/adev/shared-docs/components/copy-source-code-button/copy-source-code-button.component.html#L18