### PR TITLE
ci: prevent renovate to update typescript automatically

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -55,6 +55,7 @@
     "rxjs",
     "selenium-webdriver",
     "systemjs",
+    "typescript",
     "unist-util-filter",
     "unist-util-source",
     "unist-util-visit",


### PR DESCRIPTION
This is something we usually want to do manually.
