### PR TITLE
Control flow migration fixes

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/types.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/types.ts
@@ -390,6 +390,7 @@ export class CommonCollector extends RecursiveVisitor {
         this.count++;
       }
     }
+    super.visitBlock(ast, null);
   }
 
   override visitText(ast: Text) {

--- a/packages/core/schematics/ng-generate/control-flow-migration/types.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/types.ts
@@ -10,6 +10,7 @@ import {
   Attribute,
   Block,
   Element,
+  LetDeclaration,
   ParseTreeResult,
   RecursiveVisitor,
   Text,
@@ -397,6 +398,13 @@ export class CommonCollector extends RecursiveVisitor {
     if (this.hasPipes(ast.value)) {
       this.count++;
     }
+  }
+
+  override visitLetDeclaration(decl: LetDeclaration): void {
+    if (this.hasPipes(decl.value)) {
+      this.count++;
+    }
+    super.visitLetDeclaration(decl, null);
   }
 
   private hasDirectives(input: string): boolean {

--- a/packages/core/schematics/test/control_flow_migration_spec.ts
+++ b/packages/core/schematics/test/control_flow_migration_spec.ts
@@ -6479,6 +6479,39 @@ describe('control flow migration', () => {
 
       expect(actual).toBe(expected);
     });
+
+    it('should not remove common module if symbols are used inside new control flow', async () => {
+      writeFile(
+        '/comp.ts',
+        [
+          `import {CommonModule} from '@angular/common';`,
+          `import {Component} from '@angular/core';\n`,
+          `@Component({`,
+          `  imports: [CommonModule],`,
+          `  template: \`@if (toggle) {<div>{{ d | date }}</div>} <span *ngIf="toggle">hi</span>\``,
+          `})`,
+          `class Comp {`,
+          `  toggle = false;`,
+          `}`,
+        ].join('\n'),
+      );
+
+      await runMigration();
+      const actual = tree.readContent('/comp.ts');
+      const expected = [
+        `import {CommonModule} from '@angular/common';`,
+        `import {Component} from '@angular/core';\n`,
+        `@Component({`,
+        `  imports: [CommonModule],`,
+        `  template: \`@if (toggle) {<div>{{ d | date }}</div>} @if (toggle) {<span>hi</span>}\``,
+        `})`,
+        `class Comp {`,
+        `  toggle = false;`,
+        `}`,
+      ].join('\n');
+
+      expect(actual).toBe(expected);
+    });
   });
 
   describe('no migration needed', () => {

--- a/packages/core/schematics/test/control_flow_migration_spec.ts
+++ b/packages/core/schematics/test/control_flow_migration_spec.ts
@@ -6512,6 +6512,39 @@ describe('control flow migration', () => {
 
       expect(actual).toBe(expected);
     });
+
+    it('should not remove common module if symbols are used inside @let', async () => {
+      writeFile(
+        '/comp.ts',
+        [
+          `import {CommonModule} from '@angular/common';`,
+          `import {Component} from '@angular/core';\n`,
+          `@Component({`,
+          `  imports: [CommonModule],`,
+          `  template: \`@let foo = 123 | date; <span *ngIf="foo">{{foo}}</span>\``,
+          `})`,
+          `class Comp {`,
+          `  toggle = false;`,
+          `}`,
+        ].join('\n'),
+      );
+
+      await runMigration();
+      const actual = tree.readContent('/comp.ts');
+      const expected = [
+        `import {CommonModule} from '@angular/common';`,
+        `import {Component} from '@angular/core';\n`,
+        `@Component({`,
+        `  imports: [CommonModule],`,
+        `  template: \`@let foo = 123 | date; @if (foo) {<span>{{foo}}</span>}\``,
+        `})`,
+        `class Comp {`,
+        `  toggle = false;`,
+        `}`,
+      ].join('\n');
+
+      expect(actual).toBe(expected);
+    });
   });
 
   describe('no migration needed', () => {


### PR DESCRIPTION
Fixes a couple of issues with the control flow migration:

### fix(migrations): count used dependencies inside existing control flow 
Fixes that the control flow migration wasn't checking the content of pre-existing control flow nodes for dependencies.

### fix(migrations): account for let declarations in control flow migration 
Fixes that the control flow migration wasn't accounting for `@let` when determining which symbols are used.

Fixes #59846.