### PR TITLE
refactor(common): drop platform checks in `HttpXsrfCookieExtractor`

### DIFF
--- a/packages/common/http/src/xsrf.ts
+++ b/packages/common/http/src/xsrf.ts
@@ -13,7 +13,6 @@ import {
   inject,
   Injectable,
   InjectionToken,
-  PLATFORM_ID,
   runInInjectionContext,
 } from '@angular/core';
 import {Observable} from 'rxjs';
@@ -66,12 +65,11 @@ export class HttpXsrfCookieExtractor implements HttpXsrfTokenExtractor {
 
   constructor(
     @Inject(DOCUMENT) private doc: any,
-    @Inject(PLATFORM_ID) private platform: string,
     @Inject(XSRF_COOKIE_NAME) private cookieName: string,
   ) {}
 
   getToken(): string | null {
-    if (this.platform === 'server') {
+    if (typeof ngServerMode !== 'undefined' && ngServerMode) {
       return null;
     }
     const cookieString = this.doc.cookie || '';

--- a/packages/common/http/test/resource_spec.ts
+++ b/packages/common/http/test/resource_spec.ts
@@ -19,6 +19,14 @@ import {HttpTestingController, provideHttpClientTesting} from '../testing';
 
 describe('httpResource', () => {
   beforeEach(() => {
+    globalThis['ngServerMode'] = isNode;
+  });
+
+  afterEach(() => {
+    globalThis['ngServerMode'] = undefined;
+  });
+
+  beforeEach(() => {
     TestBed.configureTestingModule({providers: [provideHttpClient(), provideHttpClientTesting()]});
   });
 

--- a/packages/common/http/test/xsrf_spec.ts
+++ b/packages/common/http/test/xsrf_spec.ts
@@ -122,7 +122,7 @@ describe('HttpXsrfCookieExtractor', () => {
     document = {
       cookie: 'XSRF-TOKEN=test',
     };
-    extractor = new HttpXsrfCookieExtractor(document, 'browser', 'XSRF-TOKEN');
+    extractor = new HttpXsrfCookieExtractor(document, 'XSRF-TOKEN');
   });
   it('parses the cookie from document.cookie', () => {
     expect(extractor.getToken()).toEqual('test');


### PR DESCRIPTION
Replaces `PLATFORM_ID` checks with `ngServerMode` within the `HttpXsrfCookieExtractor`. It is not part of the public API, and thus this change should not affect consumers who may have called the constructor directly.