### PR TITLE
Invalidate HMR data on errors

### DIFF
--- a/packages/compiler-cli/test/ngtsc/hmr_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/hmr_spec.ts
@@ -104,18 +104,19 @@ runInEachFileSystem(() => {
       const hmrContents = env.driveHmr('test.ts', 'Cmp');
 
       expect(jsContents).toContain(`import * as i0 from "@angular/core";`);
+      expect(jsContents).toContain('const id = "test.ts%40Cmp";');
       expect(jsContents).toContain('function Cmp_HmrLoad(t) {');
       expect(jsContents).toContain(
-        'import(/* @vite-ignore */\nnew URL("./@ng/component?c=test.ts%40Cmp&t=" + encodeURIComponent(t), import.meta.url).href)',
+        'import(/* @vite-ignore */\nnew URL("./@ng/component?c=" + id + "&t=" + encodeURIComponent(t), import.meta.url).href)',
       );
       expect(jsContents).toContain(
         ').then(m => m.default && i0.ɵɵreplaceMetadata(Cmp, m.default, [i0], ' +
-          '[Dep, transformValue, TOKEN, Component, Inject, ViewChild, Input]));',
+          '[Dep, transformValue, TOKEN, Component, Inject, ViewChild, Input], import.meta, id));',
       );
       expect(jsContents).toContain('Cmp_HmrLoad(Date.now());');
       expect(jsContents).toContain(
         'import.meta.hot && import.meta.hot.on("angular:component-update", ' +
-          'd => d.id === "test.ts%40Cmp" && Cmp_HmrLoad(d.timestamp)',
+          'd => d.id === id && Cmp_HmrLoad(d.timestamp)',
       );
 
       expect(hmrContents).toContain(
@@ -171,18 +172,19 @@ runInEachFileSystem(() => {
       const hmrContents = env.driveHmr('test.ts', 'Cmp');
       expect(jsContents).toContain(`import * as i0 from "@angular/core";`);
       expect(jsContents).toContain(`import * as i1 from "./dep";`);
+      expect(jsContents).toContain('const id = "test.ts%40Cmp";');
       expect(jsContents).toContain('function Cmp_HmrLoad(t) {');
       expect(jsContents).toContain(
-        'import(/* @vite-ignore */\nnew URL("./@ng/component?c=test.ts%40Cmp&t=" + encodeURIComponent(t), import.meta.url).href)',
+        'import(/* @vite-ignore */\nnew URL("./@ng/component?c=" + id + "&t=" + encodeURIComponent(t), import.meta.url).href)',
       );
       expect(jsContents).toContain(
         ').then(m => m.default && i0.ɵɵreplaceMetadata(Cmp, m.default, [i0, i1], ' +
-          '[DepModule, Component]));',
+          '[DepModule, Component], import.meta, id));',
       );
       expect(jsContents).toContain('Cmp_HmrLoad(Date.now());');
       expect(jsContents).toContain(
         'import.meta.hot && import.meta.hot.on("angular:component-update", ' +
-          'd => d.id === "test.ts%40Cmp" && Cmp_HmrLoad(d.timestamp)',
+          'd => d.id === id && Cmp_HmrLoad(d.timestamp)',
       );
 
       expect(hmrContents).toContain(
@@ -340,7 +342,9 @@ runInEachFileSystem(() => {
       expect(jsContents).toContain('const Cmp_Defer_1_DepsFn = () => [Dep];');
       expect(jsContents).toContain('function Cmp_Defer_0_Template(rf, ctx) { if (rf & 1) {');
       expect(jsContents).toContain('i0.ɵɵdefer(1, 0, Cmp_Defer_1_DepsFn);');
-      expect(jsContents).toContain('ɵɵreplaceMetadata(Cmp, m.default, [i0], [Dep]));');
+      expect(jsContents).toContain(
+        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [Dep], import.meta, id));',
+      );
       expect(jsContents).not.toContain('setClassMetadata');
 
       expect(hmrContents).toContain(
@@ -422,7 +426,9 @@ runInEachFileSystem(() => {
       const jsContents = env.getContents('test.js');
       const hmrContents = env.driveHmr('test.ts', 'Cmp');
       expect(jsContents).toContain('dependencies: [Cmp]');
-      expect(jsContents).toContain('ɵɵreplaceMetadata(Cmp, m.default, [i0], [Component]));');
+      expect(jsContents).toContain(
+        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [Component], import.meta, id));',
+      );
       expect(hmrContents).toContain(
         'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, Component) {',
       );
@@ -445,7 +451,9 @@ runInEachFileSystem(() => {
       const jsContents = env.getContents('test.js');
       const hmrContents = env.driveHmr('test.ts', 'Cmp');
       expect(jsContents).not.toContain('dependencies');
-      expect(jsContents).toContain('ɵɵreplaceMetadata(Cmp, m.default, [i0], [Component]));');
+      expect(jsContents).toContain(
+        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [Component], import.meta, id));',
+      );
       expect(hmrContents).toContain(
         'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, Component) {',
       );
@@ -471,7 +479,7 @@ runInEachFileSystem(() => {
       const hmrContents = env.driveHmr('test.ts', 'Cmp');
 
       expect(jsContents).toContain(
-        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [providers, Component]));',
+        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [providers, Component], import.meta, id));',
       );
       expect(hmrContents).toContain(
         'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, providers, Component) {',
@@ -508,7 +516,7 @@ runInEachFileSystem(() => {
       const hmrContents = env.driveHmr('test.ts', 'Cmp');
 
       expect(jsContents).toContain(
-        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [token, value, Component]));',
+        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [token, value, Component], import.meta, id));',
       );
       expect(hmrContents).toContain(
         'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, token, value, Component) {',
@@ -542,7 +550,7 @@ runInEachFileSystem(() => {
       const hmrContents = env.driveHmr('test.ts', 'Cmp');
 
       expect(jsContents).toContain(
-        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [token, value, Component]));',
+        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [token, value, Component], import.meta, id));',
       );
       expect(hmrContents).toContain(
         'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, token, value, Component) {',
@@ -574,7 +582,7 @@ runInEachFileSystem(() => {
       const hmrContents = env.driveHmr('test.ts', 'Cmp');
 
       expect(jsContents).toContain(
-        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [condition, providersA, providersB, Component]));',
+        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [condition, providersA, providersB, Component], import.meta, id));',
       );
       expect(hmrContents).toContain(
         'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, condition, providersA, providersB, Component) {',
@@ -608,7 +616,7 @@ runInEachFileSystem(() => {
       const jsContents = env.getContents('test.js');
       const hmrContents = env.driveHmr('test.ts', 'Cmp');
       expect(jsContents).toContain(
-        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [token, value, otherValue, Component]));',
+        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [token, value, otherValue, Component], import.meta, id));',
       );
       expect(jsContents).toContain('useFactory: () => [(value), ((((otherValue))))]');
       expect(hmrContents).toContain(
@@ -646,7 +654,7 @@ runInEachFileSystem(() => {
       const hmrContents = env.driveHmr('test.ts', 'Cmp');
 
       expect(jsContents).toContain(
-        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [token, value, Optional, dep, Component]));',
+        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [token, value, Optional, dep, Component], import.meta, id));',
       );
       expect(hmrContents).toContain(
         'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, token, value, Optional, dep, Component) {',
@@ -697,7 +705,9 @@ runInEachFileSystem(() => {
       const hmrContents = env.driveHmr('test.ts', 'Cmp');
 
       expect(jsContents).toContain('dependencies: [Dep]');
-      expect(jsContents).toContain('ɵɵreplaceMetadata(Cmp, m.default, [i0], [Dep]));');
+      expect(jsContents).toContain(
+        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [Dep], import.meta, id));',
+      );
       expect(hmrContents).toContain('function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, Dep) {');
     });
 
