### PR TITLE
feat(devtools): add the onpush label for marked onpush components in …

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
@@ -39,6 +39,7 @@ import {
   idToInjector,
   injectorsSeen,
   isElementInjector,
+  isOnPushDirective,
   nodeInjectorToResolutionPath,
   queryDirectiveForest,
   serializeProviderRecord,
@@ -387,6 +388,7 @@ const prepareForestForSerialization = (
       })),
       children: prepareForestForSerialization(node.children, includeResolutionPath),
       hydration: node.hydration,
+      onPush: node.component ? isOnPushDirective(node.component) : false,
     };
     serializedNodes.push(serializedNode);
 

--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
@@ -245,6 +245,11 @@ const getDirectiveMetadata = (dir: any): DirectiveMetadata => {
   };
 };
 
+export function isOnPushDirective(dir: any): boolean {
+  const metadata = getDirectiveMetadata(dir.instance);
+  return metadata.onPush;
+}
+
 export function getInjectorProviders(injector: Injector) {
   if (isNullInjector(injector)) {
     return [];

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/component-data-source/index.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/component-data-source/index.ts
@@ -28,6 +28,7 @@ export interface FlatNode {
   original: IndexedNode;
   newItem?: boolean;
   hydration: HydrationStatus;
+  onPush?: boolean;
 }
 
 const expandable = (node: IndexedNode) => !!node.children && node.children.length > 0;
@@ -94,6 +95,7 @@ export class ComponentDataSource extends DataSource<FlatNode> {
         original: node,
         level,
         hydration: node.hydration,
+        onPush: node.onPush,
       };
       this._nodeToFlat.set(node, flatNode);
       return flatNode;

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.html
@@ -44,6 +44,10 @@
           <span class="console-reference"> == $ng0 </span>
         }
 
+        @if (node.onPush) {
+          <span class="on-push">OnPush</span>
+        }
+
         @switch (node.hydration?.status) {
           @case ('hydrated') {
             <mat-icon matTooltip="Hydrated" class="hydration">water_drop</mat-icon>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.scss
@@ -39,7 +39,8 @@
       color: #9b4807;
     }
 
-    .console-reference {
+    .console-reference,
+    .on-push {
       color: #748591;
       padding-left: 8px;
       font-style: italic;

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/index-forest/index-forest.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/index-forest/index-forest.spec.ts
@@ -41,6 +41,7 @@ describe('indexForest', () => {
               ],
               component: null,
               children: [],
+              onPush: false,
             },
             {
               element: 'Child1_2',
@@ -52,8 +53,10 @@ describe('indexForest', () => {
                 id: 1,
               },
               children: [],
+              onPush: false,
             },
           ],
+          onPush: false,
         },
         {
           element: 'Parent2',
@@ -72,6 +75,7 @@ describe('indexForest', () => {
               hydration: null,
               component: null,
               children: [],
+              onPush: true,
             },
             {
               element: 'Child2_2',
@@ -88,8 +92,10 @@ describe('indexForest', () => {
               component: null,
               hydration: null,
               children: [],
+              onPush: true,
             },
           ],
+          onPush: true,
         },
       ]),
     ).toEqual([
@@ -120,6 +126,7 @@ describe('indexForest', () => {
             component: null,
             hydration: null,
             children: [],
+            onPush: false,
           },
           {
             element: 'Child1_2',
@@ -132,8 +139,10 @@ describe('indexForest', () => {
             },
             hydration: null,
             children: [],
+            onPush: false,
           },
         ],
+        onPush: false,
       },
       {
         element: 'Parent2',
@@ -154,6 +163,7 @@ describe('indexForest', () => {
             component: null,
             hydration: null,
             children: [],
+            onPush: true,
           },
           {
             element: 'Child2_2',
@@ -171,8 +181,10 @@ describe('indexForest', () => {
             component: null,
             children: [],
             hydration: null,
+            onPush: true,
           },
         ],
+        onPush: true,
       },
     ]);
   });

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/index-forest/index.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/index-forest/index.ts
@@ -26,6 +26,7 @@ const indexTree = (
     directives: node.directives.map((d, i) => ({name: d.name, id: d.id})),
     children: node.children.map((n, i) => indexTree(n, i, position)),
     hydration: node.hydration,
+    onPush: node.onPush,
   };
 };
 

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -36,6 +36,7 @@ export interface DevToolsNode<DirType = DirectiveType, CmpType = ComponentType> 
   nativeElement?: Node;
   resolutionPath?: SerializedInjector[];
   hydration: HydrationStatus;
+  onPush?: boolean;
 }
 
 export interface SerializedInjector {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #60027 


## What is the new behavior?
When inspecting the components on the components tree tab, an "OnPush" label is added to all onpush components. 

![result_view](https://github.com/user-attachments/assets/803d0f63-edb7-41b3-a565-38ebe1c3ff9e)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
