### PR TITLE
docs: removed --all flag in documentation

### DIFF
--- a/adev/src/content/tools/cli/schematics.md
+++ b/adev/src/content/tools/cli/schematics.md
@@ -104,11 +104,10 @@ We analyzed your package.json, there are some packages to update:
     rxjs                                      6.3.3 -> 6.4.0           ng update rxjs
 
     There might be additional packages that are outdated.
-    Run "ng update --all" to try to update all at the same time.
 
 </docs-code>
 
-If you pass the command a set of libraries to update \(or the `--all` flag\), it updates those libraries, their peer dependencies, and the peer dependencies that depend on them.
+If you pass the command a set of libraries to update, it updates those libraries, their peer dependencies, and the peer dependencies that depend on them.
 
 HELPFUL: If there are inconsistencies \(for example, if peer dependencies cannot be matched by a simple [semver](https://semver.io) range\), the command generates an error and does not change anything in the workspace.
 

--- a/contributing-docs/branches-and-versioning.md
+++ b/contributing-docs/branches-and-versioning.md
@@ -6,7 +6,7 @@ merging PRs and publishing releases. Before reading, you should understand
 
 ## Distribution tags on npm
 
-Angular's branching relates directly to versions published on npm. We will reference these [npm
+Angular's branching relates directly to versions published on npm. We will reference  athese [npm
 distribution tags](https://docs.npmjs.com/cli/v6/commands/npm-dist-tag#purpose) throughout:
 
 | Tag    | Description                                                                       |


### PR DESCRIPTION
Removed flag --all in documentation file for 'ng update' command

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Docs update for flag --all in ng update command.

Issue Number: 60340


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
