### PR TITLE
ci: update bazel RBE setup on CI and use trusted build configuration for upstream CI runs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -126,6 +126,9 @@ build:remote-cache --remote_accept_cached=true
 build:remote-cache --remote_upload_local_results=false
 build:remote-cache --google_default_credentials
 
+# Additional flags added when running a "trusted build" with additional access
+build:trusted-build --remote_upload_local_results=true
+
 # Ensure that tags like "no-remote-exec" get propagated to actions created by rules,
 # even if the rule implementation does not explicitly pass them to the execution requirements.
 # https://bazel.build/reference/command-line-reference#flag--experimental_allow_tags_propagation

--- a/.github/actions/saucelabs-legacy/action.yml
+++ b/.github/actions/saucelabs-legacy/action.yml
@@ -5,9 +5,9 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Bazel
-      uses: angular/dev-infra/github-actions/bazel/setup@be69a70efc9f2331083d76073427c0c81ec15a1e
+      uses: angular/dev-infra/github-actions/bazel/setup@e3c0efecadda0e0fbb616abcdf447c788959ca64
     - name: Setup Saucelabs Variables
-      uses: angular/dev-infra/github-actions/saucelabs@be69a70efc9f2331083d76073427c0c81ec15a1e
+      uses: angular/dev-infra/github-actions/saucelabs@e3c0efecadda0e0fbb616abcdf447c788959ca64
     - name: Starting Saucelabs tunnel service
       shell: bash
       run: ./tools/saucelabs/sauce-service.sh run &

--- a/.github/workflows/adev-preview-build.yml
+++ b/.github/workflows/adev-preview-build.yml
@@ -21,16 +21,16 @@ jobs:
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'adev: preview'))
     steps:
       - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Setup Bazel
-        uses: angular/dev-infra/github-actions/bazel/setup@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/setup@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Setup Bazel RBE
-        uses: angular/dev-infra/github-actions/bazel/configure-remote@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/configure-remote@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Install node modules
         run: yarn install --frozen-lockfile
       - name: Build adev to ensure it continues to work
         run: yarn bazel build //adev:build --full_build_adev --config=release
-      - uses: angular/dev-infra/github-actions/previews/pack-and-upload-artifact@be69a70efc9f2331083d76073427c0c81ec15a1e
+      - uses: angular/dev-infra/github-actions/previews/pack-and-upload-artifact@e3c0efecadda0e0fbb616abcdf447c788959ca64
         with:
           workflow-artifact-name: 'adev-preview'
           pull-number: '${{github.event.pull_request.number}}'

--- a/.github/workflows/adev-preview-deploy.yml
+++ b/.github/workflows/adev-preview-deploy.yml
@@ -40,7 +40,7 @@ jobs:
           npx -y firebase-tools@latest target:clear --config adev/firebase.json --project ${{env.PREVIEW_PROJECT}} hosting angular-docs
           npx -y firebase-tools@latest target:apply --config adev/firebase.json --project ${{env.PREVIEW_PROJECT}} hosting angular-docs ${{env.PREVIEW_SITE}}
 
-      - uses: angular/dev-infra/github-actions/previews/upload-artifacts-to-firebase@be69a70efc9f2331083d76073427c0c81ec15a1e
+      - uses: angular/dev-infra/github-actions/previews/upload-artifacts-to-firebase@e3c0efecadda0e0fbb616abcdf447c788959ca64
         with:
           github-token: '${{secrets.GITHUB_TOKEN}}'
           workflow-artifact-name: 'adev-preview'

--- a/.github/workflows/assistant-to-the-branch-manager.yml
+++ b/.github/workflows/assistant-to-the-branch-manager.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: angular/dev-infra/github-actions/branch-manager@be69a70efc9f2331083d76073427c0c81ec15a1e
+      - uses: angular/dev-infra/github-actions/branch-manager@e3c0efecadda0e0fbb616abcdf447c788959ca64
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}

--- a/.github/workflows/benchmark-compare.yml
+++ b/.github/workflows/benchmark-compare.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: ./.github/actions/yarn-install
 
