### PR TITLE
fix(core): ensures immediate trigger fires properly with lazy loaded routes

### DIFF
--- a/packages/core/src/defer/registry.ts
+++ b/packages/core/src/defer/registry.ts
@@ -38,6 +38,16 @@ export class DehydratedBlockRegistry {
 
   add(blockId: string, info: DehydratedDeferBlock) {
     this.registry.set(blockId, info);
+    // It's possible that hydration is queued that's waiting for the
+    // resolution of a lazy loaded route. In this case, we ensure
+    // the callback function is called to continue the hydration process
+    // for the queued block set.
+    if (this.awaitingCallbacks.has(blockId)) {
+      const awaitingCallbacks = this.awaitingCallbacks.get(blockId)!;
+      for (const cb of awaitingCallbacks) {
+        cb();
+      }
+    }
   }
 
   get(blockId: string): DehydratedDeferBlock | null {
@@ -55,6 +65,7 @@ export class DehydratedBlockRegistry {
       this.jsActionMap.delete(blockId);
       this.invokeTriggerCleanupFns(blockId);
       this.hydrating.delete(blockId);
+      this.awaitingCallbacks.delete(blockId);
     }
     if (this.size === 0) {
       this.contract.instance?.cleanUp();
@@ -86,6 +97,15 @@ export class DehydratedBlockRegistry {
 
   // Blocks that are being hydrated.
   hydrating = new Map<string, PromiseWithResolvers<void>>();
+
+  // Blocks that are awaiting a defer instruction finish.
+  private awaitingCallbacks = new Map<string, Function[]>();
+
+  awaitParentBlock(topmostParentBlock: string, callback: Function) {
+    const parentBlockAwaitCallbacks = this.awaitingCallbacks.get(topmostParentBlock) ?? [];
+    parentBlockAwaitCallbacks.push(callback);
+    this.awaitingCallbacks.set(topmostParentBlock, parentBlockAwaitCallbacks);
+  }
 
   /** @nocollapse */
   static ɵprov = /** @pureOrBreakMyCode */ /* @__PURE__ */ ɵɵdefineInjectable({

--- a/packages/core/src/hydration/utils.ts
+++ b/packages/core/src/hydration/utils.ts
@@ -586,7 +586,6 @@ export function getParentBlockHydrationQueue(
     isTopMostDeferBlock = dehydratedBlockRegistry.has(currentBlockId);
     const hydratingParentBlock = dehydratedBlockRegistry.hydrating.get(currentBlockId);
     if (parentBlockPromise === null && hydratingParentBlock != null) {
-      // TODO: add an ngDevMode asset that `hydratingParentBlock.promise` exists and is of type Promise.
       parentBlockPromise = hydratingParentBlock.promise;
       break;
     }


### PR DESCRIPTION
In the case that a route was lazy loaded, some triggers would never properly finish hydrating due to things firing before the route finished resolving. This will find the topmost parent defer block and ensure the registry knows about it before trying to hydrate. In the case that the registry does not yet know, just the affected triggers await app stability before initializing. fixes #59997



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

