### PR TITLE
fix(core): fix regexp for event types

### DIFF
--- a/packages/core/src/hydration/utils.ts
+++ b/packages/core/src/hydration/utils.ts
@@ -598,12 +598,10 @@ export function getParentBlockHydrationQueue(
 function gatherDeferBlocksByJSActionAttribute(doc: Document): Set<HTMLElement> {
   const jsactionNodes = doc.body.querySelectorAll('[jsaction]');
   const blockMap = new Set<HTMLElement>();
+  const eventTypes = [hoverEventNames.join(':;'), interactionEventNames.join(':;')].join('|');
   for (let node of jsactionNodes) {
     const attr = node.getAttribute('jsaction');
     const blockId = node.getAttribute('ngb');
-    const eventTypes = [...hoverEventNames.join(':;'), ...interactionEventNames.join(':;')].join(
-      '|',
-    );
     if (attr?.match(eventTypes) && blockId !== null) {
       blockMap.add(node as HTMLElement);
     }


### PR DESCRIPTION
This regexp accidentally worked. It was splitting by individual character and putting a pipe in rather than splitting by set of event types
