### PR TITLE
fix(router): Add missing types to transition

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -1115,6 +1115,7 @@ export interface ViewTransitionInfo {
         ready: Promise<void>;
         updateCallbackDone: Promise<void>;
         skipTransition(): void;
+        readonly types: Set<string>;
     };
 }
 

--- a/packages/router/src/utils/view_transition.ts
+++ b/packages/router/src/utils/view_transition.ts
@@ -80,6 +80,12 @@ export interface ViewTransitionInfo {
      * @see https://developer.mozilla.org/en-US/docs/Web/API/ViewTransition/skipTransition
      */
     skipTransition(): void;
+
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/ViewTransition#browser_compatibility
+     * @see https://developer.chrome.com/docs/web-platform/view-transitions/same-document#default_style_and_transition_reference
+     */
+    readonly types: Set<string>;
   };
   /**
    * The `ActivatedRouteSnapshot` that the navigation is transitioning from.
@@ -125,7 +131,8 @@ export function createViewTransition(
       // routes (the DOM update). This view transition waits for the next change detection to
       // complete (below), which includes the update phase of the routed components.
       return createRenderPromise(injector);
-    });
+      // TODO(atscott): Types in DefinitelyTyped are not up-to-date
+    }) as ViewTransition & {readonly types: Set<string>};
     const {onViewTransitionCreated} = transitionOptions;
     if (onViewTransitionCreated) {
       runInInjectionContext(injector, () => onViewTransitionCreated({transition, from, to}));


### PR DESCRIPTION
The 'types' property was added recently and is available in all browsers that support view transitions

fixes #60285
