### PR TITLE
docs: fix broke $localize links

### DIFF
--- a/packages/localize/src/translate.ts
+++ b/packages/localize/src/translate.ts
@@ -58,7 +58,7 @@ declare const $localize: LocalizeFn & {TRANSLATIONS: Record<MessageId, ParsedTra
  * These messages are processed and added to a lookup based on their `MessageId`.
  *
  * @see {@link clearTranslations} for removing translations loaded using this function.
- * @see {@link $localize} for tagging messages as needing to be translated.
+ * @see [$localize](api/localize/init/$localize) for tagging messages as needing to be translated.
  * @publicApi
  */
 export function loadTranslations(translations: Record<MessageId, TargetMessage>) {
@@ -80,7 +80,7 @@ export function loadTranslations(translations: Record<MessageId, TargetMessage>)
  * All translations that had been loading into memory using `loadTranslations()` will be removed.
  *
  * @see {@link loadTranslations} for loading translations at runtime.
- * @see {@link $localize} for tagging messages as needing to be translated.
+ * @see [$localize](api/localize/init/$localize) for tagging messages as needing to be translated.
  *
  * @publicApi
  */


### PR DESCRIPTION
Remove JSDocs link, and replace with automatic linking with a regular markdown link

Fixes #59983

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
