### PR TITLE
refactor(core): Add recommendation for string tokens on `@Inject`

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -910,7 +910,10 @@ export interface InjectableType<T> extends Type<T> {
 
 // @public
 export interface InjectDecorator {
+    (token: string): any;
     (token: any): any;
+    // (undocumented)
+    new (token: string): Inject;
     // (undocumented)
     new (token: any): Inject;
 }

--- a/packages/core/src/di/metadata.ts
+++ b/packages/core/src/di/metadata.ts
@@ -18,6 +18,14 @@ import {DecoratorFlags, InternalInjectFlags} from './interface/injector';
  */
 export interface InjectDecorator {
   /**
+   * Warning: String tokens are not recommended.
+   *
+   * Use an InjectionToken or a class as a token instead.
+   */
+  (token: string): any;
+  new (token: string): Inject;
+
+  /**
    * Parameter decorator on a dependency parameter of a class constructor
    * that specifies a custom provider of the dependency.
    *


### PR DESCRIPTION
While still being supported because of ngUpgrade, string tokens are not recommended. Developers should use InjectionTokens or classes as tokens instead.
