### PR TITLE
feat(compiler): support tagged template literals in expressions

### DIFF
--- a/adev/src/content/guide/templates/expression-syntax.md
+++ b/adev/src/content/guide/templates/expression-syntax.md
@@ -8,15 +8,16 @@ Angular supports a subset of [literal values](https://developer.mozilla.org/en-U
 
 ### Supported value literals
 
-| Literal type    | Example values                  |
-| --------------- | ------------------------------- |
-| String          | `'Hello'`, `"World"`            |
-| Boolean         | `true`, `false`                 |
-| Number          | `123`, `3.14`                   |
-| Object          | `{name: 'Alice'}`               |
-| Array           | `['Onion', 'Cheese', 'Garlic']` |
-| null            | `null`                          |
-| Template string | `` `Hello ${name}` ``           |
+| Literal type           | Example values                  |
+| ---------------------- | ------------------------------- |
+| String                 | `'Hello'`, `"World"`            |
+| Boolean                | `true`, `false`                 |
+| Number                 | `123`, `3.14`                   |
+| Object                 | `{name: 'Alice'}`               |
+| Array                  | `['Onion', 'Cheese', 'Garlic']` |
+| null                   | `null`                          |
+| Template string        | `` `Hello ${name}` ``           |
+| Tagged template string | `` tag`Hello ${name}` ``        |
 
 ### Unsupported literals
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -30,6 +30,7 @@ import {
   SafeCall,
   SafeKeyedRead,
   SafePropertyRead,
+  TaggedTemplateLiteral,
   TemplateLiteral,
   TemplateLiteralElement,
   ThisReceiver,
@@ -38,12 +39,9 @@ import {
   VoidExpression,
 } from '@angular/compiler';
 import ts from 'typescript';
-
 import {TypeCheckingConfig} from '../api';
-
 import {addParseSpanInfo, wrapForDiagnostics, wrapForTypeChecker} from './diagnostics';
 import {tsCastToAny, tsNumericExpression} from './ts_util';
-
 /**
  * Expression that is cast to any. Currently represented as `0 as any`.
  *
@@ -484,6 +482,14 @@ class AstTranslator implements AstVisitor {
     throw new Error('Method not implemented');
   }
 
+  visitTaggedTemplateLiteral(ast: TaggedTemplateLiteral): ts.TaggedTemplateExpression {
+    return ts.factory.createTaggedTemplateExpression(
+      this.translate(ast.tag),
+      undefined,
+      this.visitTemplateLiteral(ast.template),
+    );
+  }
+
   private convertToSafeCall(
     ast: Call | SafeCall,
     expr: ts.Expression,
@@ -613,6 +619,9 @@ class VeSafeLhsInferenceBugDetector implements AstVisitor {
     return false;
   }
   visitTemplateLiteralElement(ast: TemplateLiteralElement, context: any) {
+    return false;
+  }
+  visitTaggedTemplateLiteral(ast: TaggedTemplateLiteral, context: any) {
     return false;
   }
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -166,6 +166,16 @@ describe('type check blocks', () => {
     );
   });
 
+  it('should handle tagged template literals', () => {
+    expect(tcb('{{ tag`hello world` }}')).toContain('"" + (((this).tag) `hello world`);');
+    expect(tcb('{{ tag`hello \\${name}!!!` }}')).toContain(
+      '"" + (((this).tag) `hello \\${name}!!!`);',
+    );
+    expect(tcb('{{ tag`${a} - ${b} - ${c}` }}')).toContain(
+      '"" + (((this).tag) `${((this).a)} - ${((this).b)} - ${((this).c)}`);',
+    );
+  });
+
   describe('type constructors', () => {
     it('should handle missing property bindings', () => {
       const TEMPLATE = `<div dir [inputA]="foo"></div>`;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/GOLDEN_PARTIAL.js
@@ -780,3 +780,62 @@ export declare class MyApp {
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "my-app", never, {}, {}, never, never, true, never>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: tagged_template_literals.js
+ ****************************************************************************************************/
+import { Component, Pipe } from '@angular/core';
+import * as i0 from "@angular/core";
+export class UppercasePipe {
+    transform(value) {
+        return value.toUpperCase();
+    }
+}
+UppercasePipe.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: UppercasePipe, deps: [], target: i0.ɵɵFactoryTarget.Pipe });
+UppercasePipe.ɵpipe = i0.ɵɵngDeclarePipe({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: UppercasePipe, isStandalone: true, name: "uppercase" });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: UppercasePipe, decorators: [{
+            type: Pipe,
+            args: [{ name: 'uppercase' }]
+        }] });
+export class MyApp {
+    constructor() {
+        this.name = 'Frodo';
+        this.timeOfDay = 'morning';
+        this.tag = (strings, ...args) => '';
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "my-app", ngImport: i0, template: `
+    <div>No interpolations: {{ tag\`hello world \` }}</div>
+    <span>With interpolations: {{ tag\`hello \${name}, it is currently \${timeOfDay}!\` }}</span>
+    <p>With pipe: {{ tag\`hello \${name}\` | uppercase }}</p>
+  `, isInline: true, dependencies: [{ kind: "pipe", type: UppercasePipe, name: "uppercase" }] });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    selector: 'my-app',
+                    template: `
+    <div>No interpolations: {{ tag\`hello world \` }}</div>
+    <span>With interpolations: {{ tag\`hello \${name}, it is currently \${timeOfDay}!\` }}</span>
+    <p>With pipe: {{ tag\`hello \${name}\` | uppercase }}</p>
+  `,
+                    imports: [UppercasePipe],
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: tagged_template_literals.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class UppercasePipe {
+    transform(value: string): string;
+    static ɵfac: i0.ɵɵFactoryDeclaration<UppercasePipe, never>;
+    static ɵpipe: i0.ɵɵPipeDeclaration<UppercasePipe, "uppercase", true>;
+}
+export declare class MyApp {
+    name: string;
+    timeOfDay: string;
+    tag: (strings: TemplateStringsArray, ...args: string[]) => string;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "my-app", never, {}, {}, never, never, true, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/TEST_CASES.json
@@ -3,9 +3,7 @@
   "cases": [
     {
       "description": "should instantiate directives",
-      "inputFiles": [
-        "directives.ts"
-      ],
+      "inputFiles": ["directives.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect ChildComponent.ɵcmp",
@@ -62,16 +60,11 @@
           ]
         }
       ],
-      "compilationModeFilter": [
-        "full compile",
-        "local compile"
-      ]
+      "compilationModeFilter": ["full compile", "local compile"]
     },
     {
       "description": "should support complex selectors",
-      "inputFiles": [
-        "complex_selectors.ts"
-      ],
+      "inputFiles": ["complex_selectors.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect SomeDirective.ɵdir",
@@ -113,23 +106,17 @@
     },
     {
       "description": "should convert #my-app selector to [\"\", \"id\", \"my-app\"]",
-      "inputFiles": [
-        "id_selector.ts"
-      ],
+      "inputFiles": ["id_selector.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect SomeComponent.ɵcomp",
-          "files": [
-            "id_selector.js"
-          ]
+          "files": ["id_selector.js"]
         }
       ]
     },
     {
       "description": "should support components without selector",
-      "inputFiles": [
-        "no_selector.ts"
-      ],
+      "inputFiles": ["no_selector.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect EmptyOutletComponent.ɵcmp",
@@ -153,9 +140,7 @@
     },
     {
       "description": "should not treat ElementRef, ViewContainerRef, or ChangeDetectorRef specially when injecting",
-      "inputFiles": [
-        "view_tokens_di.ts"
-      ],
+      "inputFiles": ["view_tokens_di.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect MyComponent.ɵcmp",
@@ -179,9 +164,7 @@
     },
     {
       "description": "should support structural directives",
-      "inputFiles": [
-        "structural_directives.ts"
-      ],
+      "inputFiles": ["structural_directives.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect IfDirective.ɵdir",
@@ -223,85 +206,71 @@
     },
     {
       "description": "should support array literals",
-      "inputFiles": [
-        "array_literals.ts"
-      ],
+      "inputFiles": ["array_literals.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid array emit",
-          "files": [
-            "array_literals.js"
-          ]
+          "files": ["array_literals.js"]
         }
       ]
     },
     {
       "description": "should support 9+ bindings in array literals",
-      "inputFiles": [
-        "array_literals_many.ts"
-      ],
+      "inputFiles": ["array_literals_many.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid array binding",
-          "files": [
-            "array_literals_many.js"
-          ]
+          "files": ["array_literals_many.js"]
         }
       ]
     },
     {
       "description": "should support object literals",
-      "inputFiles": [
-        "object_literals.ts"
-      ],
+      "inputFiles": ["object_literals.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid object literal binding",
-          "files": [
-            "object_literals.js"
-          ]
+          "files": ["object_literals.js"]
         }
       ]
     },
     {
       "description": "should support expressions nested deeply in object/array literals",
-      "inputFiles": [
-        "literal_nested_expression.ts"
-      ],
+      "inputFiles": ["literal_nested_expression.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid array/object literal binding",
-          "files": [
-            "literal_nested_expression.js"
-          ]
+          "files": ["literal_nested_expression.js"]
         }
       ]
     },
     {
       "description": "should support number literals with separators",
-      "inputFiles": [
-        "number_separator.ts"
-      ],
+      "inputFiles": ["number_separator.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid number literal",
-          "files": [
-            "number_separator.js"
-          ]
+          "files": ["number_separator.js"]
         }
       ]
     },
     {
       "description": "should support template literals",
-      "inputFiles": [
-        "template_literals.ts"
-      ],
+      "inputFiles": ["template_literals.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid template literal binding",
-          "files": [
-            "template_literals.js"
-          ]
+          "files": ["template_literals.js"]
+        }
+      ]
+    },
+    {
+      "description": "should support tagged template literals",
+      "inputFiles": ["tagged_template_literals.ts"],
+      "expectations": [
+        {
+          "failureMessage": "Invalid tagged template literal binding",
+          "files": ["tagged_template_literals.js"]
         }
       ]
     }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/tagged_template_literals.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/tagged_template_literals.js
