### PR TITLE
refactor(language-service): enable host binding features

### DIFF
--- a/packages/language-service/src/definitions.ts
+++ b/packages/language-service/src/definitions.ts
@@ -427,6 +427,15 @@ function getDefinitionForExpressionAtPosition(
     }
   }
 
+  if (resourceForExpression === null && resource.hostBindings !== null) {
+    for (const binding of resource.hostBindings) {
+      if (binding.node === expression) {
+        resourceForExpression = binding;
+        break;
+      }
+    }
+  }
+
   if (resourceForExpression === null || !isExternalResource(resourceForExpression)) {
     return;
   }

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -13,7 +13,7 @@ import {
   DisplayInfoKind,
   unsafeCastDisplayInfoKindToScriptElementKind,
 } from '../src/utils/display_parts';
-import {LanguageServiceTestEnv, OpenBuffer} from '../testing';
+import {LanguageServiceTestEnv, OpenBuffer, TestableOptions} from '../testing';
 
 const DIR_WITH_INPUT = {
   'Dir': `
@@ -2057,6 +2057,63 @@ describe('completions', () => {
       expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['hasRing', 'size']);
     });
   });
+
+  describe('host bindings', () => {
+    it('should be able to complete a property host binding', () => {
+      const {appFile} = setupInlineTemplate(
+        '',
+        `title!: string; hero!: number;`,
+        undefined,
+        `host: {'[title]': 'ti'},`,
+        {
+          typeCheckHostBindings: true,
+        },
+      );
+      appFile.moveCursorToText(`'ti¦'`);
+      const completions = appFile.getCompletionsAtPosition();
+      expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title', 'hero']);
+    });
+
+    it('should be able to complete a listener host binding', () => {
+      const {appFile} = setupInlineTemplate(
+        '',
+        `title!: string; hero!: number;`,
+        undefined,
+        `host: {'(click)': 't'},`,
+        {
+          typeCheckHostBindings: true,
+        },
+      );
+      appFile.moveCursorToText(`'(click)': 't¦'`);
+      const completions = appFile.getCompletionsAtPosition();
+      expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title', 'hero']);
+    });
+
+    it('should be able to complete inside `host` of a directive', () => {
+      const {appFile} = setupInlineTemplate(
+        '',
+        '',
+        {
+          'Dir': `
+            @Directive({
+              host: {'[title]': 'ti'},
+            })
+            export class Dir {
+              title!: string;
+              hero!: number;
+            }
+          `,
+        },
+        undefined,
+        {
+          typeCheckHostBindings: true,
+        },
+      );
+      appFile.moveCursorToText(`'ti¦'`);
+      const completions = appFile.getCompletionsAtPosition();
+      expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title', 'hero']);
+    });
+  });
 });
 
 function expectContainInsertText(
@@ -2207,6 +2264,8 @@ function setupInlineTemplate(
   template: string,
   classContents: string,
   otherDeclarations: {[name: string]: string} = {},
+  componentMetadata = '',
+  compilerOptions?: TestableOptions,
 ): {
   appFile: OpenBuffer;
 } {
@@ -2215,13 +2274,16 @@ function setupInlineTemplate(
   const otherDirectiveClassDecls = Object.values(otherDeclarations).join('\n\n');
 
   const env = LanguageServiceTestEnv.setup();
-  const project = env.addProject('test', {
-    'test.ts': `
+  const project = env.addProject(
+    'test',
+    {
+      'test.ts': `
          import {Component, Directive, NgModule, Pipe, TemplateRef} from '@angular/core';
 
          @Component({
            template: '${template}',
            selector: 'app-cmp',
+           ${componentMetadata}
          })
          export class AppCmp {
            ${classContents}
@@ -2234,6 +2296,8 @@ function setupInlineTemplate(
          })
          export class AppModule {}
          `,
-  });
+    },
+    compilerOptions,
+  );
   return {appFile: project.openFile('test.ts')};
 }

