### PR TITLE
refactor(common): update AsyncPipe to support PromiseLike

### DIFF
--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -41,11 +41,11 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
-    transform<T>(obj: Observable<T> | Subscribable<T> | Promise<T> | PromiseLike<T>): T | null;
+    transform<T>(obj: Observable<T> | Subscribable<T> | PromiseLike<T>): T | null;
     // (undocumented)
     transform<T>(obj: null | undefined): null;
     // (undocumented)
-    transform<T>(obj: Observable<T> | Subscribable<T> | Promise<T> | PromiseLike<T> | null | undefined): T | null;
+    transform<T>(obj: Observable<T> | Subscribable<T> | PromiseLike<T> | null | undefined): T | null;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<AsyncPipe, never>;
     // (undocumented)

--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -41,11 +41,11 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
-    transform<T>(obj: Observable<T> | Subscribable<T> | Promise<T>): T | null;
+    transform<T>(obj: Observable<T> | Subscribable<T> | PromiseLike<T>): T | null;
     // (undocumented)
     transform<T>(obj: null | undefined): null;
     // (undocumented)
-    transform<T>(obj: Observable<T> | Subscribable<T> | Promise<T> | null | undefined): T | null;
+    transform<T>(obj: Observable<T> | Subscribable<T> | PromiseLike<T> | null | undefined): T | null;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<AsyncPipe, never>;
     // (undocumented)

--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -41,11 +41,11 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
-    transform<T>(obj: Observable<T> | Subscribable<T> | PromiseLike<T>): T | null;
+    transform<T>(obj: Observable<T> | Subscribable<T> | Promise<T> | PromiseLike<T>): T | null;
     // (undocumented)
     transform<T>(obj: null | undefined): null;
     // (undocumented)
-    transform<T>(obj: Observable<T> | Subscribable<T> | PromiseLike<T> | null | undefined): T | null;
+    transform<T>(obj: Observable<T> | Subscribable<T> | Promise<T> | PromiseLike<T> | null | undefined): T | null;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<AsyncPipe, never>;
     // (undocumented)

--- a/packages/common/src/pipes/async_pipe.ts
+++ b/packages/common/src/pipes/async_pipe.ts
@@ -136,14 +136,10 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
   // TypeScript has a hard time matching Observable to Subscribable, for more information
   // see https://github.com/microsoft/TypeScript/issues/43643
 
-  transform<T>(obj: Observable<T> | Subscribable<T> | Promise<T> | PromiseLike<T>): T | null;
+  transform<T>(obj: Observable<T> | Subscribable<T> | PromiseLike<T>): T | null;
   transform<T>(obj: null | undefined): null;
