### PR TITLE
refactor(core): `stream` & `loader` are mutually exclusive for `resource`

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1447,6 +1447,7 @@ export type Predicate<T> = (value: T) => boolean;
 // @public
 export interface PromiseResourceOptions<T, R> extends BaseResourceOptions<T, R> {
     loader: ResourceLoader<T, R>;
+    stream?: never;
 }
 
 // @public
@@ -1769,6 +1770,7 @@ export type StaticProvider = ValueProvider | ExistingProvider | StaticClassProvi
 
 // @public
 export interface StreamingResourceOptions<T, R> extends BaseResourceOptions<T, R> {
+    loader?: never;
     stream: ResourceStreamingLoader<T, R>;
 }
 

--- a/packages/core/rxjs-interop/src/rx_resource.ts
+++ b/packages/core/rxjs-interop/src/rx_resource.ts
@@ -47,6 +47,7 @@ export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T |
   opts?.injector || assertInInjectionContext(rxResource);
   return resource<T, R>({
     ...opts,
+    loader: undefined, // Remove the loader from the options so it doesn't get passed to `resource`.
     stream: (params) => {
       let sub: Subscription;
 

--- a/packages/core/src/resource/api.ts
+++ b/packages/core/src/resource/api.ts
@@ -210,6 +210,11 @@ export interface PromiseResourceOptions<T, R> extends BaseResourceOptions<T, R> 
    * Loading function which returns a `Promise` of the resource's value for a given request.
    */
   loader: ResourceLoader<T, R>;
+
+  /**
+   * loader and stream properties are mutually exclusive.
+   */
+  stream?: never;
 }
 
 /**
@@ -223,6 +228,11 @@ export interface StreamingResourceOptions<T, R> extends BaseResourceOptions<T, R
    * request, which can change over time as new values are received from a stream.
    */
   stream: ResourceStreamingLoader<T, R>;
+
+  /**
+   * loader and stream properties are mutually exclusive.
+   */
+  loader?: never;
 }
 
 /**

--- a/packages/core/test/resource/resource_spec.ts
+++ b/packages/core/test/resource/resource_spec.ts
@@ -603,6 +603,15 @@ describe('resource', () => {
     stream.set({error: 'fail'});
     expect(res.value()).toBe(undefined);
   });
+
+  it('should not accept both stream and loader', () => {
+    // @ts-expect-error
+    const r = resource({
+      stream: () => Promise.resolve(signal({value: 3})),
+      loader: () => Promise.resolve(3),
+      injector: TestBed.inject(Injector),
+    });
+  });
 });
 
 function flushMicrotasks(): Promise<void> {


### PR DESCRIPTION
Prior to this change, both were allowed by the typing.
