### PR TITLE
compiler-cli: remove unnecessary paren logic for ternaries

### DIFF
--- a/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
@@ -322,36 +322,8 @@ export class ExpressionTranslatorVisitor<TFile, TStatement, TExpression>
   }
 
   visitConditionalExpr(ast: o.ConditionalExpr, context: Context): TExpression {
-    let cond: TExpression = ast.condition.visitExpression(this, context);
-
-    // Ordinarily the ternary operator is right-associative. The following are equivalent:
-    //   `a ? b : c ? d : e` => `a ? b : (c ? d : e)`
-    //
-    // However, occasionally Angular needs to produce a left-associative conditional, such as in
-    // the case of a null-safe navigation production: `{{a?.b ? c : d}}`. This template produces
-    // a ternary of the form:
-    //   `a == null ? null : rest of expression`
-    // If the rest of the expression is also a ternary though, this would produce the form:
-    //   `a == null ? null : a.b ? c : d`
-    // which, if left as right-associative, would be incorrectly associated as:
-    //   `a == null ? null : (a.b ? c : d)`
-    //
-    // In such cases, the left-associativity needs to be enforced with parentheses:
-    //   `(a == null ? null : a.b) ? c : d`
-    //
-    // Such parentheses could always be included in the condition (guaranteeing correct behavior) in
-    // all cases, but this has a code size cost. Instead, parentheses are added only when a
-    // conditional expression is directly used as the condition of another.
-    //
-    // TODO(alxhub): investigate better logic for precendence of conditional operators
-    if (ast.condition instanceof o.ConditionalExpr) {
-      // The condition of this ternary needs to be wrapped in parentheses to maintain
-      // left-associativity.
-      cond = this.factory.createParenthesizedExpression(cond);
-    }
-
     return this.factory.createConditional(
-      cond,
+      ast.condition.visitExpression(this, context),
       ast.trueCase.visitExpression(this, context),
       ast.falseCase!.visitExpression(this, context),
     );

--- a/packages/compiler/src/template/pipeline/src/phases/strip_nonrequired_parentheses.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/strip_nonrequired_parentheses.ts
@@ -25,6 +25,8 @@ import type {CompilationJob} from '../compilation';
  *    typescript AST, the parentheses node is removed, and then the remaining AST is printed, it
  *    incorrectly prints `a ? b : c ?? d`. This is different from how it handles the same situation
  *    with `||` and `&&` where it prints the parentheses even if they are not present in the AST.
+ *    Note: We may be able to remove this case if Typescript resolves the following issue:
+ *    https://github.com/microsoft/TypeScript/issues/61369
  */
 export function stripNonrequiredParentheses(job: CompilationJob): void {
   // Check which parentheses are required.


### PR DESCRIPTION
Removes logic that was explicitly adding parentheses around ternaries
used as the condition of another ternary. Instead we can just rely on
Typescript to add the parentheses if they are needed to make the code
match the structure of the AST.

Also added a note pointing to the issue that currently prevents us from
removing similar logic pertaining to nullish coalescing