### PR TITLE
refactor(devtools): eliminate unnecessary scrollbars on injector tree

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.scss
@@ -23,6 +23,10 @@ as-split-area {
   overflow: auto !important;
 }
 
+svg {
+  display: block;
+}
+
 :host {
   ::ng-deep {
     .mat-tab-label {


### PR DESCRIPTION
Eliminate scrollbars caused by the SVG element's default `display: inline` behavior.

![image](https://github.com/user-attachments/assets/90d93b6e-f232-4de7-8443-d7ea5a5a4fe1)


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
devtools shows a vertical scrollbar for Environment and Element Hierarchies visualizations:

![image](https://github.com/user-attachments/assets/11a53a22-91b7-443b-b664-ef950420f5f3)


## What is the new behavior?

![image](https://github.com/user-attachments/assets/0bdd6d12-ae3c-4c2b-83ef-adc09f9b151c)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No



## Other information
