### PR TITLE
refactor(core): move signal toString to primitives

### DIFF
--- a/packages/core/primitives/signals/src/computed.ts
+++ b/packages/core/primitives/signals/src/computed.ts
@@ -19,6 +19,10 @@ import {
   runPostProducerCreatedFn,
 } from './graph';
 
+// Required as the signals library is in a separate package, so we need to explicitly ensure the
+// global `ngDevMode` type is defined.
+declare const ngDevMode: boolean | undefined;
+
 /**
  * A computation, which derives a value from a declarative reactive expression.
  *
@@ -76,8 +80,15 @@ export function createComputed<T>(
 
     return node.value;
   };
+
   (computed as ComputedGetter<T>)[SIGNAL] = node;
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+    const debugName = node.debugName ? ' (' + node.debugName + ')' : '';
+    computed.toString = () => `[Computed${debugName}: ${node.value}]`;
+  }
+
   runPostProducerCreatedFn(node);
+
   return computed as unknown as ComputedGetter<T>;
 }
 

--- a/packages/core/primitives/signals/src/linked_signal.ts
+++ b/packages/core/primitives/signals/src/linked_signal.ts
@@ -21,6 +21,10 @@ import {
 } from './graph';
 import {signalSetFn, signalUpdateFn} from './signal';
 
+// Required as the signals library is in a separate package, so we need to explicitly ensure the
+// global `ngDevMode` type is defined.
+declare const ngDevMode: boolean | undefined;
+
 export type ComputationFn<S, D> = (source: S, previous?: {source: S; value: D}) => D;
 
 export interface LinkedSignalNode<S, D> extends ReactiveNode {
@@ -87,7 +91,13 @@ export function createLinkedSignal<S, D>(
 
   const getter = linkedSignalGetter as LinkedSignalGetter<S, D>;
   getter[SIGNAL] = node;
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+    const debugName = node.debugName ? ' (' + node.debugName + ')' : '';
+    getter.toString = () => `[LinkedSignal${debugName}: ${node.value}]`;
+  }
+
   runPostProducerCreatedFn(node);
+
   return getter;
 }
 

--- a/packages/core/primitives/signals/src/signal.ts
+++ b/packages/core/primitives/signals/src/signal.ts
@@ -59,7 +59,13 @@ export function createSignal<T>(initialValue: T, equal?: ValueEqualityFn<T>): Si
     return node.value;
   }) as SignalGetter<T>;
   (getter as any)[SIGNAL] = node;
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+    const debugName = node.debugName ? ' (' + node.debugName + ')' : '';
+    getter.toString = () => `[Signal${debugName}: ${node.value}]`;
+  }
+
   runPostProducerCreatedFn(node);
+
   return getter;
 }
 


### PR DESCRIPTION
This change pushes the toString implementation of signal getters down to the primitives package so it can be shared with other frameworks.

Closes #59990
