### PR TITLE
docs(localize): added link to add-package.md

### DIFF
--- a/adev/src/content/guide/i18n/add-package.md
+++ b/adev/src/content/guide/i18n/add-package.md
@@ -6,9 +6,10 @@ To add the `@angular/localize` package, use the following command to update the 
 
 <docs-code path="adev/src/content/examples/i18n/doc-files/commands.sh" visibleRegion="add-localize"/>
 
-It adds `types: ["@angular/localize"]` in the TypeScript configuration files as well as the reference to the type definition of `@angular/localize` at the top of the `main.ts` file.
+It adds `types: ["@angular/localize"]` in the TypeScript configuration files.
+It also adds line `/// <reference types="@angular/localize" />` at the top of the `main.ts` file which is the reference to the type definition.
 
-HELPFUL: For more information about `package.json` and `tsconfig.json` files, see [Workspace npm dependencies][GuideNpmPackages] and [TypeScript Configuration][GuideTsConfig].
+HELPFUL: For more information about `package.json` and `tsconfig.json` files, see [Workspace npm dependencies][GuideNpmPackages] and [TypeScript Configuration][GuideTsConfig]. To learn about Triple-slash Directives visit [Typescript Handbook](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-types-).
 
 If `@angular/localize` is not installed and you try to build a localized version of your project (for example, while using the `i18n` attributes in templates), the [Angular CLI][CliMain] will generate an error, which would contain the steps that you can take to enable i18n for your project.
 


### PR DESCRIPTION
Angular/localize may be the first time developer encounters Typescript Triple-slash Directive - added link to TS Handbook to avoid confusion.

## PR Checklist
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Documentation content changes

## What is the current behavior?

Developer runs `ng add @angular/localize` and sees new line `/// <reference types="@angular/localize" />` at the top of `main.ts`. This line can be confusing for those unfamiliar with Triple-slash Directive.

## What is the new behavior?

Developer can read about Triple-slash Directive via link provided in Angular documentation.

## Does this PR introduce a breaking change?

- [x] No
