### PR TITLE
refactor(core): add equal option to the signal and computed creation

### DIFF
--- a/goldens/public-api/core/primitives/signals/index.api.md
+++ b/goldens/public-api/core/primitives/signals/index.api.md
@@ -35,13 +35,13 @@ export function consumerMarkDirty(node: ReactiveNode): void;
 export function consumerPollProducersForChange(node: ReactiveNode): boolean;
 
 // @public
-export function createComputed<T>(computation: () => T): ComputedGetter<T>;
+export function createComputed<T>(computation: () => T, equal?: ValueEqualityFn<T>): ComputedGetter<T>;
 
 // @public (undocumented)
 export function createLinkedSignal<S, D>(sourceFn: () => S, computationFn: ComputationFn<S, D>, equalityFn?: ValueEqualityFn<D>): LinkedSignalGetter<S, D>;
 
 // @public
-export function createSignal<T>(initialValue: T): SignalGetter<T>;
+export function createSignal<T>(initialValue: T, equal?: ValueEqualityFn<T>): SignalGetter<T>;
 
 // @public (undocumented)
 export function createWatch(fn: (onCleanup: WatchCleanupRegisterFn) => void, schedule: (watch: Watch) => void, allowSignalWrites: boolean): Watch;

--- a/packages/core/primitives/signals/src/computed.ts
+++ b/packages/core/primitives/signals/src/computed.ts
@@ -51,9 +51,16 @@ export type ComputedGetter<T> = (() => T) & {
 /**
  * Create a computed signal which derives a reactive value from an expression.
  */
-export function createComputed<T>(computation: () => T): ComputedGetter<T> {
+export function createComputed<T>(
+  computation: () => T,
+  equal?: ValueEqualityFn<T>,
+): ComputedGetter<T> {
   const node: ComputedNode<T> = Object.create(COMPUTED_NODE);
   node.computation = computation;
+
+  if (equal !== undefined) {
+    node.equal = equal;
+  }
 
   const computed = () => {
     // Check if the value needs updating before returning it.

--- a/packages/core/primitives/signals/src/signal.ts
+++ b/packages/core/primitives/signals/src/signal.ts
@@ -46,9 +46,12 @@ export interface SignalGetter<T> extends SignalBaseGetter<T> {
 /**
  * Create a `Signal` that can be set or updated directly.
  */
-export function createSignal<T>(initialValue: T): SignalGetter<T> {
+export function createSignal<T>(initialValue: T, equal?: ValueEqualityFn<T>): SignalGetter<T> {
   const node: SignalNode<T> = Object.create(SIGNAL_NODE);
   node.value = initialValue;
+  if (equal !== undefined) {
+    node.equal = equal;
+  }
   const getter = (() => {
     producerAccessed(node);
     return node.value;


### PR DESCRIPTION
This change moves more logic to the primitives package by pushing the equal configuration on a reactive node to the signal and computed creation utilities.
