### PR TITLE
refactor(docs-infra): remove usage of `@angular/platform-browser-dynamic` from adev

### DIFF
--- a/adev/BUILD.bazel
+++ b/adev/BUILD.bazel
@@ -88,7 +88,6 @@ APPLICATION_DEPS = [
 ]
 
 TEST_DEPS = APPLICATION_DEPS + [
-    "@npm//@angular/platform-browser-dynamic",
     "@npm//@types/jasmine",
     "@npm//@types/node",
     "@npm//jasmine",

--- a/adev/test-main.ts
+++ b/adev/test-main.ts
@@ -8,10 +8,7 @@
 
 import {ErrorHandler, NgModule, provideExperimentalZonelessChangeDetection} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
+import {BrowserTestingModule, platformBrowserTesting} from '@angular/platform-browser/testing';
 
 @NgModule({
   providers: [
@@ -19,7 +16,7 @@ import {
     {
       provide: ErrorHandler,
       useValue: {
-        handleError: (e: any) => {
+        handleError: (e: unknown) => {
           throw e;
         },
       },
@@ -28,7 +25,4 @@ import {
 })
 export class TestModule {}
 
-TestBed.initTestEnvironment(
-  [BrowserDynamicTestingModule, TestModule],
-  platformBrowserDynamicTesting(),
-);
+TestBed.initTestEnvironment([BrowserTestingModule, TestModule], platformBrowserTesting());

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "@actions/github": "^6.0.0",
     "@angular-devkit/architect-cli": "0.2000.0-next.2",
     "@angular/build-tooling": "https://github.com/angular/dev-infra-private-build-tooling-builds.git#ce04ec6cf7604014191821a637e60964a1a3bb4a",
-    "@angular/core": "^20.0.0-next",
+    "@angular/core": "20.0.0-next.3",
     "@angular/ng-dev": "https://github.com/angular/dev-infra-private-ng-dev-builds.git#3e60055cec07598ad7160ba36dd08bf57ae2be98",
     "@babel/plugin-proposal-async-generator-functions": "7.20.7",
     "@bazel/bazelisk": "^1.7.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -318,7 +318,6 @@
 
 "@angular/build-tooling@https://github.com/angular/dev-infra-private-build-tooling-builds.git#ce04ec6cf7604014191821a637e60964a1a3bb4a":
   version "0.0.0-2670abf637fa155971cdd1f7e570a7f234922a65"
-  uid ce04ec6cf7604014191821a637e60964a1a3bb4a
   resolved "https://github.com/angular/dev-infra-private-build-tooling-builds.git#ce04ec6cf7604014191821a637e60964a1a3bb4a"
   dependencies:
     "@angular/benchpress" "0.3.0"
@@ -454,17 +453,17 @@
     symbol-observable "4.0.0"
     yargs "17.7.2"
 
+"@angular/core@20.0.0-next.3":
+  version "20.0.0-next.3"
+  resolved "https://registry.yarnpkg.com/@angular/core/-/core-20.0.0-next.3.tgz#7ee1a86a2fd92efc15722a655be228756986f214"
+  integrity sha512-UYIUKeDB6UkTrYd5pCurIJav7gK7vwsbzH8DdfUrI32Zj7Yfyn5r7odG1VDIOTiCS54sK0D7rZLa8PtWD8QR6A==
+  dependencies:
+    tslib "^2.3.0"
+
 "@angular/core@^13.0.0 || ^14.0.0-0":
   version "14.3.0"
   resolved "https://registry.yarnpkg.com/@angular/core/-/core-14.3.0.tgz#7f44c59b6e866fa4cee7221495040c1ead433895"
   integrity sha512-wYiwItc0Uyn4FWZ/OAx/Ubp2/WrD3EgUJ476y1XI7yATGPF8n9Ld5iCXT08HOvc4eBcYlDfh90kTXR6/MfhzdQ==
-  dependencies:
-    tslib "^2.3.0"
-
-"@angular/core@^20.0.0-next":
-  version "20.0.0-next.2"
-  resolved "https://registry.yarnpkg.com/@angular/core/-/core-20.0.0-next.2.tgz#a2e6e6e197c411cd192b8f9341763c26fa1a3996"
-  integrity sha512-nF1yPPXO0EZQmNsvR7p3KCPUnxVQxHEVNIBunBCoOia5DEi9E7l+VkMT/2Bnp/7h/ZCdOst4A3Uj4XqpNhUYtA==
   dependencies:
     tslib "^2.3.0"
 
@@ -477,7 +476,6 @@
 
 "@angular/ng-dev@https://github.com/angular/dev-infra-private-ng-dev-builds.git#3e60055cec07598ad7160ba36dd08bf57ae2be98":
   version "0.0.0-78bd12c8526c396fc85e5ac3d72c039dc7e0a51a"
-  uid "3e60055cec07598ad7160ba36dd08bf57ae2be98"
   resolved "https://github.com/angular/dev-infra-private-ng-dev-builds.git#3e60055cec07598ad7160ba36dd08bf57ae2be98"
   dependencies:
     "@google-cloud/spanner" "7.19.0"
@@ -8057,8 +8055,7 @@ domhandler@^5.0.2, domhandler@^5.0.3:
     domelementtype "^2.3.0"
 
 "domino@https://github.com/angular/domino.git#8f228f8862540c6ccd14f76b5a1d9bb5458618af":
-  version "2.1.6+git"
-  uid "8f228f8862540c6ccd14f76b5a1d9bb5458618af"
+  version "2.1.6"
   resolved "https://github.com/angular/domino.git#8f228f8862540c6ccd14f76b5a1d9bb5458618af"
 
 dompurify@^3.2.4:


### PR DESCRIPTION


Usage of `@angular/platform-browser-dynamic` is not needed since Angular CLI always inject `@angular/compiler` when running JIT.

