### PR TITLE
refactor(core): calculate `hasHttpTransferCacheOptions` later

### DIFF
--- a/packages/platform-browser/src/hydration.ts
+++ b/packages/platform-browser/src/hydration.ts
@@ -225,9 +225,6 @@ export function provideClientHydration(
 ): EnvironmentProviders {
   const providers: Provider[] = [];
   const featuresKind = new Set<HydrationFeatureKind>();
-  const hasHttpTransferCacheOptions = featuresKind.has(
-    HydrationFeatureKind.HttpTransferCacheOptions,
-  );
 
   for (const {ɵproviders, ɵkind} of features) {
     featuresKind.add(ɵkind);
@@ -236,6 +233,10 @@ export function provideClientHydration(
       providers.push(ɵproviders);
     }
   }
+
+  const hasHttpTransferCacheOptions = featuresKind.has(
+    HydrationFeatureKind.HttpTransferCacheOptions,
+  );
 
   if (
     typeof ngDevMode !== 'undefined' &&


### PR DESCRIPTION
Prior to this commit, `hasHttpTransferCacheOptions` was calculated immediately after the `featuresKind` set was declared, which was always defaulted to `false`.