### PR TITLE
fix(platform-browser-dynamic): ensure compiler is loaded before `@angular/common`

### DIFF
--- a/packages/platform-browser-dynamic/BUILD.bazel
+++ b/packages/platform-browser-dynamic/BUILD.bazel
@@ -25,6 +25,10 @@ ng_package(
     srcs = [
         "package.json",
     ],
+    side_effect_entry_points = [
+        "@angular/platform-browser-dynamic",
+        "@angular/platform-browser-dynamic/testing",
+    ],
     tags = [
         "release-with-framework",
     ],

--- a/packages/platform-browser-dynamic/package.json
+++ b/packages/platform-browser-dynamic/package.json
@@ -24,5 +24,8 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false
+  "sideEffects": [
+    "./fesm2022/platform-browser-dynamic.mjs",
+    "./fesm2022/testing.mjs"
+  ]
 }

--- a/packages/platform-browser-dynamic/public_api.ts
+++ b/packages/platform-browser-dynamic/public_api.ts
@@ -11,6 +11,11 @@
  * @description
  * Entry point for all public APIs of this package.
  */
+
+// Note: Historically people relied on `platform-browser-dynamic` magically
+// exposing the compiler for JIT. This is now made more explicit via this import.
+import '@angular/compiler';
+
 export * from './src/platform-browser-dynamic';
 
 // This file only reexports content of the `src` folder. Keep it that way.

--- a/packages/platform-browser-dynamic/testing/public_api.ts
+++ b/packages/platform-browser-dynamic/testing/public_api.ts
@@ -11,4 +11,9 @@
  * @description
  * Entry point for all public APIs of this package.
  */
+
+// Note: Historically people relied on `platform-browser-dynamic` magically
+// exposing the compiler for JIT. This is now made more explicit via this import.
+import '@angular/compiler';
+
 export * from './src/testing';


### PR DESCRIPTION
Note: CLI users were not affected by this. This is only for custom setups.

--

With the recent changes to the APF bundling rules, we turned on tree-shaking in rollup to support proper code splitting for FESM bundles.

This resulted in Rollup re-ordering imports in the FESM bundles of `@angular/platform-browser-dynamic`— highlighting that over the past years, this package "accidentally" resulted in the side-effects of the compiler registering itself globally.

This continues to be the case, and our changes generally didn't cause any issues in CLI applications because the CLI explicitly wires up the compiler (as expected) before `-dynamic` is even loaded. For custom setup, like Analog, this order change surfaced a breakage because e.g. `@angular/common` with its JIT decorators of e.g. directives/services are triggered before the compiler is actually loaded/made available.

This commit fixes this. The explicit imports in practice are a noop because our FESM bundling doesn't recognize compiler as side-effects true; but marking the whole -dynamic package as having side-effects; prevents rollup from swapping the import order. Long-term, we should look into improving this by teaching `ng_package` that e.g. the compiler has side-effects; so that the `import @angular/compiler` statement is not dropped when constructing FESM bundles.