### PR TITLE
fix(zone.js): `discardPeriodicTasks` should remove periodic tasks fro…

### DIFF
--- a/packages/core/test/fake_async_spec.ts
+++ b/packages/core/test/fake_async_spec.ts
@@ -241,6 +241,14 @@ describe('fake async', () => {
       clearInterval(id);
     }));
 
+    it('periodic timers should not run when discarded', fakeAsync(() => {
+      setInterval(() => {
+        fail('should never execute because we discard it');
+      }, 10);
+      discardPeriodicTasks();
+      tick(12);
+    }));
+
     it('should not run cancelled periodic timer', fakeAsync(() => {
       let ran = false;
       const id = setInterval(() => {

--- a/packages/zone.js/lib/zone-spec/fake-async-test.ts
+++ b/packages/zone.js/lib/zone-spec/fake-async-test.ts
@@ -621,6 +621,13 @@ class FakeAsyncTestZoneSpec implements ZoneSpec {
     this.pendingTimers = [];
   }
 
+  discardPeriodicTasks() {
+    for (const timer of this.pendingPeriodicTimers) {
+      this._scheduler.removeScheduledFunctionWithId(timer);
+    }
+    this.pendingPeriodicTimers.length = 0;
+  }
+
   getTimerCount() {
     return this._scheduler.getTimerCount() + this._microtasks.length;
   }
@@ -942,9 +949,7 @@ export function flush(maxTurns?: number): number {
  * @experimental
  */
 export function discardPeriodicTasks(): void {
-  const zoneSpec = _getFakeAsyncZoneSpec();
-  const pendingTimers = zoneSpec.pendingPeriodicTimers;
-  zoneSpec.pendingPeriodicTimers.length = 0;
+  _getFakeAsyncZoneSpec().discardPeriodicTasks();
 }
 
 /**


### PR DESCRIPTION
…m scheduler queue

Prior to this commit, `discardPeriodicTasks` would not remove the tasks from the scheduler queue. As a result, they would still execute after ticking beyond their scheduled time.

fixes #59577
