### PR TITLE
refactor(http): replace overriden method with a ts `declare`

### DIFF
--- a/packages/common/http/src/resource.ts
+++ b/packages/common/http/src/resource.ts
@@ -375,9 +375,8 @@ class HttpResourceImpl<T>
     this.client = injector.get(HttpClient);
   }
 
-  override hasValue(): this is HttpResourceRef<Exclude<T, undefined>> {
-    return super.hasValue();
-  }
+  // This is a type only override of the method
+  declare hasValue: () => this is HttpResourceRef<Exclude<T, undefined>>;
 }
 
 /**


### PR DESCRIPTION
This allows us to drop the useless `super.hasValue()`.
