### PR TITLE
docs: change broke Pipe link

### DIFF
--- a/adev/src/content/guide/templates/expression-syntax.md
+++ b/adev/src/content/guide/templates/expression-syntax.md
@@ -72,7 +72,7 @@ Angular expressions additionally also support the following non-standard operato
 
 | Operator                        | Example(s)                     |
 | ------------------------------- | ------------------------------ |
-| [Pipe](/guides/templates/pipes) | `{{ total \| currency }}`      |
+| [Pipe](/guide/templates/pipes) | `{{ total \| currency }}`      |
 | Optional chaining\*             | `someObj.someProp?.nestedProp` |
 | Non-null assertion (TypeScript) | `someObj!.someProp`            |
 


### PR DESCRIPTION
Change broke link, swap from /guides  to /guide

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
[`Pipe   {{ total | currency }}`](https://angular.dev/guide/templates/expression-syntax#supported-operators) link in screenshot below not working, and bring to [404](https://angular.dev/guides/templates/pipes)
![image](https://github.com/user-attachments/assets/0ad9bffd-0907-486e-9de3-b4bb07f4623e)


Issue Number: N/A


## What is the new behavior?
Now link is working

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
