### PR TITLE
[19.2.x] refactor(core): switching to relative imports within the core package

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -6,8 +6,6 @@
 
 import * as _angular_core from '@angular/core';
 import { Observable } from 'rxjs';
-import { SIGNAL } from '@angular/core/primitives/signals';
-import { SignalNode } from '@angular/core/primitives/signals';
 import { Subject } from 'rxjs';
 import { Subscription } from 'rxjs';
 
@@ -1030,11 +1028,11 @@ export interface InputSignal<T> extends InputSignalWithTransform<T, T> {
 // @public
 export interface InputSignalWithTransform<T, TransformT> extends Signal<T> {
     // (undocumented)
+    [SIGNAL]: InputSignalNode<T, TransformT>;
+    // (undocumented)
     [ɵINPUT_SIGNAL_BRAND_READ_TYPE]: T;
     // (undocumented)
     [ɵINPUT_SIGNAL_BRAND_WRITE_TYPE]: TransformT;
-    // (undocumented)
-    [SIGNAL]: InputSignalNode<T, TransformT>;
 }
 
 // @public

--- a/goldens/public-api/core/primitives/event-dispatch/index.api.md
+++ b/goldens/public-api/core/primitives/event-dispatch/index.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @public
+// @public (undocumented)
 export const Attribute: {
     JSACTION: "jsaction";
 };

--- a/goldens/public-api/core/primitives/signals/index.api.md
+++ b/goldens/public-api/core/primitives/signals/index.api.md
@@ -137,7 +137,7 @@ export function runPostSignalSetFn(): void;
 // @public (undocumented)
 export function setActiveConsumer(consumer: ReactiveNode | null): ReactiveNode | null;
 
-// @public
+// @public (undocumented)
 export function setAlternateWeakRefImpl(impl: unknown): void;
 
 // @public (undocumented)

--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -9,10 +9,7 @@
 import '../util/ng_jit_mode';
 import '../util/ng_server_mode';
 
-import {
-  setActiveConsumer,
-  setThrowInvalidWriteToSignalError,
-} from '@angular/core/primitives/signals';
+import {setActiveConsumer, setThrowInvalidWriteToSignalError} from '../../primitives/signals';
 import {Observable, Subject, Subscription} from 'rxjs';
 import {map} from 'rxjs/operators';
 

--- a/packages/core/src/authoring/input/input_signal.ts
+++ b/packages/core/src/authoring/input/input_signal.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {producerAccessed, SIGNAL} from '@angular/core/primitives/signals';
+import {producerAccessed, SIGNAL} from '../../../primitives/signals';
 
 import {RuntimeError, RuntimeErrorCode} from '../../errors';
 import {Signal} from '../../render3/reactivity/api';

--- a/packages/core/src/authoring/input/input_signal_node.ts
+++ b/packages/core/src/authoring/input/input_signal_node.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {SIGNAL_NODE, SignalNode, signalSetFn} from '@angular/core/primitives/signals';
+import {SIGNAL_NODE, SignalNode, signalSetFn} from '../../../primitives/signals';
 
 export const REQUIRED_UNSET_VALUE = /* @__PURE__ */ Symbol('InputSignalNode#UNSET');
 

--- a/packages/core/src/authoring/model/model_signal.ts
+++ b/packages/core/src/authoring/model/model_signal.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {producerAccessed, SIGNAL, signalSetFn} from '@angular/core/primitives/signals';
+import {producerAccessed, SIGNAL, signalSetFn} from '../../../primitives/signals';
 
 import {RuntimeError, RuntimeErrorCode} from '../../errors';
 import {Signal} from '../../render3/reactivity/api';

--- a/packages/core/src/authoring/output/output_emitter_ref.ts
+++ b/packages/core/src/authoring/output/output_emitter_ref.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {setActiveConsumer} from '@angular/core/primitives/signals';
+import {setActiveConsumer} from '../../../primitives/signals';
 
 import {inject} from '../../di/injector_compatibility';
 import {ErrorHandler} from '../../error_handler';

--- a/packages/core/src/core_reactivity_export_internal.ts
+++ b/packages/core/src/core_reactivity_export_internal.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-export {SIGNAL as ɵSIGNAL} from '@angular/core/primitives/signals';
+export {SIGNAL as ɵSIGNAL} from '../primitives/signals';
 
 export {isSignal, Signal, ValueEqualityFn} from './render3/reactivity/api';
 export {computed, CreateComputedOptions} from './render3/reactivity/computed';

--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {setActiveConsumer} from '@angular/core/primitives/signals';
+import {setActiveConsumer} from '../../primitives/signals';
 
 import {
   DEFER_BLOCK_ID,

--- a/packages/core/src/di/injector_compatibility.ts
+++ b/packages/core/src/di/injector_compatibility.ts
@@ -30,12 +30,12 @@ import {
   NOT_FOUND,
   InjectionToken as PrimitivesInjectionToken,
   getCurrentInjector,
-} from '@angular/core/primitives/di';
+} from '../../primitives/di';
 
 const _THROW_IF_NOT_FOUND = {};
 export const THROW_IF_NOT_FOUND = _THROW_IF_NOT_FOUND;
 
-export {getCurrentInjector, setCurrentInjector} from '@angular/core/primitives/di';
+export {getCurrentInjector, setCurrentInjector} from '../../primitives/di';
 
 /*
  * Name of a property (that we patch onto DI decorator), which is used as an annotation of which

--- a/packages/core/src/event_delegation_utils.ts
+++ b/packages/core/src/event_delegation_utils.ts
@@ -7,8 +7,8 @@
  */
 
 // tslint:disable:no-duplicate-imports
-import {EventContract} from '@angular/core/primitives/event-dispatch';
-import {Attribute} from '@angular/core/primitives/event-dispatch';
+import {EventContract} from '../primitives/event-dispatch';
+import {Attribute} from '../primitives/event-dispatch';
 import {InjectionToken} from './di';
 import {RElement} from './render3/interfaces/renderer_dom';
 

--- a/packages/core/src/event_emitter.ts
+++ b/packages/core/src/event_emitter.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {setActiveConsumer} from '@angular/core/primitives/signals';
+import {setActiveConsumer} from '../primitives/signals';
 import {PartialObserver, Subject, Subscription} from 'rxjs';
 
 import {OutputRef} from './authoring/output/output_ref';

--- a/packages/core/src/hydration/event_replay.ts
+++ b/packages/core/src/hydration/event_replay.ts
@@ -16,7 +16,7 @@ import {
   getAppScopedQueuedEventInfos,
   clearAppScopedEarlyEventContract,
   EventPhase,
-} from '@angular/core/primitives/event-dispatch';
+} from '../../primitives/event-dispatch';
 
 import {APP_BOOTSTRAP_LISTENER, ApplicationRef} from '../application/application_ref';
 import {ENVIRONMENT_INITIALIZER, Injector} from '../di';

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {setActiveConsumer} from '@angular/core/primitives/signals';
+import {setActiveConsumer} from '../../primitives/signals';
 
 import {ChangeDetectorRef} from '../change_detection/change_detector_ref';
 import {

--- a/packages/core/src/render3/hooks.ts
+++ b/packages/core/src/render3/hooks.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {setActiveConsumer} from '@angular/core/primitives/signals';
+import {setActiveConsumer} from '../../primitives/signals';
 
 import {
   AfterContentChecked,

--- a/packages/core/src/render3/instructions/change_detection.ts
+++ b/packages/core/src/render3/instructions/change_detection.ts
@@ -13,7 +13,7 @@ import {
   consumerPollProducersForChange,
   getActiveConsumer,
   ReactiveNode,
-} from '@angular/core/primitives/signals';
+} from '../../../primitives/signals';
 
 import {RuntimeError, RuntimeErrorCode} from '../../errors';
 import {assertDefined, assertEqual} from '../../util/assert';

--- a/packages/core/src/render3/instructions/control_flow.ts
+++ b/packages/core/src/render3/instructions/control_flow.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {setActiveConsumer} from '@angular/core/primitives/signals';
+import {setActiveConsumer} from '../../../primitives/signals';
 
 import {TrackByFunction} from '../../change_detection';
 import {formatRuntimeError, RuntimeErrorCode} from '../../errors';

--- a/packages/core/src/render3/instructions/write_to_directive_input.ts
+++ b/packages/core/src/render3/instructions/write_to_directive_input.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {setActiveConsumer, SIGNAL} from '@angular/core/primitives/signals';
+import {setActiveConsumer, SIGNAL} from '../../../primitives/signals';
 
 import {InputSignalWithTransform} from '../../authoring/input/input_signal';
 import {InputSignalNode} from '../../authoring/input/input_signal_node';

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {consumerDestroy, setActiveConsumer} from '@angular/core/primitives/signals';
+import {consumerDestroy, setActiveConsumer} from '../../primitives/signals';
 
 import {NotificationSource} from '../change_detection/scheduling/zoneless_scheduling';
 import {hasInSkipHydrationBlockFlag} from '../hydration/skip_hydration';

--- a/packages/core/src/render3/queries/query_execution.ts
+++ b/packages/core/src/render3/queries/query_execution.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {setActiveConsumer} from '@angular/core/primitives/signals';
+import {setActiveConsumer} from '../../../primitives/signals';
 import {LView, TView} from '../interfaces/view';
 import {DirectiveDef, RenderFlags, ViewQueriesFunction} from '../interfaces/definition';
 import {assertDefined} from '../../util/assert';

--- a/packages/core/src/render3/queries/query_reactive.ts
+++ b/packages/core/src/render3/queries/query_reactive.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ComputedNode, createComputed, SIGNAL} from '@angular/core/primitives/signals';
+import {ComputedNode, createComputed, SIGNAL} from '../../../primitives/signals';
 
 import {RuntimeError, RuntimeErrorCode} from '../../errors';
 import {unwrapElementRef} from '../../linker/element_ref';

--- a/packages/core/src/render3/reactive_lview_consumer.ts
+++ b/packages/core/src/render3/reactive_lview_consumer.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {REACTIVE_NODE, ReactiveNode} from '@angular/core/primitives/signals';
+import {REACTIVE_NODE, ReactiveNode} from '../../primitives/signals';
 
 import {
   LView,

--- a/packages/core/src/render3/reactivity/after_render_effect.ts
+++ b/packages/core/src/render3/reactivity/after_render_effect.ts
@@ -14,7 +14,7 @@ import {
   SIGNAL,
   SIGNAL_NODE,
   type SignalNode,
-} from '@angular/core/primitives/signals';
+} from '../../../primitives/signals';
 
 import {type Signal} from '../reactivity/api';
 import {type EffectCleanupFn, type EffectCleanupRegisterFn} from './effect';

