### PR TITLE
feat(core): add hook for producer creation side effects

### DIFF
--- a/goldens/public-api/core/primitives/signals/index.api.md
+++ b/goldens/public-api/core/primitives/signals/index.api.md
@@ -107,6 +107,9 @@ export interface Reactive {
 // @public (undocumented)
 export const REACTIVE_NODE: ReactiveNode;
 
+// @public (undocumented)
+export type ReactiveHookFn = (node: ReactiveNode) => void;
+
 // @public
 export interface ReactiveNode {
     consumerAllowSignalWrites: boolean;
@@ -132,7 +135,10 @@ export interface ReactiveNode {
 }
 
 // @public (undocumented)
-export function runPostSignalSetFn(): void;
+export function runPostProducerCreatedFn(node: ReactiveNode): void;
+
+// @public (undocumented)
+export function runPostSignalSetFn<T>(node: SignalNode<T>): void;
 
 // @public (undocumented)
 export function setActiveConsumer(consumer: ReactiveNode | null): ReactiveNode | null;
@@ -141,7 +147,10 @@ export function setActiveConsumer(consumer: ReactiveNode | null): ReactiveNode |
 export function setAlternateWeakRefImpl(impl: unknown): void;
 
 // @public (undocumented)
-export function setPostSignalSetFn(fn: (() => void) | null): (() => void) | null;
+export function setPostProducerCreatedFn(fn: ReactiveHookFn | null): ReactiveHookFn | null;
+
+// @public (undocumented)
+export function setPostSignalSetFn(fn: ReactiveHookFn | null): ReactiveHookFn | null;
 
 // @public (undocumented)
 export function setThrowInvalidWriteToSignalError(fn: <T>(node: SignalNode<T>) => never): void;

--- a/packages/core/primitives/signals/index.ts
+++ b/packages/core/primitives/signals/index.ts
@@ -20,6 +20,7 @@ export {setThrowInvalidWriteToSignalError} from './src/errors';
 export {
   REACTIVE_NODE,
   Reactive,
+  ReactiveHookFn,
   ReactiveNode,
   SIGNAL,
   consumerAfterComputation,
@@ -36,7 +37,9 @@ export {
   producerNotifyConsumers,
   producerUpdateValueVersion,
   producerUpdatesAllowed,
+  runPostProducerCreatedFn,
   setActiveConsumer,
+  setPostProducerCreatedFn,
 } from './src/graph';
 export {
   SIGNAL_NODE,

--- a/packages/core/primitives/signals/src/computed.ts
+++ b/packages/core/primitives/signals/src/computed.ts
@@ -16,6 +16,7 @@ import {
   ReactiveNode,
   setActiveConsumer,
   SIGNAL,
+  runPostProducerCreatedFn,
 } from './graph';
 
 /**
@@ -76,6 +77,7 @@ export function createComputed<T>(
     return node.value;
   };
   (computed as ComputedGetter<T>)[SIGNAL] = node;
+  runPostProducerCreatedFn(node);
   return computed as unknown as ComputedGetter<T>;
 }
 

--- a/packages/core/primitives/signals/src/graph.ts
+++ b/packages/core/primitives/signals/src/graph.ts
@@ -25,6 +25,13 @@ type Version = number & {__brand: 'Version'};
  */
 let epoch: Version = 1 as Version;
 
+export type ReactiveHookFn = (node: ReactiveNode) => void;
+
+/**
+ * If set, called after a producer `ReactiveNode` is created.
+ */
+let postProducerCreatedFn: ReactiveHookFn | null = null;
+
 /**
  * Symbol used to tell `Signal`s apart from other functions.
  *
@@ -526,4 +533,14 @@ function assertProducerNode(node: ReactiveNode): asserts node is ProducerNode {
 
 function isConsumerNode(node: ReactiveNode): node is ConsumerNode {
   return node.producerNode !== undefined;
+}
+
+export function runPostProducerCreatedFn(node: ReactiveNode): void {
+  postProducerCreatedFn?.(node);
+}
+
+export function setPostProducerCreatedFn(fn: ReactiveHookFn | null): ReactiveHookFn | null {
+  const prev = postProducerCreatedFn;
+  postProducerCreatedFn = fn;
+  return prev;
 }

--- a/packages/core/primitives/signals/src/linked_signal.ts
+++ b/packages/core/primitives/signals/src/linked_signal.ts
@@ -16,6 +16,7 @@ import {
   producerUpdateValueVersion,
   REACTIVE_NODE,
   ReactiveNode,
+  runPostProducerCreatedFn,
   SIGNAL,
 } from './graph';
 import {signalSetFn, signalUpdateFn} from './signal';
@@ -86,7 +87,7 @@ export function createLinkedSignal<S, D>(
 
   const getter = linkedSignalGetter as LinkedSignalGetter<S, D>;
   getter[SIGNAL] = node;
-
+  runPostProducerCreatedFn(node);
   return getter;
 }
 

--- a/packages/core/primitives/signals/src/signal.ts
+++ b/packages/core/primitives/signals/src/signal.ts
@@ -15,6 +15,8 @@ import {
   producerUpdatesAllowed,
   REACTIVE_NODE,
   ReactiveNode,
+  ReactiveHookFn,
+  runPostProducerCreatedFn,
   SIGNAL,
 } from './graph';
 
@@ -28,7 +30,7 @@ declare const ngDevMode: boolean | undefined;
  * This hook can be used to achieve various effects, such as running effects synchronously as part
  * of setting a signal.
  */
-let postSignalSetFn: (() => void) | null = null;
+let postSignalSetFn: ReactiveHookFn | null = null;
 
 export interface SignalNode<T> extends ReactiveNode {
   value: T;
@@ -57,10 +59,11 @@ export function createSignal<T>(initialValue: T, equal?: ValueEqualityFn<T>): Si
     return node.value;
   }) as SignalGetter<T>;
   (getter as any)[SIGNAL] = node;
+  runPostProducerCreatedFn(node);
   return getter;
 }
 
-export function setPostSignalSetFn(fn: (() => void) | null): (() => void) | null {
+export function setPostSignalSetFn(fn: ReactiveHookFn | null): ReactiveHookFn | null {
   const prev = postSignalSetFn;
   postSignalSetFn = fn;
   return prev;
@@ -90,8 +93,8 @@ export function signalUpdateFn<T>(node: SignalNode<T>, updater: (value: T) => T)
   signalSetFn(node, updater(node.value));
 }
 
-export function runPostSignalSetFn(): void {
-  postSignalSetFn?.();
+export function runPostSignalSetFn<T>(node: SignalNode<T>): void {
+  postSignalSetFn?.(node);
 }
 
 // Note: Using an IIFE here to ensure that the spread assignment is not considered
@@ -110,5 +113,5 @@ function signalValueChanged<T>(node: SignalNode<T>): void {
   node.version++;
   producerIncrementEpoch();
   producerNotifyConsumers(node);
-  postSignalSetFn?.();
+  postSignalSetFn?.(node);
 }

--- a/packages/core/test/signals/computed_spec.ts
+++ b/packages/core/test/signals/computed_spec.ts
@@ -7,7 +7,13 @@
  */
 
 import {computed, signal} from '@angular/core';
-import {createWatch, ReactiveNode, SIGNAL, defaultEquals} from '@angular/core/primitives/signals';
+import {
+  createWatch,
+  ReactiveNode,
+  SIGNAL,
+  defaultEquals,
+  setPostProducerCreatedFn,
+} from '@angular/core/primitives/signals';
 
 describe('computed', () => {
   it('should create computed', () => {
@@ -316,5 +322,15 @@ describe('computed', () => {
       source.set(2);
       expect(derived()).toBe(2);
     });
+  });
+
+  it('should call the post-producer-created fn when signal is called', () => {
+    const producerKindsCreated: string[] = [];
+    const prev = setPostProducerCreatedFn((node) => producerKindsCreated.push(node.kind));
+    const count = signal(0);
+    computed(() => count() % 2 === 0);
+
+    expect(producerKindsCreated).toEqual(['signal', 'computed']);
+    setPostProducerCreatedFn(prev);
   });
 });

--- a/packages/core/test/signals/linked_signal_spec.ts
+++ b/packages/core/test/signals/linked_signal_spec.ts
@@ -7,6 +7,7 @@
  */
 
 import {isSignal, linkedSignal, signal, computed} from '@angular/core';
+import {setPostProducerCreatedFn} from '@angular/core/primitives/signals';
 import {testingEffect} from './effect_util';
 
 describe('linkedSignal', () => {
@@ -274,5 +275,15 @@ describe('linkedSignal', () => {
 
     choice.set('explicit');
     expect(choice()).toBe('explicit');
+  });
+
+  it('should call the post-producer-created fn when signal is called', () => {
+    let producers = 0;
+    const prev = setPostProducerCreatedFn(() => producers++);
+    const options = signal(['apple', 'banana', 'fig']);
+    linkedSignal(() => options()[0]);
+
+    expect(producers).toBe(2);
+    setPostProducerCreatedFn(prev);
   });
 });

--- a/packages/core/test/signals/signal_spec.ts
+++ b/packages/core/test/signals/signal_spec.ts
@@ -7,7 +7,13 @@
  */
 
 import {computed, signal} from '@angular/core';
-import {ReactiveNode, setPostSignalSetFn, SIGNAL} from '@angular/core/primitives/signals';
+import {
+  ReactiveHookFn,
+  ReactiveNode,
+  setPostProducerCreatedFn,
+  setPostSignalSetFn,
+  SIGNAL,
+} from '@angular/core/primitives/signals';
 
 describe('signals', () => {
   it('should be a getter which reflects the set value', () => {
@@ -166,7 +172,7 @@ describe('signals', () => {
   });
 
   describe('post-signal-set functions', () => {
-    let prevPostSignalSetFn: (() => void) | null = null;
+    let prevPostSignalSetFn: ReactiveHookFn | null = null;
     let log: number;
     beforeEach(() => {
       log = 0;
@@ -197,5 +203,25 @@ describe('signals', () => {
       counter.set(0);
       expect(log).toBe(0);
     });
+
+    it('should pass post-signal-set fn the node that was updated', () => {
+      const counter = signal(0, {debugName: 'test-signal'});
+      let node: ReactiveNode | null = null;
+      setPostSignalSetFn((n: ReactiveNode) => {
+        node = n;
+      });
+
+      counter.set(1);
+      expect(node!.debugName).toBe('test-signal');
+    });
+  });
+
+  it('should call the post-producer-created fn when signal is called', () => {
+    const producerKindsCreated: string[] = [];
+    const prev = setPostProducerCreatedFn((node) => producerKindsCreated.push(node.kind));
+    signal(0);
+
+    expect(producerKindsCreated).toEqual(['signal']);
+    setPostProducerCreatedFn(prev);
   });
 });


### PR DESCRIPTION
Adds a hook in the same style as `postSignalSetFn` for running side effects when a producer has been created. This hook will be passed the reactive node being created.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
No hook exists to notify frameworks when producers are created.

Issue Number: N/A


## What is the new behavior?
A hook exists to notify frameworks when producers are created.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