@@ -1,0 +1,8 @@
+if (rf & 2) {
+  $r3$.ɵɵadvance();
+  $r3$.ɵɵtextInterpolate1("No interpolations: ", ctx.tag `hello world `, "");
+  $r3$.ɵɵadvance(2);
+  $r3$.ɵɵtextInterpolate1("With interpolations: ", ctx.tag `hello ${ctx.name}, it is currently ${ctx.timeOfDay}!`, "");
+  $r3$.ɵɵadvance(2);
+  $r3$.ɵɵtextInterpolate1("With pipe: ", $r3$.ɵɵpipeBind1(6, 3, ctx.tag `hello ${ctx.name}`), "");
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/tagged_template_literals.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/tagged_template_literals.ts
@@ -1,0 +1,23 @@
+import {Component, Pipe} from '@angular/core';
+
+@Pipe({name: 'uppercase'})
+export class UppercasePipe {
+  transform(value: string) {
+    return value.toUpperCase();
+  }
+}
+
+@Component({
+  selector: 'my-app',
+  template: `
+    <div>No interpolations: {{ tag\`hello world \` }}</div>
+    <span>With interpolations: {{ tag\`hello \${name}, it is currently \${timeOfDay}!\` }}</span>
+    <p>With pipe: {{ tag\`hello \${name}\` | uppercase }}</p>
+  `,
+  imports: [UppercasePipe],
+})
+export class MyApp {
+  name = 'Frodo';
+  timeOfDay = 'morning';
+  tag = (strings: TemplateStringsArray, ...args: string[]) => '';
+}

--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -442,6 +442,21 @@ export class SafeCall extends AST {
   }
 }
 
