### PR TITLE
refactor(common): prevent duplicating `Accept` header

### DIFF
--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -11,7 +11,7 @@ import {Observable, Observer} from 'rxjs';
 
 import {HttpBackend} from './backend';
 import {HttpHeaders} from './headers';
-import {HttpRequest, X_REQUEST_URL_HEADER} from './request';
+import {ACCEPT_HEADER, HttpRequest, X_REQUEST_URL_HEADER} from './request';
 import {
   HTTP_STATUS_CODE_OK,
   HttpDownloadProgressEvent,
@@ -259,7 +259,7 @@ export class FetchBackend implements HttpBackend {
 
     // Add an Accept header if one isn't present already.
     if (!req.headers.has('Accept')) {
-      headers['Accept'] = 'application/json, text/plain, */*';
+      headers['Accept'] = ACCEPT_HEADER;
     }
 
     // Auto-detect the Content-Type header if one isn't present already.

--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -85,6 +85,27 @@ function isUrlSearchParams(value: any): value is URLSearchParams {
 export const X_REQUEST_URL_HEADER = 'X-Request-URL';
 
 /**
+ * `text/plain` is a content type used to indicate that the content being
+ * sent is plain text with no special formatting or structured data
+ * like HTML, XML, or JSON.
+ */
+export const TEXT_CONTENT_TYPE = 'text/plain';
+
+/**
+ * `application/json` is a content type used to indicate that the content
+ * being sent is in the JSON format.
+ */
+export const JSON_CONTENT_TYPE = 'application/json';
+
+/**
+ * `application/json, text/plain, *\/*` is a content negotiation string often seen in the
+ * Accept header of HTTP requests. It indicates the types of content the client is willing
+ * to accept from the server, with a preference for `application/json` and `text/plain`,
+ * but also accepting any other type (*\/*).
+ */
+export const ACCEPT_HEADER = `${JSON_CONTENT_TYPE}, ${TEXT_CONTENT_TYPE}, */*`;
+
+/**
  * An outgoing HTTP request with an optional typed body.
  *
  * `HttpRequest` represents an outgoing request, including URL, method,
@@ -420,7 +441,7 @@ export class HttpRequest<T> {
     // Technically, strings could be a form of JSON data, but it's safe enough
     // to assume they're plain strings.
     if (typeof this.body === 'string') {
-      return 'text/plain';
+      return TEXT_CONTENT_TYPE;
     }
     // `HttpUrlEncodedParams` has its own content-type.
     if (this.body instanceof HttpParams) {
@@ -432,7 +453,7 @@ export class HttpRequest<T> {
       typeof this.body === 'number' ||
       typeof this.body === 'boolean'
     ) {
-      return 'application/json';
+      return JSON_CONTENT_TYPE;
     }
     // No type could be inferred.
     return null;

--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -14,7 +14,7 @@ import {switchMap} from 'rxjs/operators';
 import {HttpBackend} from './backend';
 import {RuntimeErrorCode} from './errors';
 import {HttpHeaders} from './headers';
-import {HttpRequest, X_REQUEST_URL_HEADER} from './request';
+import {ACCEPT_HEADER, HttpRequest, X_REQUEST_URL_HEADER} from './request';
 import {
   HTTP_STATUS_CODE_NO_CONTENT,
   HTTP_STATUS_CODE_OK,
@@ -98,7 +98,7 @@ export class HttpXhrBackend implements HttpBackend {
 
           // Add an Accept header if one isn't present already.
           if (!req.headers.has('Accept')) {
-            xhr.setRequestHeader('Accept', 'application/json, text/plain, */*');
+            xhr.setRequestHeader('Accept', ACCEPT_HEADER);
           }
 
           // Auto-detect the Content-Type header if one isn't present already.


### PR DESCRIPTION
In this commit, we extract content types into a variable to eliminate extra bytes, as these values are duplicated in multiple places.