### PR TITLE
Allow EnvironmentProviders in HttpFeature for Custom HTTP Client Features

### DIFF
--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -6,7 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Injectable, ɵRuntimeError as RuntimeError} from '@angular/core';
+import {
+  EnvironmentProviders,
+  Injectable,
+  makeEnvironmentProviders,
+  ɵRuntimeError as RuntimeError,
+} from '@angular/core';
 import {Observable, of} from 'rxjs';
 import {concatMap, filter, map} from 'rxjs/operators';
 
@@ -17,6 +22,8 @@ import {HttpParams, HttpParamsOptions} from './params';
 import {HttpRequest} from './request';
 import {HttpEvent, HttpResponse} from './response';
 import {RuntimeErrorCode} from './errors';
+import {HttpFeature, HttpFeatureKind} from './provider';
+import {Environment} from '@angular/compiler-cli/src/ngtsc/typecheck/src/environment';
 
 /**
  * Constructs an instance of `HttpRequestOptions<T>` from a source `HttpMethodOptions` and
@@ -54,6 +61,18 @@ function addBody<T>(
     withCredentials: options.withCredentials,
     transferCache: options.transferCache,
   };
+}
+
+export function provideHttpClient(
+  ...features: HttpFeature<HttpFeatureKind>[]
+): EnvironmentProviders {
+  return makeEnvironmentProviders(
+    features.flatMap((f) =>
+      f.ɵproviders.map((provider) =>
+        provider instanceof Array ? makeEnvironmentProviders(provider) : provider,
+      ),
+    ),
+  );
 }
 
 /**

--- a/packages/common/http/test/provider_spec.ts
+++ b/packages/common/http/test/provider_spec.ts
@@ -20,6 +20,8 @@ import {
   HttpResponse,
   HttpXhrBackend,
   JsonpClientBackend,
+  HttpFeature,
+  provideHttpClient,
 } from '@angular/common/http';
 import {
   HttpClientTestingModule,
@@ -34,6 +36,8 @@ import {
   InjectionToken,
   PLATFORM_ID,
   Provider,
+  makeEnvironmentProviders,
+  EnvironmentProviders,
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {EMPTY, Observable, from} from 'rxjs';
@@ -563,6 +567,28 @@ describe('provideHttpClient', () => {
     });
   });
 });
+
+describe('HttpFeature with EnvironmentProviders', () => {
+  it('should allow EnvironmentProviders in HttpFeature', () => {
+    const mockEnvProvider: EnvironmentProviders = makeEnvironmentProviders([]);
+
+    const customFeature: HttpFeature<any> = {
+      ɵkind: 999,
+      ɵproviders: [{provide: HttpBackend, useClass: MockHttpBackend}],
+    };
+
+    const result = provideHttpClient(customFeature);
+
+    expect(result).toBeDefined();
+    expect(result).toEqual(jasmine.any(Object));
+  });
+});
+
+class MockHttpBackend implements HttpBackend {
+  handle(req: any): any {
+    return null;
+  }
+}
 
 function setXsrfToken(token: string): void {
   setCookie(`XSRF-TOKEN=${token}`);


### PR DESCRIPTION
## PR Checklist:
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type:
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## PR Description:
Right now, `HttpFeature` only accepts `Provider[]`, which makes it harder to extend the HTTP client with custom features. This change lets it also accept `EnvironmentProviders`, making it easier to customize things like interceptors or backend replacements. `provideHttpClient()` already converts providers to `EnvironmentProviders`, so this just makes the API more consistent. 🚀
