### PR TITLE
fix(compiler-cli): report more accurate diagnostic for invalid import

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/util.ts
@@ -11,11 +11,16 @@ import {
   isResolvedModuleWithProviders,
   ResolvedModuleWithProviders,
 } from '@angular/compiler-cli/src/ngtsc/annotations/ng_module';
-import {ErrorCode, makeDiagnostic} from '@angular/compiler-cli/src/ngtsc/diagnostics';
+import {
+  ErrorCode,
+  FatalDiagnosticError,
+  makeDiagnostic,
+} from '@angular/compiler-cli/src/ngtsc/diagnostics';
 import ts from 'typescript';
 
 import {Reference} from '../../../imports';
 import {
+  DynamicValue,
   ForeignFunctionResolver,
   ResolvedValue,
   ResolvedValueMap,
@@ -96,7 +101,9 @@ export function validateAndFlattenComponentImports(
   }
   const diagnostics: ts.Diagnostic[] = [];
 
-  for (const ref of imports) {
+  for (let i = 0; i < imports.length; i++) {
+    const ref = imports[i];
+
     if (Array.isArray(ref)) {
       const {imports: childImports, diagnostics: childDiagnostics} =
         validateAndFlattenComponentImports(ref, expr, isDeferred);
@@ -132,7 +139,32 @@ export function validateAndFlattenComponentImports(
         ),
       );
     } else {
-      diagnostics.push(createValueHasWrongTypeError(expr, imports, errorMessage).toDiagnostic());
+      let diagnosticNode: ts.Node;
+      let diagnosticValue: ResolvedValue;
+
+      if (ref instanceof DynamicValue) {
+        diagnosticNode = ref.node;
+        diagnosticValue = ref;
+      } else if (
+        ts.isArrayLiteralExpression(expr) &&
+        expr.elements.length === imports.length &&
+        !expr.elements.some(ts.isSpreadAssignment) &&
+        !imports.some(Array.isArray)
+      ) {
+        // Reporting a diagnostic on the entire array can be noisy, especially if the user has a
+        // large array. The most common case is that the array will be static so we can reliably
+        // trace back a `ResolvedValue` back to its node using its index. This allows us to report
+        // the exact node that caused the issue.
+        diagnosticNode = expr.elements[i];
+        diagnosticValue = ref;
+      } else {
+        diagnosticNode = expr;
+        diagnosticValue = imports;
+      }
+
+      diagnostics.push(
+        createValueHasWrongTypeError(diagnosticNode, diagnosticValue, errorMessage).toDiagnostic(),
+      );
     }
   }
 


### PR DESCRIPTION
Currently when an incorrect value is in the `imports` array, we highlight the entire array which can be very noisy for large arrays. This comes up semi-regularly (at least for me) when an import is missing.

These changes add some logic that reports a more accurate diagnostic location for the most common case where the `imports` array is static. Non-static arrays will fall back to the current behavior.

Example of what I'm referring to:
<img width="901" alt="image" src="https://github.com/user-attachments/assets/494208b6-0944-40a2-b0ec-3db62af1df85" />
