### PR TITLE
docs(docs-infra): add comparing section of for control-flow

### DIFF
--- a/adev/src/content/guide/templates/control-flow.md
+++ b/adev/src/content/guide/templates/control-flow.md
@@ -64,6 +64,32 @@ For static collections that never change, you can use `$index` to tell Angular t
 
 If no other option is available, you can specify `identity`. This tells Angular to track the item by its reference identity using the triple-equals operator (`===`). Avoid this option whenever possible as it can lead to significantly slower rendering updates, as Angular has no way to map which data item corresponds to which DOM nodes.
 
+### Comparing built-in control flow to `NgFor`
+The `@for` block replaces `*ngFor` for iteration, and has several differences compared to its
+structural directive `NgFor` predecessor:
+
+* The `@for` block requires a tracking expression to uniquely identify items in the collection.
+  While `NgFor` requires a `trackBy` _method_, however, the `@for` block simplifies tracking by
+  accepting a `track` _expression_.
+* You can specify content to show when the collection is empty with the `@empty` block.
+* The `@for` block uses an optimized algorithm for determining a minimal number of DOM operations
+  necessary after a collection is modified. While `NgFor` allowed developers to provide a custom
+  `IterableDiffer` implementation, the `@for` block does not support custom differs.
+
+The `track` setting replaces `NgFor`'s concept of a `trackBy` function. Because `@for` is built-in,
+we can provide a better experience than passing a `trackBy` function, and directly use an expression
+representing the key instead. Migrating from `trackBy` to `track` is possible by invoking
+the `trackBy` function:
+
+```html
+@for (item of items; track itemId($index, item)) {
+  {{ item.name }}
+}
+```
+
+With `NgFor`, loops over immutable data without `trackBy` are the most common cause of performance
+bugs across Angular applications.
+
 ### Contextual variables in `@for` blocks
 
 Inside `@for` blocks, several implicit variables are always available:

--- a/adev/src/content/guide/templates/control-flow.md
+++ b/adev/src/content/guide/templates/control-flow.md
@@ -65,19 +65,15 @@ For static collections that never change, you can use `$index` to tell Angular t
 If no other option is available, you can specify `identity`. This tells Angular to track the item by its reference identity using the triple-equals operator (`===`). Avoid this option whenever possible as it can lead to significantly slower rendering updates, as Angular has no way to map which data item corresponds to which DOM nodes.
 
 ### Comparing built-in control flow to `NgFor`
-The `@for` block replaces `*ngFor` for iteration, and has several differences compared to its
-structural directive `NgFor` predecessor:
+The `@for` block replaces `NgFor` structural directive for iteration. It has several differences compared to its predecessor:
 
-* The `@for` block requires a tracking expression to uniquely identify items in the collection and simplifies tracking by accepting a `track` _expression_. While `NgFor` uses a `trackBy` _method_, if not provided `NgFor` defaults to tracking items by identity.
-* You can specify content to show when the collection is empty with the `@empty` block.
-* The `@for` block uses an optimized algorithm for determining a minimal number of DOM operations
+* The `@for` block requires a tracking expression to uniquely identify items in the collection and simplifies tracking by accepting a `track` _expression_. `NgFor` uses an optional `trackBy` _method_, that defaultd to tracking items by identity if none is provided.
+* You can specify the content to show when the collection is empty with an `@empty` block.
+* The `@for` block utilizes an optimized reconciliation algorithm to minimize the number of DOM operations.
   necessary after a collection is modified. While `NgFor` allowed developers to provide a custom
   `IterableDiffer` implementation, the `@for` block does not support custom differs.
 
-The `track` setting replaces `NgFor`'s concept of a `trackBy` function. Because `@for` is built-in,
-we can provide a better experience than passing a `trackBy` function, and directly use an expression
-representing the key instead. Migrating from `trackBy` to `track` is possible by invoking
-the `trackBy` function:
+The `track` setting serves as a replacement for NgFor's `trackBy` function. Since `@for` is a built-in feature, it allows for an improved experience by using an expression to represent the key directly, instead of passing a `trackBy` function. Transitioning from trackBy to track can be done by invoking the trackBy function:
 
 ```html
 @for (item of items; track itemId($index, item)) {

--- a/adev/src/content/guide/templates/control-flow.md
+++ b/adev/src/content/guide/templates/control-flow.md
@@ -68,9 +68,7 @@ If no other option is available, you can specify `identity`. This tells Angular 
 The `@for` block replaces `*ngFor` for iteration, and has several differences compared to its
 structural directive `NgFor` predecessor:
 
-* The `@for` block requires a tracking expression to uniquely identify items in the collection.
-  While `NgFor` requires a `trackBy` _method_, however, the `@for` block simplifies tracking by
-  accepting a `track` _expression_.
+* The `@for` block requires a tracking expression to uniquely identify items in the collection and simplifies tracking by accepting a `track` _expression_. While `NgFor` uses a `trackBy` _method_, if not provided `NgFor` defaults to tracking items by identity.
 * You can specify content to show when the collection is empty with the `@empty` block.
 * The `@for` block uses an optimized algorithm for determining a minimal number of DOM operations
   necessary after a collection is modified. While `NgFor` allowed developers to provide a custom
@@ -86,9 +84,6 @@ the `trackBy` function:
   {{ item.name }}
 }
 ```
-
-With `NgFor`, loops over immutable data without `trackBy` are the most common cause of performance
-bugs across Angular applications.
 
 ### Contextual variables in `@for` blocks
 

--- a/tools/manual_api_docs/blocks/for.md
+++ b/tools/manual_api_docs/blocks/for.md
@@ -35,7 +35,7 @@ For collections that remain static , `track $index` provides a straightforward t
 collections experiencing additions, deletions, or reordering, opt for a
 unique property of each item as the tracking key.
 
-Tip: Angular's uses the `track` keyword, like expression instead `trackBy` function. See [_Comparing built-in control flow to `NgFor`_](guide/templates/control-flow#comparing-built-in-control-flow-to-ngfor) for more info.
+HELPFUL: `@for` uses the `track` expression. However, `NgFor` instead uses `trackBy` function. See [_Comparing built-in control flow to `NgFor`_](guide/templates/control-flow#comparing-built-in-control-flow-to-ngfor) for more info.
 
 ### `$index` and other contextual variables
 

--- a/tools/manual_api_docs/blocks/for.md
+++ b/tools/manual_api_docs/blocks/for.md
@@ -35,6 +35,8 @@ For collections that remain static , `track $index` provides a straightforward t
 collections experiencing additions, deletions, or reordering, opt for a
 unique property of each item as the tracking key.
 
+Tip: Angular's uses the `track` keyword, like expression instead `trackBy` function. See [_Comparing built-in control flow to `NgFor`_](guide/templates/control-flow#comparing-built-in-control-flow-to-ngfor) for more info.
+
 ### `$index` and other contextual variables
 
 Inside `@for` contents, several implicit variables are always available:


### PR DESCRIPTION
Added the ` Comparing built-in control flow to NgFor ` section, and implement the tip section to know more about this in core

Fixes Provide example with track function in `@for` docs #59356

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?


Issue Number: #59356


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
