### PR TITLE
docs(docs-infra): add support for `@example`

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/jsdoc-transforms.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/jsdoc-transforms.ts
@@ -33,8 +33,7 @@ import {getLinkToModule} from './url-transforms';
 import {addApiLinksToHtml} from './code-transforms';
 import {getCurrentSymbol, getModuleName, unknownSymbolMessage} from '../symbol-context';
 
-export const JS_DOC_REMARKS_TAG = 'remarks';
-export const JS_DOC_USAGE_NOTES_TAG = 'usageNotes';
+const JS_DOC_USAGE_NOTE_TAGS: Set<string> = new Set(['remarks', 'usageNotes', 'example']);
 export const JS_DOC_SEE_TAG = 'see';
 export const JS_DOC_DESCRIPTION_TAG = 'description';
 
@@ -91,10 +90,11 @@ export function addHtmlAdditionalLinks<T extends HasJsDocTags & HasModuleName>(
 }
 
 export function addHtmlUsageNotes<T extends HasJsDocTags>(entry: T): T & HasHtmlUsageNotes {
-  const usageNotesTag = entry.jsdocTags.find(
-    ({name}) => name === JS_DOC_USAGE_NOTES_TAG || name === JS_DOC_REMARKS_TAG,
-  );
-  const htmlUsageNotes = usageNotesTag ? getHtmlForJsDocText(usageNotesTag.comment) : '';
+  const usageNotesTags = entry.jsdocTags.filter(({name}) => JS_DOC_USAGE_NOTE_TAGS.has(name)) ?? [];
+  let htmlUsageNotes = '';
+  for (const {comment} of usageNotesTags) {
+    htmlUsageNotes += getHtmlForJsDocText(comment);
+  }
 
   return {
     ...entry,


### PR DESCRIPTION
In TSDoc, we currently handle the `@usageNotes` annotation, but this is not a standard TSDoc tag. Instead, the `@example` annotation is the correct standard, which is used in the Angular CLI repo and on the SSR package.

This change ensures that `@example` is treated the same as `@usageNotes` during the transform process and also handle multiple instances of `@example` on the same tag.

Example
<img width="795" alt="Screenshot 2025-03-18 at 15 15 41" src="https://github.com/user-attachments/assets/cb550ab8-6c5f-42f5-b0a0-f95074dd35e8" />
