### PR TITLE
docs: update `zip` command and link to recent DevTools commits

### DIFF
--- a/devtools/docs/release.md
+++ b/devtools/docs/release.md
@@ -68,14 +68,20 @@ Then upload it:
 1.  Setup Google Authenticator with the 2FA QR code.
     *   You can find the QR code [on Valentine as well](http://valentine/#/show/1651792043556329)
 
-The Firefox publishing process is slightly more involved than Chrome. In particular, they
-require extension source code with instructions to build and run it. Since DevTools exists in
-a monorepo with critical build tooling existing outside the `devtools/` directory, we need to
-upload the entire monorepo. Package it without dependencies and generated files with the
+The Firefox publishing process is slightly more involved than Chrome.
+
+Mozilla asks for a changelog, which needs to be authored manually. You can search for recent
+`devtools` commits to see what has landed since the last release.
+
+https://github.com/search?q=repo%3Aangular%2Fangular+devtools&type=commits&s=committer-date&o=desc
+
+Mozilla also requires extension source code with instructions to build and run it. Since DevTools
+exists in a monorepo with critical build tooling existing outside the `devtools/` directory, we
+need to upload the entire monorepo. Package it without dependencies and generated files with the
 following command and upload it.
 
 ```shell
-zip -r ~/angular-source.zip * -x ".git/*" -x "node_modules/*" -x "**/node_modules/*" -x "dist/"
+rm -rf dist/ && zip -r ~/angular-source.zip * -x ".git/*" -x "node_modules/*" -x "**/node_modules/*"
 ```
 
 Suggested note to reviewer:


### PR DESCRIPTION
`-x dist/` never worked for reasons I don't really understand. Historically I've just deleted `dist/` before zipping. I tried a few different approaches, but all of them lead to some form of "Name not matched" error in `zip` of the `dist/` directory. Instead I just opted to delete `dist/` as part of the zipping command.

The link to recent DevTools commits seems good enough to manually write a changelog. All relevant commits should be using `refactor(devtools)`, so the string "devtools" should definitely be in there.