### PR TITLE
refactor(common): simplify `stripTrailingSlash`

### DIFF
--- a/packages/common/src/location/hash_location_strategy.ts
+++ b/packages/common/src/location/hash_location_strategy.ts
@@ -77,18 +77,16 @@ export class HashLocationStrategy extends LocationStrategy implements OnDestroy 
   }
 
   override pushState(state: any, title: string, path: string, queryParams: string) {
-    let url: string | null = this.prepareExternalUrl(path + normalizeQueryParams(queryParams));
-    if (url.length == 0) {
-      url = this._platformLocation.pathname;
-    }
+    const url =
+      this.prepareExternalUrl(path + normalizeQueryParams(queryParams)) ||
+      this._platformLocation.pathname;
     this._platformLocation.pushState(state, title, url);
   }
 
   override replaceState(state: any, title: string, path: string, queryParams: string) {
-    let url = this.prepareExternalUrl(path + normalizeQueryParams(queryParams));
-    if (url.length == 0) {
-      url = this._platformLocation.pathname;
-    }
+    const url =
+      this.prepareExternalUrl(path + normalizeQueryParams(queryParams)) ||
+      this._platformLocation.pathname;
     this._platformLocation.replaceState(state, title, url);
   }
 

--- a/packages/common/src/location/util.ts
+++ b/packages/common/src/location/util.ts
@@ -38,10 +38,13 @@ export function joinWithSlash(start: string, end: string) {
  * @returns The URL string, modified if needed.
  */
 export function stripTrailingSlash(url: string): string {
-  const match = url.match(/#|\?|$/);
-  const pathEndIdx = (match && match.index) || url.length;
-  const droppedSlashIdx = pathEndIdx - (url[pathEndIdx - 1] === '/' ? 1 : 0);
-  return url.slice(0, droppedSlashIdx) + url.slice(pathEndIdx);
+  // Find the index of the first occurrence of `#`, `?`, or the end of the string.
+  // This marks the start of the query string, fragment, or the end of the URL path.
+  const pathEndIdx = url.search(/#|\?|$/);
+  // Check if the character before `pathEndIdx` is a trailing slash.
+  // If it is, remove the trailing slash and return the modified URL.
+  // Otherwise, return the URL as is.
+  return url[pathEndIdx - 1] === '/' ? url.slice(0, pathEndIdx - 1) + url.slice(pathEndIdx) : url;
 }
 
 /**
@@ -52,5 +55,5 @@ export function stripTrailingSlash(url: string): string {
  * @returns The normalized URL parameters string.
  */
 export function normalizeQueryParams(params: string): string {
-  return params && params[0] !== '?' ? '?' + params : params;
+  return params && params[0] !== '?' ? `?${params}` : params;
 }


### PR DESCRIPTION
The new version of the function is smaller, eliminating extra bytes. The refactor improves both code size and readability while optimizing the implementation. Benchmark results for the old and new implementations are as follows:

```
stripTrailingSlash_old x 15,446,602 ops/sec ±0.89% (66 runs sampled)
stripTrailingSlash_new x 19,694,523 ops/sec ±1.10% (61 runs sampled)
```

Thus, the new implementation is both smaller and faster.