### PR TITLE
refactor(devtools): ignore `getDirectives` when it is not supported

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
@@ -64,7 +64,7 @@ export function getInjectorId() {
 }
 
 export function getInjectorMetadata(injector: Injector) {
-  return ngDebugClient().ɵgetInjectorMetadata(injector);
+  return ngDebugClient().ɵgetInjectorMetadata!(injector);
 }
 
 export function getInjectorResolutionPath(injector: Injector): Injector[] {
@@ -72,7 +72,7 @@ export function getInjectorResolutionPath(injector: Injector): Injector[] {
     return [];
   }
 
-  return ngDebugClient().ɵgetInjectorResolutionPath(injector);
+  return ngDebugClient().ɵgetInjectorResolutionPath!(injector);
 }
 
 export function getInjectorFromElementNode(element: Node): Injector | null {
@@ -85,12 +85,12 @@ function getDirectivesFromElement(element: HTMLElement): {
 } {
   let component = null;
   if (element instanceof Element) {
-    component = ngDebugClient().getComponent(element);
+    component = ngDebugClient().getComponent!(element);
   }
 
   return {
     component,
-    directives: ngDebugClient().getDirectives(element),
+    directives: ngDebugClient().getDirectives!(element),
   };
 }
 
@@ -108,7 +108,7 @@ export const getLatestComponentState = (
 
   const directiveProperties: DirectivesProperties = {};
 
-  const injector = getInjectorFromElementNode(node.nativeElement!);
+  const injector = getInjectorFromElementNode!(node.nativeElement!);
 
   const injectors = injector ? getInjectorResolutionPath(injector) : [];
   const resolutionPathWithProviders = !ngDebugDependencyInjectionApiIsSupported()
@@ -218,7 +218,7 @@ const enum DirectiveMetadataKey {
 // the global `getDirectiveMetadata`. For prior versions of the framework
 // the method directly interacts with the directive/component definition.
 const getDirectiveMetadata = (dir: any): DirectiveMetadata => {
-  const getMetadata = ngDebugClient().getDirectiveMetadata;
+  const getMetadata = ngDebugClient().getDirectiveMetadata!;
   const metadata = getMetadata?.(dir) as ComponentDebugMetadata;
   if (metadata) {
     return {
@@ -257,7 +257,7 @@ export function getInjectorProviders(injector: Injector) {
     return [];
   }
 
-  return ngDebugClient().ɵgetInjectorProviders(injector);
+  return ngDebugClient().ɵgetInjectorProviders!(injector);
 }
 
 const getDependenciesForDirective = (
@@ -270,7 +270,7 @@ const getDependenciesForDirective = (
   }
 
   let dependencies =
-    ngDebugClient().ɵgetDependenciesFromInjectable(injector, directive)?.dependencies ?? [];
+    ngDebugClient().ɵgetDependenciesFromInjectable!(injector, directive)?.dependencies ?? [];
   const uniqueServices = new Set<string>();
   const serializedInjectedServices: SerializedInjectedService[] = [];
 
@@ -580,7 +580,7 @@ export const updateState = (updatedStateData: UpdatedStateData): void => {
   if (updatedStateData.directiveId.directive !== undefined) {
     const directive = node.directives[updatedStateData.directiveId.directive].instance;
     mutateComponentOrDirective(updatedStateData, directive);
-    ng.applyChanges?.(ng.getOwningComponent(directive)!);
+    ng.applyChanges?.(ng.getOwningComponent!(directive)!);
     return;
   }
   if (node.component) {

--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
@@ -90,7 +90,7 @@ function getDirectivesFromElement(element: HTMLElement): {
 
   return {
     component,
-    directives: ngDebugClient().getDirectives!(element),
+    directives: ngDebugClient().getDirectives?.(element) ?? [],
   };
 }
 

--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.ts
@@ -17,14 +17,14 @@ const extractViewTree = (
   domNode: Node | Element,
   result: ComponentTreeNode[],
   getComponent: (element: Element) => {} | null,
-  getDirectives: (node: Node) => {}[],
+  getDirectives?: (node: Node) => {}[],
 ): ComponentTreeNode[] => {
   // Ignore DOM Node if it came from a different frame. Use instanceof Node to check this.
   if (!(domNode instanceof Node)) {
     return result;
   }
 
-  const directives = getDirectives(domNode);
+  const directives = getDirectives?.(domNode) ?? [];
   if (!directives.length && !(domNode instanceof Element)) {
     return result;
   }
@@ -87,7 +87,7 @@ function hydrationStatus(node: HydrationNode): HydrationStatus {
 
 export class RTreeStrategy {
   supports(): boolean {
-    return (['getDirectiveMetadata', 'getComponent', 'getDirectives'] as const).every(
+    return (['getDirectiveMetadata', 'getComponent'] as const).every(
       (method) => typeof ngDebugClient()[method] === 'function',
     );
   }
@@ -99,7 +99,7 @@ export class RTreeStrategy {
       element = element.parentElement;
     }
     const getComponent = ngDebugClient().getComponent!;
-    const getDirectives = ngDebugClient().getDirectives!;
+    const getDirectives = ngDebugClient().getDirectives;
     return extractViewTree(element, [], getComponent, getDirectives);
   }
 }

--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.ts
@@ -98,8 +98,8 @@ export class RTreeStrategy {
     while (element.parentElement) {
       element = element.parentElement;
     }
-    const getComponent = ngDebugClient().getComponent;
-    const getDirectives = ngDebugClient().getDirectives;
+    const getComponent = ngDebugClient().getComponent!;
+    const getDirectives = ngDebugClient().getDirectives!;
     return extractViewTree(element, [], getComponent, getDirectives);
   }
 }

--- a/devtools/projects/ng-devtools-backend/src/lib/hooks/profiler/native.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/hooks/profiler/native.ts
@@ -36,7 +36,7 @@ export class NgProfiler extends Profiler {
   }
 
   private _initialize(): void {
-    ngDebugClient().ɵsetProfiler(
+    ngDebugClient().ɵsetProfiler!(
       (event: ɵProfilerEvent, instanceOrLView: {} | null = null, eventFn: any) =>
         this._callbacks.forEach((cb) => cb(event, instanceOrLView, eventFn)),
     );

--- a/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.ts
@@ -13,7 +13,7 @@ import type {ɵGlobalDevModeUtils as GlobalDevModeUtils} from '@angular/core';
  *
  * @returns window.ng
  */
-export const ngDebugClient = () => (window as any as GlobalDevModeUtils).ng;
+export const ngDebugClient = () => (window as any).ng as Partial<GlobalDevModeUtils['ng']>;
 
 /**
  * Checks whether a given debug API is supported within window.ng


### PR DESCRIPTION
Previously, if `ng.getDirectives` was not implemented, Angular DevTools won't throw when attempting to load the component tree. Now it safely ignores the function and assumes no directives exist on the page.

Also made the `ng` global into a `Partial` to make it less likely we accidentally use APIs not supported by older versions of Angular.