### PR TITLE
build: prepare testing infrastructure for code splitting of `core` package

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/BUILD.bazel
@@ -23,6 +23,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/typecheck",
         "//packages/compiler-cli/src/ngtsc/typecheck/api",
         "//packages/compiler-cli/src/ngtsc/util",
+        "@npm//tinyglobby",
         "@npm//typescript",
     ],
 )

--- a/packages/language-service/test/type_definitions_spec.ts
+++ b/packages/language-service/test/type_definitions_spec.ts
@@ -10,6 +10,7 @@ import {initMockFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/te
 
 import {
   assertFileNames,
+  assertFilePaths,
   assertTextSpans,
   humanizeDocumentSpanLike,
   LanguageServiceTestEnv,
@@ -119,7 +120,7 @@ describe('type definitions', () => {
       expect(definitions!.length).toEqual(1);
 
       assertTextSpans(definitions, ['OutputEmitterRef']);
-      assertFileNames(definitions, ['index.d.ts']);
+      assertFilePaths(definitions, [/node_modules\/@angular\/core\/.*\.d\.ts/]);
     });
   });
 
@@ -158,7 +159,7 @@ describe('type definitions', () => {
       expect(definitions!.length).toEqual(1);
 
       assertTextSpans(definitions, ['OutputRef']);
-      assertFileNames(definitions, ['index.d.ts']);
+      assertFilePaths(definitions, [/node_modules\/@angular\/core\/.*\.d\.ts/]);
     });
   });
 

--- a/packages/language-service/testing/src/util.ts
+++ b/packages/language-service/testing/src/util.ts
@@ -22,6 +22,38 @@ export function assertFileNames(refs: Array<{fileName: string}>, expectedFileNam
   expect(new Set(actualFileNames)).toEqual(new Set(expectedFileNames));
 }
 
+/**
+ * Expect that a list of objects with a `fileName` property matches a set
+ * of file paths.
+ *
+ * This assertion is independent of the order of either list.
+ */
+export function assertFilePaths(refs: Array<{fileName: string}>, expectedPaths: RegExp[]) {
+  const actualPaths = Array.from(new Set(refs.map((r) => r.fileName)));
+
+  if (actualPaths.length !== expectedPaths.length) {
+    expect(actualPaths.length)
+      .withContext('Expected expected paths to be the same size.')
+      .toBe(expectedPaths.length);
+    return;
+  }
+
+  for (const pattern of expectedPaths) {
+    const matching = actualPaths.findIndex((p) => pattern.test(p));
+    if (matching !== -1) {
+      actualPaths.splice(matching, 1);
+    } else {
+      expect(true)
+        .withContext(
+          `Expected ${pattern} to match a file path. ` +
+            `Remaining unmatched paths: ${actualPaths.join(', ')}`,
+        )
+        .toBe(false);
+      return;
+    }
+  }
+}
+
 export function assertTextSpans(items: Array<{textSpan: string}>, expectedTextSpans: string[]) {
   const actualSpans = items.map((item) => item.textSpan);
   expect(new Set(actualSpans)).toEqual(new Set(expectedTextSpans));
@@ -97,9 +129,7 @@ export function humanizeDocumentSpanLike<T extends ts.DocumentSpan>(
       : undefined,
   };
 }
-type Stringy<T> = {
-  [P in keyof T]: string;
-};
+type Stringy<T> = {[P in keyof T]: string};
 
 export function getText(contents: string, textSpan: ts.TextSpan) {
   return contents.slice(textSpan.start, textSpan.start + textSpan.length);


### PR DESCRIPTION
When we switch to relative imports, shared `.d.ts` chunks can be generated.

We need to also pull these into our mock virtual FS testing environments. Notably this does not cause a test slow-down because we are talking about very few extra `.d.ts` chunk files. In our experiments before, with no dts bundling, we saw test time increase from e.g. 20seconds to 100seconds. The 20s are still the same locally!

In addition, since code for definitions can now reside in shared `.d.ts` chunks, the language service tests need to be adjusted in cases where they assert for code definition locations in `@angular/core`. A new helper prepares for more code to be moved into arbitrary `.d.ts` files; we should simply assert the definition comes out of `node_modules/@angular/core`.