### PR TITLE
refactor(core): simplify attributes extraction logic for ComponentRef

### DIFF
--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -48,7 +48,6 @@ export {
   DirectiveType as ɵDirectiveType,
   getDirectives as ɵgetDirectives,
   getHostElement as ɵgetHostElement,
-  LifecycleHooksFeature as ɵLifecycleHooksFeature,
   NgModuleFactory as ɵNgModuleFactory,
   NgModuleRef as ɵRender3NgModuleRef,
   NgModuleType as ɵNgModuleType,

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -52,7 +52,6 @@ import {ComponentDef, DirectiveDef, HostDirectiveDefs} from './interfaces/defini
 import {InputFlags} from './interfaces/input_flags';
 import {
   NodeInputBindings,
-  TAttributes,
   TContainerNode,
   TElementContainerNode,
   TElementNode,
@@ -73,9 +72,7 @@ import {MATH_ML_NAMESPACE, SVG_NAMESPACE} from './namespaces';
 
 import {ChainedInjector} from './chained_injector';
 import {createElementNode, setupStaticAttributes} from './dom_node_manipulation';
-import {AttributeMarker} from './interfaces/attribute_marker';
 import {unregisterLView} from './interfaces/lview_tracking';
-import {CssSelector} from './interfaces/projection';
 import {
   extractAttrsAndClassesFromSelector,
   stringifyCSSSelectorList,
@@ -158,18 +155,6 @@ function getNamespace(elementName: string): string | null {
   return name === 'svg' ? SVG_NAMESPACE : name === 'math' ? MATH_ML_NAMESPACE : null;
 }
 
-// TODO(pk): change the extractAttrsAndClassesFromSelector so it returns TAttributes already?
-function getRootTAttributesFromSelector(selector: CssSelector) {
-  const {attrs, classes} = extractAttrsAndClassesFromSelector(selector);
-
-  const tAtts: TAttributes = attrs;
-  if (classes.length) {
-    tAtts.push(AttributeMarker.Classes, ...classes);
-  }
-
-  return tAtts;
-}
-
 /**
  * ComponentFactory interface implementation.
  */
@@ -215,9 +200,7 @@ export class ComponentFactory<T> extends AbstractComponentFactory<T> {
     super();
     this.componentType = componentDef.type;
     this.selector = stringifyCSSSelectorList(componentDef.selectors);
-    this.ngContentSelectors = componentDef.ngContentSelectors
-      ? componentDef.ngContentSelectors
-      : [];
+    this.ngContentSelectors = componentDef.ngContentSelectors ?? [];
     this.isBoundToModule = !!ngModule;
   }
 
@@ -372,7 +355,7 @@ export class ComponentFactory<T> extends AbstractComponentFactory<T> {
         const tAttributes = rootSelectorOrNode
           ? ['ng-version', '0.0.0-PLACEHOLDER']
           : // Extract attributes and classes from the first selector only to match VE behavior.
-            getRootTAttributesFromSelector(this.componentDef.selectors[0]);
+            extractAttrsAndClassesFromSelector(this.componentDef.selectors[0]);
 
         // TODO: this logic is shared with the element instruction first create pass
         const hostTNode = getOrCreateTNode(

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -521,22 +521,3 @@ function projectNodes(
     projection.push(nodesforSlot != null && nodesforSlot.length ? Array.from(nodesforSlot) : null);
   }
 }
-
-/**
- * Used to enable lifecycle hooks on the root component.
- *
- * Include this feature when calling `renderComponent` if the root component
- * you are rendering has lifecycle hooks defined. Otherwise, the hooks won't
- * be called properly.
- *
- * Example:
- *
- * ```ts
- * renderComponent(AppComponent, {hostFeatures: [LifecycleHooksFeature]});
- * ```
- */
-export function LifecycleHooksFeature(): void {
-  const tNode = getCurrentTNode()!;
-  ngDevMode && assertDefined(tNode, 'TNode is required');
-  registerPostOrderHooks(getLView()[TVIEW], tNode);
-}

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -422,14 +422,7 @@ export class ComponentFactory<T> extends AbstractComponentFactory<T> {
         leaveView();
       }
 
-      const hostTNode = getTNode(rootTView, HEADER_OFFSET) as TElementNode;
-      return new ComponentRef(
-        this.componentType,
-        componentView[CONTEXT] as T,
-        createElementRef(hostTNode, rootLView),
-        rootLView,
-        hostTNode,
-      );
+      return new ComponentRef(this.componentType, rootLView);
     } finally {
       setActiveConsumer(prevConsumer);
     }
@@ -449,17 +442,18 @@ export class ComponentRef<T> extends AbstractComponentRef<T> {
   override hostView: ViewRef<T>;
   override changeDetectorRef: ChangeDetectorRef;
   override componentType: Type<T>;
+  override location: ElementRef;
   private previousInputValues: Map<string, unknown> | null = null;
+  private _tNode: TElementNode | TContainerNode | TElementContainerNode;
 
   constructor(
     componentType: Type<T>,
-    instance: T,
-    public location: ElementRef,
     private _rootLView: LView,
-    private _tNode: TElementNode | TContainerNode | TElementContainerNode,
   ) {
     super();
-    this.instance = instance;
+    this._tNode = getTNode(_rootLView[TVIEW], HEADER_OFFSET) as TElementNode;
+    this.location = createElementRef(this._tNode, _rootLView);
+    this.instance = getComponentLViewByIndex(this._tNode.index, _rootLView)[CONTEXT] as T;
     this.hostView = this.changeDetectorRef = new ViewRef<T>(
       _rootLView,
       undefined /* _cdRefInjectingView */,

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -5,7 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {LifecycleHooksFeature} from './component_ref';
 import {ɵɵdefineComponent, ɵɵdefineDirective, ɵɵdefineNgModule, ɵɵdefinePipe} from './definition';
 import {ɵɵCopyDefinitionFeature} from './features/copy_definition_feature';
 import {ɵɵHostDirectivesFeature} from './features/host_directives_feature';
@@ -235,7 +234,6 @@ export {
   getDirectives,
   getHostElement,
   getRenderedText,
-  LifecycleHooksFeature,
   PipeDef,
   ɵɵComponentDeclaration,
   ɵɵCopyDefinitionFeature,

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1279,7 +1279,7 @@ export function getInitialLViewFlagsFromDef(def: ComponentDef<unknown>): LViewFl
   return flags;
 }
 
-export function createComponentLView<T>(
+function createComponentLView<T>(
   lView: LView,
   hostTNode: TElementNode,
   def: ComponentDef<T>,

--- a/packages/core/src/render3/node_selector_matcher.ts
+++ b/packages/core/src/render3/node_selector_matcher.ts
@@ -440,11 +440,8 @@ export function stringifyCSSSelectorList(selectorList: CssSelectorList): string 
  * @param selector CSS selector in parsed form (in a form of array)
  * @returns object with `attrs` and `classes` fields that contain extracted information
  */
-export function extractAttrsAndClassesFromSelector(selector: CssSelector): {
-  attrs: string[];
-  classes: string[];
-} {
-  const attrs: string[] = [];
+export function extractAttrsAndClassesFromSelector(selector: CssSelector): TAttributes {
+  const attrs: TAttributes = [];
   const classes: string[] = [];
   let i = 1;
   let mode = SelectorFlags.ATTRIBUTE;
@@ -467,5 +464,9 @@ export function extractAttrsAndClassesFromSelector(selector: CssSelector): {
     }
     i++;
   }
-  return {attrs, classes};
+  if (classes.length) {
+    attrs.push(AttributeMarker.Classes, ...classes);
+  }
+
+  return attrs;
 }

--- a/packages/core/test/render3/node_selector_matcher_spec.ts
+++ b/packages/core/test/render3/node_selector_matcher_spec.ts
@@ -741,8 +741,13 @@ describe('extractAttrsAndClassesFromSelector', () => {
   cases.forEach(([selector, attrs, classes]) => {
     it(`should process ${JSON.stringify(selector)} selector`, () => {
       const extracted = extractAttrsAndClassesFromSelector(selector);
-      expect(extracted.attrs).toEqual(attrs as string[]);
-      expect(extracted.classes).toEqual(classes as string[]);
+      const cssClassMarker = extracted.indexOf(AttributeMarker.Classes);
+
+      const extractedAttrs = cssClassMarker > -1 ? extracted.slice(0, cssClassMarker) : extracted;
+      const extractedClasses = cssClassMarker > -1 ? extracted.slice(cssClassMarker + 1) : [];
+
+      expect(extractedAttrs).toEqual(attrs as string[]);
+      expect(extractedClasses).toEqual(classes as string[]);
     });
   });
 });


### PR DESCRIPTION
Make extractAttrsAndClassesFromSelector to return TAttributes directly to simplify the overall logic and remove unnecessary code.
