### PR TITLE
refactor(router): Update StateManager base class with common concrete…

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -280,12 +280,8 @@ export class Router {
     // already patch onPopState, so location change callback will
     // run into ngZone
     this.nonRouterCurrentEntryChangeSubscription ??=
-      this.stateManager.registerNonRouterCurrentEntryChangeListener((url, state) => {
-        // The `setTimeout` was added in #12160 and is likely to support Angular/AngularJS
-        // hybrid apps.
-        setTimeout(() => {
-          this.navigateToSyncWithBrowser(url, 'popstate', state);
-        }, 0);
+      this.stateManager.registerNonRouterCurrentEntryChangeListener((url, state, source) => {
+        this.navigateToSyncWithBrowser(url, source, state);
       });
   }
 

--- a/packages/router/src/statemanager/state_manager.ts
+++ b/packages/router/src/statemanager/state_manager.ts
@@ -19,6 +19,7 @@ import {
   NavigationError,
   NavigationSkipped,
   NavigationStart,
+  NavigationTrigger,
   PrivateRouterEvents,
   RoutesRecognized,
 } from '../events';
@@ -30,6 +31,15 @@ import {UrlSerializer, UrlTree} from '../url_tree';
 
 @Injectable({providedIn: 'root', useFactory: () => inject(HistoryStateManager)})
 export abstract class StateManager {
+  protected readonly urlSerializer = inject(UrlSerializer);
+  private readonly options = inject(ROUTER_CONFIGURATION, {optional: true}) || {};
+  protected readonly canceledNavigationResolution =
+    this.options.canceledNavigationResolution || 'replace';
+  protected location = inject(Location);
+  protected urlHandlingStrategy = inject(UrlHandlingStrategy);
+  protected urlUpdateStrategy = this.options.urlUpdateStrategy || 'deferred';
+
+  private currentUrlTree = new UrlTree();
   /**
    * Returns the currently activated `UrlTree`.
    *
@@ -39,8 +49,11 @@ export abstract class StateManager {
    * The value is set after finding the route config tree to activate but before activating the
    * route.
    */
-  abstract getCurrentUrlTree(): UrlTree;
+  getCurrentUrlTree(): UrlTree {
+    return this.currentUrlTree;
+  }
 
+  private rawUrlTree = this.currentUrlTree;
   /**
    * Returns a `UrlTree` that is represents what the browser is actually showing.
    *
@@ -66,13 +79,70 @@ export abstract class StateManager {
    * location change listener due to a URL update by the AngularJS router. In this case, the router
    * still need to know what the browser's URL is for future navigations.
    */
-  abstract getRawUrlTree(): UrlTree;
+  getRawUrlTree(): UrlTree {
+    return this.rawUrlTree;
+  }
+
+  protected createBrowserPath(currentTransition: Navigation): string {
+    const rawUrl =
+      currentTransition.finalUrl !== undefined
+        ? this.urlHandlingStrategy.merge(currentTransition.finalUrl!, currentTransition.initialUrl)
+        : currentTransition.initialUrl;
+    const url = currentTransition.targetBrowserUrl ?? rawUrl;
+    const path = url instanceof UrlTree ? this.urlSerializer.serialize(url) : url;
+    return path;
+  }
+
+  protected commitTransition(transition: Navigation) {
+    // If we are committing the transition after having a final URL and target state, we're updating
+    // all pieces of the state. Otherwise, we likely skipped the transition (due to URL handling strategy)
+    // and only want to update the rawUrlTree, which represents the browser URL (and doesn't necessarily match router state).
+    if (transition.finalUrl && transition.targetRouterState) {
+      this.currentUrlTree = transition.finalUrl;
+      this.rawUrlTree = this.urlHandlingStrategy.merge(transition.finalUrl, transition.initialUrl);
+      this.routerState = transition.targetRouterState;
+    } else {
+      this.rawUrlTree = transition.initialUrl;
+    }
+  }
+
+  private routerState = createEmptyState(null);
+
+  /** Returns the current RouterState. */
+  getRouterState(): RouterState {
+    return this.routerState;
+  }
+
+  private stateMemento = this.createStateMemento();
+
+  protected updateStateMemento() {
+    this.stateMemento = this.createStateMemento();
+  }
+
+  private createStateMemento() {
+    return {
+      rawUrlTree: this.rawUrlTree,
+      currentUrlTree: this.currentUrlTree,
+      routerState: this.routerState,
+    };
+  }
+
+  protected resetInternalState(navigation: Navigation): void {
+    this.routerState = this.stateMemento.routerState;
+    this.currentUrlTree = this.stateMemento.currentUrlTree;
+    // Note here that we use the urlHandlingStrategy to get the reset `rawUrlTree` because it may be
+    // configured to handle only part of the navigation URL. This means we would only want to reset
+    // the part of the navigation handled by the Angular router rather than the whole URL. In
+    // addition, the URLHandlingStrategy may be configured to specifically preserve parts of the URL
+    // when merging, such as the query params so they are not lost on a refresh.
+    this.rawUrlTree = this.urlHandlingStrategy.merge(
+      this.currentUrlTree,
+      navigation.finalUrl ?? this.rawUrlTree,
+    );
+  }
 
   /** Returns the current state stored by the browser for the current history entry. */
   abstract restoredState(): RestoredState | null | undefined;
-
-  /** Returns the current RouterState. */
-  abstract getRouterState(): RouterState;
 
   /**
    * Registers a listener that is called whenever the current history entry changes by some API
@@ -80,7 +150,11 @@ export abstract class StateManager {
    * also includes programmatic APIs called by non-Router JavaScript.
    */
   abstract registerNonRouterCurrentEntryChangeListener(
-    listener: (url: string, state: RestoredState | null | undefined) => void,
+    listener: (
+      url: string,
+      state: RestoredState | null | undefined,
+      trigger: NavigationTrigger,
+    ) => void,
   ): SubscriptionLike;
 
   /**
@@ -92,27 +166,6 @@ export abstract class StateManager {
 
 @Injectable({providedIn: 'root'})
 export class HistoryStateManager extends StateManager {
-  private readonly location = inject(Location);
-  private readonly urlSerializer = inject(UrlSerializer);
-  private readonly options = inject(ROUTER_CONFIGURATION, {optional: true}) || {};
-  private readonly canceledNavigationResolution =
-    this.options.canceledNavigationResolution || 'replace';
-
-  private urlHandlingStrategy = inject(UrlHandlingStrategy);
-  private urlUpdateStrategy = this.options.urlUpdateStrategy || 'deferred';
-
-  private currentUrlTree = new UrlTree();
-
-  override getCurrentUrlTree() {
-    return this.currentUrlTree;
-  }
-
-  private rawUrlTree = this.currentUrlTree;
-
-  override getRawUrlTree() {
-    return this.rawUrlTree;
-  }
-
   /**
    * The id of the currently active page in the router.
    * Updated to the transition's target id on a successful navigation.
@@ -140,59 +193,39 @@ export class HistoryStateManager extends StateManager {
     return this.restoredState()?.ɵrouterPageId ?? this.currentPageId;
   }
 
-  private routerState = createEmptyState(null);
-
-  override getRouterState() {
-    return this.routerState;
-  }
-
-  private stateMemento = this.createStateMemento();
-
-  private createStateMemento() {
-    return {
-      rawUrlTree: this.rawUrlTree,
-      currentUrlTree: this.currentUrlTree,
-      routerState: this.routerState,
-    };
-  }
-
   override registerNonRouterCurrentEntryChangeListener(
-    listener: (url: string, state: RestoredState | null | undefined) => void,
+    listener: (
+      url: string,
+      state: RestoredState | null | undefined,
+      trigger: NavigationTrigger,
+    ) => void,
   ): SubscriptionLike {
     return this.location.subscribe((event) => {
       if (event['type'] === 'popstate') {
-        listener(event['url']!, event.state as RestoredState | null | undefined);
+        // The `setTimeout` was added in #12160 and is likely to support Angular/AngularJS
+        // hybrid apps.
+        setTimeout(() => {
+          listener(event['url']!, event.state as RestoredState | null | undefined, 'popstate');
+        });
       }
     });
   }
 
   override handleRouterEvent(e: Event | PrivateRouterEvents, currentTransition: Navigation) {
     if (e instanceof NavigationStart) {
-      this.stateMemento = this.createStateMemento();
+      this.updateStateMemento();
     } else if (e instanceof NavigationSkipped) {
-      this.rawUrlTree = currentTransition.initialUrl;
+      this.commitTransition(currentTransition);
     } else if (e instanceof RoutesRecognized) {
       if (this.urlUpdateStrategy === 'eager') {
         if (!currentTransition.extras.skipLocationChange) {
-          const rawUrl = this.urlHandlingStrategy.merge(
-            currentTransition.finalUrl!,
-            currentTransition.initialUrl,
-          );
-          this.setBrowserUrl(currentTransition.targetBrowserUrl ?? rawUrl, currentTransition);
+          this.setBrowserUrl(this.createBrowserPath(currentTransition), currentTransition);
         }
       }
     } else if (e instanceof BeforeActivateRoutes) {
-      this.currentUrlTree = currentTransition.finalUrl!;
-      this.rawUrlTree = this.urlHandlingStrategy.merge(
-        currentTransition.finalUrl!,
-        currentTransition.initialUrl,
-      );
-      this.routerState = currentTransition.targetRouterState!;
+      this.commitTransition(currentTransition);
       if (this.urlUpdateStrategy === 'deferred' && !currentTransition.extras.skipLocationChange) {
-        this.setBrowserUrl(
-          currentTransition.targetBrowserUrl ?? this.rawUrlTree,
-          currentTransition,
-        );
+        this.setBrowserUrl(this.createBrowserPath(currentTransition), currentTransition);
       }
     } else if (
       e instanceof NavigationCancel &&
@@ -208,8 +241,7 @@ export class HistoryStateManager extends StateManager {
     }
   }
 
-  private setBrowserUrl(url: UrlTree | string, transition: Navigation) {
-    const path = url instanceof UrlTree ? this.urlSerializer.serialize(url) : url;
+  private setBrowserUrl(path: string, transition: Navigation) {
     if (this.location.isCurrentPathEqualTo(path) || !!transition.extras.replaceUrl) {
       // replacements do not update the target page
       const currentBrowserPageId = this.browserPageId;
@@ -237,11 +269,11 @@ export class HistoryStateManager extends StateManager {
       const targetPagePosition = this.currentPageId - currentBrowserPageId;
       if (targetPagePosition !== 0) {
         this.location.historyGo(targetPagePosition);
-      } else if (this.currentUrlTree === navigation.finalUrl && targetPagePosition === 0) {
+      } else if (this.getCurrentUrlTree() === navigation.finalUrl && targetPagePosition === 0) {
         // We got to the activation stage (where currentUrlTree is set to the navigation's
         // finalUrl), but we weren't moving anywhere in history (skipLocationChange or replaceUrl).
         // We still need to reset the router state back to what it was when the navigation started.
-        this.resetState(navigation);
+        this.resetInternalState(navigation);
         this.resetUrlToCurrentUrlTree();
       } else {
         // The browser URL and router state was not updated before the navigation cancelled so
@@ -253,29 +285,15 @@ export class HistoryStateManager extends StateManager {
       // reject. For 'eager' navigations, it seems like we also really should reset the state
       // because the navigation was cancelled. Investigate if this can be done by running TGP.
       if (restoringFromCaughtError) {
-        this.resetState(navigation);
+        this.resetInternalState(navigation);
       }
       this.resetUrlToCurrentUrlTree();
     }
   }
 
-  private resetState(navigation: Navigation): void {
-    this.routerState = this.stateMemento.routerState;
-    this.currentUrlTree = this.stateMemento.currentUrlTree;
-    // Note here that we use the urlHandlingStrategy to get the reset `rawUrlTree` because it may be
-    // configured to handle only part of the navigation URL. This means we would only want to reset
-    // the part of the navigation handled by the Angular router rather than the whole URL. In
-    // addition, the URLHandlingStrategy may be configured to specifically preserve parts of the URL
-    // when merging, such as the query params so they are not lost on a refresh.
-    this.rawUrlTree = this.urlHandlingStrategy.merge(
-      this.currentUrlTree,
-      navigation.finalUrl ?? this.rawUrlTree,
-    );
-  }
-
   private resetUrlToCurrentUrlTree(): void {
     this.location.replaceState(
-      this.urlSerializer.serialize(this.rawUrlTree),
+      this.urlSerializer.serialize(this.getRawUrlTree()),
       '',
       this.generateNgRouterState(this.lastSuccessfulId, this.currentPageId),
     );


### PR DESCRIPTION
… implementations

This commit updates the `StateManager` base class to contain common concrete implementations that would be the same regardless of whether the state manager is backed by the browser history API or the Navigation API.
