### PR TITLE
feat(language-service): add semantic tokens for templates

### DIFF
--- a/packages/compiler-cli/src/ngtsc/perf/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/perf/src/api.ts
@@ -155,11 +155,6 @@ export enum PerfPhase {
   OutliningSpans,
 
   /**
-   * Tracks the number of `PerfPhase`s, and must appear at the end of the list.
-   */
-  LAST,
-
-  /**
    * Time spent by the Angular Language Service calculating code fixes.
    */
   LsCodeFixes,
@@ -178,6 +173,16 @@ export enum PerfPhase {
    * Time spent computing changes for applying a given refactoring.
    */
   LSApplyRefactoring,
+
+  /**
+   * Time spent by the Angular Language Service calculating semantic classifications.
+   */
+  LSSemanticClassification,
+
+  /**
+   * Tracks the number of `PerfPhase`s, and must appear at the end of the list.
+   */
+  LAST,
 }
 
 /**

--- a/packages/language-service/src/semantic_tokens.ts
+++ b/packages/language-service/src/semantic_tokens.ts
@@ -1,0 +1,222 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  TmplAstElement,
+  TmplAstNode,
+  TmplAstTemplate,
+  TmplAstVisitor,
+  TmplAstBoundAttribute,
+  TmplAstBoundEvent,
+  TmplAstBoundText,
+  TmplAstContent,
+  TmplAstDeferredBlock,
+  TmplAstDeferredBlockError,
+  TmplAstDeferredBlockLoading,
+  TmplAstDeferredBlockPlaceholder,
+  TmplAstDeferredTrigger,
+  TmplAstForLoopBlock,
+  TmplAstForLoopBlockEmpty,
+  TmplAstIcu,
+  TmplAstIfBlock,
+  TmplAstIfBlockBranch,
+  TmplAstLetDeclaration,
+  TmplAstReference,
+  TmplAstSwitchBlock,
+  TmplAstSwitchBlockCase,
+  TmplAstText,
+  TmplAstTextAttribute,
+  TmplAstUnknownBlock,
+  TmplAstVariable,
+  TmplAstComponent,
+  TmplAstDirective,
+  ParseSourceSpan,
+} from '@angular/compiler';
+import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
+import {PotentialDirective} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
+import ts from 'typescript';
+import {TypeCheckInfo} from './utils';
+
+/**
+ * see https://github.com/microsoft/TypeScript/blob/c85e626d8e17427a6865521737b45ccbbe9c78ef/src/services/classifier2020.ts#L49
+ */
+export const enum TokenEncodingConsts {
+  typeOffset = 8,
+  modifierMask = (1 << typeOffset) - 1,
+}
+
+/**
+ * Token types extended from TypeScript
+ * see https://github.com/microsoft/TypeScript/blob/c85e626d8e17427a6865521737b45ccbbe9c78ef/src/services/classifier2020.ts#L55
+ */
+export const enum TokenType {
+  class,
+  enum,
+  interface,
+  namespace,
+  typeParameter,
+  type,
+  parameter,
+  variable,
+  enumMember,
+  property,
+  function,
+  member,
+}
+
+/**
+ * Token modifiers extended from TypeScript
+ * see https://github.com/microsoft/TypeScript/blob/c85e626d8e17427a6865521737b45ccbbe9c78ef/src/services/classifier2020.ts#L71
+ */
+export const enum TokenModifier {
+  declaration,
+  static,
+  async,
+  readonly,
+  defaultLibrary,
+  local,
+}
+
+export function getClassificationsForTemplate(
+  compiler: NgCompiler,
+  typeCheckInfo: TypeCheckInfo,
+  range: ts.TextSpan,
+): ts.Classifications {
+  const templateTypeChecker = compiler.getTemplateTypeChecker();
+  const potentialTags = templateTypeChecker.getElementsInFileScope(typeCheckInfo.declaration);
+
+  const visitor = new ClassificationVisitor(potentialTags, range);
+  visitor.visitAll(typeCheckInfo.nodes);
+
+  return {
+    spans: visitor.getSpans(),
+    endOfLineState: ts.EndOfLineState.None,
+  };
+}
+
+class ClassificationVisitor implements TmplAstVisitor {
+  private spans: number[] = [];
+  constructor(
+    private tags: Map<string, PotentialDirective | null>,
+    private range: ts.TextSpan,
+  ) {}
+
+  getSpans(): number[] {
+    return this.spans;
+  }
+
+  visit(node: TmplAstNode | null) {
+    if (node && this.rangeIntersectsWith(node.sourceSpan)) {
+      node.visit(this);
+    }
+  }
+
+  visitElement(element: TmplAstElement) {
+    const tag = element.name;
+    const potentialDirective = this.tags.get(tag);
+    // prevent classification of non-component directives that would be applied
+    // to this element due to a matching selector
+    const isComponent = potentialDirective && potentialDirective.isComponent;
+    const classification = this.classifyAs(TokenType.class);
+
+    if (isComponent && this.rangeIntersectsWith(element.startSourceSpan)) {
+      this.spans.push(element.startSourceSpan.start.offset + 1, tag.length, classification);
+    }
+
+    this.visitAll(element.children);
+
+    if (isComponent && !element.isSelfClosing && this.rangeIntersectsWith(element.endSourceSpan!)) {
+      this.spans.push(element.endSourceSpan!.start.offset + 2, tag.length, classification);
+    }
+  }
+
+  visitContent(content: TmplAstContent) {
+    this.visitAll(content.children);
+  }
+
+  visitVariable(variable: TmplAstVariable) {}
+  visitReference(reference: TmplAstReference) {}
+  visitTextAttribute(attribute: TmplAstTextAttribute) {}
+  visitBoundAttribute(attribute: TmplAstBoundAttribute) {}
+  visitBoundEvent(attribute: TmplAstBoundEvent) {}
+  visitText(text: TmplAstText) {}
+  visitBoundText(text: TmplAstBoundText) {}
+  visitIcu(icu: TmplAstIcu) {}
+
+  visitDeferredBlock(deferred: TmplAstDeferredBlock) {
+    this.visitAll(deferred.children);
+    this.visit(deferred.error);
+    this.visit(deferred.loading);
+    this.visit(deferred.placeholder);
+  }
+
+  visitDeferredBlockPlaceholder(block: TmplAstDeferredBlockPlaceholder) {
+    this.visitAll(block.children);
+  }
+
+  visitDeferredBlockError(block: TmplAstDeferredBlockError) {
+    this.visitAll(block.children);
+  }
+
+  visitDeferredBlockLoading(block: TmplAstDeferredBlockLoading) {
+    this.visitAll(block.children);
+  }
+
+  visitDeferredTrigger(trigger: TmplAstDeferredTrigger) {}
+
+  visitSwitchBlock(block: TmplAstSwitchBlock) {
+    this.visitAll(block.cases);
+  }
+
+  visitSwitchBlockCase(block: TmplAstSwitchBlockCase) {
+    this.visitAll(block.children);
+  }
+
+  visitForLoopBlock(block: TmplAstForLoopBlock) {
+    this.visitAll(block.children);
+    this.visit(block.empty);
+  }
+
+  visitForLoopBlockEmpty(block: TmplAstForLoopBlockEmpty) {
+    this.visitAll(block.children);
+  }
+
+  visitIfBlock(block: TmplAstIfBlock) {
+    this.visitAll(block.branches);
+  }
+
+  visitIfBlockBranch(block: TmplAstIfBlockBranch) {
+    this.visitAll(block.children);
+  }
+
+  visitTemplate(template: TmplAstTemplate) {
+    this.visitAll(template.children);
+  }
+
+  visitUnknownBlock(block: TmplAstUnknownBlock) {}
+  visitLetDeclaration(decl: TmplAstLetDeclaration) {}
+
+  visitComponent(component: TmplAstComponent) {}
+  visitDirective(directive: TmplAstDirective) {}
+
+  visitAll(children: TmplAstNode[]) {
+    for (const child of children) {
+      this.visit(child);
+    }
+  }
+
+  private rangeIntersectsWith(span: ParseSourceSpan) {
+    const start = span.start.offset;
+    const length = span.end.offset - start;
+    return ts.textSpanIntersectsWith(this.range, start, length);
+  }
+
+  private classifyAs(type: TokenType, modifiers: number = 0) {
+    return ((type + 1) << TokenEncodingConsts.typeOffset) + modifiers;
+  }
+}

--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -131,6 +131,24 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     return ngLS.getRenameInfo(fileName, position);
   }
 
