### PR TITLE
refactor(devtools): drop @ from inputs and outputs label

### DIFF
--- a/devtools/cypress/integration/view-component-metadata.e2e.js
+++ b/devtools/cypress/integration/view-component-metadata.e2e.js
@@ -44,13 +44,13 @@ describe('Viewing component metadata', () => {
     });
 
     it('should display correct set of inputs', () => {
-      cy.contains('.cy-inputs', '@Inputs');
+      cy.contains('.cy-inputs', 'Inputs');
       cy.contains('.cy-inputs mat-tree-node:first span:first', 'inputOne');
       cy.contains('.cy-inputs mat-tree-node:last span:first', 'inputTwo');
     });
 
     it('should display correct set of outputs', () => {
-      cy.contains('.cy-outputs', '@Outputs');
+      cy.contains('.cy-outputs', 'Outputs');
       cy.contains('.cy-outputs mat-tree-node:first span:first', 'outputOne');
       cy.contains('.cy-outputs mat-tree-node:last span:first', 'outputTwo');
     });

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.ts
@@ -57,14 +57,14 @@ export class PropertyViewBodyComponent {
   >(() => {
     return [
       {
-        title: '@Inputs',
+        title: 'Inputs',
         hidden: this.directiveInputControls().dataSource.data.length === 0,
         controls: this.directiveInputControls(),
         documentation: 'https://angular.dev/api/core/input',
         class: 'cy-inputs',
       },
       {
-        title: '@Outputs',
+        title: 'Outputs',
         hidden: this.directiveOutputControls().dataSource.data.length === 0,
         controls: this.directiveOutputControls(),
         documentation: 'https://angular.dev/api/core/output',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

Drop @ from the inputs and outputs label to fit in with the new signal-based API.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No