--- a/packages/core/src/render3/reactivity/api.ts
+++ b/packages/core/src/render3/reactivity/api.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {SIGNAL} from '@angular/core/primitives/signals';
+import {SIGNAL} from '../../../primitives/signals';
 
 /**
  * A reactive value which notifies consumers of any changes.

--- a/packages/core/src/render3/reactivity/asserts.ts
+++ b/packages/core/src/render3/reactivity/asserts.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {getActiveConsumer} from '@angular/core/primitives/signals';
+import {getActiveConsumer} from '../../../primitives/signals';
 
 import {RuntimeError, RuntimeErrorCode} from '../../errors';
 

--- a/packages/core/src/render3/reactivity/computed.ts
+++ b/packages/core/src/render3/reactivity/computed.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {createComputed, SIGNAL} from '@angular/core/primitives/signals';
+import {createComputed, SIGNAL} from '../../../primitives/signals';
 
 import {Signal, ValueEqualityFn} from './api';
 

--- a/packages/core/src/render3/reactivity/effect.ts
+++ b/packages/core/src/render3/reactivity/effect.ts
@@ -15,7 +15,7 @@ import {
   consumerDestroy,
   consumerPollProducersForChange,
   isInNotificationPhase,
-} from '@angular/core/primitives/signals';
+} from '../../../primitives/signals';
 import {FLAGS, LViewFlags, LView, EFFECTS} from '../interfaces/view';
 import {markAncestorsForTraversal} from '../util/view_utils';
 import {InjectionToken} from '../../di/injection_token';

--- a/packages/core/src/render3/reactivity/linked_signal.ts
+++ b/packages/core/src/render3/reactivity/linked_signal.ts
@@ -14,7 +14,7 @@ import {
   linkedSignalSetFn,
   linkedSignalUpdateFn,
   SIGNAL,
-} from '@angular/core/primitives/signals';
+} from '../../../primitives/signals';
 import {Signal, ValueEqualityFn} from './api';
 import {signalAsReadonlyFn, WritableSignal} from './signal';
 

--- a/packages/core/src/render3/reactivity/signal.ts
+++ b/packages/core/src/render3/reactivity/signal.ts
@@ -13,7 +13,7 @@ import {
   SignalNode,
   signalSetFn,
   signalUpdateFn,
-} from '@angular/core/primitives/signals';
+} from '../../../primitives/signals';
 
 import {isSignal, Signal, ValueEqualityFn} from './api';
 

--- a/packages/core/src/render3/reactivity/untracked.ts
+++ b/packages/core/src/render3/reactivity/untracked.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {untracked as untrackedPrimitive} from '@angular/core/primitives/signals';
+import {untracked as untrackedPrimitive} from '../../../primitives/signals';
 
 /**
  * Execute an arbitrary function in a non-reactive (non-tracking) context. The executed function

--- a/packages/core/src/render3/util/signal_debug.ts
+++ b/packages/core/src/render3/util/signal_debug.ts
@@ -24,7 +24,7 @@ import {
   SIGNAL,
   SIGNAL_NODE,
   SignalNode,
-} from '@angular/core/primitives/signals';
+} from '../../../primitives/signals';
 
 export interface DebugSignalGraphNode {
   kind: string;

--- a/packages/core/src/render3/view_manipulation.ts
+++ b/packages/core/src/render3/view_manipulation.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {setActiveConsumer} from '@angular/core/primitives/signals';
+import {setActiveConsumer} from '../../primitives/signals';
 
 import {Injector} from '../di/injector';
 import {DehydratedContainerView} from '../hydration/interfaces';

--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -22,7 +22,7 @@ import {
   ResourceStreamItem,
 } from './api';
 
-import {ValueEqualityFn} from '@angular/core/primitives/signals';
+import {ValueEqualityFn} from '../../primitives/signals';
 
 import {Injector} from '../di/injector';
 import {assertInInjectionContext} from '../di/contextual';

--- a/packages/core/src/util/assert.ts
+++ b/packages/core/src/util/assert.ts
@@ -10,7 +10,7 @@
 // about state in an instruction are correct before implementing any logic.
 // They are meant only to be called in dev mode as sanity checks.
 
-import {getActiveConsumer} from '@angular/core/primitives/signals';
+import {getActiveConsumer} from '../../primitives/signals';
 
 import {stringify} from './stringify';
 

--- a/packages/core/test/acceptance/after_render_effect_spec.ts
+++ b/packages/core/test/acceptance/after_render_effect_spec.ts
@@ -13,9 +13,9 @@ import {
   PLATFORM_ID,
   provideExperimentalZonelessChangeDetection,
   signal,
-} from '@angular/core';
-import {afterRenderEffect} from '@angular/core/src/render3/reactivity/after_render_effect';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {afterRenderEffect} from '../../src/render3/reactivity/after_render_effect';
+import {TestBed} from '../../testing';
 
 describe('afterRenderEffect', () => {
   beforeEach(() => {

--- a/packages/core/test/acceptance/after_render_hook_spec.ts
+++ b/packages/core/test/acceptance/after_render_hook_spec.ts
@@ -27,11 +27,11 @@ import {
   effect,
   inject,
   signal,
-} from '@angular/core';
-import {NoopNgZone} from '@angular/core/src/zone/ng_zone';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {NoopNgZone} from '../../src/zone/ng_zone';
+import {TestBed} from '../../testing';
 
-import {setUseMicrotaskEffectsByDefault} from '@angular/core/src/render3/reactivity/effect';
+import {setUseMicrotaskEffectsByDefault} from '../../src/render3/reactivity/effect';
 import {firstValueFrom} from 'rxjs';
 import {filter} from 'rxjs/operators';
 import {EnvironmentInjector, Injectable} from '../../src/di';

--- a/packages/core/test/acceptance/attach_source_locations_spec.ts
+++ b/packages/core/test/acceptance/attach_source_locations_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {TestBed} from '@angular/core/testing';
+import {TestBed} from '../../testing';
 import {
   RenderFlags,
   ɵɵadvance,
@@ -18,8 +18,8 @@ import {
   ɵɵelementStart,
   ɵɵtemplate,
   ɵɵtext,
-} from '@angular/core/src/render3';
-import {Directive} from '@angular/core';
+} from '../../src/render3';
+import {Directive} from '../../src/core';
 
 // The `ɵɵattachSourceLocation` calls are produced only in
 // AoT so these tests need to "be compiled manually".

--- a/packages/core/test/acceptance/attributes_spec.ts
+++ b/packages/core/test/acceptance/attributes_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {Component} from '../../src/core';
+import {TestBed} from '../../testing';
 import {By, DomSanitizer, SafeUrl} from '@angular/platform-browser';
 
 describe('attribute creation', () => {

--- a/packages/core/test/acceptance/authoring/model_inputs_spec.ts
+++ b/packages/core/test/acceptance/authoring/model_inputs_spec.ts
@@ -19,8 +19,8 @@ import {
   SimpleChanges,
   ViewChild,
 } from '@angular/core';
-import {SIGNAL} from '@angular/core/primitives/signals';
-import {TestBed} from '@angular/core/testing';
+import {SIGNAL} from '../../../primitives/signals';
+import {TestBed} from '../../../testing';
 
 describe('model inputs', () => {
   it('should support two-way binding to a signal', () => {

--- a/packages/core/test/acceptance/authoring/output_function_spec.ts
+++ b/packages/core/test/acceptance/authoring/output_function_spec.ts
@@ -17,7 +17,7 @@ import {
 } from '@angular/core';
 import {outputFromObservable} from '@angular/core/rxjs-interop';
 import {setUseMicrotaskEffectsByDefault} from '@angular/core/src/render3/reactivity/effect';
-import {TestBed} from '@angular/core/testing';
+import {TestBed} from '../../../testing';
 import {BehaviorSubject, Observable, share, Subject} from 'rxjs';
 
 describe('output() function', () => {

--- a/packages/core/test/acceptance/authoring/signal_inputs_spec.ts
+++ b/packages/core/test/acceptance/authoring/signal_inputs_spec.ts
@@ -17,8 +17,8 @@ import {
   ViewChild,
 } from '@angular/core';
 import {setUseMicrotaskEffectsByDefault} from '@angular/core/src/render3/reactivity/effect';
-import {SIGNAL} from '@angular/core/primitives/signals';
-import {TestBed} from '@angular/core/testing';
+import {SIGNAL} from '../../../primitives/signals';
+import {TestBed} from '../../../testing';
 
 describe('signal inputs', () => {
   let prev: boolean;

--- a/packages/core/test/acceptance/authoring/signal_queries_spec.ts
+++ b/packages/core/test/acceptance/authoring/signal_queries_spec.ts
@@ -20,8 +20,8 @@ import {
   ViewChildren,
   viewChildren,
 } from '@angular/core';
-import {SIGNAL} from '@angular/core/primitives/signals';
-import {TestBed} from '@angular/core/testing';
+import {SIGNAL} from '../../../primitives/signals';
+import {TestBed} from '../../../testing';
 import {By} from '@angular/platform-browser';
 
 describe('queries as signals', () => {

--- a/packages/core/test/acceptance/bootstrap_spec.ts
+++ b/packages/core/test/acceptance/bootstrap_spec.ts
@@ -21,7 +21,7 @@ import {
   ViewEncapsulation,
   ɵNoopNgZone,
   ɵZONELESS_ENABLED,
-} from '@angular/core';
+} from '../../src/core';
 import {bootstrapApplication, BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {withBody} from '@angular/private/testing';

--- a/packages/core/test/acceptance/change_detection_signals_in_zones_spec.ts
+++ b/packages/core/test/acceptance/change_detection_signals_in_zones_spec.ts
@@ -21,9 +21,9 @@ import {
   TemplateRef,
   ViewChild,
   ViewContainerRef,
-} from '@angular/core';
-import {ReactiveNode, SIGNAL} from '@angular/core/primitives/signals';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {ReactiveNode, SIGNAL} from '../../primitives/signals';
+import {TestBed} from '../../testing';
 
 describe('CheckAlways components', () => {
   it('can read a signal', () => {

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -38,9 +38,8 @@ import {
   afterRender,
   PLATFORM_ID,
   provideZoneChangeDetection,
-} from '@angular/core';
-import {} from '@angular/core/src/errors';
-import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+} from '../../src/core';
+import {ComponentFixture, fakeAsync, TestBed, tick} from '../../testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {BehaviorSubject} from 'rxjs';
 

--- a/packages/core/test/acceptance/change_detection_transplanted_view_spec.ts
+++ b/packages/core/test/acceptance/change_detection_transplanted_view_spec.ts
@@ -27,9 +27,9 @@ import {
   Type,
   ViewChild,
   ViewContainerRef,
-} from '@angular/core';
-import {provideExperimentalCheckNoChangesForDebug} from '@angular/core/src/change_detection/scheduling/exhaustive_check_no_changes';
-import {ComponentFixture, TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {provideExperimentalCheckNoChangesForDebug} from '../../src/change_detection/scheduling/exhaustive_check_no_changes';
+import {ComponentFixture, TestBed} from '../../testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {of} from 'rxjs';
 

--- a/packages/core/test/acceptance/common_integration_spec.ts
+++ b/packages/core/test/acceptance/common_integration_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, Directive} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {Component, Directive} from '../../src/core';
+import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
 
 describe('@angular/common integration', () => {

--- a/packages/core/test/acceptance/component_spec.ts
+++ b/packages/core/test/acceptance/component_spec.ts
@@ -35,9 +35,9 @@ import {
   ɵsetClassDebugInfo,
   ɵsetDocument,
   ɵɵdefineComponent,
-} from '@angular/core';
+} from '../../src/core';
 import {stringifyForError} from '@angular/core/src/render3/util/stringify_utils';
-import {TestBed} from '@angular/core/testing';
+import {TestBed} from '../../testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 import {global} from '../../src/util/global';

--- a/packages/core/test/acceptance/content_spec.ts
+++ b/packages/core/test/acceptance/content_spec.ts
@@ -19,8 +19,8 @@ import {
   TemplateRef,
   ViewChild,
   ViewContainerRef,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 

--- a/packages/core/test/acceptance/control_flow_for_spec.ts
+++ b/packages/core/test/acceptance/control_flow_for_spec.ts
@@ -18,8 +18,8 @@ import {
   PipeTransform,
   TemplateRef,
   ViewContainerRef,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {TestBed} from '../../testing';
 
 describe('control flow - for', () => {
   it('should create, remove and move views corresponding to items in a collection', () => {

--- a/packages/core/test/acceptance/control_flow_if_spec.ts
+++ b/packages/core/test/acceptance/control_flow_if_spec.ts
@@ -18,8 +18,8 @@ import {
   PipeTransform,
   TemplateRef,
   ViewContainerRef,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {TestBed} from '../../testing';
 
 // Basic shared pipe used during testing.
 @Pipe({name: 'multiply', pure: true, standalone: true})

--- a/packages/core/test/acceptance/control_flow_switch_spec.ts
+++ b/packages/core/test/acceptance/control_flow_switch_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectorRef, Component, inject, Pipe, PipeTransform} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {ChangeDetectorRef, Component, inject, Pipe, PipeTransform} from '../../src/core';
+import {TestBed} from '../../testing';
 
 // Basic shared pipe used during testing.
 @Pipe({name: 'multiply', pure: true, standalone: true})

--- a/packages/core/test/acceptance/copy_definition_feature_spec.ts
+++ b/packages/core/test/acceptance/copy_definition_feature_spec.ts
@@ -12,8 +12,8 @@ import {
   ɵɵCopyDefinitionFeature as CopyDefinitionFeature,
   ɵɵdefineComponent as defineComponent,
   ɵɵInheritDefinitionFeature as InheritDefinitionFeature,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {TestBed} from '../../testing';
 
 describe('CopyDefinitionFeature', () => {
   it('should copy the template function of a component definition from parent to child', () => {

--- a/packages/core/test/acceptance/csp_spec.ts
+++ b/packages/core/test/acceptance/csp_spec.ts
@@ -13,7 +13,7 @@ import {
   ElementRef,
   inject,
   ViewEncapsulation,
-} from '@angular/core';
+} from '../../src/core';
 import {bootstrapApplication} from '@angular/platform-browser';
 import {withBody} from '@angular/private/testing';
 

--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -34,19 +34,12 @@ import {
   Injector,
   ElementRef,
   ViewChild,
-} from '@angular/core';
-import {getComponentDef} from '@angular/core/src/render3/def_getters';
-import {
-  ComponentFixture,
-  DeferBlockBehavior,
-  fakeAsync,
-  flush,
-  TestBed,
-  tick,
-} from '@angular/core/testing';
-import {getInjectorResolutionPath} from '@angular/core/src/render3/util/injector_discovery_utils';
+} from '../../src/core';
+import {getComponentDef} from '../../src/render3/def_getters';
+import {ComponentFixture, DeferBlockBehavior, fakeAsync, flush, TestBed, tick} from '../../testing';
+import {getInjectorResolutionPath} from '../../src/render3/util/injector_discovery_utils';
 import {ActivatedRoute, provideRouter, Router, RouterOutlet} from '@angular/router';
-import {ChainedInjector} from '@angular/core/src/render3/chained_injector';
+import {ChainedInjector} from '../../src/render3/chained_injector';
 import {global} from '../../src/util/global';
 import {TimerScheduler} from '@angular/core/src/defer/timer_scheduler';
 

--- a/packages/core/test/acceptance/defer_utils_spec.ts
+++ b/packages/core/test/acceptance/defer_utils_spec.ts
@@ -5,8 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {Component} from '@angular/core';
-import {DeferBlockBehavior, DeferBlockState, TestBed} from '@angular/core/testing';
+import {Component} from '../../src/core';
+import {DeferBlockBehavior, DeferBlockState, TestBed} from '../../testing';
 
 import {getDeferBlocks} from '../../src/render3/util/defer';
 

--- a/packages/core/test/acceptance/destroy_ref_spec.ts
+++ b/packages/core/test/acceptance/destroy_ref_spec.ts
@@ -14,8 +14,8 @@ import {
   Directive,
   EnvironmentInjector,
   inject,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {TestBed} from '../../testing';
 
 describe('DestroyRef', () => {
   describe('for environnement injector', () => {

--- a/packages/core/test/acceptance/di_forward_ref_spec.ts
+++ b/packages/core/test/acceptance/di_forward_ref_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {Component, Directive, forwardRef, Host, Inject, ViewChild} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {TestBed} from '../../testing';
 
 // **NOTE**: More details on why tests relying on `forwardRef` are put into this
 // file can be found in the `BUILD.bazel` file declaring the forward ref test target.

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -60,10 +60,10 @@ import {
   ɵDEFAULT_LOCALE_ID as DEFAULT_LOCALE_ID,
   ɵINJECTOR_SCOPE,
   ɵInternalEnvironmentProviders as InternalEnvironmentProviders,
-} from '@angular/core';
-import {RuntimeError, RuntimeErrorCode} from '@angular/core/src/errors';
-import {ViewRef as ViewRefInternal} from '@angular/core/src/render3/view_ref';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {RuntimeError, RuntimeErrorCode} from '../../src/errors';
+import {ViewRef as ViewRefInternal} from '../../src/render3/view_ref';
+import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
 import {BehaviorSubject} from 'rxjs';
 

--- a/packages/core/test/acceptance/directive_spec.ts
+++ b/packages/core/test/acceptance/directive_spec.ts
@@ -21,8 +21,8 @@ import {
   TemplateRef,
   ViewChild,
   ViewContainerRef,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
 
 describe('directives', () => {

--- a/packages/core/test/acceptance/discover_utils_spec.ts
+++ b/packages/core/test/acceptance/discover_utils_spec.ts
@@ -15,11 +15,11 @@ import {
   Output,
   ViewChild,
   ViewEncapsulation,
-} from '@angular/core';
-import {EventEmitter} from '@angular/core/src/event_emitter';
-import {isLView} from '@angular/core/src/render3/interfaces/type_checks';
-import {CONTEXT} from '@angular/core/src/render3/interfaces/view';
-import {ComponentFixture, TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {EventEmitter} from '../../src/event_emitter';
+import {isLView} from '../../src/render3/interfaces/type_checks';
+import {CONTEXT} from '../../src/render3/interfaces/view';
+import {ComponentFixture, TestBed} from '../../testing';
 
 import {getLContext} from '../../src/render3/context_discovery';
 import {getHostElement} from '../../src/render3/index';

--- a/packages/core/test/acceptance/embedded_views_spec.ts
+++ b/packages/core/test/acceptance/embedded_views_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, Input} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {Component, Input} from '../../src/core';
+import {TestBed} from '../../testing';
 
 describe('embedded views', () => {
   it('should correctly resolve the implicit receiver in expressions', () => {

--- a/packages/core/test/acceptance/env_injector_standalone_spec.ts
+++ b/packages/core/test/acceptance/env_injector_standalone_spec.ts
@@ -13,8 +13,8 @@ import {
   importProvidersFrom,
   InjectionToken,
   NgModule,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {TestBed} from '../../testing';
 
 import {internalImportProvidersFrom} from '../../src/di/provider_collection';
 

--- a/packages/core/test/acceptance/environment_injector_spec.ts
+++ b/packages/core/test/acceptance/environment_injector_spec.ts
@@ -21,10 +21,10 @@ import {
   NgModuleRef,
   provideEnvironmentInitializer,
   ViewContainerRef,
-} from '@angular/core';
-import {R3Injector} from '@angular/core/src/di/r3_injector';
-import {RuntimeError, RuntimeErrorCode} from '@angular/core/src/errors';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {R3Injector} from '../../src/di/r3_injector';
+import {RuntimeError, RuntimeErrorCode} from '../../src/errors';
+import {TestBed} from '../../testing';
 
 describe('environment injector', () => {
   it('should create and destroy an environment injector', () => {

--- a/packages/core/test/acceptance/exports_spec.ts
+++ b/packages/core/test/acceptance/exports_spec.ts
@@ -15,8 +15,8 @@ import {
   OnInit,
   SimpleChanges,
   Type,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {TestBed} from '../../testing';
 
 describe('exports', () => {
   beforeEach(() => {

--- a/packages/core/test/acceptance/hmr_spec.ts
+++ b/packages/core/test/acceptance/hmr_spec.ts
@@ -30,14 +30,14 @@ import {
   ɵNG_COMP_DEF,
   ɵɵreplaceMetadata,
   ɵɵsetComponentScope,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
-import {compileComponent} from '@angular/core/src/render3/jit/directive';
-import {angularCoreEnv} from '@angular/core/src/render3/jit/environment';
+} from '../../src/core';
+import {TestBed} from '../../testing';
+import {compileComponent} from '../../src/render3/jit/directive';
+import {angularCoreEnv} from '../../src/render3/jit/environment';
 import {clearTranslations, loadTranslations} from '@angular/localize';
 import {computeMsgId} from '@angular/compiler';
 import {EVENT_MANAGER_PLUGINS} from '@angular/platform-browser';
-import {ComponentType} from '@angular/core/src/render3';
+import {ComponentType} from '../../src/render3';
 
 describe('hot module replacement', () => {
   it('should recreate a single usage of a basic component', () => {

--- a/packages/core/test/acceptance/host_binding_spec.ts
+++ b/packages/core/test/acceptance/host_binding_spec.ts
@@ -26,13 +26,13 @@ import {
   ViewChild,
   ViewChildren,
   ViewContainerRef,
-} from '@angular/core';
+} from '../../src/core';
 import {
   bypassSanitizationTrustHtml,
   bypassSanitizationTrustStyle,
   bypassSanitizationTrustUrl,
-} from '@angular/core/src/sanitization/bypass';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/sanitization/bypass';
+import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 

--- a/packages/core/test/acceptance/host_directives_spec.ts
+++ b/packages/core/test/acceptance/host_directives_spec.ts
@@ -27,8 +27,8 @@ import {
   ViewContainerRef,
   ɵɵdefineDirective,
   ɵɵHostDirectivesFeature,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
 
 import {getComponent, getDirectives} from '../../src/render3/util/discovery_utils';

--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -32,10 +32,10 @@ import {
   ViewChild,
   ViewContainerRef,
   ɵsetDocument,
-} from '@angular/core';
-import {HEADER_OFFSET} from '@angular/core/src/render3/interfaces/view';
-import {getComponentLView} from '@angular/core/src/render3/util/discovery_utils';
-import {DeferBlockBehavior, DeferBlockState, TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {HEADER_OFFSET} from '../../src/render3/interfaces/view';
+import {getComponentLView} from '../../src/render3/util/discovery_utils';
+import {DeferBlockBehavior, DeferBlockState, TestBed} from '../../testing';
 import {clearTranslations, loadTranslations} from '@angular/localize';
 import {By} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';

--- a/packages/core/test/acceptance/inherit_definition_feature_spec.ts
+++ b/packages/core/test/acceptance/inherit_definition_feature_spec.ts
@@ -19,9 +19,9 @@ import {
   Output,
   QueryList,
   ViewChildren,
-} from '@angular/core';
-import {getDirectiveDef} from '@angular/core/src/render3/def_getters';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {getDirectiveDef} from '../../src/render3/def_getters';
+import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 

--- a/packages/core/test/acceptance/injector_profiler_spec.ts
+++ b/packages/core/test/acceptance/injector_profiler_spec.ts
@@ -23,17 +23,17 @@ import {
   QueryList,
   ViewChild,
   ViewChildren,
-} from '@angular/core';
-import {NullInjector} from '@angular/core/src/di/null_injector';
+} from '../../src/core';
+import {NullInjector} from '../../src/di/null_injector';
 import {
   isClassProvider,
   isExistingProvider,
   isFactoryProvider,
   isTypeProvider,
   isValueProvider,
-} from '@angular/core/src/di/provider_collection';
-import {EnvironmentInjector, R3Injector} from '@angular/core/src/di/r3_injector';
-import {setupFrameworkInjectorProfiler} from '@angular/core/src/render3/debug/framework_injector_profiler';
+} from '../../src/di/provider_collection';
+import {EnvironmentInjector, R3Injector} from '../../src/di/r3_injector';
+import {setupFrameworkInjectorProfiler} from '../../src/render3/debug/framework_injector_profiler';
 import {
   getInjectorProfilerContext,
   InjectedServiceEvent,
@@ -42,16 +42,16 @@ import {
   InjectorProfilerEventType,
   ProviderConfiguredEvent,
   setInjectorProfiler,
-} from '@angular/core/src/render3/debug/injector_profiler';
-import {getNodeInjectorLView, NodeInjector} from '@angular/core/src/render3/di';
+} from '../../src/render3/debug/injector_profiler';
+import {getNodeInjectorLView, NodeInjector} from '../../src/render3/di';
 import {
   getDependenciesFromInjectable,
   getInjectorMetadata,
   getInjectorProviders,
   getInjectorResolutionPath,
-} from '@angular/core/src/render3/util/injector_discovery_utils';
-import {fakeAsync, tick} from '@angular/core/testing';
-import {TestBed} from '@angular/core/testing/src/test_bed';
+} from '../../src/render3/util/injector_discovery_utils';
+import {fakeAsync, tick} from '../../testing';
+import {TestBed} from '../../testing/src/test_bed';
 import {BrowserModule} from '@angular/platform-browser';
 import {Router, RouterModule, RouterOutlet} from '@angular/router';
 

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -27,16 +27,16 @@ import {
   ViewChild,
   ViewChildren,
   ViewContainerRef,
-} from '@angular/core';
-import {Inject} from '@angular/core/src/di';
-import {readPatchedLView} from '@angular/core/src/render3/context_discovery';
-import {LContainer} from '@angular/core/src/render3/interfaces/container';
-import {getLViewById} from '@angular/core/src/render3/interfaces/lview_tracking';
-import {isLView} from '@angular/core/src/render3/interfaces/type_checks';
-import {ID, LView, PARENT, TVIEW} from '@angular/core/src/render3/interfaces/view';
-import {getLView} from '@angular/core/src/render3/state';
-import {ngDevModeResetPerfCounters} from '@angular/core/src/util/ng_dev_mode';
-import {fakeAsync, flushMicrotasks, TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {Inject} from '../../src/di';
+import {readPatchedLView} from '../../src/render3/context_discovery';
+import {LContainer} from '../../src/render3/interfaces/container';
+import {getLViewById} from '../../src/render3/interfaces/lview_tracking';
+import {isLView} from '../../src/render3/interfaces/type_checks';
+import {ID, LView, PARENT, TVIEW} from '../../src/render3/interfaces/view';
+import {getLView} from '../../src/render3/state';
+import {ngDevModeResetPerfCounters} from '../../src/util/ng_dev_mode';
+import {fakeAsync, flushMicrotasks, TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {expectPerfCounters} from '@angular/private/testing';

--- a/packages/core/test/acceptance/internal_spec.ts
+++ b/packages/core/test/acceptance/internal_spec.ts
@@ -14,8 +14,8 @@ import {
   ɵgetClosestComponentName as getClosestComponentName,
   ViewChild,
   ViewContainerRef,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {TestBed} from '../../testing';
 
 describe('internal utilities', () => {
   describe('getClosestComponentName', () => {

--- a/packages/core/test/acceptance/let_spec.ts
+++ b/packages/core/test/acceptance/let_spec.ts
@@ -17,8 +17,8 @@ import {
   inject,
   ChangeDetectorRef,
   ViewChild,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {TestBed} from '../../testing';
 
 describe('@let declarations', () => {
   it('should update the value of a @let declaration over time', () => {

--- a/packages/core/test/acceptance/lifecycle_spec.ts
+++ b/packages/core/test/acceptance/lifecycle_spec.ts
@@ -23,8 +23,8 @@ import {
   TemplateRef,
   ViewChild,
   ViewContainerRef,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
 
 describe('onChanges', () => {

--- a/packages/core/test/acceptance/listener_spec.ts
+++ b/packages/core/test/acceptance/listener_spec.ts
@@ -21,8 +21,8 @@ import {
   ViewChild,
   ViewChildren,
   ViewContainerRef,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
 
 function getNoOfNativeListeners(): number {

--- a/packages/core/test/acceptance/local_compilation_spec.ts
+++ b/packages/core/test/acceptance/local_compilation_spec.ts
@@ -12,9 +12,9 @@ import {
   ɵɵdefineNgModule,
   ɵɵgetComponentDepsFactory,
   ɵɵsetNgModuleScope,
-} from '@angular/core';
-import {ComponentType} from '@angular/core/src/render3';
-import {getNgModuleDef} from '@angular/core/src/render3/def_getters';
+} from '../../src/core';
+import {ComponentType} from '../../src/render3';
+import {getNgModuleDef} from '../../src/render3/def_getters';
 
 describe('component dependencies in local compilation', () => {
   it('should compute correct set of dependencies when importing ng-modules directly', () => {

--- a/packages/core/test/acceptance/ng_module_spec.ts
+++ b/packages/core/test/acceptance/ng_module_spec.ts
@@ -25,9 +25,9 @@ import {
   ɵɵdefineNgModule as defineNgModule,
   ɵɵelement as element,
   ɵɵproperty as property,
-} from '@angular/core';
-import {KNOWN_CONTROL_FLOW_DIRECTIVES} from '@angular/core/src/render3/instructions/element_validation';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {KNOWN_CONTROL_FLOW_DIRECTIVES} from '../../src/render3/instructions/element_validation';
+import {TestBed} from '../../testing';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {withBody} from '@angular/private/testing';

--- a/packages/core/test/acceptance/ngmodule_scope_spec.ts
+++ b/packages/core/test/acceptance/ngmodule_scope_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, destroyPlatform, NgModule, Pipe, PipeTransform} from '@angular/core';
+import {Component, destroyPlatform, NgModule, Pipe, PipeTransform} from '../../src/core';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {withBody} from '@angular/private/testing';

--- a/packages/core/test/acceptance/outputs_spec.ts
+++ b/packages/core/test/acceptance/outputs_spec.ts
@@ -15,8 +15,8 @@ import {
   OnDestroy,
   Output,
   ViewChild,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {TestBed} from '../../testing';
 
 describe('outputs', () => {
   @Component({

--- a/packages/core/test/acceptance/pending_tasks_spec.ts
+++ b/packages/core/test/acceptance/pending_tasks_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ApplicationRef, PendingTasks} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {ApplicationRef, PendingTasks} from '../../src/core';
+import {TestBed} from '../../testing';
 import {EMPTY, firstValueFrom, of} from 'rxjs';
 import {filter, map, take, withLatestFrom} from 'rxjs/operators';
 

--- a/packages/core/test/acceptance/pipe_spec.ts
+++ b/packages/core/test/acceptance/pipe_spec.ts
@@ -27,8 +27,8 @@ import {
   ɵɵdefinePipe,
   ɵɵgetInheritedFactory,
   ɵɵinject,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {TestBed} from '../../testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 describe('pipe', () => {

--- a/packages/core/test/acceptance/profiler_spec.ts
+++ b/packages/core/test/acceptance/profiler_spec.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {setProfiler} from '@angular/core/src/render3/profiler';
-import {ProfilerEvent} from '@angular/core/src/render3/profiler_types';
-import {TestBed} from '@angular/core/testing';
+import {setProfiler} from '../../src/render3/profiler';
+import {ProfilerEvent} from '../../src/render3/profiler_types';
+import {TestBed} from '../../testing';
 
 import {
   AfterContentChecked,

--- a/packages/core/test/acceptance/property_binding_spec.ts
+++ b/packages/core/test/acceptance/property_binding_spec.ts
@@ -7,8 +7,8 @@
  */
 import {state, style, trigger} from '@angular/animations';
 import {CommonModule} from '@angular/common';
