### PR TITLE
refactor(http): add `context` property to `httpResource`

### DIFF
--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -1741,6 +1741,7 @@ export interface HttpResourceRef<T> extends WritableResource<T>, ResourceRef<T> 
 // @public
 export interface HttpResourceRequest {
     body?: unknown;
+    context?: HttpContext;
     headers?: HttpHeaders | Record<string, string | ReadonlyArray<string>>;
     method?: string;
     params?: HttpParams | Record<string, string | number | boolean | ReadonlyArray<string | number | boolean>>;

--- a/packages/common/http/src/resource_api.ts
+++ b/packages/common/http/src/resource_api.ts
@@ -10,6 +10,7 @@ import type {Injector, ResourceRef, Signal, ValueEqualityFn, WritableResource} f
 import type {HttpHeaders} from './headers';
 import type {HttpParams} from './params';
 import type {HttpProgressEvent} from './response';
+import {HttpContext} from './context';
 
 /**
  * The structure of an `httpResource` request which will be sent to the backend.
@@ -49,6 +50,11 @@ export interface HttpResourceRequest {
    * Dictionary of headers to include with the outgoing request.
    */
   headers?: HttpHeaders | Record<string, string | ReadonlyArray<string>>;
+
+  /**
+   * Context of the request stored in a dictionary of key-value pairs.
+   */
+  context?: HttpContext;
 
   /**
    * If `true`, progress events will be enabled for the request and delivered through the


### PR DESCRIPTION
This was an oversight, `context` can be supported out of the box.
