### PR TITLE
refactor(router): switching to relative imports within the `router` package

### DIFF
--- a/goldens/public-api/router/testing/index.api.md
+++ b/goldens/public-api/router/testing/index.api.md
@@ -4,13 +4,29 @@
 
 ```ts
 
+import { AfterContentInit } from '@angular/core';
 import * as _angular_router from '@angular/router';
+import { ChangeDetectorRef } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
+import { ComponentRef } from '@angular/core';
 import { DebugElement } from '@angular/core';
-import { ExtraOptions } from '@angular/router';
+import { ElementRef } from '@angular/core';
+import { EnvironmentInjector } from '@angular/core';
+import { EnvironmentProviders } from '@angular/core';
+import { EventEmitter } from '@angular/core';
 import * as i0 from '@angular/core';
+import { LocationStrategy } from '@angular/common';
 import { ModuleWithProviders } from '@angular/core';
-import { Routes } from '@angular/router';
+import { NgModuleFactory } from '@angular/core';
+import { Observable } from 'rxjs';
+import { OnChanges } from '@angular/core';
+import { OnDestroy } from '@angular/core';
+import { OnInit } from '@angular/core';
+import { Provider } from '@angular/core';
+import { ProviderToken } from '@angular/core';
+import { QueryList } from '@angular/core';
+import { Renderer2 } from '@angular/core';
+import { SimpleChanges } from '@angular/core';
 import { Type } from '@angular/core';
 import { WritableSignal } from '@angular/core';
 
@@ -36,7 +52,7 @@ export class RouterTestingModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<RouterTestingModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<RouterTestingModule, never, never, [typeof _angular_router.RouterModule]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<RouterTestingModule, never, never, [typeof RouterModule]>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -31,7 +31,7 @@ import {
   RouterModule,
   RouterOutlet,
   withEnabledBlockingInitialNavigation,
-} from '@angular/router';
+} from '../index';
 
 // This is needed, because all files under `packages/` are compiled together as part of the
 // [legacy-unit-tests-saucelabs][1] CI job, including the `lib.webworker.d.ts` typings brought in by

--- a/packages/router/test/computed_state_restoration.spec.ts
+++ b/packages/router/test/computed_state_restoration.spec.ts
@@ -11,7 +11,7 @@ import {provideLocationMocks, SpyLocation} from '@angular/common/testing';
 import {Component, Injectable, NgModule, Type} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {Router, RouterModule, RouterOutlet, UrlTree, withRouterConfig} from '@angular/router';
+import {Router, RouterModule, RouterOutlet, UrlTree, withRouterConfig} from '../index';
 import {EMPTY, of} from 'rxjs';
 
 import {provideRouter} from '../src/provide_router';

--- a/packages/router/test/default_export_routes.ts
+++ b/packages/router/test/default_export_routes.ts
@@ -7,7 +7,7 @@
  */
 
 import {Component} from '@angular/core';
-import {Routes} from '@angular/router';
+import {Routes} from '../index';
 
 @Component({
   template: 'default exported',

--- a/packages/router/test/directives/router_outlet.spec.ts
+++ b/packages/router/test/directives/router_outlet.spec.ts
@@ -24,8 +24,8 @@ import {
   RouterOutlet,
   withComponentInputBinding,
   ROUTER_OUTLET_DATA,
-} from '@angular/router/src';
-import {RouterTestingHarness} from '@angular/router/testing';
+} from '../../index';
+import {RouterTestingHarness} from '../../testing';
 import {InjectionToken} from '../../../core/src/di';
 
 describe('router outlet name', () => {

--- a/packages/router/test/integration/duplicate_in_flight_navigations.spec.ts
+++ b/packages/router/test/integration/duplicate_in_flight_navigations.spec.ts
@@ -17,7 +17,7 @@ import {
   withRouterConfig,
   NavigationStart,
   GuardsCheckEnd,
-} from '@angular/router/src';
+} from '../../index';
 import {createRoot, SimpleCmp, advance, RootCmp, BlankCmp} from './integration_helpers';
 
 export function duplicateInFlightNavigationsIntegrationSuite() {

--- a/packages/router/test/integration/integration.spec.ts
+++ b/packages/router/test/integration/integration.spec.ts
@@ -36,8 +36,8 @@ import {
   Router,
   RouterModule,
   RoutesRecognized,
-} from '@angular/router';
-import {RouterTestingHarness} from '@angular/router/testing';
+} from '../../index';
+import {RouterTestingHarness} from '../../testing';
 
 import {RedirectCommand} from '../../src/models';
 import {

--- a/packages/router/test/integration/integration_helpers.ts
+++ b/packages/router/test/integration/integration_helpers.ts
@@ -21,7 +21,7 @@ import {
   RouterModule,
   RouterOutlet,
   UrlSegment,
-} from '@angular/router';
+} from '../../index';
 import {Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 

--- a/packages/router/test/integration/lazy_loading.spec.ts
+++ b/packages/router/test/integration/lazy_loading.spec.ts
@@ -45,8 +45,8 @@ import {
   provideRouter,
   withRouterConfig,
   RouterLink,
-} from '@angular/router/src';
-import {getLoadedRoutes} from '@angular/router/src/router_devtools';
+} from '../../index';
+import {getLoadedRoutes} from '../../src/router_devtools';
 import {
   createRoot,
   RootCmp,

--- a/packages/router/test/integration/navigation_errors.spec.ts
+++ b/packages/router/test/integration/navigation_errors.spec.ts
@@ -32,7 +32,7 @@ import {
   NavigationCancel,
   NavigationCancellationCode,
 } from '../../src';
-import {RouterTestingHarness} from '@angular/router/testing';
+import {RouterTestingHarness} from '../../testing';
 import {
   createRoot,
   RootCmp,

--- a/packages/router/test/integration/redirects.spec.ts
+++ b/packages/router/test/integration/redirects.spec.ts
@@ -7,7 +7,7 @@
  */
 import {LocationStrategy, Location, HashLocationStrategy} from '@angular/common';
 import {fakeAsync, TestBed, inject} from '@angular/core/testing';
-import {Router, NavigationStart, RoutesRecognized} from '@angular/router/src';
+import {Router, NavigationStart, RoutesRecognized} from '../../src';
 import {createRoot, RootCmp, BlankCmp, TeamCmp, advance} from './integration_helpers';
 
 export function redirectsIntegrationSuite() {

--- a/packages/router/test/integration/route_data.spec.ts
+++ b/packages/router/test/integration/route_data.spec.ts
@@ -24,7 +24,7 @@ import {
   NavigationCancellationCode,
   RouterModule,
   ResolveFn,
-} from '@angular/router/src';
+} from '../../src';
 import {map} from 'rxjs/operators';
 import {EMPTY, Observer, Observable, of} from 'rxjs';
 import {By} from '@angular/platform-browser/src/dom/debug/by';

--- a/packages/router/test/integration/route_reuse_strategy.spec.ts
+++ b/packages/router/test/integration/route_reuse_strategy.spec.ts
@@ -17,7 +17,7 @@ import {
   Router,
   NavigationEnd,
   RouterModule,
-} from '@angular/router/src';
+} from '../../src';
 import {Subscription} from 'rxjs';
 import {filter} from 'rxjs/operators';
 import {By} from '@angular/platform-browser/src/dom/debug/by';

--- a/packages/router/test/integration/router_events.spec.ts
+++ b/packages/router/test/integration/router_events.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import {filter, tap, first} from 'rxjs/operators';
-import {Event} from '@angular/router';
+import {Event} from '../../index';
 import {fakeAsync, inject} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {
@@ -23,7 +23,7 @@ import {
   ResolveEnd,
   NavigationEnd,
   NavigationError,
-} from '@angular/router/src';
+} from '../../src';
 import {createRoot, RootCmp, BlankCmp, UserCmp, advance, expectEvents} from './integration_helpers';
 
 export function routerEventsIntegrationSuite() {

--- a/packages/router/test/integration/router_link_active.spec.ts
+++ b/packages/router/test/integration/router_link_active.spec.ts
@@ -8,7 +8,7 @@
 import {Component, NgZone} from '@angular/core';
 import {Location} from '@angular/common';
 import {fakeAsync, TestBed, inject} from '@angular/core/testing';
-import {Router, provideRouter} from '@angular/router/src';
+import {Router, provideRouter} from '../../src';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {
   createRoot,

--- a/packages/router/test/integration/router_links.spec.ts
+++ b/packages/router/test/integration/router_links.spec.ts
@@ -9,7 +9,7 @@ import {Component} from '@angular/core';
 import {Location} from '@angular/common';
 import {fakeAsync, TestBed, inject, ComponentFixture} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
-import {Router} from '@angular/router/src';
+import {Router} from '../../src';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {
   advance,

--- a/packages/router/test/operators/prioritized_guard_value.spec.ts
+++ b/packages/router/test/operators/prioritized_guard_value.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {TestBed} from '@angular/core/testing';
-import {RouterModule} from '@angular/router';
+import {RouterModule} from '../../index';
 import {TestScheduler} from 'rxjs/testing';
 
 import {prioritizedGuardValue} from '../../src/operators/prioritized_guard_value';

--- a/packages/router/test/operators/resolve_data.spec.ts
+++ b/packages/router/test/operators/resolve_data.spec.ts
@@ -8,8 +8,8 @@
 
 import {Component} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {ActivatedRouteSnapshot, provideRouter, Router} from '@angular/router';
-import {RouterTestingHarness} from '@angular/router/testing';
+import {ActivatedRouteSnapshot, provideRouter, Router} from '../../index';
+import {RouterTestingHarness} from '../../testing';
 import {EMPTY, interval, NEVER, of} from 'rxjs';
 
 describe('resolveData operator', () => {

--- a/packages/router/test/page_title_strategy_spec.ts
+++ b/packages/router/test/page_title_strategy_spec.ts
@@ -20,8 +20,8 @@ import {
   RouterStateSnapshot,
   TitleStrategy,
   withRouterConfig,
-} from '@angular/router';
-import {RouterTestingHarness} from '@angular/router/testing';
+} from '../index';
+import {RouterTestingHarness} from '../testing';
 
 describe('title strategy', () => {
   describe('DefaultTitleStrategy', () => {

--- a/packages/router/test/regression_integration.spec.ts
+++ b/packages/router/test/regression_integration.spec.ts
@@ -31,7 +31,7 @@ import {
   RouterOutlet,
   UrlSerializer,
   UrlTree,
-} from '@angular/router';
+} from '../index';
 import {of} from 'rxjs';
 import {delay, filter, mapTo, take} from 'rxjs/operators';
 

--- a/packages/router/test/router.spec.ts
+++ b/packages/router/test/router.spec.ts
@@ -9,7 +9,7 @@
 import {Location} from '@angular/common';
 import {EnvironmentInjector, inject as coreInject} from '@angular/core';
 import {inject, TestBed} from '@angular/core/testing';
-import {RouterModule} from '@angular/router';
+import {RouterModule} from '../index';
 import {of} from 'rxjs';
 
 import {ChildActivationStart} from '../src/events';

--- a/packages/router/test/router_devtools.spec.ts
+++ b/packages/router/test/router_devtools.spec.ts
@@ -8,7 +8,7 @@
 
 import {Component} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
-import {Router, RouterModule} from '@angular/router';
+import {Router, RouterModule} from '../index';
 import {getLoadedRoutes} from '../src/router_devtools';
 
 @Component({template: '<div>simple standalone</div>'})

--- a/packages/router/test/router_link_active.spec.ts
+++ b/packages/router/test/router_link_active.spec.ts
@@ -7,7 +7,7 @@
  */
 import {Component} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {Router, RouterLink, RouterLinkActive, provideRouter} from '@angular/router';
+import {Router, RouterLink, RouterLinkActive, provideRouter} from '../index';
 
 describe('RouterLinkActive', () => {
   it('removes initial active class even if never active', async () => {

--- a/packages/router/test/router_link_spec.ts
+++ b/packages/router/test/router_link_spec.ts
@@ -9,7 +9,7 @@
 import {Component, inject, signal, provideExperimentalZonelessChangeDetection} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {Router, RouterLink, RouterModule, provideRouter} from '@angular/router';
+import {Router, RouterLink, RouterModule, provideRouter} from '../index';
 
 describe('RouterLink', () => {
   beforeEach(() => {

--- a/packages/router/test/router_navigation_extras.spec.ts
+++ b/packages/router/test/router_navigation_extras.spec.ts
@@ -9,7 +9,7 @@
 import {Location} from '@angular/common';
 import {Component, inject} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {Router, withRouterConfig} from '@angular/router';
+import {Router, withRouterConfig} from '../index';
 
 import {provideRouter} from '../src/provide_router';
 

--- a/packages/router/test/router_preloader.spec.ts
+++ b/packages/router/test/router_preloader.spec.ts
@@ -26,11 +26,15 @@ import {
   RouterPreloader,
   ROUTES,
   withPreloading,
-} from '@angular/router';
+  Route,
+  RouteConfigLoadEnd,
+  RouteConfigLoadStart,
+  Router,
+  RouterModule,
+} from '../index';
 import {BehaviorSubject, Observable, of, throwError} from 'rxjs';
 import {catchError, delay, filter, switchMap, take} from 'rxjs/operators';
 
-import {Route, RouteConfigLoadEnd, RouteConfigLoadStart, Router, RouterModule} from '../index';
 import {provideRouter} from '../src/provide_router';
 import {
   getLoadedComponent,

--- a/packages/router/test/router_scroller.spec.ts
+++ b/packages/router/test/router_scroller.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {TestBed, fakeAsync, tick} from '@angular/core/testing';
-import {DefaultUrlSerializer, Event, NavigationEnd, NavigationStart} from '@angular/router';
+import {DefaultUrlSerializer, Event, NavigationEnd, NavigationStart} from '../index';
 import {Subject} from 'rxjs';
 import {filter, switchMap, take} from 'rxjs/operators';
 

--- a/packages/router/test/standalone.spec.ts
+++ b/packages/router/test/standalone.spec.ts
@@ -9,7 +9,7 @@
 import {Component, Injectable, NgModule} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {provideRoutes, Router, RouterModule, ROUTES} from '@angular/router';
+import {provideRoutes, Router, RouterModule, ROUTES} from '../index';
 
 @Component({template: '<div>simple standalone</div>'})
 export class SimpleStandaloneComponent {}

--- a/packages/router/test/view_transitions.spec.ts
+++ b/packages/router/test/view_transitions.spec.ts
@@ -17,7 +17,7 @@ import {
   Router,
   withDisabledInitialNavigation,
   withViewTransitions,
-} from '@angular/router';
+} from '../index';
 
 describe('view transitions', () => {
   if (isNode) {

--- a/packages/router/testing/src/router_testing_harness.ts
+++ b/packages/router/testing/src/router_testing_harness.ts
@@ -16,7 +16,7 @@ import {
   signal,
 } from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {Router, RouterOutlet, ɵafterNextNavigation as afterNextNavigation} from '@angular/router';
+import {Router, RouterOutlet, ɵafterNextNavigation as afterNextNavigation} from '../../index';
 
 @Injectable({providedIn: 'root'})
 export class RootFixtureService {

--- a/packages/router/testing/src/router_testing_module.ts
+++ b/packages/router/testing/src/router_testing_module.ts
@@ -17,7 +17,7 @@ import {
   Routes,
   withPreloading,
   ɵROUTER_PROVIDERS as ROUTER_PROVIDERS,
-} from '@angular/router';
+} from '../../index';
 
 /**
  * @description

--- a/packages/router/testing/src/testing.ts
+++ b/packages/router/testing/src/testing.ts
@@ -13,3 +13,14 @@
  */
 export * from './router_testing_module';
 export {RouterTestingHarness} from './router_testing_harness';
+
+// Re-export the symbols that are exposed by the `RouterTestingModule` (which re-exports
+// the symbols from the `RouterModule`). Re-exports are needed for the Angular compiler
+// to overcome its limitation (on the consumer side) of not knowing where to import import
+// symbols when relative imports are used within the package.
+// Note: These exports need to be stable and shouldn't be renamed unnecessarily because
+// consuming libraries might have references to them in their own partial compilation output.
+export {RouterOutlet as ɵɵRouterOutlet} from '../../src/directives/router_outlet';
+export {RouterLink as ɵɵRouterLink} from '../../src/directives/router_link';
+export {RouterLinkActive as ɵɵRouterLinkActive} from '../../src/directives/router_link_active';
+export {EmptyOutletComponent as ɵɵEmptyOutletComponent} from '../../src/components/empty_outlet';

--- a/packages/router/testing/test/router_testing_harness.spec.ts
+++ b/packages/router/testing/test/router_testing_harness.spec.ts
@@ -9,8 +9,8 @@
 import {AsyncPipe} from '@angular/common';
 import {Component, inject} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {ActivatedRoute, provideRouter, Router} from '@angular/router';
-import {RouterTestingHarness} from '@angular/router/testing';
+import {ActivatedRoute, provideRouter, Router} from '../../index';
+import {RouterTestingHarness} from '../../testing';
 import {of} from 'rxjs';
 import {delay} from 'rxjs/operators';
 

--- a/packages/router/upgrade/src/upgrade.ts
+++ b/packages/router/upgrade/src/upgrade.ts
@@ -8,7 +8,7 @@
 
 import {Location} from '@angular/common';
 import {APP_BOOTSTRAP_LISTENER, ComponentRef, InjectionToken} from '@angular/core';
-import {Router, ɵRestoredState as RestoredState} from '@angular/router';
+import {Router, ɵRestoredState as RestoredState} from '../../index';
 import {UpgradeModule} from '@angular/upgrade/static';
 
 /**

--- a/packages/router/upgrade/test/upgrade.spec.ts
+++ b/packages/router/upgrade/test/upgrade.spec.ts
@@ -9,8 +9,8 @@
 import {Location} from '@angular/common';
 import {$locationShim, UrlCodec} from '@angular/common/upgrade';
 import {fakeAsync, flush, TestBed} from '@angular/core/testing';
-import {Router, RouterModule} from '@angular/router';
-import {setUpLocationSync} from '@angular/router/upgrade';
+import {Router, RouterModule} from '../../index';
+import {setUpLocationSync} from '../../upgrade';
 import {UpgradeModule} from '@angular/upgrade/static';
 
 import {LocationUpgradeTestModule} from './upgrade_location_test_module';


### PR DESCRIPTION
This commit updates scripts within `packages/router` to relative imports as a prep work to the upcoming infra updates.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No