--- a/packages/language-service/test/definitions_spec.ts
+++ b/packages/language-service/test/definitions_spec.ts
@@ -567,10 +567,116 @@ describe('definitions', () => {
     assertFileNames(Array.from(definitions), ['app.ts']);
   });
 
+  it('gets definition for a host binding value of a component', () => {
+    initMockFileSystem('Native');
+    const files = {
+      'app.html': '',
+      'app.ts': `
+        import {Component} from '@angular/core';
+        @Component({
+          template: '',
+          standalone: false,
+          host: {
+            '[title]': 'myTitle',
+          }
+        })
+        export class AppCmp {
+          myTitle = 'hello';
+        }
+       `,
+    };
+    const env = LanguageServiceTestEnv.setup();
+
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files, {
+      typeCheckHostBindings: true,
+    });
+    const appFile = project.openFile('app.ts');
+    project.expectNoSourceDiagnostics();
+
+    appFile.moveCursorToText(`'[title]': 'myT¦itle'`);
+    const {definitions} = getDefinitionsAndAssertBoundSpan(env, appFile);
+    expect(definitions[0].name).toEqual('myTitle');
+    expect(definitions[0].kind).toBe(ts.ScriptElementKind.memberVariableElement);
+    expect(definitions[0].textSpan).toBe('myTitle');
+    assertFileNames(Array.from(definitions), ['app.ts']);
+  });
+
+  it('gets definition for a host listener of a component', () => {
+    initMockFileSystem('Native');
+    const files = {
+      'app.html': '',
+      'app.ts': `
+        import {Component} from '@angular/core';
+        @Component({
+          template: '',
+          standalone: false,
+          host: {
+            '(click)': 'handleClick($event)',
+          }
+        })
+        export class AppCmp {
+          handleClick(event: MouseEvent) {}
+        }
+       `,
+    };
+    const env = LanguageServiceTestEnv.setup();
+
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files, {
+      typeCheckHostBindings: true,
+    });
+    const appFile = project.openFile('app.ts');
+    project.expectNoSourceDiagnostics();
+
+    appFile.moveCursorToText(`'(click)': 'handle¦Click($event)'`);
+    const {definitions} = getDefinitionsAndAssertBoundSpan(env, appFile);
+    expect(definitions[0].name).toEqual('handleClick');
+    expect(definitions[0].kind).toBe(ts.ScriptElementKind.memberFunctionElement);
+    expect(definitions[0].textSpan).toBe('handleClick');
+    assertFileNames(Array.from(definitions), ['app.ts']);
+  });
+
+  it('gets definition for a host binding value of a directive', () => {
+    initMockFileSystem('Native');
+    const files = {
+      'dir.ts': `
+        import {Directive} from '@angular/core';
+        @Directive({
+          selector: '[my-dir]',
+          standalone: false,
+          host: {
+            '[title]': 'myTitle',
+          }
+        })
+        export class MyDir {
+          myTitle = 'hello';
+        }
+       `,
+    };
+    const env = LanguageServiceTestEnv.setup();
+
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files, {
+      typeCheckHostBindings: true,
+    });
+    const dirFile = project.openFile('dir.ts');
+    project.expectNoSourceDiagnostics();
+
+    dirFile.moveCursorToText(`'[title]': 'myT¦itle'`);
+    const {definitions} = getDefinitionsAndAssertBoundSpan(env, dirFile);
+    expect(definitions[0].name).toEqual('myTitle');
+    expect(definitions[0].kind).toBe(ts.ScriptElementKind.memberVariableElement);
+    expect(definitions[0].textSpan).toBe('myTitle');
+    assertFileNames(Array.from(definitions), ['dir.ts']);
+  });
+
   function getDefinitionsAndAssertBoundSpan(env: LanguageServiceTestEnv, file: OpenBuffer) {
     env.expectNoSourceDiagnostics();
     const definitionAndBoundSpan = file.getDefinitionAndBoundSpan();
-    const {textSpan, definitions} = definitionAndBoundSpan!;
+
+    if (!definitionAndBoundSpan) {
+      throw new Error('Could not retrieve definition');
+    }
+
+    const {textSpan, definitions} = definitionAndBoundSpan;
     expect(definitions).toBeTruthy();
     return {textSpan, definitions: definitions!.map((d) => humanizeDocumentSpanLike(d, env))};
   }

