### PR TITLE
refactor(core): split global utils type into internal and external versions

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/BUILD.bazel
@@ -159,3 +159,18 @@ ts_library(
         "//packages/core",
     ],
 )
+
+ts_test_library(
+    name = "component_tree_test_lib",
+    srcs = ["component-tree.spec.ts"],
+    deps = [
+        ":component_tree",
+        "//packages/core",
+        "@npm//jasmine",
+    ],
+)
+
+karma_web_test_suite(
+    name = "component_tree_test",
+    deps = [":component_tree_test_lib"],
+)

--- a/devtools/projects/ng-devtools-backend/src/lib/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/BUILD.bazel
@@ -41,6 +41,7 @@ ts_library(
     name = "highlighter",
     srcs = ["highlighter.ts"],
     deps = [
+        "//devtools/projects/ng-devtools-backend/src/lib/ng-debug-api",
         "//devtools/projects/protocol",
         "//packages/core",
     ],

--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Injector, ɵGlobalDevModeUtils} from '@angular/core';
+import {getInjectorFromElementNode} from './component-tree';
+
+type Ng = ɵGlobalDevModeUtils['ng'];
+
+describe('component-tree', () => {
+  afterEach(() => {
+    delete (globalThis as any).ng;
+  });
+
+  describe('getInjectorFromElementNode', () => {
+    it('returns injector', () => {
+      const injector = Injector.create({
+        providers: [],
+      });
+
+      const ng: Partial<Ng> = {
+        getInjector: jasmine.createSpy('getInjector').and.returnValue(injector),
+      };
+      (globalThis as any).ng = ng;
+
+      const el = document.createElement('div');
+      expect(getInjectorFromElementNode(el)).toBe(injector);
+      expect(ng.getInjector).toHaveBeenCalledOnceWith(el);
+    });
+
+    it('returns `null` when `getInjector` is not supported', () => {
+      (globalThis as any).ng = {};
+
+      const el = document.createElement('div');
+      expect(getInjectorFromElementNode(el)).toBeNull();
+    });
+  });
+});

--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
@@ -90,7 +90,7 @@ function getDirectivesFromElement(element: HTMLElement): {
 
   return {
     component,
-    directives: ngDebugClient().getDirectives!(element),
+    directives: ngDebugClient().getDirectives?.(element) ?? [],
   };
 }
 

