### PR TITLE
fix(compiler-cli): handle transformed classes when generating HMR code

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -1879,7 +1879,7 @@ export class ComponentDecoratorHandler
     const res = compileResults(fac, def, classMetadata, 'ɵcmp', null, null, debugInfo, null);
     return hmrMeta === null || res.length === 0
       ? null
-      : getHmrUpdateDeclaration(res, pool.statements, hmrMeta, node.getSourceFile());
+      : getHmrUpdateDeclaration(res, pool.statements, hmrMeta, node);
   }
 
   /**

--- a/packages/compiler-cli/src/ngtsc/hmr/src/extract_dependencies.ts
+++ b/packages/compiler-cli/src/ngtsc/hmr/src/extract_dependencies.ts
@@ -42,7 +42,7 @@ export function extractHmrDependencies(
 } | null {
   const name = ts.isClassDeclaration(node) && node.name ? node.name.text : null;
   const visitor = new PotentialTopLevelReadsVisitor();
-  const sourceFile = node.getSourceFile();
+  const sourceFile = ts.getOriginalNode(node).getSourceFile();
 
   // Visit all of the compiled expressions to look for potential
   // local references that would have to be retained.

--- a/packages/compiler-cli/src/ngtsc/hmr/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/hmr/src/metadata.ts
@@ -47,7 +47,7 @@ export function extractHmrMetatadata(
     return null;
   }
 
-  const sourceFile = clazz.getSourceFile();
+  const sourceFile = ts.getOriginalNode(clazz).getSourceFile();
   const filePath =
     getProjectRelativePath(sourceFile.fileName, rootDirs, compilerHost) ||
     compilerHost.getCanonicalFileName(sourceFile.fileName);

--- a/packages/compiler-cli/src/ngtsc/hmr/src/update_declaration.ts
+++ b/packages/compiler-cli/src/ngtsc/hmr/src/update_declaration.ts
@@ -13,19 +13,20 @@ import {
   presetImportManagerForceNamespaceImports,
   translateStatement,
 } from '../../translator';
+import {ClassDeclaration} from '../../reflection';
 import ts from 'typescript';
 
 /**
  * Gets the declaration for the function that replaces the metadata of a class during HMR.
  * @param compilationResults Code generated for the class during compilation.
  * @param meta HMR metadata about the class.
- * @param sourceFile File in which the class is defined.
+ * @param declaration Class for which the update declaration is being generated.
  */
 export function getHmrUpdateDeclaration(
   compilationResults: CompileResult[],
   constantStatements: o.Statement[],
   meta: R3HmrMetadata,
-  sourceFile: ts.SourceFile,
+  declaration: ClassDeclaration,
 ): ts.FunctionDeclaration {
   const namespaceSpecifiers = meta.namespaceDependencies.reduce((result, current) => {
     result.set(current.moduleName, current.assignedName);
@@ -37,6 +38,7 @@ export function getHmrUpdateDeclaration(
     rewriter: importRewriter,
   });
   const callback = compileHmrUpdateCallback(compilationResults, constantStatements, meta);
+  const sourceFile = ts.getOriginalNode(declaration).getSourceFile();
   const node = translateStatement(sourceFile, callback, importManager) as ts.FunctionDeclaration;
 
   // The output AST doesn't support modifiers so we have to emit to


### PR DESCRIPTION
We had several places where we were trying to get the source file of a class for which we're generating HMR-related code. These calls will fail if the class was transformed so we have to get its source file through the original node.

Fixes #60287.
