### PR TITLE
refactor(http): Make sur to pass `context` & `transferCache` from `ht…

### DIFF
--- a/packages/common/http/src/resource.ts
+++ b/packages/common/http/src/resource.ts
@@ -279,6 +279,8 @@ function normalizeRequest(
       reportProgress: unwrappedRequest.reportProgress,
       withCredentials: unwrappedRequest.withCredentials,
       responseType,
+      context: unwrappedRequest.context,
+      transferCache: unwrappedRequest.transferCache,
     },
   );
 }


### PR DESCRIPTION
…tpResource` to the underlying request.

Prior to this change, both were accepted as argument but never passed to the client.
