### PR TITLE
feat(core): Expose `Injector.destroy` on `Injector` created with …

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -589,6 +589,12 @@ export class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChan
 export const defineInjectable: typeof ɵɵdefineInjectable;
 
 // @public
+export interface DestroyableInjector extends Injector {
+    // (undocumented)
+    destroy(): void;
+}
+
+// @public
 export function destroyPlatform(): void;
 
 // @public
@@ -949,7 +955,7 @@ export abstract class Injector {
         providers: Array<Provider | StaticProvider>;
         parent?: Injector;
         name?: string;
-    }): Injector;
+    }): DestroyableInjector;
     abstract get<T>(token: ProviderToken<T>, notFoundValue: undefined, options: InjectOptions & {
         optional?: false;
     }): T;

--- a/packages/core/src/di/index.ts
+++ b/packages/core/src/di/index.ts
@@ -24,7 +24,7 @@ export {
 } from './interface/defs';
 export {forwardRef, resolveForwardRef, ForwardRefFn} from './forward_ref';
 export {Injectable, InjectableDecorator, InjectableProvider} from './injectable';
-export {Injector} from './injector';
+export {Injector, DestroyableInjector} from './injector';
 export {EnvironmentInjector} from './r3_injector';
 export {
   importProvidersFrom,

--- a/packages/core/src/di/injector.ts
+++ b/packages/core/src/di/injector.ts
@@ -117,7 +117,7 @@ export abstract class Injector {
     providers: Array<Provider | StaticProvider>;
     parent?: Injector;
     name?: string;
-  }): Injector;
+  }): DestroyableInjector;
 
   static create(
     options:
@@ -145,4 +145,13 @@ export abstract class Injector {
    * @nocollapse
    */
   static __NG_ELEMENT_ID__ = InjectorMarkers.Injector;
+}
+
+/**
+ * An Injector that the owner can destroy and trigger the DestroyRef.destroy hooks.
+ *
+ * @publicApi
+ */
+export interface DestroyableInjector extends Injector {
+  destroy(): void;
 }

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -113,6 +113,8 @@ interface Record<T> {
 /**
  * An `Injector` that's part of the environment injector hierarchy, which exists outside of the
  * component tree.
+ *
+ * @publicApi
  */
 export abstract class EnvironmentInjector implements Injector {
   /**

--- a/packages/platform-browser/test/browser/tools/tools_spec.ts
+++ b/packages/platform-browser/test/browser/tools/tools_spec.ts
@@ -34,7 +34,7 @@ describe('profiler', () => {
             deps: [],
           },
         ],
-      }),
+      }) as Injector,
     } as ComponentRef<any>);
   });
 


### PR DESCRIPTION
…`Injector.create`

There is no implementation change, this only expose `destroy` in a case where the injector can be owned in userland.
