### PR TITLE
refactor(bazel): move `.d.ts` files into a dedicated `/types` folder

### DIFF
--- a/adev/src/content/tools/libraries/angular-package-format.md
+++ b/adev/src/content/tools/libraries/angular-package-format.md
@@ -28,26 +28,26 @@ The following example shows a simplified version of the `@angular/core` package'
 node_modules/@angular/core
 ├── README.md
 ├── package.json
-├── index.d.ts
-├── fesm2022
+├── fesm2022/
 │   ├── core.mjs
 │   ├── core.mjs.map
 │   ├── testing.mjs
 │   └── testing.mjs.map
-└── testing
-    └── index.d.ts
+└── types/
+    ├── core.d.ts
+    └── testing.d.ts
 ```
 
 This table describes the file layout under `node_modules/@angular/core` annotated to describe the purpose of files and directories:
 
-| Files                                                                                                                                                     | Purpose |
-|:---                                                                                                                                                       |:---     |
-| `README.md`                                                                                                                                               | Package README, used by npmjs web UI.                                                                                                                                                                          |
-| `package.json`                                                                                                                                            | Primary `package.json`, describing the package itself as well as all available entrypoints and code formats. This file contains the "exports" mapping used by runtimes and tools to perform module resolution. |
-| `index.d.ts`                                                                                                                                               | Bundled `.d.ts` for the primary entrypoint `@angular/core`.                                                                                                                                                    |
-| `fesm2022/` <br /> &nbsp;&nbsp;─ `core.mjs` <br /> &nbsp;&nbsp;─ `core.mjs.map` <br /> &nbsp;&nbsp;─ `testing.mjs` <br /> &nbsp;&nbsp;─ `testing.mjs.map` | Code for all entrypoints in flattened \(FESM\) ES2022 format, along with source maps.                                                                                                                           |
-| `testing/`                                                                                                                                                | Directory representing the "testing" entrypoint.                                                                                                                                                               |
-| `testing/index.d.ts`                                                                                                                                    | Bundled `.d.ts` for the `@angular/core/testing` entrypoint.                                                                                                                                                     |
+| Files                                                                                                                                                                         | Purpose                                                                                                                                                                                                        |
+| :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `README.md`                                                                                                                                                                   | Package README, used by npmjs web UI.                                                                                                                                                                          |
+| `package.json`                                                                                                                                                                | Primary `package.json`, describing the package itself as well as all available entrypoints and code formats. This file contains the "exports" mapping used by runtimes and tools to perform module resolution. |
+| `fesm2022/` <br /> &nbsp;&nbsp;─&nbsp;`core.mjs` <br /> &nbsp;&nbsp;─&nbsp;`core.mjs.map` <br /> &nbsp;&nbsp;─&nbsp;`testing.mjs` <br /> &nbsp;&nbsp;─&nbsp;`testing.mjs.map` | Code for all entrypoints in flattened \(FESM\) ES2022 format, along with source maps.                                                                                                                          |
+
+| `types/`<br/>&nbsp;─&nbsp;`core.d.ts`<br/>&nbsp;─&nbsp;`testing.d.ts`
+| Directory containing all type definitions. |
 
 ## `package.json`
 
@@ -88,11 +88,11 @@ The `"exports"` field has the following structure:
     "default": "./package.json"
   },
   ".": {
-    "types": "./core.d.ts",
+    "types": "./types/core.d.ts",
     "default": "./fesm2022/core.mjs"
   },
   "./testing": {
-    "types": "./testing/testing.d.ts",
+    "types": "./types/testing.d.ts",
     "default": "./fesm2022/testing.mjs"
   }
 }
@@ -122,7 +122,7 @@ For `@angular/core` these are:
 
 {
   "module": "./fesm2022/core.mjs",
-  "typings": "./core.d.ts",
+  "typings": "./types/core.d.ts",
 }
 
 </docs-code>

--- a/adev/tsconfig.json
+++ b/adev/tsconfig.json
@@ -16,7 +16,7 @@
     "noFallthroughCasesInSwitch": true,
     "sourceMap": true,
     "declaration": false,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "ES2022",
     "module": "ES2022",
@@ -31,8 +31,8 @@
     "skipLibCheck": true,
     "paths": {
       "@angular/docs": ["./shared-docs"],
-      "@angular/*": ["../packages/*"],
-    },
+      "@angular/*": ["../packages/*"]
+    }
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,

--- a/packages/bazel/src/ng_package/ng_package.bzl
+++ b/packages/bazel/src/ng_package/ng_package.bzl
@@ -369,7 +369,6 @@ def _ng_package_impl(ctx):
             guessed_paths = True
 
         bundle_name_base = primary_bundle_name if is_primary_entry_point else entry_point
-        dts_bundle_name_base = "index" if is_primary_entry_point else "%s/index" % entry_point
 
         # Store the collected entry point in a list of all entry-points. This
         # can be later passed to the packager as a manifest.
@@ -377,8 +376,7 @@ def _ng_package_impl(ctx):
             module_name = module_name,
             es2022_entry_point = es2022_entry_point,
             fesm2022_file = "fesm2022/%s.mjs" % bundle_name_base,
-            # TODO(devversion): Put all types under `/types/` folder. Breaking change in v20.
-            dts_bundle_relative_path = "%s.d.ts" % dts_bundle_name_base,
+            dts_bundle_relative_path = "types/%s.d.ts" % bundle_name_base,
             typings_entry_point = typings_entry_point,
             guessed_paths = guessed_paths,
         ))

--- a/packages/bazel/src/ng_package/packager.ts
+++ b/packages/bazel/src/ng_package/packager.ts
@@ -168,8 +168,7 @@ function main(args: string[]): void {
   // Copy all dts files (and their potential shared chunks) into the package output.
   const dtsFiles = globSync('**/*', {cwd: metadata.dtsBundlesOut.path});
   dtsFiles.forEach((f) =>
-    // TODO(devversion): Put all types under `/types/` folder. Breaking change in v20.
-    copyFile(path.join(metadata.dtsBundlesOut.path, f), f),
+    copyFile(path.join(metadata.dtsBundlesOut.path, f), path.join('types', f)),
   );
 
   for (const file of staticFiles) {

--- a/packages/bazel/src/ng_package/rollup.config.js
+++ b/packages/bazel/src/ng_package/rollup.config.js
@@ -165,7 +165,7 @@ const input = {};
 for (const info of Object.values(entrypointMetadata)) {
   const entryFile = dtsMode ? info.typingsEntryPoint.path : info.index.path;
   const chunkName = dtsMode
-    ? info.dtsBundleRelativePath.replace(/\.d\.ts$/, '')
+    ? info.dtsBundleRelativePath.replace(/\.d\.ts$/, '').replace('types/', '')
     : info.fesm2022RelativePath.replace(/\.mjs$/, '').replace('fesm2022/', '');
 
   input[chunkName] = entryFile;

--- a/packages/bazel/test/ng_package/example/BUILD.bazel
+++ b/packages/bazel/test/ng_package/example/BUILD.bazel
@@ -31,6 +31,7 @@ ng_package(
     deps = [
         ":example",
         "//packages/bazel/test/ng_package/example/a11y",
+        "//packages/bazel/test/ng_package/example/a11y/tertiary",
         "//packages/bazel/test/ng_package/example/imports",
         "//packages/bazel/test/ng_package/example/secondary",
     ],

--- a/packages/bazel/test/ng_package/example/a11y/tertiary/BUILD.bazel
+++ b/packages/bazel/test/ng_package/example/a11y/tertiary/BUILD.bazel
@@ -1,0 +1,12 @@
+load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//packages/bazel/test:__subpackages__"])
+
+ng_module(
+    name = "tertiary",
+    srcs = glob(["*.ts"]),
+    module_name = "example/a11y/tertiary",
+    deps = [
+        "//packages/core",
+    ],
+)

--- a/packages/bazel/test/ng_package/example/a11y/tertiary/index.ts
+++ b/packages/bazel/test/ng_package/example/a11y/tertiary/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+export const tertiary = 'works';

--- a/packages/bazel/test/ng_package/example_package.golden
+++ b/packages/bazel/test/ng_package/example_package.golden
@@ -1,32 +1,35 @@
 LICENSE
 README.md
 _index.scss
-a11y
-  a11y/index.d.ts
 arbitrary-npm-package-main.js
 arbitrary_bin.txt
 arbitrary_genfiles.txt
 extra-styles.css
 fesm2022
-  fesm2022/a11y.mjs
-  fesm2022/a11y.mjs.map
-  fesm2022/example.mjs
-  fesm2022/example.mjs.map
-  fesm2022/imports.mjs
-  fesm2022/imports.mjs.map
-  fesm2022/index-D4QyjRX7.mjs
-  fesm2022/index-D4QyjRX7.mjs.map
-  fesm2022/secondary.mjs
-  fesm2022/secondary.mjs.map
-imports
-  imports/index.d.ts
-index.d-peWegT6k.d.ts
-index.d.ts
+  a11y
+    tertiary.mjs
+    tertiary.mjs.map
+  a11y.mjs
+  a11y.mjs.map
+  example.mjs
+  example.mjs.map
+  imports.mjs
+  imports.mjs.map
+  index-D4QyjRX7.mjs
+  index-D4QyjRX7.mjs.map
+  secondary.mjs
+  secondary.mjs.map
 logo.png
 package.json
-secondary
-  secondary/index.d.ts
 some-file.txt
+types
+  a11y
+    tertiary.d.ts
+  a11y.d.ts
+  example.d.ts
+  imports.d.ts
+  index.d-peWegT6k.d.ts
+  secondary.d.ts
 --- LICENSE ---
 
 The MIT License
@@ -69,25 +72,6 @@ License: MIT
 /// test file which should ship as part of the NPM package.
 
 
---- a11y/index.d.ts ---
-
-/**
- * @license Angular v0.0.0
- * (c) 2010-2025 Google LLC. https://angular.io/
- * License: MIT
- */
-
-import * as i0 from '@angular/core';
-
-declare class A11yModule {
-    static ɵfac: i0.ɵɵFactoryDeclaration<A11yModule, never>;
-    static ɵmod: i0.ɵɵNgModuleDeclaration<A11yModule, never, never, never>;
-    static ɵinj: i0.ɵɵInjectorDeclaration<A11yModule>;
-}
-
-export { A11yModule };
-
-
 --- arbitrary-npm-package-main.js ---
 
 /**
@@ -116,6 +100,20 @@ Hello
 .special {
   color: goldenrod;
 }
+
+
+--- fesm2022/a11y/tertiary.mjs ---
+
+/**
+ * @license Angular v0.0.0
+ * (c) 2010-2025 Google LLC. https://angular.io/
+ * License: MIT
+ */
+
+const tertiary = 'works';
+
+export { tertiary };
+//# sourceMappingURL=tertiary.mjs.map
 
 
 --- fesm2022/a11y.mjs ---
@@ -247,7 +245,65 @@ export { SecondaryModule, a };
 //# sourceMappingURL=secondary.mjs.map
 
 
---- imports/index.d.ts ---
+--- logo.png ---
+
+611871c1f492a69a8a5f57e01096b145
+
+--- package.json ---
+
+{
+  "name": "example",
+  "version": "0.0.0",
+  "exports": {
+    ".": {
+      "sass": "./_index.scss",
+      "types": "./types/example.d.ts",
+      "default": "./fesm2022/example.mjs"
+    },
+    "./package.json": {
+      "default": "./package.json"
+    },
+    "./a11y": {
+      "types": "./types/a11y.d.ts",
+      "default": "./fesm2022/a11y.mjs"
+    },
+    "./a11y/tertiary": {
+      "types": "./types/a11y/tertiary.d.ts",
+      "default": "./fesm2022/a11y/tertiary.mjs"
+    },
+    "./imports": {
+      "types": "./types/imports.d.ts",
+      "default": "./fesm2022/imports.mjs"
+    },
+    "./secondary": {
+      "types": "./types/secondary.d.ts",
+      "default": "./fesm2022/secondary.mjs"
+    }
+  },
+  "module": "./fesm2022/example.mjs",
+  "typings": "./types/example.d.ts",
+  "type": "module"
+}
+
+--- some-file.txt ---
+
+This file is just copied into the package.
+
+
+--- types/a11y/tertiary.d.ts ---
+
+/**
+ * @license Angular v0.0.0
+ * (c) 2010-2025 Google LLC. https://angular.io/
+ * License: MIT
+ */
+
+declare const tertiary = "works";
+
+export { tertiary };
+
+
+--- types/a11y.d.ts ---
 
 /**
  * @license Angular v0.0.0
@@ -256,37 +312,17 @@ export { SecondaryModule, a };
  */
 
 import * as i0 from '@angular/core';
-export { s as sharedBetweenEntryPoints } from '../index.d-peWegT6k.js';
 
-declare class MySecondService {
-    static ɵfac: i0.ɵɵFactoryDeclaration<MySecondService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MySecondService>;
+declare class A11yModule {
+    static ɵfac: i0.ɵɵFactoryDeclaration<A11yModule, never>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<A11yModule, never, never, never>;
+    static ɵinj: i0.ɵɵInjectorDeclaration<A11yModule>;
 }
 
-declare class MyService {
-    secondService: MySecondService;
-    constructor(secondService: MySecondService);
-    static ɵfac: i0.ɵɵFactoryDeclaration<MyService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
-}
-
-export { MyService };
+export { A11yModule };
 
 
---- index.d-peWegT6k.d.ts ---
-
-/**
- * @license Angular v0.0.0
- * (c) 2010-2025 Google LLC. https://angular.io/
- * License: MIT
- */
-
-declare const sharedBetweenEntryPoints = "This export is shared between entry-points";
-
-export { sharedBetweenEntryPoints as s };
-
-
---- index.d.ts ---
+--- types/example.d.ts ---
 
 /**
  * @license Angular v0.0.0
@@ -305,43 +341,7 @@ declare class MyModule {
 export { MyModule };
 
 
---- logo.png ---
-
-611871c1f492a69a8a5f57e01096b145
-
---- package.json ---
-
-{
-  "name": "example",
-  "version": "0.0.0",
-  "exports": {
-    ".": {
-      "sass": "./_index.scss",
-      "types": "./index.d.ts",
-      "default": "./fesm2022/example.mjs"
-    },
-    "./package.json": {
-      "default": "./package.json"
-    },
-    "./a11y": {
-      "types": "./a11y/index.d.ts",
-      "default": "./fesm2022/a11y.mjs"
-    },
-    "./imports": {
-      "types": "./imports/index.d.ts",
-      "default": "./fesm2022/imports.mjs"
-    },
-    "./secondary": {
-      "types": "./secondary/index.d.ts",
-      "default": "./fesm2022/secondary.mjs"
-    }
-  },
-  "module": "./fesm2022/example.mjs",
-  "typings": "./index.d.ts",
-  "type": "module"
-}
-
---- secondary/index.d.ts ---
+--- types/imports.d.ts ---
 
 /**
  * @license Angular v0.0.0
@@ -349,7 +349,46 @@ export { MyModule };
  * License: MIT
  */
 
-export { s as sharedBetweenEntryPoints } from '../index.d-peWegT6k.js';
+import * as i0 from '@angular/core';
+export { s as sharedBetweenEntryPoints } from './index.d-peWegT6k.js';
+
+declare class MySecondService {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MySecondService, never>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<MySecondService>;
+}
+
+declare class MyService {
+    secondService: MySecondService;
+    constructor(secondService: MySecondService);
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyService, never>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
+}
+
+export { MyService };
+
+
+--- types/index.d-peWegT6k.d.ts ---
+
+/**
+ * @license Angular v0.0.0
+ * (c) 2010-2025 Google LLC. https://angular.io/
+ * License: MIT
+ */
+
+declare const sharedBetweenEntryPoints = "This export is shared between entry-points";
+
+export { sharedBetweenEntryPoints as s };
+
+
+--- types/secondary.d.ts ---
+
+/**
+ * @license Angular v0.0.0
+ * (c) 2010-2025 Google LLC. https://angular.io/
+ * License: MIT
+ */
+
+export { s as sharedBetweenEntryPoints } from './index.d-peWegT6k.js';
 import * as i0 from '@angular/core';
 
 declare class SecondaryModule {
@@ -360,9 +399,4 @@ declare class SecondaryModule {
 declare const a = 1;
 
 export { SecondaryModule, a };
-
-
---- some-file.txt ---
-
-This file is just copied into the package.
 

--- a/packages/bazel/test/ng_package/example_package.spec.ts
+++ b/packages/bazel/test/ng_package/example_package.spec.ts
@@ -60,10 +60,7 @@ function getIndentedDirectoryStructure(directoryPath: string, depth = 0): string
       .sort()
       .forEach((f) => {
         const filePath = path.posix.join(directoryPath, f);
-        result.push(
-          '  '.repeat(depth) + filePath,
-          ...getIndentedDirectoryStructure(filePath, depth + 1),
-        );
+        result.push('  '.repeat(depth) + f, ...getIndentedDirectoryStructure(filePath, depth + 1));
       });
   }
   return result;

--- a/packages/bazel/test/ng_package/example_with_ts_library_package.golden
+++ b/packages/bazel/test/ng_package/example_with_ts_library_package.golden
@@ -1,18 +1,17 @@
 LICENSE
 README.md
 fesm2022
-  fesm2022/example-with-ts-library.mjs
-  fesm2022/example-with-ts-library.mjs.map
-  fesm2022/portal.mjs
-  fesm2022/portal.mjs.map
-  fesm2022/utils.mjs
-  fesm2022/utils.mjs.map
-index.d.ts
+  example-with-ts-library.mjs
+  example-with-ts-library.mjs.map
+  portal.mjs
+  portal.mjs.map
+  utils.mjs
+  utils.mjs.map
 package.json
-portal
-  portal/index.d.ts
-utils
-  utils/index.d.ts
+types
+  example-with-ts-library.d.ts
+  portal.d.ts
+  utils.d.ts
 --- LICENSE ---
 
 The MIT License
@@ -106,7 +105,35 @@ export { dispatchFakeEvent };
 //# sourceMappingURL=utils.mjs.map
 
 
---- index.d.ts ---
+--- package.json ---
+
+{
+  "name": "example-with-ts-library",
+  "version": "0.0.0",
+  "schematics": "Custom property that should be preserved.",
+  "module": "./fesm2022/example-with-ts-library.mjs",
+  "typings": "./types/example-with-ts-library.d.ts",
+  "type": "module",
+  "exports": {
+    "./package.json": {
+      "default": "./package.json"
+    },
+    ".": {
+      "types": "./types/example-with-ts-library.d.ts",
+      "default": "./fesm2022/example-with-ts-library.mjs"
+    },
+    "./portal": {
+      "types": "./types/portal.d.ts",
+      "default": "./fesm2022/portal.mjs"
+    },
+    "./utils": {
+      "types": "./types/utils.d.ts",
+      "default": "./fesm2022/utils.mjs"
+    }
+  }
+}
+
+--- types/example-with-ts-library.d.ts ---
 
 /**
  * @license Angular v0.0.0
@@ -119,35 +146,7 @@ declare const VERSION = "0.0.0";
 export { VERSION };
 
 
---- package.json ---
-
-{
-  "name": "example-with-ts-library",
-  "version": "0.0.0",
-  "schematics": "Custom property that should be preserved.",
-  "module": "./fesm2022/example-with-ts-library.mjs",
-  "typings": "./index.d.ts",
-  "type": "module",
-  "exports": {
-    "./package.json": {
-      "default": "./package.json"
-    },
-    ".": {
-      "types": "./index.d.ts",
-      "default": "./fesm2022/example-with-ts-library.mjs"
-    },
-    "./portal": {
-      "types": "./portal/index.d.ts",
-      "default": "./fesm2022/portal.mjs"
-    },
-    "./utils": {
-      "types": "./utils/index.d.ts",
-      "default": "./fesm2022/utils.mjs"
-    }
-  }
-}
-
---- portal/index.d.ts ---
+--- types/portal.d.ts ---
 
 /**
  * @license Angular v0.0.0
@@ -167,7 +166,7 @@ declare const a = 1;
 export { PortalModule, a };
 
 
---- utils/index.d.ts ---
+--- types/utils.d.ts ---
 
 /**
  * @license Angular v0.0.0

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -159,11 +159,11 @@ export function angularCoreDtsFiles(): TestFile[] {
   return [
     {
       name: absoluteFrom('/node_modules/@angular/core/index.d.ts'),
-      contents: readFileSync(path.join(directory, 'index.d.ts'), 'utf8'),
+      contents: readFileSync(path.join(directory, 'types/core.d.ts'), 'utf8'),
     },
     {
       name: absoluteFrom('/node_modules/@angular/core/primitives/signals/index.d.ts'),
-      contents: readFileSync(path.join(directory, 'primitives/signals/index.d.ts'), 'utf8'),
+      contents: readFileSync(path.join(directory, 'types/primitives/signals.d.ts'), 'utf8'),
     },
   ];
 }

--- a/packages/compiler-cli/test/compliance/test_helpers/compile_test.ts
+++ b/packages/compiler-cli/test/compliance/test_helpers/compile_test.ts
@@ -132,7 +132,7 @@ function getOptions(
     target: ts.ScriptTarget.ES2015,
     newLine: ts.NewLineKind.LineFeed,
     module: ts.ModuleKind.ES2015,
-    moduleResolution: ts.ModuleResolutionKind.Node10,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
     typeRoots: ['node_modules/@types'],
     ...convertedCompilerOptions.options,
     enableI18nLegacyMessageIdFormat: false,


### PR DESCRIPTION
This is a breaking change we want to make for v20, to clean-up and advance our APF format further. The types will not be mixed with other files in the package, but instead will be living inside a dedicated `/types/` folder.

This makes it very easy to discover type bundles for entry-points and generally makes the package more "browsable"/"discoverable".

BREAKING CHANGE: Angular Package Format (APF) is updated for v20 to fully rely on `package.json` `exports`. This will not affect the majority of users, relying on the CLI, but custom tooling that is relying on TypeScript's old "node10" module resolution will end up failing. The solution is to update to "node16" as the resolution mechanism (as this one will then respect the "exports" field).

<img width="735" alt="Screenshot 2025-03-12 at 12 28 28" src="https://github.com/user-attachments/assets/d3a05879-2529-46bd-9021-44b7551859e8" />


TODO: A migration for ensuring people use `bundler` module resolution