### PR TITLE
refactor(docs-infra): lazy-load `EmbeddedTutorialManager` in code editor

### DIFF
--- a/adev/src/app/editor/code-editor/code-editor.component.spec.ts
+++ b/adev/src/app/editor/code-editor/code-editor.component.spec.ts
@@ -148,6 +148,9 @@ describe('CodeEditor', () => {
     });
 
     it('should focused on a new tab when adding a new file', async () => {
+      // Wait until the asynchronous injection stuff is done.
+      await fixture.whenStable();
+
       const button = fixture.debugElement.query(By.css('button.adev-add-file')).nativeElement;
       button.click();
 


### PR DESCRIPTION
In this commit, we lazy-load the `EmbeddedTutorialManager` in the code editor component as done in other parts of the code.