### PR TITLE
refactor(compiler): rework how parens are emitted

### DIFF
--- a/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
@@ -462,6 +462,10 @@ export class ExpressionTranslatorVisitor<TFile, TStatement, TExpression>
     );
   }
 
+  visitParenthesizedExpr(ast: o.ParenthesizedExpr, context: any) {
+    return this.factory.createParenthesizedExpression(ast.expr.visitExpression(this, context));
+  }
+
   private visitStatements(statements: o.Statement[], context: Context): TStatement[] {
     return statements
       .map((stmt) => stmt.visitStatement(this, context))

--- a/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
@@ -280,6 +280,10 @@ class TypeTranslatorVisitor implements o.ExpressionVisitor, o.TypeVisitor {
     throw new Error('Method not implemented.');
   }
 
+  visitParenthesizedExpr(ast: o.ParenthesizedExpr, context: any) {
+    throw new Error('Method not implemented.');
+  }
+
   private translateType(type: o.Type, context: Context): ts.TypeNode {
     const typeNode = type.visitType(this, context);
     if (!ts.isTypeNode(typeNode)) {

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -94,6 +94,7 @@ export {
   MapType,
   NONE_TYPE,
   NotExpr,
+  ParenthesizedExpr,
   ReadKeyExpr,
   ReadPropExpr,
   ReadVarExpr,

--- a/packages/compiler/src/render3/util.ts
+++ b/packages/compiler/src/render3/util.ts
@@ -75,7 +75,6 @@ export function guardedExpression(guard: string, expr: o.Expression): o.Expressi
     guardExpr,
     /* type */ undefined,
     /* sourceSpan */ undefined,
-    true,
   );
   return new o.BinaryOperatorExpr(o.BinaryOperator.And, guardUndefinedOrTrue, expr);
 }

--- a/packages/compiler/src/render3/view/query_generation.ts
+++ b/packages/compiler/src/render3/view/query_generation.ts
@@ -17,7 +17,7 @@ import {CONTEXT_NAME, RENDER_FLAGS, TEMPORARY_NAME, temporaryAllocator} from './
 
 //  if (rf & flags) { .. }
 function renderFlagCheckIfStmt(flags: core.RenderFlags, statements: o.Statement[]): o.IfStmt {
-  return o.ifStmt(o.variable(RENDER_FLAGS).bitwiseAnd(o.literal(flags), null, false), statements);
+  return o.ifStmt(o.variable(RENDER_FLAGS).bitwiseAnd(o.literal(flags), null), statements);
 }
 
 /**

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -1318,6 +1318,8 @@ export function transformExpressionsInExpression(
     for (let i = 0; i < expr.expressions.length; i++) {
       expr.expressions[i] = transformExpressionsInExpression(expr.expressions[i], transform, flags);
     }
+  } else if (expr instanceof o.ParenthesizedExpr) {
+    expr.expr = transformExpressionsInExpression(expr.expr, transform, flags);
   } else if (
     expr instanceof o.ReadVarExpr ||
     expr instanceof o.ExternalExpr ||


### PR DESCRIPTION
Instead of using a property on BinaryOperatorExpr / UnaryOperatorExpr, introduce a ParenthesizedExpr which can be used to parenthesize any expression.
