### PR TITLE
refactor(core): prevent duplicating `isRootView` checks

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -47,7 +47,7 @@ import {
   TNodeProviderIndexes,
   TNodeType,
 } from './interfaces/node';
-import {isComponentDef, isComponentHost} from './interfaces/type_checks';
+import {isComponentDef, isComponentHost, isRootView} from './interfaces/type_checks';
 import {
   DECLARATION_COMPONENT_VIEW,
   DECLARATION_VIEW,
@@ -958,7 +958,7 @@ function lookupTokenUsingEmbeddedInjector<T>(
     currentTNode !== null &&
     currentLView !== null &&
     currentLView[FLAGS] & LViewFlags.HasEmbeddedViewInjector &&
-    !(currentLView[FLAGS] & LViewFlags.IsRoot)
+    !isRootView(currentLView)
   ) {
     ngDevMode && assertTNodeForLView(currentTNode, currentLView);
 

--- a/packages/core/src/render3/hmr.ts
+++ b/packages/core/src/render3/hmr.ts
@@ -22,18 +22,16 @@ import {CONTAINER_HEADER_OFFSET} from './interfaces/container';
 import {ComponentDef} from './interfaces/definition';
 import {getTrackedLViews} from './interfaces/lview_tracking';
 import {isTNodeShape, TElementNode, TNodeFlags, TNodeType} from './interfaces/node';
-import {isLContainer, isLView} from './interfaces/type_checks';
+import {isLContainer, isLView, isRootView} from './interfaces/type_checks';
 import {
   CHILD_HEAD,
   CHILD_TAIL,
   CONTEXT,
   ENVIRONMENT,
-  FLAGS,
   HEADER_OFFSET,
   HOST,
   INJECTOR,
   LView,
-  LViewFlags,
   NEXT,
   PARENT,
   RENDERER,
@@ -85,7 +83,7 @@ export function ɵɵreplaceMetadata(
     for (const root of trackedViews) {
       // Note: we have the additional check, because `IsRoot` can also indicate
       // a component created through something like `createComponent`.
-      if (root[FLAGS] & LViewFlags.IsRoot && root[PARENT] === null) {
+      if (isRootView(root) && root[PARENT] === null) {
         recreateMatchingLViews(newDef, oldDef, root);
       }
     }

--- a/packages/core/src/render3/interfaces/type_checks.ts
+++ b/packages/core/src/render3/interfaces/type_checks.ts
@@ -45,6 +45,7 @@ export function isComponentDef<T>(def: DirectiveDef<T>): def is ComponentDef<T> 
 }
 
 export function isRootView(target: LView): boolean {
+  // Determines whether a given LView is marked as a root view.
   return (target[FLAGS] & LViewFlags.IsRoot) !== 0;
 }
 

--- a/packages/core/src/render3/util/discovery_utils.ts
+++ b/packages/core/src/render3/util/discovery_utils.ts
@@ -21,7 +21,8 @@ import {getComponentDef, getDirectiveDef} from '../def_getters';
 import {NodeInjector} from '../di';
 import {DirectiveDef} from '../interfaces/definition';
 import {TElementNode, TNode, TNodeProviderIndexes} from '../interfaces/node';
-import {CLEANUP, CONTEXT, FLAGS, LView, LViewFlags, TVIEW, TViewType} from '../interfaces/view';
+import {isRootView} from '../interfaces/type_checks';
+import {CLEANUP, CONTEXT, LView, TVIEW, TViewType} from '../interfaces/view';
 
 import {getRootContext} from './view_traversal_utils';
 import {getLViewParent, unwrapRNode} from './view_utils';
@@ -109,7 +110,7 @@ export function getOwningComponent<T>(elementOrDir: Element | {}): T | null {
   while (lView[TVIEW].type === TViewType.Embedded && (parent = getLViewParent(lView)!)) {
     lView = parent;
   }
-  return lView[FLAGS] & LViewFlags.IsRoot ? null : (lView[CONTEXT] as unknown as T);
+  return isRootView(lView) ? null : (lView[CONTEXT] as unknown as T);
 }
 
 /**

--- a/packages/core/src/render3/util/view_traversal_utils.ts
+++ b/packages/core/src/render3/util/view_traversal_utils.ts
@@ -10,8 +10,8 @@ import {assertDefined} from '../../util/assert';
 import {assertLView} from '../assert';
 import {readPatchedLView} from '../context_discovery';
 import {LContainer} from '../interfaces/container';
-import {isLContainer, isLView} from '../interfaces/type_checks';
-import {CHILD_HEAD, CONTEXT, FLAGS, LView, LViewFlags, NEXT, PARENT} from '../interfaces/view';
+import {isLContainer, isLView, isRootView} from '../interfaces/type_checks';
+import {CHILD_HEAD, CONTEXT, LView, NEXT} from '../interfaces/view';
 
 import {getLViewParent} from './view_utils';
 
@@ -24,7 +24,7 @@ import {getLViewParent} from './view_utils';
 export function getRootView<T>(componentOrLView: LView | {}): LView<T> {
   ngDevMode && assertDefined(componentOrLView, 'component');
   let lView = isLView(componentOrLView) ? componentOrLView : readPatchedLView(componentOrLView)!;
-  while (lView && !(lView[FLAGS] & LViewFlags.IsRoot)) {
+  while (lView && !isRootView(lView)) {
     lView = getLViewParent(lView)!;
   }
   ngDevMode && assertLView(lView);


### PR DESCRIPTION
The `type_checks` module already exposes a utility function that checks whether `LView` is marked as a root view. There is no need to check flags in other places, as we can reuse the helper function.