### PR TITLE
refactor(zone.js): fix incompatiblity with JSCompiler checks

### DIFF
--- a/packages/zone.js/lib/zone-global.d.ts
+++ b/packages/zone.js/lib/zone-global.d.ts
@@ -10,4 +10,4 @@
 // This code should run in a Browser, so we don't want to include the whole node.d.ts
 // typings for this compilation unit.
 // We'll just fake the global "global" var for now.
-declare var global: NodeJS.Global;
+declare var global: typeof globalThis;

--- a/packages/zone.js/lib/zone-spec/async-test.ts
+++ b/packages/zone.js/lib/zone-spec/async-test.ts
@@ -9,7 +9,9 @@
 import {__symbol__, ZoneType} from '../zone-impl';
 
 const __global: any =
-  (typeof window !== 'undefined' && window) || (typeof self !== 'undefined' && self) || global;
+  (typeof window !== 'undefined' && window) ||
+  (typeof self !== 'undefined' && self) ||
+  globalThis.global;
 class AsyncTestZoneSpec implements ZoneSpec {
   // Needs to be a getter and not a plain property in order run this just-in-time. Otherwise
   // `__symbol__` would be evaluated during top-level execution prior to the Zone prefix being

--- a/packages/zone.js/lib/zone-spec/wtf.ts
+++ b/packages/zone.js/lib/zone-spec/wtf.ts
@@ -13,7 +13,7 @@
 import {ZoneType} from '../zone-impl';
 
 const _global: any =
-  (typeof window === 'object' && window) || (typeof self === 'object' && self) || global;
+  (typeof window === 'object' && window) || (typeof self === 'object' && self) || globalThis.global;
 
 export function patchWtf(Zone: ZoneType): void {
   interface Wtf {


### PR DESCRIPTION
this commit updates the code which causes the error [JSC_UNDEFINED_VARIABLE] variable global is undeclared
