### PR TITLE
docs(forms): escape inequality signs of input tags in flowchart

### DIFF
--- a/adev/src/content/guide/forms/overview.md
+++ b/adev/src/content/guide/forms/overview.md
@@ -110,7 +110,7 @@ The view-to-model diagram shows how data flows when an input field's value is ch
 ```mermaid
 flowchart TB
     U{User}
-    I("<input>")
+    I("&lt;input&gt;")
     CVA(ControlValueAccessor)
     FC(FormControl)
     O(Observers)
@@ -130,14 +130,14 @@ The model-to-view diagram shows how a programmatic change to the model is propag
 ```mermaid
 flowchart TB
     U{User}
-    I(<input>)
+    I("&lt;input&gt;")
     CVA(ControlValueAccessor)
     FC(FormControl)
     O(Observers)
     U-->|"Calls setValue() on the FormControl"|FC
     FC-->|Notifies the ControlValueAccessor|CVA
     FC-.->|Fires a 'valueChanges' event to observers|O
-    CVA-->|"Updates the value of the <input>"|I
+    CVA-->|"Updates the value of the &lt;input&gt;"|I
 ```
 
 ### Data flow in template-driven forms
@@ -157,7 +157,7 @@ The view-to-model diagram shows how data flows when an input field's value is ch
 ```mermaid
 flowchart TB
     U{User}
-    I(<input>)
+    I("&lt;input&gt;")
     CVA(ControlValueAccessor)
     FC(FormControl)
     M(NgModel)
@@ -207,7 +207,7 @@ flowchart TB
         FC2(FormControl)
         O(Observers)
         CVA(ControlValueAccessor)
-        I("<input>")
+        I("&lt;input&gt;")
         FC2-.->|Fires a 'valueChanges' event to observers|O
         O-->|ControlValueAccessor receives valueChanges event|CVA
         CVA-->|Sets the value in the control|I


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The input tag written in the flowchart of the document is not escaped, so the input element appears in the flowchart.

## What is the new behavior?

The input tag written in the flowchart of the document will be properly displayed as a string.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
