### PR TITLE
fix(docs-infra): terminal light mode text color

### DIFF
--- a/adev/src/styles/_xterm.scss
+++ b/adev/src/styles/_xterm.scss
@@ -74,6 +74,10 @@
     background-color: var(--quinary-contrast) !important;
   }
 
+  .xterm-dim {
+    color: var(--primary-contrast) !important;
+  }
+
   .xterm-fg-11 {
     color: var(--electric-violet) !important;
   }


### PR DESCRIPTION
This commit changes the text color in terminal light mode to improve visibility and user experience. The previous color was too light and made it difficult to read the text.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Some text fields of build text in terminal are not visible

Issue Number: #57942 


## What is the new behavior?
Text fields are contrasting background and visible for user

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