-      - uses: angular/dev-infra/github-actions/bazel/configure-remote@be69a70efc9f2331083d76073427c0c81ec15a1e
+      - uses: angular/dev-infra/github-actions/bazel/configure-remote@e3c0efecadda0e0fbb616abcdf447c788959ca64
         with:
           bazelrc: ./.bazelrc.user
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@e3c0efecadda0e0fbb616abcdf447c788959ca64
         with:
           cache-node-modules: true
       - name: Install node modules
@@ -41,13 +41,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@e3c0efecadda0e0fbb616abcdf447c788959ca64
         with:
           cache-node-modules: true
       - name: Setup Bazel
-        uses: angular/dev-infra/github-actions/bazel/setup@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/setup@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Setup Bazel RBE
-        uses: angular/dev-infra/github-actions/bazel/configure-remote@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/configure-remote@e3c0efecadda0e0fbb616abcdf447c788959ca64
+        with:
+          google_credential: ${{ secrets.RBE_TRUSTED_BUILDS_USER }}
       - name: Install node modules
         run: yarn install --frozen-lockfile
       - name: Run unit tests
@@ -59,13 +61,15 @@ jobs:
     runs-on: ubuntu-latest-4core
     steps:
       - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@e3c0efecadda0e0fbb616abcdf447c788959ca64
         with:
           cache-node-modules: true
       - name: Setup Bazel
-        uses: angular/dev-infra/github-actions/bazel/setup@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/setup@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Setup Bazel Remote Caching
-        uses: angular/dev-infra/github-actions/bazel/configure-remote@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/configure-remote@e3c0efecadda0e0fbb616abcdf447c788959ca64
+        with:
+          google_credential: ${{ secrets.RBE_TRUSTED_BUILDS_USER }}
       - name: Install node modules
         run: yarn install --frozen-lockfile --network-timeout 100000
       - name: Run CI tests for framework
@@ -76,11 +80,13 @@ jobs:
       labels: ubuntu-latest-4core
     steps:
       - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Setup Bazel
-        uses: angular/dev-infra/github-actions/bazel/setup@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/setup@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Setup Bazel RBE
-        uses: angular/dev-infra/github-actions/bazel/configure-remote@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/configure-remote@e3c0efecadda0e0fbb616abcdf447c788959ca64
+        with:
+          google_credential: ${{ secrets.RBE_TRUSTED_BUILDS_USER }}
       - name: Install node modules
         run: yarn install --frozen-lockfile
       # TODO: re-enable all tests once the next release is shipped
@@ -95,13 +101,13 @@ jobs:
       labels: ubuntu-latest
     steps:
       - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@e3c0efecadda0e0fbb616abcdf447c788959ca64
         with:
           cache-node-modules: true
       - name: Setup Bazel
-        uses: angular/dev-infra/github-actions/bazel/setup@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/setup@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Setup Bazel RBE
-        uses: angular/dev-infra/github-actions/bazel/configure-remote@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/configure-remote@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Install node modules
         run: yarn install --frozen-lockfile
       - run: echo "https://${{secrets.SNAPSHOT_BUILDS_GITHUB_TOKEN}}:@github.com" > ${HOME}/.git_credentials
@@ -113,7 +119,7 @@ jobs:
       labels: ubuntu-latest-4core
     steps:
       - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@e3c0efecadda0e0fbb616abcdf447c788959ca64
         with:
           cache-node-modules: true
           node-module-directories: |
@@ -121,9 +127,11 @@ jobs:
             ./packages/zone.js/node_modules
             ./packages/zone.js/test/typings/node_modules
       - name: Setup Bazel
-        uses: angular/dev-infra/github-actions/bazel/setup@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/setup@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Setup Bazel RBE
-        uses: angular/dev-infra/github-actions/bazel/configure-remote@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/configure-remote@e3c0efecadda0e0fbb616abcdf447c788959ca64
+        with:
+          google_credential: ${{ secrets.RBE_TRUSTED_BUILDS_USER }}
       - name: Install node modules
         run: yarn install --frozen-lockfile
       - run: |
