### PR TITLE
ci: disable adev tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,10 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Build adev in fast mode to ensure it continues to work
         run: yarn bazel build //adev:build --config=release
-      - name: Run tests
-        run: yarn bazel test //adev/...
+      # TODO: re-enable tests once the next release is shipped
+      # Tests are broken because of https://github.com/angular/angular/issues/54858
+      # - name: Run tests
+      # run: yarn bazel test //adev/...
 
   publish-snapshots:
     runs-on:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -114,8 +114,10 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Build adev in fast mode to ensure it continues to work
         run: yarn bazel build //adev:build --config=release
-      - name: Run tests
-        run: yarn bazel test //adev/...
+      # TODO: re-enable tests once the next release is shipped
+      # Tests are broken because of https://github.com/angular/angular/issues/54858
+      # - name: Run tests
+      #   run: yarn bazel test //adev/...
 
   zone-js:
     runs-on:


### PR DESCRIPTION
Due toe #54858 and in the introduction of the new `FakeNavigation` by #59857, adev tests now fails to build. We have to disable them until the next 19.1 release is out.
