### PR TITLE
fix(core): prevents event replay from being called on comment nodes

### DIFF
--- a/packages/core/src/event_delegation_utils.ts
+++ b/packages/core/src/event_delegation_utils.ts
@@ -57,8 +57,8 @@ export const sharedStashFunction = (rEl: RElement, eventType: string, listenerFn
 };
 
 export const sharedMapFunction = (rEl: RElement, jsActionMap: Map<string, Set<Element>>) => {
-  let blockName = rEl.getAttribute(DEFER_BLOCK_SSR_ID_ATTRIBUTE) ?? '';
   const el = rEl as unknown as Element;
+  let blockName = el.getAttribute(DEFER_BLOCK_SSR_ID_ATTRIBUTE) ?? '';
   const blockSet = jsActionMap.get(blockName) ?? new Set<Element>();
   if (!blockSet.has(el)) {
     blockSet.add(el);

--- a/packages/core/src/render3/instructions/listener.ts
+++ b/packages/core/src/render3/instructions/listener.ts
@@ -12,7 +12,7 @@ import {NotificationSource} from '../../change_detection/scheduling/zoneless_sch
 import {assertIndexInRange} from '../../util/assert';
 import {TNode, TNodeType} from '../interfaces/node';
 import {GlobalTargetResolver, Renderer} from '../interfaces/renderer';
-import {RElement} from '../interfaces/renderer_dom';
+import {RElement, RNode} from '../interfaces/renderer_dom';
 import {isComponentHost, isDirectiveHost} from '../interfaces/type_checks';
 import {CLEANUP, CONTEXT, LView, RENDERER, TView} from '../interfaces/view';
 import {assertTNodeType} from '../node_assert';
@@ -37,7 +37,7 @@ import {DirectiveDef} from '../interfaces/definition';
  * an actual implementation when the event replay feature is enabled via
  * `withEventReplay()` call.
  */
-let stashEventListener = (el: RElement, eventName: string, listenerFn: (e?: any) => any) => {};
+let stashEventListener = (el: RNode, eventName: string, listenerFn: (e?: any) => any) => {};
 
 export function setStashFn(fn: typeof stashEventListener) {
   stashEventListener = fn;
@@ -218,7 +218,7 @@ export function listenerInternal(
       processOutputs = false;
     } else {
       listenerFn = wrapListener(tNode, lView, context, listenerFn);
-      stashEventListener(native, eventName, listenerFn);
+      stashEventListener(target as RElement, eventName, listenerFn);
       const cleanupFn = renderer.listen(target as RElement, eventName, listenerFn);
       ngDevMode && ngDevMode.rendererAddEventListener++;
 

--- a/packages/platform-server/test/BUILD.bazel
+++ b/packages/platform-server/test/BUILD.bazel
@@ -15,11 +15,16 @@ circular_dependency_test(
 
 ts_library(
     name = "dom_utils",
-    srcs = ["dom_utils.ts"],
+    srcs = [
+        "dom_utils.ts",
+        "hydration_utils.ts",
+    ],
     deps = [
         "//packages/common",
         "//packages/core",
+        "//packages/core/testing",
         "//packages/platform-browser",
+        "//packages/platform-server",
     ],
 )
 
@@ -30,6 +35,7 @@ ts_library(
         ["*.ts"],
         exclude = [
             "event_replay_spec.ts",
+            "hydration_utils.ts",
             "dom_utils.ts",
         ],
     ),


### PR DESCRIPTION
In some rare cases with directives, it is possible that the stash function might be called on a comment node. This actually verifies that the node is an element and exits otherwise. A second commit also cleans up the event replay tests to use all the same utilities as hydration tests.
    
fixes: #60070

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
