### PR TITLE
feat(router): add disableScrollToTop to NavigationBehaviorOptions (#2…

### DIFF
--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -253,6 +253,14 @@ export class RouterLink implements OnChanges, OnDestroy {
   @Input({transform: booleanAttribute}) replaceUrl: boolean = false;
 
   /**
+   * Passed to {@link Router#navigateByUrl} as part of the
+   * `NavigationBehaviorOptions`.
+   * @see {@link NavigationBehaviorOptions#disableScrollToTop}
+   * @see {@link Router#navigateByUrl}
+   */
+  @Input({transform: booleanAttribute}) disableScrollToTop: boolean = false;
+
+  /**
    * Modifies the tab index if there was not a tabindex attribute on the element during
    * instantiation.
    */
@@ -352,6 +360,7 @@ export class RouterLink implements OnChanges, OnDestroy {
       replaceUrl: this.replaceUrl,
       state: this.state,
       info: this.info,
+      disableScrollToTop: this.disableScrollToTop,
     };
     this.router.navigateByUrl(urlTree, extras).catch((e) => {
       this.applicationErrorHandler(e);

--- a/packages/router/src/events.ts
+++ b/packages/router/src/events.ts
@@ -601,6 +601,9 @@ export class Scroll {
 
     /** @docsNotRequired */
     readonly anchor: string | null,
+
+    /** @docsNotRequired */
+    readonly isScrollToTopDisabled: boolean,
   ) {}
 
   toString(): string {

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -1441,6 +1441,14 @@ export interface NavigationBehaviorOptions {
   replaceUrl?: boolean;
 
   /**
+   * When true, navigates without scrolling to the top.
+   *
+   * Angular will scroll to the top on a navigation when
+   * {@link InMemoryScrollingOptions.scrollPositionRestoration} is set to 'top' or 'enabled'.
+   */
+  readonly disableScrollToTop?: boolean;
+
+  /**
    * Developer-defined state that can be passed to any navigation.
    * Access this value through the `Navigation.extras` object
    * returned from the [Router.getCurrentNavigation()

--- a/packages/router/src/router_config.ts
+++ b/packages/router/src/router_config.ts
@@ -171,6 +171,19 @@ export interface InMemoryScrollingOptions {
    *   }
    * }
    * ```
+   *
+   * When 'top' or 'enabled' is set, if you want to disable the scroll to the top on a specific
+   * navigation, you can use {@link NavigationBehaviorOptions.disableScrollToTop}.
+   *
+   * ```ts
+   * class AppComponent {
+   *   constructor() {
+   *     const router = inject(Router);
+   *
+   *     router.navigateByUrl('/feature', { disableScrollToTop: true });
+   *   }
+   * }
+   * ```
    */
   scrollPositionRestoration?: 'disabled' | 'enabled' | 'top';
 }

--- a/packages/router/src/router_scroller.ts
+++ b/packages/router/src/router_scroller.ts
@@ -7,14 +7,7 @@
  */
 
 import {ViewportScroller} from '@angular/common';
-import {
-  EnvironmentInjector,
-  inject,
-  Injectable,
-  InjectionToken,
-  NgZone,
-  OnDestroy,
-} from '@angular/core';
+import {Injectable, InjectionToken, NgZone, OnDestroy} from '@angular/core';
 import {Unsubscribable} from 'rxjs';
 
 import {
@@ -101,7 +94,10 @@ export class RouterScroller implements OnDestroy {
       } else {
         if (e.anchor && this.options.anchorScrolling === 'enabled') {
           this.viewportScroller.scrollToAnchor(e.anchor);
-        } else if (this.options.scrollPositionRestoration !== 'disabled') {
+        } else if (
+          this.options.scrollPositionRestoration !== 'disabled' &&
+          !e.isScrollToTopDisabled
+        ) {
           this.viewportScroller.scrollToPosition([0, 0]);
         }
       }
@@ -112,6 +108,9 @@ export class RouterScroller implements OnDestroy {
     routerEvent: NavigationEnd | NavigationSkipped,
     anchor: string | null,
   ): void {
+    const isScrollToTopDisabled =
+      this.transitions.currentTransition?.extras?.disableScrollToTop === true;
+
     this.zone.runOutsideAngular(async () => {
       // The scroll event needs to be delayed until after change detection. Otherwise, we may
       // attempt to restore the scroll position before the router outlet has fully rendered the
@@ -133,6 +132,7 @@ export class RouterScroller implements OnDestroy {
             routerEvent,
             this.lastSource === 'popstate' ? this.store[this.restoredId] : null,
             anchor,
+            isScrollToTopDisabled,
           ),
         );
       });

--- a/packages/router/test/router_link_spec.ts
+++ b/packages/router/test/router_link_spec.ts
@@ -45,7 +45,8 @@ describe('RouterLink', () => {
           [routerLink]="link()"
           [preserveFragment]="preserveFragment()"
           [skipLocationChange]="skipLocationChange()"
-          [replaceUrl]="replaceUrl()"></div>
+          [replaceUrl]="replaceUrl()"
+          [disableScrollToTop]="disableScrollToTop()"></div>
       `,
       standalone: false,
     })
@@ -54,6 +55,7 @@ describe('RouterLink', () => {
       preserveFragment = signal<unknown>(undefined);
       skipLocationChange = signal<unknown>(undefined);
       replaceUrl = signal<unknown>(undefined);
+      disableScrollToTop = signal<unknown>(undefined);
     }
     let fixture: ComponentFixture<LinkComponent>;
     let link: HTMLDivElement;
@@ -100,20 +102,24 @@ describe('RouterLink', () => {
         fixture.componentInstance.preserveFragment.set(truthy);
         fixture.componentInstance.skipLocationChange.set(truthy);
         fixture.componentInstance.replaceUrl.set(truthy);
+        fixture.componentInstance.disableScrollToTop.set(truthy);
         await fixture.whenStable();
         expect(dir.preserveFragment).toBeTrue();
         expect(dir.skipLocationChange).toBeTrue();
         expect(dir.replaceUrl).toBeTrue();
+        expect(dir.disableScrollToTop).toBeTrue();
       }
 
       for (const falsy of [false, null, undefined, 'false']) {
         fixture.componentInstance.preserveFragment.set(falsy);
         fixture.componentInstance.skipLocationChange.set(falsy);
         fixture.componentInstance.replaceUrl.set(falsy);
+        fixture.componentInstance.disableScrollToTop.set(falsy);
         await fixture.whenStable();
         expect(dir.preserveFragment).toBeFalse();
         expect(dir.skipLocationChange).toBeFalse();
         expect(dir.replaceUrl).toBeFalse();
+        expect(dir.disableScrollToTop).toBeFalse();
       }
     });
   });
@@ -126,7 +132,8 @@ describe('RouterLink', () => {
             [routerLink]="link()"
             [preserveFragment]="preserveFragment()"
             [skipLocationChange]="skipLocationChange()"
-            [replaceUrl]="replaceUrl()"></a>
+            [replaceUrl]="replaceUrl()"
+            [disableScrollToTop]="disableScrollToTop()"></a>
         `,
         standalone: false,
       })
@@ -135,6 +142,7 @@ describe('RouterLink', () => {
         preserveFragment = signal<unknown>(undefined);
         skipLocationChange = signal<unknown>(undefined);
         replaceUrl = signal<unknown>(undefined);
+        disableScrollToTop = signal<unknown>(undefined);
       }
       let fixture: ComponentFixture<LinkComponent>;
       let link: HTMLAnchorElement;
@@ -170,20 +178,24 @@ describe('RouterLink', () => {
           fixture.componentInstance.preserveFragment.set(truthy);
           fixture.componentInstance.skipLocationChange.set(truthy);
           fixture.componentInstance.replaceUrl.set(truthy);
+          fixture.componentInstance.disableScrollToTop.set(truthy);
           await fixture.whenStable();
           expect(dir.preserveFragment).toBeTrue();
           expect(dir.skipLocationChange).toBeTrue();
           expect(dir.replaceUrl).toBeTrue();
+          expect(dir.disableScrollToTop).toBeTrue();
         }
 
         for (const falsy of [false, null, undefined, 'false']) {
           fixture.componentInstance.preserveFragment.set(falsy);
           fixture.componentInstance.skipLocationChange.set(falsy);
           fixture.componentInstance.replaceUrl.set(falsy);
+          fixture.componentInstance.disableScrollToTop.set(falsy);
           await fixture.whenStable();
           expect(dir.preserveFragment).toBeFalse();
           expect(dir.skipLocationChange).toBeFalse();
           expect(dir.replaceUrl).toBeFalse();
+          expect(dir.disableScrollToTop).toBeFalse();
         }
       });
     });


### PR DESCRIPTION
…6744)

Add a new option to NavigationBehaviorOptions that allows to disable the scroll to the top for this navigation. This option allows to override the default behaviour of InMemoryScrollingOptions.scrollPositionRestoration 'top' or 'enabled'.

PR Close #26744

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #26744

## What is the new behavior?

Add a new option to NavigationBehaviorOptions that allows to disable the scroll to the top for this navigation.
This option allows to override the default behavior of InMemoryScrollingOptions.scrollPositionRestoration 'top' or 'enabled'.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

I couldn't verify that the tests are successful locally, it wasn't working on WSL... So I'm hoping for them to work on GitHub.
It's maybe missing some integration tests but I didn't see where to do them.
I could do them if this change is approved by the maintainers.
