### PR TITLE
fix(core): fix typing on injector.get to omit 'any'

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -695,7 +695,7 @@ export abstract class EnvironmentInjector implements Injector {
     // @deprecated
     abstract get<T>(token: ProviderToken<T>, notFoundValue?: T, flags?: InjectFlags): T;
     // @deprecated (undocumented)
-    abstract get(token: any, notFoundValue?: any): any;
+    abstract get<T>(token: string | ProviderToken<T>, notFoundValue?: any): any;
     // @deprecated
     abstract runInContext<ReturnT>(fn: () => ReturnT): ReturnT;
 }
@@ -966,7 +966,7 @@ export abstract class Injector {
     // @deprecated
     abstract get<T>(token: ProviderToken<T>, notFoundValue?: T, flags?: InjectFlags): T;
     // @deprecated (undocumented)
-    abstract get(token: any, notFoundValue?: any): any;
+    abstract get<T>(token: string | ProviderToken<T>, notFoundValue?: any): any;
     // (undocumented)
     static NULL: Injector;
     // (undocumented)

--- a/packages/core/src/di/injector.ts
+++ b/packages/core/src/di/injector.ts
@@ -94,7 +94,7 @@ export abstract class Injector {
    * @deprecated from v4.0.0 use ProviderToken<T>
    * @suppress {duplicate}
    */
-  abstract get(token: any, notFoundValue?: any): any;
+  abstract get<T>(token: string | ProviderToken<T>, notFoundValue?: any): any;
 
   /**
    * @deprecated from v5 use the new signature Injector.create(options)

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -157,7 +157,7 @@ export abstract class EnvironmentInjector implements Injector {
    * @deprecated from v4.0.0 use ProviderToken<T>
    * @suppress {duplicate}
    */
-  abstract get(token: any, notFoundValue?: any): any;
+  abstract get<T>(token: string | ProviderToken<T>, notFoundValue?: any): any;
 
   /**
    * Runs the given function in the context of this `EnvironmentInjector`.


### PR DESCRIPTION
This commit further restricts the deprecated type on injector.get to exclude all but `string`. Progresses towards #48408

BREAKING CHANGE: The `any` overload has been removed from `injector.get`. It now only supports `ProviderToken<T>` and (deprecated since v4) `string`.
