### PR TITLE
docs: fix programmatic-rendering example

### DIFF
--- a/adev/src/content/guide/components/programmatic-rendering.md
+++ b/adev/src/content/guide/components/programmatic-rendering.md
@@ -117,10 +117,11 @@ JavaScript [dynamic import](https://developer.mozilla.org/docs/Web/JavaScript/Re
   `
 })
 export class AdminSettings {
-  advancedSettings: {new(): AdminSettings} | undefined;
+  advancedSettings: {new(): AdvancedSettings} | undefined;
 
   async loadAdvanced() {
-    this.advancedSettings = await import('path/to/advanced_settings.js');
+    const { AdvancedSettings } = await import('path/to/advanced_settings.js');
+    this.advancedSettings = AdvancedSettings;
   }
 }
 ```


### PR DESCRIPTION
Fixes example of programmatically rendering of components using dynamic import, as calling dynamic import returns module namespace object rather than component instance

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
