### PR TITLE
build: remove `@angular/common` from Service Worker dependencies

### DIFF
--- a/packages/service-worker/BUILD.bazel
+++ b/packages/service-worker/BUILD.bazel
@@ -11,7 +11,6 @@ ng_module(
         ],
     ),
     deps = [
-        "//packages/common",
         "//packages/core",
         "@npm//rxjs",
     ],

--- a/packages/service-worker/package.json
+++ b/packages/service-worker/package.json
@@ -22,7 +22,8 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@angular/core": "0.0.0-PLACEHOLDER"
+    "@angular/core": "0.0.0-PLACEHOLDER",
+    "rxjs": "^6.5.3 || ^7.4.0"
   },
   "repository": {
     "type": "git",

--- a/packages/service-worker/package.json
+++ b/packages/service-worker/package.json
@@ -22,8 +22,7 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@angular/core": "0.0.0-PLACEHOLDER",
-    "@angular/common": "0.0.0-PLACEHOLDER"
+    "@angular/core": "0.0.0-PLACEHOLDER"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The `@angular/service-worker` package no longer directly depends on `@angular/common`.
