### PR TITLE
doc: fix commit message guideline link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,7 +243,7 @@ The following documents can help you sort out issues with GitHub accounts and mu
 [coc]: https://github.com/angular/code-of-conduct/blob/main/CODE_OF_CONDUCT.md
 [corporate-cla]: https://cla.developers.google.com/about/google-corporate
 [dev-doc]: ./contributing-docs/building-and-testing-angular.md
-[commit-message-guidelines]: ./contributing-docs/building-and-testing-angular.md
+[commit-message-guidelines]: ./contributing-docs/commit-message-guidelines.md
 [github]: https://github.com/angular/angular
 [discord]: https://discord.gg/angular
 [individual-cla]: https://cla.developers.google.com/about/google-individual


### PR DESCRIPTION
Fixes the link for the commit message guideline in CONTRIBUTING.md pointing to the building and testing angular guide instead of the commit message guidelines

Fixes #60925

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Link to the commit message guideline in CONTRIBUTING.md points to the Building and Testing Angular guide
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #60295 


## What is the new behavior?

Link to the commit message guideline in CONTRIBUTING.md points to the correct doc


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
