### PR TITLE
refactor(core): move linkedSignal implementation to primitives

### DIFF
--- a/goldens/public-api/core/primitives/signals/index.api.md
+++ b/goldens/public-api/core/primitives/signals/index.api.md
@@ -5,6 +5,12 @@
 ```ts
 
 // @public
+export type ComputationFn<S, D> = (source: S, previous?: {
+    source: S;
+    value: D;
+}) => D;
+
+// @public
 export interface ComputedNode<T> extends ReactiveNode {
     computation: () => T;
     // (undocumented)
@@ -31,6 +37,9 @@ export function consumerPollProducersForChange(node: ReactiveNode): boolean;
 // @public
 export function createComputed<T>(computation: () => T): ComputedGetter<T>;
 
+// @public (undocumented)
+export function createLinkedSignal<S, D>(sourceFn: () => S, computationFn: ComputationFn<S, D>, equalityFn?: ValueEqualityFn<D>): LinkedSignalGetter<S, D>;
+
 // @public
 export function createSignal<T>(initialValue: T): SignalGetter<T>;
 
@@ -48,6 +57,28 @@ export function isInNotificationPhase(): boolean;
 
 // @public (undocumented)
 export function isReactive(value: unknown): value is Reactive;
+
+// @public (undocumented)
+export type LinkedSignalGetter<S, D> = (() => D) & {
+    [SIGNAL]: LinkedSignalNode<S, D>;
+};
+
+// @public (undocumented)
+export interface LinkedSignalNode<S, D> extends ReactiveNode {
+    computation: ComputationFn<S, D>;
+    // (undocumented)
+    equal: ValueEqualityFn<D>;
+    error: unknown;
+    source: () => S;
+    sourceValue: S;
+    value: D;
+}
+
+// @public (undocumented)
+export function linkedSignalSetFn<S, D>(node: LinkedSignalNode<S, D>, newValue: D): void;
+
+// @public (undocumented)
+export function linkedSignalUpdateFn<S, D>(node: LinkedSignalNode<S, D>, updater: (value: D) => D): void;
 
 // @public
 export function producerAccessed(node: ReactiveNode): void;

--- a/packages/core/primitives/signals/index.ts
+++ b/packages/core/primitives/signals/index.ts
@@ -7,6 +7,14 @@
  */
 
 export {ComputedNode, createComputed} from './src/computed';
+export {
+  ComputationFn,
+  LinkedSignalNode,
+  LinkedSignalGetter,
+  createLinkedSignal,
+  linkedSignalSetFn,
+  linkedSignalUpdateFn,
+} from './src/linked_signal';
 export {ValueEqualityFn, defaultEquals} from './src/equality';
 export {setThrowInvalidWriteToSignalError} from './src/errors';
 export {

--- a/packages/core/primitives/signals/src/computed.ts
+++ b/packages/core/primitives/signals/src/computed.ts
@@ -76,21 +76,21 @@ export function createComputed<T>(computation: () => T): ComputedGetter<T> {
  * A dedicated symbol used before a computed value has been calculated for the first time.
  * Explicitly typed as `any` so we can use it as signal's value.
  */
-const UNSET: any = /* @__PURE__ */ Symbol('UNSET');
+export const UNSET: any = /* @__PURE__ */ Symbol('UNSET');
 
 /**
  * A dedicated symbol used in place of a computed signal value to indicate that a given computation
  * is in progress. Used to detect cycles in computation chains.
  * Explicitly typed as `any` so we can use it as signal's value.
  */
-const COMPUTING: any = /* @__PURE__ */ Symbol('COMPUTING');
+export const COMPUTING: any = /* @__PURE__ */ Symbol('COMPUTING');
 
 /**
  * A dedicated symbol used in place of a computed signal value to indicate that a given computation
  * failed. The thrown error is cached until the computation gets dirty again.
  * Explicitly typed as `any` so we can use it as signal's value.
  */
-const ERRORED: any = /* @__PURE__ */ Symbol('ERRORED');
+export const ERRORED: any = /* @__PURE__ */ Symbol('ERRORED');
 
 // Note: Using an IIFE here to ensure that the spread assignment is not considered
 // a side-effect, ending up preserving `COMPUTED_NODE` and `REACTIVE_NODE`.

--- a/packages/core/primitives/signals/src/linked_signal.ts
+++ b/packages/core/primitives/signals/src/linked_signal.ts
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {COMPUTING, ERRORED, UNSET} from './computed';
+import {defaultEquals, ValueEqualityFn} from './equality';
+import {
+  consumerAfterComputation,
+  consumerBeforeComputation,
+  producerAccessed,
+  producerMarkClean,
+  producerUpdateValueVersion,
+  REACTIVE_NODE,
+  ReactiveNode,
+  SIGNAL,
+} from './graph';
+import {signalSetFn, signalUpdateFn} from './signal';
+
+export type ComputationFn<S, D> = (source: S, previous?: {source: S; value: D}) => D;
+
+export interface LinkedSignalNode<S, D> extends ReactiveNode {
+  /**
+   * Value of the source signal that was used to derive the computed value.
+   */
+  sourceValue: S;
+
+  /**
+   * Current state value, or one of the sentinel values (`UNSET`, `COMPUTING`,
+   * `ERROR`).
+   */
+  value: D;
+
+  /**
+   * If `value` is `ERRORED`, the error caught from the last computation attempt which will
+   * be re-thrown.
+   */
+  error: unknown;
+
+  /**
+   * The source function represents reactive dependency based on which the linked state is reset.
+   */
+  source: () => S;
+
+  /**
+   * The computation function which will produce a new value based on the source and, optionally - previous values.
+   */
+  computation: ComputationFn<S, D>;
+
+  equal: ValueEqualityFn<D>;
+}
+
+export type LinkedSignalGetter<S, D> = (() => D) & {
+  [SIGNAL]: LinkedSignalNode<S, D>;
+};
+
+export function createLinkedSignal<S, D>(
+  sourceFn: () => S,
+  computationFn: ComputationFn<S, D>,
+  equalityFn?: ValueEqualityFn<D>,
+): LinkedSignalGetter<S, D> {
+  const node: LinkedSignalNode<S, D> = Object.create(LINKED_SIGNAL_NODE);
+
+  node.source = sourceFn;
+  node.computation = computationFn;
+  if (equalityFn != undefined) {
+    node.equal = equalityFn;
+  }
+
+  const linkedSignalGetter = () => {
+    // Check if the value needs updating before returning it.
+    producerUpdateValueVersion(node);
+
+    // Record that someone looked at this signal.
+    producerAccessed(node);
+
+    if (node.value === ERRORED) {
+      throw node.error;
+    }
+
+    return node.value;
+  };
+
+  const getter = linkedSignalGetter as LinkedSignalGetter<S, D>;
+  getter[SIGNAL] = node;
+
+  return getter;
+}
+
+export function linkedSignalSetFn<S, D>(node: LinkedSignalNode<S, D>, newValue: D) {
+  producerUpdateValueVersion(node);
+  signalSetFn(node, newValue);
+  producerMarkClean(node);
+}
+
+export function linkedSignalUpdateFn<S, D>(
+  node: LinkedSignalNode<S, D>,
+  updater: (value: D) => D,
+): void {
+  producerUpdateValueVersion(node);
+  signalUpdateFn(node, updater);
+  producerMarkClean(node);
+}
+
+// Note: Using an IIFE here to ensure that the spread assignment is not considered
+// a side-effect, ending up preserving `LINKED_SIGNAL_NODE` and `REACTIVE_NODE`.
+// TODO: remove when https://github.com/evanw/esbuild/issues/3392 is resolved.
+export const LINKED_SIGNAL_NODE = /* @__PURE__ */ (() => {
+  return {
+    ...REACTIVE_NODE,
+    value: UNSET,
+    dirty: true,
+    error: null,
+    equal: defaultEquals,
+
+    producerMustRecompute(node: LinkedSignalNode<unknown, unknown>): boolean {
+      // Force a recomputation if there's no current value, or if the current value is in the
+      // process of being calculated (which should throw an error).
+      return node.value === UNSET || node.value === COMPUTING;
+    },
+
+    producerRecomputeValue(node: LinkedSignalNode<unknown, unknown>): void {
+      if (node.value === COMPUTING) {
+        // Our computation somehow led to a cyclic read of itself.
+        throw new Error('Detected cycle in computations.');
+      }
+
+      const oldValue = node.value;
+      node.value = COMPUTING;
+
+      const prevConsumer = consumerBeforeComputation(node);
+      let newValue: unknown;
+      try {
+        const newSourceValue = node.source();
+        const prev =
+          oldValue === UNSET || oldValue === ERRORED
+            ? undefined
+            : {
+                source: node.sourceValue,
+                value: oldValue,
+              };
+        newValue = node.computation(newSourceValue, prev);
+        node.sourceValue = newSourceValue;
+      } catch (err) {
+        newValue = ERRORED;
+        node.error = err;
+      } finally {
+        consumerAfterComputation(node, prevConsumer);
+      }
+
+      if (oldValue !== UNSET && newValue !== ERRORED && node.equal(oldValue, newValue)) {
+        // No change to `valueVersion` - old and new values are
+        // semantically equivalent.
+        node.value = oldValue;
+        return;
+      }
+
+      node.value = newValue;
+      node.version++;
+    },
+  };
+})();

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -572,6 +572,7 @@
   "init_let_declaration",
   "init_lift",
   "init_linked_signal",
+  "init_linked_signal2",
   "init_linker",
   "init_list_reconciliation",
   "init_listener",


### PR DESCRIPTION
This change refactors the Angular-specific linkedSignal implementation such that its core logic can be shared with other frameworks.