+export class TaggedTemplateLiteral extends AST {
+  constructor(
+    span: ParseSpan,
+    sourceSpan: AbsoluteSourceSpan,
+    public tag: AST,
+    public template: TemplateLiteral,
+  ) {
+    super(span, sourceSpan);
+  }
+
+  override visit(visitor: AstVisitor, context?: any) {
+    return visitor.visitTaggedTemplateLiteral(this, context);
+  }
+}
+
 export class TemplateLiteral extends AST {
   constructor(
     span: ParseSpan,
@@ -456,6 +471,7 @@ export class TemplateLiteral extends AST {
     return visitor.visitTemplateLiteral(this, context);
   }
 }
+
 export class TemplateLiteralElement extends AST {
   constructor(
     span: ParseSpan,
@@ -599,6 +615,7 @@ export interface AstVisitor {
   visitSafeCall(ast: SafeCall, context: any): any;
   visitTemplateLiteral(ast: TemplateLiteral, context: any): any;
   visitTemplateLiteralElement(ast: TemplateLiteralElement, context: any): any;
+  visitTaggedTemplateLiteral(ast: TaggedTemplateLiteral, context: any): any;
   visitASTWithSource?(ast: ASTWithSource, context: any): any;
   /**
    * This function is optionally defined to allow classes that implement this
@@ -703,6 +720,10 @@ export class RecursiveAstVisitor implements AstVisitor {
     }
   }
   visitTemplateLiteralElement(ast: TemplateLiteralElement, context: any) {}
+  visitTaggedTemplateLiteral(ast: TaggedTemplateLiteral, context: any) {
+    this.visit(ast.tag, context);
+    this.visit(ast.template, context);
+  }
   // This is not part of the AstVisitor interface, just a helper method
   visitAll(asts: AST[], context: any): any {
     for (const ast of asts) {

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -43,6 +43,7 @@ import {
   SafeCall,
   SafeKeyedRead,
   SafePropertyRead,
+  TaggedTemplateLiteral,
   TemplateBinding,
   TemplateBindingIdentifier,
   TemplateLiteral,
@@ -54,7 +55,6 @@ import {
   VoidExpression,
 } from './ast';
 import {EOF, Lexer, StringTokenKind, Token, TokenType} from './lexer';
-
 export interface InterpolationPiece {
   text: string;
   start: number;
@@ -1035,6 +1035,10 @@ class _ParseAST {
         result = this.parseCall(result, start, false);
       } else if (this.consumeOptionalOperator('!')) {
         result = new NonNullAssert(this.span(start), this.sourceSpan(start), result);
+      } else if (this.next.isTemplateLiteralEnd()) {
+        result = this.parseNoInterpolationTaggedTemplateLiteral(result, start);
+      } else if (this.next.isTemplateLiteralPart()) {
+        result = this.parseTaggedTemplateLiteral(result, start);
       } else {
         return result;
       }
@@ -1084,7 +1088,7 @@ class _ParseAST {
       this.advance();
       return new LiteralPrimitive(this.span(start), this.sourceSpan(start), value);
     } else if (this.next.isTemplateLiteralEnd()) {
-      return this.parseNoInterpolationTemplateLiteral(start);
+      return this.parseNoInterpolationTemplateLiteral();
     } else if (this.next.isTemplateLiteralPart()) {
       return this.parseTemplateLiteral();
     } else if (this.next.isString() && this.next.kind === StringTokenKind.Plain) {
@@ -1450,11 +1454,16 @@ class _ParseAST {
     return new VariableBinding(sourceSpan, key, value);
   }
 
-  private parseNoInterpolationTemplateLiteral(start: number): AST {
+  private parseNoInterpolationTaggedTemplateLiteral(tag: AST, start: number) {
+    const template = this.parseNoInterpolationTemplateLiteral();
+    return new TaggedTemplateLiteral(this.span(start), this.sourceSpan(start), tag, template);
+  }
+
+  private parseNoInterpolationTemplateLiteral(): TemplateLiteral {
     const text = this.next.strValue;
     this.advance();
-    const span = this.span(start);
-    const sourceSpan = this.sourceSpan(start);
+    const span = this.span(this.inputIndex);
+    const sourceSpan = this.sourceSpan(this.inputIndex);
     return new TemplateLiteral(
       span,
       sourceSpan,
@@ -1463,10 +1472,15 @@ class _ParseAST {
     );
   }
 
-  private parseTemplateLiteral(): AST {
-    const start = this.inputIndex;
+  private parseTaggedTemplateLiteral(tag: AST, start: number): AST {
+    const template = this.parseTemplateLiteral();
+    return new TaggedTemplateLiteral(this.span(start), this.sourceSpan(start), tag, template);
+  }
+
+  private parseTemplateLiteral(): TemplateLiteral {
     const elements: TemplateLiteralElement[] = [];
     const expressions: AST[] = [];
+    const start = this.inputIndex;
 
     while (this.next !== EOF) {
       const token = this.next;

--- a/packages/compiler/src/expression_parser/serializer.ts
+++ b/packages/compiler/src/expression_parser/serializer.ts
@@ -163,6 +163,10 @@ class SerializeExpressionVisitor implements expr.AstVisitor {
   visitTemplateLiteralElement(ast: expr.TemplateLiteralElement, context: any) {
     return ast.text;
   }
+
+  visitTaggedTemplateLiteral(ast: expr.TaggedTemplateLiteral, context: any) {
+    return ast.tag.visit(this, context) + ast.template.visit(this, context);
+  }
 }
 
 /** Zips the two input arrays into a single array of pairs of elements at the same index. */

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -1171,14 +1171,12 @@ function convertAst(
       convertSourceSpan(ast.span, baseSourceSpan),
     );
   } else if (ast instanceof e.TemplateLiteral) {
-    return new o.TemplateLiteralExpr(
-      ast.elements.map((el) => {
-        return new o.TemplateLiteralElementExpr(
-          el.text,
-          convertSourceSpan(el.span, baseSourceSpan),
-        );
-      }),
-      ast.expressions.map((expr) => convertAst(expr, job, baseSourceSpan)),
+    return convertTemplateLiteral(ast, job, baseSourceSpan);
+  } else if (ast instanceof e.TaggedTemplateLiteral) {
+    return new o.TaggedTemplateLiteralExpr(
+      convertAst(ast.tag, job, baseSourceSpan),
+      convertTemplateLiteral(ast.template, job, baseSourceSpan),
+      undefined,
       convertSourceSpan(ast.span, baseSourceSpan),
     );
   } else {
@@ -1186,6 +1184,20 @@ function convertAst(
       `Unhandled expression type "${ast.constructor.name}" in file "${baseSourceSpan?.start.file.url}"`,
     );
   }
+}
+
+function convertTemplateLiteral(
+  ast: e.TemplateLiteral,
+  job: CompilationJob,
+  baseSourceSpan: ParseSourceSpan | null,
+) {
+  return new o.TemplateLiteralExpr(
+    ast.elements.map((el) => {
+      return new o.TemplateLiteralElementExpr(el.text, convertSourceSpan(el.span, baseSourceSpan));
+    }),
+    ast.expressions.map((expr) => convertAst(expr, job, baseSourceSpan)),
+    convertSourceSpan(ast.span, baseSourceSpan),
+  );
 }
 
 function convertAstWithInterpolation(

--- a/packages/compiler/test/expression_parser/lexer_spec.ts
+++ b/packages/compiler/test/expression_parser/lexer_spec.ts
@@ -620,6 +620,25 @@ describe('lexer', () => {
           'Lexer Error: Unterminated template literal at column 15 in expression [`hello ${name!`]',
         );
       });
+
+      it('should tokenize tagged template literal with no interpolations', () => {
+        const tokens: Token[] = lex('tag`hello world`');
+        expect(tokens.length).toBe(2);
+        expectIdentifierToken(tokens[0], 0, 3, 'tag');
+        expectStringToken(tokens[1], 3, 16, 'hello world', StringTokenKind.TemplateLiteralEnd);
+      });
+
+      it('should tokenize nested tagged template literals', () => {
+        const tokens: Token[] = lex('tag`hello ${tag`world`}`');
+        expect(tokens.length).toBe(7);
+        expectIdentifierToken(tokens[0], 0, 3, 'tag');
+        expectStringToken(tokens[1], 3, 10, 'hello ', StringTokenKind.TemplateLiteralPart);
+        expectOperatorToken(tokens[2], 10, 12, '${');
+        expectIdentifierToken(tokens[3], 12, 15, 'tag');
+        expectStringToken(tokens[4], 15, 22, 'world', StringTokenKind.TemplateLiteralEnd);
+        expectOperatorToken(tokens[5], 22, 23, '}');
+        expectStringToken(tokens[6], 23, 24, '', StringTokenKind.TemplateLiteralEnd);
+      });
     });
   });
 });

