### PR TITLE
fix(language-service): provide correct rename info for elements

### DIFF
--- a/packages/language-service/src/references_and_rename_utils.ts
+++ b/packages/language-service/src/references_and_rename_utils.ts
@@ -16,6 +16,7 @@ import {
   TmplAstBoundEvent,
   TmplAstLetDeclaration,
   TmplAstNode,
+  TmplAstElement,
   TmplAstReference,
   TmplAstTextAttribute,
   TmplAstVariable,
@@ -341,9 +342,7 @@ export function getRenameTextAndSpanAtPosition(
     } else if (node.valueSpan && isWithin(position, node.valueSpan)) {
       return {text: node.valueSpan.toString(), span: toTextSpan(node.valueSpan)};
     }
-  }
-
-  if (
+  } else if (
     node instanceof PropertyRead ||
     node instanceof PropertyWrite ||
     node instanceof SafePropertyRead ||
@@ -359,6 +358,8 @@ export function getRenameTextAndSpanAtPosition(
       span.length -= 2;
     }
     return {text, span};
+  } else if (node instanceof TmplAstElement) {
+    return {text: node.name, span: toTextSpan(node.startSourceSpan)};
   }
 
   return null;

--- a/packages/language-service/test/references_and_rename_spec.ts
+++ b/packages/language-service/test/references_and_rename_spec.ts
@@ -1814,6 +1814,14 @@ describe('find references and rename locations', () => {
       });
 
       it('finds rename locations', () => {
+        env.expectNoSourceDiagnostics();
+        const result = file.getRenameInfo() as ts.RenameInfoSuccess;
+        // Note that although we do not provide rename locations, we must _not_ respond with
+        // a result that indicates the item cannot be renamed when info is requested or we will prevent
+        // other rename providers from performing the rename.
+        expect(result.canRename).toBeTrue();
+        expect(result.displayName).toEqual('my-comp');
+        expect(result.kind).toEqual('component');
         const renameLocations = getRenameLocationsAtPosition(file)!;
         expect(renameLocations).toBeUndefined();
         // TODO(atscott): We may consider supporting rename of component selector in the future


### PR DESCRIPTION
This commit ensures we do not block element rename if it is supported by other rename providers.

fixes https://github.com/angular/vscode-ng-language-service/issues/2077
