### PR TITLE
fix(devtools): regressions in component tree

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
@@ -155,6 +155,9 @@ const getLatestComponentExplorerViewCallback =
     if (state) {
       const {directiveProperties} = state;
       messageBus.emit('latestComponentExplorerView', [{forest, properties: directiveProperties}]);
+    } else {
+      // if the node is not found in the tree, we assume its gone and send the tree as is.
+      messageBus.emit('latestComponentExplorerView', [{forest}]);
     }
   };
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-tab-body.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-tab-body.component.html
@@ -3,7 +3,7 @@
     <div class="explorer-panel">
       <ng-property-view
         (inspect)="inspect.emit($event)"
-        (viewSource)="viewSource.emit(directive)"
+        (viewSource)="viewSource.emit(directive.name)"
         [directive]="directive"
       />
     </div>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-tab-body.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-tab-body.component.ts
@@ -29,9 +29,9 @@ export class PropertyTabBodyComponent {
     if (!selected) {
       return;
     }
-    const directives = selected.directives.map((d) => d.name);
+    const directives = [...selected.directives];
     if (selected.component) {
-      directives.push(selected.component.name);
+      directives.push(selected.component);
     }
     return directives;
   });

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view.component.html
@@ -1,5 +1,5 @@
 <ng-property-view-header
-  [directive]="directive()"
+  [directive]="directive().name"
   (viewSource)="viewSource.emit()"
 ></ng-property-view-header>
 <ng-property-view-body

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view.component.ts
@@ -20,13 +20,15 @@ import {PropertyViewHeaderComponent} from './property-view-header.component';
   imports: [PropertyViewHeaderComponent, PropertyViewBodyComponent],
 })
 export class PropertyViewComponent {
-  readonly directive = input.required<string>();
+  readonly directive = input.required<{name: string}>();
   readonly inspect = output<{node: FlatNode; directivePosition: DirectivePosition}>();
   readonly viewSource = output<void>();
 
   private _nestedProps = inject(ElementPropertyResolver);
 
-  readonly controller = computed(() => this._nestedProps.getDirectiveController(this.directive()));
+  readonly controller = computed(() =>
+    this._nestedProps.getDirectiveController(this.directive().name),
+  );
 
   readonly directiveInputControls = computed(() => this.controller()?.directiveInputControls);
 


### PR DESCRIPTION
This commit solves two cases

Bug: When a directive of the same name is selected, the property view tab would not update properly. This was caused by a signals refactor that changed the behaviour of a string input property to not re-render because the underlying signal did not change (string equality). This is fixed by converting this input into an object.

Bug: When a selected element is removed from the component tree, DevTools would not rerender the component tree properly and would not deselect that component. Now if DevTools detects that a component is removed, it re-renders the tree and deselects the component.
