### PR TITLE
refactor(devtools): refactors property view drag-and-drop behavior

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.html
@@ -22,17 +22,16 @@
         </mat-expansion-panel>
       </div>
     }
-    @for (index of categoryOrder; track $index) {
+    @for (panel of panels(); track $index) {
       <div class="mat-accordion-content" cdkDrag>
-        @let panel = panels()[index];
-        @if (!panel.hidden) {
+        @if (panel.controls().dataSource.data.length > 0) {
           <mat-expansion-panel [class]="panel.class" [expanded]="true">
             <mat-expansion-panel-header collapsedHeight="25px" expandedHeight="25px">
               <mat-panel-title>{{ panel.title }}</mat-panel-title>
             </mat-expansion-panel-header>
             <ng-property-view-tree
-              [dataSource]="panel.controls.dataSource"
-              [treeControl]="panel.controls.treeControl"
+              [dataSource]="panel.controls().dataSource"
+              [treeControl]="panel.controls().treeControl"
               (updateValue)="updateValue($event)"
               (inspect)="handleInspect($event)"
             />


### PR DESCRIPTION
The main goal of this change is to remove `categoryOrder` which effectively hard-codes the supported length of `panels`. Adding another item to `panels` is not rendered unless that is added to `categoryOrder`.

My solution to this is to make the set of categories a signal, with each category able to produce the data inside it. This allow `CdkDragDrop` to rearrange categories but then still produce the correct data in the template without needing a separate array to track order.

Also removed `hidden` and inlined it in the template, since the logic was the same for every panel.

`moveItemInArray` is unfortunately an in-place move, so I needed to manually clone the array to ensure `panels` observes an immutable update which works better with signals and change detection.