### PR TITLE
Revert "fix(router): update symbols (#60233)" from 19.2.x

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -694,7 +694,7 @@
   "standardizeConfig",
   "storeLViewOnDestroy",
   "stringify",
-  "stringify13",
+  "stringify12",
   "stringifyCSSSelector",
   "stripTrailingSlash",
   "subscribeOn",


### PR DESCRIPTION
This reverts commit 7bcdf7c1435f766b2b0bbd383358ef2ddabf217a. The original change causing CI failures was affecting the main branch only, reverting from the patch branch (since it causes CI failures).