### PR TITLE
refactor(compiler-cli): eliminate `new URL` from HMR initializer

### DIFF
--- a/packages/compiler-cli/test/ngtsc/hmr_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/hmr_spec.ts
@@ -106,7 +106,7 @@ runInEachFileSystem(() => {
       expect(jsContents).toContain(`import * as i0 from "@angular/core";`);
       expect(jsContents).toContain('function Cmp_HmrLoad(t) {');
       expect(jsContents).toContain(
-        'import(/* @vite-ignore */\nnew URL("./@ng/component?c=test.ts%40Cmp&t=" + encodeURIComponent(t), import.meta.url).href)',
+        'import(/* @vite-ignore */\n"./@ng/component?c=test.ts%40Cmp&t=" + encodeURIComponent(t))',
       );
       expect(jsContents).toContain(
         ').then(m => m.default && i0.ɵɵreplaceMetadata(Cmp, m.default, [i0], ' +
@@ -173,7 +173,7 @@ runInEachFileSystem(() => {
       expect(jsContents).toContain(`import * as i1 from "./dep";`);
       expect(jsContents).toContain('function Cmp_HmrLoad(t) {');
       expect(jsContents).toContain(
-        'import(/* @vite-ignore */\nnew URL("./@ng/component?c=test.ts%40Cmp&t=" + encodeURIComponent(t), import.meta.url).href)',
+        'import(/* @vite-ignore */\n"./@ng/component?c=test.ts%40Cmp&t=" + encodeURIComponent(t))',
       );
       expect(jsContents).toContain(
         ').then(m => m.default && i0.ɵɵreplaceMetadata(Cmp, m.default, [i0, i1], ' +

--- a/packages/compiler/src/render3/r3_hmr_compiler.ts
+++ b/packages/compiler/src/render3/r3_hmr_compiler.ts
@@ -80,14 +80,8 @@ export function compileHmrInitializer(meta: R3HmrMetadata): o.Expression {
     .literal(urlPartial)
     .plus(o.variable('encodeURIComponent').callFn([o.variable(timestampName)]));
 
-  // import.meta.url
-  const urlBase = o.variable('import').prop('meta').prop('url');
-
-  // new URL(urlValue, urlBase).href
-  const urlHref = new o.InstantiateExpr(o.variable('URL'), [urlValue, urlBase]).prop('href');
-
   // function Cmp_HmrLoad(t) {
-  //   import(/* @vite-ignore */ urlHref).then((m) => m.default && replaceMetadata(...));
+  //   import(/* @vite-ignore */ urlValue).then((m) => m.default && replaceMetadata(...));
   // }
   const importCallback = new o.DeclareFunctionStmt(
     importCallbackName,
@@ -96,7 +90,7 @@ export function compileHmrInitializer(meta: R3HmrMetadata): o.Expression {
       // The vite-ignore special comment is required to prevent Vite from generating a superfluous
       // warning for each usage within the development code. If Vite provides a method to
       // programmatically avoid this warning in the future, this added comment can be removed here.
-      new o.DynamicImportExpr(urlHref, null, '@vite-ignore')
+      new o.DynamicImportExpr(urlValue, null, '@vite-ignore')
         .prop('then')
         .callFn([replaceCallback])
         .toStmt(),


### PR DESCRIPTION
This commit removes the use of `new URL` from the HMR initializer, as it is no longer required now that the URL is relative (`./`).

Additionally, this change simplifies the integration within the Angular CLI.
