### PR TITLE
feat(core): support multiple responses in resource()

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -185,6 +185,13 @@ export interface AttributeDecorator {
 }
 
 // @public
+export interface BaseResourceOptions<T, R> {
+    equal?: ValueEqualityFn<T>;
+    injector?: Injector;
+    request?: () => R;
+}
+
+// @public
 export function booleanAttribute(value: unknown): boolean;
 
 // @public
@@ -1437,6 +1444,11 @@ export class PlatformRef {
 export type Predicate<T> = (value: T) => boolean;
 
 // @public
+export interface PromiseResourceOptions<T, R> extends BaseResourceOptions<T, R> {
+    loader: ResourceLoader<T, R>;
+}
+
+// @public
 export function provideAppInitializer(initializerFn: () => Observable<unknown> | Promise<unknown> | void): EnvironmentProviders;
 
 // @public
@@ -1610,13 +1622,8 @@ export interface ResourceLoaderParams<R> {
     request: Exclude<NoInfer<R>, undefined>;
 }
 
-// @public
-export interface ResourceOptions<T, R> {
-    equal?: ValueEqualityFn<T>;
-    injector?: Injector;
-    loader: ResourceLoader<T, R>;
-    request?: () => R;
-}
+// @public (undocumented)
+export type ResourceOptions<T, R> = PromiseResourceOptions<T, R> | StreamingResourceOptions<T, R>;
 
 // @public
 export interface ResourceRef<T> extends WritableResource<T> {
@@ -1632,6 +1639,13 @@ export enum ResourceStatus {
     Reloading = 3,
     Resolved = 4
 }
+
+// @public
+export type ResourceStreamingLoader<T, R> = (param: ResourceLoaderParams<R>) => PromiseLike<Signal<{
+    value: T;
+} | {
+    error: unknown;
+}>>;
 
 // @public
 export const RESPONSE_INIT: InjectionToken<ResponseInit | null>;
@@ -1746,6 +1760,11 @@ export interface StaticClassSansProvider {
 
 // @public
 export type StaticProvider = ValueProvider | ExistingProvider | StaticClassProvider | ConstructorProvider | FactoryProvider | any[];
+
+// @public
+export interface StreamingResourceOptions<T, R> extends BaseResourceOptions<T, R> {
+    stream: ResourceStreamingLoader<T, R>;
+}
 
 // @public
 export abstract class TemplateRef<C> {

--- a/goldens/public-api/core/rxjs-interop/index.api.md
+++ b/goldens/public-api/core/rxjs-interop/index.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { BaseResourceOptions } from '@angular/core';
 import { DestroyRef } from '@angular/core';
 import { Injector } from '@angular/core';
 import { MonoTypeOperatorFunction } from 'rxjs';
@@ -11,7 +12,6 @@ import { Observable } from 'rxjs';
 import { OutputOptions } from '@angular/core';
 import { OutputRef } from '@angular/core';
 import { ResourceLoaderParams } from '@angular/core';
-import { ResourceOptions } from '@angular/core';
 import { ResourceRef } from '@angular/core';
 import { Signal } from '@angular/core';
 import { Subscribable } from 'rxjs';
@@ -30,7 +30,7 @@ export function pendingUntilEvent<T>(injector?: Injector): MonoTypeOperatorFunct
 export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T | undefined>;
 
 // @public
-export interface RxResourceOptions<T, R> extends Omit<ResourceOptions<T, R>, 'loader'> {
+export interface RxResourceOptions<T, R> extends BaseResourceOptions<T, R> {
     // (undocumented)
     loader: (params: ResourceLoaderParams<R>) => Observable<T>;
 }

--- a/packages/core/rxjs-interop/test/rx_resource_spec.ts
+++ b/packages/core/rxjs-interop/test/rx_resource_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {of, Observable} from 'rxjs';
+import {of, Observable, BehaviorSubject} from 'rxjs';
 import {TestBed} from '@angular/core/testing';
 import {ApplicationRef, Injector, signal} from '@angular/core';
 import {rxResource} from '@angular/core/rxjs-interop';
@@ -54,6 +54,27 @@ describe('rxResource()', () => {
     request.set(2);
     await appRef.whenStable();
     expect(unsub).toBe(true);
+  });
+
+  it('should stream when the loader returns multiple values', async () => {
+    const injector = TestBed.inject(Injector);
+    const appRef = TestBed.inject(ApplicationRef);
+    const response = new BehaviorSubject(1);
+    const res = rxResource({
+      loader: () => response,
+      injector,
+    });
+    await appRef.whenStable();
+    expect(res.value()).toBe(1);
+
+    response.next(2);
+    expect(res.value()).toBe(2);
+
+    response.next(3);
+    expect(res.value()).toBe(3);
+
+    response.error('fail');
+    expect(res.error()).toBe('fail');
   });
 });
 

--- a/packages/core/src/resource/api.ts
+++ b/packages/core/src/resource/api.ts
@@ -161,11 +161,20 @@ export interface ResourceLoaderParams<R> {
 export type ResourceLoader<T, R> = (param: ResourceLoaderParams<R>) => PromiseLike<T>;
 
 /**
+ * Streaming loader for a `Resource`.
+ *
+ * @experimental
+ */
+export type ResourceStreamingLoader<T, R> = (
+  param: ResourceLoaderParams<R>,
+) => PromiseLike<Signal<{value: T} | {error: unknown}>>;
+
+/**
  * Options to the `resource` function, for creating a resource.
  *
  * @experimental
  */
-export interface ResourceOptions<T, R> {
+export interface BaseResourceOptions<T, R> {
   /**
    * A reactive function which determines the request to be made. Whenever the request changes, the
    * loader will be triggered to fetch a new value for the resource.
@@ -173,11 +182,6 @@ export interface ResourceOptions<T, R> {
    * If a request function isn't provided, the loader won't rerun unless the resource is reloaded.
    */
   request?: () => R;
-
-  /**
-   * Loading function which returns a `Promise` of the resource's value for a given request.
-   */
-  loader: ResourceLoader<T, R>;
 
   /**
    * Equality function used to compare the return value of the loader.
@@ -189,3 +193,33 @@ export interface ResourceOptions<T, R> {
    */
   injector?: Injector;
 }
+
+/**
+ * Options to the `resource` function, for creating a resource.
+ *
+ * @experimental
+ */
+export interface PromiseResourceOptions<T, R> extends BaseResourceOptions<T, R> {
+  /**
+   * Loading function which returns a `Promise` of the resource's value for a given request.
+   */
+  loader: ResourceLoader<T, R>;
+}
+
+/**
+ * Options to the `resource` function, for creating a resource.
+ *
+ * @experimental
+ */
+export interface StreamingResourceOptions<T, R> extends BaseResourceOptions<T, R> {
+  /**
+   * Loading function which returns a `Promise` of a signal of the resource's value for a given
+   * request, which can change over time as new values are received from a stream.
+   */
+  stream: ResourceStreamingLoader<T, R>;
+}
+
+/**
+ * @experimental
+ */
+export type ResourceOptions<T, R> = PromiseResourceOptions<T, R> | StreamingResourceOptions<T, R>;


### PR DESCRIPTION
This commit adds support for creating `resource()`s with streaming response data. A streaming resource is defined by a `stream` option instead of a `loader`, with `stream` being a function returning `Promise<Signal<{value: T}|{error: unknown}>>`. Once the streaming loader resolves to a `Signal`, it can continue to update that signal over time, and the values (or errors) will be delivered to via the resource's state.

`rxResource()` is updated to leverage this new functionality to handle multiple responses from the underlying Observable.