### PR TITLE
fix(common): Handle errors in async pipe subscriptions

### DIFF
--- a/packages/common/test/pipes/async_pipe_spec.ts
+++ b/packages/common/test/pipes/async_pipe_spec.ts
@@ -7,7 +7,14 @@
  */
 
 import {AsyncPipe} from '@angular/common';
-import {ChangeDetectorRef, Component, computed, EventEmitter, signal} from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  computed,
+  ErrorHandler,
+  EventEmitter,
+  signal,
+} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {Observable, of, Subscribable, Unsubscribable} from 'rxjs';
 
@@ -21,7 +28,7 @@ describe('AsyncPipe', () => {
 
   beforeEach(() => {
     ref = getChangeDetectorRefSpy();
-    pipe = new AsyncPipe(ref);
+    pipe = TestBed.runInInjectionContext(() => new AsyncPipe(ref));
   });
 
   afterEach(() => {
@@ -167,8 +174,6 @@ describe('AsyncPipe', () => {
     let resolve: (result: any) => void;
     let reject: (error: any) => void;
     let promise: Promise<any>;
-    // adds longer timers for passing tests in IE
-    const timer = 10;
 
     beforeEach(() => {
       promise = new Promise((res, rej) => {
@@ -182,50 +187,52 @@ describe('AsyncPipe', () => {
         expect(pipe.transform(promise)).toBe(null);
       });
 
-      it('should return the latest available value', (done) => {
+      it('should return the latest available value', async () => {
         pipe.transform(promise);
 
         resolve(message);
+        await promise;
 
-        setTimeout(() => {
-          expect(pipe.transform(promise)).toEqual(message);
-          done();
-        }, timer);
+        expect(pipe.transform(promise)).toEqual(message);
       });
 
-      it('should return value when nothing has changed since the last call', (done) => {
+      it('should return value when nothing has changed since the last call', async () => {
         pipe.transform(promise);
         resolve(message);
+        await promise;
 
-        setTimeout(() => {
-          pipe.transform(promise);
-          expect(pipe.transform(promise)).toBe(message);
-          done();
-        }, timer);
+        pipe.transform(promise);
+        expect(pipe.transform(promise)).toBe(message);
       });
 
-      it('should dispose of the existing subscription when subscribing to a new promise', (done) => {
+      it('should report rejections to error handler', async () => {
+        const spy = spyOn(TestBed.inject(ErrorHandler), 'handleError');
+        pipe.transform(promise);
+        reject(message);
+        try {
+          await promise;
+        } catch {}
+        expect(spy).toHaveBeenCalledWith(message);
+      });
+
+      it('should dispose of the existing subscription when subscribing to a new promise', async () => {
         pipe.transform(promise);
 
-        promise = new Promise<any>(() => {});
+        const newPromise = new Promise<any>(() => {});
+        expect(pipe.transform(newPromise)).toBe(null);
+
+        resolve(message);
+        await promise;
+
         expect(pipe.transform(promise)).toBe(null);
-
-        resolve(message);
-
-        setTimeout(() => {
-          expect(pipe.transform(promise)).toBe(null);
-          done();
-        }, timer);
       });
 
-      it('should request a change detection check upon receiving a new value', (done) => {
+      it('should request a change detection check upon receiving a new value', async () => {
         pipe.transform(promise);
         resolve(message);
+        await promise;
 
-        setTimeout(() => {
-          expect(ref.markForCheck).toHaveBeenCalled();
-          done();
-        }, timer);
+        expect(ref.markForCheck).toHaveBeenCalled();
       });
 
       describe('ngOnDestroy', () => {
@@ -233,29 +240,25 @@ describe('AsyncPipe', () => {
           expect(() => pipe.ngOnDestroy()).not.toThrow();
         });
 
-        it('should dispose of the existing source', (done) => {
+        it('should dispose of the existing source', async () => {
           pipe.transform(promise);
           expect(pipe.transform(promise)).toBe(null);
           resolve(message);
+          await promise;
 
-          setTimeout(() => {
-            expect(pipe.transform(promise)).toEqual(message);
-            pipe.ngOnDestroy();
-            expect(pipe.transform(promise)).toBe(null);
-            done();
-          }, timer);
+          expect(pipe.transform(promise)).toEqual(message);
+          pipe.ngOnDestroy();
+          expect(pipe.transform(promise)).toBe(null);
         });
 
-        it('should ignore signals after the pipe has been destroyed', (done) => {
+        it('should ignore signals after the pipe has been destroyed', async () => {
           pipe.transform(promise);
           expect(pipe.transform(promise)).toBe(null);
           pipe.ngOnDestroy();
           resolve(message);
+          await promise;
 
-          setTimeout(() => {
-            expect(pipe.transform(promise)).toBe(null);
-            done();
-          }, timer);
+          expect(pipe.transform(promise)).toBe(null);
         });
       });
     });


### PR DESCRIPTION
`AsyncPipe` would previously promise rejections unhandled and subscription errors uncaught. This is more or less fine in a Zone-based application because errors inside the Angular Zone are caught be the Zone's error trap and reported to `ErrorHandler`. However, in zoneless applications, these errors are never caught or reported by the FW and can reach the node process in SSR and cause it to shut down.

BREAKING CHANGE: `AsyncPipe` now directly catches unhandled errors in subscriptions and promises and reports them to the application's `ErrorHandler`. For Zone-based applications, these errors would have been caught by ZoneJS and reported to `ErrorHandler` so the result is generally the same. The change to the exact mechanism for reporting can result in differences in test environments that will require test updates.
