### PR TITLE
docs: fix self-closing-tags-migration command

### DIFF
--- a/adev/src/content/reference/migrations/self-closing-tags.md
+++ b/adev/src/content/reference/migrations/self-closing-tags.md
@@ -8,7 +8,7 @@ Run the schematic using the following command:
 
 <docs-code language="shell">
 
-ng generate @angular/core:self-closing-tag
+ng generate @angular/core:self-closing-tags-migration
 
 </docs-code>
 

--- a/packages/core/schematics/ng-generate/self-closing-tags-migration/README.md
+++ b/packages/core/schematics/ng-generate/self-closing-tags-migration/README.md
@@ -6,13 +6,13 @@ This is a purely aesthetic change and does not affect the behavior of the applic
 The migration can be run using the following command:
 
 ```bash
-ng generate @angular/core:self-closing-tag
+ng generate @angular/core:self-closing-tags-migration
 ```
 
 By default, the migration will go over the entire application. If you want to apply this migration to a subset of the files, you can pass the path argument as shown below:
 
 ```bash
-ng generate @angular/core:self-closing-tag --path src/app/sub-component
+ng generate @angular/core:self-closing-tags-migration --path src/app/sub-component
 ```
 
 ### How does it work?


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The actual command is `ng generate @angular/core:self-closing-tags-migration` instead of the declared in the docs.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
