### PR TITLE
refactor(http): rename `map` to `parse` on `HttpResourceOptions`

### DIFF
--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -2208,7 +2208,7 @@ export interface HttpResourceOptions<TResult, TRaw> {
     defaultValue?: NoInfer<TResult>;
     equal?: ValueEqualityFn<NoInfer<TResult>>;
     injector?: Injector;
-    map?: (value: TRaw) => TResult;
+    parse?: (value: TRaw) => TResult;
 }
 
 // @public

--- a/packages/common/http/src/resource.ts
+++ b/packages/common/http/src/resource.ts
@@ -239,7 +239,7 @@ function makeHttpResourceFn<TRaw>(responseType: 'arraybuffer' | 'blob' | 'json' 
       injector,
       () => normalizeRequest(request, responseType),
       options?.defaultValue,
-      options?.map as (value: unknown) => TResult,
+      options?.parse as (value: unknown) => TResult,
     ) as HttpResourceRef<TResult>;
   };
 }
@@ -312,7 +312,7 @@ class HttpResourceImpl<T>
     injector: Injector,
     request: () => HttpRequest<T> | undefined,
     defaultValue: T,
-    map?: (value: unknown) => T,
+    parse?: (value: unknown) => T,
   ) {
     super(
       request,
@@ -342,7 +342,7 @@ class HttpResourceImpl<T>
                 this._headers.set(event.headers);
                 this._statusCode.set(event.status);
                 try {
-                  send({value: map ? map(event.body) : (event.body as T)});
+                  send({value: parse ? parse(event.body) : (event.body as T)});
                 } catch (error) {
                   send({error});
                 }

--- a/packages/common/http/src/resource_api.ts
+++ b/packages/common/http/src/resource_api.ts
@@ -81,12 +81,12 @@ export interface HttpResourceOptions<TResult, TRaw> {
   /**
    * Transform the result of the HTTP request before it's delivered to the resource.
    *
-   * `map` receives the value from the HTTP layer as its raw type (e.g. as `unknown` for JSON data).
+   * `parse` receives the value from the HTTP layer as its raw type (e.g. as `unknown` for JSON data).
    * It can be used to validate or transform the type of the resource, and return a more specific
    * type. This is also useful for validating backend responses using a runtime schema validation
    * library such as Zod.
    */
-  map?: (value: TRaw) => TResult;
+  parse?: (value: TRaw) => TResult;
 
   /**
    * Value that the resource will take when in Idle, Loading, or Error states.

--- a/packages/common/http/test/resource_spec.ts
+++ b/packages/common/http/test/resource_spec.ts
@@ -154,7 +154,7 @@ describe('httpResource', () => {
       },
       {
         injector: TestBed.inject(Injector),
-        map: (value) => JSON.stringify(value),
+        parse: (value) => JSON.stringify(value),
       },
     );
     TestBed.flushEffects();


### PR DESCRIPTION
This reflects more the feature intended for this callback.
