### PR TITLE
feat(core): add support for two-way bindings on dynamically-created components

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1836,6 +1836,9 @@ export const TRANSLATIONS: InjectionToken<string>;
 export const TRANSLATIONS_FORMAT: InjectionToken<string>;
 
 // @public
+export function twoWayBinding(publicName: string, value: WritableSignal<unknown>): Binding;
+
+// @public
 export const Type: FunctionConstructor;
 
 // @public (undocumented)

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -112,7 +112,7 @@ export {
   afterNextRender,
   ɵFirstAvailable,
 } from './render3/after_render/hooks';
-export {inputBinding, outputBinding} from './render3/dynamic_bindings';
+export {inputBinding, outputBinding, twoWayBinding} from './render3/dynamic_bindings';
 export {ApplicationConfig, mergeApplicationConfig} from './application/application_config';
 export {makeStateKey, StateKey, TransferState} from './transfer_state';
 export {booleanAttribute, numberAttribute} from './util/coercion';

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -458,7 +458,8 @@ function getRootTViewTemplate(
 }
 
 function isInputBinding(binding: Binding): boolean {
-  return binding[BINDING].kind === 'input';
+  const kind = binding[BINDING].kind;
+  return kind === 'input' || kind === 'twoWay';
 }
 
 /**
@@ -498,7 +499,7 @@ export class ComponentRef<T> extends AbstractComponentRef<T> {
     if (this._hasInputBindings && ngDevMode) {
       throw new RuntimeError(
         RuntimeErrorCode.INVALID_SET_INPUT_CALL,
-        'Cannot call `setInput` on a component that is using the `inputBinding` function.',
+        'Cannot call `setInput` on a component that is using the `inputBinding` or `twoWayBinding` functions.',
       );
     }
 


### PR DESCRIPTION
Builds on the changes from #60137 to add support for two-way bindings on dynamically-created components. Example usage:

```typescript
import {createComponent, signal, twoWayBinding} from '@angular/core';

const value = signal('');

createComponent(MyCheckbox, {
  bindings: [
    twoWayBinding('value', value),
  ],
});
```

In the example above the value of `MyCheckbox` and the `value` signal will be kept in sync.
