### PR TITLE
refactor(common): convert scripts within `packages/common` to relative imports

### DIFF
--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -16,7 +16,6 @@ import { ResourceRef } from '@angular/core';
 import { Signal } from '@angular/core';
 import { ValueEqualityFn } from '@angular/core';
 import { WritableResource } from '@angular/core';
-import { XhrFactory } from '@angular/common';
 
 // @public
 export class FetchBackend implements HttpBackend {

--- a/goldens/public-api/common/http/testing/index.api.md
+++ b/goldens/public-api/common/http/testing/index.api.md
@@ -4,11 +4,7 @@
 
 ```ts
 
-import { HttpEvent } from '@angular/common/http';
-import { HttpHeaders } from '@angular/common/http';
-import { HttpRequest } from '@angular/common/http';
 import * as i0 from '@angular/core';
-import * as i1 from '@angular/common/http';
 import { Observer } from 'rxjs';
 import { Provider } from '@angular/core';
 
@@ -19,7 +15,7 @@ export class HttpClientTestingModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<HttpClientTestingModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<HttpClientTestingModule, never, [typeof i1.HttpClientModule], never>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<HttpClientTestingModule, never, [typeof HttpClientModule], never>;
 }
 
 // @public

--- a/goldens/public-api/common/testing/index.api.md
+++ b/goldens/public-api/common/testing/index.api.md
@@ -7,9 +7,7 @@
 import * as i0 from '@angular/core';
 import { InjectionToken } from '@angular/core';
 import { Location as Location_2 } from '@angular/common';
-import { LocationChangeListener } from '@angular/common';
 import { LocationStrategy } from '@angular/common';
-import { PlatformLocation } from '@angular/common';
 import { Provider } from '@angular/core';
 import { SubscriptionLike } from 'rxjs';
 

--- a/goldens/public-api/common/upgrade/index.api.md
+++ b/goldens/public-api/common/upgrade/index.api.md
@@ -4,14 +4,30 @@
 
 ```ts
 
+import { ChangeDetectorRef } from '@angular/core';
+import { DoCheck } from '@angular/core';
+import { ElementRef } from '@angular/core';
 import * as i0 from '@angular/core';
-import * as i1 from '@angular/common';
 import { InjectionToken } from '@angular/core';
-import { Location as Location_2 } from '@angular/common';
-import { LocationStrategy } from '@angular/common';
+import { Injector } from '@angular/core';
+import { IterableDiffers } from '@angular/core';
+import { KeyValueDiffers } from '@angular/core';
 import { ModuleWithProviders } from '@angular/core';
-import { PlatformLocation } from '@angular/common';
+import { NgIterable } from '@angular/core';
+import { NgModuleFactory } from '@angular/core';
+import { Observable } from 'rxjs';
+import { OnChanges } from '@angular/core';
+import { OnDestroy } from '@angular/core';
+import { PipeTransform } from '@angular/core';
+import { Renderer2 } from '@angular/core';
+import { SimpleChanges } from '@angular/core';
+import { Subscribable } from 'rxjs';
+import { SubscriptionLike } from 'rxjs';
+import { TemplateRef } from '@angular/core';
+import { TrackByFunction } from '@angular/core';
+import { Type } from '@angular/core';
 import { UpgradeModule } from '@angular/upgrade/static';
+import { ViewContainerRef } from '@angular/core';
 
 // @public
 export class $locationShim {
@@ -117,7 +133,7 @@ export class LocationUpgradeModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<LocationUpgradeModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<LocationUpgradeModule, never, [typeof i1.CommonModule], never>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<LocationUpgradeModule, never, [typeof CommonModule], never>;
 }
 
 // @public

--- a/packages/bazel/test/ng_package/common_package.spec.ts
+++ b/packages/bazel/test/ng_package/common_package.spec.ts
@@ -33,7 +33,7 @@ describe('@angular/common ng_package', () => {
   });
 
   it('should have right fesm files', () => {
-    const expected = [
+    const expectedFiles = [
       'common.mjs',
       'common.mjs.map',
       'http',
@@ -46,13 +46,18 @@ describe('@angular/common ng_package', () => {
       'upgrade.mjs',
       'upgrade.mjs.map',
     ];
-    expect(
-      shx
-        .ls('-R', 'fesm2022')
-        .stdout.split('\n')
-        .filter((n) => !!n)
-        .sort(),
-    ).toEqual(expected);
+    const allFiles = shx
+      .ls('-R', 'fesm2022')
+      .stdout.split('\n')
+      .filter((n) => !!n)
+      .sort();
+    // The list of files would contain some shared chunks too (e.g. `location-CprIx2Bv.mjs`),
+    // so we make sure that the actual list of files properly represent main entrypoints
+    // (ignoring extra chunks info).
+    const allFilesAsSet = new Set(allFiles);
+    for (const expectedFile of expectedFiles) {
+      expect(allFilesAsSet.has(expectedFile)).toBe(true);
+    }
   });
 
   it('should have the correct source map paths', () => {

--- a/packages/common/http/src/interceptor.ts
+++ b/packages/common/http/src/interceptor.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {isPlatformServer} from '@angular/common';
+import {isPlatformServer} from '../../index';
 import {
   EnvironmentInjector,
   inject,

--- a/packages/common/http/src/jsonp.ts
+++ b/packages/common/http/src/jsonp.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT} from '@angular/common';
+import {DOCUMENT} from '../../index';
 import {
   EnvironmentInjector,
   Inject,

--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {XhrFactory} from '@angular/common';
+import {XhrFactory} from '../../index';
 import {Injectable, ɵRuntimeError as RuntimeError} from '@angular/core';
 import {from, Observable, Observer, of} from 'rxjs';
 import {switchMap} from 'rxjs/operators';

--- a/packages/common/http/src/xsrf.ts
+++ b/packages/common/http/src/xsrf.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT, ɵparseCookieValue as parseCookieValue} from '@angular/common';
+import {DOCUMENT, ɵparseCookieValue as parseCookieValue} from '../../index';
 import {
   EnvironmentInjector,
   Inject,

--- a/packages/common/http/test/client_spec.ts
+++ b/packages/common/http/test/client_spec.ts
@@ -6,14 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {HttpClient} from '@angular/common/http/src/client';
-import {
-  HttpErrorResponse,
-  HttpEventType,
-  HttpResponse,
-  HttpStatusCode,
-} from '@angular/common/http/src/response';
-import {HttpClientTestingBackend} from '@angular/common/http/testing/src/backend';
+import {HttpClient} from '../src/client';
+import {HttpErrorResponse, HttpEventType, HttpResponse, HttpStatusCode} from '../src/response';
+import {HttpClientTestingBackend} from '../testing/src/backend';
 import {toArray} from 'rxjs/operators';
 
 describe('HttpClient', () => {

--- a/packages/common/http/test/fetch_spec.ts
+++ b/packages/common/http/test/fetch_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {HttpEvent, HttpEventType, HttpRequest, HttpResponse} from '@angular/common/http';
+import {HttpEvent, HttpEventType, HttpRequest, HttpResponse} from '../index';
 import {TestBed} from '@angular/core/testing';
 import {Observable, of, Subject} from 'rxjs';
 import {catchError, retry, scan, skip, take, toArray} from 'rxjs/operators';

--- a/packages/common/http/test/headers_spec.ts
+++ b/packages/common/http/test/headers_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {HttpHeaders} from '@angular/common/http/src/headers';
+import {HttpHeaders} from '../src/headers';
 
 describe('HttpHeaders', () => {
   describe('initialization', () => {

--- a/packages/common/http/test/jsonp_spec.ts
+++ b/packages/common/http/test/jsonp_spec.ts
@@ -6,16 +6,16 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {HttpHeaders} from '@angular/common/http/src/headers';
+import {HttpHeaders} from '../src/headers';
 import {
   JSONP_ERR_HEADERS_NOT_SUPPORTED,
   JSONP_ERR_NO_CALLBACK,
   JSONP_ERR_WRONG_METHOD,
   JSONP_ERR_WRONG_RESPONSE_TYPE,
   JsonpClientBackend,
-} from '@angular/common/http/src/jsonp';
-import {HttpRequest} from '@angular/common/http/src/request';
-import {HttpErrorResponse, HttpEventType} from '@angular/common/http/src/response';
+} from '../src/jsonp';
+import {HttpRequest} from '../src/request';
+import {HttpErrorResponse, HttpEventType} from '../src/response';
 import {toArray} from 'rxjs/operators';
 
 import {MockDocument} from './jsonp_mock';

--- a/packages/common/http/test/module_spec.ts
+++ b/packages/common/http/test/module_spec.ts
@@ -6,15 +6,15 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {HttpHandler} from '@angular/common/http/src/backend';
-import {HttpClient} from '@angular/common/http/src/client';
-import {HttpContext, HttpContextToken} from '@angular/common/http/src/context';
-import {HTTP_INTERCEPTORS, HttpInterceptor} from '@angular/common/http/src/interceptor';
-import {HttpRequest} from '@angular/common/http/src/request';
-import {HttpEvent, HttpResponse} from '@angular/common/http/src/response';
-import {HttpTestingController} from '@angular/common/http/testing/src/api';
-import {HttpClientTestingModule} from '@angular/common/http/testing/src/module';
-import {TestRequest} from '@angular/common/http/testing/src/request';
+import {HttpHandler} from '../src/backend';
+import {HttpClient} from '../src/client';
+import {HttpContext, HttpContextToken} from '../src/context';
+import {HTTP_INTERCEPTORS, HttpInterceptor} from '../src/interceptor';
+import {HttpRequest} from '../src/request';
+import {HttpEvent, HttpResponse} from '../src/response';
+import {HttpTestingController} from '../testing/src/api';
+import {HttpClientTestingModule} from '../testing/src/module';
+import {TestRequest} from '../testing/src/request';
 import {Injectable, Injector} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {Observable} from 'rxjs';

--- a/packages/common/http/test/params_spec.ts
+++ b/packages/common/http/test/params_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {HttpParams} from '@angular/common/http/src/params';
+import {HttpParams} from '../src/params';
 
 describe('HttpUrlEncodedParams', () => {
   describe('initialization', () => {

--- a/packages/common/http/test/provider_spec.ts
+++ b/packages/common/http/test/provider_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT, XhrFactory} from '@angular/common';
+import {DOCUMENT, XhrFactory} from '../../index';
 import {
   FetchBackend,
   HTTP_INTERCEPTORS,
@@ -20,12 +20,8 @@ import {
   HttpResponse,
   HttpXhrBackend,
   JsonpClientBackend,
-} from '@angular/common/http';
-import {
-  HttpClientTestingModule,
-  HttpTestingController,
-  provideHttpClientTesting,
-} from '@angular/common/http/testing';
+} from '../index';
+import {HttpClientTestingModule, HttpTestingController, provideHttpClientTesting} from '../testing';
 import {
   ApplicationRef,
   createEnvironmentInjector,

--- a/packages/common/http/test/request_spec.ts
+++ b/packages/common/http/test/request_spec.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {HttpContext} from '@angular/common/http/src/context';
-import {HttpHeaders} from '@angular/common/http/src/headers';
-import {HttpParams} from '@angular/common/http/src/params';
-import {HttpRequest} from '@angular/common/http/src/request';
+import {HttpContext} from '../src/context';
+import {HttpHeaders} from '../src/headers';
+import {HttpParams} from '../src/params';
+import {HttpRequest} from '../src/request';
 
 const TEST_URL = 'https://angular.io/';
 const TEST_STRING = `I'm a body!`;

--- a/packages/common/http/test/resource_spec.ts
+++ b/packages/common/http/test/resource_spec.ts
@@ -14,8 +14,8 @@ import {
   httpResource,
   HttpContext,
   HttpContextToken,
-} from '@angular/common/http';
-import {HttpTestingController, provideHttpClientTesting} from '@angular/common/http/testing';
+} from '../index';
+import {HttpTestingController, provideHttpClientTesting} from '../testing';
 
 describe('httpResource', () => {
   beforeEach(() => {

--- a/packages/common/http/test/response_spec.ts
+++ b/packages/common/http/test/response_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {HttpHeaders} from '@angular/common/http/src/headers';
-import {HttpResponse, HttpStatusCode} from '@angular/common/http/src/response';
+import {HttpHeaders} from '../src/headers';
+import {HttpResponse, HttpStatusCode} from '../src/response';
 
 describe('HttpResponse', () => {
   describe('constructor()', () => {

--- a/packages/common/http/test/transfer_cache_spec.ts
+++ b/packages/common/http/test/transfer_cache_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT} from '@angular/common';
+import {DOCUMENT} from '../../index';
 import {ApplicationRef, Component, Injectable, PLATFORM_ID} from '@angular/core';
 import {makeStateKey, TransferState} from '@angular/core/src/transfer_state';
 import {fakeAsync, flush, TestBed} from '@angular/core/testing';

--- a/packages/common/http/test/xhr_mock.ts
+++ b/packages/common/http/test/xhr_mock.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {XhrFactory} from '@angular/common';
-import {HttpHeaders} from '@angular/common/http/src/headers';
+import {XhrFactory} from '../../index';
+import {HttpHeaders} from '../src/headers';
 
 export class MockXhrFactory implements XhrFactory {
   // TODO(issue/24571): remove '!'.

--- a/packages/common/http/test/xhr_spec.ts
+++ b/packages/common/http/test/xhr_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {HttpRequest} from '@angular/common/http/src/request';
+import {HttpRequest} from '../src/request';
 import {
   HttpDownloadProgressEvent,
   HttpErrorResponse,
@@ -17,8 +17,8 @@ import {
   HttpResponseBase,
   HttpStatusCode,
   HttpUploadProgressEvent,
-} from '@angular/common/http/src/response';
-import {HttpXhrBackend} from '@angular/common/http/src/xhr';
+} from '../src/response';
+import {HttpXhrBackend} from '../src/xhr';
 import {Observable} from 'rxjs';
 import {toArray} from 'rxjs/operators';
 

--- a/packages/common/http/test/xsrf_spec.ts
+++ b/packages/common/http/test/xsrf_spec.ts
@@ -6,16 +6,16 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {HttpHeaders} from '@angular/common/http/src/headers';
-import {HttpRequest} from '@angular/common/http/src/request';
+import {HttpHeaders} from '../src/headers';
+import {HttpRequest} from '../src/request';
 import {
   HttpXsrfCookieExtractor,
   HttpXsrfInterceptor,
   HttpXsrfTokenExtractor,
   XSRF_ENABLED,
   XSRF_HEADER_NAME,
-} from '@angular/common/http/src/xsrf';
-import {HttpClientTestingBackend} from '@angular/common/http/testing/src/backend';
+} from '../src/xsrf';
+import {HttpClientTestingBackend} from '../testing/src/backend';
 import {TestBed} from '@angular/core/testing';
 
 class SampleTokenExtractor extends HttpXsrfTokenExtractor {

--- a/packages/common/http/testing/src/api.ts
+++ b/packages/common/http/testing/src/api.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {HttpRequest} from '@angular/common/http';
+import {HttpRequest} from '../../index';
 
 import {TestRequest} from './request';
 

--- a/packages/common/http/testing/src/backend.ts
+++ b/packages/common/http/testing/src/backend.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {HttpBackend, HttpEvent, HttpEventType, HttpRequest} from '@angular/common/http';
+import {HttpBackend, HttpEvent, HttpEventType, HttpRequest} from '../../index';
 import {Injectable} from '@angular/core';
 import {Observable, Observer} from 'rxjs';
 

--- a/packages/common/http/testing/src/module.ts
+++ b/packages/common/http/testing/src/module.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {HttpClientModule} from '@angular/common/http';
+import {HttpClientModule} from '../../index';
 import {NgModule} from '@angular/core';
 
 import {provideHttpClientTesting} from './provider';

--- a/packages/common/http/testing/src/provider.ts
+++ b/packages/common/http/testing/src/provider.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {HttpBackend, ɵREQUESTS_CONTRIBUTE_TO_STABILITY} from '@angular/common/http';
+import {HttpBackend, ɵREQUESTS_CONTRIBUTE_TO_STABILITY} from '../../index';
 import {Provider} from '@angular/core';
 
 import {HttpTestingController} from './api';

--- a/packages/common/http/testing/src/request.ts
+++ b/packages/common/http/testing/src/request.ts
@@ -13,7 +13,7 @@ import {
   HttpRequest,
   HttpResponse,
   HttpStatusCode,
-} from '@angular/common/http';
+} from '../../index';
 import {Observer} from 'rxjs';
 
 /**

--- a/packages/common/http/testing/test/request_spec.ts
+++ b/packages/common/http/testing/test/request_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {HttpClient} from '@angular/common/http';
-import {HttpClientTestingBackend} from '@angular/common/http/testing/src/backend';
+import {HttpClient} from '../../index';
+import {HttpClientTestingBackend} from '../../testing/src/backend';
 
 describe('HttpClient TestRequest', () => {
   it('accepts a null body', () => {

--- a/packages/common/test/cookie_spec.ts
+++ b/packages/common/test/cookie_spec.ts
@@ -14,7 +14,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {parseCookieValue} from '@angular/common/src/cookie';
+import {parseCookieValue} from '../src/cookie';
 
 describe('cookies', () => {
   it('parses cookies', () => {

--- a/packages/common/test/directives/ng_class_spec.ts
+++ b/packages/common/test/directives/ng_class_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {NgClass} from '@angular/common';
+import {NgClass} from '../../index';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 

--- a/packages/common/test/directives/ng_component_outlet_spec.ts
+++ b/packages/common/test/directives/ng_component_outlet_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CommonModule} from '@angular/common';
-import {NgComponentOutlet} from '@angular/common/src/directives/ng_component_outlet';
+import {CommonModule} from '../../index';
+import {NgComponentOutlet} from '../../src/directives/ng_component_outlet';
 import {
   Compiler,
   Component,

--- a/packages/common/test/directives/ng_for_spec.ts
+++ b/packages/common/test/directives/ng_for_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CommonModule, NgFor, NgForOf} from '@angular/common';
+import {CommonModule, NgFor, NgForOf} from '../../index';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';

--- a/packages/common/test/directives/ng_if_spec.ts
+++ b/packages/common/test/directives/ng_if_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CommonModule, NgIf, ɵgetDOM as getDOM} from '@angular/common';
+import {CommonModule, NgIf, ɵgetDOM as getDOM} from '../../index';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CommonModule, DOCUMENT, IMAGE_CONFIG, ImageConfig} from '@angular/common';
-import {RuntimeErrorCode} from '@angular/common/src/errors';
-import {PLATFORM_SERVER_ID} from '@angular/common/src/platform_id';
+import {CommonModule, DOCUMENT, IMAGE_CONFIG, ImageConfig} from '../../index';
+import {RuntimeErrorCode} from '../../src/errors';
+import {PLATFORM_SERVER_ID} from '../../src/platform_id';
 import {ChangeDetectionStrategy, Component, PLATFORM_ID, Provider, Type} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {DomSanitizer, SafeResourceUrl} from '@angular/platform-browser';

--- a/packages/common/test/directives/ng_plural_spec.ts
+++ b/packages/common/test/directives/ng_plural_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CommonModule, NgLocalization, NgPlural, NgPluralCase} from '@angular/common';
+import {CommonModule, NgLocalization, NgPlural, NgPluralCase} from '../../index';
 import {Component, Injectable} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';

--- a/packages/common/test/directives/ng_style_spec.ts
+++ b/packages/common/test/directives/ng_style_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CommonModule, NgStyle} from '@angular/common';
+import {CommonModule, NgStyle} from '../../index';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 

--- a/packages/common/test/directives/ng_switch_spec.ts
+++ b/packages/common/test/directives/ng_switch_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CommonModule, NgSwitch, NgSwitchCase, NgSwitchDefault} from '@angular/common';
+import {CommonModule, NgSwitch, NgSwitchCase, NgSwitchDefault} from '../../index';
 import {Attribute, Component, Directive, TemplateRef, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';

--- a/packages/common/test/directives/ng_template_outlet_spec.ts
+++ b/packages/common/test/directives/ng_template_outlet_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CommonModule, NgTemplateOutlet} from '@angular/common';
+import {CommonModule, NgTemplateOutlet} from '../../index';
 import {
   Component,
   ContentChildren,

--- a/packages/common/test/i18n/format_date_spec.ts
+++ b/packages/common/test/i18n/format_date_spec.ts
@@ -5,20 +5,15 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import localeAr from '@angular/common/locales/ar';
-import localeDe from '@angular/common/locales/de';
-import localeEn from '@angular/common/locales/en';
-import localeEnExtra from '@angular/common/locales/extra/en';
-import localeFi from '@angular/common/locales/fi';
-import localeHu from '@angular/common/locales/hu';
-import localeSr from '@angular/common/locales/sr';
-import localeTh from '@angular/common/locales/th';
-import {
-  formatDate,
-  getThursdayThisIsoWeek,
-  isDate,
-  toDate,
-} from '@angular/common/src/i18n/format_date';
+import localeAr from '../../locales/ar';
+import localeDe from '../../locales/de';
+import localeEn from '../../locales/en';
+import localeEnExtra from '../../locales/extra/en';
+import localeFi from '../../locales/fi';
+import localeHu from '../../locales/hu';
+import localeSr from '../../locales/sr';
+import localeTh from '../../locales/th';
+import {formatDate, getThursdayThisIsoWeek, isDate, toDate} from '../../src/i18n/format_date';
 import {ɵDEFAULT_LOCALE_ID, ɵregisterLocaleData, ɵunregisterLocaleData} from '@angular/core';
 
 describe('Format date', () => {

--- a/packages/common/test/i18n/format_number_spec.ts
+++ b/packages/common/test/i18n/format_number_spec.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {formatCurrency, formatNumber, formatPercent} from '@angular/common';
-import localeAr from '@angular/common/locales/ar';
-import localeEn from '@angular/common/locales/en';
-import localeEsUS from '@angular/common/locales/es-US';
-import localeFr from '@angular/common/locales/fr';
+import {formatCurrency, formatNumber, formatPercent} from '../../index';
+import localeAr from '../../locales/ar';
+import localeEn from '../../locales/en';
+import localeEsUS from '../../locales/es-US';
+import localeFr from '../../locales/fr';
 import {ɵDEFAULT_LOCALE_ID, ɵregisterLocaleData, ɵunregisterLocaleData} from '@angular/core';
 
 describe('Format number', () => {

--- a/packages/common/test/i18n/locale_data_api_spec.ts
+++ b/packages/common/test/i18n/locale_data_api_spec.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import localeEn from '@angular/common/locales/en';
-import localeEnAU from '@angular/common/locales/en-AU';
-import localeFr from '@angular/common/locales/fr';
-import localeHe from '@angular/common/locales/he';
-import localeZh from '@angular/common/locales/zh';
+import localeEn from '../../locales/en';
+import localeEnAU from '../../locales/en-AU';
+import localeFr from '../../locales/fr';
+import localeHe from '../../locales/he';
+import localeZh from '../../locales/zh';
 import {ɵregisterLocaleData, ɵunregisterLocaleData} from '@angular/core';
 
 import {
@@ -23,7 +23,7 @@ import {
   getLocaleMonthNames,
   getNumberOfCurrencyDigits,
   TranslationWidth,
-} from '@angular/common';
+} from '../..';
 
 describe('locale data api', () => {
   beforeAll(() => {

--- a/packages/common/test/i18n/localization_spec.ts
+++ b/packages/common/test/i18n/localization_spec.ts
@@ -6,15 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import localeFr from '@angular/common/locales/fr';
-import localeRo from '@angular/common/locales/ro';
-import localeSr from '@angular/common/locales/sr';
-import localeZgh from '@angular/common/locales/zgh';
-import {
-  getPluralCategory,
-  NgLocaleLocalization,
-  NgLocalization,
-} from '@angular/common/src/i18n/localization';
+import localeFr from '../../locales/fr';
+import localeRo from '../../locales/ro';
+import localeSr from '../../locales/sr';
+import localeZgh from '../../locales/zgh';
+import {getPluralCategory, NgLocaleLocalization, NgLocalization} from '../../src/i18n/localization';
 import {LOCALE_ID, ɵregisterLocaleData, ɵunregisterLocaleData} from '@angular/core';
 import {inject, TestBed} from '@angular/core/testing';
 

--- a/packages/common/test/image_loaders/image_loader_spec.ts
+++ b/packages/common/test/image_loaders/image_loader_spec.ts
@@ -11,13 +11,13 @@ import {
   ImageLoader,
   ImageLoaderConfig,
   provideNetlifyLoader,
-} from '@angular/common/src/directives/ng_optimized_image';
-import {provideCloudflareLoader} from '@angular/common/src/directives/ng_optimized_image/image_loaders/cloudflare_loader';
-import {provideCloudinaryLoader} from '@angular/common/src/directives/ng_optimized_image/image_loaders/cloudinary_loader';
-import {provideImageKitLoader} from '@angular/common/src/directives/ng_optimized_image/image_loaders/imagekit_loader';
-import {provideImgixLoader} from '@angular/common/src/directives/ng_optimized_image/image_loaders/imgix_loader';
-import {isValidPath} from '@angular/common/src/directives/ng_optimized_image/url';
-import {RuntimeErrorCode} from '@angular/common/src/errors';
+} from '../../src/directives/ng_optimized_image';
+import {provideCloudflareLoader} from '../../src/directives/ng_optimized_image/image_loaders/cloudflare_loader';
+import {provideCloudinaryLoader} from '../../src/directives/ng_optimized_image/image_loaders/cloudinary_loader';
+import {provideImageKitLoader} from '../../src/directives/ng_optimized_image/image_loaders/imagekit_loader';
+import {provideImgixLoader} from '../../src/directives/ng_optimized_image/image_loaders/imgix_loader';
+import {isValidPath} from '../../src/directives/ng_optimized_image/url';
+import {RuntimeErrorCode} from '../../src/errors';
 import {createEnvironmentInjector, EnvironmentInjector} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 

--- a/packages/common/test/location/location_spec.ts
+++ b/packages/common/test/location/location_spec.ts
@@ -13,8 +13,8 @@ import {
   LocationStrategy,
   PathLocationStrategy,
   PlatformLocation,
-} from '@angular/common';
-import {MockLocationStrategy, MockPlatformLocation} from '@angular/common/testing';
+} from '../../index';
+import {MockLocationStrategy, MockPlatformLocation} from '../../testing';
 import {TestBed} from '@angular/core/testing';
 
 const baseUrl = '/base';

--- a/packages/common/test/location/provide_location_mocks_spec.ts
+++ b/packages/common/test/location/provide_location_mocks_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Location, LocationStrategy} from '@angular/common';
-import {MockLocationStrategy, provideLocationMocks, SpyLocation} from '@angular/common/testing';
+import {Location, LocationStrategy} from '../../index';
+import {MockLocationStrategy, provideLocationMocks, SpyLocation} from '../../testing';
 import {TestBed} from '@angular/core/testing';
 
 describe('provideLocationMocks() function', () => {

--- a/packages/common/test/pipes/async_pipe_spec.ts
+++ b/packages/common/test/pipes/async_pipe_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {AsyncPipe} from '@angular/common';
+import {AsyncPipe} from '../../index';
 import {
   ChangeDetectorRef,
   Component,

--- a/packages/common/test/pipes/case_conversion_pipes_spec.ts
+++ b/packages/common/test/pipes/case_conversion_pipes_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {LowerCasePipe, TitleCasePipe, UpperCasePipe} from '@angular/common';
+import {LowerCasePipe, TitleCasePipe, UpperCasePipe} from '../../index';
 import {Component} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 

--- a/packages/common/test/pipes/date_pipe_spec.ts
+++ b/packages/common/test/pipes/date_pipe_spec.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DATE_PIPE_DEFAULT_OPTIONS, DatePipe} from '@angular/common';
-import localeEn from '@angular/common/locales/en';
-import localeEnExtra from '@angular/common/locales/extra/en';
+import {DATE_PIPE_DEFAULT_OPTIONS, DatePipe} from '../../index';
+import localeEn from '../../locales/en';
+import localeEnExtra from '../../locales/extra/en';
 import {Component, ɵregisterLocaleData, ɵunregisterLocaleData} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 

--- a/packages/common/test/pipes/i18n_plural_pipe_spec.ts
+++ b/packages/common/test/pipes/i18n_plural_pipe_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {I18nPluralPipe, NgLocalization} from '@angular/common';
+import {I18nPluralPipe, NgLocalization} from '../../index';
 import {Component} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 

--- a/packages/common/test/pipes/i18n_select_pipe_spec.ts
+++ b/packages/common/test/pipes/i18n_select_pipe_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {I18nSelectPipe} from '@angular/common';
+import {I18nSelectPipe} from '../../index';
 import {Component} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 

--- a/packages/common/test/pipes/json_pipe_spec.ts
+++ b/packages/common/test/pipes/json_pipe_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CommonModule, JsonPipe} from '@angular/common';
+import {CommonModule, JsonPipe} from '../../index';
 import {Component} from '@angular/core';
 import {TestBed, waitForAsync} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';

--- a/packages/common/test/pipes/keyvalue_pipe_spec.ts
+++ b/packages/common/test/pipes/keyvalue_pipe_spec.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {KeyValuePipe} from '@angular/common';
-import {JsonPipe} from '@angular/common/public_api';
-import {defaultComparator} from '@angular/common/src/pipes/keyvalue_pipe';
+import {KeyValuePipe} from '../../index';
+import {JsonPipe} from '../../public_api';
+import {defaultComparator} from '../../src/pipes/keyvalue_pipe';
 import {Component, ɵdefaultKeyValueDiffers as defaultKeyValueDiffers} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 

--- a/packages/common/test/pipes/number_pipe_spec.ts
+++ b/packages/common/test/pipes/number_pipe_spec.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CurrencyPipe, DecimalPipe, PercentPipe} from '@angular/common';
-import localeAr from '@angular/common/locales/ar';
-import localeDa from '@angular/common/locales/da';
-import localeDeAt from '@angular/common/locales/de-AT';
-import localeEn from '@angular/common/locales/en';
-import localeEsUS from '@angular/common/locales/es-US';
-import localeFr from '@angular/common/locales/fr';
+import {CurrencyPipe, DecimalPipe, PercentPipe} from '../../index';
+import localeAr from '../../locales/ar';
+import localeDa from '../../locales/da';
+import localeDeAt from '../../locales/de-AT';
+import localeEn from '../../locales/en';
+import localeEsUS from '../../locales/es-US';
+import localeFr from '../../locales/fr';
 import {Component, ɵregisterLocaleData, ɵunregisterLocaleData} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 

--- a/packages/common/test/pipes/slice_pipe_spec.ts
+++ b/packages/common/test/pipes/slice_pipe_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CommonModule, SlicePipe} from '@angular/common';
+import {CommonModule, SlicePipe} from '../../index';
 import {Component} from '@angular/core';
 import {TestBed, waitForAsync} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';

--- a/packages/common/testing/src/mock_platform_location.ts
+++ b/packages/common/testing/src/mock_platform_location.ts
@@ -12,7 +12,7 @@ import {
   LocationChangeListener,
   PlatformLocation,
   ɵPlatformNavigation as PlatformNavigation,
-} from '@angular/common';
+} from '../../index';
 import {Inject, inject, Injectable, InjectionToken, Optional} from '@angular/core';
 import {Subject} from 'rxjs';
 

--- a/packages/common/testing/src/navigation/provide_fake_platform_navigation.ts
+++ b/packages/common/testing/src/navigation/provide_fake_platform_navigation.ts
@@ -10,7 +10,7 @@ import {
   DOCUMENT,
   PlatformLocation,
   ɵPlatformNavigation as PlatformNavigation,
-} from '@angular/common';
+} from '../../../index';
 import {inject, Provider} from '@angular/core';
 
 import {

--- a/packages/common/testing/src/provide_location_mocks.ts
+++ b/packages/common/testing/src/provide_location_mocks.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Location, LocationStrategy} from '@angular/common';
+import {Location, LocationStrategy} from '../../index';
 import {Provider} from '@angular/core';
 
 import {SpyLocation} from './location_mock';

--- a/packages/common/upgrade/src/location_shim.ts
+++ b/packages/common/upgrade/src/location_shim.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Location, LocationStrategy, PlatformLocation} from '@angular/common';
+import {Location, LocationStrategy, PlatformLocation} from '../../index';
 import {ɵisPromise as isPromise} from '@angular/core';
 import {UpgradeModule} from '@angular/upgrade/static';
 import {ReplaySubject} from 'rxjs';

--- a/packages/common/upgrade/src/location_upgrade_module.ts
+++ b/packages/common/upgrade/src/location_upgrade_module.ts
@@ -14,7 +14,7 @@ import {
   LocationStrategy,
   PathLocationStrategy,
   PlatformLocation,
-} from '@angular/common';
+} from '../../index';
 import {Inject, InjectionToken, ModuleWithProviders, NgModule, Optional} from '@angular/core';
 import {UpgradeModule} from '@angular/upgrade/static';
 

--- a/packages/common/upgrade/test/upgrade.spec.ts
+++ b/packages/common/upgrade/test/upgrade.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CommonModule, PathLocationStrategy} from '@angular/common';
+import {CommonModule, PathLocationStrategy} from '../../index';
 import {inject, TestBed} from '@angular/core/testing';
 import {UpgradeModule} from '@angular/upgrade/static';
 

--- a/packages/common/upgrade/test/upgrade_location_test_module.ts
+++ b/packages/common/upgrade/test/upgrade_location_test_module.ts
@@ -12,8 +12,8 @@ import {
   Location,
   LocationStrategy,
   PlatformLocation,
-} from '@angular/common';
-import {MockPlatformLocation} from '@angular/common/testing';
+} from '../../index';
+import {MockPlatformLocation} from '../../testing';
 import {Inject, InjectionToken, ModuleWithProviders, NgModule, Optional} from '@angular/core';
 import {UpgradeModule} from '@angular/upgrade/static';
 


### PR DESCRIPTION
This commit updates scripts within `packages/common` to relative imports as a prep work to the upcoming infra updates.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No