### PR TITLE
refactor(dev-infra): disable progressBar test

### DIFF
--- a/adev/src/app/core/layout/progress-bar/progress-bar.component.spec.ts
+++ b/adev/src/app/core/layout/progress-bar/progress-bar.component.spec.ts
@@ -25,7 +25,10 @@ describe('ProgressBarComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should call progressBar.complete() on route change', async () => {
+  // This test often timeouts
+  // We suspect a racing condition inside the RouterTestingHarness.
+  // Until this has been investigated, we will skip this test.
+  xit('should call progressBar.complete() on route change', async () => {
     const progressBar = component.progressBar();
     const progressBarCompleteSpy = spyOn(progressBar, 'complete');
 


### PR DESCRIPTION
This test often (but inconsitantly) timeouts with
```
Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
```

We suspect a racing condition within the RouterTestingHarness. 
Until this has been investigated, we'll disable this test. 