### PR TITLE
refactor(common): prevent duplicating `Accept` header name

### DIFF
--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -11,7 +11,13 @@ import {Observable, Observer} from 'rxjs';
 
 import {HttpBackend} from './backend';
 import {HttpHeaders} from './headers';
-import {ACCEPT_HEADER, CONTENT_TYPE_HEADER, HttpRequest, X_REQUEST_URL_HEADER} from './request';
+import {
+  ACCEPT_HEADER,
+  ACCEPT_HEADER_VALUE,
+  CONTENT_TYPE_HEADER,
+  HttpRequest,
+  X_REQUEST_URL_HEADER,
+} from './request';
 import {
   HTTP_STATUS_CODE_OK,
   HttpDownloadProgressEvent,
@@ -258,8 +264,8 @@ export class FetchBackend implements HttpBackend {
     req.headers.forEach((name, values) => (headers[name] = values.join(',')));
 
     // Add an Accept header if one isn't present already.
-    if (!req.headers.has('Accept')) {
-      headers['Accept'] = ACCEPT_HEADER;
+    if (!req.headers.has(ACCEPT_HEADER)) {
+      headers[ACCEPT_HEADER] = ACCEPT_HEADER_VALUE;
     }
 
     // Auto-detect the Content-Type header if one isn't present already.

--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -85,6 +85,12 @@ function isUrlSearchParams(value: any): value is URLSearchParams {
 export const CONTENT_TYPE_HEADER = 'Content-Type';
 
 /**
+ * The `Accept` header is an HTTP request header that indicates the media types
+ * (or content types) the client is willing to receive from the server.
+ */
+export const ACCEPT_HEADER = 'Accept';
+
+/**
  * `X-Request-URL` is a custom HTTP header used in older browser versions,
  * including Firefox (< 32), Chrome (< 37), Safari (< 8), and Internet Explorer,
  * to include the full URL of the request in cross-origin requests.
@@ -110,7 +116,7 @@ export const JSON_CONTENT_TYPE = 'application/json';
  * to accept from the server, with a preference for `application/json` and `text/plain`,
  * but also accepting any other type (*\/*).
  */
-export const ACCEPT_HEADER = `${JSON_CONTENT_TYPE}, ${TEXT_CONTENT_TYPE}, */*`;
+export const ACCEPT_HEADER_VALUE = `${JSON_CONTENT_TYPE}, ${TEXT_CONTENT_TYPE}, */*`;
 
 /**
  * An outgoing HTTP request with an optional typed body.

--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -14,7 +14,13 @@ import {switchMap} from 'rxjs/operators';
 import {HttpBackend} from './backend';
 import {RuntimeErrorCode} from './errors';
 import {HttpHeaders} from './headers';
-import {ACCEPT_HEADER, CONTENT_TYPE_HEADER, HttpRequest, X_REQUEST_URL_HEADER} from './request';
+import {
+  ACCEPT_HEADER,
+  ACCEPT_HEADER_VALUE,
+  CONTENT_TYPE_HEADER,
+  HttpRequest,
+  X_REQUEST_URL_HEADER,
+} from './request';
 import {
   HTTP_STATUS_CODE_NO_CONTENT,
   HTTP_STATUS_CODE_OK,
@@ -97,8 +103,8 @@ export class HttpXhrBackend implements HttpBackend {
           req.headers.forEach((name, values) => xhr.setRequestHeader(name, values.join(',')));
 
           // Add an Accept header if one isn't present already.
-          if (!req.headers.has('Accept')) {
-            xhr.setRequestHeader('Accept', ACCEPT_HEADER);
+          if (!req.headers.has(ACCEPT_HEADER)) {
+            xhr.setRequestHeader(ACCEPT_HEADER, ACCEPT_HEADER_VALUE);
           }
 
           // Auto-detect the Content-Type header if one isn't present already.


### PR DESCRIPTION
Drops some bytes by moving `Accept` into a variable, which is then minified to something like `var a="Accept"` and reused in all the places.