### PR TITLE
refactor(core): tree-shake `REF_EXTRACTOR_REGEXP`

### DIFF
--- a/packages/core/src/hydration/compression.ts
+++ b/packages/core/src/hydration/compression.ts
@@ -15,7 +15,7 @@ import {NodeNavigationStep, REFERENCE_NODE_BODY, REFERENCE_NODE_HOST} from './in
  *  - the `b` char which indicates that the lookup should start from the `document.body`
  *  - the `h` char to start lookup from the component host node (`lView[HOST]`)
  */
-const REF_EXTRACTOR_REGEXP = new RegExp(
+const REF_EXTRACTOR_REGEXP = /* @__PURE__ */ new RegExp(
   `^(\\d+)*(${REFERENCE_NODE_BODY}|${REFERENCE_NODE_HOST})*(.*)`,
 );
 


### PR DESCRIPTION
The `REF_EXTRACTOR_REGEXP` is a `new` expression that has side effects and is not dropped in production, even if it is unused.