### PR TITLE
docs: update description for `AfterRenderPhase.EarlyRead`

### DIFF
--- a/packages/core/src/render3/after_render/api.ts
+++ b/packages/core/src/render3/after_render/api.ts
@@ -32,7 +32,7 @@ export enum AfterRenderPhase {
    * Use `AfterRenderPhase.EarlyRead` for callbacks that only need to **read** from the
    * DOM before a subsequent `AfterRenderPhase.Write` callback, for example to perform
    * custom layout that the browser doesn't natively support. Prefer the
-   * `AfterRenderPhase.EarlyRead` phase if reading can wait until after the write phase.
+   * `AfterRenderPhase.Read` phase if reading can wait until after the write phase.
    * **Never** write to the DOM in this phase.
    *
    * <div class="docs-alert docs-alert-important">


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
This PR updates the description for `AfterRenderPhase.EarlyRead` at https://angular.dev/api/core/AfterRenderPhase#EarlyRead from 

 > Use [AfterRenderPhase.EarlyRead](https://angular.dev/api/core/AfterRenderPhase#EarlyRead) for callbacks that only need to read from the DOM before a subsequent [AfterRenderPhase.Write](https://angular.dev/api/core/AfterRenderPhase#Write) callback, for example to perform custom layout that the browser doesn't natively support. Prefer the [AfterRenderPhase.EarlyRead](https://angular.dev/api/core/AfterRenderPhase#EarlyRead) phase if reading can wait until after the write phase. Never write to the DOM in this phase.

to

> Use [AfterRenderPhase.EarlyRead](https://angular.dev/api/core/AfterRenderPhase#EarlyRead) for callbacks that only need to read from the DOM before a subsequent [AfterRenderPhase.Write](https://angular.dev/api/core/AfterRenderPhase#Write) callback, for example to perform custom layout that the browser doesn't natively support. Prefer the [AfterRenderPhase.Read](https://angular.dev/api/core/AfterRenderPhase#Read) phase if reading can wait until after the write phase. Never write to the DOM in this phase. 

Issue Number: #60525 


## What is the new behavior?

The text was updated as mentioned above.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