@@ -160,7 +168,7 @@ jobs:
       SAUCE_TUNNEL_IDENTIFIER: angular-framework-${{ github.run_number }}
     steps:
       - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@e3c0efecadda0e0fbb616abcdf447c788959ca64
         with:
           cache-node-modules: true
       - name: Install node modules
@@ -173,11 +181,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Setup Bazel
-        uses: angular/dev-infra/github-actions/bazel/setup@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/setup@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Setup Bazel RBE
-        uses: angular/dev-infra/github-actions/bazel/configure-remote@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/configure-remote@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Install node modules
         run: yarn install --frozen-lockfile
       - name: Build adev to ensure it continues to work

--- a/.github/workflows/dev-infra.yml
+++ b/.github/workflows/dev-infra.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: angular/dev-infra/github-actions/commit-message-based-labels@be69a70efc9f2331083d76073427c0c81ec15a1e
+      - uses: angular/dev-infra/github-actions/commit-message-based-labels@e3c0efecadda0e0fbb616abcdf447c788959ca64
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}
   post_approval_changes:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: angular/dev-infra/github-actions/post-approval-changes@be69a70efc9f2331083d76073427c0c81ec15a1e
+      - uses: angular/dev-infra/github-actions/post-approval-changes@e3c0efecadda0e0fbb616abcdf447c788959ca64
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}

--- a/.github/workflows/google-internal-tests.yml
+++ b/.github/workflows/google-internal-tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: angular/dev-infra/github-actions/google-internal-tests@be69a70efc9f2331083d76073427c0c81ec15a1e
+      - uses: angular/dev-infra/github-actions/google-internal-tests@e3c0efecadda0e0fbb616abcdf447c788959ca64
         with:
           run-tests-guide-url: http://go/angular-g3sync-start
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -13,17 +13,17 @@ jobs:
       JOBS: 2
     steps:
       - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@e3c0efecadda0e0fbb616abcdf447c788959ca64
         with:
           cache-node-modules: true
       - name: Install node modules
         run: yarn install --frozen-lockfile
       - name: Setup Bazel
-        uses: angular/dev-infra/github-actions/bazel/setup@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/setup@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Setup Bazel Remote Caching
-        uses: angular/dev-infra/github-actions/bazel/configure-remote@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/configure-remote@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Setup Saucelabs Variables
-        uses: angular/dev-infra/github-actions/saucelabs@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/saucelabs@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Set up Sauce Tunnel Daemon
         run: yarn bazel run //tools/saucelabs-daemon/background-service -- $JOBS &
         env:

--- a/.github/workflows/merge-ready-status.yml
+++ b/.github/workflows/merge-ready-status.yml
@@ -9,6 +9,6 @@ jobs:
   status:
     runs-on: ubuntu-latest
     steps:
-      - uses: angular/dev-infra/github-actions/unified-status-check@be69a70efc9f2331083d76073427c0c81ec15a1e
+      - uses: angular/dev-infra/github-actions/unified-status-check@e3c0efecadda0e0fbb616abcdf447c788959ca64
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -21,7 +21,7 @@ jobs:
       workflows: ${{ steps.workflows.outputs.workflows }}
     steps:
       - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Install node modules
         run: yarn -s install --frozen-lockfile
       - id: workflows
@@ -36,9 +36,9 @@ jobs:
         workflow: ${{ fromJSON(needs.list.outputs.workflows) }}
     steps:
       - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Setup Bazel
-        uses: angular/dev-infra/github-actions/bazel/setup@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/setup@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Install node modules
         run: yarn -s install --frozen-lockfile
       # We utilize the google-github-actions/auth action to allow us to get an active credential using workflow

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@e3c0efecadda0e0fbb616abcdf447c788959ca64
         with:
           cache-node-modules: true
       - name: Install node modules
@@ -39,7 +39,7 @@ jobs:
       - name: Check code format
         run: yarn ng-dev format changed --check ${{ github.event.pull_request.base.sha }}
       - name: Check Package Licenses
-        uses: angular/dev-infra/github-actions/linting/licenses@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/linting/licenses@e3c0efecadda0e0fbb616abcdf447c788959ca64
         with:
           allow-dependencies-licenses: 'pkg:npm/google-protobuf@'
 
