### PR TITLE
refactor: add untracked to primitives

### DIFF
--- a/goldens/public-api/core/primitives/signals/index.api.md
+++ b/goldens/public-api/core/primitives/signals/index.api.md
@@ -173,6 +173,9 @@ export function signalSetFn<T>(node: SignalNode<T>, newValue: T): void;
 export function signalUpdateFn<T>(node: SignalNode<T>, updater: (value: T) => T): void;
 
 // @public
+export function untracked<T>(nonReactiveReadsFn: () => T): T;
+
+// @public
 export type ValueEqualityFn<T> = (a: T, b: T) => boolean;
 
 // @public (undocumented)

--- a/packages/core/primitives/signals/README.md
+++ b/packages/core/primitives/signals/README.md
@@ -65,6 +65,23 @@ counter.set(1);
 
 Effects do not execute synchronously with the set (see the section on glitch-free execution below), but are scheduled and resolved by the framework. The exact timing of effects is unspecified.
 
+## Untracked
+
+`untracked` executes an arbitrary function in a non-reactive (non-tracking) context. All signals read inside of the function are not added as a dependency to a surrounding `effect`.
+
+```typescript
+const counter = signal(0);
+const untrackedCounter = signal(0)
+effect(() => console.log(`counter: ${counter()}, untrackedCounter: ${untracked(untrackedCounter)}`);
+// counter: 0, untrackedCounter: 0
+
+untrackedCounter.set(1);
+// effect does not rerun because untrackedCounter was untracked 
+
+counter.set(1);
+// counter: 1, untrackedCounter: 1
+```
+
 ## Producer and Consumer
 
 Internally, the signals implementation is defined in terms of two abstractions, producers and consumers. Producers represents values which can deliver change notifications, such as the various flavors of `Signal`s. Consumers represents a reactive context which may depend on some number of producers. In other words, producers produce reactivity, and consumers consume it.

--- a/packages/core/primitives/signals/README.md
+++ b/packages/core/primitives/signals/README.md
@@ -71,8 +71,8 @@ Effects do not execute synchronously with the set (see the section on glitch-fre
 
 ```typescript
 const counter = signal(0);
-const untrackedCounter = signal(0)
-effect(() => console.log(`counter: ${counter()}, untrackedCounter: ${untracked(untrackedCounter)}`);
+const untrackedCounter = signal(0);
+effect(() => console.log(`counter: ${counter()}, untrackedCounter: ${untracked(untrackedCounter)}`));
 // counter: 0, untrackedCounter: 0
 
 untrackedCounter.set(1);

--- a/packages/core/primitives/signals/index.ts
+++ b/packages/core/primitives/signals/index.ts
@@ -50,3 +50,4 @@ export {
 } from './src/signal';
 export {Watch, WatchCleanupFn, WatchCleanupRegisterFn, createWatch} from './src/watch';
 export {setAlternateWeakRefImpl} from './src/weak_ref';
+export {untracked} from './src/untracked';

--- a/packages/core/primitives/signals/src/untracked.ts
+++ b/packages/core/primitives/signals/src/untracked.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {setActiveConsumer} from './graph';
+
+/**
+ * Execute an arbitrary function in a non-reactive (non-tracking) context. The executed function
+ * can, optionally, return a value.
+ */
+export function untracked<T>(nonReactiveReadsFn: () => T): T {
+  const prevConsumer = setActiveConsumer(null);
+  // We are not trying to catch any particular errors here, just making sure that the consumers
+  // stack is restored in case of errors.
+  try {
+    return nonReactiveReadsFn();
+  } finally {
+    setActiveConsumer(prevConsumer);
+  }
+}

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -719,6 +719,7 @@
   "init_type_checks",
   "init_types",
   "init_untracked",
+  "init_untracked2",
   "init_url_sanitizer",
   "init_util",
   "init_util2",

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -620,7 +620,7 @@
   "trackMovedView",
   "uniqueIdCounter",
   "unregisterLView",
-  "untracked",
+  "untracked2",
   "unwrapRNode",
   "updateAncestorTraversalFlagsOnAttach",
   "updateControl",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -613,7 +613,7 @@
   "trackMovedView",
   "uniqueIdCounter",
   "unregisterLView",
-  "untracked",
+  "untracked2",
   "unwrapRNode",
   "updateAncestorTraversalFlagsOnAttach",
   "updateControl",


### PR DESCRIPTION
add untracked to primitives to allow Wiz to use it

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
untracked is not available in primitives

Issue Number: N/A


## What is the new behavior?
untracked is available in primitives

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
