### PR TITLE
feat(core): signal utils for input and model

### DIFF
--- a/packages/core/src/authoring/input/input_signal_node.ts
+++ b/packages/core/src/authoring/input/input_signal_node.ts
@@ -44,6 +44,7 @@ export const INPUT_SIGNAL_NODE: InputSignalNode<unknown, unknown> = /* @__PURE__
   return {
     ...SIGNAL_NODE,
     transformFn: undefined,
+    kind: 'input',
 
     applyValueToInputSignal<T, TransformT>(node: InputSignalNode<T, TransformT>, value: T) {
       signalSetFn(node, value);

--- a/packages/core/src/core_reactivity_export_internal.ts
+++ b/packages/core/src/core_reactivity_export_internal.ts
@@ -8,7 +8,13 @@
 
 export {SIGNAL as ɵSIGNAL} from '@angular/core/primitives/signals';
 
-export {isSignal, Signal, ValueEqualityFn} from './render3/reactivity/api';
+export {
+  isSignal,
+  isInputSignal,
+  isModelSignal,
+  Signal,
+  ValueEqualityFn,
+} from './render3/reactivity/api';
 export {computed, CreateComputedOptions} from './render3/reactivity/computed';
 export {
   CreateSignalOptions,

--- a/packages/core/src/render3/reactivity/api.ts
+++ b/packages/core/src/render3/reactivity/api.ts
@@ -7,6 +7,7 @@
  */
 
 import {SIGNAL} from '@angular/core/primitives/signals';
+import {InputSignal, ModelSignal} from '../../authoring';
 
 /**
  * A reactive value which notifies consumers of any changes.
@@ -25,6 +26,20 @@ export type Signal<T> = (() => T) & {
  */
 export function isSignal(value: unknown): value is Signal<unknown> {
   return typeof value === 'function' && (value as Signal<unknown>)[SIGNAL] !== undefined;
+}
+
+/**
+ * Checks if the given `value` is a reactive `InputSignal`.
+ */
+export function isInputSignal(value: unknown): value is InputSignal<unknown> {
+  return isSignal(value) && (value as InputSignal<unknown>)[SIGNAL].kind === 'input';
+}
+
+/**
+ * Checks if the given `value` is a reactive `ModelSignal`.
+ */
+export function isModelSignal(value: unknown): value is ModelSignal<unknown> {
+  return isInputSignal(value) && typeof (value as ModelSignal<unknown>).subscribe === 'function';
 }
 
 /**

--- a/packages/core/test/signals/BUILD.bazel
+++ b/packages/core/test/signals/BUILD.bazel
@@ -12,12 +12,13 @@ ts_library(
         "//packages/core",
         "//packages/core/primitives/signals",
         "//packages/core/src/util",
+        "//packages/core/testing",
     ],
 )
 
 jasmine_node_test(
     name = "signals",
-    bootstrap = ["//tools/testing:node_no_angular"],
+    bootstrap = ["//tools/testing:node"],
     deps = [
         ":signals_lib",
     ],

--- a/packages/core/test/signals/is_signal_spec.ts
+++ b/packages/core/test/signals/is_signal_spec.ts
@@ -6,7 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, isSignal, signal} from '@angular/core';
+import {computed, input, isSignal, model, runInInjectionContext, signal} from '@angular/core';
+import {createInputSignal} from '@angular/core/src/authoring/input/input_signal';
+import {isInputSignal, isModelSignal} from '@angular/core/src/render3/reactivity/api';
+import {TestBed} from '@angular/core/testing';
 
 describe('isSignal', () => {
   it('should return true for writable signal', () => {
@@ -32,5 +35,29 @@ describe('isSignal', () => {
   it('should return false for function', () => {
     const fn = () => {};
     expect(isSignal(fn)).toBe(false);
+  });
+});
+
+describe('isInputSignal', () => {
+  it('should return true for input signal', () => {
+    const inputSignal = TestBed.runInInjectionContext(() => input('Angular'));
+    expect(isInputSignal(inputSignal)).toBe(true);
+  });
+
+  it('should return false for signal', () => {
+    const writableSignal = signal('Angular');
+    expect(isInputSignal(writableSignal)).toBe(false);
+  });
+});
+
+describe('isModelSignal', () => {
+  it('should return true for model signal', () => {
+    const modelSignal = TestBed.runInInjectionContext(() => model('Angular'));
+    expect(isModelSignal(modelSignal)).toBe(true);
+  });
+
+  it('should return false for input signal', () => {
+    const inputSignal = createInputSignal('Angular');
+    expect(isModelSignal(inputSignal)).toBe(false);
   });
 });


### PR DESCRIPTION
provides `isInputSignal` and `isModelSignal` to check whether given value is `InputSignal` or `ModelSignal` respectively.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently we have only `isSignal` which only check if the given value is signal or not. 

Issue Number: N/A


## What is the new behavior?
Introduced two new methods similar to `isSignal` to check if given value is `InputSignal` or `ModelSignal`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
