### PR TITLE
docs(docs-infra): Remove leading path from zipped files.

### DIFF
--- a/adev/shared-docs/testing/testing-helper.ts
+++ b/adev/shared-docs/testing/testing-helper.ts
@@ -144,12 +144,16 @@ class FakeFileSystemAPI implements FileSystemAPI {
   ): Promise<DirEnt<string>[]>;
   readdir(
     path: unknown,
-    options?: unknown,
+    options?: {encoding?: string | null | undefined; withFileTypes?: boolean} | string | null,
   ):
     | Promise<Uint8Array[]>
     | Promise<string[]>
     | Promise<DirEnt<Uint8Array>[]>
     | Promise<DirEnt<string>[]> {
+    if (typeof options === 'object' && options?.withFileTypes === true) {
+      return Promise.resolve([{name: 'fake-file', isFile: () => true, isDirectory: () => false}]);
+    }
+
     return Promise.resolve(['/fake-dirname']);
   }
 

--- a/adev/shared-docs/utils/zip.utils.ts
+++ b/adev/shared-docs/utils/zip.utils.ts
@@ -14,9 +14,6 @@ import {zip, strToU8} from 'fflate';
 export async function generateZip(files: FileAndContent[]): Promise<Uint8Array> {
   const filesObj: Record<string, Uint8Array> = {};
   files.forEach(({path, content}) => {
-    if (path.startsWith('/')) {
-      path = path.slice(1);
-    }
     filesObj[path] = typeof content === 'string' ? strToU8(content) : content;
   });
 

--- a/adev/shared-docs/utils/zip.utils.ts
+++ b/adev/shared-docs/utils/zip.utils.ts
@@ -14,6 +14,9 @@ import {zip, strToU8} from 'fflate';
 export async function generateZip(files: FileAndContent[]): Promise<Uint8Array> {
   const filesObj: Record<string, Uint8Array> = {};
   files.forEach(({path, content}) => {
+    if (path.startsWith('/')) {
+      path = path.slice(1);
+    }
     filesObj[path] = typeof content === 'string' ? strToU8(content) : content;
   });
 

--- a/adev/src/app/editor/node-runtime-sandbox.service.spec.ts
+++ b/adev/src/app/editor/node-runtime-sandbox.service.spec.ts
@@ -300,4 +300,18 @@ describe('NodeRuntimeSandbox', () => {
       expect(deleteFileSpy).toHaveBeenCalledWith(fileToDelete);
     }
   });
+
+  it('should not have any filePath starting with "/" in solutions files', async () => {
+    service['webContainerPromise'] = Promise.resolve(
+      new FakeWebContainer() as unknown as WebContainer,
+    );
+    setValuesToInitializeProject();
+
+    await service.init();
+
+    const files = await service.getSolutionFiles();
+
+    expect(files.length).toBe(1);
+    expect(files[0].path).toBe('fake-file');
+  });
 });

--- a/adev/src/app/editor/node-runtime-sandbox.service.ts
+++ b/adev/src/app/editor/node-runtime-sandbox.service.ts
@@ -146,7 +146,7 @@ export class NodeRuntimeSandbox {
     const excludeFolders = ['node_modules', '.angular', 'dist'];
 
     return await checkFilesInDirectory(
-      '/',
+      '',
       webContainer.fs,
       (path?: string) => !!path && !excludeFolders.includes(path),
     );


### PR DESCRIPTION
In certain circonstances, a leading slash in the file paths created a incorrect unarchived project.

fixes #57075
