### PR TITLE
feat(compiler): support void and exponentiation operators in templates

### DIFF
--- a/adev/src/content/guide/templates/expression-syntax.md
+++ b/adev/src/content/guide/templates/expression-syntax.md
@@ -8,22 +8,22 @@ Angular supports a subset of [literal values](https://developer.mozilla.org/en-U
 
 ### Supported value literals
 
-| Literal type     | Example values                  |
-| ---------------- | ------------------------------- |
-| String           | `'Hello'`, `"World"`            |
-| Boolean          | `true`, `false`                 |
-| Number           | `123`, `3.14`                   |
-| Object           | `{name: 'Alice'}`               |
-| Array            | `['Onion', 'Cheese', 'Garlic']` |
-| null             | `null`                          |
-| Template string  | `` `Hello ${name}` ``           |
+| Literal type    | Example values                  |
+| --------------- | ------------------------------- |
+| String          | `'Hello'`, `"World"`            |
+| Boolean         | `true`, `false`                 |
+| Number          | `123`, `3.14`                   |
+| Object          | `{name: 'Alice'}`               |
+| Array           | `['Onion', 'Cheese', 'Garlic']` |
+| null            | `null`                          |
+| Template string | `` `Hello ${name}` ``           |
 
 ### Unsupported literals
 
-| Literal type             | Example value             |
-| ------------------------ | ------------------------- |
-| RegExp                   | `/\d+/`                   |
-| Tagged template string   | `` tag`Hello ${name}` ``  |
+| Literal type           | Example value            |
+| ---------------------- | ------------------------ |
+| RegExp                 | `/\d+/`                  |
+| Tagged template string | `` tag`Hello ${name}` `` |
 
 ## Globals
 
@@ -58,11 +58,13 @@ Angular supports the following operators from standard JavaScript.
 | And (Logical)         | `&&`                                     |
 | Or (Logical)          | `\|\|`                                   |
 | Not (Logical)         | `!`                                      |
-| Nullish Coalescing    | `const foo = null ?? 'default'`          |
+| Nullish Coalescing    | `possiblyNullValue ?? 'default'`         |
 | Comparison Operators  | `<`, `<=`, `>`, `>=`, `==`, `===`, `!==` |
-| Unary Negation        | `const y = -x`                           |
-| Unary Plus            | `const x = +y`                           |
-| Property Accessor     | `person['name'] = 'Mirabel'`             |
+| Unary Negation        | `-x`                                     |
+| Unary Plus            | `+y`                                     |
+| Property Accessor     | `person['name']`                         |
+| typeof                | `typeof 42`                              |
+| void                  | `void 1`                                 |
 
 Angular expressions additionally also support the following non-standard operators:
 
@@ -83,8 +85,6 @@ Angular expressions additionally also support the following non-standard operato
 | Object destructuring  | `const { name } = person`         |
 | Array destructuring   | `const [firstItem] = items`       |
 | Comma operator        | `x = (x++, x)`                    |
-| typeof                | `typeof 42`                       |
-| void                  | `void 1`                          |
 | in                    | `'model' in car`                  |
 | instanceof            | `car instanceof Automobile`       |
 | new                   | `new Car()`                       |

--- a/adev/src/content/guide/templates/expression-syntax.md
+++ b/adev/src/content/guide/templates/expression-syntax.md
@@ -53,6 +53,7 @@ Angular supports the following operators from standard JavaScript.
 | Multiply              | `41 * 6`                                 |
 | Divide                | `20 / 4`                                 |
 | Remainder (Modulo)    | `17 % 5`                                 |
+| Exponentiation        | `10 ** 3`                                |
 | Parenthesis           | `9 * (8 + 4)`                            |
 | Conditional (Ternary) | `a > b ? true : false`                   |
 | And (Logical)         | `&&`                                     |

--- a/packages/compiler-cli/linker/babel/src/ast/babel_ast_factory.ts
+++ b/packages/compiler-cli/linker/babel/src/ast/babel_ast_factory.ts
@@ -184,6 +184,10 @@ export class BabelAstFactory implements AstFactory<t.Statement, t.Expression> {
     return t.unaryExpression('typeof', expression);
   }
 
+  createVoidExpression(expression: t.Expression): t.Expression {
+    return t.unaryExpression('void', expression);
+  }
+
   createUnaryExpression = t.unaryExpression;
 
   createVariableDeclaration(

--- a/packages/compiler-cli/linker/babel/test/ast/babel_ast_factory_spec.ts
+++ b/packages/compiler-cli/linker/babel/test/ast/babel_ast_factory_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import {leadingComment} from '@angular/compiler';
-import {template, types as t} from '@babel/core';
+import {types as t, template} from '@babel/core';
 import _generate from '@babel/generator';
 
 import {BabelAstFactory} from '../../src/ast/babel_ast_factory';
@@ -345,6 +345,14 @@ describe('BabelAstFactory', () => {
       const expr = expression.ast`42`;
       const typeofExpr = factory.createTypeOfExpression(expr);
       expect(generate(typeofExpr).code).toEqual('typeof 42');
+    });
+  });
+
+  describe('createVoidExpression()', () => {
+    it('should create a void expression node', () => {
+      const expr = expression.ast`42`;
+      const voidExpr = factory.createVoidExpression(expr);
+      expect(generate(voidExpr).code).toEqual('void 42');
     });
   });
 

--- a/packages/compiler-cli/linker/babel/test/ast/babel_ast_factory_spec.ts
+++ b/packages/compiler-cli/linker/babel/test/ast/babel_ast_factory_spec.ts
@@ -82,6 +82,13 @@ describe('BabelAstFactory', () => {
       expect(t.isLogicalExpression(expr)).toBe(true);
       expect(generate(expr).code).toEqual('17 && 42');
     });
