### PR TITLE
refactor(devtools): extract and organize colors into themes

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/BUILD.bazel
@@ -8,7 +8,6 @@ package(default_visibility = ["//visibility:public"])
 sass_binary(
     name = "devtools_component_styles",
     src = "devtools.component.scss",
-    deps = ["//devtools/projects/ng-devtools/src/styles:theme"],
 )
 
 ng_module(

--- a/devtools/projects/ng-devtools/src/lib/application-services/theme_service.ts
+++ b/devtools/projects/ng-devtools/src/lib/application-services/theme_service.ts
@@ -35,8 +35,8 @@ export class ThemeService {
   toggleDarkMode(isDark: boolean): void {
     const removeClass = isDark ? LIGHT_THEME_CLASS : DARK_THEME_CLASS;
     const addClass = !isDark ? LIGHT_THEME_CLASS : DARK_THEME_CLASS;
-    this.renderer.removeClass(this.doc.body, removeClass);
-    this.renderer.addClass(this.doc.body, addClass);
+    this.renderer.removeClass(this.doc.documentElement, removeClass);
+    this.renderer.addClass(this.doc.documentElement, addClass);
     this.currentTheme.set(addClass);
   }
 

--- a/devtools/projects/ng-devtools/src/lib/application-services/theme_service_spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/application-services/theme_service_spec.ts
@@ -57,7 +57,7 @@ describe('ThemeService', () => {
     const doc = TestBed.inject(DOCUMENT);
 
     expect(service.currentTheme()).toEqual('light-theme');
-    expect(doc.body.classList.contains('light-theme')).toBeTrue();
+    expect(doc.documentElement.classList.contains('light-theme')).toBeTrue();
   });
 
   it(`should enable dark mode, if it's the preferred/system one`, () => {
@@ -69,7 +69,7 @@ describe('ThemeService', () => {
     const doc = TestBed.inject(DOCUMENT);
 
     expect(service.currentTheme()).toEqual('dark-theme');
-    expect(doc.body.classList.contains('dark-theme')).toBeTrue();
+    expect(doc.documentElement.classList.contains('dark-theme')).toBeTrue();
   });
 
   it('should toggle dark mode', () => {
@@ -84,7 +84,7 @@ describe('ThemeService', () => {
     const doc = TestBed.inject(DOCUMENT);
 
     expect(service.currentTheme()).toEqual('dark-theme');
-    expect(doc.body.classList.contains('dark-theme')).toBeTrue();
+    expect(doc.documentElement.classList.contains('dark-theme')).toBeTrue();
   });
 
   it('should update the theme automatically, if the system one changes', () => {
@@ -95,7 +95,7 @@ describe('ThemeService', () => {
     // Initialize the watcher.
     service.initializeThemeWatcher();
 
-    const docClassList = TestBed.inject(DOCUMENT).body.classList;
+    const docClassList = TestBed.inject(DOCUMENT).documentElement.classList;
 
     expect(service.currentTheme()).toEqual('light-theme');
     expect(docClassList.contains('light-theme')).toBeTrue();

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/BUILD.bazel
@@ -8,7 +8,6 @@ package(default_visibility = ["//visibility:public"])
 sass_binary(
     name = "devtools_tabs_component_styles",
     src = "devtools-tabs.component.scss",
-    deps = ["//devtools/projects/ng-devtools/src/styles:theme"],
 )
 
 ng_module(

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/dependency-injection/resolution-path/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/dependency-injection/resolution-path/BUILD.bazel
@@ -9,7 +9,6 @@ sass_binary(
     name = "resolution_path_styles",
     src = "resolution-path.component.scss",
     visibility = ["//visibility:private"],
-    deps = ["//devtools/projects/ng-devtools/src/styles:theme"],
 )
 
 ng_module(

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/dependency-injection/resolution-path/resolution-path.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/dependency-injection/resolution-path/resolution-path.component.scss
@@ -1,21 +1,15 @@
-@use '../../../../styles/theme' as theme;
-
-/* TODO: Extract */
-$darkBg: #1a1a1a;
-$lightBg: #f3f3f3;
-
 :host {
   display: flex;
   flex-wrap: wrap;
-  background: $lightBg;
-  border-top: 1px solid black;
+  background: var(--octonary-contrast);
   padding: 0.5rem 0.5rem 0.25rem 0.5rem;
+  border-top: 1px solid var(--senary-contrast);
 
   .node {
     position: relative;
     border-radius: 5px;
-    background: #c4c4c4;
-    color: black;
+    background: var(--octonary-contrast);
+    color: var(--black);
     padding: 4px 25px 4px 15px;
     margin-bottom: 0.25rem;
     font-size: 0.75rem;
@@ -23,15 +17,15 @@ $lightBg: #f3f3f3;
     box-sizing: border-box;
 
     &.type-env {
-      background: #f9c2c5;
+      background: var(--red-06);
     }
 
     &.type-element {
-      background: #a6d5a9;
+      background: var(--green-03);
     }
 
     &.type-imported {
-      background: #c79eff;
+      background: var(--purple-03);
     }
 
     &.type-hidden {
@@ -60,7 +54,7 @@ $lightBg: #f3f3f3;
 
     &:not(:last-of-type)::before {
       content: '';
-      background: $lightBg;
+      background: var(--octonary-contrast);
       width: 21px;
       height: 21px;
       top: calc(50% - 6px);
@@ -74,12 +68,5 @@ $lightBg: #f3f3f3;
     &:not(:last-of-type) {
       margin-right: -14px;
     }
-  }
-}
-
-@include theme.dark-theme {
-  :host,
-  .node:not(:last-of-type)::before {
-    background: #1a1a1a;
   }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/dependency-injection/resolution-path/resolution-path.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/dependency-injection/resolution-path/resolution-path.component.scss
@@ -9,7 +9,7 @@
     position: relative;
     border-radius: 5px;
     background: var(--octonary-contrast);
-    color: var(--black);
+    color: black;
     padding: 4px 25px 4px 15px;
     margin-bottom: 0.25rem;
     font-size: 0.75rem;

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.scss
@@ -1,5 +1,3 @@
-@use '../../styles/theme' as theme;
-
 :host {
   position: relative;
   width: 100%;
@@ -23,6 +21,10 @@ ng-injector-tree.hidden {
   height: calc(100% - 31px);
 }
 
+nav {
+  border-bottom: 1px solid var(--color-separator);
+}
+
 #nav-buttons {
   display: flex;
 
@@ -31,6 +33,7 @@ ng-injector-tree.hidden {
     border: none;
     cursor: pointer;
     opacity: 0.8;
+    color: var(--secondary-contrast);
 
     &:active {
       opacity: 1;
@@ -39,7 +42,7 @@ ng-injector-tree.hidden {
 }
 
 .inspector-active {
-  color: #1a73e8 !important;
+  color: var(--blue-02) !important;
 }
 
 #app-angular-version {
@@ -54,7 +57,7 @@ ng-injector-tree.hidden {
 }
 
 #version-number {
-  color: #1b1aa5;
+  color: var(--blue-02);
   cursor: text;
   -moz-user-select: text;
   -khtml-user-select: text;
@@ -63,7 +66,7 @@ ng-injector-tree.hidden {
   user-select: text;
 
   &.unsupported-version {
-    color: red;
+    color: var(--red-04);
   }
 }
 
@@ -109,42 +112,11 @@ mat-icon {
 }
 
 .frame-selector {
-  background-color: #e2e2e2;
   border-radius: 2px;
-  color: #474747;
   border: none;
   margin: 4px 4px 2px 4px;
   padding: 2px;
   outline-offset: -2px;
   width: 100px;
   font-size: 12px;
-}
-
-@include theme.dark-theme {
-  .frame-selector {
-    background-color: #464646;
-    color: #fff;
-  }
-
-  #app-angular-version {
-    color: #fff;
-  }
-
-  #nav-buttons {
-    button {
-      color: #fff;
-    }
-  }
-
-  #version-number {
-    color: #5caace;
-
-    &.unsupported-version {
-      color: red;
-    }
-  }
-
-  .inspector-active {
-    color: #4688f1 !important;
-  }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = ["//visibility:public"])
 sass_binary(
     name = "directive_forest_component_styles",
     src = "directive-forest.component.scss",
-    deps = ["//devtools/projects/ng-devtools/src/styles:theme"],
 )
 
 ng_module(

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/breadcrumbs/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/breadcrumbs/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = ["//visibility:public"])
 sass_binary(
     name = "breadcrumbs_component_styles",
     src = "breadcrumbs.component.scss",
-    deps = ["//devtools/projects/ng-devtools/src/styles:theme"],
 )
 
 ng_module(

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/breadcrumbs/breadcrumbs.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/breadcrumbs/breadcrumbs.component.scss
@@ -1,5 +1,3 @@
-@use '../../../../../styles/theme' as theme;
-
 .mdc-card.breadcrumb-card {
   padding: 0;
   width: 100%;
@@ -9,7 +7,7 @@
 
   .scroll-button {
     height: 100%;
-    background-color: rgb(243, 243, 243);
+    background-color: var(--septenary-contrast);
     border: none;
     cursor: pointer;
 
@@ -34,7 +32,7 @@
       height: 24px;
 
       &.selected {
-        background-color: rgb(243, 243, 243);
+        background-color: var(--color-tree-node-highlighted);
       }
     }
   }
@@ -45,36 +43,10 @@
     font-size: 11px;
     margin-right: 5px;
     width: fit-content;
-    color: #8a1882;
+    color: var(--color-tree-node-element-name);
 
     &:hover {
-      background-color: #ebf1fb;
-    }
-  }
-}
-
-@include theme.dark-theme {
-  .mdc-card {
-    &.breadcrumb-card {
-      .scroll-button {
-        background-color: rgb(41, 42, 45);
-        color: #ffffff;
-      }
-
-      .breadcrumbs {
-        button {
-          &.selected {
-            background-color: rgb(41, 42, 45);
-          }
-        }
-      }
-
-      .mdc-button {
-        color: #5caace;
-        &:hover {
-          background-color: #093e69;
-        }
-      }
+      background-color: var(--color-tree-node-hovered);
     }
   }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.scss
@@ -1,5 +1,3 @@
-@use '../../../../styles/theme' as theme;
-
 :host {
   width: 100%;
   height: 100%;
@@ -7,7 +5,7 @@
 
   .tree-node {
     position: relative;
-    color: #8a1882;
+    color: var(--color-tree-node-element-name);
 
     cursor: default;
     font-family: Menlo, monospace;
@@ -35,50 +33,47 @@
       width: 16px;
       height: 13px;
       display: inline-block;
+      color: var(--primary-contrast);
     }
 
     .dir-names {
-      color: #9b4807;
+      color: var(--color-tree-node-dir-name);
     }
 
     .console-reference,
     .on-push {
-      color: #748591;
+      color: var(--color-tree-node-console-ref);
       padding-left: 8px;
       font-style: italic;
     }
 
     &:hover {
-      background-color: #ebf1fb;
+      background-color: var(--color-tree-node-hovered);
     }
 
     &.matched {
-      background-color: #ebf1fb;
-
-      &:hover {
-        background-color: #cfe8fc;
-      }
+      background-color: var(--color-tree-node-matched);
     }
 
     &.selected,
     &.highlighted {
-      background-color: #cfe8fc;
+      background-color: var(--color-tree-node-highlighted);
     }
 
     .hydration {
       margin: auto 8px auto auto;
       font-size: 14px;
-      color: #60a6fc;
+      color: var(--blue-02);
 
       position: sticky;
       right: 0;
 
       &.skipped {
-        color: #9a9a9a;
+        color: var(--senary-contrast);
       }
 
       &.mismatched {
-        color: #ff0040;
+        color: var(--red-04);
       }
     }
   }
@@ -89,7 +84,7 @@
     background-color: transparent;
   }
   50% {
-    background-color: #cfe8fc;
+    background-color: var(--blue-04);
   }
   100% {
     background-color: transparent;
@@ -98,29 +93,6 @@
 
 .new-node {
   animation: appear 1.5s;
-}
-
-.filter {
-  display: flex;
-
-  .icon {
-    width: 20px;
-    height: 20px;
-    margin: auto 12px;
-    opacity: 0.7;
-  }
-
-  .filter-input {
-    border: none;
-    background: rgba(0, 0, 0, 0.003);
-    box-shadow: inset 0 -2px 1px rgba(0, 0, 0, 0.03);
-    width: 100%;
-    font-size: 2em;
-    font-family: inherit;
-    font-weight: inherit;
-    line-height: 1.4em;
-    padding: 12px 6px;
-  }
 }
 
 .up-down-buttons {
@@ -135,7 +107,7 @@
 
 .angular-element {
   content: '';
-  color: #1b1aa5;
+  color: var(--color-tree-node-ng-element);
 
   &::before {
     content: '<';
@@ -147,72 +119,18 @@
 }
 
 .hydration-error {
-  color: #e62222;
+  color: var(--dynamic-red-01);
   margin-left: 16px;
   padding: 0 8px 8px 0px;
 
   pre {
     margin: 0;
-    background: rgba(1, 1, 1, 0.05);
+    background: var(--dynamic-transparent-01);
     padding: 8px;
     border-radius: 8px;
 
     &:not(:last-child) {
       margin-bottom: 16px;
-    }
-  }
-}
-
-@include theme.dark-theme {
-  .tree-node {
-    color: #5cadd3;
-
-    .mat-icon {
-      color: #bcc5ce;
-    }
-
-    .dir-names {
-      color: #91adcb;
-    }
-
-    .angular-element {
-      color: #dc8c61;
-    }
-
-    &:hover {
-      background-color: #262d36;
-    }
-
-    &.matched {
-      background-color: #262d36;
-
-      &:hover {
-        background-color: #073d69;
-      }
-    }
-
-    &.selected,
-    &.highlighted {
-      background-color: #073d69;
-    }
-
-    .hydration {
-      color: #60a6fc;
-
-      &.skipped {
-        color: #9a9a9a;
-      }
-
-      &.mismatched {
-        color: #ff0040;
-      }
-    }
-
-    .hydration-error {
-      color: #ea7171;
-      pre {
-        background: rgb(1, 1, 1, 0.2);
-      }
     }
   }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = ["//visibility:public"])
 sass_binary(
     name = "filter_component_styles",
     src = "filter.component.scss",
-    deps = ["//devtools/projects/ng-devtools/src/styles:theme"],
 )
 
 ng_module(

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/filter.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/filter.component.scss
@@ -1,11 +1,9 @@
-@use '../../../../../styles/theme' as theme;
-
 .filter {
   display: flex;
   padding: 0px;
   border-radius: 0px;
   box-shadow: none !important;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+  border-bottom: 1px solid var(--color-separator);
 
   label {
     display: flex;
@@ -25,7 +23,6 @@
 
     .filter-input {
       border: none;
-      border-left: 1px solid rgba(0, 0, 0, 0.12);
       padding-left: 5px;
       width: 100%;
       font-size: 11px;
@@ -33,7 +30,7 @@
       font-weight: inherit;
       height: 30px;
       outline: none;
-      color: rgba(0, 0, 0, 0.87);
+      background: var(--color-background);
     }
   }
 }
@@ -62,20 +59,5 @@
     &:active {
       opacity: 1;
     }
-  }
-}
-
-@include theme.dark-theme {
-  .filter {
-    label {
-      .filter-input {
-        background-color: #202124;
-        color: #ffffff;
-      }
-    }
-  }
-
-  mat-icon {
-    color: #fff;
   }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/BUILD.bazel
@@ -18,7 +18,6 @@ _STYLE_LABELS = [
     sass_binary(
         name = label,
         src = src,
-        deps = ["//devtools/projects/ng-devtools/src/styles:theme"],
     )
     for label, src in zip(_STYLE_LABELS, _STYLE_SRCS)
 ]

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header.component.scss
@@ -1,5 +1,3 @@
-@use '../../../../styles/theme' as theme;
-
 .element-header {
   display: flex;
   justify-content: space-between;
@@ -43,11 +41,5 @@
         }
       }
     }
-  }
-}
-
-@include theme.dark-theme {
-  .element-name {
-    color: #ffffff;
   }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/BUILD.bazel
@@ -22,7 +22,6 @@ _STYLE_LABELS = [
     sass_binary(
         name = label,
         src = src,
-        deps = ["//devtools/projects/ng-devtools/src/styles:theme"],
     )
     for label, src in zip(_STYLE_LABELS, _STYLE_SRCS)
 ]

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-editor.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-editor.component.scss
@@ -1,5 +1,3 @@
-@use '../../../../../styles/theme' as theme;
-
 .editor {
   cursor: text;
   border: none;
@@ -10,8 +8,7 @@
 }
 
 .editor-input {
-  background-color: #bbddfb;
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 0 0 1px var(--dynamic-transparent-01);
 }
 
 input {
@@ -21,16 +18,4 @@ input {
   font-size: 1em;
   border: none;
   outline: none;
-}
-
-@include theme.dark-theme {
-  input {
-    color: #bcc5ce;
-    background-color: #202124;
-  }
-
-  .editor-input {
-    background-color: #454546;
-    box-shadow: 0 0 0 1px rgba(165, 165, 165, 0.05);
-  }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-preview.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-preview.component.scss
@@ -1,7 +1,7 @@
 .function {
   &:hover {
-    background: #4da1ff;
-    color: #fff;
+    background: var(--blue-02);
+    color: var(--white);
     cursor: pointer;
   }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-preview.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-preview.component.scss
@@ -1,7 +1,7 @@
 .function {
   &:hover {
     background: var(--blue-02);
-    color: var(--white);
+    color: white;
     cursor: pointer;
   }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.scss
@@ -1,9 +1,13 @@
-@use '../../../../../styles/theme' as theme;
-
 :host {
   ::ng-deep {
     mat-expansion-panel {
       border-radius: unset !important;
+    }
+
+    .mat-expansion-panel {
+      box-shadow:
+        0 -2px 5px -2px var(--dynamic-transparent-02),
+        0 2px 5px 0 var(--dynamic-transparent-02);
     }
 
     .mat-expansion-panel-body {
@@ -24,14 +28,13 @@
       }
 
       .docs-link {
-        color: #000000de;
         height: inherit;
         width: fit-content;
         font-size: initial;
         padding-left: 0.1rem;
 
         &:active {
-          color: #1b1aa5;
+          color: var(--blue-02);
         }
       }
     }
@@ -45,16 +48,6 @@
       &::after {
         padding: 2.5px;
         margin-bottom: 4.5px;
-      }
-    }
-
-    @include theme.dark-theme {
-      .docs-link {
-        color: #bcc5ce;
-
-        &:active {
-          color: #5caace;
-        }
       }
     }
   }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.ts
@@ -152,7 +152,6 @@ export class DependencyViewerComponent {
   styles: [
     `
       ng-dependency-viewer {
-        border-bottom: 1px solid color-mix(in srgb, currentColor, #bdbdbd 85%);
         display: block;
       }
     `,

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-header.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-header.component.scss
@@ -1,5 +1,3 @@
-@use '../../../../../styles/theme' as theme;
-
 mat-toolbar {
   padding-left: 10px;
   justify-content: space-between;
@@ -31,11 +29,5 @@ button {
 
   &:active {
     opacity: 1;
-  }
-}
-
-@include theme.dark-theme {
-  button {
-    color: #fff;
   }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-tree.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-tree.component.scss
@@ -1,5 +1,3 @@
-@use '../../../../../styles/theme' as theme;
-
 :host {
   width: 100%;
   display: block;
@@ -38,29 +36,21 @@
   margin: 5px 5px 5px 15px;
   mat-tree-node {
     .name {
-      color: #ce271e;
+      color: var(--color-tree-node-element-name);
       font-weight: 500;
-    }
-  }
-}
-
-@include theme.dark-theme {
-  .property-list {
-    .name {
-      color: #54c9bd !important;
     }
   }
 }
 
 .property-list mat-tree-node.disabled .name,
 .disabled {
-  color: #333;
+  color: var(--secondary-contrast);
 }
 
 .arrow {
   font-family: monospace;
   font-size: 0.5em;
-  color: #6e6e6e;
+  color: var(--quaternary-contrast);
 }
 
 :host ::ng-deep .mat-tree-node,

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/BUILD.bazel
@@ -8,7 +8,6 @@ package(default_visibility = ["//:__subpackages__"])
 sass_binary(
     name = "injector_tree_styles",
     src = "injector-tree.component.scss",
-    deps = ["//devtools/projects/ng-devtools/src/styles:theme"],
 )
 
 ng_module(

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-providers/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-providers/BUILD.bazel
@@ -11,7 +11,6 @@ sass_binary(
     ],
     deps = [
         "//devtools/projects/ng-devtools/src/styles:material_sass_deps",
-        "//devtools/projects/ng-devtools/src/styles:theme",
     ],
 )
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-providers/injector-providers.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-providers/injector-providers.component.scss
@@ -1,5 +1,4 @@
 @use '@angular/material' as mat;
-@use '../../../../styles/theme' as theme;
 
 h2 {
   font-size: 0.875rem;
@@ -82,7 +81,7 @@ tr.example-detail-row {
 
 .example-element-diagram {
   min-width: 80px;
-  border: 2px solid black;
+  border: 2px solid var(--black);
   padding: 8px;
   font-weight: lighter;
   margin: 8px 0;
@@ -107,14 +106,4 @@ tr.example-detail-row {
   font-size: 0.8rem;
   padding: 0.5rem 0;
   text-align: center;
-}
-
-@include theme.dark-theme {
-  .providers-title {
-    color: #ffffff;
-  }
-
-  .no-providers-label {
-    color: #bcc5ce;
-  }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-providers/injector-providers.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-providers/injector-providers.component.scss
@@ -81,7 +81,7 @@ tr.example-detail-row {
 
 .example-element-diagram {
   min-width: 80px;
-  border: 2px solid var(--black);
+  border: 2px solid black;
   padding: 8px;
   font-weight: lighter;
   margin: 8px 0;

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.scss
@@ -1,5 +1,3 @@
-@use '../../../styles/theme' as theme;
-
 :host {
   width: 100%;
   height: 100%;
@@ -56,14 +54,14 @@ svg {
       }
 
       .docs-link {
-        color: #000000de;
+        color: var(--black);
         height: inherit;
         width: fit-content;
         font-size: initial;
         padding-left: 0.1rem;
 
         &:active {
-          color: #1b1aa5;
+          color: var(--blue-02);
         }
       }
     }
@@ -89,7 +87,7 @@ svg {
         height: 90px;
         flex-shrink: 0;
         align-items: center;
-        border-right: 1px solid #e8e8e8;
+        border-right: 1px solid var(--septenary-contrast);
       }
 
       .parameter {
@@ -113,20 +111,20 @@ svg {
       }
 
       .parameter-name {
-        color: #d23a32;
+        color: var(--dynamic-red-01);
       }
 
       .parameter-flag {
         a {
           display: inline-block;
           padding: 0px 6px;
-          background: #dddddd;
+          background: var(--senary-contrast);
           border-radius: 10px;
           color: inherit;
           text-decoration: none;
 
           &:hover {
-            background: #c6c6c6;
+            background: var(--senary-contrast);
           }
         }
       }
@@ -162,16 +160,16 @@ svg {
   display: flex;
   overflow: auto;
 
-  background: #f5f5f5;
+  background: var(--septenary-contrast);
 
   .dep {
-    border-top: 1px solid #e8e8e8;
-    border-bottom: 1px solid #e8e8e8;
-    border-left: 1px solid #e8e8e8;
+    border-top: 1px solid var(--septenary-contrast);
+    border-bottom: 1px solid var(--septenary-contrast);
+    border-left: 1px solid var(--septenary-contrast);
     padding: 1rem;
 
     &:last-of-type {
-      border-right: 1px solid #e8e8e8;
+      border-right: 1px solid var(--septenary-contrast);
     }
 
     .dep-header {
@@ -195,7 +193,7 @@ svg {
   font-size: 11px;
   font-weight: 500;
   height: auto;
-  background: #f5f5f5;
+  background: var(--septenary-contrast);
 }
 
 .injector-hierarchy {
@@ -207,7 +205,7 @@ svg {
     margin: 0;
     display: flex;
     align-items: center;
-    border-bottom: 1px solid #777777;
+    border-bottom: 1px solid var(--quaternary-contrast);
     font-size: 0.875rem;
     display: flex;
     align-items: center;
@@ -224,27 +222,11 @@ svg {
 
 .injector-graph {
   overflow: auto;
-  background: #f3f3f3;
+  background: var(--octonary-contrast);
   height: calc(100% - 50px);
 }
 
 .hierarchy-ref {
   color: currentColor;
   text-decoration: none;
-}
-
-@include theme.dark-theme {
-  .injector-hierarchy {
-    h2 {
-      color: #ffffff;
-    }
-  }
-
-  .deps {
-    background: #161515;
-  }
-
-  .injector-graph {
-    background: #1a1a1a;
-  }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.scss
@@ -54,7 +54,7 @@ svg {
       }
 
       .docs-link {
-        color: var(--black);
+        color: black;
         height: inherit;
         width: fit-content;
         font-size: initial;

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/BUILD.bazel
@@ -17,7 +17,6 @@ _STYLE_LABELS = [
     sass_binary(
         name = label,
         src = src,
-        deps = ["//devtools/projects/ng-devtools/src/styles:theme"],
     )
     for label, src in zip(_STYLE_LABELS, _STYLE_SRCS)
 ]

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/profiler-import-dialog.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/profiler-import-dialog.component.scss
@@ -4,10 +4,10 @@
 }
 
 .profiler-version {
-  color: #388e3c;
+  color: var(--green-01);
 }
 
 .imported-version,
 .error {
-  color: #d32f2f;
+  color: var(--dynamic-red-01);
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/profiler.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/profiler.component.html
@@ -32,7 +32,7 @@
     }
     <p class="instructions" [class.hidden]="state() !== 'idle'">
       <span>
-        Click the record button to start a new recording, or upload a json file containing profiler
+        Click the record button to start a new recording, or upload a JSON file containing profiler
         data.
       </span>
       <br />

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/profiler.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/profiler.component.scss
@@ -1,5 +1,3 @@
-@use '../../../styles/theme' as theme;
-
 :host,
 .profiler-wrapper {
   font-size: 1em;
@@ -21,7 +19,7 @@
   cursor: pointer;
 
   &.recording-button {
-    color: #d83c34;
+    color: var(--dynamic-red-01);
   }
 }
 
@@ -38,12 +36,6 @@
   }
 }
 
-@include theme.dark-theme {
-  .instructions {
-    color: #ffffff;
-  }
-}
-
 #profiler-content-wrapper {
   margin: 0;
   height: calc(100% - 30px);
@@ -53,14 +45,6 @@
 .visualization {
   margin: 0;
   height: 100%;
-}
-
-@include theme.dark-theme {
-  .profiler-control {
-    &.recording-button {
-      color: #ff625a;
-    }
-  }
 }
 
 .mdc-card {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/BUILD.bazel
@@ -21,7 +21,6 @@ _STYLE_LABELS = [
     sass_binary(
         name = label,
         src = src,
-        deps = ["//devtools/projects/ng-devtools/src/styles:theme"],
     )
     for label, src in zip(_STYLE_LABELS, _STYLE_SRCS)
 ]

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/frame-selector.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/frame-selector.component.scss
@@ -1,5 +1,3 @@
-@use '../../../../styles/theme' as theme;
-
 .bar-graph-container {
   padding: 2px;
   height: 54px;
@@ -43,7 +41,7 @@
       margin-top: 2px;
 
       &:hover {
-        background-color: #ebf1fb;
+        background-color: var(--septenary-contrast);
       }
 
       &.selected {
@@ -53,31 +51,14 @@
         padding-left: 0.5px;
         padding-right: 0.5px;
 
-        background-color: #cfe8fc;
-        border: 2px solid #cfe8fc;
+        background-color: var(--dynamic-blue-01);
+        border: 2px solid var(--dynamic-blue-01);
       }
     }
   }
 
   button {
     margin-bottom: 5px;
-  }
-}
-
-@include theme.dark-theme {
-  .bar-graph-container .bar-container .frame-bar {
-    &:hover {
-      background-color: #262d36;
-    }
-
-    &.selected {
-      background-color: #073d69;
-      border: 2px solid #073d69;
-    }
-  }
-
-  .txt-frames {
-    color: #ffffff;
   }
 }
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/recording-visualizer/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/recording-visualizer/BUILD.bazel
@@ -21,7 +21,6 @@ _STYLE_LABELS = [
     sass_binary(
         name = label,
         src = src,
-        deps = ["//devtools/projects/ng-devtools/src/styles:theme"],
     )
     for label, src in zip(_STYLE_LABELS, _STYLE_SRCS)
 ]

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/recording-visualizer/bar-chart.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/recording-visualizer/bar-chart.component.scss
@@ -1,5 +1,3 @@
-@use '../../../../../styles/theme' as theme;
-
 .bar {
   width: 0%;
   margin-bottom: 7px;
@@ -22,6 +20,7 @@
   text-overflow: ellipsis;
   overflow: hidden;
   opacity: 1;
+  color: var(--color-text);
 }
 
 .bar:hover {
@@ -33,10 +32,4 @@
   width: calc(100% - 5px);
   height: 100%;
   display: block;
-}
-
-@include theme.dark-theme {
-  .bar span {
-    color: #bcc5ce;
-  }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/recording-visualizer/execution-details.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/recording-visualizer/execution-details.component.scss
@@ -1,5 +1,3 @@
-@use '../../../../../styles/theme' as theme;
-
 table {
   border-collapse: collapse;
   width: 100%;
@@ -10,13 +8,5 @@ table {
 
 th,
 td {
-  border-bottom: 1px solid #ddd;
-}
-
-@include theme.dark-theme {
-  .name,
-  .method,
-  .value {
-    color: #ffffff;
-  }
+  border-bottom: 1px solid var(--senary-contrast);
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/recording-visualizer/flamegraph-visualizer.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/recording-visualizer/flamegraph-visualizer.component.scss
@@ -1,5 +1,3 @@
-@use '../../../../../styles/theme' as theme;
-
 :host {
   width: 100%;
   height: 100%;
@@ -17,32 +15,18 @@
 
   ::ng-deep {
     .ngx-fg-label {
-      color: #000000de;
       font-weight: 500;
       font-size: 1em;
-    }
-  }
-
-  @include theme.dark-theme {
-    .entry-statistics {
-      span {
-        color: #54c9bd;
-      }
+      color: var(--senary-contrast);
     }
 
-    ::ng-deep {
-      .ngx-fg-rect {
-        stroke: #303030;
-        transition: none;
-      }
+    .ngx-fg-rect {
+      stroke: var(--secondary-contrast);
+      transition: none;
+    }
 
-      .ngx-fg-label {
-        color: #bcc5ce;
-      }
-
-      .ngx-fg-svg-g {
-        transition: none;
-      }
+    .ngx-fg-svg-g {
+      transition: none;
     }
   }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/recording-visualizer/timeline-visualizer.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/recording-visualizer/timeline-visualizer.component.scss
@@ -1,5 +1,3 @@
-@use '../../../../../styles/theme' as theme;
-
 :host {
   display: block;
   overflow: auto;
@@ -47,7 +45,7 @@
   }
 
   span {
-    color: #8a1882;
+    color: var(--purple-01);
   }
 }
 
@@ -59,16 +57,4 @@ ul {
   list-style-type: square;
   margin-block-start: 0px;
   padding-inline-start: 20px;
-}
-
-@include theme.dark-theme {
-  .entry-statistics {
-    span {
-      color: #5cadd3;
-    }
-  }
-
-  .txt-total-time {
-    color: #ffffff;
-  }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/recording-visualizer/tree-map-visualizer.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/recording-visualizer/tree-map-visualizer.component.scss
@@ -1,5 +1,3 @@
-@use '../../../../../styles/theme' as theme;
-
 .web-tree {
   height: calc(100% - 25px);
   width: calc(100% - 25px);
@@ -8,25 +6,15 @@
 
 :host {
   ::ng-deep {
+    .webtreemap-node {
+      background: var(--primary-contrast);
+    }
     .webtreemap-caption {
       font-size: 0.9em;
+      // color: var(--white);
     }
     .webtreemap-node:hover {
-      background: #ebf1fb;
-    }
-  }
-}
-
-@include theme.dark-theme {
-  ::ng-deep {
-    .webtreemap-node {
-      background: #202124;
-    }
-    .webtreemap-node:hover {
-      background: #262d36;
-    }
-    .webtreemap-caption {
-      color: #ffffff;
+      background: var(--septenary-contrast);
     }
   }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/recording-visualizer/tree-map-visualizer.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/recording-visualizer/tree-map-visualizer.component.scss
@@ -11,7 +11,7 @@
     }
     .webtreemap-caption {
       font-size: 0.9em;
-      // color: var(--white);
+      // color: white;
     }
     .webtreemap-node:hover {
       background: var(--septenary-contrast);

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/timeline-controls.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/timeline-controls.component.scss
@@ -1,5 +1,3 @@
-@use '../../../../styles/theme' as theme;
-
 .visual-controls {
   display: flex;
   flex-direction: column;
@@ -49,12 +47,12 @@
       text-overflow: ellipsis;
 
       &.warning-label {
-        color: #d83c34;
+        color: var(--dynamic-red-01);
       }
     }
 
     .value {
-      color: #8a1882;
+      color: var(--dynamic-purple-01);
     }
   }
 
@@ -64,18 +62,5 @@
 
   .flame-details {
     min-height: 85px;
-  }
-}
-
-@include theme.dark-theme {
-  .details .value {
-    color: #5cadd3;
-  }
-
-  .warning-label {
-    color: #ff625a;
-  }
-  .details {
-    color: #ffffff;
   }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/timeline.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/timeline.component.scss
@@ -1,5 +1,3 @@
-@use '../../../../styles/theme' as theme;
-
 :host {
   font-size: 11px;
   width: 100%;
@@ -27,10 +25,4 @@
   flex-direction: column;
   height: 100%;
   margin: 0 10px;
-}
-
-@include theme.dark-theme {
-  .info {
-    color: #ffffff;
-  }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = ["//:__subpackages__"])
 sass_binary(
     name = "router_tree_styles",
     src = "router-tree.component.scss",
-    deps = ["//devtools/projects/ng-devtools/src/styles:theme"],
 )
 
 ng_module(

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree-visualizer.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree-visualizer.ts
@@ -105,8 +105,8 @@ export class RouterTreeVisualizer {
       .attr('y', 10)
       .attr('width', size)
       .attr('height', size)
-      .style('stroke', '#ff7a7e')
-      .style('fill', '#f9c2c5');
+      .style('stroke', 'var(--red-05)')
+      .style('fill', 'var(--red-06)');
 
     svg
       .append('rect')
@@ -114,8 +114,8 @@ export class RouterTreeVisualizer {
       .attr('y', 45)
       .attr('width', size)
       .attr('height', size)
-      .style('stroke', 'oklch(0.65 0.25 266/1)')
-      .style('fill', '#8bc1ff');
+      .style('stroke', 'var(--blue-02)')
+      .style('fill', 'var(--blue-03)');
 
     svg
       .append('rect')
@@ -123,8 +123,8 @@ export class RouterTreeVisualizer {
       .attr('y', 80)
       .attr('width', size)
       .attr('height', size)
-      .style('stroke', '#28ab2c')
-      .style('fill', '#a7d5a9');
+      .style('stroke', 'var(--green-02)')
+      .style('fill', 'var(--green-03)');
 
     svg
       .append('text')

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.scss
@@ -15,5 +15,5 @@
   font-size: 11px;
   height: 28px;
   outline: none;
-  color: var(--black);
+  color: black;
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.scss
@@ -1,5 +1,3 @@
-@use '../../../styles/theme' as theme;
-
 .router-tree-wrapper {
   font-size: 1em;
   width: 100%;
@@ -9,7 +7,7 @@
 }
 
 .filter-input {
-  border: 1px solid rgba(0, 0, 0, 0.12);
+  border: 1px solid var(--senary-contrast);
   border-radius: 3px;
   padding-left: 5px;
   margin: 0 5px 0 10px;
@@ -17,12 +15,5 @@
   font-size: 11px;
   height: 28px;
   outline: none;
-  color: rgba(0, 0, 0, 0.87);
-}
-
-@include theme.dark-theme {
-  .filter-input {
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    color: rgba(255, 255, 255, 0.87);
-  }
+  color: var(--black);
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/tree-visualizer-host/tree-visualizer-host.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/tree-visualizer-host/tree-visualizer-host.component.scss
@@ -15,39 +15,30 @@
         display: none;
       }
 
+      .legend {
+        background: var(--primary-contrast);
+      }
+
+      .arrow {
+        fill: var(--full-contrast);
+      }
+
+      .legend-router-tree {
+        fill: var(--full-contrast) !important;
+      }
+
       .link {
-        stroke: #9b9b9b;
+        stroke: var(--quaternary-contrast);
         stroke-width: 3px;
         fill: none;
 
         &.highlighted {
-          stroke: #4da1ff;
+          stroke: var(--blue-02);
         }
       }
 
       .node {
         cursor: pointer;
-
-        &.highlighted {
-          .node-container,
-          .node-container:hover {
-            background: oklch(0.65 0.25 266 / 1);
-            border-color: white;
-            color: white;
-            font-weight: 400;
-          }
-
-          &.selected {
-            .node-container,
-            .node-container:hover {
-              color: oklch(0.65 0.25 266 / 1);
-              background: white;
-              border-width: 3px;
-              border-color: oklch(0.65 0.25 266 / 1);
-              font-weight: 800;
-            }
-          }
-        }
 
         .node-container {
           display: flex;
@@ -55,13 +46,38 @@
           justify-content: center;
           width: 100%;
           height: 100%;
-          color: #000;
+          color: var(--black);
           font-size: 16px;
           box-sizing: border-box;
           border-radius: 2px;
           border-style: solid;
           border-width: 2px;
           font-weight: 300;
+
+          &:hover {
+            color: var(--white);
+          }
+        }
+
+        &.highlighted {
+          .node-container,
+          .node-container:hover {
+            background: var(--blue-02);
+            border-color: var(--white);
+            color: var(--white);
+            font-weight: 400;
+          }
+
+          &.selected {
+            .node-container,
+            .node-container:hover {
+              color: var(--blue-02);
+              background: var(--white);
+              border-width: 3px;
+              border-color: var(--blue-02);
+              font-weight: 800;
+            }
+          }
         }
 
         .node-search {
@@ -72,82 +88,57 @@
         }
 
         .node-environment {
-          border: 1px solid #ff7a7e;
-          background: #f9c2c5;
+          border: 1px solid var(--red-05);
+          background: var(--red-06);
 
           &:hover {
-            background: #ff7a7e;
+            background: var(--red-05);
           }
         }
 
         .node-imported-module {
-          border-color: #8838f7;
-          background: #c79eff;
+          border-color: var(--purple-02);
+          background: var(--purple-03);
 
           &:hover {
-            background: #8838f7;
+            background: var(--purple-02);
           }
         }
 
         .node-lazy {
-          border-color: oklch(0.65 0.25 266/1);
-          background: #8bc1ff;
+          border-color: var(--blue-02);
+          background: var(--blue-03);
 
           &:hover {
-            background: #8bc1ff;
+            background: var(--blue-02);
           }
         }
 
         .node-element {
-          border-color: #28ab2c;
-          background: #a7d5a9;
+          border-color: var(--green-02);
+          background: var(--green-03);
 
           &:hover {
-            background: #28ab2c;
+            background: var(--green-02);
           }
         }
 
         .node-null {
-          border: 1px solid #8b8b8b;
-          background: white;
+          border: 1px solid var(--quaternary-contrast);
+          background: var(--white);
+
+          &:hover {
+            color: var(--black);
+          }
         }
 
         .node-label {
-          color: black;
+          color: var(--black);
           font-weight: 300;
           font-size: 18px;
           text-align: center;
         }
       }
-    }
-  }
-}
-
-:host-context(.dark-theme) {
-  svg ::ng-deep {
-    .legend {
-      background: #2f2c2c;
-    }
-
-    .link {
-      stroke: #bcc5ce;
-      fill: none;
-
-      &.highlighted {
-        stroke: #4da1ff;
-      }
-    }
-
-    .arrow {
-      fill: white;
-    }
-
-    .node-label {
-      color: #000;
-    }
-
-    .legend-router-tree {
-      fill: #ffffff !important;
     }
   }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/tree-visualizer-host/tree-visualizer-host.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/tree-visualizer-host/tree-visualizer-host.component.scss
@@ -46,7 +46,7 @@
           justify-content: center;
           width: 100%;
           height: 100%;
-          color: var(--black);
+          color: black;
           font-size: 16px;
           box-sizing: border-box;
           border-radius: 2px;
@@ -55,7 +55,7 @@
           font-weight: 300;
 
           &:hover {
-            color: var(--white);
+            color: white;
           }
         }
 
@@ -63,8 +63,8 @@
           .node-container,
           .node-container:hover {
             background: var(--blue-02);
-            border-color: var(--white);
-            color: var(--white);
+            border-color: white;
+            color: white;
             font-weight: 400;
           }
 
@@ -72,7 +72,7 @@
             .node-container,
             .node-container:hover {
               color: var(--blue-02);
-              background: var(--white);
+              background: white;
               border-width: 3px;
               border-color: var(--blue-02);
               font-weight: 800;
@@ -125,15 +125,15 @@
 
         .node-null {
           border: 1px solid var(--quaternary-contrast);
-          background: var(--white);
+          background: white;
 
           &:hover {
-            color: var(--black);
+            color: black;
           }
         }
 
         .node-label {
-          color: var(--black);
+          color: black;
           font-weight: 300;
           font-size: 18px;
           text-align: center;

--- a/devtools/projects/ng-devtools/src/lib/devtools.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools.component.scss
@@ -1,20 +1,9 @@
-@use '../styles/theme' as theme;
-
 @keyframes pulse {
   0% {
-    box-shadow: 0 0 0 0px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 0 0 0px var(--dynamic-red-02);
   }
   100% {
-    box-shadow: 0 0 0 35px rgba(0, 0, 0, 0);
-  }
-}
-
-@keyframes darkmode-pulse {
-  0% {
-    box-shadow: 0 0 0 0px rgb(126, 40, 40);
-  }
-  100% {
-    box-shadow: 0 0 0 35px rgba(0, 0, 0, 0);
+    box-shadow: 0 0 0 35px var(--dynamic-transparent-01);
   }
 }
 
@@ -28,18 +17,6 @@
   width: 100%;
   height: 100%;
   display: block;
-}
-
-@include theme.dark-theme {
-  .devtools-wrapper {
-    background: #202124;
-  }
-
-  .initializing {
-    .loading {
-      animation: darkmode-pulse 1s infinite;
-    }
-  }
 }
 
 .noselect {
@@ -74,22 +51,12 @@
     display: inline-block;
     font-size: 0.8em;
     border-radius: 50%;
-    border: solid 2px rgb(17, 17, 17);
+    border: solid 2px var(--primary-contrast);
     cursor: pointer;
     width: 16px;
     height: 16px;
     font-weight: bold;
     text-align: center;
-  }
-}
-
-@include theme.dark-theme {
-  .info-icon {
-    border: solid 2px #bcc5ce;
-  }
-
-  a {
-    color: #bcc5ce;
   }
 }
 
@@ -99,13 +66,13 @@
   padding: 1rem;
   width: 80%;
   margin: auto;
-  border: 1px solid;
+  border: 1px solid var(--quinary-contrast);
   border-radius: 16px;
 
   code {
     padding: 2px;
-    color: lightgreen;
-    background: #3e3e3e;
+    color: var(--dynamic-green-01);
+    background: var(--senary-contrast);
     border-radius: 5px;
   }
 

--- a/devtools/projects/ng-devtools/src/lib/vendor/angular-split/lib/component/split.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/vendor/angular-split/lib/component/split.component.scss
@@ -63,7 +63,7 @@
       }
 
       &:not(:first-of-type) {
-        border-left: 1px solid #eeeeee;
+        border-left: 1px solid var(--color-separator);
       }
     }
   }
@@ -91,7 +91,7 @@
       }
 
       &:not(:first-of-type) {
-        border-top: 1px solid #eeeeee;
+        border-top: 1px solid var(--color-separator);
       }
 
       &.as-hidden {
@@ -114,24 +114,6 @@
     & > .as-split-gutter,
     ::ng-deep > .as-split-area {
       transition: flex-basis 0.3s;
-    }
-  }
-}
-
-:host-context(.dark-theme) {
-  &.as-horizontal {
-    ::ng-deep > .as-split-area {
-      &:not(:first-of-type) {
-        border-left: 1px solid #3f3f3f;
-      }
-    }
-  }
-
-  &.as-vertical {
-    ::ng-deep > .as-split-area {
-      &:not(:first-of-type) {
-        border-top: 1px solid #3f3f3f;
-      }
     }
   }
 }

--- a/devtools/projects/ng-devtools/src/styles/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/styles/BUILD.bazel
@@ -13,7 +13,10 @@ npm_sass_library(
 sass_library(
     name = "global",
     srcs = ["_global.scss"],
-    deps = [":material_sass_deps"],
+    deps = [
+        ":colors",
+        ":material_sass_deps",
+    ],
 )
 
 sass_library(
@@ -29,6 +32,9 @@ sass_library(
 sass_library(
     name = "colors",
     srcs = ["_colors.scss"],
+    deps = [
+        ":theme",
+    ],
 )
 
 sass_binary(

--- a/devtools/projects/ng-devtools/src/styles/_colors.scss
+++ b/devtools/projects/ng-devtools/src/styles/_colors.scss
@@ -31,10 +31,6 @@ $_colors: (
   purple-02: oklch(57.9% 0.26 295),
   purple-03: oklch(76% 0.15 305),
 
-  /* Full contrast */
-  black: oklch(0% 0 0),
-  white: oklch(100% 0 0),
-
   /* Grayscale */
   gray-1000: oklch(16.93% 0 0),
   gray-900: oklch(19.37% 0 0),
@@ -57,7 +53,7 @@ $_colors: (
 
 @mixin _light-colors {
   /* Dynamic general purpose colors */
-  --full-contrast: var(--black);
+  --full-contrast: black;
 
   --primary-contrast: var(--gray-900);
   --secondary-contrast: var(--gray-800);
@@ -78,9 +74,9 @@ $_colors: (
   --dynamic-transparent-02: var(--transparent-02);
 
   /* Main colors – general UI colors like background and text color */
-  --color-background: var(--white);
+  --color-background: white;
   --color-foreground: var(--blue-06);
-  --color-text: var(--black);
+  --color-text: black;
   --color-separator: var(--blue-05);
 
   /* Special colors – usually a single-use colors meant for specific elements */
@@ -97,7 +93,7 @@ $_colors: (
 
 @mixin _dark-colors {
   /* Dynamic general purpose colors */
-  --full-contrast: var(--white);
+  --full-contrast: white;
 
   --primary-contrast: var(--gray-50);
   --secondary-contrast: var(--gray-300);
@@ -120,7 +116,7 @@ $_colors: (
   /* Main colors – general UI colors like background and text color */
   --color-background: var(--gray-800);
   --color-foreground: var(--gray-700);
-  --color-text: var(--white);
+  --color-text: white;
   --color-separator: var(--gray-600);
 
   /* Special colors – usually a single-use colors meant for specific elements */

--- a/devtools/projects/ng-devtools/src/styles/_colors.scss
+++ b/devtools/projects/ng-devtools/src/styles/_colors.scss
@@ -1,1 +1,175 @@
-$dummy: #f00;
+@use 'sass:color';
+@use 'sass:map';
+@use './theme' as theme;
+
+/* A map with all available solid colors (excl. Special). Available as CSS vars as well. */
+/* prettier-ignore */
+$_colors: (
+  /* Reds */
+  red-01: oklch(40% 0.1 26),
+  red-02: oklch(49.3% 0.2 26),
+  red-03: oklch(55% 0.2 26),
+  red-04: oklch(63% 0.2 26),
+  red-05: oklch(68.8% 0.2 26),
+  red-06: oklch(86% 0.06 15),
+
+  /* Greens */
+  green-01: oklch(58% 0.13 145),
+  green-02: oklch(65% 0.13 145),
+  green-03: oklch(83% 0.13 145),
+
+  /* Blues */
+  blue-01: oklch(36% 0.1 258),
+  blue-02: oklch(57% 0.2 258),
+  blue-03: oklch(72% 0.2 258),
+  blue-04: oklch(83% 0.2 258),
+  blue-05: oklch(91% 0.04 258),
+  blue-06: oklch(96% 0.01 258),
+
+  /* Purples */
+  purple-01: oklch(47.5% 0.26 295),
+  purple-02: oklch(57.9% 0.26 295),
+  purple-03: oklch(76% 0.15 305),
+
+  /* Full contrast */
+  black: oklch(0% 0 0),
+  white: oklch(100% 0 0),
+
+  /* Grayscale */
+  gray-1000: oklch(16.93% 0 0),
+  gray-900: oklch(19.37% 0 0),
+  gray-800: oklch(27.68% 0 0),
+  gray-700: oklch(36.98% 0 0),
+  gray-600: oklch(47% 0 0),
+  gray-500: oklch(54.84% 0 0),
+  gray-400: oklch(70.9% 0 0),
+  gray-300: oklch(84.01% 0 0),
+  gray-200: oklch(91.75% 0 0),
+  gray-100: oklch(97.12% 0 0),
+  gray-50: oklch(98.81% 0 0),
+
+  /* Transparent */
+  transparent-01: oklch(0% 0 0 / 0.8),
+  transparent-02: oklch(0% 0 0 / 0.35),
+  transparent-03: oklch(0% 0 0 / 0.2),
+  transparent-04: oklch(0% 0 0 / 0.05),
+);
+
+@mixin _light-colors {
+  /* Dynamic general purpose colors */
+  --full-contrast: var(--black);
+
+  --primary-contrast: var(--gray-900);
+  --secondary-contrast: var(--gray-800);
+  --tertiary-contrast: var(--gray-700);
+  --quaternary-contrast: var(--gray-500);
+  --quinary-contrast: var(--gray-300);
+  --senary-contrast: var(--gray-200);
+  --septenary-contrast: var(--gray-100);
+  --octonary-contrast: var(--gray-50);
+
+  --dynamic-red-01: var(--red-03);
+  --dynamic-red-02: var(--red-06);
+  --dynamic-green-01: var(--green-01);
+  --dynamic-blue-01: var(--blue-05);
+  --dynamic-purple-01: var(--purple-01);
+
+  --dynamic-transparent-01: var(--transparent-04);
+  --dynamic-transparent-02: var(--transparent-02);
+
+  /* Main colors – general UI colors like background and text color */
+  --color-background: var(--white);
+  --color-foreground: var(--blue-06);
+  --color-text: var(--black);
+  --color-separator: var(--blue-05);
+
+  /* Special colors – usually a single-use colors meant for specific elements */
+  --color-tree-node-element-name: #830042;
+  --color-tree-node-dir-name: #953b13;
+  --color-tree-node-ng-element: #0c3a96;
+  --color-tree-node-console-ref: #146129;
+  --color-tree-node-hovered: #f2f2f2;
+  --color-tree-node-highlighted: #cddffd;
+  --color-tree-node-matched: #f3ce49;
+
+  --color-property-list-name: #71a2f7;
+}
+
+@mixin _dark-colors {
+  /* Dynamic general purpose colors */
+  --full-contrast: var(--white);
+
+  --primary-contrast: var(--gray-50);
+  --secondary-contrast: var(--gray-300);
+  --tertiary-contrast: var(--gray-300);
+  --quaternary-contrast: var(--gray-400);
+  --quinary-contrast: var(--gray-500);
+  --senary-contrast: var(--gray-700);
+  --septenary-contrast: var(--gray-800);
+  --octonary-contrast: var(--gray-900);
+
+  --dynamic-red-01: var(--red-05);
+  --dynamic-red-02: var(--red-01);
+  --dynamic-green-01: var(--green-03);
+  --dynamic-blue-01: var(--blue-01);
+  --dynamic-purple-01: var(--purple-03);
+
+  --dynamic-transparent-01: var(--transparent-03);
+  --dynamic-transparent-02: var(--transparent-01);
+
+  /* Main colors – general UI colors like background and text color */
+  --color-background: var(--gray-800);
+  --color-foreground: var(--gray-700);
+  --color-text: var(--white);
+  --color-separator: var(--gray-600);
+
+  /* Special colors – usually a single-use colors meant for specific elements */
+  --color-tree-node-element-name: #71a2f7;
+  --color-tree-node-dir-name: #9ec0f9;
+  --color-tree-node-ng-element: #fe824f;
+  --color-tree-node-console-ref: #a1a1a1;
+  --color-tree-node-hovered: #393939;
+  --color-tree-node-highlighted: #00416c;
+  --color-tree-node-matched: #906921;
+
+  --color-property-list-name: #0c3a96;
+}
+
+/* Utilities */
+
+@function convert-to-rgb($map) {
+  $rgb-map: ();
+
+  @each $name, $color in $map {
+    $rgb-map: map-merge(
+      $rgb-map,
+      (
+        $name: color.to-space($color, rgb),
+      )
+    );
+  }
+
+  @return $rgb-map;
+}
+
+@mixin convert-color-map-to-vars($colors) {
+  @each $name, $color in $colors {
+    --#{$name}: #{$color};
+  }
+}
+
+/* Main */
+
+/* Since Oklch global browser support is ~93%, we are converting colors to RGB. */
+$colors: convert-to-rgb($_colors); /* Main color map */
+
+@mixin root-colors {
+  :root {
+    @include convert-color-map-to-vars($colors);
+    @include _light-colors();
+
+    &.#{theme.$dark-theme-class} {
+      @include _dark-colors();
+    }
+  }
+}

--- a/devtools/projects/ng-devtools/src/styles/_global.scss
+++ b/devtools/projects/ng-devtools/src/styles/_global.scss
@@ -2,13 +2,24 @@
 
 @use 'sass:map';
 @use 'external/npm/node_modules/@angular/material/index' as mat;
+@use './colors' as clr;
+
 @include mat.all-component-typographies();
 @include mat.core();
+@include clr.root-colors();
 
 html,
 body {
   padding: 0;
   margin: 0;
+  background: var(--color-background);
+  color: var(--color-text);
+}
+
+input,
+select {
+  color: var(--primary-contrast);
+  background: var(--color-foreground);
 }
 
 // Light theme
@@ -24,19 +35,19 @@ $dark-theme: map.deep-merge(
   (
     'color': (
       'background': (
-        background: #202124,
-        card: #202124,
+        background: map.get(clr.$colors, gray-800),
+        card: map.get(clr.$colors, gray-800),
       ),
       'foreground': (
-        text: #bcc5ce,
+        text: map.get(clr.$colors, gray-200),
       ),
     ),
     'background': (
-      background: #202124,
-      card: #202124,
+      background: map.get(clr.$colors, gray-800),
+      card: map.get(clr.$colors, gray-800),
     ),
     'foreground': (
-      'text': #bcc5ce,
+      'text': map.get(clr.$colors, gray-200),
     ),
   )
 );
@@ -53,7 +64,6 @@ $dark-theme: map.deep-merge(
 /* Keep class name in sync with ThemeService */
 .dark-theme {
   color-scheme: dark;
-  background: #202124;
   @include mat.all-component-themes($dark-theme);
 
   .mat-mdc-chip.mat-mdc-standard-chip {

--- a/devtools/projects/ng-devtools/src/styles/_theme.scss
+++ b/devtools/projects/ng-devtools/src/styles/_theme.scss
@@ -1,30 +1,30 @@
 /* Keep class names in sync with ThemeService */
-$_dark-theme-class: 'dark-theme';
-$_light-theme-class: 'light-theme';
+$dark-theme-class: 'dark-theme';
+$light-theme-class: 'light-theme';
 
 /* $browser expects 'chrome', 'firefox' or 'safari' */
 @mixin _theme($theme, $browser: '') {
   @if $browser == '' {
-    :host-context(body.#{$theme}) {
+    :host-context(:root.#{$theme}) {
       @content;
     }
   } @else {
     /* Keep browser class name in sync with BrowserService. */
     $browser-class: $browser + '-ui';
-    :host-context(body.#{$theme}.#{$browser-class}) {
+    :host-context(:root.#{$theme}.#{$browser-class}) {
       @content;
     }
   }
 }
 
 @mixin dark-theme($browser: '') {
-  @include _theme($_dark-theme-class, $browser) {
+  @include _theme($dark-theme-class, $browser) {
     @content;
   }
 }
 
 @mixin light-theme($browser: '') {
-  @include _theme($_light-theme-class, $browser) {
+  @include _theme($light-theme-class, $browser) {
     @content;
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## What is the new behavior?

The refactoring consists of:

1. Extraction of colors from the stylesheets and their replacement with variables.
2. Color number reduction (we had ~84 pre-refactoring) and color correction.
3. Theming. It's similar to what we use in A.dev.

Here is a diagram with all solid colors that the app uses (excl. Special colors; check the code comments).

<img width="1134" alt="Screenshot 2025-03-13 at 18 02 48" src="https://github.com/user-attachments/assets/50bd4843-842e-4d28-ac89-ee591cededa9" />

Hopefully, the change should make color management easier and cleaner.

@dgp1130, there is some room for improvement in terms of accessibility. I did some tests by simulating some vision deficiencies – most of the colors are distinguishable but not by a huge margin. I am not sure if that's something that we should handle ourselves or let the OS do its work. Alternatively, we can introduce a high contrast theme (BTW, Chrome DevTools do not react to the high-contrast OS setting).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
