### PR TITLE
refactor(core): inline `depPath` in `throwCyclicDependencyError` to be dropped

### DIFF
--- a/packages/core/src/render3/errors_di.ts
+++ b/packages/core/src/render3/errors_di.ts
@@ -16,10 +16,11 @@ import {stringifyForError} from './util/stringify_utils';
 
 /** Called when directives inject each other (creating a circular dependency) */
 export function throwCyclicDependencyError(token: string, path?: string[]): never {
-  const depPath = path ? `. Dependency path: ${path.join(' > ')} > ${token}` : '';
   throw new RuntimeError(
     RuntimeErrorCode.CYCLIC_DI_DEPENDENCY,
-    ngDevMode ? `Circular dependency in DI detected for ${token}${depPath}` : token,
+    ngDevMode
+      ? `Circular dependency in DI detected for ${token}${path ? `. Dependency path: ${path.join(' > ')} > ${token}` : ''}`
+      : token,
   );
 }
 


### PR DESCRIPTION
Inlines the `depPath` within the `throwCyclicDependencyError`, because it's not being tree-shaken in production.

![image](https://github.com/user-attachments/assets/bc31ef4f-6d70-48cc-9b66-717543f195cb)
