### PR TITLE
feat(bazel): support shared chunks in `ng_package`

### DIFF
--- a/packages/bazel/src/ng_package/BUILD.bazel
+++ b/packages/bazel/src/ng_package/BUILD.bazel
@@ -14,6 +14,7 @@ ts_library(
     tsconfig = ":tsconfig.json",
     deps = [
         "@npm//@types/node",
+        "@npm//fast-glob",
         "@npm//typescript",
     ],
 )

--- a/packages/bazel/src/ng_package/api.ts
+++ b/packages/bazel/src/ng_package/api.ts
@@ -21,8 +21,8 @@ export interface BazelFileInfo {
 export interface EntryPointInfo {
   /** ES2022 index file for the APF entry-point. */
   index: BazelFileInfo;
-  /** Flat ES2022 ES module bundle file. */
-  fesm2022Bundle: BazelFileInfo;
+  /** Relative path to flat ES2022 ES module bundle file (also applicable in the rollup output). */
+  fesm2022RelativePath: string;
   /** Index type definition file for the APF entry-point. */
   typings: BazelFileInfo;
   /**
@@ -39,4 +39,9 @@ export interface PackageMetadata {
   npmPackageName: string;
   /** Record of entry-points (including the primary one) and their info. */
   entryPoints: Record<string, EntryPointInfo>;
+  /**
+   * Path to the Rollup bundle output directory, containing all FESM
+   * bundles and shared chunks.
+   */
+  bundlesOut: BazelFileInfo;
 }

--- a/packages/bazel/src/ng_package/cross_entry_points_imports.ts
+++ b/packages/bazel/src/ng_package/cross_entry_points_imports.ts
@@ -50,7 +50,11 @@ export function analyzeFileAndEnsureNoCrossImports(
 
   // TODO: Consider handling deep dynamic import expressions.
   for (const st of sf.statements) {
-    if (!ts.isImportDeclaration(st) || !ts.isStringLiteralLike(st.moduleSpecifier)) {
+    if (
+      (!ts.isImportDeclaration(st) && !ts.isExportDeclaration(st)) ||
+      st.moduleSpecifier === undefined ||
+      !ts.isStringLiteralLike(st.moduleSpecifier)
+    ) {
       continue;
     }
     // Skip module imports.
@@ -74,13 +78,6 @@ export function analyzeFileAndEnsureNoCrossImports(
           `You can skip this import by adding a comment: ${skipComment}`,
       );
       continue;
-    }
-
-    if (targetPackage.path !== owningPkg.path) {
-      failures.push(
-        `Found relative cross entry-point import in: ${fileDebugName}. Import to: ${st.moduleSpecifier.text}\n` +
-          `You can skip this import by adding a comment: ${skipComment}`,
-      );
     }
   }
 

--- a/packages/bazel/src/ng_package/ng_package.bzl
+++ b/packages/bazel/src/ng_package/ng_package.bzl
@@ -188,7 +188,7 @@ def _run_rollup(ctx, rollup_config, inputs, format):
     args = ctx.actions.args()
     args.add("--config", rollup_config)
     args.add("--output.format", format)
-    args.add("--output.dir", outdir.path)
+    args.add("--output.dir", outdir.path + "/fesm2022")
 
     # After updating to build_bazel_rules_nodejs 0.27.0+, rollup has been updated to v1.3.1
     # which tree shakes @__PURE__ annotations and const variables which are later amended by NGCC.

--- a/packages/bazel/src/ng_package/ng_package.bzl
+++ b/packages/bazel/src/ng_package/ng_package.bzl
@@ -190,15 +190,6 @@ def _run_rollup(ctx, rollup_config, inputs, format):
     args.add("--output.format", format)
     args.add("--output.dir", outdir.path + "/fesm2022")
 
-    # After updating to build_bazel_rules_nodejs 0.27.0+, rollup has been updated to v1.3.1
-    # which tree shakes @__PURE__ annotations and const variables which are later amended by NGCC.
-    # We turn this feature off for ng_package as Angular bundles contain these and there are
-    # test failures if they are removed.
-    # See comments in:
-    # https://github.com/angular/angular/pull/29210
-    # https://github.com/angular/angular/pull/32069
-    args.add("--no-treeshake")
-
     # Note: if the input has external source maps then we need to also install and use
     #   `rollup-plugin-sourcemaps`, which will require us to use rollup.config.js file instead
     #   of command line args

--- a/packages/bazel/src/ng_package/ng_package.bzl
+++ b/packages/bazel/src/ng_package/ng_package.bzl
@@ -136,6 +136,7 @@ def _compute_node_modules_root(ctx):
 def _write_rollup_config(
         ctx,
         root_dir,
+        metadata_arg,
         filename = "_%s.rollup.conf.js"):
     """Generate a rollup config file.
 
@@ -172,6 +173,7 @@ def _write_rollup_config(
             "TMPL_banner_file": "\"%s\"" % ctx.file.license_banner.path if ctx.file.license_banner else "undefined",
             "TMPL_module_mappings": str(mappings),
             "TMPL_node_modules_root": _compute_node_modules_root(ctx),
+            "TMPL_metadata": json.encode(metadata_arg),
             "TMPL_root_dir": root_dir,
             "TMPL_workspace_name": ctx.workspace_name,
             "TMPL_external": ", ".join(["'%s'" % e for e in externals]),
@@ -180,14 +182,13 @@ def _write_rollup_config(
 
     return config
 
-def _run_rollup(ctx, bundle_name, rollup_config, entry_point, inputs, js_output, format):
-    map_output = ctx.actions.declare_file(js_output.basename + ".map", sibling = js_output)
+def _run_rollup(ctx, rollup_config, inputs, format):
+    outdir = ctx.actions.declare_directory("%s_fesm_bundle_out" % ctx.label.name)
 
     args = ctx.actions.args()
-    args.add("--input", entry_point.path)
     args.add("--config", rollup_config)
-    args.add("--output.file", js_output)
     args.add("--output.format", format)
+    args.add("--output.dir", outdir.path)
 
     # After updating to build_bazel_rules_nodejs 0.27.0+, rollup has been updated to v1.3.1
     # which tree shakes @__PURE__ annotations and const variables which are later amended by NGCC.
@@ -213,15 +214,15 @@ def _run_rollup(ctx, bundle_name, rollup_config, entry_point, inputs, js_output,
     if ctx.file.license_banner:
         other_inputs.append(ctx.file.license_banner)
     ctx.actions.run(
-        progress_message = "ng_package: Rollup %s (%s)" % (bundle_name, entry_point.short_path),
+        progress_message = "ng_package: Rollup %s" % (ctx.label),
         mnemonic = "AngularPackageRollup",
         inputs = inputs.to_list() + other_inputs,
-        outputs = [js_output, map_output],
+        outputs = [outdir],
         executable = ctx.executable.rollup,
         tools = [ctx.executable.rollup],
         arguments = [args],
     )
-    return [js_output, map_output]
+    return outdir
 
 # Serializes a file into a struct that matches the `BazelFileInfo` type in the
 # packager implementation. Useful for transmission of such information.
@@ -288,9 +289,6 @@ def _ng_package_impl(ctx):
         else:
             static_files.append(file)
 
-    # These accumulators match the directory names where the files live in the
-    # Angular package format.
-    fesm2022 = []
     type_files = []
 
     # List of unscoped direct and transitive ESM sources that are provided
@@ -390,7 +388,7 @@ def _ng_package_impl(ctx):
             guessed_paths = True
 
         bundle_name = "%s.mjs" % (primary_bundle_name if is_primary_entry_point else entry_point)
-        fesm2022_file = ctx.actions.declare_file("fesm2022/%s" % bundle_name)
+        fesm2022_file = "fesm2022/%s" % bundle_name
 
         # By default, we will bundle the typings entry-point, unless explicitly opted-out
         # through the `skip_type_bundling` rule attribute.
@@ -425,28 +423,11 @@ def _ng_package_impl(ctx):
             guessed_paths = guessed_paths,
         ))
 
-        # Note: For creating the bundles, we use all the ESM2022 sources that have been
-        # collected from the dependencies. This allows for bundling of code that is not
-        # necessarily part of the owning package (with respect to the `externals` attribute)
-        rollup_inputs = unscoped_esm2022_depset
-        esm2022_config = _write_rollup_config(ctx, ctx.bin_dir.path, filename = "_%s.rollup_esm2022.conf.js")
-
-        fesm2022.extend(
-            _run_rollup(
-                ctx,
-                "fesm2022",
-                esm2022_config,
-                es2022_entry_point,
-                rollup_inputs,
-                fesm2022_file,
-                format = "esm",
-            ),
-        )
-
     # Note: Using `to_list()` is expensive but we cannot get around this here as
     # we need to filter out generated files and need to be able to iterate through
     # JavaScript files in order to capture the relevant package-owned `esm2022/` in the APF.
-    unscoped_all_entry_point_esm2022_list = depset(transitive = unscoped_all_entry_point_esm2022).to_list()
+    unscoped_all_entry_point_esm2022_depset = depset(transitive = unscoped_all_entry_point_esm2022)
+    unscoped_all_entry_point_esm2022_list = unscoped_all_entry_point_esm2022_depset.to_list()
 
     # Filter ESM2022 JavaScript inputs to files which are part of the owning package. The
     # packager should not copy external files into the package.
@@ -455,7 +436,7 @@ def _ng_package_impl(ctx):
     packager_inputs = (
         static_files +
         type_files +
-        fesm2022 + esm2022
+        esm2022
     )
 
     packager_args = ctx.actions.args()
@@ -473,12 +454,17 @@ def _ng_package_impl(ctx):
         # in the packager executable tool.
         metadata_arg[m.module_name] = {
             "index": _serialize_file(m.es2022_entry_point),
-            "fesm2022Bundle": _serialize_file(m.fesm2022_file),
+            "fesm2022RelativePath": m.fesm2022_file,
             "typings": _serialize_file(m.typings_file),
             # If the paths for that entry-point were guessed (e.g. "ts_library" rule or
             # "ng_module" without flat module bundle), we pass this information to the packager.
             "guessedPaths": m.guessed_paths,
         }
+
+    rollup_config = _write_rollup_config(ctx, ctx.bin_dir.path, metadata_arg)
+    bundles_out = _run_rollup(ctx, rollup_config, unscoped_all_entry_point_esm2022_depset, "esm")
+
+    packager_inputs.append(bundles_out)
 
     # Encodes the package metadata with all its entry-points into JSON so that
     # it can be deserialized by the packager tool. The struct needs to match with
@@ -486,6 +472,7 @@ def _ng_package_impl(ctx):
     packager_args.add(json.encode(struct(
         npmPackageName = npm_package_name,
         entryPoints = metadata_arg,
+        bundlesOut = _serialize_file(bundles_out),
     )))
 
     if ctx.file.readme_md:
@@ -502,7 +489,6 @@ def _ng_package_impl(ctx):
         #placeholder
         packager_args.add("")
 
-    packager_args.add(_serialize_files_for_arg(fesm2022))
     packager_args.add(_serialize_files_for_arg(esm2022))
     packager_args.add(_serialize_files_for_arg(static_files))
     packager_args.add(_serialize_files_for_arg(type_files))

--- a/packages/bazel/src/ng_package/rollup.config.js
+++ b/packages/bazel/src/ng_package/rollup.config.js
@@ -26,6 +26,7 @@ const rootDir = 'TMPL_root_dir';
 const bannerFile = TMPL_banner_file;
 const moduleMappings = TMPL_module_mappings;
 const nodeModulesRoot = 'TMPL_node_modules_root';
+const metadata = JSON.parse(`TMPL_metadata`);
 
 log_verbose(`running with
   cwd: ${process.cwd()}
@@ -148,20 +149,12 @@ const stripBannerPlugin = {
     const pos = code.indexOf(bannerContent);
     magicString.remove(pos, pos + bannerContent.length).trimStart();
 
-    return {
-      code: magicString.toString(),
-      map: magicString.generateMap({
-        hires: true,
-      }),
-    };
+    return {code: magicString.toString(), map: magicString.generateMap({hires: true})};
   },
 };
 
 const plugins = [
-  {
-    name: 'resolveBazel',
-    resolveId: resolveBazel,
-  },
+  {name: 'resolveBazel', resolveId: resolveBazel},
   nodeResolve({
     mainFields: ['es2020', 'es2015', 'module', 'browser'],
     jail: process.cwd(),
@@ -172,11 +165,21 @@ const plugins = [
   sourcemaps(),
 ];
 
+// Rollup input option:
+// https://rollupjs.org/configuration-options/#input.
+const input = {};
+
+for (const info of Object.values(metadata)) {
+  input[info.fesm2022RelativePath.replace(/\.mjs$/, '')] = info.index.path;
+}
+
 const config = {
+  input,
   plugins,
   external: [TMPL_external],
   output: {
     banner: bannerContent,
+    entryFileNames: '[name].mjs',
   },
 };
 

--- a/packages/bazel/src/ng_package/rollup.config.js
+++ b/packages/bazel/src/ng_package/rollup.config.js
@@ -170,7 +170,7 @@ const plugins = [
 const input = {};
 
 for (const info of Object.values(metadata)) {
-  input[info.fesm2022RelativePath.replace(/\.mjs$/, '')] = info.index.path;
+  input[info.fesm2022RelativePath.replace(/\.mjs$/, '').replace('fesm2022/', '')] = info.index.path;
 }
 
 const config = {
@@ -180,6 +180,7 @@ const config = {
   output: {
     banner: bannerContent,
     entryFileNames: '[name].mjs',
+    chunkFileNames: '[name]-[hash].mjs',
   },
 };
 

--- a/packages/bazel/src/ng_package/rollup.config.js
+++ b/packages/bazel/src/ng_package/rollup.config.js
@@ -26,7 +26,8 @@ const rootDir = 'TMPL_root_dir';
 const bannerFile = TMPL_banner_file;
 const moduleMappings = TMPL_module_mappings;
 const nodeModulesRoot = 'TMPL_node_modules_root';
-const metadata = JSON.parse(`TMPL_metadata`);
+const entrypointMetadata = JSON.parse(`TMPL_metadata`);
+const sideEffectEntryPoints = JSON.parse('TMPL_side_effect_entrypoints');
 
 log_verbose(`running with
   cwd: ${process.cwd()}
@@ -168,27 +169,33 @@ const plugins = [
 // Rollup input option:
 // https://rollupjs.org/configuration-options/#input.
 const input = {};
-
-for (const info of Object.values(metadata)) {
+for (const info of Object.values(entrypointMetadata)) {
   input[info.fesm2022RelativePath.replace(/\.mjs$/, '').replace('fesm2022/', '')] = info.index.path;
 }
+
+const sideEffectFileMatchers = sideEffectEntryPoints.map((entryPointModule) => {
+  const entryPointDir = path.join(
+    process.cwd(), // Execroot.
+    path.dirname(entrypointMetadata[entryPointModule].index.path),
+  );
+
+  return (file) => file.startsWith(`${entryPointDir}/`);
+});
 
 const config = {
   input,
   plugins,
   external: [TMPL_external],
   treeshake: {
-    // After updating to build_bazel_rules_nodejs 0.27.0+, rollup has been updated to v1.3.1
-    // which tree shakes @__PURE__ annotations and const variables which are later amended by NGCC.
-    // We turn this feature off for ng_package as Angular bundles contain these and there are
-    // test failures if they are removed.
-    // See comments in:
-    // https://github.com/angular/angular/pull/29210
-    // https://github.com/angular/angular/pull/32069
-    unknownGlobalSideEffects: false,
+    // Note: Rollup would otherwise eagerly remove e.g. PURE statements. We should
+    // keep those and leave elision to end-user bundling, depending on if they are
+    // necessary or not.
     annotations: false,
     propertyReadSideEffects: false,
-    moduleSideEffects: false,
+    unknownGlobalSideEffects: false,
+    moduleSideEffects: (id) => {
+      return sideEffectFileMatchers.some((matcher) => matcher(id));
+    },
   },
   output: {
     banner: bannerContent,

--- a/packages/bazel/src/ng_package/rollup.config.js
+++ b/packages/bazel/src/ng_package/rollup.config.js
@@ -188,7 +188,7 @@ const config = {
     unknownGlobalSideEffects: false,
     annotations: false,
     propertyReadSideEffects: false,
-    moduleSideEffects: ['@angular/core'],
+    moduleSideEffects: false,
   },
   output: {
     banner: bannerContent,

--- a/packages/bazel/src/ng_package/rollup.config.js
+++ b/packages/bazel/src/ng_package/rollup.config.js
@@ -177,6 +177,19 @@ const config = {
   input,
   plugins,
   external: [TMPL_external],
+  treeshake: {
+    // After updating to build_bazel_rules_nodejs 0.27.0+, rollup has been updated to v1.3.1
+    // which tree shakes @__PURE__ annotations and const variables which are later amended by NGCC.
+    // We turn this feature off for ng_package as Angular bundles contain these and there are
+    // test failures if they are removed.
+    // See comments in:
+    // https://github.com/angular/angular/pull/29210
+    // https://github.com/angular/angular/pull/32069
+    unknownGlobalSideEffects: false,
+    annotations: false,
+    propertyReadSideEffects: false,
+    moduleSideEffects: ['@angular/core'],
+  },
   output: {
     banner: bannerContent,
     entryFileNames: '[name].mjs',

--- a/packages/bazel/test/ng_package/example/a11y/BUILD.bazel
+++ b/packages/bazel/test/ng_package/example/a11y/BUILD.bazel
@@ -7,6 +7,7 @@ ng_module(
     srcs = glob(["*.ts"]),
     module_name = "example/a11y",
     deps = [
+        "//packages/bazel/test/ng_package/example/secondary",
         "//packages/core",
     ],
 )

--- a/packages/bazel/test/ng_package/example/imports/BUILD.bazel
+++ b/packages/bazel/test/ng_package/example/imports/BUILD.bazel
@@ -7,6 +7,7 @@ ng_module(
     srcs = glob(["*.ts"]),
     module_name = "example/imports",
     deps = [
+        "//packages/bazel/test/ng_package/example/secondary",
         "//packages/core",
     ],
 )

--- a/packages/bazel/test/ng_package/example/imports/index.ts
+++ b/packages/bazel/test/ng_package/example/imports/index.ts
@@ -7,3 +7,4 @@
  */
 
 export * from './public-api';
+export {sharedBetweenEntryPoints} from '../secondary';

--- a/packages/bazel/test/ng_package/example/secondary/index.ts
+++ b/packages/bazel/test/ng_package/example/secondary/index.ts
@@ -7,3 +7,5 @@
  */
 
 export * from './secondarymodule';
+
+export const sharedBetweenEntryPoints = 'This export is shared between entry-points';

--- a/packages/bazel/test/ng_package/example_package.golden
+++ b/packages/bazel/test/ng_package/example_package.golden
@@ -18,6 +18,8 @@ fesm2022
   fesm2022/waffels.mjs.map
 imports
   imports/index.d.ts
+index-effb6ff1.js
+index-effb6ff1.js.map
 index.d.ts
 logo.png
 package.json
@@ -155,6 +157,7 @@ export { A11yModule };
 
 import * as i0 from '@angular/core';
 import { Injectable } from '@angular/core';
+export { s as sharedBetweenEntryPoints } from '../index-effb6ff1.js';
 
 class MySecondService {
     static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: MySecondService, deps: [], target: i0.ɵɵFactoryTarget.Injectable });
@@ -194,25 +197,12 @@ export { MyService };
  * License: MIT
  */
 
-import * as i0 from '@angular/core';
-import { NgModule } from '@angular/core';
-
-class SecondaryModule {
-    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
-    static ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule });
-    static ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule });
-}
-i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule, decorators: [{
-            type: NgModule,
-            args: [{}]
-        }] });
-const a = 1;
+export { S as SecondaryModule, a, s as sharedBetweenEntryPoints } from '../index-effb6ff1.js';
+import '@angular/core';
 
 /**
  * Generated bundle index. Do not edit.
  */
-
-export { SecondaryModule, a };
 //# sourceMappingURL=secondary.mjs.map
 
 
@@ -268,7 +258,37 @@ export declare class MyService {
     static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
 }
 
+export declare const sharedBetweenEntryPoints = "This export is shared between entry-points";
+
 export { }
+
+
+--- index-effb6ff1.js ---
+
+/**
+ * @license Angular v0.0.0
+ * (c) 2010-2025 Google LLC. https://angular.io/
+ * License: MIT
+ */
+
+import * as i0 from '@angular/core';
+import { NgModule } from '@angular/core';
+
+class SecondaryModule {
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
+    static ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule });
+    static ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule });
+}
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule, decorators: [{
+            type: NgModule,
+            args: [{}]
+        }] });
+const a = 1;
+
+const sharedBetweenEntryPoints = 'This export is shared between entry-points';
+
+export { SecondaryModule as S, a, sharedBetweenEntryPoints as s };
+//# sourceMappingURL=index-effb6ff1.js.map
 
 
 --- index.d.ts ---
@@ -345,6 +365,8 @@ export declare class SecondaryModule {
     static ɵmod: i0.ɵɵNgModuleDeclaration<SecondaryModule, never, never, never>;
     static ɵinj: i0.ɵɵInjectorDeclaration<SecondaryModule>;
 }
+
+export declare const sharedBetweenEntryPoints = "This export is shared between entry-points";
 
 export { }
 

--- a/packages/bazel/test/ng_package/example_package.golden
+++ b/packages/bazel/test/ng_package/example_package.golden
@@ -12,8 +12,8 @@ fesm2022
   fesm2022/a11y.mjs.map
   fesm2022/imports.mjs
   fesm2022/imports.mjs.map
-  fesm2022/index-6fe4cd54.mjs
-  fesm2022/index-6fe4cd54.mjs.map
+  fesm2022/index-1e1ea2d8.mjs
+  fesm2022/index-1e1ea2d8.mjs.map
   fesm2022/secondary.mjs
   fesm2022/secondary.mjs.map
   fesm2022/waffels.mjs
@@ -139,10 +139,6 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport
             args: [{}]
         }] });
 
-/**
- * Generated bundle index. Do not edit.
- */
-
 export { A11yModule };
 //# sourceMappingURL=a11y.mjs.map
 
@@ -155,9 +151,9 @@ export { A11yModule };
  * License: MIT
  */
 
+export { s as sharedBetweenEntryPoints } from './index-1e1ea2d8.mjs';
 import * as i0 from '@angular/core';
 import { Injectable } from '@angular/core';
-export { s as sharedBetweenEntryPoints } from './index-6fe4cd54.mjs';
 
 class MySecondService {
     static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: MySecondService, deps: [], target: i0.ɵɵFactoryTarget.Injectable });
@@ -181,15 +177,11 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport
             args: [{ providedIn: 'root' }]
         }], ctorParameters: () => [{ type: MySecondService }] });
 
-/**
- * Generated bundle index. Do not edit.
- */
-
 export { MyService };
 //# sourceMappingURL=imports.mjs.map
 
 
---- fesm2022/index-6fe4cd54.mjs ---
+--- fesm2022/index-1e1ea2d8.mjs ---
 
 /**
  * @license Angular v0.0.0
@@ -197,6 +189,21 @@ export { MyService };
  * License: MIT
  */
 
+const sharedBetweenEntryPoints = 'This export is shared between entry-points';
+
+export { sharedBetweenEntryPoints as s };
+//# sourceMappingURL=index-1e1ea2d8.mjs.map
+
+
+--- fesm2022/secondary.mjs ---
+
+/**
+ * @license Angular v0.0.0
+ * (c) 2010-2025 Google LLC. https://angular.io/
+ * License: MIT
+ */
+
+export { s as sharedBetweenEntryPoints } from './index-1e1ea2d8.mjs';
 import * as i0 from '@angular/core';
 import { NgModule } from '@angular/core';
 
@@ -211,26 +218,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport
         }] });
 const a = 1;
 
-const sharedBetweenEntryPoints = 'This export is shared between entry-points';
-
-export { SecondaryModule as S, a, sharedBetweenEntryPoints as s };
-//# sourceMappingURL=index-6fe4cd54.mjs.map
-
-
---- fesm2022/secondary.mjs ---
-
-/**
- * @license Angular v0.0.0
- * (c) 2010-2025 Google LLC. https://angular.io/
- * License: MIT
- */
-
-export { S as SecondaryModule, a, s as sharedBetweenEntryPoints } from './index-6fe4cd54.mjs';
-import '@angular/core';
-
-/**
- * Generated bundle index. Do not edit.
- */
+export { SecondaryModule, a };
 //# sourceMappingURL=secondary.mjs.map
 
 
@@ -254,10 +242,6 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport
             type: NgModule,
             args: [{}]
         }] });
-
-/**
- * Generated bundle index. Do not edit.
- */
 
 export { MyModule };
 //# sourceMappingURL=waffels.mjs.map

--- a/packages/bazel/test/ng_package/example_package.golden
+++ b/packages/bazel/test/ng_package/example_package.golden
@@ -12,14 +12,14 @@ fesm2022
   fesm2022/a11y.mjs.map
   fesm2022/imports.mjs
   fesm2022/imports.mjs.map
+  fesm2022/index-6fe4cd54.mjs
+  fesm2022/index-6fe4cd54.mjs.map
   fesm2022/secondary.mjs
   fesm2022/secondary.mjs.map
   fesm2022/waffels.mjs
   fesm2022/waffels.mjs.map
 imports
   imports/index.d.ts
-index-effb6ff1.js
-index-effb6ff1.js.map
 index.d.ts
 logo.png
 package.json
@@ -157,7 +157,7 @@ export { A11yModule };
 
 import * as i0 from '@angular/core';
 import { Injectable } from '@angular/core';
-export { s as sharedBetweenEntryPoints } from '../index-effb6ff1.js';
+export { s as sharedBetweenEntryPoints } from './index-6fe4cd54.mjs';
 
 class MySecondService {
     static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: MySecondService, deps: [], target: i0.ɵɵFactoryTarget.Injectable });
@@ -189,6 +189,34 @@ export { MyService };
 //# sourceMappingURL=imports.mjs.map
 
 
+--- fesm2022/index-6fe4cd54.mjs ---
+
+/**
+ * @license Angular v0.0.0
+ * (c) 2010-2025 Google LLC. https://angular.io/
+ * License: MIT
+ */
+
+import * as i0 from '@angular/core';
+import { NgModule } from '@angular/core';
+
+class SecondaryModule {
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
+    static ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule });
+    static ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule });
+}
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule, decorators: [{
+            type: NgModule,
+            args: [{}]
+        }] });
+const a = 1;
+
+const sharedBetweenEntryPoints = 'This export is shared between entry-points';
+
+export { SecondaryModule as S, a, sharedBetweenEntryPoints as s };
+//# sourceMappingURL=index-6fe4cd54.mjs.map
+
+
 --- fesm2022/secondary.mjs ---
 
 /**
@@ -197,7 +225,7 @@ export { MyService };
  * License: MIT
  */
 
-export { S as SecondaryModule, a, s as sharedBetweenEntryPoints } from '../index-effb6ff1.js';
+export { S as SecondaryModule, a, s as sharedBetweenEntryPoints } from './index-6fe4cd54.mjs';
 import '@angular/core';
 
 /**
@@ -261,34 +289,6 @@ export declare class MyService {
 export declare const sharedBetweenEntryPoints = "This export is shared between entry-points";
 
 export { }
-
-
---- index-effb6ff1.js ---
-
-/**
- * @license Angular v0.0.0
- * (c) 2010-2025 Google LLC. https://angular.io/
- * License: MIT
- */
-
-import * as i0 from '@angular/core';
-import { NgModule } from '@angular/core';
-
-class SecondaryModule {
-    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
-    static ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule });
-    static ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule });
-}
-i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule, decorators: [{
-            type: NgModule,
-            args: [{}]
-        }] });
-const a = 1;
-
-const sharedBetweenEntryPoints = 'This export is shared between entry-points';
-
-export { SecondaryModule as S, a, sharedBetweenEntryPoints as s };
-//# sourceMappingURL=index-effb6ff1.js.map
 
 
 --- index.d.ts ---

--- a/packages/bazel/test/ng_package/example_with_ts_library_package.golden
+++ b/packages/bazel/test/ng_package/example_with_ts_library_package.golden
@@ -86,10 +86,6 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport
         }] });
 const a = 1;
 
-/**
- * Generated bundle index. Do not edit.
- */
-
 export { PortalModule, a };
 //# sourceMappingURL=portal.mjs.map
 

--- a/packages/compiler/BUILD.bazel
+++ b/packages/compiler/BUILD.bazel
@@ -23,6 +23,9 @@ ng_package(
     srcs = [
         "package.json",
     ],
+    side_effect_entry_points = [
+        "@angular/compiler",
+    ],
     tags = [
         "release-with-framework",
     ],

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -26,5 +26,7 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": true
+  "sideEffects": [
+    "./fesm2022/compiler.mjs"
+  ]
 }

--- a/packages/localize/BUILD.bazel
+++ b/packages/localize/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//tools:defaults.bzl", "api_golden_test_npm_package", "generate_api_docs", "ng_package", "ts_library")
 load("//packages/bazel:index.bzl", "types_bundle")
+load("//tools:defaults.bzl", "api_golden_test_npm_package", "generate_api_docs", "ng_package", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -35,6 +35,9 @@ ng_package(
     nested_packages = [
         "//packages/localize/schematics:npm_package",
         "//packages/localize/tools:npm_package",
+    ],
+    side_effect_entry_points = [
+        "@angular/localize/init",
     ],
     skip_type_bundling = [
         # For the primary entry-point we disable automatic type bundling because API extractor

--- a/packages/platform-server/BUILD.bazel
+++ b/packages/platform-server/BUILD.bazel
@@ -57,6 +57,9 @@ ng_package(
     externals = [
         "xhr2",
     ],
+    side_effect_entry_points = [
+        "@angular/platform-server/init",
+    ],
     tags = [
         "release-with-framework",
     ],


### PR DESCRIPTION
Historically we've had to be VERY cautious about the way we import things between entry-points. That is because the `ng_package` rule bundling is subject to silently introducing code duplication, breaking singletons etc. We've had this surface a couple of times already, and dev-infra tried to help detect such cases by adding safety analysis into `ng_package`.

Long-term we want to get to an approach where it's easy to simply share code between chunks. Precisely, with the upcoming `rules_js` migration, this will be necessary as we will have different import "guidelines" that would currently, before this commit, result in code duplication, or trigger our "safety check/lint".

This commit prepares `ng_package` to support relative imports between entry-points, so that we only need the safety check for cross-package imports/exports. The result is that `ng_package`/APF is now smartly able to generate shared chunks for things that are needed between multiple entry-points. Yay!

Note that those shared chunks still remain private, and are guarded by our `package.json` "exports"; so no new public API surface is exposed.