### PR TITLE
refactor(platform-server): expose internal `render` method for extensibility

### DIFF
--- a/packages/platform-server/src/private_export.ts
+++ b/packages/platform-server/src/private_export.ts
@@ -10,5 +10,5 @@ export {
   INTERNAL_SERVER_PLATFORM_PROVIDERS as ɵINTERNAL_SERVER_PLATFORM_PROVIDERS,
   SERVER_RENDER_PROVIDERS as ɵSERVER_RENDER_PROVIDERS,
 } from './server';
-export {SERVER_CONTEXT as ɵSERVER_CONTEXT} from './utils';
+export {SERVER_CONTEXT as ɵSERVER_CONTEXT, renderInternal as ɵrenderInternal} from './utils';
 export {ENABLE_DOM_EMULATION as ɵENABLE_DOM_EMULATION} from './tokens';

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -181,24 +181,12 @@ function insertEventRecordScript(
  *
  * @param platformRef - Reference to the Angular platform.
  * @param applicationRef - Reference to the Angular application.
- * @param checkWhenStable - Whether to check for stability before rendering. When false, stability should be handled by the caller of this function.
  * @returns A promise that resolves to the rendered string.
  */
 export async function renderInternal(
   platformRef: PlatformRef,
   applicationRef: ApplicationRef,
-  checkWhenStable = true,
 ): Promise<string> {
-  if (checkWhenStable) {
-    const measuringLabel = 'whenStable';
-    startMeasuring(measuringLabel);
-
-    // Block until application is stable.
-    await applicationRef.whenStable();
-
-    stopMeasuring(measuringLabel);
-  }
-
   const platformState = platformRef.injector.get(PlatformState);
   prepareForHydration(platformState, applicationRef);
   appendServerContextInfo(applicationRef);
@@ -288,6 +276,13 @@ export async function renderModule<T>(
   try {
     const moduleRef = await platformRef.bootstrapModule(moduleType);
     const applicationRef = moduleRef.injector.get(ApplicationRef);
+
+    const measuringLabel = 'whenStable';
+    startMeasuring(measuringLabel);
+    // Block until application is stable.
+    await applicationRef.whenStable();
+    stopMeasuring(measuringLabel);
+
     return await renderInternal(platformRef, applicationRef);
   } finally {
     await asyncDestroyPlatform(platformRef);
@@ -330,6 +325,13 @@ export async function renderApplication<T>(
     stopMeasuring(bootstrapLabel);
 
     startMeasuring(_renderLabel);
+
+    const measuringLabel = 'whenStable';
+    startMeasuring(measuringLabel);
+    // Block until application is stable.
+    await applicationRef.whenStable();
+    stopMeasuring(measuringLabel);
+
     const rendered = await renderInternal(platformRef, applicationRef);
     stopMeasuring(_renderLabel);
     return rendered;


### PR DESCRIPTION

The `renderApplication` and `renderModule` methods currently encapsulate the entire rendering process, making it difficult to intercept key phases from a non-Angular context. This change exports the internal `render` method, allowing us to perform operations such as:

- Flushing headers before hydration preparation
- Handling non static redirects (e.g., 302 responses)
- Intercepting router events for additional processing

This refactor serves as an experimental step toward improving the API for better customization and integration in the future.

//cc @jkrems, I believe you might also find this useful.