### PR TITLE
build: add build step to the symbol extractor script

### DIFF
--- a/tools/symbol-extractor/run_all_symbols_extractor_tests.js
+++ b/tools/symbol-extractor/run_all_symbols_extractor_tests.js
@@ -11,14 +11,18 @@ const {spawnSync} = require('child_process');
 const {Parser: parser} = require('yargs/helpers');
 const path = require('path');
 
+// Location of all targets that we'd need to run.
+const TEST_TARGETS_LOCATION = 'packages/core/test/bundling/...';
+
 // Remove all command line flags from the arguments.
 const argv = parser(process.argv.slice(2));
 
 // The command the user would like to run, either 'accept' or 'test'
 const USER_COMMAND = argv._[0];
+
 // The shell command to query for all tests.
 // Bazel targets for testing goldens
-process.stdout.write('Gathering all symbol extractor targets');
+process.stdout.write('Gathering all symbol extractor targets...');
 const ALL_TEST_TARGETS = spawnSync(
   'yarn',
   [
@@ -27,7 +31,7 @@ const ALL_TEST_TARGETS = spawnSync(
     'query',
     '--output',
     'label',
-    `'kind(nodejs_test, ...) intersect attr("tags", "symbol_extractor", ...)'`,
+    `'kind(nodejs_test, ${TEST_TARGETS_LOCATION}) intersect attr("tags", "symbol_extractor", ${TEST_TARGETS_LOCATION})'`,
   ],
   {encoding: 'utf8', shell: true, cwd: path.resolve(__dirname, '../..')},
 )
@@ -38,6 +42,21 @@ process.stdout.clearLine();
 process.stdout.cursorTo(0);
 // Bazel targets for generating goldens
 const ALL_ACCEPT_TARGETS = ALL_TEST_TARGETS.map((test) => `${test}.accept`);
+
+/** Builds all targets in parallel. */
+function buildTargets(targets) {
+  process.stdout.write('Building all symbol extractor targets...');
+  const commandResult = spawnSync('yarn', ['-s', 'bazel', 'build', targets.join(' ')], {
+    encoding: 'utf8',
+    shell: true,
+  });
+  if (commandResult.status) {
+    console.error(commandResult.stdout || commandResult.stderr);
+  } else {
+    process.stdout.clearLine();
+    process.stdout.cursorTo(0);
+  }
+}
 
 /** Run the provided bazel commands on each provided target individually. */
 function runBazelCommandOnTargets(command, targets, present) {
@@ -59,9 +78,11 @@ function runBazelCommandOnTargets(command, targets, present) {
 
 switch (USER_COMMAND) {
   case 'accept':
+    buildTargets(ALL_ACCEPT_TARGETS);
     runBazelCommandOnTargets('run', ALL_ACCEPT_TARGETS, 'Running');
     break;
   case 'test':
+    buildTargets(ALL_TEST_TARGETS);
     runBazelCommandOnTargets('test', ALL_TEST_TARGETS, 'Testing');
     break;
   default:


### PR DESCRIPTION
This commit adds a step where we build all found targets in parallel, which speeds up the process of completing symbol extractor test/update.

Running `yarn symbol-extractor:accept` with partially-populated Bazel cache (built a single target to populate NPM deps, etc) before this change:
```
✨  Done in 148.53s.
```

After this change:
```
✨  Done in 90.26s.
```

Almost 1 min faster!

Thanks @dgp1130 for the idea! 👍 

## PR Type
What kind of change does this PR introduce?

- [x] Build related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No