### PR TITLE
Type checking support for host bindings

### DIFF
--- a/goldens/public-api/compiler-cli/compiler_options.api.md
+++ b/goldens/public-api/compiler-cli/compiler_options.api.md
@@ -60,6 +60,7 @@ export interface MiscOptions {
     compileNonExportedClasses?: boolean;
     disableTypeScriptVersionCheck?: boolean;
     forbidOrphanComponents?: boolean;
+    typeCheckHostBindings?: boolean;
 }
 
 // @public

--- a/goldens/public-api/compiler-cli/compiler_options.api.md
+++ b/goldens/public-api/compiler-cli/compiler_options.api.md
@@ -60,11 +60,15 @@ export interface MiscOptions {
     compileNonExportedClasses?: boolean;
     disableTypeScriptVersionCheck?: boolean;
     forbidOrphanComponents?: boolean;
-    typeCheckHostBindings?: boolean;
 }
 
 // @public
-export interface StrictTemplateOptions {
+export interface TargetOptions {
+    compilationMode?: 'full' | 'partial' | 'experimental-local';
+}
+
+// @public
+export interface TypeCheckingOptions {
     strictAttributeTypes?: boolean;
     strictContextGenerics?: boolean;
     strictDomEventTypes?: boolean;
@@ -76,11 +80,7 @@ export interface StrictTemplateOptions {
     strictOutputEventTypes?: boolean;
     strictSafeNavigationTypes?: boolean;
     strictTemplates?: boolean;
-}
-
-// @public
-export interface TargetOptions {
-    compilationMode?: 'full' | 'partial' | 'experimental-local';
+    typeCheckHostBindings?: boolean;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -94,6 +94,7 @@ export async function runOneBuild(
     '_enableLetSyntax',
     '_enableHmr',
     'strictStandalone',
+    'typeCheckHostBindings',
   ]);
 
   const userOverrides = Object.entries(userOptions)

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/metadata.ts
@@ -33,6 +33,7 @@ import {ClassDeclaration} from '../../../reflection';
 import {SubsetOfKeys} from '../../../util/src/typescript';
 
 import {ParsedTemplateWithSource, StyleUrlMeta} from './resources';
+import {HostBindingNodes} from '../../directive';
 
 /**
  * These fields of `R3ComponentMetadata` are updated in the `resolve` phase.
@@ -108,6 +109,9 @@ export interface ComponentAnalysisData {
 
   /** Raw expression that defined the host directives array. Used for diagnostics. */
   rawHostDirectives: ts.Expression | null;
+
+  /** Raw nodes representing the host bindings of the directive. */
+  hostBindingNodes: HostBindingNodes;
 }
 
 export interface ComponentResolutionData {

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/resources.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/resources.ts
@@ -745,10 +745,10 @@ export function extractInlineStyleResources(component: Map<string, ts.Expression
   if (stylesExpr !== undefined) {
     if (ts.isArrayLiteralExpression(stylesExpr)) {
       for (const expression of stringLiteralElements(stylesExpr)) {
-        styles.add({path: null, expression});
+        styles.add({path: null, node: expression});
       }
     } else if (ts.isStringLiteralLike(stylesExpr)) {
-      styles.add({path: null, expression: stylesExpr});
+      styles.add({path: null, node: stylesExpr});
     }
   }
 

--- a/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
@@ -160,6 +160,7 @@ function setup(
     /* strictStandalone */ false,
     /* enableHmr */ false,
     /* implicitStandaloneValue */ true,
+    /* typeCheckHostBindings */ true,
   );
   return {reflectionHost, handler, resourceLoader, metaRegistry};
 }

--- a/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
@@ -231,7 +231,7 @@ runInEachFileSystem(() => {
       }
       const {analysis} = handler.analyze(TestCmp, detected.metadata);
       expect(analysis?.resources.template?.path).toBeNull();
-      expect(analysis?.resources.template?.expression.getText()).toEqual(`'${template}'`);
+      expect(analysis?.resources.template?.node.getText()).toEqual(`'${template}'`);
     });
 
     it('should keep track of external template', () => {
@@ -264,7 +264,7 @@ runInEachFileSystem(() => {
       }
       const {analysis} = handler.analyze(TestCmp, detected.metadata);
       expect(analysis?.resources.template?.path).toContain(templateUrl);
-      expect(analysis?.resources.template?.expression.getText()).toContain(`'${templateUrl}'`);
+      expect(analysis?.resources.template?.node.getText()).toContain(`'${templateUrl}'`);
     });
 
     it('should keep track of internal and external styles', () => {

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/BUILD.bazel
@@ -20,6 +20,8 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/scope",
         "//packages/compiler-cli/src/ngtsc/transform",
         "//packages/compiler-cli/src/ngtsc/translator",
+        "//packages/compiler-cli/src/ngtsc/typecheck",
+        "//packages/compiler-cli/src/ngtsc/typecheck/api",
         "@npm//@types/node",
         "@npm//typescript",
     ],

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
@@ -16,6 +16,7 @@ import {
   makeBindingParser,
   R3ClassMetadata,
   R3DirectiveMetadata,
+  R3TargetBinder,
   WrappedNodeExpr,
 } from '@angular/compiler';
 import ts from 'typescript';
@@ -47,7 +48,7 @@ import {
   Decorator,
   ReflectionHost,
 } from '../../../reflection';
-import {LocalModuleScopeRegistry} from '../../../scope';
+import {LocalModuleScopeRegistry, TypeCheckScopeRegistry} from '../../../scope';
 import {
   AnalysisOutput,
   CompilationMode,
@@ -79,6 +80,12 @@ import {
 import {extractDirectiveMetadata, extractHostBindingResources, HostBindingNodes} from './shared';
 import {DirectiveSymbol} from './symbol';
 import {JitDeclarationRegistry} from '../../common/src/jit_declaration_registry';
+import {
+  HostBindingsContext,
+  TypeCheckableDirectiveMeta,
+  TypeCheckContext,
+} from '../../../typecheck/api';
+import {createHostElement} from '../../../typecheck';
 
 const FIELD_DECORATORS = [
   'Input',
@@ -138,11 +145,14 @@ export class DirectiveDecoratorHandler
     private perf: PerfRecorder,
     private importTracker: ImportedSymbolsTracker,
     private includeClassMetadata: boolean,
+    private typeCheckScopeRegistry: TypeCheckScopeRegistry,
     private readonly compilationMode: CompilationMode,
     private readonly jitDeclarationRegistry: JitDeclarationRegistry,
     private readonly resourceRegistry: ResourceRegistry,
     private readonly strictStandalone: boolean,
     private readonly implicitStandaloneValue: boolean,
+    private readonly usePoisonedData: boolean,
+    private readonly typeCheckHostBindings: boolean,
   ) {}
 
   readonly precedence = HandlerPrecedence.PRIMARY;
@@ -303,6 +313,53 @@ export class DirectiveDecoratorHandler
     });
   }
 
+  typeCheck(
+    ctx: TypeCheckContext,
+    node: ClassDeclaration,
+    meta: Readonly<DirectiveHandlerData>,
+  ): void {
+    // Currently type checking in directives is only supported for host bindings
+    // so we can skip everything below if type checking is disabled.
+    if (!this.typeCheckHostBindings) {
+      return;
+    }
+
+    if (!ts.isClassDeclaration(node) || (meta.isPoisoned && !this.usePoisonedData)) {
+      return;
+    }
+    const scope = this.typeCheckScopeRegistry.getTypeCheckScope(node);
+    if (scope.isPoisoned && !this.usePoisonedData) {
+      // Don't type-check components that had errors in their scopes, unless requested.
+      return;
+    }
+
+    const hostElement = createHostElement(
+      'directive',
+      meta.meta.selector,
+      node,
+      meta.hostBindingNodes.literal,
+      meta.hostBindingNodes.bindingDecorators,
+      meta.hostBindingNodes.listenerDecorators,
+    );
+
+    if (hostElement !== null) {
+      const binder = new R3TargetBinder<TypeCheckableDirectiveMeta>(scope.matcher);
+      const hostBindingsContext: HostBindingsContext = {
+        node: hostElement,
+        sourceMapping: {type: 'direct', node},
+      };
+
+      ctx.addDirective(
+        new Reference(node),
+        binder,
+        scope.schemas,
+        null,
+        hostBindingsContext,
+        meta.meta.isStandalone,
+      );
+    }
+  }
+
   resolve(
     node: ClassDeclaration,
     analysis: DirectiveHandlerData,
@@ -354,7 +411,13 @@ export class DirectiveDecoratorHandler
       diagnostics.push(...hostDirectivesDiagnotics);
     }
 
-    return {diagnostics: diagnostics.length > 0 ? diagnostics : undefined};
+    if (diagnostics.length > 0) {
+      return {diagnostics};
+    }
+
+    // Note: we need to produce *some* sort of the data in order
+    // for the host binding diagnostics to be surfaced.
+    return {data: {}};
   }
 
   compileFull(

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
@@ -43,6 +43,7 @@ import {
   InputMapping,
   InputOrOutput,
   isHostDirectiveMetaForGlobalMode,
+  Resource,
 } from '../../../metadata';
 import {
   DynamicValue,
@@ -97,6 +98,12 @@ export const queryDecoratorNames: QueryDecoratorName[] = [
   'ContentChildren',
 ];
 
+export interface HostBindingNodes {
+  literal: ts.ObjectLiteralExpression | null;
+  bindingDecorators: Set<ts.Decorator>;
+  listenerDecorators: Set<ts.Decorator>;
+}
+
 const QUERY_TYPES = new Set<string>(queryDecoratorNames);
 
 /**
@@ -130,6 +137,7 @@ export function extractDirectiveMetadata(
       hostDirectives: HostDirectiveMeta[] | null;
       rawHostDirectives: ts.Expression | null;
       inputFieldNamesFromMetadataArray: Set<string>;
+      hostBindingNodes: HostBindingNodes;
     }
   | {jitForced: true} {
   let directive: Map<string, ts.Expression>;
@@ -272,11 +280,18 @@ export function extractDirectiveMetadata(
     }
   }
 
+  const hostBindingNodes: HostBindingNodes = {
+    literal: null,
+    bindingDecorators: new Set<ts.Decorator>(),
+    listenerDecorators: new Set<ts.Decorator>(),
+  };
+
   const host = extractHostBindings(
     decoratedElements,
     evaluator,
     coreModule,
     compilationMode,
+    hostBindingNodes,
     directive,
   );
 
@@ -434,6 +449,7 @@ export function extractDirectiveMetadata(
     isStructural,
     hostDirectives,
     rawHostDirectives,
+    hostBindingNodes,
     // Track inputs from class metadata. This is useful for migration efforts.
     inputFieldNamesFromMetadataArray: new Set(
       Object.values(inputsFromMeta).map((i) => i.classPropertyName),
@@ -558,16 +574,21 @@ export function extractDecoratorQueryMetadata(
   };
 }
 
-export function extractHostBindings(
+function extractHostBindings(
   members: ClassMember[],
   evaluator: PartialEvaluator,
   coreModule: string | undefined,
   compilationMode: CompilationMode,
+  hostBindingNodes: HostBindingNodes,
   metadata?: Map<string, ts.Expression>,
 ): ParsedHostBindings {
   let bindings: ParsedHostBindings;
   if (metadata && metadata.has('host')) {
-    bindings = evaluateHostExpressionBindings(metadata.get('host')!, evaluator);
+    const hostExpression = metadata.get('host')!;
+    bindings = evaluateHostExpressionBindings(hostExpression, evaluator);
+    if (ts.isObjectLiteralExpression(hostExpression)) {
+      hostBindingNodes.literal = hostExpression;
+    }
   } else {
     bindings = parseHostBindings({});
   }
@@ -608,6 +629,10 @@ export function extractHostBindings(
           }
 
           hostPropertyName = resolved;
+        }
+
+        if (ts.isDecorator(decorator.node)) {
+          hostBindingNodes.bindingDecorators.add(decorator.node);
         }
 
         // Since this is a decorator, we know that the value is a class member. Always access it
@@ -669,6 +694,10 @@ export function extractHostBindings(
             }
             args = resolvedArgs;
           }
+        }
+
+        if (ts.isDecorator(decorator.node)) {
+          hostBindingNodes.listenerDecorators.add(decorator.node);
         }
 
         bindings.listeners[eventName] = `${member.name}(${args.join(',')})`;
@@ -1825,4 +1854,22 @@ function toR3InputMetadata(mapping: InputMapping): R3InputMetadata {
       mapping.transform !== null ? new WrappedNodeExpr(mapping.transform.node) : null,
     isSignal: mapping.isSignal,
   };
+}
+
+export function extractHostBindingResources(nodes: HostBindingNodes): ReadonlySet<Resource> {
+  const result = new Set<Resource>();
+
+  if (nodes.literal !== null) {
+    result.add({path: null, node: nodes.literal});
+  }
+
+  for (const current of nodes.bindingDecorators) {
+    result.add({path: null, node: current.expression});
+  }
+
+  for (const current of nodes.listenerDecorators) {
+    result.add({path: null, node: current.expression});
+  }
+
+  return result;
 }

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/test/directive_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/test/directive_spec.ts
@@ -18,7 +18,12 @@ import ts from 'typescript';
 import {absoluteFrom} from '../../../file_system';
 import {runInEachFileSystem} from '../../../file_system/testing';
 import {ImportedSymbolsTracker, ReferenceEmitter} from '../../../imports';
-import {CompoundMetadataReader, DtsMetadataReader, LocalMetadataRegistry} from '../../../metadata';
+import {
+  CompoundMetadataReader,
+  DtsMetadataReader,
+  LocalMetadataRegistry,
+  ResourceRegistry,
+} from '../../../metadata';
 import {PartialEvaluator} from '../../../partial_evaluator';
 import {NOOP_PERF_RECORDER} from '../../../perf';
 import {
@@ -195,6 +200,7 @@ runInEachFileSystem(() => {
     const injectableRegistry = new InjectableClassRegistry(reflectionHost, /* isCore */ false);
     const importTracker = new ImportedSymbolsTracker();
     const jitDeclarationRegistry = new JitDeclarationRegistry();
+    const resourceRegistry = new ResourceRegistry();
 
     const handler = new DirectiveDecoratorHandler(
       reflectionHost,
@@ -214,6 +220,7 @@ runInEachFileSystem(() => {
       /*includeClassMetadata*/ true,
       /*compilationMode */ CompilationMode.FULL,
       jitDeclarationRegistry,
+      resourceRegistry,
       /* strictStandalone */ false,
       /* implicitStandaloneValue */ true,
     );

--- a/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
@@ -14,7 +14,7 @@ import {
   I18nOptions,
   LegacyNgcOptions,
   MiscOptions,
-  StrictTemplateOptions,
+  TypeCheckingOptions,
   TargetOptions,
 } from './public_options';
 
@@ -148,7 +148,7 @@ export interface NgCompilerOptions
     LegacyNgcOptions,
     BazelAndG3Options,
     DiagnosticOptions,
-    StrictTemplateOptions,
+    TypeCheckingOptions,
     TestOnlyOptions,
     I18nOptions,
     TargetOptions,

--- a/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
@@ -430,6 +430,9 @@ export interface TargetOptions {
  * @publicApi
  */
 export interface MiscOptions {
+  /** Whether type checking of host bindings is enabled. */
+  typeCheckHostBindings?: boolean;
+
   /**
    * Whether the compiler should avoid generating code for classes that haven't been exported.
    * Defaults to `true`.

--- a/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
@@ -89,11 +89,14 @@ export interface LegacyNgcOptions {
 }
 
 /**
- * Options related to template type-checking and its strictness.
+ * Options related to Angular-specific type-checking and its strictness.
  *
  * @publicApi
  */
-export interface StrictTemplateOptions {
+export interface TypeCheckingOptions {
+  /** Whether type checking of host bindings is enabled. */
+  typeCheckHostBindings?: boolean;
+
   /**
    * If `true`, implies all template strictness flags below (unless individually disabled).
    *
@@ -430,9 +433,6 @@ export interface TargetOptions {
  * @publicApi
  */
 export interface MiscOptions {
-  /** Whether type checking of host bindings is enabled. */
-  typeCheckHostBindings?: boolean;
-
   /**
    * Whether the compiler should avoid generating code for classes that haven't been exported.
    * Defaults to `true`.

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -1431,6 +1431,7 @@ export class NgCompiler {
     const supportJitMode = this.options['supportJitMode'] ?? true;
     const supportTestBed = this.options['supportTestBed'] ?? true;
     const externalRuntimeStyles = this.options['externalRuntimeStyles'] ?? false;
+    const typeCheckHostBindings = this.options.typeCheckHostBindings ?? false;
 
     // Libraries compiled in partial mode could potentially be used with TestBed within an
     // application. Since this is not known at library compilation time, support is required to
@@ -1503,6 +1504,7 @@ export class NgCompiler {
         !!this.options.strictStandalone,
         this.enableHmr,
         this.implicitStandaloneValue,
+        typeCheckHostBindings,
       ),
 
       // TODO(alxhub): understand why the cast here is necessary (something to do with `null`

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -1525,11 +1525,14 @@ export class NgCompiler {
         this.delegatingPerfRecorder,
         importTracker,
         supportTestBed,
+        typeCheckScopeRegistry,
         compilationMode,
         jitDeclarationRegistry,
         resourceRegistry,
         !!this.options.strictStandalone,
         this.implicitStandaloneValue,
+        this.usePoisonedData,
+        typeCheckHostBindings,
       ) as Readonly<DecoratorHandler<unknown, unknown, SemanticSymbol | null, unknown>>,
       // Pipe handler must be before injectable handler in list so pipe factories are printed
       // before injectable factories (so injectable factories can delegate to them)

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -738,7 +738,8 @@ export class NgCompiler {
     const {resourceRegistry} = this.ensureAnalyzed();
     const styles = resourceRegistry.getStyles(classDecl);
     const template = resourceRegistry.getTemplate(classDecl);
-    return {styles, template};
+    const hostBindings = resourceRegistry.getHostBindings(classDecl);
+    return {styles, template, hostBindings};
   }
 
   getMeta(classDecl: DeclarationNode): PipeMeta | DirectiveMeta | null {
@@ -1524,6 +1525,7 @@ export class NgCompiler {
         supportTestBed,
         compilationMode,
         jitDeclarationRegistry,
+        resourceRegistry,
         !!this.options.strictStandalone,
         this.implicitStandaloneValue,
       ) as Readonly<DecoratorHandler<unknown, unknown, SemanticSymbol | null, unknown>>,

--- a/packages/compiler-cli/src/ngtsc/metadata/src/resource_registry.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/resource_registry.ts
@@ -20,7 +20,7 @@ import {ClassDeclaration} from '../../reflection';
  */
 export interface Resource {
   path: AbsoluteFsPath | null;
-  expression: ts.Expression;
+  node: ts.Node;
 }
 
 export interface ExternalResource extends Resource {
@@ -40,6 +40,7 @@ export function isExternalResource(resource: Resource): resource is ExternalReso
 export interface DirectiveResources {
   template: Resource | null;
   styles: ReadonlySet<Resource> | null;
+  hostBindings: ReadonlySet<Resource> | null;
 }
 
 /**
@@ -54,6 +55,7 @@ export class ResourceRegistry {
   private componentToTemplateMap = new Map<ClassDeclaration, Resource>();
   private componentToStylesMap = new Map<ClassDeclaration, Set<Resource>>();
   private externalStyleToComponentsMap = new Map<AbsoluteFsPath, Set<ClassDeclaration>>();
+  private directiveToHostBindingsMap = new Map<ClassDeclaration, ReadonlySet<Resource>>();
 
   getComponentsWithTemplate(template: AbsoluteFsPath): ReadonlySet<ClassDeclaration> {
     if (!this.externalTemplateToComponentsMap.has(template)) {
@@ -71,6 +73,9 @@ export class ResourceRegistry {
       for (const style of resources.styles) {
         this.registerStyle(style, directive);
       }
+    }
+    if (resources.hostBindings !== null) {
+      this.directiveToHostBindingsMap.set(directive, resources.hostBindings);
     }
   }
 
@@ -119,5 +124,9 @@ export class ResourceRegistry {
     }
 
     return this.externalStyleToComponentsMap.get(styleUrl)!;
+  }
+
+  getHostBindings(directive: ClassDeclaration): ReadonlySet<Resource> | null {
+    return this.directiveToHostBindingsMap.get(directive) ?? null;
   }
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/BUILD.bazel
@@ -10,6 +10,7 @@ ts_library(
     deps = [
         "//packages:types",
         "//packages/compiler",
+        "//packages/compiler-cli/src/ngtsc/annotations/common",
         "//packages/compiler-cli/src/ngtsc/diagnostics",
         "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler-cli/src/ngtsc/imports",

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
@@ -376,7 +376,7 @@ export type SourceMapping =
  */
 export interface DirectSourceMapping {
   type: 'direct';
-  node: ts.Expression;
+  node: ts.Node;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
@@ -14,6 +14,7 @@ import {
   SafePropertyRead,
   TemplateEntity,
   TmplAstElement,
+  TmplAstHostElement,
   TmplAstNode,
   TmplAstTemplate,
   TmplAstTextAttribute,
@@ -49,6 +50,14 @@ export interface TemplateTypeChecker {
    * Retrieve the template in use for the given component.
    */
   getTemplate(component: ts.ClassDeclaration, optimizeFor?: OptimizeFor): TmplAstNode[] | null;
+
+  /**
+   * Retrieve the host element of the given directive.
+   */
+  getHostElement(
+    directive: ts.ClassDeclaration,
+    optimizeFor?: OptimizeFor,
+  ): TmplAstHostElement | null;
 
   /**
    * Get all `ts.Diagnostic`s currently available for the given `ts.SourceFile`.

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/context.ts
@@ -11,6 +11,7 @@ import {
   ParseSourceFile,
   R3TargetBinder,
   SchemaMetadata,
+  TmplAstHostElement,
   TmplAstNode,
 } from '@angular/compiler';
 import ts from 'typescript';
@@ -42,6 +43,15 @@ export interface TemplateContext {
   preserveWhitespaces: boolean;
 }
 
+/** Contextual data for type checking the host bindings of a directive. */
+export interface HostBindingsContext {
+  /** AST node representing the host element of the directive. */
+  node: TmplAstHostElement;
+
+  /** Describes the source of the host bindings. Used for mapping errors back. */
+  sourceMapping: SourceMapping;
+}
+
 /**
  * A currently pending type checking operation, into which templates for type-checking can be
  * registered.
@@ -60,6 +70,8 @@ export interface TypeCheckContext {
    * @param schemas Schemas that will apply when checking the directive.
    * @param templateContext Contextual information necessary for checking the template.
    * Only relevant for component classes.
+   * @param hostBindingContext Contextual information necessary for checking the host bindings of
+   * a directive.
    * @param isStandalone a boolean indicating whether the directive is standalone.
    */
   addDirective(
@@ -67,6 +79,7 @@ export interface TypeCheckContext {
     binder: R3TargetBinder<TypeCheckableDirectiveMeta>,
     schemas: SchemaMetadata[],
     templateContext: TemplateContext | null,
+    hostBindingContext: HostBindingsContext | null,
     isStandalone: boolean,
   ): void;
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/index.ts
@@ -10,3 +10,4 @@ export {FileTypeCheckingData, TemplateTypeCheckerImpl} from './src/checker';
 export {TypeCheckContextImpl, getTemplateDiagnostics} from './src/context';
 export {TypeCheckShimGenerator} from './src/shim';
 export {typeCheckFilePath} from './src/type_check_file';
+export {createHostElement} from './src/host_bindings';

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -17,6 +17,7 @@ import {
   SafePropertyRead,
   TemplateEntity,
   TmplAstElement,
+  TmplAstHostElement,
   TmplAstNode,
   TmplAstTemplate,
   TmplAstTextAttribute,
@@ -150,18 +151,23 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
 
   getTemplate(component: ts.ClassDeclaration, optimizeFor?: OptimizeFor): TmplAstNode[] | null {
     const {data} = this.getLatestComponentState(component, optimizeFor);
-    if (data === null) {
-      return null;
-    }
-    return data.template;
+    return data?.template ?? null;
+  }
+
+  getHostElement(
+    directive: ts.ClassDeclaration,
+    optimizeFor?: OptimizeFor,
+  ): TmplAstHostElement | null {
+    const {data} = this.getLatestComponentState(directive, optimizeFor);
+    return data?.hostElement ?? null;
   }
 
   getUsedDirectives(component: ts.ClassDeclaration): TypeCheckableDirectiveMeta[] | null {
-    return this.getLatestComponentState(component).data?.boundTarget.getUsedDirectives() || null;
+    return this.getLatestComponentState(component).data?.boundTarget.getUsedDirectives() ?? null;
   }
 
   getUsedPipes(component: ts.ClassDeclaration): string[] | null {
-    return this.getLatestComponentState(component).data?.boundTarget.getUsedPipes() || null;
+    return this.getLatestComponentState(component).data?.boundTarget.getUsedPipes() ?? null;
   }
 
   private getLatestComponentState(
@@ -446,7 +452,7 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
 
   getExpressionTarget(expression: AST, clazz: ts.ClassDeclaration): TemplateEntity | null {
     return (
-      this.getLatestComponentState(clazz).data?.boundTarget.getExpressionTarget(expression) || null
+      this.getLatestComponentState(clazz).data?.boundTarget.getExpressionTarget(expression) ?? null
     );
   }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
@@ -9,8 +9,10 @@
 import {
   BoundTarget,
   ParseError,
+  ParseSourceFile,
   R3TargetBinder,
   SchemaMetadata,
+  TmplAstHostElement,
   TmplAstNode,
 } from '@angular/compiler';
 import MagicString from 'magic-string';
@@ -24,6 +26,7 @@ import {FileUpdate} from '../../program_driver';
 import {ClassDeclaration, ReflectionHost} from '../../reflection';
 import {ImportManager} from '../../translator';
 import {
+  HostBindingsContext,
   TemplateDiagnostic,
   TypeCheckId,
   SourceMapping,
@@ -91,6 +94,11 @@ export interface TypeCheckData {
    * Errors found while parsing the template, which have been converted to diagnostics.
    */
   templateParsingDiagnostics: TemplateDiagnostic[];
+
+  /**
+   * Element representing the host bindings of a directive.
+   */
+  hostElement: TmplAstHostElement | null;
 }
 
 /**
@@ -230,13 +238,15 @@ export class TypeCheckContextImpl implements TypeCheckContext {
     binder: R3TargetBinder<TypeCheckableDirectiveMeta>,
     schemas: SchemaMetadata[],
     templateContext: TemplateContext | null,
+    hostBindingContext: HostBindingsContext | null,
     isStandalone: boolean,
   ): void {
     if (!this.host.shouldCheckClass(ref.node)) {
       return;
     }
 
-    const fileData = this.dataForFile(ref.node.getSourceFile());
+    const sourceFile = ref.node.getSourceFile();
+    const fileData = this.dataForFile(sourceFile);
     const shimData = this.pendingShimForClass(ref.node);
     const id = fileData.sourceManager.getTypeCheckId(ref.node);
     const templateParsingDiagnostics: TemplateDiagnostic[] = [];
@@ -247,7 +257,10 @@ export class TypeCheckContextImpl implements TypeCheckContext {
       );
     }
 
-    const boundTarget = binder.bind({template: templateContext?.nodes});
+    const boundTarget = binder.bind({
+      template: templateContext?.nodes,
+      host: hostBindingContext?.node,
+    });
 
     if (this.inlining === InliningMode.InlineOps) {
       // Get all of the directives used in the template and record inline type constructors when
@@ -281,6 +294,7 @@ export class TypeCheckContextImpl implements TypeCheckContext {
       template: templateContext?.nodes || null,
       boundTarget,
       templateParsingDiagnostics,
+      hostElement: hostBindingContext?.node ?? null,
     });
 
     const usedPipes: Reference<ClassDeclaration<ts.ClassDeclaration>>[] = [];
@@ -326,6 +340,16 @@ export class TypeCheckContextImpl implements TypeCheckContext {
         id,
         templateContext.sourceMapping,
         templateContext.file,
+      );
+    }
+
+    if (hostBindingContext !== null) {
+      fileData.sourceManager.captureHostBindingsMapping(
+        id,
+        hostBindingContext.sourceMapping,
+        // We only support host bindings in the same file as the directive
+        // so we can get the source file from here.
+        new ParseSourceFile(sourceFile.text, sourceFile.fileName),
       );
     }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/host_bindings.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/host_bindings.ts
@@ -1,0 +1,475 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  BindingType,
+  CssSelector,
+  makeBindingParser,
+  ParsedEvent,
+  ParseSourceSpan,
+  TmplAstBoundAttribute,
+  TmplAstBoundEvent,
+  TmplAstHostElement,
+  BindingParser,
+  AbsoluteSourceSpan,
+  ParseSpan,
+  PropertyRead,
+  ParsedEventType,
+  Call,
+  ThisReceiver,
+  KeyedRead,
+  LiteralPrimitive,
+  AST,
+  RecursiveAstVisitor,
+  ASTWithName,
+  SafeCall,
+  ImplicitReceiver,
+} from '@angular/compiler';
+import ts from 'typescript';
+import {createSourceSpan} from '../../annotations/common';
+import {ClassDeclaration} from '../../reflection';
+
+/** Node that represent a static name of a member. */
+type StaticName = ts.Identifier | ts.StringLiteralLike;
+
+/** Property assignment node with a static name and initializer. */
+type StaticPropertyAssignment = ts.PropertyAssignment & {
+  name: StaticName;
+  initializer: ts.StringLiteralLike;
+};
+
+/**
+ * Creates an AST node that represents the host element of a directive.
+ * Can return null if there are no valid bindings to be checked.
+ * @param type Whether the host element is for a directive or a component.
+ * @param selector Selector of the directive.
+ * @param sourceNode Class declaration for the directive.
+ * @param literal `host` object literal from the decorator.
+ * @param bindingDecorators `HostBinding` decorators discovered on the node.
+ * @param listenerDecorators `HostListener` decorators discovered on the node.
+ */
+export function createHostElement(
+  type: 'component' | 'directive',
+  selector: string | null,
+  sourceNode: ClassDeclaration,
+  literal: ts.ObjectLiteralExpression | null,
+  bindingDecorators: Iterable<ts.Decorator>,
+  listenerDecorators: Iterable<ts.Decorator>,
+): TmplAstHostElement | null {
+  const bindings: TmplAstBoundAttribute[] = [];
+  const listeners: TmplAstBoundEvent[] = [];
+  let parser: BindingParser | null = null;
+
+  if (literal !== null) {
+    for (const prop of literal.properties) {
+      // We only support type checking of static bindings.
+      if (
+        ts.isPropertyAssignment(prop) &&
+        ts.isStringLiteralLike(prop.initializer) &&
+        isStaticName(prop.name)
+      ) {
+        parser ??= makeBindingParser();
+        createNodeFromHostLiteralProperty(
+          prop as StaticPropertyAssignment,
+          parser,
+          bindings,
+          listeners,
+        );
+      }
+    }
+  }
+
+  for (const decorator of bindingDecorators) {
+    createNodeFromBindingDecorator(decorator, bindings);
+  }
+
+  for (const decorator of listenerDecorators) {
+    parser ??= makeBindingParser();
+    createNodeFromListenerDecorator(decorator, parser, listeners);
+  }
+
+  // The element will be a no-op if there are no bindings.
+  if (bindings.length === 0 && listeners.length === 0) {
+    return null;
+  }
+
+  const tagNames: string[] = [];
+
+  if (selector !== null) {
+    const parts = CssSelector.parse(selector);
+
+    for (const part of parts) {
+      if (part.element !== null) {
+        tagNames.push(part.element);
+      }
+    }
+  }
+
+  // If none of the selectors have a tag name, fall back to `ng-component`/`ng-directive`.
+  // This is how the runtime handles components without tag names as well.
+  if (tagNames.length === 0) {
+    tagNames.push(`ng-${type}`);
+  }
+
+  return new TmplAstHostElement(tagNames, bindings, listeners, createSourceSpan(sourceNode.name));
+}
+
+/**
+ * If possible, creates and tracks the relevant AST node for a binding declared
+ * through a property on the `host` literal.
+ * @param prop Property to parse.
+ * @param parser Binding parser used to parse the expressions.
+ * @param bindings Array tracking the bound attributes of the host element.
+ * @param listeners Array tracking the event listeners of the host element.
+ */
+function createNodeFromHostLiteralProperty(
+  property: StaticPropertyAssignment,
+  parser: BindingParser,
+  bindings: TmplAstBoundAttribute[],
+  listeners: TmplAstBoundEvent[],
+): void {
+  // TODO(crisbeto): surface parsing errors here, because currently they just get ignored.
+  // They'll still get reported when the handler tries to parse the bindings, but here we
+  // can highlight the nodes more accurately.
+  const {name, initializer} = property;
+
+  if (name.text.startsWith('[') && name.text.endsWith(']')) {
+    const {attrName, type} = inferBoundAttribute(name.text.slice(1, -1));
+    const valueSpan = createStaticExpressionSpan(initializer);
+    const ast = parser.parseBinding(initializer.text, true, valueSpan, valueSpan.start.offset);
+
+    if (ast.errors.length > 0) {
+      return; // See TODO above.
+    }
+
+    fixupSpans(ast, initializer);
+    bindings.push(
+      new TmplAstBoundAttribute(
+        attrName,
+        type,
+        0,
+        ast,
+        null,
+        createSourceSpan(property),
+        createStaticExpressionSpan(name),
+        valueSpan,
+        undefined,
+      ),
+    );
+  } else if (name.text.startsWith('(') && name.text.endsWith(')')) {
+    const events: ParsedEvent[] = [];
+    parser.parseEvent(
+      name.text.slice(1, -1),
+      initializer.text,
+      false,
+      createSourceSpan(property),
+      createStaticExpressionSpan(initializer),
+      [],
+      events,
+      createStaticExpressionSpan(name),
+    );
+
+    if (events.length === 0 || events[0].handler.errors.length > 0) {
+      return; // See TODO above.
+    }
+
+    fixupSpans(events[0].handler, initializer);
+    listeners.push(TmplAstBoundEvent.fromParsedEvent(events[0]));
+  }
+}
+
+/**
+ * If possible, creates and tracks a bound attribute node from a `HostBinding` decorator.
+ * @param decorator Decorator from which to create the node.
+ * @param bindings Array tracking the bound attributes of the host element.
+ */
+function createNodeFromBindingDecorator(
+  decorator: ts.Decorator,
+  bindings: TmplAstBoundAttribute[],
+): void {
+  // We only support decorators that are being called.
+  if (!ts.isCallExpression(decorator.expression)) {
+    return;
+  }
+
+  const args = decorator.expression.arguments;
+  const property = decorator.parent;
+  let nameNode: StaticName | null = null;
+  let propertyName: StaticName | null = null;
+
+  if (property && ts.isPropertyDeclaration(property) && isStaticName(property.name)) {
+    propertyName = property.name;
+  }
+
+  // The first parameter is optional. If omitted, the name
+  // of the class member is used as the property.
+  if (args.length === 0) {
+    nameNode = propertyName;
+  } else if (ts.isStringLiteralLike(args[0])) {
+    nameNode = args[0];
+  } else {
+    return;
+  }
+
+  if (nameNode === null || propertyName === null) {
+    return;
+  }
+
+  // We can't synthesize a fake expression here and pass it through the binding parser, because
+  // it constructs all the spans based on the source code origin and they aren't easily mappable
+  // back to the source. E.g. `@HostBinding('foo') id = '123'` in source code would look
+  // something like `[foo]="this.id"` in the AST. Instead we construct the expressions
+  // manually here. Note that we use a dummy span with -1/-1 as offsets, because it isn't
+  // used for type checking and constructing it accurately would take some effort.
+  const span = new ParseSpan(-1, -1);
+  const propertyStart = property.getStart();
+  const receiver = new ThisReceiver(span, new AbsoluteSourceSpan(propertyStart, propertyStart));
+  const nameSpan = new AbsoluteSourceSpan(propertyName.getStart(), propertyName.getEnd());
+  const read = ts.isIdentifier(propertyName)
+    ? new PropertyRead(span, nameSpan, nameSpan, receiver, propertyName.text)
+    : new KeyedRead(
+        span,
+        nameSpan,
+        receiver,
+        new LiteralPrimitive(span, nameSpan, propertyName.text),
+      );
+  const {attrName, type} = inferBoundAttribute(nameNode.text);
+
+  bindings.push(
+    new TmplAstBoundAttribute(
+      attrName,
+      type,
+      0,
+      read,
+      null,
+      createSourceSpan(decorator),
+      createStaticExpressionSpan(nameNode),
+      createSourceSpan(decorator),
+      undefined,
+    ),
+  );
+}
+
+/**
+ * If possible, creates and tracks a bound event node from a `HostBinding` decorator.
+ * @param decorator Decorator from which to create the node.
+ * @param parser Binding parser used to parse the expressions.
+ * @param bindings Array tracking the bound events of the host element.
+ */
+function createNodeFromListenerDecorator(
+  decorator: ts.Decorator,
+  parser: BindingParser,
+  listeners: TmplAstBoundEvent[],
+): void {
+  // We only support decorators that are being called with at least one argument.
+  if (!ts.isCallExpression(decorator.expression) || decorator.expression.arguments.length === 0) {
+    return;
+  }
+
+  const args = decorator.expression.arguments;
+  const method = decorator.parent;
+
+  // Only handle decorators that are statically analyzable.
+  if (
+    !method ||
+    !ts.isMethodDeclaration(method) ||
+    !isStaticName(method.name) ||
+    !ts.isStringLiteralLike(args[0])
+  ) {
+    return;
+  }
+
+  // We can't synthesize a fake expression here and pass it through the binding parser, because
+  // it constructs all the spans based on the source code origin and they aren't easily mappable
+  // back to the source. E.g. `@HostListener('foo') handleFoo() {}` in source code would look
+  // something like `(foo)="handleFoo()"` in the AST. Instead we construct the expressions
+  // manually here. Note that we use a dummy span with -1/-1 as offsets, because it isn't
+  // used for type checking and constructing it accurately would take some effort.
+  const span = new ParseSpan(-1, -1);
+  const [name, phase] = method.name.text.split('.');
+  const argNodes: AST[] = [];
+  const methodStart = method.getStart();
+  const methodReceiver = new ThisReceiver(span, new AbsoluteSourceSpan(methodStart, methodStart));
+  const nameSpan = new AbsoluteSourceSpan(method.name.getStart(), method.name.getEnd());
+  const receiver = ts.isIdentifier(method.name)
+    ? new PropertyRead(span, nameSpan, nameSpan, methodReceiver, method.name.text)
+    : new KeyedRead(
+        span,
+        nameSpan,
+        methodReceiver,
+        new LiteralPrimitive(span, nameSpan, method.name.text),
+      );
+
+  if (args.length > 1 && ts.isArrayLiteralExpression(args[1])) {
+    for (const expr of args[1].elements) {
+      // If the parameter is a static string, parse it using the binding parser since it can be any
+      // expression, otherwise treat it as `any` so the rest of the parameters can be checked.
+      if (ts.isStringLiteralLike(expr)) {
+        const span = createStaticExpressionSpan(expr);
+        const ast = parser.parseBinding(expr.text, true, span, span.start.offset);
+        fixupSpans(ast, expr);
+        argNodes.push(ast);
+      } else {
+        // Represents `$any(0)`. We need to construct it manually in order to set the right spans.
+        const expressionSpan = new AbsoluteSourceSpan(expr.getStart(), expr.getEnd());
+        const anyRead = new PropertyRead(
+          span,
+          expressionSpan,
+          expressionSpan,
+          new ImplicitReceiver(span, expressionSpan),
+          '$any',
+        );
+        const anyCall = new Call(
+          span,
+          expressionSpan,
+          anyRead,
+          [new LiteralPrimitive(span, expressionSpan, 0)],
+          expressionSpan,
+        );
+        argNodes.push(anyCall);
+      }
+    }
+  }
+
+  const callNode = new Call(span, nameSpan, receiver, argNodes, span);
+
+  listeners.push(
+    new TmplAstBoundEvent(
+      name,
+      name.startsWith('@') ? ParsedEventType.Animation : ParsedEventType.Regular,
+      callNode,
+      null,
+      phase,
+      createSourceSpan(decorator),
+      createSourceSpan(decorator),
+      createStaticExpressionSpan(method.name),
+    ),
+  );
+}
+
+/**
+ * Infers the attribute name and binding type of a bound attribute based on its raw name.
+ * @param name Name from which to infer the information.
+ */
+function inferBoundAttribute(name: string): {attrName: string; type: BindingType} {
+  const attrPrefix = 'attr.';
+  const classPrefix = 'class.';
+  const stylePrefix = 'style.';
+  const animationPrefix = '@';
+  let attrName: string;
+  let type: BindingType;
+
+  // Infer the binding type based on the prefix.
+  if (name.startsWith(attrPrefix)) {
+    attrName = name.slice(attrPrefix.length);
+    type = BindingType.Attribute;
+  } else if (name.startsWith(classPrefix)) {
+    attrName = name.slice(classPrefix.length);
+    type = BindingType.Class;
+  } else if (name.startsWith(stylePrefix)) {
+    attrName = name.slice(stylePrefix.length);
+    type = BindingType.Style;
+  } else if (name.startsWith(animationPrefix)) {
+    attrName = name.slice(animationPrefix.length);
+    type = BindingType.Animation;
+  } else {
+    attrName = name;
+    type = BindingType.Property;
+  }
+
+  return {attrName, type};
+}
+
+/** Checks whether the specified node is a static name node. */
+function isStaticName(node: ts.Node): node is StaticName {
+  return ts.isIdentifier(node) || ts.isStringLiteralLike(node);
+}
+
+/** Creates a `ParseSourceSpan` pointing to a static expression AST node's source. */
+function createStaticExpressionSpan(node: ts.StringLiteralLike | ts.Identifier): ParseSourceSpan {
+  const span = createSourceSpan(node);
+
+  // Offset by one on both sides to skip over the quotes.
+  if (ts.isStringLiteralLike(node)) {
+    span.fullStart = span.fullStart.moveBy(1);
+    span.start = span.start.moveBy(1);
+    span.end = span.end.moveBy(-1);
+  }
+
+  return span;
+}
+
+/**
+ * Adjusts the spans of a parsed AST so that they're appropriate for a host bindings context.
+ * @param ast The parsed AST that may need to be adjusted.
+ * @param initializer TypeScript node from which the source of the AST was extracted.
+ */
+function fixupSpans(ast: AST, initializer: ts.StringLiteralLike): void {
+  // When parsing the initializer as a property/event binding, we use `.text` which excludes escaped
+  // quotes and is generally what we want, because preserving them would result in a parser error,
+  // however it has the downside in that the spans of the expressions following the escaped
+  // characters are no longer accurate relative to the source code. The more escaped characters
+  // there are before a node, the more inaccurate its span will be. If we detect cases like that,
+  // we override the spans of all nodes following the escaped string to point to the entire
+  // initializer string so that we don't surface diagnostics with mangled spans. This isn't ideal,
+  // but is likely rare in user code. Some workarounds that were attempted and ultimately discarded:
+  // 1. Counting the number of escaped strings before a node and adjusting its span accordingly -
+  // There's a prototype of this approach in https://github.com/crisbeto/angular/commit/1eb92353784a609f6be7e6653ae5a9faef549e6a
+  // It works for the most part, but is complex and somewhat brittle, because it's not just the
+  // escaped literals that need to be updated, but also any nodes _after_ them and any nodes
+  // _containing_ them which gets increasingly complex with more complicated ASTs.
+  // 2. Replacing escape characters with whitespaces, for example `\'foo\' + 123` would become
+  // ` 'foo ' + 123` - this appears to produce accurate ASTs for some simpler use cases, but has
+  // the potential of either changing the user's code into something that's no longer parseable or
+  // causing type checking errors (e.g. the typings might require the exact string 'foo').
+  // 3. Passing the raw text (e.g. `initializer.getText().slice(1, -1)`) into the binding parser -
+  // This will preserve the right mappings, but can lead to parsing errors, because some of the
+  // strings won't have to be escaped anymore. We could add a mode to the parser that allows it to
+  // recover from such cases, but it'll introduce more complexity that we may not want to take on.
+  // 4. Constructing some sort of string like `<host ${name.getText()}=${initializer.getText()}/>`,
+  // passing it through the HTML parser and extracting the first attribute from it - wasn't explored
+  // much, but likely has the same issues as approach #3.
+  const escapeIndex = initializer.getText().indexOf('\\', 1);
+
+  if (escapeIndex > -1) {
+    const newSpan = new ParseSpan(0, initializer.getWidth());
+    const newSourceSpan = new AbsoluteSourceSpan(initializer.getStart(), initializer.getEnd());
+    ast.visit(new ReplaceSpanVisitor(escapeIndex, newSpan, newSourceSpan));
+  }
+}
+
+/**
+ * Visitor that replaces the spans of all nodes with new ones,
+ * if they're defined after a specific index.
+ */
+class ReplaceSpanVisitor extends RecursiveAstVisitor {
+  constructor(
+    private readonly afterIndex: number,
+    private readonly overrideSpan: ParseSpan,
+    private readonly overrideSourceSpan: AbsoluteSourceSpan,
+  ) {
+    super();
+  }
+
+  override visit(ast: AST) {
+    // Only nodes after the index need to be adjusted, but all nodes should be visited.
+    if (ast.span.start >= this.afterIndex || ast.span.end >= this.afterIndex) {
+      ast.span = this.overrideSpan;
+      ast.sourceSpan = this.overrideSourceSpan;
+
+      if (ast instanceof ASTWithName) {
+        ast.nameSpan = this.overrideSourceSpan;
+      }
+
+      if (ast instanceof Call || ast instanceof SafeCall) {
+        ast.argumentSpan = this.overrideSourceSpan;
+      }
+    }
+    super.visit(ast);
+  }
+}

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_util.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_util.ts
@@ -55,6 +55,16 @@ export interface TypeCheckSourceResolver {
    * numbers in addition to only absolute offsets and gives access to the original source code.
    */
   toTemplateParseSourceSpan(id: TypeCheckId, span: AbsoluteSourceSpan): ParseSourceSpan | null;
+
+  /** For the given type checking id, retrieve the source mapping of its host bindings. */
+  getHostBindingsMapping(id: TypeCheckId): SourceMapping;
+
+  /**
+   * Convert an absolute source span coming from a host binding associated with the given type
+   * checking id into a full `ParseSourceSpan`. The returned parse span has line and column
+   * numbers in addition to only absolute offsets and gives access to the original source code.
+   */
+  toHostParseSourceSpan(id: TypeCheckId, span: AbsoluteSourceSpan): ParseSourceSpan | null;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_util.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_util.ts
@@ -17,6 +17,7 @@ import {FullSourceMapping, SourceLocation, TypeCheckId, SourceMapping} from '../
 import {hasIgnoreForDiagnosticsMarker, readSpanComment} from './comments';
 import {ReferenceEmitEnvironment} from './reference_emit_environment';
 import {TypeParameterEmitter} from './type_parameter_emitter';
+import {isHostBindingsBlockGuard} from './host_bindings';
 
 /**
  * External modules/identifiers that always should exist for type check
@@ -129,14 +130,37 @@ export function getSourceMapping(
     return null;
   }
 
-  const mapping = resolver.getTemplateSourceMapping(sourceLocation.id);
+  if (isInHostBindingTcb(node)) {
+    const hostSourceMapping = resolver.getHostBindingsMapping(sourceLocation.id);
+    const span = resolver.toHostParseSourceSpan(sourceLocation.id, sourceLocation.span);
+    if (span === null) {
+      return null;
+    }
+    return {sourceLocation, sourceMapping: hostSourceMapping, span};
+  }
+
   const span = resolver.toTemplateParseSourceSpan(sourceLocation.id, sourceLocation.span);
   if (span === null) {
     return null;
   }
   // TODO(atscott): Consider adding a context span by walking up from `node` until we get a
   // different span.
-  return {sourceLocation, sourceMapping: mapping, span};
+  return {
+    sourceLocation,
+    sourceMapping: resolver.getTemplateSourceMapping(sourceLocation.id),
+    span,
+  };
+}
+
+function isInHostBindingTcb(node: ts.Node): boolean {
+  let current = node;
+  while (current && !ts.isFunctionDeclaration(current)) {
+    if (isHostBindingsBlockGuard(current)) {
+      return true;
+    }
+    current = current.parent;
+  }
+  return false;
 }
 
 export function findTypeCheckBlock(
@@ -145,7 +169,7 @@ export function findTypeCheckBlock(
   isDiagnosticRequest: boolean,
 ): ts.Node | null {
   for (const stmt of file.statements) {
-    if (ts.isFunctionDeclaration(stmt) && getTemplateId(stmt, file, isDiagnosticRequest) === id) {
+    if (ts.isFunctionDeclaration(stmt) && getTypeCheckId(stmt, file, isDiagnosticRequest) === id) {
       return stmt;
     }
   }
@@ -174,7 +198,7 @@ export function findSourceLocation(
     if (span !== null) {
       // Once the positional information has been extracted, search further up the TCB to extract
       // the unique id that is attached with the TCB's function declaration.
-      const id = getTemplateId(node, sourceFile, isDiagnosticsRequest);
+      const id = getTypeCheckId(node, sourceFile, isDiagnosticsRequest);
       if (id === null) {
         return null;
       }
@@ -187,7 +211,7 @@ export function findSourceLocation(
   return null;
 }
 
-function getTemplateId(
+function getTypeCheckId(
   node: ts.Node,
   sourceFile: ts.SourceFile,
   isDiagnosticRequest: boolean,

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -50,6 +50,7 @@ import {
   TmplAstText,
   TmplAstTextAttribute,
   TmplAstVariable,
+  TmplAstHostElement,
   TmplAstViewportDeferredTrigger,
   TransplantedType,
 } from '@angular/compiler';
@@ -81,6 +82,7 @@ import {
 } from './ts_util';
 import {requiresInlineTypeCtor} from './type_constructor';
 import {TypeParameterEmitter} from './type_parameter_emitter';
+import {createHostBindingsBlockGuard} from './host_bindings';
 
 /**
  * Controls how generics for the component context class will be handled during TCB generation.
@@ -154,7 +156,6 @@ export function generateTypeCheckBlock(
     meta.isStandalone,
     meta.preserveWhitespaces,
   );
-  const scope = Scope.forNodes(tcb, null, null, tcb.boundTarget.target.template!, /* guard */ null);
   const ctxRawType = env.referenceType(ref);
   if (!ts.isTypeReferenceNode(ctxRawType)) {
     throw new Error(
@@ -195,15 +196,28 @@ export function generateTypeCheckBlock(
   }
 
   const paramList = [tcbThisParam(ctxRawType.typeName, typeArguments)];
+  const statements: ts.Statement[] = [];
 
-  const scopeStatements = scope.render();
-  const innerBody = ts.factory.createBlock([...env.getPreludeStatements(), ...scopeStatements]);
+  // Add the template type checking code.
+  if (tcb.boundTarget.target.template !== undefined) {
+    const templateScope = Scope.forNodes(
+      tcb,
+      null,
+      null,
+      tcb.boundTarget.target.template,
+      /* guard */ null,
+    );
 
-  // Wrap the body in an "if (true)" expression. This is unnecessary but has the effect of causing
-  // the `ts.Printer` to format the type-check block nicely.
-  const body = ts.factory.createBlock([
-    ts.factory.createIfStatement(ts.factory.createTrue(), innerBody, undefined),
-  ]);
+    statements.push(renderBlockStatements(env, templateScope, ts.factory.createTrue()));
+  }
+
+  // Add the host bindings type checking code.
+  if (tcb.boundTarget.target.host !== undefined) {
+    const hostScope = Scope.forNodes(tcb, null, tcb.boundTarget.target.host, null, null);
+    statements.push(renderBlockStatements(env, hostScope, createHostBindingsBlockGuard()));
+  }
+
+  const body = ts.factory.createBlock(statements);
   const fnDecl = ts.factory.createFunctionDeclaration(
     /* modifiers */ undefined,
     /* asteriskToken */ undefined,
@@ -217,13 +231,28 @@ export function generateTypeCheckBlock(
   return fnDecl;
 }
 
+function renderBlockStatements(
+  env: Environment,
+  scope: Scope,
+  wrapperExpression: ts.Expression,
+): ts.Statement {
+  const scopeStatements = scope.render();
+  const innerBody = ts.factory.createBlock([...env.getPreludeStatements(), ...scopeStatements]);
+
+  // Wrap the body in an if statement. This serves two purposes:
+  // 1. It allows us to distinguish between the sections of the block (e.g. host or template).
+  // 2. It allows the `ts.Printer` to produce better-looking output.
+  return ts.factory.createIfStatement(wrapperExpression, innerBody);
+}
+
 /** Types that can referenced locally in a template. */
 type LocalSymbol =
   | TmplAstElement
   | TmplAstTemplate
   | TmplAstVariable
   | TmplAstLetDeclaration
-  | TmplAstReference;
+  | TmplAstReference
+  | TmplAstHostElement;
 
 /**
  * A code generation operation that's involved in the construction of a Type Check Block.
@@ -1104,9 +1133,9 @@ class TcbDirectiveCtorCircularFallbackOp extends TcbOp {
 class TcbDomSchemaCheckerOp extends TcbOp {
   constructor(
     private tcb: Context,
-    private element: TmplAstElement,
+    private element: TmplAstElement | TmplAstHostElement,
     private checkElement: boolean,
-    private claimedInputs: Set<string>,
+    private claimedInputs: Set<string> | null,
   ) {
     super();
   }
@@ -1116,21 +1145,25 @@ class TcbDomSchemaCheckerOp extends TcbOp {
   }
 
   override execute(): ts.Expression | null {
-    if (this.checkElement) {
+    const element = this.element;
+    const isTemplateElement = element instanceof TmplAstElement;
+    const bindings = isTemplateElement ? element.inputs : element.bindings;
+
+    if (this.checkElement && isTemplateElement) {
       this.tcb.domSchemaChecker.checkElement(
         this.tcb.id,
-        this.element,
+        element,
         this.tcb.schemas,
         this.tcb.hostIsStandalone,
       );
     }
 
     // TODO(alxhub): this could be more efficient.
-    for (const binding of this.element.inputs) {
+    for (const binding of bindings) {
       const isPropertyBinding =
         binding.type === BindingType.Property || binding.type === BindingType.TwoWay;
 
-      if (isPropertyBinding && this.claimedInputs.has(binding.name)) {
+      if (isPropertyBinding && this.claimedInputs?.has(binding.name)) {
         // Skip this binding as it was claimed by a directive.
         continue;
       }
@@ -1138,14 +1171,25 @@ class TcbDomSchemaCheckerOp extends TcbOp {
       if (isPropertyBinding && binding.name !== 'style' && binding.name !== 'class') {
         // A direct binding to a property.
         const propertyName = ATTR_TO_PROP.get(binding.name) ?? binding.name;
-        this.tcb.domSchemaChecker.checkProperty(
-          this.tcb.id,
-          this.element,
-          propertyName,
-          binding.sourceSpan,
-          this.tcb.schemas,
-          this.tcb.hostIsStandalone,
-        );
+
+        if (isTemplateElement) {
+          this.tcb.domSchemaChecker.checkTemplateElementProperty(
+            this.tcb.id,
+            element,
+            propertyName,
+            binding.sourceSpan,
+            this.tcb.schemas,
+            this.tcb.hostIsStandalone,
+          );
+        } else {
+          this.tcb.domSchemaChecker.checkHostElementProperty(
+            this.tcb.id,
+            element,
+            propertyName,
+            binding.keySpan,
+            this.tcb.schemas,
+          );
+        }
       }
     }
     return null;
@@ -1285,6 +1329,31 @@ class TcbControlFlowContentProjectionOp extends TcbOp {
 }
 
 /**
+ * A `TcbOp` which creates an expression for a the host element of a directive.
+ *
+ * Executing this operation returns a reference to the element variable.
+ */
+class TcbHostElementOp extends TcbOp {
+  override readonly optional = true;
+
+  constructor(
+    private tcb: Context,
+    private scope: Scope,
+    private element: TmplAstHostElement,
+  ) {
+    super();
+  }
+
+  override execute(): ts.Identifier {
+    const id = this.tcb.allocateId();
+    const initializer = tsCreateElement(...this.element.tagNames);
+    addParseSpanInfo(initializer, this.element.sourceSpan);
+    this.scope.addStatement(tsCreateVariable(id, initializer));
+    return id;
+  }
+}
+
+/**
  * Mapping between attributes names that don't correspond to their element property names.
  * Note: this mapping has to be kept in sync with the equally named mapping in the runtime.
  */
@@ -1313,8 +1382,9 @@ class TcbUnclaimedInputsOp extends TcbOp {
   constructor(
     private tcb: Context,
     private scope: Scope,
-    private element: TmplAstElement,
-    private claimedInputs: Set<string>,
+    private inputs: TmplAstBoundAttribute[],
+    private target: LocalSymbol,
+    private claimedInputs: Set<string> | null,
   ) {
     super();
   }
@@ -1329,11 +1399,11 @@ class TcbUnclaimedInputsOp extends TcbOp {
     let elId: ts.Expression | null = null;
 
     // TODO(alxhub): this could be more efficient.
-    for (const binding of this.element.inputs) {
+    for (const binding of this.inputs) {
       const isPropertyBinding =
         binding.type === BindingType.Property || binding.type === BindingType.TwoWay;
 
-      if (isPropertyBinding && this.claimedInputs.has(binding.name)) {
+      if (isPropertyBinding && this.claimedInputs?.has(binding.name)) {
         // Skip this binding as it was claimed by a directive.
         continue;
       }
@@ -1343,7 +1413,7 @@ class TcbUnclaimedInputsOp extends TcbOp {
       if (this.tcb.env.config.checkTypeOfDomBindings && isPropertyBinding) {
         if (binding.name !== 'style' && binding.name !== 'class') {
           if (elId === null) {
-            elId = this.scope.resolve(this.element);
+            elId = this.scope.resolve(this.target);
           }
           // A direct binding to a property.
           const propertyName = ATTR_TO_PROP.get(binding.name) ?? binding.name;
@@ -1459,8 +1529,10 @@ class TcbUnclaimedOutputsOp extends TcbOp {
   constructor(
     private tcb: Context,
     private scope: Scope,
-    private element: TmplAstElement,
-    private claimedOutputs: Set<string>,
+    private target: LocalSymbol,
+    private outputs: TmplAstBoundEvent[],
+    private inputs: TmplAstBoundAttribute[] | null,
+    private claimedOutputs: Set<string> | null,
   ) {
     super();
   }
@@ -1473,15 +1545,19 @@ class TcbUnclaimedOutputsOp extends TcbOp {
     let elId: ts.Expression | null = null;
 
     // TODO(alxhub): this could be more efficient.
-    for (const output of this.element.outputs) {
-      if (this.claimedOutputs.has(output.name)) {
+    for (const output of this.outputs) {
+      if (this.claimedOutputs?.has(output.name)) {
         // Skip this event handler as it was claimed by a directive.
         continue;
       }
 
-      if (this.tcb.env.config.checkTypeOfOutputEvents && output.name.endsWith('Change')) {
+      if (
+        this.tcb.env.config.checkTypeOfOutputEvents &&
+        this.inputs !== null &&
+        output.name.endsWith('Change')
+      ) {
         const inputName = output.name.slice(0, -6);
-        if (checkSplitTwoWayBinding(inputName, output, this.element.inputs, this.tcb)) {
+        if (checkSplitTwoWayBinding(inputName, output, this.inputs, this.tcb)) {
           // Skip this event handler as the error was already handled.
           continue;
         }
@@ -1504,7 +1580,7 @@ class TcbUnclaimedOutputsOp extends TcbOp {
         const handler = tcbCreateEventHandler(output, this.tcb, this.scope, EventParamType.Infer);
 
         if (elId === null) {
-          elId = this.scope.resolve(this.element);
+          elId = this.scope.resolve(this.target);
         }
         const propertyAccess = ts.factory.createPropertyAccessExpression(elId, 'addEventListener');
         addParseSpanInfo(propertyAccess, output.keySpan);
@@ -1993,6 +2069,12 @@ class Scope {
    * A map of `TmplAstElement`s to the index of their `TcbElementOp` in the `opQueue`
    */
   private elementOpMap = new Map<TmplAstElement, number>();
+
+  /**
+   * A map of `TmplAstHostElement`s to the index of their `TcbHostElementOp` in the `opQueue`
+   */
+  private hostElementOpMap = new Map<TmplAstHostElement, number>();
+
   /**
    * A map of maps which tracks the index of `TcbDirectiveCtorOp`s in the `opQueue` for each
    * directive on a `TmplAstElement` or `TmplAstTemplate` node.
@@ -2066,8 +2148,13 @@ class Scope {
   static forNodes(
     tcb: Context,
     parentScope: Scope | null,
-    scopedNode: TmplAstTemplate | TmplAstIfBlockBranch | TmplAstForLoopBlock | null,
-    children: TmplAstNode[],
+    scopedNode:
+      | TmplAstTemplate
+      | TmplAstIfBlockBranch
+      | TmplAstForLoopBlock
+      | TmplAstHostElement
+      | null,
+    children: TmplAstNode[] | null,
     guard: ts.Expression | null,
   ): Scope {
     const scope = new Scope(tcb, parentScope, guard);
@@ -2128,9 +2215,13 @@ class Scope {
           new TcbBlockImplicitVariableOp(tcb, scope, type, variable),
         );
       }
+    } else if (scopedNode instanceof TmplAstHostElement) {
+      scope.appendNode(scopedNode);
     }
-    for (const node of children) {
-      scope.appendNode(node);
+    if (children !== null) {
+      for (const node of children) {
+        scope.appendNode(node);
+      }
     }
     // Once everything is registered, we need to check if there are `@let`
     // declarations that conflict with other local symbols defined after them.
@@ -2301,6 +2392,8 @@ class Scope {
     } else if (ref instanceof TmplAstElement && this.elementOpMap.has(ref)) {
       // Resolving the DOM node of an element in this template.
       return this.resolveOp(this.elementOpMap.get(ref)!);
+    } else if (ref instanceof TmplAstHostElement && this.hostElementOpMap.has(ref)) {
+      return this.resolveOp(this.hostElementOpMap.get(ref)!);
     } else {
       return null;
     }
@@ -2389,6 +2482,14 @@ class Scope {
       } else {
         this.letDeclOpMap.set(node.name, {opIndex, node});
       }
+    } else if (node instanceof TmplAstHostElement) {
+      const opIndex = this.opQueue.push(new TcbHostElementOp(this.tcb, this, node)) - 1;
+      this.hostElementOpMap.set(node, opIndex);
+      this.opQueue.push(
+        new TcbUnclaimedInputsOp(this.tcb, this, node.bindings, node, null),
+        new TcbUnclaimedOutputsOp(this.tcb, this, node, node.listeners, null, null),
+        new TcbDomSchemaCheckerOp(this.tcb, node, false, null),
+      );
     }
   }
 
@@ -2427,8 +2528,8 @@ class Scope {
       // If there are no directives, then all inputs are unclaimed inputs, so queue an operation
       // to add them if needed.
       if (node instanceof TmplAstElement) {
-        this.opQueue.push(new TcbUnclaimedInputsOp(this.tcb, this, node, claimedInputs));
         this.opQueue.push(
+          new TcbUnclaimedInputsOp(this.tcb, this, node.inputs, node, claimedInputs),
           new TcbDomSchemaCheckerOp(this.tcb, node, /* checkElement */ true, claimedInputs),
         );
       }
@@ -2486,7 +2587,7 @@ class Scope {
         }
       }
 
-      this.opQueue.push(new TcbUnclaimedInputsOp(this.tcb, this, node, claimedInputs));
+      this.opQueue.push(new TcbUnclaimedInputsOp(this.tcb, this, node.inputs, node, claimedInputs));
       // If there are no directives which match this element, then it's a "plain" DOM element (or a
       // web component), and should be checked against the DOM schema. If any directives match,
       // we must assume that the element could be custom (either a component, or a directive like
@@ -2504,7 +2605,16 @@ class Scope {
       // If there are no directives, then all outputs are unclaimed outputs, so queue an operation
       // to add them if needed.
       if (node instanceof TmplAstElement) {
-        this.opQueue.push(new TcbUnclaimedOutputsOp(this.tcb, this, node, claimedOutputs));
+        this.opQueue.push(
+          new TcbUnclaimedOutputsOp(
+            this.tcb,
+            this,
+            node,
+            node.outputs,
+            node.inputs,
+            claimedOutputs,
+          ),
+        );
       }
       return;
     }
@@ -2524,7 +2634,9 @@ class Scope {
         }
       }
 
-      this.opQueue.push(new TcbUnclaimedOutputsOp(this.tcb, this, node, claimedOutputs));
+      this.opQueue.push(
+        new TcbUnclaimedOutputsOp(this.tcb, this, node, node.outputs, node.inputs, claimedOutputs),
+      );
     }
   }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -10,13 +10,11 @@ import {
   BindingPipe,
   CssSelector,
   ParseSourceFile,
-  ParseSourceSpan,
   parseTemplate,
   ParseTemplateOptions,
   PropertyRead,
   PropertyWrite,
   R3TargetBinder,
-  SchemaMetadata,
   SelectorMatcher,
   TmplAstElement,
   TmplAstLetDeclaration,
@@ -1011,20 +1009,9 @@ export class NoopSchemaChecker implements DomSchemaChecker {
     return [];
   }
 
-  checkElement(
-    id: string,
-    element: TmplAstElement,
-    schemas: SchemaMetadata[],
-    hostIsStandalone: boolean,
-  ): void {}
-  checkProperty(
-    id: string,
-    element: TmplAstElement,
-    name: string,
-    span: ParseSourceSpan,
-    schemas: SchemaMetadata[],
-    hostIsStandalone: boolean,
-  ): void {}
+  checkElement(): void {}
+  checkTemplateElementProperty(): void {}
+  checkHostElementProperty(): void {}
 }
 
 export class NoopOobRecorder implements OutOfBandDiagnosticRecorder {

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -648,7 +648,7 @@ export function setup(
           preserveWhitespaces: false,
         };
 
-        ctx.addDirective(classRef, binder, [], templateContext, false);
+        ctx.addDirective(classRef, binder, [], templateContext, null, false);
       }
     }
   });

--- a/packages/compiler-cli/test/ngtsc/host_bindings_type_check_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/host_bindings_type_check_spec.ts
@@ -1,0 +1,720 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+import {NgtscTestEnvironment} from './env';
+import ts from 'typescript';
+
+const testFiles = loadStandardTestFiles();
+
+function getDiagnosticSourceCode(diag: ts.Diagnostic): string {
+  return diag.file!.text.slice(diag.start!, diag.start! + diag.length!);
+}
+
+runInEachFileSystem(() => {
+  describe('type checking of host bindings', () => {
+    let env!: NgtscTestEnvironment;
+
+    beforeEach(() => {
+      env = NgtscTestEnvironment.setup(testFiles);
+      env.tsconfig({
+        // Necessary for testing host bindings.
+        typeCheckHostBindings: true,
+
+        // Not required for host bindings, but they allow us to
+        // exercise more parts of the type checker.
+        strictTemplates: true,
+        strictAttributeTypes: true,
+        strictDomEventTypes: true,
+        strictOutputEventTypes: true,
+      });
+    });
+
+    it('should check the value of an attribute host binding', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component} from '@angular/core';
+
+          @Component({
+            template: '',
+            host: {'[attr.id]': 'exists + doesNotExist'},
+          })
+          export class Comp {
+            exists = 'exists';
+          }
+      `,
+      );
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(`Property 'doesNotExist' does not exist on type 'Comp'.`);
+      expect(getDiagnosticSourceCode(diags[0])).toBe('doesNotExist');
+    });
+
+    it('should check the value of a style host binding', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component} from '@angular/core';
+
+          @Component({
+            template: '',
+            host: {'[style.color]': 'exists + doesNotExist'},
+          })
+          export class Comp {
+            exists = 'exists';
+          }
+      `,
+      );
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(`Property 'doesNotExist' does not exist on type 'Comp'.`);
+      expect(getDiagnosticSourceCode(diags[0])).toBe('doesNotExist');
+    });
+
+    it('should check the value of a class host binding', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component} from '@angular/core';
+
+          @Component({
+            template: '',
+            host: {'[class.foo]': 'exists + doesNotExist'},
+          })
+          export class Comp {
+            exists = 'exists';
+          }
+      `,
+      );
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(`Property 'doesNotExist' does not exist on type 'Comp'.`);
+      expect(getDiagnosticSourceCode(diags[0])).toBe('doesNotExist');
+    });
+
+    it('should check the value of an animation host binding', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component} from '@angular/core';
+
+          @Component({
+            template: '',
+            host: {'[@someAnimation]': 'exists + doesNotExist'},
+          })
+          export class Comp {
+            exists = 'exists';
+          }
+      `,
+      );
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(`Property 'doesNotExist' does not exist on type 'Comp'.`);
+      expect(getDiagnosticSourceCode(diags[0])).toBe('doesNotExist');
+    });
+
+    it('should check the value of a property host binding', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component} from '@angular/core';
+
+          @Component({
+            template: '',
+            host: {'[id]': 'exists + doesNotExist'},
+          })
+          export class Comp {
+            exists = 'exists';
+          }
+        `,
+      );
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(`Property 'doesNotExist' does not exist on type 'Comp'.`);
+      expect(getDiagnosticSourceCode(diags[0])).toBe('doesNotExist');
+    });
+
+    it('should validate host bidings against the schema', () => {
+      env.write(
+        'test.ts',
+        `
+        import {Component} from '@angular/core';
+
+        @Component({
+          template: '',
+          host: {'[foo]': '123'},
+        })
+        export class Comp {}
+      `,
+      );
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(
+        `Can't bind to 'foo' since it isn't a known property of 'ng-component'.`,
+      );
+      expect(getDiagnosticSourceCode(diags[0])).toBe('[foo]');
+    });
+
+    it('should infer the element name from the selector', () => {
+      env.write(
+        'test.ts',
+        `
+        import {Component} from '@angular/core';
+
+        @Component({
+          template: '',
+          selector: 'input[foo]',
+          host: {'[foo]': '123'},
+        })
+        export class Comp {}
+      `,
+      );
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(
+        `Can't bind to 'foo' since it isn't a known property of 'input'.`,
+      );
+      expect(getDiagnosticSourceCode(diags[0])).toBe('[foo]');
+    });
+
+    it('should report if one tag name supports a property, but another one does not', () => {
+      env.write(
+        'test.ts',
+        `
+        import {Component} from '@angular/core';
+
+        @Component({
+          template: '',
+          selector: 'input[foo], div[foo]',
+          host: {'[value]': '123'},
+        })
+        export class Comp {}
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(
+        `Can't bind to 'value' since it isn't a known property of 'div'.`,
+      );
+      expect(getDiagnosticSourceCode(diags[0])).toBe('[value]');
+    });
+
+    it('should check host event listeners', () => {
+      env.write(
+        'test.ts',
+        `
+        import {Component} from '@angular/core';
+
+        @Component({
+          template: '',
+          selector: 'button[foo]',
+          host: {'(click)': 'handleEvent($event)'},
+        })
+        export class Comp {
+          handleEvent(event: KeyboardEvent) {}
+        }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect((diags[0].messageText as ts.DiagnosticMessageChain).messageText).toBe(
+        `Argument of type 'MouseEvent' is not assignable to parameter of type 'KeyboardEvent'.`,
+      );
+      expect(getDiagnosticSourceCode(diags[0])).toBe('$event');
+    });
+
+    it('should check host event listeners with a target', () => {
+      env.write(
+        'test.ts',
+        `
+        import {Component} from '@angular/core';
+
+        @Component({
+          template: '',
+          selector: 'button[foo]',
+          host: {'(document:click)': 'handleEvent($event)'},
+        })
+        export class Comp {
+          handleEvent(event: KeyboardEvent) {}
+        }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect((diags[0].messageText as ts.DiagnosticMessageChain).messageText).toBe(
+        `Argument of type 'MouseEvent' is not assignable to parameter of type 'KeyboardEvent'.`,
+      );
+      expect(getDiagnosticSourceCode(diags[0])).toBe('$event');
+    });
+
+    it('should check host animation event listeners', () => {
+      env.write(
+        'test.ts',
+        `
+        import {Component} from '@angular/core';
+
+        @Component({
+          template: '',
+          selector: 'button[foo]',
+          host: {'(@someAnimation.done)': 'handleEvent()'},
+        })
+        export class Comp {
+          handleEvent(event: Event) {}
+        }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(`Expected 1 arguments, but got 0.`);
+      expect(getDiagnosticSourceCode(diags[0])).toBe('handleEvent');
+    });
+
+    it('should not leak @let from the template into the host bindings', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component} from '@angular/core';
+
+          @Component({
+            host: {'[attr.id]': 'foo + bar'},
+            template: \`
+              @let bar = 'bar';
+              {{foo + bar}}
+            \`,
+          })
+          export class Comp {
+            foo = 'foo';
+          }
+      `,
+      );
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(`Property 'bar' does not exist on type 'Comp'.`);
+      expect(getDiagnosticSourceCode(diags[0])).toBe('bar');
+    });
+
+    it('should not leak local reference from the template into the host bindings', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component} from '@angular/core';
+
+          @Component({
+            host: {'[attr.id]': 'foo + bar.id'},
+            template: \`
+              <div #bar></div>
+              {{foo + bar.id}}
+            \`,
+          })
+          export class Comp {
+            foo = 'foo';
+          }
+      `,
+      );
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(`Property 'bar' does not exist on type 'Comp'.`);
+      expect(getDiagnosticSourceCode(diags[0])).toBe('bar');
+    });
+
+    it('should be able to report diagnostics both from a static inline template and host bindings', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component} from '@angular/core';
+
+          @Component({
+            template: '<div>{{doesNotExistTemplate}}</div>',
+            host: {'[attr.id]': 'doesNotExistHost'},
+          })
+          export class Comp {}
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(2);
+      expect(diags[0].messageText).toBe(
+        `Property 'doesNotExistTemplate' does not exist on type 'Comp'.`,
+      );
+      expect(diags[1].messageText).toBe(
+        `Property 'doesNotExistHost' does not exist on type 'Comp'.`,
+      );
+      expect(getDiagnosticSourceCode(diags[0])).toBe('doesNotExistTemplate');
+      expect(getDiagnosticSourceCode(diags[1])).toBe('doesNotExistHost');
+    });
+
+    it('should be able to report diagnostics both from an external template and host bindings', () => {
+      env.write('template.html', '<div>{{doesNotExistTemplate}}</div>');
+
+      env.write(
+        'test.ts',
+        `
+          import {Component} from '@angular/core';
+
+          @Component({
+            templateUrl: './template.html',
+            host: {'[attr.id]': 'doesNotExistHost'},
+          })
+          export class Comp {}
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(2);
+      expect(diags[0].messageText).toBe(
+        `Property 'doesNotExistTemplate' does not exist on type 'Comp'.`,
+      );
+      expect(diags[1].messageText).toBe(
+        `Property 'doesNotExistHost' does not exist on type 'Comp'.`,
+      );
+      expect(getDiagnosticSourceCode(diags[0])).toBe('doesNotExistTemplate');
+      expect(getDiagnosticSourceCode(diags[1])).toBe('doesNotExistHost');
+    });
+
+    it('should be able to report diagnostics both from a dynamic template and host bindings', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component} from '@angular/core';
+
+          const templateRemainder = 'ExistTemplate}}</div>';
+
+          @Component({
+            template: '<div>{{doesNot' + templateRemainder,
+            host: {'[attr.id]': 'doesNotExistHost'},
+          })
+          export class Comp {}
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(2);
+      expect(diags[0].messageText).toBe(
+        `Property 'doesNotExistTemplate' does not exist on type 'Comp'.`,
+      );
+      expect(diags[1].messageText).toBe(
+        `Property 'doesNotExistHost' does not exist on type 'Comp'.`,
+      );
+      expect(getDiagnosticSourceCode(diags[0])).toBe('doesNotExistTemplate');
+      expect(getDiagnosticSourceCode(diags[1])).toBe('doesNotExistHost');
+    });
+
+    it('should check @HostBinding decorator with no arguments', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component, HostBinding} from '@angular/core';
+
+          @Component({template: ''})
+          export class Comp {
+            @HostBinding() foo = 'foo';
+          }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(
+        `Can't bind to 'foo' since it isn't a known property of 'ng-component'.`,
+      );
+      expect(getDiagnosticSourceCode(diags[0])).toBe('foo');
+    });
+
+    it('should check @HostBinding decorator with a string argument', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component, HostBinding} from '@angular/core';
+
+          @Component({template: ''})
+          export class Comp {
+            @HostBinding('foo') id = 'foo';
+          }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(
+        `Can't bind to 'foo' since it isn't a known property of 'ng-component'.`,
+      );
+      expect(getDiagnosticSourceCode(diags[0])).toBe('foo');
+    });
+
+    it('should check @HostListener decorator that does not pass enough arguments', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component, HostListener} from '@angular/core';
+
+          @Component({template: ''})
+          export class Comp {
+            @HostListener('click') handleClick(event: MouseEvent) {};
+          }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(`Expected 1 arguments, but got 0.`);
+      expect(getDiagnosticSourceCode(diags[0])).toBe('handleClick');
+    });
+
+    it('should check @HostListener decorator that passes too many arguments', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component, HostListener} from '@angular/core';
+
+          @Component({template: ''})
+          export class Comp {
+            @HostListener('click', ['$event']) handleClick() {};
+          }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(`Expected 0 arguments, but got 1.`);
+      expect(getDiagnosticSourceCode(diags[0])).toBe('$event');
+    });
+
+    it('should infer the type of @HostListener parameters', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component, HostListener} from '@angular/core';
+
+          @Component({template: ''})
+          export class Comp {
+            @HostListener('click', ['$event']) handleClick(value: string) {};
+          }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(
+        `Argument of type 'Event' is not assignable to parameter of type 'string'.`,
+      );
+      expect(getDiagnosticSourceCode(diags[0])).toBe('$event');
+    });
+
+    it('should ignore @HostListener parameters that are not static', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component, HostListener} from '@angular/core';
+
+          const two = 'null';
+
+          @Component({template: ''})
+          export class Comp {
+            @HostListener('click', ['1', two, '3']) handleClick(value: string) {};
+          }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe('Expected 1 arguments, but got 3.');
+      expect(getDiagnosticSourceCode(diags[0])).toBe('two');
+    });
+
+    it('should report host decorators on private members', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component, HostBinding, HostListener} from '@angular/core';
+
+          @Component({template: ''})
+          export class Comp {
+            @HostBinding() private id = '123';
+            @HostListener('click') private handleClick() {};
+          }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(2);
+      expect(diags[0].messageText).toBe(
+        `Property 'id' is private and only accessible within class 'Comp'.`,
+      );
+      expect(diags[1].messageText).toBe(
+        `Property 'handleClick' is private and only accessible within class 'Comp'.`,
+      );
+      expect(getDiagnosticSourceCode(diags[0])).toBe('id');
+      expect(getDiagnosticSourceCode(diags[1])).toBe('handleClick');
+    });
+
+    it('should report diagnostic on the entire initializer of property binding if node contains escaped string', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            host: {
+              '[attr.id]': 'prefix + \\'123\\' + doesNotExist'
+            },
+          })
+          export class Dir {
+            prefix = 'prefix';
+          }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(`Property 'doesNotExist' does not exist on type 'Dir'.`);
+      expect(getDiagnosticSourceCode(diags[0])).toBe(`'prefix + \\'123\\' + doesNotExist'`);
+    });
+
+    it('should report diagnostic on the entire initializer of event binding if node contains escaped string', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            host: {
+              '(click)': 'handleClick(\\'foo\\')'
+            },
+          })
+          export class Dir {
+            handleClick(value: number) {}
+          }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(
+        `Argument of type 'string' is not assignable to parameter of type 'number'.`,
+      );
+      expect(getDiagnosticSourceCode(diags[0])).toBe(`'handleClick(\\'foo\\')'`);
+    });
+
+    it('should preserve diagnostic location of nodes that occur before escaped string', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            host: {
+              '[attr.id]': 'getIdFromString(123) + \\'foo\\''
+            },
+          })
+          export class Dir {
+            getIdFromString(value: string) {
+              return value;
+            }
+          }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(
+        `Argument of type 'number' is not assignable to parameter of type 'string'.`,
+      );
+      expect(getDiagnosticSourceCode(diags[0])).toBe('123');
+    });
+
+    it('should not check non-static host bindings', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component} from '@angular/core';
+
+          const BINDINGS = {'[attr.id]': 'doesNotExist'};
+
+          @Component({
+            template: '',
+            host: {
+              ...BINDINGS,
+            }
+          })
+          export class Comp {}
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(0);
+    });
+
+    it('should check host bindings on a directive', () => {
+      env.write(
+        'dir.ts',
+        `
+        import {Directive, HostBinding, HostListener} from '@angular/core';
+
+        @Directive({
+          selector: 'button[dir]',
+          host: {
+            '[attr.id]': 'exists + literalBindingDoesNotExist',
+            '(click)': 'literalListenerDoesNotExist($event)',
+          }
+        })
+        export class SomeDir {
+          exists = 'exists';
+
+          @HostBinding('foo') doesNotExistDecorator = 123;
+
+          @HostListener('mousedown')
+          directiveDecoratorHostListener(event: Event) {}
+        }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(4);
+      expect(diags[0].messageText).toBe(
+        `Property 'literalBindingDoesNotExist' does not exist on type 'SomeDir'.`,
+      );
+      expect(getDiagnosticSourceCode(diags[0])).toBe('literalBindingDoesNotExist');
+      expect(diags[1].messageText).toBe(
+        `Property 'literalListenerDoesNotExist' does not exist on type 'SomeDir'.`,
+      );
+      expect(getDiagnosticSourceCode(diags[1])).toBe('literalListenerDoesNotExist');
+      expect(diags[2].messageText).toBe(`Expected 1 arguments, but got 0.`);
+      expect(getDiagnosticSourceCode(diags[2])).toBe('directiveDecoratorHostListener');
+      expect(diags[3].messageText).toBe(
+        `Can't bind to 'foo' since it isn't a known property of 'button'.`,
+      );
+      expect(getDiagnosticSourceCode(diags[3])).toBe('foo');
+    });
+
+    it('should not check host bindings if the compiler flag is disabled', () => {
+      env.tsconfig({typeCheckHostBindings: false});
+      env.write(
+        'test.ts',
+        `
+          import {Component} from '@angular/core';
+
+          @Component({
+            template: '',
+            host: {'[attr.id]': 'exists + doesNotExist'},
+          })
+          export class Comp {
+            exists = 'exists';
+          }
+      `,
+      );
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(0);
+    });
+  });
+});

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -174,6 +174,7 @@ export {
   UnknownBlock as TmplAstUnknownBlock,
   Variable as TmplAstVariable,
   ViewportDeferredTrigger as TmplAstViewportDeferredTrigger,
+  HostElement as TmplAstHostElement,
   visitAll as tmplAstVisitAll,
   Visitor as TmplAstVisitor,
 } from './render3/r3_ast';
@@ -234,6 +235,10 @@ export {
   parseTemplate,
   ParseTemplateOptions,
 } from './render3/view/template';
+
+// Note: BindingParser is intentionally exported as a type only, because it should
+// be constructed through `makeBindingParser`, rather than its constructor.
+export {type BindingParser} from './template_parser/binding_parser';
 export {createCssSelectorFromNode} from './render3/view/util';
 export * from './resource_loader';
 export * from './schema/dom_element_schema_registry';

--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -615,6 +615,27 @@ export class Icu implements Node {
   }
 }
 
+/**
+ * AST node that represents the host element of a directive.
+ * This node is used only for type checking purposes and cannot be produced from a user's template.
+ */
+export class HostElement implements Node {
+  constructor(
+    readonly tagNames: string[],
+    readonly bindings: BoundAttribute[],
+    readonly listeners: BoundEvent[],
+    readonly sourceSpan: ParseSourceSpan,
+  ) {
+    if (tagNames.length === 0) {
+      throw new Error('HostElement must have at least one tag name.');
+    }
+  }
+
+  visit<Result>(): Result {
+    throw new Error(`HostElement cannot be visited`);
+  }
+}
+
 export interface Visitor<Result = any> {
   // Returning a truthy value from `visit()` will prevent `visitAll()` from the call to the typed
   // method and result returned will become the result included in `visitAll()`s result array.

--- a/packages/compiler/src/render3/view/t2_api.ts
+++ b/packages/compiler/src/render3/view/t2_api.ts
@@ -19,6 +19,7 @@ import {
   Element,
   ForLoopBlock,
   ForLoopBlockEmpty,
+  HostElement,
   IfBlockBranch,
   LetDeclaration,
   Node,
@@ -40,7 +41,8 @@ export type ScopedNode =
   | DeferredBlockError
   | DeferredBlockLoading
   | DeferredBlockPlaceholder
-  | Content;
+  | Content
+  | HostElement;
 
 /** Possible values that a reference can be resolved to. */
 export type ReferenceTarget<DirectiveT> =
@@ -68,6 +70,7 @@ export type TemplateEntity = Reference | Variable | LetDeclaration;
  */
 export interface Target {
   template?: Node[];
+  host?: HostElement;
 }
 
 /**

--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -31,6 +31,7 @@ import {
   Element,
   ForLoopBlock,
   ForLoopBlockEmpty,
+  HostElement,
   HoverDeferredTrigger,
   Icu,
   IfBlock,
@@ -169,7 +170,7 @@ export class R3TargetBinder<DirectiveT extends DirectiveMeta> implements TargetB
    * metadata about the types referenced in the template.
    */
   bind(target: Target): BoundTarget<DirectiveT> {
-    if (!target.template) {
+    if (!target.template && !target.host) {
       throw new Error('Empty bound targets are not supported');
     }
 
@@ -212,6 +213,21 @@ export class R3TargetBinder<DirectiveT extends DirectiveMeta> implements TargetB
       TemplateBinder.applyWithScope(
         target.template,
         scope,
+        expressions,
+        symbols,
+        nestingLevel,
+        usedPipes,
+        eagerPipes,
+        deferBlocks,
+      );
+    }
+
+    // Bind the host element in a separate scope. Note that it only uses the
+    // `TemplateBinder` since directives don't apply inside a host context.
+    if (target.host) {
+      TemplateBinder.applyWithScope(
+        target.host,
+        Scope.apply(target.host),
         expressions,
         symbols,
         nestingLevel,
@@ -280,7 +296,7 @@ class Scope implements Visitor {
    * Process a template (either as a `Template` sub-template with variables, or a plain array of
    * template `Node`s) and construct its `Scope`.
    */
-  static apply(template: Node[]): Scope {
+  static apply(template: ScopedNode | Node[]): Scope {
     const scope = Scope.newRootScope();
     scope.ingest(template);
     return scope;
@@ -315,7 +331,7 @@ class Scope implements Visitor {
       nodeOrNodes instanceof Content
     ) {
       nodeOrNodes.children.forEach((node) => node.visit(this));
-    } else {
+    } else if (!(nodeOrNodes instanceof HostElement)) {
       // No overarching `Template` instance, so process the nodes directly.
       nodeOrNodes.forEach((node) => node.visit(this));
     }
@@ -702,7 +718,7 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
   /**
    * Process a template and extract metadata about expressions and symbols within.
    *
-   * @param nodes the nodes of the template to process
+   * @param nodeOrNodes the nodes of the template to process
    * @param scope the `Scope` of the template being processed.
    * @returns three maps which contain metadata about the template: `expressions` which interprets
    * special `AST` nodes in expressions as pointing to references or variables declared within the
@@ -712,7 +728,7 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
    * at 1.
    */
   static applyWithScope(
-    nodes: Node[],
+    nodeOrNodes: ScopedNode | Node[],
     scope: Scope,
     expressions: Map<AST, TemplateEntity>,
     symbols: Map<TemplateEntity, Template>,
@@ -721,7 +737,7 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
     eagerPipes: Set<string>,
     deferBlocks: DeferBlockScopes,
   ): void {
-    const template = nodes instanceof Template ? nodes : null;
+    const template = nodeOrNodes instanceof Template ? nodeOrNodes : null;
     // The top-level template has nesting level 0.
     const binder = new TemplateBinder(
       expressions,
@@ -734,7 +750,7 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
       template,
       0,
     );
-    binder.ingest(nodes);
+    binder.ingest(nodeOrNodes);
   }
 
   private ingest(nodeOrNodes: ScopedNode | Node[]): void {
@@ -777,6 +793,9 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
     ) {
       nodeOrNodes.children.forEach((node) => node.visit(this));
       this.nestingLevel.set(nodeOrNodes, this.level);
+    } else if (nodeOrNodes instanceof HostElement) {
+      // Host elements are always at the top level.
+      this.nestingLevel.set(nodeOrNodes, 0);
     } else {
       // Visit each node from the top-level template.
       nodeOrNodes.forEach(this.visitNode);
@@ -967,7 +986,7 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
  *
  * See `BoundTarget` for documentation on the individual methods.
  */
-export class R3BoundTarget<DirectiveT extends DirectiveMeta> implements BoundTarget<DirectiveT> {
+class R3BoundTarget<DirectiveT extends DirectiveMeta> implements BoundTarget<DirectiveT> {
   /** Deferred blocks, ordered as they appear in the template. */
   private deferredBlocks: DeferredBlock[];
 

--- a/packages/language-service/src/definitions.ts
+++ b/packages/language-service/src/definitions.ts
@@ -414,13 +414,13 @@ function getDefinitionForExpressionAtPosition(
 
   let resourceForExpression: Resource | null = null;
 
-  if (resource.template?.expression === expression) {
+  if (resource.template?.node === expression) {
     resourceForExpression = resource.template;
   }
 
   if (resourceForExpression === null && resource.styles !== null) {
     for (const style of resource.styles) {
-      if (style.expression === expression) {
+      if (style.node === expression) {
         resourceForExpression = style;
         break;
       }

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -504,11 +504,8 @@ export class LanguageService {
           span = ts.createTextSpanFromBounds(0, 0);
           templateFileName = template.path;
         } else {
-          span = ts.createTextSpanFromBounds(
-            template.expression.getStart(),
-            template.expression.getEnd(),
-          );
-          templateFileName = template.expression.getSourceFile().fileName;
+          span = ts.createTextSpanFromBounds(template.node.getStart(), template.node.getEnd());
+          templateFileName = template.node.getSourceFile().fileName;
         }
         return {fileName: templateFileName, textSpan: span, contextSpan: span};
       },

--- a/packages/language-service/src/utils/index.ts
+++ b/packages/language-service/src/utils/index.ts
@@ -140,7 +140,7 @@ function getInlineTypeCheckInfoAtPosition(
     resources === null ||
     resources.template === null ||
     isExternalResource(resources.template) ||
-    expression !== resources.template.expression
+    expression !== resources.template.node
   ) {
     return undefined;
   }

--- a/packages/language-service/testing/src/project.ts
+++ b/packages/language-service/testing/src/project.ts
@@ -9,7 +9,7 @@
 import {
   InternalOptions,
   LegacyNgcOptions,
-  StrictTemplateOptions,
+  TypeCheckingOptions,
 } from '@angular/compiler-cli/src/ngtsc/core/api';
 import {
   absoluteFrom,
@@ -63,7 +63,7 @@ function writeTsconfig(
   );
 }
 
-export type TestableOptions = StrictTemplateOptions &
+export type TestableOptions = TypeCheckingOptions &
   InternalOptions &
   Pick<LegacyNgcOptions, 'fullTemplateTypeCheck'>;
 


### PR DESCRIPTION
Historically Angular's type checking only extended to templates, however host bindings can contain expressions as well which can have type checking issues of their own ([example](https://github.com/angular/components/pull/30570) and [example](https://github.com/angular/components/pull/30606)). These changes add the ability to type check the `host` object literal, `@HostBinding` and `@HostListener` decorators of `@Directive` and `@Component` classes. The new functionality is hidden behind the `typeCheckHostBindings` compiler flag, but we plan to enable it by default in a future version.

This also allows us to enable language service features in host bindings like renaming and hover information. Here's demo showing how it's integrated:

![host-bindings-demo](https://github.com/user-attachments/assets/0492c2dc-b6bd-4f7a-a98a-cc7e54303ef1)


**Note:** the language service integration for this is done, but I'll send it out in a separate PR to make this one easier to review.