### PR TITLE
fix(router): relax required types on router commands

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -207,7 +207,7 @@ export type ComponentInputBindingFeature = RouterFeature<RouterFeatureKind.Compo
 export function convertToParamMap(params: Params): ParamMap;
 
 // @public
-export function createUrlTreeFromSnapshot(relativeTo: ActivatedRouteSnapshot, commands: any[], queryParams?: Params | null, fragment?: string | null): UrlTree;
+export function createUrlTreeFromSnapshot(relativeTo: ActivatedRouteSnapshot, commands: readonly any[], queryParams?: Params | null, fragment?: string | null): UrlTree;
 
 // @public
 export type Data = {
@@ -710,7 +710,7 @@ export class Router {
     readonly componentInputBindingEnabled: boolean;
     // (undocumented)
     config: Routes;
-    createUrlTree(commands: any[], navigationExtras?: UrlCreationOptions): UrlTree;
+    createUrlTree(commands: readonly any[], navigationExtras?: UrlCreationOptions): UrlTree;
     dispose(): void;
     get events(): Observable<Event_2>;
     getCurrentNavigation(): Navigation | null;
@@ -719,7 +719,7 @@ export class Router {
     isActive(url: string | UrlTree, exact: boolean): boolean;
     isActive(url: string | UrlTree, matchOptions: IsActiveMatchOptions): boolean;
     get lastSuccessfulNavigation(): Navigation | null;
-    navigate(commands: any[], extras?: NavigationExtras): Promise<boolean>;
+    navigate(commands: readonly any[], extras?: NavigationExtras): Promise<boolean>;
     navigateByUrl(url: string | UrlTree, extras?: NavigationBehaviorOptions): Promise<boolean>;
     navigated: boolean;
     // (undocumented)
@@ -821,7 +821,7 @@ class RouterLink implements OnChanges, OnDestroy {
     queryParamsHandling?: QueryParamsHandling | null;
     relativeTo?: ActivatedRoute | null;
     replaceUrl: boolean;
-    set routerLink(commandsOrUrlTree: any[] | string | UrlTree | null | undefined);
+    set routerLink(commandsOrUrlTree: readonly any[] | string | UrlTree | null | undefined);
     skipLocationChange: boolean;
     state?: {
         [k: string]: any;

--- a/packages/router/src/create_url_tree.ts
+++ b/packages/router/src/create_url_tree.ts
@@ -67,7 +67,7 @@ import {last, shallowEqual} from './utils/collection';
  */
 export function createUrlTreeFromSnapshot(
   relativeTo: ActivatedRouteSnapshot,
-  commands: any[],
+  commands: readonly any[],
   queryParams: Params | null = null,
   fragment: string | null = null,
 ): UrlTree {
@@ -100,7 +100,7 @@ export function createSegmentGroupFromRoute(route: ActivatedRouteSnapshot): UrlS
 
 export function createUrlTreeFromSegmentGroup(
   relativeTo: UrlSegmentGroup,
-  commands: any[],
+  commands: readonly any[],
   queryParams: Params | null,
   fragment: string | null,
 ): UrlTree {
@@ -192,7 +192,7 @@ class Navigation {
   constructor(
     public isAbsolute: boolean,
     public numberOfDoubleDots: number,
-    public commands: any[],
+    public commands: readonly any[],
   ) {
     if (isAbsolute && commands.length > 0 && isMatrixParams(commands[0])) {
       throw new RuntimeError(
@@ -218,7 +218,7 @@ class Navigation {
 }
 
 /** Transforms commands to a normalized `Navigation` */
-function computeNavigation(commands: any[]): Navigation {
+function computeNavigation(commands: readonly any[]): Navigation {
   if (typeof commands[0] === 'string' && commands.length === 1 && commands[0] === '/') {
     return new Navigation(true, 0, commands);
   }
@@ -324,7 +324,7 @@ function createPositionApplyingDoubleDots(
   return new Position(g, false, ci - dd);
 }
 
-function getOutlets(commands: unknown[]): {[k: string]: unknown[] | string} {
+function getOutlets(commands: readonly unknown[]): {[k: string]: readonly unknown[] | string} {
   if (isCommandWithOutlets(commands[0])) {
     return commands[0].outlets;
   }
@@ -335,7 +335,7 @@ function getOutlets(commands: unknown[]): {[k: string]: unknown[] | string} {
 function updateSegmentGroup(
   segmentGroup: UrlSegmentGroup | undefined,
   startIndex: number,
-  commands: any[],
+  commands: readonly any[],
 ): UrlSegmentGroup {
   segmentGroup ??= new UrlSegmentGroup([], {});
   if (segmentGroup.segments.length === 0 && segmentGroup.hasChildren()) {
@@ -365,7 +365,7 @@ function updateSegmentGroup(
 function updateSegmentGroupChildren(
   segmentGroup: UrlSegmentGroup,
   startIndex: number,
-  commands: any[],
+  commands: readonly any[],
 ): UrlSegmentGroup {
   if (commands.length === 0) {
     return new UrlSegmentGroup(segmentGroup.segments, {});
@@ -425,7 +425,7 @@ function updateSegmentGroupChildren(
   }
 }
 
-function prefixedWith(segmentGroup: UrlSegmentGroup, startIndex: number, commands: any[]) {
+function prefixedWith(segmentGroup: UrlSegmentGroup, startIndex: number, commands: readonly any[]) {
   let currentCommandIndex = 0;
   let currentPathIndex = startIndex;
 
@@ -462,7 +462,7 @@ function prefixedWith(segmentGroup: UrlSegmentGroup, startIndex: number, command
 function createNewSegmentGroup(
   segmentGroup: UrlSegmentGroup,
   startIndex: number,
-  commands: any[],
+  commands: readonly any[],
 ): UrlSegmentGroup {
   const paths = segmentGroup.segments.slice(0, startIndex);
 
@@ -495,7 +495,7 @@ function createNewSegmentGroup(
   return new UrlSegmentGroup(paths, {});
 }
 
-function createNewSegmentChildren(outlets: {[name: string]: unknown[] | string}): {
+function createNewSegmentChildren(outlets: {[name: string]: readonly unknown[] | string}): {
   [outlet: string]: UrlSegmentGroup;
 } {
   const children: {[outlet: string]: UrlSegmentGroup} = {};

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -309,7 +309,7 @@ export class RouterLink implements OnChanges, OnDestroy {
     this.onChanges.next(this);
   }
 
-  private routerLinkInput: any[] | UrlTree | null = null;
+  private routerLinkInput: readonly any[] | UrlTree | null = null;
 
   /**
    * Commands to pass to {@link Router#createUrlTree} or a `UrlTree`.
@@ -321,7 +321,7 @@ export class RouterLink implements OnChanges, OnDestroy {
    * @see {@link Router#createUrlTree}
    */
   @Input()
-  set routerLink(commandsOrUrlTree: any[] | string | UrlTree | null | undefined) {
+  set routerLink(commandsOrUrlTree: readonly any[] | string | UrlTree | null | undefined) {
     if (commandsOrUrlTree == null) {
       this.routerLinkInput = null;
       this.setTabIndexIfNotOnNativeEl(null);

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -438,7 +438,7 @@ export class Router {
    * tree should be created relative to the root.
    * ```
    */
-  createUrlTree(commands: any[], navigationExtras: UrlCreationOptions = {}): UrlTree {
+  createUrlTree(commands: readonly any[], navigationExtras: UrlCreationOptions = {}): UrlTree {
     const {relativeTo, queryParams, fragment, queryParamsHandling, preserveFragment} =
       navigationExtras;
     const f = preserveFragment ? this.currentUrlTree.fragment : fragment;
@@ -549,7 +549,7 @@ export class Router {
    *
    */
   navigate(
-    commands: any[],
+    commands: readonly any[],
     extras: NavigationExtras = {skipLocationChange: false},
   ): Promise<boolean> {
     validateCommands(commands);
@@ -673,7 +673,7 @@ export class Router {
   }
 }
 
-function validateCommands(commands: string[]): void {
+function validateCommands(commands: readonly string[]): void {
   for (let i = 0; i < commands.length; i++) {
     const cmd = commands[i];
     if (cmd == null) {

--- a/packages/router/src/utils/collection.ts
+++ b/packages/router/src/utils/collection.ts
@@ -9,7 +9,7 @@
 import {ɵisPromise as isPromise} from '@angular/core';
 import {from, isObservable, Observable, of} from 'rxjs';
 
-export function shallowEqualArrays(a: any[], b: any[]): boolean {
+export function shallowEqualArrays(a: readonly any[], b: readonly any[]): boolean {
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; ++i) {
     if (!shallowEqual(a[i], b[i])) return false;
@@ -48,7 +48,7 @@ export function getDataKeys(obj: Object): Array<string | symbol> {
 /**
  * Test equality for arrays of strings or a string.
  */
-export function equalArraysOrString(a: string | string[], b: string | string[]) {
+export function equalArraysOrString(a: string | readonly string[], b: string | readonly string[]) {
   if (Array.isArray(a) && Array.isArray(b)) {
     if (a.length !== b.length) return false;
     const aSorted = [...a].sort();
@@ -62,7 +62,7 @@ export function equalArraysOrString(a: string | string[], b: string | string[]) 
 /**
  * Return the last element of an array.
  */
-export function last<T>(a: T[]): T | null {
+export function last<T>(a: readonly T[]): T | null {
   return a.length > 0 ? a[a.length - 1] : null;
 }
 

--- a/packages/router/test/create_url_tree.spec.ts
+++ b/packages/router/test/create_url_tree.spec.ts
@@ -616,7 +616,7 @@ describe('defaultQueryParamsHandling', () => {
 
 async function createRoot(
   tree: UrlTree,
-  commands: any[],
+  commands: readonly any[],
   queryParams?: Params,
   fragment?: string,
 ): Promise<UrlTree> {
@@ -631,7 +631,7 @@ async function createRoot(
 
 function create(
   relativeTo: ActivatedRoute,
-  commands: any[],
+  commands: readonly any[],
   queryParams?: Params,
   fragment?: string,
 ) {


### PR DESCRIPTION
only require a readonly array as input

implements #60269

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

router requires a writable array for command arrays

Issue Number: #60269


## What is the new behavior?

router only requires a readonly array for command arrays

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

as only method parameters and directive inputs changed, it should not cause any breaking change.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
