### PR TITLE
docs: fix misspelled link text in overview.md

### DIFF
--- a/adev/src/content/reference/migrations/overview.md
+++ b/adev/src/content/reference/migrations/overview.md
@@ -24,7 +24,7 @@ Learn about how you can migrate your existing angular project to the latest feat
   <docs-card title="Queries as signal" link="Migrate now" href="reference/migrations/signal-queries">
     Convert existing decorator query fields to the improved signal queries API. The API is now production ready.
   </docs-card>
-  <docs-card title="Cleanup unused imports" link="Try it not" href="reference/migrations/cleanup-unused-imports">
+  <docs-card title="Cleanup unused imports" link="Try it now" href="reference/migrations/cleanup-unused-imports">
     Clean up unused imports in your project.
   </docs-card>
 </docs-card-container>


### PR DESCRIPTION
I assume that the link text should read "Try it now" instead of "Try it not". The latter is funnier, but also implies that this migration is not a recommended one.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Link implies migration should not be used


Issue Number: N/A


## What is the new behavior?

Link encourages use of the migration

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
