### PR TITLE
fix(common): rename httpResource function in factory

### DIFF
--- a/packages/common/http/src/resource.ts
+++ b/packages/common/http/src/resource.ts
@@ -226,7 +226,7 @@ type ResponseType = 'arraybuffer' | 'blob' | 'json' | 'text';
 type RawRequestType = (() => string | undefined) | (() => HttpResourceRequest | undefined);
 
 function makeHttpResourceFn<TRaw>(responseType: ResponseType) {
-  return function httpResourceRef<TResult = TRaw>(
+  return function httpResource<TResult = TRaw>(
     request: RawRequestType,
     options?: HttpResourceOptions<TResult, TRaw>,
   ): HttpResourceRef<TResult> {

--- a/packages/common/http/test/resource_spec.ts
+++ b/packages/common/http/test/resource_spec.ts
@@ -22,6 +22,12 @@ describe('httpResource', () => {
     TestBed.configureTestingModule({providers: [provideHttpClient(), provideHttpClientTesting()]});
   });
 
+  it('should throw if used outside injection context', () => {
+    expect(() => httpResource(() => '/data')).toThrowMatching((thrown) =>
+      thrown.message.includes('httpResource() can only be used within an injection context'),
+    );
+  });
+
   it('should send a basic request', async () => {
     const backend = TestBed.inject(HttpTestingController);
     const res = httpResource(() => '/data', {injector: TestBed.inject(Injector)});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

As the function in the factory was named `httpResourceRef`, error NG0203 had with the following message:

```
Error: NG0203: httpResourceRef() can only be used within an injection context such as a constructor, a factory function, a field initializer, or a function used with `runInInjectionContext`. Find more at https://angular.dev/errors/NG0203
```

## What is the new behavior?

The new message mentions `httpRessource` as shown by the added unit test


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
