### PR TITLE
refactor(core): tree-shake `getNgModuleDef` error

### DIFF
--- a/packages/core/src/render3/def_getters.ts
+++ b/packages/core/src/render3/def_getters.ts
@@ -13,11 +13,13 @@ import {stringify} from '../util/stringify';
 import {NG_COMP_DEF, NG_DIR_DEF, NG_MOD_DEF, NG_PIPE_DEF} from './fields';
 import type {ComponentDef, DirectiveDef, PipeDef} from './interfaces/definition';
 
-export function getNgModuleDef<T>(type: any, throwIfNotFound: true): NgModuleDef<T>;
-export function getNgModuleDef<T>(type: any): NgModuleDef<T> | null;
-export function getNgModuleDef<T>(type: any, throwIfNotFound?: boolean): NgModuleDef<T> | null {
-  const ngModuleDef = type[NG_MOD_DEF] || null;
-  if (!ngModuleDef && throwIfNotFound) {
+export function getNgModuleDef<T>(type: any): NgModuleDef<T> | null {
+  return type[NG_MOD_DEF] || null;
+}
+
+export function getNgModuleDefOrThrow<T>(type: any): NgModuleDef<T> | never {
+  const ngModuleDef = getNgModuleDef<T>(type);
+  if (!ngModuleDef) {
     throw new RuntimeError(
       RuntimeErrorCode.MISSING_NG_MODULE_DEFINITION,
       (typeof ngDevMode === 'undefined' || ngDevMode) &&

--- a/packages/core/src/render3/deps_tracker/deps_tracker.ts
+++ b/packages/core/src/render3/deps_tracker/deps_tracker.ts
@@ -17,7 +17,7 @@ import type {
   RawScopeInfoFromDecorator,
 } from '../interfaces/definition';
 import {isComponent, isDirective, isNgModule, isPipe, verifyStandaloneImport} from '../jit/util';
-import {getComponentDef, getNgModuleDef, isStandalone} from '../def_getters';
+import {getComponentDef, getNgModuleDef, getNgModuleDefOrThrow, isStandalone} from '../def_getters';
 import {maybeUnwrapFn} from '../util/misc_utils';
 
 import {
@@ -150,7 +150,7 @@ class DepsTracker implements DepsTrackerApi {
 
   /** Compute NgModule scope afresh. */
   private computeNgModuleScope(type: NgModuleType<any>): NgModuleScope {
-    const def = getNgModuleDef(type, true);
+    const def = getNgModuleDefOrThrow(type);
     const scope: NgModuleScope = {
       exported: {directives: new Set(), pipes: new Set()},
       compilation: {directives: new Set(), pipes: new Set()},

--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -31,6 +31,7 @@ import {
   getComponentDef,
   getDirectiveDef,
   getNgModuleDef,
+  getNgModuleDefOrThrow,
   getPipeDef,
   isStandalone,
 } from '../def_getters';
@@ -253,7 +254,7 @@ function verifySemanticsOfNgModuleDef(
       );
     }
   } else {
-    ngModuleDef = getNgModuleDef(moduleType, true);
+    ngModuleDef = getNgModuleDefOrThrow(moduleType);
   }
   const errors: string[] = [];
   const declarations = maybeUnwrapFn(ngModuleDef.declarations);
@@ -553,7 +554,7 @@ export function transitiveScopesFor<T>(type: Type<T>): NgModuleTransitiveScopes 
   if (isNgModule(type)) {
     if (USE_RUNTIME_DEPS_TRACKER_FOR_JIT) {
       const scope = depsTracker.getNgModuleScope(type);
-      const def = getNgModuleDef(type, true);
+      const def = getNgModuleDefOrThrow(type);
       return {
         schemas: def.schemas || null,
         ...scope,
@@ -607,7 +608,7 @@ export function transitiveScopesFor<T>(type: Type<T>): NgModuleTransitiveScopes 
  * @param moduleType module that transitive scope should be calculated for.
  */
 export function transitiveScopesForNgModule<T>(moduleType: Type<T>): NgModuleTransitiveScopes {
-  const def = getNgModuleDef(moduleType, true);
+  const def = getNgModuleDefOrThrow(moduleType);
 
   if (def.transitiveCompileScopes !== null) {
     return def.transitiveCompileScopes;

--- a/packages/core/src/render3/scope.ts
+++ b/packages/core/src/render3/scope.ts
@@ -11,7 +11,7 @@ import {Type} from '../interface/type';
 import {flatten} from '../util/array_utils';
 import {noSideEffects} from '../util/closure';
 import {EMPTY_ARRAY} from '../util/empty';
-import {getNgModuleDef} from './def_getters';
+import {getNgModuleDefOrThrow} from './def_getters';
 
 import {extractDefListOrFactory} from './definition';
 import {depsTracker} from './deps_tracker/deps_tracker';
@@ -54,7 +54,7 @@ export function ɵɵsetComponentScope(
  */
 export function ɵɵsetNgModuleScope(type: any, scope: NgModuleScopeInfoFromDecorator): unknown {
   return noSideEffects(() => {
-    const ngModuleDef = getNgModuleDef(type, true);
+    const ngModuleDef = getNgModuleDefOrThrow(type);
     ngModuleDef.declarations = convertToTypeArray(scope.declarations || EMPTY_ARRAY);
     ngModuleDef.imports = convertToTypeArray(scope.imports || EMPTY_ARRAY);
     ngModuleDef.exports = convertToTypeArray(scope.exports || EMPTY_ARRAY);


### PR DESCRIPTION
Currently, the error thrown in `getNgModuleDef` is guarded by `throwIfNotFound`, which is only set to `true` when `ɵɵsetNgModuleScope` is called in production. In all other cases, `throwIfNotFound` is never used in production. This means that if NgModules aren't used, `getNgModuleDef` is never called with the second argument. We can split it into two functions to allow tree-shaking of the error when NgModules aren't used at all.