### PR TITLE
docs(docs-infra): fix card highlighting in the API reference details page

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/class-member.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/class-member.tsx
@@ -55,7 +55,7 @@ export function ClassMember(props: {member: MemberEntryRenderable}) {
   const memberName = member.name;
   const returnType = getMemberType(member);
   return (
-    <div id={memberName} tabIndex={-1} className={REFERENCE_MEMBER_CARD}>
+    <div id={memberName} className={REFERENCE_MEMBER_CARD}>
       <header className={REFERENCE_MEMBER_CARD_HEADER}>
         <h3>{memberName}</h3>
         {isClassMethodEntry(member) && member.signatures.length > 1 ? (

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/function-reference.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/function-reference.tsx
@@ -35,7 +35,7 @@ export const signatureCard = (
   printSignaturesAsHeader: boolean,
 ) => {
   return (
-    <div id={opts.id} tabIndex={-1} class={REFERENCE_MEMBER_CARD}>
+    <div id={opts.id} class={REFERENCE_MEMBER_CARD}>
       <header class={REFERENCE_MEMBER_CARD_HEADER}>
         {printSignaturesAsHeader ? (
           <code>

--- a/adev/shared-docs/styles/_reference.scss
+++ b/adev/shared-docs/styles/_reference.scss
@@ -88,7 +88,6 @@
       border-radius: 0.25rem;
       position: relative;
       transition: border 0.3s ease;
-      pointer-events: none;
 
       &::before {
         content: '';
@@ -99,7 +98,7 @@
         z-index: 0;
       }
 
-      &:focus {
+      &.highlighted {
         box-shadow: 10px 4px 40px 0 rgba(0, 0, 0, 0.01);
 
         &::before {
@@ -112,10 +111,6 @@
         margin-block-end: 0;
       }
 
-      a {
-        pointer-events: initial;
-      }
-
       .docs-reference-card-header {
         display: flex;
         align-items: center;
@@ -125,7 +120,6 @@
         position: relative;
         z-index: 10;
         padding: 0.7rem 1rem;
-        cursor: pointer;
         gap: 0.5rem;
         flex-wrap: wrap;
         transition:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Member cards use `pointer-events: none` in order to prevent highlighting on member card interaction (clicks, text selection, etc.). This, however, blocks other interactions that should be available like scrolling.

## What is the new behavior?

Currently, the member cards highlighting relies on element focus which doesn't seem very right by itself given we enforce `tabIndex=-1`. The highlighting should be active when the user clicks on a member/property which, respectively, adds a fragment to the URL, scrolls the page down and adds an outline to the specific card. Since using `pointer-events: none` in order to prevent highlighting on card click is problematic, the new solution delegates the highlighting entirely to JS.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No