### PR TITLE
refactor(devtools): ignore `getInjector` when it is not supported

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/BUILD.bazel
@@ -159,3 +159,18 @@ ts_library(
         "//packages/core",
     ],
 )
+
+ts_test_library(
+    name = "component_tree_test_lib",
+    srcs = ["component-tree.spec.ts"],
+    deps = [
+        ":component_tree",
+        "//packages/core",
+        "@npm//jasmine",
+    ],
+)
+
+karma_web_test_suite(
+    name = "component_tree_test",
+    deps = [":component_tree_test_lib"],
+)

--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Injector, ɵGlobalDevModeUtils} from '@angular/core';
+import {getInjectorFromElementNode} from './component-tree';
+
+type Ng = ɵGlobalDevModeUtils['ng'];
+
+describe('component-tree', () => {
+  afterEach(() => {
+    delete (globalThis as any).ng;
+  });
+
+  describe('getInjectorFromElementNode', () => {
+    it('returns injector', () => {
+      const injector = Injector.create({
+        providers: [],
+      });
+
+      const ng: Partial<Ng> = {
+        getInjector: jasmine.createSpy('getInjector').and.returnValue(injector),
+      };
+      (globalThis as any).ng = ng;
+
+      const el = document.createElement('div');
+      expect(getInjectorFromElementNode(el)).toBe(injector);
+      expect(ng.getInjector).toHaveBeenCalledOnceWith(el);
+    });
+
+    it('returns `null` when `getInjector` is not supported', () => {
+      (globalThis as any).ng = {};
+
+      const el = document.createElement('div');
+      expect(getInjectorFromElementNode(el)).toBeNull();
+    });
+  });
+});

--- a/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/BUILD.bazel
@@ -1,5 +1,6 @@
-# load("//devtools/tools:typescript.bzl", "ts_library")
+load("//devtools/tools:defaults.bzl", "karma_web_test_suite")
 load("//devtools/tools:ng_module.bzl", "ng_module")
+load("//devtools/tools:typescript.bzl", "ts_test_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -12,4 +13,19 @@ ng_module(
     deps = [
         "//packages/core",
     ],
+)
+
+ts_test_library(
+    name = "ng-debug-api_test_lib",
+    srcs = ["ng-debug-api.spec.ts"],
+    deps = [
+        ":ng-debug-api",
+        "//packages/core",
+        "@npm//jasmine",
+    ],
+)
+
+karma_web_test_suite(
+    name = "ng-debug-api_test",
+    deps = [":ng-debug-api_test_lib"],
 )

--- a/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {ɵGlobalDevModeUtils} from '@angular/core';
+import {ngDebugDependencyInjectionApiIsSupported} from './ng-debug-api';
+
+type Ng = ɵGlobalDevModeUtils['ng'];
+
+describe('ng-debug-api', () => {
+  afterEach(() => {
+    delete (globalThis as any).ng;
+  });
+
+  describe('ngDebugDependencyInjectionApiIsSupported', () => {
+    const goldenNg: Partial<Record<keyof Ng, () => void>> = {
+      getInjector() {},
+      ɵgetInjectorResolutionPath() {},
+      ɵgetDependenciesFromInjectable() {},
+      ɵgetInjectorProviders() {},
+      ɵgetInjectorMetadata() {},
+    };
+
+    it('returns true when required APIs are supported', () => {
+      (globalThis as any).ng = goldenNg;
+
+      expect(ngDebugDependencyInjectionApiIsSupported()).toBeTrue();
+    });
+
+    it('returns false when any required API is missing', () => {
+      (globalThis as any).ng = {...goldenNg, getInjector: undefined};
+      expect(ngDebugDependencyInjectionApiIsSupported()).toBeFalse();
+
+      (globalThis as any).ng = {...goldenNg, ɵgetInjectorResolutionPath: undefined};
+      expect(ngDebugDependencyInjectionApiIsSupported()).toBeFalse();
+
+      (globalThis as any).ng = {...goldenNg, ɵgetDependenciesFromInjectable: undefined};
+      expect(ngDebugDependencyInjectionApiIsSupported()).toBeFalse();
+
+      (globalThis as any).ng = {...goldenNg, ɵgetInjectorProviders: undefined};
+      expect(ngDebugDependencyInjectionApiIsSupported()).toBeFalse();
+
+      (globalThis as any).ng = {...goldenNg, ɵgetInjectorMetadata: undefined};
+      expect(ngDebugDependencyInjectionApiIsSupported()).toBeFalse();
+    });
+  });
+});

--- a/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.ts
@@ -31,6 +31,9 @@ export function ngDebugApiIsSupported(api: keyof GlobalDevModeUtils['ng']): bool
  * @returns boolean
  */
 export function ngDebugDependencyInjectionApiIsSupported(): boolean {
+  if (!ngDebugApiIsSupported('getInjector')) {
+    return false;
+  }
   if (!ngDebugApiIsSupported('ɵgetInjectorResolutionPath')) {
     return false;
   }


### PR DESCRIPTION
Previously Angular DevTools would throw when run on an application which does not support `getInjector`, now it safely ignores it and assumes dependency injection is not supported.