### PR TITLE
test: `ng-modules-importability` test should import every module in isolation

### DIFF
--- a/integration/ng-modules-importability/BUILD.bazel
+++ b/integration/ng-modules-importability/BUILD.bazel
@@ -26,6 +26,7 @@ module_test(
         "//packages/service-worker:npm_package": "packages/service-worker/npm_package",
         "//packages/upgrade:npm_package": "packages/upgrade/npm_package",
     },
+    shard_count = 4,
     skipped_entry_points = [
         # Core does not expose any modules and just needs to be made available.
         "@angular/core",

--- a/integration/ng-modules-importability/index.bzl
+++ b/integration/ng-modules-importability/index.bzl
@@ -1,7 +1,7 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//tools:defaults.bzl", "nodejs_test")
 
-def module_test(name, npm_packages, skipped_entry_points = [], additional_deps = []):
+def module_test(name, npm_packages, skipped_entry_points = [], additional_deps = [], **kwargs):
     write_file(
         name = "%s_config" % name,
         out = "%s_config.json" % name,
@@ -20,4 +20,5 @@ def module_test(name, npm_packages, skipped_entry_points = [], additional_deps =
         entry_point = "//integration/ng-modules-importability:index.ts",
         enable_linker = True,
         templated_args = ["$(rootpath :%s_config)" % name],
+        **kwargs
     )


### PR DESCRIPTION
This will make the test even more useful, as it ensures that we aren't accidentally relying on the compiler potentially discovering best guessed modules from other imports that previously were part of the same file (importing all modules as part of the test).