### PR TITLE
refactor(core): inline functions used once

### DIFF
--- a/packages/core/src/render3/instructions/render.ts
+++ b/packages/core/src/render3/instructions/render.ts
@@ -135,7 +135,11 @@ export function renderView<T>(tView: TView, lView: LView<T>, context: T): void {
     // Render child component views.
     const components = tView.components;
     if (components !== null) {
-      renderChildComponents(lView, components);
+      // Renders child components in the current view (creation mode).
+      // Perf note: Do not extract this into a separate function, as it is faster this way.
+      for (let i = 0; i < components.length; i++) {
+        renderComponent(lView, components[i]);
+      }
     }
   } catch (error) {
     // If we didn't manage to get past the first template pass due to
@@ -149,12 +153,5 @@ export function renderView<T>(tView: TView, lView: LView<T>, context: T): void {
   } finally {
     lView[FLAGS] &= ~LViewFlags.CreationMode;
     leaveView();
-  }
-}
-
-/** Renders child components in the current view (creation mode). */
-function renderChildComponents(hostLView: LView, components: number[]): void {
-  for (let i = 0; i < components.length; i++) {
-    renderComponent(hostLView, components[i]);
   }
 }

--- a/packages/core/src/render3/util/injector_utils.ts
+++ b/packages/core/src/render3/util/injector_utils.ts
@@ -36,10 +36,6 @@ export function getParentInjectorIndex(parentLocation: RelativeInjectorLocation)
   return parentLocation & RelativeInjectorLocationFlags.InjectorIndexMask;
 }
 
-export function getParentInjectorViewOffset(parentLocation: RelativeInjectorLocation): number {
-  return parentLocation >> RelativeInjectorLocationFlags.ViewOffsetShift;
-}
-
 /**
  * Unwraps a parent injector location number to find the view offset from the current injector,
  * then walks up the declaration view tree until the view is found that contains the parent
@@ -50,7 +46,8 @@ export function getParentInjectorViewOffset(parentLocation: RelativeInjectorLoca
  * @returns The LView instance that contains the parent injector
  */
 export function getParentInjectorView(location: RelativeInjectorLocation, startView: LView): LView {
-  let viewOffset = getParentInjectorViewOffset(location);
+  // Gets parent injector view offset.
+  let viewOffset = location >> RelativeInjectorLocationFlags.ViewOffsetShift;
   let parentView = startView;
   // For most cases, the parent injector can be found on the host node (e.g. for component
   // or container), but we must keep the loop here to support the rarer case of deeply nested


### PR DESCRIPTION
In this commit, we inline `getParentInjectorViewOffset` and `renderChildComponents` at their call sites. ESBuild, by default, does not inline functions used only once. `renderChildComponents` is part of change detection and pollutes the stack trace when an error is thrown, so there is no reason to keep it separate.

```
renderComponent (no inlined) x 606,888 ops/sec ±4.43% (29 runs sampled)
renderComponent (inlined) x 666,358 ops/sec ±4.46% (21 runs sampled)
```