### PR TITLE
refactor: remove peer dependency on core from compiler

### DIFF
--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -10,14 +10,6 @@
   "dependencies": {
     "tslib": "^2.3.0"
   },
-  "peerDependencies": {
-    "@angular/core": "0.0.0-PLACEHOLDER"
-  },
-  "peerDependenciesMeta": {
-    "@angular/core": {
-      "optional": true
-    }
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/angular/angular.git",


### PR DESCRIPTION
Note that this is not a public-facing change because the compiler is not supposed to be used directly. See `public-api-surface.md`

We are changing this because in the current state, for advanced setups like our Bazel infrastructure in Material, this peer dependency can result in a cycle. That is because we may decide to link the `@angular/core` package using the compiler-cli/compiler; while transitively the compiler has a dependency on core. That's a cycle (surfacing in Bazel w/ `rules_js`).

Dropping this optional peer dependency is acceptable because `core`, since recently, also has an optional peer dependency on the compiler. This one makes more sense and is also more user-facing (people generally never install the compiler directly).

Notably the compiler does not have any runtime dependency on `core` and this was purely added for some safety checking. See: https://github.com/angular/angular/commit/8c171da29f499648273e61cfb5bffaa4278097e5