### PR TITLE
docs(docs-infra): fix correct HTML tag typo in welcome message

### DIFF
--- a/adev/src/content/guide/components/content-projection.md
+++ b/adev/src/content/guide/components/content-projection.md
@@ -140,7 +140,7 @@ did not match a `select` attribute:
     <card-title>Hello</card-title>
     <div class="card-divider"></div>
     <img src="..." />
-    <p>Welcome to the example></p>
+    <p>Welcome to the example</p>
   </div>
 </custom-card>
 ```
@@ -210,7 +210,7 @@ placeholder, Angular compares against the `ngProjectAs` value instead of the ele
   <div class="card-shadow">
     <h3>Hello</h3>
     <div class="card-divider"></div>
-    <p>Welcome to the example></p>
+    <p>Welcome to the example</p>
   </div>
 </custom-card>
 ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The HTML tag in the welcome message is incorrectly closed. While this may not cause an error, it is a typo in the documentation.

Issue Number: N/A


## What is the new behavior?
The HTML tag in the welcome message is now correctly closed, ensuring proper formatting in the documentation.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
No functional impact, this is a minor documentation typo fix.
