### PR TITLE
refactor(core): access `firstChild` through constant

### DIFF
--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -14,6 +14,7 @@ import {TElementNode, TNode, TNodeFlags, TNodeType} from '../render3/interfaces/
 import {isComponentHost, isLContainer} from '../render3/interfaces/type_checks';
 import {
   DECLARATION_COMPONENT_VIEW,
+  FIRST_CHILD_KEY,
   LView,
   PARENT,
   T_HOST,
@@ -495,9 +496,9 @@ function _queryNodeChildren(
       // If the element is the host of a component, then all nodes in its view have to be processed.
       // Note: the component's content (tNode.child) will be processed from the insertion points.
       const componentView = getComponentLViewByIndex(tNode.index, lView);
-      if (componentView && componentView[TVIEW].firstChild) {
+      if (componentView && componentView[TVIEW][FIRST_CHILD_KEY]) {
         _queryNodeChildren(
-          componentView[TVIEW].firstChild!,
+          componentView[TVIEW][FIRST_CHILD_KEY]!,
           componentView,
           predicate,
           matches,
@@ -591,7 +592,7 @@ function _queryNodeChildrenInContainer(
 ) {
   for (let i = CONTAINER_HEADER_OFFSET; i < lContainer.length; i++) {
     const childView = lContainer[i] as LView;
-    const firstChild = childView[TVIEW].firstChild;
+    const firstChild = childView[TVIEW][FIRST_CHILD_KEY];
     if (firstChild) {
       _queryNodeChildren(firstChild, childView, predicate, matches, elementsOnly, rootNativeNode);
     }

--- a/packages/core/src/hydration/annotate.ts
+++ b/packages/core/src/hydration/annotate.ts
@@ -33,6 +33,7 @@ import {
 } from '../render3/interfaces/type_checks';
 import {
   CONTEXT,
+  FIRST_CHILD_KEY,
   HEADER_OFFSET,
   HOST,
   INJECTOR,
@@ -378,7 +379,7 @@ function serializeLContainer(
         numRootNodes = 1;
       } else {
         template = getSsrId(childTView);
-        numRootNodes = calcNumRootNodes(childTView, childLView, childTView.firstChild);
+        numRootNodes = calcNumRootNodes(childTView, childLView, childTView[FIRST_CHILD_KEY]);
       }
 
       serializedView = {

--- a/packages/core/src/hydration/cleanup.ts
+++ b/packages/core/src/hydration/cleanup.ts
@@ -17,7 +17,15 @@ import {
 import {Renderer} from '../render3/interfaces/renderer';
 import {RNode} from '../render3/interfaces/renderer_dom';
 import {isLContainer, isLView} from '../render3/interfaces/type_checks';
-import {HEADER_OFFSET, HOST, LView, PARENT, RENDERER, TVIEW} from '../render3/interfaces/view';
+import {
+  FIRST_CHILD_KEY,
+  HEADER_OFFSET,
+  HOST,
+  LView,
+  PARENT,
+  RENDERER,
+  TVIEW,
+} from '../render3/interfaces/view';
 import {nativeRemoveNode} from '../render3/dom_node_manipulation';
 
 import {validateSiblingNodeExists} from './error_handling';
@@ -58,7 +66,7 @@ export function removeDehydratedViews(lContainer: LContainer) {
  */
 function removeDehydratedView(dehydratedView: DehydratedContainerView, renderer: Renderer) {
   let nodesRemoved = 0;
-  let currentRNode = dehydratedView.firstChild;
+  let currentRNode = dehydratedView[FIRST_CHILD_KEY];
   if (currentRNode) {
     const numNodes = dehydratedView.data[NUM_ROOT_NODES];
     while (nodesRemoved < numNodes) {

--- a/packages/core/src/hydration/node_lookup_utils.ts
+++ b/packages/core/src/hydration/node_lookup_utils.ts
@@ -10,6 +10,7 @@ import {TNode, TNodeType} from '../render3/interfaces/node';
 import {RElement, RNode} from '../render3/interfaces/renderer_dom';
 import {
   DECLARATION_COMPONENT_VIEW,
+  FIRST_CHILD_KEY,
   HEADER_OFFSET,
   HOST,
   LView,
@@ -129,10 +130,10 @@ export function locateNextRNode<T extends RNode>(
     if (nodes?.[noOffsetIndex]) {
       // We know the exact location of the node.
       native = locateRNodeByPath(nodes[noOffsetIndex], lView);
-    } else if (tView.firstChild === tNode) {
+    } else if (tView[FIRST_CHILD_KEY] === tNode) {
       // We create a first node in this view, so we use a reference
       // to the first child in this DOM segment.
-      native = hydrationInfo.firstChild;
+      native = hydrationInfo[FIRST_CHILD_KEY];
     } else {
       // Locate a node based on a previous sibling or a parent node.
       const previousTNodeParent = tNode.prev === null;
@@ -149,7 +150,7 @@ export function locateNextRNode<T extends RNode>(
       } else {
         let previousRElement = getNativeByTNode(previousTNode, lView);
         if (previousTNodeParent) {
-          native = (previousRElement as RElement).firstChild;
+          native = (previousRElement as RElement)[FIRST_CHILD_KEY];
         } else {
           // If the previous node is an element, but it also has container info,
           // this means that we are processing a node like `<div #vcrTarget>`, which is
@@ -221,7 +222,7 @@ function navigateToNode(from: Node, instructions: (number | NodeNavigationStep)[
       }
       switch (step) {
         case NODE_NAVIGATION_STEP_FIRST_CHILD:
-          node = node.firstChild!;
+          node = node[FIRST_CHILD_KEY]!;
           break;
         case NODE_NAVIGATION_STEP_NEXT_SIBLING:
           node = node.nextSibling!;
@@ -274,7 +275,7 @@ export function navigateBetween(start: Node, finish: Node): NodeNavigationStep[]
     const parent = finish.parentElement!;
 
     const parentPath = navigateBetween(start, parent);
-    const childPath = navigateBetween(parent.firstChild!, finish);
+    const childPath = navigateBetween(parent[FIRST_CHILD_KEY]!, finish);
     if (!parentPath || !childPath) return null;
 
     return [

--- a/packages/core/src/hydration/utils.ts
+++ b/packages/core/src/hydration/utils.ts
@@ -13,7 +13,7 @@ import {LContainer} from '../render3/interfaces/container';
 import {getDocument} from '../render3/interfaces/document';
 import {RElement, RNode} from '../render3/interfaces/renderer_dom';
 import {isRootView} from '../render3/interfaces/type_checks';
-import {HEADER_OFFSET, LView, TVIEW, TViewType} from '../render3/interfaces/view';
+import {FIRST_CHILD_KEY, HEADER_OFFSET, LView, TVIEW, TViewType} from '../render3/interfaces/view';
 import {makeStateKey, TransferState} from '../transfer_state';
 import {assertDefined, assertEqual} from '../util/assert';
 import type {HydrationContext} from './annotate';
@@ -155,7 +155,7 @@ export function retrieveHydrationInfoImpl(
   }
   const dehydratedView: DehydratedView = {
     data,
-    firstChild: rNode.firstChild ?? null,
+    firstChild: rNode[FIRST_CHILD_KEY] ?? null,
   };
 
   if (isRootView) {
@@ -166,7 +166,7 @@ export function retrieveHydrationInfoImpl(
     // i.e. `<app-root /><#VIEW1><#VIEW2>...<!--container-->`. In this case, the current
     // node becomes the first child of this root view and the next sibling is the first
     // element in the DOM segment.
-    dehydratedView.firstChild = rNode;
+    dehydratedView[FIRST_CHILD_KEY] = rNode;
 
     // We use `0` here, since this is the slot (right after the HEADER_OFFSET)
     // where a component LView or an LContainer is located in a root LView.

--- a/packages/core/src/hydration/views.ts
+++ b/packages/core/src/hydration/views.ts
@@ -8,6 +8,7 @@
 
 import {DEHYDRATED_VIEWS, LContainer} from '../render3/interfaces/container';
 import {RNode} from '../render3/interfaces/renderer_dom';
+import {FIRST_CHILD_KEY} from '../render3/interfaces/view';
 
 import {removeDehydratedViews} from './cleanup';
 import {
@@ -35,12 +36,12 @@ export function locateDehydratedViewsInContainer(
     for (let i = 0; i < (serializedView[MULTIPLIER] ?? 1); i++) {
       const view: DehydratedContainerView = {
         data: serializedView,
-        firstChild: null,
+        [FIRST_CHILD_KEY]: null,
       };
       if (serializedView[NUM_ROOT_NODES] > 0) {
         // Keep reference to the first node in this view,
         // so it can be accessed while invoking template instructions.
-        view.firstChild = currentRNode as HTMLElement;
+        view[FIRST_CHILD_KEY] = currentRNode as HTMLElement;
 
         // Move over to the next node after this view, which can
         // either be a first node of the next view or an anchor comment

--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -42,6 +42,7 @@ import {
 import {RComment, RNode} from '../render3/interfaces/renderer_dom';
 import {isLContainer} from '../render3/interfaces/type_checks';
 import {
+  FIRST_CHILD_KEY,
   HEADER_OFFSET,
   HYDRATION,
   LView,
@@ -546,7 +547,7 @@ const R3ViewContainerRef = class ViewContainerRef extends VE_ViewContainerRef {
 
     const componentDef = getComponentDef(componentFactory.componentType ?? {});
     const dehydratedView = findMatchingDehydratedView(this._lContainer, componentDef?.id ?? null);
-    const rNode = dehydratedView?.firstChild ?? null;
+    const rNode = dehydratedView?.[FIRST_CHILD_KEY] ?? null;
     const componentRef = componentFactory.create(
       contextInjector,
       projectableNodes,

--- a/packages/core/src/render3/collect_native_nodes.ts
+++ b/packages/core/src/render3/collect_native_nodes.ts
@@ -12,7 +12,14 @@ import {CONTAINER_HEADER_OFFSET, LContainer, NATIVE} from './interfaces/containe
 import {TIcuContainerNode, TNode, TNodeType} from './interfaces/node';
 import {RNode} from './interfaces/renderer_dom';
 import {isLContainer} from './interfaces/type_checks';
-import {DECLARATION_COMPONENT_VIEW, HOST, LView, TVIEW, TView} from './interfaces/view';
+import {
+  DECLARATION_COMPONENT_VIEW,
+  FIRST_CHILD_KEY,
+  HOST,
+  LView,
+  TVIEW,
+  TView,
+} from './interfaces/view';
 import {assertTNodeType} from './node_assert';
 import {getProjectionNodes} from './node_manipulation';
 import {getLViewParent, unwrapRNode} from './util/view_utils';
@@ -80,7 +87,7 @@ export function collectNativeNodes(
 export function collectNativeNodesInLContainer(lContainer: LContainer, result: any[]) {
   for (let i = CONTAINER_HEADER_OFFSET; i < lContainer.length; i++) {
     const lViewInAContainer = lContainer[i];
-    const lViewFirstChildTNode = lViewInAContainer[TVIEW].firstChild;
+    const lViewFirstChildTNode = lViewInAContainer[TVIEW][FIRST_CHILD_KEY];
     if (lViewFirstChildTNode !== null) {
       collectNativeNodes(lViewInAContainer[TVIEW], lViewInAContainer, lViewFirstChildTNode, result);
     }

--- a/packages/core/src/render3/context_discovery.ts
+++ b/packages/core/src/render3/context_discovery.ts
@@ -16,7 +16,7 @@ import {getLViewById, registerLView} from './interfaces/lview_tracking';
 import {TNode} from './interfaces/node';
 import {RElement, RNode} from './interfaces/renderer_dom';
 import {isLView} from './interfaces/type_checks';
-import {CONTEXT, HEADER_OFFSET, HOST, ID, LView, TVIEW} from './interfaces/view';
+import {CONTEXT, FIRST_CHILD_KEY, HEADER_OFFSET, HOST, ID, LView, TVIEW} from './interfaces/view';
 import {getComponentLViewByIndex, unwrapRNode} from './util/view_utils';
 
 /**
@@ -294,7 +294,7 @@ function findViaDirective(lView: LView, directiveInstance: {}): number {
   // element bound to the directive being search lives somewhere
   // in the view data. We loop through the nodes and check their
   // list of directives for the instance.
-  let tNode = lView[TVIEW].firstChild;
+  let tNode = lView[TVIEW][FIRST_CHILD_KEY];
   while (tNode) {
     const directiveIndexStart = tNode.directiveStart;
     const directiveIndexEnd = tNode.directiveEnd;

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -95,6 +95,7 @@ import {
   DECLARATION_VIEW,
   EMBEDDED_VIEW_INJECTOR,
   ENVIRONMENT,
+  FIRST_CHILD_KEY,
   FLAGS,
   HEADER_OFFSET,
   HOST,
@@ -322,8 +323,8 @@ export function createTNodeAtIndex(
   // Assign a pointer to the first child node of a given view. The first node is not always the one
   // at index 0, in case of i18n, index 0 can be the instruction `i18nStart` and the first node has
   // the index 1 or more, so we can't just check node index.
-  if (tView.firstChild === null) {
-    tView.firstChild = tNode;
+  if (tView[FIRST_CHILD_KEY] === null) {
+    tView[FIRST_CHILD_KEY] = tNode;
   }
   if (currentTNode !== null) {
     if (isParent) {

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -84,6 +84,13 @@ export interface OpaqueViewState {
   '__brand__': 'Brand for OpaqueViewState that nothing will match';
 }
 
+// This is extracted because `.firstChild` is a frequently used property name.
+// Extracting it into a constant can reduce the overall bundle size. This is because
+// minifiers often shorten variable names to single letters, so every usage of `firstChild`
+// will be replaced with something like `f`, which reduces the number of bytes compared
+// to repeatedly using the string `.firstChild`.
+export const FIRST_CHILD_KEY = 'firstChild';
+
 /**
  * `LView` stores all of the information needed to process the instructions as
  * they are invoked from the template. Each embedded view and component view has its

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -60,6 +60,7 @@ import {
   DestroyHookData,
   EFFECTS,
   ENVIRONMENT,
+  FIRST_CHILD_KEY,
   FLAGS,
   HookData,
   HookFn,
@@ -848,7 +849,7 @@ export function getBeforeNodeForView(
   const nextViewIndex = CONTAINER_HEADER_OFFSET + viewIndexInContainer + 1;
   if (nextViewIndex < lContainer.length) {
     const lView = lContainer[nextViewIndex] as LView;
-    const firstTNodeOfView = lView[TVIEW].firstChild;
+    const firstTNodeOfView = lView[TVIEW][FIRST_CHILD_KEY];
     if (firstTNodeOfView !== null) {
       return getFirstNativeNode(lView, firstTNodeOfView);
     }
@@ -968,7 +969,7 @@ function applyView(
   parentRElement: RElement | null,
   beforeNode: RNode | null,
 ): void {
-  applyNodes(renderer, action, tView.firstChild, lView, parentRElement, beforeNode, false);
+  applyNodes(renderer, action, tView[FIRST_CHILD_KEY], lView, parentRElement, beforeNode, false);
 }
 
 /**

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -22,6 +22,7 @@ import {TNode, TNodeType} from './interfaces/node';
 import {
   CONTEXT,
   DECLARATION_VIEW,
+  FIRST_CHILD_KEY,
   HEADER_OFFSET,
   LView,
   OpaqueViewState,
@@ -648,8 +649,8 @@ export function enterView(newView: LView): void {
   }
   const tView = newView[TVIEW];
   instructionState.lFrame = newLFrame;
-  ngDevMode && tView.firstChild && assertTNodeForTView(tView.firstChild, tView);
-  newLFrame.currentTNode = tView.firstChild!;
+  ngDevMode && tView[FIRST_CHILD_KEY] && assertTNodeForTView(tView[FIRST_CHILD_KEY], tView);
+  newLFrame.currentTNode = tView[FIRST_CHILD_KEY]!;
   newLFrame.lView = newView;
   newLFrame.tView = tView;
   newLFrame.contextLView = newView;

--- a/packages/core/src/render3/util/defer.ts
+++ b/packages/core/src/render3/util/defer.ts
@@ -24,7 +24,7 @@ import {assertLView} from '../assert';
 import {collectNativeNodes} from '../collect_native_nodes';
 import {getLContext} from '../context_discovery';
 import {CONTAINER_HEADER_OFFSET} from '../interfaces/container';
-import {INJECTOR, LView, TVIEW} from '../interfaces/view';
+import {FIRST_CHILD_KEY, INJECTOR, LView, TVIEW} from '../interfaces/view';
 import {getNativeByTNode} from './view_utils';
 
 /** Retrieved information about a `@defer` block. */
@@ -112,7 +112,7 @@ function findDeferBlocks(node: Node, lView: LView, results: DeferBlockData[]) {
       collectNativeNodes(
         renderedLView[TVIEW],
         renderedLView,
-        renderedLView[TVIEW].firstChild,
+        renderedLView[TVIEW][FIRST_CHILD_KEY],
         rootNodes,
       );
     }

--- a/packages/core/src/render3/view_manipulation.ts
+++ b/packages/core/src/render3/view_manipulation.ts
@@ -21,6 +21,7 @@ import {TNode} from './interfaces/node';
 import {RComment, RElement} from './interfaces/renderer_dom';
 import {
   DECLARATION_LCONTAINER,
+  FIRST_CHILD_KEY,
   FLAGS,
   HYDRATION,
   LView,
@@ -115,7 +116,9 @@ export function shouldAddViewToDom(
   dehydratedView?: DehydratedContainerView | null,
 ): boolean {
   return (
-    !dehydratedView || dehydratedView.firstChild === null || hasInSkipHydrationBlockFlag(tNode)
+    !dehydratedView ||
+    dehydratedView[FIRST_CHILD_KEY] === null ||
+    hasInSkipHydrationBlockFlag(tNode)
   );
 }
 
@@ -144,8 +147,8 @@ export function addLViewToLContainer(
   // the dehydrated view. This indicates that the view was hydrated and
   // further attaching/detaching should work with this view as normal.
   const hydrationInfo = lView[HYDRATION];
-  if (hydrationInfo !== null && hydrationInfo.firstChild !== null) {
-    hydrationInfo.firstChild = null;
+  if (hydrationInfo !== null && hydrationInfo[FIRST_CHILD_KEY] !== null) {
+    hydrationInfo[FIRST_CHILD_KEY] = null;
   }
 }
 

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -22,6 +22,7 @@ import {isDestroyed, isLContainer, isRootView} from './interfaces/type_checks';
 import {
   CONTEXT,
   DECLARATION_LCONTAINER,
+  FIRST_CHILD_KEY,
   FLAGS,
   LView,
   LViewFlags,
@@ -55,7 +56,7 @@ export class ViewRef<T> implements EmbeddedViewRef<T>, ChangeDetectorRefInterfac
   get rootNodes(): any[] {
     const lView = this._lView;
     const tView = lView[TVIEW];
-    return collectNativeNodes(tView, lView, tView.firstChild, []);
+    return collectNativeNodes(tView, lView, tView[FIRST_CHILD_KEY], []);
   }
 
   constructor(

--- a/packages/core/src/sanitization/html_sanitizer.ts
+++ b/packages/core/src/sanitization/html_sanitizer.ts
@@ -7,6 +7,7 @@
  */
 
 import {XSS_SECURITY_URL} from '../error_details_base_url';
+import {FIRST_CHILD_KEY} from '../render3/interfaces/view';
 import {TrustedHTML} from '../util/security/trusted_type_defs';
 import {trustedHTMLFromString} from '../util/security/trusted_types';
 
@@ -126,7 +127,7 @@ class SanitizingHtmlSerializer {
     // This cannot use a TreeWalker, as it has to run on Angular's various DOM adapters.
     // However this code never accesses properties off of `document` before deleting its contents
     // again, so it shouldn't be vulnerable to DOM clobbering.
-    let current: Node = el.firstChild!;
+    let current: Node = el[FIRST_CHILD_KEY]!;
     let traverseContent = true;
     let parentNodes = [];
     while (current) {
@@ -138,7 +139,7 @@ class SanitizingHtmlSerializer {
         // Strip non-element, non-text nodes.
         this.sanitizedSomething = true;
       }
-      if (traverseContent && current.firstChild) {
+      if (traverseContent && current[FIRST_CHILD_KEY]) {
         // Push current node to the parent stack before entering its content.
         parentNodes.push(current);
         current = getFirstChild(current)!;
@@ -245,7 +246,7 @@ function getNextSibling(node: Node): Node | null {
  * clobbering of the `firstChild` property happening.
  */
 function getFirstChild(node: Node): Node | null {
-  const firstChild = node.firstChild;
+  const firstChild = node[FIRST_CHILD_KEY];
   if (firstChild && isClobberedElement(node, firstChild)) {
     throw clobberedElementError(firstChild);
   }
@@ -334,8 +335,8 @@ export function _sanitizeHtml(defaultDoc: any, unsafeHtmlInput: string): Trusted
     // In case anything goes wrong, clear out inertElement to reset the entire DOM structure.
     if (inertBodyElement) {
       const parent = getTemplateContent(inertBodyElement) || inertBodyElement;
-      while (parent.firstChild) {
-        parent.firstChild.remove();
+      while (parent[FIRST_CHILD_KEY]) {
+        parent[FIRST_CHILD_KEY].remove();
       }
     }
   }

--- a/packages/core/src/sanitization/inert_body.ts
+++ b/packages/core/src/sanitization/inert_body.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {FIRST_CHILD_KEY} from '../render3/interfaces/view';
 import {trustedHTMLFromString} from '../util/security/trusted_types';
 
 /**
@@ -51,7 +52,7 @@ class DOMParserHelper implements InertBodyHelper {
         // the `inertDocumentHelper` instead.
         return this.inertDocumentHelper.getInertBodyElement(html);
       }
-      body.firstChild?.remove();
+      body[FIRST_CHILD_KEY]?.remove();
       return body;
     } catch {
       return null;

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -72,6 +72,7 @@
   "EventEmitter",
   "EventManager",
   "EventManagerPlugin",
+  "FIRST_CHILD_KEY",
   "GenericBrowserDomAdapter",
   "HYDRATE_TRIGGER_CLEANUP_FNS",
   "INJECTOR",

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -53,6 +53,7 @@
   "EventEmitter",
   "EventManager",
   "EventManagerPlugin",
+  "FIRST_CHILD_KEY",
   "GenericBrowserDomAdapter",
   "HEADERS",
   "HTTP_ROOT_INTERCEPTOR_FNS",

--- a/packages/core/test/render3/view_fixture.ts
+++ b/packages/core/test/render3/view_fixture.ts
@@ -24,6 +24,7 @@ import {
 } from '../../src/render3/interfaces/definition';
 import {TConstants, TElementNode, TNodeType} from '../../src/render3/interfaces/node';
 import {
+  FIRST_CHILD_KEY,
   HEADER_OFFSET,
   LView,
   LViewFlags,
@@ -178,7 +179,7 @@ export class ViewFixture {
   }
 
   get html(): string {
-    return toHtml(this.host.firstChild as Element);
+    return toHtml(this.host[FIRST_CHILD_KEY] as Element);
   }
 
   /**


### PR DESCRIPTION
`.firstChild` is a frequently used property name throughout the code. We can reduce the overall bundle size by extracting its name into a variable. The minifier will shorten the variable name to a single letter, so every usage of `firstChild` will be replaced with something like `[f]`, which reduces the number of bytes compared to repeatedly using the string `.firstChild`.