### PR TITLE
fix(benchpress): Ensure future-proof correct initialization order for JsonFileReporter

### DIFF
--- a/packages/benchpress/src/reporter/json_file_reporter.ts
+++ b/packages/benchpress/src/reporter/json_file_reporter.ts
@@ -46,9 +46,11 @@ export class JsonFileReporter extends Reporter {
     @Inject(Options.NOW) private _now: Function,
   ) {
     super();
+
+    this.textReporter = new TextReporterBase(this._columnWidth, this._description);
   }
 
-  private textReporter = new TextReporterBase(this._columnWidth, this._description);
+  private textReporter: TextReporterBase;
 
   override reportMeasureValues(measureValues: MeasureValues): Promise<any> {
     return Promise.resolve(null);


### PR DESCRIPTION
Future changes to initialization order can cause this previously OK code to start having compiler erroring like: `TS2729: Property 'foo' is used before its initialization.`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Not relevant for missing items.

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

If you enable `tsc` --target=ES2022` and `--useDefineForClassFields`, will result in a `TS2729` compilation error.

Issue Number: N/A

## What is the new behavior?

No compilation error with the previous flags.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
