### PR TITLE
fix(core): fix removal of a container reference used in the component…

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/migration.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/migration.ts
@@ -49,7 +49,7 @@ export function migrateTemplate(
       return {migrated: template, errors: switchResult.errors};
     }
     const caseResult = migrateCase(switchResult.migrated);
-    const templateResult = processNgTemplates(caseResult.migrated);
+    const templateResult = processNgTemplates(caseResult.migrated, file.sourceFile);
     if (templateResult.err !== undefined) {
       return {migrated: template, errors: [{type: 'template', error: templateResult.err}]};
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix


## What is the current behavior?
ng generate @angular/core:control-flow migration removes the container reference even if it is used in component file

Issue Number: #56565

## What is the new behavior?

During migration a container reference was deleted even though it was used in the component file.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No