### PR TITLE
fix(compiler-cli): avoid crash in isolated transform operations

### DIFF
--- a/packages/compiler-cli/src/ngtsc/imports/src/default.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/default.ts
@@ -109,7 +109,7 @@ export class DefaultImportTracker {
             if (clausesToPreserve === null) {
               clausesToPreserve = loadIsReferencedAliasDeclarationPatch(context);
             }
-            clausesToPreserve.add(clause);
+            clausesToPreserve?.add(clause);
           }
         }
 

--- a/packages/compiler-cli/src/ngtsc/imports/src/patch_alias_reference_resolution.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/patch_alias_reference_resolution.ts
@@ -68,8 +68,12 @@ interface EmitResolver {
  *
  * The set that is returned by this function is meant to be filled with import declaration nodes
  * that have been referenced in a value-position by the transform, such the installed patch can
- * ensure that those import declarations are not elided. If `null` is returned then the transform
- * operates in an isolated context.
+ * ensure that those import declarations are not elided.
+ *
+ * If `null` is returned then the transform operates in an isolated context, i.e. using the
+ * `ts.transform` API. In such scenario there is no information whether an alias declaration
+ * is referenced, so all alias declarations are naturally preserved and explicitly registering
+ * an alias declaration as used isn't necessary.
  *
  * See below. Note that this uses sourcegraph as the TypeScript checker file doesn't display on
  * Github.

--- a/packages/compiler-cli/src/ngtsc/transform/jit/src/downlevel_decorators_transform.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/jit/src/downlevel_decorators_transform.ts
@@ -378,7 +378,7 @@ export function getDownlevelDecoratorsTransform(
       // ensure that the alias declaration is not elided by TypeScript, and use its
       // name identifier to reference it at runtime.
       if (isAliasImportDeclaration(decl)) {
-        referencedParameterTypes.add(decl);
+        referencedParameterTypes?.add(decl);
         // If the entity name resolves to an alias import declaration, we reference the
         // entity based on the alias import name. This ensures that TypeScript properly
         // resolves the link to the import. Cloning the original entity name identifier

--- a/packages/compiler-cli/src/ngtsc/translator/src/import_manager/import_typescript_transform.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/import_manager/import_typescript_transform.ts
@@ -37,9 +37,11 @@ export function createTsTransformForImportManager(
     // doesn't drop these thinking they are unused.
     if (reusedOriginalAliasDeclarations.size > 0) {
       const referencedAliasDeclarations = loadIsReferencedAliasDeclarationPatch(ctx);
-      reusedOriginalAliasDeclarations.forEach((aliasDecl) =>
-        referencedAliasDeclarations.add(aliasDecl),
-      );
+      if (referencedAliasDeclarations !== null) {
+        reusedOriginalAliasDeclarations.forEach((aliasDecl) =>
+          referencedAliasDeclarations.add(aliasDecl),
+        );
+      }
     }
 
     // Update the set of affected files to include files that need extra statements to be inserted.


### PR DESCRIPTION
The CLI uses the `ts.transform` API to apply the Angular compiler's transformers on the source files when `isolatedModules` is true (and various other constraints) instead of going through a full `ts.Program.emit` operation. This results in the transformers to operate in an environment where no emit resolver is available, which was not previously accounted for. This commit reflects the possibility for the emit resolver to be missing and handles this scenario accordingly.

Fixes #59837