### PR TITLE
fix(core): include input name in error message

### DIFF
--- a/packages/core/src/authoring/input/input_signal.ts
+++ b/packages/core/src/authoring/input/input_signal.ts
@@ -127,10 +127,12 @@ export function createInputSignal<T, TransformT>(
     producerAccessed(node);
 
     if (node.value === REQUIRED_UNSET_VALUE) {
-      throw new RuntimeError(
-        RuntimeErrorCode.REQUIRED_INPUT_NO_VALUE,
-        ngDevMode && 'Input is required but no value is available yet.',
-      );
+      let message: string | null = null;
+      if (ngDevMode) {
+        const name = options?.debugName ?? options?.alias;
+        message = `Input${name ? ` "${name}"` : ''} is required but no value is available yet.`;
+      }
+      throw new RuntimeError(RuntimeErrorCode.REQUIRED_INPUT_NO_VALUE, message);
     }
 
     return node.value;

--- a/packages/core/test/authoring/input_signal_spec.ts
+++ b/packages/core/test/authoring/input_signal_spec.ts
@@ -78,6 +78,34 @@ describe('input signal', () => {
     });
   });
 
+  it('should include debugName in required inputs error message, if available', () => {
+    TestBed.runInInjectionContext(() => {
+      const signal = input.required({debugName: 'mySignal'});
+      const node = signal[SIGNAL];
+
+      expect(() => signal()).toThrowError(
+        /Input "mySignal" is required but no value is available yet\./,
+      );
+
+      node.applyValueToInputSignal(node, 1);
+      expect(signal()).toBe(1);
+    });
+  });
+
+  it('should include alias in required inputs error message, if available', () => {
+    TestBed.runInInjectionContext(() => {
+      const signal = input.required({alias: 'alias'});
+      const node = signal[SIGNAL];
+
+      expect(() => signal()).toThrowError(
+        /Input "alias" is required but no value is available yet\./,
+      );
+
+      node.applyValueToInputSignal(node, 1);
+      expect(signal()).toBe(1);
+    });
+  });
+
   it('should throw if a `computed` depends on an uninitialized required input', () => {
     TestBed.runInInjectionContext(() => {
       const signal = input.required<number>();


### PR DESCRIPTION
Includes either the `debugName` or alias of an input in the error message about a value not being available.

Fixes #60199.
