### PR TITLE
Default type `T` for InputFunction's `TransformT`

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -992,11 +992,11 @@ export interface InputFunction {
     <T>(): InputSignal<T | undefined>;
     <T>(initialValue: T, opts?: InputOptionsWithoutTransform<T>): InputSignal<T>;
     <T>(initialValue: undefined, opts: InputOptionsWithoutTransform<T>): InputSignal<T | undefined>;
-    <T, TransformT>(initialValue: T, opts: InputOptionsWithTransform<T, TransformT>): InputSignalWithTransform<T, TransformT>;
-    <T, TransformT>(initialValue: undefined, opts: InputOptionsWithTransform<T | undefined, TransformT>): InputSignalWithTransform<T | undefined, TransformT>;
+    <T, TransformT = T>(initialValue: T, opts: InputOptionsWithTransform<T, TransformT>): InputSignalWithTransform<T, TransformT>;
+    <T, TransformT = T>(initialValue: undefined, opts: InputOptionsWithTransform<T | undefined, TransformT>): InputSignalWithTransform<T | undefined, TransformT>;
     required: {
         <T>(opts?: InputOptionsWithoutTransform<T>): InputSignal<T>;
-        <T, TransformT>(opts: InputOptionsWithTransform<T, TransformT>): InputSignalWithTransform<T, TransformT>;
+        <T, TransformT = T>(opts: InputOptionsWithTransform<T, TransformT>): InputSignalWithTransform<T, TransformT>;
     };
 }
 

--- a/packages/core/src/authoring/input/input.ts
+++ b/packages/core/src/authoring/input/input.ts
@@ -60,7 +60,7 @@ export interface InputFunction {
    * The input accepts values of type `TransformT` and the given
    * transform function will transform the value to type `T`.
    */
-  <T, TransformT>(
+  <T, TransformT = T>(
     initialValue: T,
     opts: InputOptionsWithTransform<T, TransformT>,
   ): InputSignalWithTransform<T, TransformT>;
@@ -70,7 +70,7 @@ export interface InputFunction {
    *
    * The input accepts values of type `TransformT` and the given
    * transform function will transform the value to type `T|undefined`.
-   */ <T, TransformT>(
+   */ <T, TransformT = T>(
     initialValue: undefined,
     opts: InputOptionsWithTransform<T | undefined, TransformT>,
   ): InputSignalWithTransform<T | undefined, TransformT>;
@@ -92,7 +92,7 @@ export interface InputFunction {
      * The input accepts values of type `TransformT` and the given
      * transform function will transform the value to type `T`.
      */
-    <T, TransformT>(
+    <T, TransformT = T>(
       opts: InputOptionsWithTransform<T, TransformT>,
     ): InputSignalWithTransform<T, TransformT>;
   };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## Description
Curious why this isn't the default behavior so I'm quite sure there **is** a reason? Never the less, find it much more comfortable to not be forced to always write the type twice on using a converter:

`multiple= input<boolean | 'append', boolean | 'append'>(true, { transform: v => v === 'append' ? 'append' : coerceBooleanProperty(v) });`

-->

`multiple = input<boolean | 'append'>(true, { transform: v => v === 'append' ? 'append' : coerceBooleanProperty(v) });`


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No