### PR TITLE
Internal compiler refactors

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -116,7 +116,7 @@ import {
   HandlerPrecedence,
   ResolveResult,
 } from '../../../transform';
-import {TemplateId, TypeCheckableDirectiveMeta, TypeCheckContext} from '../../../typecheck/api';
+import {TypeCheckId, TypeCheckableDirectiveMeta, TypeCheckContext} from '../../../typecheck/api';
 import {ExtendedTemplateChecker} from '../../../typecheck/extended/api';
 import {TemplateSemanticsChecker} from '../../../typecheck/template_semantics/api/api';
 import {getSourceFile} from '../../../util/src/typescript';
@@ -695,7 +695,8 @@ export class ComponentDecoratorHandler
         template.errors &&
         template.errors.length > 0
       ) {
-        // Template errors are handled at the type check phase. But we skip this phase in local compilation mode. As a result we need to handle the errors now and add them to the diagnostics.
+        // Template errors are handled at the type check phase. But we skip this phase in local
+        // compilation mode. As a result we need to handle the errors now and add them to the diagnostics.
         if (diagnostics === undefined) {
           diagnostics = [];
         }
@@ -703,7 +704,10 @@ export class ComponentDecoratorHandler
         diagnostics.push(
           ...getTemplateDiagnostics(
             template.errors,
-            '' as TemplateId, // Template ID is required as part of the template type check, mainly for mapping the template to its component class. But here we are generating the diagnostic outside of the type check context, and so we skip the template ID.
+            // Type check ID is required as part of the ype check, mainly for mapping the
+            // diagnostic back to its source. But here we are generating the diagnostic outside
+            // of the type check context, and so we skip the template ID.
+            '' as TypeCheckId,
             template.sourceMapping,
           ),
         );

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -116,7 +116,12 @@ import {
   HandlerPrecedence,
   ResolveResult,
 } from '../../../transform';
-import {TypeCheckId, TypeCheckableDirectiveMeta, TypeCheckContext} from '../../../typecheck/api';
+import {
+  TypeCheckId,
+  TypeCheckableDirectiveMeta,
+  TypeCheckContext,
+  TemplateContext,
+} from '../../../typecheck/api';
 import {ExtendedTemplateChecker} from '../../../typecheck/extended/api';
 import {TemplateSemanticsChecker} from '../../../typecheck/template_semantics/api/api';
 import {getSourceFile} from '../../../util/src/typescript';
@@ -1043,17 +1048,21 @@ export class ComponentDecoratorHandler
     }
 
     const binder = new R3TargetBinder<TypeCheckableDirectiveMeta>(scope.matcher);
