### PR TITLE
refactor(core): specify reactive node kind for linked signal

### DIFF
--- a/packages/core/primitives/signals/src/linked_signal.ts
+++ b/packages/core/primitives/signals/src/linked_signal.ts
@@ -116,6 +116,7 @@ export const LINKED_SIGNAL_NODE = /* @__PURE__ */ (() => {
     dirty: true,
     error: null,
     equal: defaultEquals,
+    kind: 'linkedSignal',
 
     producerMustRecompute(node: LinkedSignalNode<unknown, unknown>): boolean {
       // Force a recomputation if there's no current value, or if the current value is in the


### PR DESCRIPTION
This commit adds reactive node kind for linked signal.
