### PR TITLE
docs: fix AnimationGroupMetadata description

### DIFF
--- a/packages/animations/src/animation_metadata.ts
+++ b/packages/animations/src/animation_metadata.ts
@@ -403,7 +403,7 @@ export interface AnimationSequenceMetadata extends AnimationMetadata {
 
 /**
  * Encapsulates an animation group.
- * Instantiated and returned by the `{@link animations/group group()}` function.
+ * Instantiated and returned by the `group()` function.
  *
  * @publicApi
  */


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

It seems that the link to the `group()` function is not properly parsed due to its format on A.dev:

https://angular.dev/api/animations/AnimationGroupMetadata
<img width="462" alt="Screenshot 2025-01-27 at 15 41 22" src="https://github.com/user-attachments/assets/2b76662c-3027-4460-b0b6-1ba83bdfcc2b" />


## What is the new behavior?

Fix the `animations/group()` link by dropping the redundant code.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
