### PR TITLE
docs: Add link to Language Service page from the Installation page

### DIFF
--- a/adev/src/content/introduction/installation.md
+++ b/adev/src/content/introduction/installation.md
@@ -22,6 +22,7 @@ If you're starting a new project, you'll most likely want to create a local proj
 - **Node.js** - v[^18.19.1 or newer](/reference/versions)
 - **Text editor** - We recommend [Visual Studio Code](https://code.visualstudio.com/)
 - **Terminal** - Required for running Angular CLI commands
+- **Development Tool** - To improve your development workflow, we recommend the [Angular Language Service](/tools/language-service)
 
 ### Instructions
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

[Installation Page](https://angular.dev/installation) did not have a direct link to the Language Service which is very useful for new Angular Developers when setting up their new project.

Issue Number: [59608](https://github.com/angular/angular/issues/59608)


## What is the new behavior?

Angular Language Service is now in the Prerequisites section for all Angular Developers to access, directly, without having to scroll all the way to the Developer Tools Section.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Change :

![image](https://github.com/user-attachments/assets/2986108e-f5a8-4b43-a07c-bbffc414478f)

