### PR TITLE
refactor(schematics): Don't migrate twice the same file on the self-c…

### DIFF
--- a/packages/core/schematics/test/self_closing_tags_migration_spec.ts
+++ b/packages/core/schematics/test/self_closing_tags_migration_spec.ts
@@ -19,6 +19,7 @@ describe('self-closing-tags migration', () => {
   let tree: UnitTestTree;
   let tmpDirPath: string;
   let previousWorkingDir: string;
+  let logs: string[];
 
   function writeFile(filePath: string, contents: string) {
     host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
@@ -32,6 +33,7 @@ describe('self-closing-tags migration', () => {
     runner = new SchematicTestRunner('test', runfiles.resolvePackageRelative('../collection.json'));
     host = new TempScopedNodeJsSyncHost();
     tree = new UnitTestTree(new HostTree(host));
+    logs = [];
 
     writeFile('/tsconfig.json', '{}');
     writeFile(
@@ -44,6 +46,7 @@ describe('self-closing-tags migration', () => {
 
     previousWorkingDir = shx.pwd();
     tmpDirPath = getSystemPath(host.root);
+    runner.logger.subscribe((log) => logs.push(log.message));
     shx.cd(tmpDirPath);
   });
 
@@ -66,5 +69,39 @@ describe('self-closing-tags migration', () => {
 
     const content = tree.readContent('/app.component.ts').replace(/\s+/g, ' ');
     expect(content).toContain('<my-cmp />');
+    expect(logs.pop()).toBe(
+      '  -> Migrated 1 components to self-closing tags in 1 component files.',
+    );
+  });
+
+  it('should handle a file that is present in multiple projects', async () => {
+    writeFile('/tsconfig-2.json', '{}');
+    writeFile(
+      '/angular.json',
+      JSON.stringify({
+        version: 1,
+        projects: {
+          a: {root: '', architect: {build: {options: {tsConfig: './tsconfig.json'}}}},
+          b: {root: '', architect: {build: {options: {tsConfig: './tsconfig-2.json'}}}},
+        },
+      }),
+    );
+
+    writeFile(
+      '/app.component.ts',
+      `
+      import {Component} from '@angular/core';
+      @Component({ template: '<my-cmp></my-cmp>' })
+      export class Cmp {}
+      `,
+    );
+
+    await runMigration();
+
+    const content = tree.readContent('/app.component.ts').replace(/\s+/g, ' ');
+    expect(content).toContain('<my-cmp />');
+    expect(logs.pop()).toBe(
+      '  -> Migrated 1 components to self-closing tags in 1 component files.',
+    );
   });
 });


### PR DESCRIPTION
…losing tag migration

This commit fixes an issue when ts files are referenced multiple times (and thus analyzed multiple times) for example from a `tsconfig.json` and `tsconfig.spec.json`.
