### PR TITLE
docs: add clarification for sourceLocale location in angular.json

### DIFF
--- a/adev/src/content/guide/i18n/locale-id.md
+++ b/adev/src/content/guide/i18n/locale-id.md
@@ -47,7 +47,18 @@ By default, Angular uses `en-US` as the source locale of your project.
 To change the source locale of your project for the build, complete the following actions.
 
 1. Open the [`angular.json`][GuideWorkspaceConfig] workspace build configuration file.
-1. Change the source locale in the `sourceLocale` field.
+2. Add or modify the `sourceLocale` field inside the `i18n` section:
+```json
+{
+  "projects": {
+    "your-project": {
+      "i18n": {
+        "sourceLocale": "ca"  // Use your desired locale code
+      }
+    }
+  }
+}
+```
 
 ## What's next
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The current documentation doesn't clarify where the sourceLocale should be setted if we don't have it already in our angular.json file.

Issue Number: N/A


## What is the new behavior?
In this commit there is explained that sourceLocale has to be inside the i18n section, and there is an example to see the context of sourceLocale.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
