### PR TITLE
refactor(devtools): fix reading `resolutionPath`

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
@@ -223,13 +223,15 @@ const getRoutes = (messageBus: MessageBus<Events>) => {
     initializeOrGetDirectiveForestHooks().getIndexedDirectiveForest(),
     ngDebugDependencyInjectionApiIsSupported(),
   );
+  if (forest.length === 0) return;
+
   const rootInjector = (forest[0].resolutionPath ?? []).find((i) => i.name === 'Root');
-  if (rootInjector) {
-    const route = getRouterConfigFromRoot(rootInjector);
-    if (route) {
-      messageBus.emit('updateRouterTree', [[route]]);
-    }
-  }
+  if (!rootInjector) return;
+
+  const route = getRouterConfigFromRoot(rootInjector);
+  if (!route) return;
+
+  messageBus.emit('updateRouterTree', [[route]]);
 };
 
 const getSerializedProviderRecords = (injector: SerializedInjector) => {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
@@ -89,11 +89,13 @@ export class InjectorTreeComponent {
 
   private init() {
     this._messageBus.on('latestComponentExplorerView', (view: ComponentExplorerView) => {
-      if (view.forest[0].resolutionPath !== undefined) {
-        this.diDebugAPIsAvailable.set(true);
-        this.rawDirectiveForest = view.forest;
-        this.updateInjectorTreeVisualization(view.forest);
-      }
+      if (view.forest.length === 0) return;
+
+      if (!view.forest[0].resolutionPath) return;
+
+      this.diDebugAPIsAvailable.set(true);
+      this.rawDirectiveForest = view.forest;
+      this.updateInjectorTreeVisualization(view.forest);
     });
 
     this._messageBus.on(


### PR DESCRIPTION
Sometimes `forest` can be empty if the provided roots are empty, and was leading to a "Cannot read `resolutionPath` of `undefined`" error. Now we check the forest has a tree in it before looking up `resolutionPath`.