--- a/packages/compiler/test/expression_parser/utils/unparser.ts
+++ b/packages/compiler/test/expression_parser/utils/unparser.ts
@@ -30,6 +30,7 @@ import {
   SafeCall,
   SafeKeyedRead,
   SafePropertyRead,
+  TaggedTemplateLiteral,
   TemplateLiteral,
   TemplateLiteralElement,
   ThisReceiver,
@@ -239,6 +240,11 @@ class Unparser implements AstVisitor {
 
   visitTemplateLiteralElement(ast: TemplateLiteralElement, context: any) {
     this._expression += ast.text;
+  }
+
+  visitTaggedTemplateLiteral(ast: TaggedTemplateLiteral, context: any) {
+    this._visit(ast.tag);
+    this._visit(ast.template);
   }
 
   private _visit(ast: AST) {

--- a/packages/compiler/test/expression_parser/utils/validator.ts
+++ b/packages/compiler/test/expression_parser/utils/validator.ts
@@ -28,6 +28,7 @@ import {
   SafeCall,
   SafeKeyedRead,
   SafePropertyRead,
+  TaggedTemplateLiteral,
   TemplateLiteral,
   TemplateLiteralElement,
   TypeofExpression,
@@ -154,6 +155,10 @@ class ASTValidator extends RecursiveAstVisitor {
 
   override visitTemplateLiteralElement(ast: TemplateLiteralElement, context: any): any {
     this.validate(ast, () => super.visitTemplateLiteralElement(ast, context));
+  }
+
+  override visitTaggedTemplateLiteral(ast: TaggedTemplateLiteral, context: any): void {
+    this.validate(ast, () => super.visitTaggedTemplateLiteral(ast, context));
   }
 }
 

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -127,6 +127,10 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
     this.recordAst(ast);
     super.visitTemplateLiteralElement(ast, null);
   }
+  override visitTaggedTemplateLiteral(ast: e.TaggedTemplateLiteral, context: any): void {
+    this.recordAst(ast);
+    super.visitTaggedTemplateLiteral(ast, null);
+  }
 
   visitTemplate(ast: t.Template) {
     t.visitAll(this, ast.children);

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -2797,6 +2797,54 @@ describe('acceptance integration tests', () => {
     expect(fixture.nativeElement.textContent).toEqual('256');
   });
 
+  it('should support tagged template literals with no interpolations in expressions', () => {
+    @Component({
+      standalone: true,
+      template: `
+        <p>:{{ caps\`Hello, World!\` }}:{{ excited?.caps(3)\`Uncomfortably excited\` }}:</p> 
+        <p>{{ greet\`Hi, I'm \${name}, and I'm \${age}\` }}</p>
+      `,
+    })
+    class TestComponent {
+      name = 'Frodo';
+      age = 50;
+      greet(strings: TemplateStringsArray, person: string, age: number) {
+        return `${strings[0]}${person}${strings[1]}${age} years old${strings[2]}`;
+      }
+      caps(strings: TemplateStringsArray) {
+        return strings.join('').toUpperCase();
+      }
+      excited = {
+        caps: (excitementLevel: number) => {
+          return (strings: TemplateStringsArray) => {
+            return strings.join('').toUpperCase() + '!'.repeat(excitementLevel);
+          };
+        },
+      };
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain(':HELLO, WORLD!:');
+    expect(text).toContain(':UNCOMFORTABLY EXCITED!!!:');
+    expect(text).toContain(`Hi, I'm Frodo, and I'm 50 years old`);
+  });
+
+  it('should not confuse operators for template literal tags', () => {
+    @Component({
+      standalone: true,
+      template: '{{ typeof`test` }}',
+    })
+    class TestComponent {
+      typeof = (...args: unknown[]) => 'fail';
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toBe(`string`);
+  });
+
   describe('tView.firstUpdatePass', () => {
     function isFirstUpdatePass() {
       const lView = getLView();

--- a/packages/language-service/test/quick_info_spec.ts
+++ b/packages/language-service/test/quick_info_spec.ts
@@ -75,6 +75,7 @@ function quickInfoSkeleton(): {[fileName: string]: string} {
               }
             }
           };
+          someTag = (...args: any[]) => '';
         }
 
         @Directive({
@@ -410,6 +411,14 @@ describe('quick info', () => {
           expectedDisplayString: '(variable) name: { readonly name: "name"; }',
         });
       });
+
+      it('should work for tagged template literals', () => {
+        expectQuickInfo({
+          templateOverride: `<div *ngFor="let name of constNames">{{someTag\`Hello \${na¦me}\`}}</div>`,
+          expectedSpanText: 'name',
+          expectedDisplayString: '(variable) name: { readonly name: "name"; }',
+        });
+      });
     });
 
     describe('pipes', () => {
@@ -614,6 +623,14 @@ describe('quick info', () => {
           templateOverride: `<div (click)="void myClick($e¦vent)"></div>`,
           expectedSpanText: '$event',
           expectedDisplayString: '(parameter) $event: MouseEvent',
+        });
+      });
+
+      it('should work for tagged template literal tag', () => {
+        expectQuickInfo({
+          templateOverride: `<div>{{ some¦Tag\`text\` }}</div>`,
+          expectedSpanText: 'someTag',
+          expectedDisplayString: '(property) AppCmp.someTag: (...args: any[]) => string',
         });
       });
 


### PR DESCRIPTION
Adds support for using tagged template literals in Angular templates.

Ex:
```
@Component({
  template: '{{ greet`Hello, ${name()}` }}'
})
export class MyComp {
  name = input();

  greet(strings: TemplateStringsArray, name: string) {
    return strings[0] + name + strings[1] + '!';
  }
}
```