### PR TITLE
refactor(common): tree-shake `lcpObserver` in `NgOptimizedImage`

### DIFF
--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -601,7 +601,8 @@ export abstract class NgLocalization {
 }
 
 // @public
-export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
+export class NgOptimizedImage implements OnInit, OnChanges {
+    constructor();
     disableOptimizedSrcset: boolean;
     fill: boolean;
     height: number | undefined;
@@ -625,8 +626,6 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
     static ngAcceptInputType_width: unknown;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
-    // (undocumented)
-    ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;
     ngSrc: string;


### PR DESCRIPTION
Prior to this commit, the `this.lcpObserver?.updateImage` expression was still preserved in the production code because it wasn't wrapped with `ngDevMode`. The observer is injected only in development mode. Additionally, we moved the logic from `ngOnDestroy` to avoid having an empty method in production.