### PR TITLE
HMR-related fixes

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -1229,6 +1229,11 @@ export class ComponentDecoratorHandler
         for (const dep of dependencies) {
           if (dep.ref.node !== node) {
             eagerlyUsed.add(dep.ref.node);
+          } else {
+            const used = bound.getEagerlyUsedDirectives();
+            if (used.some((current) => current.ref.node === node)) {
+              eagerlyUsed.add(node);
+            }
           }
         }
       } else {

--- a/packages/platform-browser/animations/async/src/async_animation_renderer.ts
+++ b/packages/platform-browser/animations/async/src/async_animation_renderer.ts
@@ -167,6 +167,16 @@ export class AsyncAnimationRendererFactory implements OnDestroy, RendererFactory
   whenRenderingDone?(): Promise<any> {
     return this.delegate.whenRenderingDone?.() ?? Promise.resolve();
   }
+
+  /**
+   * Used during HMR to clear any cached data about a component.
+   * @param componentId ID of the component that is being replaced.
+   */
+  protected componentReplaced(componentId: string) {
+    // Flush the engine since the renderer destruction waits for animations to be done.
+    this._engine?.flush();
+    (this.delegate as {componentReplaced?: (id: string) => void}).componentReplaced?.(componentId);
+  }
 }
 
 /**


### PR DESCRIPTION
Includes the following HMR-related fixes:

### fix(core): replace metadata in place during HMR 

Currently during HMR we swap out the entire module definition (e.g. `MyComp.ɵcmp = newDef`). In standalone components and most module-based ones this works fine, however in some cases (e.g. circular dependencies) the compiler can produce a `setComponentScope` call for a module-based component. This call doesn't make it into the HMR replacement function, because it is defined in the module's file, not the component's. As a result, the dependencies of these components are cleared out upon replacement.

A secondary problem is that the `directiveDefs` and `pipeDefs` fields can save references to definitions that later become stale as a result of HMR.

These changes resolve both issues by:
1. Performing the replacement by copying the properties from the new definition onto the old one, while keeping it in place.
2. Preserving the initial `directiveDefs`, `pipeDefs` and `setInput`.

### fix(core): capture self-referencing component during HMR 

Fixes that we were filtering out the component itself from the set of dependencies when HMR is enabled, breaking self-referencing components.

### fix(platform-browser): clear renderer cache during HMR when using async animations

Fixes that the async animations renderer didn't have the logic to clean up its style cache during HMR. This is identical to #59393.

### fix(compiler-cli): extract parenthesized dependencies during HMR 
Fixes that the HMR dependency extraction logic wasn't accounting for parenthesized identifiers correctly.

Fixes #59640.
Fixes #59632.
Fixes #59639.