### PR TITLE
feat(router): support custom elements for RouterLink

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -211,6 +211,9 @@ export function convertToParamMap(params: Params): ParamMap;
 export function createUrlTreeFromSnapshot(relativeTo: ActivatedRouteSnapshot, commands: any[], queryParams?: Params | null, fragment?: string | null): UrlTree;
 
 // @public
+export const CUSTOM_ELEMENT_ANCHOR_TAG_NAMES: InjectionToken<readonly string[]>;
+
+// @public
 export type Data = {
     [key: string | symbol]: any;
 };
@@ -796,7 +799,7 @@ export type RouterHashLocationFeature = RouterFeature<RouterFeatureKind.RouterHa
 
 // @public
 class RouterLink implements OnChanges, OnDestroy {
-    constructor(router: Router, route: ActivatedRoute, tabIndexAttribute: string | null | undefined, renderer: Renderer2, el: ElementRef, locationStrategy?: LocationStrategy | undefined);
+    constructor(router: Router, route: ActivatedRoute, tabIndexAttribute: string | null | undefined, renderer: Renderer2, el: ElementRef, locationStrategy?: LocationStrategy | undefined, customElementAnchorTagNames?: readonly string[]);
     fragment?: string;
     href: string | null;
     info?: unknown;
@@ -828,7 +831,7 @@ class RouterLink implements OnChanges, OnDestroy {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<RouterLink, "[routerLink]", never, { "target": { "alias": "target"; "required": false; }; "queryParams": { "alias": "queryParams"; "required": false; }; "fragment": { "alias": "fragment"; "required": false; }; "queryParamsHandling": { "alias": "queryParamsHandling"; "required": false; }; "state": { "alias": "state"; "required": false; }; "info": { "alias": "info"; "required": false; }; "relativeTo": { "alias": "relativeTo"; "required": false; }; "preserveFragment": { "alias": "preserveFragment"; "required": false; }; "skipLocationChange": { "alias": "skipLocationChange"; "required": false; }; "replaceUrl": { "alias": "replaceUrl"; "required": false; }; "routerLink": { "alias": "routerLink"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<RouterLink, [null, null, { attribute: "tabindex"; }, null, null, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<RouterLink, [null, null, { attribute: "tabindex"; }, null, null, null, { optional: true; }]>;
 }
 export { RouterLink }
 export { RouterLink as RouterLinkWithHref }

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -7,7 +7,11 @@
  */
 
 export {createUrlTreeFromSnapshot} from './create_url_tree';
-export {RouterLink, RouterLinkWithHref} from './directives/router_link';
+export {
+  RouterLink,
+  RouterLinkWithHref,
+  CUSTOM_ELEMENT_ANCHOR_TAG_NAMES,
+} from './directives/router_link';
 export {RouterLinkActive} from './directives/router_link_active';
 export {RouterOutlet, ROUTER_OUTLET_DATA, RouterOutletContract} from './directives/router_outlet';
 export {

--- a/packages/router/test/router_link_spec.ts
+++ b/packages/router/test/router_link_spec.ts
@@ -9,7 +9,13 @@
 import {Component, inject, signal, provideExperimentalZonelessChangeDetection} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {Router, RouterLink, RouterModule, provideRouter} from '@angular/router';
+import {
+  Router,
+  RouterLink,
+  RouterModule,
+  provideRouter,
+  CUSTOM_ELEMENT_ANCHOR_TAG_NAMES,
+} from '@angular/router';
 
 describe('RouterLink', () => {
   beforeEach(() => {
@@ -207,6 +213,85 @@ describe('RouterLink', () => {
     });
   });
 
+  // Avoid executing in node environment because customElements is not defined.
+  if (typeof customElements === 'object') {
+    describe('on a custom element anchor', () => {
+      /** Simple anchor element imitation. */
+      class CustomAnchor extends HTMLElement {
+        get href(): string {
+          return this.getAttribute('href') ?? '';
+        }
+        set href(value: string) {
+          this.setAttribute('href', value);
+        }
+
+        constructor() {
+          super();
+          const shadow = this.attachShadow({mode: 'open'});
+          shadow.innerHTML = '<a><slot></slot></a>';
+        }
+
+        attributedChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
+          if (name === 'href') {
+            const anchor = this.shadowRoot!.querySelector('a')!;
+
+            if (newValue === null) {
+              anchor.removeAttribute('href');
+            } else {
+              anchor.setAttribute('href', newValue);
+            }
+          }
+        }
+      }
+
+      if (!customElements.get('custom-anchor')) {
+        customElements.define('custom-anchor', CustomAnchor);
+      }
+
+      @Component({
+        template: `
+          <custom-anchor [routerLink]="link()"></custom-anchor>
+        `,
+        standalone: false,
+        providers: [
+          {provide: CUSTOM_ELEMENT_ANCHOR_TAG_NAMES, useValue: 'custom-anchor', multi: true},
+        ],
+      })
+      class LinkComponent {
+        link = signal<string | null | undefined>('/');
+      }
+      let fixture: ComponentFixture<LinkComponent>;
+      let link: HTMLAnchorElement;
+
+      beforeEach(async () => {
+        TestBed.configureTestingModule({
+          imports: [RouterModule.forRoot([])],
+          declarations: [LinkComponent],
+        });
+        fixture = TestBed.createComponent(LinkComponent);
+        await fixture.whenStable();
+        link = fixture.debugElement.query(By.css('custom-anchor')).nativeElement;
+      });
+
+      it('does not touch tabindex', async () => {
+        expect(link.outerHTML).not.toContain('tabindex');
+      });
+
+      it('null, removes href', async () => {
+        expect(link.outerHTML).toContain('href');
+        fixture.componentInstance.link.set(null);
+        await fixture.whenStable();
+        expect(link.outerHTML).not.toContain('href');
+      });
+
+      it('undefined, removes href', async () => {
+        expect(link.outerHTML).toContain('href');
+        fixture.componentInstance.link.set(undefined);
+        await fixture.whenStable();
+        expect(link.outerHTML).not.toContain('href');
+      });
+    });
+  }
   it('can use a UrlTree as the input', async () => {
     @Component({
       template: '<a [routerLink]="urlTree">link</a>',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Relates to #28345

We as Web Component library authors have the problem that routerLink does not properly work with custom element anchor tags (native anchor tag wrapped in Shadow DOM). This is due to the lack of automatic href updates for elements besides `<a>`/ `<area>` and the internal logic of adding a `tabindex="0"` attribute for non `<a>`/ `<area>` elements.

## What is the new behavior?

This PR adds a multi provider `CUSTOM_ELEMENT_ANCHOR_TAG_NAMES` for adding RouterLink compatible custom elements.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
