### PR TITLE
docs: fix mermaid event node text visibility in light mode

### DIFF
--- a/adev/shared-docs/styles/docs/_mermaid.scss
+++ b/adev/shared-docs/styles/docs/_mermaid.scss
@@ -58,7 +58,7 @@
     fill: var(--page-background) !important;
   }
 
-  .nodeLabel:not(.node:has(polygon) .nodeLabel) {
+  .nodeLabel:not(.node:has(polygon) .nodeLabel):not(.eventNode .nodeLabel) {
     fill: var(--primary-contrast) !important;
     color: var(--primary-contrast) !important;
   }
@@ -71,7 +71,6 @@
     }
 
     .nodeLabel p {
-      color: var(--page-background) !important;
       font-weight: 800 !important;
     }
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
https://angular.dev/best-practices/skipping-subtrees#an-event-is-handled-by-a-descendant-of-a-component-with-onpush
Mermaid diagram event node text is not visible when using light mode theme. (white text on light yellow background)
![image](https://github.com/user-attachments/assets/6c3895ff-6e4e-4d25-93fb-29ebad982869)

## What is the new behavior?
The text inside mermaid diagram event nodes is now visible in dark mode.
![image](https://github.com/user-attachments/assets/1b572696-0636-4101-9d59-557c3d867719)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


