### PR TITLE
refactor(devtools): remove input/output/property links

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.html
@@ -27,18 +27,7 @@
         @if (!panel.hidden) {
           <mat-expansion-panel [class]="panel.class" [expanded]="true">
             <mat-expansion-panel-header collapsedHeight="25px" expandedHeight="25px">
-              <mat-panel-title>
-                {{ panel.title }}
-                <a
-                  href="{{ panel.documentation }}"
-                  target="_blank"
-                  class="documentation"
-                  matTooltip="Open docs reference"
-                  (click)="$event.stopPropagation()"
-                >
-                  <mat-icon class="docs-link">open_in_new</mat-icon>
-                </a>
-              </mat-panel-title>
+              <mat-panel-title>{{ panel.title }}</mat-panel-title>
             </mat-expansion-panel-header>
             <ng-property-view-tree
               [dataSource]="panel.controls.dataSource"

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.ts
@@ -51,7 +51,6 @@ export class PropertyViewBodyComponent {
       title: string;
       hidden: boolean;
       controls: DirectiveTreeData;
-      documentation: string;
       class: string;
     }[]
   >(() => {
@@ -60,21 +59,18 @@ export class PropertyViewBodyComponent {
         title: 'Inputs',
         hidden: this.directiveInputControls().dataSource.data.length === 0,
         controls: this.directiveInputControls(),
-        documentation: 'https://angular.dev/api/core/input',
         class: 'cy-inputs',
       },
       {
         title: 'Outputs',
         hidden: this.directiveOutputControls().dataSource.data.length === 0,
         controls: this.directiveOutputControls(),
-        documentation: 'https://angular.dev/api/core/output',
         class: 'cy-outputs',
       },
       {
         title: 'Properties',
         hidden: this.directiveStateControls().dataSource.data.length === 0,
         controls: this.directiveStateControls(),
-        documentation: 'https://angular.dev/guide/templates/property-binding',
         class: 'cy-properties',
       },
     ];


### PR DESCRIPTION
These links aren't that helpful in the context of Angular DevTools for a few reasons:
1. Users of the extension should already have a general understanding of core Angular concepts, inputs and outputs included.
2. The input and output links go to API documentation which isn't useful for someone who doesn't actually understand the core concepts anyways.
3. These links point to signals documentation even though DevTools shows non-signal inputs and outputs.
4. Properties linked to template binding docs, which doesn't *really* have anything to do with the plain JS properties being shown in DevTools anyways.