### PR TITLE
refactor(core): Improve NG0600 error message.

### DIFF
--- a/packages/core/src/render3/reactive_lview_consumer.ts
+++ b/packages/core/src/render3/reactive_lview_consumer.ts
@@ -8,16 +8,8 @@
 
 import {REACTIVE_NODE, ReactiveNode} from '../../primitives/signals';
 
-import {
-  LView,
-  PARENT,
-  REACTIVE_TEMPLATE_CONSUMER,
-  TVIEW,
-  TView,
-  TViewType,
-} from './interfaces/view';
+import {LView, REACTIVE_TEMPLATE_CONSUMER, TVIEW, TView, TViewType} from './interfaces/view';
 import {getLViewParent, markAncestorsForTraversal, markViewForRefresh} from './util/view_utils';
-import {assertDefined} from '../util/assert';
 
 let freeConsumers: ReactiveNode[] = [];
 export interface ReactiveLViewConsumer extends ReactiveNode {
@@ -116,4 +108,8 @@ export const TEMPORARY_CONSUMER_NODE = {
  */
 export function viewShouldHaveReactiveConsumer(tView: TView) {
   return tView.type !== TViewType.Embedded;
+}
+
+export function isReactiveLViewConsumer(node: ReactiveNode): node is ReactiveLViewConsumer {
+  return node.kind === 'template';
 }

--- a/packages/core/test/render3/reactivity_spec.ts
+++ b/packages/core/test/render3/reactivity_spec.ts
@@ -751,6 +751,41 @@ describe('reactivity', () => {
       expect(effectRef[SIGNAL].debugName).toBe('TEST_DEBUG_NAME');
     });
 
+    it('should disallow writing to signals within computed', () => {
+      @Component({
+        selector: 'with-input',
+        template: '{{comp()}}',
+      })
+      class WriteComputed {
+        sig = signal(0);
+        comp = computed(() => {
+          this.sig.set(this.sig() + 1);
+          return this.sig();
+        });
+      }
+
+      const fixture = TestBed.createComponent(WriteComputed);
+
+      expect(() => fixture.detectChanges()).toThrowError(/NG0600.*in a `computed`/);
+    });
+
+    it('should disallow writing to signals within a template', () => {
+      @Component({
+        selector: 'with-input',
+        template: '{{func()}}',
+      })
+      class WriteComputed {
+        sig = signal(0);
+        func() {
+          this.sig.set(this.sig() + 1);
+        }
+      }
+
+      const fixture = TestBed.createComponent(WriteComputed);
+
+      expect(() => fixture.detectChanges()).toThrowError(/NG0600.*template/);
+    });
+
     describe('effects created in components should first run after ngOnInit', () => {
       it('when created during bootstrapping', () => {
         let log: string[] = [];


### PR DESCRIPTION
This commit adds the mention of templates as illegal context to write signals.

fixes #60143
