### PR TITLE
feat(forms): Allow to reset a form without emitting events

### DIFF
--- a/goldens/public-api/forms/index.api.md
+++ b/goldens/public-api/forms/index.api.md
@@ -502,7 +502,10 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
     removeControl(dir: FormControlName): void;
     removeFormArray(dir: FormArrayName): void;
     removeFormGroup(dir: FormGroupName): void;
-    resetForm(value?: any): void;
+    resetForm(value?: any, options?: {
+        onlySelf?: boolean;
+        emitEvent?: boolean;
+    }): void;
     get submitted(): boolean;
     updateModel(dir: FormControlName, value: any): void;
     // (undocumented)

--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -339,12 +339,14 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
    * @description
    * Resets the form to an initial value and resets its submitted status.
    *
-   * @param value The new value for the form.
+   * @param value The new value for the form, `undefined` by default
    */
-  resetForm(value: any = undefined): void {
-    this.form.reset(value);
+  resetForm(value: any = undefined, options: {onlySelf?: boolean; emitEvent?: boolean} = {}): void {
+    this.form.reset(value, options);
     this._submittedReactive.set(false);
-    this.form._events.next(new FormResetEvent(this.form));
+    if (options?.emitEvent !== false) {
+      this.form._events.next(new FormResetEvent(this.form));
+    }
   }
 
   /** @internal */


### PR DESCRIPTION
This change  add an option paramter to `resetForm` that is passed to the FormGroup.

fixes #60274
