### PR TITLE
Linked signal shared with refactor

### DIFF
--- a/packages/core/src/render3/reactivity/linked_signal.ts
+++ b/packages/core/src/render3/reactivity/linked_signal.ts
@@ -8,101 +8,18 @@
 
 import {signalAsReadonlyFn, WritableSignal} from './signal';
 import {Signal, ValueEqualityFn} from './api';
-import {
-  producerMarkClean,
-  ReactiveNode,
-  SIGNAL,
-  signalSetFn,
-  signalUpdateFn,
-  producerUpdateValueVersion,
-  REACTIVE_NODE,
-  defaultEquals,
-  consumerBeforeComputation,
-  consumerAfterComputation,
-  producerAccessed,
-} from '@angular/core/primitives/signals';
 import {performanceMarkFeature} from '../../util/performance';
-
-type ComputationFn<S, D> = (source: S, previous?: {source: S; value: D}) => D;
-
-interface LinkedSignalNode<S, D> extends ReactiveNode {
-  /**
-   * Value of the source signal that was used to derive the computed value.
-   */
-  sourceValue: S;
-
-  /**
-   * Current state value, or one of the sentinel values (`UNSET`, `COMPUTING`,
-   * `ERROR`).
-   */
-  value: D;
-
-  /**
-   * If `value` is `ERRORED`, the error caught from the last computation attempt which will
-   * be re-thrown.
-   */
-  error: unknown;
-
-  /**
-   * The source function represents reactive dependency based on which the linked state is reset.
-   */
-  source: () => S;
-
-  /**
-   * The computation function which will produce a new value based on the source and, optionally - previous values.
-   */
-  computation: ComputationFn<S, D>;
-
-  equal: ValueEqualityFn<D>;
-}
-
-export type LinkedSignalGetter<S, D> = (() => D) & {
-  [SIGNAL]: LinkedSignalNode<S, D>;
-};
+import {
+  ComputationFn,
+  createLinkedSignal,
+  LinkedSignalGetter,
+  LinkedSignalNode,
+  SIGNAL,
+  linkedSignalSetFn,
+  linkedSignalUpdateFn,
+} from '@angular/core/primitives/signals';
 
 const identityFn = <T>(v: T) => v;
