### PR TITLE
build: update zone.js pullapprove rule

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -227,9 +227,9 @@ groups:
     <<: *defaults
     conditions:
       - >
-        contains_any_globs(files, [
+        contains_any_globs(files.exclude('yarn.lock','package.json'), [
           'packages/zone.js/**/{*,.*}',
-          ])
+        ])
     reviewers:
       users:
         - JiaLiPassion


### PR DESCRIPTION
This excludes lock and package files from requiring zones approval.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

