### PR TITLE
fix(compiler-cli): support relative imports to symbols outside `rootDir`

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -1301,10 +1301,7 @@ export class NgCompiler {
       // namespace" and the logic of `LogicalProjectStrategy` is required to generate correct
       // imports which may cross these multiple directories. Otherwise, plain relative imports are
       // sufficient.
-      if (
-        this.options.rootDir !== undefined ||
-        (this.options.rootDirs !== undefined && this.options.rootDirs.length > 0)
-      ) {
+      if (this.options.rootDirs !== undefined && this.options.rootDirs.length > 0) {
         // rootDirs logic is in effect - use the `LogicalProjectStrategy` for in-project relative
         // imports.
         localImportStrategy = new LogicalProjectStrategy(

--- a/packages/compiler-cli/test/ngtsc/imports_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/imports_spec.ts
@@ -133,6 +133,45 @@ runInEachFileSystem(() => {
       expect(diags[0].file!.fileName).toEqual(absoluteFrom('/app/comp.ts'));
       expect(getDiagnosticSourceCode(diags[0])).toEqual('MyComponent');
     });
+
+    it('should be possible to use a directive outside of `rootDir` when no `rootDirs` are set.', () => {
+      env.write(
+        'tsconfig.json',
+        JSON.stringify(
+          {
+            extends: './tsconfig-base.json',
+            compilerOptions: {rootDir: './app'},
+          },
+          null,
+          2,
+        ),
+      );
+      env.write(
+        '/app/module.ts',
+        `
+          import {NgModule} from '@angular/core';
+          import {ExternalDir} from '../lib/dir';
+
+          @NgModule({
+            imports: [ExternalDir],
+          })
+          export class MyModule {}
+    `,
+      );
+      env.write(
+        '/lib/dir.d.ts',
+        `
+          import {ɵɵDirectiveDeclaration} from '@angular/core';
+
+          export class ExternalDir {
+            static ɵdir: ɵɵDirectiveDeclaration<ExternalDir, '[external]', never, never, never, never, never, true>;
+          }
+    `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(0);
+    });
   });
 });
 


### PR DESCRIPTION
By default, the compiler-cli uses the relative import strategy when there is no `rootDir` or `rootDirs`. This is expected as everything is assumed to be somehow reachable through relative imports.

With `rootDirs` that allow for a "virtual file system"-like environment, the compiler is not necessarily able to always construct proper relative imports. The compiler includes the `LogicalProjectStrategy` for this reason. This strategy is able to respect `rootDirs` to construct relative paths when possible.

This logic currently accidentally triggers when there is a `rootDir` set. This option is not to be confused with the virtual directory option called `rootDirs`. The compiler currently confuses this and accidentally enters this mode when there is just a `rootDir`— breaking in monorepos that imports can point outside the `rootDir` to e.g. other compilation unit's `.d.ts` (which is valid; just not `.ts` sources can live outside the root dir).

This is necessary for our Bazel toolchain migration.