### PR TITLE
refactor(platform-browser): remove empty `deps` lists

### DIFF
--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -186,7 +186,7 @@ export function _document(): any {
 const INTERNAL_BROWSER_PLATFORM_PROVIDERS: StaticProvider[] = [
   {provide: PLATFORM_ID, useValue: PLATFORM_BROWSER_ID},
   {provide: PLATFORM_INITIALIZER, useValue: initDomAdapter, multi: true},
-  {provide: DOCUMENT, useFactory: _document, deps: []},
+  {provide: DOCUMENT, useFactory: _document},
 ];
 
 /**
@@ -212,7 +212,6 @@ const TESTABILITY_PROVIDERS = [
   {
     provide: TESTABILITY_GETTER,
     useClass: BrowserGetTestability,
-    deps: [],
   },
   {
     provide: TESTABILITY,
@@ -228,7 +227,7 @@ const TESTABILITY_PROVIDERS = [
 
 const BROWSER_MODULE_PROVIDERS: Provider[] = [
   {provide: INJECTOR_SCOPE, useValue: 'root'},
-  {provide: ErrorHandler, useFactory: errorHandler, deps: []},
+  {provide: ErrorHandler, useFactory: errorHandler},
   {
     provide: EVENT_MANAGER_PLUGINS,
     useClass: DomEventsPlugin,
@@ -240,7 +239,7 @@ const BROWSER_MODULE_PROVIDERS: Provider[] = [
   SharedStylesHost,
   EventManager,
   {provide: RendererFactory2, useExisting: DomRendererFactory2},
-  {provide: XhrFactory, useClass: BrowserXhr, deps: []},
+  {provide: XhrFactory, useClass: BrowserXhr},
   typeof ngDevMode === 'undefined' || ngDevMode
     ? {provide: BROWSER_MODULE_PROVIDERS_MARKER, useValue: true}
     : [],

--- a/packages/platform-browser/src/dom/events/hammer_gestures.ts
+++ b/packages/platform-browser/src/dom/events/hammer_gestures.ts
@@ -312,7 +312,7 @@ export class HammerGesturesPlugin extends EventManagerPlugin {
       multi: true,
       deps: [DOCUMENT, HAMMER_GESTURE_CONFIG, Injector, [new Optional(), HAMMER_LOADER]],
     },
-    {provide: HAMMER_GESTURE_CONFIG, useClass: HammerGestureConfig, deps: []},
+    {provide: HAMMER_GESTURE_CONFIG, useClass: HammerGestureConfig},
   ],
 })
 export class HammerModule {}


### PR DESCRIPTION
Removes empty `deps` lists in platform-browser providers.