### PR TITLE
fix(devtools): show preview content even after expanding node

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-tree.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-tree.component.html
@@ -27,7 +27,7 @@
         <span class="name">{{ node.prop.name }}</span
         >:
         <span class="value">
-          {{ treeControl().isExpanded(node) ? '' : node.prop.descriptor.preview }}
+          {{ node.prop.descriptor.preview }}
         </span>
       </div>
     </mat-tree-node>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

<img width="167" alt="Screenshot 2025-03-13 at 12 48 16 AM" src="https://github.com/user-attachments/assets/3fe657d0-dc9c-4341-928b-1172e4b291b5" />

<img width="266" alt="Screenshot 2025-03-13 at 12 51 37 AM" src="https://github.com/user-attachments/assets/a74f3ba1-73e1-4ac3-ba4c-6038385bfa82" />

## What is the new behavior?

<img width="206" alt="Screenshot 2025-03-13 at 12 47 49 AM" src="https://github.com/user-attachments/assets/75a9625b-84a8-42c1-aaed-3c411b772ecd" />
<img width="297" alt="Screenshot 2025-03-13 at 12 51 28 AM" src="https://github.com/user-attachments/assets/f7029ded-197e-40cd-afd9-9e05e44dfa9b" />

This aligns with Chrome devtools behavior, and now shows that an object is a signal even if it has been expanded

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Here's what the current Chrome devtools behavior looks like (note that it still shows the preview for the class even though the class has been expanded)

<img width="276" alt="Screenshot 2025-03-13 at 12 49 35 AM" src="https://github.com/user-attachments/assets/c8238de6-6593-43ad-8e50-60a44a01855d" />
