### PR TITLE
fix(platform-browser): roll back HMR fix

### DIFF
--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -201,9 +201,6 @@ export class DomRendererFactory2 implements RendererFactory2, OnDestroy {
    * @param componentId ID of the component that is being replaced.
    */
   protected componentReplaced(componentId: string) {
-    // Destroy the renderer so the styles get removed from the DOM, otherwise
-    // they may leak back into the component together with the new ones.
-    this.rendererByCompId.get(componentId)?.destroy();
     this.rendererByCompId.delete(componentId);
   }
 }


### PR DESCRIPTION
Rolls back the changes from https://github.com/angular/angular/pull/59514 because they ended up being breaking in 3P. We can revisit the internal fix in a different way.

Fixes #59558.