### PR TITLE
feat(core): add observed getter on OutputEmitterRef class

### DIFF
--- a/packages/core/src/authoring/output/output_emitter_ref.ts
+++ b/packages/core/src/authoring/output/output_emitter_ref.ts
@@ -33,6 +33,13 @@ export class OutputEmitterRef<T> implements OutputRef<T> {
   private listeners: Array<(value: T) => void> | null = null;
   private errorHandler = inject(ErrorHandler, {optional: true});
 
+  /**
+   * Whether the output has any listeners
+   */
+  get observed(): boolean {
+    return this.listeners ? this.listeners.length > 0 : false;
+  }
+
   /** @internal */
   destroyRef: DestroyRef = inject(DestroyRef);
 

--- a/packages/core/test/acceptance/authoring/output_function_spec.ts
+++ b/packages/core/test/acceptance/authoring/output_function_spec.ts
@@ -42,6 +42,8 @@ describe('output() function', () => {
     fixture.detectChanges();
 
     expect(fixture.componentInstance.values).toEqual([]);
+    expect(dir.onBla.observed).toBe(true);
+
     dir.onBla.emit(1);
     dir.onBla.emit(2);
 
@@ -362,6 +364,28 @@ describe('output() function', () => {
       expect(handledErrors.length).toBe(1);
       expect((handledErrors[0] as Error).message).toBe('first programmatic listener failure');
       expect(triggered).toBe(1);
+    });
+
+    it('should not be observed if no listeners are present', () => {
+      @Directive({
+        selector: '[dir]',
+      })
+      class Dir {
+        onBla = output();
+      }
+
+      @Component({
+        template: '<div dir></div>',
+        imports: [Dir],
+      })
+      class App {}
+
+      const fixture = TestBed.createComponent(App);
+      const dir = fixture.debugElement.children[0].injector.get(Dir);
+
+      fixture.detectChanges();
+
+      expect(dir.onBla.observed).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
- [x] Feature


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We cannot check if the output is being listened from the parent component or not. 

Issue Number: [54837](https://github.com/angular/angular/issues/54837)

## What is the new behavior?
We will be able to check if an output has any observers (listeners) listening on it's changes or not. 

---

I went with a getter and not a signal, because I wanted the calculation to be lazy. Even if the `observed` was a `computed` and not a getter, I didn't want to increment some signal or update some signal just for the sake of this feature.
Also because there is no way to know if the `observed` computed would've been observed (pun intended) (called/used) somewhere (using public APIs), there would be no way to lazily mark that computed as dirty.

## Does this PR introduce a breaking change?

- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Open to any changes, but I'd like to have this possibility sooner or later 👋