--- a/packages/language-service/test/gettcb_spec.ts
+++ b/packages/language-service/test/gettcb_spec.ts
@@ -76,6 +76,114 @@ describe('get typecheck block', () => {
     expect(content.substring(start, start + length)).toContain('myProp');
   });
 
+  it('should find type check block for a host binding of a component', () => {
+    const files = {
+      'app.ts': `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: '',
+        standalone: false,
+        host: {'[id]': 'getId()'}
+      })
+      export class AppCmp {
+        getId() {
+          return 'test';
+        }
+      }`,
+    };
+    const env = LanguageServiceTestEnv.setup();
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files, {
+      typeCheckHostBindings: true,
+    });
+    project.expectNoSourceDiagnostics();
+
+    const appFile = project.openFile('app.ts');
+    appFile.moveCursorToText(`'get¦Id()'`);
+    const result = appFile.getTcb();
+    if (result === undefined) {
+      fail('Expected a valid TCB response');
+      return;
+    }
+
+    const {content, selections} = result;
+    expect(selections.length).toBe(1);
+    const {start, length} = selections[0];
+    expect(content.substring(start, start + length)).toContain('getId');
+  });
+
+  it('should find type check block for a host listener of a component', () => {
+    const files = {
+      'app.ts': `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: '',
+        standalone: false,
+        host: {
+          '(click)': 'handleClick()'
+        }
+      })
+      export class AppCmp {
+        handleClick() {}
+      }`,
+    };
+    const env = LanguageServiceTestEnv.setup();
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files, {
+      typeCheckHostBindings: true,
+    });
+    project.expectNoSourceDiagnostics();
+
+    const appFile = project.openFile('app.ts');
+    appFile.moveCursorToText(`'handl¦eClick()'`);
+    const result = appFile.getTcb();
+    if (result === undefined) {
+      fail('Expected a valid TCB response');
+      return;
+    }
+
+    const {content, selections} = result;
+    expect(selections.length).toBe(1);
+    const {start, length} = selections[0];
+    expect(content.substring(start, start + length)).toContain('handleClick');
+  });
+
+  it('should find type check block for a host binding of a directive', () => {
+    const files = {
+      'app.ts': `
+      import {Directive} from '@angular/core';
+
+      @Directive({
+        standalone: false,
+        selector: '[my-dir]',
+        host: {'[id]': 'getId()'}
+      })
+      export class MyDir {
+        getId() {
+          return 'test';
+        }
+      }`,
+    };
+    const env = LanguageServiceTestEnv.setup();
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files, {
+      typeCheckHostBindings: true,
+    });
+    project.expectNoSourceDiagnostics();
+
+    const appFile = project.openFile('app.ts');
+    appFile.moveCursorToText(`'get¦Id()'`);
+    const result = appFile.getTcb();
+    if (result === undefined) {
+      fail('Expected a valid TCB response');
+      return;
+    }
+
+    const {content, selections} = result;
+    expect(selections.length).toBe(1);
+    const {start, length} = selections[0];
+    expect(content.substring(start, start + length)).toContain('getId');
+  });
+
   it('should not find typecheck blocks outside a template', () => {
     const files = {
       'app.ts': `

--- a/packages/language-service/test/references_and_rename_spec.ts
+++ b/packages/language-service/test/references_and_rename_spec.ts
@@ -1497,6 +1497,127 @@ describe('find references and rename locations', () => {
     });
   });
 
+  describe('when cursor is on symbol referenced in host bindings', () => {
+    let appFile: OpenBuffer;
+
+    beforeEach(() => {
+      const files = {
+        'app.ts': `
+          import {Component, Directive} from '@angular/core';
+
+          @Component({
+            template: '',
+            standalone: false,
+            host: {
+              '[attr.id]': 'getCompId()',
+              '(click)': 'handleCompClick()',
+            }
+          })
+          export class AppCmp {
+            getCompId() {
+              return 'my-id';
+            }
+
+            handleCompClick() {}
+          }
+
+          @Component({
+            template: '',
+            standalone: false,
+            host: {
+              '[attr.title]': 'getDirTitle()',
+              '(keydown)': 'handleDirKeydown()',
+            }
+          })
+          export class Dir {
+            getDirTitle() {
+              return 'my title';
+            }
+
+            handleDirKeydown() {}
+          }
+        `,
+      };
+      env = LanguageServiceTestEnv.setup();
+      const project = createModuleAndProjectWithDeclarations(env, 'test', files, {
+        typeCheckHostBindings: true,
+      });
+      appFile = project.openFile('app.ts');
+    });
+
+    it('gets component member reference in property binding', () => {
+      appFile.moveCursorToText('get¦CompId() {');
+      const refs = getReferencesAtPosition(appFile)!;
+      expect(refs.length).toBe(2);
+
+      assertFileNames(refs, ['app.ts']);
+      assertTextSpans(refs, ['getCompId']);
+    });
+
+    it('gets component rename location in property binding', () => {
+      appFile.moveCursorToText('get¦CompId() {');
+      const renameLocations = getRenameLocationsAtPosition(appFile)!;
+      expect(renameLocations.length).toBe(2);
+
+      assertFileNames(renameLocations, ['app.ts']);
+      assertTextSpans(renameLocations, ['getCompId']);
+    });
+
+    it('gets component member reference listener', () => {
+      appFile.moveCursorToText('handle¦CompClick() {');
+      const refs = getReferencesAtPosition(appFile)!;
+      expect(refs.length).toBe(2);
+
+      assertFileNames(refs, ['app.ts']);
+      assertTextSpans(refs, ['handleCompClick']);
+    });
+
+    it('gets component rename location listener', () => {
+      appFile.moveCursorToText('handle¦CompClick() {');
+      const renameLocations = getRenameLocationsAtPosition(appFile)!;
+      expect(renameLocations.length).toBe(2);
+
+      assertFileNames(renameLocations, ['app.ts']);
+      assertTextSpans(renameLocations, ['handleCompClick']);
+    });
+
+    it('gets directive member reference in property binding', () => {
+      appFile.moveCursorToText('getDir¦Title() {');
+      const refs = getReferencesAtPosition(appFile)!;
+      expect(refs.length).toBe(2);
+
+      assertFileNames(refs, ['app.ts']);
+      assertTextSpans(refs, ['getDirTitle']);
+    });
+
+    it('gets directive rename location in property binding', () => {
+      appFile.moveCursorToText('getDir¦Title() {');
+      const renameLocations = getRenameLocationsAtPosition(appFile)!;
+      expect(renameLocations.length).toBe(2);
+
+      assertFileNames(renameLocations, ['app.ts']);
+      assertTextSpans(renameLocations, ['getDirTitle']);
+    });
+
+    it('gets directive member reference listener', () => {
+      appFile.moveCursorToText('handle¦DirKeydown() {');
+      const refs = getReferencesAtPosition(appFile)!;
+      expect(refs.length).toBe(2);
+
+      assertFileNames(refs, ['app.ts']);
+      assertTextSpans(refs, ['handleDirKeydown']);
+    });
+
+    it('gets directive rename location listener', () => {
+      appFile.moveCursorToText('handleDir¦Keydown() {');
+      const renameLocations = getRenameLocationsAtPosition(appFile)!;
+      expect(renameLocations.length).toBe(2);
+
+      assertFileNames(renameLocations, ['app.ts']);
+      assertTextSpans(renameLocations, ['handleDirKeydown']);
+    });
+  });
+
   it('should get references to both input and output for two-way binding', () => {
     const files = {
       'dir.ts': `


### PR DESCRIPTION
Reworks the language service to enable features like quick info and definitions inside host bindings.

**Note:** for the full range of language service features to work, the changes from https://github.com/angular/vscode-ng-language-service/pull/2155 have to be released.
