### PR TITLE
refactor(common): remove redundant `transferCacheInterceptorFn` dependencies

### DIFF
--- a/packages/common/http/src/transfer_cache.ts
+++ b/packages/common/http/src/transfer_cache.ts
@@ -328,7 +328,6 @@ export function withHttpTransferCache(cacheOptions: HttpTransferCacheOptions): P
       provide: HTTP_ROOT_INTERCEPTOR_FNS,
       useValue: transferCacheInterceptorFn,
       multi: true,
-      deps: [TransferState, CACHE_OPTIONS],
     },
     {
       provide: APP_BOOTSTRAP_LISTENER,


### PR DESCRIPTION
The `transferCacheInterceptorFn` injects dependencies in itself; the `TransferCache` and cache options are redundant in the `deps` list.