### PR TITLE
build: improve partial compliance golden generation and add debug logging

### DIFF
--- a/packages/compiler-cli/test/compliance/partial/cli.ts
+++ b/packages/compiler-cli/test/compliance/partial/cli.ts
@@ -10,4 +10,9 @@ import {fs} from '../test_helpers/get_compliance_tests';
 
 import {generateGoldenPartial} from './generate_golden_partial';
 
-generateGoldenPartial(fs.resolve(process.argv[2]));
+// TODO(devversion): Remove this when RBE issues are resolved.
+// tslint:disable-next-line
+console.log('TEMPORARY FOR DEBUGGING: Building golden partial:', process.argv.slice(2));
+
+const [testTsconfigPath, outputPath] = process.argv.slice(2);
+generateGoldenPartial(fs.resolve(testTsconfigPath), fs.resolve(outputPath));

--- a/packages/compiler-cli/test/compliance/partial/generate_golden_partial.ts
+++ b/packages/compiler-cli/test/compliance/partial/generate_golden_partial.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
+import fs from 'node:fs';
 import {AbsoluteFsPath, FileSystem} from '../../../src/ngtsc/file_system';
 import {
   compileTest,
@@ -18,8 +19,12 @@ import {PartiallyCompiledFile, renderGoldenPartial} from '../test_helpers/golden
  * Generate the golden partial output for the tests described in the `testConfigPath` config file.
  *
  * @param testConfigPath Absolute disk path of the `TEST_CASES.json` file that describes the tests.
+ * @param outputPath Absolute disk path for the golden output.
  */
-export function generateGoldenPartial(absTestConfigPath: AbsoluteFsPath): void {
+export function generateGoldenPartial(
+  absTestConfigPath: AbsoluteFsPath,
+  outputPath: AbsoluteFsPath,
+): void {
   const files: PartiallyCompiledFile[] = [];
   const tests = getComplianceTests(absTestConfigPath);
   for (const test of tests) {
@@ -28,7 +33,7 @@ export function generateGoldenPartial(absTestConfigPath: AbsoluteFsPath): void {
       files.push(file);
     }
   }
-  writeGoldenPartial(files);
+  writeGoldenPartial(files, outputPath);
 }
 
 /**
@@ -61,11 +66,15 @@ function* compilePartials(fs: FileSystem, test: ComplianceTest): Generator<Parti
 /**
  * Write the partially compiled files to the appropriate output destination.
  *
- * For now just push the concatenated partial files to standard out.
- *
  * @param files The partially compiled files.
+ * @param outputPath absolute disk path for the golden to write to.
  */
-function writeGoldenPartial(files: PartiallyCompiledFile[]): void {
-  // tslint:disable-next-line: no-console
-  console.log(renderGoldenPartial(files));
+function writeGoldenPartial(files: PartiallyCompiledFile[], outputPath: AbsoluteFsPath): void {
+  const goldenOutput = renderGoldenPartial(files);
+  fs.writeFileSync(
+    outputPath,
+    // Note: Keeping trailing \n as otherwise many goldens need to be re-approved.
+    goldenOutput + '\n',
+    'utf8',
+  );
 }

--- a/packages/compiler-cli/test/compliance/partial/partial_compliance_goldens.bzl
+++ b/packages/compiler-cli/test/compliance/partial/partial_compliance_goldens.bzl
@@ -36,11 +36,11 @@ def partial_compliance_golden(filePath):
         name = "_generated_%s" % path,
         tool = generate_partial_name,
         testonly = True,
-        stdout = "%s/_generated.js" % path,
+        outs = ["%s/_generated.js" % path],
         link_workspace_root = True,
         # Disable the linker and rely on patched resolution which works better on Windows
         # and is less prone to race conditions when targets build concurrently.
-        args = ["--nobazel_run_linker"],
+        args = ["--nobazel_run_linker", "$@"],
         visibility = [":__pkg__"],
         data = [],
     )


### PR DESCRIPTION
    Improves the partial compliance golden generation to not rely on large
files being transmitted via `stdout`. Instead the files are written
directly as it's done in idiomatic Bazel generation actions.
    
In addition, we add extra stdout logging for the Bazel action, to see if
the process is actually invoked in RBE workers. Right now those are
occassionally stuck, but neither us, nor the RBE team can see anything
running, and they're occasionally stuck for 1hr.