### PR TITLE
refactor(core): clean up when blocks fail to fetch or hydrate

### DIFF
--- a/packages/core/src/defer/rendering.ts
+++ b/packages/core/src/defer/rendering.ts
@@ -222,13 +222,14 @@ export function renderDeferBlockState(
 function findMatchingDehydratedViewForDeferBlock(
   lContainer: LContainer,
   lDetails: LDeferBlockDetails,
-): DehydratedContainerView | null {
-  // Find matching view based on serialized defer block state.
-  return (
-    lContainer[DEHYDRATED_VIEWS]?.find(
+): {dehydratedView: DehydratedContainerView | null; dehydratedViewIx: number} {
+  const dehydratedViewIx =
+    lContainer[DEHYDRATED_VIEWS]?.findIndex(
       (view: any) => view.data[SERIALIZED_DEFER_BLOCK_STATE] === lDetails[DEFER_BLOCK_STATE],
-    ) ?? null
-  );
+    ) ?? -1;
+  const dehydratedView =
+    dehydratedViewIx > -1 ? lContainer[DEHYDRATED_VIEWS]![dehydratedViewIx] : null;
+  return {dehydratedView, dehydratedViewIx};
 }
 
 /**
@@ -273,10 +274,10 @@ function applyDeferBlockState(
         injector = createDeferBlockInjector(hostLView[INJECTOR], tDetails, providers);
       }
     }
-    const dehydratedView = findMatchingDehydratedViewForDeferBlock(lContainer, lDetails);
-    // Erase dehydrated view info, so that it's not removed later
-    // by post-hydration cleanup process.
-    lContainer[DEHYDRATED_VIEWS] = null;
+    const {dehydratedView, dehydratedViewIx} = findMatchingDehydratedViewForDeferBlock(
+      lContainer,
+      lDetails,
+    );
 
     const embeddedLView = createAndRenderEmbeddedLView(hostLView, activeBlockTNode, null, {
       injector,
@@ -290,11 +291,16 @@ function applyDeferBlockState(
     );
     markViewDirty(embeddedLView, NotificationSource.DeferBlockStateUpdate);
 
-    // TODO(incremental-hydration):
-    // - what if we had some views in `lContainer[DEHYDRATED_VIEWS]`, but
-    //   we didn't find a view that matches the expected state?
-    // - for example, handle a situation when a block was in the "completed" state
-    //   on the server, but the loading failing on the client. How do we reconcile and cleanup?
+    if (dehydratedViewIx > -1) {
+      // Erase dehydrated view info in a given LContainer, so that the view is not
+      // removed later by post-hydration cleanup process (which iterates over all
+      // dehydrated views in component tree). This clears only the dehydrated view
+      // that was found for this render, which in most cases will be the only view.
+      // In the case that there was control flow that changed, there may be either
+      // more than one or the views would not match up due to the server rendered
+      // content being a different branch of the control flow.
+      lContainer[DEHYDRATED_VIEWS]?.splice(dehydratedViewIx, 1);
+    }
 
     if (
       (newState === DeferBlockState.Complete || newState === DeferBlockState.Error) &&

--- a/packages/core/src/defer/triggering.ts
+++ b/packages/core/src/defer/triggering.ts
@@ -10,7 +10,11 @@ import {afterNextRender} from '../render3/after_render/hooks';
 import {Injector} from '../di';
 import {internalImportProvidersFrom} from '../di/provider_collection';
 import {RuntimeError, RuntimeErrorCode} from '../errors';
-import {cleanupHydratedDeferBlocks} from '../hydration/cleanup';
+import {
+  cleanupHydratedDeferBlocks,
+  cleanupLContainer,
+  removeDehydratedViewList,
+} from '../hydration/cleanup';
 import {BlockSummary, ElementTrigger, NUM_ROOT_NODES} from '../hydration/interfaces';
 import {
   assertSsrIdDefined,
@@ -35,10 +39,12 @@ import {
 import {onViewport} from './dom_triggers';
 import {onIdle} from './idle_scheduler';
 import {
+  DEFER_BLOCK_STATE,
   DeferBlockBehavior,
   DeferBlockState,
   DeferBlockTrigger,
   DeferDependenciesLoadingState,
+  DehydratedDeferBlock,
   HydrateTriggerDetails,
   LDeferBlockDetails,
   ON_COMPLETE_FNS,
@@ -64,6 +70,7 @@ import {
   getTDeferBlockDetails,
 } from './utils';
 import {ApplicationRef} from '../application/application_ref';
+import {DEHYDRATED_VIEWS} from '../render3/interfaces/container';
 
 /**
  * Schedules triggering of a defer block for `on idle` and `on timer` conditions.
@@ -400,17 +407,40 @@ export async function triggerHydrationFromBlockName(
   }
 
   // Actually do the triggering and hydration of the queue of blocks
-  for (const dehydratedBlockId of hydrationQueue) {
-    await triggerResourceLoadingForHydration(dehydratedBlockId, dehydratedBlockRegistry);
-    await nextRender(injector);
-    // TODO(incremental-hydration): assert (in dev mode) that a defer block is present in the dehydrated registry
-    // at this point. If not - it means that the block has not been hydrated, for example due to different
-    // `@if` conditions on the client and the server. If we detect this case, we should also do the cleanup
-    // of all child block (promises, registry state, etc).
-    // TODO(incremental-hydration): call `rejectFn` when lDetails[DEFER_BLOCK_STATE] is `DeferBlockState.Error`.
-    blocksBeingHydrated.get(dehydratedBlockId)!.resolve();
+  for (let blockQueueIdx = 0; blockQueueIdx < hydrationQueue.length; blockQueueIdx++) {
+    const dehydratedBlockId = hydrationQueue[blockQueueIdx];
+    const dehydratedDeferBlock = dehydratedBlockRegistry.get(dehydratedBlockId);
 
-    // TODO(incremental-hydration): consider adding a wait for stability here
+    if (dehydratedDeferBlock != null) {
+      // trigger the block resources and await next render for hydration. This should result
+      // in the next block ɵɵdefer instruction being called and that block being added to the dehydrated registry.
+      await triggerResourceLoadingForHydration(dehydratedDeferBlock);
+      await nextRender(injector);
+
+      // if the content has changed since server rendering, we need to check for the expected block
+      // being in the registry or if errors occurred. In that case, we need to clean up the remaining expected
+      // content that won't be rendered or fetched.
+      if (deferBlockHasErrored(dehydratedDeferBlock)) {
+        // Either the expected block has not yet had its ɵɵdefer instruction called or the block errored out when fetching
+        // resources. In the former case, either we're hydrating too soon or the client and server differ. In both cases,
+        // we need to clean up child content and promises.
+        removeDehydratedViewList(dehydratedDeferBlock);
+        cleanupRemainingHydrationQueue(
+          hydrationQueue.slice(blockQueueIdx),
+          dehydratedBlockRegistry,
+        );
+        break;
+      }
+      // The defer block has not errored and we've finished fetching resources and rendering.
+      // At this point it is safe to resolve the hydration promise.
+      blocksBeingHydrated.get(dehydratedBlockId)!.resolve();
+    } else {
+      // The expected block has not yet had its ɵɵdefer instruction called. This is likely due to content changing between
+      // client and server. We need to clean up the dehydrated DOM in the container since it no longer is valid.
+      cleanupParentContainer(blockQueueIdx, hydrationQueue, dehydratedBlockRegistry);
+      cleanupRemainingHydrationQueue(hydrationQueue.slice(blockQueueIdx), dehydratedBlockRegistry);
+      break;
+    }
   }
 
   // Await hydration completion for the requested block.
@@ -433,6 +463,46 @@ export async function triggerHydrationFromBlockName(
   );
 }
 
+export function deferBlockHasErrored(deferBlock: DehydratedDeferBlock): boolean {
+  return (
+    getLDeferBlockDetails(deferBlock.lView, deferBlock.tNode)[DEFER_BLOCK_STATE] ===
+    DeferBlockState.Error
+  );
+}
+
+/**
+ * Clean up the parent container of a block where content changed between server and client.
+ * The parent of a block going through `triggerHydrationFromBlockName` will contain the
+ * dehydrated content that needs to be cleaned up. So we have to do the clean up from that location
+ * in the tree.
+ */
+function cleanupParentContainer(
+  currentBlockIdx: number,
+  hydrationQueue: string[],
+  dehydratedBlockRegistry: DehydratedBlockRegistry,
+) {
+  // If a parent block exists, it's in the hydration queue in front of the current block.
+  const parentDeferBlockIdx = currentBlockIdx - 1;
+  const parentDeferBlock =
+    parentDeferBlockIdx > -1
+      ? dehydratedBlockRegistry.get(hydrationQueue[parentDeferBlockIdx])
+      : null;
+  if (parentDeferBlock) {
+    cleanupLContainer(parentDeferBlock.lContainer);
+  }
+}
+
+function cleanupRemainingHydrationQueue(
+  hydrationQueue: string[],
+  dehydratedBlockRegistry: DehydratedBlockRegistry,
+) {
+  const blocksBeingHydrated = dehydratedBlockRegistry.hydrating;
+  for (const dehydratedBlockId in hydrationQueue) {
+    blocksBeingHydrated.get(dehydratedBlockId)?.reject();
+  }
+  dehydratedBlockRegistry.cleanup(hydrationQueue);
+}
+
 /**
  * Generates a new promise for every defer block in the hydrating queue
  */
@@ -448,22 +518,9 @@ function nextRender(injector: Injector): Promise<void> {
 }
 
 async function triggerResourceLoadingForHydration(
-  dehydratedBlockId: string,
-  dehydratedBlockRegistry: DehydratedBlockRegistry,
+  dehydratedBlock: DehydratedDeferBlock,
 ): Promise<void> {
-  const deferBlock = dehydratedBlockRegistry.get(dehydratedBlockId);
-  // Since we trigger hydration for nested defer blocks in a sequence (parent -> child),
-  // there is a chance that a defer block may not be present at hydration time. For example,
-  // when a nested block was in an `@if` condition, which has changed.
-  if (deferBlock === null) {
-    // TODO(incremental-hydration): handle the cleanup for cases when
-    // defer block is no longer present during hydration (e.g. `@if` condition
-    // has changed during hydration/rendering).
-
-    return;
-  }
-
-  const {tNode, lView} = deferBlock;
+  const {tNode, lView} = dehydratedBlock;
   const lDetails = getLDeferBlockDetails(lView, tNode);
 
   return new Promise<void>((resolve) => {

--- a/packages/core/src/hydration/cleanup.ts
+++ b/packages/core/src/hydration/cleanup.ts
@@ -53,6 +53,18 @@ export function removeDehydratedViews(lContainer: LContainer) {
   lContainer[DEHYDRATED_VIEWS] = retainedViews;
 }
 
+export function removeDehydratedViewList(deferBlock: DehydratedDeferBlock) {
+  const {lContainer} = deferBlock;
+  const dehydratedViews = lContainer[DEHYDRATED_VIEWS];
+  if (dehydratedViews === null) return;
+  const parentLView = lContainer[PARENT];
+  const renderer = parentLView[RENDERER];
+  for (const view of dehydratedViews) {
+    removeDehydratedView(view, renderer);
+    ngDevMode && ngDevMode.dehydratedViewsRemoved++;
+  }
+}
+
 /**
  * Helper function to remove all nodes from a dehydrated view.
  */


### PR DESCRIPTION
There are cases where resources fail to fetch or the DOM has changed due to an if block. This should clean up the remaining promises and any registry references to those blocks in that case.

## PR Type
What kind of change does this PR introduce?


- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No



