### PR TITLE
refactor(devtools): use more appropriate cursor types while panning in the tree vis

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/tree-visualizer-host/tree-visualizer-host.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/tree-visualizer-host/tree-visualizer-host.component.scss
@@ -3,7 +3,11 @@
   height: 100%;
 
   svg {
-    cursor: move;
+    cursor: grab;
+
+    &.panning {
+      cursor: grabbing;
+    }
 
     ::ng-deep {
       .node-hidden,

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/tree-visualizer-host/tree-visualizer-host.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/tree-visualizer-host/tree-visualizer-host.component.ts
@@ -6,12 +6,17 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, ElementRef, viewChild} from '@angular/core';
+import {Component, ElementRef, signal, viewChild} from '@angular/core';
 
 @Component({
   selector: 'ng-tree-visualizer-host',
   template: `
-    <svg #container>
+    <svg
+      #container
+      [class.panning]="panning()"
+      (pointerdown)="panning.set(true)"
+      (pointerup)="panning.set(false)"
+    >
       <g #group></g>
     </svg>
   `,
@@ -20,4 +25,6 @@ import {Component, ElementRef, viewChild} from '@angular/core';
 export class TreeVisualizerHostComponent {
   readonly container = viewChild.required<ElementRef>('container');
   readonly group = viewChild.required<ElementRef>('group');
+
+  panning = signal<boolean>(false);
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Static `cursor: move`.

## What is the new behavior?

A minor UX improvement: Use `grab` and `grabbing` cursors while panning. They are the de facto standard. Note that I am using `pointer*` events since [there is a conflict](https://github.com/d3/d3-zoom/issues/66#issuecomment-255175895) with `mouse*` events due to D3 zoom. They should suffice our needs.

cc @dgp1130 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