-
-/**
- * Create a linked signal which represents state that is (re)set from a linked reactive expression.
- */
-function createLinkedSignal<S, D>(node: LinkedSignalNode<S, D>): WritableSignal<D> {
-  const linkedSignalGetter = () => {
-    // Check if the value needs updating before returning it.
-    producerUpdateValueVersion(node);
-
-    // Record that someone looked at this signal.
-    producerAccessed(node);
-
-    if (node.value === ERRORED) {
-      throw node.error;
-    }
-
-    return node.value;
-  };
-
-  const getter = linkedSignalGetter as LinkedSignalGetter<S, D> & WritableSignal<D>;
-  getter[SIGNAL] = node;
-
-  if (ngDevMode) {
-    getter.toString = () => `[LinkedSignal: ${getter()}]`;
-  }
-
-  getter.set = (newValue: D) => {
-    producerUpdateValueVersion(node);
-    signalSetFn(node, newValue);
-    producerMarkClean(node);
-  };
-
-  getter.update = (updateFn: (value: D) => D) => {
-    producerUpdateValueVersion(node);
-    signalUpdateFn(node, updateFn);
-    producerMarkClean(node);
-  };
-
-  getter.asReadonly = signalAsReadonlyFn.bind(getter as any) as () => Signal<D>;
-
-  return getter;
-}
 
 /**
  * Creates a writable signals whose value is initialized and reset by the linked, reactive computation.
@@ -140,95 +57,34 @@ export function linkedSignal<S, D>(
 ): WritableSignal<D> {
   performanceMarkFeature('NgSignals');
 
-  const isShorthand = typeof optionsOrComputation === 'function';
-  const node: LinkedSignalNode<unknown, unknown> = Object.create(LINKED_SIGNAL_NODE);
-  node.source = isShorthand ? optionsOrComputation : optionsOrComputation.source;
-  if (!isShorthand) {
-    node.computation = optionsOrComputation.computation as ComputationFn<unknown, unknown>;
+  if (typeof optionsOrComputation === 'function') {
+    const getter = createLinkedSignal<D, D>(
+      optionsOrComputation,
+      identityFn<D>,
+      options?.equal,
+    ) as LinkedSignalGetter<D, D> & WritableSignal<D>;
+    return upgradeLinkedSignalGetter(getter);
+  } else {
+    const getter = createLinkedSignal<S, D>(
+      optionsOrComputation.source,
+      optionsOrComputation.computation,
+      optionsOrComputation.equal,
+    );
+    return upgradeLinkedSignalGetter(getter);
   }
-  const equal = isShorthand ? options?.equal : optionsOrComputation.equal;
-  if (equal) {
-    node.equal = equal as ValueEqualityFn<unknown>;
-  }
-  return createLinkedSignal(node as LinkedSignalNode<S, D>);
 }
 
-/**
- * A dedicated symbol used before a state value has been set / calculated for the first time.
- * Explicitly typed as `any` so we can use it as signal's value.
- */
-const UNSET: any = /* @__PURE__ */ Symbol('UNSET');
+function upgradeLinkedSignalGetter<S, D>(getter: LinkedSignalGetter<S, D>): WritableSignal<D> {
+  if (ngDevMode) {
+    getter.toString = () => `[LinkedSignal: ${getter()}]`;
+  }
 
-/**
- * A dedicated symbol used in place of a linked signal value to indicate that a given computation
- * is in progress. Used to detect cycles in computation chains.
- * Explicitly typed as `any` so we can use it as signal's value.
- */
-const COMPUTING: any = /* @__PURE__ */ Symbol('COMPUTING');
+  const node = getter[SIGNAL] as LinkedSignalNode<S, D>;
+  const upgradedGetter = getter as LinkedSignalGetter<S, D> & WritableSignal<D>;
 
-/**
- * A dedicated symbol used in place of a linked signal value to indicate that a given computation
- * failed. The thrown error is cached until the computation gets dirty again or the state is set.
- * Explicitly typed as `any` so we can use it as signal's value.
- */
-const ERRORED: any = /* @__PURE__ */ Symbol('ERRORED');
+  upgradedGetter.set = (newValue: D) => linkedSignalSetFn(node, newValue);
+  upgradedGetter.update = (updateFn: (value: D) => D) => linkedSignalUpdateFn(node, updateFn);
+  upgradedGetter.asReadonly = signalAsReadonlyFn.bind(getter as any) as () => Signal<D>;
 
-// Note: Using an IIFE here to ensure that the spread assignment is not considered
-// a side-effect, ending up preserving `LINKED_SIGNAL_NODE` and `REACTIVE_NODE`.
-// TODO: remove when https://github.com/evanw/esbuild/issues/3392 is resolved.
-const LINKED_SIGNAL_NODE = /* @__PURE__ */ (() => {
-  return {
-    ...REACTIVE_NODE,
-    value: UNSET,
-    dirty: true,
-    error: null,
-    equal: defaultEquals,
-    computation: identityFn,
-
-    producerMustRecompute(node: LinkedSignalNode<unknown, unknown>): boolean {
-      // Force a recomputation if there's no current value, or if the current value is in the
-      // process of being calculated (which should throw an error).
-      return node.value === UNSET || node.value === COMPUTING;
-    },
-
-    producerRecomputeValue(node: LinkedSignalNode<unknown, unknown>): void {
-      if (node.value === COMPUTING) {
-        // Our computation somehow led to a cyclic read of itself.
-        throw new Error('Detected cycle in computations.');
-      }
-
-      const oldValue = node.value;
-      node.value = COMPUTING;
-
-      const prevConsumer = consumerBeforeComputation(node);
-      let newValue: unknown;
-      try {
-        const newSourceValue = node.source();
-        const prev =
-          oldValue === UNSET || oldValue === ERRORED
-            ? undefined
-            : {
-                source: node.sourceValue,
-                value: oldValue,
-              };
-        newValue = node.computation(newSourceValue, prev);
-        node.sourceValue = newSourceValue;
-      } catch (err) {
-        newValue = ERRORED;
-        node.error = err;
-      } finally {
-        consumerAfterComputation(node, prevConsumer);
-      }
-
-      if (oldValue !== UNSET && newValue !== ERRORED && node.equal(oldValue, newValue)) {
-        // No change to `valueVersion` - old and new values are
-        // semantically equivalent.
-        node.value = oldValue;
-        return;
-      }
-
-      node.value = newValue;
-      node.version++;
-    },
-  };
-})();
+  return upgradedGetter;
+}

--- a/packages/core/test/signals/linked_signal_spec.ts
+++ b/packages/core/test/signals/linked_signal_spec.ts
@@ -147,6 +147,35 @@ describe('linkedSignal', () => {
     expect(choice()).toBe(0);
   });
 
+  it('should not recompute downstream dependencies when computed value is equal to the currently set value', () => {
+    const source = signal(0);
+    const isEven = linkedSignal(() => source() % 2 === 0);
+
+    let updateCounter = 0;
+    const updateTracker = computed(() => {
+      isEven();
+      return updateCounter++;
+    });
+
+    updateTracker();
+    expect(updateCounter).toEqual(1);
+    expect(isEven()).toBeTrue();
+
+    isEven.set(false);
+    updateTracker();
+    expect(updateCounter).toEqual(2);
+
+    // Setting the source signal such that the linked value is the same
+    source.set(1);
+    updateTracker();
+    // downstream dependency should _not_ be recomputed
+    expect(updateCounter).toEqual(2);
+
+    source.set(4);
+    updateTracker();
+    expect(updateCounter).toEqual(3);
+  });
+
   it('should support shorthand version', () => {
     const options = signal(['apple', 'banana', 'fig']);
     const choice = linkedSignal(() => options()[0]);


### PR DESCRIPTION
Use the linkedSignal implementation from the primitives package.

This PR builds on top of https://github.com/angular/angular/pull/59501 and will be ready to merge only when https://github.com/angular/angular/pull/59501 lands.