--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
@@ -64,7 +64,7 @@ export function getInjectorId() {
 }
 
 export function getInjectorMetadata(injector: Injector) {
-  return ngDebugClient().ɵgetInjectorMetadata(injector);
+  return ngDebugClient().ɵgetInjectorMetadata!(injector);
 }
 
 export function getInjectorResolutionPath(injector: Injector): Injector[] {
@@ -72,7 +72,7 @@ export function getInjectorResolutionPath(injector: Injector): Injector[] {
     return [];
   }
 
-  return ngDebugClient().ɵgetInjectorResolutionPath(injector);
+  return ngDebugClient().ɵgetInjectorResolutionPath!(injector);
 }
 
 export function getInjectorFromElementNode(element: Node): Injector | null {
@@ -85,12 +85,12 @@ function getDirectivesFromElement(element: HTMLElement): {
 } {
   let component = null;
   if (element instanceof Element) {
-    component = ngDebugClient().getComponent(element);
+    component = ngDebugClient().getComponent!(element);
   }
 
   return {
     component,
-    directives: ngDebugClient().getDirectives(element),
+    directives: ngDebugClient().getDirectives!(element),
   };
 }
 
@@ -218,7 +218,7 @@ const enum DirectiveMetadataKey {
 // the global `getDirectiveMetadata`. For prior versions of the framework
 // the method directly interacts with the directive/component definition.
 const getDirectiveMetadata = (dir: any): DirectiveMetadata => {
-  const getMetadata = ngDebugClient().getDirectiveMetadata;
+  const getMetadata = ngDebugClient().getDirectiveMetadata!;
   const metadata = getMetadata?.(dir) as ComponentDebugMetadata;
   if (metadata) {
     return {
@@ -257,7 +257,7 @@ export function getInjectorProviders(injector: Injector) {
     return [];
   }
 
-  return ngDebugClient().ɵgetInjectorProviders(injector);
+  return ngDebugClient().ɵgetInjectorProviders!(injector);
 }
 
 const getDependenciesForDirective = (
@@ -270,7 +270,7 @@ const getDependenciesForDirective = (
   }
 
   let dependencies =
-    ngDebugClient().ɵgetDependenciesFromInjectable(injector, directive)?.dependencies ?? [];
+    ngDebugClient().ɵgetDependenciesFromInjectable!(injector, directive)?.dependencies ?? [];
   const uniqueServices = new Set<string>();
   const serializedInjectedServices: SerializedInjectedService[] = [];
 
@@ -580,7 +580,7 @@ export const updateState = (updatedStateData: UpdatedStateData): void => {
   if (updatedStateData.directiveId.directive !== undefined) {
     const directive = node.directives[updatedStateData.directiveId.directive].instance;
     mutateComponentOrDirective(updatedStateData, directive);
-    ng.applyChanges?.(ng.getOwningComponent(directive)!);
+    ng.applyChanges?.(ng.getOwningComponent!(directive)!);
     return;
   }
   if (node.component) {

--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
@@ -580,13 +580,13 @@ export const updateState = (updatedStateData: UpdatedStateData): void => {
   if (updatedStateData.directiveId.directive !== undefined) {
     const directive = node.directives[updatedStateData.directiveId.directive].instance;
     mutateComponentOrDirective(updatedStateData, directive);
-    ng.applyChanges(ng.getOwningComponent(directive)!);
+    ng.applyChanges?.(ng.getOwningComponent(directive)!);
     return;
   }
   if (node.component) {
     const comp = node.component.instance;
     mutateComponentOrDirective(updatedStateData, comp);
-    ng.applyChanges(comp);
+    ng.applyChanges?.(comp);
     return;
   }
 };

--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.ts
@@ -17,14 +17,14 @@ const extractViewTree = (
   domNode: Node | Element,
   result: ComponentTreeNode[],
   getComponent: (element: Element) => {} | null,
-  getDirectives: (node: Node) => {}[],
+  getDirectives?: (node: Node) => {}[],
 ): ComponentTreeNode[] => {
   // Ignore DOM Node if it came from a different frame. Use instanceof Node to check this.
   if (!(domNode instanceof Node)) {
     return result;
   }
 
-  const directives = getDirectives(domNode);
+  const directives = getDirectives?.(domNode) ?? [];
   if (!directives.length && !(domNode instanceof Element)) {
     return result;
   }
@@ -87,7 +87,7 @@ function hydrationStatus(node: HydrationNode): HydrationStatus {
 
 export class RTreeStrategy {
   supports(): boolean {
-    return (['getDirectiveMetadata', 'getComponent', 'getDirectives'] as const).every(
+    return (['getDirectiveMetadata', 'getComponent'] as const).every(
       (method) => typeof ngDebugClient()[method] === 'function',
     );
   }
@@ -99,7 +99,7 @@ export class RTreeStrategy {
       element = element.parentElement;
     }
     const getComponent = ngDebugClient().getComponent!;
-    const getDirectives = ngDebugClient().getDirectives!;
+    const getDirectives = ngDebugClient().getDirectives;
     return extractViewTree(element, [], getComponent, getDirectives);
   }
 }

--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.ts
@@ -98,8 +98,8 @@ export class RTreeStrategy {
     while (element.parentElement) {
       element = element.parentElement;
     }
-    const getComponent = ngDebugClient().getComponent;
-    const getDirectives = ngDebugClient().getDirectives;
+    const getComponent = ngDebugClient().getComponent!;
+    const getDirectives = ngDebugClient().getDirectives!;
     return extractViewTree(element, [], getComponent, getDirectives);
   }
 }

--- a/devtools/projects/ng-devtools-backend/src/lib/highlighter.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/highlighter.ts
@@ -6,13 +6,14 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import type {ɵGlobalDevModeUtils as GlobalDevModeUtils, Type} from '@angular/core';
+import type {Type} from '@angular/core';
+import {NgGlobal} from './ng-debug-api/ng-debug-api';
 import {HydrationStatus} from 'protocol';
 
 let hydrationOverlayItems: HTMLElement[] = [];
 let selectedElementOverlay: HTMLElement | null = null;
 
-declare const ng: GlobalDevModeUtils['ng'];
+declare const ng: NgGlobal;
 
 const DEV_TOOLS_HIGHLIGHT_NODE_ID = '____ngDevToolsHighlight';
 
@@ -65,7 +66,7 @@ export function findComponentAndHost(el: Node | undefined): {
     return {component: null, host: null};
   }
   while (el) {
-    const component = el instanceof HTMLElement && ng.getComponent(el);
+    const component = el instanceof HTMLElement && ng.getComponent!(el);
     if (component) {
       return {component, host: el as HTMLElement};
     }

--- a/devtools/projects/ng-devtools-backend/src/lib/hooks/profiler/native.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/hooks/profiler/native.ts
@@ -36,7 +36,7 @@ export class NgProfiler extends Profiler {
   }
 
   private _initialize(): void {
-    ngDebugClient().ɵsetProfiler(
+    ngDebugClient().ɵsetProfiler!(
       (event: ɵProfilerEvent, instanceOrLView: {} | null = null, eventFn: any) =>
         this._callbacks.forEach((cb) => cb(event, instanceOrLView, eventFn)),
     );

--- a/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/BUILD.bazel
@@ -1,5 +1,6 @@
-# load("//devtools/tools:typescript.bzl", "ts_library")
+load("//devtools/tools:defaults.bzl", "karma_web_test_suite")
 load("//devtools/tools:ng_module.bzl", "ng_module")
+load("//devtools/tools:typescript.bzl", "ts_test_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -12,4 +13,19 @@ ng_module(
     deps = [
         "//packages/core",
     ],
+)
+
+ts_test_library(
+    name = "ng-debug-api_test_lib",
+    srcs = ["ng-debug-api.spec.ts"],
+    deps = [
+        ":ng-debug-api",
+        "//packages/core",
+        "@npm//jasmine",
+    ],
+)
+
+karma_web_test_suite(
+    name = "ng-debug-api_test",
+    deps = [":ng-debug-api_test_lib"],
 )

--- a/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/BUILD.bazel
@@ -12,6 +12,7 @@ ng_module(
     ),
     deps = [
         "//packages/core",
+        "//packages/router",
     ],
 )
 

--- a/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {ɵGlobalDevModeUtils} from '@angular/core';
+import {ngDebugDependencyInjectionApiIsSupported} from './ng-debug-api';
+
+type Ng = ɵGlobalDevModeUtils['ng'];
+
+describe('ng-debug-api', () => {
+  afterEach(() => {
+    delete (globalThis as any).ng;
+  });
+
+  describe('ngDebugDependencyInjectionApiIsSupported', () => {
+    const goldenNg: Partial<Record<keyof Ng, () => void>> = {
+      getInjector() {},
+      ɵgetInjectorResolutionPath() {},
+      ɵgetDependenciesFromInjectable() {},
+      ɵgetInjectorProviders() {},
+      ɵgetInjectorMetadata() {},
+    };
+
+    it('returns true when required APIs are supported', () => {
+      (globalThis as any).ng = goldenNg;
+
+      expect(ngDebugDependencyInjectionApiIsSupported()).toBeTrue();
+    });
+
+    it('returns false when any required API is missing', () => {
+      (globalThis as any).ng = {...goldenNg, getInjector: undefined};
+      expect(ngDebugDependencyInjectionApiIsSupported()).toBeFalse();
+
+      (globalThis as any).ng = {...goldenNg, ɵgetInjectorResolutionPath: undefined};
+      expect(ngDebugDependencyInjectionApiIsSupported()).toBeFalse();
+
+      (globalThis as any).ng = {...goldenNg, ɵgetDependenciesFromInjectable: undefined};
+      expect(ngDebugDependencyInjectionApiIsSupported()).toBeFalse();
+
+      (globalThis as any).ng = {...goldenNg, ɵgetInjectorProviders: undefined};
+      expect(ngDebugDependencyInjectionApiIsSupported()).toBeFalse();
+
+      (globalThis as any).ng = {...goldenNg, ɵgetInjectorMetadata: undefined};
+      expect(ngDebugDependencyInjectionApiIsSupported()).toBeFalse();
+    });
+  });
+});

--- a/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.ts
@@ -13,7 +13,7 @@ import type {ɵGlobalDevModeUtils as GlobalDevModeUtils} from '@angular/core';
  *
  * @returns window.ng
  */
-export const ngDebugClient = () => (window as any as GlobalDevModeUtils).ng;
+export const ngDebugClient = () => (window as any).ng as Partial<GlobalDevModeUtils['ng']>;
 
 /**
  * Checks whether a given debug API is supported within window.ng

--- a/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.ts
@@ -6,29 +6,34 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import type {ɵGlobalDevModeUtils as GlobalDevModeUtils} from '@angular/core';
+import type {ɵExternalGlobalUtils, ɵInternalGlobalUtils} from '@angular/core';
+import type {ɵGlobalUtils as RouterGlobalUtils} from '@angular/router';
+
+/**
+ * Full set of all `ng` global utilities.
+ *
+ * There is no single canonical definition of the `ng` global because it comes from multiple
+ * locations, so this aggregates all of them together and wraps it in a `Partial` because it
+ * is generally not safe to assume that any particular function is implemented without first
+ * verifying it via runtime feature detection.
+ */
+export type NgGlobal = Partial<ɵExternalGlobalUtils & ɵInternalGlobalUtils & RouterGlobalUtils>;
 
 /**
  * Returns a handle to window.ng APIs (global angular debugging).
- *
- * @returns window.ng
  */
-export const ngDebugClient = () => (window as any).ng as Partial<GlobalDevModeUtils['ng']>;
+export const ngDebugClient = () => (window as any).ng as NgGlobal;
 
 /**
  * Checks whether a given debug API is supported within window.ng
- *
- * @returns boolean
  */
-export function ngDebugApiIsSupported(api: keyof GlobalDevModeUtils['ng']): boolean {
+export function ngDebugApiIsSupported(api: keyof NgGlobal): boolean {
   const ng = ngDebugClient();
   return typeof ng[api] === 'function';
 }
 
 /**
  * Checks whether Dependency Injection debug API is supported within window.ng
- *
- * @returns boolean
  */
 export function ngDebugDependencyInjectionApiIsSupported(): boolean {
   if (!ngDebugApiIsSupported('getInjector')) {

--- a/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.ts
@@ -31,6 +31,9 @@ export function ngDebugApiIsSupported(api: keyof GlobalDevModeUtils['ng']): bool
  * @returns boolean
  */
 export function ngDebugDependencyInjectionApiIsSupported(): boolean {
+  if (!ngDebugApiIsSupported('getInjector')) {
+    return false;
+  }
   if (!ngDebugApiIsSupported('ɵgetInjectorResolutionPath')) {
     return false;
   }

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -280,7 +280,10 @@ export {
 export {compilePipe as ɵcompilePipe} from './render3/jit/pipe';
 export {isNgModule as ɵisNgModule} from './render3/jit/util';
 export {Profiler as ɵProfiler, ProfilerEvent as ɵProfilerEvent} from './render3/profiler_types';
-export {GlobalDevModeUtils as ɵGlobalDevModeUtils} from './render3/util/global_utils';
+export {
+  ExternalGlobalUtils as ɵExternalGlobalUtils,
+  InternalGlobalUtils as ɵInternalGlobalUtils,
+} from './render3/util/global_utils';
 export {ViewRef as ɵViewRef} from './render3/view_ref';
 export {
   bypassSanitizationTrustHtml as ɵbypassSanitizationTrustHtml,

--- a/packages/core/test/render3/global_utils_spec.ts
+++ b/packages/core/test/render3/global_utils_spec.ts
@@ -19,8 +19,7 @@ import {
   getRootComponents,
 } from '../../src/render3/util/discovery_utils';
 import {
-  GLOBAL_PUBLISH_EXPANDO_KEY,
-  GlobalDevModeUtils,
+  ExternalGlobalUtils,
   publishDefaultGlobalUtils,
   publishGlobalUtil,
 } from '../../src/render3/util/global_utils';
@@ -28,17 +27,15 @@ import {setProfiler} from '../../src/render3/profiler';
 import {getDeferBlocks} from '../../src/render3/util/defer';
 import {global} from '../../src/util/global';
 
-type GlobalUtilFunctions = keyof GlobalDevModeUtils['ng'];
-
 describe('global utils', () => {
   describe('publishGlobalUtil', () => {
     it('should publish a function to the window', () => {
-      const w = global as any as GlobalDevModeUtils;
-      const foo = 'foo' as GlobalUtilFunctions;
-      expect(w[GLOBAL_PUBLISH_EXPANDO_KEY][foo]).toBeFalsy();
+      const ng = (global as any).ng as ExternalGlobalUtils;
+      const foo = 'foo' as keyof ExternalGlobalUtils;
+      expect(ng[foo]).toBeFalsy();
       const fooFn = () => {};
       publishGlobalUtil(foo, fooFn);
-      expect(w[GLOBAL_PUBLISH_EXPANDO_KEY][foo]).toBe(fooFn);
+      expect(ng[foo]).toBe(fooFn);
     });
   });
 
@@ -95,7 +92,7 @@ describe('global utils', () => {
   });
 });
 
-function assertPublished(name: GlobalUtilFunctions, value: Function) {
-  const w = global as any as GlobalDevModeUtils;
-  expect(w[GLOBAL_PUBLISH_EXPANDO_KEY][name]).toBe(value);
+function assertPublished(name: keyof ExternalGlobalUtils, value: Function) {
+  const ng = (global as any).ng as ExternalGlobalUtils;
+  expect(ng[name]).toBe(value);
 }

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -143,6 +143,7 @@ export {
   mapToResolve,
 } from './utils/functional_guards';
 export {VERSION} from './version';
+export {GlobalUtils as ɵGlobalUtils} from './router_devtools';
 
 export * from './private_export';
 import './router_devtools';

--- a/packages/router/src/router_devtools.ts
+++ b/packages/router/src/router_devtools.ts
@@ -13,4 +13,8 @@ export function getLoadedRoutes(route: Route): Route[] | undefined {
   return route._loadedRoutes;
 }
 
+export type GlobalUtils = {
+  getLoadedRoutes: typeof getLoadedRoutes;
+};
+
 ɵpublishExternalGlobalUtil('ɵgetLoadedRoutes', getLoadedRoutes);


### PR DESCRIPTION
_Creating this as a draft while soliciting design feedback from the team. Note that this is based on a couple other PRs and will be rebased when they are merged, only the last commit is relevant to this discussion._

Context: Angular DevTools uses the `ng` global to interact with an Angular application and it has some unique versioning constraints. Because Angular DevTools is released independently and auto-updates in the browser, it is consistently at or near the latest version even when developers might be working on a years-out-of-date Angular app. However the `ng` global is shipped with the Angular framework version. As a result, Angular DevTools cannot assume the application uses an up-to-date `ng` implementation and must support all previous versions of the `ng` API which have ever shipped in an Angular framework release.

Internally (meaning inside google3) things work differently. There is exactly one version of the framework which is consistently evolving at HEAD. Any given application just uses the current HEAD at the time of any particular build. Therefore, Angular's "version" is effectively meaningless. Semver does not apply and any breaking change is allowed at any time provided the team takes the effort to migrate affected users. This means Angular DevTools does *not* need to support older `ng` implementations because we do not have "long-lived" Angular versions internally. Note that http://go/build-horizon does technically apply, but for debug tooling like this is not really a significant problem.

This divergence in versioning constraints creates a challenge where internal use cases of the `ng` global interface are throttled by external versioning requirements. The team is generally hesitant to add new functions or make breaking changes because of the maintenance burden it places on Angular DevTools which will need to support that API for the forseeable future, even if we eventually change it later. From an internal perspective, this slows down iteration of APIs for no practical benefit given that internal apps don't have the versioning constraints this pace is designed to support.

This commit splits the `ng` global interface into two interfaces:
* `ExternalGlobalUtils` includes all the functionality which has been shipped in a long-lived Angular version externally and which is subject to the versioning constraints described above.
* `InternalGlobalUtils` includes internal-only functionality which has **not** been shipped in a long-lived Angular version.

This split means that all APIs in `InternalGlobalUtils` can be iterated and evolved at a much faster pace. Angular DevTools can support those features, and we can make breaking changes more-or-less whenever we want. The downside is that external Angular developers cannot take advantage of those APIs or else we would be subject to the same versioning constraint we're trying to avoid here.

This means we can use `InternalGlobalUtils` as a kind of "beta" channel for new DevTools APIs. Once that functionality is validated and the design is stabilized, the feature can be moved into `ExternalGlobalUtils` and made available for external Angular developers when we're ready to commit to the long-lived version constraint. This will hopefully help us strike a better balance between iterating on new APIs quickly and maintaining stable APIs for external Angular users.