### PR TITLE
fix(service-worker): update service worker to handle seeking better for videos

### DIFF
--- a/packages/examples/service-worker/push/ngsw-worker.js
+++ b/packages/examples/service-worker/push/ngsw-worker.js
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.dev/license
+ * found in the LICENSE file at https://angular.dev/license.
  */
 
 // Mock `ngsw-worker.js` used for testing the examples.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) <-- {i will do this  before i merge if you all think this is a good change}


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

"If you ng run app:build:production and your pwa comes with a <video> element where you also utilize seeking (setting currentTime depending on your app logic and/or user input) it will not work or only very inconsistently. Most videos will simply run from start and not at the setted currentTime position. This is only the case when videos are delivered/fetched by the service worker. So it works in development mode."

Issue Number: #25865


## What is the new behavior?

Added logic to **driver.ts** in the worker src folder that does the following:

The  `onFetch` method now: 

- Checks for Range headers in incoming requests.

- Calls the `handleRangeRequest` function if a Range header is present.


The newly added `handleRangeRequest` function:  

- Parses the Range header to determine the requested byte range.

- Fetches the full content and extracts the requested byte range.

- Constructs a response with the appropriate Content-Range and Content-Length headers.

- Returns a 206 Partial Content response with the requested byte range.

These changes ensure that the service worker can handle Range requests, allowing videos to start at the specified `currentTime` when delivered by the service worker as well as fixing seeking.





## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


Should not be a breaking change