### PR TITLE
feat(platform-browser): add Hammer provider functions

### DIFF
--- a/goldens/public-api/platform-browser/index.api.md
+++ b/goldens/public-api/platform-browser/index.api.md
@@ -197,6 +197,12 @@ export const platformBrowser: (extraProviders?: StaticProvider[]) => PlatformRef
 export function provideClientHydration(...features: HydrationFeature<HydrationFeatureKind>[]): EnvironmentProviders;
 
 // @public
+export function provideHammer(): EnvironmentProviders;
+
+// @public
+export function provideHammerLoader(loader: HammerLoader): EnvironmentProviders;
+
+// @public
 export function provideProtractorTestingSupport(): Provider[];
 
 // @public

--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -26,6 +26,8 @@ export {
   HammerGestureConfig,
   HammerLoader,
   HammerModule,
+  provideHammerLoader,
+  provideHammer,
 } from './dom/events/hammer_gestures';
 export {
   DomSanitizer,


### PR DESCRIPTION
Prior to this commit, there were no functions that allowed providing HammerJS in a "new" way through environment providers; it required using `importProvidersFrom(HammerModule)` when bootstrapping the application. In this commit, we add two new functions that return environment providers and can be called directly in the providers when bootstrapping the application.