### PR TITLE
Revert PR #59233 "Devtools profiler calls"

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/hooks/profiler/native.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/hooks/profiler/native.ts
@@ -43,7 +43,7 @@ export class NgProfiler extends Profiler {
 
   private _initialize(): void {
     ngDebugClient().ɵsetProfiler(
-      (event: ɵProfilerEvent, instanceOrLView: {} | null = null, hookOrListener: any) =>
+      (event: ɵProfilerEvent, instanceOrLView: {} | null, hookOrListener: any) =>
         this._callbacks.forEach((cb) => cb(event, instanceOrLView, hookOrListener)),
     );
   }

--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -47,8 +47,6 @@ import {NgZone} from '../zone/ng_zone';
 import {ApplicationInitStatus} from './application_init';
 import {TracingAction, TracingService, TracingSnapshot} from './tracing';
 import {EffectScheduler} from '../render3/reactivity/root_effect_scheduler';
-import {ProfilerEvent} from '../render3/profiler_types';
-import {profiler} from '../render3/profiler';
 
 /**
  * A DI token that provides a set of callbacks to
@@ -533,8 +531,6 @@ export class ApplicationRef {
     componentOrFactory: ComponentFactory<C> | Type<C>,
     rootSelectorOrNode?: string | any,
   ): ComponentRef<C> {
-    profiler(ProfilerEvent.BootstrapComponentStart);
-
     (typeof ngDevMode === 'undefined' || ngDevMode) && warnIfDestroyed(this._destroyed);
     const isComponentFactory = componentOrFactory instanceof ComponentFactory;
     const initStatus = this._injector.get(ApplicationInitStatus);
@@ -580,9 +576,6 @@ export class ApplicationRef {
       const _console = this._injector.get(Console);
       _console.log(`Angular is running in development mode.`);
     }
-
-    profiler(ProfilerEvent.BootstrapComponentEnd, compRef);
-
     return compRef;
   }
 
@@ -605,8 +598,6 @@ export class ApplicationRef {
 
   /** @internal */
   _tick = (): void => {
-    profiler(ProfilerEvent.ChangeDetectionStart);
-
     if (this.tracingSnapshot !== null) {
       const snapshot = this.tracingSnapshot;
       this.tracingSnapshot = null;
@@ -631,6 +622,7 @@ export class ApplicationRef {
     try {
       this._runningTick = true;
       this.synchronize();
+
       if (typeof ngDevMode === 'undefined' || ngDevMode) {
         for (let view of this.allViews) {
           view.checkNoChanges();
@@ -643,8 +635,6 @@ export class ApplicationRef {
       this._runningTick = false;
       setActiveConsumer(prevConsumer);
       this.afterTick.next();
-
-      profiler(ProfilerEvent.ChangeDetectionEnd);
     }
   };
 
@@ -663,9 +653,7 @@ export class ApplicationRef {
 
     let runs = 0;
     while (this.dirtyFlags !== ApplicationRefDirtyFlags.None && runs++ < MAXIMUM_REFRESH_RERUNS) {
-      profiler(ProfilerEvent.ChangeDetectionSyncStart);
       this.synchronizeOnce();
-      profiler(ProfilerEvent.ChangeDetectionSyncEnd);
     }
 
     if ((typeof ngDevMode === 'undefined' || ngDevMode) && runs >= MAXIMUM_REFRESH_RERUNS) {

--- a/packages/core/src/application/create_application.ts
+++ b/packages/core/src/application/create_application.ts
@@ -13,13 +13,12 @@ import {Type} from '../interface/type';
 import {createOrReusePlatformInjector} from '../platform/platform';
 import {assertStandaloneComponentType} from '../render3/errors';
 import {EnvironmentNgModuleRefAdapter} from '../render3/ng_module_ref';
+import {NgZone} from '../zone/ng_zone';
 
 import {_callAndReportToErrorHandler, ApplicationRef} from './application_ref';
 import {ChangeDetectionScheduler} from '../change_detection/scheduling/zoneless_scheduling';
 import {ChangeDetectionSchedulerImpl} from '../change_detection/scheduling/zoneless_scheduling_impl';
 import {bootstrap} from '../platform/bootstrap';
-import {profiler} from '../render3/profiler';
-import {ProfilerEvent} from '../render3/profiler_types';
 
 /**
  * Internal create application API that implements the core application creation logic and optional
@@ -38,7 +37,6 @@ export function internalCreateApplication(config: {
   appProviders?: Array<Provider | EnvironmentProviders>;
   platformProviders?: Provider[];
 }): Promise<ApplicationRef> {
-  profiler(ProfilerEvent.BootstrapApplicationStart);
   try {
     const {rootComponent, appProviders, platformProviders} = config;
 
@@ -71,7 +69,5 @@ export function internalCreateApplication(config: {
     });
   } catch (e) {
     return Promise.reject(e);
-  } finally {
-    profiler(ProfilerEvent.BootstrapApplicationEnd);
   }
 }

--- a/packages/core/src/defer/rendering.ts
+++ b/packages/core/src/defer/rendering.ts
@@ -56,8 +56,6 @@ import {
   getTDeferBlockDetails,
   getTemplateIndexForState,
 } from './utils';
-import {profiler} from '../render3/profiler';
-import {ProfilerEvent} from '../render3/profiler_types';
 
 /**
  * **INTERNAL**, avoid referencing it in application code.
@@ -245,8 +243,6 @@ function applyDeferBlockState(
   tNode: TNode,
   hostLView: LView<unknown>,
 ) {
-  profiler(ProfilerEvent.DeferBlockStateStart);
-
   const stateTmplIndex = getTemplateIndexForState(newState, hostLView, tNode);
 
   if (stateTmplIndex !== null) {
@@ -310,8 +306,6 @@ function applyDeferBlockState(
       lDetails[ON_COMPLETE_FNS] = null;
     }
   }
-
-  profiler(ProfilerEvent.DeferBlockStateEnd);
 }
 
 /**

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -89,8 +89,6 @@ import {getComponentLViewByIndex, getNativeByTNode, getTNode} from './util/view_
 import {ViewRef} from './view_ref';
 import {ChainedInjector} from './chained_injector';
 import {unregisterLView} from './interfaces/lview_tracking';
-import {profiler} from './profiler';
-import {ProfilerEvent} from './profiler_types';
 
 export class ComponentFactoryResolver extends AbstractComponentFactoryResolver {
   /**
@@ -216,8 +214,6 @@ export class ComponentFactory<T> extends AbstractComponentFactory<T> {
     rootSelectorOrNode?: any,
     environmentInjector?: NgModuleRef<any> | EnvironmentInjector | undefined,
   ): AbstractComponentRef<T> {
-    profiler(ProfilerEvent.DynamicComponentStart);
-
     const prevConsumer = setActiveConsumer(null);
     try {
       // Check if the component is orphan
@@ -401,7 +397,6 @@ export class ComponentFactory<T> extends AbstractComponentFactory<T> {
         unregisterLView(rootLView);
         throw e;
       } finally {
-        profiler(ProfilerEvent.DynamicComponentEnd);
         leaveView();
       }
 

--- a/packages/core/src/render3/instructions/change_detection.ts
+++ b/packages/core/src/render3/instructions/change_detection.ts
@@ -70,8 +70,6 @@ import {
 } from './shared';
 import {runEffectsInView} from '../reactivity/view_effect_runner';
 import {isDestroyed} from '../interfaces/type_checks';
-import {ProfilerEvent} from '../profiler_types';
-import {profiler} from '../profiler';
 
 /**
  * The maximum number of times the change detection traversal will rerun before throwing an error.
@@ -430,12 +428,8 @@ function detectChangesInComponent(
   mode: ChangeDetectionMode,
 ): void {
   ngDevMode && assertEqual(isCreationMode(hostLView), false, 'Should be run in update mode');
-  profiler(ProfilerEvent.ComponentStart);
-
   const componentView = getComponentLViewByIndex(componentHostIdx, hostLView);
   detectChangesInViewIfAttached(componentView, mode);
-
-  profiler(ProfilerEvent.ComponentEnd, componentView[CONTEXT] as any as {});
 }
 
 /**

--- a/packages/core/src/render3/instructions/render.ts
+++ b/packages/core/src/render3/instructions/render.ts
@@ -21,8 +21,6 @@ import {
   TVIEW,
   TView,
 } from '../interfaces/view';
-import {profiler} from '../profiler';
-import {ProfilerEvent} from '../profiler_types';
 import {enterView, leaveView} from '../state';
 import {getComponentLViewByIndex, isCreationMode} from '../util/view_utils';
 
@@ -40,11 +38,7 @@ export function renderComponent(hostLView: LView, componentHostIdx: number) {
     componentView[HYDRATION] = retrieveHydrationInfo(hostRNode, componentView[INJECTOR]);
   }
 
-  profiler(ProfilerEvent.ComponentStart);
-
   renderView(componentTView, componentView, componentView[CONTEXT]);
-
-  profiler(ProfilerEvent.ComponentEnd, componentView[CONTEXT] as any as {});
 }
 
 /**

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -182,10 +182,7 @@ export function processHostBindingOpCodes(tView: TView, lView: LView): void {
         const hostBindingFn = hostBindingOpCodes[++i] as HostBindingsFunction<any>;
         setBindingRootForHostBindings(bindingRootIndx, directiveIdx);
         const context = lView[directiveIdx];
-
-        profiler(ProfilerEvent.HostBindingsUpdateStart, context);
         hostBindingFn(RenderFlags.Update, context);
-        profiler(ProfilerEvent.HostBindingsUpdateEnd, context);
       }
     }
   } finally {

--- a/packages/core/src/render3/profiler.ts
+++ b/packages/core/src/render3/profiler.ts
@@ -33,7 +33,7 @@ export const setProfiler = (profiler: Profiler | null) => {
  *  execution context
  * @returns
  */
-export const profiler: Profiler = function (event, instance = null, hookOrListener) {
+export const profiler: Profiler = function (event, instance, hookOrListener) {
   if (profilerCallback != null /* both `null` and `undefined` */) {
     profilerCallback(event, instance, hookOrListener);
   }

--- a/packages/core/src/render3/profiler_types.ts
+++ b/packages/core/src/render3/profiler_types.ts
@@ -160,5 +160,5 @@ export const enum ProfilerEvent {
  * Profiler function which the runtime will invoke before and after user code.
  */
 export interface Profiler {
-  (event: ProfilerEvent, instance?: {} | null, hookOrListener?: (e?: any) => any): void;
+  (event: ProfilerEvent, instance: {} | null, hookOrListener?: (e?: any) => any): void;
 }


### PR DESCRIPTION
Reason for revert: Angular DevTools code fails at handling `null` as an instance passed to the `profile` call ([see here](https://github.com/angular/angular/blob/main/devtools/projects/ng-devtools-backend/src/lib/hooks/profiler/shared.ts#L247)).