### PR TITLE
refactor(core): move callAndReportToErrorHandler to bootstrap file

### DIFF
--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -41,7 +41,6 @@ import {publishDefaultGlobalUtils as _publishDefaultGlobalUtils} from '../render
 import {requiresRefreshOrTraversal} from '../render3/util/view_utils';
 import {ViewRef as InternalViewRef} from '../render3/view_ref';
 import {TESTABILITY} from '../testability/testability';
-import {isPromise} from '../util/lang';
 import {NgZone} from '../zone/ng_zone';
 
 import {ApplicationInitStatus} from './application_init';
@@ -177,29 +176,6 @@ export interface BootstrapOptions {
 
 /** Maximum number of times ApplicationRef will refresh all attached views in a single tick. */
 const MAXIMUM_REFRESH_RERUNS = 10;
-
-export function _callAndReportToErrorHandler(
-  errorHandler: ErrorHandler,
-  ngZone: NgZone,
-  callback: () => any,
-): any {
-  try {
-    const result = callback();
-    if (isPromise(result)) {
-      return result.catch((e: any) => {
-        ngZone.runOutsideAngular(() => errorHandler.handleError(e));
-        // rethrow as the exception handler might not do it
-        throw e;
-      });
-    }
-
-    return result;
-  } catch (e) {
-    ngZone.runOutsideAngular(() => errorHandler.handleError(e));
-    // rethrow as the exception handler might not do it
-    throw e;
-  }
-}
 
 export function optionsReducer<T extends Object>(dst: T, objs: T | T[]): T {
   if (Array.isArray(objs)) {

--- a/packages/core/src/application/create_application.ts
+++ b/packages/core/src/application/create_application.ts
@@ -14,7 +14,7 @@ import {createOrReusePlatformInjector} from '../platform/platform';
 import {assertStandaloneComponentType} from '../render3/errors';
 import {EnvironmentNgModuleRefAdapter} from '../render3/ng_module_ref';
 
-import {_callAndReportToErrorHandler, ApplicationRef} from './application_ref';
+import {ApplicationRef} from './application_ref';
 import {ChangeDetectionScheduler} from '../change_detection/scheduling/zoneless_scheduling';
 import {ChangeDetectionSchedulerImpl} from '../change_detection/scheduling/zoneless_scheduling_impl';
 import {bootstrap} from '../platform/bootstrap';

--- a/packages/core/src/platform/platform_ref.ts
+++ b/packages/core/src/platform/platform_ref.ts
@@ -7,11 +7,7 @@
  */
 
 import {compileNgModuleFactory} from '../application/application_ngmodule_factory_compiler';
-import {
-  _callAndReportToErrorHandler,
-  BootstrapOptions,
-  optionsReducer,
-} from '../application/application_ref';
+import {BootstrapOptions, optionsReducer} from '../application/application_ref';
 import {
   getNgZoneOptions,
   internalProvideZoneChangeDetection,


### PR DESCRIPTION
This function is only used in the bootstrap file and does not need to be in application_ref
