### PR TITLE
refactor(compiler): improve `stringify`

### DIFF
--- a/packages/compiler/src/util.ts
+++ b/packages/compiler/src/util.ts
@@ -89,19 +89,16 @@ export function stringify(token: any): string {
   }
 
   if (Array.isArray(token)) {
-    return '[' + token.map(stringify).join(', ') + ']';
+    return `[${token.map(stringify).join(', ')}]`;
   }
 
   if (token == null) {
     return '' + token;
   }
 
-  if (token.overriddenName) {
-    return `${token.overriddenName}`;
-  }
-
-  if (token.name) {
-    return `${token.name}`;
+  const name = token.overriddenName || token.name;
+  if (name) {
+    return `${name}`;
   }
 
   if (!token.toString) {
@@ -110,14 +107,14 @@ export function stringify(token: any): string {
 
   // WARNING: do not try to `JSON.stringify(token)` here
   // see https://github.com/angular/angular/issues/23440
-  const res = token.toString();
+  const result = token.toString();
 
-  if (res == null) {
-    return '' + res;
+  if (result == null) {
+    return '' + result;
   }
 
-  const newLineIndex = res.indexOf('\n');
-  return newLineIndex === -1 ? res : res.substring(0, newLineIndex);
+  const newLineIndex = result.indexOf('\n');
+  return newLineIndex >= 0 ? result.slice(0, newLineIndex) : result;
 }
 
 export class Version {


### PR DESCRIPTION
This is the same change that was made in this commit (https://github.com/angular/angular/commit/cf3a5073ece9eb313bb4832b3f78aa1bfeca09c6). See its description for clarification.