### PR TITLE
fix(devtools): do not emit a route object with functions

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/router-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/router-tree.ts
@@ -7,9 +7,8 @@
  */
 
 import {Route} from 'protocol';
+import type {Route as AngularRoute} from '@angular/router';
 
-// todo(aleksanderbodurri): type these properly
-type AngularRoute = any;
 type Routes = any;
 type Router = any;
 
@@ -61,7 +60,7 @@ function assignChildrenToParent(
     const isActive = routePath === currentUrl;
 
     const routeConfig: Route = {
-      title: child.title,
+      title: child.title?.toString(), // can be a function, so convert to string
       pathMatch: child.pathMatch,
       component: childName,
       canActivateGuards: getGuardNames(child),


### PR DESCRIPTION
In the case where a Route has title defined as a function, it eventually throw when it reaches `window.postMessage`

fixes #60595
