### PR TITLE
test: narrow down signal-input typescript tests

### DIFF
--- a/packages/core/schematics/migrations/signal-migration/test/ts-versions/index.bzl
+++ b/packages/core/schematics/migrations/signal-migration/test/ts-versions/index.bzl
@@ -1,11 +1,5 @@
 """Exposes information about the tested TS versions."""
 
 TS_VERSIONS = [
-    "typescript-5.5.2",
-    "typescript-5.5.3",
-    "typescript-5.5.4",
-    "typescript-5.6.2",
-    "typescript-5.6.3",
-    "typescript-5.7.2",
-    "typescript-5.7.3",
+    "typescript-5.8.2",
 ]

--- a/packages/core/schematics/migrations/signal-migration/test/ts-versions/package.json
+++ b/packages/core/schematics/migrations/signal-migration/test/ts-versions/package.json
@@ -2,12 +2,6 @@
   "name": "ts-versions",
   "license": "MIT",
   "dependencies": {
-    "typescript-5.5.2": "npm:typescript@5.5.2",
-    "typescript-5.5.3": "npm:typescript@5.5.3",
-    "typescript-5.5.4": "npm:typescript@5.5.4",
-    "typescript-5.6.2": "npm:typescript@5.6.2",
-    "typescript-5.6.3": "npm:typescript@5.6.3",
-    "typescript-5.7.2": "npm:typescript@5.7.2",
-    "typescript-5.7.3": "npm:typescript@5.7.3"
+    "typescript-5.8.2": "npm:typescript@5.8.2"
   }
 }

--- a/packages/core/schematics/migrations/signal-migration/test/ts-versions/yarn.lock
+++ b/packages/core/schematics/migrations/signal-migration/test/ts-versions/yarn.lock
@@ -2,37 +2,7 @@
 # yarn lockfile v1
 
 
-"typescript-5.5.2@npm:typescript@5.5.2":
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.2.tgz#c26f023cb0054e657ce04f72583ea2d85f8d0507"
-  integrity sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==
-
-"typescript-5.5.3@npm:typescript@5.5.3":
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.3.tgz#e1b0a3c394190838a0b168e771b0ad56a0af0faa"
-  integrity sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==
-
-"typescript-5.5.4@npm:typescript@5.5.4":
-  version "5.5.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
-  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
-
-"typescript-5.6.2@npm:typescript@5.6.2":
-  version "5.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.2.tgz#d1de67b6bef77c41823f822df8f0b3bcff60a5a0"
-  integrity sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==
-
-"typescript-5.6.3@npm:typescript@5.6.3":
-  version "5.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.3.tgz#5f3449e31c9d94febb17de03cc081dd56d81db5b"
-  integrity sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==
-
-"typescript-5.7.2@npm:typescript@5.7.2":
-  version "5.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
-  integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==
-
-"typescript-5.7.3@npm:typescript@5.7.3":
-  version "5.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
-  integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
+"typescript-5.8.2@npm:typescript@5.8.2":
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.2.tgz#8170b3702f74b79db2e5a96207c15e65807999e4"
+  integrity sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==


### PR DESCRIPTION
Remove TS versions that are no longer supported.
