### PR TITLE
feat(router): Allow resolvers to read resolved data from ancestors

### DIFF
--- a/packages/router/test/operators/resolve_data.spec.ts
+++ b/packages/router/test/operators/resolve_data.spec.ts
@@ -8,7 +8,7 @@
 
 import {Component} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {provideRouter, Router} from '@angular/router';
+import {ActivatedRouteSnapshot, provideRouter, Router} from '@angular/router';
 import {RouterTestingHarness} from '@angular/router/testing';
 import {EMPTY, interval, NEVER, of} from 'rxjs';
 
@@ -183,6 +183,38 @@ describe('resolveData operator', () => {
     const rootSnapshot = TestBed.inject(Router).routerState.root.firstChild!.snapshot;
     expect(rootSnapshot.title).toBe('a title');
     expect(rootSnapshot.firstChild!.title).toBe('b title');
+  });
+
+  it('can used parent data in child resolver', async () => {
+    @Component({
+      template: '',
+    })
+    class Empty {}
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([
+          {
+            path: 'a',
+            resolve: {
+              aResolve: () => new Promise<string>((resolve) => setTimeout(() => resolve('a'), 5)),
+            },
+            children: [
+              {
+                path: 'b',
+                resolve: {
+                  bResolve: (route: ActivatedRouteSnapshot) => route.data['aResolve'] + 'b',
+                },
+                children: [{path: 'c', component: Empty}],
+              },
+            ],
+          },
+        ]),
+      ],
+    });
+    await RouterTestingHarness.create('/a/b/c');
+    const rootSnapshot = TestBed.inject(Router).routerState.root.firstChild!.snapshot;
+    expect(rootSnapshot.firstChild!.firstChild!.data).toEqual({bResolve: 'ab', aResolve: 'a'});
   });
 
   it('should inherit resolved data from parent of parent route', async () => {


### PR DESCRIPTION
This commit updates the resolver execution to ensure that resolvers in children routes are able to read the resolved data from anything above them in the route tree. Because resolvers on one level block execution of those below, it seems more of an oversight in the initial implementation than anything else that this wasn't already possible.

resolves #47287
