### PR TITLE
fix(core): release `hasPendingTasks` observers

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -143,7 +143,7 @@ export class ApplicationRef {
     get destroyed(): boolean;
     detachView(viewRef: ViewRef): void;
     get injector(): EnvironmentInjector;
-    readonly isStable: Observable<boolean>;
+    get isStable(): Observable<boolean>;
     onDestroy(callback: () => void): VoidFunction;
     tick(): void;
     get viewCount(): number;

--- a/packages/common/http/test/transfer_cache_spec.ts
+++ b/packages/common/http/test/transfer_cache_spec.ts
@@ -103,7 +103,9 @@ describe('TransferCache', () => {
 
         @Injectable()
         class ApplicationRefPatched extends ApplicationRef {
-          override isStable = new BehaviorSubject<boolean>(false);
+          override get isStable() {
+            return isStable;
+          }
         }
 
         TestBed.configureTestingModule({
@@ -120,7 +122,6 @@ describe('TransferCache', () => {
 
         const appRef = TestBed.inject(ApplicationRef);
         appRef.bootstrap(SomeComponent);
-        isStable = appRef.isStable as BehaviorSubject<boolean>;
       }),
     );
 
@@ -346,7 +347,9 @@ describe('TransferCache', () => {
 
           @Injectable()
           class ApplicationRefPatched extends ApplicationRef {
-            override isStable = new BehaviorSubject<boolean>(false);
+            override get isStable() {
+              return new BehaviorSubject<boolean>(false);
+            }
           }
 
           TestBed.configureTestingModule({
@@ -381,7 +384,9 @@ describe('TransferCache', () => {
 
           @Injectable()
           class ApplicationRefPatched extends ApplicationRef {
-            override isStable = new BehaviorSubject<boolean>(false);
+            override get isStable() {
+              return new BehaviorSubject<boolean>(false);
+            }
           }
 
           TestBed.configureTestingModule({
@@ -479,7 +484,9 @@ describe('TransferCache', () => {
 
           @Injectable()
           class ApplicationRefPatched extends ApplicationRef {
-            override isStable = new BehaviorSubject<boolean>(false);
+            override get isStable() {
+              return new BehaviorSubject<boolean>(false);
+            }
           }
 
           TestBed.configureTestingModule({
@@ -527,7 +534,9 @@ describe('TransferCache', () => {
 
             @Injectable()
             class ApplicationRefPatched extends ApplicationRef {
-              override isStable = new BehaviorSubject<boolean>(false);
+              override get isStable() {
+                return new BehaviorSubject<boolean>(false);
+              }
             }
 
             TestBed.configureTestingModule({
@@ -577,7 +586,9 @@ describe('TransferCache', () => {
 
             @Injectable()
             class ApplicationRefPatched extends ApplicationRef {
-              override isStable = new BehaviorSubject<boolean>(false);
+              override get isStable() {
+                return new BehaviorSubject<boolean>(false);
+              }
             }
 
             TestBed.configureTestingModule({

--- a/packages/core/rxjs-interop/test/pending_until_event_spec.ts
+++ b/packages/core/rxjs-interop/test/pending_until_event_spec.ts
@@ -40,10 +40,10 @@ describe('pendingUntilEvent', () => {
   it('should not block stability until subscription', async () => {
     const originalSource = new BehaviorSubject(0);
     const delayedSource = originalSource.pipe(delay(5), pendingUntilEvent(injector));
-    expect(taskService.hasPendingTasks.value).toEqual(false);
+    expect(taskService.hasPendingTasks).toEqual(false);
 
     const emitPromise = firstValueFrom(delayedSource);
-    expect(taskService.hasPendingTasks.value).toEqual(true);
+    expect(taskService.hasPendingTasks).toEqual(true);
 
     await expectAsync(emitPromise).toBeResolvedTo(0);
     await expectAsync(appRef.whenStable()).toBeResolved();
@@ -53,10 +53,10 @@ describe('pendingUntilEvent', () => {
     const source = of(1).pipe(pendingUntilEvent(injector));
 
     // stable before subscription
-    expect(taskService.hasPendingTasks.value).toEqual(false);
+    expect(taskService.hasPendingTasks).toEqual(false);
     source.subscribe(() => {
       // unstable within synchronous subscription body
-      expect(taskService.hasPendingTasks.value).toBe(true);
+      expect(taskService.hasPendingTasks).toBe(true);
     });
     // stable after above synchronous subscription execution
     await expectAsync(appRef.whenStable()).toBeResolved();
@@ -64,12 +64,12 @@ describe('pendingUntilEvent', () => {
 
   it('only blocks stability until first emit', async () => {
     const intervalSource = interval(5).pipe(pendingUntilEvent(injector));
-    expect(taskService.hasPendingTasks.value).toEqual(false);
+    expect(taskService.hasPendingTasks).toEqual(false);
 
     await new Promise<void>(async (resolve) => {
       const subscription = intervalSource.subscribe(async (v) => {
         if (v === 0) {
-          expect(taskService.hasPendingTasks.value).toBe(true);
+          expect(taskService.hasPendingTasks).toBe(true);
         } else {
           await expectAsync(appRef.whenStable()).toBeResolved();
         }
@@ -78,14 +78,14 @@ describe('pendingUntilEvent', () => {
           resolve();
         }
       });
-      expect(taskService.hasPendingTasks.value).toBe(true);
+      expect(taskService.hasPendingTasks).toBe(true);
     });
   });
 
   it('should unblock stability on complete (but no emit)', async () => {
     const sub = new Subject();
     sub.asObservable().pipe(pendingUntilEvent(injector)).subscribe();
-    expect(taskService.hasPendingTasks.value).toBe(true);
+    expect(taskService.hasPendingTasks).toBe(true);
     sub.complete();
     await expectAsync(appRef.whenStable()).toBeResolved();
   });
@@ -93,7 +93,7 @@ describe('pendingUntilEvent', () => {
   it('should unblock stability on unsubscribe before emit', async () => {
     const sub = new Subject();
     const subscription = sub.asObservable().pipe(pendingUntilEvent(injector)).subscribe();
-    expect(taskService.hasPendingTasks.value).toBe(true);
+    expect(taskService.hasPendingTasks).toBe(true);
     subscription.unsubscribe();
     await expectAsync(appRef.whenStable()).toBeResolved();
   });
@@ -111,12 +111,12 @@ describe('pendingUntilEvent', () => {
       .pipe(
         finalize(() => {
           finalizeExecuted = true;
-          expect(taskService.hasPendingTasks.value).toBe(true);
+          expect(taskService.hasPendingTasks).toBe(true);
         }),
         pendingUntilEvent(injector),
       )
       .subscribe();
-    expect(taskService.hasPendingTasks.value).toBe(true);
+    expect(taskService.hasPendingTasks).toBe(true);
     subscription.unsubscribe();
     await expectAsync(appRef.whenStable()).toBeResolved();
     expect(finalizeExecuted).toBe(true);
@@ -125,7 +125,7 @@ describe('pendingUntilEvent', () => {
   it('should not throw if application is destroyed before emit', async () => {
     const sub = new Subject<void>();
     sub.asObservable().pipe(pendingUntilEvent(injector)).subscribe();
-    expect(taskService.hasPendingTasks.value).toBe(true);
+    expect(taskService.hasPendingTasks).toBe(true);
     TestBed.resetTestingModule();
     await expectAsync(appRef.whenStable()).toBeResolved();
     sub.next();
@@ -141,7 +141,7 @@ describe('pendingUntilEvent', () => {
         catchError(() => EMPTY),
       )
       .subscribe();
-    expect(taskService.hasPendingTasks.value).toBe(true);
+    expect(taskService.hasPendingTasks).toBe(true);
     sub.error(new Error('error in pipe'));
     await expectAsync(appRef.whenStable()).toBeResolved();
     sub.next();
@@ -166,7 +166,7 @@ describe('pendingUntilEvent', () => {
           throw new Error('oh noes');
         },
       });
-    expect(taskService.hasPendingTasks.value).toBe(true);
+    expect(taskService.hasPendingTasks).toBe(true);
     const errorPromise = nextUncaughtError();
     sub.next();
     await expectAsync(errorPromise).toBeResolved();
@@ -229,13 +229,13 @@ describe('pendingUntilEvent', () => {
     const observable = sub.asObservable().pipe(delay(5), pendingUntilEvent(injector));
 
     observable.subscribe();
-    expect(taskService.hasPendingTasks.value).toBe(true);
+    expect(taskService.hasPendingTasks).toBe(true);
     sub.next();
     observable.subscribe();
     // first subscription unblocks
     await new Promise((r) => setTimeout(r, 5));
     // still pending because the other subscribed after the emit
-    expect(taskService.hasPendingTasks.value).toBe(true);
+    expect(taskService.hasPendingTasks).toBe(true);
 
     sub.next();
     await new Promise((r) => setTimeout(r, 3));
@@ -244,7 +244,7 @@ describe('pendingUntilEvent', () => {
     // second subscription unblocks
     await new Promise((r) => setTimeout(r, 2));
     // still pending because third subscription delay not finished
-    expect(taskService.hasPendingTasks.value).toBe(true);
+    expect(taskService.hasPendingTasks).toBe(true);
 
     // finishes third subscription
     await new Promise((r) => setTimeout(r, 3));

--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -11,7 +11,7 @@ import '../util/ng_jit_mode';
 import '../util/ng_server_mode';
 
 import {setActiveConsumer, setThrowInvalidWriteToSignalError} from '../../primitives/signals';
-import {Observable, Subject, Subscription} from 'rxjs';
+import {type Observable, Subject, type Subscription} from 'rxjs';
 import {map} from 'rxjs/operators';
 
 import {ZONELESS_ENABLED} from '../change_detection/scheduling/zoneless_scheduling';
@@ -22,7 +22,7 @@ import {InjectionToken} from '../di/injection_token';
 import {Injector} from '../di/injector';
 import {EnvironmentInjector, type R3Injector} from '../di/r3_injector';
 import {formatRuntimeError, RuntimeError, RuntimeErrorCode} from '../errors';
-import {ErrorHandler, INTERNAL_APPLICATION_ERROR_HANDLER} from '../error_handler';
+import {INTERNAL_APPLICATION_ERROR_HANDLER} from '../error_handler';
 import {Type} from '../interface/type';
 import {ComponentFactory, ComponentRef} from '../linker/component_factory';
 import {ComponentFactoryResolver} from '../linker/component_factory_resolver';
@@ -334,12 +334,15 @@ export class ApplicationRef {
    */
   public readonly components: ComponentRef<any>[] = [];
 
+  private internalPendingTask = inject(PendingTasksInternal);
+
   /**
    * Returns an Observable that indicates when the application is stable or unstable.
    */
-  public readonly isStable: Observable<boolean> = inject(PendingTasksInternal).hasPendingTasks.pipe(
-    map((pending) => !pending),
-  );
+  public get isStable(): Observable<boolean> {
+    // This is a getter because it might be invoked after the application has been destroyed.
+    return this.internalPendingTask.hasPendingTasksObservable.pipe(map((pending) => !pending));
+  }
 
   constructor() {
     // Inject the tracing service to initialize it.

--- a/packages/core/src/pending_tasks.ts
+++ b/packages/core/src/pending_tasks.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {BehaviorSubject} from 'rxjs';
+import {BehaviorSubject, Observable} from 'rxjs';
 
 import {inject} from './di/injector_compatibility';
 import {ɵɵdefineInjectable} from './di/interface/defs';
@@ -23,14 +23,35 @@ import {INTERNAL_APPLICATION_ERROR_HANDLER} from './error_handler';
 export class PendingTasksInternal implements OnDestroy {
   private taskId = 0;
   private pendingTasks = new Set<number>();
-  private get _hasPendingTasks() {
-    return this.hasPendingTasks.value;
+  private destroyed = false;
+
+  private pendingTask = new BehaviorSubject<boolean>(false);
+
+  get hasPendingTasks(): boolean {
+    // Accessing the value of a closed `BehaviorSubject` throws an error.
+    return this.destroyed ? false : this.pendingTask.value;
   }
-  hasPendingTasks = new BehaviorSubject<boolean>(false);
+
+  /**
+   * In case the service is about to be destroyed, return a self-completing observable.
+   * Otherwise, return the observable that emits the current state of pending tasks.
+   */
+  get hasPendingTasksObservable(): Observable<boolean> {
+    if (this.destroyed) {
+      // Manually creating the observable pulls less symbols from RxJS than `of(false)`.
+      return new Observable<boolean>((subscriber) => {
+        subscriber.next(false);
+        subscriber.complete();
+      });
+    }
+
+    return this.pendingTask;
+  }
 
   add(): number {
-    if (!this._hasPendingTasks) {
-      this.hasPendingTasks.next(true);
+    // Emitting a value to a closed subject throws an error.
+    if (!this.hasPendingTasks && !this.destroyed) {
+      this.pendingTask.next(true);
     }
     const taskId = this.taskId++;
     this.pendingTasks.add(taskId);
@@ -43,16 +64,23 @@ export class PendingTasksInternal implements OnDestroy {
 
   remove(taskId: number): void {
     this.pendingTasks.delete(taskId);
-    if (this.pendingTasks.size === 0 && this._hasPendingTasks) {
-      this.hasPendingTasks.next(false);
+    if (this.pendingTasks.size === 0 && this.hasPendingTasks) {
+      this.pendingTask.next(false);
     }
   }
 
   ngOnDestroy(): void {
     this.pendingTasks.clear();
-    if (this._hasPendingTasks) {
-      this.hasPendingTasks.next(false);
+    if (this.hasPendingTasks) {
+      this.pendingTask.next(false);
     }
+    // We call `unsubscribe()` to release observers, as users may forget to
+    // unsubscribe manually when subscribing to `isStable`. We do not call
+    // `complete()` because it is unsafe; if someone subscribes using the `first`
+    // operator and the observable completes before emitting a value,
+    // RxJS will throw an error.
+    this.destroyed = true;
+    this.pendingTask.unsubscribe();
   }
 
   /** @nocollapse */

--- a/packages/core/test/acceptance/pending_tasks_spec.ts
+++ b/packages/core/test/acceptance/pending_tasks_spec.ts
@@ -122,7 +122,7 @@ function applicationRefIsStable(applicationRef: ApplicationRef) {
 function hasPendingTasks(pendingTasks: PendingTasksInternal): Promise<boolean> {
   return of(EMPTY)
     .pipe(
-      withLatestFrom(pendingTasks.hasPendingTasks),
+      withLatestFrom(pendingTasks.hasPendingTasksObservable),
       map(([_, hasPendingTasks]) => hasPendingTasks),
     )
     .toPromise() as Promise<boolean>;

--- a/packages/core/testing/src/component_fixture.ts
+++ b/packages/core/testing/src/component_fixture.ts
@@ -208,7 +208,7 @@ export class ComponentFixture<T> {
    * yet.
    */
   isStable(): boolean {
-    return !this.pendingTasks.hasPendingTasks.value;
+    return !this.pendingTasks.hasPendingTasks;
   }
 
   /**

--- a/packages/platform-browser/test/hydration_spec.ts
+++ b/packages/platform-browser/test/hydration_spec.ts
@@ -50,7 +50,9 @@ describe('provideClientHydration', () => {
 
   @Injectable()
   class ApplicationRefPatched extends ApplicationRef {
-    override isStable = new BehaviorSubject<boolean>(false);
+    override get isStable() {
+      return new BehaviorSubject(false);
+    }
   }
 
   beforeEach(() => {

--- a/packages/platform-server/test/event_replay_spec.ts
+++ b/packages/platform-server/test/event_replay_spec.ts
@@ -420,8 +420,6 @@ describe('event replay', () => {
 
     expect(logs).toEqual([
       'isStable=false',
-      'isStable=true',
-      'isStable=false',
       // In the end, the application became stable while being destroyed.
       'isStable=true',
     ]);

--- a/packages/platform-server/test/full_app_hydration_spec.ts
+++ b/packages/platform-server/test/full_app_hydration_spec.ts
@@ -7071,8 +7071,6 @@ describe('platform-server full application hydration integration', () => {
 
         expect(logs).toEqual([
           'isStable=false',
-          'isStable=true',
-          'isStable=false',
           // In the end, the application became stable while being destroyed.
           'isStable=true',
         ]);


### PR DESCRIPTION
In this commit, we unsubscribe the `hasPendingTasks` subject to remove all active observers and enable granular garbage collection, as users may forget to unsubscribe manually when subscribing to `isStable`.