### PR TITLE
refactor(core): move more host directive matching logic into feature

### DIFF
--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -645,7 +645,7 @@ function getNgDirectiveDef<T>(directiveDefinition: DirectiveDefinition<T>): Dire
     viewQuery: directiveDefinition.viewQuery || null,
     features: directiveDefinition.features || null,
     setInput: null,
-    findHostDirectiveDefs: null,
+    resolveHostDirectives: null,
     hostDirectives: null,
     inputs: parseAndConvertInputsForDefinition(directiveDefinition.inputs, declaredInputs),
     outputs: parseAndConvertOutputsForDefinition(directiveDefinition.outputs),

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -237,21 +237,11 @@ export interface DirectiveDef<T> {
   debugInfo: ClassDebugInfo | null;
 
   /**
-   * Function that will add the host directives to the list of matches during directive matching.
-   * Patched onto the definition by the `HostDirectivesFeature`.
-   * @param currentDef Definition that has been matched.
-   * @param matchedDefs List of all matches for a specified node. Will be mutated to include the
-   * host directives.
-   * @param hostDirectiveDefs Mapping of directive definitions to their host directive
-   * configuration. Host directives will be added to the map as they're being matched to the node.
+   * Function inteded to be called after template selector matching is done
+   * in order to resolve information about their host directives. Patched
+   * onto the definition by the `ɵɵHostDirectivesFeature`.
    */
-  findHostDirectiveDefs:
-    | ((
-        currentDef: DirectiveDef<unknown>,
-        matchedDefs: DirectiveDef<unknown>[],
-        hostDirectiveDefs: HostDirectiveDefs,
-      ) => void)
-    | null;
+  resolveHostDirectives: ((matches: DirectiveDef<unknown>[]) => HostDirectiveResolution) | null;
 
   /**
    * Additional directives to be applied whenever the directive has been matched.
@@ -260,8 +250,8 @@ export interface DirectiveDef<T> {
    * already pre-processed when the definition was created. A function needs to be resolved lazily
    * during directive matching, because it's a forward reference.
    *
-   * **Note:** we can't `HostDirectiveConfig` in the array, because there's no way to distinguish if
-   * a function in the array is a `Type` or a `() => HostDirectiveConfig[]`.
+   * **Note:** we can't use `HostDirectiveConfig` in the array, because there's no way to
+   * distinguish if a function in the array is a `Type` or a `() => HostDirectiveConfig[]`.
    */
   hostDirectives: (HostDirectiveDef | (() => HostDirectiveConfig[]))[] | null;
 
@@ -471,6 +461,20 @@ export interface DirectiveDefFeature {
    */
   ngInherit?: true;
 }
+
+/** Data produced after host directives are resolved for a node. */
+export type HostDirectiveResolution = [
+  matches: DirectiveDef<unknown>[],
+  hostDirectiveDefs: HostDirectiveDefs | null,
+  hostDirectiveRanges: HostDirectiveRanges | null,
+];
+
+/**
+ * Map that tracks a selector-matched directive to the range within which its host directives
+ * are declared. Host directives for a specific directive are always contiguous within the runtime.
+ * Note that both the start and end are inclusive and they're both **after** `tNode.directiveStart`.
+ */
+export type HostDirectiveRanges = Map<DirectiveDef<unknown>, [start: number, end: number]>;
 
 /** Runtime information used to configure a host directive. */
 export interface HostDirectiveDef<T = unknown> {

--- a/packages/core/src/render3/util/discovery_utils.ts
+++ b/packages/core/src/render3/util/discovery_utils.ts
@@ -441,7 +441,7 @@ function isDirectiveDefHack(obj: any): obj is DirectiveDef<any> {
   return (
     obj.type !== undefined &&
     obj.declaredInputs !== undefined &&
-    obj.findHostDirectiveDefs !== undefined
+    obj.resolveHostDirectives !== undefined
   );
 }
 

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -443,7 +443,6 @@
   "requiresRefreshOrTraversal",
   "resetPreOrderHookFlags",
   "resolveForwardRef",
-  "resolveHostDirectivesForDef",
   "resolveTiming",
   "resolveTimingValue",
   "roundOffset",

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -469,7 +469,6 @@
   "requiresRefreshOrTraversal",
   "resetPreOrderHookFlags",
   "resolveForwardRef",
-  "resolveHostDirectivesForDef",
   "resolveTiming",
   "resolveTimingValue",
   "roundOffset",

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -380,7 +380,6 @@
   "requiresRefreshOrTraversal",
   "resetPreOrderHookFlags",
   "resolveForwardRef",
-  "resolveHostDirectivesForDef",
   "runEffectsInView",
   "runInInjectionContext",
   "saveNameToExportMap",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -845,7 +845,6 @@
   "resetPreOrderHookFlags",
   "resolveDirectives",
   "resolveForwardRef",
-  "resolveHostDirectivesForDef",
   "retrieveHydrationInfo",
   "runEffectsInView",
   "runInInjectionContext",

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -570,7 +570,6 @@
   "resetPreOrderHookFlags",
   "resolveDirectives",
   "resolveForwardRef",
-  "resolveHostDirectivesForDef",
   "resolveProvider",
   "runEffectsInView",
   "runInInjectionContext",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -561,7 +561,6 @@
   "resetPreOrderHookFlags",
   "resolveDirectives",
   "resolveForwardRef",
-  "resolveHostDirectivesForDef",
   "resolveProvider",
   "resolvedPromise",
   "resolvedPromise2",

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -307,7 +307,6 @@
   "requiresRefreshOrTraversal",
   "resetPreOrderHookFlags",
   "resolveForwardRef",
-  "resolveHostDirectivesForDef",
   "runEffectsInView",
   "runInInjectionContext",
   "saveNameToExportMap",

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -408,7 +408,6 @@
   "requiresRefreshOrTraversal",
   "resetPreOrderHookFlags",
   "resolveForwardRef",
-  "resolveHostDirectivesForDef",
   "retrieveHydrationInfo",
   "retrieveHydrationInfoImpl",
   "runEffectsInView",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -651,7 +651,6 @@
   "requiresRefreshOrTraversal",
   "resetPreOrderHookFlags",
   "resolveForwardRef",
-  "resolveHostDirectivesForDef",
   "rootRoute",
   "routes",
   "runEffectsInView",

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -340,7 +340,6 @@
   "requiresRefreshOrTraversal",
   "resetPreOrderHookFlags",
   "resolveForwardRef",
-  "resolveHostDirectivesForDef",
   "runEffectsInView",
   "runInInjectionContext",
   "saveNameToExportMap",

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -454,7 +454,6 @@
   "resetPreOrderHookFlags",
   "resolveDirectives",
   "resolveForwardRef",
-  "resolveHostDirectivesForDef",
   "runEffectsInView",
   "runInInjectionContext",
   "saveNameToExportMap",


### PR DESCRIPTION
Moves the logic that tracks host directives into the `ɵɵHostDirectivesFeature` so it can be tree shaken.
