### PR TITLE
refactor: update `platform*` packages to use relative imports

### DIFF
--- a/goldens/public-api/platform-browser/animations/index.api.md
+++ b/goldens/public-api/platform-browser/animations/index.api.md
@@ -6,7 +6,7 @@
 
 import { ANIMATION_MODULE_TYPE } from '@angular/core';
 import * as i0 from '@angular/core';
-import * as i1 from '@angular/platform-browser';
+import * as i1 from '@angular/common';
 import { ModuleWithProviders } from '@angular/core';
 import { Provider } from '@angular/core';
 
@@ -20,7 +20,7 @@ export class BrowserAnimationsModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<BrowserAnimationsModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<BrowserAnimationsModule, never, never, [typeof i1.BrowserModule]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<BrowserAnimationsModule, never, never, [typeof BrowserModule]>;
 }
 
 // @public
@@ -35,7 +35,7 @@ export class NoopAnimationsModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<NoopAnimationsModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<NoopAnimationsModule, never, never, [typeof i1.BrowserModule]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<NoopAnimationsModule, never, never, [typeof BrowserModule]>;
 }
 
 // @public

--- a/goldens/public-api/platform-browser/testing/index.api.md
+++ b/goldens/public-api/platform-browser/testing/index.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 import * as i0 from '@angular/core';
-import * as i1 from '@angular/platform-browser';
+import * as i1 from '@angular/common';
 import { StaticProvider } from '@angular/core';
 
 // @public
@@ -15,7 +15,7 @@ export class BrowserTestingModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<BrowserTestingModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<BrowserTestingModule, never, never, [typeof i1.BrowserModule]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<BrowserTestingModule, never, never, [typeof BrowserModule]>;
 }
 
 // @public

