### PR TITLE
refactor(core): inline `isFactory` within `getNodeInjectable`

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -32,7 +32,6 @@ import {registerPreOrderHooks} from './hooks';
 import {AttributeMarker} from './interfaces/attribute_marker';
 import {ComponentDef, DirectiveDef} from './interfaces/definition';
 import {
-  isFactory,
   NO_PARENT_INJECTOR,
   NodeInjectorFactory,
   NodeInjectorOffset,
@@ -728,7 +727,7 @@ export function getNodeInjectable(
 ): any {
   let value = lView[index];
   const tData = tView.data;
-  if (isFactory(value)) {
+  if (value instanceof NodeInjectorFactory) {
     const factory: NodeInjectorFactory = value;
     if (factory.resolving) {
       throwCyclicDependencyError(stringifyForError(tData[index]));

--- a/packages/core/src/render3/instructions/write_to_directive_input.ts
+++ b/packages/core/src/render3/instructions/write_to_directive_input.ts
@@ -13,7 +13,7 @@ import {InputSignalNode} from '../../authoring/input/input_signal_node';
 import {applyValueToInputField} from '../apply_value_input_field';
 import {DirectiveDef} from '../interfaces/definition';
 import {InputFlags} from '../interfaces/input_flags';
-import {isFactory} from '../interfaces/injector';
+import {NodeInjectorFactory} from '../interfaces/injector';
 
 export function writeToDirectiveInput<T>(
   def: DirectiveDef<T>,
@@ -33,7 +33,7 @@ export function writeToDirectiveInput<T>(
       // Usually we resolve the directive instance using `LView[someIndex]` before writing to an
       // input, however if the read happens to early, the `LView[someIndex]` might actually be a
       // `NodeInjectorFactory`. Check for this specific case here since it can break in subtle ways.
-      if (isFactory(instance)) {
+      if (instance instanceof NodeInjectorFactory) {
         throw new Error(
           `ASSERTION ERROR: Cannot write input to factory for type ${def.type.name}. Directive has not been created yet.`,
         );

--- a/packages/core/src/render3/interfaces/injector.ts
+++ b/packages/core/src/render3/interfaces/injector.ts
@@ -287,7 +287,3 @@ export class NodeInjectorFactory {
     this.injectImpl = injectImplementation;
   }
 }
-
-export function isFactory(obj: any): obj is NodeInjectorFactory {
-  return obj instanceof NodeInjectorFactory;
-}


### PR DESCRIPTION
This commit inlines the `isFactory` function body directly within `getNodeInjectable` because it is only used once. ESBuild does not inline its body within the function, which can be observed when running the build with `NG_BUILD_MANGLE=0`. The results after inlining are as follows:

```
getNodeInjectable x 70,397,377 ops/sec ±3.88% (52 runs sampled)
getNodeInjectable_inlined x 77,834,432 ops/sec ±3.13% (60 runs sampled)
```

Since `isFactory` is passed with different argument shapes, it never gets optimized.

The function is also used only once, so there's no reason to keep it separate, because in minified code it's `function n(n){return n instanceof NodeInjectorFactory}`.