### PR TITLE
feat(core): export signalGetFn from signal primitives

### DIFF
--- a/goldens/public-api/core/primitives/signals/index.api.md
+++ b/goldens/public-api/core/primitives/signals/index.api.md
@@ -162,6 +162,9 @@ export const SIGNAL: unique symbol;
 export const SIGNAL_NODE: SignalNode<unknown>;
 
 // @public (undocumented)
+export function signalGetFn<T>(node: SignalNode<T>): T;
+
+// @public (undocumented)
 export interface SignalGetter<T> extends SignalBaseGetter<T> {
     // (undocumented)
     readonly [SIGNAL]: SignalNode<T>;

--- a/packages/core/primitives/signals/index.ts
+++ b/packages/core/primitives/signals/index.ts
@@ -48,6 +48,7 @@ export {
   createSignal,
   runPostSignalSetFn,
   setPostSignalSetFn,
+  signalGetFn,
   signalSetFn,
   signalUpdateFn,
 } from './src/signal';

--- a/packages/core/primitives/signals/src/signal.ts
+++ b/packages/core/primitives/signals/src/signal.ts
@@ -54,10 +54,7 @@ export function createSignal<T>(initialValue: T, equal?: ValueEqualityFn<T>): Si
   if (equal !== undefined) {
     node.equal = equal;
   }
-  const getter = (() => {
-    producerAccessed(node);
-    return node.value;
-  }) as SignalGetter<T>;
+  const getter = (() => signalGetFn(node)) as SignalGetter<T>;
   (getter as any)[SIGNAL] = node;
   runPostProducerCreatedFn(node);
   return getter;
@@ -69,9 +66,9 @@ export function setPostSignalSetFn(fn: ReactiveHookFn | null): ReactiveHookFn | 
   return prev;
 }
 
-export function signalGetFn<T>(this: SignalNode<T>): T {
-  producerAccessed(this);
-  return this.value;
+export function signalGetFn<T>(node: SignalNode<T>): T {
+  producerAccessed(node);
+  return node.value;
 }
 
 export function signalSetFn<T>(node: SignalNode<T>, newValue: T) {


### PR DESCRIPTION
This exports `signalGetFn` from the shared signal primitives which follows suit from `signalSetFn` and `signalUpdateFn` (both are already exported).