### PR TITLE
docs: remove mention of #59443 in 19.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,10 +127,6 @@
 | -- | -- | -- |
 | [5b20bab96d](https://github.com/angular/angular/commit/5b20bab96d20fe89b5cc4b4af28edbaae2604da1) | feat | Add Skip Hydration diagnostic. ([#59576](https://github.com/angular/angular/pull/59576)) |
 | [fe8a68329b](https://github.com/angular/angular/commit/fe8a68329b50363f914a728579392f3fc68670a6) | feat | support untagged template literals in expressions ([#59230](https://github.com/angular/angular/pull/59230)) |
-### compiler-cli
-| Commit | Type | Description |
-| -- | -- | -- |
-| [ed705a856a](https://github.com/angular/angular/commit/ed705a856a164f91d33e2173b4f371329d07c472) | feat | detect missing structural directive imports ([#59443](https://github.com/angular/angular/pull/59443)) |
 ### core
 | Commit | Type | Description |
 | -- | -- | -- |


### PR DESCRIPTION
#59443 was reverted for breaking projects in G3.
