### PR TITLE
refactor(compiler): fix typo in method name

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -276,7 +276,7 @@ class AstTranslator implements AstVisitor {
     return node;
   }
 
-  visitTypeofExpresion(ast: TypeofExpression): ts.Expression {
+  visitTypeofExpression(ast: TypeofExpression): ts.Expression {
     const expression = wrapForDiagnostics(this.translate(ast.expression));
     const node = ts.factory.createTypeOfExpression(expression);
     addParseSpanInfo(node, ast.sourceSpan);
@@ -549,7 +549,7 @@ class VeSafeLhsInferenceBugDetector implements AstVisitor {
   visitPrefixNot(ast: PrefixNot): boolean {
     return ast.expression.visit(this);
   }
-  visitTypeofExpresion(ast: PrefixNot): boolean {
+  visitTypeofExpression(ast: PrefixNot): boolean {
     return ast.expression.visit(this);
   }
   visitNonNullAssert(ast: PrefixNot): boolean {

--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -382,7 +382,7 @@ export class TypeofExpression extends AST {
     super(span, sourceSpan);
   }
   override visit(visitor: AstVisitor, context: any = null): any {
-    return visitor.visitTypeofExpresion(this, context);
+    return visitor.visitTypeofExpression(this, context);
   }
 }
 
@@ -547,7 +547,7 @@ export interface AstVisitor {
   visitLiteralPrimitive(ast: LiteralPrimitive, context: any): any;
   visitPipe(ast: BindingPipe, context: any): any;
   visitPrefixNot(ast: PrefixNot, context: any): any;
-  visitTypeofExpresion(ast: TypeofExpression, context: any): any;
+  visitTypeofExpression(ast: TypeofExpression, context: any): any;
   visitNonNullAssert(ast: NonNullAssert, context: any): any;
   visitPropertyRead(ast: PropertyRead, context: any): any;
   visitPropertyWrite(ast: PropertyWrite, context: any): any;
@@ -615,7 +615,7 @@ export class RecursiveAstVisitor implements AstVisitor {
   visitPrefixNot(ast: PrefixNot, context: any): any {
     this.visit(ast.expression, context);
   }
-  visitTypeofExpresion(ast: TypeofExpression, context: any) {
+  visitTypeofExpression(ast: TypeofExpression, context: any) {
     this.visit(ast.expression, context);
   }
   visitNonNullAssert(ast: NonNullAssert, context: any): any {
@@ -732,7 +732,7 @@ export class AstTransformer implements AstVisitor {
     return new PrefixNot(ast.span, ast.sourceSpan, ast.expression.visit(this));
   }
 
-  visitTypeofExpresion(ast: TypeofExpression, context: any): AST {
+  visitTypeofExpression(ast: TypeofExpression, context: any): AST {
     return new TypeofExpression(ast.span, ast.sourceSpan, ast.expression.visit(this));
   }
 
@@ -912,7 +912,7 @@ export class AstMemoryEfficientTransformer implements AstVisitor {
     return ast;
   }
 
-  visitTypeofExpresion(ast: TypeofExpression, context: any): AST {
+  visitTypeofExpression(ast: TypeofExpression, context: any): AST {
     const expression = ast.expression.visit(this);
     if (expression !== ast.expression) {
       return new TypeofExpression(ast.span, ast.sourceSpan, expression);

--- a/packages/compiler/src/expression_parser/serializer.ts
+++ b/packages/compiler/src/expression_parser/serializer.ts
@@ -136,7 +136,7 @@ class SerializeExpressionVisitor implements expr.AstVisitor {
       .join(', ')})`;
   }
 
-  visitTypeofExpresion(ast: expr.TypeofExpression, context: any) {
+  visitTypeofExpression(ast: expr.TypeofExpression, context: any) {
     return `typeof ${ast.expression.visit(this, context)}`;
   }
 

--- a/packages/compiler/test/expression_parser/utils/unparser.ts
+++ b/packages/compiler/test/expression_parser/utils/unparser.ts
@@ -193,7 +193,7 @@ class Unparser implements AstVisitor {
     this._visit(ast.expression);
   }
 
-  visitTypeofExpresion(ast: TypeofExpression, context: any) {
+  visitTypeofExpression(ast: TypeofExpression, context: any) {
     this._expression += 'typeof ';
     this._visit(ast.expression);
   }

--- a/packages/compiler/test/expression_parser/utils/validator.ts
+++ b/packages/compiler/test/expression_parser/utils/validator.ts
@@ -113,8 +113,8 @@ class ASTValidator extends RecursiveAstVisitor {
     this.validate(ast, () => super.visitPrefixNot(ast, context));
   }
 
-  override visitTypeofExpresion(ast: TypeofExpression, context: any): any {
-    this.validate(ast, () => super.visitTypeofExpresion(ast, context));
+  override visitTypeofExpression(ast: TypeofExpression, context: any): any {
+    this.validate(ast, () => super.visitTypeofExpression(ast, context));
   }
 
   override visitPropertyRead(ast: PropertyRead, context: any): any {

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -87,9 +87,9 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
     this.recordAst(ast);
     super.visitPrefixNot(ast, null);
   }
-  override visitTypeofExpresion(ast: e.TypeofExpression) {
+  override visitTypeofExpression(ast: e.TypeofExpression) {
     this.recordAst(ast);
-    super.visitTypeofExpresion(ast, null);
+    super.visitTypeofExpression(ast, null);
   }
   override visitPropertyRead(ast: e.PropertyRead) {
     this.recordAst(ast);


### PR DESCRIPTION
Fixes a typo in the `AstVisitor.visitTypeofExpresion` method's name.
