### PR TITLE
docs(docs-infra): disable adev tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,10 @@ jobs:
         uses: angular/dev-infra/github-actions/bazel/configure-remote@78bd12c8526c396fc85e5ac3d72c039dc7e0a51a
       - name: Install node modules
         run: yarn install --frozen-lockfile
-      - name: Run tests
-        run: yarn bazel test //adev/...
+      # TODO: re-enable all tests once the next release is shipped
+      # Tests are broken because of https://github.com/angular/angular/issues/54858
+      #- name: Run tests
+      #  run: yarn bazel test //adev:test #//adev/...
       - name: Build adev in fast mode to ensure it continues to work
         run: yarn bazel build //adev:build --config=release
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -118,8 +118,10 @@ jobs:
         uses: angular/dev-infra/github-actions/bazel/configure-remote@78bd12c8526c396fc85e5ac3d72c039dc7e0a51a
       - name: Install node modules
         run: yarn install --frozen-lockfile
-      - name: Run tests
-        run: yarn bazel test //adev/...
+      # TODO: re-enable all tests once the next release is shipped
+      # Tests are broken because of https://github.com/angular/angular/issues/54858
+      #- name: Run tests
+      #  run: yarn bazel test //adev:test #//adev/...
       - name: Build adev in fast mode to ensure it continues to work
         run: yarn bazel build //adev:build --config=release
 


### PR DESCRIPTION
Those tests are currently broken until we bump the angular version (pending release).
