### PR TITLE
refactor(core): Make unsupported styling type error message clearer

### DIFF
--- a/packages/core/src/render3/instructions/styling.ts
+++ b/packages/core/src/render3/instructions/styling.ts
@@ -692,7 +692,9 @@ export function toStylingKeyValueArray(
     stringParser(styleKeyValueArray, unwrappedValue);
   } else {
     ngDevMode &&
-      throwError('Unsupported styling type ' + typeof unwrappedValue + ': ' + unwrappedValue);
+      throwError(
+        'Unsupported styling type: ' + typeof unwrappedValue + ' (' + unwrappedValue + ')',
+      );
   }
   return styleKeyValueArray;
 }


### PR DESCRIPTION
The previous message would sound like a full sentence when using a signal without `()` (Example: Unsupported styling type function: [Input Signal: neutral]). The new formatting makes it a bit more obvious that the type itself is the problem.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

When using code such as this:
```typescript
@Component({
    selector: "comp",
    templateUrl: "./comp.html",
    styleUrls: ["./comp.scss"],
    host: {
        "[class]": "theme",
    },
})
class Comp {
    public theme = input<string>();
}
```

you get the runtime error:


```
ERROR Error: ASSERTION ERROR: Unsupported styling type function: [Input Signal: neutral]
    at throwError (http://localhost:4200/@fs/C:/Users/project/.angular/cache/19.1.0/project/vite/deps/chunk-GK5E6G5J.js?v=75de14bc:1936:9) [angular]
    at toStylingKeyValueArray (http://localhost:4200/@fs/C:/Users/project/.angular/cache/19.1.0/project/vite/deps/chunk-GK5E6G5J.js?v=75de14bc:17944:18) [angular]
    at checkStylingMap (http://localhost:4200/@fs/C:/Users/project/.angular/cache/19.1.0/project/vite/deps/chunk-GK5E6G5J.js?v=75de14bc:17811:113) [angular]
    at Module.ɵɵclassMap (http://localhost:4200/@fs/C:/Users/project/.angular/cache/19.1.0/project/vite/deps/chunk-GK5E6G5J.js?v=75de14bc:17771:3) [angular]
    at Comp_HostBindings (http://localhost:4200/chunk-FELJIUSQ.js:100:13) [angular]
    at processHostBindingOpCodes (http://localhost:4200/@fs/C:/Users/project/.angular/cache/19.1.0/project/vite/deps/chunk-GK5E6G5J.js?v=75de14bc:9273:9) [angular]
    at refreshView (http://localhost:4200/@fs/C:/Users/project/.angular/cache/19.1.0/project/vite/deps/chunk-GK5E6G5J.js?v=75de14bc:10503:5) [angular]
    at detectChangesInView (http://localhost:4200/@fs/C:/Users/project/.angular/cache/19.1.0/project/vite/deps/chunk-GK5E6G5J.js?v=75de14bc:10612:5) [angular]
    at detectChangesInViewIfAttached (http://localhost:4200/@fs/C:/Users/project/.angular/cache/19.1.0/project/vite/deps/chunk-GK5E6G5J.js?v=75de14bc:10595:3) [angular]
    at detectChangesInEmbeddedViews (http://localhost:4200/@fs/C:/Users/project/.angular/cache/19.1.0/project/vite/deps/chunk-GK5E6G5J.js?v=75de14bc:10571:7) [angular]
    at refreshView (http://localhost:4200/@fs/C:/Users/project/.angular/cache/19.1.0/project/vite/deps/chunk-GK5E6G5J.js?v=75de14bc:10472:5) [angular]
    at detectChangesInView (http://localhost:4200/@fs/C:/Users/project/.angular/cache/19.1.0/project/vite/deps/chunk-GK5E6G5J.js?v=75de14bc:10612:5) [angular]
    at detectChangesInViewIfAttached (http://localhost:4200/@fs/C:/Users/project/.angular/cache/19.1.0/project/vite/deps/chunk-GK5E6G5J.js?v=75de14bc:10595:3) [angular]
    at detectChangesInEmbeddedViews (http://localhost:4200/@fs/C:/Users/project/.angular/cache/19.1.0/project/vite/deps/chunk-GK5E6G5J.js?v=75de14bc:10571:7) [angular]
```


## What is the new behavior?
ERROR Error: ASSERTION ERROR: Unsupported styling type: function ([Input Signal: neutral])


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Note that it could be desirable to have more information about where the error occurred in general. But that's out of the scope of this PR.
