### PR TITLE
fix(core): destroy renderer when replacing styles during HMR

### DIFF
--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -201,6 +201,9 @@ export class DomRendererFactory2 implements RendererFactory2, OnDestroy {
    * @param componentId ID of the component that is being replaced.
    */
   protected componentReplaced(componentId: string) {
+    // Destroy the renderer so the styles get removed from the DOM, otherwise
+    // they may leak back into the component together with the new ones.
+    this.rendererByCompId.get(componentId)?.destroy();
     this.rendererByCompId.delete(componentId);
   }
 }


### PR DESCRIPTION
Currently when we swap out the component during HMR, we remove the renderer from the cache, but we never destroy it which means that its styles are still in the DOM. This can cause the old styles to leak into the component after they're replaced. These changes add a `destroy` call to ensure that they're removed.
