### PR TITLE
refactor(router): Clean up the transition subject

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -179,13 +179,11 @@ export class Router {
   constructor() {
     this.resetConfig(this.config);
 
-    this.navigationTransitions
-      .setupNavigations(this, this.currentUrlTree, this.routerState)
-      .subscribe({
-        error: (e) => {
-          this.console.warn(ngDevMode ? `Unhandled Navigation Error: ${e}` : e);
-        },
-      });
+    this.navigationTransitions.setupNavigations(this).subscribe({
+      error: (e) => {
+        this.console.warn(ngDevMode ? `Unhandled Navigation Error: ${e}` : e);
+      },
+    });
     this.subscribeToNavigationEvents();
   }
 


### PR DESCRIPTION
This commit cleans up the transition subject a bit so it doesn't use a dummy initial value that needs to be skipped
