### PR TITLE
fix(core): check ngDevMode for undefined

### DIFF
--- a/packages/core/rxjs-interop/src/to_signal.ts
+++ b/packages/core/rxjs-interop/src/to_signal.ts
@@ -122,7 +122,8 @@ export function toSignal<T, U = undefined>(
   source: Observable<T> | Subscribable<T>,
   options?: ToSignalOptions<T | U> & {initialValue?: U},
 ): Signal<T | U> {
-  ngDevMode &&
+  typeof ngDevMode !== 'undefined' &&
+    ngDevMode &&
     assertNotInReactiveContext(
       toSignal,
       'Invoking `toSignal` causes new subscriptions every time. ' +


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In some MFE applications, ngDevMode is not defined in some cases (see e.g., https://github.com/ngrx/platform/pull/4703) caused by webpack's tree shaking approx, by not checking if it is defined at all, this breaks.

Issue Number: N/A


## What is the new behavior?
ngDevMode is also checked for undefined (as already done in other places in the same file).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
