### PR TITLE
refactor(common): inline supports check in `slice` pipe

### DIFF
--- a/packages/common/src/pipes/slice_pipe.ts
+++ b/packages/common/src/pipes/slice_pipe.ts
@@ -81,14 +81,12 @@ export class SlicePipe implements PipeTransform {
   ): Array<T> | string | null {
     if (value == null) return null;
 
-    if (!this.supports(value)) {
+    const supports = typeof value === 'string' || Array.isArray(value);
+
+    if (!supports) {
       throw invalidPipeArgumentError(SlicePipe, value);
     }
 
     return value.slice(start, end);
-  }
-
-  private supports(obj: any): boolean {
-    return typeof obj === 'string' || Array.isArray(obj);
   }
 }


### PR DESCRIPTION
The refactored version improves the original code by removing the `supports` method from the prototype and inlining the logic directly into the `transform` method. This reduces indirection and simplifies the class, especially since `supports` is not reused elsewhere. ESBuild can directly inline the condition into the `if` statement by removing the variable: `if (!("string" == typeof e || Array.isArray(e))) throw i(s, e);`.