### PR TITLE
fix(devtools): remove property tab css that is hiding directive metadata

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-tree.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-tree.component.scss
@@ -2,7 +2,6 @@
   width: 100%;
   display: block;
   overflow: auto;
-  height: calc(100% - 24px);
 
   mat-tree {
     display: table;


### PR DESCRIPTION
It looks like this height property was redundant prior to upgrading to angular/material 19.1.0-rc.0. An interaction between this property and that update caused elements inside of material expansion panels to be hidden.

This PR removes this unnecessary height assignment entirely.

Before
![Screenshot 2025-01-13 at 1 57 57 AM](https://github.com/user-attachments/assets/3b1da1b2-cc93-4e1a-8a6e-ac2600b4a2dc)

After
![Screenshot 2025-01-13 at 1 58 12 AM](https://github.com/user-attachments/assets/1ebee1aa-5f85-42b4-b184-a6fdeb283d9f)
