### PR TITLE
perf(core): avoid marking components for check from signal input changes

### DIFF
--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -38,6 +38,7 @@ import {renderView} from './instructions/render';
 import {
   createDirectivesInstances,
   locateHostElement,
+  REQUIRES_MARK_FOR_CHECK,
   setAllInputsForProperty,
 } from './instructions/shared';
 import {ComponentDef, DirectiveDef} from './interfaces/definition';
@@ -391,12 +392,13 @@ export class ComponentRef<T> extends AbstractComponentRef<T> {
     }
 
     const lView = this._rootLView;
-    const hasSetInput = setAllInputsForProperty(tNode, lView[TVIEW], lView, name, value);
+    const flags = setAllInputsForProperty(tNode, lView[TVIEW], lView, name, value);
     this.previousInputValues.set(name, value);
     const childComponentLView = getComponentLViewByIndex(tNode.index, lView);
-    markViewDirty(childComponentLView, NotificationSource.SetInput);
+    flags & REQUIRES_MARK_FOR_CHECK &&
+      markViewDirty(childComponentLView, NotificationSource.SetInput);
 
-    if (ngDevMode && !hasSetInput) {
+    if (ngDevMode && !flags) {
       const cmpNameForError = stringifyForError(this.componentType);
       let message = `Can't set value of the '${name}' input on the '${cmpNameForError}' component. `;
       message += `Make sure that the '${name}' property is annotated with @Input() or a mapped @Input('${name}') exists.`;


### PR DESCRIPTION
When signal inputs were introduced, we chose to treat them identically to property inputs for purposes of input setting logic (ngOnChanges, marking for check, ng-reflect, etc). This made sense to ensure switching from `@Input` to `input()` was as seamless and non-breaking as possible.

However, a consequence of this choice is that a property binding to an input signal causes the receiving component to be marked for check even if the input signal is _not_ used in the template directly. For example, it could be used in a `computed` which might not actually change, or it may only be used to drive an `effect`. In those cases, it's unnecessary to check the template at all.

This commit introduces logic to treat input signals differently in the binding path, and avoid marking components for check _purely_ when the input changes. If the input signal is used in the template (either directly or indirectly) the signal change notification will cause the template to be checked via the fast path for signals.