@@ -741,7 +751,9 @@ runInEachFileSystem(() => {
       const hmrContents = env.driveHmr('test.ts', 'Cmp');
 
       expect(jsContents).toContain('dependencies: [DepModule, i1.Dep]');
-      expect(jsContents).toContain('ɵɵreplaceMetadata(Cmp, m.default, [i0, i1], [DepModule]));');
+      expect(jsContents).toContain(
+        'ɵɵreplaceMetadata(Cmp, m.default, [i0, i1], [DepModule], import.meta, id));',
+      );
       expect(hmrContents).toContain('function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, DepModule) {');
     });
 
@@ -797,7 +809,9 @@ runInEachFileSystem(() => {
       const hmrContents = env.driveHmr('test.ts', 'Cmp');
 
       expect(jsContents).toContain('dependencies: [i1.Dep]');
-      expect(jsContents).toContain('ɵɵreplaceMetadata(Cmp, m.default, [i0, i1], []));');
+      expect(jsContents).toContain(
+        'ɵɵreplaceMetadata(Cmp, m.default, [i0, i1], [], import.meta, id));',
+      );
       expect(hmrContents).toContain('function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces) {');
     });
 
@@ -834,7 +848,7 @@ runInEachFileSystem(() => {
       const jsContents = env.getContents('test.js');
       const hmrContents = env.driveHmr('test.ts', 'Cmp');
       expect(jsContents).toContain(
-        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [token, { one: 0, two: "2", three: 3 }, Component]));',
+        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [token, { one: 0, two: "2", three: 3 }, Component], import.meta, id));',
       );
       expect(hmrContents).toContain(
         'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, token, Foo, Component) {',
@@ -881,7 +895,7 @@ runInEachFileSystem(() => {
       const jsContents = env.getContents('test.js');
       const hmrContents = env.driveHmr('test.ts', 'Cmp');
       expect(jsContents).toContain(
-        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [token, { one: 0, two: "2", three: 3 }, Component]));',
+        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [token, { one: 0, two: "2", three: 3 }, Component], import.meta, id));',
       );
       expect(hmrContents).toContain(
         'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, token, Foo, Component) {',

--- a/packages/core/src/render3/hmr.ts
+++ b/packages/core/src/render3/hmr.ts
@@ -45,14 +45,23 @@ import {NgZone} from '../zone';
 import {ViewEncapsulation} from '../metadata/view';
 import {NG_COMP_DEF} from './fields';
 
+/** Represents `import.meta` plus some information that's not in the built-in types. */
+type ImportMetaExtended = ImportMeta & {
+  hot?: {
+    send?: (name: string, payload: unknown) => void;
+  };
+};
+
 /**
  * Replaces the metadata of a component type and re-renders all live instances of the component.
  * @param type Class whose metadata will be replaced.
  * @param applyMetadata Callback that will apply a new set of metadata on the `type` when invoked.
  * @param environment Syntehtic namespace imports that need to be passed along to the callback.
  * @param locals Local symbols from the source location that have to be exposed to the callback.
+ * @param importMeta `import.meta` from the call site of the replacement function. Optional since
+ *   it isn't used internally.
  * @param id ID to the class being replaced. **Not** the same as the component definition ID.
- *  Optional since the ID might not be available internally.
+ *   Optional since the ID might not be available internally.
  * @codeGenApi
  */
 export function ɵɵreplaceMetadata(
@@ -60,6 +69,7 @@ export function ɵɵreplaceMetadata(
   applyMetadata: (...args: [Type<unknown>, unknown[], ...unknown[]]) => void,
   namespaces: unknown[],
   locals: unknown[],
+  importMeta: ImportMetaExtended | null = null,
   id: string | null = null,
 ) {
   ngDevMode && assertComponentDef(type);
@@ -87,7 +97,7 @@ export function ɵɵreplaceMetadata(
       // Note: we have the additional check, because `IsRoot` can also indicate
       // a component created through something like `createComponent`.
       if (isRootView(root) && root[PARENT] === null) {
-        recreateMatchingLViews(newDef, oldDef, root);
+        recreateMatchingLViews(importMeta, id, newDef, oldDef, root);
       }
     }
   }
@@ -132,10 +142,14 @@ function mergeWithExistingDefinition(
 
 /**
  * Finds all LViews matching a specific component definition and recreates them.
+ * @param importMeta `import.meta` information.
+ * @param id HMR ID of the component.
  * @param oldDef Component definition to search for.
  * @param rootLView View from which to start the search.
  */
 function recreateMatchingLViews(
+  importMeta: ImportMetaExtended | null,
+  id: string | null,
   newDef: ComponentDef<unknown>,
   oldDef: ComponentDef<unknown>,
   rootLView: LView,
@@ -152,7 +166,7 @@ function recreateMatchingLViews(
   // produce false positives when using inheritance.
   if (tView === oldDef.tView) {
     ngDevMode && assertComponentDef(oldDef.type);
-    recreateLView(newDef, oldDef, rootLView);
+    recreateLView(importMeta, id, newDef, oldDef, rootLView);
     return;
   }
 
@@ -162,14 +176,14 @@ function recreateMatchingLViews(
     if (isLContainer(current)) {
       // The host can be an LView if a component is injecting `ViewContainerRef`.
       if (isLView(current[HOST])) {
-        recreateMatchingLViews(newDef, oldDef, current[HOST]);
+        recreateMatchingLViews(importMeta, id, newDef, oldDef, current[HOST]);
       }
 
       for (let j = CONTAINER_HEADER_OFFSET; j < current.length; j++) {
-        recreateMatchingLViews(newDef, oldDef, current[j]);
+        recreateMatchingLViews(importMeta, id, newDef, oldDef, current[j]);
       }
     } else if (isLView(current)) {
-      recreateMatchingLViews(newDef, oldDef, current);
+      recreateMatchingLViews(importMeta, id, newDef, oldDef, current);
     }
   }
 }
@@ -190,11 +204,15 @@ function clearRendererCache(factory: RendererFactory, def: ComponentDef<unknown>
 
 /**
  * Recreates an LView in-place from a new component definition.
+ * @param importMeta `import.meta` information.
+ * @param id HMR ID for the component.
  * @param newDef Definition from which to recreate the view.
  * @param oldDef Previous component definition being swapped out.
  * @param lView View to be recreated.
  */
 function recreateLView(
+  importMeta: ImportMetaExtended | null,
+  id: string | null,
   newDef: ComponentDef<unknown>,
   oldDef: ComponentDef<unknown>,
   lView: LView<unknown>,
@@ -272,9 +290,34 @@ function recreateLView(
 
   // The callback isn't guaranteed to be inside the Zone so we need to bring it in ourselves.
   if (zone === null) {
-    recreate();
+    executeWithInvalidateFallback(importMeta, id, recreate);
   } else {
-    zone.run(recreate);
+    zone.run(() => executeWithInvalidateFallback(importMeta, id, recreate));
+  }
+}
+
+/**
+ * Runs an HMR-related function and falls back to
+ * invalidating the HMR data if it throws an error.
+ */
+function executeWithInvalidateFallback(
+  importMeta: ImportMetaExtended | null,
+  id: string | null,
+  callback: () => void,
+) {
+  try {
+    callback();
+  } catch (e) {
+    const errorMessage = (e as {message?: string}).message;
+
+    // If we have all the necessary information and APIs to send off the invalidation
+    // request, send it before rethrowing so the dev server can decide what to do.
+    if (id !== null && errorMessage) {
+      importMeta?.hot?.send?.('angular:invalidate', {id, message: errorMessage, error: true});
+    }
+
+    // Throw the error in case the page doesn't get refreshed.
+    throw e;
   }
 }
 

--- a/packages/core/src/render3/hmr.ts
+++ b/packages/core/src/render3/hmr.ts
@@ -51,6 +51,8 @@ import {NG_COMP_DEF} from './fields';
  * @param applyMetadata Callback that will apply a new set of metadata on the `type` when invoked.
  * @param environment Syntehtic namespace imports that need to be passed along to the callback.
  * @param locals Local symbols from the source location that have to be exposed to the callback.
+ * @param id ID to the class being replaced. **Not** the same as the component definition ID.
+ *  Optional since the ID might not be available internally.
  * @codeGenApi
  */
 export function ɵɵreplaceMetadata(
@@ -58,6 +60,7 @@ export function ɵɵreplaceMetadata(
   applyMetadata: (...args: [Type<unknown>, unknown[], ...unknown[]]) => void,
   namespaces: unknown[],
   locals: unknown[],
+  id: string | null = null,
 ) {
   ngDevMode && assertComponentDef(type);
   const currentDef = getComponentDef(type)!;

--- a/packages/core/test/acceptance/hmr_spec.ts
+++ b/packages/core/test/acceptance/hmr_spec.ts
@@ -2157,6 +2157,7 @@ describe('hot module replacement', () => {
       },
       [angularCoreEnv],
       [],
+      '',
     );
   }
 

--- a/packages/core/test/acceptance/hmr_spec.ts
+++ b/packages/core/test/acceptance/hmr_spec.ts
@@ -2157,6 +2157,7 @@ describe('hot module replacement', () => {
       },
       [angularCoreEnv],
       [],
+      null,
       '',
     );
   }


### PR DESCRIPTION
Includes the following changes:

### refactor(compiler): pass more information to HMR replacement function
Adjusts the code we generate for HMR so that it passes in the HMR ID and `import.meta` to the `replaceMetadata` call. This is necessary so we can do better logging of errors.

### fix(core): invalidate HMR component if replacement throws an error 
Integrates angular/angular-cli#29510 which allows us to invalidate the data in the dev server for a component if a replacement threw an error.