### PR TITLE
docs(docs-infra): fix CSS media queries boundaries

### DIFF
--- a/adev/shared-docs/styles/_media-queries.scss
+++ b/adev/shared-docs/styles/_media-queries.scss
@@ -9,38 +9,39 @@ $screen-xl: 1800px;
     @content;
   }
 }
+
 @mixin for-tablet-portrait-up {
-  @media (min-width: $screen-xs) {
+  @media (min-width: calc($screen-xs + 1px)) {
     @content;
   }
 }
 
 @mixin for-tablet {
-  @media (min-width: $screen-xs) and (max-width: $screen-md) {
+  @media (min-width: calc($screen-xs + 1px)) and (max-width: $screen-md) {
     @content;
   }
 }
 
 @mixin for-tablet-up {
-  @media (min-width: $screen-sm) {
+  @media (min-width: calc($screen-sm + 1px)) {
     @content;
   }
 }
 
 @mixin for-tablet-landscape-up {
-  @media (min-width: $screen-md) {
+  @media (min-width: calc($screen-md + 1px)) {
     @content;
   }
 }
 
 @mixin for-desktop-up {
-  @media (min-width: $screen-lg) {
+  @media (min-width: calc($screen-lg + 1px)) {
     @content;
   }
 }
 
 @mixin for-big-desktop-up {
-  @media (min-width: $screen-xl) {
+  @media (min-width: calc($screen-xl + 1px)) {
     @content;
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] angular.dev application / infrastructure changes

## What is the current behavior?
 
In the rare occasions where the viewport width is exactly equal to a media query boundary value and there is an element that uses two media queries that have a common boundary value (e.g. `VW width = 700px` & `MQ1 ∈ max-width: 700px` & `MQ2 ∈ min-width: 700px`) that equals to the viewport width, we have a CSS conflict that can break and breaks (one found instance so far) the UI.

## What is the new behavior?

The boundary values are now updated so the lower one is exclusive but the upper one remains inclusive. This is achieved by adding a single pixel offset to the lower boundaries.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
