### PR TITLE
fix(compiler-cli): handle conditional expressions when extracting dependencies

### DIFF
--- a/packages/compiler-cli/src/ngtsc/hmr/src/extract_dependencies.ts
+++ b/packages/compiler-cli/src/ngtsc/hmr/src/extract_dependencies.ts
@@ -245,7 +245,8 @@ class PotentialTopLevelReadsVisitor extends o.RecursiveAstVisitor {
       ts.isWhileStatement(parent) ||
       ts.isSwitchStatement(parent) ||
       ts.isCaseClause(parent) ||
-      ts.isThrowStatement(parent)
+      ts.isThrowStatement(parent) ||
+      ts.isNewExpression(parent)
     ) {
       return parent.expression === node;
     }

--- a/packages/compiler-cli/src/ngtsc/hmr/src/extract_dependencies.ts
+++ b/packages/compiler-cli/src/ngtsc/hmr/src/extract_dependencies.ts
@@ -310,6 +310,10 @@ class PotentialTopLevelReadsVisitor extends o.RecursiveAstVisitor {
       return (parent.propertyName || parent.name) === node;
     }
 
+    if (ts.isConditionalExpression(parent)) {
+      return parent.condition === node || parent.whenFalse === node || parent.whenTrue === node;
+    }
+
     // Otherwise it's not top-level.
     return false;
   }

--- a/packages/compiler-cli/test/ngtsc/hmr_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/hmr_spec.ts
@@ -549,6 +549,38 @@ runInEachFileSystem(() => {
       );
     });
 
+    it('should capture conditional expression dependencies', () => {
+      enableHmr();
+      env.write(
+        'test.ts',
+        `
+          import {Component, InjectionToken} from '@angular/core';
+
+          const providersA: any[] = [];
+          const providersB: any[] = [];
+          const condition = true;
+
+          @Component({
+            template: '',
+            providers: [condition ? providersA : providersB]
+          })
+          export class Cmp {}
+        `,
+      );
+
+      env.driveMain();
+
+      const jsContents = env.getContents('test.js');
+      const hmrContents = env.driveHmr('test.ts', 'Cmp');
+
+      expect(jsContents).toContain(
+        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [condition, providersA, providersB, Component]));',
+      );
+      expect(hmrContents).toContain(
+        'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, condition, providersA, providersB, Component) {',
+      );
+    });
+
     it('should capture parenthesized dependencies', () => {
       enableHmr();
       env.write(


### PR DESCRIPTION
Updates the HMR dependencies extraction logic to handle conditional expressions. For example, `providers: [condition ? providersA : providersB]`.

Closes #59634