### PR TITLE
fix(core): capture stack for HMR errors

### DIFF
--- a/packages/core/src/render3/hmr.ts
+++ b/packages/core/src/render3/hmr.ts
@@ -308,12 +308,13 @@ function executeWithInvalidateFallback(
   try {
     callback();
   } catch (e) {
-    const errorMessage = (e as {message?: string}).message;
+    const error = e as {message?: string; stack?: string};
 
     // If we have all the necessary information and APIs to send off the invalidation
     // request, send it before rethrowing so the dev server can decide what to do.
-    if (id !== null && errorMessage) {
-      importMeta?.hot?.send?.('angular:invalidate', {id, message: errorMessage, error: true});
+    if (id !== null && error.message) {
+      const toLog = error.message + (error.stack ? '\n' + error.stack : '');
+      importMeta?.hot?.send?.('angular:invalidate', {id, message: toLog, error: true});
     }
 
     // Throw the error in case the page doesn't get refreshed.


### PR DESCRIPTION
Currently we send the `message` of an error thrown during HMR. That's usually not enough so now we also capture the stack trace.

Relates to https://github.com/angular/angular-cli/issues/29695.
