### PR TITLE
refactor(core): mark `@Inject(string)` as deprecated

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -902,7 +902,11 @@ export interface InjectableType<T> extends Type<T> {
 
 // @public
 export interface InjectDecorator {
+    // @deprecated (undocumented)
+    (token: string): any;
     (token: any): any;
+    // (undocumented)
+    new (token: string): Inject;
     // (undocumented)
     new (token: any): Inject;
 }

--- a/packages/core/src/di/metadata.ts
+++ b/packages/core/src/di/metadata.ts
@@ -18,6 +18,12 @@ import {DecoratorFlags, InternalInjectFlags} from './interface/injector';
  */
 export interface InjectDecorator {
   /**
+   * @deprecated Use an InjectionToken or a class instead
+   */
+  (token: string): any;
+  new (token: string): Inject;
+
+  /**
    * Parameter decorator on a dependency parameter of a class constructor
    * that specifies a custom provider of the dependency.
    *
@@ -33,6 +39,7 @@ export interface InjectDecorator {
    * @see [Dependency Injection Guide](guide/di/dependency-injection
    *
    */
+
   (token: any): any;
   new (token: any): Inject;
 }


### PR DESCRIPTION
Strings as injection tokens are long deprecated.

DEPRECATED: @Inject('myString')
