### PR TITLE
refactor(platform-browser): replace `isPlatformServer` with `ngServerMode`

### DIFF
--- a/packages/core/test/acceptance/renderer_factory_spec.ts
+++ b/packages/core/test/acceptance/renderer_factory_spec.ts
@@ -101,6 +101,14 @@ describe('renderer factory lifecycle', () => {
   }
 
   beforeEach(() => {
+    globalThis['ngServerMode'] = isNode;
+  });
+
+  afterEach(() => {
+    globalThis['ngServerMode'] = undefined;
+  });
+
+  beforeEach(() => {
     logs = [];
 
     TestBed.configureTestingModule({

--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -1006,8 +1006,16 @@ describe('AppRef', () => {
     describe('unstable', () => {
       let unstableCalled = false;
 
+      beforeEach(() => {
+        globalThis['ngServerMode'] = isNode;
+      });
+
       afterEach(() => {
         expect(unstableCalled).toBe(true, 'isStable did not emit false on unstable');
+      });
+
+      afterEach(() => {
+        globalThis['ngServerMode'] = undefined;
       });
 
       function expectUnstable(appRef: ApplicationRef) {

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -377,7 +377,6 @@
   "isNodeMatchingSelector",
   "isNodeMatchingSelectorList",
   "isNotFound",
-  "isPlatformServer",
   "isPositive",
   "isPromise",
   "isRefreshingViews",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -387,7 +387,6 @@
   "isNodeMatchingSelector",
   "isNodeMatchingSelectorList",
   "isNotFound",
-  "isPlatformServer",
   "isPositive",
   "isPromise",
   "isRefreshingViews",

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -471,7 +471,6 @@
   "isNodeMatchingSelectorList",
   "isNotFound",
   "isOptionsObj",
-  "isPlatformServer",
   "isPositive",
   "isPresent",
   "isPromise",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -458,7 +458,6 @@
   "isNodeMatchingSelectorList",
   "isNotFound",
   "isOptionsObj",
-  "isPlatformServer",
   "isPositive",
   "isPresent",
   "isPromise",

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -341,7 +341,6 @@
   "isLContainer",
   "isLView",
   "isNotFound",
-  "isPlatformServer",
   "isPositive",
   "isPromise",
   "isPromise2",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -549,7 +549,6 @@
   "isNodeMatchingSelector",
   "isNodeMatchingSelectorList",
   "isNotFound",
-  "isPlatformServer",
   "isPositive",
   "isPromise",
   "isPromise2",

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -286,7 +286,6 @@
   "isLContainer",
   "isLView",
   "isNotFound",
-  "isPlatformServer",
   "isPositive",
   "isPromise",
   "isRefreshingViews",

--- a/packages/core/test/component_fixture_spec.ts
+++ b/packages/core/test/component_fixture_spec.ts
@@ -27,7 +27,7 @@ import {
   waitForAsync,
   withModule,
 } from '../testing';
-import {dispatchEvent} from '@angular/private/testing';
+import {dispatchEvent, isNode} from '@angular/private/testing';
 import {expect} from '@angular/private/testing/matchers';
 
 @Component({
@@ -155,6 +155,14 @@ class NestedAsyncTimeoutComp {
 }
 
 describe('ComponentFixture', () => {
+  beforeEach(() => {
+    globalThis['ngServerMode'] = isNode;
+  });
+
+  afterEach(() => {
+    globalThis['ngServerMode'] = undefined;
+  });
+
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT, isPlatformServer, ɵgetDOM as getDOM} from '@angular/common';
+import {DOCUMENT, ɵgetDOM as getDOM} from '@angular/common';
 import {
   APP_ID,
   CSP_NONCE,
@@ -150,7 +150,7 @@ export class DomRendererFactory2 implements RendererFactory2, OnDestroy {
     @Optional()
     private readonly tracingService: TracingService<TracingSnapshot> | null = null,
   ) {
-    this.platformIsServer = isPlatformServer(platformId);
+    this.platformIsServer = typeof ngServerMode !== 'undefined' && ngServerMode;
     this.defaultRenderer = new DefaultDomRenderer2(
       eventManager,
       doc,
@@ -165,7 +165,11 @@ export class DomRendererFactory2 implements RendererFactory2, OnDestroy {
       return this.defaultRenderer;
     }
 
-    if (this.platformIsServer && type.encapsulation === ViewEncapsulation.ShadowDom) {
+    if (
+      typeof ngServerMode !== 'undefined' &&
+      ngServerMode &&
+      type.encapsulation === ViewEncapsulation.ShadowDom
+    ) {
       // Domino does not support shadow DOM.
       type = {...type, encapsulation: ViewEncapsulation.Emulated};
     }
@@ -458,9 +462,10 @@ class DefaultDomRenderer2 implements Renderer2 {
 
       // Run the event handler inside the ngZone because event handlers are not patched
       // by Zone on the server. This is required only for tests.
-      const allowDefaultBehavior = this.platformIsServer
-        ? this.ngZone.runGuarded(() => eventHandler(event))
-        : eventHandler(event);
+      const allowDefaultBehavior =
+        typeof ngServerMode !== 'undefined' && ngServerMode
+          ? this.ngZone.runGuarded(() => eventHandler(event))
+          : eventHandler(event);
       if (allowDefaultBehavior === false) {
         event.preventDefault();
       }


### PR DESCRIPTION
In this commit, we switch from using the `isPlatformServer` runtime call to the `ngServerMode`.

Note: constructors haven't been touched in order to prevent any breaking changes for the public API.