### PR TITLE
fix(core): ensures triggers fire properly with lazy loaded routes

### DIFF
--- a/packages/core/src/hydration/utils.ts
+++ b/packages/core/src/hydration/utils.ts
@@ -562,17 +562,13 @@ export function convertHydrateTriggersToJsAction(
  * hierarchical order as a list of defer block ids.
  * Note: This is utilizing serialized information to navigate up the tree
  */
-export function getParentBlockHydrationQueue(
-  deferBlockId: string,
-  injector: Injector,
-): {parentBlockPromise: Promise<void> | null; hydrationQueue: string[]} {
+export function getParentBlockHydrationQueue(deferBlockId: string, injector: Injector): string[] {
   const dehydratedBlockRegistry = injector.get(DEHYDRATED_BLOCK_REGISTRY);
   const transferState = injector.get(TransferState);
   const deferBlockParents = transferState.get(NGH_DEFER_BLOCKS_KEY, {});
 
   let isTopMostDeferBlock = false;
   let currentBlockId: string | undefined = deferBlockId;
-  let parentBlockPromise: Promise<void> | null = null;
   const hydrationQueue: string[] = [];
 
   while (!isTopMostDeferBlock && currentBlockId) {
@@ -585,15 +581,11 @@ export function getParentBlockHydrationQueue(
 
     isTopMostDeferBlock = dehydratedBlockRegistry.has(currentBlockId);
     const hydratingParentBlock = dehydratedBlockRegistry.hydrating.get(currentBlockId);
-    if (parentBlockPromise === null && hydratingParentBlock != null) {
-      // TODO: add an ngDevMode asset that `hydratingParentBlock.promise` exists and is of type Promise.
-      parentBlockPromise = hydratingParentBlock.promise;
-      break;
-    }
+    if (hydratingParentBlock != null) break;
     hydrationQueue.unshift(currentBlockId);
     currentBlockId = deferBlockParents[currentBlockId][DEFER_PARENT_BLOCK_ID];
   }
-  return {parentBlockPromise, hydrationQueue};
+  return hydrationQueue;
 }
 
 function gatherDeferBlocksByJSActionAttribute(doc: Document): Set<HTMLElement> {

--- a/packages/platform-server/test/incremental_hydration_spec.ts
+++ b/packages/platform-server/test/incremental_hydration_spec.ts
@@ -1202,7 +1202,7 @@ describe('platform-server partial hydration integration', () => {
         appRef.tick();
 
         expect(appHostNode.outerHTML).toContain('<span id="test">end</span>');
-      }, 100_000);
+      });
 
       describe('idle', () => {
         /**
@@ -2618,6 +2618,84 @@ describe('platform-server partial hydration integration', () => {
       expect(location.path()).toBe('/other/thing/stuff');
 
       expect(appHostNode.outerHTML).toContain('<p>OtherCmp content</p>');
+    });
+
+    it('should trigger immediate with a lazy loaded route', async () => {
+      @Component({
+        selector: 'lazy',
+        template: `
+          @defer (hydrate on immediate) {
+            <button id="click-me" (click)="clickMe()">Click me I'm dehydrated?</button>
+          }
+          <p id="stuff">{{stuff()}}</p>
+        `,
+      })
+      class LazyCmp {
+        stuff = signal('');
+        clickMe() {
+          this.stuff.set('stuff');
+        }
+      }
+
+      const routes: Routes = [
+        {
+          path: '',
+          loadComponent: () => dynamicImportOf(LazyCmp, 100),
+        },
+      ];
+
+      @Component({
+        selector: 'app',
+        imports: [RouterOutlet],
+        template: `
+          Works!
+          <router-outlet />
+        `,
+      })
+      class SimpleComponent {
+        location = inject(Location);
+      }
+
+      const appId = 'custom-app-id';
+      const providers = [
+        {provide: APP_ID, useValue: appId},
+        {provide: PlatformLocation, useClass: MockPlatformLocation},
+        provideRouter(routes),
+      ] as unknown as Provider[];
+      const hydrationFeatures = () => [withIncrementalHydration()];
+
+      const html = await ssr(SimpleComponent, {envProviders: providers, hydrationFeatures});
+      const ssrContents = getAppContents(html);
+
+      expect(ssrContents).toContain(
+        `<button id="click-me" jsaction="click:;" ngb="d0">Click me I'm dehydrated?</button>`,
+      );
+      expect(ssrContents).not.toContain('<p id="stuff">stuff</p>');
+
+      resetTViewsFor(SimpleComponent, LazyCmp);
+
+      const doc = getDocument();
+      const appRef = await prepareEnvironmentAndHydrate(doc, html, SimpleComponent, {
+        envProviders: [...providers],
+        hydrationFeatures,
+      });
+      const compRef = getComponentRef<SimpleComponent>(appRef);
+      await appRef.whenStable();
+
+      await allPendingDynamicImports();
+      const appHostNode = compRef.location.nativeElement;
+
+      expect(appHostNode.outerHTML).toContain(
+        `<button id="click-me">Click me I'm dehydrated?</button>`,
+      );
+
+      const clickMe = doc.getElementById('click-me')!;
+      const clickEvent = new CustomEvent('click', {bubbles: true});
+      clickMe.dispatchEvent(clickEvent);
+      await allPendingDynamicImports();
+      await appRef.whenStable();
+
+      expect(appHostNode.outerHTML).toContain('<p id="stuff">stuff</p>');
     });
   });
 });


### PR DESCRIPTION
In the case that a route was lazy loaded, the immediate and viewport triggers would never properly finish hydrating due to things firing in a different order. This ensures app stability is present with both immediate and viewport triggers and that the promise for the defer block is present at the right time.

fixes #59997

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

