### PR TITLE
fix(language-service): Forward the tags for quick info from the type definition

### DIFF
--- a/packages/language-service/src/quick_info.ts
+++ b/packages/language-service/src/quick_info.ts
@@ -145,38 +145,41 @@ export class QuickInfoBuilder {
   }
 
   private getQuickInfoForVariableSymbol(symbol: VariableSymbol): ts.QuickInfo {
-    const documentation = this.getDocumentationFromTypeDefAtLocation(symbol.initializerLocation);
+    const info = this.getQuickInfoFromTypeDefAtLocation(symbol.initializerLocation);
     return createQuickInfo(
       symbol.declaration.name,
       DisplayInfoKind.VARIABLE,
       getTextSpanOfNode(this.node),
       undefined /* containerName */,
       this.typeChecker.typeToString(symbol.tsType),
-      documentation,
+      info?.documentation,
+      info?.tags,
     );
   }
 
   private getQuickInfoForLetDeclarationSymbol(symbol: LetDeclarationSymbol): ts.QuickInfo {
-    const documentation = this.getDocumentationFromTypeDefAtLocation(symbol.initializerLocation);
+    const info = this.getQuickInfoFromTypeDefAtLocation(symbol.initializerLocation);
     return createQuickInfo(
       symbol.declaration.name,
       DisplayInfoKind.LET,
       getTextSpanOfNode(this.node),
       undefined /* containerName */,
       this.typeChecker.typeToString(symbol.tsType),
-      documentation,
+      info?.documentation,
+      info?.tags,
     );
   }
 
   private getQuickInfoForReferenceSymbol(symbol: ReferenceSymbol): ts.QuickInfo {
-    const documentation = this.getDocumentationFromTypeDefAtLocation(symbol.targetLocation);
+    const info = this.getQuickInfoFromTypeDefAtLocation(symbol.targetLocation);
     return createQuickInfo(
       symbol.declaration.name,
       DisplayInfoKind.REFERENCE,
       getTextSpanOfNode(this.node),
       undefined /* containerName */,
       this.typeChecker.typeToString(symbol.tsType),
-      documentation,
+      info?.documentation,
+      info?.tags,
     );
   }
 
@@ -217,7 +220,7 @@ export class QuickInfoBuilder {
     node: TmplAstNode | AST = this.node,
   ): ts.QuickInfo {
     const kind = dir.isComponent ? DisplayInfoKind.COMPONENT : DisplayInfoKind.DIRECTIVE;
-    const documentation = this.getDocumentationFromTypeDefAtLocation(dir.tcbLocation);
+    const info = this.getQuickInfoFromTypeDefAtLocation(dir.tcbLocation);
     let containerName: string | undefined;
     if (ts.isClassDeclaration(dir.tsSymbol.valueDeclaration) && dir.ngModule !== null) {
       containerName = dir.ngModule.name.getText();
@@ -229,13 +232,12 @@ export class QuickInfoBuilder {
       getTextSpanOfNode(this.node),
       containerName,
       undefined,
-      documentation,
+      info?.documentation,
+      info?.tags,
     );
   }
 
-  private getDocumentationFromTypeDefAtLocation(
-    tcbLocation: TcbLocation,
-  ): ts.SymbolDisplayPart[] | undefined {
+  private getQuickInfoFromTypeDefAtLocation(tcbLocation: TcbLocation): ts.QuickInfo | undefined {
     const typeDefs = this.tsLS.getTypeDefinitionAtPosition(
       tcbLocation.tcbPath,
       tcbLocation.positionInFile,
@@ -243,8 +245,7 @@ export class QuickInfoBuilder {
     if (typeDefs === undefined || typeDefs.length === 0) {
       return undefined;
     }
-    return this.tsLS.getQuickInfoAtPosition(typeDefs[0].fileName, typeDefs[0].textSpan.start)
-      ?.documentation;
+    return this.tsLS.getQuickInfoAtPosition(typeDefs[0].fileName, typeDefs[0].textSpan.start);
   }
 
   private getQuickInfoAtTcbLocation(location: TcbLocation): ts.QuickInfo | undefined {

--- a/packages/language-service/test/quick_info_spec.ts
+++ b/packages/language-service/test/quick_info_spec.ts
@@ -105,6 +105,17 @@ function quickInfoSkeleton(): {[fileName: string]: string} {
           @Input() config?: {color?: string};
         }
 
+        /**
+         * Don't use me
+         * 
+         * @deprecated use the new thing
+         */
+        @Directive({
+          selector: '[deprecated]',
+          standalone: false,
+        })
+        export class DeprecatedDirective {}
+
         @NgModule({
           declarations: [
             AppCmp,
@@ -112,6 +123,7 @@ function quickInfoSkeleton(): {[fileName: string]: string} {
             StringModel,
             TestComponent,
             SignalModel,
+            DeprecatedDirective
           ],
           imports: [
             CommonModule,
@@ -215,6 +227,20 @@ describe('quick info', () => {
           expectedSpanText: 'hero',
           expectedDisplayString: '(variable) hero: Hero',
         });
+      });
+
+      it('should get tags', () => {
+        const templateOverride = '<div depr¦ecated></div>';
+        const text = templateOverride.replace('¦', '');
+        const template = project.openFile('app.html');
+        template.contents = text;
+        env.expectNoSourceDiagnostics();
+
+        template.moveCursorToText(templateOverride);
+        const quickInfo = template.getQuickInfoAtPosition();
+        const tags = quickInfo!.tags!;
+        expect(tags[0].name).toBe('deprecated');
+        expect(toText(tags[0].text)).toBe('use the new thing');
       });
     });
 


### PR DESCRIPTION
Prior to this commit, the tags from the type definition were dropped. Tags may include, but are not limited to, deprecation information from the jsdoc.
