### PR TITLE
fix: add missing import to input behavior

### DIFF
--- a/adev/src/content/examples/forms-overview/src/app/reactive/favorite-color/favorite-color.component.ts
+++ b/adev/src/content/examples/forms-overview/src/app/reactive/favorite-color/favorite-color.component.ts
@@ -1,11 +1,12 @@
 import {Component} from '@angular/core';
-import {FormControl} from '@angular/forms';
+import {FormControl, ReactiveFormsModule} from '@angular/forms';
 
 @Component({
   selector: 'app-reactive-favorite-color',
   template: `
     Favorite Color: <input type="text" [formControl]="favoriteColorControl">
   `,
+  imports: [ReactiveFormsModule],
   standalone: false,
 })
 export class FavoriteColorComponent {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Following the example from doc (https://angular.dev/guide/forms) the IDE report a error "Can't bind to 'formControl' since it isn't a known property of 'input'.ngtsc(-998002)"

![image](https://github.com/user-attachments/assets/f8378d04-6df3-4cdc-a19e-6ebfd7cf7743)


Issue Number: N/A


## What is the new behavior?
With o import the error is solved


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
