### PR TITLE
Revert "refactor: initialize headers map directly in HttpHeaders class (#59268)"

### DIFF
--- a/packages/common/http/src/headers.ts
+++ b/packages/common/http/src/headers.ts
@@ -23,7 +23,8 @@ export class HttpHeaders {
   /**
    * Internal map of lowercase header names to values.
    */
-  private headers: Map<string, string[]> = new Map();
+  // TODO(issue/24571): remove '!'.
+  private headers!: Map<string, string[]>;
 
   /**
    * Internal map of lowercased header names to the normalized
@@ -46,9 +47,11 @@ export class HttpHeaders {
   constructor(
     headers?: string | {[name: string]: string | number | (string | number)[]} | Headers,
   ) {
-    if (!headers) return;
-    if (typeof headers === 'string') {
+    if (!headers) {
+      this.headers = new Map<string, string[]>();
+    } else if (typeof headers === 'string') {
       this.lazyInit = () => {
+        this.headers = new Map<string, string[]>();
         headers.split('\n').forEach((line) => {
           const index = line.indexOf(':');
           if (index > 0) {
@@ -59,6 +62,7 @@ export class HttpHeaders {
         });
       };
     } else if (typeof Headers !== 'undefined' && headers instanceof Headers) {
+      this.headers = new Map<string, string[]>();
       headers.forEach((value: string, name: string) => {
         this.addHeaderEntry(name, value);
       });
@@ -67,6 +71,7 @@ export class HttpHeaders {
         if (typeof ngDevMode === 'undefined' || ngDevMode) {
           assertValidHeaders(headers);
         }
+        this.headers = new Map<string, string[]>();
         Object.entries(headers).forEach(([name, values]) => {
           this.setHeaderEntries(name, values);
         });


### PR DESCRIPTION
This reverts commit e15226a444a3cf34feea226976c489735feb963e due to some breakages internally.