### PR TITLE
Updates `ng.getDirectiveMetadata` to support Wiz and ACX implementations

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
@@ -16,6 +16,7 @@ import type {
   Type,
   ValueProvider,
   ɵAngularComponentDebugMetadata as AngularComponentDebugMetadata,
+  ɵAngularDirectiveDebugMetadata as AngularDirectiveDebugMetadata,
   ɵProviderRecord as ProviderRecord,
 } from '@angular/core';
 import {
@@ -219,7 +220,9 @@ const enum DirectiveMetadataKey {
 // the method directly interacts with the directive/component definition.
 const getDirectiveMetadata = (dir: any): DirectiveMetadata => {
   const getMetadata = ngDebugClient().getDirectiveMetadata!;
-  const metadata = getMetadata?.(dir) as AngularComponentDebugMetadata;
+  const metadata = getMetadata?.(dir) as
+    | (AngularDirectiveDebugMetadata & Partial<AngularComponentDebugMetadata>)
+    | null;
   if (metadata) {
     return {
       inputs: metadata.inputs,
@@ -249,7 +252,7 @@ const getDirectiveMetadata = (dir: any): DirectiveMetadata => {
 
 export function isOnPushDirective(dir: any): boolean {
   const metadata = getDirectiveMetadata(dir.instance);
-  return metadata.onPush;
+  return Boolean(metadata.onPush);
 }
 
 export function getInjectorProviders(injector: Injector) {

--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
@@ -15,7 +15,7 @@ import type {
   Injector,
   Type,
   ValueProvider,
-  ɵComponentDebugMetadata as ComponentDebugMetadata,
+  ɵAngularComponentDebugMetadata as AngularComponentDebugMetadata,
   ɵProviderRecord as ProviderRecord,
 } from '@angular/core';
 import {
@@ -219,7 +219,7 @@ const enum DirectiveMetadataKey {
 // the method directly interacts with the directive/component definition.
 const getDirectiveMetadata = (dir: any): DirectiveMetadata => {
   const getMetadata = ngDebugClient().getDirectiveMetadata!;
-  const metadata = getMetadata?.(dir) as ComponentDebugMetadata;
+  const metadata = getMetadata?.(dir) as AngularComponentDebugMetadata;
   if (metadata) {
     return {
       inputs: metadata.inputs,

--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//devtools/tools:typescript.bzl", "ts_library", "ts_test_library")
 load("//devtools/tools:defaults.bzl", "karma_web_test_suite")
+load("//devtools/tools:typescript.bzl", "ts_library", "ts_test_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -37,6 +37,7 @@ ts_test_library(
         ":directive-forest",
         "//devtools/projects/ng-devtools-backend/src/lib:interfaces",
         "//devtools/projects/ng-devtools-backend/src/lib:utils",
+        "//packages/core",
         "@npm//@types",
     ],
 )

--- a/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.ts
@@ -6,24 +6,24 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import type {ɵGlobalDevModeUtils as GlobalDevModeUtils} from '@angular/core';
+import type {ɵFrameworkAgnosticGlobalUtils as GlobalUtils} from '@angular/core';
 
 /**
  * Returns a handle to window.ng APIs (global angular debugging).
  *
  * @returns window.ng
  */
-export const ngDebugClient = () => (window as any).ng as Partial<GlobalDevModeUtils['ng']>;
+export const ngDebugClient = () => (window as any).ng as Partial<GlobalUtils>;
 
 /**
  * Type guard that checks whether a given debug API is supported within window.ng
  *
  * @returns whether the ng object includes the given debug API
  */
-export function ngDebugApiIsSupported<
-  T extends Partial<GlobalDevModeUtils['ng']>,
-  K extends keyof T,
->(ng: T, api: K): ng is T & Record<K, NonNullable<T[K]>> {
+export function ngDebugApiIsSupported<T extends Partial<GlobalUtils>, K extends keyof T>(
+  ng: T,
+  api: K,
+): ng is T & Record<K, NonNullable<T[K]>> {
   return typeof ng[api] === 'function';
 }
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/BUILD.bazel
@@ -1,6 +1,6 @@
+load("//devtools/tools:defaults.bzl", "karma_web_test_suite")
 load("//devtools/tools:ng_module.bzl", "ng_module")
 load("//devtools/tools:typescript.bzl", "ts_test_library")
-load("//devtools/tools:defaults.bzl", "karma_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -38,6 +38,7 @@ ts_test_library(
         ":property-resolver",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/index-forest",
         "//devtools/projects/protocol",
+        "//packages/core",
         "@npm//@angular/cdk",
         "@npm//@angular/material",
     ],

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/directive-property-resolver.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/directive-property-resolver.spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {ɵFramework as Framework} from '@angular/core';
 import {Properties, PropType} from 'protocol';
 
 import {DirectivePropertyResolver} from './directive-property-resolver';
@@ -98,6 +99,7 @@ const properties: Properties = {
     },
   },
   metadata: {
+    framework: Framework.Angular,
     inputs: {
       i: 'i',
       i1: 'i_1',
@@ -131,6 +133,36 @@ describe('DirectivePropertyResolver', () => {
     expect(resolver.directiveOutputControls.dataSource.data[2].prop.name).toBe('b1');
     expect(resolver.directiveOutputControls.dataSource.data[3].prop.name).toBe('o_1');
     expect(resolver.directiveStateControls.dataSource.data[0].prop.name).toBe('p');
+  });
+
+  it('should register directive props', () => {
+    const resolver = new DirectivePropertyResolver(
+      messageBusMock,
+      {
+        props: {
+          foo: {
+            editable: false,
+            expandable: false,
+            preview: '',
+            type: PropType.Object,
+            value: {},
+            containerType: null,
+          },
+        },
+        metadata: {
+          framework: Framework.Wiz,
+          props: {
+            foo: 'foo',
+          },
+        },
+      },
+      {
+        element: [0],
+        directive: 0,
+      },
+    );
+
+    expect(resolver.directivePropControls.dataSource.data[0].prop.name).toBe('foo');
   });
 
   it('should sort properties', () => {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/directive-property-resolver.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/directive-property-resolver.ts
@@ -67,11 +67,11 @@ export class DirectivePropertyResolver {
     private _props: Properties,
     private _directivePosition: DirectivePosition,
   ) {
-    const {inputProps, outputProps, stateProps} = this._classifyProperties();
+    const {inputs, outputs, state} = this._classifyProperties();
 
-    this._inputsDataSource = this._createDataSourceFromProps(inputProps);
-    this._outputsDataSource = this._createDataSourceFromProps(outputProps);
-    this._stateDataSource = this._createDataSourceFromProps(stateProps);
+    this._inputsDataSource = this._createDataSourceFromProps(inputs);
+    this._outputsDataSource = this._createDataSourceFromProps(outputs);
+    this._stateDataSource = this._createDataSourceFromProps(state);
   }
 
   get directiveInputControls(): DirectiveTreeData {
@@ -116,11 +116,11 @@ export class DirectivePropertyResolver {
 
   updateProperties(newProps: Properties): void {
     this._props = newProps;
-    const {inputProps, outputProps, stateProps} = this._classifyProperties();
+    const {inputs, outputs, state} = this._classifyProperties();
 
-    this._inputsDataSource.update(inputProps);
-    this._outputsDataSource.update(outputProps);
-    this._stateDataSource.update(stateProps);
+    this._inputsDataSource.update(inputs);
+    this._outputsDataSource.update(outputs);
+    this._stateDataSource.update(state);
   }
 
   updateValue(node: FlatNode, newValue: unknown): void {
@@ -141,31 +141,31 @@ export class DirectivePropertyResolver {
   }
 
   private _classifyProperties(): {
-    inputProps: {[name: string]: Descriptor};
-    outputProps: {[name: string]: Descriptor};
-    stateProps: {[name: string]: Descriptor};
+    inputs: {[name: string]: Descriptor};
+    outputs: {[name: string]: Descriptor};
+    state: {[name: string]: Descriptor};
   } {
     const inputLabels: Set<string> = new Set(Object.values(this._props.metadata?.inputs || {}));
     const outputLabels: Set<string> = new Set(Object.values(this._props.metadata?.outputs || {}));
 
-    const inputProps = {};
-    const outputProps = {};
-    const stateProps = {};
+    const inputs = {};
+    const outputs = {};
+    const state = {};
     let propPointer: {[name: string]: Descriptor};
 
     Object.keys(this.directiveProperties).forEach((propName) => {
       propPointer = inputLabels.has(propName)
-        ? inputProps
+        ? inputs
         : outputLabels.has(propName)
-          ? outputProps
-          : stateProps;
+          ? outputs
+          : state;
       propPointer[propName] = this.directiveProperties[propName];
     });
 
     return {
-      inputProps,
-      outputProps,
-      stateProps,
+      inputs,
+      outputs,
+      state,
     };
   }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/component-metadata.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/component-metadata.component.ts
@@ -6,8 +6,15 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, computed, inject, input} from '@angular/core';
-import {ComponentType} from 'protocol';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ɵFramework as Framework,
+  computed,
+  inject,
+  input,
+} from '@angular/core';
+import {AngularDirectiveMetadata, AcxDirectiveMetadata, ComponentType} from 'protocol';
 
 import {ElementPropertyResolver} from '../property-resolver/element-property-resolver';
 
@@ -22,7 +29,8 @@ export class ComponentMetadataComponent {
 
   private _nestedProps = inject(ElementPropertyResolver);
 
-  viewEncapsulationModes = ['Emulated', 'Native', 'None', 'ShadowDom'];
+  angularViewEncapsulationModes = ['Emulated', 'Native', 'None', 'ShadowDom'];
+  acxViewEncapsulationModes = ['Emulated', 'None'];
 
   readonly controller = computed(() => {
     const comp = this.currentSelectedComponent();
@@ -33,15 +41,32 @@ export class ComponentMetadataComponent {
   });
 
   readonly viewEncapsulation = computed(() => {
-    const encapsulationIndex = this.controller()?.directiveViewEncapsulation;
-    if (encapsulationIndex !== undefined) {
-      return this.viewEncapsulationModes[encapsulationIndex];
+    const metadata = this.controller()?.directiveMetadata;
+    if (!metadata) return undefined;
+
+    const encapsulation = (metadata as AngularDirectiveMetadata | AcxDirectiveMetadata)
+      .encapsulation;
+    if (!encapsulation) return undefined;
+
+    switch (metadata.framework) {
+      case Framework.Angular:
+        return this.angularViewEncapsulationModes[encapsulation];
+      case Framework.ACX:
+        return this.acxViewEncapsulationModes[encapsulation];
+      default:
+        return undefined;
     }
-    return undefined;
   });
 
   readonly changeDetectionStrategy = computed(() => {
-    const onPush = this.controller()?.directiveHasOnPushStrategy;
-    return onPush ? 'OnPush' : onPush !== undefined ? 'Default' : undefined;
+    const metadata = this.controller()?.directiveMetadata;
+    if (!metadata) return undefined;
+
+    const meta = metadata as Partial<AcxDirectiveMetadata | AngularDirectiveMetadata>;
+    if (meta.onPush !== undefined) {
+      return meta.onPush ? 'OnPush' : 'Default';
+    } else {
+      return undefined;
+    }
   });
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.html
@@ -27,7 +27,7 @@
         @if (panel.controls().dataSource.data.length > 0) {
           <mat-expansion-panel [expanded]="true">
             <mat-expansion-panel-header collapsedHeight="25px" expandedHeight="25px">
-              <mat-panel-title>{{ panel.title }}</mat-panel-title>
+              <mat-panel-title>{{ panel.title() }}</mat-panel-title>
             </mat-expansion-panel-header>
             <ng-property-view-tree
               [dataSource]="panel.controls().dataSource"

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.html
@@ -1,7 +1,7 @@
 @if (controlsLoaded()) {
   <mat-accordion cdkDropList (cdkDropListDropped)="drop($event)" [multi]="true">
-    @let dependencies = controller().directiveMetadata?.dependencies;
-    @if (dependencies && dependencies.length > 0) {
+    @let deps = dependencies();
+    @if (deps && deps.length > 0) {
       <div class="mat-accordion-content">
         <mat-expansion-panel [expanded]="true">
           <mat-expansion-panel-header collapsedHeight="25px" expandedHeight="25px">

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.html
@@ -25,7 +25,7 @@
     @for (panel of panels(); track $index) {
       <div class="mat-accordion-content" cdkDrag>
         @if (panel.controls().dataSource.data.length > 0) {
-          <mat-expansion-panel [class]="panel.class" [expanded]="true">
+          <mat-expansion-panel [expanded]="true">
             <mat-expansion-panel-header collapsedHeight="25px" expandedHeight="25px">
               <mat-panel-title>{{ panel.title }}</mat-panel-title>
             </mat-expansion-panel-header>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.ts
@@ -39,15 +39,27 @@ import {MatExpansionModule} from '@angular/material/expansion';
 export class PropertyViewBodyComponent {
   readonly controller = input.required<DirectivePropertyResolver>();
   readonly directiveInputControls = input.required<DirectiveTreeData>();
+  readonly directivePropControls = input.required<DirectiveTreeData>();
   readonly directiveOutputControls = input.required<DirectiveTreeData>();
   readonly directiveStateControls = input.required<DirectiveTreeData>();
 
   readonly inspect = output<{node: FlatNode; directivePosition: DirectivePosition}>();
 
+  protected readonly dependencies = computed(() => {
+    const metadata = this.controller().directiveMetadata;
+    if (!metadata) return [];
+    if (!('dependencies' in metadata)) return [];
+    return metadata.dependencies;
+  });
+
   protected readonly panels = signal([
     {
       title: 'Inputs',
       controls: () => this.directiveInputControls(),
+    },
+    {
+      title: 'Props',
+      controls: () => this.directivePropControls(),
     },
     {
       title: 'Outputs',
@@ -160,6 +172,10 @@ export class InjectedServicesComponent {
   readonly controller = input.required<DirectivePropertyResolver>();
 
   readonly dependencies = computed<SerializedInjectedService[]>(() => {
-    return this.controller().directiveMetadata?.dependencies ?? [];
+    const metadata = this.controller().directiveMetadata;
+    if (!metadata) return [];
+    if (!('dependencies' in metadata)) return [];
+
+    return metadata.dependencies ?? [];
   });
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.ts
@@ -48,17 +48,14 @@ export class PropertyViewBodyComponent {
     {
       title: 'Inputs',
       controls: () => this.directiveInputControls(),
-      class: 'cy-inputs',
     },
     {
       title: 'Outputs',
       controls: () => this.directiveOutputControls(),
-      class: 'cy-outputs',
     },
     {
       title: 'Properties',
       controls: () => this.directiveStateControls(),
-      class: 'cy-properties',
     },
   ]);
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.ts
@@ -7,7 +7,15 @@
  */
 
 import {CdkDragDrop, moveItemInArray, CdkDropList, CdkDrag} from '@angular/cdk/drag-drop';
-import {Component, computed, forwardRef, input, output, signal} from '@angular/core';
+import {
+  Component,
+  ɵFramework as Framework,
+  computed,
+  forwardRef,
+  input,
+  output,
+  signal,
+} from '@angular/core';
 import {DirectivePosition, SerializedInjectedService} from 'protocol';
 
 import {
@@ -54,19 +62,20 @@ export class PropertyViewBodyComponent {
 
   protected readonly panels = signal([
     {
-      title: 'Inputs',
+      title: () => 'Inputs',
       controls: () => this.directiveInputControls(),
     },
     {
-      title: 'Props',
+      title: () => 'Props',
       controls: () => this.directivePropControls(),
     },
     {
-      title: 'Outputs',
+      title: () => 'Outputs',
       controls: () => this.directiveOutputControls(),
     },
     {
-      title: 'Properties',
+      title: () =>
+        this.controller().directiveMetadata?.framework === Framework.Wiz ? 'State' : 'Properties',
       controls: () => this.directiveStateControls(),
     },
   ]);

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view.component.html
@@ -5,6 +5,7 @@
 <ng-property-view-body
   [controller]="controller()!"
   [directiveInputControls]="directiveInputControls()!"
+  [directivePropControls]="directivePropControls()!"
   [directiveOutputControls]="directiveOutputControls()!"
   [directiveStateControls]="directiveStateControls()!"
   (inspect)="inspect.emit($event)"

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view.component.ts
@@ -26,13 +26,20 @@ export class PropertyViewComponent {
 
   private _nestedProps = inject(ElementPropertyResolver);
 
-  readonly controller = computed(() =>
+  protected readonly controller = computed(() =>
     this._nestedProps.getDirectiveController(this.directive().name),
   );
 
-  readonly directiveInputControls = computed(() => this.controller()?.directiveInputControls);
-
-  readonly directiveOutputControls = computed(() => this.controller()?.directiveOutputControls);
-
-  readonly directiveStateControls = computed(() => this.controller()?.directiveStateControls);
+  protected readonly directiveInputControls = computed(
+    () => this.controller()?.directiveInputControls,
+  );
+  protected readonly directivePropControls = computed(
+    () => this.controller()?.directivePropControls,
+  );
+  protected readonly directiveOutputControls = computed(
+    () => this.controller()?.directiveOutputControls,
+  );
+  protected readonly directiveStateControls = computed(
+    () => this.controller()?.directiveStateControls,
+  );
 }

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -6,7 +6,15 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {InjectionToken, InjectOptions, Injector, Type, ViewEncapsulation} from '@angular/core';
+import {
+  ɵFramework as Framework,
+  ɵAcxViewEncapsulation as AcxViewEncapsulation,
+  InjectionToken,
+  InjectOptions,
+  Injector,
+  Type,
+  ViewEncapsulation as AngularViewEncapsulation,
+} from '@angular/core';
 
 export interface DirectiveType {
   name: string;
@@ -99,13 +107,42 @@ export interface DirectivesProperties {
   [name: string]: Properties;
 }
 
-export interface DirectiveMetadata {
+/** Directive metadata shared by all frameworks. */
+export interface BaseDirectiveMetadata {
+  framework: Framework;
+  name?: string;
+}
+
+/** Directive metadata specific to Angular. */
+export interface AngularDirectiveMetadata extends BaseDirectiveMetadata {
+  framework: Framework.Angular;
   inputs: {[name: string]: string};
   outputs: {[name: string]: string};
-  encapsulation?: ViewEncapsulation;
+  encapsulation?: AngularViewEncapsulation;
   onPush?: boolean;
   dependencies?: SerializedInjectedService[];
 }
+
+/** Directive metadata specific to ACX. */
+export interface AcxDirectiveMetadata extends BaseDirectiveMetadata {
+  framework: Framework.ACX;
+  inputs: {[name: string]: string};
+  outputs: {[name: string]: string};
+  encapsulation?: AcxViewEncapsulation;
+  onPush?: boolean;
+}
+
+/** Directive metadata specific to Wiz. */
+export interface WizComponentMetadata extends BaseDirectiveMetadata {
+  framework: Framework.Wiz;
+  props: {[name: string]: string};
+}
+
+/** Directive metadata for all supported frameworks. */
+export type DirectiveMetadata =
+  | AngularDirectiveMetadata
+  | AcxDirectiveMetadata
+  | WizComponentMetadata;
 
 export interface SerializedInjectedService {
   token: string;

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -102,8 +102,8 @@ export interface DirectivesProperties {
 export interface DirectiveMetadata {
   inputs: {[name: string]: string};
   outputs: {[name: string]: string};
-  encapsulation: ViewEncapsulation;
-  onPush: boolean;
+  encapsulation?: ViewEncapsulation;
+  onPush?: boolean;
   dependencies?: SerializedInjectedService[];
 }
 

--- a/goldens/public-api/core/global_utils.api.md
+++ b/goldens/public-api/core/global_utils.api.md
@@ -8,20 +8,7 @@
 export function applyChanges(component: {}): void;
 
 // @public
-export interface ComponentDebugMetadata extends DirectiveDebugMetadata {
-    // (undocumented)
-    changeDetection: ChangeDetectionStrategy;
-    // (undocumented)
-    encapsulation: ViewEncapsulation;
-}
-
-// @public
-export interface DirectiveDebugMetadata {
-    // (undocumented)
-    inputs: Record<string, string>;
-    // (undocumented)
-    outputs: Record<string, string>;
-}
+export type DirectiveDebugMetadata = AngularDirectiveDebugMetadata | AcxDirectiveDebugMetadata | AngularComponentDebugMetadata | AcxComponentDebugMetadata | WizComponentDebugMetadata;
 
 // @public
 export function getComponent<T>(element: Element): T | null;
@@ -30,7 +17,7 @@ export function getComponent<T>(element: Element): T | null;
 export function getContext<T extends {}>(element: Element): T | null;
 
 // @public
-export function getDirectiveMetadata(directiveOrComponentInstance: any): ComponentDebugMetadata | DirectiveDebugMetadata | null;
+export function getDirectiveMetadata(directiveOrComponentInstance: any): AngularComponentDebugMetadata | AngularDirectiveDebugMetadata | null;
 
 // @public
 export function getDirectives(node: Node): {}[];

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -39,7 +39,6 @@ export {
 export {
   AttributeMarker as ɵAttributeMarker,
   ComponentDef as ɵComponentDef,
-  ComponentDebugMetadata as ɵComponentDebugMetadata,
   ComponentFactory as ɵRender3ComponentFactory,
   ComponentRef as ɵRender3ComponentRef,
   ComponentType as ɵComponentType,
@@ -62,6 +61,16 @@ export {
   ɵDeferBlockDependencyInterceptor,
   ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR,
   ɵDEFER_BLOCK_CONFIG,
+  Framework as ɵFramework,
+  BaseDirectiveDebugMetadata as ɵBaseDirectiveDebugMetadata,
+  AngularDirectiveDebugMetadata as ɵAngularDirectiveDebugMetadata,
+  AngularComponentDebugMetadata as ɵAngularComponentDebugMetadata,
+  AcxChangeDetectionStrategy as ɵAcxChangeDetectionStrategy,
+  AcxViewEncapsulation as ɵAcxViewEncapsulation,
+  AcxDirectiveDebugMetadata as ɵAcxDirectiveDebugMetadata,
+  AcxComponentDebugMetadata as ɵAcxComponentDebugMetadata,
+  WizComponentDebugMetadata as ɵWizComponentDebugMetadata,
+  DirectiveDebugMetadata as ɵDirectiveDebugMetadata,
   ɵɵadvance,
   ɵɵattribute,
   ɵɵattributeInterpolate1,
@@ -282,7 +291,10 @@ export {
 export {compilePipe as ɵcompilePipe} from './render3/jit/pipe';
 export {isNgModule as ɵisNgModule} from './render3/jit/util';
 export {Profiler as ɵProfiler, ProfilerEvent as ɵProfilerEvent} from './render3/profiler_types';
-export {GlobalDevModeUtils as ɵGlobalDevModeUtils} from './render3/util/global_utils';
+export {
+  FrameworkAgnosticGlobalUtils as ɵFrameworkAgnosticGlobalUtils,
+  GlobalDevModeUtils as ɵGlobalDevModeUtils,
+} from './render3/util/global_utils';
 export {
   ViewRef as ɵViewRef,
   isViewDirty as ɵisViewDirty,

--- a/packages/core/src/render3/global_utils_api.ts
+++ b/packages/core/src/render3/global_utils_api.ts
@@ -17,7 +17,6 @@
 
 export {applyChanges} from './util/change_detection_utils';
 export {
-  ComponentDebugMetadata,
   DirectiveDebugMetadata,
   getComponent,
   getContext,

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -30,7 +30,15 @@ import {
 } from './interfaces/public_definitions';
 import {ɵɵsetComponentScope, ɵɵsetNgModuleScope} from './scope';
 import {
-  ComponentDebugMetadata,
+  Framework,
+  BaseDirectiveDebugMetadata,
+  AngularDirectiveDebugMetadata,
+  AngularComponentDebugMetadata,
+  AcxChangeDetectionStrategy,
+  AcxViewEncapsulation,
+  AcxDirectiveDebugMetadata,
+  AcxComponentDebugMetadata,
+  WizComponentDebugMetadata,
   DirectiveDebugMetadata,
   getComponent,
   getDirectiveMetadata,
@@ -223,10 +231,18 @@ export {ɵsetClassDebugInfo} from './debug/set_debug_info';
 export {ɵɵreplaceMetadata} from './hmr';
 
 export {
-  ComponentDebugMetadata,
   ComponentDef,
   ComponentTemplate,
   ComponentType,
+  Framework,
+  BaseDirectiveDebugMetadata,
+  AngularDirectiveDebugMetadata,
+  AngularComponentDebugMetadata,
+  AcxChangeDetectionStrategy,
+  AcxViewEncapsulation,
+  AcxDirectiveDebugMetadata,
+  AcxComponentDebugMetadata,
+  WizComponentDebugMetadata,
   DirectiveDebugMetadata,
   DirectiveDef,
   DirectiveType,

--- a/packages/core/src/render3/util/global_utils.ts
+++ b/packages/core/src/render3/util/global_utils.ts
@@ -14,6 +14,7 @@ import {isSignal} from '../reactivity/api';
 import {applyChanges} from './change_detection_utils';
 import {getDeferBlocks} from './defer';
 import {
+  DirectiveDebugMetadata,
   getComponent,
   getContext,
   getDirectiveMetadata,
@@ -124,6 +125,21 @@ export function publishGlobalUtil<K extends CoreGlobalUtilsFunctions>(
 ): void {
   publishUtil(name, fn);
 }
+
+/**
+ * Defines the framework-agnostic `ng` global type, not just the `@angular/core` implementation.
+ *
+ * `typeof globalUtilsFunctions` is specifically the `@angular/core` implementation, so we
+ * overwrite some properties to make them more framework-agnostic. Longer term, we should define
+ * the `ng` global type as an interface implemented by `globalUtilsFunctions` rather than a type
+ * derived from it.
+ */
+export type FrameworkAgnosticGlobalUtils = Omit<
+  typeof globalUtilsFunctions,
+  'getDirectiveMetadata'
+> & {
+  getDirectiveMetadata(directiveOrComponentInstance: any): DirectiveDebugMetadata | null;
+};
 
 /**
  * Publishes the given function to `window.ng` from package other than @angular/core

--- a/packages/core/test/acceptance/discover_utils_spec.ts
+++ b/packages/core/test/acceptance/discover_utils_spec.ts
@@ -24,7 +24,7 @@ import {ComponentFixture, TestBed} from '../../testing';
 import {getLContext} from '../../src/render3/context_discovery';
 import {getHostElement} from '../../src/render3/index';
 import {
-  ComponentDebugMetadata,
+  AngularComponentDebugMetadata,
   getComponent,
   getComponentLView,
   getContext,
@@ -383,13 +383,11 @@ describe('discovery utils', () => {
 
   describe('getDirectiveMetadata', () => {
     it('should work with components', () => {
-      const metadata = getDirectiveMetadata(myApp);
-      expect(metadata!.inputs).toEqual({a: 'b'});
-      expect(metadata!.outputs).toEqual({c: 'd'});
-      expect((metadata as ComponentDebugMetadata).changeDetection).toBe(
-        ChangeDetectionStrategy.Default,
-      );
-      expect((metadata as ComponentDebugMetadata).encapsulation).toBe(ViewEncapsulation.None);
+      const metadata = getDirectiveMetadata(myApp)! as AngularComponentDebugMetadata;
+      expect(metadata.inputs).toEqual({a: 'b'});
+      expect(metadata.outputs).toEqual({c: 'd'});
+      expect(metadata.changeDetection).toBe(ChangeDetectionStrategy.Default);
+      expect(metadata.encapsulation).toBe(ViewEncapsulation.None);
     });
 
     it('should work with directives', () => {


### PR DESCRIPTION
This PR does a few things:
1. Updates `ng.getDirectiveMetadata` type to support Wiz and ACX variants.
2. Updates DevTools to consume Wiz and ACX metadata.
3. Updates the property view to identify Wiz component inputs as "Props", aligning with that framework's convention.
4. Updates the property view to identify Wiz component internal properties as "State", aligning with that framework's convention.
5. Updates the component tree to use the component name provided by `ng.getDirectiveMetadata`.
    * Wiz components often do not have meaningful tag names, so we want to use the component name provided by the framework.

Angular's implementation of `ng.getDirectiveMetadata` is unchanged. This PR only expands the type of allowed return values which DevTools will accept.

While this does change the return type of `ng.getDirectiveMetadata`, this should be done in a non-breaking fashion and safe to merge to `patch`.