### PR TITLE
refactor(platform-browser): drop unsupported event target error message in production

### DIFF
--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -419,13 +419,17 @@ class DefaultDomRenderer2 implements Renderer2 {
     if (typeof target === 'string') {
       target = getDOM().getGlobalEventTarget(this.doc, target);
       if (!target) {
-        throw new Error(`Unsupported event target ${target} for event ${event}`);
+        throw new RuntimeError(
+          RuntimeErrorCode.UNSUPPORTED_EVENT_TARGET,
+          (typeof ngDevMode === 'undefined' || ngDevMode) &&
+            `Unsupported event target ${target} for event ${event}`,
+        );
       }
     }
 
     let wrappedCallback = this.decoratePreventDefault(callback);
 
-    if (this.tracingService !== null && this.tracingService.wrapEventListener) {
+    if (this.tracingService?.wrapEventListener) {
       wrappedCallback = this.tracingService.wrapEventListener(target, event, wrappedCallback);
     }
 


### PR DESCRIPTION
Drops unsupported event target error message in production and replaces it with an existing error code.