### PR TITLE
fix(core): prevent stash listener conflicts

### DIFF
--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -611,6 +611,7 @@
   "signal",
   "signalAsReadonlyFn",
   "signalSetFn",
+  "stashEventListeners",
   "storeLViewOnDestroy",
   "storeListenerCleanup",
   "stringify",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -606,6 +606,7 @@
   "signal",
   "signalAsReadonlyFn",
   "signalSetFn",
+  "stashEventListeners",
   "storeLViewOnDestroy",
   "storeListenerCleanup",
   "stringify",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -692,6 +692,7 @@
   "split",
   "squashSegmentGroup",
   "standardizeConfig",
+  "stashEventListeners",
   "storeLViewOnDestroy",
   "storeListenerCleanup",
   "stringify",


### PR DESCRIPTION
The stash event listener is a global function that might be unsafely overridden if multiple microfrontend applications exist on the page.

In this commit, we create a map of `APP_ID` to stash event listener functions. This map prevents conflicts because multiple applications might be bootstrapped simultaneously on the client (one rendered on the server and one rendering only on the client).

I.e., the code that might be used is:

```ts
// Given that `app-root` is rendered on the server
bootstrapApplication(AppComponent, appConfig);

bootstrapApplication(BlogRootComponent, appBlogConfig);
```

Two bootstrapped applications would conflict and override each other's code.