### PR TITLE
refactor(core): move DOM manipulation logic to its own file

### DIFF
--- a/packages/core/src/hydration/cleanup.ts
+++ b/packages/core/src/hydration/cleanup.ts
@@ -18,7 +18,7 @@ import {Renderer} from '../render3/interfaces/renderer';
 import {RNode} from '../render3/interfaces/renderer_dom';
 import {isLContainer, isLView} from '../render3/interfaces/type_checks';
 import {HEADER_OFFSET, HOST, LView, PARENT, RENDERER, TVIEW} from '../render3/interfaces/view';
-import {nativeRemoveNode} from '../render3/node_manipulation';
+import {nativeRemoveNode} from '../render3/dom_node_manipulation';
 
 import {validateSiblingNodeExists} from './error_handling';
 import {cleanupI18nHydrationData} from './i18n';

--- a/packages/core/src/hydration/i18n.ts
+++ b/packages/core/src/hydration/i18n.ts
@@ -14,7 +14,8 @@ import {isTNodeShape, TNode, TNodeType} from '../render3/interfaces/node';
 import type {Renderer} from '../render3/interfaces/renderer';
 import type {RNode} from '../render3/interfaces/renderer_dom';
 import {HEADER_OFFSET, HYDRATION, LView, RENDERER, TView, TVIEW} from '../render3/interfaces/view';
-import {getFirstNativeNode, nativeRemoveNode} from '../render3/node_manipulation';
+import {getFirstNativeNode} from '../render3/node_manipulation';
+import {nativeRemoveNode} from '../render3/dom_node_manipulation';
 import {unwrapRNode} from '../render3/util/view_utils';
 import {assertDefined, assertNotEqual} from '../util/assert';
 

--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -51,13 +51,8 @@ import {
   TVIEW,
 } from '../render3/interfaces/view';
 import {assertTNodeType} from '../render3/node_assert';
