### PR TITLE
Decouple platform-server from animations

### DIFF
--- a/goldens/public-api/platform-server/index.api.md
+++ b/goldens/public-api/platform-server/index.api.md
@@ -7,8 +7,7 @@
 import { ApplicationRef } from '@angular/core';
 import { EnvironmentProviders } from '@angular/core';
 import * as i0 from '@angular/core';
-import * as i1 from '@angular/platform-browser/animations';
-import * as i2 from '@angular/platform-browser';
+import * as i1 from '@angular/platform-browser';
 import { InjectionToken } from '@angular/core';
 import { PlatformRef } from '@angular/core';
 import { Provider } from '@angular/core';
@@ -66,7 +65,7 @@ export class ServerModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<ServerModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<ServerModule, never, [typeof i1.NoopAnimationsModule], [typeof i2.BrowserModule]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<ServerModule, never, never, [typeof i1.BrowserModule]>;
 }
 
 // @public (undocumented)

--- a/goldens/public-api/platform-server/testing/index.api.md
+++ b/goldens/public-api/platform-server/testing/index.api.md
@@ -5,8 +5,7 @@
 ```ts
 
 import * as i0 from '@angular/core';
-import * as i1 from '@angular/platform-browser/animations';
-import * as i2 from '@angular/platform-browser-dynamic/testing';
+import * as i1 from '@angular/platform-browser-dynamic/testing';
 import { PlatformRef } from '@angular/core';
 import { StaticProvider } from '@angular/core';
 
@@ -20,7 +19,7 @@ export class ServerTestingModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<ServerTestingModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<ServerTestingModule, never, [typeof i1.NoopAnimationsModule], [typeof i2.BrowserDynamicTestingModule]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<ServerTestingModule, never, never, [typeof i1.BrowserDynamicTestingModule]>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -38,6 +38,7 @@ import {getLView} from '@angular/core/src/render3/state';
 import {ngDevModeResetPerfCounters} from '@angular/core/src/util/ng_dev_mode';
 import {fakeAsync, flushMicrotasks, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {expectPerfCounters} from '@angular/private/testing';
 
 describe('acceptance integration tests', () => {
@@ -2889,6 +2890,7 @@ describe('acceptance integration tests', () => {
 
       TestBed.configureTestingModule({
         declarations: [Cmp, AnimationComp],
+        imports: [NoopAnimationsModule],
         providers: [{provide: AnimationDriver, useClass: MockAnimationDriver}],
       });
       const fixture = TestBed.createComponent(Cmp);
@@ -2979,6 +2981,7 @@ describe('acceptance integration tests', () => {
 
       TestBed.configureTestingModule({
         declarations: [Cmp, InnerComp],
+        imports: [NoopAnimationsModule],
         providers: [{provide: AnimationDriver, useClass: MockAnimationDriver}],
       });
       const fixture = TestBed.createComponent(Cmp);

--- a/packages/core/test/acceptance/property_binding_spec.ts
+++ b/packages/core/test/acceptance/property_binding_spec.ts
@@ -10,6 +10,7 @@ import {CommonModule} from '@angular/common';
 import {Component, Directive, EventEmitter, Input, Output, ViewContainerRef} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By, DomSanitizer, SafeUrl} from '@angular/platform-browser';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 describe('property bindings', () => {
   it('should support bindings to properties', () => {
@@ -689,7 +690,10 @@ describe('property bindings', () => {
     })
     class App {}
 
-    TestBed.configureTestingModule({declarations: [App, MyDir, MyComp]});
+    TestBed.configureTestingModule({
+      declarations: [App, MyDir, MyComp],
+      imports: [NoopAnimationsModule],
+    });
 
     expect(() => {
       const fixture = TestBed.createComponent(App);

--- a/packages/core/test/change_detection_scheduler_spec.ts
+++ b/packages/core/test/change_detection_scheduler_spec.ts
@@ -372,12 +372,8 @@ describe('Angular with zoneless enabled', () => {
       expect(host.innerHTML).toEqual('<dynamic-cmp>binding</dynamic-cmp>');
 
       const component2 = createComponent(DynamicCmp, {environmentInjector});
-      // TODO(atscott): Only needed because renderFactory will not run if ApplicationRef has no
-      // views. This should likely be fixed in ApplicationRef
       appRef.attachView(component2.hostView);
       appRef.detachView(component.hostView);
-      // DOM is not synchronously removed because change detection hasn't run
-      expect(host.innerHTML).toEqual('<dynamic-cmp>binding</dynamic-cmp>');
       expect(isStable()).toBe(false);
       await whenStable();
       expect(host.innerHTML).toEqual('');

--- a/packages/core/test/linker/change_detection_integration_spec.ts
+++ b/packages/core/test/linker/change_detection_integration_spec.ts
@@ -45,6 +45,7 @@ import {isTextNode} from '@angular/platform-browser/testing/src/browser_util';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 import {MockResourceLoader} from './resource_loader_mock';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 const TEST_COMPILER_PROVIDERS: Provider[] = [
   {provide: ResourceLoader, useClass: MockResourceLoader, deps: []},
@@ -110,6 +111,7 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
     beforeEach(() => {
       TestBed.configureCompiler({providers: TEST_COMPILER_PROVIDERS});
       TestBed.configureTestingModule({
+        imports: [NoopAnimationsModule],
         declarations: [
           TestData,
           TestDirective,

--- a/packages/platform-browser/animations/async/src/providers.ts
+++ b/packages/platform-browser/animations/async/src/providers.ts
@@ -14,7 +14,6 @@ import {
   NgZone,
   RendererFactory2,
   ɵperformanceMarkFeature as performanceMarkFeature,
-  InjectionToken,
 } from '@angular/core';
 import {ɵDomRendererFactory2 as DomRendererFactory2} from '@angular/platform-browser';
 
@@ -51,6 +50,12 @@ export function provideAnimationsAsync(
   type: 'animations' | 'noop' = 'animations',
 ): EnvironmentProviders {
   performanceMarkFeature('NgAsyncAnimations');
+
+  // Animations don't work on the server so we switch them over to no-op automatically.
+  if (typeof ngServerMode !== 'undefined' && ngServerMode) {
+    type = 'noop';
+  }
+
   return makeEnvironmentProviders([
     {
       provide: RendererFactory2,

--- a/packages/platform-browser/animations/src/providers.ts
+++ b/packages/platform-browser/animations/src/providers.ts
@@ -71,20 +71,31 @@ const SHARED_ANIMATION_PROVIDERS: Provider[] = [
 
 /**
  * Separate providers from the actual module so that we can do a local modification in Google3 to
- * include them in the BrowserModule.
- */
-export const BROWSER_ANIMATIONS_PROVIDERS: Provider[] = [
-  {provide: AnimationDriver, useFactory: () => new WebAnimationsDriver()},
-  {provide: ANIMATION_MODULE_TYPE, useValue: 'BrowserAnimations'},
-  ...SHARED_ANIMATION_PROVIDERS,
-];
-
-/**
- * Separate providers from the actual module so that we can do a local modification in Google3 to
  * include them in the BrowserTestingModule.
  */
 export const BROWSER_NOOP_ANIMATIONS_PROVIDERS: Provider[] = [
   {provide: AnimationDriver, useClass: NoopAnimationDriver},
   {provide: ANIMATION_MODULE_TYPE, useValue: 'NoopAnimations'},
+  ...SHARED_ANIMATION_PROVIDERS,
+];
+
+/**
+ * Separate providers from the actual module so that we can do a local modification in Google3 to
+ * include them in the BrowserModule.
+ */
+export const BROWSER_ANIMATIONS_PROVIDERS: Provider[] = [
+  // Note: the `ngServerMode` happen inside factories to give the variable time to initialize.
+  {
+    provide: AnimationDriver,
+    useFactory: () =>
+      typeof ngServerMode !== 'undefined' && ngServerMode
+        ? new NoopAnimationDriver()
+        : new WebAnimationsDriver(),
+  },
+  {
+    provide: ANIMATION_MODULE_TYPE,
+    useFactory: () =>
+      typeof ngServerMode !== 'undefined' && ngServerMode ? 'NoopAnimations' : 'BrowserAnimations',
+  },
   ...SHARED_ANIMATION_PROVIDERS,
 ];

--- a/packages/platform-server/BUILD.bazel
+++ b/packages/platform-server/BUILD.bazel
@@ -15,13 +15,11 @@ ng_module(
     ),
     deps = [
         ":bundled_domino_lib",
-        "//packages/animations/browser",
         "//packages/common",
         "//packages/common/http",
         "//packages/compiler",
         "//packages/core",
         "//packages/platform-browser",
-        "//packages/platform-browser/animations",
         "//packages/zone.js/lib:zone_d_ts",
         "@npm//@types/node",
         "@npm//rxjs",

--- a/packages/platform-server/package.json
+++ b/packages/platform-server/package.json
@@ -8,7 +8,6 @@
     "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
   },
   "peerDependencies": {
-    "@angular/animations": "0.0.0-PLACEHOLDER",
     "@angular/common": "0.0.0-PLACEHOLDER",
     "@angular/compiler": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-PLACEHOLDER",

--- a/packages/platform-server/src/provide_server.ts
+++ b/packages/platform-server/src/provide_server.ts
@@ -7,7 +7,6 @@
  */
 
 import {EnvironmentProviders, makeEnvironmentProviders} from '@angular/core';
-import {provideNoopAnimations} from '@angular/platform-browser/animations';
 
 import {PLATFORM_SERVER_PROVIDERS} from './server';
 
@@ -31,5 +30,5 @@ export function provideServerRendering(): EnvironmentProviders {
     globalThis['ngServerMode'] = true;
   }
 
-  return makeEnvironmentProviders([provideNoopAnimations(), ...PLATFORM_SERVER_PROVIDERS]);
+  return makeEnvironmentProviders([...PLATFORM_SERVER_PROVIDERS]);
 }

--- a/packages/platform-server/src/server.ts
+++ b/packages/platform-server/src/server.ts
@@ -35,7 +35,6 @@ import {
   EVENT_MANAGER_PLUGINS,
   ɵBrowserDomAdapter as BrowserDomAdapter,
 } from '@angular/platform-browser';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 import {DominoAdapter, parseDocument} from './domino_adapter';
 import {SERVER_HTTP_PROVIDERS} from './http';
@@ -90,7 +89,6 @@ export const PLATFORM_SERVER_PROVIDERS: Provider[] = [
  */
 @NgModule({
   exports: [BrowserModule],
-  imports: [NoopAnimationsModule],
   providers: PLATFORM_SERVER_PROVIDERS,
 })
 export class ServerModule {}

--- a/packages/platform-server/test/BUILD.bazel
+++ b/packages/platform-server/test/BUILD.bazel
@@ -47,6 +47,7 @@ ts_library(
         "//packages/localize",
         "//packages/localize/init",
         "//packages/platform-browser",
+        "//packages/platform-browser/animations",
         "//packages/platform-server",
         "//packages/private/testing",
         "//packages/router",

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -66,6 +66,7 @@ import {provideRouter, RouterOutlet, Routes} from '@angular/router';
 import {Observable} from 'rxjs';
 
 import {renderApplication, SERVER_CONTEXT} from '../src/utils';
+import {BrowserAnimationsModule, provideAnimations} from '@angular/platform-browser/animations';
 
 const APP_CONFIG: ApplicationConfig = {
   providers: [provideServerRendering()],
@@ -390,11 +391,13 @@ function createMyAnimationApp(standalone: boolean) {
 }
 
 const MyAnimationApp = createMyAnimationApp(false);
-const MyAnimationAppStandalone = getStandaloneBootstrapFn(createMyAnimationApp(true));
+const MyAnimationAppStandalone = getStandaloneBootstrapFn(createMyAnimationApp(true), [
+  provideAnimations(),
+]);
 
 @NgModule({
   declarations: [MyAnimationApp],
-  imports: [BrowserModule, ServerModule],
+  imports: [BrowserModule, BrowserAnimationsModule, ServerModule],
   bootstrap: [MyAnimationApp],
 })
 class AnimationServerModule {}

--- a/packages/platform-server/testing/BUILD.bazel
+++ b/packages/platform-server/testing/BUILD.bazel
@@ -10,7 +10,6 @@ ng_module(
     deps = [
         "//packages/core",
         "//packages/platform-browser-dynamic/testing",
-        "//packages/platform-browser/animations",
         "//packages/platform-server",
     ],
 )

--- a/packages/platform-server/testing/src/server.ts
+++ b/packages/platform-server/testing/src/server.ts
@@ -11,7 +11,6 @@ import {
   BrowserDynamicTestingModule,
   ɵplatformCoreDynamicTesting as platformCoreDynamicTesting,
 } from '@angular/platform-browser-dynamic/testing';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {
   ɵINTERNAL_SERVER_PLATFORM_PROVIDERS as INTERNAL_SERVER_PLATFORM_PROVIDERS,
   ɵSERVER_RENDER_PROVIDERS as SERVER_RENDER_PROVIDERS,
@@ -35,7 +34,6 @@ export const platformServerTesting = createPlatformFactory(
  */
 @NgModule({
   exports: [BrowserDynamicTestingModule],
-  imports: [NoopAnimationsModule],
   providers: SERVER_RENDER_PROVIDERS,
 })
 export class ServerTestingModule {}


### PR DESCRIPTION
Includes the following changes that should remove the hard dependency between `platform-server` and the animations module:

### fix(platform-browser): automatically disable animations on the server 
Uses `ngServerMode` to automatically disable browser animations on the server. This allows us to decouple `platform-server` from the animations package.

### fix(platform-server): decouple server from animations module 

Removes the hard dependency between `platform-server` and `platform-browser/animations` since now the animations module will disable itself automatically.

### test(core): update tests that were relying on implicit animations module

We had some tests that were relying on the fact that the server module was importing animations implicitly.