### PR TITLE
fix(platform-server): add missing peer dependency for `rxjs`

### DIFF
--- a/packages/platform-server/package.json
+++ b/packages/platform-server/package.json
@@ -11,7 +11,8 @@
     "@angular/common": "0.0.0-PLACEHOLDER",
     "@angular/compiler": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-PLACEHOLDER",
-    "@angular/platform-browser": "0.0.0-PLACEHOLDER"
+    "@angular/platform-browser": "0.0.0-PLACEHOLDER",
+    "rxjs": "^6.5.3 || ^7.4.0"
   },
   "dependencies": {
     "tslib": "^2.3.0",


### PR DESCRIPTION
The server package imports from `rxjs`, but the dependency was not specified as `peerDependency`, nor `dependency`. This surfaces as an error in strict dependency environments, like with pnpm's symlinked node modules structure.

This commit fixes this. It presumably doesn't fail with e.g. Yarn, or npm because of node modules hoisting.