### PR TITLE
Resource fixes

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1634,6 +1634,8 @@ export type ResourceOptions<T, R> = PromiseResourceOptions<T, R> | StreamingReso
 // @public
 export interface ResourceRef<T> extends WritableResource<T> {
     destroy(): void;
+    // (undocumented)
+    hasValue(): this is ResourceRef<Exclude<T, undefined>>;
 }
 
 // @public

--- a/packages/core/src/resource/api.ts
+++ b/packages/core/src/resource/api.ts
@@ -133,6 +133,8 @@ export interface WritableResource<T> extends Resource<T> {
  * @experimental
  */
 export interface ResourceRef<T> extends WritableResource<T> {
+  hasValue(): this is ResourceRef<Exclude<T, undefined>>;
+
   /**
    * Manually destroy the resource, which cancels pending requests and returns it to `idle` state.
    */

--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -103,7 +103,7 @@ abstract class BaseWritableResource<T> implements WritableResource<T> {
     () => this.status() === ResourceStatus.Loading || this.status() === ResourceStatus.Reloading,
   );
 
-  hasValue(): this is WritableResource<Exclude<T, undefined>> {
+  hasValue(): this is ResourceRef<Exclude<T, undefined>> {
     return this.value() !== undefined;
   }
 

--- a/packages/core/test/resource/resource_spec.ts
+++ b/packages/core/test/resource/resource_spec.ts
@@ -107,6 +107,25 @@ describe('resource', () => {
     expect(echoResource.error()).toBe(undefined);
   });
 
+  it('should report idle status as the previous status on first run', async () => {
+    let prevStatus: ResourceStatus | undefined;
+    resource({
+      loader: async ({previous}) => {
+        // Ensure the loader only runs once.
+        expect(prevStatus).toBeUndefined();
+
+        prevStatus = previous.status;
+        return true;
+      },
+      injector: TestBed.inject(Injector),
+    });
+
+    TestBed.flushEffects();
+    await flushMicrotasks();
+
+    expect(prevStatus).toBe(ResourceStatus.Idle);
+  });
+
   it('should expose errors thrown during resource loading', async () => {
     const backend = new MockEchoBackend();
     const requestParam = {};


### PR DESCRIPTION
2 fixes for `resource()`