@@ -47,13 +47,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@e3c0efecadda0e0fbb616abcdf447c788959ca64
         with:
           cache-node-modules: true
       - name: Setup Bazel
-        uses: angular/dev-infra/github-actions/bazel/setup@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/setup@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Setup Bazel RBE
-        uses: angular/dev-infra/github-actions/bazel/configure-remote@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/configure-remote@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Install node modules
         run: yarn install --frozen-lockfile
       - name: Run unit tests
@@ -65,13 +65,13 @@ jobs:
     runs-on: ubuntu-latest-4core
     steps:
       - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@e3c0efecadda0e0fbb616abcdf447c788959ca64
         with:
           cache-node-modules: true
       - name: Setup Bazel
-        uses: angular/dev-infra/github-actions/bazel/setup@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/setup@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Setup Bazel Remote Caching
-        uses: angular/dev-infra/github-actions/bazel/configure-remote@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/configure-remote@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Install node modules
         run: yarn install --frozen-lockfile --network-timeout 100000
       - name: Run CI tests for framework
@@ -89,13 +89,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@e3c0efecadda0e0fbb616abcdf447c788959ca64
         with:
           cache-node-modules: true
       - name: Setup Bazel
-        uses: angular/dev-infra/github-actions/bazel/setup@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/setup@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Setup Bazel Remote Caching
-        uses: angular/dev-infra/github-actions/bazel/configure-remote@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/configure-remote@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Install node modules
         run: yarn install --frozen-lockfile --network-timeout 100000
       - name: Run CI tests for framework
@@ -111,11 +111,11 @@ jobs:
       labels: ubuntu-latest-4core
     steps:
       - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Setup Bazel
-        uses: angular/dev-infra/github-actions/bazel/setup@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/setup@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Setup Bazel RBE
-        uses: angular/dev-infra/github-actions/bazel/configure-remote@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/configure-remote@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Install node modules
         run: yarn install --frozen-lockfile
       # TODO: re-enable all tests once the next release is shipped
@@ -130,7 +130,7 @@ jobs:
       labels: ubuntu-latest-4core
     steps:
       - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@e3c0efecadda0e0fbb616abcdf447c788959ca64
         with:
           cache-node-modules: true
           node-module-directories: |
@@ -138,9 +138,9 @@ jobs:
             ./packages/zone.js/node_modules
             ./packages/zone.js/test/typings/node_modules
       - name: Setup Bazel
-        uses: angular/dev-infra/github-actions/bazel/setup@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/setup@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Setup Bazel RBE
-        uses: angular/dev-infra/github-actions/bazel/configure-remote@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/bazel/configure-remote@e3c0efecadda0e0fbb616abcdf447c788959ca64
       - name: Install node modules
         run: yarn install --frozen-lockfile
       - run: |
@@ -177,7 +177,7 @@ jobs:
       SAUCE_TUNNEL_IDENTIFIER: angular-framework-${{ github.run_number }}
     steps:
       - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@e3c0efecadda0e0fbb616abcdf447c788959ca64
         with:
           cache-node-modules: true
       - name: Install node modules

--- a/.github/workflows/update-cli-help.yml
+++ b/.github/workflows/update-cli-help.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           ANGULAR_CLI_BUILDS_READONLY_GITHUB_TOKEN: ${{ secrets.ANGULAR_CLI_BUILDS_READONLY_GITHUB_TOKEN }}
       - name: Create a PR (if necessary)
-        uses: angular/dev-infra/github-actions/create-pr-for-changes@be69a70efc9f2331083d76073427c0c81ec15a1e
+        uses: angular/dev-infra/github-actions/create-pr-for-changes@e3c0efecadda0e0fbb616abcdf447c788959ca64
         with:
           branch-prefix: update-cli-help
           pr-title: 'docs: update Angular CLI help [${{github.ref_name}}]'


### PR DESCRIPTION
Update to use the latest bazel/configure-remote action from dev-infra and set up trusted builds for CI runs from upstream branches.
