### PR TITLE
refactor(common): drop `ngIf` assert template error in production

### DIFF
--- a/goldens/public-api/common/errors.api.md
+++ b/goldens/public-api/common/errors.api.md
@@ -25,6 +25,8 @@ export const enum RuntimeErrorCode {
     // (undocumented)
     NG_FOR_MISSING_DIFFER = -2200,
     // (undocumented)
+    NG_IF_NOT_A_TEMPLATE_REF = 2020,
+    // (undocumented)
     OVERSIZED_IMAGE = 2960,
     // (undocumented)
     OVERSIZED_PLACEHOLDER = 2965,

--- a/packages/common/src/directives/ng_if.ts
+++ b/packages/common/src/directives/ng_if.ts
@@ -13,7 +13,10 @@ import {
   TemplateRef,
   ViewContainerRef,
   ɵstringify as stringify,
+  ɵRuntimeError as RuntimeError,
 } from '@angular/core';
+
+import {RuntimeErrorCode} from '../errors';
 
 /**
  * A structural directive that conditionally includes a template based on the value of
@@ -185,7 +188,7 @@ export class NgIf<T = unknown> {
    */
   @Input()
   set ngIfThen(templateRef: TemplateRef<NgIfContext<T>> | null) {
-    assertTemplate('ngIfThen', templateRef);
+    assertTemplate(templateRef, (typeof ngDevMode === 'undefined' || ngDevMode) && 'ngIfThen');
     this._thenTemplateRef = templateRef;
     this._thenViewRef = null; // clear previous view if any.
     this._updateView();
@@ -196,7 +199,7 @@ export class NgIf<T = unknown> {
    */
   @Input()
   set ngIfElse(templateRef: TemplateRef<NgIfContext<T>> | null) {
-    assertTemplate('ngIfElse', templateRef);
+    assertTemplate(templateRef, (typeof ngDevMode === 'undefined' || ngDevMode) && 'ngIfElse');
     this._elseTemplateRef = templateRef;
     this._elseViewRef = null; // clear previous view if any.
     this._updateView();
@@ -263,9 +266,15 @@ export class NgIfContext<T = unknown> {
   public ngIf: T = null!;
 }
 
-function assertTemplate(property: string, templateRef: TemplateRef<any> | null): void {
-  const isTemplateRefOrNull = !!(!templateRef || templateRef.createEmbeddedView);
-  if (!isTemplateRefOrNull) {
-    throw new Error(`${property} must be a TemplateRef, but received '${stringify(templateRef)}'.`);
+function assertTemplate(
+  templateRef: TemplateRef<any> | null,
+  property: string | false | null,
+): void {
+  if (templateRef && !templateRef.createEmbeddedView) {
+    throw new RuntimeError(
+      RuntimeErrorCode.NG_IF_NOT_A_TEMPLATE_REF,
+      (typeof ngDevMode === 'undefined' || ngDevMode) &&
+        `${property} must be a TemplateRef, but received '${stringify(templateRef)}'.`,
+    );
   }
 }

--- a/packages/common/src/errors.ts
+++ b/packages/common/src/errors.ts
@@ -15,6 +15,9 @@ export const enum RuntimeErrorCode {
   PARENT_NG_SWITCH_NOT_FOUND = 2000,
   EQUALITY_NG_SWITCH_DIFFERENCE = 2001,
 
+  // NgIf errors
+  NG_IF_NOT_A_TEMPLATE_REF = 2020,
+
   // Pipe errors
   INVALID_PIPE_ARGUMENT = 2100,
 

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -692,7 +692,7 @@
   "standardizeConfig",
   "storeLViewOnDestroy",
   "stringify",
-  "stringify11",
+  "stringify12",
   "stringifyCSSSelector",
   "stripTrailingSlash",
   "subscribeOn",


### PR DESCRIPTION
This commit removes the `assertTemplate` error message in production.