### PR TITLE
refactor(core): allow multiple profilers

### DIFF
--- a/packages/core/src/render3/profiler.ts
+++ b/packages/core/src/render3/profiler.ts
@@ -8,21 +8,40 @@
 
 import {type Profiler} from './profiler_types';
 
-let profilerCallback: Profiler | null = null;
+const profilerCallbacks: Profiler[] = [];
+
+const NOOP_PROFILER_REMOVAL = () => {};
+
+function removeProfiler(profiler: Profiler) {
+  const profilerIdx = profilerCallbacks.indexOf(profiler);
+  if (profilerIdx !== -1) {
+    profilerCallbacks.splice(profilerIdx, 1);
+  }
+}
 
 /**
- * Sets the callback function which will be invoked before and after performing certain actions at
- * runtime (for example, before and after running change detection).
+ * Adds a callback function which will be invoked before and after performing certain actions at
+ * runtime (for example, before and after running change detection). Multiple profiler callbacks can be set:
+ * in this case profiling events are reported to every registered callback.
  *
  * Warning: this function is *INTERNAL* and should not be relied upon in application's code.
  * The contract of the function might be changed in any release and/or the function can be removed
  * completely.
  *
- * @param profiler function provided by the caller or null value to disable profiling.
+ * @param profiler function provided by the caller or null value to disable all profilers.
+ * @returns a cleanup function that, when invoked, removes a given profiler callback.
  */
-export const setProfiler = (profiler: Profiler | null) => {
-  profilerCallback = profiler;
-};
+export function setProfiler(profiler: Profiler | null): () => void {
+  if (profiler !== null) {
+    if (!profilerCallbacks.includes(profiler)) {
+      profilerCallbacks.push(profiler);
+    }
+    return () => removeProfiler(profiler);
+  } else {
+    profilerCallbacks.length = 0;
+    return NOOP_PROFILER_REMOVAL;
+  }
+}
 
 /**
  * Profiler function which wraps user code executed by the runtime.
@@ -32,10 +51,10 @@ export const setProfiler = (profiler: Profiler | null) => {
  * @param eventFn function associated with event.
  *    For example a template function, lifecycle hook, or output listener.
  *    The value depends on the execution context
- * @returns
  */
-export const profiler: Profiler = function (event, instance = null, eventFn) {
-  if (profilerCallback != null /* both `null` and `undefined` */) {
+export const profiler: Profiler = function (event, instance = null, eventFn): void {
+  for (let i = 0; i < profilerCallbacks.length; i++) {
+    const profilerCallback = profilerCallbacks[i];
     profilerCallback(event, instance, eventFn);
   }
 };

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -429,6 +429,8 @@
   "producerMarkClean",
   "producerRemoveLiveConsumerAtIndex",
   "producerUpdateValueVersion",
+  "profiler",
+  "profilerCallbacks",
   "refreshContentQueries",
   "refreshView",
   "rememberChangeHistoryAndInvokeOnChangesHook",

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -455,6 +455,8 @@
   "producerMarkClean",
   "producerRemoveLiveConsumerAtIndex",
   "producerUpdateValueVersion",
+  "profiler",
+  "profilerCallbacks",
   "refreshContentQueries",
   "refreshView",
   "rememberChangeHistoryAndInvokeOnChangesHook",

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -369,6 +369,8 @@
   "producerMarkClean",
   "producerRemoveLiveConsumerAtIndex",
   "producerUpdateValueVersion",
+  "profiler",
+  "profilerCallbacks",
   "refreshContentQueries",
   "refreshView",
   "rememberChangeHistoryAndInvokeOnChangesHook",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -433,6 +433,7 @@
   "producerRemoveLiveConsumerAtIndex",
   "producerUpdateValueVersion",
   "profiler",
+  "profilerCallbacks",
   "refreshContentQueries",
   "refreshView",
   "registerPostOrderHooks",

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -552,6 +552,8 @@
   "producerRemoveLiveConsumerAtIndex",
   "producerUpdateValueVersion",
   "producerUpdatesAllowed",
+  "profiler",
+  "profilerCallbacks",
   "providerToFactory",
   "readableStreamLikeToAsyncGenerator",
   "refreshContentQueries",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -541,6 +541,8 @@
   "producerRemoveLiveConsumerAtIndex",
   "producerUpdateValueVersion",
   "producerUpdatesAllowed",
+  "profiler",
+  "profilerCallbacks",
   "providerToFactory",
   "readableStreamLikeToAsyncGenerator",
   "refreshContentQueries",

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -297,6 +297,8 @@
   "producerMarkClean",
   "producerRemoveLiveConsumerAtIndex",
   "producerUpdateValueVersion",
+  "profiler",
+  "profilerCallbacks",
   "refreshContentQueries",
   "refreshView",
   "rememberChangeHistoryAndInvokeOnChangesHook",

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -396,6 +396,8 @@
   "producerMarkClean",
   "producerRemoveLiveConsumerAtIndex",
   "producerUpdateValueVersion",
+  "profiler",
+  "profilerCallbacks",
   "readableStreamLikeToAsyncGenerator",
   "refreshContentQueries",
   "refreshView",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -633,6 +633,8 @@
   "producerNotifyConsumers",
   "producerRemoveLiveConsumerAtIndex",
   "producerUpdateValueVersion",
+  "profiler",
+  "profilerCallbacks",
   "readableStreamLikeToAsyncGenerator",
   "redirectIfUrlTree",
   "redirectingNavigationError",

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -329,6 +329,8 @@
   "producerMarkClean",
   "producerRemoveLiveConsumerAtIndex",
   "producerUpdateValueVersion",
+  "profiler",
+  "profilerCallbacks",
   "refreshContentQueries",
   "refreshView",
   "rememberChangeHistoryAndInvokeOnChangesHook",

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -442,6 +442,8 @@
   "producerMarkClean",
   "producerRemoveLiveConsumerAtIndex",
   "producerUpdateValueVersion",
+  "profiler",
+  "profilerCallbacks",
   "refreshContentQueries",
   "refreshView",
   "registerPostOrderHooks",


### PR DESCRIPTION
This commit changes the profiler infrastructure to allow multiple profilers running at the same time.
