### PR TITLE
fix(language-service): Ensure dollar signs are escaped in completions

### DIFF
--- a/packages/language-service/src/attribute_completions.ts
+++ b/packages/language-service/src/attribute_completions.ts
@@ -409,7 +409,7 @@ export function buildAttributeCompletionTable(
 }
 
 function buildSnippet(insertSnippet: true | undefined, text: string): string | undefined {
-  return insertSnippet ? `${text}="$1"` : undefined;
+  return insertSnippet ? `${text.replace(/\$/gi, '\\$')}="$1"` : undefined;
 }
 
 /**


### PR DESCRIPTION
Dollar signs need to be escaped so they are not replaced during snippet expansion: https://code.visualstudio.com/docs/editing/userdefinedsnippets#_how-do-i-have-a-snippet-place-a-variable-in-the-pasted-script
