### PR TITLE
fix(core): Ensure ComponentFixture does not duplicate error reporting…

### DIFF
--- a/packages/zone.js/lib/zone-spec/fake-async-test.ts
+++ b/packages/zone.js/lib/zone-spec/fake-async-test.ts
@@ -780,6 +780,8 @@ class FakeAsyncTestZoneSpec implements ZoneSpec {
     targetZone: Zone,
     error: any,
   ): boolean {
+    // ComponentFixture has a special-case handling to detect FakeAsyncTestZoneSpec
+    // and prevent rethrowing the error from the onError subscription since it's handled here.
     this._lastError = error;
     return false; // Don't propagate error to parent zone.
   }


### PR DESCRIPTION
… from FakeAsync

When using `fakeAsync`, if errors happen inside the Angular zone, they are also handled by the fakeAsync machinery. Rethrowing errors from the `NgZone.onError` subscription is not appropriate in this case because it results in the error being thrown twice.

https://github.com/angular/angular/blob/db2f2d99c82aae52d8a0ae46616c6411d070b35e/packages/zone.js/lib/zone-spec/fake-async-test.ts#L783-L784 https://github.com/angular/angular/blob/db2f2d99c82aae52d8a0ae46616c6411d070b35e/packages/zone.js/lib/zone-spec/fake-async-test.ts#L473-L478
