### PR TITLE
fix(core): remove `rejectErrors` option encourages uncaught exceptions

### DIFF
--- a/goldens/public-api/core/rxjs-interop/index.api.md
+++ b/goldens/public-api/core/rxjs-interop/index.api.md
@@ -84,7 +84,6 @@ export interface ToSignalOptions<T> {
     initialValue?: unknown;
     injector?: Injector;
     manualCleanup?: boolean;
-    rejectErrors?: boolean;
     requireSync?: boolean;
 }
 

--- a/packages/core/rxjs-interop/src/to_signal.ts
+++ b/packages/core/rxjs-interop/src/to_signal.ts
@@ -63,16 +63,6 @@ export interface ToSignalOptions<T> {
   manualCleanup?: boolean;
 
   /**
-   * Whether `toSignal` should throw errors from the Observable error channel back to RxJS, where
-   * they'll be processed as uncaught exceptions.
-   *
-   * In practice, this means that the signal returned by `toSignal` will keep returning the last
-   * good value forever, as Observables which error produce no further values. This option emulates
-   * the behavior of the `async` pipe.
-   */
-  rejectErrors?: boolean;
-
-  /**
    * A comparison function which defines equality for values emitted by the observable.
    *
    * Equality comparisons are executed against the initial value if one is provided.
@@ -172,11 +162,6 @@ export function toSignal<T, U = undefined>(
   const sub = source.subscribe({
     next: (value) => state.set({kind: StateKind.Value, value}),
     error: (error) => {
-      if (options?.rejectErrors) {
-        // Kick the error back to RxJS. It will be caught and rethrown in a macrotask, which causes
-        // the error to end up as an uncaught exception.
-        throw error;
-      }
       state.set({kind: StateKind.Error, error});
     },
     // Completion of the Observable is meaningless to the signal. Signals don't have a concept of

--- a/packages/core/rxjs-interop/test/to_signal_spec.ts
+++ b/packages/core/rxjs-interop/test/to_signal_spec.ts
@@ -152,28 +152,6 @@ describe('toSignal()', () => {
     );
   });
 
-  it('should throw the error back to RxJS if rejectErrors is set', () => {
-    let capturedObserver: Observer<number> = null!;
-    const fake$ = {
-      subscribe(observer: Observer<number>): Unsubscribable {
-        capturedObserver = observer;
-        return {unsubscribe(): void {}};
-      },
-    } as Subscribable<number>;
-
-    const s = toSignal(fake$, {initialValue: 0, rejectErrors: true, manualCleanup: true});
-    expect(s()).toBe(0);
-    if (capturedObserver === null) {
-      return fail('Observer not captured as expected.');
-    }
-
-    capturedObserver.next(1);
-    expect(s()).toBe(1);
-
-    expect(() => capturedObserver.error('test')).toThrow('test');
-    expect(s()).toBe(1);
-  });
-
   describe('with no initial value', () => {
     it(
       'should return `undefined` if read before a value is emitted',


### PR DESCRIPTION
This commit removes the previously added `rejectErrors` option from `toSignal` which was meant to create similar behavior to what happens with unhandled errors in `AsyncPipe`.

This option promotes unhandled exceptions and attaches behaviors that we do not believe are desirable as an option offered by the framework:

* Unhandled errors that are thrown lose the context of where the error ocurred. Throwing the error where the signal is read allows error handling to be performed at the signal's usage location
* With this feature, the value of the signal remains set to the initial value or the previous successful value coming out of the `Observable`. We do not feel this is appropriate implicit behavior but should be an explicit choice by the application. Signals are built to represent state. When an observable stream is converted to a stateful representation, there should be a choice made about what state should be presented when an error occurs
* If an error occurs but the signal value is never read in its error state, this is not an application state error that should result in an unhandled exception.
* While Angular does not have error boundaries today, there is likely to be investigation in the near future to address increased risk of errors thrown from signals such as this in templates. Without pre-designing any specifics, it is possible that this type of feature would require the error to be thrown from the signal. We are subsequently not prepared to commit to stabilizing the `toSignal` API with the `rejectErrors` option and its current behavior.

Developers that desire similar behavior to `rejectErrors` have several options, the simplest of which would be something similar to `toSignal(myStream.pipe(catchError(() => EMPTY)))`.
