### PR TITLE
fix(core): animation sometimes renderer not being destroyed during HMR

### DIFF
--- a/packages/animations/browser/src/render/animation_renderer.ts
+++ b/packages/animations/browser/src/render/animation_renderer.ts
@@ -138,6 +138,8 @@ export class AnimationRendererFactory implements RendererFactory2 {
    * @param componentId ID of the component that is being replaced.
    */
   protected componentReplaced(componentId: string) {
+    // Flush the engine since the renderer destruction waits for animations to be done.
+    this.engine.flush();
     (this.delegate as {componentReplaced?: (id: string) => void}).componentReplaced?.(componentId);
   }
 }


### PR DESCRIPTION
These changes aim to resolve the issue that prompted #59514. The animations module is a bit tricky for HMR, because it schedules the destruction of its renderer after the currently-running animations are done. If there are no running animations, the renderer gets destroyed next time around. This is a problem, because it means that the styles can stay around for a long time.

These changes resolve the issue by:
1. Moving the cleanup of the renderer to after the destruction of the old view. This ensures that the usual clean up flow has been kicked off.
2. Flushing the animations when a component is replaced to ensure that the renderer is cleaned up in a timely manner.
