### PR TITLE
fix(compiler-cli): preserve all HMR dependencies

### DIFF
--- a/packages/compiler-cli/src/ngtsc/hmr/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/hmr/src/metadata.ts
@@ -21,7 +21,7 @@ import ts from 'typescript';
 /**
  * Extracts the HMR metadata for a class declaration.
  * @param clazz Class being analyzed.
- * @param reflection Reflection host.
+ * @param reflectionHost Reflection host.
  * @param compilerHost Compiler host to use when resolving file names.
  * @param rootDirs Root directories configured by the user.
  * @param definition Analyzed component definition.
@@ -32,7 +32,7 @@ import ts from 'typescript';
  */
 export function extractHmrMetatadata(
   clazz: DeclarationNode,
-  reflection: ReflectionHost,
+  reflectionHost: ReflectionHost,
   compilerHost: Pick<ts.CompilerHost, 'getCanonicalFileName'>,
   rootDirs: readonly string[],
   definition: R3CompiledExpression,
@@ -41,7 +41,7 @@ export function extractHmrMetatadata(
   classMetadata: o.Statement | null,
   debugInfo: o.Statement | null,
 ): R3HmrMetadata | null {
-  if (!reflection.isClass(clazz)) {
+  if (!reflectionHost.isClass(clazz)) {
     return null;
   }
 
@@ -52,6 +52,7 @@ export function extractHmrMetatadata(
 
   const dependencies = extractHmrDependencies(
     clazz,
+    reflectionHost,
     definition,
     factory,
     deferBlockMetadata,

--- a/packages/compiler-cli/test/ngtsc/hmr_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/hmr_spec.ts
@@ -110,7 +110,7 @@ runInEachFileSystem(() => {
       );
       expect(jsContents).toContain(
         ').then(m => m.default && i0.ɵɵreplaceMetadata(Cmp, m.default, [i0], ' +
-          '[Dep, transformValue, TOKEN, Component, Inject, ViewChild, Input]));',
+          '[Component, ViewChild, Input, Inject, Dep, transformValue, TOKEN]));',
       );
       expect(jsContents).toContain('Cmp_HmrLoad(Date.now());');
       expect(jsContents).toContain(
@@ -119,7 +119,7 @@ runInEachFileSystem(() => {
       );
 
       expect(hmrContents).toContain(
-        'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, Dep, transformValue, TOKEN, Component, Inject, ViewChild, Input) {',
+        'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, Component, ViewChild, Input, Inject, Dep, transformValue, TOKEN) {',
       );
       expect(hmrContents).toContain(`const ɵhmr0 = ɵɵnamespaces[0];`);
       expect(hmrContents).toContain('Cmp.ɵfac = function Cmp_Factory');
@@ -177,7 +177,7 @@ runInEachFileSystem(() => {
       );
       expect(jsContents).toContain(
         ').then(m => m.default && i0.ɵɵreplaceMetadata(Cmp, m.default, [i0, i1], ' +
-          '[DepModule, Component]));',
+          '[Component, ViewChild, Input, Inject, DepModule]));',
       );
       expect(jsContents).toContain('Cmp_HmrLoad(Date.now());');
       expect(jsContents).toContain(
@@ -186,7 +186,7 @@ runInEachFileSystem(() => {
       );
 
       expect(hmrContents).toContain(
-        'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, DepModule, Component) {',
+        'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, Component, ViewChild, Input, Inject, DepModule) {',
       );
       expect(hmrContents).toContain(`const ɵhmr0 = ɵɵnamespaces[0];`);
       expect(hmrContents).toContain(`const ɵhmr1 = ɵɵnamespaces[1];`);
@@ -340,11 +340,11 @@ runInEachFileSystem(() => {
       expect(jsContents).toContain('const Cmp_Defer_1_DepsFn = () => [Dep];');
       expect(jsContents).toContain('function Cmp_Defer_0_Template(rf, ctx) { if (rf & 1) {');
       expect(jsContents).toContain('i0.ɵɵdefer(1, 0, Cmp_Defer_1_DepsFn);');
-      expect(jsContents).toContain('ɵɵreplaceMetadata(Cmp, m.default, [i0], [Dep]));');
+      expect(jsContents).toContain('ɵɵreplaceMetadata(Cmp, m.default, [i0], [Component, Dep]));');
       expect(jsContents).not.toContain('setClassMetadata');
 
       expect(hmrContents).toContain(
-        'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, Dep) {',
+        'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, Component, Dep) {',
       );
       expect(hmrContents).toContain('const Cmp_Defer_1_DepsFn = () => [Dep];');
       expect(hmrContents).toContain('function Cmp_Defer_0_Template(rf, ctx) {');
@@ -425,10 +425,10 @@ runInEachFileSystem(() => {
       const hmrContents = env.driveHmr('test.ts', 'Cmp');
 
       expect(jsContents).toContain(
-        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [providers, Component]));',
+        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [Component, providers]));',
       );
       expect(hmrContents).toContain(
-        'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, providers, Component) {',
+        'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, Component, providers) {',
       );
     });
 
@@ -462,10 +462,10 @@ runInEachFileSystem(() => {
       const hmrContents = env.driveHmr('test.ts', 'Cmp');
 
       expect(jsContents).toContain(
-        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [token, value, Component]));',
+        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [Component, InjectionToken, token, value]));',
       );
       expect(hmrContents).toContain(
-        'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, token, value, Component) {',
+        'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, Component, InjectionToken, token, value) {',
       );
     });
 
@@ -496,10 +496,57 @@ runInEachFileSystem(() => {
       const hmrContents = env.driveHmr('test.ts', 'Cmp');
 
       expect(jsContents).toContain(
-        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [token, value, Component]));',
+        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [Component, InjectionToken, token, value]));',
       );
       expect(hmrContents).toContain(
-        'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, token, value, Component) {',
+        'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, Component, InjectionToken, token, value) {',
+      );
+    });
+
+    it('should not capture a plain import to a type-only dependency', () => {
+      enableHmr();
+
+      env.write(
+        'enums.ts',
+        `
+        export enum PlainEnum {
+          value = 1
+        }
+
+        export const enum ConstEnum {
+          value = 1
+        }
+      `,
+      );
+
+      env.write(
+        'test.ts',
+        `
+          import {Component, OnInit, InjectionToken, Signal} from '@angular/core';
+          import {PlainEnum, ConstEnum} from './enums';
+
+          export const someToken = new InjectionToken<number>('token');
+
+          @Component({template: ''})
+          export class Cmp implements OnInit {
+            someSignal: Signal<unknown> = null!;
+            plainValue = PlainEnum.value;
+            constValue = ConstEnum.value;
+            ngOnInit() {}
+          }
+        `,
+      );
+
+      env.driveMain();
+
+      const jsContents = env.getContents('test.js');
+      const hmrContents = env.driveHmr('test.ts', 'Cmp');
+
+      expect(jsContents).toContain(
+        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [Component, InjectionToken, PlainEnum, someToken]));',
+      );
+      expect(hmrContents).toContain(
+        'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, Component, InjectionToken, PlainEnum, someToken) {',
       );
     });
   });


### PR DESCRIPTION
Previously when generating the HMR code, we would determine only the dependencies used within the component's metadata so that they can be passed along both to the HMR replacer file and the HMR event listener callback. This turns out to be problematic, because changing the template will change which symbols are referenced in the metadata, causing the replacer and callback to be out of sync.

These changes resolve the issue by capturing all the top-level dependencies, except the ones that won't generate runtime code (e.g. interfaces).

Fixes #59581.