### PR TITLE
refactor(common): drop platform check in `LCPImageObserver`

### DIFF
--- a/packages/common/src/directives/ng_optimized_image/lcp_image_observer.ts
+++ b/packages/common/src/directives/ng_optimized_image/lcp_image_observer.ts
@@ -11,7 +11,6 @@ import {
   Injectable,
   OnDestroy,
   ɵformatRuntimeError as formatRuntimeError,
-  PLATFORM_ID,
   DOCUMENT,
 } from '@angular/core';
 
@@ -20,7 +19,6 @@ import {RuntimeErrorCode} from '../../errors';
 import {assertDevMode} from './asserts';
 import {imgDirectiveDetails} from './error_helper';
 import {getUrl} from './url';
-import {isPlatformBrowser} from '../../platform_id';
 
 interface ObservedImageState {
   priority: boolean;
@@ -44,15 +42,16 @@ export class LCPImageObserver implements OnDestroy {
   // Map of full image URLs -> original `ngSrc` values.
   private images = new Map<string, ObservedImageState>();
 
-  private window: Window | null = null;
+  private window: Window | null = inject(DOCUMENT).defaultView;
   private observer: PerformanceObserver | null = null;
 
   constructor() {
-    const isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
     assertDevMode('LCP checker');
-    const win = inject(DOCUMENT).defaultView;
-    if (isBrowser && typeof PerformanceObserver !== 'undefined') {
-      this.window = win;
+
+    if (
+      (typeof ngServerMode === 'undefined' || !ngServerMode) &&
+      typeof PerformanceObserver !== 'undefined'
+    ) {
       this.observer = this.initPerformanceObserver();
     }
   }


### PR DESCRIPTION
Replaces platform check within the `LCPImageObserver` with the `ngServerMode` global.