### PR TITLE
build: upload grpc remote logs for debugging

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -114,6 +114,8 @@ build:remote --bes_instance_name=internal-200822
 build:remote --remote_cache=remotebuildexecution.googleapis.com
 build:remote --remote_executor=remotebuildexecution.googleapis.com
 
+build:remote --experimental_remote_grpc_log=/tmp/rbe-grpc.log
+
 # See: https://docs.google.com/document/d/1NgDPsCIwprDdqC1zj0qQrh5KGK2hQTSTux1DAvi4rSc/edit?tab=t.0.
 build:remote --experimental_remote_execution_keepalive
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -76,6 +76,12 @@ jobs:
         run: yarn install --frozen-lockfile --network-timeout 100000
       - name: Run CI tests for framework
         run: yarn test:ci
+      - name: Upload GRPC logs (for debugging of RBE issues)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          path: /tmp/rbe-grpc.log
+          retention-days: 1
 
   artifacts:
     needs: [test]


### PR DESCRIPTION
This should be helpful in figuring out why RBE is currently unstable.