### PR TITLE
build: add build step to the public API extractor script

### DIFF
--- a/goldens/public-api/manage.js
+++ b/goldens/public-api/manage.js
@@ -5,18 +5,37 @@ const {Parser: parser} = require('yargs/helpers');
 const argv = parser(process.argv.slice(2));
 // The command the user would like to run, either 'accept' or 'test'
 const USER_COMMAND = argv._[0];
+
+// Location of all packages that we'd need to process.
+const API_TARGETS_LOCATION = 'packages/...';
+
 // The shell command to query for all Public API guard tests.
-const BAZEL_PUBLIC_API_TARGET_QUERY_CMD = `yarn -s bazel query --output label 'kind(nodejs_test, ...) intersect attr("tags", "api_guard", ...)'`;
+const BAZEL_PUBLIC_API_TARGET_QUERY_CMD =
+  `yarn -s bazel query --output label 'kind(nodejs_test, ${API_TARGETS_LOCATION}) ` +
+  `intersect attr("tags", "api_guard", ${API_TARGETS_LOCATION})'`;
 // Bazel targets for testing Public API goldens
-process.stdout.write('Gathering all Public API targets');
+process.stdout.write('Gathering all Public API targets...');
 const ALL_PUBLIC_API_TESTS = exec(BAZEL_PUBLIC_API_TARGET_QUERY_CMD, {silent: true})
   .trim()
   .split('\n')
   .map((test) => test.trim());
 process.stdout.clearLine();
 process.stdout.cursorTo(0);
+
 // Bazel targets for generating Public API goldens
 const ALL_PUBLIC_API_ACCEPTS = ALL_PUBLIC_API_TESTS.map((test) => `${test}.accept`);
+
+/** Builds all targets in parallel. */
+function buildTargets(targets) {
+  process.stdout.write('Building all public API targets...');
+  const commandResult = exec(`yarn -s bazel build ${targets.join(' ')}`, {silent: true});
+  if (commandResult.code) {
+    console.error(commandResult.stdout || commandResult.stderr);
+  } else {
+    process.stdout.clearLine();
+    process.stdout.cursorTo(0);
+  }
+}
 
 /**
  * Run the provided bazel commands on each provided target individually.
@@ -40,9 +59,11 @@ function runBazelCommandOnTargets(command, targets, present) {
 
 switch (USER_COMMAND) {
   case 'accept':
+    buildTargets(ALL_PUBLIC_API_ACCEPTS);
     runBazelCommandOnTargets('run', ALL_PUBLIC_API_ACCEPTS, 'Running');
     break;
   case 'test':
+    buildTargets(ALL_PUBLIC_API_TESTS);
     runBazelCommandOnTargets('test', ALL_PUBLIC_API_TESTS, 'Testing');
     break;
   default:


### PR DESCRIPTION
Similar to #60573. This commit adds a step where we build all found targets in parallel, which speeds up the process of completing public API extractor test/update.

Running `public-api:update` with partially-populated Bazel cache (built a single target to populate NPM deps, etc) before this change:
```
✨  Done in 301.70s.
```

After this change:
```
✨  Done in 204.54s.
```


## PR Type
What kind of change does this PR introduce?

- [x] Build related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No