### PR TITLE
test(zone.js): reduce flakiness of a timer-related test

### DIFF
--- a/packages/zone.js/test/jest/jest.spec.js
+++ b/packages/zone.js/test/jest/jest.spec.js
@@ -141,7 +141,7 @@ describe('jest modern fakeTimers with zone.js fakeAsync', () => {
     let d = fakeAsyncZoneSpec.getRealSystemTime();
     jest.setSystemTime(d);
     expect(Date.now()).toEqual(d);
-    for (let i = 0; i < 100000; i++) {}
+    for (let i = 0; i < 10_000_000; i++) {}
     expect(fakeAsyncZoneSpec.getRealSystemTime()).not.toEqual(d);
     d = fakeAsyncZoneSpec.getRealSystemTime();
     let timeoutTriggered = false;


### PR DESCRIPTION
This commit updates a flaky test to increase the amount of work (more `for` loop iterations) to minimize the chance of getting the same timestamp after that work.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No