### PR TITLE
refactor(core): move LContainer manipulation logic to its own file

### DIFF
--- a/packages/core/src/defer/rendering.ts
+++ b/packages/core/src/defer/rendering.ts
@@ -22,12 +22,7 @@ import {TContainerNode, TNode} from '../render3/interfaces/node';
 import {isDestroyed} from '../render3/interfaces/type_checks';
 import {HEADER_OFFSET, INJECTOR, LView, PARENT, TVIEW, TView} from '../render3/interfaces/view';
 import {getConstant, getTNode} from '../render3/util/view_utils';
-import {
-  addLViewToLContainer,
-  createAndRenderEmbeddedLView,
-  removeLViewFromLContainer,
-  shouldAddViewToDom,
-} from '../render3/view_manipulation';
+import {createAndRenderEmbeddedLView, shouldAddViewToDom} from '../render3/view_manipulation';
 import {assertDefined} from '../util/assert';
 
 import {
@@ -58,6 +53,7 @@ import {
 } from './utils';
 import {profiler} from '../render3/profiler';
 import {ProfilerEvent} from '../render3/profiler_types';
+import {addLViewToLContainer, removeLViewFromLContainer} from '../render3/view/container';
 
 /**
  * **INTERNAL**, avoid referencing it in application code.

--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -22,7 +22,6 @@ import {assertNodeInjector} from '../render3/assert';
 import {ComponentFactory as R3ComponentFactory} from '../render3/component_ref';
 import {getComponentDef} from '../render3/def_getters';
 import {getParentInjectorLocation, NodeInjector} from '../render3/di';
-import {addToEndOfViewTree, createLContainer} from '../render3/instructions/shared';
 import {
   CONTAINER_HEADER_OFFSET,
   DEHYDRATED_VIEWS,
@@ -51,7 +50,7 @@ import {
   TVIEW,
 } from '../render3/interfaces/view';
 import {assertTNodeType} from '../render3/node_assert';
-import {destroyLView, detachView} from '../render3/node_manipulation';
+import {destroyLView} from '../render3/node_manipulation';
 import {nativeInsertBefore} from '../render3/dom_node_manipulation';
 import {getCurrentTNode, getLView} from '../render3/state';
 import {
@@ -60,7 +59,7 @@ import {
   hasParentInjector,
 } from '../render3/util/injector_utils';
 import {getNativeByTNode, unwrapRNode, viewAttachedToContainer} from '../render3/util/view_utils';
-import {addLViewToLContainer, shouldAddViewToDom} from '../render3/view_manipulation';
+import {shouldAddViewToDom} from '../render3/view_manipulation';
 import {ViewRef as R3ViewRef} from '../render3/view_ref';
 import {addToArray, removeFromArray} from '../util/array_utils';
 import {
@@ -76,6 +75,8 @@ import {createElementRef, ElementRef} from './element_ref';
 import {NgModuleRef} from './ng_module_factory';
 import {TemplateRef} from './template_ref';
 import {EmbeddedViewRef, ViewRef} from './view_ref';
+import {addLViewToLContainer, createLContainer, detachView} from '../render3/view/container';
+import {addToEndOfViewTree} from '../render3/view/construction';
 
 /**
  * Represents a container where one or more views can be attached to a component.

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -32,15 +32,11 @@ import {attachPatchData} from './context_discovery';
 import {getComponentDef} from './def_getters';
 import {depsTracker} from './deps_tracker/deps_tracker';
 import {NodeInjector} from './di';
-import {registerPostOrderHooks} from './hooks';
 import {reportUnknownPropertyError} from './instructions/element_validation';
 import {markViewDirty} from './instructions/mark_view_dirty';
 import {renderView} from './instructions/render';
 import {
   createDirectivesInstances,
-  createLView,
-  createTView,
-  getInitialLViewFlagsFromDef,
   locateHostElement,
   setInputsForProperty,
 } from './instructions/shared';
@@ -82,6 +78,7 @@ import {debugStringifyTypeForError, stringifyForError} from './util/stringify_ut
 import {getComponentLViewByIndex, getTNode} from './util/view_utils';
 import {elementEndFirstCreatePass, elementStartFirstCreatePass} from './view/elements';
 import {ViewRef} from './view_ref';
+import {createLView, createTView, getInitialLViewFlagsFromDef} from './view/construction';
 
 export class ComponentFactoryResolver extends AbstractComponentFactoryResolver {
   /**

--- a/packages/core/src/render3/hmr.ts
+++ b/packages/core/src/render3/hmr.ts
@@ -13,11 +13,6 @@ import {getComponentDef} from './def_getters';
 import {assertComponentDef} from './errors';
 import {refreshView} from './instructions/change_detection';
 import {renderView} from './instructions/render';
-import {
-  createLView,
-  getInitialLViewFlagsFromDef,
-  getOrCreateComponentTView,
-} from './instructions/shared';
 import {CONTAINER_HEADER_OFFSET} from './interfaces/container';
 import {ComponentDef} from './interfaces/definition';
 import {getTrackedLViews} from './interfaces/lview_tracking';
@@ -44,6 +39,11 @@ import {RendererFactory} from './interfaces/renderer';
 import {NgZone} from '../zone';
 import {ViewEncapsulation} from '../metadata/view';
 import {NG_COMP_DEF} from './fields';
+import {
+  createLView,
+  getInitialLViewFlagsFromDef,
+  getOrCreateComponentTView,
+} from './view/construction';
 
 /** Represents `import.meta` plus some information that's not in the built-in types. */
 type ImportMetaExtended = ImportMeta & {

--- a/packages/core/src/render3/instructions/control_flow.ts
+++ b/packages/core/src/render3/instructions/control_flow.ts
@@ -29,19 +29,19 @@ import {
   TView,
 } from '../interfaces/view';
 import {LiveCollection, reconcile} from '../list_reconciliation';
-import {destroyLView, detachView} from '../node_manipulation';
+import {destroyLView} from '../node_manipulation';
 import {getLView, getSelectedIndex, getTView, nextBindingIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
 import {getConstant, getTNode} from '../util/view_utils';
-import {
-  addLViewToLContainer,
-  createAndRenderEmbeddedLView,
-  getLViewFromLContainer,
-  removeLViewFromLContainer,
-  shouldAddViewToDom,
-} from '../view_manipulation';
+import {createAndRenderEmbeddedLView, shouldAddViewToDom} from '../view_manipulation';
 
 import {declareTemplate} from './template';
+import {
+  addLViewToLContainer,
+  detachView,
+  getLViewFromLContainer,
+  removeLViewFromLContainer,
+} from '../view/container';
 
 /**
  * The conditional instruction represents the basic building block on the runtime side to support

--- a/packages/core/src/render3/instructions/projection.ts
+++ b/packages/core/src/render3/instructions/projection.ts
@@ -28,11 +28,8 @@ import {
 } from '../node_selector_matcher';
 import {getLView, getTView, isInSkipHydrationBlock, setCurrentTNodeAsNotParent} from '../state';
 import {getOrCreateTNode} from '../tnode_manipulation';
-import {
-  addLViewToLContainer,
-  createAndRenderEmbeddedLView,
-  shouldAddViewToDom,
-} from '../view_manipulation';
+import {addLViewToLContainer} from '../view/container';
+import {createAndRenderEmbeddedLView, shouldAddViewToDom} from '../view_manipulation';
 
 import {declareTemplate} from './template';
 

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -8,42 +8,29 @@
 
 import {Injector} from '../../di/injector';
 import {ErrorHandler} from '../../error_handler';
-import {DehydratedView} from '../../hydration/interfaces';
 import {hasSkipHydrationAttrOnRElement} from '../../hydration/skip_hydration';
 import {PRESERVE_HOST_CONTENT, PRESERVE_HOST_CONTENT_DEFAULT} from '../../hydration/tokens';
 import {processTextNodeMarkersBeforeHydration} from '../../hydration/utils';
-import {SchemaMetadata} from '../../metadata/schema';
 import {ViewEncapsulation} from '../../metadata/view';
 import {
   validateAgainstEventAttributes,
   validateAgainstEventProperties,
 } from '../../sanitization/sanitization';
-import {assertDefined, assertEqual, assertIndexInRange, assertNotSame} from '../../util/assert';
+import {assertIndexInRange, assertNotSame} from '../../util/assert';
 import {escapeCommentText} from '../../util/dom';
 import {normalizeDebugBindingName, normalizeDebugBindingValue} from '../../util/ng_reflect';
 import {stringify} from '../../util/stringify';
-import {assertFirstCreatePass, assertLView, assertTNodeForLView} from '../assert';
+import {assertFirstCreatePass, assertLView} from '../assert';
 import {attachPatchData} from '../context_discovery';
 import {getNodeInjectable, getOrCreateNodeInjectorForNode} from '../di';
 import {throwMultipleComponentError} from '../errors';
-import {CONTAINER_HEADER_OFFSET, LContainer} from '../interfaces/container';
-import {
-  ComponentDef,
-  ComponentTemplate,
-  DirectiveDef,
-  DirectiveDefListOrFactory,
-  PipeDefListOrFactory,
-  RenderFlags,
-  ViewQueriesFunction,
-} from '../interfaces/definition';
+import {ComponentDef, ComponentTemplate, DirectiveDef, RenderFlags} from '../interfaces/definition';
 import {InputFlags} from '../interfaces/input_flags';
-import {getUniqueLViewId} from '../interfaces/lview_tracking';
 import {
   InitialInputData,
   InitialInputs,
   LocalRefExtractor,
   NodeInputBindings,
-  TConstantsOrFactory,
   TContainerNode,
   TDirectiveHostNode,
   TElementContainerNode,
@@ -57,30 +44,15 @@ import {RComment, RElement} from '../interfaces/renderer_dom';
 import {SanitizerFn} from '../interfaces/sanitization';
 import {isComponentDef, isComponentHost} from '../interfaces/type_checks';
 import {
-  CHILD_HEAD,
-  CHILD_TAIL,
   CONTEXT,
-  DECLARATION_COMPONENT_VIEW,
-  DECLARATION_VIEW,
-  EMBEDDED_VIEW_INJECTOR,
-  ENVIRONMENT,
   FLAGS,
   HEADER_OFFSET,
-  HOST,
-  HYDRATION,
-  ID,
   INJECTOR,
   LView,
-  LViewEnvironment,
   LViewFlags,
-  NEXT,
-  PARENT,
   RENDERER,
-  T_HOST,
   TData,
-  TVIEW,
   TView,
-  TViewType,
 } from '../interfaces/view';
 import {assertTNodeType} from '../node_assert';
 import {isNodeMatchingSelectorList} from '../node_selector_matcher';
@@ -97,70 +69,13 @@ import {
 import {NO_CHANGE} from '../tokens';
 import {INTERPOLATION_DELIMITER} from '../util/misc_utils';
 import {renderStringify} from '../util/stringify_utils';
-import {
-  getComponentLViewByIndex,
-  getNativeByTNode,
-  resetPreOrderHookFlags,
-  unwrapLView,
-} from '../util/view_utils';
+import {getComponentLViewByIndex, getNativeByTNode, unwrapLView} from '../util/view_utils';
 
 import {clearElementContents} from '../dom_node_manipulation';
+import {createComponentLView} from '../view/construction';
 import {selectIndexInternal} from './advance';
 import {handleUnknownPropertyError, isPropertyValid, matchingSchemas} from './element_validation';
 import {writeToDirectiveInput} from './write_to_directive_input';
-
-export function createLView<T>(
-  parentLView: LView | null,
-  tView: TView,
-  context: T | null,
-  flags: LViewFlags,
-  host: RElement | null,
-  tHostNode: TNode | null,
-  environment: LViewEnvironment | null,
-  renderer: Renderer | null,
-  injector: Injector | null,
-  embeddedViewInjector: Injector | null,
-  hydrationInfo: DehydratedView | null,
-): LView<T> {
-  const lView = tView.blueprint.slice() as LView;
-  lView[HOST] = host;
-  lView[FLAGS] =
-    flags |
-    LViewFlags.CreationMode |
-    LViewFlags.Attached |
-    LViewFlags.FirstLViewPass |
-    LViewFlags.Dirty |
-    LViewFlags.RefreshView;
-  if (
-    embeddedViewInjector !== null ||
-    (parentLView && parentLView[FLAGS] & LViewFlags.HasEmbeddedViewInjector)
-  ) {
-    lView[FLAGS] |= LViewFlags.HasEmbeddedViewInjector;
-  }
-  resetPreOrderHookFlags(lView);
-  ngDevMode && tView.declTNode && parentLView && assertTNodeForLView(tView.declTNode, parentLView);
-  lView[PARENT] = lView[DECLARATION_VIEW] = parentLView;
-  lView[CONTEXT] = context;
-  lView[ENVIRONMENT] = (environment || (parentLView && parentLView[ENVIRONMENT]))!;
-  ngDevMode && assertDefined(lView[ENVIRONMENT], 'LViewEnvironment is required');
-  lView[RENDERER] = (renderer || (parentLView && parentLView[RENDERER]))!;
-  ngDevMode && assertDefined(lView[RENDERER], 'Renderer is required');
-  lView[INJECTOR as any] = injector || (parentLView && parentLView[INJECTOR]) || null;
-  lView[T_HOST] = tHostNode;
-  lView[ID] = getUniqueLViewId();
-  lView[HYDRATION] = hydrationInfo;
-  lView[EMBEDDED_VIEW_INJECTOR as any] = embeddedViewInjector;
-
-  ngDevMode &&
-    assertEqual(
-      tView.type == TViewType.Embedded ? parentLView !== null : true,
-      true,
-      'Embedded views must have parentLView',
-    );
-  lView[DECLARATION_COMPONENT_VIEW] =
-    tView.type == TViewType.Embedded ? parentLView![DECLARATION_COMPONENT_VIEW] : lView;
-  return lView as LView<T>;
-}
 
 export function executeTemplate<T>(
   tView: TView,
@@ -241,126 +156,6 @@ export function saveResolvedLocalsInData(
       viewData[localIndex++] = value;
     }
   }
-}
-
-/**
- * Gets TView from a template function or creates a new TView
- * if it doesn't already exist.
- *
- * @param def ComponentDef
- * @returns TView
- */
-export function getOrCreateComponentTView(def: ComponentDef<any>): TView {
-  const tView = def.tView;
-
-  // Create a TView if there isn't one, or recreate it if the first create pass didn't
-  // complete successfully since we can't know for sure whether it's in a usable shape.
-  if (tView === null || tView.incompleteFirstPass) {
-    // Declaration node here is null since this function is called when we dynamically create a
-    // component and hence there is no declaration.
-    const declTNode = null;
-    return (def.tView = createTView(
-      TViewType.Component,
-      declTNode,
-      def.template,
-      def.decls,
-      def.vars,
-      def.directiveDefs,
-      def.pipeDefs,
-      def.viewQuery,
-      def.schemas,
-      def.consts,
-      def.id,
-    ));
-  }
-
-  return tView;
-}
-
-/**
- * Creates a TView instance
- *
- * @param type Type of `TView`.
- * @param declTNode Declaration location of this `TView`.
- * @param templateFn Template function
- * @param decls The number of nodes, local refs, and pipes in this template
- * @param directives Registry of directives for this view
- * @param pipes Registry of pipes for this view
- * @param viewQuery View queries for this view
- * @param schemas Schemas for this view
- * @param consts Constants for this view
- */
-export function createTView(
-  type: TViewType,
-  declTNode: TNode | null,
-  templateFn: ComponentTemplate<any> | null,
-  decls: number,
-  vars: number,
-  directives: DirectiveDefListOrFactory | null,
-  pipes: PipeDefListOrFactory | null,
-  viewQuery: ViewQueriesFunction<any> | null,
-  schemas: SchemaMetadata[] | null,
-  constsOrFactory: TConstantsOrFactory | null,
-  ssrId: string | null,
-): TView {
-  ngDevMode && ngDevMode.tView++;
-  const bindingStartIndex = HEADER_OFFSET + decls;
-  // This length does not yet contain host bindings from child directives because at this point,
-  // we don't know which directives are active on this template. As soon as a directive is matched
-  // that has a host binding, we will update the blueprint with that def's hostVars count.
-  const initialViewLength = bindingStartIndex + vars;
-  const blueprint = createViewBlueprint(bindingStartIndex, initialViewLength);
-  const consts = typeof constsOrFactory === 'function' ? constsOrFactory() : constsOrFactory;
-  const tView = (blueprint[TVIEW as any] = {
-    type: type,
-    blueprint: blueprint,
-    template: templateFn,
-    queries: null,
-    viewQuery: viewQuery,
-    declTNode: declTNode,
-    data: blueprint.slice().fill(null, bindingStartIndex),
-    bindingStartIndex: bindingStartIndex,
-    expandoStartIndex: initialViewLength,
-    hostBindingOpCodes: null,
-    firstCreatePass: true,
-    firstUpdatePass: true,
-    staticViewQueries: false,
-    staticContentQueries: false,
-    preOrderHooks: null,
-    preOrderCheckHooks: null,
-    contentHooks: null,
-    contentCheckHooks: null,
-    viewHooks: null,
-    viewCheckHooks: null,
-    destroyHooks: null,
-    cleanup: null,
-    contentQueries: null,
-    components: null,
-    directiveRegistry: typeof directives === 'function' ? directives() : directives,
-    pipeRegistry: typeof pipes === 'function' ? pipes() : pipes,
-    firstChild: null,
-    schemas: schemas,
-    consts: consts,
-    incompleteFirstPass: false,
-    ssrId,
-  });
-  if (ngDevMode) {
-    // For performance reasons it is important that the tView retains the same shape during runtime.
-    // (To make sure that all of the code is monomorphic.) For this reason we seal the object to
-    // prevent class transitions.
-    Object.seal(tView);
-  }
-  return tView;
-}
-
-function createViewBlueprint(bindingStartIndex: number, initialViewLength: number): LView {
-  const blueprint = [];
-
-  for (let i = 0; i < initialViewLength; i++) {
-    blueprint.push(i < bindingStartIndex ? null : NO_CHANGE);
-  }
-
-  return blueprint as LView;
 }
 
 /**
@@ -672,53 +467,6 @@ export function findDirectiveDefMatches(
   return matches;
 }
 
-/**
- * Gets the initial set of LView flags based on the component definition that the LView represents.
- * @param def Component definition from which to determine the flags.
- */
-export function getInitialLViewFlagsFromDef(def: ComponentDef<unknown>): LViewFlags {
-  let flags = LViewFlags.CheckAlways;
-  if (def.signals) {
-    flags = LViewFlags.SignalView;
-  } else if (def.onPush) {
-    flags = LViewFlags.Dirty;
-  }
-  return flags;
-}
-
-function createComponentLView<T>(
-  lView: LView,
-  hostTNode: TElementNode,
-  def: ComponentDef<T>,
-): LView {
-  const native = getNativeByTNode(hostTNode, lView) as RElement;
-  const tView = getOrCreateComponentTView(def);
-
-  // Only component views should be added to the view tree directly. Embedded views are
-  // accessed through their containers because they may be removed / re-added later.
-  const rendererFactory = lView[ENVIRONMENT].rendererFactory;
-  const componentView = addToEndOfViewTree(
-    lView,
-    createLView(
-      lView,
-      tView,
-      null,
-      getInitialLViewFlagsFromDef(def),
-      native,
-      hostTNode as TElementNode,
-      null,
-      rendererFactory.createRenderer(native, def),
-      null,
-      null,
-      null,
-    ),
-  );
-
-  // Component view will always be created before any injected LContainers,
-  // so this is a regular element, wrap it with the component view
-  return (lView[hostTNode.index] = componentView);
-}
-
 export function elementAttributeInternal(
   tNode: TNode,
   lView: LView,
@@ -795,76 +543,6 @@ function setInputsFromAttrs<T>(
       }
     }
   }
-}
-
-//////////////////////////
-//// ViewContainer & View
-//////////////////////////
-
-/**
- * Creates a LContainer, either from a container instruction, or for a ViewContainerRef.
- *
- * @param hostNative The host element for the LContainer
- * @param hostTNode The host TNode for the LContainer
- * @param currentView The parent view of the LContainer
- * @param native The native comment element
- * @param isForViewContainerRef Optional a flag indicating the ViewContainerRef case
- * @returns LContainer
- */
-export function createLContainer(
-  hostNative: RElement | RComment | LView,
-  currentView: LView,
-  native: RComment,
-  tNode: TNode,
-): LContainer {
-  ngDevMode && assertLView(currentView);
-  const lContainer: LContainer = [
-    hostNative, // host native
-    true, // Boolean `true` in this position signifies that this is an `LContainer`
-    0, // flags
-    currentView, // parent
-    null, // next
-    tNode, // t_host
-    null, // dehydrated views
-    native, // native,
-    null, // view refs
-    null, // moved views
-  ];
-  ngDevMode &&
-    assertEqual(
-      lContainer.length,
-      CONTAINER_HEADER_OFFSET,
-      'Should allocate correct number of slots for LContainer header.',
-    );
-  return lContainer;
-}
-
-/**
- * Adds LView or LContainer to the end of the current view tree.
- *
- * This structure will be used to traverse through nested views to remove listeners
- * and call onDestroy callbacks.
- *
- * @param lView The view where LView or LContainer should be added
- * @param adjustedHostIndex Index of the view's host node in LView[], adjusted for header
- * @param lViewOrLContainer The LView or LContainer to add to the view tree
- * @returns The state passed in
- */
-export function addToEndOfViewTree<T extends LView | LContainer>(
-  lView: LView,
-  lViewOrLContainer: T,
-): T {
-  // TODO(benlesh/misko): This implementation is incorrect, because it always adds the LContainer
-  // to the end of the queue, which means if the developer retrieves the LContainers from RNodes out
-  // of order, the change detection will run out of order, as the act of retrieving the the
-  // LContainer from the RNode is what adds it to the queue.
-  if (lView[CHILD_HEAD]) {
-    lView[CHILD_TAIL]![NEXT] = lViewOrLContainer;
-  } else {
-    lView[CHILD_HEAD] = lViewOrLContainer;
-  }
-  lView[CHILD_TAIL] = lViewOrLContainer;
-  return lViewOrLContainer;
 }
 
 ///////////////////////////////

--- a/packages/core/src/render3/instructions/template.ts
+++ b/packages/core/src/render3/instructions/template.ts
@@ -38,13 +38,12 @@ import {
 import {getOrCreateTNode} from '../tnode_manipulation';
 import {mergeHostAttrs} from '../util/attrs_utils';
 import {getConstant} from '../util/view_utils';
+import {addToEndOfViewTree, createTView} from '../view/construction';
+import {createLContainer} from '../view/container';
 import {resolveDirectives} from '../view/directives';
 
 import {
-  addToEndOfViewTree,
   createDirectivesInstancesInInstruction,
-  createLContainer,
-  createTView,
   findDirectiveDefMatches,
   saveResolvedLocalsInData,
 } from './shared';

--- a/packages/core/src/render3/view/construction.ts
+++ b/packages/core/src/render3/view/construction.ts
@@ -6,9 +6,270 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {type TView, type LView, TVIEW} from '../interfaces/view';
-import {assertFirstCreatePass, assertFirstUpdatePass} from '../assert';
-import {assertSame, assertEqual} from '../../util/assert';
+import {
+  TView,
+  TVIEW,
+  LViewFlags,
+  LViewEnvironment,
+  HOST,
+  FLAGS,
+  DECLARATION_VIEW,
+  PARENT,
+  CONTEXT,
+  ENVIRONMENT,
+  RENDERER,
+  INJECTOR,
+  T_HOST,
+  ID,
+  HYDRATION,
+  EMBEDDED_VIEW_INJECTOR,
+  TViewType,
+  DECLARATION_COMPONENT_VIEW,
+  HEADER_OFFSET,
+  CHILD_HEAD,
+  CHILD_TAIL,
+  NEXT,
+  LView,
+} from '../interfaces/view';
+import {assertFirstCreatePass, assertFirstUpdatePass, assertTNodeForLView} from '../assert';
+import {assertSame, assertEqual, assertDefined} from '../../util/assert';
+import {RElement} from '../interfaces/renderer_dom';
+import {TConstantsOrFactory, TElementNode, TNode} from '../interfaces/node';
+import {Renderer} from '../interfaces/renderer';
+import {Injector} from '../../di';
+import {DehydratedView} from '../../hydration/interfaces';
+import {getNativeByTNode, resetPreOrderHookFlags} from '../util/view_utils';
+import {getUniqueLViewId} from '../interfaces/lview_tracking';
+import {NO_CHANGE} from '../tokens';
+import {
+  ComponentDef,
+  ComponentTemplate,
+  DirectiveDefListOrFactory,
+  PipeDefListOrFactory,
+  ViewQueriesFunction,
+} from '../interfaces/definition';
+import {SchemaMetadata} from '../../metadata/schema';
+import {LContainer} from '../interfaces/container';
+
+/**
+ * Creates a TView instance
+ *
+ * @param type Type of `TView`.
+ * @param declTNode Declaration location of this `TView`.
+ * @param templateFn Template function
+ * @param decls The number of nodes, local refs, and pipes in this template
+ * @param directives Registry of directives for this view
+ * @param pipes Registry of pipes for this view
+ * @param viewQuery View queries for this view
+ * @param schemas Schemas for this view
+ * @param consts Constants for this view
+ */
+export function createTView(
+  type: TViewType,
+  declTNode: TNode | null,
+  templateFn: ComponentTemplate<any> | null,
+  decls: number,
+  vars: number,
+  directives: DirectiveDefListOrFactory | null,
+  pipes: PipeDefListOrFactory | null,
+  viewQuery: ViewQueriesFunction<any> | null,
+  schemas: SchemaMetadata[] | null,
+  constsOrFactory: TConstantsOrFactory | null,
+  ssrId: string | null,
+): TView {
+  ngDevMode && ngDevMode.tView++;
+  const bindingStartIndex = HEADER_OFFSET + decls;
+  // This length does not yet contain host bindings from child directives because at this point,
+  // we don't know which directives are active on this template. As soon as a directive is matched
+  // that has a host binding, we will update the blueprint with that def's hostVars count.
+  const initialViewLength = bindingStartIndex + vars;
+  const blueprint = createViewBlueprint(bindingStartIndex, initialViewLength);
+  const consts = typeof constsOrFactory === 'function' ? constsOrFactory() : constsOrFactory;
+  const tView = (blueprint[TVIEW as any] = {
+    type: type,
+    blueprint: blueprint,
+    template: templateFn,
+    queries: null,
+    viewQuery: viewQuery,
+    declTNode: declTNode,
+    data: blueprint.slice().fill(null, bindingStartIndex),
+    bindingStartIndex: bindingStartIndex,
+    expandoStartIndex: initialViewLength,
+    hostBindingOpCodes: null,
+    firstCreatePass: true,
+    firstUpdatePass: true,
+    staticViewQueries: false,
+    staticContentQueries: false,
+    preOrderHooks: null,
+    preOrderCheckHooks: null,
+    contentHooks: null,
+    contentCheckHooks: null,
+    viewHooks: null,
+    viewCheckHooks: null,
+    destroyHooks: null,
+    cleanup: null,
+    contentQueries: null,
+    components: null,
+    directiveRegistry: typeof directives === 'function' ? directives() : directives,
+    pipeRegistry: typeof pipes === 'function' ? pipes() : pipes,
+    firstChild: null,
+    schemas: schemas,
+    consts: consts,
+    incompleteFirstPass: false,
+    ssrId,
+  });
+  if (ngDevMode) {
+    // For performance reasons it is important that the tView retains the same shape during runtime.
+    // (To make sure that all of the code is monomorphic.) For this reason we seal the object to
+    // prevent class transitions.
+    Object.seal(tView);
+  }
+  return tView;
+}
+
+function createViewBlueprint(bindingStartIndex: number, initialViewLength: number): LView {
+  const blueprint = [];
+
+  for (let i = 0; i < initialViewLength; i++) {
+    blueprint.push(i < bindingStartIndex ? null : NO_CHANGE);
+  }
+
+  return blueprint as LView;
+}
+
+/**
+ * Gets TView from a template function or creates a new TView
+ * if it doesn't already exist.
+ *
+ * @param def ComponentDef
+ * @returns TView
+ */
+export function getOrCreateComponentTView(def: ComponentDef<any>): TView {
+  const tView = def.tView;
+
+  // Create a TView if there isn't one, or recreate it if the first create pass didn't
+  // complete successfully since we can't know for sure whether it's in a usable shape.
+  if (tView === null || tView.incompleteFirstPass) {
+    // Declaration node here is null since this function is called when we dynamically create a
+    // component and hence there is no declaration.
+    const declTNode = null;
+    return (def.tView = createTView(
+      TViewType.Component,
+      declTNode,
+      def.template,
+      def.decls,
+      def.vars,
+      def.directiveDefs,
+      def.pipeDefs,
+      def.viewQuery,
+      def.schemas,
+      def.consts,
+      def.id,
+    ));
+  }
+
+  return tView;
+}
+
+export function createLView<T>(
+  parentLView: LView | null,
+  tView: TView,
+  context: T | null,
+  flags: LViewFlags,
+  host: RElement | null,
+  tHostNode: TNode | null,
+  environment: LViewEnvironment | null,
+  renderer: Renderer | null,
+  injector: Injector | null,
+  embeddedViewInjector: Injector | null,
+  hydrationInfo: DehydratedView | null,
+): LView<T> {
+  const lView = tView.blueprint.slice() as LView;
+  lView[HOST] = host;
+  lView[FLAGS] =
+    flags |
+    LViewFlags.CreationMode |
+    LViewFlags.Attached |
+    LViewFlags.FirstLViewPass |
+    LViewFlags.Dirty |
+    LViewFlags.RefreshView;
+  if (
+    embeddedViewInjector !== null ||
+    (parentLView && parentLView[FLAGS] & LViewFlags.HasEmbeddedViewInjector)
+  ) {
+    lView[FLAGS] |= LViewFlags.HasEmbeddedViewInjector;
+  }
+  resetPreOrderHookFlags(lView);
+  ngDevMode && tView.declTNode && parentLView && assertTNodeForLView(tView.declTNode, parentLView);
+  lView[PARENT] = lView[DECLARATION_VIEW] = parentLView;
+  lView[CONTEXT] = context;
+  lView[ENVIRONMENT] = (environment || (parentLView && parentLView[ENVIRONMENT]))!;
+  ngDevMode && assertDefined(lView[ENVIRONMENT], 'LViewEnvironment is required');
+  lView[RENDERER] = (renderer || (parentLView && parentLView[RENDERER]))!;
+  ngDevMode && assertDefined(lView[RENDERER], 'Renderer is required');
+  lView[INJECTOR as any] = injector || (parentLView && parentLView[INJECTOR]) || null;
+  lView[T_HOST] = tHostNode;
+  lView[ID] = getUniqueLViewId();
+  lView[HYDRATION] = hydrationInfo;
+  lView[EMBEDDED_VIEW_INJECTOR as any] = embeddedViewInjector;
+
+  ngDevMode &&
+    assertEqual(
+      tView.type == TViewType.Embedded ? parentLView !== null : true,
+      true,
+      'Embedded views must have parentLView',
+    );
+  lView[DECLARATION_COMPONENT_VIEW] =
+    tView.type == TViewType.Embedded ? parentLView![DECLARATION_COMPONENT_VIEW] : lView;
+  return lView as LView<T>;
+}
+
+export function createComponentLView<T>(
+  lView: LView,
+  hostTNode: TElementNode,
+  def: ComponentDef<T>,
+): LView {
+  const native = getNativeByTNode(hostTNode, lView) as RElement;
+  const tView = getOrCreateComponentTView(def);
+
+  // Only component views should be added to the view tree directly. Embedded views are
+  // accessed through their containers because they may be removed / re-added later.
+  const rendererFactory = lView[ENVIRONMENT].rendererFactory;
+  const componentView = addToEndOfViewTree(
+    lView,
+    createLView(
+      lView,
+      tView,
+      null,
+      getInitialLViewFlagsFromDef(def),
+      native,
+      hostTNode as TElementNode,
+      null,
+      rendererFactory.createRenderer(native, def),
+      null,
+      null,
+      null,
+    ),
+  );
+
+  // Component view will always be created before any injected LContainers,
+  // so this is a regular element, wrap it with the component view
+  return (lView[hostTNode.index] = componentView);
+}
+
+/**
+ * Gets the initial set of LView flags based on the component definition that the LView represents.
+ * @param def Component definition from which to determine the flags.
+ */
+export function getInitialLViewFlagsFromDef(def: ComponentDef<unknown>): LViewFlags {
+  let flags = LViewFlags.CheckAlways;
+  if (def.signals) {
+    flags = LViewFlags.SignalView;
+  } else if (def.onPush) {
+    flags = LViewFlags.Dirty;
+  }
+  return flags;
+}
 
 /**
  * When elements are created dynamically after a view blueprint is created (e.g. through
@@ -44,4 +305,32 @@ export function allocExpando(
     tView.data.push(null);
   }
   return allocIdx;
+}
+
+/**
+ * Adds LView or LContainer to the end of the current view tree.
+ *
+ * This structure will be used to traverse through nested views to remove listeners
+ * and call onDestroy callbacks.
+ *
+ * @param lView The view where LView or LContainer should be added
+ * @param adjustedHostIndex Index of the view's host node in LView[], adjusted for header
+ * @param lViewOrLContainer The LView or LContainer to add to the view tree
+ * @returns The state passed in
+ */
+export function addToEndOfViewTree<T extends LView | LContainer>(
+  lView: LView,
+  lViewOrLContainer: T,
+): T {
+  // TODO(benlesh/misko): This implementation is incorrect, because it always adds the LContainer
+  // to the end of the queue, which means if the developer retrieves the LContainers from RNodes out
+  // of order, the change detection will run out of order, as the act of retrieving the the
+  // LContainer from the RNode is what adds it to the queue.
+  if (lView[CHILD_HEAD]) {
+    lView[CHILD_TAIL]![NEXT] = lViewOrLContainer;
+  } else {
+    lView[CHILD_HEAD] = lViewOrLContainer;
+  }
+  lView[CHILD_TAIL] = lViewOrLContainer;
+  return lViewOrLContainer;
 }

--- a/packages/core/src/render3/view/container.ts
+++ b/packages/core/src/render3/view/container.ts
@@ -1,0 +1,260 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {addToArray, removeFromArray} from '../../util/array_utils';
+import {assertDefined, assertEqual} from '../../util/assert';
+import {assertLContainer, assertLView} from '../assert';
+import {
+  CONTAINER_HEADER_OFFSET,
+  LContainer,
+  LContainerFlags,
+  MOVED_VIEWS,
+  NATIVE,
+} from '../interfaces/container';
+import {TNode} from '../interfaces/node';
+import {RComment, RElement} from '../interfaces/renderer_dom';
+import {isLView} from '../interfaces/type_checks';
+import {
+  DECLARATION_COMPONENT_VIEW,
+  DECLARATION_LCONTAINER,
+  FLAGS,
+  HYDRATION,
+  LView,
+  LViewFlags,
+  NEXT,
+  PARENT,
+  QUERIES,
+  RENDERER,
+  T_HOST,
+  TView,
+  TVIEW,
+} from '../interfaces/view';
+import {
+  addViewToDOM,
+  destroyLView,
+  detachMovedView,
+  getBeforeNodeForView,
+  removeViewFromDOM,
+} from '../node_manipulation';
+import {updateAncestorTraversalFlagsOnAttach} from '../util/view_utils';
+
+/**
+ * Creates a LContainer, either from a container instruction, or for a ViewContainerRef.
+ *
+ * @param hostNative The host element for the LContainer
+ * @param hostTNode The host TNode for the LContainer
+ * @param currentView The parent view of the LContainer
+ * @param native The native comment element
+ * @param isForViewContainerRef Optional a flag indicating the ViewContainerRef case
+ * @returns LContainer
+ */
+export function createLContainer(
+  hostNative: RElement | RComment | LView,
+  currentView: LView,
+  native: RComment,
+  tNode: TNode,
+): LContainer {
+  ngDevMode && assertLView(currentView);
+  const lContainer: LContainer = [
+    hostNative, // host native
+    true, // Boolean `true` in this position signifies that this is an `LContainer`
+    0, // flags
+    currentView, // parent
+    null, // next
+    tNode, // t_host
+    null, // dehydrated views
+    native, // native,
+    null, // view refs
+    null, // moved views
+  ];
+  ngDevMode &&
+    assertEqual(
+      lContainer.length,
+      CONTAINER_HEADER_OFFSET,
+      'Should allocate correct number of slots for LContainer header.',
+    );
+  return lContainer;
+}
+
+export function getLViewFromLContainer<T>(
+  lContainer: LContainer,
+  index: number,
+): LView<T> | undefined {
+  const adjustedIndex = CONTAINER_HEADER_OFFSET + index;
+  // avoid reading past the array boundaries
+  if (adjustedIndex < lContainer.length) {
+    const lView = lContainer[adjustedIndex];
+    ngDevMode && assertLView(lView);
+    return lView as LView<T>;
+  }
+  return undefined;
+}
+
+export function addLViewToLContainer(
+  lContainer: LContainer,
+  lView: LView<unknown>,
+  index: number,
+  addToDOM = true,
+): void {
+  const tView = lView[TVIEW];
+
+  // Insert into the view tree so the new view can be change-detected
+  insertView(tView, lView, lContainer, index);
+
+  // Insert elements that belong to this view into the DOM tree
+  if (addToDOM) {
+    const beforeNode = getBeforeNodeForView(index, lContainer);
+    const renderer = lView[RENDERER];
+    const parentRNode = renderer.parentNode(lContainer[NATIVE] as RElement | RComment);
+    if (parentRNode !== null) {
+      addViewToDOM(tView, lContainer[T_HOST], renderer, lView, parentRNode, beforeNode);
+    }
+  }
+
+  // When in hydration mode, reset the pointer to the first child in
+  // the dehydrated view. This indicates that the view was hydrated and
+  // further attaching/detaching should work with this view as normal.
+  const hydrationInfo = lView[HYDRATION];
+  if (hydrationInfo !== null && hydrationInfo.firstChild !== null) {
+    hydrationInfo.firstChild = null;
+  }
+}
+
+export function removeLViewFromLContainer(
+  lContainer: LContainer,
+  index: number,
+): LView<unknown> | undefined {
+  const lView = detachView(lContainer, index);
+  if (lView !== undefined) {
+    destroyLView(lView[TVIEW], lView);
+  }
+  return lView;
+}
+
+/**
+ * Detaches a view from a container.
+ *
+ * This method removes the view from the container's array of active views. It also
+ * removes the view's elements from the DOM.
+ *
+ * @param lContainer The container from which to detach a view
+ * @param removeIndex The index of the view to detach
+ * @returns Detached LView instance.
+ */
+export function detachView(lContainer: LContainer, removeIndex: number): LView | undefined {
+  if (lContainer.length <= CONTAINER_HEADER_OFFSET) return;
+
+  const indexInContainer = CONTAINER_HEADER_OFFSET + removeIndex;
+  const viewToDetach = lContainer[indexInContainer];
+
+  if (viewToDetach) {
+    const declarationLContainer = viewToDetach[DECLARATION_LCONTAINER];
+    if (declarationLContainer !== null && declarationLContainer !== lContainer) {
+      detachMovedView(declarationLContainer, viewToDetach);
+    }
+
+    if (removeIndex > 0) {
+      lContainer[indexInContainer - 1][NEXT] = viewToDetach[NEXT] as LView;
+    }
+    const removedLView = removeFromArray(lContainer, CONTAINER_HEADER_OFFSET + removeIndex);
+    removeViewFromDOM(viewToDetach[TVIEW], viewToDetach);
+
+    // notify query that a view has been removed
+    const lQueries = removedLView[QUERIES];
+    if (lQueries !== null) {
+      lQueries.detachView(removedLView[TVIEW]);
+    }
+
+    viewToDetach[PARENT] = null;
+    viewToDetach[NEXT] = null;
+    // Unsets the attached flag
+    viewToDetach[FLAGS] &= ~LViewFlags.Attached;
+  }
+  return viewToDetach;
+}
+
+/**
+ * Inserts a view into a container.
+ *
+ * This adds the view to the container's array of active views in the correct
+ * position. It also adds the view's elements to the DOM if the container isn't a
+ * root node of another view (in that case, the view's elements will be added when
+ * the container's parent view is added later).
+ *
+ * @param tView The `TView' of the `LView` to insert
+ * @param lView The view to insert
+ * @param lContainer The container into which the view should be inserted
+ * @param index Which index in the container to insert the child view into
+ */
+function insertView(tView: TView, lView: LView, lContainer: LContainer, index: number) {
+  ngDevMode && assertLView(lView);
+  ngDevMode && assertLContainer(lContainer);
+  const indexInContainer = CONTAINER_HEADER_OFFSET + index;
+  const containerLength = lContainer.length;
+
+  if (index > 0) {
+    // This is a new view, we need to add it to the children.
+    lContainer[indexInContainer - 1][NEXT] = lView;
+  }
+  if (index < containerLength - CONTAINER_HEADER_OFFSET) {
+    lView[NEXT] = lContainer[indexInContainer];
+    addToArray(lContainer, CONTAINER_HEADER_OFFSET + index, lView);
+  } else {
+    lContainer.push(lView);
+    lView[NEXT] = null;
+  }
+
+  lView[PARENT] = lContainer;
+
+  // track views where declaration and insertion points are different
+  const declarationLContainer = lView[DECLARATION_LCONTAINER];
+  if (declarationLContainer !== null && lContainer !== declarationLContainer) {
+    trackMovedView(declarationLContainer, lView);
+  }
+
+  // notify query that a new view has been added
+  const lQueries = lView[QUERIES];
+  if (lQueries !== null) {
+    lQueries.insertView(tView);
+  }
+
+  updateAncestorTraversalFlagsOnAttach(lView);
+  // Sets the attached flag
+  lView[FLAGS] |= LViewFlags.Attached;
+}
+
+/**
+ * Track views created from the declaration container (TemplateRef) and inserted into a
+ * different LContainer or attached directly to ApplicationRef.
+ */
+export function trackMovedView(declarationContainer: LContainer, lView: LView) {
+  ngDevMode && assertDefined(lView, 'LView required');
+  ngDevMode && assertLContainer(declarationContainer);
+  const movedViews = declarationContainer[MOVED_VIEWS];
+  const parent = lView[PARENT]!;
+  ngDevMode && assertDefined(parent, 'missing parent');
+  if (isLView(parent)) {
+    declarationContainer[FLAGS] |= LContainerFlags.HasTransplantedViews;
+  } else {
+    const insertedComponentLView = parent[PARENT]![DECLARATION_COMPONENT_VIEW];
+    ngDevMode && assertDefined(insertedComponentLView, 'Missing insertedComponentLView');
+    const declaredComponentLView = lView[DECLARATION_COMPONENT_VIEW];
+    ngDevMode && assertDefined(declaredComponentLView, 'Missing declaredComponentLView');
+    if (declaredComponentLView !== insertedComponentLView) {
+      // At this point the declaration-component is not same as insertion-component; this means that
+      // this is a transplanted view. Mark the declared lView as having transplanted views so that
+      // those views can participate in CD.
+      declarationContainer[FLAGS] |= LContainerFlags.HasTransplantedViews;
+    }
+  }
+  if (movedViews === null) {
+    declarationContainer[MOVED_VIEWS] = [lView];
+  } else {
+    movedViews.push(lView);
+  }
+}

--- a/packages/core/src/render3/view_manipulation.ts
+++ b/packages/core/src/render3/view_manipulation.ts
@@ -13,30 +13,11 @@ import {DehydratedContainerView} from '../hydration/interfaces';
 import {hasInSkipHydrationBlockFlag} from '../hydration/skip_hydration';
 import {assertDefined} from '../util/assert';
 
-import {assertLContainer, assertLView, assertTNodeForLView} from './assert';
+import {assertLContainer, assertTNodeForLView} from './assert';
 import {renderView} from './instructions/render';
-import {createLView} from './instructions/shared';
-import {CONTAINER_HEADER_OFFSET, LContainer, NATIVE} from './interfaces/container';
 import {TNode} from './interfaces/node';
-import {RComment, RElement} from './interfaces/renderer_dom';
-import {
-  DECLARATION_LCONTAINER,
-  FLAGS,
-  HYDRATION,
-  LView,
-  LViewFlags,
-  QUERIES,
-  RENDERER,
-  T_HOST,
-  TVIEW,
-} from './interfaces/view';
-import {
-  addViewToDOM,
-  destroyLView,
-  detachView,
-  getBeforeNodeForView,
-  insertView,
-} from './node_manipulation';
+import {DECLARATION_LCONTAINER, FLAGS, LView, LViewFlags, QUERIES} from './interfaces/view';
+import {createLView} from './view/construction';
 
 export function createAndRenderEmbeddedLView<T>(
   declarationLView: LView<unknown>,
@@ -89,20 +70,6 @@ export function createAndRenderEmbeddedLView<T>(
   }
 }
 
-export function getLViewFromLContainer<T>(
-  lContainer: LContainer,
-  index: number,
-): LView<T> | undefined {
-  const adjustedIndex = CONTAINER_HEADER_OFFSET + index;
-  // avoid reading past the array boundaries
-  if (adjustedIndex < lContainer.length) {
-    const lView = lContainer[adjustedIndex];
-    ngDevMode && assertLView(lView);
-    return lView as LView<T>;
-  }
-  return undefined;
-}
-
 /**
  * Returns whether an elements that belong to a view should be
  * inserted into the DOM. For client-only cases, DOM elements are
@@ -117,45 +84,4 @@ export function shouldAddViewToDom(
   return (
     !dehydratedView || dehydratedView.firstChild === null || hasInSkipHydrationBlockFlag(tNode)
   );
-}
-
-export function addLViewToLContainer(
-  lContainer: LContainer,
-  lView: LView<unknown>,
-  index: number,
-  addToDOM = true,
-): void {
-  const tView = lView[TVIEW];
-
-  // Insert into the view tree so the new view can be change-detected
-  insertView(tView, lView, lContainer, index);
-
-  // Insert elements that belong to this view into the DOM tree
-  if (addToDOM) {
-    const beforeNode = getBeforeNodeForView(index, lContainer);
-    const renderer = lView[RENDERER];
-    const parentRNode = renderer.parentNode(lContainer[NATIVE] as RElement | RComment);
-    if (parentRNode !== null) {
-      addViewToDOM(tView, lContainer[T_HOST], renderer, lView, parentRNode, beforeNode);
-    }
-  }
-
-  // When in hydration mode, reset the pointer to the first child in
-  // the dehydrated view. This indicates that the view was hydrated and
-  // further attaching/detaching should work with this view as normal.
-  const hydrationInfo = lView[HYDRATION];
-  if (hydrationInfo !== null && hydrationInfo.firstChild !== null) {
-    hydrationInfo.firstChild = null;
-  }
-}
-
-export function removeLViewFromLContainer(
-  lContainer: LContainer,
-  index: number,
-): LView<unknown> | undefined {
-  const lView = detachView(lContainer, index);
-  if (lView !== undefined) {
-    destroyLView(lView[TVIEW], lView);
-  }
-  return lView;
 }

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -29,19 +29,14 @@ import {
   REACTIVE_TEMPLATE_CONSUMER,
   TVIEW,
 } from './interfaces/view';
-import {
-  destroyLView,
-  detachMovedView,
-  detachView,
-  detachViewFromDOM,
-  trackMovedView,
-} from './node_manipulation';
+import {destroyLView, detachMovedView, detachViewFromDOM} from './node_manipulation';
 import {CheckNoChangesMode} from './state';
 import {
   markViewForRefresh,
   storeLViewOnDestroy,
   updateAncestorTraversalFlagsOnAttach,
 } from './util/view_utils';
+import {detachView, trackMovedView} from './view/container';
 
 // Needed due to tsickle downleveling where multiple `implements` with classes creates
 // multiple @extends in Closure annotations, which is illegal. This workaround fixes

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -433,6 +433,7 @@
   "init_constants",
   "init_construction",
   "init_container",
+  "init_container2",
   "init_context",
   "init_context_discovery",
   "init_contextual",

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -158,6 +158,7 @@
   "consumerPollProducersForChange",
   "context",
   "convertToBitFlags",
+  "createDirectivesInstances",
   "createElementRef",
   "createErrorClass",
   "createInjector",

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -211,6 +211,7 @@
   "consumerPollProducersForChange",
   "context",
   "convertToBitFlags",
+  "createDirectivesInstances",
   "createElementNode",
   "createElementRef",
   "createErrorClass",

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -184,6 +184,7 @@
   "consumerPollProducersForChange",
   "context",
   "convertToBitFlags",
+  "createDirectivesInstances",
   "createElementRef",
   "createErrorClass",
   "createInjector",

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -7,7 +7,6 @@
  */
 
 import {Component, Directive, Self} from '@angular/core';
-import {createLView, createTView} from '@angular/core/src/render3/instructions/shared';
 import {NodeInjectorOffset} from '@angular/core/src/render3/interfaces/injector';
 import {TestBed} from '@angular/core/testing';
 
@@ -21,6 +20,7 @@ import {TNodeType} from '../../src/render3/interfaces/node';
 import {HEADER_OFFSET, LViewFlags, TVIEW, TViewType} from '../../src/render3/interfaces/view';
 import {enterView, leaveView} from '../../src/render3/state';
 import {getOrCreateTNode} from '@angular/core/src/render3/tnode_manipulation';
+import {createLView, createTView} from '@angular/core/src/render3/view/construction';
 
 describe('di', () => {
   describe('directive injection', () => {

--- a/packages/core/test/render3/instructions/shared_spec.ts
+++ b/packages/core/test/render3/instructions/shared_spec.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {createLView, createTView} from '@angular/core/src/render3/instructions/shared';
 import {TNodeType} from '@angular/core/src/render3/interfaces/node';
 import {
   HEADER_OFFSET,
@@ -24,6 +23,7 @@ import {
 
 import {MockRendererFactory} from './mock_renderer_factory';
 import {createTNode} from '@angular/core/src/render3/tnode_manipulation';
+import {createLView, createTView} from '@angular/core/src/render3/view/construction';
 
 /**
  * Setups a simple `LView` so that it is possible to do unit tests on instructions.

--- a/packages/core/test/render3/matchers_spec.ts
+++ b/packages/core/test/render3/matchers_spec.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {createTView} from '@angular/core/src/render3/instructions/shared';
 import {TNodeType} from '@angular/core/src/render3/interfaces/node';
 import {TViewType} from '@angular/core/src/render3/interfaces/view';
 
 import {isShapeOf, ShapeOf} from './is_shape_of';
 import {matchDomElement, matchDomText, matchObjectShape, matchTNode, matchTView} from './matchers';
 import {createTNode} from '@angular/core/src/render3/tnode_manipulation';
+import {createTView} from '@angular/core/src/render3/view/construction';
 
 describe('render3 matchers', () => {
   const fakeMatcherUtil = {equals: (a: any, b: any) => a === b} as jasmine.MatchersUtil;

--- a/packages/core/test/render3/view_fixture.ts
+++ b/packages/core/test/render3/view_fixture.ts
@@ -12,7 +12,6 @@ import {stringifyElement} from '@angular/platform-browser/testing/src/browser_ut
 import {extractDirectiveDef} from '../../src/render3/definition';
 import {refreshView} from '../../src/render3/instructions/change_detection';
 import {renderView} from '../../src/render3/instructions/render';
-import {createLView, createTView} from '../../src/render3/instructions/shared';
 import {
   DirectiveDef,
   DirectiveDefList,
@@ -35,6 +34,7 @@ import {noop} from '../../src/util/noop';
 
 import {getRendererFactory2} from './imported_renderer2';
 import {createTNode} from '@angular/core/src/render3/tnode_manipulation';
+import {createLView, createTView} from '@angular/core/src/render3/view/construction';
 
 /**
  * Fixture useful for testing operations which need `LView` / `TView`

--- a/packages/core/test/render3/view_utils_spec.ts
+++ b/packages/core/test/render3/view_utils_spec.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {createLContainer} from '@angular/core/src/render3/instructions/shared';
 import {isLContainer, isLView} from '@angular/core/src/render3/interfaces/type_checks';
 import {ViewFixture} from './view_fixture';
 import {createTNode} from '@angular/core/src/render3/tnode_manipulation';
+import {createLContainer} from '@angular/core/src/render3/view/container';
 
 describe('view_utils', () => {
   it('should verify unwrap methods (isLView and isLContainer)', () => {


### PR DESCRIPTION
Move all the "view in a container logic" into its own file
(packages/core/src/render3/view/container.ts)
plus some other associated refactorings.