-  transform<T>(
-    obj: Observable<T> | Subscribable<T> | Promise<T> | PromiseLike<T> | null | undefined,
-  ): T | null;
-  transform<T>(
-    obj: Observable<T> | Subscribable<T> | Promise<T> | PromiseLike<T> | null | undefined,
-  ): T | null {
+  transform<T>(obj: Observable<T> | Subscribable<T> | PromiseLike<T> | null | undefined): T | null;
+  transform<T>(obj: Observable<T> | Subscribable<T> | PromiseLike<T> | null | undefined): T | null {
     if (!this._obj) {
       if (obj) {
         try {

--- a/packages/common/src/pipes/async_pipe.ts
+++ b/packages/common/src/pipes/async_pipe.ts
@@ -136,10 +136,14 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
   // TypeScript has a hard time matching Observable to Subscribable, for more information
   // see https://github.com/microsoft/TypeScript/issues/43643
 
-  transform<T>(obj: Observable<T> | Subscribable<T> | PromiseLike<T>): T | null;
+  transform<T>(obj: Observable<T> | Subscribable<T> | Promise<T> | PromiseLike<T>): T | null;
   transform<T>(obj: null | undefined): null;
-  transform<T>(obj: Observable<T> | Subscribable<T> | PromiseLike<T> | null | undefined): T | null;
-  transform<T>(obj: Observable<T> | Subscribable<T> | PromiseLike<T> | null | undefined): T | null {
+  transform<T>(
+    obj: Observable<T> | Subscribable<T> | Promise<T> | PromiseLike<T> | null | undefined,
+  ): T | null;
+  transform<T>(
+    obj: Observable<T> | Subscribable<T> | Promise<T> | PromiseLike<T> | null | undefined,
+  ): T | null {
     if (!this._obj) {
       if (obj) {
         try {

--- a/packages/common/src/pipes/async_pipe.ts
+++ b/packages/common/src/pipes/async_pipe.ts
@@ -24,11 +24,11 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 
 interface SubscriptionStrategy {
   createSubscription(
-    async: Subscribable<any> | Promise<any>,
+    async: Subscribable<any> | PromiseLike<any>,
     updateLatestValue: any,
     onError: (e: unknown) => void,
-  ): Unsubscribable | Promise<any>;
-  dispose(subscription: Unsubscribable | Promise<any>): void;
+  ): Unsubscribable | PromiseLike<any>;
+  dispose(subscription: Unsubscribable | PromiseLike<any>): void;
 }
 
 class SubscribableStrategy implements SubscriptionStrategy {
@@ -60,14 +60,14 @@ class SubscribableStrategy implements SubscriptionStrategy {
 
 class PromiseStrategy implements SubscriptionStrategy {
   createSubscription(
-    async: Promise<any>,
+    async: PromiseLike<any>,
     updateLatestValue: (v: any) => any,
     onError: (e: unknown) => void,
-  ): Promise<any> {
+  ): PromiseLike<any> {
     return async.then(updateLatestValue, onError);
   }
 
-  dispose(subscription: Promise<any>): void {}
+  dispose(subscription: PromiseLike<any>): void {}
 }
 
 const _promiseStrategy = new PromiseStrategy();
@@ -110,8 +110,8 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
   private _latestValue: any = null;
   private markForCheckOnValueUpdate = true;
 
-  private _subscription: Unsubscribable | Promise<any> | null = null;
-  private _obj: Subscribable<any> | Promise<any> | EventEmitter<any> | null = null;
+  private _subscription: Unsubscribable | PromiseLike<any> | null = null;
+  private _obj: Subscribable<any> | PromiseLike<any> | EventEmitter<any> | null = null;
   private _strategy: SubscriptionStrategy | null = null;
   private readonly applicationErrorHandler = inject(INTERNAL_APPLICATION_ERROR_HANDLER);
 
@@ -136,10 +136,10 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
   // TypeScript has a hard time matching Observable to Subscribable, for more information
   // see https://github.com/microsoft/TypeScript/issues/43643
 
-  transform<T>(obj: Observable<T> | Subscribable<T> | Promise<T>): T | null;
+  transform<T>(obj: Observable<T> | Subscribable<T> | PromiseLike<T>): T | null;
   transform<T>(obj: null | undefined): null;
-  transform<T>(obj: Observable<T> | Subscribable<T> | Promise<T> | null | undefined): T | null;
-  transform<T>(obj: Observable<T> | Subscribable<T> | Promise<T> | null | undefined): T | null {
+  transform<T>(obj: Observable<T> | Subscribable<T> | PromiseLike<T> | null | undefined): T | null;
+  transform<T>(obj: Observable<T> | Subscribable<T> | PromiseLike<T> | null | undefined): T | null {
     if (!this._obj) {
       if (obj) {
         try {
@@ -163,7 +163,7 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
     return this._latestValue;
   }
 
-  private _subscribe(obj: Subscribable<any> | Promise<any> | EventEmitter<any>): void {
+  private _subscribe(obj: Subscribable<any> | PromiseLike<any> | EventEmitter<any>): void {
     this._obj = obj;
     this._strategy = this._selectStrategy(obj);
     this._subscription = this._strategy.createSubscription(
@@ -174,7 +174,7 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
   }
 
   private _selectStrategy(
-    obj: Subscribable<any> | Promise<any> | EventEmitter<any>,
+    obj: Subscribable<any> | PromiseLike<any> | EventEmitter<any>,
   ): SubscriptionStrategy {
     if (ɵisPromise(obj)) {
       return _promiseStrategy;

--- a/packages/common/test/pipes/async_pipe_spec.ts
+++ b/packages/common/test/pipes/async_pipe_spec.ts
@@ -264,6 +264,14 @@ describe('AsyncPipe', () => {
     });
   });
 
+  describe('PromiseLike', () => {
+    it('should infer the type from the subscribable', () => {
+      const promiseLike = {then: (resolve) => resolve!({name: 'T'})} as PromiseLike<{name: 'T'}>;
+      // The following line will fail to compile if the type cannot be inferred.
+      const name = pipe.transform(promiseLike)?.name;
+    });
+  });
+
   describe('null', () => {
     it('should return null when given null', () => {
       expect(pipe.transform(null)).toEqual(null);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
AsyncPipe today works with Observable|Subscribale|Promise.

Issue Number: N/A


## What is the new behavior?
Widen Promise support with duck-typing such that third-party libraries that may not be using native Promises can still be passed into the AsyncPipe.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
