### PR TITLE
refactor(core): produce a message about `@defer` behavior when HMR is enabled

### DIFF
--- a/adev/src/content/reference/errors/NG0751.md
+++ b/adev/src/content/reference/errors/NG0751.md
@@ -1,0 +1,13 @@
+# @defer behavior when HMR is enabled
+
+Hot Module Replacement (HMR) is a technique used by development servers to avoid reloading the entire page when only part of an application is changed.
+
+When the HMR is enabled in Angular, all `@defer` block dependencies are loaded
+eagerly, instead of waiting for configured trigger conditions (both for client-only and incremental hydration triggers). This is needed
+for the HMR to function properly, replacing components in an application at runtime
+without the need to reload the entire page. Note: the actual rendering of defer
+blocks respects trigger conditions in the HMR mode.
+
+If you want to test `@defer` block behavior in development mode and ensure that
+the necessary dependencies are loaded when a triggering condition is met, you can
+disable the HMR mode as described in [`this document`](/tools/cli/build-system-migration#hot-module-replacement).

--- a/goldens/public-api/core/errors.api.md
+++ b/goldens/public-api/core/errors.api.md
@@ -7,6 +7,9 @@
 // @public
 export function formatRuntimeError<T extends number = RuntimeErrorCode>(code: T, message: null | false | string): string;
 
+// @public (undocumented)
+export function formatRuntimeErrorCode<T extends number = RuntimeErrorCode>(code: T): string;
+
 // @public
 export class RuntimeError<T extends number = RuntimeErrorCode> extends Error {
     constructor(code: T, message: null | false | string);
@@ -28,6 +31,8 @@ export const enum RuntimeErrorCode {
     COMPONENT_ID_COLLISION = -912,
     // (undocumented)
     CYCLIC_DI_DEPENDENCY = -200,
+    // (undocumented)
+    DEFER_IN_HMR_MODE = -751,
     // (undocumented)
     DEFER_LOADING_FAILED = -750,
     // (undocumented)

--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import '../util/ng_hmr_mode';
 import '../util/ng_jit_mode';
 import '../util/ng_server_mode';
 

--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -65,6 +65,35 @@ import {
   triggerResourceLoading,
   shouldAttachTrigger,
 } from './triggering';
+import {formatRuntimeError, RuntimeErrorCode} from '../errors';
+import {Console} from '../console';
+import {Injector} from '../di';
+
+/**
+ * Indicates whether we've already produced a warning,
+ * prevents the logic from producing it multiple times.
+ */
+let _hmrWarningProduced = false;
+
+/**
+ * Logs a message into the console to indicate that `@defer` block
+ * dependencies are loaded eagerly when the HMR mode is enabled.
+ */
+function logHmrWarning(injector: Injector) {
+  if (!_hmrWarningProduced) {
+    _hmrWarningProduced = true;
+    const console = injector.get(Console);
+    // tslint:disable-next-line:no-console
+    console.log(
+      formatRuntimeError(
+        RuntimeErrorCode.DEFER_IN_HMR_MODE,
+        'Angular has detected that this application contains `@defer` blocks ' +
+          'and the hot module replacement (HMR) mode is enabled. All `@defer` ' +
+          'block dependencies will be loaded eagerly.',
+      ),
+    );
+  }
+}
 
 /**
  * Creates runtime data structures for defer blocks.
@@ -107,6 +136,10 @@ export function ɵɵdefer(
 
   if (tView.firstCreatePass) {
     performanceMarkFeature('NgDefer');
+
+    if (ngDevMode && typeof ngHmrMode !== 'undefined' && ngHmrMode) {
+      logHmrWarning(injector);
+    }
 
     const tDetails: TDeferBlockDetails = {
       primaryTmplIndex,

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -101,6 +101,7 @@ export const enum RuntimeErrorCode {
 
   // Defer errors (750-799 range)
   DEFER_LOADING_FAILED = -750,
+  DEFER_IN_HMR_MODE = -751,
 
   // standalone errors
   IMPORT_PROVIDERS_FROM_STANDALONE = 800,
@@ -169,6 +170,13 @@ export class RuntimeError<T extends number = RuntimeErrorCode> extends Error {
   }
 }
 
+export function formatRuntimeErrorCode<T extends number = RuntimeErrorCode>(code: T): string {
+  // Error code might be a negative number, which is a special marker that instructs the logic to
+  // generate a link to the error details page on angular.io.
+  // We also prepend `0` to non-compile-time errors.
+  return `NG0${Math.abs(code)}`;
+}
+
 /**
  * Called to format a runtime error.
  * See additional info on the `message` argument type in the `RuntimeError` class description.
@@ -177,10 +185,7 @@ export function formatRuntimeError<T extends number = RuntimeErrorCode>(
   code: T,
   message: null | false | string,
 ): string {
-  // Error code might be a negative number, which is a special marker that instructs the logic to
-  // generate a link to the error details page on angular.io.
-  // We also prepend `0` to non-compile-time errors.
-  const fullCode = `NG0${Math.abs(code)}`;
+  const fullCode = formatRuntimeErrorCode(code);
 
   let errorMessage = `${fullCode}${message ? ': ' + message : ''}`;
 

--- a/packages/core/src/util/ng_hmr_mode.ts
+++ b/packages/core/src/util/ng_hmr_mode.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+declare global {
+  /**
+   * Indicates whether HMR is enabled for the application.
+   *
+   * `ngHmrMode` is a global flag set by Angular's CLI.
+   *
+   * @remarks
+   * - **Internal Angular Flag**: This is an *internal* Angular flag (not a public API), avoid relying on it in application code.
+   * - **Avoid Direct Use**: This variable is intended for runtime configuration; it should not be accessed directly in application code.
+   */
+  var ngHmrMode: boolean | undefined;
+}
+
+// Export an empty object to ensure this file is treated as an ES module, allowing augmentation of the global scope.
+export {};


### PR DESCRIPTION
When the HMR is enabled in Angular, all `@defer` block dependencies are loaded eagerly, instead of waiting for configured trigger conditions. From the DX perspective, it might be seen as an issue when all dependencies are being loaded eagerly. This commit adds a logic to produce a message into the console to provide more info for developers.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No