### PR TITLE
refactor(core): remove unused `APP_EFFECT_SCHEDULER` in effect code

### DIFF
--- a/packages/core/src/render3/reactivity/effect.ts
+++ b/packages/core/src/render3/reactivity/effect.ts
@@ -18,7 +18,6 @@ import {
 } from '@angular/core/primitives/signals';
 import {FLAGS, LViewFlags, LView, EFFECTS} from '../interfaces/view';
 import {markAncestorsForTraversal} from '../util/view_utils';
-import {InjectionToken} from '../../di/injection_token';
 import {inject} from '../../di/injector_compatibility';
 import {performanceMarkFeature} from '../../util/performance';
 import {Injector} from '../../di/injector';
@@ -234,15 +233,6 @@ export interface ViewEffectNode extends EffectNode {
 export interface RootEffectNode extends EffectNode {
   scheduler: EffectScheduler;
 }
-
-/**
- * Not public API, which guarantees `EffectScheduler` only ever comes from the application root
- * injector.
- */
-export const APP_EFFECT_SCHEDULER = /* @__PURE__ */ new InjectionToken('', {
-  providedIn: 'root',
-  factory: () => inject(EffectScheduler),
-});
 
 export const BASE_EFFECT_NODE: Omit<EffectNode, 'fn' | 'destroy' | 'injector' | 'notifier'> =
   /* @__PURE__ */ (() => ({

--- a/packages/core/src/render3/reactivity/root_effect_scheduler.ts
+++ b/packages/core/src/render3/reactivity/root_effect_scheduler.ts
@@ -7,8 +7,6 @@
  */
 
 import {ɵɵdefineInjectable} from '../../di/interface/defs';
-import {PendingTasksInternal} from '../../pending_tasks';
-import {inject} from '../../di/injector_compatibility';
 
 /**
  * Abstraction that encompasses any kind of effect that can be scheduled.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

The `APP_EFFECT_SCHEDULER` Injection token is never used and not a public API.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
