### PR TITLE
fix(router): Remove 'any' type from route guards

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -244,7 +244,10 @@ export class DefaultUrlSerializer implements UrlSerializer {
 }
 
 // @public @deprecated
-export type DeprecatedGuard = ProviderToken<any> | any;
+export type DeprecatedGuard = ProviderToken<any> | string;
+
+// @public @deprecated
+export type DeprecatedResolve = DeprecatedGuard | any;
 
 // @public
 export type DetachedRouteHandle = {};
@@ -611,7 +614,7 @@ export interface Resolve<T> {
 
 // @public
 export type ResolveData = {
-    [key: string | symbol]: ResolveFn<unknown> | DeprecatedGuard;
+    [key: string | symbol]: ResolveFn<unknown> | DeprecatedResolve;
 };
 
 // @public

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -46,7 +46,7 @@ import type {UrlSegment, UrlSegmentGroup, UrlTree} from './url_tree';
 export type OnSameUrlNavigation = 'reload' | 'ignore';
 
 /**
- * The `InjectionToken` and `@Injectable` classes for guards and resolvers are deprecated in favor
+ * The `InjectionToken` and `@Injectable` classes for guards are deprecated in favor
  * of plain JavaScript functions instead. Dependency injection can still be achieved using the
  * [`inject`](api/core/inject) function from `@angular/core` and an injectable class can be used as
  * a functional guard using [`inject`](api/core/inject): `canActivate: [() =>
@@ -58,11 +58,23 @@ export type OnSameUrlNavigation = 'reload' | 'ignore';
  * @see {@link CanActivateFn}
  * @see {@link CanActivateChildFn}
  * @see {@link CanDeactivateFn}
+ * @see {@link /api/core/inject inject}
+ * @publicApi
+ */
+export type DeprecatedGuard = ProviderToken<any> | string;
+
+/**
+ * The `InjectionToken` and `@Injectable` classes for resolvers are deprecated in favor
+ * of plain JavaScript functions instead. Dependency injection can still be achieved using the
+ * [`inject`](api/core/inject) function from `@angular/core` and an injectable class can be used as
+ * a functional guard using [`inject`](api/core/inject): `myResolvedData: () => inject(MyResolver).resolve()`.
+ *
+ * @deprecated
  * @see {@link ResolveFn}
  * @see {@link /api/core/inject inject}
  * @publicApi
  */
-export type DeprecatedGuard = ProviderToken<any> | any;
+export type DeprecatedResolve = DeprecatedGuard | any;
 
 /**
  * The supported types that can be returned from a `Router` guard.
@@ -197,7 +209,7 @@ export type Data = {
  * @publicApi
  */
 export type ResolveData = {
-  [key: string | symbol]: ResolveFn<unknown> | DeprecatedGuard;
+  [key: string | symbol]: ResolveFn<unknown> | DeprecatedResolve;
 };
 
 /**

--- a/packages/router/src/models_deprecated.ts
+++ b/packages/router/src/models_deprecated.ts
@@ -10,4 +10,4 @@
 // The public API re-exports everything from this file, which can be patched
 // locally in g3 to prevent regressions after cleanups complete.
 
-export {DeprecatedGuard} from './models';
+export {DeprecatedGuard, DeprecatedResolve} from './models';

--- a/packages/router/test/computed_state_restoration.spec.ts
+++ b/packages/router/test/computed_state_restoration.spec.ts
@@ -70,7 +70,6 @@ describe('`restoredState#ɵrouterPageId`', () => {
     TestBed.configureTestingModule({
       imports: [TestModule],
       providers: [
-        {provide: 'alwaysFalse', useValue: (a: any) => false},
         {provide: Location, useClass: SpyLocation},
         provideRouter(
           [
@@ -106,7 +105,7 @@ describe('`restoredState#ɵrouterPageId`', () => {
             {
               path: 'loaded',
               loadChildren: () => of(ModuleWithSimpleCmpAsRoute),
-              canLoad: ['alwaysFalse'],
+              canLoad: [() => false],
             },
           ],
           withRouterConfig({

--- a/packages/router/test/helpers.ts
+++ b/packages/router/test/helpers.ts
@@ -23,14 +23,6 @@ export class Logger {
   }
 }
 
-export function provideTokenLogger(token: string, returnValue = true as boolean | UrlTree) {
-  return {
-    provide: token,
-    useFactory: (logger: Logger) => () => (logger.add(token), returnValue),
-    deps: [Logger],
-  };
-}
-
 export declare type ARSArgs = {
   url?: UrlSegment[];
   params?: Params;

--- a/packages/router/test/integration/duplicate_in_flight_navigations.spec.ts
+++ b/packages/router/test/integration/duplicate_in_flight_navigations.spec.ts
@@ -34,18 +34,7 @@ export function duplicateInFlightNavigationsIntegrationSuite() {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        providers: [
-          {
-            provide: 'in1Second',
-            useValue: (c: any, a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
-              let res: any = null;
-              const p = new Promise((_) => (res = _));
-              setTimeout(() => res(true), 1000);
-              return p;
-            },
-          },
-          RedirectingGuard,
-        ],
+        providers: [RedirectingGuard],
       });
     });
 
@@ -54,7 +43,13 @@ export function duplicateInFlightNavigationsIntegrationSuite() {
       const location = TestBed.inject(Location);
       const fixture = createRoot(router, RootCmp);
 
-      router.resetConfig([{path: 'simple', component: SimpleCmp, canActivate: ['in1Second']}]);
+      router.resetConfig([
+        {
+          path: 'simple',
+          component: SimpleCmp,
+          canActivate: [() => new Promise((resolve) => setTimeout(resolve, 1000))],
+        },
+      ]);
 
       // Trigger two location changes to the same URL.
       // Because of the guard the order will look as follows:
@@ -162,8 +157,16 @@ export function duplicateInFlightNavigationsIntegrationSuite() {
     it('should accurately track currentNavigation', fakeAsync(() => {
       const router = TestBed.inject(Router);
       router.resetConfig([
-        {path: 'one', component: SimpleCmp, canActivate: ['in1Second']},
-        {path: 'two', component: BlankCmp, canActivate: ['in1Second']},
+        {
+          path: 'one',
+          component: SimpleCmp,
+          canActivate: [() => new Promise((resolve) => setTimeout(resolve, 1000))],
+        },
+        {
+          path: 'two',
+          component: BlankCmp,
+          canActivate: [() => new Promise((resolve) => setTimeout(resolve, 1000))],
+        },
       ]);
 
       router.events.subscribe((e) => {

--- a/packages/router/test/integration/eager_url_update_strategy.spec.ts
+++ b/packages/router/test/integration/eager_url_update_strategy.spec.ts
@@ -53,14 +53,6 @@ export function eagerUrlUpdateStrategyIntegrationSuite() {
       const serializer = new DefaultUrlSerializer();
       TestBed.configureTestingModule({
         providers: [
-          {
-            provide: 'authGuardFail',
-            useValue: (a: any, b: any) => {
-              return new Promise((res) => {
-                setTimeout(() => res(serializer.parse('/login')), 1);
-              });
-            },
-          },
           AuthGuard,
           DelayedGuard,
           provideRouter([], withRouterConfig({urlUpdateStrategy: 'eager'})),
@@ -102,7 +94,16 @@ export function eagerUrlUpdateStrategyIntegrationSuite() {
         advance(fixture);
 
         router.resetConfig([
-          {path: 'team/:id', component: SimpleCmp, canActivate: ['authGuardFail']},
+          {
+            path: 'team/:id',
+            component: SimpleCmp,
+            canActivate: [
+              () =>
+                new Promise((res) => {
+                  setTimeout(() => res(new DefaultUrlSerializer().parse('/login')), 1);
+                }),
+            ],
+          },
           {path: 'login', component: AbsoluteSimpleLinkCmp},
         ]);
 

--- a/packages/router/test/integration/lazy_loading.spec.ts
+++ b/packages/router/test/integration/lazy_loading.spec.ts
@@ -769,16 +769,7 @@ export function lazyLoadingIntegrationSuite() {
       beforeEach(() => {
         log.length = 0;
         TestBed.configureTestingModule({
-          providers: [
-            {provide: PreloadingStrategy, useExisting: PreloadAllModules},
-            {
-              provide: 'loggingReturnsTrue',
-              useValue: () => {
-                log.push('loggingReturnsTrue');
-                return true;
-              },
-            },
-          ],
+          providers: [{provide: PreloadingStrategy, useExisting: PreloadAllModules}],
         });
         const preloader = TestBed.inject(RouterPreloader);
         preloader.setUpPreloading();
@@ -813,7 +804,16 @@ export function lazyLoadingIntegrationSuite() {
 
         router.resetConfig([
           {path: 'blank', component: BlankCmp},
-          {path: 'lazy', loadChildren: () => LoadedModule1, canLoad: ['loggingReturnsTrue']},
+          {
+            path: 'lazy',
+            loadChildren: () => LoadedModule1,
+            canLoad: [
+              () => {
+                log.push('loggingReturnsTrue');
+                return true;
+              },
+            ],
+          },
         ]);
 
         router.navigateByUrl('/blank');

--- a/packages/router/test/integration/navigation.spec.ts
+++ b/packages/router/test/integration/navigation.spec.ts
@@ -445,31 +445,6 @@ export function navigationIntegrationTestSuite() {
 
     beforeEach(() => {
       log = [];
-
-      TestBed.configureTestingModule({
-        providers: [
-          {
-            provide: 'trueRightAway',
-            useValue: () => {
-              log.push('trueRightAway');
-              return true;
-            },
-          },
-          {
-            provide: 'trueIn2Seconds',
-            useValue: () => {
-              log.push('trueIn2Seconds-start');
-              let res: (value: boolean) => void;
-              const p = new Promise<boolean>((r) => (res = r));
-              setTimeout(() => {
-                log.push('trueIn2Seconds-end');
-                res(true);
-              }, 2000);
-              return p;
-            },
-          },
-        ],
-      });
     });
 
     describe('route activation', () => {
@@ -680,10 +655,22 @@ export function navigationIntegrationTestSuite() {
     it('should not wait for prior navigations to start a new navigation', fakeAsync(
       inject([Router, Location], (router: Router) => {
         const fixture = createRoot(router, RootCmp);
-
+        const trueRightAway = () => {
+          log.push('trueRightAway');
+          return true;
+        };
+        const trueIn2Seconds = () => {
+          log.push('trueIn2Seconds-start');
+          return new Promise<boolean>((res) => {
+            setTimeout(() => {
+              log.push('trueIn2Seconds-end');
+              res(true);
+            }, 2000);
+          });
+        };
         router.resetConfig([
-          {path: 'a', component: SimpleCmp, canActivate: ['trueRightAway', 'trueIn2Seconds']},
-          {path: 'b', component: SimpleCmp, canActivate: ['trueRightAway', 'trueIn2Seconds']},
+          {path: 'a', component: SimpleCmp, canActivate: [trueRightAway, trueIn2Seconds]},
+          {path: 'b', component: SimpleCmp, canActivate: [trueRightAway, trueIn2Seconds]},
         ]);
 
         router.navigateByUrl('/a');

--- a/packages/router/test/integration/navigation_errors.spec.ts
+++ b/packages/router/test/integration/navigation_errors.spec.ts
@@ -352,10 +352,6 @@ export function navigationErrorsIntegrationSuite() {
   });
 
   it('should dispatch NavigationCancel after the url has been reset back', fakeAsync(() => {
-    TestBed.configureTestingModule({
-      providers: [{provide: 'returnsFalse', useValue: () => false}],
-    });
-
     const router: Router = TestBed.inject(Router);
     const location = TestBed.inject(Location);
 
@@ -366,7 +362,7 @@ export function navigationErrorsIntegrationSuite() {
       {
         path: 'throwing',
         loadChildren: jasmine.createSpy('doesnotmatter'),
-        canLoad: ['returnsFalse'],
+        canLoad: [() => false],
       },
     ]);
 

--- a/packages/router/test/integration/route_data.spec.ts
+++ b/packages/router/test/integration/route_data.spec.ts
@@ -71,13 +71,6 @@ export function routeDataIntegrationSuite() {
           {provide: 'resolveNullError', useValue: (a: any, b: any) => Promise.reject(null)},
           {provide: 'resolveEmpty', useValue: (a: any, b: any) => EMPTY},
           {provide: 'numberOfUrlSegments', useValue: (a: any, b: any) => a.url.length},
-          {
-            provide: 'overridingGuard',
-            useValue: (route: ActivatedRouteSnapshot) => {
-              route.data = {prop: 10};
-              return true;
-            },
-          },
         ],
       });
     });
@@ -596,7 +589,12 @@ export function routeDataIntegrationSuite() {
           {
             path: 'route',
             component: NestedComponentWithData,
-            canActivate: ['overridingGuard'],
+            canActivate: [
+              (route: ActivatedRouteSnapshot) => {
+                route.data = {prop: 10};
+                return true;
+              },
+            ],
           },
         ]);
 

--- a/packages/router/test/regression_integration.spec.ts
+++ b/packages/router/test/regression_integration.spec.ts
@@ -18,6 +18,7 @@ import {
   Type,
   ViewChild,
   ViewContainerRef,
+  inject,
 } from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {
@@ -294,20 +295,11 @@ describe('Integration', () => {
         imports: [
           RouterModule.forRoot([
             {path: '', component: SimpleCmp},
-            {path: 'one', component: OneCmp, canActivate: ['returnRootUrlTree']},
+            {path: 'one', component: OneCmp, canActivate: [() => inject(Router).parseUrl('/')]},
           ]),
         ],
         declarations: [SimpleCmp, RootCmp, OneCmp],
-        providers: [
-          provideLocationMocks(),
-          {
-            provide: 'returnRootUrlTree',
-            useFactory: (router: Router) => () => {
-              return router.parseUrl('/');
-            },
-            deps: [Router],
-          },
-        ],
+        providers: [provideLocationMocks()],
       });
 
       const router = TestBed.inject(Router);

--- a/packages/router/test/router_preloader.spec.ts
+++ b/packages/router/test/router_preloader.spec.ts
@@ -52,7 +52,7 @@ describe('RouterPreloader', () => {
         providers: [
           provideLocationMocks(),
           provideRouter(
-            [{path: 'lazy', loadChildren: jasmine.createSpy('expected'), canLoad: ['someGuard']}],
+            [{path: 'lazy', loadChildren: jasmine.createSpy('expected'), canLoad: [() => true]}],
             withPreloading(PreloadAllModules),
           ),
         ],
@@ -85,7 +85,7 @@ describe('RouterPreloader', () => {
         providers: [
           provideLocationMocks(),
           provideRouter(
-            [{path: 'lazy', loadChildren: () => LoadedModule, canLoad: ['someGuard']}],
+            [{path: 'lazy', loadChildren: () => LoadedModule, canLoad: [() => true]}],
             withPreloading(PreloadAllModules),
           ),
         ],


### PR DESCRIPTION
This commit removes `'any'` from the type union for router guards and replaces it with 'string', which will eventually also be removed. This change allows TypeScript to infer the parameter types of functions when using functional guards and enables stricter type-checking to ensure the guard array contains valid values.

BREAKING CHANGE: The guards arrays on `Route` no longer include `any` in the type union. The union includes functions for the functional guards as well as a type matching `Injector.get`: `ProviderToken<T>|string`. Note that string is still deprecated on both the route guards and `Injector.get`.