### PR TITLE
fix(core): remove `forceRoot` flag for effects

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -467,7 +467,6 @@ export interface CreateEffectOptions {
     // @deprecated (undocumented)
     allowSignalWrites?: boolean;
     debugName?: string;
-    forceRoot?: true;
     injector?: Injector;
     manualCleanup?: boolean;
 }

--- a/packages/core/src/render3/reactivity/effect.ts
+++ b/packages/core/src/render3/reactivity/effect.ts
@@ -83,12 +83,6 @@ export interface CreateEffectOptions {
   manualCleanup?: boolean;
 
   /**
-   * Always create a root effect (which is scheduled as a microtask) regardless of whether `effect`
-   * is called within a component.
-   */
-  forceRoot?: true;
-
-  /**
    * @deprecated no longer required, signal writes are allowed by default.
    */
   allowSignalWrites?: boolean;
@@ -122,7 +116,7 @@ export type EffectCleanupRegisterFn = (cleanupFn: EffectCleanupFn) => void;
  * Angular has two different kinds of effect: component effects and root effects. Component effects
  * are created when `effect()` is called from a component, directive, or within a service of a
  * component/directive. Root effects are created when `effect()` is called from outside the
- * component tree, such as in a root service, or when the `forceRoot` option is provided.
+ * component tree, such as in a root service.
  *
  * The two effect types differ in their timing. Component effects run as a component lifecycle
  * event during Angular's synchronization (change detection) process, and can safely read input
@@ -159,7 +153,7 @@ export function effect(
 
   const viewContext = injector.get(ViewContext, null, {optional: true});
   const notifier = injector.get(ChangeDetectionScheduler);
-  if (viewContext !== null && !options?.forceRoot) {
+  if (viewContext !== null) {
     // This effect was created in the context of a view, and will be associated with the view.
     node = createViewEffect(viewContext.view, notifier, effectFn);
     if (destroyRef instanceof NodeInjectorDestroyRef && destroyRef._lView === viewContext.view) {

--- a/packages/core/test/render3/reactivity_spec.ts
+++ b/packages/core/test/render3/reactivity_spec.ts
@@ -290,31 +290,6 @@ describe('reactivity', () => {
       expect(log).toEqual([0, 1]);
     });
 
-    it('should create root effects inside a component when specified', () => {
-      TestBed.configureTestingModule({});
-      const counter = signal(0);
-      const log: number[] = [];
-
-      @Component({
-        template: '',
-      })
-      class TestCmp {
-        constructor() {
-          effect(() => log.push(counter()), {forceRoot: true});
-        }
-      }
-
-      // Running this creates the effect. Note: we never CD this component.
-      TestBed.createComponent(TestCmp);
-
-      TestBed.flushEffects();
-      expect(log).toEqual([0]);
-
-      counter.set(1);
-      TestBed.flushEffects();
-      expect(log).toEqual([0, 1]);
-    });
-
     it('should check components made dirty from markForCheck() from an effect', async () => {
       TestBed.configureTestingModule({
         providers: [provideExperimentalZonelessChangeDetection()],
@@ -426,33 +401,6 @@ describe('reactivity', () => {
     });
 
     describe('destruction', () => {
-      it('should still destroy root effects with the DestroyRef of the component', () => {
-        TestBed.configureTestingModule({});
-        const counter = signal(0);
-        const log: number[] = [];
-
-        @Component({
-          template: '',
-        })
-        class TestCmp {
-          constructor() {
-            effect(() => log.push(counter()), {forceRoot: true});
-          }
-        }
-
-        const fix = TestBed.createComponent(TestCmp);
-
-        TestBed.flushEffects();
-        expect(log).toEqual([0]);
-
-        // Destroy the effect.
-        fix.destroy();
-
-        counter.set(1);
-        TestBed.flushEffects();
-        expect(log).toEqual([0]);
-      });
-
       it('should destroy effects when the parent component is destroyed', () => {
         let destroyed = false;
         @Component({})


### PR DESCRIPTION
This flag is effectively unused in Angular code that we've seen, and is only serving to complicate the mental model of effects. It could be reintroduced if needed.