+  function getEncodedSemanticClassifications(
+    fileName: string,
+    span: ts.TextSpan,
+    format?: ts.SemanticClassificationFormat,
+  ): ts.Classifications {
+    if (angularOnly || !isTypeScriptFile(fileName)) {
+      return ngLS.getEncodedSemanticClassifications(fileName, span, format);
+    } else {
+      const ngClassifications = ngLS.getEncodedSemanticClassifications(fileName, span, format);
+      const tsClassifications = tsLS.getEncodedSemanticClassifications(fileName, span, format);
+      const spans = [...ngClassifications.spans, ...tsClassifications.spans];
+      return {
+        spans,
+        endOfLineState: tsClassifications.endOfLineState,
+      };
+    }
+  }
+
   function getCompletionsAtPosition(
     fileName: string,
     position: number,
@@ -352,6 +370,7 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     getReferencesAtPosition,
     findRenameLocations,
     getRenameInfo,
+    getEncodedSemanticClassifications,
     getCompletionsAtPosition,
     getCompletionEntryDetails,
     getCompletionEntrySymbol,

--- a/packages/language-service/test/semantic_tokens_spec.ts
+++ b/packages/language-service/test/semantic_tokens_spec.ts
@@ -1,0 +1,378 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import ts from 'typescript';
+
+import {initMockFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
+import {LanguageServiceTestEnv, OpenBuffer} from '../testing';
+import {TokenEncodingConsts, TokenType, TokenModifier} from '../src/semantic_tokens';
+
+describe('semantic tokens', () => {
+  beforeEach(() => {
+    initMockFileSystem('Native');
+  });
+
+  it('should return no classifications with format "Original"', () => {
+    const {templateFile} = setup('<test-comp/>');
+    const actual = templateFile.getEncodedSemanticClassifications(
+      undefined,
+      ts.SemanticClassificationFormat.Original,
+    );
+
+    expect(actual.spans).toHaveSize(0);
+    expect(actual.endOfLineState).toBe(ts.EndOfLineState.None);
+  });
+
+  it('should classify components in external template', () => {
+    const template = `
+    <!-- top level -->
+    <test-comp></test-comp>
+    <test-comp />
+
+    <!-- nested -->
+    <div>
+      <unknown-comp>
+        <test-comp/>
+      </unknown-comp>
+    </div>
+    <test-comp>
+      content
+    </test-comp>
+
+    <!-- template -->
+    <ng-template>
+      <test-comp/>
+    </ng-template>
+    
+    <!-- content -->
+    <ng-content>
+      <test-comp/>
+    </ng-content>
+
+    <!-- defer -->
+    @defer {
+      <test-comp />
+    } @placeholder {
+      <test-comp />
+    } @loading {
+      <test-comp />
+    } @error {
+      <test-comp />
+    }
+
+    <!-- switch -->
+    @switch (true) {
+      @case (1) {
+        <test-comp/>
+      } @case (2) {
+        <test-comp/>
+      } @default {
+        <test-comp/>
+      }
+    }
+
+    <!-- for -->
+    @for (item of items;track item) {
+      <li> <test-comp/> </li>
+    } @empty {
+      <li> <test-comp/> </li>
+    }
+    
+    <!-- if / else -->
+    @if (true) {
+      <test-comp/>
+    } @else if (false) {
+      <test-comp/>
+    } @else {
+      <test-comp/>
+    }`;
+    const {templateFile} = setup(template);
+    const actual = templateFile.getEncodedSemanticClassifications();
+
+    expectClassifications(
+      templateFile,
+      actual,
+      // top level
+      semanticToken('class', 'test-comp', 29),
+      semanticToken('class', 'test-comp', 41),
+      semanticToken('class', 'test-comp', 57),
+
+      // nested
+      semanticToken('class', 'test-comp', 131),
+      semanticToken('class', 'test-comp', 181),
+      semanticToken('class', 'test-comp', 212),
+
+      // template
+      semanticToken('class', 'test-comp', 271),
+
+      // ng-content
+      semanticToken('class', 'test-comp', 352),
+
+      // @defer
+      semanticToken('class', 'test-comp', 422),
+      semanticToken('class', 'test-comp', 463),
+      semanticToken('class', 'test-comp', 500),
+      semanticToken('class', 'test-comp', 535),
+
+      // @switch
+      semanticToken('class', 'test-comp', 623),
+      semanticToken('class', 'test-comp', 664),
+      semanticToken('class', 'test-comp', 704),
+
+      // @for
+      semanticToken('class', 'test-comp', 798),
+      semanticToken('class', 'test-comp', 843),
+
+      // @if/else
+      semanticToken('class', 'test-comp', 919),
+      semanticToken('class', 'test-comp', 963),
+      semanticToken('class', 'test-comp', 996),
+    );
+  });
+
+  it('should classify components in inline template', () => {
+    const {templateFile, templateStart} = setupInlineTemplate('<test-comp/>');
+    const actual = templateFile.getEncodedSemanticClassifications();
+    expectClassifications(
+      templateFile,
+      actual,
+      semanticToken('class', 'test-comp', templateStart + 1),
+    );
+  });
+
+  it('should perform classification in given range', () => {
+    const template = `
+    <test-comp>
+      <!-- RANGE START -->
+      <div>
+        <test-comp/>
+      </div>
+      <!-- RANGE END -->
+
+      <test-comp />
+    </test-comp>
+  `;
+    const {templateFile} = setup(template);
+    const actual = templateFile.getEncodedSemanticClassifications({
+      start: template.indexOf('RANGE START'),
+      length: template.indexOf('RANGE END') - template.indexOf('RANGE START'),
+    });
+
+    expectClassifications(templateFile, actual, semanticToken('class', 'test-comp', 65));
+  });
+
+  it('should exclude non-component directives', () => {
+    const template = `
+    <button>Test</button>
+    <button test>Test</button>
+    `;
+    const {templateFile} = setup(template, '', {
+      'ButtonDirective': `
+        @Directive({
+          selector: "button"
+        })
+        export class ButtonDirective {}
+      `,
+      'TestDirective': `
+        @Directive({
+          selector: "[test]"
+        })
+        export class TestDirective {}
+      `,
+    });
+    const actual = templateFile.getEncodedSemanticClassifications();
+    expectClassifications(templateFile, actual);
+  });
+});
+
+function setup(
+  template: string,
+  classContents: string = '',
+  otherDeclarations: {[name: string]: string} = {},
+): {
+  templateFile: OpenBuffer;
+} {
+  const decls = ['AppCmp', ...Object.keys(otherDeclarations)];
+
+  const otherDirectiveClassDecls = Object.values(otherDeclarations).join('\n\n');
+
+  const env = LanguageServiceTestEnv.setup();
+  const project = env.addProject('test', {
+    'test.ts': `
+         import { Component, Directive, Input, Output, NgModule } from '@angular/core';
+
+         @Component({
+           templateUrl: './test.html',
+           selector: 'app-cmp',
+         })
+         export class AppCmp {
+           ${classContents}
+         }
+
+        @Component({
+          selector: 'test-comp',
+          template: '<div>Testing: {{name}}</div>',
+        })
+        export class TestComponent {
+          @Input() name!: string;
+          @Output() testEvent!: EventEmitter<string>;
+        }
+         ${otherDirectiveClassDecls}
+
+         @NgModule({
+           declarations: [${decls.join(', ')}],
+         })
+         export class AppModule {}
+         `,
+    'test.html': template,
+  });
+  return {templateFile: project.openFile('test.html')};
+}
+
+function setupInlineTemplate(
+  template: string,
+  classContents: string = '',
+  otherDeclarations: {[name: string]: string} = {},
+): {
+  templateFile: OpenBuffer;
+  templateStart: number;
+} {
+  const decls = ['AppCmp', ...Object.keys(otherDeclarations)];
+
+  const otherDirectiveClassDecls = Object.values(otherDeclarations).join('\n\n');
+
+  const env = LanguageServiceTestEnv.setup();
+  const project = env.addProject('test', {
+    'test.ts': `
+         import { Component, Input, Output, NgModule } from '@angular/core';
+
+         @Component({
+           template: '${template}',
+           selector: 'app-cmp',
+         })
+         export class AppCmp {
+           ${classContents}
+         }
+
+        @Component({
+          selector: 'test-comp',
+          template: '<div>Testing: {{name}}</div>',
+        })
+        export class TestComponent {
+          @Input() name!: string;
+          @Output() testEvent!: EventEmitter<string>;
+        }
+         ${otherDirectiveClassDecls}
+
+         @NgModule({
+           declarations: [${decls.join(', ')}],
+         })
+         export class AppModule {}
+         `,
+  });
+  return {templateFile: project.openFile('test.ts'), templateStart: 123};
+}
+
+function expectClassifications(
+  buffer: OpenBuffer,
+  actual: ts.Classifications,
+  ...expected: TestClassification[]
+) {
+  expect(actual.spans.length).toBe(expected.length * 3);
+  expect(actual.endOfLineState).toBe(ts.EndOfLineState.None);
+
+  for (const expectedToken of expected) {
+    const {start, length, type} = findTokenAtPosition(actual.spans, expectedToken.position);
+    const text = buffer.contents.substring(start, start + length);
+
+    expect(start).toBe(expectedToken.position);
+    expect(text).toBe(expectedToken.text);
+    expect(type).toBe(expectedToken.type);
+  }
+}
+
+interface TestClassification {
+  type: string;
+  text: string;
+  position: number;
+}
+
+/**
+ * Creates a semantic token
+ * @param type type and modifiers in dot notation, e.g. `class.defaultLibrary`.
+ * @param text the expected text to be highlighted
+ * @param position the expected offset to the start of the token
+ *
+ */
+function semanticToken(type: string, text: string, position: number): TestClassification {
+  return {
+    type,
+    text,
+    position,
+  };
+}
+
+/**
+ * Converts the token type bit set to a human readable string
+ * @param classification the encoded bit set
+ */
+function convertToString(classification: number) {
+  const typeIdx =
+    classification > TokenEncodingConsts.typeOffset
+      ? (classification >> TokenEncodingConsts.typeOffset) - 1
+      : 0;
+  const modifiers = classification & TokenEncodingConsts.modifierMask;
+
+  const typeName = TOKEN_TYPES[typeIdx];
+  const modifierNames = Object.keys(TOKEN_MODIFIERS)
+    .filter((i) => modifiers & (1 << parseInt(i)))
+    .map(([_, name]) => name);
+
+  return [typeName, ...modifierNames].join('.');
+}
+
+function findTokenAtPosition(spans: number[], pos: number) {
+  const idx = spans.findIndex((n, i) => i % 3 === 0 && pos === n);
+  expect(idx).withContext(`Expected token for position ${pos}`).toBeGreaterThanOrEqual(0);
+
+  return {
+    start: spans[idx],
+    length: spans[idx + 1],
+    type: convertToString(spans[idx + 2]),
+  };
+}
+
+/**
+ * Mappings to string representation of token types
+ */
+const TOKEN_TYPES: {[type: number]: string} = {
+  [TokenType.class]: 'class',
+  [TokenType.enum]: 'enum',
+  [TokenType.interface]: 'interface',
+  [TokenType.namespace]: 'namespace',
+  [TokenType.typeParameter]: 'typeParameter',
+  [TokenType.type]: 'type',
+  [TokenType.parameter]: 'parameter',
+  [TokenType.variable]: 'variable',
+  [TokenType.enumMember]: 'enumMember',
+  [TokenType.property]: 'property',
+  [TokenType.function]: 'function',
+  [TokenType.member]: 'member',
+};
+
+/**
+ * Mappings to string representation of token modifiers
+ */
+const TOKEN_MODIFIERS: {[type: number]: string} = {
+  [TokenModifier.declaration]: 'declaration',
+  [TokenModifier.static]: 'static',
+  [TokenModifier.async]: 'async',
+  [TokenModifier.readonly]: 'readonly',
+  [TokenModifier.defaultLibrary]: 'defaultLibrary',
+  [TokenModifier.local]: 'local',
+};

--- a/packages/language-service/testing/src/buffer.ts
+++ b/packages/language-service/testing/src/buffer.ts
@@ -72,6 +72,17 @@ export class OpenBuffer {
     return this.ngLS.getDefinitionAndBoundSpan(this.scriptInfo.fileName, this._cursor);
   }
 
+  getEncodedSemanticClassifications(
+    span?: ts.TextSpan,
+    format?: ts.SemanticClassificationFormat,
+  ): ts.Classifications {
+    return this.ngLS.getEncodedSemanticClassifications(
+      this.scriptInfo.fileName,
+      span ?? {start: 0, length: this.scriptInfo.getSnapshot().getLength()},
+      format ?? ts.SemanticClassificationFormat.TwentyTwenty,
+    );
+  }
+
   getCompletionsAtPosition(
     options?: ts.GetCompletionsAtPositionOptions,
   ): ts.WithMetadata<ts.CompletionInfo> | undefined {


### PR DESCRIPTION
Adds support for `getEncodedSemanticClassifications` to the language service. The service now classifies components in a template as the `class` type.


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The language service does not provide semantic tokens.

Issue Number: #60262 


## What is the new behavior?
The Angular language service now implements the `getEncodedSemanticClassifications` call, which in turn is needed on the language server/client side to provide the desired contextual syntax highlighting in the editor. 

For now, the service only tries to highlight component tags by classifying them as classes (similiar to  TSX highlighting done by TypeScript).  To this extent the token types are the same as in the TypeScript language service to ensure this service keeps working as a strict superset.   

For details about semantic tokens see the [LSP protocol](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No