-    ctx.addTemplate(
+    const templateContext: TemplateContext = {
+      nodes: meta.template.diagNodes,
+      pipes: scope.pipes,
+      sourceMapping: meta.template.sourceMapping,
+      file: meta.template.file,
+      parseErrors: meta.template.errors,
+      preserveWhitespaces: meta.meta.template.preserveWhitespaces ?? false,
+    };
+
+    ctx.addDirective(
       new Reference(node),
       binder,
-      meta.template.diagNodes,
-      scope.pipes,
       scope.schemas,
-      meta.template.sourceMapping,
-      meta.template.file,
-      meta.template.errors,
+      templateContext,
       meta.meta.isStandalone,
-      meta.meta.template.preserveWhitespaces ?? false,
     );
   }
 

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/metadata.ts
@@ -24,7 +24,7 @@ import ts from 'typescript';
 import {Reference} from '../../../imports';
 import {
   ClassPropertyMapping,
-  ComponentResources,
+  DirectiveResources,
   DirectiveTypeCheckMeta,
   HostDirectiveMeta,
   InputMapping,
@@ -74,7 +74,7 @@ export interface ComponentAnalysisData {
    */
   viewProvidersRequiringFactory: Set<Reference<ClassDeclaration>> | null;
 
-  resources: ComponentResources;
+  resources: DirectiveResources;
 
   /**
    * `styleUrls` extracted from the decorator, if present.

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/resources.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/resources.ts
@@ -22,10 +22,10 @@ import {ErrorCode, FatalDiagnosticError} from '../../../diagnostics';
 import {absoluteFrom} from '../../../file_system';
 import {DependencyTracker} from '../../../incremental/api';
 import {Resource} from '../../../metadata';
-import {DynamicValue, PartialEvaluator, traceDynamicValue} from '../../../partial_evaluator';
+import {PartialEvaluator} from '../../../partial_evaluator';
 import {ClassDeclaration, DeclarationNode, Decorator} from '../../../reflection';
 import {CompilationMode} from '../../../transform';
-import {TemplateSourceMapping} from '../../../typecheck/api';
+import {SourceMapping} from '../../../typecheck/api';
 import {
   createValueHasWrongTypeError,
   isStringArray,
@@ -82,7 +82,7 @@ export interface ParsedComponentTemplate extends ParsedTemplate {
 export interface ParsedTemplateWithSource extends ParsedComponentTemplate {
   /** The string contents of the template. */
   content: string;
-  sourceMapping: TemplateSourceMapping;
+  sourceMapping: SourceMapping;
   declaration: TemplateDeclaration;
 }
 
@@ -151,7 +151,7 @@ export function extractTemplate(
     let sourceStr: string;
     let sourceParseRange: LexerRange | null = null;
     let templateContent: string;
-    let sourceMapping: TemplateSourceMapping;
+    let sourceMapping: SourceMapping;
     let escapedString = false;
     let sourceMapUrl: string | null;
     // We only support SourceMaps for inline templates that are simple string literals.

--- a/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
@@ -230,8 +230,8 @@ runInEachFileSystem(() => {
         return fail('Failed to recognize @Component');
       }
       const {analysis} = handler.analyze(TestCmp, detected.metadata);
-      expect(analysis?.resources.template.path).toBeNull();
-      expect(analysis?.resources.template.expression.getText()).toEqual(`'${template}'`);
+      expect(analysis?.resources.template?.path).toBeNull();
+      expect(analysis?.resources.template?.expression.getText()).toEqual(`'${template}'`);
     });
 
     it('should keep track of external template', () => {
@@ -263,8 +263,8 @@ runInEachFileSystem(() => {
         return fail('Failed to recognize @Component');
       }
       const {analysis} = handler.analyze(TestCmp, detected.metadata);
-      expect(analysis?.resources.template.path).toContain(templateUrl);
-      expect(analysis?.resources.template.expression.getText()).toContain(`'${templateUrl}'`);
+      expect(analysis?.resources.template?.path).toContain(templateUrl);
+      expect(analysis?.resources.template?.expression.getText()).toContain(`'${templateUrl}'`);
     });
 
     it('should keep track of internal and external styles', () => {
@@ -300,7 +300,7 @@ runInEachFileSystem(() => {
         return fail('Failed to recognize @Component');
       }
       const {analysis} = handler.analyze(TestCmp, detected.metadata);
-      expect(analysis?.resources.styles.size).toBe(3);
+      expect(analysis?.resources.styles?.size).toBe(3);
     });
 
     it('should use an empty source map URL for an indirect template', () => {
@@ -402,7 +402,7 @@ runInEachFileSystem(() => {
         return fail('Failed to recognize @Component');
       }
       const {analysis} = handler.analyze(TestCmp, detected.metadata);
-      expect(analysis?.resources.styles.size).toBe(2);
+      expect(analysis?.resources.styles?.size).toBe(2);
       expect(analysis?.meta.externalStyles).toEqual(['/myStyle.css']);
     });
 
@@ -438,7 +438,7 @@ runInEachFileSystem(() => {
         return fail('Failed to recognize @Component');
       }
       const {analysis} = handler.analyze(TestCmp, detected.metadata);
-      expect(analysis?.resources.styles.size).toBe(2);
+      expect(analysis?.resources.styles?.size).toBe(2);
       expect(analysis?.meta.externalStyles).toEqual(['/myStyle.css', '/myOtherStyle.css']);
     });
 
@@ -507,7 +507,7 @@ runInEachFileSystem(() => {
         return fail('Failed to recognize @Component');
       }
       const {analysis} = handler.analyze(TestCmp, detected.metadata);
-      expect(analysis?.resources.styles.size).toBe(2);
+      expect(analysis?.resources.styles?.size).toBe(2);
       expect(analysis?.meta.externalStyles).toEqual(['myTemplateStyle.css']);
     });
 
@@ -544,7 +544,7 @@ runInEachFileSystem(() => {
         return fail('Failed to recognize @Component');
       }
       const {analysis} = handler.analyze(TestCmp, detected.metadata);
-      expect(analysis?.resources.styles.size).toBe(2);
+      expect(analysis?.resources.styles?.size).toBe(2);
       expect(analysis?.meta.externalStyles).toEqual([
         'abc//myStyle.css',
         'abc/myTemplateStyle.css',
@@ -592,7 +592,7 @@ runInEachFileSystem(() => {
       await handler.preanalyze(TestCmp, detected.metadata);
 
       const {analysis} = handler.analyze(TestCmp, detected.metadata);
-      expect(analysis?.resources.styles.size).toBe(1);
+      expect(analysis?.resources.styles?.size).toBe(1);
       expect(analysis?.meta.externalStyles).toEqual(['abc/myInlineStyle.css']);
       expect(analysis?.meta.styles).toEqual([]);
     });
@@ -628,7 +628,7 @@ runInEachFileSystem(() => {
       await handler.preanalyze(TestCmp, detected.metadata);
 
       const {analysis} = handler.analyze(TestCmp, detected.metadata);
-      expect(analysis?.resources.styles.size).toBe(1);
+      expect(analysis?.resources.styles?.size).toBe(1);
       expect(analysis?.meta.externalStyles).toEqual([]);
       expect(analysis?.meta.styles).toEqual(['.abc {}']);
     });
@@ -662,7 +662,7 @@ runInEachFileSystem(() => {
       }
 
       const {analysis} = handler.analyze(TestCmp, detected.metadata);
-      expect(analysis?.resources.styles.size).toBe(1);
+      expect(analysis?.resources.styles?.size).toBe(1);
       expect(analysis?.meta.externalStyles).toEqual([]);
       expect(analysis?.meta.styles).toEqual(['.abc {}']);
     });

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -65,7 +65,7 @@ import {
 import {SemanticSymbol} from '../../incremental/semantic_graph';
 import {generateAnalysis, IndexedComponent, IndexingContext} from '../../indexer';
 import {
-  ComponentResources,
+  DirectiveResources,
   CompoundMetadataReader,
   CompoundMetadataRegistry,
   DirectiveMeta,
@@ -729,19 +729,15 @@ export class NgCompiler {
   }
 
   /**
-   * Retrieves external resources for the given component.
+   * Retrieves external resources for the given directive.
    */
-  getComponentResources(classDecl: DeclarationNode): ComponentResources | null {
+  getDirectiveResources(classDecl: DeclarationNode): DirectiveResources | null {
     if (!isNamedClassDeclaration(classDecl)) {
       return null;
     }
     const {resourceRegistry} = this.ensureAnalyzed();
     const styles = resourceRegistry.getStyles(classDecl);
     const template = resourceRegistry.getTemplate(classDecl);
-    if (template === null) {
-      return null;
-    }
-
     return {styles, template};
   }
 

--- a/packages/compiler-cli/src/ngtsc/core/test/compiler_test.ts
+++ b/packages/compiler-cli/src/ngtsc/core/test/compiler_test.ts
@@ -240,7 +240,7 @@ runInEachFileSystem(() => {
       });
     });
 
-    describe('getComponentResources', () => {
+    describe('getDirectiveResources', () => {
       it('should return the component resources', () => {
         const styleFile = _('/style.css');
         fs.writeFile(styleFile, `/* This is the template, used by components CmpA */`);
@@ -277,12 +277,12 @@ runInEachFileSystem(() => {
           /** enableTemplateTypeChecker */ false,
           /* usePoisonedData */ false,
         );
-        const resources = compiler.getComponentResources(CmpA);
+        const resources = compiler.getDirectiveResources(CmpA);
         expect(resources).not.toBeNull();
         const {template, styles} = resources!;
         expect(template!.path).toEqual(templateFile);
-        expect(styles.size).toEqual(2);
-        const actualPaths = new Set(Array.from(styles).map((r) => r.path));
+        expect(styles?.size).toEqual(2);
+        const actualPaths = new Set(Array.from(styles || []).map((r) => r.path));
         expect(actualPaths).toEqual(new Set([styleFile, styleFile2]));
       });
 
@@ -321,10 +321,10 @@ runInEachFileSystem(() => {
           /** enableTemplateTypeChecker */ false,
           /* usePoisonedData */ false,
         );
-        const resources = compiler.getComponentResources(CmpA);
+        const resources = compiler.getDirectiveResources(CmpA);
         expect(resources).not.toBeNull();
         const {styles} = resources!;
-        expect(styles.size).toEqual(0);
+        expect(styles?.size).toEqual(0);
       });
     });
 

--- a/packages/compiler-cli/src/ngtsc/metadata/index.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/index.ts
@@ -13,7 +13,7 @@ export {CompoundMetadataRegistry, LocalMetadataRegistry} from './src/registry';
 export {
   ResourceRegistry,
   Resource,
-  ComponentResources,
+  DirectiveResources,
   isExternalResource,
   ExternalResource,
 } from './src/resource_registry';

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
@@ -44,7 +44,7 @@ export interface TypeCheckableDirectiveMeta extends DirectiveMeta, DirectiveType
   rawImports: ts.Expression | null;
 }
 
-export type TemplateId = string & {__brand: 'TemplateId'};
+export type TypeCheckId = string & {__brand: 'TypeCheckId'};
 
 /**
  * A `ts.Diagnostic` with additional information about the diagnostic related to template
@@ -54,12 +54,12 @@ export interface TemplateDiagnostic extends ts.Diagnostic {
   /**
    * The component with the template that resulted in this diagnostic.
    */
-  componentFile: ts.SourceFile;
+  sourceFile: ts.SourceFile;
 
   /**
-   * The template id of the component that resulted in this diagnostic.
+   * The type check ID of the directive that resulted in this diagnostic.
    */
-  templateId: TemplateId;
+  typeCheckId: TypeCheckId;
 }
 
 /**
@@ -75,9 +75,9 @@ export interface TypeCheckBlockMetadata {
   /**
    * A unique identifier for the class which gave rise to this TCB.
    *
-   * This can be used to map errors back to the `ts.ClassDeclaration` for the component.
+   * This can be used to map errors back to the `ts.ClassDeclaration` for the directive.
    */
-  id: TemplateId;
+  id: TypeCheckId;
 
   /**
    * Semantic information about the template of the component.
@@ -410,10 +410,10 @@ export interface ExternalTemplateSourceMapping {
 }
 
 /**
- * A mapping of a TCB template id to a span in the corresponding template source.
+ * A mapping of a TCB template id to a span in the corresponding source code.
  */
 export interface SourceLocation {
-  id: TemplateId;
+  id: TypeCheckId;
   span: AbsoluteSourceSpan;
 }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
@@ -416,11 +416,11 @@ export interface SourceLocation {
 }
 
 /**
- * A representation of all a node's template mapping information we know. Useful for producing
+ * A representation of all a node's type checking information we know. Useful for producing
  * diagnostics based on a TCB node or generally mapping from a TCB node back to a template location.
  */
-export interface FullTemplateMapping {
+export interface FullSourceMapping {
   sourceLocation: SourceLocation;
-  templateSourceMapping: SourceMapping;
+  sourceMapping: SourceMapping;
   span: ParseSourceSpan;
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
@@ -87,7 +87,7 @@ export interface TypeCheckBlockMetadata {
   /*
    * Pipes used in the template of the component.
    */
-  pipes: Map<string, PipeMeta>;
+  pipes: Map<string, PipeMeta> | null;
 
   /**
    * Schemas that apply to this template.
@@ -364,31 +364,29 @@ export interface TypeCheckingConfig {
   checkTwoWayBoundEvents: boolean;
 }
 
-export type TemplateSourceMapping =
-  | DirectTemplateSourceMapping
-  | IndirectTemplateSourceMapping
+export type SourceMapping =
+  | DirectSourceMapping
+  | IndirectSourceMapping
   | ExternalTemplateSourceMapping;
 
 /**
- * A mapping to an inline template in a TS file.
+ * A mapping to a node within the same source file..
  *
- * `ParseSourceSpan`s for this template should be accurate for direct reporting in a TS error
- * message.
+ * `ParseSourceSpan`s for this node should be accurate for direct reporting in a TS error message.
  */
-export interface DirectTemplateSourceMapping {
+export interface DirectSourceMapping {
   type: 'direct';
-  node: ts.StringLiteral | ts.NoSubstitutionTemplateLiteral;
+  node: ts.Expression;
 }
 
 /**
- * A mapping to a template which is still in a TS file, but where the node positions in any
+ * A mapping to a node which is still in a TS file, but where the positions in any
  * `ParseSourceSpan`s are not accurate for one reason or another.
  *
- * This can occur if the template expression was interpolated in a way where the compiler could not
- * construct a contiguous mapping for the template string. The `node` refers to the `template`
- * expression.
+ * This can occur if the expression was interpolated in a way where the compiler could not
+ * construct a contiguous mapping for the template string.
  */
-export interface IndirectTemplateSourceMapping {
+export interface IndirectSourceMapping {
   type: 'indirect';
   componentClass: ClassDeclaration;
   node: ts.Expression;
@@ -423,6 +421,6 @@ export interface SourceLocation {
  */
 export interface FullTemplateMapping {
   sourceLocation: SourceLocation;
-  templateSourceMapping: TemplateSourceMapping;
+  templateSourceMapping: SourceMapping;
   span: ParseSourceSpan;
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
@@ -26,7 +26,7 @@ import {Reference} from '../../imports';
 import {NgModuleMeta, PipeMeta} from '../../metadata';
 import {ClassDeclaration} from '../../reflection';
 
-import {FullTemplateMapping, NgTemplateDiagnostic, TypeCheckableDirectiveMeta} from './api';
+import {FullSourceMapping, NgTemplateDiagnostic, TypeCheckableDirectiveMeta} from './api';
 import {GlobalCompletion} from './completion';
 import {PotentialDirective, PotentialImport, PotentialImportMode, PotentialPipe} from './scope';
 import {ElementSymbol, Symbol, TcbLocation, TemplateSymbol} from './symbols';
@@ -67,10 +67,10 @@ export interface TemplateTypeChecker {
   getDiagnosticsForFile(sf: ts.SourceFile, optimizeFor: OptimizeFor): ts.Diagnostic[];
 
   /**
-   * Given a `shim` and position within the file, returns information for mapping back to a template
+   * Given a `shim` and position within the file, returns information for mapping back to a source
    * location.
    */
-  getTemplateMappingAtTcbLocation(tcbLocation: TcbLocation): FullTemplateMapping | null;
+  getSourceMappingAtTcbLocation(tcbLocation: TcbLocation): FullSourceMapping | null;
 
   /**
    * Get all `ts.Diagnostic`s currently available that pertain to the given component.

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/context.ts
@@ -19,7 +19,28 @@ import {Reference} from '../../imports';
 import {PipeMeta} from '../../metadata';
 import {ClassDeclaration} from '../../reflection';
 
-import {TemplateSourceMapping, TypeCheckableDirectiveMeta} from './api';
+import {SourceMapping, TypeCheckableDirectiveMeta} from './api';
+
+/** Contextuable data for type checking the template of a component. */
+export interface TemplateContext {
+  /** AST nodes representing the template. */
+  nodes: TmplAstNode[];
+
+  /** Describes the origin of the template text. Used for mapping errors back. */
+  sourceMapping: SourceMapping;
+
+  /** `ParseSourceFile` associated with the template. */
+  file: ParseSourceFile;
+
+  /** Errors produced while parsing the template. */
+  parseErrors: ParseError[] | null;
+
+  /** Pipes available within the template. */
+  pipes: Map<string, PipeMeta>;
+
+  /** Whether the template preserves whitespaces. */
+  preserveWhitespaces: boolean;
+}
 
 /**
  * A currently pending type checking operation, into which templates for type-checking can be
@@ -27,37 +48,26 @@ import {TemplateSourceMapping, TypeCheckableDirectiveMeta} from './api';
  */
 export interface TypeCheckContext {
   /**
-   * Register a template to potentially be type-checked.
+   * Register a directive to be potentially be type-checked.
    *
-   * Templates registered via `addTemplate` are available for checking, but might be skipped if
-   * checking of that component is not required. This can happen for a few reasons, including if
-   * the component was previously checked and the prior results are still valid.
+   * Directives registered via `addDIrective` are available for checking, but might be skipped if
+   * checking of that class is not required. This can happen for a few reasons, including if it was
+   * previously checked and the prior results are still valid.
    *
-   * @param ref a `Reference` to the component class which yielded this template.
+   * @param ref a `Reference` to the directive class which yielded this template.
    * @param binder an `R3TargetBinder` which encapsulates the scope of this template, including all
    * available directives.
-   * @param template the original template AST of this component.
-   * @param pipes a `Map` of pipes available within the scope of this template.
-   * @param schemas any schemas which apply to this template.
-   * @param sourceMapping a `TemplateSourceMapping` instance which describes the origin of the
-   * template text described by the AST.
-   * @param file the `ParseSourceFile` associated with the template.
-   * @param parseErrors the `ParseError`'s associated with the template.
-   * @param isStandalone a boolean indicating whether the component is standalone.
-   * @param preserveWhitespaces a boolean indicating whether the component's template preserves
-   * whitespaces.
+   * @param schemas Schemas that will apply when checking the directive.
+   * @param templateContext Contextual information necessary for checking the template.
+   * Only relevant for component classes.
+   * @param isStandalone a boolean indicating whether the directive is standalone.
    */
-  addTemplate(
+  addDirective(
     ref: Reference<ClassDeclaration<ts.ClassDeclaration>>,
     binder: R3TargetBinder<TypeCheckableDirectiveMeta>,
-    template: TmplAstNode[],
-    pipes: Map<string, PipeMeta>,
     schemas: SchemaMetadata[],
-    sourceMapping: TemplateSourceMapping,
-    file: ParseSourceFile,
-    parseErrors: ParseError[] | null,
+    templateContext: TemplateContext | null,
     isStandalone: boolean,
-    preserveWhitespaces: boolean,
   ): void;
 }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/diagnostics/src/diagnostic.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/diagnostics/src/diagnostic.ts
@@ -12,10 +12,10 @@ import ts from 'typescript';
 import {addDiagnosticChain, makeDiagnosticChain} from '../../../diagnostics';
 import {
   ExternalTemplateSourceMapping,
-  IndirectTemplateSourceMapping,
+  IndirectSourceMapping,
   TemplateDiagnostic,
   TypeCheckId,
-  TemplateSourceMapping,
+  SourceMapping,
 } from '../../api';
 
 /**
@@ -23,7 +23,7 @@ import {
  */
 export function makeTemplateDiagnostic(
   id: TypeCheckId,
-  mapping: TemplateSourceMapping,
+  mapping: SourceMapping,
   span: ParseSourceSpan,
   category: ts.DiagnosticCategory,
   code: number,
@@ -150,7 +150,7 @@ const TemplateSourceFile = Symbol('TemplateSourceFile');
 
 type TemplateSourceMappingWithSourceFile = (
   | ExternalTemplateSourceMapping
-  | IndirectTemplateSourceMapping
+  | IndirectSourceMapping
 ) & {
   [TemplateSourceFile]?: ts.SourceFile;
 };

--- a/packages/compiler-cli/src/ngtsc/typecheck/diagnostics/src/diagnostic.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/diagnostics/src/diagnostic.ts
@@ -14,7 +14,7 @@ import {
   ExternalTemplateSourceMapping,
   IndirectTemplateSourceMapping,
   TemplateDiagnostic,
-  TemplateId,
+  TypeCheckId,
   TemplateSourceMapping,
 } from '../../api';
 
@@ -22,7 +22,7 @@ import {
  * Constructs a `ts.Diagnostic` for a given `ParseSourceSpan` within a template.
  */
 export function makeTemplateDiagnostic(
-  templateId: TemplateId,
+  id: TypeCheckId,
   mapping: TemplateSourceMapping,
   span: ParseSourceSpan,
   category: ts.DiagnosticCategory,
@@ -59,8 +59,8 @@ export function makeTemplateDiagnostic(
       category,
       messageText,
       file: mapping.node.getSourceFile(),
-      componentFile: mapping.node.getSourceFile(),
-      templateId,
+      sourceFile: mapping.node.getSourceFile(),
+      typeCheckId: id,
       start: span.start.offset,
       length: span.end.offset - span.start.offset,
       relatedInformation,
@@ -107,8 +107,8 @@ export function makeTemplateDiagnostic(
         code,
         messageText: addDiagnosticChain(messageText, [failureChain]),
         file: componentSf,
-        componentFile: componentSf,
-        templateId,
+        sourceFile: componentSf,
+        typeCheckId: id,
         // mapping.node represents either the 'template' or 'templateUrl' expression. getStart()
         // and getEnd() are used because they don't include surrounding whitespace.
         start: mapping.node.getStart(),
@@ -134,8 +134,8 @@ export function makeTemplateDiagnostic(
       code,
       messageText,
       file: sf,
-      componentFile: componentSf,
-      templateId,
+      sourceFile: componentSf,
+      typeCheckId: id,
       start: span.start.offset,
       length: span.end.offset - span.start.offset,
       // Show a secondary message indicating the component whose template contains the error.

--- a/packages/compiler-cli/src/ngtsc/typecheck/diagnostics/src/id.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/diagnostics/src/id.ts
@@ -9,21 +9,21 @@
 import ts from 'typescript';
 import {DeclarationNode} from '../../../reflection';
 
-import {TemplateId} from '../../api';
+import {TypeCheckId} from '../../api';
 
-const TEMPLATE_ID_MAP = Symbol('ngTemplateId');
+const TYPE_CHECK_ID_MAP = Symbol('TypeCheckId');
 
-interface HasNextTemplateId {
-  [TEMPLATE_ID_MAP]: Map<ts.Node, TemplateId>;
+interface HasNextTypeCheckId {
+  [TYPE_CHECK_ID_MAP]: Map<ts.Node, TypeCheckId>;
 }
 
-export function getTemplateId(clazz: DeclarationNode): TemplateId {
-  const sf = clazz.getSourceFile() as ts.SourceFile & Partial<HasNextTemplateId>;
-  if (sf[TEMPLATE_ID_MAP] === undefined) {
-    sf[TEMPLATE_ID_MAP] = new Map();
+export function getTypeCheckId(clazz: DeclarationNode): TypeCheckId {
+  const sf = clazz.getSourceFile() as ts.SourceFile & Partial<HasNextTypeCheckId>;
+  if (sf[TYPE_CHECK_ID_MAP] === undefined) {
+    sf[TYPE_CHECK_ID_MAP] = new Map();
   }
-  if (sf[TEMPLATE_ID_MAP].get(clazz) === undefined) {
-    sf[TEMPLATE_ID_MAP].set(clazz, `tcb${sf[TEMPLATE_ID_MAP].size + 1}` as TemplateId);
+  if (sf[TYPE_CHECK_ID_MAP].get(clazz) === undefined) {
+    sf[TYPE_CHECK_ID_MAP].set(clazz, `tcb${sf[TYPE_CHECK_ID_MAP].size + 1}` as TypeCheckId);
   }
-  return sf[TEMPLATE_ID_MAP].get(clazz)!;
+  return sf[TYPE_CHECK_ID_MAP].get(clazz)!;
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/interpolated_signal_not_invoked/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/interpolated_signal_not_invoked/index.ts
@@ -96,7 +96,7 @@ function buildDiagnosticForSignal(
   // check for `{{ mySignal }}`
   const symbol = ctx.templateTypeChecker.getSymbolOfNode(node, component);
   if (symbol !== null && symbol.kind === SymbolKind.Expression && isSignalReference(symbol)) {
-    const templateMapping = ctx.templateTypeChecker.getTemplateMappingAtTcbLocation(
+    const templateMapping = ctx.templateTypeChecker.getSourceMappingAtTcbLocation(
       symbol.tcbLocation,
     )!;
     const errorString = `${node.name} is a function and should be invoked: ${node.name}()`;
@@ -116,7 +116,7 @@ function buildDiagnosticForSignal(
     symbolOfReceiver.kind === SymbolKind.Expression &&
     isSignalReference(symbolOfReceiver)
   ) {
-    const templateMapping = ctx.templateTypeChecker.getTemplateMappingAtTcbLocation(
+    const templateMapping = ctx.templateTypeChecker.getSourceMappingAtTcbLocation(
       symbolOfReceiver.tcbLocation,
     )!;
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/nullish_coalescing_not_nullable/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/nullish_coalescing_not_nullable/index.ts
@@ -51,7 +51,7 @@ class NullishCoalescingNotNullableCheck extends TemplateCheckWithVisitor<ErrorCo
     if (symbol.kind !== SymbolKind.Expression) {
       return [];
     }
-    const templateMapping = ctx.templateTypeChecker.getTemplateMappingAtTcbLocation(
+    const templateMapping = ctx.templateTypeChecker.getSourceMappingAtTcbLocation(
       symbol.tcbLocation,
     );
     if (templateMapping === null) {

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/optional_chain_not_nullable/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/optional_chain_not_nullable/index.ts
@@ -56,7 +56,7 @@ class OptionalChainNotNullableCheck extends TemplateCheckWithVisitor<ErrorCode.O
     if (symbol.kind !== SymbolKind.Expression) {
       return [];
     }
-    const templateMapping = ctx.templateTypeChecker.getTemplateMappingAtTcbLocation(
+    const templateMapping = ctx.templateTypeChecker.getSourceMappingAtTcbLocation(
       symbol.tcbLocation,
     );
     if (templateMapping === null) {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -74,7 +74,7 @@ import {CompletionEngine} from './completion';
 import {
   InliningMode,
   ShimTypeCheckingData,
-  TemplateData,
+  TypeCheckData,
   TypeCheckContextImpl,
   TypeCheckingHost,
 } from './context';
@@ -168,7 +168,7 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
     component: ts.ClassDeclaration,
     optimizeFor: OptimizeFor = OptimizeFor.SingleFile,
   ): {
-    data: TemplateData | null;
+    data: TypeCheckData | null;
     tcb: ts.Node | null;
     tcbPath: AbsoluteFsPath;
     tcbIsShim: boolean;
@@ -215,9 +215,9 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
       }
     }
 
-    let data: TemplateData | null = null;
-    if (shimRecord.templates.has(id)) {
-      data = shimRecord.templates.get(id)!;
+    let data: TypeCheckData | null = null;
+    if (shimRecord.data.has(id)) {
+      data = shimRecord.data.get(id)!;
     }
 
     return {data, tcb, tcbPath, tcbIsShim: tcbPath === shimPath};
@@ -323,8 +323,8 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
         );
         diagnostics.push(...shimRecord.genesisDiagnostics);
 
-        for (const templateData of shimRecord.templates.values()) {
-          diagnostics.push(...templateData.templateDiagnostics);
+        for (const templateData of shimRecord.data.values()) {
+          diagnostics.push(...templateData.templateParsingDiagnostics);
         }
       }
 
@@ -371,8 +371,8 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
       );
       diagnostics.push(...shimRecord.genesisDiagnostics);
 
-      for (const templateData of shimRecord.templates.values()) {
-        diagnostics.push(...templateData.templateDiagnostics);
+      for (const templateData of shimRecord.data.values()) {
+        diagnostics.push(...templateData.templateParsingDiagnostics);
       }
 
       return diagnostics.filter(
@@ -1060,7 +1060,7 @@ class WholeProgramTypeCheckingHost implements TypeCheckingHost {
     return this.impl.getFileData(sfPath).sourceManager;
   }
 
-  shouldCheckComponent(node: ts.ClassDeclaration): boolean {
+  shouldCheckClass(node: ts.ClassDeclaration): boolean {
     const sfPath = absoluteFromSourceFile(node.getSourceFile());
     const shimPath = TypeCheckShimGenerator.shimFor(sfPath);
     const fileData = this.impl.getFileData(sfPath);
@@ -1104,7 +1104,7 @@ class SingleFileTypeCheckingHost implements TypeCheckingHost {
     return this.fileData.sourceManager;
   }
 
-  shouldCheckComponent(node: ts.ClassDeclaration): boolean {
+  shouldCheckClass(node: ts.ClassDeclaration): boolean {
     if (this.sfPath !== absoluteFromSourceFile(node.getSourceFile())) {
       return false;
     }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -63,7 +63,6 @@ import {
   Symbol,
   TcbLocation,
   TemplateDiagnostic,
-  TemplateId,
   TemplateSymbol,
   TemplateTypeChecker,
   TypeCheckableDirectiveMeta,
@@ -193,9 +192,8 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
       return {data: null, tcb: null, tcbPath: shimPath, tcbIsShim: true};
     }
 
-    const templateId = fileRecord.sourceManager.getTemplateId(component);
+    const id = fileRecord.sourceManager.getTypeCheckId(component);
     const shimRecord = fileRecord.shimData.get(shimPath)!;
-    const id = fileRecord.sourceManager.getTemplateId(component);
 
     const program = this.programDriver.getProgram();
     const shimSf = getSourceFileOrNull(program, shimPath);
@@ -218,8 +216,8 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
     }
 
     let data: TemplateData | null = null;
-    if (shimRecord.templates.has(templateId)) {
-      data = shimRecord.templates.get(templateId)!;
+    if (shimRecord.templates.has(id)) {
+      data = shimRecord.templates.get(id)!;
     }
 
     return {data, tcb, tcbPath, tcbIsShim: tcbPath === shimPath};
@@ -350,7 +348,7 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
         return [];
       }
 
-      const templateId = fileRecord.sourceManager.getTemplateId(component);
+      const id = fileRecord.sourceManager.getTypeCheckId(component);
       const shimRecord = fileRecord.shimData.get(shimPath)!;
 
       const typeCheckProgram = this.programDriver.getProgram();
@@ -379,7 +377,7 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
 
       return diagnostics.filter(
         (diag: TemplateDiagnostic | null): diag is TemplateDiagnostic =>
-          diag !== null && diag.templateId === templateId,
+          diag !== null && diag.typeCheckId === id,
       );
     });
   }
@@ -438,7 +436,7 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
     const sfPath = absoluteFromSourceFile(sf);
     const shimPath = TypeCheckShimGenerator.shimFor(sfPath);
     const fileData = this.getFileData(sfPath);
-    const templateId = fileData.sourceManager.getTemplateId(clazz);
+    const id = fileData.sourceManager.getTypeCheckId(clazz);
 
     fileData.shimData.delete(shimPath);
     fileData.isComplete = false;
@@ -467,12 +465,12 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
   ): NgTemplateDiagnostic<T> {
     const sfPath = absoluteFromSourceFile(clazz.getSourceFile());
     const fileRecord = this.state.get(sfPath)!;
-    const templateId = fileRecord.sourceManager.getTemplateId(clazz);
-    const mapping = fileRecord.sourceManager.getSourceMapping(templateId);
+    const id = fileRecord.sourceManager.getTypeCheckId(clazz);
+    const mapping = fileRecord.sourceManager.getSourceMapping(id);
 
     return {
       ...makeTemplateDiagnostic(
-        templateId,
+        id,
         mapping,
         sourceSpan,
         category,

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/completion.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/completion.ts
@@ -10,7 +10,6 @@ import {
   AST,
   EmptyExpr,
   ImplicitReceiver,
-  LetDeclaration,
   LiteralPrimitive,
   PropertyRead,
   PropertyWrite,
@@ -34,7 +33,7 @@ import {
 } from '../api';
 
 import {ExpressionIdentifier, findFirstMatchingNode} from './comments';
-import {TemplateData} from './context';
+import {TypeCheckData} from './context';
 
 /**
  * Powers autocompletion for a specific component.
@@ -61,7 +60,7 @@ export class CompletionEngine {
 
   constructor(
     private tcb: ts.Node,
-    private data: TemplateData,
+    private data: TypeCheckData,
     private tcbPath: AbsoluteFsPath,
     private tcbIsShim: boolean,
   ) {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
@@ -9,7 +9,6 @@
 import {
   BoundTarget,
   ParseError,
-  ParseSourceFile,
   R3TargetBinder,
   SchemaMetadata,
   TmplAstNode,
@@ -20,7 +19,6 @@ import ts from 'typescript';
 import {ErrorCode, ngErrorCode} from '../../../../src/ngtsc/diagnostics';
 import {absoluteFromSourceFile, AbsoluteFsPath} from '../../file_system';
 import {Reference, ReferenceEmitter} from '../../imports';
-import {PipeMeta} from '../../metadata';
 import {PerfEvent, PerfRecorder} from '../../perf';
 import {FileUpdate} from '../../program_driver';
 import {ClassDeclaration, ReflectionHost} from '../../reflection';
@@ -28,12 +26,13 @@ import {ImportManager} from '../../translator';
 import {
   TemplateDiagnostic,
   TypeCheckId,
-  TemplateSourceMapping,
+  SourceMapping,
   TypeCheckableDirectiveMeta,
   TypeCheckBlockMetadata,
   TypeCheckContext,
   TypeCheckingConfig,
   TypeCtorMetadata,
+  TemplateContext,
 } from '../api';
 import {makeTemplateDiagnostic} from '../diagnostics';
 
@@ -70,17 +69,17 @@ export interface ShimTypeCheckingData {
    * Map of `TypeCheckId` to information collected about the template during the template
    * type-checking process.
    */
-  templates: Map<TypeCheckId, TemplateData>;
+  data: Map<TypeCheckId, TypeCheckData>;
 }
 
 /**
- * Data tracked for each template processed by the template type-checking system.
+ * Data tracked for each class processed by the type-checking system.
  */
-export interface TemplateData {
+export interface TypeCheckData {
   /**
    * Template nodes for which the TCB was generated.
    */
-  template: TmplAstNode[];
+  template: TmplAstNode[] | null;
 
   /**
    * `BoundTarget` which was used to generate the TCB, and contains bindings for the associated
@@ -89,9 +88,9 @@ export interface TemplateData {
   boundTarget: BoundTarget<TypeCheckableDirectiveMeta>;
 
   /**
-   * Errors found while parsing them template, which have been converted to diagnostics.
+   * Errors found while parsing the template, which have been converted to diagnostics.
    */
-  templateDiagnostics: TemplateDiagnostic[];
+  templateParsingDiagnostics: TemplateDiagnostic[];
 }
 
 /**
@@ -134,7 +133,7 @@ export interface PendingShimData {
   /**
    * Map of `TypeCheckId` to information collected about the template as it's ingested.
    */
-  templates: Map<TypeCheckId, TemplateData>;
+  data: Map<TypeCheckId, TypeCheckData>;
 }
 
 /**
@@ -146,18 +145,18 @@ export interface PendingShimData {
  */
 export interface TypeCheckingHost {
   /**
-   * Retrieve the `TemplateSourceManager` responsible for components in the given input file path.
+   * Retrieve the `TemplateSourceManager` responsible for directives in the given input file path.
    */
   getSourceManager(sfPath: AbsoluteFsPath): TemplateSourceManager;
 
   /**
-   * Whether a particular component class should be included in the current type-checking pass.
+   * Whether a particular class should be included in the current type-checking pass.
    *
-   * Not all components offered to the `TypeCheckContext` for checking may require processing. For
-   * example, the component may have results already available from a prior pass or from a previous
+   * Not all classes offered to the `TypeCheckContext` for checking may require processing. For
+   * example, the directive may have results already available from a prior pass or from a previous
    * program.
    */
-  shouldCheckComponent(node: ts.ClassDeclaration): boolean;
+  shouldCheckClass(node: ts.ClassDeclaration): boolean;
 
   /**
    * Report data from a shim generated from the given input file path.
@@ -165,7 +164,7 @@ export interface TypeCheckingHost {
   recordShimData(sfPath: AbsoluteFsPath, data: ShimTypeCheckingData): void;
 
   /**
-   * Record that all of the components within the given input file path had code generated - that
+   * Record that all of the classes within the given input file path had code generated - that
    * is, coverage for the file can be considered complete.
    */
   recordComplete(sfPath: AbsoluteFsPath): void;
@@ -189,8 +188,7 @@ export enum InliningMode {
 /**
  * A template type checking context for a program.
  *
- * The `TypeCheckContext` allows registration of components and their templates which need to be
- * type checked.
+ * The `TypeCheckContext` allows registration of directives to be type checked.
  */
 export class TypeCheckContextImpl implements TypeCheckContext {
   private fileMap = new Map<AbsoluteFsPath, PendingFileTypeCheckingData>();
@@ -227,33 +225,29 @@ export class TypeCheckContextImpl implements TypeCheckContext {
    *
    * Implements `TypeCheckContext.addTemplate`.
    */
-  addTemplate(
+  addDirective(
     ref: Reference<ClassDeclaration<ts.ClassDeclaration>>,
     binder: R3TargetBinder<TypeCheckableDirectiveMeta>,
-    template: TmplAstNode[],
-    pipes: Map<string, PipeMeta>,
     schemas: SchemaMetadata[],
-    sourceMapping: TemplateSourceMapping,
-    file: ParseSourceFile,
-    parseErrors: ParseError[] | null,
+    templateContext: TemplateContext | null,
     isStandalone: boolean,
-    preserveWhitespaces: boolean,
   ): void {
-    if (!this.host.shouldCheckComponent(ref.node)) {
+    if (!this.host.shouldCheckClass(ref.node)) {
       return;
     }
 
     const fileData = this.dataForFile(ref.node.getSourceFile());
-    const shimData = this.pendingShimForComponent(ref.node);
+    const shimData = this.pendingShimForClass(ref.node);
     const id = fileData.sourceManager.getTypeCheckId(ref.node);
+    const templateParsingDiagnostics: TemplateDiagnostic[] = [];
 
-    const templateDiagnostics: TemplateDiagnostic[] = [];
-
-    if (parseErrors !== null) {
-      templateDiagnostics.push(...getTemplateDiagnostics(parseErrors, id, sourceMapping));
+    if (templateContext !== null && templateContext.parseErrors !== null) {
+      templateParsingDiagnostics.push(
+        ...getTemplateDiagnostics(templateContext.parseErrors, id, templateContext.sourceMapping),
+      );
     }
 
-    const boundTarget = binder.bind({template});
+    const boundTarget = binder.bind({template: templateContext?.nodes});
 
     if (this.inlining === InliningMode.InlineOps) {
       // Get all of the directives used in the template and record inline type constructors when
@@ -283,18 +277,24 @@ export class TypeCheckContextImpl implements TypeCheckContext {
       }
     }
 
-    shimData.templates.set(id, {
-      template,
+    shimData.data.set(id, {
+      template: templateContext?.nodes || null,
       boundTarget,
-      templateDiagnostics,
+      templateParsingDiagnostics,
     });
 
     const usedPipes: Reference<ClassDeclaration<ts.ClassDeclaration>>[] = [];
-    for (const name of boundTarget.getUsedPipes()) {
-      if (!pipes.has(name)) {
-        continue;
+
+    if (templateContext !== null) {
+      for (const name of boundTarget.getUsedPipes()) {
+        if (templateContext.pipes.has(name)) {
+          usedPipes.push(
+            templateContext.pipes.get(name)!.ref as Reference<
+              ClassDeclaration<ts.ClassDeclaration>
+            >,
+          );
+        }
       }
-      usedPipes.push(pipes.get(name)!.ref as Reference<ClassDeclaration<ts.ClassDeclaration>>);
     }
 
     const inliningRequirement = requiresInlineTypeCheckBlock(
@@ -321,13 +321,21 @@ export class TypeCheckContextImpl implements TypeCheckContext {
       return;
     }
 
+    if (templateContext !== null) {
+      fileData.sourceManager.captureSource(
+        ref.node,
+        templateContext.sourceMapping,
+        templateContext.file,
+      );
+    }
+
     const meta = {
-      id: fileData.sourceManager.captureSource(ref.node, sourceMapping, file),
+      id,
       boundTarget,
-      pipes,
+      pipes: templateContext?.pipes || null,
       schemas,
       isStandalone,
-      preserveWhitespaces,
+      preserveWhitespaces: templateContext?.preserveWhitespaces ?? false,
     };
     this.perf.eventCount(PerfEvent.GenerateTcb);
     if (
@@ -341,10 +349,10 @@ export class TypeCheckContextImpl implements TypeCheckContext {
       inliningRequirement === TcbInliningRequirement.ShouldInlineForGenericBounds &&
       this.inlining === InliningMode.Error
     ) {
-      // It's suggested that this TCB should be generated inline due to the component's generic
+      // It's suggested that this TCB should be generated inline due to the class' generic
       // bounds, but inlining is not supported by the current environment. Use a non-inline type
       // check block, but fall back to `any` generic parameters since the generic bounds can't be
-      // referenced in that context. This will infer a less useful type for the component, but allow
+      // referenced in that context. This will infer a less useful type for the class, but allow
       // for type-checking it in an environment where that would not be possible otherwise.
       shimData.file.addTypeCheckBlock(
         ref,
@@ -484,7 +492,7 @@ export class TypeCheckContextImpl implements TypeCheckContext {
           ],
           hasInlines: pendingFileData.hasInlines,
           path: pendingShimData.file.fileName,
-          templates: pendingShimData.templates,
+          data: pendingShimData.data,
         });
         const sfText = pendingShimData.file.render(false /* removeComments */);
         updates.set(pendingShimData.file.fileName, {
@@ -523,7 +531,7 @@ export class TypeCheckContextImpl implements TypeCheckContext {
     fileData.hasInlines = true;
   }
 
-  private pendingShimForComponent(node: ts.ClassDeclaration): PendingShimData {
+  private pendingShimForClass(node: ts.ClassDeclaration): PendingShimData {
     const fileData = this.dataForFile(node.getSourceFile());
     const shimPath = TypeCheckShimGenerator.shimFor(absoluteFromSourceFile(node.getSourceFile()));
     if (!fileData.shimData.has(shimPath)) {
@@ -537,7 +545,7 @@ export class TypeCheckContextImpl implements TypeCheckContext {
           this.reflector,
           this.compilerHost,
         ),
-        templates: new Map<TypeCheckId, TemplateData>(),
+        data: new Map<TypeCheckId, TypeCheckData>(),
       });
     }
     return fileData.shimData.get(shimPath)!;
@@ -562,7 +570,7 @@ export class TypeCheckContextImpl implements TypeCheckContext {
 export function getTemplateDiagnostics(
   parseErrors: ParseError[],
   templateId: TypeCheckId,
-  sourceMapping: TemplateSourceMapping,
+  sourceMapping: SourceMapping,
 ): TemplateDiagnostic[] {
   return parseErrors.map((error) => {
     const span = error.span;
@@ -612,7 +620,7 @@ interface Op {
 }
 
 /**
- * A type check block operation which produces inline type check code for a particular component.
+ * A type check block operation which produces inline type check code for a particular directive.
  */
 class InlineTcbOp implements Op {
   constructor(
@@ -625,7 +633,7 @@ class InlineTcbOp implements Op {
   ) {}
 
   /**
-   * Type check blocks are inserted immediately after the end of the component class.
+   * Type check blocks are inserted immediately after the end of the directve class.
    */
   get splitPoint(): number {
     return this.ref.node.end + 1;

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
@@ -41,7 +41,7 @@ import {Environment} from './environment';
 import {OutOfBandDiagnosticRecorder, OutOfBandDiagnosticRecorderImpl} from './oob';
 import {ReferenceEmitEnvironment} from './reference_emit_environment';
 import {TypeCheckShimGenerator} from './shim';
-import {TemplateSourceManager} from './source';
+import {DirectiveSourceManager} from './source';
 import {requiresInlineTypeCheckBlock, TcbInliningRequirement} from './tcb_util';
 import {generateTypeCheckBlock, TcbGenericContextBehavior} from './type_check_block';
 import {TypeCheckFile} from './type_check_file';
@@ -106,7 +106,7 @@ export interface PendingFileTypeCheckingData {
    * Source mapping information for mapping diagnostics from inlined type check blocks back to the
    * original template.
    */
-  sourceManager: TemplateSourceManager;
+  sourceManager: DirectiveSourceManager;
 
   /**
    * Map of in-progress shim data for shims generated from this input file.
@@ -145,9 +145,9 @@ export interface PendingShimData {
  */
 export interface TypeCheckingHost {
   /**
-   * Retrieve the `TemplateSourceManager` responsible for directives in the given input file path.
+   * Retrieve the `DirectiveSourceManager` responsible for directives in the given input file path.
    */
-  getSourceManager(sfPath: AbsoluteFsPath): TemplateSourceManager;
+  getSourceManager(sfPath: AbsoluteFsPath): DirectiveSourceManager;
 
   /**
    * Whether a particular class should be included in the current type-checking pass.
@@ -322,8 +322,8 @@ export class TypeCheckContextImpl implements TypeCheckContext {
     }
 
     if (templateContext !== null) {
-      fileData.sourceManager.captureSource(
-        ref.node,
+      fileData.sourceManager.captureTemplateSource(
+        id,
         templateContext.sourceMapping,
         templateContext.file,
       );

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/diagnostics.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/diagnostics.ts
@@ -8,7 +8,7 @@
 import {AbsoluteSourceSpan, ParseSourceSpan} from '@angular/compiler';
 import ts from 'typescript';
 
-import {TemplateDiagnostic, TemplateId} from '../api';
+import {TemplateDiagnostic, TypeCheckId} from '../api';
 import {makeTemplateDiagnostic} from '../diagnostics';
 
 import {getTemplateMapping, TemplateSourceResolver} from './tcb_util';
@@ -58,10 +58,10 @@ export function addParseSpanInfo(node: ts.Node, span: AbsoluteSourceSpan | Parse
 }
 
 /**
- * Adds a synthetic comment to the function declaration that contains the template id
+ * Adds a synthetic comment to the function declaration that contains the type checking ID
  * of the class declaration.
  */
-export function addTemplateId(tcb: ts.FunctionDeclaration, id: TemplateId): void {
+export function addTypeCheckId(tcb: ts.FunctionDeclaration, id: TypeCheckId): void {
   ts.addSyntheticLeadingComment(tcb, ts.SyntaxKind.MultiLineCommentTrivia, id, true);
 }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/diagnostics.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/diagnostics.ts
@@ -11,7 +11,7 @@ import ts from 'typescript';
 import {TemplateDiagnostic, TypeCheckId} from '../api';
 import {makeTemplateDiagnostic} from '../diagnostics';
 
-import {getTemplateMapping, TemplateSourceResolver} from './tcb_util';
+import {getSourceMapping, TypeCheckSourceResolver} from './tcb_util';
 
 /**
  * Wraps the node in parenthesis such that inserted span comments become attached to the proper
@@ -94,12 +94,12 @@ export function shouldReportDiagnostic(diagnostic: ts.Diagnostic): boolean {
  */
 export function translateDiagnostic(
   diagnostic: ts.Diagnostic,
-  resolver: TemplateSourceResolver,
+  resolver: TypeCheckSourceResolver,
 ): TemplateDiagnostic | null {
   if (diagnostic.file === undefined || diagnostic.start === undefined) {
     return null;
   }
-  const fullMapping = getTemplateMapping(
+  const fullMapping = getSourceMapping(
     diagnostic.file,
     diagnostic.start,
     resolver,
@@ -109,7 +109,7 @@ export function translateDiagnostic(
     return null;
   }
 
-  const {sourceLocation, templateSourceMapping, span} = fullMapping;
+  const {sourceLocation, sourceMapping: templateSourceMapping, span} = fullMapping;
   return makeTemplateDiagnostic(
     sourceLocation.id,
     templateSourceMapping,

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/dom.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/dom.ts
@@ -18,7 +18,7 @@ import {ErrorCode, ngErrorCode} from '../../diagnostics';
 import {TemplateDiagnostic, TypeCheckId} from '../api';
 import {makeTemplateDiagnostic} from '../diagnostics';
 
-import {TemplateSourceResolver} from './tcb_util';
+import {TypeCheckSourceResolver} from './tcb_util';
 
 const REGISTRY = new DomElementSchemaRegistry();
 const REMOVE_XHTML_REGEX = /^:xhtml:/;
@@ -88,7 +88,7 @@ export class RegistryDomSchemaChecker implements DomSchemaChecker {
     return this._diagnostics;
   }
 
-  constructor(private resolver: TemplateSourceResolver) {}
+  constructor(private resolver: TypeCheckSourceResolver) {}
 
   checkElement(
     id: TypeCheckId,
@@ -102,7 +102,7 @@ export class RegistryDomSchemaChecker implements DomSchemaChecker {
     const name = element.name.replace(REMOVE_XHTML_REGEX, '');
 
     if (!REGISTRY.hasElement(name, schemas)) {
-      const mapping = this.resolver.getSourceMapping(id);
+      const mapping = this.resolver.getTemplateSourceMapping(id);
 
       const schemas = `'${hostIsStandalone ? '@Component' : '@NgModule'}.schemas'`;
       let errorMsg = `'${name}' is not a known element:\n`;
@@ -138,7 +138,7 @@ export class RegistryDomSchemaChecker implements DomSchemaChecker {
     hostIsStandalone: boolean,
   ): void {
     if (!REGISTRY.hasProperty(element.name, name, schemas)) {
-      const mapping = this.resolver.getSourceMapping(id);
+      const mapping = this.resolver.getTemplateSourceMapping(id);
 
       const decorator = hostIsStandalone ? '@Component' : '@NgModule';
       const schemas = `'${decorator}.schemas'`;

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/dom.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/dom.ts
@@ -15,7 +15,7 @@ import {
 import ts from 'typescript';
 
 import {ErrorCode, ngErrorCode} from '../../diagnostics';
-import {TemplateDiagnostic, TemplateId} from '../api';
+import {TemplateDiagnostic, TypeCheckId} from '../api';
 import {makeTemplateDiagnostic} from '../diagnostics';
 
 import {TemplateSourceResolver} from './tcb_util';
@@ -91,7 +91,7 @@ export class RegistryDomSchemaChecker implements DomSchemaChecker {
   constructor(private resolver: TemplateSourceResolver) {}
 
   checkElement(
-    id: TemplateId,
+    id: TypeCheckId,
     element: TmplAstElement,
     schemas: SchemaMetadata[],
     hostIsStandalone: boolean,
@@ -130,7 +130,7 @@ export class RegistryDomSchemaChecker implements DomSchemaChecker {
   }
 
   checkProperty(
-    id: TemplateId,
+    id: TypeCheckId,
     element: TmplAstElement,
     name: string,
     span: ParseSourceSpan,

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/source.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/source.ts
@@ -14,8 +14,8 @@ import {
 } from '@angular/compiler';
 import ts from 'typescript';
 
-import {TemplateId, TemplateSourceMapping} from '../api';
-import {getTemplateId} from '../diagnostics';
+import {TypeCheckId, TemplateSourceMapping} from '../api';
+import {getTypeCheckId} from '../diagnostics';
 
 import {computeLineStartsMap, getLineAndCharacterFromPosition} from './line_mappings';
 import {TemplateSourceResolver} from './tcb_util';
@@ -53,7 +53,7 @@ export class TemplateSource {
 }
 
 /**
- * Assigns IDs to templates and keeps track of their origins.
+ * Assigns IDs for type checking and keeps track of their origins.
  *
  * Implements `TemplateSourceResolver` to resolve the source of a template based on these IDs.
  */
@@ -63,30 +63,30 @@ export class TemplateSourceManager implements TemplateSourceResolver {
    * attached to a TCB's function declaration as leading trivia. This enables translation of
    * diagnostics produced for TCB code to their source location in the template.
    */
-  private templateSources = new Map<TemplateId, TemplateSource>();
+  private templateSources = new Map<TypeCheckId, TemplateSource>();
 
-  getTemplateId(node: ts.ClassDeclaration): TemplateId {
-    return getTemplateId(node);
+  getTypeCheckId(node: ts.ClassDeclaration): TypeCheckId {
+    return getTypeCheckId(node);
   }
 
   captureSource(
     node: ts.ClassDeclaration,
     mapping: TemplateSourceMapping,
     file: ParseSourceFile,
-  ): TemplateId {
-    const id = getTemplateId(node);
+  ): TypeCheckId {
+    const id = getTypeCheckId(node);
     this.templateSources.set(id, new TemplateSource(mapping, file));
     return id;
   }
 
-  getSourceMapping(id: TemplateId): TemplateSourceMapping {
+  getSourceMapping(id: TypeCheckId): TemplateSourceMapping {
     if (!this.templateSources.has(id)) {
       throw new Error(`Unexpected unknown template ID: ${id}`);
     }
     return this.templateSources.get(id)!.mapping;
   }
 
-  toParseSourceSpan(id: TemplateId, span: AbsoluteSourceSpan): ParseSourceSpan | null {
+  toParseSourceSpan(id: TypeCheckId, span: AbsoluteSourceSpan): ParseSourceSpan | null {
     if (!this.templateSources.has(id)) {
       return null;
     }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/source.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/source.ts
@@ -18,7 +18,7 @@ import {TypeCheckId, SourceMapping} from '../api';
 import {getTypeCheckId} from '../diagnostics';
 
 import {computeLineStartsMap, getLineAndCharacterFromPosition} from './line_mappings';
-import {TemplateSourceResolver} from './tcb_util';
+import {TypeCheckSourceResolver} from './tcb_util';
 
 /**
  * Represents the source of a template that was processed during type-checking. This information is
@@ -55,9 +55,9 @@ export class TemplateSource {
 /**
  * Assigns IDs for type checking and keeps track of their origins.
  *
- * Implements `TemplateSourceResolver` to resolve the source of a template based on these IDs.
+ * Implements `TypeCheckSourceResolver` to resolve the source of a template based on these IDs.
  */
-export class TemplateSourceManager implements TemplateSourceResolver {
+export class DirectiveSourceManager implements TypeCheckSourceResolver {
   /**
    * This map keeps track of all template sources that have been type-checked by the id that is
    * attached to a TCB's function declaration as leading trivia. This enables translation of
@@ -69,24 +69,18 @@ export class TemplateSourceManager implements TemplateSourceResolver {
     return getTypeCheckId(node);
   }
 
-  captureSource(
-    node: ts.ClassDeclaration,
-    mapping: SourceMapping,
-    file: ParseSourceFile,
-  ): TypeCheckId {
-    const id = getTypeCheckId(node);
+  captureTemplateSource(id: TypeCheckId, mapping: SourceMapping, file: ParseSourceFile): void {
     this.templateSources.set(id, new TemplateSource(mapping, file));
-    return id;
   }
 
-  getSourceMapping(id: TypeCheckId): SourceMapping {
+  getTemplateSourceMapping(id: TypeCheckId): SourceMapping {
     if (!this.templateSources.has(id)) {
-      throw new Error(`Unexpected unknown template ID: ${id}`);
+      throw new Error(`Unexpected unknown type check ID: ${id}`);
     }
     return this.templateSources.get(id)!.mapping;
   }
 
-  toParseSourceSpan(id: TypeCheckId, span: AbsoluteSourceSpan): ParseSourceSpan | null {
+  toTemplateParseSourceSpan(id: TypeCheckId, span: AbsoluteSourceSpan): ParseSourceSpan | null {
     if (!this.templateSources.has(id)) {
       return null;
     }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/source.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/source.ts
@@ -14,7 +14,7 @@ import {
 } from '@angular/compiler';
 import ts from 'typescript';
 
-import {TypeCheckId, TemplateSourceMapping} from '../api';
+import {TypeCheckId, SourceMapping} from '../api';
 import {getTypeCheckId} from '../diagnostics';
 
 import {computeLineStartsMap, getLineAndCharacterFromPosition} from './line_mappings';
@@ -28,7 +28,7 @@ export class TemplateSource {
   private lineStarts: number[] | null = null;
 
   constructor(
-    readonly mapping: TemplateSourceMapping,
+    readonly mapping: SourceMapping,
     private file: ParseSourceFile,
   ) {}
 
@@ -71,7 +71,7 @@ export class TemplateSourceManager implements TemplateSourceResolver {
 
   captureSource(
     node: ts.ClassDeclaration,
-    mapping: TemplateSourceMapping,
+    mapping: SourceMapping,
     file: ParseSourceFile,
   ): TypeCheckId {
     const id = getTypeCheckId(node);
@@ -79,7 +79,7 @@ export class TemplateSourceManager implements TemplateSourceResolver {
     return id;
   }
 
-  getSourceMapping(id: TypeCheckId): TemplateSourceMapping {
+  getSourceMapping(id: TypeCheckId): SourceMapping {
     if (!this.templateSources.has(id)) {
       throw new Error(`Unexpected unknown template ID: ${id}`);
     }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_util.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_util.ts
@@ -12,7 +12,7 @@ import ts from 'typescript';
 import {ClassDeclaration, ReflectionHost} from '../../../../src/ngtsc/reflection';
 import {Reference} from '../../imports';
 import {getTokenAtPosition} from '../../util/src/typescript';
-import {FullTemplateMapping, SourceLocation, TypeCheckId, TemplateSourceMapping} from '../api';
+import {FullTemplateMapping, SourceLocation, TypeCheckId, SourceMapping} from '../api';
 
 import {hasIgnoreForDiagnosticsMarker, readSpanComment} from './comments';
 import {ReferenceEmitEnvironment} from './reference_emit_environment';
@@ -47,7 +47,7 @@ export interface TemplateSourceResolver {
    * For the given type checking id, retrieve the original source mapping which describes how the
    * offsets in the template should be interpreted.
    */
-  getSourceMapping(id: TypeCheckId): TemplateSourceMapping;
+  getSourceMapping(id: TypeCheckId): SourceMapping;
 
   /**
    * Convert an absolute source span associated with the given type checking id into a full

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_util.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_util.ts
@@ -12,7 +12,7 @@ import ts from 'typescript';
 import {ClassDeclaration, ReflectionHost} from '../../../../src/ngtsc/reflection';
 import {Reference} from '../../imports';
 import {getTokenAtPosition} from '../../util/src/typescript';
-import {FullTemplateMapping, SourceLocation, TemplateId, TemplateSourceMapping} from '../api';
+import {FullTemplateMapping, SourceLocation, TypeCheckId, TemplateSourceMapping} from '../api';
 
 import {hasIgnoreForDiagnosticsMarker, readSpanComment} from './comments';
 import {ReferenceEmitEnvironment} from './reference_emit_environment';
@@ -37,24 +37,24 @@ const TCB_FILE_IMPORT_GRAPH_PREPARE_IDENTIFIERS = [
 ];
 
 /**
- * Adapter interface which allows the template type-checking diagnostics code to interpret offsets
+ * Adapter interface which allows the directive type-checking diagnostics code to interpret offsets
  * in a TCB and map them back to original locations in the template.
  */
 export interface TemplateSourceResolver {
-  getTemplateId(node: ts.ClassDeclaration): TemplateId;
+  getTypeCheckId(node: ts.ClassDeclaration): TypeCheckId;
 
   /**
-   * For the given template id, retrieve the original source mapping which describes how the offsets
-   * in the template should be interpreted.
+   * For the given type checking id, retrieve the original source mapping which describes how the
+   * offsets in the template should be interpreted.
    */
-  getSourceMapping(id: TemplateId): TemplateSourceMapping;
+  getSourceMapping(id: TypeCheckId): TemplateSourceMapping;
 
   /**
-   * Convert an absolute source span associated with the given template id into a full
+   * Convert an absolute source span associated with the given type checking id into a full
    * `ParseSourceSpan`. The returned parse span has line and column numbers in addition to only
-   * absolute offsets and gives access to the original template source.
+   * absolute offsets and gives access to the original source code.
    */
-  toParseSourceSpan(id: TemplateId, span: AbsoluteSourceSpan): ParseSourceSpan | null;
+  toParseSourceSpan(id: TypeCheckId, span: AbsoluteSourceSpan): ParseSourceSpan | null;
 }
 
 /**
@@ -131,7 +131,7 @@ export function getTemplateMapping(
 
 export function findTypeCheckBlock(
   file: ts.SourceFile,
-  id: TemplateId,
+  id: TypeCheckId,
   isDiagnosticRequest: boolean,
 ): ts.Node | null {
   for (const stmt of file.statements) {
@@ -181,7 +181,7 @@ function getTemplateId(
   node: ts.Node,
   sourceFile: ts.SourceFile,
   isDiagnosticRequest: boolean,
-): TemplateId | null {
+): TypeCheckId | null {
   // Walk up to the function declaration of the TCB, the file information is attached there.
   while (!ts.isFunctionDeclaration(node)) {
     if (hasIgnoreForDiagnosticsMarker(node, sourceFile) && isDiagnosticRequest) {
@@ -204,7 +204,7 @@ function getTemplateId(
       }
       const commentText = sourceFile.text.substring(pos + 2, end - 2);
       return commentText;
-    }) as TemplateId) || null
+    }) as TypeCheckId) || null
   );
 }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/template_symbol_builder.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/template_symbol_builder.ts
@@ -60,7 +60,7 @@ import {
   findFirstMatchingNode,
   hasExpressionIdentifier,
 } from './comments';
-import {TemplateData} from './context';
+import {TypeCheckData} from './context';
 import {isAccessExpression} from './ts_util';
 
 /**
@@ -76,7 +76,7 @@ export class SymbolBuilder {
     private readonly tcbPath: AbsoluteFsPath,
     private readonly tcbIsShim: boolean,
     private readonly typeCheckBlock: ts.Node,
-    private readonly templateData: TemplateData,
+    private readonly typeCheckData: TypeCheckData,
     private readonly componentScopeReader: ComponentScopeReader,
     // The `ts.TypeChecker` depends on the current type-checking program, and so must be requested
     // on-demand instead of cached.
@@ -257,7 +257,7 @@ export class SymbolBuilder {
     host: TmplAstTemplate | TmplAstElement,
     directiveDeclaration: ts.Declaration,
   ): TypeCheckableDirectiveMeta | null {
-    let directives = this.templateData.boundTarget.getDirectivesOfNode(host);
+    let directives = this.typeCheckData.boundTarget.getDirectivesOfNode(host);
 
     // `getDirectivesOfNode` will not return the directives intended for an element
     // on a microsyntax template, for example `<div *ngFor="let user of users;" dir>`,
@@ -267,7 +267,7 @@ export class SymbolBuilder {
       const isMicrosyntaxTemplate =
         host instanceof TmplAstTemplate && sourceSpanEqual(firstChild.sourceSpan, host.sourceSpan);
       if (isMicrosyntaxTemplate) {
-        const firstChildDirectives = this.templateData.boundTarget.getDirectivesOfNode(firstChild);
+        const firstChildDirectives = this.typeCheckData.boundTarget.getDirectivesOfNode(firstChild);
         if (firstChildDirectives !== null && directives !== null) {
           directives = directives.concat(firstChildDirectives);
         } else {
@@ -291,7 +291,7 @@ export class SymbolBuilder {
   }
 
   private getSymbolOfBoundEvent(eventBinding: TmplAstBoundEvent): OutputBindingSymbol | null {
-    const consumer = this.templateData.boundTarget.getConsumerOfBinding(eventBinding);
+    const consumer = this.typeCheckData.boundTarget.getConsumerOfBinding(eventBinding);
     if (consumer === null) {
       return null;
     }
@@ -402,7 +402,7 @@ export class SymbolBuilder {
   private getSymbolOfInputBinding(
     binding: TmplAstBoundAttribute | TmplAstTextAttribute,
   ): InputBindingSymbol | DomBindingSymbol | null {
-    const consumer = this.templateData.boundTarget.getConsumerOfBinding(binding);
+    const consumer = this.typeCheckData.boundTarget.getConsumerOfBinding(binding);
     if (consumer === null) {
       return null;
     }
@@ -568,7 +568,7 @@ export class SymbolBuilder {
   }
 
   private getSymbolOfReference(ref: TmplAstReference): ReferenceSymbol | null {
-    const target = this.templateData.boundTarget.getReferenceTarget(ref);
+    const target = this.typeCheckData.boundTarget.getReferenceTarget(ref);
     // Find the node for the reference declaration, i.e. `var _t2 = _t1;`
     let node = findFirstMatchingNode(this.typeCheckBlock, {
       withSpan: ref.sourceSpan,
@@ -702,7 +702,7 @@ export class SymbolBuilder {
       expression = expression.ast;
     }
 
-    const expressionTarget = this.templateData.boundTarget.getExpressionTarget(expression);
+    const expressionTarget = this.typeCheckData.boundTarget.getExpressionTarget(expression);
     if (expressionTarget !== null) {
       return this.getSymbol(expressionTarget);
     }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -1936,7 +1936,7 @@ export class Context {
     readonly oobRecorder: OutOfBandDiagnosticRecorder,
     readonly id: TypeCheckId,
     readonly boundTarget: BoundTarget<TypeCheckableDirectiveMeta>,
-    private pipes: Map<string, PipeMeta>,
+    private pipes: Map<string, PipeMeta> | null,
     readonly schemas: SchemaMetadata[],
     readonly hostIsStandalone: boolean,
     readonly hostPreserveWhitespaces: boolean,
@@ -1953,7 +1953,7 @@ export class Context {
   }
 
   getPipeByName(name: string): PipeMeta | null {
-    if (!this.pipes.has(name)) {
+    if (this.pipes === null || !this.pipes.has(name)) {
       return null;
     }
     return this.pipes.get(name)!;

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -58,12 +58,12 @@ import ts from 'typescript';
 import {Reference} from '../../imports';
 import {BindingPropertyName, ClassPropertyName, PipeMeta} from '../../metadata';
 import {ClassDeclaration} from '../../reflection';
-import {TemplateId, TypeCheckableDirectiveMeta, TypeCheckBlockMetadata} from '../api';
+import {TypeCheckId, TypeCheckableDirectiveMeta, TypeCheckBlockMetadata} from '../api';
 
 import {addExpressionIdentifier, ExpressionIdentifier, markIgnoreDiagnostics} from './comments';
 import {
   addParseSpanInfo,
-  addTemplateId,
+  addTypeCheckId,
   wrapForDiagnostics,
   wrapForTypeChecker,
 } from './diagnostics';
@@ -213,7 +213,7 @@ export function generateTypeCheckBlock(
     /* type */ undefined,
     /* body */ body,
   );
-  addTemplateId(fnDecl, meta.id);
+  addTypeCheckId(fnDecl, meta.id);
   return fnDecl;
 }
 
@@ -1934,7 +1934,7 @@ export class Context {
     readonly env: Environment,
     readonly domSchemaChecker: DomSchemaChecker,
     readonly oobRecorder: OutOfBandDiagnosticRecorder,
-    readonly id: TemplateId,
+    readonly id: TypeCheckId,
     readonly boundTarget: BoundTarget<TypeCheckableDirectiveMeta>,
     private pipes: Map<string, PipeMeta>,
     readonly schemas: SchemaMetadata[],

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
@@ -119,7 +119,7 @@ runInEachFileSystem(() => {
         ).toEqual('name');
 
         // Ensure we can go back to the original location using the shim location
-        const mapping = templateTypeChecker.getTemplateMappingAtTcbLocation(
+        const mapping = templateTypeChecker.getSourceMappingAtTcbLocation(
           symbol.bindings[0].tcbLocation,
         )!;
         expect(mapping.span.toString()).toEqual('name');
@@ -198,11 +198,11 @@ runInEachFileSystem(() => {
           expect(symbol.declaration.name).toEqual('contextFoo');
 
           // Ensure we can map the shim locations back to the template
-          const initializerMapping = templateTypeChecker.getTemplateMappingAtTcbLocation(
+          const initializerMapping = templateTypeChecker.getSourceMappingAtTcbLocation(
             symbol.initializerLocation,
           )!;
           expect(initializerMapping.span.toString()).toEqual('bar');
-          const localVarMapping = templateTypeChecker.getTemplateMappingAtTcbLocation(
+          const localVarMapping = templateTypeChecker.getSourceMappingAtTcbLocation(
             symbol.localVarLocation,
           )!;
           expect(localVarMapping.span.toString()).toEqual('contextFoo');
@@ -225,7 +225,7 @@ runInEachFileSystem(() => {
           assertDirectiveReference(symbol);
 
           // Ensure we can map the var shim location back to the template
-          const localVarMapping = templateTypeChecker.getTemplateMappingAtTcbLocation(
+          const localVarMapping = templateTypeChecker.getSourceMappingAtTcbLocation(
             symbol.referenceVarLocation,
           );
           expect(localVarMapping!.span.toString()).toEqual('ref1');
@@ -2039,11 +2039,11 @@ runInEachFileSystem(() => {
         expect(symbol.declaration.name).toEqual('message');
 
         // Ensure we can map the shim locations back to the template
-        const initializerMapping = templateTypeChecker.getTemplateMappingAtTcbLocation(
+        const initializerMapping = templateTypeChecker.getSourceMappingAtTcbLocation(
           symbol.initializerLocation,
         )!;
         expect(initializerMapping.span.toString()).toEqual(`'The value is ' + value`);
-        const localVarMapping = templateTypeChecker.getTemplateMappingAtTcbLocation(
+        const localVarMapping = templateTypeChecker.getSourceMappingAtTcbLocation(
           symbol.localVarLocation,
         )!;
         expect(localVarMapping.span.toString()).toEqual('message');

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_constructor_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_constructor_spec.ts
@@ -35,7 +35,7 @@ import {
   TypeCheckContextImpl,
   TypeCheckingHost,
 } from '../src/context';
-import {TemplateSourceManager} from '../src/source';
+import {DirectiveSourceManager} from '../src/source';
 import {TypeCheckFile} from '../src/type_check_file';
 import {ALL_ENABLED_CONFIG} from '../testing';
 
@@ -302,15 +302,15 @@ TestClass.ngTypeCtor({value: 'test'});
 function makePendingFile(): PendingFileTypeCheckingData {
   return {
     hasInlines: false,
-    sourceManager: new TemplateSourceManager(),
+    sourceManager: new DirectiveSourceManager(),
     shimData: new Map(),
   };
 }
 
 class TestTypeCheckingHost implements TypeCheckingHost {
-  private sourceManager = new TemplateSourceManager();
+  private sourceManager = new DirectiveSourceManager();
 
-  getSourceManager(): TemplateSourceManager {
+  getSourceManager(): DirectiveSourceManager {
     return this.sourceManager;
   }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_constructor_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_constructor_spec.ts
@@ -314,7 +314,7 @@ class TestTypeCheckingHost implements TypeCheckingHost {
     return this.sourceManager;
   }
 
-  shouldCheckComponent(): boolean {
+  shouldCheckClass(): boolean {
     return true;
   }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -74,13 +74,13 @@ import {getRootDirs} from '../../util/src/typescript';
 import {
   OptimizeFor,
   ProgramTypeCheckAdapter,
+  TemplateContext,
   TemplateDiagnostic,
   TemplateTypeChecker,
   TypeCheckContext,
 } from '../api';
 import {
   TypeCheckId,
-  TemplateSourceMapping,
   TypeCheckableDirectiveMeta,
   TypeCheckBlockMetadata,
   TypeCheckingConfig,
@@ -633,28 +633,22 @@ export function setup(
         );
         const binder = new R3TargetBinder<DirectiveMeta>(matcher);
         const classRef = new Reference(classDecl);
-
-        const sourceMapping: TemplateSourceMapping = {
-          type: 'external',
-          template,
-          templateUrl,
-          componentClass: classRef.node,
-          // Use the class's name for error mappings.
-          node: classRef.node.name,
-        };
-
-        ctx.addTemplate(
-          classRef,
-          binder,
+        const templateContext: TemplateContext = {
           nodes,
           pipes,
-          [],
-          sourceMapping,
-          templateFile,
-          errors,
-          false,
-          false,
-        );
+          sourceMapping: {
+            type: 'external',
+            template,
+            templateUrl,
+            componentClass: classRef.node,
+            node: classRef.node.name, // Use the class's name for error mappings.
+          },
+          file: templateFile,
+          parseErrors: errors,
+          preserveWhitespaces: false,
+        };
+
+        ctx.addDirective(classRef, binder, [], templateContext, false);
       }
     }
   });

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -79,7 +79,7 @@ import {
   TypeCheckContext,
 } from '../api';
 import {
-  TemplateId,
+  TypeCheckId,
   TemplateSourceMapping,
   TypeCheckableDirectiveMeta,
   TypeCheckBlockMetadata,
@@ -388,7 +388,7 @@ export function tcb(
   const binder = new R3TargetBinder<DirectiveMeta>(matcher);
   const boundTarget = binder.bind({template: nodes});
 
-  const id = 'tcb' as TemplateId;
+  const id = 'tcb' as TypeCheckId;
   const meta: TypeCheckBlockMetadata = {
     id,
     boundTarget,
@@ -1039,8 +1039,8 @@ export class NoopOobRecorder implements OutOfBandDiagnosticRecorder {
   }
   missingReferenceTarget(): void {}
   missingPipe(): void {}
-  deferredPipeUsedEagerly(templateId: TemplateId, ast: BindingPipe): void {}
-  deferredComponentUsedEagerly(templateId: TemplateId, element: TmplAstElement): void {}
+  deferredPipeUsedEagerly(id: TypeCheckId, ast: BindingPipe): void {}
+  deferredComponentUsedEagerly(id: TypeCheckId, element: TmplAstElement): void {}
   duplicateTemplateVar(): void {}
   requiresInlineTcb(): void {}
   requiresInlineTypeConstructors(): void {}
@@ -1051,14 +1051,14 @@ export class NoopOobRecorder implements OutOfBandDiagnosticRecorder {
   inaccessibleDeferredTriggerElement(): void {}
   controlFlowPreventingContentProjection(): void {}
   illegalWriteToLetDeclaration(
-    templateId: TemplateId,
+    id: TypeCheckId,
     node: PropertyWrite,
     target: TmplAstLetDeclaration,
   ): void {}
   letUsedBeforeDefinition(
-    templateId: TemplateId,
+    id: TypeCheckId,
     node: PropertyRead,
     target: TmplAstLetDeclaration,
   ): void {}
-  conflictingDeclaration(templateId: TemplateId, current: TmplAstLetDeclaration): void {}
+  conflictingDeclaration(id: TypeCheckId, current: TmplAstLetDeclaration): void {}
 }

--- a/packages/language-service/src/codefixes/code_fixes.ts
+++ b/packages/language-service/src/codefixes/code_fixes.ts
@@ -9,7 +9,7 @@
 import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
 import tss from 'typescript';
 
-import {TemplateInfo} from '../utils';
+import {TypeCheckInfo} from '../utils';
 
 import {CodeActionMeta, FixIdForCodeFixesAll, isFixAllAvailable} from './utils';
 
@@ -50,7 +50,7 @@ export class CodeFixes {
    */
   getCodeFixesAtPosition(
     fileName: string,
-    templateInfo: TemplateInfo | null,
+    typeCheckInfo: TypeCheckInfo | null,
     compiler: NgCompiler,
     start: number,
     end: number,
@@ -68,7 +68,7 @@ export class CodeFixes {
       for (const meta of metas) {
         const codeActionsForMeta = meta.getCodeActions({
           fileName,
-          templateInfo,
+          typeCheckInfo: typeCheckInfo,
           compiler,
           start,
           end,

--- a/packages/language-service/src/codefixes/fix_invalid_banana_in_box.ts
+++ b/packages/language-service/src/codefixes/fix_invalid_banana_in_box.ts
@@ -11,7 +11,7 @@ import {ErrorCode, ngErrorCode} from '@angular/compiler-cli/src/ngtsc/diagnostic
 import tss from 'typescript';
 
 import {getTargetAtPosition, TargetNodeKind} from '../template_target';
-import {getTemplateInfoAtPosition, TemplateInfo} from '../utils';
+import {getTypeCheckInfoAtPosition, TypeCheckInfo} from '../utils';
 
 import {CodeActionMeta, FixIdForCodeFixesAll} from './utils';
 
@@ -20,9 +20,9 @@ import {CodeActionMeta, FixIdForCodeFixesAll} from './utils';
  */
 export const fixInvalidBananaInBoxMeta: CodeActionMeta = {
   errorCodes: [ngErrorCode(ErrorCode.INVALID_BANANA_IN_BOX)],
-  getCodeActions({start, fileName, templateInfo}) {
+  getCodeActions({start, fileName, typeCheckInfo}) {
     const boundEvent =
-      templateInfo === null ? null : getTheBoundEventAtPosition(templateInfo, start);
+      typeCheckInfo === null ? null : getTheBoundEventAtPosition(typeCheckInfo, start);
     if (boundEvent === null) {
       return [];
     }
@@ -54,8 +54,8 @@ export const fixInvalidBananaInBoxMeta: CodeActionMeta = {
       if (start === undefined) {
         continue;
       }
-      const templateInfo = getTemplateInfoAtPosition(fileName, start, compiler);
-      if (templateInfo === undefined) {
+      const typeCheckInfo = getTypeCheckInfoAtPosition(fileName, start, compiler);
+      if (typeCheckInfo === undefined) {
         continue;
       }
 
@@ -64,7 +64,7 @@ export const fixInvalidBananaInBoxMeta: CodeActionMeta = {
        * parens (the BoundEvent `([thing])`) when it should be the other way around `[(thing)]` so
        * this function is trying to find the bound event in order to flip the syntax.
        */
-      const boundEvent = getTheBoundEventAtPosition(templateInfo, start);
+      const boundEvent = getTheBoundEventAtPosition(typeCheckInfo, start);
       if (boundEvent === null) {
         continue;
       }
@@ -91,7 +91,7 @@ export const fixInvalidBananaInBoxMeta: CodeActionMeta = {
 };
 
 function getTheBoundEventAtPosition(
-  templateInfo: TemplateInfo,
+  typeCheckInfo: TypeCheckInfo,
   start: number,
 ): TmplAstBoundEvent | null {
   // It's safe to get the bound event at the position `start + 1` because the `start` is at the
@@ -99,7 +99,7 @@ function getTheBoundEventAtPosition(
   // the function `getTargetAtPosition`.
   // https://github.com/angular/vscode-ng-language-service/blob/8553115972ca40a55602747667c3d11d6f47a6f8/server/src/session.ts#L220
   // https://github.com/angular/angular/blob/4e10a7494130b9bb4772ee8f76b66675867b2145/packages/language-service/src/template_target.ts#L347-L356
-  const positionDetail = getTargetAtPosition(templateInfo.template, start + 1);
+  const positionDetail = getTargetAtPosition(typeCheckInfo.nodes, start + 1);
   if (positionDetail === null) {
     return null;
   }

--- a/packages/language-service/src/codefixes/fix_missing_import.ts
+++ b/packages/language-service/src/codefixes/fix_missing_import.ts
@@ -47,14 +47,14 @@ export const missingImportMeta: CodeActionMeta = {
   },
 };
 
-function getCodeActions({templateInfo, start, compiler}: CodeActionContext) {
-  if (templateInfo === null) {
+function getCodeActions({typeCheckInfo, start, compiler}: CodeActionContext) {
+  if (typeCheckInfo === null) {
     return [];
   }
 
   let codeActions: ts.CodeFixAction[] = [];
   const checker = compiler.getTemplateTypeChecker();
-  const target = getTargetAtPosition(templateInfo.template, start);
+  const target = getTargetAtPosition(typeCheckInfo.nodes, start);
   if (target === null) {
     return [];
   }
@@ -64,21 +64,21 @@ function getCodeActions({templateInfo, start, compiler}: CodeActionContext) {
     target.context.kind === TargetNodeKind.ElementInTagContext &&
     target.context.node instanceof TmplAstElement
   ) {
-    const allPossibleDirectives = checker.getPotentialTemplateDirectives(templateInfo.component);
+    const allPossibleDirectives = checker.getPotentialTemplateDirectives(typeCheckInfo.declaration);
     matches = getDirectiveMatchesForElementTag(target.context.node, allPossibleDirectives);
   } else if (
     target.context.kind === TargetNodeKind.RawExpression &&
     target.context.node instanceof ASTWithName
   ) {
     const name = (target.context.node as any).name;
-    const allPossiblePipes = checker.getPotentialPipes(templateInfo.component);
+    const allPossiblePipes = checker.getPotentialPipes(typeCheckInfo.declaration);
     matches = new Set(allPossiblePipes.filter((p) => p.name === name));
   } else {
     return [];
   }
 
   // Find all possible importable directives with a matching selector.
-  const importOn = standaloneTraitOrNgModule(checker, templateInfo.component);
+  const importOn = standaloneTraitOrNgModule(checker, typeCheckInfo.declaration);
   if (importOn === null) {
     return [];
   }

--- a/packages/language-service/src/codefixes/fix_missing_member.ts
+++ b/packages/language-service/src/codefixes/fix_missing_member.ts
@@ -9,7 +9,7 @@
 import tss from 'typescript';
 
 import {getTcbNodesOfTemplateAtPosition} from '../template_target';
-import {getTemplateInfoAtPosition} from '../utils';
+import {getTypeCheckInfoAtPosition} from '../utils';
 
 import {CodeActionMeta, convertFileTextChangeInTcb, FixIdForCodeFixesAll} from './utils';
 
@@ -25,7 +25,7 @@ const errorCodes: number[] = [
 export const missingMemberMeta: CodeActionMeta = {
   errorCodes,
   getCodeActions: function ({
-    templateInfo,
+    typeCheckInfo,
     start,
     compiler,
     formatOptions,
@@ -34,7 +34,9 @@ export const missingMemberMeta: CodeActionMeta = {
     tsLs,
   }) {
     const tcbNodesInfo =
-      templateInfo === null ? null : getTcbNodesOfTemplateAtPosition(templateInfo, start, compiler);
+      typeCheckInfo === null
+        ? null
+        : getTcbNodesOfTemplateAtPosition(typeCheckInfo, start, compiler);
     if (tcbNodesInfo === null) {
       return [];
     }
@@ -87,16 +89,16 @@ export const missingMemberMeta: CodeActionMeta = {
       if (diag.start === undefined) {
         continue;
       }
-      const componentClass = getTemplateInfoAtPosition(fileName, diag.start, compiler)?.component;
-      if (componentClass === undefined) {
+      const declaration = getTypeCheckInfoAtPosition(fileName, diag.start, compiler)?.declaration;
+      if (declaration === undefined) {
         continue;
       }
-      if (seen.has(componentClass)) {
+      if (seen.has(declaration)) {
         continue;
       }
-      seen.add(componentClass);
+      seen.add(declaration);
 
-      const tcb = compiler.getTemplateTypeChecker().getTypeCheckBlock(componentClass);
+      const tcb = compiler.getTemplateTypeChecker().getTypeCheckBlock(declaration);
       if (tcb === null) {
         continue;
       }

--- a/packages/language-service/src/codefixes/utils.ts
+++ b/packages/language-service/src/codefixes/utils.ts
@@ -74,15 +74,15 @@ export function convertFileTextChangeInTcb(
     let fileName: string | undefined;
     const seenTextChangeInTemplate = new Set<string>();
     for (const textChange of fileTextChange.textChanges) {
-      const templateMap = ttc.getTemplateMappingAtTcbLocation({
+      const sourceLocation = ttc.getSourceMappingAtTcbLocation({
         tcbPath: absoluteFrom(fileTextChange.fileName),
         isShimFile: true,
         positionInFile: textChange.span.start,
       });
-      if (templateMap === null) {
+      if (sourceLocation === null) {
         continue;
       }
-      const mapping = templateMap.templateSourceMapping;
+      const mapping = sourceLocation.sourceMapping;
       if (mapping.type === 'external') {
         fileName = mapping.templateUrl;
       } else if (mapping.type === 'direct') {
@@ -90,8 +90,8 @@ export function convertFileTextChangeInTcb(
       } else {
         continue;
       }
-      const start = templateMap.span.start.offset;
-      const length = templateMap.span.end.offset - templateMap.span.start.offset;
+      const start = sourceLocation.span.start.offset;
+      const length = sourceLocation.span.end.offset - sourceLocation.span.start.offset;
       const changeSpanKey = `${start},${length}`;
       if (seenTextChangeInTemplate.has(changeSpanKey)) {
         continue;

--- a/packages/language-service/src/codefixes/utils.ts
+++ b/packages/language-service/src/codefixes/utils.ts
@@ -10,7 +10,7 @@ import {absoluteFrom} from '@angular/compiler-cli';
 import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
 import tss from 'typescript';
 
-import {TemplateInfo} from '../utils';
+import {TypeCheckInfo} from '../utils';
 
 /**
  * This context is the info includes the `errorCode` at the given span the user selected in the
@@ -20,7 +20,7 @@ import {TemplateInfo} from '../utils';
  * context will be provided to the `CodeActionMeta` which could handle the `errorCode`.
  */
 export interface CodeActionContext {
-  templateInfo: TemplateInfo | null;
+  typeCheckInfo: TypeCheckInfo | null;
   fileName: string;
   compiler: NgCompiler;
   start: number;

--- a/packages/language-service/src/definitions.ts
+++ b/packages/language-service/src/definitions.ts
@@ -17,7 +17,7 @@ import {
 } from '@angular/compiler';
 import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
 import {absoluteFrom} from '@angular/compiler-cli/src/ngtsc/file_system';
-import {isExternalResource} from '@angular/compiler-cli/src/ngtsc/metadata';
+import {isExternalResource, Resource} from '@angular/compiler-cli/src/ngtsc/metadata';
 import {
   DirectiveSymbol,
   DomBindingSymbol,
@@ -407,15 +407,27 @@ function getDefinitionForExpressionAtPosition(
   if (classDeclaration === undefined) {
     return;
   }
-  const componentResources = compiler.getComponentResources(classDeclaration);
-  if (componentResources === null) {
+  const resource = compiler.getDirectiveResources(classDeclaration);
+  if (resource === null) {
     return;
   }
 
-  const allResources = [...componentResources.styles, componentResources.template];
+  let resourceForExpression: Resource | null = null;
 
-  const resourceForExpression = allResources.find((resource) => resource.expression === expression);
-  if (resourceForExpression === undefined || !isExternalResource(resourceForExpression)) {
+  if (resource.template?.expression === expression) {
+    resourceForExpression = resource.template;
+  }
+
+  if (resourceForExpression === null && resource.styles !== null) {
+    for (const style of resource.styles) {
+      if (style.expression === expression) {
+        resourceForExpression = style;
+        break;
+      }
+    }
+  }
+
+  if (resourceForExpression === null || !isExternalResource(resourceForExpression)) {
     return;
   }
 

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -494,11 +494,10 @@ export class LanguageService {
         if (classDeclaration === undefined) {
           return undefined;
         }
-        const resources = compiler.getComponentResources(classDeclaration);
-        if (resources === null) {
+        const template = compiler.getDirectiveResources(classDeclaration)?.template || null;
+        if (template === null) {
           return undefined;
         }
-        const {template} = resources;
         let templateFileName: string;
         let span: ts.TextSpan;
         if (template.path !== null) {

--- a/packages/language-service/src/outlining_spans.ts
+++ b/packages/language-service/src/outlining_spans.ts
@@ -51,12 +51,8 @@ export function getOutliningSpans(compiler: NgCompiler, fileName: string): ts.Ou
     }
     return templatesInFile.map((template) => BlockVisitor.getBlockSpans(template)).flat();
   } else {
-    const templateInfo = getFirstComponentForTemplateFile(fileName, compiler);
-    if (templateInfo === undefined) {
-      return [];
-    }
-    const {template} = templateInfo;
-    return BlockVisitor.getBlockSpans(template);
+    const typeCheckInfo = getFirstComponentForTemplateFile(fileName, compiler);
+    return typeCheckInfo === undefined ? [] : BlockVisitor.getBlockSpans(typeCheckInfo.nodes);
   }
 }
 

--- a/packages/language-service/src/outlining_spans.ts
+++ b/packages/language-service/src/outlining_spans.ts
@@ -34,8 +34,12 @@ export function getOutliningSpans(compiler: NgCompiler, fileName: string): ts.Ou
     const templatesInFile: Array<TmplAstNode[]> = [];
     for (const stmt of sf.statements) {
       if (isNamedClassDeclaration(stmt)) {
-        const resources = compiler.getComponentResources(stmt);
-        if (resources === null || isExternalResource(resources.template)) {
+        const resources = compiler.getDirectiveResources(stmt);
+        if (
+          resources === null ||
+          resources.template === null ||
+          isExternalResource(resources.template)
+        ) {
           continue;
         }
         const template = compiler.getTemplateTypeChecker().getTemplate(stmt);

--- a/packages/language-service/src/references_and_rename_utils.ts
+++ b/packages/language-service/src/references_and_rename_utils.ts
@@ -44,7 +44,7 @@ import {
   getDirectiveMatchesForElementTag,
   getTemplateLocationFromTcbLocation,
   isWithin,
-  TemplateInfo,
+  TypeCheckInfo,
   toTextSpan,
 } from './utils';
 
@@ -84,12 +84,12 @@ export interface TemplateLocationDetails {
  * the targeted template node.
  */
 export function getTargetDetailsAtTemplatePosition(
-  {template, component}: TemplateInfo,
+  info: TypeCheckInfo,
   position: number,
   templateTypeChecker: TemplateTypeChecker,
 ): TemplateLocationDetails[] | null {
   // Find the AST node in the template at the position.
-  const positionDetails = getTargetAtPosition(template, position);
+  const positionDetails = getTargetAtPosition(info.nodes, position);
   if (positionDetails === null) {
     return null;
   }
@@ -103,7 +103,7 @@ export function getTargetDetailsAtTemplatePosition(
 
   for (const node of nodes) {
     // Get the information about the TCB at the template position.
-    const symbol = templateTypeChecker.getSymbolOfNode(node, component);
+    const symbol = templateTypeChecker.getSymbolOfNode(node, info.declaration);
     if (symbol === null) {
       continue;
     }

--- a/packages/language-service/src/signature_help.ts
+++ b/packages/language-service/src/signature_help.ts
@@ -14,7 +14,7 @@ import ts from 'typescript';
 
 import {getTargetAtPosition, TargetNodeKind} from './template_target';
 import {findTightestNode} from './utils/ts_utils';
-import {getTemplateInfoAtPosition} from './utils';
+import {getTypeCheckInfoAtPosition} from './utils';
 
 /**
  * Queries the TypeScript Language Service to get signature help for a template position.
@@ -26,12 +26,12 @@ export function getSignatureHelp(
   position: number,
   options: ts.SignatureHelpItemsOptions | undefined,
 ): ts.SignatureHelpItems | undefined {
-  const templateInfo = getTemplateInfoAtPosition(fileName, position, compiler);
-  if (templateInfo === undefined) {
+  const typeCheckInfo = getTypeCheckInfoAtPosition(fileName, position, compiler);
+  if (typeCheckInfo === undefined) {
     return undefined;
   }
 
-  const targetInfo = getTargetAtPosition(templateInfo.template, position);
+  const targetInfo = getTargetAtPosition(typeCheckInfo.nodes, position);
   if (targetInfo === null) {
     return undefined;
   }
@@ -46,7 +46,7 @@ export function getSignatureHelp(
 
   const symbol = compiler
     .getTemplateTypeChecker()
-    .getSymbolOfNode(targetInfo.context.node, templateInfo.component);
+    .getSymbolOfNode(targetInfo.context.node, typeCheckInfo.declaration);
   if (symbol === null || symbol.kind !== SymbolKind.Expression) {
     return undefined;
   }

--- a/packages/language-service/src/template_target.ts
+++ b/packages/language-service/src/template_target.ts
@@ -55,7 +55,7 @@ import {
   isTemplateNodeWithKeyAndValue,
   isWithin,
   isWithinKeyValue,
-  TemplateInfo,
+  TypeCheckInfo,
 } from './utils';
 
 /**
@@ -349,16 +349,16 @@ interface TcbNodesInfoForTemplate {
  *
  */
 export function getTcbNodesOfTemplateAtPosition(
-  templateInfo: TemplateInfo,
+  typeCheckInfo: TypeCheckInfo,
   position: number,
   compiler: NgCompiler,
 ): TcbNodesInfoForTemplate | null {
-  const target = getTargetAtPosition(templateInfo.template, position);
+  const target = getTargetAtPosition(typeCheckInfo.nodes, position);
   if (target === null) {
     return null;
   }
 
-  const tcb = compiler.getTemplateTypeChecker().getTypeCheckBlock(templateInfo.component);
+  const tcb = compiler.getTemplateTypeChecker().getTypeCheckBlock(typeCheckInfo.declaration);
   if (tcb === null) {
     return null;
   }

--- a/packages/language-service/src/utils/index.ts
+++ b/packages/language-service/src/utils/index.ts
@@ -422,7 +422,7 @@ export function getTemplateLocationFromTcbLocation(
   tcbIsShim: boolean,
   positionInFile: number,
 ): {templateUrl: AbsoluteFsPath; span: ParseSourceSpan} | null {
-  const mapping = templateTypeChecker.getTemplateMappingAtTcbLocation({
+  const mapping = templateTypeChecker.getSourceMappingAtTcbLocation({
     tcbPath,
     isShimFile: tcbIsShim,
     positionInFile,
@@ -430,13 +430,13 @@ export function getTemplateLocationFromTcbLocation(
   if (mapping === null) {
     return null;
   }
-  const {templateSourceMapping, span} = mapping;
+  const {sourceMapping, span} = mapping;
 
   let templateUrl: AbsoluteFsPath;
-  if (templateSourceMapping.type === 'direct') {
-    templateUrl = absoluteFromSourceFile(templateSourceMapping.node.getSourceFile());
-  } else if (templateSourceMapping.type === 'external') {
-    templateUrl = absoluteFrom(templateSourceMapping.templateUrl);
+  if (sourceMapping.type === 'direct') {
+    templateUrl = absoluteFromSourceFile(sourceMapping.node.getSourceFile());
+  } else if (sourceMapping.type === 'external') {
+    templateUrl = absoluteFrom(sourceMapping.templateUrl);
   } else {
     // This includes indirect mappings, which are difficult to map directly to the code
     // location. Diagnostics similarly return a synthetic template string for this case rather

--- a/packages/language-service/src/utils/index.ts
+++ b/packages/language-service/src/utils/index.ts
@@ -135,9 +135,10 @@ function getInlineTemplateInfoAtPosition(
 
   // Return `undefined` if the position is not on the template expression or the template resource
   // is not inline.
-  const resources = compiler.getComponentResources(classDecl);
+  const resources = compiler.getDirectiveResources(classDecl);
   if (
     resources === null ||
+    resources.template === null ||
     isExternalResource(resources.template) ||
     expression !== resources.template.expression
   ) {

--- a/packages/language-service/src/utils/index.ts
+++ b/packages/language-service/src/utils/index.ts
@@ -114,16 +114,16 @@ export function isExpressionNode(node: TmplAstNode | AST): node is AST {
   return node instanceof AST;
 }
 
-export interface TemplateInfo {
-  template: TmplAstNode[];
-  component: ts.ClassDeclaration;
+export interface TypeCheckInfo {
+  nodes: TmplAstNode[];
+  declaration: ts.ClassDeclaration;
 }
 
-function getInlineTemplateInfoAtPosition(
+function getInlineTypeCheckInfoAtPosition(
   sf: ts.SourceFile,
   position: number,
   compiler: NgCompiler,
-): TemplateInfo | undefined {
+): TypeCheckInfo | undefined {
   const expression = findTightestNode(sf, position);
   if (expression === undefined) {
     return undefined;
@@ -150,24 +150,24 @@ function getInlineTemplateInfoAtPosition(
     return undefined;
   }
 
-  return {template, component: classDecl};
+  return {nodes: template, declaration: classDecl};
 }
 
 /**
- * Retrieves the `ts.ClassDeclaration` at a location along with its template nodes.
+ * Retrieves the `ts.ClassDeclaration` at a location along with its template AST nodes.
  */
-export function getTemplateInfoAtPosition(
+export function getTypeCheckInfoAtPosition(
   fileName: string,
   position: number,
   compiler: NgCompiler,
-): TemplateInfo | undefined {
+): TypeCheckInfo | undefined {
   if (isTypeScriptFile(fileName)) {
     const sf = compiler.getCurrentProgram().getSourceFile(fileName);
     if (sf === undefined) {
       return undefined;
     }
 
-    return getInlineTemplateInfoAtPosition(sf, position, compiler);
+    return getInlineTypeCheckInfoAtPosition(sf, position, compiler);
   } else {
     return getFirstComponentForTemplateFile(fileName, compiler);
   }
@@ -192,7 +192,7 @@ function tsDeclarationSortComparator(a: DeclarationNode, b: DeclarationNode): nu
 export function getFirstComponentForTemplateFile(
   fileName: string,
   compiler: NgCompiler,
-): TemplateInfo | undefined {
+): TypeCheckInfo | undefined {
   const templateTypeChecker = compiler.getTemplateTypeChecker();
   const components = compiler.getComponentsWithTemplateFile(fileName);
   const sortedComponents = Array.from(components).sort(tsDeclarationSortComparator);
@@ -204,7 +204,7 @@ export function getFirstComponentForTemplateFile(
     if (template === null) {
       continue;
     }
-    return {template, component};
+    return {nodes: template, declaration: component};
   }
 
   return undefined;


### PR DESCRIPTION
Makes the following changes to the compiler to accommodate some future changes:

### refactor(compiler): allow binder to apply to more than one set of nodes 
Currently `R3TargetBinder.bind` gets a set of data back from `DirectiveBinder.apply` and `TemplateBinder.applyWithScope`. This will be annoying  if we have multiple sources of data, because we'd have to do merge them at the end.

These changes switch to constructing the various data structures ahead of time and passing them into the binders to populate them instead.

I also extracted some of the less trivial types into type aliases so we don't have to repeat them.

### refactor(compiler-cli): change TemplateId terminology 

Renames the `TemplateId` and terminology related to it, because we'll be using it for more than just templates.

### refactor(compiler-cli): rework type checking internals to accommodate more than components

Currently a lot of the internal type checking data structures are set up specifically for components, because we only support type checking of templates. Since this will change in future commits, these changes prepare for it by renaming various methods and separating out component-specific data.

### refactor(compiler-cli): rework source manager to accommodate directives 

Currently the `TemplateSourceManager` is set up to specifically cater to component templates. These changes make it more generic so we can reuse it for directives.

### refactor(compiler-cli): rework resource handling to allow directives 

Currently only components can have resources, because they're the only symbol kinds being type checked. Since we want to add directives to it, these changes rework the resource handling to accommodate them.


### refactor(language-service): rename internal symbols to accommodate type checking outside a template

Currently the language service has some template-specific terminology around type checking, because that's the only place where we had TCB support. These changes make it more generic to accommodate future functionality.