### PR TITLE
docs(docs-infra): fix shared-docs build warning

### DIFF
--- a/adev/shared-docs/components/search-dialog/search-dialog.component.html
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.html
@@ -49,7 +49,7 @@
               </div>
 
               <!-- Page title -->
-              <span class="docs-result-page-title">{{ result.hierarchy?.lvl0 }}</span>
+              <span class="docs-result-page-title">{{ result.hierarchy.lvl0 }}</span>
             </a>
           </li>
         }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] angular.dev application / infrastructure changes


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Warning:

```html
NG8107: The left side of this optional chain operation does not include 'null' or 'undefined' in its type, therefore the '?.' operator can be replaced with the '.' operator.

52               <span class="docs-result-page-title">{{ result.hierarchy?.lvl0 }}</span>
```


## What is the new behavior?

Fix NG8107 warning in the search-dialog component.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
