### PR TITLE
fix(core): use custom data attribute as identifyer for test components

### DIFF
--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -2856,7 +2856,7 @@ describe('ViewContainerRef', () => {
       return {
         insertRootElement(rootElementId: string) {
           const rootEl = document.createElement('div');
-          rootEl.id = rootElementId;
+          rootEl.setAttribute('data-ng-test-id', rootElementId);
 
           containerEl = document.createElement('div');
           document.body.appendChild(containerEl);

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -653,7 +653,7 @@ export class TestBedImpl implements TestBed {
       const componentRef = componentFactory.create(
         Injector.NULL,
         [],
-        `#${rootElId}`,
+        `[data-ng-test-id=${rootElId}]`,
         this.testModuleRef,
       ) as ComponentRef<T>;
       return this.runInInjectionContext(() => new ComponentFixture(componentRef));

--- a/packages/platform-browser/testing/src/dom_test_component_renderer.ts
+++ b/packages/platform-browser/testing/src/dom_test_component_renderer.ts
@@ -22,7 +22,9 @@ export class DOMTestComponentRenderer extends TestComponentRenderer {
   override insertRootElement(rootElId: string) {
     this.removeAllRootElementsImpl();
     const rootElement = getDOM().getDefaultDocument().createElement('div');
-    rootElement.setAttribute('id', rootElId);
+    // This verbose attribute name is chosen to minimize the chances
+    // of collision with a host binding of the tested component
+    rootElement.setAttribute('data-ng-test-id', rootElId);
     this._doc.body.appendChild(rootElement);
   }
 
@@ -38,7 +40,7 @@ export class DOMTestComponentRenderer extends TestComponentRenderer {
   }
 
   private removeAllRootElementsImpl() {
-    const oldRoots = this._doc.querySelectorAll('[id^=root]');
+    const oldRoots = this._doc.querySelectorAll('[data-ng-test-id^=root]');
     for (let i = 0; i < oldRoots.length; i++) {
       getDOM().remove(oldRoots[i]);
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, test components are identified by adding an `id` attribute to the component's DOM. This method fails to identify components if the host's ID is overridden via host binding, resulting in components not being cleaned up.

Issue Number: Closes #35215 


## What is the new behavior?

 The new approach uses a custom `data-ng-test-id` attribute, preventing such overrides and ensuring proper identification and cleanup of test components.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
