### PR TITLE
refactor(core): prevent duplicating `componentOffset` checks

### DIFF
--- a/packages/core/src/render3/context_discovery.ts
+++ b/packages/core/src/render3/context_discovery.ts
@@ -15,7 +15,7 @@ import {LContext} from './interfaces/context';
 import {getLViewById, registerLView} from './interfaces/lview_tracking';
 import {TNode} from './interfaces/node';
 import {RElement, RNode} from './interfaces/renderer_dom';
-import {isLView} from './interfaces/type_checks';
+import {isComponentHost, isLView} from './interfaces/type_checks';
 import {CONTEXT, HEADER_OFFSET, HOST, ID, LView, TVIEW} from './interfaces/view';
 import {getComponentLViewByIndex, unwrapRNode} from './util/view_utils';
 
@@ -331,8 +331,7 @@ export function getDirectivesAtNodeIndex(nodeIndex: number, lView: LView): any[]
 
 export function getComponentAtNodeIndex(nodeIndex: number, lView: LView): {} | null {
   const tNode = lView[TVIEW].data[nodeIndex] as TNode;
-  const {directiveStart, componentOffset} = tNode;
-  return componentOffset > -1 ? lView[directiveStart + componentOffset] : null;
+  return isComponentHost(tNode) ? lView[tNode.directiveStart + tNode.componentOffset] : null;
 }
 
 /**

--- a/packages/core/src/render3/instructions/listener.ts
+++ b/packages/core/src/render3/instructions/listener.ts
@@ -13,7 +13,7 @@ import {assertIndexInRange} from '../../util/assert';
 import {NodeOutputBindings, TNode, TNodeType} from '../interfaces/node';
 import {GlobalTargetResolver, Renderer} from '../interfaces/renderer';
 import {RElement} from '../interfaces/renderer_dom';
-import {isDirectiveHost} from '../interfaces/type_checks';
+import {isComponentHost, isDirectiveHost} from '../interfaces/type_checks';
 import {CLEANUP, CONTEXT, LView, RENDERER, TView} from '../interfaces/view';
 import {assertTNodeType} from '../node_assert';
 import {profiler} from '../profiler';
@@ -305,8 +305,7 @@ function wrapListener(
 
     // In order to be backwards compatible with View Engine, events on component host nodes
     // must also mark the component view itself dirty (i.e. the view that it owns).
-    const startView =
-      tNode.componentOffset > -1 ? getComponentLViewByIndex(tNode.index, lView) : lView;
+    const startView = isComponentHost(tNode) ? getComponentLViewByIndex(tNode.index, lView) : lView;
     markViewDirty(startView, NotificationSource.Listener);
 
     let result = executeListenerWithErrorHandling(lView, context, listenerFn, e);

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -51,7 +51,7 @@ import {
 } from './interfaces/node';
 import {Renderer} from './interfaces/renderer';
 import {RElement, RNode} from './interfaces/renderer_dom';
-import {isDestroyed, isLContainer, isLView} from './interfaces/type_checks';
+import {isComponentHost, isDestroyed, isLContainer, isLView} from './interfaces/type_checks';
 import {
   CHILD_HEAD,
   CLEANUP,
@@ -632,11 +632,10 @@ export function getClosestRElement(
     return lView[HOST];
   } else {
     ngDevMode && assertTNodeType(parentTNode, TNodeType.AnyRNode | TNodeType.Container);
-    const {componentOffset} = parentTNode;
-    if (componentOffset > -1) {
+    if (isComponentHost(parentTNode)) {
       ngDevMode && assertTNodeForLView(parentTNode, lView);
       const {encapsulation} = tView.data[
-        parentTNode.directiveStart + componentOffset
+        parentTNode.directiveStart + parentTNode.componentOffset
       ] as ComponentDef<unknown>;
       // We've got a parent which is an element in the current view. We just need to verify if the
       // parent element is not a component. Component's content nodes are not inserted immediately


### PR DESCRIPTION
The `type_checks` module already exposes a utility function that checks whether `TNode.componentOffset` is greater than -1. There is no need to check that property manually in other places, as we can reuse the helper function.