### PR TITLE
refactor(core): remove duplicated checks for ngNonBindable

### DIFF
--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -32,11 +32,10 @@ import {
   createElementNode,
   setupStaticAttributes,
 } from '../dom_node_manipulation';
-import {registerPostOrderHooks} from '../hooks';
 import {hasClassInput, hasStyleInput, TElementNode, TNode, TNodeType} from '../interfaces/node';
 import {Renderer} from '../interfaces/renderer';
 import {RElement} from '../interfaces/renderer_dom';
-import {isComponentHost, isContentQueryHost, isDirectiveHost} from '../interfaces/type_checks';
+import {isComponentHost, isDirectiveHost} from '../interfaces/type_checks';
 import {HEADER_OFFSET, HYDRATION, LView, RENDERER, TView} from '../interfaces/view';
 import {assertTNodeType} from '../node_assert';
 import {appendChild} from '../node_manipulation';
@@ -66,7 +65,7 @@ import {elementEndFirstCreatePass, elementStartFirstCreatePass} from '../view/el
 import {validateElementIsKnown} from './element_validation';
 import {setDirectiveInputsWhichShadowsStyling} from './property';
 import {
-  createDirectivesInstancesInInstruction,
+  createDirectivesInstances,
   findDirectiveDefMatches,
   saveResolvedLocalsInData,
 } from './shared';
