### PR TITLE
refactor(core): improve the messaging on effect manualCleanup option

### DIFF
--- a/packages/core/src/render3/reactivity/effect.ts
+++ b/packages/core/src/render3/reactivity/effect.ts
@@ -79,6 +79,9 @@ export interface CreateEffectOptions {
    *
    * If this is `false` (the default) the effect will automatically register itself to be cleaned up
    * with the current `DestroyRef`.
+   *
+   * If this is `true` and you want to use the effect outside an injection context, you still
+   * need to provide an `Injector` to the effect.
    */
   manualCleanup?: boolean;
 

--- a/packages/core/test/render3/reactivity_spec.ts
+++ b/packages/core/test/render3/reactivity_spec.ts
@@ -290,6 +290,29 @@ describe('reactivity', () => {
       expect(log).toEqual([0, 1]);
     });
 
+    it('should cleanup effect when manualCleanup is enabled and an injector is provided', () => {
+      TestBed.configureTestingModule({});
+      const counter = signal(0);
+      const log: number[] = [];
+      // It needs the injector to be able to inject the other deps (and not just the DestroyRef).
+      const ref = effect(() => log.push(counter()), {
+        manualCleanup: true,
+        injector: TestBed.inject(Injector),
+      });
+
+      TestBed.flushEffects();
+      expect(log).toEqual([0]);
+
+      counter.set(1);
+      TestBed.flushEffects();
+      expect(log).toEqual([0, 1]);
+
+      ref.destroy();
+      counter.set(2);
+      TestBed.flushEffects();
+      expect(log).toEqual([0, 1]);
+    });
+
     it('should check components made dirty from markForCheck() from an effect', async () => {
       TestBed.configureTestingModule({
         providers: [provideExperimentalZonelessChangeDetection()],


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## What is the current behavior?
When using the `manualCleanup` option in effect and we're outside an injection context, it feels like we're good to go without having to pass an injector, but that's not the case. No matter what, we always have to pass an injector when using the effect outside the injection context. 

## What is the new behavior?
Adds the messaging on the option comment. Also introduced a test for the option. If the injector is removed, the test fails ofc.

## Does this PR introduce a breaking change?
- [x] No


## Other information
This has caught me off guard a couple of times. 