### PR TITLE
refactor: add fast-glob to `bazel` dependencies

### DIFF
--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "@microsoft/api-extractor": "^7.24.2",
     "magic-string": "^0.30.0",
-    "tslib": "^2.3.0"
+    "tslib": "^2.3.0",
+    "fast-glob": "^3.3.3"
   },
   "peerDependencies": {
     "@angular/compiler-cli": "0.0.0-PLACEHOLDER",


### PR DESCRIPTION
This will be necessary for downstream (private) consumers of the `@angular/bazel` package.