@@ -139,13 +138,13 @@ export function ɵɵelementStart(
   // any immediate children of a component or template container must be pre-emptively
   // monkey-patched with the component view data so that the element can be inspected
   // later on using any element discovery utility methods (see `element_discovery.ts`)
-  if (getElementDepthCount() === 0) {
+  if (getElementDepthCount() === 0 || hasDirectives) {
     attachPatchData(native, lView);
   }
   increaseElementDepthCount();
 
   if (hasDirectives) {
-    createDirectivesInstancesInInstruction(tView, lView, tNode);
+    createDirectivesInstances(tView, lView, tNode);
     executeContentQueries(tView, tNode, lView);
   }
   if (localRefsIndex !== null) {

--- a/packages/core/src/render3/instructions/element_container.ts
+++ b/packages/core/src/render3/instructions/element_container.ts
@@ -17,15 +17,15 @@ import {isDetachedByI18n} from '../../i18n/utils';
 import {assertEqual, assertIndexInRange, assertNumber} from '../../util/assert';
 import {assertHasParent} from '../assert';
 import {attachPatchData} from '../context_discovery';
+import {createCommentNode} from '../dom_node_manipulation';
 import {registerPostOrderHooks} from '../hooks';
 import {TAttributes, TElementContainerNode, TNode, TNodeType} from '../interfaces/node';
 import {RComment} from '../interfaces/renderer_dom';
 import {isContentQueryHost, isDirectiveHost} from '../interfaces/type_checks';
 import {HEADER_OFFSET, HYDRATION, LView, RENDERER, TView} from '../interfaces/view';
 import {assertTNodeType} from '../node_assert';
-import {executeContentQueries} from '../queries/query_execution';
 import {appendChild} from '../node_manipulation';
-import {createCommentNode} from '../dom_node_manipulation';
+import {executeContentQueries} from '../queries/query_execution';
 import {
   getBindingIndex,
   getBindingsEnabled,
@@ -43,13 +43,13 @@ import {computeStaticStyling} from '../styling/static_styling';
 import {mergeHostAttrs} from '../util/attrs_utils';
 import {getConstant} from '../util/view_utils';
 
+import {getOrCreateTNode} from '../tnode_manipulation';
+import {resolveDirectives} from '../view/directives';
 import {
-  createDirectivesInstancesInInstruction,
+  createDirectivesInstances,
   findDirectiveDefMatches,
   saveResolvedLocalsInData,
 } from './shared';
-import {getOrCreateTNode} from '../tnode_manipulation';
-import {resolveDirectives} from '../view/directives';
 
 function elementContainerStartFirstCreatePass(
   index: number,
@@ -131,7 +131,7 @@ export function ɵɵelementContainerStart(
   attachPatchData(comment, lView);
 
   if (isDirectiveHost(tNode)) {
-    createDirectivesInstancesInInstruction(tView, lView, tNode);
+    createDirectivesInstances(tView, lView, tNode);
     executeContentQueries(tView, tNode, lView);
   }
 

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -75,7 +75,6 @@ import {createComponentLView} from '../view/construction';
 import {selectIndexInternal} from './advance';
 import {handleUnknownPropertyError, isPropertyValid, matchingSchemas} from './element_validation';
 import {writeToDirectiveInput} from './write_to_directive_input';
-import {InputFlags} from '../interfaces/input_flags';
 
 export function executeTemplate<T>(
   tView: TView,
@@ -107,19 +106,6 @@ export function executeTemplate<T>(
       : ProfilerEvent.TemplateCreateEnd;
     profiler(postHookType, context as unknown as {});
   }
-}
-
-/**
- * Creates directive instances.
- */
-export function createDirectivesInstancesInInstruction(
-  tView: TView,
-  lView: LView,
-  tNode: TDirectiveHostNode,
-) {
-  if (!getBindingsEnabled()) return;
-  attachPatchData(getNativeByTNode(tNode, lView), lView);
-  createDirectivesInstances(tView, lView, tNode);
 }
 
 /**

--- a/packages/core/src/render3/instructions/template.ts
+++ b/packages/core/src/render3/instructions/template.ts
@@ -43,7 +43,7 @@ import {createLContainer} from '../view/container';
 import {resolveDirectives} from '../view/directives';
 
 import {
-  createDirectivesInstancesInInstruction,
+  createDirectivesInstances,
   findDirectiveDefMatches,
   saveResolvedLocalsInData,
 } from './shared';
@@ -168,7 +168,7 @@ export function declareTemplate(
   populateDehydratedViewsInLContainer(lContainer, tNode, declarationLView);
 
   if (isDirectiveHost(tNode)) {
-    createDirectivesInstancesInInstruction(declarationTView, declarationLView, tNode);
+    createDirectivesInstances(declarationTView, declarationLView, tNode);
   }
 
   if (localRefsIndex != null) {

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -298,7 +298,6 @@
   "forwardRef",
   "freeConsumers",
   "generateInitialInputs",
-  "getBindingsEnabled",
   "getClosureSafeProperty",
   "getComponentDef",
   "getComponentLViewByIndex",

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -319,7 +319,6 @@
   "forwardRef",
   "freeConsumers",
   "generateInitialInputs",
-  "getBindingsEnabled",
   "getClosureSafeProperty",
   "getComponentDef",
   "getComponentLViewByIndex",

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -247,7 +247,6 @@
   "forwardRef",
   "freeConsumers",
   "generateInitialInputs",
-  "getBindingsEnabled",
   "getClosureSafeProperty",
   "getComponentDef",
   "getComponentLViewByIndex",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -247,7 +247,6 @@
   "convertToBitFlags",
   "createContainerAnchorImpl",
   "createDirectivesInstances",
-  "createDirectivesInstancesInInstruction",
   "createElementNode",
   "createElementRef",
   "createEnvironmentInjector",

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -295,7 +295,6 @@
   "controlPath",
   "convertToBitFlags",
   "createDirectivesInstances",
-  "createDirectivesInstancesInInstruction",
   "createElementNode",
   "createElementRef",
   "createErrorClass",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -283,7 +283,6 @@
   "controlPath",
   "convertToBitFlags",
   "createDirectivesInstances",
-  "createDirectivesInstancesInInstruction",
   "createElementNode",
   "createElementRef",
   "createErrorClass",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -425,7 +425,6 @@
   "generateInitialInputs",
   "getAllRouteGuards",
   "getBeforeNodeForView",
-  "getBindingsEnabled",
   "getBootstrapListener",
   "getChildRouteGuards",
   "getClosestRouteInjector",

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -240,7 +240,6 @@
   "context",
   "convertToBitFlags",
   "createDirectivesInstances",
-  "createDirectivesInstancesInInstruction",
   "createElementNode",
   "createElementRef",
   "createErrorClass",


### PR DESCRIPTION
This refactoring consolidates logic around detecting ngNonBindable mode - previously those checks were done in two separate places. By doing the check in one place we can simplify the directive resolution logic.
