### PR TITLE
refactor(docs-infra): lazy-load `EmbeddedTutorialManager` in home editor

### DIFF
--- a/adev/src/app/editor/index.ts
+++ b/adev/src/app/editor/index.ts
@@ -13,3 +13,5 @@ export {NodeRuntimeState} from './node-runtime-state.service';
 export {NodeRuntimeSandbox} from './node-runtime-sandbox.service';
 
 export {EmbeddedEditor, EMBEDDED_EDITOR_SELECTOR} from './embedded-editor.component';
+
+export {injectEmbeddedTutorialManager} from './inject-embedded-tutorial-manager';

--- a/adev/src/app/editor/inject-embedded-tutorial-manager.ts
+++ b/adev/src/app/editor/inject-embedded-tutorial-manager.ts
@@ -1,0 +1,17 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {EnvironmentInjector} from '@angular/core';
+
+import {injectAsync} from '../core/services/inject-async';
+
+export function injectEmbeddedTutorialManager(injector: EnvironmentInjector) {
+  return injectAsync(injector, () =>
+    import('./embedded-tutorial-manager.service').then((c) => c.EmbeddedTutorialManager),
+  );
+}


### PR DESCRIPTION
In this commit, we lazy-load `EmbeddedTutorialManager` in the home editor component via `injectAsync` as done in other parts of the code.
