### PR TITLE
fix(core): cache ComponentRef inputs and outputs

### DIFF
--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -186,6 +186,15 @@ export class ComponentFactory<T> extends AbstractComponentFactory<T> {
   override componentType: Type<any>;
   override ngContentSelectors: string[];
   isBoundToModule: boolean;
+  private cachedInputs:
+    | {
+        propName: string;
+        templateName: string;
+        isSignal: boolean;
+        transform?: (value: any) => any;
+      }[]
+    | null = null;
+  private cachedOutputs: {propName: string; templateName: string}[] | null = null;
 
   override get inputs(): {
     propName: string;
@@ -193,11 +202,13 @@ export class ComponentFactory<T> extends AbstractComponentFactory<T> {
     isSignal: boolean;
     transform?: (value: any) => any;
   }[] {
-    return toInputRefArray(this.componentDef.inputs);
+    this.cachedInputs ??= toInputRefArray(this.componentDef.inputs);
+    return this.cachedInputs;
   }
 
   override get outputs(): {propName: string; templateName: string}[] {
-    return toOutputRefArray(this.componentDef.outputs);
+    this.cachedOutputs ??= toOutputRefArray(this.componentDef.outputs);
+    return this.cachedOutputs;
   }
 
   /**


### PR DESCRIPTION
The set of inputs and outputs of a component is static, but the getter for the `inputs` and `outputs` property was re-computing them every time which the user might not expect. These changes add a couple of lines to cache them instead.
