### PR TITLE
fix(localize): handle @angular/build:karma in ng add

### DIFF
--- a/packages/localize/schematics/ng-add/index.ts
+++ b/packages/localize/schematics/ng-add/index.ts
@@ -36,6 +36,7 @@ function addPolyfillToConfig(projectName: string): Rule {
     for (const target of project.targets.values()) {
       switch (target.builder) {
         case AngularBuilder.Karma:
+        case AngularBuilder.BuildKarma:
         case AngularBuilder.Server:
         case AngularBuilder.Browser:
         case AngularBuilder.BrowserEsbuild:

--- a/packages/localize/schematics/ng-add/index_spec.ts
+++ b/packages/localize/schematics/ng-add/index_spec.ts
@@ -77,6 +77,13 @@ describe('ng-add schematic', () => {
                   polyfills: 'zone.js',
                 },
               },
+              testKarmaBuild: {
+                builder: '@angular/build:karma',
+                options: {
+                  tsConfig: './tsconfig.spec.json',
+                  polyfills: 'zone.js',
+                },
+              },
               server: {
                 builder: '@angular-devkit/build-angular:server',
                 options: {
@@ -170,6 +177,13 @@ describe('ng-add schematic', () => {
     host = await schematicRunner.runSchematic('ng-add', defaultOptions, host);
     const workspace = host.readJson('angular.json') as any;
     const polyfills = workspace.projects['demo'].architect.test.options.polyfills;
+    expect(polyfills).toEqual(['zone.js', '@angular/localize/init']);
+  });
+
+  it(`should add '@angular/localize/init' in 'polyfills' in karma application builder`, async () => {
+    host = await schematicRunner.runSchematic('ng-add', defaultOptions, host);
+    const workspace = host.readJson('angular.json') as any;
+    const polyfills = workspace.projects['demo'].architect.testKarmaBuild.options.polyfills;
     expect(polyfills).toEqual(['zone.js', '@angular/localize/init']);
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

New applications generated by the CLI v20-next use the karma application builder by default.
When running `ng add` this builder is ignored, and the localize polyfill is not added in the test configuration.

## What is the new behavior?

`ng add @angular/localize` now also adds the localize polyfill to the configuration of Karma if the `@angular/build:karma` builder is used (which is the default in Angular CLI v20)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