-import {Component, Directive, EventEmitter, Input, Output, ViewContainerRef} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {Component, Directive, EventEmitter, Input, Output, ViewContainerRef} from '../../src/core';
+import {TestBed} from '../../testing';
 import {By, DomSanitizer, SafeUrl} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 

--- a/packages/core/test/acceptance/property_interpolation_spec.ts
+++ b/packages/core/test/acceptance/property_interpolation_spec.ts
@@ -5,8 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {Component} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {Component} from '../../src/core';
+import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
 import {of} from 'rxjs';
 

--- a/packages/core/test/acceptance/providers_spec.ts
+++ b/packages/core/test/acceptance/providers_spec.ts
@@ -17,9 +17,9 @@ import {
   Injector,
   NgModule,
   Optional,
-} from '@angular/core';
-import {leaveView, specOnlyIsInstructionStateEmpty} from '@angular/core/src/render3/state';
-import {inject, TestBed, waitForAsync} from '@angular/core/testing';
+} from '../../src/core';
+import {leaveView, specOnlyIsInstructionStateEmpty} from '../../src/render3/state';
+import {inject, TestBed, waitForAsync} from '../../testing';
 import {By} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 

--- a/packages/core/test/acceptance/pure_function_spec.ts
+++ b/packages/core/test/acceptance/pure_function_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import {CommonModule} from '@angular/common';
-import {Component, Directive, Input, QueryList, ViewChild, ViewChildren} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {Component, Directive, Input, QueryList, ViewChild, ViewChildren} from '../../src/core';
+import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
 
 describe('components using pure function instructions internally', () => {

--- a/packages/core/test/acceptance/query_spec.ts
+++ b/packages/core/test/acceptance/query_spec.ts
@@ -25,8 +25,8 @@ import {
   ViewChildren,
   ViewContainerRef,
   ViewRef,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
 
 describe('query logic', () => {

--- a/packages/core/test/acceptance/renderer_factory_spec.ts
+++ b/packages/core/test/acceptance/renderer_factory_spec.ts
@@ -24,11 +24,11 @@ import {
   RendererStyleFlags2,
   RendererType2,
   ViewEncapsulation,
-} from '@angular/core';
-import {RElement} from '@angular/core/src/render3/interfaces/renderer_dom';
-import {ngDevModeResetPerfCounters} from '@angular/core/src/util/ng_dev_mode';
-import {NoopNgZone} from '@angular/core/src/zone/ng_zone';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {RElement} from '../../src/render3/interfaces/renderer_dom';
+import {ngDevModeResetPerfCounters} from '../../src/util/ng_dev_mode';
+import {NoopNgZone} from '../../src/zone/ng_zone';
+import {TestBed} from '../../testing';
 import {EventManager, ɵSharedStylesHost} from '@angular/platform-browser';
 import {DomRendererFactory2} from '@angular/platform-browser/src/dom/dom_renderer';
 import {expect} from '@angular/platform-browser/testing/src/matchers';

--- a/packages/core/test/acceptance/router_integration_spec.ts
+++ b/packages/core/test/acceptance/router_integration_spec.ts
@@ -7,8 +7,8 @@
  */
 
 import {APP_BASE_HREF} from '@angular/common';
-import {NgModule} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {NgModule} from '../../src/core';
+import {TestBed} from '../../testing';
 import {Router, RouterModule} from '@angular/router';
 
 describe('router integration acceptance', () => {

--- a/packages/core/test/acceptance/security_spec.ts
+++ b/packages/core/test/acceptance/security_spec.ts
@@ -15,10 +15,10 @@ import {
   Type,
   ViewChild,
   ViewContainerRef,
-} from '@angular/core';
-import {RuntimeErrorCode} from '@angular/core/src/errors';
-import {global} from '@angular/core/src/util/global';
-import {ComponentFixture, TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {RuntimeErrorCode} from '../../src/errors';
+import {global} from '../../src/util/global';
+import {ComponentFixture, TestBed} from '../../testing';
 import {DomSanitizer} from '@angular/platform-browser';
 
 describe('comment node text escaping', () => {

--- a/packages/core/test/acceptance/signal_debug_spec.ts
+++ b/packages/core/test/acceptance/signal_debug_spec.ts
@@ -6,17 +6,17 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, signal, effect, computed, Injectable, inject} from '@angular/core/public_api';
+import {Component, signal, effect, computed, Injectable, inject} from '../../src/core';
 import {
   setupFrameworkInjectorProfiler,
   getFrameworkDIDebugData,
-} from '@angular/core/src/render3/debug/framework_injector_profiler';
+} from '../../src/render3/debug/framework_injector_profiler';
 import {
   DebugSignalGraphEdge,
   DebugSignalGraphNode,
   getSignalGraph,
-} from '@angular/core/src/render3/util/signal_debug';
-import {TestBed, fakeAsync, tick} from '@angular/core/testing';
+} from '../../src/render3/util/signal_debug';
+import {TestBed, fakeAsync, tick} from '../../testing';
 
 describe('getSignalGraph', () => {
   beforeEach(() => {

--- a/packages/core/test/acceptance/standalone_injector_spec.ts
+++ b/packages/core/test/acceptance/standalone_injector_spec.ts
@@ -14,8 +14,8 @@ import {
   NgModule,
   ViewChild,
   ViewContainerRef,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {TestBed} from '../../testing';
 
 describe('standalone injector', () => {
   it('should create one standalone injector for each parent EnvInjector', () => {

--- a/packages/core/test/acceptance/standalone_spec.ts
+++ b/packages/core/test/acceptance/standalone_spec.ts
@@ -25,8 +25,8 @@ import {
   PipeTransform,
   ViewChild,
   ViewContainerRef,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {TestBed} from '../../testing';
 
 describe('standalone components, directives, and pipes', () => {
   it('should render a standalone component', () => {

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -16,16 +16,16 @@ import {
   Renderer2,
   ViewChild,
   ViewContainerRef,
-} from '@angular/core';
-import {bypassSanitizationTrustStyle} from '@angular/core/src/sanitization/bypass';
-import {ngDevModeResetPerfCounters} from '@angular/core/src/util/ng_dev_mode';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {bypassSanitizationTrustStyle} from '../../src/sanitization/bypass';
+import {ngDevModeResetPerfCounters} from '../../src/util/ng_dev_mode';
+import {TestBed} from '../../testing';
 import {
   getElementClasses,
   getElementStyles,
   getSortedClassName,
   getSortedStyle,
-} from '@angular/core/testing/src/styling';
+} from '../../testing/src/styling';
 import {By, DomSanitizer, SafeStyle} from '@angular/platform-browser';
 import {expectPerfCounters} from '@angular/private/testing';
 

--- a/packages/core/test/acceptance/template_ref_spec.ts
+++ b/packages/core/test/acceptance/template_ref_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, Injector, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {Component, Injector, TemplateRef, ViewChild, ViewContainerRef} from '../../src/core';
+import {TestBed} from '../../testing';
 
 describe('TemplateRef', () => {
   describe('rootNodes', () => {

--- a/packages/core/test/acceptance/text_spec.ts
+++ b/packages/core/test/acceptance/text_spec.ts
@@ -5,8 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {Component} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {Component} from '../../src/core';
+import {TestBed} from '../../testing';
 import {of} from 'rxjs';
 
 describe('text instructions', () => {

--- a/packages/core/test/acceptance/tracing_spec.ts
+++ b/packages/core/test/acceptance/tracing_spec.ts
@@ -12,8 +12,8 @@ import {
   ɵTracingAction as TracingAction,
   ɵTracingService as TracingService,
   ɵTracingSnapshot as TracingSnapshot,
-} from '@angular/core';
-import {fakeAsync, TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {fakeAsync, TestBed} from '../../testing';
 
 describe('TracingService', () => {
   let actions: TracingAction[];

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -40,9 +40,9 @@ import {
   ViewChildren,
   ViewContainerRef,
   ɵsetDocument,
-} from '@angular/core';
-import {ngDevModeResetPerfCounters} from '@angular/core/src/util/ng_dev_mode';
-import {ComponentFixture, TestBed, TestComponentRenderer} from '@angular/core/testing';
+} from '../../src/core';
+import {ngDevModeResetPerfCounters} from '../../src/util/ng_dev_mode';
+import {ComponentFixture, TestBed, TestComponentRenderer} from '../../testing';
 import {clearTranslations, loadTranslations} from '@angular/localize';
 import {By, DomSanitizer} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';

--- a/packages/core/test/acceptance/view_insertion_spec.ts
+++ b/packages/core/test/acceptance/view_insertion_spec.ts
@@ -19,8 +19,8 @@ import {
   ViewChild,
   ViewContainerRef,
   ViewRef,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
 
 describe('view insertion', () => {

--- a/packages/core/test/acceptance/view_ref_spec.ts
+++ b/packages/core/test/acceptance/view_ref_spec.ts
@@ -19,9 +19,9 @@ import {
   TemplateRef,
   ViewChild,
   ViewContainerRef,
-} from '@angular/core';
-import {ViewRef as InternalViewRef} from '@angular/core/src/render3/view_ref';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {ViewRef as InternalViewRef} from '../../src/render3/view_ref';
+import {TestBed} from '../../testing';
 
 describe('ViewRef', () => {
   it('should remove nodes from DOM when the view is detached from app ref', () => {

--- a/packages/core/test/animation/animation_integration_spec.ts
+++ b/packages/core/test/animation/animation_integration_spec.ts
@@ -35,8 +35,8 @@ import {
   RendererFactory2,
   ViewChild,
   ViewContainerRef,
-} from '@angular/core';
-import {fakeAsync, flushMicrotasks, TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {fakeAsync, flushMicrotasks, TestBed} from '../../testing';
 import {ɵDomRendererFactory2} from '@angular/platform-browser';
 import {
   ANIMATION_MODULE_TYPE,

--- a/packages/core/test/animation/animation_query_integration_spec.ts
+++ b/packages/core/test/animation/animation_query_integration_spec.ts
@@ -29,8 +29,8 @@ import {TransitionAnimationPlayer} from '@angular/animations/browser/src/render/
 import {ENTER_CLASSNAME, LEAVE_CLASSNAME} from '@angular/animations/browser/src/util';
 import {MockAnimationDriver, MockAnimationPlayer} from '@angular/animations/browser/testing';
 import {CommonModule} from '@angular/common';
-import {Component, HostBinding, ViewChild} from '@angular/core';
-import {fakeAsync, flushMicrotasks, TestBed} from '@angular/core/testing';
+import {Component, HostBinding, ViewChild} from '../../src/core';
+import {fakeAsync, flushMicrotasks, TestBed} from '../../testing';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 
 import {HostListener} from '../../src/metadata/directives';

--- a/packages/core/test/animation/animation_router_integration_spec.ts
+++ b/packages/core/test/animation/animation_router_integration_spec.ts
@@ -19,8 +19,8 @@ import {
 import {AnimationDriver, ɵAnimationEngine} from '@angular/animations/browser';
 import {TransitionAnimationPlayer} from '@angular/animations/browser/src/render/transition_animation_engine';
 import {MockAnimationDriver, MockAnimationPlayer} from '@angular/animations/browser/testing';
-import {Component, HostBinding} from '@angular/core';
-import {fakeAsync, flushMicrotasks, TestBed, tick} from '@angular/core/testing';
+import {Component, HostBinding} from '../../src/core';
+import {fakeAsync, flushMicrotasks, TestBed, tick} from '../../testing';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {ActivatedRoute, Router, RouterModule, RouterOutlet} from '@angular/router';
 

--- a/packages/core/test/animation/animations_with_web_animations_integration_spec.ts
+++ b/packages/core/test/animation/animations_with_web_animations_integration_spec.ts
@@ -14,8 +14,8 @@ import {
 } from '@angular/animations/browser';
 import {TransitionAnimationPlayer} from '@angular/animations/browser/src/render/transition_animation_engine';
 import {AnimationGroupPlayer} from '@angular/animations/src/players/animation_group_player';
-import {Component, ViewChild} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {Component, ViewChild} from '../../src/core';
+import {TestBed} from '../../testing';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 
 (function () {

--- a/packages/core/test/application_config_spec.ts
+++ b/packages/core/test/application_config_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {ApplicationConfig, InjectionToken, mergeApplicationConfig} from '@angular/core';
+import {ApplicationConfig, InjectionToken, mergeApplicationConfig} from '../src/core';
 
 describe('ApplicationConfig', () => {
   describe('mergeApplicationConfig', () => {

--- a/packages/core/test/application_init_spec.ts
+++ b/packages/core/test/application_init_spec.ts
@@ -12,7 +12,7 @@ import {
   inject,
   InjectionToken,
   provideAppInitializer,
-} from '@angular/core';
+} from '../src/core';
 import {EMPTY, Observable, Subscriber} from 'rxjs';
 
 import {TestBed} from '../testing';

--- a/packages/core/test/application_module_spec.ts
+++ b/packages/core/test/application_module_spec.ts
@@ -6,13 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DEFAULT_CURRENCY_CODE, LOCALE_ID} from '@angular/core';
-import {inject} from '@angular/core/testing';
+import {DEFAULT_CURRENCY_CODE, LOCALE_ID} from '../src/core';
 
 import {DEFAULT_LOCALE_ID} from '../src/i18n/localization';
 import {getLocaleId, setLocaleId} from '../src/render3';
 import {global} from '../src/util/global';
-import {TestBed} from '../testing';
+import {inject, TestBed} from '../testing';
 
 describe('Application module', () => {
   beforeEach(() => {

--- a/packages/core/test/application_ref_integration_spec.ts
+++ b/packages/core/test/application_ref_integration_spec.ts
@@ -14,8 +14,8 @@ import {
   NgModule,
   OnInit,
   TestabilityRegistry,
-} from '@angular/core';
-import {getTestBed} from '@angular/core/testing';
+} from '../src/core';
+import {getTestBed} from '../testing';
 import {BrowserModule} from '@angular/platform-browser';
 import {withBody} from '@angular/private/testing';
 

--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -27,10 +27,10 @@ import {
   Type,
   ViewChild,
   ViewContainerRef,
-} from '@angular/core';
-import {ErrorHandler} from '@angular/core/src/error_handler';
-import {ComponentRef} from '@angular/core/src/linker/component_factory';
-import {createEnvironmentInjector, getLocaleId} from '@angular/core/src/render3';
+} from '../src/core';
+import {ErrorHandler} from '../src/error_handler';
+import {ComponentRef} from '../src/linker/component_factory';
+import {createEnvironmentInjector, getLocaleId} from '../src/render3';
 import {BrowserModule} from '@angular/platform-browser';
 import {DomRendererFactory2} from '@angular/platform-browser/src/dom/dom_renderer';
 import {

--- a/packages/core/test/authoring/input_signal_spec.ts
+++ b/packages/core/test/authoring/input_signal_spec.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, computed, effect, input} from '@angular/core';
-import {SIGNAL} from '@angular/core/primitives/signals';
-import {setUseMicrotaskEffectsByDefault} from '@angular/core/src/render3/reactivity/effect';
-import {TestBed} from '@angular/core/testing';
+import {Component, computed, effect, input} from '../../src/core';
+import {SIGNAL} from '../../primitives/signals';
+import {setUseMicrotaskEffectsByDefault} from '../../src/render3/reactivity/effect';
+import {TestBed} from '../../testing';
 
 describe('input signal', () => {
   let prev: boolean;

--- a/packages/core/test/authoring/model_input_spec.ts
+++ b/packages/core/test/authoring/model_input_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, isSignal, model, WritableSignal} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {computed, isSignal, model, WritableSignal} from '../../src/core';
+import {TestBed} from '../../testing';
 
 describe('model signal', () => {
   it('should work with computed expressions', () => {

--- a/packages/core/test/authoring/signal_input_signature_test.ts
+++ b/packages/core/test/authoring/signal_input_signature_test.ts
@@ -12,10 +12,10 @@
  * the resulting types match our expectations (via comments asserting the `.d.ts`).
  */
 
-import {input} from '@angular/core';
+import {input} from '../../src/core';
 // import preserved to simplify `.d.ts` emit and simplify the `type_tester` logic.
 // tslint:disable-next-line no-duplicate-imports
-import {InputSignal, InputSignalWithTransform} from '@angular/core';
+import {InputSignal, InputSignalWithTransform} from '../../src/core';
 
 export class InputSignatureTest {
   /** string | undefined */

--- a/packages/core/test/authoring/signal_model_signature_test.ts
+++ b/packages/core/test/authoring/signal_model_signature_test.ts
@@ -12,10 +12,10 @@
  * the resulting types match our expectations (via comments asserting the `.d.ts`).
  */
 
-import {model} from '@angular/core';
+import {model} from '../../src/core';
 // import preserved to simplify `.d.ts` emit and simplify the `type_tester` logic.
 // tslint:disable-next-line no-duplicate-imports
-import {ModelSignal} from '@angular/core';
+import {ModelSignal} from '../../src/core';
 
 export class SignalModelSignatureTest {
   /** string | undefined */

--- a/packages/core/test/authoring/signal_queries_signature_test.ts
+++ b/packages/core/test/authoring/signal_queries_signature_test.ts
@@ -15,7 +15,7 @@ import {
   Signal,
   viewChild,
   viewChildren,
-} from '@angular/core';
+} from '../../src/core';
 
 class QueryType {
   // a random field to brand the type

--- a/packages/core/test/authoring/unwrap_writable_signal_signature_test.ts
+++ b/packages/core/test/authoring/unwrap_writable_signal_signature_test.ts
@@ -12,10 +12,10 @@
  * the resulting types match our expectations (via comments asserting the `.d.ts`).
  */
 
-import {input, model, signal, ɵunwrapWritableSignal as unwrapWritableSignal} from '@angular/core';
+import {input, model, signal, ɵunwrapWritableSignal as unwrapWritableSignal} from '../../src/core';
 // import preserved to simplify `.d.ts` emit and simplify the `type_tester` logic.
 // tslint:disable-next-line no-duplicate-imports
-import {InputSignal, WritableSignal} from '@angular/core';
+import {InputSignal, WritableSignal} from '../../src/core';
 
 export class SignalModelSignatureTest {
   /** string | undefined */

--- a/packages/core/test/bundling/animation_world/index.ts
+++ b/packages/core/test/bundling/animation_world/index.ts
@@ -15,7 +15,7 @@ import {
   HostBinding,
   HostListener,
   NgModule,
-} from '@angular/core';
+} from '../../../src/core';
 import {BrowserModule, platformBrowser} from '@angular/platform-browser';
 
 @Directive({

--- a/packages/core/test/bundling/animations-standalone/index.ts
+++ b/packages/core/test/bundling/animations-standalone/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import {animate, style, transition, trigger} from '@angular/animations';
-import {Component, NgModule, ɵNgModuleFactory as NgModuleFactory} from '@angular/core';
+import {Component, NgModule, ɵNgModuleFactory as NgModuleFactory} from '../../../src/core';
 import {bootstrapApplication, BrowserModule, platformBrowser} from '@angular/platform-browser';
 import {BrowserAnimationsModule, provideAnimations} from '@angular/platform-browser/animations';
 

--- a/packages/core/test/bundling/animations/index.ts
+++ b/packages/core/test/bundling/animations/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import {animate, style, transition, trigger} from '@angular/animations';
-import {Component, NgModule, ɵNgModuleFactory as NgModuleFactory} from '@angular/core';
+import {Component, NgModule, ɵNgModuleFactory as NgModuleFactory} from '../../../src/core';
 import {BrowserModule, platformBrowser} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 

--- a/packages/core/test/bundling/core_all/index.ts
+++ b/packages/core/test/bundling/core_all/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import * as core from '@angular/core';
+import * as core from '../../../src/core';
 
 // We need to something with the "core" import in order to ensure
 // that all symbols from core are preserved in the bundle.

--- a/packages/core/test/bundling/cyclic_import/index.ts
+++ b/packages/core/test/bundling/cyclic_import/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ApplicationRef, Component, NgModule} from '@angular/core';
+import {ApplicationRef, Component, NgModule} from '../../../src/core';
 import {BrowserModule, platformBrowser} from '@angular/platform-browser';
 
 import {TriggerComponent} from './trigger';

--- a/packages/core/test/bundling/cyclic_import/trigger.ts
+++ b/packages/core/test/bundling/cyclic_import/trigger.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component} from '@angular/core';
+import {Component} from '../../../src/core';
 
 @Component({
   selector: 'trigger',

--- a/packages/core/test/bundling/defer/defer.component.ts
+++ b/packages/core/test/bundling/defer/defer.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component} from '@angular/core';
+import {Component} from '../../../src/core';
 
 @Component({
   standalone: true,

--- a/packages/core/test/bundling/defer/index.ts
+++ b/packages/core/test/bundling/defer/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component} from '@angular/core';
+import {Component} from '../../../src/core';
 import {bootstrapApplication} from '@angular/platform-browser';
 
 import {DeferComponent} from './defer.component';

--- a/packages/core/test/bundling/forms_reactive/index.ts
+++ b/packages/core/test/bundling/forms_reactive/index.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {Component, NgModule} from '@angular/core';
+import {Component, NgModule} from '../../../src/core';
 import {
   FormArray,
   FormBuilder,

--- a/packages/core/test/bundling/forms_template_driven/index.ts
+++ b/packages/core/test/bundling/forms_template_driven/index.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {Component, NgModule} from '@angular/core';
+import {Component, NgModule} from '../../../src/core';
 import {FormsModule} from '@angular/forms';
 import {BrowserModule, platformBrowser} from '@angular/platform-browser';
 

--- a/packages/core/test/bundling/hello_world/index.ts
+++ b/packages/core/test/bundling/hello_world/index.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {Component, NgModule} from '@angular/core';
+import {Component, NgModule} from '../../../src/core';
 import {platformBrowser} from '@angular/platform-browser';
 
 @Component({

--- a/packages/core/test/bundling/hello_world_i18n/index.ts
+++ b/packages/core/test/bundling/hello_world_i18n/index.ts
@@ -7,7 +7,7 @@
  */
 import './translations';
 
-import {Component, NgModule} from '@angular/core';
+import {Component, NgModule} from '../../../src/core';
 import {BrowserModule, platformBrowser} from '@angular/platform-browser';
 
 @Component({

--- a/packages/core/test/bundling/hydration/index.ts
+++ b/packages/core/test/bundling/hydration/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component} from '@angular/core';
+import {Component} from '../../../src/core';
 import {bootstrapApplication, provideClientHydration} from '@angular/platform-browser';
 
 @Component({

--- a/packages/core/test/bundling/image-directive/e2e/basic/basic.ts
+++ b/packages/core/test/bundling/image-directive/e2e/basic/basic.ts
@@ -7,7 +7,7 @@
  */
 
 import {IMAGE_LOADER, NgOptimizedImage} from '@angular/common';
-import {Component} from '@angular/core';
+import {Component} from '../../../../../src/core';
 
 @Component({
   selector: 'basic',

--- a/packages/core/test/bundling/image-directive/e2e/fill-mode/fill-mode.ts
+++ b/packages/core/test/bundling/image-directive/e2e/fill-mode/fill-mode.ts
@@ -7,7 +7,7 @@
  */
 
 import {NgOptimizedImage} from '@angular/common';
-import {Component} from '@angular/core';
+import {Component} from '../../../../../src/core';
 
 @Component({
   selector: 'fill-mode-passing',

--- a/packages/core/test/bundling/image-directive/e2e/image-distortion/image-distortion.ts
+++ b/packages/core/test/bundling/image-directive/e2e/image-distortion/image-distortion.ts
@@ -7,7 +7,7 @@
  */
 
 import {NgOptimizedImage} from '@angular/common';
-import {Component} from '@angular/core';
+import {Component} from '../../../../../src/core';
 
 @Component({
   selector: 'image-distortion-passing',

--- a/packages/core/test/bundling/image-directive/e2e/image-perf-warnings-lazy/image-perf-warnings-lazy.ts
+++ b/packages/core/test/bundling/image-directive/e2e/image-perf-warnings-lazy/image-perf-warnings-lazy.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component} from '@angular/core';
+import {Component} from '../../../../../src/core';
 
 @Component({
   selector: 'image-perf-warnings-lazy',

--- a/packages/core/test/bundling/image-directive/e2e/image-perf-warnings-oversized/image-perf-warnings-oversized.ts
+++ b/packages/core/test/bundling/image-directive/e2e/image-perf-warnings-oversized/image-perf-warnings-oversized.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component} from '@angular/core';
+import {Component} from '../../../../../src/core';
 
 @Component({
   selector: 'image-perf-warnings-oversized',

--- a/packages/core/test/bundling/image-directive/e2e/image-perf-warnings-oversized/svg-no-perf-oversized-warnings.ts
+++ b/packages/core/test/bundling/image-directive/e2e/image-perf-warnings-oversized/svg-no-perf-oversized-warnings.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component} from '@angular/core';
+import {Component} from '../../../../../src/core';
 
 @Component({
   selector: 'svg-no-perf-oversized-warnings',

--- a/packages/core/test/bundling/image-directive/e2e/lcp-check/lcp-check.ts
+++ b/packages/core/test/bundling/image-directive/e2e/lcp-check/lcp-check.ts
@@ -7,7 +7,7 @@
  */
 
 import {NgOptimizedImage} from '@angular/common';
-import {Component} from '@angular/core';
+import {Component} from '../../../../../src/core';
 
 @Component({
   selector: 'lcp-check',

--- a/packages/core/test/bundling/image-directive/e2e/oversized-image/oversized-image.ts
+++ b/packages/core/test/bundling/image-directive/e2e/oversized-image/oversized-image.ts
@@ -7,7 +7,7 @@
  */
 
 import {IMAGE_LOADER, ImageLoaderConfig, NgOptimizedImage} from '@angular/common';
-import {Component} from '@angular/core';
+import {Component} from '../../../../../src/core';
 
 const imageLoader = {
   provide: IMAGE_LOADER,

--- a/packages/core/test/bundling/image-directive/e2e/preconnect-check/preconnect-check.ts
+++ b/packages/core/test/bundling/image-directive/e2e/preconnect-check/preconnect-check.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT, IMAGE_LOADER, NgOptimizedImage} from '@angular/common';
-import {Component, Inject} from '@angular/core';
+import {Component, Inject} from '../../../../../src/core';
 
 @Component({
   selector: 'preconnect-check',

--- a/packages/core/test/bundling/image-directive/index.ts
+++ b/packages/core/test/bundling/image-directive/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, importProvidersFrom} from '@angular/core';
+import {Component, importProvidersFrom} from '../../../src/core';
 import {bootstrapApplication, provideProtractorTestingSupport} from '@angular/platform-browser';
 import {RouterModule} from '@angular/router';
 

--- a/packages/core/test/bundling/image-directive/playground.ts
+++ b/packages/core/test/bundling/image-directive/playground.ts
@@ -7,7 +7,7 @@
  */
 
 import {NgOptimizedImage, provideImgixLoader} from '@angular/common';
-import {Component} from '@angular/core';
+import {Component} from '../../../src/core';
 
 @Component({
   selector: 'basic',

--- a/packages/core/test/bundling/injection/usage.ts
+++ b/packages/core/test/bundling/injection/usage.ts
@@ -10,7 +10,7 @@ import {
   ɵcreateInjector as createInjector,
   ɵɵdefineInjectable,
   ɵɵdefineInjector,
-} from '@angular/core';
+} from '../../../src/core';
 
 export class RootService {
   static ɵprov = ɵɵdefineInjectable({

--- a/packages/core/test/bundling/router/index.ts
+++ b/packages/core/test/bundling/router/index.ts
@@ -7,7 +7,7 @@
  */
 
 import {APP_BASE_HREF} from '@angular/common';
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit} from '../../../src/core';
 import {bootstrapApplication} from '@angular/platform-browser';
 import {
   ActivatedRoute,

--- a/packages/core/test/bundling/standalone_bootstrap/index.ts
+++ b/packages/core/test/bundling/standalone_bootstrap/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component} from '@angular/core';
+import {Component} from '../../../src/core';
 import {bootstrapApplication} from '@angular/platform-browser';
 
 @Component({

--- a/packages/core/test/bundling/todo/index.ts
+++ b/packages/core/test/bundling/todo/index.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {Component, Injectable, NgModule} from '@angular/core';
+import {Component, Injectable, NgModule} from '../../../src/core';
 import {BrowserModule, platformBrowser} from '@angular/platform-browser';
 
 class Todo {

--- a/packages/core/test/bundling/todo_i18n/index.ts
+++ b/packages/core/test/bundling/todo_i18n/index.ts
@@ -6,7 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectorRef, Component, Injectable, NgModule, ViewEncapsulation} from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  Injectable,
+  NgModule,
+  ViewEncapsulation,
+} from '../../../src/core';
 import {loadTranslations} from '@angular/localize';
 import {BrowserModule, platformBrowser} from '@angular/platform-browser';
 

--- a/packages/core/test/change_detection/differs/default_iterable_differ_spec.ts
+++ b/packages/core/test/change_detection/differs/default_iterable_differ_spec.ts
@@ -9,7 +9,7 @@
 import {
   DefaultIterableDiffer,
   DefaultIterableDifferFactory,
-} from '@angular/core/src/change_detection/differs/default_iterable_differ';
+} from '../../../src/change_detection/differs/default_iterable_differ';
 
 import {TestIterable} from '../../util/iterable';
 import {iterableChangesAsString, iterableDifferToString} from '../util';

--- a/packages/core/test/change_detection/differs/default_keyvalue_differ_spec.ts
+++ b/packages/core/test/change_detection/differs/default_keyvalue_differ_spec.ts
@@ -9,7 +9,7 @@
 import {
   DefaultKeyValueDiffer,
   DefaultKeyValueDifferFactory,
-} from '@angular/core/src/change_detection/differs/default_keyvalue_differ';
+} from '../../../src/change_detection/differs/default_keyvalue_differ';
 
 import {kvChangesAsString, testChangesAsString} from '../util';
 

--- a/packages/core/test/change_detection/differs/iterable_differs_spec.ts
+++ b/packages/core/test/change_detection/differs/iterable_differs_spec.ts
@@ -13,8 +13,8 @@ import {
   IterableDiffers,
   NgModule,
   TrackByFunction,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../../../src/core';
+import {TestBed} from '../../../testing';
 
 describe('IterableDiffers', function () {
   let factory1: jasmine.SpyObj<IterableDifferFactory>;

--- a/packages/core/test/change_detection/differs/keyvalue_differs_spec.ts
+++ b/packages/core/test/change_detection/differs/keyvalue_differs_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {KeyValueDiffer, KeyValueDifferFactory, KeyValueDiffers, NgModule} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {KeyValueDiffer, KeyValueDifferFactory, KeyValueDiffers, NgModule} from '../../../src/core';
+import {TestBed} from '../../../testing';
 
 describe('KeyValueDiffers', function () {
   it('should support .extend in root NgModule', () => {

--- a/packages/core/test/change_detection/util.ts
+++ b/packages/core/test/change_detection/util.ts
@@ -9,11 +9,11 @@
 import {
   IterableChangeRecord,
   IterableChanges,
-} from '@angular/core/src/change_detection/differs/iterable_differs';
+} from '../../src/change_detection/differs/iterable_differs';
 import {
   KeyValueChangeRecord,
   KeyValueChanges,
-} from '@angular/core/src/change_detection/differs/keyvalue_differs';
+} from '../../src/change_detection/differs/keyvalue_differs';
 
 import {stringify} from '../../src/util/stringify';
 

--- a/packages/core/test/change_detection_scheduler_spec.ts
+++ b/packages/core/test/change_detection_scheduler_spec.ts
@@ -32,8 +32,8 @@ import {
   Type,
   ViewChild,
   ViewContainerRef,
-} from '@angular/core';
-import {toSignal} from '@angular/core/rxjs-interop';
+} from '../src/core';
+import {toSignal} from '../rxjs-interop';
 import {
   ComponentFixture,
   ComponentFixtureAutoDetect,
@@ -41,7 +41,7 @@ import {
   fakeAsync,
   flush,
   tick,
-} from '@angular/core/testing';
+} from '../testing';
 import {bootstrapApplication} from '@angular/platform-browser';
 import {withBody} from '@angular/private/testing';
 import {BehaviorSubject, firstValueFrom} from 'rxjs';

--- a/packages/core/test/component_fixture_spec.ts
+++ b/packages/core/test/component_fixture_spec.ts
@@ -17,14 +17,14 @@ import {
   createComponent,
   provideExperimentalZonelessChangeDetection,
   signal,
-} from '@angular/core';
+} from '../src/core';
 import {
   ComponentFixtureAutoDetect,
   ComponentFixtureNoNgZone,
   TestBed,
   waitForAsync,
   withModule,
-} from '@angular/core/testing';
+} from '../testing';
 import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 

--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -26,8 +26,8 @@ import {
   TemplateRef,
   ViewChild,
   ViewContainerRef,
-} from '@angular/core';
-import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+} from '../../src/core';
+import {ComponentFixture, TestBed, waitForAsync} from '../../testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {createMouseEvent, hasClass} from '@angular/platform-browser/testing/src/browser_util';
 import {expect} from '@angular/platform-browser/testing/src/matchers';

--- a/packages/core/test/defer_fixture_spec.ts
+++ b/packages/core/test/defer_fixture_spec.ts
@@ -7,8 +7,8 @@
  */
 
 import {ɵPLATFORM_BROWSER_ID as PLATFORM_BROWSER_ID} from '@angular/common';
-import {Component, PLATFORM_ID, ɵPendingTasksInternal as PendingTasks} from '@angular/core';
-import {DeferBlockBehavior, DeferBlockState, TestBed} from '@angular/core/testing';
+import {Component, PLATFORM_ID, ɵPendingTasksInternal as PendingTasks} from '../src/core';
+import {DeferBlockBehavior, DeferBlockState, TestBed} from '../testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 @Component({

--- a/packages/core/test/dev_mode_spec.ts
+++ b/packages/core/test/dev_mode_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {isDevMode} from '@angular/core';
+import {isDevMode} from '../src/core';
 
 describe('dev mode', () => {
   it('is enabled in our tests by default', () => {

--- a/packages/core/test/di/forward_ref_spec.ts
+++ b/packages/core/test/di/forward_ref_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Type} from '@angular/core';
-import {forwardRef, resolveForwardRef} from '@angular/core/src/di';
+import {Type} from '../../src/core';
+import {forwardRef, resolveForwardRef} from '../../src/di';
 
 describe('forwardRef', () => {
   it('should wrap and unwrap the reference', () => {

--- a/packages/core/test/di/injector_spec.ts
+++ b/packages/core/test/di/injector_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Injector} from '@angular/core';
+import {Injector} from '../../src/core';
 
 describe('Injector.NULL', () => {
   it('should throw if no arg is given', () => {

--- a/packages/core/test/di/r3_injector_spec.ts
+++ b/packages/core/test/di/r3_injector_spec.ts
@@ -15,9 +15,9 @@ import {
   ɵɵdefineInjectable,
   ɵɵdefineInjector,
   ɵɵinject,
-} from '@angular/core';
-import {createInjector} from '@angular/core/src/di/create_injector';
-import {R3Injector} from '@angular/core/src/di/r3_injector';
+} from '../../src/core';
+import {createInjector} from '../../src/di/create_injector';
+import {R3Injector} from '../../src/di/r3_injector';
 
 describe('InjectorDef-based createInjector()', () => {
   class CircularA {

--- a/packages/core/test/di/static_injector_spec.ts
+++ b/packages/core/test/di/static_injector_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {forwardRef, Inject, InjectFlags, Injector, Self, SkipSelf} from '@angular/core';
+import {forwardRef, Inject, Injector, InjectFlags, Self, SkipSelf} from '../../src/core';
 
 import {stringify} from '../../src/util/stringify';
 

--- a/packages/core/test/directive_lifecycle_integration_spec.ts
+++ b/packages/core/test/directive_lifecycle_integration_spec.ts
@@ -16,9 +16,9 @@ import {
   DoCheck,
   OnChanges,
   OnInit,
-} from '@angular/core';
-import {inject, TestBed} from '@angular/core/testing';
-import {Log} from '@angular/core/testing/src/testing_internal';
+} from '../src/core';
+import {inject, TestBed} from '../testing';
+import {Log} from '../testing/src/testing_internal';
 
 describe('directive lifecycle integration spec', () => {
   let log: Log;

--- a/packages/core/test/dom/shim_spec.ts
+++ b/packages/core/test/dom/shim_spec.ts
@@ -8,7 +8,7 @@
 
 // This isn't used for anything, but for some reason Bazel won't
 // serve the file if there isn't at least one import.
-import '@angular/core/testing';
+import '../../testing';
 
 describe('Shim', () => {
   it('should provide correct function.name ', () => {

--- a/packages/core/test/event_emitter_spec.ts
+++ b/packages/core/test/event_emitter_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {TestBed} from '@angular/core/testing';
+import {TestBed} from '../testing';
 import {filter, tap} from 'rxjs/operators';
 
 import {EventEmitter} from '../src/event_emitter';

--- a/packages/core/test/fake_async_spec.ts
+++ b/packages/core/test/fake_async_spec.ts
@@ -6,15 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  discardPeriodicTasks,
-  fakeAsync,
-  flush,
-  flushMicrotasks,
-  inject,
-  tick,
-} from '@angular/core/testing';
-import {Log} from '@angular/core/testing/src/testing_internal';
+import {discardPeriodicTasks, fakeAsync, flush, flushMicrotasks, inject, tick} from '../testing';
+import {Log} from '../testing/src/testing_internal';
 import {EventManager} from '@angular/platform-browser';
 
 const resolvedPromise = Promise.resolve(null);

--- a/packages/core/test/forward_ref_integration_spec.ts
+++ b/packages/core/test/forward_ref_integration_spec.ts
@@ -17,8 +17,8 @@ import {
   NgModule,
   NO_ERRORS_SCHEMA,
   QueryList,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../src/core';
+import {TestBed} from '../testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 class Frame {

--- a/packages/core/test/linker/change_detection_integration_spec.ts
+++ b/packages/core/test/linker/change_detection_integration_spec.ts
@@ -38,8 +38,8 @@ import {
   Type,
   ViewChild,
   ViewContainerRef,
-} from '@angular/core';
-import {ComponentFixture, fakeAsync, TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {ComponentFixture, fakeAsync, TestBed} from '../../testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {isTextNode} from '@angular/platform-browser/testing/src/browser_util';
 import {expect} from '@angular/platform-browser/testing/src/matchers';

--- a/packages/core/test/linker/inheritance_integration_spec.ts
+++ b/packages/core/test/linker/inheritance_integration_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, Directive, HostBinding} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {Component, Directive, HostBinding} from '../../src/core';
+import {TestBed} from '../../testing';
 
 @Directive({
   selector: '[directiveA]',

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -37,20 +37,20 @@ import {
   ViewChild,
   ViewRef,
   ɵsetClassDebugInfo,
-} from '@angular/core';
+} from '../../src/core';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   PipeTransform,
-} from '@angular/core/src/change_detection/change_detection';
-import {ComponentFactoryResolver} from '@angular/core/src/linker/component_factory_resolver';
-import {ElementRef} from '@angular/core/src/linker/element_ref';
-import {QueryList} from '@angular/core/src/linker/query_list';
-import {TemplateRef} from '@angular/core/src/linker/template_ref';
-import {ViewContainerRef} from '@angular/core/src/linker/view_container_ref';
-import {EmbeddedViewRef} from '@angular/core/src/linker/view_ref';
-import {fakeAsync, getTestBed, TestBed, tick, waitForAsync} from '@angular/core/testing';
-import {TestBedCompiler} from '@angular/core/testing/src/test_bed_compiler';
+} from '../../src/change_detection/change_detection';
+import {ComponentFactoryResolver} from '../../src/linker/component_factory_resolver';
+import {ElementRef} from '../../src/linker/element_ref';
+import {QueryList} from '../../src/linker/query_list';
+import {TemplateRef} from '../../src/linker/template_ref';
+import {ViewContainerRef} from '../../src/linker/view_container_ref';
+import {EmbeddedViewRef} from '../../src/linker/view_ref';
+import {fakeAsync, getTestBed, TestBed, tick, waitForAsync} from '../../testing';
+import {TestBedCompiler} from '../../testing/src/test_bed_compiler';
 import {
   createMouseEvent,
   dispatchEvent,

--- a/packages/core/test/linker/ng_container_integration_spec.ts
+++ b/packages/core/test/linker/ng_container_integration_spec.ts
@@ -18,8 +18,8 @@ import {
   Input,
   QueryList,
   ViewChildren,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {TestBed} from '../../testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 describe('<ng-container>', function () {

--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -27,11 +27,11 @@ import {
   Provider,
   Self,
   Type,
-} from '@angular/core';
-import {ɵɵdefineInjectable} from '@angular/core/src/di/interface/defs';
-import {NgModuleType} from '@angular/core/src/render3';
-import {getNgModuleDef} from '@angular/core/src/render3/def_getters';
-import {ComponentFixture, inject, TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {ɵɵdefineInjectable} from '../../src/di/interface/defs';
+import {NgModuleType} from '../../src/render3';
+import {getNgModuleDef} from '../../src/render3/def_getters';
+import {ComponentFixture, inject, TestBed} from '../../testing';
 
 import {InternalNgModuleRef, NgModuleFactory} from '../../src/linker/ng_module_factory';
 import {

--- a/packages/core/test/linker/projection_integration_spec.ts
+++ b/packages/core/test/linker/projection_integration_spec.ts
@@ -24,8 +24,8 @@ import {
   ViewChild,
   ViewContainerRef,
   ViewEncapsulation,
-} from '@angular/core';
-import {ComponentFixture, TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {ComponentFixture, TestBed} from '../../testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 

--- a/packages/core/test/linker/query_integration_spec.ts
+++ b/packages/core/test/linker/query_integration_spec.ts
@@ -22,9 +22,9 @@ import {
   ViewChild,
   ViewChildren,
   ViewContainerRef,
-} from '@angular/core';
-import {ElementRef} from '@angular/core/src/core';
-import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+  ElementRef,
+} from '../../src/core';
+import {ComponentFixture, TestBed, waitForAsync} from '../../testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {Subject} from 'rxjs';
 

--- a/packages/core/test/linker/query_list_spec.ts
+++ b/packages/core/test/linker/query_list_spec.ts
@@ -7,9 +7,9 @@
  */
 
 import {ɵgetDOM as getDOM} from '@angular/common';
-import {QueryList} from '@angular/core/src/linker/query_list';
-import {iterateListLike} from '@angular/core/src/util/iterable';
-import {fakeAsync, tick} from '@angular/core/testing';
+import {QueryList} from '../../src/linker/query_list';
+import {iterateListLike} from '../../src/util/iterable';
+import {fakeAsync, tick} from '../../testing';
 
 describe('QueryList', () => {
   let queryList: QueryList<string>;

--- a/packages/core/test/linker/regression_integration_spec.ts
+++ b/packages/core/test/linker/regression_integration_spec.ts
@@ -34,8 +34,8 @@ import {
   TemplateRef,
   ViewChildren,
   ViewContainerRef,
-} from '@angular/core';
-import {fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
+} from '../../src/core';
+import {fakeAsync, inject, TestBed, tick} from '../../testing';
 import {BrowserModule, By} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {expect} from '@angular/platform-browser/testing/src/matchers';

--- a/packages/core/test/linker/security_integration_spec.ts
+++ b/packages/core/test/linker/security_integration_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, Directive, HostBinding, Input, NO_ERRORS_SCHEMA} from '@angular/core';
-import {ComponentFixture, getTestBed, TestBed} from '@angular/core/testing';
+import {Component, Directive, HostBinding, Input, NO_ERRORS_SCHEMA} from '../../src/core';
+import {ComponentFixture, getTestBed, TestBed} from '../../testing';
 import {DomSanitizer} from '@angular/platform-browser/src/security/dom_sanitization_service';
 
 @Component({

--- a/packages/core/test/linker/source_map_integration_node_only_spec.ts
+++ b/packages/core/test/linker/source_map_integration_node_only_spec.ts
@@ -10,10 +10,10 @@ import {ResourceLoader, SourceMap} from '@angular/compiler';
 import {CompilerFacadeImpl} from '@angular/compiler/src/jit_compiler_facade';
 import {JitEvaluator} from '@angular/compiler/src/output/output_jit';
 import {escapeRegExp} from '@angular/compiler/src/util';
-import {Attribute, Component, Directive, ErrorHandler} from '@angular/core';
-import {CompilerFacade, ExportedCompilerFacade} from '@angular/core/src/compiler/compiler_facade';
-import {resolveComponentResources} from '@angular/core/src/metadata/resource_loading';
-import {fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {Attribute, Component, Directive, ErrorHandler} from '../../src/core';
+import {CompilerFacade, ExportedCompilerFacade} from '../../src/compiler/compiler_facade';
+import {resolveComponentResources} from '../../src/metadata/resource_loading';
+import {fakeAsync, TestBed, tick} from '../../testing';
 
 import {MockResourceLoader} from './resource_loader_mock';
 import {extractSourceMap, originalPositionFor} from './source_map_util';

--- a/packages/core/test/linker/view_injector_integration_spec.ts
+++ b/packages/core/test/linker/view_injector_integration_spec.ts
@@ -33,8 +33,8 @@ import {
   TemplateRef,
   Type,
   ViewContainerRef,
-} from '@angular/core';
-import {ComponentFixture, fakeAsync, TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {ComponentFixture, fakeAsync, TestBed} from '../../testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 @Directive({

--- a/packages/core/test/metadata/di_spec.ts
+++ b/packages/core/test/metadata/di_spec.ts
@@ -15,8 +15,8 @@ import {
   QueryList,
   ViewChild,
   ViewChildren,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {TestBed} from '../../testing';
 
 describe('ViewChild', () => {
   beforeEach(() => {

--- a/packages/core/test/render3/change_detection_spec.ts
+++ b/packages/core/test/render3/change_detection_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {TestBed} from '@angular/core/testing';
+import {TestBed} from '../../testing';
 import {withBody} from '@angular/private/testing';
 
 import {Component, RendererFactory2} from '../../src/core';

--- a/packages/core/test/render3/component_ref_spec.ts
+++ b/packages/core/test/render3/component_ref_spec.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ComponentRef} from '@angular/core';
-import {ComponentFactoryResolver} from '@angular/core/src/render3/component_ref';
-import {Renderer} from '@angular/core/src/render3/interfaces/renderer';
-import {RElement} from '@angular/core/src/render3/interfaces/renderer_dom';
-import {TestBed} from '@angular/core/testing';
+import {ComponentFactoryResolver} from '../../src/render3/component_ref';
+import {Renderer} from '../../src/render3/interfaces/renderer';
+import {RElement} from '../../src/render3/interfaces/renderer_dom';
+import {TestBed} from '../../testing';
 
 import {
+  ComponentRef,
   ChangeDetectionStrategy,
   Component,
   Injector,

--- a/packages/core/test/render3/deps_tracker_spec.ts
+++ b/packages/core/test/render3/deps_tracker_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, Directive, forwardRef, NgModule, Pipe} from '@angular/core';
+import {Component, Directive, forwardRef, NgModule, Pipe} from '../../src/core';
 
 import {NgModuleDef} from '../../src/r3_symbols';
 import {

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, Directive, Self} from '@angular/core';
-import {NodeInjectorOffset} from '@angular/core/src/render3/interfaces/injector';
-import {TestBed} from '@angular/core/testing';
+import {Component, Directive, Self} from '../../src/core';
+import {NodeInjectorOffset} from '../../src/render3/interfaces/injector';
+import {TestBed} from '../../testing';
 
 import {
   bloomAdd,
@@ -19,8 +19,8 @@ import {
 import {TNodeType} from '../../src/render3/interfaces/node';
 import {HEADER_OFFSET, LViewFlags, TVIEW, TViewType} from '../../src/render3/interfaces/view';
 import {enterView, leaveView} from '../../src/render3/state';
-import {getOrCreateTNode} from '@angular/core/src/render3/tnode_manipulation';
-import {createLView, createTView} from '@angular/core/src/render3/view/construction';
+import {getOrCreateTNode} from '../../src/render3/tnode_manipulation';
+import {createLView, createTView} from '../../src/render3/view/construction';
 
 describe('di', () => {
   describe('directive injection', () => {

--- a/packages/core/test/render3/i18n/i18n_insert_before_index_spec.ts
+++ b/packages/core/test/render3/i18n/i18n_insert_before_index_spec.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {addTNodeAndUpdateInsertBeforeIndex} from '@angular/core/src/render3/i18n/i18n_insert_before_index';
-import {TNode, TNodeType} from '@angular/core/src/render3/interfaces/node';
-import {HEADER_OFFSET} from '@angular/core/src/render3/interfaces/view';
+import {addTNodeAndUpdateInsertBeforeIndex} from '../../../src/render3/i18n/i18n_insert_before_index';
+import {TNode, TNodeType} from '../../../src/render3/interfaces/node';
+import {HEADER_OFFSET} from '../../../src/render3/interfaces/view';
 import {matchTNode} from '../matchers';
-import {createTNode} from '@angular/core/src/render3/tnode_manipulation';
+import {createTNode} from '../../../src/render3/tnode_manipulation';
 
 describe('addTNodeAndUpdateInsertBeforeIndex', () => {
   function tNode(index: number, type: TNodeType, insertBeforeIndex: number | null = null): TNode {

--- a/packages/core/test/render3/i18n/i18n_parse_spec.ts
+++ b/packages/core/test/render3/i18n/i18n_parse_spec.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ɵɵi18nApply, ɵɵi18nExp} from '@angular/core';
-import {applyCreateOpCodes} from '@angular/core/src/render3/i18n/i18n_apply';
-import {i18nStartFirstCreatePass} from '@angular/core/src/render3/i18n/i18n_parse';
-import {getTIcu} from '@angular/core/src/render3/i18n/i18n_util';
-import {I18nUpdateOpCodes, IcuType, TI18n} from '@angular/core/src/render3/interfaces/i18n';
-import {HEADER_OFFSET, HOST} from '@angular/core/src/render3/interfaces/view';
+import {ɵɵi18nApply, ɵɵi18nExp} from '../../../src/core';
+import {applyCreateOpCodes} from '../../../src/render3/i18n/i18n_apply';
+import {i18nStartFirstCreatePass} from '../../../src/render3/i18n/i18n_parse';
+import {getTIcu} from '../../../src/render3/i18n/i18n_util';
+import {I18nUpdateOpCodes, IcuType, TI18n} from '../../../src/render3/interfaces/i18n';
+import {HEADER_OFFSET, HOST} from '../../../src/render3/interfaces/view';
 
 import {matchTI18n, matchTIcu} from '../matchers';
 import {matchDebug} from '../utils';

--- a/packages/core/test/render3/i18n/i18n_spec.ts
+++ b/packages/core/test/render3/i18n/i18n_spec.ts
@@ -6,14 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ɵɵi18nAttributes, ɵɵi18nPostprocess, ɵɵi18nStart} from '@angular/core';
-import {ɵɵi18n} from '@angular/core/src/core';
+import {ɵɵi18nAttributes, ɵɵi18n, ɵɵi18nPostprocess, ɵɵi18nStart} from '../../../src/core';
 import {
   getTranslationForTemplate,
   i18nStartFirstCreatePass,
-} from '@angular/core/src/render3/i18n/i18n_parse';
-import {getTIcu} from '@angular/core/src/render3/i18n/i18n_util';
-import {TNodeType} from '@angular/core/src/render3/interfaces/node';
+} from '../../../src/render3/i18n/i18n_parse';
+import {getTIcu} from '../../../src/render3/i18n/i18n_util';
+import {TNodeType} from '../../../src/render3/interfaces/node';
 
 import {ɵɵelementEnd, ɵɵelementStart} from '../../../src/render3/instructions/all';
 import {

--- a/packages/core/test/render3/i18n_debug_spec.ts
+++ b/packages/core/test/render3/i18n_debug_spec.ts
@@ -11,7 +11,7 @@ import {
   i18nRemoveOpCodesToString,
   i18nUpdateOpCodesToString,
   icuCreateOpCodesToString,
-} from '@angular/core/src/render3/i18n/i18n_debug';
+} from '../../src/render3/i18n/i18n_debug';
 import {
   ELEMENT_MARKER,
   I18nCreateOpCode,
@@ -21,7 +21,7 @@ import {
   I18nUpdateOpCodes,
   ICU_MARKER,
   IcuCreateOpCode,
-} from '@angular/core/src/render3/interfaces/i18n';
+} from '../../src/render3/interfaces/i18n';
 
 describe('i18n debug', () => {
   describe('i18nUpdateOpCodesToString', () => {

--- a/packages/core/test/render3/imported_renderer2.ts
+++ b/packages/core/test/render3/imported_renderer2.ts
@@ -7,8 +7,8 @@
  */
 
 import {PLATFORM_BROWSER_ID, PLATFORM_SERVER_ID} from '@angular/common/src/platform_id';
-import {type ListenerOptions, NgZone, RendererFactory2, RendererType2} from '@angular/core';
-import {NoopNgZone} from '@angular/core/src/zone/ng_zone';
+import {type ListenerOptions, NgZone, RendererFactory2, RendererType2} from '../../src/core';
+import {NoopNgZone} from '../../src/zone/ng_zone';
 import {EventManager, ɵDomRendererFactory2, ɵSharedStylesHost} from '@angular/platform-browser';
 import {EventManagerPlugin} from '@angular/platform-browser/src/dom/events/event_manager';
 

--- a/packages/core/test/render3/instructions/mock_renderer_factory.ts
+++ b/packages/core/test/render3/instructions/mock_renderer_factory.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {RendererStyleFlags2, RendererType2} from '@angular/core';
-import {Renderer, RendererFactory} from '@angular/core/src/render3/interfaces/renderer';
-import {RElement} from '@angular/core/src/render3/interfaces/renderer_dom';
+import {RendererStyleFlags2, RendererType2} from '../../../src/core';
+import {Renderer, RendererFactory} from '../../../src/render3/interfaces/renderer';
+import {RElement} from '../../../src/render3/interfaces/renderer_dom';
 
 export class MockRendererFactory implements RendererFactory {
   wasCalled = false;

--- a/packages/core/test/render3/instructions/shared_spec.ts
+++ b/packages/core/test/render3/instructions/shared_spec.ts
@@ -6,24 +6,19 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {TNodeType} from '@angular/core/src/render3/interfaces/node';
-import {
-  HEADER_OFFSET,
-  LViewFlags,
-  TVIEW,
-  TViewType,
-} from '@angular/core/src/render3/interfaces/view';
+import {TNodeType} from '../../../src/render3/interfaces/node';
+import {HEADER_OFFSET, LViewFlags, TVIEW, TViewType} from '../../../src/render3/interfaces/view';
 import {
   enterView,
   getBindingRoot,
   getLView,
   setBindingIndex,
   setSelectedIndex,
-} from '@angular/core/src/render3/state';
+} from '../../../src/render3/state';
 
 import {MockRendererFactory} from './mock_renderer_factory';
-import {createTNode} from '@angular/core/src/render3/tnode_manipulation';
-import {createLView, createTView} from '@angular/core/src/render3/view/construction';
+import {createTNode} from '../../../src/render3/tnode_manipulation';
+import {createLView, createTView} from '../../../src/render3/view/construction';
 
 /**
  * Setups a simple `LView` so that it is possible to do unit tests on instructions.

--- a/packages/core/test/render3/instructions/styling_spec.ts
+++ b/packages/core/test/render3/instructions/styling_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {AttributeMarker, DirectiveDef} from '@angular/core/src/render3';
-import {ɵɵdefineDirective} from '@angular/core/src/render3/definition';
+import {AttributeMarker, DirectiveDef} from '../../../src/render3';
+import {ɵɵdefineDirective} from '../../../src/render3/definition';
 import {
   classStringParser,
   styleStringParser,
@@ -15,8 +15,8 @@ import {
   ɵɵclassProp,
   ɵɵstyleMap,
   ɵɵstyleProp,
-} from '@angular/core/src/render3/instructions/styling';
-import {TAttributes} from '@angular/core/src/render3/interfaces/node';
+} from '../../../src/render3/instructions/styling';
+import {TAttributes} from '../../../src/render3/interfaces/node';
 import {
   getTStylingRangeNext,
   getTStylingRangeNextDuplicate,
@@ -28,13 +28,13 @@ import {
   toTStylingRange,
   TStylingKey,
   TStylingRange,
-} from '@angular/core/src/render3/interfaces/styling';
-import {HEADER_OFFSET, TVIEW} from '@angular/core/src/render3/interfaces/view';
-import {getLView, leaveView, setBindingRootForHostBindings} from '@angular/core/src/render3/state';
-import {getNativeByIndex} from '@angular/core/src/render3/util/view_utils';
-import {keyValueArraySet} from '@angular/core/src/util/array_utils';
-import {ngDevModeResetPerfCounters} from '@angular/core/src/util/ng_dev_mode';
-import {getElementClasses, getElementStyles} from '@angular/core/testing/src/styling';
+} from '../../../src/render3/interfaces/styling';
+import {HEADER_OFFSET, TVIEW} from '../../../src/render3/interfaces/view';
+import {getLView, leaveView, setBindingRootForHostBindings} from '../../../src/render3/state';
+import {getNativeByIndex} from '../../../src/render3/util/view_utils';
+import {keyValueArraySet} from '../../../src/util/array_utils';
+import {ngDevModeResetPerfCounters} from '../../../src/util/ng_dev_mode';
+import {getElementClasses, getElementStyles} from '../../../testing/src/styling';
 
 import {clearFirstUpdatePass, enterViewWithOneDiv, rewindBindingIndex} from './shared_spec';
 

--- a/packages/core/test/render3/instructions_spec.ts
+++ b/packages/core/test/render3/instructions_spec.ts
@@ -7,10 +7,10 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {Component, Input} from '@angular/core/public_api';
-import {ngDevModeResetPerfCounters} from '@angular/core/src/util/ng_dev_mode';
-import {TestBed} from '@angular/core/testing';
-import {getSortedClassName} from '@angular/core/testing/src/styling';
+import {Component, Input} from '../../src/core';
+import {ngDevModeResetPerfCounters} from '../../src/util/ng_dev_mode';
+import {TestBed} from '../../testing';
+import {getSortedClassName} from '../../testing/src/styling';
 
 import {
   ɵɵadvance,

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -7,8 +7,8 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {Component, Directive, HostBinding} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {Component, Directive, HostBinding} from '../../src/core';
+import {TestBed} from '../../testing';
 
 import {getLContext, readPatchedData} from '../../src/render3/context_discovery';
 import {CONTEXT, HEADER_OFFSET} from '../../src/render3/interfaces/view';

--- a/packages/core/test/render3/interfaces/node_spec.ts
+++ b/packages/core/test/render3/interfaces/node_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {TNodeType, toTNodeTypeAsString} from '@angular/core/src/render3/interfaces/node';
+import {TNodeType, toTNodeTypeAsString} from '../../../src/render3/interfaces/node';
 
 describe('node interfaces', () => {
   describe('TNodeType', () => {

--- a/packages/core/test/render3/is_shape_of.ts
+++ b/packages/core/test/render3/is_shape_of.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {TI18n, TIcu} from '@angular/core/src/render3/interfaces/i18n';
-import {TNode} from '@angular/core/src/render3/interfaces/node';
-import {TView} from '@angular/core/src/render3/interfaces/view';
+import {TI18n, TIcu} from '../../src/render3/interfaces/i18n';
+import {TNode} from '../../src/render3/interfaces/node';
+import {TView} from '../../src/render3/interfaces/view';
 
 /**
  * A type used to create a runtime representation of a shape of object which matches the declared

--- a/packages/core/test/render3/ivy/jit_spec.ts
+++ b/packages/core/test/render3/ivy/jit_spec.ts
@@ -24,13 +24,13 @@ import {
   ViewChildren,
   ɵNgModuleDef as NgModuleDef,
   ɵɵngDeclareComponent as ngDeclareComponent,
-} from '@angular/core';
-import {Injectable} from '@angular/core/src/di/injectable';
-import {setCurrentInjector, ɵɵinject} from '@angular/core/src/di/injector_compatibility';
-import {ɵɵdefineInjectable, ɵɵInjectorDef} from '@angular/core/src/di/interface/defs';
-import {FactoryFn} from '@angular/core/src/render3/definition_factory';
-import {ComponentDef, PipeDef} from '@angular/core/src/render3/interfaces/definition';
-import {InputFlags} from '@angular/core/src/render3/interfaces/input_flags';
+} from '../../../src/core';
+import {Injectable} from '../../../src/di/injectable';
+import {setCurrentInjector, ɵɵinject} from '../../../src/di/injector_compatibility';
+import {ɵɵdefineInjectable, ɵɵInjectorDef} from '../../../src/di/interface/defs';
+import {FactoryFn} from '../../../src/render3/definition_factory';
+import {ComponentDef, PipeDef} from '../../../src/render3/interfaces/definition';
+import {InputFlags} from '../../../src/render3/interfaces/input_flags';
 
 describe('render3 jit', () => {
   let injector: any;

--- a/packages/core/test/render3/jit/declare_classmetadata_spec.ts
+++ b/packages/core/test/render3/jit/declare_classmetadata_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Injectable, Input, Type, ɵɵngDeclareClassMetadata} from '@angular/core';
+import {Injectable, Input, Type, ɵɵngDeclareClassMetadata} from '../../../src/core';
 
 interface Decorator {
   type: any;

--- a/packages/core/test/render3/jit/declare_component_spec.ts
+++ b/packages/core/test/render3/jit/declare_component_spec.ts
@@ -17,7 +17,7 @@ import {
   Type,
   ViewEncapsulation,
   ɵɵngDeclareComponent,
-} from '@angular/core';
+} from '../../../src/core';
 
 import {
   AttributeMarker,

--- a/packages/core/test/render3/jit/declare_directive_spec.ts
+++ b/packages/core/test/render3/jit/declare_directive_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ElementRef, forwardRef, ɵɵngDeclareDirective} from '@angular/core';
+import {ElementRef, forwardRef, ɵɵngDeclareDirective} from '../../../src/core';
 
 import {
   AttributeMarker,
@@ -16,7 +16,7 @@ import {
 } from '../../../src/render3';
 
 import {functionContaining} from './matcher';
-import {InputFlags} from '@angular/core/src/render3/interfaces/input_flags';
+import {InputFlags} from '../../../src/render3/interfaces/input_flags';
 
 describe('directive declaration jit compilation', () => {
   it('should compile a minimal directive declaration', () => {

--- a/packages/core/test/render3/jit/declare_factory_spec.ts
+++ b/packages/core/test/render3/jit/declare_factory_spec.ts
@@ -13,9 +13,9 @@ import {
   ɵsetInjectorProfilerContext,
   ɵɵFactoryTarget,
   ɵɵngDeclareFactory,
-} from '@angular/core';
-import {ɵɵdefineInjector} from '@angular/core/src/di';
-import {RetrievingInjector, setCurrentInjector} from '@angular/core/src/di/injector_compatibility';
+} from '../../../src/core';
+import {ɵɵdefineInjector} from '../../../src/di';
+import {RetrievingInjector, setCurrentInjector} from '../../../src/di/injector_compatibility';
 
 describe('Factory declaration jit compilation', () => {
   let previousInjector: RetrievingInjector | null | undefined;

--- a/packages/core/test/render3/jit/declare_injectable_spec.ts
+++ b/packages/core/test/render3/jit/declare_injectable_spec.ts
@@ -18,8 +18,8 @@ import {
   ɵɵInjectableDeclaration,
   ɵɵngDeclareInjectable,
   ɵɵngDeclareInjector,
-} from '@angular/core';
-import {RetrievingInjector} from '@angular/core/src/di/injector_compatibility';
+} from '../../../src/core';
+import {RetrievingInjector} from '../../../src/di/injector_compatibility';
 
 describe('Injectable declaration jit compilation', () => {
   let previousInjector: RetrievingInjector | null | undefined;

--- a/packages/core/test/render3/jit/declare_injector_spec.ts
+++ b/packages/core/test/render3/jit/declare_injector_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {InjectionToken, ɵɵInjectorDef, ɵɵngDeclareInjector} from '@angular/core';
+import {InjectionToken, ɵɵInjectorDef, ɵɵngDeclareInjector} from '../../../src/core';
 
 describe('Injector declaration jit compilation', () => {
   it('should compile a minimal Injector declaration', () => {

--- a/packages/core/test/render3/jit/declare_ng_module_spec.ts
+++ b/packages/core/test/render3/jit/declare_ng_module_spec.ts
@@ -12,7 +12,7 @@ import {
   Type,
   ɵNgModuleDef,
   ɵɵngDeclareNgModule,
-} from '@angular/core';
+} from '../../../src/core';
 
 describe('NgModule declaration jit compilation', () => {
   it('should compile a minimal NgModule declaration', () => {

--- a/packages/core/test/render3/jit/declare_pipe_spec.ts
+++ b/packages/core/test/render3/jit/declare_pipe_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ɵɵngDeclarePipe} from '@angular/core';
+import {ɵɵngDeclarePipe} from '../../../src/core';
 import {PipeDef} from '../../../src/render3';
 
 describe('Pipe declaration jit compilation', () => {

--- a/packages/core/test/render3/jit/directive_spec.ts
+++ b/packages/core/test/render3/jit/directive_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Directive, HostListener, Input} from '@angular/core';
+import {Directive, HostListener, Input} from '../../../src/core';
 
 import {
   convertToR3QueryMetadata,

--- a/packages/core/test/render3/list_reconciliation_spec.ts
+++ b/packages/core/test/render3/list_reconciliation_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {LiveCollection, reconcile} from '@angular/core/src/render3/list_reconciliation';
-import {assertDefined} from '@angular/core/src/util/assert';
+import {LiveCollection, reconcile} from '../../src/render3/list_reconciliation';
+import {assertDefined} from '../../src/util/assert';
 
 interface ItemAdapter<T, V> {
   create(index: number, value: V): T;
@@ -41,7 +41,7 @@ class LoggingLiveCollection<T, V> extends LiveCollection<T, V> {
     super();
   }
 
-  get length(): number {
+  override get length(): number {
     return this.arr.length;
   }
   override at(index: number): V {

--- a/packages/core/test/render3/matchers.ts
+++ b/packages/core/test/render3/matchers.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {I18nDebug, IcuCreateOpCodes, TI18n, TIcu} from '@angular/core/src/render3/interfaces/i18n';
-import {TNode} from '@angular/core/src/render3/interfaces/node';
-import {TView} from '@angular/core/src/render3/interfaces/view';
+import {I18nDebug, IcuCreateOpCodes, TI18n, TIcu} from '../../src/render3/interfaces/i18n';
+import {TNode} from '../../src/render3/interfaces/node';
+import {TView} from '../../src/render3/interfaces/view';
 
 import {isDOMElement, isDOMText, isTI18n, isTIcu, isTNode, isTView} from './is_shape_of';
 

--- a/packages/core/test/render3/matchers_spec.ts
+++ b/packages/core/test/render3/matchers_spec.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {TNodeType} from '@angular/core/src/render3/interfaces/node';
-import {TViewType} from '@angular/core/src/render3/interfaces/view';
+import {TNodeType} from '../../src/render3/interfaces/node';
+import {TViewType} from '../../src/render3/interfaces/view';
 
 import {isShapeOf, ShapeOf} from './is_shape_of';
 import {matchDomElement, matchDomText, matchObjectShape, matchTNode, matchTView} from './matchers';
-import {createTNode} from '@angular/core/src/render3/tnode_manipulation';
-import {createTView} from '@angular/core/src/render3/view/construction';
+import {createTNode} from '../../src/render3/tnode_manipulation';
+import {createTView} from '../../src/render3/view/construction';
 
 describe('render3 matchers', () => {
   const fakeMatcherUtil = {equals: (a: any, b: any) => a === b} as jasmine.MatchersUtil;

--- a/packages/core/test/render3/multi_map_spec.ts
+++ b/packages/core/test/render3/multi_map_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {UniqueValueMultiKeyMap} from '@angular/core/src/render3/list_reconciliation';
+import {UniqueValueMultiKeyMap} from '../../src/render3/list_reconciliation';
 
 describe('MultiMap', () => {
   it('should set, get and remove items with duplicated keys', () => {

--- a/packages/core/test/render3/providers_helper.ts
+++ b/packages/core/test/render3/providers_helper.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, Directive, Provider, Type, ViewEncapsulation} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {Component, Directive, Provider, Type, ViewEncapsulation} from '../../src/core';
+import {TestBed} from '../../testing';
 
 export interface ComponentTest {
   providers?: Provider[];

--- a/packages/core/test/render3/providers_spec.ts
+++ b/packages/core/test/render3/providers_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {TestBed} from '@angular/core/testing';
+import {TestBed} from '../../testing';
 
 import {
   Component,

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -15,8 +15,8 @@ import {
   ViewChild,
   ViewChildren,
   ViewContainerRef,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {TestBed} from '../../testing';
 
 describe('query', () => {
   describe('predicate', () => {

--- a/packages/core/test/render3/reactive_safety_spec.ts
+++ b/packages/core/test/render3/reactive_safety_spec.ts
@@ -23,11 +23,11 @@ import {
   TemplateRef,
   ViewChild,
   ViewContainerRef,
-} from '@angular/core';
-import {getActiveConsumer} from '@angular/core/primitives/signals';
-import {createInjector} from '@angular/core/src/di/create_injector';
-import {setUseMicrotaskEffectsByDefault} from '@angular/core/src/render3/reactivity/effect';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {getActiveConsumer} from '../../primitives/signals';
+import {createInjector} from '../../src/di/create_injector';
+import {setUseMicrotaskEffectsByDefault} from '../../src/render3/reactivity/effect';
+import {TestBed} from '../../testing';
 
 /*
  * Contains tests which validate that certain actions within the framework (for example, creating

--- a/packages/core/test/render3/reactivity_spec.ts
+++ b/packages/core/test/render3/reactivity_spec.ts
@@ -34,14 +34,11 @@ import {
   TemplateRef,
   ViewChild,
   ViewContainerRef,
-} from '@angular/core';
-import {SIGNAL} from '@angular/core/primitives/signals';
-import {toObservable} from '@angular/core/rxjs-interop';
-import {
-  EffectNode,
-  setUseMicrotaskEffectsByDefault,
-} from '@angular/core/src/render3/reactivity/effect';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {SIGNAL} from '../../primitives/signals';
+import {toObservable} from '../../rxjs-interop';
+import {EffectNode, setUseMicrotaskEffectsByDefault} from '../../src/render3/reactivity/effect';
+import {TestBed} from '../../testing';
 import {bootstrapApplication} from '@angular/platform-browser';
 import {withBody} from '@angular/private/testing';
 

--- a/packages/core/test/render3/styling_next/static_styling_spec.ts
+++ b/packages/core/test/render3/styling_next/static_styling_spec.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {AttributeMarker} from '@angular/core/src/render3/interfaces/attribute_marker';
-import {TAttributes, TNode, TNodeType} from '@angular/core/src/render3/interfaces/node';
-import {LView} from '@angular/core/src/render3/interfaces/view';
-import {enterView} from '@angular/core/src/render3/state';
-import {computeStaticStyling} from '@angular/core/src/render3/styling/static_styling';
-import {createTNode} from '@angular/core/src/render3/tnode_manipulation';
+import {AttributeMarker} from '../../../src/render3/interfaces/attribute_marker';
+import {TAttributes, TNode, TNodeType} from '../../../src/render3/interfaces/node';
+import {LView} from '../../../src/render3/interfaces/view';
+import {enterView} from '../../../src/render3/state';
+import {computeStaticStyling} from '../../../src/render3/styling/static_styling';
+import {createTNode} from '../../../src/render3/tnode_manipulation';
 
 describe('static styling', () => {
   const mockFirstCreatePassLView: LView = [null, {firstCreatePass: true}] as any;

--- a/packages/core/test/render3/styling_next/style_binding_list_spec.ts
+++ b/packages/core/test/render3/styling_next/style_binding_list_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {TNode, TNodeType} from '@angular/core/src/render3/interfaces/node';
+import {TNode, TNodeType} from '../../../src/render3/interfaces/node';
 import {
   getTStylingRangeNext,
   getTStylingRangeNextDuplicate,
@@ -14,12 +14,12 @@ import {
   getTStylingRangePrevDuplicate,
   TStylingKey,
   TStylingRange,
-} from '@angular/core/src/render3/interfaces/styling';
-import {LView, TData} from '@angular/core/src/render3/interfaces/view';
-import {enterView, leaveView} from '@angular/core/src/render3/state';
-import {insertTStylingBinding} from '@angular/core/src/render3/styling/style_binding_list';
-import {createTNode} from '@angular/core/src/render3/tnode_manipulation';
-import {newArray} from '@angular/core/src/util/array_utils';
+} from '../../../src/render3/interfaces/styling';
+import {LView, TData} from '../../../src/render3/interfaces/view';
+import {enterView, leaveView} from '../../../src/render3/state';
+import {insertTStylingBinding} from '../../../src/render3/styling/style_binding_list';
+import {createTNode} from '../../../src/render3/tnode_manipulation';
+import {newArray} from '../../../src/util/array_utils';
 
 describe('TNode styling linked list', () => {
   const mockFirstUpdatePassLView: LView = [null, {firstUpdatePass: true}] as any;

--- a/packages/core/test/render3/util/attr_util_spec.ts
+++ b/packages/core/test/render3/util/attr_util_spec.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {AttributeMarker} from '@angular/core/src/render3';
-import {TAttributes} from '@angular/core/src/render3/interfaces/node';
-import {mergeHostAttribute, mergeHostAttrs} from '@angular/core/src/render3/util/attrs_utils';
+import {AttributeMarker} from '../../../src/render3';
+import {TAttributes} from '../../../src/render3/interfaces/node';
+import {mergeHostAttribute, mergeHostAttrs} from '../../../src/render3/util/attrs_utils';
 
 describe('attr_util', () => {
   describe('mergeHostAttribute', () => {

--- a/packages/core/test/render3/util/stringify_util_spec.ts
+++ b/packages/core/test/render3/util/stringify_util_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ɵsetClassDebugInfo, ɵɵdefineComponent} from '@angular/core/src/render3';
-import {debugStringifyTypeForError} from '@angular/core/src/render3/util/stringify_utils';
+import {ɵsetClassDebugInfo, ɵɵdefineComponent} from '../../../src/render3';
+import {debugStringifyTypeForError} from '../../../src/render3/util/stringify_utils';
 
 describe('stringify utils', () => {
   describe('stringifyTypeForError util', () => {

--- a/packages/core/test/render3/view_fixture.ts
+++ b/packages/core/test/render3/view_fixture.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Sanitizer, Type} from '@angular/core';
+import {Sanitizer, Type} from '../../src/core';
 import {stringifyElement} from '@angular/platform-browser/testing/src/browser_util';
 
 import {extractDirectiveDef} from '../../src/render3/definition';
@@ -33,8 +33,8 @@ import {enterView, leaveView, specOnlyIsInstructionStateEmpty} from '../../src/r
 import {noop} from '../../src/util/noop';
 
 import {getRendererFactory2} from './imported_renderer2';
-import {createTNode} from '@angular/core/src/render3/tnode_manipulation';
-import {createLView, createTView} from '@angular/core/src/render3/view/construction';
+import {createTNode} from '../../src/render3/tnode_manipulation';
+import {createLView, createTView} from '../../src/render3/view/construction';
 
 /**
  * Fixture useful for testing operations which need `LView` / `TView`

--- a/packages/core/test/render3/view_utils_spec.ts
+++ b/packages/core/test/render3/view_utils_spec.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {isLContainer, isLView} from '@angular/core/src/render3/interfaces/type_checks';
+import {isLContainer, isLView} from '../../src/render3/interfaces/type_checks';
 import {ViewFixture} from './view_fixture';
-import {createTNode} from '@angular/core/src/render3/tnode_manipulation';
-import {createLContainer} from '@angular/core/src/render3/view/container';
+import {createTNode} from '../../src/render3/tnode_manipulation';
+import {createLContainer} from '../../src/render3/view/container';
 
 describe('view_utils', () => {
   it('should verify unwrap methods (isLView and isLContainer)', () => {

--- a/packages/core/test/resource/resource_spec.ts
+++ b/packages/core/test/resource/resource_spec.ts
@@ -14,8 +14,8 @@ import {
   resource,
   ResourceStatus,
   signal,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../../src/core';
+import {TestBed} from '../../testing';
 
 abstract class MockBackend<T, R> {
   protected pending = new Map<

--- a/packages/core/test/sanitization/sanitization_spec.ts
+++ b/packages/core/test/sanitization/sanitization_spec.ts
@@ -7,8 +7,8 @@
  */
 
 import {SECURITY_SCHEMA} from '@angular/compiler/src/schema/dom_security_schema';
-import {ENVIRONMENT, LView} from '@angular/core/src/render3/interfaces/view';
-import {enterView, leaveView} from '@angular/core/src/render3/state';
+import {ENVIRONMENT, LView} from '../../src/render3/interfaces/view';
+import {enterView, leaveView} from '../../src/render3/state';
 
 import {
   bypassSanitizationTrustHtml,

--- a/packages/core/test/signals/computed_spec.ts
+++ b/packages/core/test/signals/computed_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, signal} from '@angular/core';
-import {createWatch, ReactiveNode, SIGNAL, defaultEquals} from '@angular/core/primitives/signals';
+import {computed, signal} from '../../src/core';
+import {createWatch, ReactiveNode, SIGNAL, defaultEquals} from '../../primitives/signals';
 
 describe('computed', () => {
   it('should create computed', () => {

--- a/packages/core/test/signals/effect_util.ts
+++ b/packages/core/test/signals/effect_util.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {createWatch, Watch, WatchCleanupFn} from '@angular/core/primitives/signals';
+import {createWatch, Watch, WatchCleanupFn} from '../../primitives/signals';
 
 let queue = new Set<Watch>();
 

--- a/packages/core/test/signals/glitch_free_spec.ts
+++ b/packages/core/test/signals/glitch_free_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, signal} from '@angular/core';
+import {computed, signal} from '../../src/core';
 
 describe('glitch-free computations', () => {
   it('should recompute only once for diamond dependency graph', () => {

--- a/packages/core/test/signals/is_signal_spec.ts
+++ b/packages/core/test/signals/is_signal_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, isSignal, signal} from '@angular/core';
+import {computed, isSignal, signal} from '../../src/core';
 
 describe('isSignal', () => {
   it('should return true for writable signal', () => {

--- a/packages/core/test/signals/linked_signal_spec.ts
+++ b/packages/core/test/signals/linked_signal_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {isSignal, linkedSignal, signal, computed} from '@angular/core';
+import {isSignal, linkedSignal, signal, computed} from '../../src/core';
 import {testingEffect} from './effect_util';
 
 describe('linkedSignal', () => {

--- a/packages/core/test/signals/non_reactive_spec.ts
+++ b/packages/core/test/signals/non_reactive_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, signal, untracked} from '@angular/core';
+import {computed, signal, untracked} from '../../src/core';
 
 import {flushEffects, resetEffects, testingEffect} from './effect_util';
 

--- a/packages/core/test/signals/signal_spec.ts
+++ b/packages/core/test/signals/signal_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, signal} from '@angular/core';
-import {ReactiveNode, setPostSignalSetFn, SIGNAL} from '@angular/core/primitives/signals';
+import {computed, signal} from '../../src/core';
+import {ReactiveNode, setPostSignalSetFn, SIGNAL} from '../../primitives/signals';
 
 describe('signals', () => {
   it('should be a getter which reflects the set value', () => {

--- a/packages/core/test/signals/watch_spec.ts
+++ b/packages/core/test/signals/watch_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, signal} from '@angular/core';
-import {createWatch} from '@angular/core/primitives/signals';
+import {computed, signal} from '../../src/core';
+import {createWatch} from '../../primitives/signals';
 
 import {flushEffects, resetEffects, testingEffect} from './effect_util';
 

--- a/packages/core/test/strict_types/inheritance_spec.ts
+++ b/packages/core/test/strict_types/inheritance_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ɵɵComponentDeclaration, ɵɵPipeDeclaration} from '@angular/core';
+import {ɵɵComponentDeclaration, ɵɵPipeDeclaration} from '../../src/core';
 
 declare class SuperComponent {
   static ɵcmp: ɵɵComponentDeclaration<SuperComponent, '[super]', never, {}, {}, never, never>;

--- a/packages/core/test/test_bed_effect_spec.ts
+++ b/packages/core/test/test_bed_effect_spec.ts
@@ -17,8 +17,8 @@ import {
   NgZone,
   provideZoneChangeDetection,
   signal,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+} from '../src/core';
+import {TestBed} from '../testing';
 import {setUseMicrotaskEffectsByDefault} from '../src/render3/reactivity/effect';
 
 describe('effects in TestBed', () => {

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -40,9 +40,9 @@ import {
   ɵɵelementStart as elementStart,
   ɵɵsetNgModuleScope as setNgModuleScope,
   ɵɵtext as text,
-} from '@angular/core';
-import {DeferBlockBehavior} from '@angular/core/testing';
-import {TestBed, TestBedImpl} from '@angular/core/testing/src/test_bed';
+} from '../src/core';
+import {DeferBlockBehavior} from '../testing';
+import {TestBed, TestBedImpl} from '../testing/src/test_bed';
 import {By} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 

--- a/packages/core/test/testability/testability_spec.ts
+++ b/packages/core/test/testability/testability_spec.ts
@@ -6,18 +6,17 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {EventEmitter} from '@angular/core';
-import {Injectable} from '@angular/core/src/di';
+import {EventEmitter} from '../../src/core';
+import {Injectable} from '../../src/di';
 import {
   GetTestability,
   PendingMacrotask,
   Testability,
   TestabilityRegistry,
-} from '@angular/core/src/testability/testability';
-import {NgZone} from '@angular/core/src/zone/ng_zone';
-import {fakeAsync, tick, waitForAsync} from '@angular/core/testing';
-
-import {setTestabilityGetter} from '../../src/testability/testability';
+  setTestabilityGetter,
+} from '../../src/testability/testability';
+import {NgZone} from '../../src/zone/ng_zone';
+import {fakeAsync, tick, waitForAsync} from '../../testing';
 
 // Schedules a microtasks (using queueMicrotask)
 function microTask(fn: Function): void {

--- a/packages/core/test/transfer_state_spec.ts
+++ b/packages/core/test/transfer_state_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {APP_ID as APP_ID_TOKEN, PLATFORM_ID} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {APP_ID as APP_ID_TOKEN, PLATFORM_ID} from '../src/core';
+import {TestBed} from '../testing';
 
 import {getDocument} from '../src/render3/interfaces/document';
 import {makeStateKey, TransferState} from '../src/transfer_state';

--- a/packages/core/test/util/coercion_spec.ts
+++ b/packages/core/test/util/coercion_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {booleanAttribute, numberAttribute} from '@angular/core';
+import {booleanAttribute, numberAttribute} from '../../src/core';
 
 describe('coercion functions', () => {
   describe('booleanAttribute', () => {

--- a/packages/core/test/util/comparison.ts
+++ b/packages/core/test/util/comparison.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {devModeEqual} from '@angular/core/src/util/comparison';
+import {devModeEqual} from '../../src/util/comparison';
 
 describe('Comparison util', () => {
   describe('devModeEqual', () => {

--- a/packages/core/test/util/dom_spec.ts
+++ b/packages/core/test/util/dom_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {escapeCommentText} from '@angular/core/src/util/dom';
+import {escapeCommentText} from '../../src/util/dom';
 
 describe('comment node text escaping', () => {
   describe('escapeCommentText', () => {

--- a/packages/core/test/util/lang_spec.ts
+++ b/packages/core/test/util/lang_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {isSubscribable} from '@angular/core/src/util/lang';
+import {isSubscribable} from '../../src/util/lang';
 import {of} from 'rxjs';
 
 describe('isSubscribable', () => {

--- a/packages/core/test/util/stringify_spec.ts
+++ b/packages/core/test/util/stringify_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {concatStringsWithSpace} from '@angular/core/src/util/stringify';
+import {concatStringsWithSpace} from '../../src/util/stringify';
 
 describe('stringify', () => {
   describe('concatStringsWithSpace', () => {

--- a/packages/core/test/zone/ng_zone_spec.ts
+++ b/packages/core/test/zone/ng_zone_spec.ts
@@ -12,7 +12,7 @@ import {
   NgZone,
   afterRender,
   provideZoneChangeDetection,
-} from '@angular/core';
+} from '../../src/core';
 import {
   TestBed,
   fakeAsync,
@@ -21,8 +21,8 @@ import {
   inject,
   tick,
   waitForAsync,
-} from '@angular/core/testing';
-import {Log} from '@angular/core/testing/src/testing_internal';
+} from '../../testing';
+import {Log} from '../../testing/src/testing_internal';
 import {firstValueFrom} from 'rxjs';
 
 import {scheduleCallbackWithRafRace as scheduler} from '../../src/util/callback_scheduler';


### PR DESCRIPTION
This is a cherry-pick version of https://github.com/angular/angular/pull/60227 into the patch (19.2.x) branch.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No