### PR TITLE
refactor(common): drop enums by changing to `const enum`

### DIFF
--- a/packages/common/src/i18n/format_date.ts
+++ b/packages/common/src/i18n/format_date.ts
@@ -32,14 +32,14 @@ const NAMED_FORMATS: {[localeId: string]: {[format: string]: string}} = {};
 const DATE_FORMATS_SPLIT =
   /((?:[^BEGHLMOSWYZabcdhmswyz']+)|(?:'(?:[^']|'')*')|(?:G{1,5}|y{1,4}|Y{1,4}|M{1,5}|L{1,5}|w{1,2}|W{1}|d{1,2}|E{1,6}|c{1,6}|a{1,5}|b{1,5}|B{1,5}|h{1,2}|H{1,2}|m{1,2}|s{1,2}|S{1,3}|z{1,4}|Z{1,5}|O{1,4}))([\s\S]*)/;
 
-enum ZoneWidth {
+const enum ZoneWidth {
   Short,
   ShortGMT,
   Long,
   Extended,
 }
 
-enum DateType {
+const enum DateType {
   FullYear,
   Month,
   Date,
@@ -50,7 +50,7 @@ enum DateType {
   Day,
 }
 
-enum TranslationType {
+const enum TranslationType {
   DayPeriods,
   Days,
   Months,


### PR DESCRIPTION
Note: this enums are not a part of the public API.

Prior to this commit, the compiler produced:

```js
var DateType;
(function (DateType) {
    DateType[DateType["FullYear"] = 0] = "FullYear";
    DateType[DateType["Month"] = 1] = "Month";
    DateType[DateType["Date"] = 2] = "Date";
    DateType[DateType["Hours"] = 3] = "Hours";
    DateType[DateType["Minutes"] = 4] = "Minutes";
    DateType[DateType["Seconds"] = 5] = "Seconds";
    DateType[DateType["FractionalSeconds"] = 6] = "FractionalSeconds";
    DateType[DateType["Day"] = 7] = "Day";
})(DateType || (DateType = {}));
```

With these changes, we allow objects to be dropped entirely and inlined.