### PR TITLE
refactor(core): log a warning instead of throwing error on `OutputRef…

### DIFF
--- a/packages/core/src/authoring/output/output_emitter_ref.ts
+++ b/packages/core/src/authoring/output/output_emitter_ref.ts
@@ -10,7 +10,7 @@ import {setActiveConsumer} from '@angular/core/primitives/signals';
 
 import {inject} from '../../di/injector_compatibility';
 import {ErrorHandler} from '../../error_handler';
-import {RuntimeError, RuntimeErrorCode} from '../../errors';
+import {formatRuntimeError, RuntimeError, RuntimeErrorCode} from '../../errors';
 import {DestroyRef} from '../../linker/destroy_ref';
 
 import {OutputRef, OutputRefSubscription} from './output_ref';
@@ -69,12 +69,15 @@ export class OutputEmitterRef<T> implements OutputRef<T> {
   /** Emits a new value to the output. */
   emit(value: T): void {
     if (this.destroyed) {
-      throw new RuntimeError(
-        RuntimeErrorCode.OUTPUT_REF_DESTROYED,
-        ngDevMode &&
-          'Unexpected emit for destroyed `OutputRef`. ' +
-            'The owning directive/component is destroyed.',
+      console.warn(
+        formatRuntimeError(
+          RuntimeErrorCode.OUTPUT_REF_DESTROYED,
+          ngDevMode &&
+            'Unexpected emit for destroyed `OutputRef`. ' +
+              'The owning directive/component is destroyed.',
+        ),
       );
+      return;
     }
 
     if (this.listeners === null) {

--- a/packages/core/test/acceptance/authoring/model_inputs_spec.ts
+++ b/packages/core/test/acceptance/authoring/model_inputs_spec.ts
@@ -435,7 +435,9 @@ describe('model inputs', () => {
     expect(emittedEvents).toBe(1);
 
     fixture.destroy();
-    expect(() => modelRef.set(2)).toThrowError(/Unexpected emit for destroyed `OutputRef`/);
+    const warnSpy = spyOn(console, 'warn');
+    modelRef.set(2);
+    expect(warnSpy.calls.mostRecent().args[0]).toMatch(/Unexpected emit for destroyed `OutputRef`/);
     expect(emittedEvents).toBe(1);
   });
 

--- a/packages/core/test/acceptance/authoring/output_function_spec.ts
+++ b/packages/core/test/acceptance/authoring/output_function_spec.ts
@@ -109,7 +109,10 @@ describe('output() function', () => {
     fixture.componentInstance.show = false;
     fixture.detectChanges();
 
-    expect(() => dir.onBla.emit(3)).toThrowError(/Unexpected emit for destroyed `OutputRef`/);
+    fixture.destroy();
+    const warnSpy = spyOn(console, 'warn');
+    dir.onBla.emit(3);
+    expect(warnSpy.calls.mostRecent().args[0]).toMatch(/Unexpected emit for destroyed `OutputRef`/);
   });
 
   it('should error when subscribing to a destroyed output', () => {


### PR DESCRIPTION
….emit` when the directive is destroyed.

This should not be a hard error, as nothing bad happens but the users should be warned that no event will be emitted.

fixes #60110
