### PR TITLE
refactor(core): drop platform check in `ImagePerformanceWarning`

### DIFF
--- a/packages/core/src/image_performance_warning.ts
+++ b/packages/core/src/image_performance_warning.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {IMAGE_CONFIG, ImageConfig, PLATFORM_ID} from './application/application_tokens';
+import {IMAGE_CONFIG, ImageConfig} from './application/application_tokens';
 import {Injectable} from './di';
 import {inject} from './di/injector_compatibility';
 import {formatRuntimeError, RuntimeErrorCode} from './errors';
@@ -27,12 +27,11 @@ export class ImagePerformanceWarning implements OnDestroy {
   private window: Window | null = null;
   private observer: PerformanceObserver | null = null;
   private options: ImageConfig = inject(IMAGE_CONFIG);
-  private readonly isBrowser = inject(PLATFORM_ID) === 'browser';
   private lcpImageUrl?: string;
 
   public start() {
     if (
-      !this.isBrowser ||
+      (typeof ngServerMode !== 'undefined' && ngServerMode) ||
       typeof PerformanceObserver === 'undefined' ||
       (this.options?.disableImageSizeWarning && this.options?.disableImageLazyLoadWarning)
     ) {
@@ -41,7 +40,7 @@ export class ImagePerformanceWarning implements OnDestroy {
     this.observer = this.initPerformanceObserver();
     const doc = getDocument();
     const win = doc.defaultView;
-    if (typeof win !== 'undefined') {
+    if (win) {
       this.window = win;
       // Wait to avoid race conditions where LCP image triggers
       // load event before it's recorded by the performance observer


### PR DESCRIPTION
Replaces `PLATFORM_ID` checks with `ngServerMode` within the `ImagePerformanceWarning`.