### PR TITLE
docs: clarify that `@for` doesn't support break/continue

### DIFF
--- a/adev/src/content/guide/templates/control-flow.md
+++ b/adev/src/content/guide/templates/control-flow.md
@@ -50,6 +50,8 @@ A typical `@for` loop looks like:
 }
 ```
 
+Angular's `@for` block does not support flow-modifying statements like JavaScript's `continue` or `break`.
+
 ### Why is `track` in `@for` blocks important?
 
 The `track` expression allows Angular to maintain a relationship between your data and the DOM nodes on the page. This allows Angular to optimize performance by executing the minimum necessary DOM operations when the data changes.

--- a/tools/manual_api_docs/blocks/for.md
+++ b/tools/manual_api_docs/blocks/for.md
@@ -19,6 +19,8 @@ but there are performance advantages of using a regular `Array`.
 You can optionally include an `@empty` section immediately after the `@for` block content. The
 content of the `@empty` block displays when there are no items.
 
+Angular's `@for` block does not support flow-modifying statements like JavaScript's `continue` or `break`.
+
 ### `track` and objects identity
 
 The value of the `track` expression determines a key used to associate array items with the views in


### PR DESCRIPTION
We recently saw some confusion around this, so it's worth adding a sentence to clarify