### PR TITLE
docs: fix broken (ng build) link

### DIFF
--- a/packages/core/src/util/is_dev_mode.ts
+++ b/packages/core/src/util/is_dev_mode.ts
@@ -13,7 +13,7 @@ import {global} from './global';
  *
  * By default, this is true, unless `enableProdMode` is invoked prior to calling this method or the
  * application is built using the Angular CLI with the `optimization` option.
- * @see {@link cli/build ng build}
+ * @see [ng build](cli/build)
  *
  * @publicApi
  */


### PR DESCRIPTION
Remove JSDoc link, and replace the automatic linking with a regular markdown link

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

[Link `/build ng build` ](https://angular.dev/api/core/isDevMode)  - is not working

Issue Number: N/A


## What is the new behavior?
Link now is working

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
