### PR TITLE
ci: configure merge tool to enforce mandatory PR statuses

### DIFF
--- a/.ng-dev/pull-request.mts
+++ b/.ng-dev/pull-request.mts
@@ -22,4 +22,12 @@ export const pullRequest: PullRequestConfig = {
     assertEnforceTested: true,
     assertIsolatedSeparateFiles: true,
   },
+
+  requiredStatuses: [
+    {type: 'check', name: 'test'},
+    {type: 'check', name: 'lint'},
+    {type: 'check', name: 'adev'},
+    {type: 'check', name: 'zone-js'},
+    {type: 'status', name: 'google-internal-tests'},
+  ],
 };


### PR DESCRIPTION
The merge tool is currently hard-coded to only check `lint` as a required status. This was added because at some point the old GitHub robot was replaced with a so-called `unified-statuses` check GitHub action; but that one never worked/impacted productivity of the team.

I've added support to the merge tool to require specific jobs/checks to run, before allowing merge (can be forcibly ignored). We are using this ability now to enforce a few "common" required jobs, as a safety measure when GitHub didn't trigger CI runs (e.g. for new contributors).

This recently became a more prominent issue as the GitHub org enforces that CI doesn't run for e.g. first time contributors.