### PR TITLE
docs(docs-infra): fix the top position of the search dialog

### DIFF
--- a/adev/shared-docs/components/search-dialog/search-dialog.component.scss
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.scss
@@ -2,6 +2,8 @@ dialog {
   background-color: transparent;
   border: none;
   padding-block-end: 3rem;
+  margin: 0 auto;
+  top: 15vh;
 
   &::backdrop {
     backdrop-filter: blur(5px);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When you type in the search input and the results change, the dialog "jumps".

## What is the new behavior?

Instead of centering the dialog, fix the top position in such a way that when the results container is full the dialog looks centered. This should improve the UX.

https://github.com/user-attachments/assets/ddb8f487-5f6a-474a-9d9f-87513b5346bf

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