+
+    it('should create a binary operation node for exponentiation', () => {
+      const left = expression.ast`2`;
+      const right = expression.ast`3`;
+      const expr = factory.createBinaryExpression(left, '**', right);
+      expect(generate(expr).code).toEqual('2 ** 3');
+    });
   });
 
   describe('createBlock()', () => {

--- a/packages/compiler-cli/src/ngtsc/translator/src/api/ast_factory.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/api/ast_factory.ts
@@ -311,6 +311,7 @@ export type BinaryOperator =
   | '-'
   | '%'
   | '*'
+  | '**'
   | '!='
   | '!=='
   | '||'

--- a/packages/compiler-cli/src/ngtsc/translator/src/api/ast_factory.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/api/ast_factory.ts
@@ -244,6 +244,13 @@ export interface AstFactory<TStatement, TExpression> {
   createTypeOfExpression(expression: TExpression): TExpression;
 
   /**
+   * Create an expression that evaluates an expression and returns `undefined`.
+   *
+   * @param expression the expression whose type we want.
+   */
+  createVoidExpression(expression: TExpression): TExpression;
+
+  /**
    * Prefix the `operand` with the given `operator` (e.g. `-expr`).
    *
    * @param operator the text of the operator to apply (e.g. `+`, `-` or `!`).

--- a/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
@@ -43,6 +43,7 @@ const BINARY_OPERATORS = new Map<o.BinaryOperator, BinaryOperator>([
   [o.BinaryOperator.Or, '||'],
   [o.BinaryOperator.Plus, '+'],
   [o.BinaryOperator.NullishCoalesce, '??'],
+  [o.BinaryOperator.Exponentiation, '**'],
 ]);
 
 export type RecordWrappedNodeFn<TExpression> = (node: o.WrappedNodeExpr<TExpression>) => void;

--- a/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
@@ -447,6 +447,10 @@ export class ExpressionTranslatorVisitor<TFile, TStatement, TExpression>
     return this.factory.createTypeOfExpression(ast.expr.visitExpression(this, context));
   }
 
+  visitVoidExpr(ast: o.VoidExpr, context: Context): TExpression {
+    return this.factory.createVoidExpression(ast.expr.visitExpression(this, context));
+  }
+
   visitUnaryOperatorExpr(ast: o.UnaryOperatorExpr, context: Context): TExpression {
     if (!UNARY_OPERATORS.has(ast.operator)) {
       throw new Error(`Unknown unary operator: ${o.UnaryOperator[ast.operator]}`);

--- a/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
@@ -276,6 +276,10 @@ class TypeTranslatorVisitor implements o.ExpressionVisitor, o.TypeVisitor {
     return ts.factory.createTypeQueryNode(typeNode.typeName);
   }
 
+  visitVoidExpr(ast: o.VoidExpr, context: Context) {
+    throw new Error('Method not implemented.');
+  }
+
   private translateType(type: o.Type, context: Context): ts.TypeNode {
     const typeNode = type.visitType(this, context);
     if (!ts.isTypeNode(typeNode)) {

--- a/packages/compiler-cli/src/ngtsc/translator/src/typescript_ast_factory.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/typescript_ast_factory.ts
@@ -291,6 +291,8 @@ export class TypeScriptAstFactory implements AstFactory<ts.Statement, ts.Express
 
   createTypeOfExpression = ts.factory.createTypeOfExpression;
 
+  createVoidExpression = ts.factory.createVoidExpression;
+
   createUnaryExpression(operator: UnaryOperator, operand: ts.Expression): ts.Expression {
     return ts.factory.createPrefixUnaryExpression(UNARY_OPERATORS[operator], operand);
   }

--- a/packages/compiler-cli/src/ngtsc/translator/src/typescript_ast_factory.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/typescript_ast_factory.ts
@@ -54,6 +54,7 @@ const BINARY_OPERATORS: Record<BinaryOperator, ts.BinaryOperator> = {
   '-': ts.SyntaxKind.MinusToken,
   '%': ts.SyntaxKind.PercentToken,
   '*': ts.SyntaxKind.AsteriskToken,
+  '**': ts.SyntaxKind.AsteriskAsteriskToken,
   '!=': ts.SyntaxKind.ExclamationEqualsToken,
   '!==': ts.SyntaxKind.ExclamationEqualsEqualsToken,
   '||': ts.SyntaxKind.BarBarToken,

--- a/packages/compiler-cli/src/ngtsc/translator/test/typescript_ast_factory_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/test/typescript_ast_factory_spec.ts
@@ -409,6 +409,17 @@ describe('TypeScriptAstFactory', () => {
     });
   });
 
+  describe('createVoidExpression()', () => {
+    it('should create a void expression node', () => {
+      const {
+        items: [expr],
+        generate,
+      } = setupExpressions(`42`);
+      const voidExpr = factory.createVoidExpression(expr);
+      expect(generate(voidExpr)).toEqual('void 42');
+    });
+  });
+
   describe('createUnaryExpression()', () => {
     it('should create a unary expression with the operator and operand', () => {
       const {

--- a/packages/compiler-cli/src/ngtsc/translator/test/typescript_ast_factory_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/test/typescript_ast_factory_spec.ts
@@ -73,6 +73,15 @@ describe('TypeScriptAstFactory', () => {
       const assignment = factory.createBinaryExpression(left, '+', right);
       expect(generate(assignment)).toEqual('17 + 42');
     });
+
+    it('should create a binary operation node for exponentiation', () => {
+      const {
+        items: [left, right],
+        generate,
+      } = setupExpressions(`2`, `3`);
+      const assignment = factory.createBinaryExpression(left, '**', right);
+      expect(generate(assignment)).toEqual('2 ** 3');
+    });
   });
 
   describe('createDynamicImport()', () => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -76,6 +76,7 @@ const BINARY_OPS = new Map<string, ts.BinaryOperator>([
   ['==', ts.SyntaxKind.EqualsEqualsToken],
   ['===', ts.SyntaxKind.EqualsEqualsEqualsToken],
   ['*', ts.SyntaxKind.AsteriskToken],
+  ['**', ts.SyntaxKind.AsteriskAsteriskToken],
   ['/', ts.SyntaxKind.SlashToken],
   ['%', ts.SyntaxKind.PercentToken],
   ['!=', ts.SyntaxKind.ExclamationEqualsToken],

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -25,16 +25,17 @@ import {
   LiteralPrimitive,
   NonNullAssert,
   PrefixNot,
-  TypeofExpression,
   PropertyRead,
   PropertyWrite,
   SafeCall,
   SafeKeyedRead,
   SafePropertyRead,
-  ThisReceiver,
-  Unary,
   TemplateLiteral,
   TemplateLiteralElement,
+  ThisReceiver,
+  TypeofExpression,
+  Unary,
+  VoidExpression,
 } from '@angular/compiler';
 import ts from 'typescript';
 
@@ -281,6 +282,13 @@ class AstTranslator implements AstVisitor {
   visitTypeofExpression(ast: TypeofExpression): ts.Expression {
     const expression = wrapForDiagnostics(this.translate(ast.expression));
     const node = ts.factory.createTypeOfExpression(expression);
+    addParseSpanInfo(node, ast.sourceSpan);
+    return node;
+  }
+
+  visitVoidExpression(ast: VoidExpression): ts.Expression {
+    const expression = wrapForDiagnostics(this.translate(ast.expression));
+    const node = ts.factory.createVoidExpression(expression);
     addParseSpanInfo(node, ast.sourceSpan);
     return node;
   }
@@ -579,10 +587,13 @@ class VeSafeLhsInferenceBugDetector implements AstVisitor {
   visitPrefixNot(ast: PrefixNot): boolean {
     return ast.expression.visit(this);
   }
-  visitTypeofExpression(ast: PrefixNot): boolean {
+  visitTypeofExpression(ast: TypeofExpression): boolean {
     return ast.expression.visit(this);
   }
-  visitNonNullAssert(ast: PrefixNot): boolean {
+  visitVoidExpression(ast: VoidExpression): boolean {
+    return ast.expression.visit(this);
+  }
+  visitNonNullAssert(ast: NonNullAssert): boolean {
     return ast.expression.visit(this);
   }
   visitPropertyRead(ast: PropertyRead): boolean {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -69,6 +69,12 @@ describe('type check blocks', () => {
     );
   });
 
+  it('should handle void expressions', () => {
+    expect(tcb('{{void a}}')).toContain('void (((this).a))');
+    expect(tcb('{{!(void a)}}')).toContain('!(void (((this).a)))');
+    expect(tcb('{{!(void a === "object")}}')).toContain('!((void (((this).a))) === ("object"))');
+  });
+
   it('should handle attribute values for directive inputs', () => {
     const TEMPLATE = `<div dir inputA="value"></div>`;
     const DIRECTIVES: TestDeclaration[] = [

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -75,6 +75,12 @@ describe('type check blocks', () => {
     expect(tcb('{{!(void a === "object")}}')).toContain('!((void (((this).a))) === ("object"))');
   });
 
+  it('should handle exponentiation expressions', () => {
+    expect(tcb('{{a * b ** c + d}}')).toContain(
+      '(((((this).a)) * ((((this).b)) ** (((this).c)))) + (((this).d)))',
+    );
+  });
+
   it('should handle attribute values for directive inputs', () => {
     const TEMPLATE = `<div dir inputA="value"></div>`;
     const DIRECTIVES: TestDeclaration[] = [

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/GOLDEN_PARTIAL.js
@@ -91,7 +91,7 @@ export class MyApp {
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
     {{ 1 + 2 }}
-    {{ (1 % 2) + 3 / 4 * 5 }}
+    {{ (1 % 2) + 3 / 4 * 5 ** 6 }}
     {{ +1 }}
     {{ typeof {} === 'object' }}
     {{ !(typeof {} === 'object') }}
@@ -104,7 +104,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
             args: [{
                     template: `
     {{ 1 + 2 }}
-    {{ (1 % 2) + 3 / 4 * 5 }}
+    {{ (1 % 2) + 3 / 4 * 5 ** 6 }}
     {{ +1 }}
     {{ typeof {} === 'object' }}
     {{ !(typeof {} === 'object') }}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/GOLDEN_PARTIAL.js
@@ -97,6 +97,7 @@ MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-
     {{ !(typeof {} === 'object') }}
     {{ typeof foo?.bar === 'string' }}
     {{ typeof foo?.bar | identity }}
+    {{ void 'test' }}
   `, isInline: true, dependencies: [{ kind: "pipe", type: IdentityPipe, name: "identity" }] });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
             type: Component,
@@ -109,6 +110,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
     {{ !(typeof {} === 'object') }}
     {{ typeof foo?.bar === 'string' }}
     {{ typeof foo?.bar | identity }}
+    {{ void 'test' }}
   `,
                     imports: [IdentityPipe],
                 }]

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/TEST_CASES.json
@@ -3,9 +3,7 @@
   "cases": [
     {
       "description": "should be able to generate the TODO example",
-      "inputFiles": [
-        "todo_example.ts"
-      ],
+      "inputFiles": ["todo_example.ts"],
       "expectations": [
         {
           "files": [
@@ -20,9 +18,10 @@
     },
     {
       "description": "should handle binary and unary operators",
-      "inputFiles": [
-        "operators.ts"
-      ],
+      "compilerOptions": {
+        "target": "es2020"
+      },
+      "inputFiles": ["operators.ts"],
       "expectations": [
         {
           "files": [

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/operators.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/operators.ts
@@ -10,7 +10,7 @@ export class IdentityPipe {
 @Component({
   template: `
     {{ 1 + 2 }}
-    {{ (1 % 2) + 3 / 4 * 5 }}
+    {{ (1 % 2) + 3 / 4 * 5 ** 6 }}
     {{ +1 }}
     {{ typeof {} === 'object' }}
     {{ !(typeof {} === 'object') }}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/operators.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/operators.ts
@@ -16,6 +16,7 @@ export class IdentityPipe {
     {{ !(typeof {} === 'object') }}
     {{ typeof foo?.bar === 'string' }}
     {{ typeof foo?.bar | identity }}
+    {{ void 'test' }}
   `,
   imports: [IdentityPipe],
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/operators_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/operators_template.js
@@ -5,7 +5,7 @@ template: function MyApp_Template(rf, $ctx$) {
 	} if (rf & 2) {
 	  i0.ɵɵtextInterpolate8(" ", 
 		1 + 2, " ", 
-		1 % 2 + 3 / 4 * 5, " ", 
+		1 % 2 + 3 / 4 * 5 ** 6, " ", 
 		+1, " ", 
 		typeof i0.ɵɵpureFunction0(10, _c0) === "object", " ", 
 		!(typeof i0.ɵɵpureFunction0(11, _c0) === "object"), " ", 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/operators_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/operators_template.js
@@ -3,14 +3,15 @@ template: function MyApp_Template(rf, $ctx$) {
 	  $i0$.ɵɵtext(0);
 	  i0.ɵɵpipe(1, "identity");
 	} if (rf & 2) {
-	  i0.ɵɵtextInterpolate7(" ", 
+	  i0.ɵɵtextInterpolate8(" ", 
 		1 + 2, " ", 
 		1 % 2 + 3 / 4 * 5, " ", 
 		+1, " ", 
-		typeof i0.ɵɵpureFunction0(9, _c0) === "object", " ", 
-		!(typeof i0.ɵɵpureFunction0(10, _c0) === "object"), " ", 
+		typeof i0.ɵɵpureFunction0(10, _c0) === "object", " ", 
+		!(typeof i0.ɵɵpureFunction0(11, _c0) === "object"), " ", 
 		typeof (ctx.foo == null ? null : ctx.foo.bar) === "string", " ", 
-		i0.ɵɵpipeBind1(1, 7, typeof (ctx.foo == null ? null : ctx.foo.bar)), " "
+		i0.ɵɵpipeBind1(1, 8, typeof (ctx.foo == null ? null : ctx.foo.bar)), " ",
+		void "test", " "
 	  );	
 	}
   }

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -29,32 +29,38 @@
 
 import * as core from './core';
 import {publishFacade} from './jit_compiler_facade';
+import * as outputAst from './output/output_ast';
 import {global} from './util';
 
 export {CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA, SchemaMetadata} from './core';
 export {core};
 
-export * from './version';
 export {CompilerConfig, preserveWhitespacesDefault} from './config';
-export * from './resource_loader';
 export {ConstantPool} from './constant_pool';
-export {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from './ml_parser/defaults';
-export * from './schema/element_schema_registry';
-export * from './i18n/index';
+export {
+  ChangeDetectionStrategy,
+  emitDistinctChangesOnlyDefaultValue,
+  ViewEncapsulation,
+} from './core';
 export * from './expression_parser/ast';
 export * from './expression_parser/lexer';
 export * from './expression_parser/parser';
+export * from './i18n/index';
+export * from './injectable_compiler_2';
+export {publishFacade} from './jit_compiler_facade';
 export * from './ml_parser/ast';
+export {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from './ml_parser/defaults';
 export * from './ml_parser/html_parser';
 export * from './ml_parser/html_tags';
-export * from './ml_parser/tags';
-export {ParseTreeResult, TreeError} from './ml_parser/parser';
 export {LexerRange} from './ml_parser/lexer';
-export * from './ml_parser/xml_parser';
+export {ParseTreeResult, TreeError} from './ml_parser/parser';
+export * from './ml_parser/tags';
 export {TokenType as LexerTokenType} from './ml_parser/tokens';
+export * from './ml_parser/xml_parser';
+export {EmitterVisitorContext} from './output/abstract_emitter';
 export {
   ArrayType,
-  DYNAMIC_TYPE,
+  ArrowFunctionExpr,
   BinaryOperator,
   BinaryOperatorExpr,
   BuiltinType,
@@ -63,164 +69,62 @@ export {
   ConditionalExpr,
   DeclareFunctionStmt,
   DeclareVarStmt,
+  DYNAMIC_TYPE,
+  DynamicImportExpr,
   Expression,
   ExpressionStatement,
   ExpressionType,
   ExpressionVisitor,
   ExternalExpr,
   ExternalReference,
-  literalMap,
   FunctionExpr,
   IfStmt,
   InstantiateExpr,
   InvokeFunctionExpr,
-  ArrowFunctionExpr,
+  jsDocComment,
+  JSDocComment,
+  leadingComment,
+  LeadingComment,
+  literal,
   LiteralArrayExpr,
   LiteralExpr,
+  literalMap,
   LiteralMapExpr,
+  LocalizedString,
   MapType,
-  NotExpr,
   NONE_TYPE,
+  NotExpr,
   ReadKeyExpr,
   ReadPropExpr,
   ReadVarExpr,
   ReturnStatement,
+  Statement,
   StatementVisitor,
+  StmtModifier,
+  STRING_TYPE,
   TaggedTemplateLiteralExpr,
-  TemplateLiteralExpr,
   TemplateLiteralElementExpr,
+  TemplateLiteralExpr,
+  TransplantedType,
   Type,
   TypeModifier,
+  TypeofExpr,
   TypeVisitor,
+  UnaryOperator,
+  UnaryOperatorExpr,
+  VoidExpr,
   WrappedNodeExpr,
-  literal,
   WriteKeyExpr,
   WritePropExpr,
   WriteVarExpr,
-  StmtModifier,
-  Statement,
-  STRING_TYPE,
-  TypeofExpr,
-  jsDocComment,
-  leadingComment,
-  LeadingComment,
-  JSDocComment,
-  UnaryOperator,
-  UnaryOperatorExpr,
-  LocalizedString,
-  TransplantedType,
-  DynamicImportExpr,
 } from './output/output_ast';
-export {EmitterVisitorContext} from './output/abstract_emitter';
 export {JitEvaluator} from './output/output_jit';
-export * from './parse_util';
-export * from './schema/dom_element_schema_registry';
-export * from './selector';
-export {Version} from './util';
 export {SourceMap} from './output/source_map';
-export * from './injectable_compiler_2';
+export * from './parse_util';
 export * from './render3/partial/api';
-export * from './render3/view/api';
 export {
-  visitAll as tmplAstVisitAll,
-  BlockNode as TmplAstBlockNode,
-  BoundAttribute as TmplAstBoundAttribute,
-  BoundEvent as TmplAstBoundEvent,
-  BoundText as TmplAstBoundText,
-  Content as TmplAstContent,
-  Element as TmplAstElement,
-  Icu as TmplAstIcu,
-  Node as TmplAstNode,
-  Visitor as TmplAstVisitor,
-  RecursiveVisitor as TmplAstRecursiveVisitor,
-  Reference as TmplAstReference,
-  Template as TmplAstTemplate,
-  Text as TmplAstText,
-  TextAttribute as TmplAstTextAttribute,
-  Variable as TmplAstVariable,
-  DeferredBlock as TmplAstDeferredBlock,
-  DeferredBlockPlaceholder as TmplAstDeferredBlockPlaceholder,
-  DeferredBlockLoading as TmplAstDeferredBlockLoading,
-  DeferredBlockError as TmplAstDeferredBlockError,
-  DeferredTrigger as TmplAstDeferredTrigger,
-  BoundDeferredTrigger as TmplAstBoundDeferredTrigger,
-  IdleDeferredTrigger as TmplAstIdleDeferredTrigger,
-  ImmediateDeferredTrigger as TmplAstImmediateDeferredTrigger,
-  HoverDeferredTrigger as TmplAstHoverDeferredTrigger,
-  TimerDeferredTrigger as TmplAstTimerDeferredTrigger,
-  InteractionDeferredTrigger as TmplAstInteractionDeferredTrigger,
-  ViewportDeferredTrigger as TmplAstViewportDeferredTrigger,
-  NeverDeferredTrigger as TmplAstNeverDeferredTrigger,
-  SwitchBlock as TmplAstSwitchBlock,
-  SwitchBlockCase as TmplAstSwitchBlockCase,
-  ForLoopBlock as TmplAstForLoopBlock,
-  ForLoopBlockEmpty as TmplAstForLoopBlockEmpty,
-  IfBlock as TmplAstIfBlock,
-  IfBlockBranch as TmplAstIfBlockBranch,
-  DeferredBlockTriggers as TmplAstDeferredBlockTriggers,
-  UnknownBlock as TmplAstUnknownBlock,
-  LetDeclaration as TmplAstLetDeclaration,
-} from './render3/r3_ast';
-export * from './render3/view/t2_api';
-export * from './render3/view/t2_binder';
-export {createCssSelectorFromNode} from './render3/view/util';
-export {Identifiers as R3Identifiers} from './render3/r3_identifiers';
-export {
-  R3ClassMetadata,
-  CompileClassMetadataFn,
-  compileClassMetadata,
-  compileComponentClassMetadata,
-  compileOpaqueAsyncClassMetadata,
-} from './render3/r3_class_metadata_compiler';
-export {compileClassDebugInfo, R3ClassDebugInfo} from './render3/r3_class_debug_info_compiler';
-export {
-  compileHmrInitializer,
-  compileHmrUpdateCallback,
-  R3HmrMetadata,
-  R3HmrNamespaceDependency,
-} from './render3/r3_hmr_compiler';
-export {
-  compileFactoryFunction,
-  R3DependencyMetadata,
-  R3FactoryMetadata,
-  FactoryTarget,
-} from './render3/r3_factory';
-export {
-  compileNgModule,
-  R3NgModuleMetadata,
-  R3SelectorScopeMode,
-  R3NgModuleMetadataKind,
-  R3NgModuleMetadataGlobal,
-} from './render3/r3_module_compiler';
-export {compileInjector, R3InjectorMetadata} from './render3/r3_injector_compiler';
-export {compilePipeFromMetadata, R3PipeMetadata} from './render3/r3_pipe_compiler';
-export {
-  makeBindingParser,
-  ParsedTemplate,
-  parseTemplate,
-  ParseTemplateOptions,
-} from './render3/view/template';
-export {
-  ForwardRefHandling,
-  MaybeForwardRefExpression,
-  R3CompiledExpression,
-  R3Reference,
-  createMayBeForwardRefExpression,
-  devOnlyGuardedExpression,
-  getSafePropertyAccessString,
-} from './render3/util';
-export {
-  compileComponentFromMetadata,
-  compileDirectiveFromMetadata,
-  parseHostBindings,
-  ParsedHostBindings,
-  verifyHostBindings,
-  encapsulateStyle,
-  compileDeferResolverFunction,
-} from './render3/view/compiler';
-export {
-  compileDeclareClassMetadata,
   compileComponentDeclareClassMetadata,
+  compileDeclareClassMetadata,
 } from './render3/partial/class_metadata';
 export {
   compileDeclareComponentFromMetadata,
@@ -232,13 +136,110 @@ export {compileDeclareInjectableFromMetadata} from './render3/partial/injectable
 export {compileDeclareInjectorFromMetadata} from './render3/partial/injector';
 export {compileDeclareNgModuleFromMetadata} from './render3/partial/ng_module';
 export {compileDeclarePipeFromMetadata} from './render3/partial/pipe';
-export {publishFacade} from './jit_compiler_facade';
 export {
-  emitDistinctChangesOnlyDefaultValue,
-  ChangeDetectionStrategy,
-  ViewEncapsulation,
-} from './core';
-import * as outputAst from './output/output_ast';
+  BlockNode as TmplAstBlockNode,
+  BoundAttribute as TmplAstBoundAttribute,
+  BoundDeferredTrigger as TmplAstBoundDeferredTrigger,
+  BoundEvent as TmplAstBoundEvent,
+  BoundText as TmplAstBoundText,
+  Content as TmplAstContent,
+  DeferredBlock as TmplAstDeferredBlock,
+  DeferredBlockError as TmplAstDeferredBlockError,
+  DeferredBlockLoading as TmplAstDeferredBlockLoading,
+  DeferredBlockPlaceholder as TmplAstDeferredBlockPlaceholder,
+  DeferredBlockTriggers as TmplAstDeferredBlockTriggers,
+  DeferredTrigger as TmplAstDeferredTrigger,
+  Element as TmplAstElement,
+  ForLoopBlock as TmplAstForLoopBlock,
+  ForLoopBlockEmpty as TmplAstForLoopBlockEmpty,
+  HoverDeferredTrigger as TmplAstHoverDeferredTrigger,
+  Icu as TmplAstIcu,
+  IdleDeferredTrigger as TmplAstIdleDeferredTrigger,
+  IfBlock as TmplAstIfBlock,
+  IfBlockBranch as TmplAstIfBlockBranch,
+  ImmediateDeferredTrigger as TmplAstImmediateDeferredTrigger,
+  InteractionDeferredTrigger as TmplAstInteractionDeferredTrigger,
+  LetDeclaration as TmplAstLetDeclaration,
+  NeverDeferredTrigger as TmplAstNeverDeferredTrigger,
+  Node as TmplAstNode,
+  RecursiveVisitor as TmplAstRecursiveVisitor,
+  Reference as TmplAstReference,
+  SwitchBlock as TmplAstSwitchBlock,
+  SwitchBlockCase as TmplAstSwitchBlockCase,
+  Template as TmplAstTemplate,
+  Text as TmplAstText,
+  TextAttribute as TmplAstTextAttribute,
+  TimerDeferredTrigger as TmplAstTimerDeferredTrigger,
+  UnknownBlock as TmplAstUnknownBlock,
+  Variable as TmplAstVariable,
+  ViewportDeferredTrigger as TmplAstViewportDeferredTrigger,
+  visitAll as tmplAstVisitAll,
+  Visitor as TmplAstVisitor,
+} from './render3/r3_ast';
+export {compileClassDebugInfo, R3ClassDebugInfo} from './render3/r3_class_debug_info_compiler';
+export {
+  compileClassMetadata,
+  CompileClassMetadataFn,
+  compileComponentClassMetadata,
+  compileOpaqueAsyncClassMetadata,
+  R3ClassMetadata,
+} from './render3/r3_class_metadata_compiler';
+export {
+  compileFactoryFunction,
+  FactoryTarget,
+  R3DependencyMetadata,
+  R3FactoryMetadata,
+} from './render3/r3_factory';
+export {
+  compileHmrInitializer,
+  compileHmrUpdateCallback,
+  R3HmrMetadata,
+  R3HmrNamespaceDependency,
+} from './render3/r3_hmr_compiler';
+export {Identifiers as R3Identifiers} from './render3/r3_identifiers';
+export {compileInjector, R3InjectorMetadata} from './render3/r3_injector_compiler';
+export {
+  compileNgModule,
+  R3NgModuleMetadata,
+  R3NgModuleMetadataGlobal,
+  R3NgModuleMetadataKind,
+  R3SelectorScopeMode,
+} from './render3/r3_module_compiler';
+export {compilePipeFromMetadata, R3PipeMetadata} from './render3/r3_pipe_compiler';
+export {
+  createMayBeForwardRefExpression,
+  devOnlyGuardedExpression,
+  ForwardRefHandling,
+  getSafePropertyAccessString,
+  MaybeForwardRefExpression,
+  R3CompiledExpression,
+  R3Reference,
+} from './render3/util';
+export * from './render3/view/api';
+export {
+  compileComponentFromMetadata,
+  compileDeferResolverFunction,
+  compileDirectiveFromMetadata,
+  encapsulateStyle,
+  ParsedHostBindings,
+  parseHostBindings,
+  verifyHostBindings,
+} from './render3/view/compiler';
+export * from './render3/view/t2_api';
+export * from './render3/view/t2_binder';
+export {
+  makeBindingParser,
+  ParsedTemplate,
+  parseTemplate,
+  ParseTemplateOptions,
+} from './render3/view/template';
+export {createCssSelectorFromNode} from './render3/view/util';
+export * from './resource_loader';
+export * from './schema/dom_element_schema_registry';
+export * from './schema/element_schema_registry';
+export * from './selector';
+export {Version} from './util';
+export * from './version';
 export {outputAst};
 // This file only reexports content of the `src` folder. Keep it that way.
 

--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -386,6 +386,19 @@ export class TypeofExpression extends AST {
   }
 }
 
+export class VoidExpression extends AST {
+  constructor(
+    span: ParseSpan,
+    sourceSpan: AbsoluteSourceSpan,
+    public expression: AST,
+  ) {
+    super(span, sourceSpan);
+  }
+  override visit(visitor: AstVisitor, context: any = null): any {
+    return visitor.visitVoidExpression(this, context);
+  }
+}
+
 export class NonNullAssert extends AST {
   constructor(
     span: ParseSpan,
@@ -576,6 +589,7 @@ export interface AstVisitor {
   visitPipe(ast: BindingPipe, context: any): any;
   visitPrefixNot(ast: PrefixNot, context: any): any;
   visitTypeofExpression(ast: TypeofExpression, context: any): any;
+  visitVoidExpression(ast: TypeofExpression, context: any): any;
   visitNonNullAssert(ast: NonNullAssert, context: any): any;
   visitPropertyRead(ast: PropertyRead, context: any): any;
   visitPropertyWrite(ast: PropertyWrite, context: any): any;
@@ -646,6 +660,9 @@ export class RecursiveAstVisitor implements AstVisitor {
     this.visit(ast.expression, context);
   }
   visitTypeofExpression(ast: TypeofExpression, context: any) {
+    this.visit(ast.expression, context);
+  }
+  visitVoidExpression(ast: VoidExpression, context: any) {
     this.visit(ast.expression, context);
   }
   visitNonNullAssert(ast: NonNullAssert, context: any): any {

--- a/packages/compiler/src/expression_parser/lexer.ts
+++ b/packages/compiler/src/expression_parser/lexer.ts
@@ -37,6 +37,7 @@ const KEYWORDS = [
   'else',
   'this',
   'typeof',
+  'void',
 ];
 
 export class Lexer {
@@ -112,6 +113,10 @@ export class Token {
 
   isKeywordTypeof(): boolean {
     return this.type === TokenType.Keyword && this.strValue === 'typeof';
+  }
+
+  isKeywordVoid(): boolean {
+    return this.type === TokenType.Keyword && this.strValue === 'void';
   }
 
   isError(): boolean {

--- a/packages/compiler/src/expression_parser/lexer.ts
+++ b/packages/compiler/src/expression_parser/lexer.ts
@@ -291,11 +291,12 @@ class _Scanner {
         return this.scanPrivateIdentifier();
       case chars.$PLUS:
       case chars.$MINUS:
-      case chars.$STAR:
       case chars.$SLASH:
       case chars.$PERCENT:
       case chars.$CARET:
         return this.scanOperator(start, String.fromCharCode(peek));
+      case chars.$STAR:
+        return this.scanComplexOperator(start, '*', chars.$STAR, '*');
       case chars.$QUESTION:
         return this.scanQuestion(start);
       case chars.$LT:

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -37,7 +37,6 @@ import {
   ParserError,
   ParseSpan,
   PrefixNot,
-  TypeofExpression,
   PropertyRead,
   PropertyWrite,
   RecursiveAstVisitor,
@@ -46,11 +45,13 @@ import {
   SafePropertyRead,
   TemplateBinding,
   TemplateBindingIdentifier,
-  ThisReceiver,
-  Unary,
-  VariableBinding,
   TemplateLiteral,
   TemplateLiteralElement,
+  ThisReceiver,
+  TypeofExpression,
+  Unary,
+  VariableBinding,
+  VoidExpression,
 } from './ast';
 import {EOF, Lexer, StringTokenKind, Token, TokenType} from './lexer';
 
@@ -968,6 +969,11 @@ class _ParseAST {
       const start = this.inputIndex;
       let result = this.parsePrefix();
       return new TypeofExpression(this.span(start), this.sourceSpan(start), result);
+    } else if (this.next.isKeywordVoid()) {
+      this.advance();
+      const start = this.inputIndex;
+      let result = this.parsePrefix();
+      return new VoidExpression(this.span(start), this.sourceSpan(start), result);
     }
     return this.parseCallChain();
   }

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -515,6 +515,7 @@ enum ParseContextFlags {
 }
 
 class _ParseAST {
+  private lastUnary: Unary | PrefixNot | TypeofExpression | VoidExpression | null = null;
   private rparensExpected = 0;
   private rbracketsExpected = 0;
   private rbracesExpected = 0;
@@ -928,7 +929,7 @@ class _ParseAST {
   private parseMultiplicative(): AST {
     // '*', '%', '/'
     const start = this.inputIndex;
-    let result = this.parsePrefix();
+    let result = this.parseExponentiation();
     while (this.next.type == TokenType.Operator) {
       const operator = this.next.strValue;
       switch (operator) {
@@ -936,11 +937,31 @@ class _ParseAST {
         case '%':
         case '/':
           this.advance();
-          let right = this.parsePrefix();
+          const right = this.parseExponentiation();
           result = new Binary(this.span(start), this.sourceSpan(start), operator, result, right);
           continue;
       }
       break;
+    }
+    return result;
+  }
+
+  private parseExponentiation(): AST {
+    // '**'
+    const start = this.inputIndex;
+    let result = this.parsePrefix();
+    while (this.next.type == TokenType.Operator && this.next.strValue === '**') {
+      // This aligns with Javascript semantics which require any unary operator preceeding the
+      // exponentiation operation to be explicitly grouped as either applying to the base or result
+      // of the exponentiation operation.
+      if (result === this.lastUnary) {
+        this.error(
+          'Unary operator used immediately before exponentiation expression. Parenthesis must be used to disambiguate operator precedence',
+        );
+      }
+      this.advance();
+      const right = this.parsePrefix();
+      result = new Binary(this.span(start), this.sourceSpan(start), '**', result, right);
     }
     return result;
   }
@@ -954,26 +975,42 @@ class _ParseAST {
         case '+':
           this.advance();
           result = this.parsePrefix();
-          return Unary.createPlus(this.span(start), this.sourceSpan(start), result);
+          return (this.lastUnary = Unary.createPlus(
+            this.span(start),
+            this.sourceSpan(start),
+            result,
+          ));
         case '-':
           this.advance();
           result = this.parsePrefix();
-          return Unary.createMinus(this.span(start), this.sourceSpan(start), result);
+          return (this.lastUnary = Unary.createMinus(
+            this.span(start),
+            this.sourceSpan(start),
+            result,
+          ));
         case '!':
           this.advance();
           result = this.parsePrefix();
-          return new PrefixNot(this.span(start), this.sourceSpan(start), result);
+          return (this.lastUnary = new PrefixNot(this.span(start), this.sourceSpan(start), result));
       }
     } else if (this.next.isKeywordTypeof()) {
       this.advance();
       const start = this.inputIndex;
       let result = this.parsePrefix();
-      return new TypeofExpression(this.span(start), this.sourceSpan(start), result);
+      return (this.lastUnary = new TypeofExpression(
+        this.span(start),
+        this.sourceSpan(start),
+        result,
+      ));
     } else if (this.next.isKeywordVoid()) {
       this.advance();
       const start = this.inputIndex;
       let result = this.parsePrefix();
-      return new VoidExpression(this.span(start), this.sourceSpan(start), result);
+      return (this.lastUnary = new VoidExpression(
+        this.span(start),
+        this.sourceSpan(start),
+        result,
+      ));
     }
     return this.parseCallChain();
   }
@@ -1010,6 +1047,7 @@ class _ParseAST {
       this.rparensExpected++;
       const result = this.parsePipe();
       this.rparensExpected--;
+      this.lastUnary = null;
       this.expectCharacter(chars.$RPAREN);
       return result;
     } else if (this.next.isKeywordNull()) {

--- a/packages/compiler/src/expression_parser/serializer.ts
+++ b/packages/compiler/src/expression_parser/serializer.ts
@@ -140,6 +140,10 @@ class SerializeExpressionVisitor implements expr.AstVisitor {
     return `typeof ${ast.expression.visit(this, context)}`;
   }
 
+  visitVoidExpression(ast: expr.VoidExpression, context: any) {
+    return `void ${ast.expression.visit(this, context)}`;
+  }
+
   visitASTWithSource(ast: expr.ASTWithSource, context: any): string {
     return ast.ast.visit(this, context);
   }

--- a/packages/compiler/src/output/abstract_emitter.ts
+++ b/packages/compiler/src/output/abstract_emitter.ts
@@ -330,6 +330,10 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     ctx.print(expr, 'typeof ');
     expr.expr.visitExpression(this, ctx);
   }
+  visitVoidExpr(expr: o.VoidExpr, ctx: EmitterVisitorContext): any {
+    ctx.print(expr, 'void ');
+    expr.expr.visitExpression(this, ctx);
+  }
   visitReadVarExpr(ast: o.ReadVarExpr, ctx: EmitterVisitorContext): any {
     ctx.print(ast, ast.name);
     return null;

--- a/packages/compiler/src/output/abstract_emitter.ts
+++ b/packages/compiler/src/output/abstract_emitter.ts
@@ -456,6 +456,9 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
       case o.BinaryOperator.Modulo:
         opStr = '%';
         break;
+      case o.BinaryOperator.Exponentiation:
+        opStr = '**';
+        break;
       case o.BinaryOperator.Lower:
         opStr = '<';
         break;

--- a/packages/compiler/src/output/output_ast.ts
+++ b/packages/compiler/src/output/output_ast.ts
@@ -140,6 +140,7 @@ export enum BinaryOperator {
   Bigger,
   BiggerEquals,
   NullishCoalesce,
+  Exponentiation,
 }
 
 export function nullSafeIsEquivalent<T extends {isEquivalent(other: T): boolean}>(
@@ -260,6 +261,9 @@ export abstract class Expression {
   }
   modulo(rhs: Expression, sourceSpan?: ParseSourceSpan | null): BinaryOperatorExpr {
     return new BinaryOperatorExpr(BinaryOperator.Modulo, this, rhs, null, sourceSpan);
+  }
+  power(rhs: Expression, sourceSpan?: ParseSourceSpan | null): BinaryOperatorExpr {
+    return new BinaryOperatorExpr(BinaryOperator.Exponentiation, this, rhs, null, sourceSpan);
   }
   and(rhs: Expression, sourceSpan?: ParseSourceSpan | null): BinaryOperatorExpr {
     return new BinaryOperatorExpr(BinaryOperator.And, this, rhs, null, sourceSpan);

--- a/packages/compiler/src/output/output_ast.ts
+++ b/packages/compiler/src/output/output_ast.ts
@@ -363,6 +363,32 @@ export class TypeofExpr extends Expression {
   }
 }
 
+export class VoidExpr extends Expression {
+  constructor(
+    public expr: Expression,
+    type?: Type | null,
+    sourceSpan?: ParseSourceSpan | null,
+  ) {
+    super(type, sourceSpan);
+  }
+
+  override visitExpression(visitor: ExpressionVisitor, context: any) {
+    return visitor.visitVoidExpr(this, context);
+  }
+
+  override isEquivalent(e: Expression): boolean {
+    return e instanceof VoidExpr && e.expr.isEquivalent(this.expr);
+  }
+
+  override isConstant(): boolean {
+    return this.expr.isConstant();
+  }
+
+  override clone(): VoidExpr {
+    return new VoidExpr(this.expr.clone());
+  }
+}
+
 export class WrappedNodeExpr<T> extends Expression {
   constructor(
     public node: T,
@@ -1434,6 +1460,7 @@ export interface ExpressionVisitor {
   visitCommaExpr(ast: CommaExpr, context: any): any;
   visitWrappedNodeExpr(ast: WrappedNodeExpr<any>, context: any): any;
   visitTypeofExpr(ast: TypeofExpr, context: any): any;
+  visitVoidExpr(ast: VoidExpr, context: any): any;
   visitArrowFunctionExpr(ast: ArrowFunctionExpr, context: any): any;
 }
 
@@ -1639,6 +1666,9 @@ export class RecursiveAstVisitor implements StatementVisitor, ExpressionVisitor 
     return ast;
   }
   visitTypeofExpr(ast: TypeofExpr, context: any): any {
+    return this.visitExpression(ast, context);
+  }
+  visitVoidExpr(ast: VoidExpr, context: any) {
     return this.visitExpression(ast, context);
   }
   visitReadVarExpr(ast: ReadVarExpr, context: any): any {

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -1289,6 +1289,8 @@ export function transformExpressionsInExpression(
     }
   } else if (expr instanceof o.TypeofExpr) {
     expr.expr = transformExpressionsInExpression(expr.expr, transform, flags);
+  } else if (expr instanceof o.VoidExpr) {
+    expr.expr = transformExpressionsInExpression(expr.expr, transform, flags);
   } else if (expr instanceof o.WriteVarExpr) {
     expr.value = transformExpressionsInExpression(expr.value, transform, flags);
   } else if (expr instanceof o.LocalizedString) {

--- a/packages/compiler/src/template/pipeline/src/conversion.ts
+++ b/packages/compiler/src/template/pipeline/src/conversion.ts
@@ -22,6 +22,7 @@ export const BINARY_OPERATORS = new Map([
   ['<=', o.BinaryOperator.LowerEquals],
   ['-', o.BinaryOperator.Minus],
   ['%', o.BinaryOperator.Modulo],
+  ['**', o.BinaryOperator.Exponentiation],
   ['*', o.BinaryOperator.Multiply],
   ['!=', o.BinaryOperator.NotEquals],
   ['!==', o.BinaryOperator.NotIdentical],

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -1164,6 +1164,12 @@ function convertAst(
     );
   } else if (ast instanceof e.TypeofExpression) {
     return o.typeofExpr(convertAst(ast.expression, job, baseSourceSpan));
+  } else if (ast instanceof e.VoidExpression) {
+    return new o.VoidExpr(
+      convertAst(ast.expression, job, baseSourceSpan),
+      undefined,
+      convertSourceSpan(ast.span, baseSourceSpan),
+    );
   } else if (ast instanceof e.TemplateLiteral) {
     return new o.TemplateLiteralExpr(
       ast.elements.map((el) => {

--- a/packages/compiler/test/expression_parser/lexer_spec.ts
+++ b/packages/compiler/test/expression_parser/lexer_spec.ts
@@ -303,6 +303,15 @@ describe('lexer', () => {
       expectNumberToken(lex('0.5')[0], 0, 3, 0.5);
     });
 
+    it('should tokenize multiplication and exponentiation', () => {
+      const tokens: Token[] = lex('1 * 2 ** 3');
+      expectNumberToken(tokens[0], 0, 1, 1);
+      expectOperatorToken(tokens[1], 2, 3, '*');
+      expectNumberToken(tokens[2], 4, 5, 2);
+      expectOperatorToken(tokens[3], 6, 8, '**');
+      expectNumberToken(tokens[4], 9, 10, 3);
+    });
+
     it('should tokenize number with exponent', () => {
       let tokens: Token[] = lex('0.5E-10');
       expect(tokens.length).toEqual(1);

--- a/packages/compiler/test/expression_parser/lexer_spec.ts
+++ b/packages/compiler/test/expression_parser/lexer_spec.ts
@@ -198,6 +198,12 @@ describe('lexer', () => {
       expect(tokens[0].isKeywordTypeof()).toBe(true);
     });
 
+    it('should tokenize void', () => {
+      const tokens: Token[] = lex('void');
+      expectKeywordToken(tokens[0], 0, 4, 'void');
+      expect(tokens[0].isKeywordVoid()).toBe(true);
+    });
+
     it('should ignore whitespace', () => {
       const tokens: Token[] = lex('a \t \n \r b');
       expectIdentifierToken(tokens[0], 0, 1, 'a');

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -103,6 +103,11 @@ describe('parser', () => {
       checkAction('(!(typeof {} === "number"))', '!typeof {} === "number"');
     });
 
+    it('should parse void expression', () => {
+      checkAction(`void 0`);
+      checkAction('(!(void 0))', '!void 0');
+    });
+
     it('should parse grouped expressions', () => {
       checkAction('(1 + 2) * 3', '1 + 2 * 3');
     });

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -66,6 +66,10 @@ describe('parser', () => {
       checkAction('a.b!()');
     });
 
+    it('should parse exponentiation expressions', () => {
+      checkAction('1*2**3', '1 * 2 ** 3');
+    });
+
     it('should parse multiplicative expressions', () => {
       checkAction('3*4/2%5', '3 * 4 / 2 % 5');
     });

--- a/packages/compiler/test/expression_parser/serializer_spec.ts
+++ b/packages/compiler/test/expression_parser/serializer_spec.ts
@@ -119,5 +119,9 @@ describe('serializer', () => {
       expect(serialize(parse(' foo   ?.   (   bar   ,   ) '))).toBe('foo?.(bar, )');
       expect(serialize(parse(' foo   ?.   (   bar   ,   baz   ) '))).toBe('foo?.(bar, baz)');
     });
+
+    it('serializes void expressions', () => {
+      expect(serialize(parse(' void   0 '))).toBe('void 0');
+    });
   });
 });

--- a/packages/compiler/test/expression_parser/serializer_spec.ts
+++ b/packages/compiler/test/expression_parser/serializer_spec.ts
@@ -35,6 +35,10 @@ describe('serializer', () => {
       expect(serialize(parse(' 1234   +   4321 '))).toBe('1234 + 4321');
     });
 
+    it('serializes exponentiation', () => {
+      expect(serialize(parse(' 1  *  2  **  3 '))).toBe('1 * 2 ** 3');
+    });
+
     it('serializes chains', () => {
       expect(serialize(parseAction(' 1234;   4321 '))).toBe('1234; 4321');
     });

--- a/packages/compiler/test/expression_parser/utils/unparser.ts
+++ b/packages/compiler/test/expression_parser/utils/unparser.ts
@@ -24,17 +24,18 @@ import {
   LiteralPrimitive,
   NonNullAssert,
   PrefixNot,
-  TypeofExpression,
   PropertyRead,
   PropertyWrite,
   RecursiveAstVisitor,
   SafeCall,
   SafeKeyedRead,
   SafePropertyRead,
-  ThisReceiver,
-  Unary,
-  TemplateLiteralElement,
   TemplateLiteral,
+  TemplateLiteralElement,
+  ThisReceiver,
+  TypeofExpression,
+  Unary,
+  VoidExpression,
 } from '../../../src/expression_parser/ast';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../../../src/ml_parser/defaults';
 
@@ -197,6 +198,11 @@ class Unparser implements AstVisitor {
 
   visitTypeofExpression(ast: TypeofExpression, context: any) {
     this._expression += 'typeof ';
+    this._visit(ast.expression);
+  }
+
+  visitVoidExpression(ast: VoidExpression, context: any) {
+    this._expression += 'void ';
     this._visit(ast.expression);
   }
 

--- a/packages/compiler/test/expression_parser/utils/validator.ts
+++ b/packages/compiler/test/expression_parser/utils/validator.ts
@@ -22,16 +22,17 @@ import {
   LiteralPrimitive,
   ParseSpan,
   PrefixNot,
-  TypeofExpression,
   PropertyRead,
   PropertyWrite,
   RecursiveAstVisitor,
   SafeCall,
   SafeKeyedRead,
   SafePropertyRead,
-  Unary,
   TemplateLiteral,
   TemplateLiteralElement,
+  TypeofExpression,
+  Unary,
+  VoidExpression,
 } from '../../../src/expression_parser/ast';
 
 import {unparse} from './unparser';
@@ -117,6 +118,10 @@ class ASTValidator extends RecursiveAstVisitor {
 
   override visitTypeofExpression(ast: TypeofExpression, context: any): any {
     this.validate(ast, () => super.visitTypeofExpression(ast, context));
+  }
+
+  override visitVoidExpression(ast: VoidExpression, context: any): any {
+    this.validate(ast, () => super.visitVoidExpression(ast, context));
   }
 
   override visitPropertyRead(ast: PropertyRead, context: any): any {

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -91,6 +91,10 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
     this.recordAst(ast);
     super.visitTypeofExpression(ast, null);
   }
+  override visitVoidExpression(ast: e.VoidExpression) {
+    this.recordAst(ast);
+    super.visitVoidExpression(ast, null);
+  }
   override visitPropertyRead(ast: e.PropertyRead) {
     this.recordAst(ast);
     super.visitPropertyRead(ast, null);

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -2736,6 +2736,28 @@ describe('acceptance integration tests', () => {
     expect(fixture.nativeElement.textContent).toContain('Message: Hello, Bilbo - 1');
   });
 
+  it('should support void expressions', () => {
+    @Component({
+      host: {
+        '(click)': 'void doStuff($event)',
+      },
+    })
+    class TestComponent {
+      e: Event | null = null;
+
+      doStuff(e: Event) {
+        this.e = e;
+        return false;
+      }
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    fixture.nativeElement.click();
+    expect(fixture.componentInstance.e).not.toBeNull();
+    expect(fixture.componentInstance.e!.defaultPrevented).toBe(false);
+  });
+
   describe('tView.firstUpdatePass', () => {
     function isFirstUpdatePass() {
       const lView = getLView();

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -2758,6 +2758,36 @@ describe('acceptance integration tests', () => {
     expect(fixture.componentInstance.e!.defaultPrevented).toBe(false);
   });
 
+  it('should have correct operator precedence', () => {
+    @Component({
+      template: '{{1 + 10 ** -2 * 3}}',
+    })
+    class TestComponent {}
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toEqual('1.03');
+  });
+
+  it('should throw on ambiguous unary operator in exponentiation expression', () => {
+    @Component({
+      template: '{{1 + -10 ** -2 * 3}}',
+    })
+    class TestComponent {}
+    expect(() => TestBed.createComponent(TestComponent)).toThrowError(
+      /Unary operator used immediately before exponentiation expression. Parenthesis must be used to disambiguate operator precedence/,
+    );
+  });
+
+  it('should not throw on unambiguous unary operator in exponentiation expression', () => {
+    @Component({
+      template: '{{1 + (-10) ** -2 * 3}} | {{1 + -(10 ** -2) * 3}}',
+    })
+    class TestComponent {}
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toEqual('1.03 | 0.97');
+  });
+
   describe('tView.firstUpdatePass', () => {
     function isFirstUpdatePass() {
       const lView = getLView();

--- a/packages/language-service/test/quick_info_spec.ts
+++ b/packages/language-service/test/quick_info_spec.ts
@@ -604,6 +604,19 @@ describe('quick info', () => {
         });
       });
 
+      it('should work with void operator', () => {
+        expectQuickInfo({
+          templateOverride: `<div (click)="void myC¦lick($event)"></div>`,
+          expectedSpanText: 'myClick',
+          expectedDisplayString: '(method) AppCmp.myClick(event: any): void',
+        });
+        expectQuickInfo({
+          templateOverride: `<div (click)="void myClick($e¦vent)"></div>`,
+          expectedSpanText: '$event',
+          expectedDisplayString: '(parameter) $event: MouseEvent',
+        });
+      });
+
       it('should provide documentation', () => {
         const template = project.openFile('app.html');
         template.contents = `<div>{{title}}</div>`;


### PR DESCRIPTION
Add support for the `void` operator in templates and host bindings.

This is useful when binding a listener that may return `false` and
unintentionally prevent the default event behavior.

Ex:
```
@Directive({
  host: { '(mousedown)': 'void handleMousedown()' }
})
```

Also adds support for the exponentiation (`**`) operator

Ex:
```
@Component {
  template: '{{2 ** 3}}'
}
```

BREAKING CHANGE: `void` in an expression now refers to the operator

Previously an expression in the template like `{{void}}` referred to a
property on the component class. After this change it now refers to the
`void` operator, which would make the above example invalid. If you have
existing expressions that need to refer to a property named `void`,
change the expression to use `this.void` instead: `{{this.void}}`.