### PR TITLE
docs: Adjust lines of server.ts example in server-side-rendering docs

### DIFF
--- a/adev/src/content/guide/ssr.md
+++ b/adev/src/content/guide/ssr.md
@@ -45,7 +45,7 @@ Note: In Angular v17 and later, `server.ts` is no longer used by `ng serve`. The
 
 The `server.ts` file configures a Node.js Express server and Angular server-side rendering. `CommonEngine` is used to render an Angular application.
 
-<docs-code path="adev/src/content/examples/ssr/server.ts" visibleLines="[31,45]"></docs-code>
+<docs-code path="adev/src/content/examples/ssr/server.ts" visibleLines="[33,47]"></docs-code>
 
 Angular CLI will scaffold an initial server implementation focused on server-side rendering your Angular application. This server can be extended to support other features such as API routes, redirects, static assets, and more. See [Express documentation](https://expressjs.com/) for more details.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
docs: Adjust lines of server.ts example in ssr docs

The server.ts excerpt used in the server-side-rendering docs (https://angular.dev/guide/ssr#configure-server-side-rendering) does not fully encapsulate the commonEngine code-block.

It begins too early in line 31, leading to the inclusions of lines from another codeblock that is not intended to be shown here:
```ts
);

  // All regular routes use the Angular engine
  server.get('*', (req, res, next) => {
    const {protocol, originalUrl, baseUrl, headers} = req;
    commonEngine
      .render({
        bootstrap,
        documentFilePath: indexHtml,
        url: `${protocol}://${headers.host}${originalUrl}`,
        publicPath: browserDistFolder,
        providers: [{provide: APP_BASE_HREF, useValue: req.baseUrl}],
      })
      .then((html) => res.send(html))
```
It should be beginning with the line
`// All regular routes use the Angular engine`.

It also ends too soon, cutting off these parts of the code-block:
```
      .catch((err) => next(err));
  });
```

Issue Number: N/A


## What is the new behavior?
The example should now only be displaying the commonEngine codeblock, but do so without cutting off parts of it:
```ts
  // All regular routes use the Angular engine
  server.get('*', (req, res, next) => {
    const {protocol, originalUrl, baseUrl, headers} = req;

    commonEngine
      .render({
        bootstrap,
        documentFilePath: indexHtml,
        url: `${protocol}://${headers.host}${originalUrl}`,
        publicPath: browserDistFolder,
        providers: [{provide: APP_BASE_HREF, useValue: req.baseUrl}],
      })
      .then((html) => res.send(html))
      .catch((err) => next(err));
  });
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
I am a first time contributor.
As described in [CONTRIBUTING.md](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-signing-the-cla) I signed the CLA and noted my Github Username, though the github account runs under a different email address than the google-account through which I did the confirmation. Not sure if that is relevant or might cause issues.