### PR TITLE
refactor(devtools): ignore `ng.applyChanges` if not supported

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
@@ -578,13 +578,13 @@ export const updateState = (updatedStateData: UpdatedStateData): void => {
   if (updatedStateData.directiveId.directive !== undefined) {
     const directive = node.directives[updatedStateData.directiveId.directive].instance;
     mutateComponentOrDirective(updatedStateData, directive);
-    ng.applyChanges(ng.getOwningComponent(directive)!);
+    ng.applyChanges?.(ng.getOwningComponent(directive)!);
     return;
   }
   if (node.component) {
     const comp = node.component.instance;
     mutateComponentOrDirective(updatedStateData, comp);
-    ng.applyChanges(comp);
+    ng.applyChanges?.(comp);
     return;
   }
 };


### PR DESCRIPTION
Previously Angular DevTools would throw if `ng.applyChanges` was not defined. Now DevTools silently ignores the issue, assuming `mutateComponentOrDirective` was sufficient to update the application.