### PR TITLE
refactor(core): inline `isDirectiveHost`

### DIFF
--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -32,10 +32,17 @@ import {
   createElementNode,
   setupStaticAttributes,
 } from '../dom_node_manipulation';
-import {hasClassInput, hasStyleInput, TElementNode, TNode, TNodeType} from '../interfaces/node';
+import {
+  hasClassInput,
+  hasStyleInput,
+  TElementNode,
+  TNode,
+  TNodeFlags,
+  TNodeType,
+} from '../interfaces/node';
 import {Renderer} from '../interfaces/renderer';
 import {RElement} from '../interfaces/renderer_dom';
-import {isComponentHost, isDirectiveHost} from '../interfaces/type_checks';
+import {isComponentHost} from '../interfaces/type_checks';
 import {HEADER_OFFSET, HYDRATION, LView, RENDERER, TView} from '../interfaces/view';
 import {assertTNodeType} from '../node_assert';
 import {appendChild} from '../node_manipulation';
@@ -120,7 +127,11 @@ export function ɵɵelementStart(
   const native = _locateOrCreateElementNode(tView, lView, tNode, renderer, name, index);
   lView[adjustedIndex] = native;
 
-  const hasDirectives = isDirectiveHost(tNode);
+  // Checks if the given `TNode` is a directive host.
+  // A directive host is an element that has one or more directives applied to it.
+  // Perf note: This is a hot-path function used in the generated code.
+  // Do not extract it into a separate function, as an inline check is faster.
+  const hasDirectives = (tNode.flags & TNodeFlags.isDirectiveHost) === TNodeFlags.isDirectiveHost;
 
   if (ngDevMode && tView.firstCreatePass) {
     validateElementIsKnown(native, lView, tNode.value, tView.schemas, hasDirectives);


### PR DESCRIPTION
This commit inlines the `isDirectiveHost` function at the call site. The inline check is faster than using a separate function because `ɵɵelementStart` is a hot path function in the generated code.

Benchmarks were conducted by bootstrapping an application with 100 `<div></div>` elements (`div*100`):

```js
suite
  .add('ɵɵelementStart (old)', async () => {
    // globalThis.bootstrapMe = () => bootstrapApplication(...);
    const appRef = await globalThis.bootstrapMe();
    appRef.destroy();
    document.body.appendChild(document.createElement('app-root'));
  })
```

The results compare the previous and inlined implementations:

```
ɵɵelementStart (old)  x 10,955 ops/sec ±1.55% (56 runs sampled)
ɵɵelementStart (new)  x 13,195 ops/sec ±2.02% (21 runs sampled)
```