### PR TITLE
fix(devtools): handle case where directive metadata has `undefined` dependencies

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.html
@@ -1,6 +1,7 @@
 @if (controlsLoaded()) {
   <mat-accordion cdkDropList (cdkDropListDropped)="drop($event)" [multi]="true">
-    @if (controller().directiveMetadata?.dependencies.length > 0) {
+    @let dependencies = controller().directiveMetadata?.dependencies;
+    @if (dependencies && dependencies.length > 0) {
       <div class="mat-accordion-content">
         <mat-expansion-panel [expanded]="true">
           <mat-expansion-panel-header collapsedHeight="25px" expandedHeight="25px">


### PR DESCRIPTION
This fixes a bug introduced by [#60206](https://github.com/angular/angular/pull/60206/files#diff-c07b9ecd59f6e0ed636ac9672b9644178d9a999f04bc8b8198b13e86589dfa5b). Previously `DirectiveMetadata.prototype.dependencies` was always set, but in that PR `dependencies` is only set if an `Injector` is found (which only happens when `ng.getInjector` is *not* defined). This causes an error when evaluating `dependencies.length` in the template.

Fix is just to check for existance before calling `length`.