### PR TITLE
refactor(core): throw an Cyclic Dependency Error in prod mode

### DIFF
--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -469,7 +469,7 @@ export class R3Injector extends EnvironmentInjector {
   private hydrate<T>(token: ProviderToken<T>, record: Record<T>): T {
     const prevConsumer = setActiveConsumer(null);
     try {
-      if (ngDevMode && record.value === CIRCULAR) {
+      if (record.value === CIRCULAR) {
         throwCyclicDependencyError(stringify(token));
       } else if (record.value === NOT_YET) {
         record.value = CIRCULAR;

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -476,6 +476,7 @@
   "stringify",
   "stringifyCSSSelector",
   "style",
+  "throwCyclicDependencyError",
   "throwProviderNotFoundError",
   "timeoutProvider",
   "transition",

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -502,6 +502,7 @@
   "stringify",
   "stringifyCSSSelector",
   "style",
+  "throwCyclicDependencyError",
   "throwProviderNotFoundError",
   "timeoutProvider",
   "transition",

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -408,6 +408,7 @@
   "storeLViewOnDestroy",
   "stringify",
   "stringifyCSSSelector",
+  "throwCyclicDependencyError",
   "throwProviderNotFoundError",
   "timeoutProvider",
   "uniqueIdCounter",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -875,6 +875,7 @@
   "storeLViewOnDestroy",
   "stringify",
   "stringifyCSSSelector",
+  "throwCyclicDependencyError",
   "throwProviderNotFoundError",
   "timeoutProvider",
   "trackMovedView",

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -613,6 +613,7 @@
   "storeLViewOnDestroy",
   "stringify",
   "stringifyCSSSelector",
+  "throwCyclicDependencyError",
   "throwInvalidWriteToSignalError",
   "throwInvalidWriteToSignalErrorFn",
   "throwProviderNotFoundError",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -606,6 +606,7 @@
   "storeLViewOnDestroy",
   "stringify",
   "stringifyCSSSelector",
+  "throwCyclicDependencyError",
   "throwInvalidWriteToSignalError",
   "throwInvalidWriteToSignalErrorFn",
   "throwProviderNotFoundError",

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -328,6 +328,7 @@
   "storeLViewOnDestroy",
   "stringify",
   "stringifyCSSSelector",
+  "throwCyclicDependencyError",
   "throwProviderNotFoundError",
   "timeoutProvider",
   "uniqueIdCounter",

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -440,6 +440,7 @@
   "stringify",
   "stringifyCSSSelector",
   "subscribeOn",
+  "throwCyclicDependencyError",
   "throwProviderNotFoundError",
   "timeoutProvider",
   "transferCacheInterceptorFn",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -702,6 +702,7 @@
   "take",
   "takeLast",
   "tap",
+  "throwCyclicDependencyError",
   "throwError2",
   "throwIfEmpty",
   "throwInvalidWriteToSignalErrorFn",

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -365,6 +365,7 @@
   "storeLViewOnDestroy",
   "stringify",
   "stringifyCSSSelector",
+  "throwCyclicDependencyError",
   "throwProviderNotFoundError",
   "timeoutProvider",
   "uniqueIdCounter",

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -489,6 +489,7 @@
   "storeLViewOnDestroy",
   "stringify",
   "stringifyCSSSelector",
+  "throwCyclicDependencyError",
   "throwProviderNotFoundError",
   "timeoutProvider",
   "toTStylingRange",


### PR DESCRIPTION
Prior to this change, cyclic injection didn't trigger any error in prod mode, resulting into injecting the `CIRCULAR` object. This could lead to strange errors where no method would be found on the token.

fixes #60074
