### PR TITLE
fix(compiler): report unterminated quotes in interpolations

### DIFF
--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -1052,10 +1052,6 @@ describe('parser', () => {
       checkInterpolation(`{{foo.split('\\\\\\\\\\\\')}}`, `{{ foo.split("\\\\\\") }}`);
     });
 
-    it('should not parse interpolation with mismatching quotes', () => {
-      expect(parseInterpolation(`{{ "{{a}}' }}`)).toBeNull();
-    });
-
     it('should parse prefix/suffix with multiple interpolation', () => {
       const originalExp = 'before {{ a }} middle {{ b }} after';
       const ast = parseInterpolation(originalExp)!.ast;
@@ -1096,6 +1092,12 @@ describe('parser', () => {
       expect(ast.strings).toEqual(['', '']);
       expect(ast.expressions.length).toEqual(1);
       expect(ast.expressions[0].name).toEqual('a');
+    });
+
+    it('should report unterminated quote in interpolation', () => {
+      expectError(parseInterpolation(`{{ 123 + '123 }}`)!, 'Unterminated quote at column 11 in');
+      expectError(parseInterpolation(`{{ " }}`)!, 'Unterminated quote at column 5 in');
+      expectError(parseInterpolation('{{ foo || ` }}')!, 'Unterminated quote at column 12 in');
     });
 
     describe('comments', () => {


### PR DESCRIPTION
There were two issues that caused unterminated quotes not to be reported as errors in interpolations (e.g. `{{ 'Hello }}`):
1. We weren't actually reporting such cases after we introduced the logic to skip over interpolation characters inside of strings a few years ago.
2. Even if we did report errors, the compiler is set up to be more forgiving to malformed interpolations so users can write something like `Curly braces: {{` in a template without getting an error.

These changes address the issue by throwing an error for unterminated quotes and reporting it when producing the interpolation AST.

Fixes #59507.