### PR TITLE
refactor(forms): remove `_checkFormPresent` and move directly to `ngOnChanges`

### DIFF
--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -149,7 +149,10 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
 
   /** @nodoc */
   ngOnChanges(changes: SimpleChanges): void {
-    this._checkFormPresent();
+    if ((typeof ngDevMode === 'undefined' || ngDevMode) && !this.form) {
+      throw missingFormException();
+    }
+
     if (changes.hasOwnProperty('form')) {
       this._updateValidators();
       this._updateDomValue();
@@ -403,12 +406,6 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
     setUpValidators(this.form, this);
     if (this._oldForm) {
       cleanUpValidators(this._oldForm, this);
-    }
-  }
-
-  private _checkFormPresent() {
-    if (!this.form && (typeof ngDevMode === 'undefined' || ngDevMode)) {
-      throw missingFormException();
     }
   }
 }


### PR DESCRIPTION
In this commit, we remove `_checkFormPresent` because it is a no-op in production. We move its body directly into `ngOnChanges` to eliminate the redundant method from the prototype. Previously, `_checkFormPresent` was being called with no body in production each time `ngOnChanges` was executed.