### PR TITLE
feat(common): introduce experimental `httpResource`

### DIFF
--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -8,9 +8,13 @@ import { EnvironmentInjector } from '@angular/core';
 import { EnvironmentProviders } from '@angular/core';
 import * as i0 from '@angular/core';
 import { InjectionToken } from '@angular/core';
+import { Injector } from '@angular/core';
 import { ModuleWithProviders } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Provider } from '@angular/core';
+import { Signal } from '@angular/core';
+import { ValueEqualityFn } from '@angular/core';
+import { WritableResource } from '@angular/core';
 import { XhrFactory } from '@angular/common';
 
 // @public
@@ -1997,6 +2001,16 @@ export interface HttpInterceptor {
 export type HttpInterceptorFn = (req: HttpRequest<unknown>, next: HttpHandlerFn) => Observable<HttpEvent<unknown>>;
 
 // @public
+export interface HttpJsonResourceFn extends HttpResourceFn<unknown> {
+    // (undocumented)
+    readonly arrayBuffer: HttpResourceFn<ArrayBuffer>;
+    // (undocumented)
+    readonly blob: HttpResourceFn<Blob>;
+    // (undocumented)
+    readonly text: HttpResourceFn<string>;
+}
+
+// @public
 export interface HttpParameterCodec {
     // (undocumented)
     decodeKey(key: string): string;
@@ -2151,6 +2165,61 @@ export class HttpRequest<T> {
     readonly url: string;
     readonly urlWithParams: string;
     readonly withCredentials: boolean;
+}
+
+// @public
+export interface HttpResource<T> extends WritableResource<T> {
+    readonly headers: Signal<HttpHeaders | undefined>;
+    readonly progress: Signal<HttpProgressEvent | undefined>;
+    readonly statusCode: Signal<number | undefined>;
+}
+
+// @public (undocumented)
+export const httpResource: HttpJsonResourceFn;
+
+// @public
+export interface HttpResourceFn<TRaw> {
+    <TResult = TRaw>(url: string | (() => string), options: HttpResourceOptions<TResult, TRaw> & {
+        defaultValue: NoInfer<TResult>;
+    }): HttpResource<TResult>;
+    <TResult = TRaw>(url: string | (() => string), options?: HttpResourceOptions<TResult, TRaw>): HttpResource<TResult | undefined>;
+    <TResult = TRaw>(request: HttpResourceRequest | (() => HttpResourceRequest), options: HttpResourceOptions<TResult, TRaw> & {
+        defaultValue: NoInfer<TResult>;
+    }): HttpResource<TResult>;
+    <TResult = TRaw>(request: HttpResourceRequest | (() => HttpResourceRequest), options?: HttpResourceOptions<TResult, TRaw>): HttpResource<TResult | undefined>;
+}
+
+// @public
+export interface HttpResourceOptions<TResult, TRaw> {
+    defaultValue?: NoInfer<TResult>;
+    // (undocumented)
+    equal?: ValueEqualityFn<NoInfer<TResult>>;
+    // (undocumented)
+    injector?: Injector;
+    // (undocumented)
+    map?: (value: TRaw) => TResult;
+}
+
+// @public
+export interface HttpResourceRequest {
+    // (undocumented)
+    body?: unknown;
+    // (undocumented)
+    headers?: HttpHeaders | Record<string, string | ReadonlyArray<string>>;
+    // (undocumented)
+    method?: string;
+    // (undocumented)
+    params?: HttpParams | Record<string, string | number | boolean | ReadonlyArray<string | number | boolean>>;
+    // (undocumented)
+    reportProgress?: boolean;
+    // (undocumented)
+    transferCache?: {
+        includeHeaders?: string[];
+    } | boolean;
+    // (undocumented)
+    url: string;
+    // (undocumented)
+    withCredentials?: boolean;
 }
 
 // @public

--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -55,6 +55,14 @@ export {
   HttpUserEvent,
 } from './src/response';
 export {
+  httpResource,
+  HttpResource,
+  HttpJsonResourceFn,
+  HttpResourceFn,
+  HttpResourceOptions,
+  HttpResourceRequest,
+} from './src/resource';
+export {
   HttpTransferCacheOptions,
   withHttpTransferCache as ɵwithHttpTransferCache,
   HTTP_TRANSFER_CACHE_ORIGIN_MAP,

--- a/packages/common/http/src/resource.ts
+++ b/packages/common/http/src/resource.ts
@@ -1,0 +1,355 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  Injector,
+  Signal,
+  WritableResource,
+  ɵResourceImpl as ResourceImpl,
+  inject,
+  linkedSignal,
+  assertInInjectionContext,
+  ValueEqualityFn,
+  signal,
+  ResourceStatus,
+  computed,
+  Resource,
+  WritableSignal,
+} from '@angular/core';
+import {Subscription} from 'rxjs';
+
+import {HttpRequest} from './request';
+import {HttpClient} from './client';
+import {HttpEventType, HttpProgressEvent, HttpResponseBase} from './response';
+import {HttpHeaders} from './headers';
+import {HttpParams} from './params';
+
+/**
+ * The structure of an `httpResource` request.
+ *
+ * @experimental
+ */
+export interface HttpResourceRequest {
+  url: string;
+  method?: string;
+  body?: unknown;
+  params?:
+    | HttpParams
+    | Record<string, string | number | boolean | ReadonlyArray<string | number | boolean>>;
+  headers?: HttpHeaders | Record<string, string | ReadonlyArray<string>>;
+  reportProgress?: boolean;
+  withCredentials?: boolean;
+  transferCache?: {includeHeaders?: string[]} | boolean;
+}
+
+/**
+ * Options for creating an `httpResource`.
+ *
+ * @experimental
+ */
+export interface HttpResourceOptions<TResult, TRaw> {
+  map?: (value: TRaw) => TResult;
+
+  /**
+   * Value that the resource will take when in Idle, Loading, or Error states.
+   */
+  defaultValue?: NoInfer<TResult>;
+
+  // TODO: equal?
+  injector?: Injector;
+
+  equal?: ValueEqualityFn<NoInfer<TResult>>;
+}
+
+/**
+ * Call signatures for `httpResource`-flavored functions, using `TRaw` as the raw type returned from
+ * the HTTP request.
+ */
+export interface HttpResourceFn<TRaw> {
+  /**
+   * Create a `Resource` that fetches data with an HTTP GET request to the given URL, which may be
+   * reactive.
+   *
+   * Uses `HttpClient` to make requests and supports interceptors, testing, and the other features
+   * of the `HttpClient` API.
+   *
+   * @experimental
+   */
+  <TResult = TRaw>(
+    url: string | (() => string),
+    options: HttpResourceOptions<TResult, TRaw> & {defaultValue: NoInfer<TResult>},
+  ): HttpResource<TResult>;
+
+  /**
+   * Create a `Resource` that fetches data with an HTTP GET request to the given URL, which may be
+   * reactive.
+   *
+   * Uses `HttpClient` to make requests and supports interceptors, testing, and the other features
+   * of the `HttpClient` API.
+   *
+   * @experimental
+   */
+  <TResult = TRaw>(
+    url: string | (() => string),
+    options?: HttpResourceOptions<TResult, TRaw>,
+  ): HttpResource<TResult | undefined>;
+
+  /**
+   * Create a `Resource` that fetches data with the given HTTP request, which may be reactive.
+   *
+   * Uses `HttpClient` to make requests and supports interceptors, testing, and the other features
+   * of the `HttpClient` API.
+   *
+   * @experimental
+   */
+  <TResult = TRaw>(
+    request: HttpResourceRequest | (() => HttpResourceRequest),
+    options: HttpResourceOptions<TResult, TRaw> & {defaultValue: NoInfer<TResult>},
+  ): HttpResource<TResult>;
+
+  /**
+   * Create a `Resource` that fetches data with the given HTTP request, which may be reactive.
+   *
+   * Uses `HttpClient` to make requests and supports interceptors, testing, and the other features
+   * of the `HttpClient` API.
+   *
+   * @experimental
+   */
+  <TResult = TRaw>(
+    request: HttpResourceRequest | (() => HttpResourceRequest),
+    options?: HttpResourceOptions<TResult, TRaw>,
+  ): HttpResource<TResult | undefined>;
+}
+
+/**
+ * Type for the `httpRequest` top-level function, which includes the call signatures for the JSON-
+ * based `httpRequest` as well as sub-functions for `ArrayBuffer`, `Blob`, and `string` type
+ * requests.
+ *
+ * @experimental
+ */
+export interface HttpJsonResourceFn extends HttpResourceFn<unknown> {
+  readonly arrayBuffer: HttpResourceFn<ArrayBuffer>;
+  readonly blob: HttpResourceFn<Blob>;
+  readonly text: HttpResourceFn<string>;
+}
+
+export const httpResource: HttpJsonResourceFn = (() => {
+  const jsonFn = httpResourceImpl.bind(undefined, 'json') as unknown as HttpJsonResourceFn;
+  (jsonFn as {arrayBuffer: HttpResourceFn<ArrayBuffer>}).arrayBuffer = httpResourceImpl.bind(
+    undefined,
+    'arraybuffer',
+  ) as HttpResourceFn<ArrayBuffer>;
+  (jsonFn as {blob: HttpResourceFn<Blob>}).blob = httpResourceImpl.bind(
+    undefined,
+    'blob',
+  ) as HttpResourceFn<Blob>;
+  (jsonFn as {text: HttpResourceFn<string>}).text = httpResourceImpl.bind(
+    undefined,
+    'text',
+  ) as HttpResourceFn<string>;
+  return jsonFn;
+})();
+
+function httpResourceImpl(
+  responseType: 'arraybuffer' | 'blob' | 'json' | 'text',
+  request: string | (() => string) | HttpResourceRequest | (() => HttpResourceRequest),
+  options?: HttpResourceOptions<unknown, unknown>,
+): HttpResource<unknown> {
+  options?.injector || assertInInjectionContext(httpResource);
+  const injector = options?.injector ?? inject(Injector);
+
+  const toHttpRequest = () => {
+    let unwrappedRequest = typeof request === 'function' ? request() : request;
+    if (typeof unwrappedRequest === 'string') {
+      unwrappedRequest = {url: unwrappedRequest};
+    }
+
+    return new HttpRequest(
+      unwrappedRequest.method ?? 'GET',
+      unwrappedRequest.url,
+      unwrappedRequest.body ?? null,
+      {
+        headers:
+          unwrappedRequest.headers instanceof HttpHeaders
+            ? unwrappedRequest.headers
+            : new HttpHeaders(
+                unwrappedRequest.headers as
+                  | Record<string, string | number | Array<string | number>>
+                  | undefined,
+              ),
+        params:
+          unwrappedRequest.params instanceof HttpParams
+            ? unwrappedRequest.params
+            : new HttpParams({fromObject: unwrappedRequest.params}),
+        reportProgress: unwrappedRequest.reportProgress,
+        withCredentials: unwrappedRequest.withCredentials,
+        responseType,
+      },
+    );
+  };
+
+  return new HttpResourceImpl(injector, toHttpRequest, options?.defaultValue, options?.map);
+}
+
+/**
+ * A `WritableResource` that represents the results of a reactive HTTP request.
+ *
+ * `HttpResource`s are backed by `HttpClient`, including support for interceptors, testing, and the
+ * other features of the `HttpClient` API.
+ *
+ * @experimental
+ */
+export interface HttpResource<T> extends WritableResource<T> {
+  /**
+   * Signal of the response headers, when available.
+   */
+  readonly headers: Signal<HttpHeaders | undefined>;
+
+  /**
+   * Signal of the response status code, when available.
+   */
+  readonly statusCode: Signal<number | undefined>;
+
+  /**
+   * Signal of the latest progress update, if the request was made with `reportProgress: true`.
+   */
+  readonly progress: Signal<HttpProgressEvent | undefined>;
+}
+
+class HttpResourceImpl<T> extends ResourceImpl<T, HttpRequest<unknown>> implements HttpResource<T> {
+  private client!: HttpClient;
+  private _headers = linkedSignal({
+    source: this.extRequest,
+    computation: () => undefined as HttpHeaders | undefined,
+  });
+  private _progress = linkedSignal({
+    source: this.extRequest,
+    computation: () => undefined as HttpProgressEvent | undefined,
+  });
+  private _statusCode = linkedSignal({
+    source: this.extRequest,
+    computation: () => undefined as number | undefined,
+  });
+
+  readonly headers = computed(() =>
+    this.status() === ResourceStatus.Resolved || this.status() === ResourceStatus.Error
+      ? this._headers()
+      : undefined,
+  );
+  readonly progress = this._progress.asReadonly();
+  readonly statusCode = this._statusCode.asReadonly();
+
+  constructor(
+    injector: Injector,
+    request: () => HttpRequest<T>,
+    defaultValue: T,
+    map?: (value: unknown) => T,
+  ) {
+    super(
+      request,
+      ({request, abortSignal}) => {
+        let sub: Subscription;
+
+        // Track the abort listener so it can be removed if the Observable completes (as a memory
+        // optimization).
+        const onAbort = () => sub.unsubscribe();
+        abortSignal.addEventListener('abort', onAbort);
+
+        // Start off stream as undefined.
+        const stream = signal<{value: T} | {error: unknown}>({value: undefined as T});
+        let resolve: ((value: Signal<{value: T} | {error: unknown}>) => void) | undefined;
+        const promise = new Promise<Signal<{value: T} | {error: unknown}>>((r) => (resolve = r));
+
+        function send(value: {value: T} | {error: unknown}): void {
+          stream.set(value);
+          resolve?.(stream);
+          resolve = undefined;
+        }
+
+        sub = this.client.request(request).subscribe({
+          next: (event) => {
+            switch (event.type) {
+              case HttpEventType.Response:
+                this._headers.set(event.headers);
+                this._statusCode.set(event.status);
+                try {
+                  send({value: map ? map(event.body) : (event.body as T)});
+                } catch (error) {
+                  send({error});
+                }
+                break;
+              case HttpEventType.DownloadProgress:
+                this._progress.set(event);
+                break;
+            }
+          },
+          error: (error) => send({error}),
+          complete: () => {
+            if (resolve) {
+              send({error: new Error('Resource completed before producing a value')});
+            }
+            abortSignal.removeEventListener('abort', onAbort);
+          },
+        });
+
+        abortSignal.addEventListener('abort', () => sub.unsubscribe());
+        return promise;
+      },
+      defaultValue,
+      undefined,
+      injector,
+    );
+    this.client = injector.get(HttpClient);
+  }
+}
+
+/**
+ * A `Resource` of the `HttpResponse` meant for use in `HttpResource` if we decide to go this route.
+ *
+ * TODO(alxhub): delete this if we decide we don't want it.
+ */
+class HttpResponseResource implements Resource<HttpResponseBase | undefined> {
+  readonly status: Signal<ResourceStatus>;
+  readonly value: WritableSignal<HttpResponseBase | undefined>;
+  readonly error: Signal<unknown>;
+  readonly isLoading: Signal<boolean>;
+
+  constructor(
+    private parent: Resource<unknown>,
+    request: Signal<unknown>,
+  ) {
+    this.status = computed(() => {
+      // There are two kinds of errors which can occur in an HTTP request: HTTP errors or normal JS
+      // errors. Since we have a response for HTTP errors, we report `Resolved` status even if the
+      // overall request is considered to be in an Error state.
+      if (parent.status() === ResourceStatus.Error) {
+        return this.value() !== undefined ? ResourceStatus.Resolved : ResourceStatus.Error;
+      }
+      return parent.status();
+    });
+    this.error = computed(() => {
+      // Filter out HTTP errors.
+      return this.value() === undefined ? parent.error() : undefined;
+    });
+    this.value = linkedSignal({
+      source: request,
+      computation: () => undefined as HttpResponseBase | undefined,
+    });
+    this.isLoading = parent.isLoading;
+  }
+
+  hasValue(): this is Resource<HttpResponseBase> {
+    return this.value() !== undefined;
+  }
+
+  reload(): boolean {
+    // TODO: should you be able to reload this way?
+    return this.parent.reload();
+  }
+}

--- a/packages/common/http/test/resource_spec.ts
+++ b/packages/common/http/test/resource_spec.ts
@@ -1,0 +1,175 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {ApplicationRef, Injector, signal} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {HttpEventType, provideHttpClient, httpResource} from '@angular/common/http';
+import {HttpTestingController, provideHttpClientTesting} from '@angular/common/http/testing';
+
+describe('httpResource', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({providers: [provideHttpClient(), provideHttpClientTesting()]});
+  });
+
+  it('should send a basic request', async () => {
+    const backend = TestBed.inject(HttpTestingController);
+    const res = httpResource('/data', {injector: TestBed.inject(Injector)});
+    TestBed.flushEffects();
+    const req = backend.expectOne('/data');
+    req.flush([]);
+    await TestBed.inject(ApplicationRef).whenStable();
+    expect(res.value()).toEqual([]);
+  });
+
+  it('should be reactive in its request URL', async () => {
+    const id = signal(0);
+    const backend = TestBed.inject(HttpTestingController);
+    const res = httpResource(() => `/data/${id()}`, {injector: TestBed.inject(Injector)});
+    TestBed.flushEffects();
+    const req1 = backend.expectOne('/data/0');
+    req1.flush(0);
+    await TestBed.inject(ApplicationRef).whenStable();
+    expect(res.value()).toEqual(0);
+
+    id.set(1);
+    TestBed.flushEffects();
+    const req2 = backend.expectOne('/data/1');
+    req2.flush(1);
+    await TestBed.inject(ApplicationRef).whenStable();
+    expect(res.value()).toEqual(1);
+  });
+
+  it('should support the suite of HttpRequest APIs', async () => {
+    const backend = TestBed.inject(HttpTestingController);
+    const res = httpResource(
+      {
+        url: '/data',
+        method: 'POST',
+        body: {message: 'Hello, backend!'},
+        headers: {
+          'X-Special': 'true',
+        },
+        params: {
+          'fast': 'yes',
+        },
+        withCredentials: true,
+      },
+      {injector: TestBed.inject(Injector)},
+    );
+    TestBed.flushEffects();
+    const req = backend.expectOne('/data?fast=yes');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({message: 'Hello, backend!'});
+    expect(req.request.headers.get('X-Special')).toBe('true');
+    expect(req.request.withCredentials).toBe(true);
+
+    req.flush([]);
+
+    await TestBed.inject(ApplicationRef).whenStable();
+    expect(res.value()).toEqual([]);
+  });
+
+  it('should return response headers & status when resolved', async () => {
+    const backend = TestBed.inject(HttpTestingController);
+    const res = httpResource('/data', {injector: TestBed.inject(Injector)});
+    TestBed.flushEffects();
+    const req = backend.expectOne('/data');
+    req.flush([], {
+      headers: {
+        'X-Special': '123',
+      },
+    });
+    await TestBed.inject(ApplicationRef).whenStable();
+    expect(res.value()).toEqual([]);
+    expect(res.headers()?.get('X-Special')).toBe('123');
+    expect(res.statusCode()).toBe(200);
+  });
+
+  it('should support progress events', async () => {
+    const backend = TestBed.inject(HttpTestingController);
+    const res = httpResource(
+      {
+        url: '/data',
+        reportProgress: true,
+      },
+      {injector: TestBed.inject(Injector)},
+    );
+    TestBed.flushEffects();
+    const req = backend.expectOne('/data');
+    req.event({
+      type: HttpEventType.DownloadProgress,
+      loaded: 100,
+      total: 200,
+    });
+
+    expect(res.progress()).toEqual({
+      type: HttpEventType.DownloadProgress,
+      loaded: 100,
+      total: 200,
+    });
+
+    req.flush([]);
+
+    await TestBed.inject(ApplicationRef).whenStable();
+    expect(res.value()).toEqual([]);
+  });
+
+  it('should allow mapping data to an arbitrary type', async () => {
+    const backend = TestBed.inject(HttpTestingController);
+    const res = httpResource(
+      {
+        url: '/data',
+        reportProgress: true,
+      },
+      {
+        injector: TestBed.inject(Injector),
+        map: (value) => JSON.stringify(value),
+      },
+    );
+    TestBed.flushEffects();
+    const req = backend.expectOne('/data');
+    req.flush([1, 2, 3]);
+
+    await TestBed.inject(ApplicationRef).whenStable();
+    expect(res.value()).toEqual('[1,2,3]');
+  });
+
+  it('should support text responses', async () => {
+    const backend = TestBed.inject(HttpTestingController);
+    const res = httpResource.text(
+      {
+        url: '/data',
+        reportProgress: true,
+      },
+      {injector: TestBed.inject(Injector)},
+    );
+    TestBed.flushEffects();
+    const req = backend.expectOne('/data');
+    req.flush('[1,2,3]');
+
+    await TestBed.inject(ApplicationRef).whenStable();
+    expect(res.value()).toEqual('[1,2,3]');
+  });
+
+  it('should support text responses', async () => {
+    const backend = TestBed.inject(HttpTestingController);
+    const res = httpResource.text(
+      {
+        url: '/data',
+        reportProgress: true,
+      },
+      {injector: TestBed.inject(Injector)},
+    );
+    TestBed.flushEffects();
+    const req = backend.expectOne('/data');
+    req.flush('[1,2,3]');
+
+    await TestBed.inject(ApplicationRef).whenStable();
+    expect(res.value()).toEqual('[1,2,3]');
+  });
+});

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -148,4 +148,6 @@ export {
   disableProfiling as ɵdisableProfiling,
 } from './profiler';
 
