### PR TITLE
refactor(core): getting resource value throws an error instead of returning undefined

### DIFF
--- a/packages/core/src/resource/api.ts
+++ b/packages/core/src/resource/api.ts
@@ -66,7 +66,7 @@ export enum ResourceStatus {
  */
 export interface Resource<T> {
   /**
-   * The current value of the `Resource`, or `undefined` if there is no current value.
+   * The current value of the `Resource`, or throws an error if the resource is in an error state.
    */
   readonly value: Signal<T>;
 
@@ -187,7 +187,7 @@ export interface BaseResourceOptions<T, R> {
 
   /**
    * The value which will be returned from the resource when a server value is unavailable, such as
-   * when the resource is still loading, or in an error state.
+   * when the resource is still loading.
    */
   defaultValue?: NoInfer<T>;
 

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -8,7 +8,7 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "module": "esnext",
-    "target": "es2020",
+    "target": "es2022",
     "strict": true,
     "moduleResolution": "node",
     "esModuleInterop": true,
@@ -29,7 +29,7 @@
     },
     "rootDir": ".",
     "inlineSourceMap": true,
-    "lib": ["es2020", "dom", "dom.iterable"],
+    "lib": ["es2020", "es2022", "dom", "dom.iterable"],
     "skipDefaultLibCheck": true,
     "skipLibCheck": true,
     "types": ["angular"]


### PR DESCRIPTION
When there is an underlying error state it would not be possible to swallow the error with: 

```typescript
computed(() => res.value()?.inner);
```

