### PR TITLE
feat(core): pass signal node to throwInvalidWriteToSignalErrorFn

### DIFF
--- a/goldens/public-api/core/primitives/signals/index.api.md
+++ b/goldens/public-api/core/primitives/signals/index.api.md
@@ -113,7 +113,7 @@ export function setAlternateWeakRefImpl(impl: unknown): void;
 export function setPostSignalSetFn(fn: (() => void) | null): (() => void) | null;
 
 // @public (undocumented)
-export function setThrowInvalidWriteToSignalError(fn: () => never): void;
+export function setThrowInvalidWriteToSignalError(fn: <T>(node: SignalNode<T>) => never): void;
 
 // @public
 export const SIGNAL: unique symbol;

--- a/packages/core/primitives/signals/src/errors.ts
+++ b/packages/core/primitives/signals/src/errors.ts
@@ -6,16 +6,18 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import type {SignalNode} from './signal';
+
 function defaultThrowError(): never {
   throw new Error();
 }
 
-let throwInvalidWriteToSignalErrorFn = defaultThrowError;
+let throwInvalidWriteToSignalErrorFn: <T>(node: SignalNode<T>) => never = defaultThrowError;
 
-export function throwInvalidWriteToSignalError() {
-  throwInvalidWriteToSignalErrorFn();
+export function throwInvalidWriteToSignalError<T>(node: SignalNode<T>) {
+  throwInvalidWriteToSignalErrorFn(node);
 }
 
-export function setThrowInvalidWriteToSignalError(fn: () => never): void {
+export function setThrowInvalidWriteToSignalError(fn: <T>(node: SignalNode<T>) => never): void {
   throwInvalidWriteToSignalErrorFn = fn;
 }

--- a/packages/core/primitives/signals/src/signal.ts
+++ b/packages/core/primitives/signals/src/signal.ts
@@ -70,7 +70,7 @@ export function signalGetFn<T>(this: SignalNode<T>): T {
 
 export function signalSetFn<T>(node: SignalNode<T>, newValue: T) {
   if (!producerUpdatesAllowed()) {
-    throwInvalidWriteToSignalError();
+    throwInvalidWriteToSignalError(node);
   }
 
   if (!node.equal(node.value, newValue)) {
@@ -81,7 +81,7 @@ export function signalSetFn<T>(node: SignalNode<T>, newValue: T) {
 
 export function signalUpdateFn<T>(node: SignalNode<T>, updater: (value: T) => T): void {
   if (!producerUpdatesAllowed()) {
-    throwInvalidWriteToSignalError();
+    throwInvalidWriteToSignalError(node);
   }
 
   signalSetFn(node, updater(node.value));


### PR DESCRIPTION
Updates the signature of the `throwInvalidWriteToSignalError` to take the signal node in question and pass it along to the throwInvalidWriteToSignalErrorFn handler function. This allows the handler to e.g. include the signal name in error messaging.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
`throwInvalidWriteToSignalError` calls `throwInvalidWriteToSignalErrorFn` with no arguments.

Issue Number: N/A


## What is the new behavior?
`throwInvalidWriteToSignalError` calls `throwInvalidWriteToSignalErrorFn` with the signal node as an argument.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
