### PR TITLE
test(platform-server): fix flaky hydration test

### DIFF
--- a/packages/platform-server/test/dom_utils.ts
+++ b/packages/platform-server/test/dom_utils.ts
@@ -93,18 +93,20 @@ export function hydrate(
     hydrationFeatures?: () => HydrationFeature<HydrationFeatureKind>[];
   } = {},
 ) {
-  function _document(): any {
-    ɵsetDocument(doc);
-    global.document = doc; // needed for `DefaultDomRenderer2`
-    return doc;
-  }
-
   const {envProviders = [], hydrationFeatures = () => []} = options;
+
+  // Apply correct reference to the `document` object,
+  // which will be used by runtime.
+  ɵsetDocument(doc);
+
+  // Define `document` to make `DefaultDomRenderer2` work, since it
+  // references `document` directly to create style tags.
+  global.document = doc;
 
   const providers = [
     ...envProviders,
     {provide: PLATFORM_ID, useValue: 'browser'},
-    {provide: DOCUMENT, useFactory: _document, deps: []},
+    {provide: DOCUMENT, useFactory: () => doc},
     provideClientHydration(...hydrationFeatures()),
   ];
 


### PR DESCRIPTION
This commit updates testing setup logic to apply correct `document` reference, which should be used by the runtime. Previously, the timing of that operation was less predictable and in some cases led to reusing document state from previous tests.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No