### PR TITLE
refactor(core): re-use `isDetachedByI18n`

### DIFF
--- a/packages/core/src/render3/instructions/projection.ts
+++ b/packages/core/src/render3/instructions/projection.ts
@@ -6,10 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import {findMatchingDehydratedView} from '../../hydration/views';
+import {isDetachedByI18n} from '../../i18n/utils';
 import {newArray} from '../../util/array_utils';
 import {assertLContainer, assertTNode} from '../assert';
 import {ComponentTemplate} from '../interfaces/definition';
-import {TAttributes, TElementNode, TNode, TNodeFlags, TNodeType} from '../interfaces/node';
+import {TAttributes, TElementNode, TNode, TNodeType} from '../interfaces/node';
 import {ProjectionSlots} from '../interfaces/projection';
 import {
   DECLARATION_COMPONENT_VIEW,
@@ -200,10 +201,7 @@ export function ɵɵprojection(
 
   if (isEmpty && fallbackIndex !== null) {
     insertFallbackContent(lView, tView, fallbackIndex);
-  } else if (
-    isNodeCreationMode &&
-    (tProjectionNode.flags & TNodeFlags.isDetached) !== TNodeFlags.isDetached
-  ) {
+  } else if (isNodeCreationMode && !isDetachedByI18n(tProjectionNode)) {
     // re-distribution of projectable nodes is stored on a component's view level
     applyProjection(tView, lView, tProjectionNode);
   }

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -92,6 +92,7 @@ import {
   nativeInsertBefore,
   nativeRemoveNode,
 } from './dom_node_manipulation';
+import {isDetachedByI18n} from '../i18n/utils';
 
 const enum WalkTNodeTreeAction {
   /** node create in the native environment. Run on initial creation. */
@@ -890,7 +891,7 @@ function applyNodes(
         tNode.flags |= TNodeFlags.isProjected;
       }
     }
-    if ((tNode.flags & TNodeFlags.isDetached) !== TNodeFlags.isDetached) {
+    if (!isDetachedByI18n(tNode)) {
       if (tNodeType & TNodeType.ElementContainer) {
         applyNodes(renderer, action, tNode.child, lView, parentRElement, beforeNode, false);
         applyToElementOrContainer(action, renderer, parentRElement, rawSlotValue, beforeNode);

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -366,6 +366,7 @@
   "isCssClassMatching",
   "isCurrentTNodeParent",
   "isDestroyed",
+  "isDetachedByI18n",
   "isElementNode",
   "isEnvironmentProviders",
   "isFunction",

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -389,6 +389,7 @@
   "isCssClassMatching",
   "isCurrentTNodeParent",
   "isDestroyed",
+  "isDetachedByI18n",
   "isElementNode",
   "isEnvironmentProviders",
   "isFunction",

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -311,6 +311,7 @@
   "isCssClassMatching",
   "isCurrentTNodeParent",
   "isDestroyed",
+  "isDetachedByI18n",
   "isEnvironmentProviders",
   "isFunction",
   "isInlineTemplate",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -764,6 +764,7 @@
   "isCssClassMatching",
   "isCurrentTNodeParent",
   "isDestroyed",
+  "isDetachedByI18n",
   "isDirectiveHost",
   "isEnvironmentProviders",
   "isFunction",

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -455,6 +455,7 @@
   "isCssClassMatching",
   "isCurrentTNodeParent",
   "isDestroyed",
+  "isDetachedByI18n",
   "isDirectiveHost",
   "isEmptyInputValue",
   "isEnvironmentProviders",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -441,6 +441,7 @@
   "isCssClassMatching",
   "isCurrentTNodeParent",
   "isDestroyed",
+  "isDetachedByI18n",
   "isDirectiveHost",
   "isEnvironmentProviders",
   "isFormControlState",

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -247,6 +247,7 @@
   "isComponentDef",
   "isComponentHost",
   "isDestroyed",
+  "isDetachedByI18n",
   "isEnvironmentProviders",
   "isFunction",
   "isInlineTemplate",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -531,6 +531,7 @@
   "isCssClassMatching",
   "isCurrentTNodeParent",
   "isDestroyed",
+  "isDetachedByI18n",
   "isDirectiveHost",
   "isEmptyError",
   "isEnvironmentProviders",

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -276,6 +276,7 @@
   "isComponentDef",
   "isComponentHost",
   "isDestroyed",
+  "isDetachedByI18n",
   "isEnvironmentProviders",
   "isFunction",
   "isInlineTemplate",

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -372,6 +372,7 @@
   "isCssClassMatching",
   "isCurrentTNodeParent",
   "isDestroyed",
+  "isDetachedByI18n",
   "isDirectiveHost",
   "isEnvironmentProviders",
   "isFunction",


### PR DESCRIPTION
We already have a function called `isDetachedByI18n` which checks whether a `tNode` is in `isDetached` state; as thus, there's no reason to apply those checks manually.