### PR TITLE
fix(docs-infra): reset sandbox runtime on template change

### DIFF
--- a/adev/src/app/features/playground/playground.component.ts
+++ b/adev/src/app/features/playground/playground.component.ts
@@ -87,6 +87,7 @@ export default class PlaygroundComponent implements AfterViewInit {
   async changeTemplate(template: PlaygroundTemplate): Promise<void> {
     this.selectedTemplate = template;
     await this.loadTemplate(template.path);
+    await this.nodeRuntimeSandbox!.reset();
   }
 
   private async loadTemplate(tutorialPath: string) {


### PR DESCRIPTION
We have the issue of switching templates which would break when going from "minigame" to any other template with HMR disabled.

This fixes it by resetting the node runtime sandbox on template change.