### PR TITLE
refactor(core): pass signal equal function to primitives

### DIFF
--- a/packages/core/src/render3/reactivity/computed.ts
+++ b/packages/core/src/render3/reactivity/computed.ts
@@ -8,8 +8,6 @@
 
 import {createComputed, SIGNAL} from '@angular/core/primitives/signals';
 
-import {performanceMarkFeature} from '../../util/performance';
-
 import {Signal, ValueEqualityFn} from './api';
 
 /**
@@ -31,10 +29,7 @@ export interface CreateComputedOptions<T> {
  * Create a computed `Signal` which derives a reactive value from an expression.
  */
 export function computed<T>(computation: () => T, options?: CreateComputedOptions<T>): Signal<T> {
-  const getter = createComputed(computation);
-  if (options?.equal) {
-    getter[SIGNAL].equal = options.equal;
-  }
+  const getter = createComputed(computation, options?.equal);
 
   if (ngDevMode) {
     getter.toString = () => `[Computed: ${getter()}]`;

--- a/packages/core/src/render3/reactivity/linked_signal.ts
+++ b/packages/core/src/render3/reactivity/linked_signal.ts
@@ -6,18 +6,17 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {signalAsReadonlyFn, WritableSignal} from './signal';
-import {Signal, ValueEqualityFn} from './api';
-import {performanceMarkFeature} from '../../util/performance';
 import {
   ComputationFn,
   createLinkedSignal,
   LinkedSignalGetter,
   LinkedSignalNode,
-  SIGNAL,
   linkedSignalSetFn,
   linkedSignalUpdateFn,
+  SIGNAL,
 } from '@angular/core/primitives/signals';
+import {Signal, ValueEqualityFn} from './api';
+import {signalAsReadonlyFn, WritableSignal} from './signal';
 
 const identityFn = <T>(v: T) => v;
 

--- a/packages/core/src/render3/reactivity/signal.ts
+++ b/packages/core/src/render3/reactivity/signal.ts
@@ -15,8 +15,6 @@ import {
   signalUpdateFn,
 } from '@angular/core/primitives/signals';
 
-import {performanceMarkFeature} from '../../util/performance';
-
 import {isSignal, Signal, ValueEqualityFn} from './api';
 
 /** Symbol used distinguish `WritableSignal` from other non-writable signals and functions. */
@@ -76,11 +74,10 @@ export interface CreateSignalOptions<T> {
  * Create a `Signal` that can be set or updated directly.
  */
 export function signal<T>(initialValue: T, options?: CreateSignalOptions<T>): WritableSignal<T> {
-  const signalFn = createSignal(initialValue) as SignalGetter<T> & WritableSignal<T>;
+  const signalFn = createSignal(initialValue, options?.equal) as SignalGetter<T> &
+    WritableSignal<T>;
+
   const node = signalFn[SIGNAL];
-  if (options?.equal) {
-    node.equal = options.equal;
-  }
 
   signalFn.set = (newValue: T) => signalSetFn(node, newValue);
   signalFn.update = (updateFn: (value: T) => T) => signalUpdateFn(node, updateFn);


### PR DESCRIPTION
The signals primitives package understands the equals option now so we can pass it to the signal / computed creation methods instead of manually assigning the equality function on a reactive node.
