### PR TITLE
build: update zone.js pullapprove rule

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -227,7 +227,7 @@ groups:
     <<: *defaults
     conditions:
       - >
-        contains_any_globs(files.exclude('yarn.lock','package.json'), [
+        contains_any_globs(files.exclude('yarn.lock'), [
           'packages/zone.js/**/{*,.*}',
         ])
     reviewers:


### PR DESCRIPTION
This fixes the broken pullapprove config due to a missing array.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


