### PR TITLE
fix(forms): Fix typing on `FormRecord`.

### DIFF
--- a/goldens/public-api/forms/index.api.md
+++ b/goldens/public-api/forms/index.api.md
@@ -556,7 +556,7 @@ export interface FormRecord<TControl> {
         emitEvent?: boolean;
     }): void;
     setValue(value: {
-        [key: string]: ɵValue<TControl>;
+        [key: string]: ɵRawValue<TControl>;
     }, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;

--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -769,7 +769,7 @@ export interface FormRecord<TControl> {
    * See `FormGroup#setValue` for additional information.
    */
   setValue(
-    value: {[key: string]: ɵValue<TControl>},
+    value: {[key: string]: ɵRawValue<TControl>},
     options?: {
       onlySelf?: boolean;
       emitEvent?: boolean;

--- a/packages/forms/test/typed_integration_spec.ts
+++ b/packages/forms/test/typed_integration_spec.ts
@@ -9,6 +9,7 @@
 // These tests mainly check the types of strongly typed form controls, which is generally enforced
 // at compile time.
 
+import {ɵRawValue} from '@angular/forms';
 import {FormBuilder, NonNullableFormBuilder, UntypedFormBuilder} from '../src/form_builder';
 import {
   AbstractControl,
@@ -727,6 +728,44 @@ describe('Typed Class', () => {
       c.patchValue({c: 42});
       c.reset({c: 42, d: 0});
       c.removeControl('c');
+    });
+
+    it('should only accept non-partial values', () => {
+      const fr = new FormRecord<FormGroup<{foo: FormControl<number>; bar: FormControl<number>}>>({
+        group1: new FormGroup({
+          foo: new FormControl(42, {nonNullable: true}),
+          bar: new FormControl(42, {nonNullable: true}),
+        }),
+      });
+
+      type ValueParam = Parameters<typeof fr.setValue>[0];
+
+      // This should error if the typing allows partial values
+      const value: ValueParam = {
+        // @ts-expect-error
+        group1: {
+          foo: 42,
+          // bar value is missing
+        },
+      };
+
+      type RecordRawValue = ɵRawValue<typeof fr>;
+      const rawValue: RecordRawValue = {
+        // @ts-expect-error
+        group1: {
+          foo: 42,
+          // bar value is missing
+        },
+      };
+
+      expect(() =>
+        fr.setValue({
+          // @ts-expect-error
+          group1: {
+            foo: 42,
+          },
+        }),
+      ).toThrowError(/NG01002: Must supply a value for form control/);
     });
   });
 


### PR DESCRIPTION
Priori to this change, `ɵRawValue` of a `FormRecord` returned a `Partial`. This commit fixes it.

fixes #59985
