### PR TITLE
refactor(core): retrieve the jsActionMap only once.

### DIFF
--- a/packages/core/src/hydration/utils.ts
+++ b/packages/core/src/hydration/utils.ts
@@ -613,8 +613,8 @@ function gatherDeferBlocksByJSActionAttribute(doc: Document): Set<HTMLElement> {
 
 export function appendDeferBlocksToJSActionMap(doc: Document, injector: Injector) {
   const blockMap = gatherDeferBlocksByJSActionAttribute(doc);
+  const jsActionMap = injector.get(JSACTION_BLOCK_ELEMENT_MAP);
   for (let rNode of blockMap) {
-    const jsActionMap = injector.get(JSACTION_BLOCK_ELEMENT_MAP);
     sharedMapFunction(rNode, jsActionMap);
   }
 }


### PR DESCRIPTION
Before the change, the map was pull on every loop execution.