--- a/packages/platform-browser-dynamic/test/resource_loader/resource_loader_impl_spec.ts
+++ b/packages/platform-browser-dynamic/test/resource_loader/resource_loader_impl_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ResourceLoaderImpl} from '@angular/platform-browser-dynamic/src/resource_loader/resource_loader_impl';
+import {ResourceLoaderImpl} from '../../src/resource_loader/resource_loader_impl';
 
 if (isBrowser) {
   describe('ResourceLoaderImpl', () => {

--- a/packages/platform-browser-dynamic/test/testing_public_browser_spec.ts
+++ b/packages/platform-browser-dynamic/test/testing_public_browser_spec.ts
@@ -9,7 +9,7 @@
 import {ResourceLoader} from '@angular/compiler';
 import {Compiler, Component, NgModule} from '@angular/core';
 import {fakeAsync, inject, TestBed, tick, waitForAsync} from '@angular/core/testing';
-import {ResourceLoaderImpl} from '@angular/platform-browser-dynamic/src/resource_loader/resource_loader_impl';
+import {ResourceLoaderImpl} from '../src/resource_loader/resource_loader_impl';
 
 // Components for the tests.
 class FancyService {

--- a/packages/platform-browser-dynamic/testing/src/testing.ts
+++ b/packages/platform-browser-dynamic/testing/src/testing.ts
@@ -7,7 +7,7 @@
  */
 
 import {createPlatformFactory, NgModule, PlatformRef, StaticProvider} from '@angular/core';
-import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
+import {platformBrowserDynamic} from '../../index';
 import {BrowserTestingModule} from '@angular/platform-browser/testing';
 
 /**

--- a/packages/platform-browser/animations/async/src/async_animation_renderer.ts
+++ b/packages/platform-browser/animations/async/src/async_animation_renderer.ts
@@ -28,7 +28,7 @@ import {
   type ListenerOptions,
   Injector,
 } from '@angular/core';
-import {ɵRuntimeErrorCode as RuntimeErrorCode} from '@angular/platform-browser';
+import {ɵRuntimeErrorCode as RuntimeErrorCode} from '../../../index';
 
 const ANIMATION_PREFIX = '@';
 

--- a/packages/platform-browser/animations/async/src/providers.ts
+++ b/packages/platform-browser/animations/async/src/providers.ts
@@ -15,7 +15,7 @@ import {
   RendererFactory2,
   ɵperformanceMarkFeature as performanceMarkFeature,
 } from '@angular/core';
-import {ɵDomRendererFactory2 as DomRendererFactory2} from '@angular/platform-browser';
+import {ɵDomRendererFactory2 as DomRendererFactory2} from '../../../index';
 
 import {AsyncAnimationRendererFactory} from './async_animation_renderer';
 

--- a/packages/platform-browser/animations/async/test/animation_renderer_spec.ts
+++ b/packages/platform-browser/animations/async/test/animation_renderer_spec.ts
@@ -35,9 +35,9 @@ import {
   ViewChild,
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {ɵDomRendererFactory2 as DomRendererFactory2} from '@angular/platform-browser';
-import {InjectableAnimationEngine} from '@angular/platform-browser/animations/src/providers';
-import {el} from '@angular/platform-browser/testing/src/browser_util';
+import {ɵDomRendererFactory2 as DomRendererFactory2} from '../../../index';
+import {InjectableAnimationEngine} from '../../../animations/src/providers';
+import {el} from '../../../testing/src/browser_util';
 
 import {
   AsyncAnimationRendererFactory,

--- a/packages/platform-browser/animations/src/module.ts
+++ b/packages/platform-browser/animations/src/module.ts
@@ -11,7 +11,7 @@ import {
   Provider,
   ɵperformanceMarkFeature as performanceMarkFeature,
 } from '@angular/core';
-import {BrowserModule} from '@angular/platform-browser';
+import {BrowserModule} from '../../index';
 
 import {BROWSER_ANIMATIONS_PROVIDERS, BROWSER_NOOP_ANIMATIONS_PROVIDERS} from './providers';
 

--- a/packages/platform-browser/animations/src/providers.ts
+++ b/packages/platform-browser/animations/src/providers.ts
@@ -27,7 +27,7 @@ import {
   RendererFactory2,
   ɵChangeDetectionScheduler as ChangeDetectionScheduler,
 } from '@angular/core';
-import {ɵDomRendererFactory2 as DomRendererFactory2} from '@angular/platform-browser';
+import {ɵDomRendererFactory2 as DomRendererFactory2} from '../../index';
 
 @Injectable()
 export class InjectableAnimationEngine extends AnimationEngine implements OnDestroy {

--- a/packages/platform-browser/animations/test/animation_renderer_spec.ts
+++ b/packages/platform-browser/animations/test/animation_renderer_spec.ts
@@ -30,14 +30,14 @@ import {
   ViewChild,
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {bootstrapApplication} from '@angular/platform-browser';
+import {bootstrapApplication} from '../../index';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {
   BrowserAnimationsModule,
   ɵInjectableAnimationEngine as InjectableAnimationEngine,
-} from '@angular/platform-browser/animations';
-import {provideAnimationsAsync} from '@angular/platform-browser/animations/async';
-import {DomRendererFactory2} from '@angular/platform-browser/src/dom/dom_renderer';
+} from '../index';
+import {provideAnimationsAsync} from '../async';
+import {DomRendererFactory2} from '../../src/dom/dom_renderer';
 import {withBody} from '@angular/private/testing';
 
 import {el} from '../../testing/src/browser_util';

--- a/packages/platform-browser/animations/test/noop_animations_module_spec.ts
+++ b/packages/platform-browser/animations/test/noop_animations_module_spec.ts
@@ -9,11 +9,7 @@ import {animate, style, transition, trigger} from '@angular/animations';
 import {ɵAnimationEngine} from '@angular/animations/browser';
 import {Component} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {
-  BrowserAnimationsModule,
-  NoopAnimationsModule,
-  provideNoopAnimations,
-} from '@angular/platform-browser/animations';
+import {BrowserAnimationsModule, NoopAnimationsModule, provideNoopAnimations} from '../index';
 
 describe('NoopAnimationsModule', () => {
   beforeEach(() => {

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -50,10 +50,10 @@ import {
 } from '@angular/core/src/platform/platform';
 import {inject, TestBed} from '@angular/core/testing';
 import {Log} from '@angular/core/testing/src/testing_internal';
-import {BrowserModule} from '@angular/platform-browser';
+import {BrowserModule} from '../../index';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
-import {provideAnimations, provideNoopAnimations} from '@angular/platform-browser/animations';
-import {expect} from '@angular/platform-browser/testing/src/matchers';
+import {provideAnimations, provideNoopAnimations} from '../../animations';
+import {expect} from '../../testing/src/matchers';
 
 import {bootstrapApplication} from '../../src/browser';
 

--- a/packages/platform-browser/test/browser/meta_spec.ts
+++ b/packages/platform-browser/test/browser/meta_spec.ts
@@ -9,8 +9,8 @@
 import {ɵgetDOM as getDOM} from '@angular/common';
 import {Injectable} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {BrowserModule, Meta} from '@angular/platform-browser';
-import {expect} from '@angular/platform-browser/testing/src/matchers';
+import {BrowserModule, Meta} from '../../index';
+import {expect} from '../../testing/src/matchers';
 
 describe('Meta service', () => {
   let doc: Document;

--- a/packages/platform-browser/test/browser/title_spec.ts
+++ b/packages/platform-browser/test/browser/title_spec.ts
@@ -9,8 +9,8 @@
 import {ɵgetDOM as getDOM} from '@angular/common';
 import {Injectable} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {BrowserModule, Title} from '@angular/platform-browser';
-import {expect} from '@angular/platform-browser/testing/src/matchers';
+import {BrowserModule, Title} from '../../index';
+import {expect} from '../../testing/src/matchers';
 
 describe('title service', () => {
   let doc: Document;

--- a/packages/platform-browser/test/browser/tools/tools_spec.ts
+++ b/packages/platform-browser/test/browser/tools/tools_spec.ts
@@ -8,7 +8,7 @@
 
 import {ApplicationRef, Injector, ɵglobal as global} from '@angular/core';
 import {ComponentRef} from '@angular/core/src/render3';
-import {disableDebugTools, enableDebugTools} from '@angular/platform-browser';
+import {disableDebugTools, enableDebugTools} from '../../../index';
 
 import {AngularProfiler} from '../../../src/browser/tools/common_tools';
 

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -7,13 +7,13 @@
  */
 import {Component, Renderer2, ViewEncapsulation} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {By} from '@angular/platform-browser/src/dom/debug/by';
+import {By} from '../../src/dom/debug/by';
 import {
   addBaseHrefToCssSourceMap,
   NAMESPACE_URIS,
   REMOVE_STYLES_ON_COMPONENT_DESTROY,
-} from '@angular/platform-browser/src/dom/dom_renderer';
-import {expect} from '@angular/platform-browser/testing/src/matchers';
+} from '../../src/dom/dom_renderer';
+import {expect} from '../../testing/src/matchers';
 
 describe('DefaultDomRendererV2', () => {
   if (isNode) {

--- a/packages/platform-browser/test/dom/events/event_manager_spec.ts
+++ b/packages/platform-browser/test/dom/events/event_manager_spec.ts
@@ -8,11 +8,8 @@
 
 import {ɵgetDOM as getDOM} from '@angular/common';
 import {NgZone} from '@angular/core/src/zone/ng_zone';
-import {DomEventsPlugin} from '@angular/platform-browser/src/dom/events/dom_events';
-import {
-  EventManager,
-  EventManagerPlugin,
-} from '@angular/platform-browser/src/dom/events/event_manager';
+import {DomEventsPlugin} from '../../../src/dom/events/dom_events';
+import {EventManager, EventManagerPlugin} from '../../../src/dom/events/event_manager';
 
 import {createMouseEvent, el} from '../../../testing/src/browser_util';
 import {TestBed} from '@angular/core/testing';

--- a/packages/platform-browser/test/dom/events/hammer_gestures_spec.ts
+++ b/packages/platform-browser/test/dom/events/hammer_gestures_spec.ts
@@ -7,11 +7,8 @@
  */
 import {ApplicationRef, Injector, NgZone} from '@angular/core';
 import {fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
-import {EventManager} from '@angular/platform-browser';
-import {
-  HammerGestureConfig,
-  HammerGesturesPlugin,
-} from '@angular/platform-browser/src/dom/events/hammer_gestures';
+import {EventManager} from '../../../index';
+import {HammerGestureConfig, HammerGesturesPlugin} from '../../../src/dom/events/hammer_gestures';
 
 describe('HammerGesturesPlugin', () => {
   let plugin: HammerGesturesPlugin;

--- a/packages/platform-browser/test/dom/events/key_events_spec.ts
+++ b/packages/platform-browser/test/dom/events/key_events_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {KeyEventsPlugin} from '@angular/platform-browser/src/dom/events/key_events';
+import {KeyEventsPlugin} from '../../../src/dom/events/key_events';
 
 describe('KeyEventsPlugin', () => {
   it('should ignore unrecognized events', () => {

--- a/packages/platform-browser/test/dom/shadow_dom_spec.ts
+++ b/packages/platform-browser/test/dom/shadow_dom_spec.ts
@@ -8,8 +8,8 @@
 
 import {Component, NgModule, ViewEncapsulation} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {BrowserModule} from '@angular/platform-browser';
-import {expect} from '@angular/platform-browser/testing/src/matchers';
+import {BrowserModule} from '../../index';
+import {expect} from '../../testing/src/matchers';
 
 describe('ShadowDOM Support', () => {
   if (isNode) {

--- a/packages/platform-browser/test/dom/shared_styles_host_spec.ts
+++ b/packages/platform-browser/test/dom/shared_styles_host_spec.ts
@@ -7,8 +7,8 @@
  */
 
 import {ɵgetDOM as getDOM} from '@angular/common';
-import {SharedStylesHost} from '@angular/platform-browser/src/dom/shared_styles_host';
-import {expect} from '@angular/platform-browser/testing/src/matchers';
+import {SharedStylesHost} from '../../src/dom/shared_styles_host';
+import {expect} from '../../testing/src/matchers';
 
 describe('SharedStylesHost', () => {
   let doc: Document;

--- a/packages/platform-browser/test/security/dom_sanitization_service_spec.ts
+++ b/packages/platform-browser/test/security/dom_sanitization_service_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {SecurityContext} from '@angular/core';
-import {DomSanitizerImpl} from '@angular/platform-browser/src/security/dom_sanitization_service';
+import {DomSanitizerImpl} from '../../src/security/dom_sanitization_service';
 
 describe('DOM Sanitization Service', () => {
   it('accepts resource URL values for resource contexts', () => {

--- a/packages/platform-browser/test/testing_public_spec.ts
+++ b/packages/platform-browser/test/testing_public_spec.ts
@@ -34,7 +34,7 @@ import {
   waitForAsync,
   withModule,
 } from '@angular/core/testing';
-import {expect} from '@angular/platform-browser/testing/src/matchers';
+import {expect} from '../testing/src/matchers';
 
 // Services, and components for the tests.
 

--- a/packages/platform-browser/testing/src/browser.ts
+++ b/packages/platform-browser/testing/src/browser.ts
@@ -17,7 +17,7 @@ import {
   ɵChangeDetectionSchedulerImpl as ChangeDetectionSchedulerImpl,
 } from '@angular/core';
 import {TestComponentRenderer} from '@angular/core/testing';
-import {BrowserModule, platformBrowser} from '@angular/platform-browser';
+import {BrowserModule, platformBrowser} from '../../index';
 import {DOMTestComponentRenderer} from './dom_test_component_renderer';
 
 /**

--- a/packages/platform-browser/testing/src/matchers.ts
+++ b/packages/platform-browser/testing/src/matchers.ts
@@ -9,7 +9,7 @@
 import {ɵgetDOM as getDOM} from '@angular/common';
 import {Type} from '@angular/core';
 import {ComponentFixture} from '@angular/core/testing';
-import {By} from '@angular/platform-browser';
+import {By} from '../../index';
 
 import {childNodesAsList, hasClass, hasStyle, isCommentNode} from './browser_util';
 

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -61,7 +61,7 @@ import {
   provideServerRendering,
   renderModule,
   ServerModule,
-} from '@angular/platform-server';
+} from '../index';
 import {provideRouter, RouterOutlet, Routes} from '@angular/router';
 import {Observable} from 'rxjs';
 

--- a/packages/platform-server/test/transfer_state_spec.ts
+++ b/packages/platform-server/test/transfer_state_spec.ts
@@ -8,7 +8,7 @@
 
 import {Component, makeStateKey, NgModule, TransferState} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
-import {renderModule, ServerModule} from '@angular/platform-server';
+import {renderModule, ServerModule} from '../index';
 
 describe('transfer_state', () => {
   const defaultExpectedOutput =

--- a/packages/platform-server/testing/src/server.ts
+++ b/packages/platform-server/testing/src/server.ts
@@ -12,7 +12,7 @@ import {BrowserDynamicTestingModule} from '@angular/platform-browser-dynamic/tes
 import {
   ɵINTERNAL_SERVER_PLATFORM_PROVIDERS as INTERNAL_SERVER_PLATFORM_PROVIDERS,
   ɵSERVER_RENDER_PROVIDERS as SERVER_RENDER_PROVIDERS,
-} from '@angular/platform-server';
+} from '../../index';
 
 const INTERNAL_SERVER_DYNAMIC_PLATFORM_TESTING_PROVIDERS: StaticProvider[] = [
   ...INTERNAL_BROWSER_DYNAMIC_PLATFORM_PROVIDERS,


### PR DESCRIPTION
This PR updates scripts within `packages/platform*` folders to relative imports as a prep work to the upcoming infra updates.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No