### PR TITLE
docs(docs-infra): Don't truncate types in symbol extraction

### DIFF
--- a/packages/compiler-cli/src/ngtsc/docs/src/type_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/type_extractor.ts
@@ -10,5 +10,9 @@ import ts from 'typescript';
 
 /** Gets the string representation of a node's resolved type. */
 export function extractResolvedTypeString(node: ts.Node, checker: ts.TypeChecker): string {
-  return checker.typeToString(checker.getTypeAtLocation(node));
+  return checker.typeToString(
+    checker.getTypeAtLocation(node),
+    undefined,
+    ts.TypeFormatFlags.NoTruncation,
+  );
 }


### PR DESCRIPTION
Example: https://ng-dev-previews-fw--pr-angular-angular-59909-adev-prev-loogj15i.web.app/api/common/http/HttpClient 