+export {ResourceImpl as ɵResourceImpl} from './resource/resource';
+
 export {getClosestComponentName as ɵgetClosestComponentName} from './internal/get_closest_component_name';

--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -130,7 +130,7 @@ abstract class BaseWritableResource<T> implements WritableResource<T> {
 /**
  * Implementation for `resource()` which uses a `linkedSignal` to manage the resource's state.
  */
-class ResourceImpl<T, R> extends BaseWritableResource<T> implements ResourceRef<T> {
+export class ResourceImpl<T, R> extends BaseWritableResource<T> implements ResourceRef<T> {
   private readonly pendingTasks: PendingTasks;
 
   /**
@@ -142,7 +142,7 @@ class ResourceImpl<T, R> extends BaseWritableResource<T> implements ResourceRef<
    * Combines the current request with a reload counter which allows the resource to be reloaded on
    * imperative command.
    */
-  private readonly extRequest: WritableSignal<WrappedRequest>;
+  protected readonly extRequest: WritableSignal<WrappedRequest>;
   private readonly effectRef: EffectRef;
 
   private pendingController: AbortController | undefined;


### PR DESCRIPTION
`httpResource` is a new frontend to the `HttpClient` infrastructure. It declares a dependency on an HTTP endpoint. The request to be made can be reactive, updating in response to signals for the URL, method, or otherwise. The response is returned as an instance of `HttpResource`, a `WritableResource` with some additional signals which represent parts of the HTTP response metadata (status, headers, etc).
