### PR TITLE
docs: replace `*ngFor` with `@for` in Reactive forms

### DIFF
--- a/adev/src/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.1.html
+++ b/adev/src/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.1.html
@@ -31,11 +31,13 @@
     <h2>Aliases</h2>
     <button type="button" (click)="addAlias()">+ Add another alias</button>
 
-    <div *ngFor="let address of aliases.controls; let i=index">
+    @for (address of aliases.controls; track $index) {
+    <div>
       <!-- The repeated alias template -->
-      <label for="alias-{{ i }}">Alias: </label>
-      <input id="alias-{{ i }}" type="text" [formControlName]="i">
+      <label for="alias-{{ $index }}">Alias: </label>
+      <input id="alias-{{ $index }}" type="text" [formControlName]="$index">
     </div>
+    }
   </div>
 <!-- #docregion formgroup -->
 </form>

--- a/adev/src/content/guide/forms/reactive-forms.md
+++ b/adev/src/content/guide/forms/reactive-forms.md
@@ -379,7 +379,7 @@ Add the following template HTML after the `<div>` closing the `formGroupName` el
 
 <docs-code header="src/app/profile-editor/profile-editor.component.html (aliases form array template)" path="adev/src/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.html" visibleRegion="formarrayname"/>
 
-The `*ngFor` directive iterates over each form control instance provided by the aliases form array instance. Because form array elements are unnamed, you assign the index to the `i` variable and pass it to each control to bind it to the `formControlName` input.
+The `@for` directive iterates over each form control instance provided by the aliases form array instance. Because form array elements are unnamed, you assign the index to the `$index` variable and pass it to each control to bind it to the `formControlName` input.
 
 Each time a new alias instance is added, the new form array instance is provided its control based on the index. This lets you track each individual control when calculating the status and value of the root control.
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The documentation examples currently use the `*ngFor` directive for iteration, which is the legacy syntax. With Angular 17 and newer, the `@for` loop syntax is preferred for better performance and clarity.


## What is the new behavior?
Updated the documentation examples to use the `@for` loop syntax instead of `*ngFor`.
This brings the examples in line with modern Angular best practices and improves code readability for developers using the latest versions.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
