### PR TITLE
Fixes for the inject migration

### DIFF
--- a/packages/core/schematics/ng-generate/inject-migration/analysis.ts
+++ b/packages/core/schematics/ng-generate/inject-migration/analysis.ts
@@ -302,6 +302,16 @@ export function getSuperParameters(
       localTypeChecker.getSymbolAtLocation(node)?.declarations?.forEach((decl) => {
         if (ts.isParameter(decl) && topLevelParameters.has(decl)) {
           usedParams.add(decl);
+        } else if (
+          ts.isShorthandPropertyAssignment(decl) &&
+          topLevelParameterNames.has(decl.name.text)
+        ) {
+          for (const param of topLevelParameters) {
+            if (ts.isIdentifier(param.name) && decl.name.text === param.name.text) {
+              usedParams.add(param);
+              break;
+            }
+          }
         }
       });
       // Parameters referenced inside callbacks can be used directly

--- a/packages/core/schematics/ng-generate/inject-migration/analysis.ts
+++ b/packages/core/schematics/ng-generate/inject-migration/analysis.ts
@@ -304,7 +304,9 @@ export function getSuperParameters(
           usedParams.add(decl);
         }
       });
-    } else {
+      // Parameters referenced inside callbacks can be used directly
+      // within `super` so don't descend into inline functions.
+    } else if (!isInlineFunction(node)) {
       node.forEachChild(walk);
     }
   });
@@ -422,4 +424,13 @@ function findSuperCall(root: ts.Node): ts.CallExpression | null {
   });
 
   return result;
+}
+
+/** Checks whether a node is an inline function. */
+export function isInlineFunction(
+  node: ts.Node,
+): node is ts.FunctionDeclaration | ts.FunctionExpression | ts.ArrowFunction {
+  return (
+    ts.isFunctionDeclaration(node) || ts.isFunctionExpression(node) || ts.isArrowFunction(node)
+  );
 }

--- a/packages/core/schematics/ng-generate/inject-migration/internal.ts
+++ b/packages/core/schematics/ng-generate/inject-migration/internal.ts
@@ -7,7 +7,7 @@
  */
 
 import ts from 'typescript';
-import {isAccessedViaThis, parameterDeclaresProperty} from './analysis';
+import {isAccessedViaThis, isInlineFunction, parameterDeclaresProperty} from './analysis';
 
 /** Property that is a candidate to be combined. */
 interface CombineCandidate {
@@ -299,11 +299,7 @@ function isInsideInlineFunction(startNode: ts.Node, boundary: ts.Node): boolean 
       return false;
     }
 
-    if (
-      ts.isFunctionDeclaration(current) ||
-      ts.isFunctionExpression(current) ||
-      ts.isArrowFunction(current)
-    ) {
+    if (isInlineFunction(current)) {
       return true;
     }
 


### PR DESCRIPTION
Fixes a couple of issues in the `inject` migration that came up internally.

### fix(migrations): inject migration not handling super parameter referenced via this
The inject migration has some logic that treats parameters referenced directly inside of `super` differently. This logic didn't account for the fact that the parameters could be inside of inline functions which have less strict access requirements.

### fix(migrations): handle shorthand assignments in super call 
Fixes that the logic which checks whether a parameter is used inside a `super` call wasn't accounting for shorthand assignments.