### PR TITLE
refactor(core): use stream in rxResource instead of loader

### DIFF
--- a/goldens/public-api/core/rxjs-interop/index.api.md
+++ b/goldens/public-api/core/rxjs-interop/index.api.md
@@ -35,10 +35,7 @@ export function rxResource<T, R>(opts: RxResourceOptions<T, R> & {
 export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T | undefined>;
 
 // @public
-export interface RxResourceOptions<T, R> extends BaseResourceOptions<T, R> {
-    // (undocumented)
-    loader: (params: ResourceLoaderParams<R>) => Observable<T>;
-}
+export type RxResourceOptions<T, R> = RxResourceStreamOptions<T, R> | RxResourceLoaderOptions<T, R>;
 
 // @public
 export function takeUntilDestroyed<T>(destroyRef?: DestroyRef): MonoTypeOperatorFunction<T>;

--- a/packages/core/rxjs-interop/test/rx_resource_spec.ts
+++ b/packages/core/rxjs-interop/test/rx_resource_spec.ts
@@ -16,7 +16,7 @@ describe('rxResource()', () => {
     const injector = TestBed.inject(Injector);
     const appRef = TestBed.inject(ApplicationRef);
     const res = rxResource({
-      loader: () => of(1),
+      stream: () => of(1),
       injector,
     });
     await appRef.whenStable();
@@ -31,7 +31,7 @@ describe('rxResource()', () => {
     let lastSeenRequest: number = 0;
     rxResource({
       request,
-      loader: ({request}) => {
+      stream: ({request}) => {
         lastSeenRequest = request;
         return new Observable((sub) => {
           if (request === 2) {
@@ -61,7 +61,7 @@ describe('rxResource()', () => {
     const appRef = TestBed.inject(ApplicationRef);
     const response = new BehaviorSubject(1);
     const res = rxResource({
-      loader: () => response,
+      stream: () => response,
       injector,
     });
     await appRef.whenStable();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

With the changes in #59573, `resource` can now define a `stream` rather than a `loader`. In the same PR, `rxResource` was updated to leverage this new functionality to handle multiple responses from the underlying observable, rather than just the first one as it was previously. 


## What is the new behavior?

This commit renames the `loader` option of `rxResource` into `stream` to be better aligned with its new behavior.

The previous version is temporarily kept and marked as deprecated to help migrating the current usage.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No (still experimental)


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This was briefly discussed with @alxhub on Slack
