### PR TITLE
fix(devtools): handle case where router tree does not exist

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
@@ -226,7 +226,9 @@ const getRoutes = (messageBus: MessageBus<Events>) => {
   const rootInjector = (forest[0].resolutionPath ?? []).find((i) => i.name === 'Root');
   if (rootInjector) {
     const route = getRouterConfigFromRoot(rootInjector);
-    messageBus.emit('updateRouterTree', [[route]]);
+    if (route) {
+      messageBus.emit('updateRouterTree', [[route]]);
+    }
   }
 };
 
@@ -294,12 +296,17 @@ const getProviderValue = (
   }
 };
 
-const getRouterConfigFromRoot = (injector: SerializedInjector): Route => {
+const getRouterConfigFromRoot = (injector: SerializedInjector): Route | void => {
   const serializedProviderRecords = getSerializedProviderRecords(injector) ?? [];
-  const routerInstance = serializedProviderRecords.filter(
+  const routerInstance = serializedProviderRecords.find(
     (provider) => provider.token === 'Router', // get the instance of router using token
   );
-  const routerProvider = getProviderValue(injector, routerInstance[0]);
+
+  if (!routerInstance) {
+    return;
+  }
+
+  const routerProvider = getProviderValue(injector, routerInstance);
 
   return parseRoutes(routerProvider);
 };


### PR DESCRIPTION

Previously this was throwing errors in applications with no Router token.

Now it skips emitting events for the router tree when it is unable to find the Router token.

Note: If these events don't emit, DevTools treats the RouterTree feature as disabled.

Closes #60193 