### PR TITLE
refactor(core): narrow error type for resources API

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1599,7 +1599,7 @@ export function resolveForwardRef<T>(type: T): T;
 
 // @public
 export interface Resource<T> {
-    readonly error: Signal<unknown>;
+    readonly error: Signal<Error | undefined>;
     hasValue(): this is Resource<Exclude<T, undefined>>;
     readonly isLoading: Signal<boolean>;
     reload(): boolean;
@@ -1657,7 +1657,7 @@ export type ResourceStreamingLoader<T, R> = (param: ResourceLoaderParams<R>) => 
 export type ResourceStreamItem<T> = {
     value: T;
 } | {
-    error: unknown;
+    error: Error;
 };
 
 // @public

--- a/packages/common/http/src/resource.ts
+++ b/packages/common/http/src/resource.ts
@@ -29,6 +29,7 @@ import {HttpEventType, HttpProgressEvent, HttpResponseBase} from './response';
 import {HttpHeaders} from './headers';
 import {HttpParams} from './params';
 import {HttpResourceRef, HttpResourceOptions, HttpResourceRequest} from './resource_api';
+import {encapsulateResourceError} from '@angular/core/src/resource/resource';
 
 /**
  * Type for the `httpRequest` top-level function, which includes the call signatures for the JSON-
@@ -349,7 +350,7 @@ class HttpResourceImpl<T>
                 try {
                   send({value: parse ? parse(event.body) : (event.body as T)});
                 } catch (error) {
-                  send({error});
+                  send({error: encapsulateResourceError(error)});
                 }
                 break;
               case HttpEventType.DownloadProgress:
@@ -387,7 +388,7 @@ class HttpResourceImpl<T>
 class HttpResponseResource implements Resource<HttpResponseBase | undefined> {
   readonly status: Signal<ResourceStatus>;
   readonly value: WritableSignal<HttpResponseBase | undefined>;
-  readonly error: Signal<unknown>;
+  readonly error: Signal<Error | undefined>;
   readonly isLoading: Signal<boolean>;
 
   constructor(

--- a/packages/core/rxjs-interop/src/rx_resource.ts
+++ b/packages/core/rxjs-interop/src/rx_resource.ts
@@ -16,6 +16,7 @@ import {
   BaseResourceOptions,
 } from '@angular/core';
 import {Observable, Subscription} from 'rxjs';
+import {encapsulateResourceError} from '@angular/core/src/resource/resource';
 
 /**
  * Like `ResourceOptions` but uses an RxJS-based `loader`.
@@ -57,11 +58,11 @@ export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T |
       params.abortSignal.addEventListener('abort', onAbort);
 
       // Start off stream as undefined.
-      const stream = signal<{value: T} | {error: unknown}>({value: undefined as T});
-      let resolve: ((value: Signal<{value: T} | {error: unknown}>) => void) | undefined;
-      const promise = new Promise<Signal<{value: T} | {error: unknown}>>((r) => (resolve = r));
+      const stream = signal<{value: T} | {error: Error}>({value: undefined as T});
+      let resolve: ((value: Signal<{value: T} | {error: Error}>) => void) | undefined;
+      const promise = new Promise<Signal<{value: T} | {error: Error}>>((r) => (resolve = r));
 
-      function send(value: {value: T} | {error: unknown}): void {
+      function send(value: {value: T} | {error: Error}): void {
         stream.set(value);
         resolve?.(stream);
         resolve = undefined;
@@ -69,7 +70,7 @@ export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T |
 
       sub = opts.loader(params).subscribe({
         next: (value) => send({value}),
-        error: (error) => send({error}),
+        error: (error: unknown) => send({error: encapsulateResourceError(error)}),
         complete: () => {
           if (resolve) {
             send({error: new Error('Resource completed before producing a value')});

--- a/packages/core/rxjs-interop/test/rx_resource_spec.ts
+++ b/packages/core/rxjs-interop/test/rx_resource_spec.ts
@@ -74,7 +74,7 @@ describe('rxResource()', () => {
     expect(res.value()).toBe(3);
 
     response.error('fail');
-    expect(res.error()).toBe('fail');
+    expect(res.error()).toEqual(new Error('Unknown error', {cause: 'fail'}));
   });
 });
 

--- a/packages/core/src/resource/api.ts
+++ b/packages/core/src/resource/api.ts
@@ -79,7 +79,7 @@ export interface Resource<T> {
   /**
    * When in the `error` state, this returns the last known error from the `Resource`.
    */
-  readonly error: Signal<unknown>;
+  readonly error: Signal<Error | undefined>;
 
   /**
    * Whether this resource is loading a new value (or reloading the existing one).
@@ -245,4 +245,4 @@ export type ResourceOptions<T, R> = PromiseResourceOptions<T, R> | StreamingReso
 /**
  * @experimental
  */
-export type ResourceStreamItem<T> = {value: T} | {error: unknown};
+export type ResourceStreamItem<T> = {value: T} | {error: Error};

--- a/packages/core/test/resource/resource_spec.ts
+++ b/packages/core/test/resource/resource_spec.ts
@@ -68,6 +68,7 @@ class MockEchoBackend<T> extends MockBackend<T, T> {
 
 class MockResponseCountingBackend extends MockBackend<number, string> {
   counter = 0;
+
   override prepareResponse(request: number) {
     return request + ':' + this.counter++;
   }
@@ -142,7 +143,9 @@ describe('resource', () => {
     expect(echoResource.isLoading()).toBeFalse();
     expect(echoResource.hasValue()).toBeFalse();
     expect(echoResource.value()).toEqual(undefined);
-    expect(echoResource.error()).toBe('Something went wrong....');
+    expect(echoResource.error()).toEqual(
+      new Error('Unknown error', {cause: 'Something went wrong....'}),
+    );
   });
 
   it('should expose errors on reload', async () => {
@@ -605,18 +608,18 @@ describe('resource', () => {
   it('should error via error()', async () => {
     const appRef = TestBed.inject(ApplicationRef);
     const res = resource({
-      stream: async () => signal({error: 'fail'}),
+      stream: async () => signal({error: new Error('fail')}),
       injector: TestBed.inject(Injector),
     });
 
     await appRef.whenStable();
     expect(res.status()).toBe(ResourceStatus.Error);
-    expect(res.error()).toBe('fail');
+    expect(res.error()).toEqual(new Error('fail'));
   });
 
   it('should transition across streamed states', async () => {
     const appRef = TestBed.inject(ApplicationRef);
-    const stream = signal<{value: number} | {error: unknown}>({value: 1});
+    const stream = signal<{value: number} | {error: Error}>({value: 1});
 
     const res = resource({
       stream: async () => stream,
@@ -630,8 +633,8 @@ describe('resource', () => {
     stream.set({value: 3});
     expect(res.value()).toBe(3);
 
-    stream.set({error: 'fail'});
-    expect(res.error()).toBe('fail');
+    stream.set({error: new Error('fail')});
+    expect(res.error()).toEqual(new Error('fail'));
 
     stream.set({value: 4});
     expect(res.value()).toBe(4);
@@ -639,7 +642,7 @@ describe('resource', () => {
 
   it('should not accept new values/errors after a request is cancelled', async () => {
     const appRef = TestBed.inject(ApplicationRef);
-    const stream = signal<{value: number} | {error: unknown}>({value: 0});
+    const stream = signal<{value: number} | {error: Error}>({value: 0});
     const request = signal(1);
     const res = resource({
       request,
@@ -663,7 +666,7 @@ describe('resource', () => {
     // The previous set/error functions should no longer result in changes to the resource.
     stream.set({value: 2});
     expect(res.value()).toBe(undefined);
-    stream.set({error: 'fail'});
+    stream.set({error: new Error('fail')});
     expect(res.value()).toBe(undefined);
   });
 

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -8,7 +8,7 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "module": "esnext",
-    "target": "es2020",
+    "target": "es2022",
     "strict": true,
     "moduleResolution": "node",
     "esModuleInterop": true,
@@ -29,7 +29,7 @@
     },
     "rootDir": ".",
     "inlineSourceMap": true,
-    "lib": ["es2020", "dom", "dom.iterable"],
+    "lib": ["es2020", "es2022", "dom", "dom.iterable"],
     "skipDefaultLibCheck": true,
     "skipLibCheck": true,
     "types": ["angular"]


### PR DESCRIPTION
It used to return `unknown`.
Now it's `Error | undefined`.

For non-`Error` types they are encapsulated in new `UnknownError` 