### PR TITLE
fix(core): remove unused parameter from listener instruction

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/host_listeners.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/host_listeners.js
@@ -2,6 +2,6 @@ function MyComponent_HostBindings(rf, ctx) {
 	if (rf & 1) {
 		i0.ɵɵlistener("dragover", function MyComponent_dragover_HostBindingHandler($event) {
 			return ctx.foo($event);
-		}, false, i0.ɵɵresolveDocument);
+		}, i0.ɵɵresolveDocument);
 	}
 }

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -5067,7 +5067,7 @@ runInEachFileSystem((os: string) => {
       const hostBindingsFn = `
       hostBindings: function FooCmp_HostBindings(rf, ctx) {
         if (rf & 1) {
-          i0.ɵɵlistener("click", function FooCmp_click_HostBindingHandler() { return ctx.onClick(); })("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onDocumentClick($event.target); }, false, i0.ɵɵresolveDocument)("scroll", function FooCmp_scroll_HostBindingHandler() { return ctx.onWindowScroll(); }, false, i0.ɵɵresolveWindow);
+          i0.ɵɵlistener("click", function FooCmp_click_HostBindingHandler() { return ctx.onClick(); })("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onDocumentClick($event.target); }, i0.ɵɵresolveDocument)("scroll", function FooCmp_scroll_HostBindingHandler() { return ctx.onWindowScroll(); }, i0.ɵɵresolveWindow);
         }
       }
     `;
@@ -5198,7 +5198,7 @@ runInEachFileSystem((os: string) => {
       hostVars: 4,
       hostBindings: function FooCmp_HostBindings(rf, ctx) {
         if (rf & 1) {
-          i0.ɵɵlistener("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onClick($event); })("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onBodyClick($event); }, false, i0.ɵɵresolveBody)("change", function FooCmp_change_HostBindingHandler() { return ctx.onChange(ctx.arg1, ctx.arg2, ctx.arg3); });
+          i0.ɵɵlistener("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onClick($event); })("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onBodyClick($event); }, i0.ɵɵresolveBody)("change", function FooCmp_change_HostBindingHandler() { return ctx.onChange(ctx.arg1, ctx.arg2, ctx.arg3); });
         }
         if (rf & 2) {
           i0.ɵɵhostProperty("prop", ctx.bar);

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -158,7 +158,6 @@ export function listener(
 ): ir.CreateOp {
   const args = [o.literal(name), handlerFn];
   if (eventTargetResolver !== null) {
-    args.push(o.literal(false)); // `useCapture` flag, defaults to `false`
     args.push(o.importExpr(eventTargetResolver));
   }
   return call(

--- a/packages/core/src/render3/instructions/listener.ts
+++ b/packages/core/src/render3/instructions/listener.ts
@@ -51,8 +51,6 @@ export function setStashFn(fn: typeof stashEventListener) {
  *
  * @param eventName Name of the event
  * @param listenerFn The function to be called when event emits
- * @param useCapture Whether or not to use capture in event listener - this argument is a reminder
- *     from the Renderer3 infrastructure and should be removed from the instruction arguments
  * @param eventTargetResolver Function that returns global target information in case this listener
  * should be attached to a global object like window, document or body
  *
@@ -61,7 +59,6 @@ export function setStashFn(fn: typeof stashEventListener) {
 export function ɵɵlistener(
   eventName: string,
   listenerFn: (e?: any) => any,
-  useCapture?: boolean,
   eventTargetResolver?: GlobalTargetResolver,
 ): typeof ɵɵlistener {
   const lView = getLView<{} | null>();


### PR DESCRIPTION
Removes the `useCapture` parameter from the `listener` instruction, because it's not used.
