### PR TITLE
refactor(service-worker): drop platform checks

### DIFF
--- a/packages/service-worker/src/provider.ts
+++ b/packages/service-worker/src/provider.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {isPlatformBrowser} from '@angular/common';
 import {
   APP_INITIALIZER,
   ApplicationRef,
@@ -15,7 +14,6 @@ import {
   Injector,
   makeEnvironmentProviders,
   NgZone,
-  PLATFORM_ID,
 } from '@angular/core';
 import {merge, from, Observable, of} from 'rxjs';
 import {delay, take} from 'rxjs/operators';
@@ -30,12 +28,13 @@ export function ngswAppInitializer(
   injector: Injector,
   script: string,
   options: SwRegistrationOptions,
-  platformId: string,
 ): Function {
   return () => {
-    if (
-      !(isPlatformBrowser(platformId) && 'serviceWorker' in navigator && options.enabled !== false)
-    ) {
+    if (typeof ngServerMode !== 'undefined' && ngServerMode) {
+      return;
+    }
+
+    if (!('serviceWorker' in navigator && options.enabled !== false)) {
       return;
     }
 
@@ -109,12 +108,11 @@ function delayWithTimeout(timeout: number): Observable<unknown> {
   return of(null).pipe(delay(timeout));
 }
 
-export function ngswCommChannelFactory(
-  opts: SwRegistrationOptions,
-  platformId: string,
-): NgswCommChannel {
+export function ngswCommChannelFactory(opts: SwRegistrationOptions): NgswCommChannel {
+  const isBrowser = !(typeof ngServerMode !== 'undefined' && ngServerMode);
+
   return new NgswCommChannel(
-    isPlatformBrowser(platformId) && opts.enabled !== false ? navigator.serviceWorker : undefined,
+    isBrowser && opts.enabled !== false ? navigator.serviceWorker : undefined,
   );
 }
 
@@ -207,12 +205,12 @@ export function provideServiceWorker(
     {
       provide: NgswCommChannel,
       useFactory: ngswCommChannelFactory,
-      deps: [SwRegistrationOptions, PLATFORM_ID],
+      deps: [SwRegistrationOptions],
     },
     {
       provide: APP_INITIALIZER,
       useFactory: ngswAppInitializer,
-      deps: [Injector, SCRIPT, SwRegistrationOptions, PLATFORM_ID],
+      deps: [Injector, SCRIPT, SwRegistrationOptions],
       multi: true,
     },
   ]);

--- a/packages/service-worker/test/comm_spec.ts
+++ b/packages/service-worker/test/comm_spec.ts
@@ -62,21 +62,32 @@ describe('ServiceWorker library', () => {
   });
 
   describe('ngswCommChannelFactory', () => {
-    it('gives disabled NgswCommChannel for platform-server', () => {
-      TestBed.configureTestingModule({
-        providers: [
-          {provide: PLATFORM_ID, useValue: 'server'},
-          {provide: SwRegistrationOptions, useValue: {enabled: true}},
-          {
-            provide: NgswCommChannel,
-            useFactory: ngswCommChannelFactory,
-            deps: [SwRegistrationOptions, PLATFORM_ID],
-          },
-        ],
+    describe('server', () => {
+      beforeEach(() => {
+        globalThis['ngServerMode'] = true;
       });
 
-      expect(TestBed.inject(NgswCommChannel).isEnabled).toEqual(false);
+      afterEach(() => {
+        globalThis['ngServerMode'] = undefined;
+      });
+
+      it('gives disabled NgswCommChannel for platform-server', () => {
+        TestBed.configureTestingModule({
+          providers: [
+            {provide: PLATFORM_ID, useValue: 'server'},
+            {provide: SwRegistrationOptions, useValue: {enabled: true}},
+            {
+              provide: NgswCommChannel,
+              useFactory: ngswCommChannelFactory,
+              deps: [SwRegistrationOptions, PLATFORM_ID],
+            },
+          ],
+        });
+
+        expect(TestBed.inject(NgswCommChannel).isEnabled).toEqual(false);
+      });
     });
+
     it("gives disabled NgswCommChannel when 'enabled' option is false", () => {
       TestBed.configureTestingModule({
         providers: [


### PR DESCRIPTION
In this commit, we drop `isPlatformBrowser` checks in favor of `ngServerMode` compile-time variable.