-import {
-  destroyLView,
-  detachView,
-  nativeInsertBefore,
-  nativeNextSibling,
-  nativeParentNode,
-} from '../render3/node_manipulation';
+import {destroyLView, detachView} from '../render3/node_manipulation';
+import {nativeInsertBefore} from '../render3/dom_node_manipulation';
 import {getCurrentTNode, getLView} from '../render3/state';
 import {
   getParentInjectorIndex,
@@ -723,12 +718,12 @@ function insertAnchorNode(hostLView: LView, hostTNode: TNode): RComment {
   const commentNode = renderer.createComment(ngDevMode ? 'container' : '');
 
   const hostNative = getNativeByTNode(hostTNode, hostLView)!;
-  const parentOfHostNative = nativeParentNode(renderer, hostNative);
+  const parentOfHostNative = renderer.parentNode(hostNative);
   nativeInsertBefore(
     renderer,
     parentOfHostNative!,
     commentNode,
-    nativeNextSibling(renderer, hostNative),
+    renderer.nextSibling(hostNative),
     false,
   );
   return commentNode;

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -75,7 +75,7 @@ import {
   TViewType,
 } from './interfaces/view';
 import {MATH_ML_NAMESPACE, SVG_NAMESPACE} from './namespaces';
-import {createElementNode, setupStaticAttributes, writeDirectClass} from './node_manipulation';
+import {setupStaticAttributes, writeDirectClass} from './node_manipulation';
 import {
   extractAttrsAndClassesFromSelector,
   stringifyCSSSelectorList,
@@ -91,6 +91,7 @@ import {unregisterLView} from './interfaces/lview_tracking';
 import {profiler} from './profiler';
 import {ProfilerEvent} from './profiler_types';
 import {executeContentQueries} from './queries/query_execution';
+import {createElementNode} from './dom_node_manipulation';
 
 export class ComponentFactoryResolver extends AbstractComponentFactoryResolver {
   /**

--- a/packages/core/src/render3/dom_node_manipulation.ts
+++ b/packages/core/src/render3/dom_node_manipulation.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Renderer} from './interfaces/renderer';
+import {RComment, RElement, RNode, RText} from './interfaces/renderer_dom';
+import {escapeCommentText} from '../util/dom';
+import {assertDefined} from '../util/assert';
+
+export function createTextNode(renderer: Renderer, value: string): RText {
+  ngDevMode && ngDevMode.rendererCreateTextNode++;
+  ngDevMode && ngDevMode.rendererSetText++;
+  return renderer.createText(value);
+}
+
+export function updateTextNode(renderer: Renderer, rNode: RText, value: string): void {
+  ngDevMode && ngDevMode.rendererSetText++;
+  renderer.setValue(rNode, value);
+}
+
+export function createCommentNode(renderer: Renderer, value: string): RComment {
+  ngDevMode && ngDevMode.rendererCreateComment++;
+  return renderer.createComment(escapeCommentText(value));
+}
+
+/**
+ * Creates a native element from a tag name, using a renderer.
+ * @param renderer A renderer to use
+ * @param name the tag name
+ * @param namespace Optional namespace for element.
+ * @returns the element created
+ */
+export function createElementNode(
+  renderer: Renderer,
+  name: string,
+  namespace: string | null,
+): RElement {
+  ngDevMode && ngDevMode.rendererCreateElement++;
+  return renderer.createElement(name, namespace);
+}
+
+/**
+ * Inserts a native node before another native node for a given parent.
+ * This is a utility function that can be used when native nodes were determined.
+ */
+export function nativeInsertBefore(
+  renderer: Renderer,
+  parent: RElement,
+  child: RNode,
+  beforeNode: RNode | null,
+  isMove: boolean,
+): void {
+  ngDevMode && ngDevMode.rendererInsertBefore++;
+  renderer.insertBefore(parent, child, beforeNode, isMove);
+}
+
+export function nativeAppendChild(renderer: Renderer, parent: RElement, child: RNode): void {
+  ngDevMode && ngDevMode.rendererAppendChild++;
+  ngDevMode && assertDefined(parent, 'parent node must be defined');
+  renderer.appendChild(parent, child);
+}
+
+export function nativeAppendOrInsertBefore(
+  renderer: Renderer,
+  parent: RElement,
+  child: RNode,
+  beforeNode: RNode | null,
+  isMove: boolean,
+) {
+  if (beforeNode !== null) {
+    nativeInsertBefore(renderer, parent, child, beforeNode, isMove);
+  } else {
+    nativeAppendChild(renderer, parent, child);
+  }
+}
+
+/**
+ * Removes a native node itself using a given renderer. To remove the node we are looking up its
+ * parent from the native tree as not all platforms / browsers support the equivalent of
+ * node.remove().
+ *
+ * @param renderer A renderer to be used
+ * @param rNode The native node that should be removed
+ * @param isHostElement A flag indicating if a node to be removed is a host of a component.
+ */
+export function nativeRemoveNode(renderer: Renderer, rNode: RNode, isHostElement?: boolean): void {
+  ngDevMode && ngDevMode.rendererRemoveNode++;
+  renderer.removeChild(null, rNode, isHostElement);
+}
+
+/**
+ * Clears the contents of a given RElement.
+ *
+ * @param rElement the native RElement to be cleared
+ */
+export function clearElementContents(rElement: RElement): void {
+  rElement.textContent = '';
+}

--- a/packages/core/src/render3/i18n/i18n_apply.ts
+++ b/packages/core/src/render3/i18n/i18n_apply.ts
@@ -44,10 +44,9 @@ import {
   createElementNode,
   createTextNode,
   nativeInsertBefore,
-  nativeParentNode,
   nativeRemoveNode,
   updateTextNode,
-} from '../node_manipulation';
+} from '../dom_node_manipulation';
 import {
   getBindingIndex,
   isInSkipHydrationBlock,
@@ -272,7 +271,7 @@ export function applyMutableOpCodes(
             // must insert into the root. (Only subsequent operations can insert into a dynamic
             // parent)
             rootIdx = parentIdx;
-            rootRNode = nativeParentNode(renderer, anchorRNode);
+            rootRNode = renderer.parentNode(anchorRNode);
           }
           let insertInFrontOf: RNode | null;
           let parentRNode: RElement | null;

--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -34,7 +34,6 @@ import {
   TAttributes,
   TElementNode,
   TNode,
-  TNodeFlags,
   TNodeType,
 } from '../interfaces/node';
 import {Renderer} from '../interfaces/renderer';
@@ -42,13 +41,9 @@ import {RElement} from '../interfaces/renderer_dom';
 import {isComponentHost, isContentQueryHost, isDirectiveHost} from '../interfaces/type_checks';
 import {HEADER_OFFSET, HYDRATION, LView, RENDERER, TView} from '../interfaces/view';
 import {assertTNodeType} from '../node_assert';
-import {
-  appendChild,
-  clearElementContents,
-  createElementNode,
-  setupStaticAttributes,
-} from '../node_manipulation';
 import {executeContentQueries} from '../queries/query_execution';
+import {appendChild, setupStaticAttributes} from '../node_manipulation';
+import {clearElementContents, createElementNode} from '../dom_node_manipulation';
 import {
   decreaseElementDepthCount,
   enterSkipHydrationBlock,

--- a/packages/core/src/render3/instructions/element_container.ts
+++ b/packages/core/src/render3/instructions/element_container.ts
@@ -23,8 +23,9 @@ import {RComment} from '../interfaces/renderer_dom';
 import {isContentQueryHost, isDirectiveHost} from '../interfaces/type_checks';
 import {HEADER_OFFSET, HYDRATION, LView, RENDERER, TView} from '../interfaces/view';
 import {assertTNodeType} from '../node_assert';
-import {appendChild, createCommentNode} from '../node_manipulation';
 import {executeContentQueries} from '../queries/query_execution';
+import {appendChild} from '../node_manipulation';
+import {createCommentNode} from '../dom_node_manipulation';
 import {
   getBindingIndex,
   getCurrentTNode,

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -115,7 +115,6 @@ import {
   TViewType,
 } from '../interfaces/view';
 import {assertPureTNodeType, assertTNodeType} from '../node_assert';
-import {clearElementContents} from '../node_manipulation';
 import {isInlineTemplate, isNodeMatchingSelectorList} from '../node_selector_matcher';
 import {profiler} from '../profiler';
 import {ProfilerEvent} from '../profiler_types';
@@ -148,6 +147,7 @@ import {selectIndexInternal} from './advance';
 import {ɵɵdirectiveInject} from './di';
 import {handleUnknownPropertyError, isPropertyValid, matchingSchemas} from './element_validation';
 import {writeToDirectiveInput} from './write_to_directive_input';
+import {clearElementContents, updateTextNode} from '../dom_node_manipulation';
 
 export function createLView<T>(
   parentLView: LView | null,

--- a/packages/core/src/render3/instructions/text.ts
+++ b/packages/core/src/render3/instructions/text.ts
@@ -12,8 +12,9 @@ import {isDetachedByI18n} from '../../i18n/utils';
 import {assertEqual, assertIndexInRange} from '../../util/assert';
 import {TElementNode, TNode, TNodeType} from '../interfaces/node';
 import {RText} from '../interfaces/renderer_dom';
-import {HEADER_OFFSET, HYDRATION, LView, RENDERER, T_HOST, TView} from '../interfaces/view';
-import {appendChild, createTextNode} from '../node_manipulation';
+import {HEADER_OFFSET, HYDRATION, LView, RENDERER, TView} from '../interfaces/view';
+import {appendChild} from '../node_manipulation';
+import {createTextNode} from '../dom_node_manipulation';
 import {
   getBindingIndex,
   getLView,

--- a/packages/core/src/render3/instructions/text_interpolation.ts
+++ b/packages/core/src/render3/instructions/text_interpolation.ts
@@ -8,7 +8,7 @@
 import {assertDefined, assertIndexInRange, assertNotSame, assertString} from '../../util/assert';
 import {RText} from '../interfaces/renderer_dom';
 import {LView, RENDERER} from '../interfaces/view';
-import {updateTextNode} from '../node_manipulation';
+import {updateTextNode} from '../dom_node_manipulation';
 import {getLView, getSelectedIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
 import {getNativeByIndex} from '../util/view_utils';

--- a/packages/core/src/render3/node_manipulation_i18n.ts
+++ b/packages/core/src/render3/node_manipulation_i18n.ts
@@ -8,11 +8,12 @@
 
 import {assertDomNode, assertIndexInRange} from '../util/assert';
 
-import {TNode, TNodeFlags, TNodeType} from './interfaces/node';
+import {TNode, TNodeType} from './interfaces/node';
 import {Renderer} from './interfaces/renderer';
 import {RElement, RNode} from './interfaces/renderer_dom';
 import {LView} from './interfaces/view';
-import {getInsertInFrontOfRNodeWithNoI18n, nativeInsertBefore} from './node_manipulation';
+import {getInsertInFrontOfRNodeWithNoI18n} from './node_manipulation';
+import {nativeInsertBefore} from './dom_node_manipulation';
 import {unwrapRNode} from './util/view_utils';
 
 /**

--- a/packages/core/src/render3/view_manipulation.ts
+++ b/packages/core/src/render3/view_manipulation.ts
@@ -36,7 +36,6 @@ import {
   detachView,
   getBeforeNodeForView,
   insertView,
-  nativeParentNode,
 } from './node_manipulation';
 
 export function createAndRenderEmbeddedLView<T>(
@@ -135,7 +134,7 @@ export function addLViewToLContainer(
   if (addToDOM) {
     const beforeNode = getBeforeNodeForView(index, lContainer);
     const renderer = lView[RENDERER];
-    const parentRNode = nativeParentNode(renderer, lContainer[NATIVE] as RElement | RComment);
+    const parentRNode = renderer.parentNode(lContainer[NATIVE] as RElement | RComment);
     if (parentRNode !== null) {
       addViewToDOM(tView, lContainer[T_HOST], renderer, lView, parentRNode, beforeNode);
     }

--- a/packages/core/src/sanitization/iframe_attrs_validation.ts
+++ b/packages/core/src/sanitization/iframe_attrs_validation.ts
@@ -11,7 +11,7 @@ import {getTemplateLocationDetails} from '../render3/instructions/element_valida
 import {TNodeType} from '../render3/interfaces/node';
 import {RComment, RElement} from '../render3/interfaces/renderer_dom';
 import {RENDERER} from '../render3/interfaces/view';
-import {nativeRemoveNode} from '../render3/node_manipulation';
+import {nativeRemoveNode} from '../render3/dom_node_manipulation';
 import {getLView, getSelectedTNode} from '../render3/state';
 import {getNativeByTNode} from '../render3/util/view_utils';
 import {trustedHTMLFromString} from '../util/security/trusted_types';

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -469,6 +469,7 @@
   "init_dispatcher",
   "init_document",
   "init_dom",
+  "init_dom_node_manipulation",
   "init_dom_triggers",
   "init_earlyeventcontract",
   "init_effect",

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -521,7 +521,6 @@
   "nativeAppendChild",
   "nativeAppendOrInsertBefore",
   "nativeInsertBefore",
-  "nativeParentNode",
   "nextNgElementId",
   "ngOnChangesSetInput",
   "ngZoneInstanceId",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -509,7 +509,6 @@
   "nativeAppendChild",
   "nativeAppendOrInsertBefore",
   "nativeInsertBefore",
-  "nativeParentNode",
   "nextBindingIndex",
   "nextNgElementId",
   "ngOnChangesSetInput",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -597,7 +597,6 @@
   "nativeAppendChild",
   "nativeAppendOrInsertBefore",
   "nativeInsertBefore",
-  "nativeParentNode",
   "navigationCancelingError",
   "nextBindingIndex",
   "nextNgElementId",

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -419,7 +419,6 @@
   "nativeAppendChild",
   "nativeAppendOrInsertBefore",
   "nativeInsertBefore",
-  "nativeParentNode",
   "nextBindingIndex",
   "nextNgElementId",
   "ngOnChangesSetInput",


### PR DESCRIPTION
This refactoring takes a step toward breaking down the node_manipulation file into smaller, more focused files.
