### PR TITLE
ci: add hawkgs to pullapprove

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -287,6 +287,7 @@ groups:
         - MarkTechson
         - kirjs
         - mmalerba
+        - ~hawkgs
 
   # =========================================================
   #  Angular DevTools


### PR DESCRIPTION
Add hawkgs to pullaprove for angular-dev.
