### PR TITLE
test(core): reduce test flakiness by increasing allowed time delta

### DIFF
--- a/packages/core/test/zone/ng_zone_spec.ts
+++ b/packages/core/test/zone/ng_zone_spec.ts
@@ -977,7 +977,7 @@ function commonTests() {
         });
       });
       await transition.finished;
-      expect(performance.now() - startTime).toBeLessThan(1000);
+      expect(performance.now() - startTime).toBeLessThan(2000);
     });
 
     describe('shouldCoalesceRunChangeDetection = false, shouldCoalesceEventChangeDetection = false', () => {


### PR DESCRIPTION
This commit updates an expected delta range for a duration of a view transition to reduce flakiness of that test.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No