### PR TITLE
refactor(core): remove performance mark feature for signals

### DIFF
--- a/packages/core/src/render3/reactivity/computed.ts
+++ b/packages/core/src/render3/reactivity/computed.ts
@@ -31,7 +31,6 @@ export interface CreateComputedOptions<T> {
  * Create a computed `Signal` which derives a reactive value from an expression.
  */
 export function computed<T>(computation: () => T, options?: CreateComputedOptions<T>): Signal<T> {
-  performanceMarkFeature('NgSignals');
   const getter = createComputed(computation);
   if (options?.equal) {
     getter[SIGNAL].equal = options.equal;

--- a/packages/core/src/render3/reactivity/effect.ts
+++ b/packages/core/src/render3/reactivity/effect.ts
@@ -157,7 +157,6 @@ export function effect(
     return microtaskEffect(effectFn, options);
   }
 
-  performanceMarkFeature('NgSignals');
   ngDevMode &&
     assertNotInReactiveContext(
       effect,

--- a/packages/core/src/render3/reactivity/linked_signal.ts
+++ b/packages/core/src/render3/reactivity/linked_signal.ts
@@ -55,8 +55,6 @@ export function linkedSignal<S, D>(
     | (() => D),
   options?: {equal?: ValueEqualityFn<D>},
 ): WritableSignal<D> {
-  performanceMarkFeature('NgSignals');
-
   if (typeof optionsOrComputation === 'function') {
     const getter = createLinkedSignal<D, D>(
       optionsOrComputation,

--- a/packages/core/src/render3/reactivity/microtask_effect.ts
+++ b/packages/core/src/render3/reactivity/microtask_effect.ts
@@ -121,7 +121,6 @@ export function microtaskEffect(
   effectFn: (onCleanup: EffectCleanupRegisterFn) => void,
   options?: CreateEffectOptions,
 ): EffectRef {
-  performanceMarkFeature('NgSignals');
   ngDevMode &&
     assertNotInReactiveContext(
       effect,

--- a/packages/core/src/render3/reactivity/signal.ts
+++ b/packages/core/src/render3/reactivity/signal.ts
@@ -76,7 +76,6 @@ export interface CreateSignalOptions<T> {
  * Create a `Signal` that can be set or updated directly.
  */
 export function signal<T>(initialValue: T, options?: CreateSignalOptions<T>): WritableSignal<T> {
-  performanceMarkFeature('NgSignals');
   const signalFn = createSignal(initialValue) as SignalGetter<T> & WritableSignal<T>;
   const node = signalFn[SIGNAL];
   if (options?.equal) {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -540,7 +540,6 @@
   "optionsReducer",
   "parseAndConvertInputsForDefinition",
   "parseAndConvertOutputsForDefinition",
-  "performanceMarkFeature",
   "pickAsyncValidators",
   "pickValidators",
   "platformBrowser",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -529,7 +529,6 @@
   "optionsReducer",
   "parseAndConvertInputsForDefinition",
   "parseAndConvertOutputsForDefinition",
-  "performanceMarkFeature",
   "pickAsyncValidators",
   "pickValidators",
   "platformBrowser",


### PR DESCRIPTION
Remove the performance mark feature from the Angular signal impl so more code can be shared between primitives and other frameworks.
