### PR TITLE
fix(core): Ensure errors in listeners report to the application error…

### DIFF
--- a/packages/core/test/acceptance/create_component_spec.ts
+++ b/packages/core/test/acceptance/create_component_spec.ts
@@ -1173,6 +1173,7 @@ describe('createComponent', () => {
       }
 
       TestBed.configureTestingModule({
+        rethrowApplicationErrors: false,
         providers: [
           {
             provide: ErrorHandler,

--- a/packages/core/test/acceptance/listener_spec.ts
+++ b/packages/core/test/acceptance/listener_spec.ts
@@ -440,6 +440,7 @@ describe('event listeners', () => {
       }
 
       TestBed.configureTestingModule({
+        rethrowApplicationErrors: false,
         declarations: [TestCmpt, LikesClicks, ThrowsOnClicks],
         providers: [{provide: ErrorHandler, useClass: CountingErrorHandler}],
       });

--- a/packages/core/test/acceptance/profiler_spec.ts
+++ b/packages/core/test/acceptance/profiler_spec.ts
@@ -175,6 +175,7 @@ describe('profiler', () => {
       const errorSpy = spyOn(handler, 'handleError');
 
       TestBed.configureTestingModule({
+        rethrowApplicationErrors: false,
         declarations: [MyComponent],
         providers: [{provide: ErrorHandler, useValue: handler}],
       });


### PR DESCRIPTION
… handler

Practically speaking, this change ensures that Angular is able to make decisions about what to do when an uncaught error happens.

For tests, this will mean that, by default, the error either causes the `fixture.whenStable` promise to reject if there is one or rethrow the error. This ensures tests do not accidentally ignore errors. Opting out of this can be done with the `rethrowApplicationErrors: false` option in `TestBed`.

For SSR, there may be additional behaviors in the future that we want to add, such as redirecting to an error page or responding with a 500 status code.

BREAKING CHANGE: Uncaught errors in listeners which were previously only reported to `ErrorHandler` are now also reported to Angular's internal error handling machinery. For tests, this means that the error will be rethrown by default rather than only logging the error. Developers should fix these errors, catch them in the test if the test is intentionally covering an error case, or use `rethrowApplicationErrors: false` in `configureTestingModule` as a last resort.
