### PR TITLE
build: enable remote execution keepalive

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -114,6 +114,9 @@ build:remote --bes_instance_name=internal-200822
 build:remote --remote_cache=remotebuildexecution.googleapis.com
 build:remote --remote_executor=remotebuildexecution.googleapis.com
 
+# See: https://docs.google.com/document/d/1NgDPsCIwprDdqC1zj0qQrh5KGK2hQTSTux1DAvi4rSc/edit?tab=t.0.
+build:remote --experimental_remote_execution_keepalive
+
 # Use HTTP remote cache
 build:remote-cache --remote_cache=https://storage.googleapis.com/angular-team-cache
 build:remote-cache --remote_accept_cached=true


### PR DESCRIPTION
This should help with network issues of spawned RBE actions. It should also introduce timeouts when actions couldn't be spawned in a timely manner.