### PR TITLE
test(devtools): disable flaky highlighter test

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/highlighter.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/highlighter.spec.ts
@@ -100,7 +100,8 @@ describe('highlighter', () => {
     });
   });
 
-  describe('highlightHydrationElement', () => {
+  // Those test were disabled since very flaky on the CI - needs investigation before re-enabling
+  xdescribe('highlightHydrationElement', () => {
     afterEach(() => {
       document.body.innerHTML = '';
       delete (window as any).ng;


### PR DESCRIPTION
The test in question was very flaky on CI, example run: https://github.com/angular/angular/actions/runs/12805645683/job/35702462974?pr=59557

Disabling as it is causing productivity loose for the team.

