### PR TITLE
refactor(compiler): convert scripts within `packages/compiler*` to relative imports

### DIFF
--- a/packages/compiler-cli/linker/test/ast/ast_value_spec.ts
+++ b/packages/compiler-cli/linker/test/ast/ast_value_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import {WrappedNodeExpr} from '@angular/compiler';
-import {TypeScriptAstFactory} from '@angular/compiler-cli/src/ngtsc/translator';
+import {TypeScriptAstFactory} from '../../../src/ngtsc/translator';
 import ts from 'typescript';
 
 import {AstHost} from '../../src/ast/ast_host';

--- a/packages/compiler-cli/linker/test/file_linker/translator_spec.ts
+++ b/packages/compiler-cli/linker/test/file_linker/translator_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import * as o from '@angular/compiler';
-import {TypeScriptAstFactory} from '@angular/compiler-cli/src/ngtsc/translator';
+import {TypeScriptAstFactory} from '../../../src/ngtsc/translator';
 import ts from 'typescript';
 
 import {Translator} from '../../src/file_linker/translator';

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/util.ts
@@ -7,15 +7,8 @@
  */
 
 import {AnimationTriggerNames} from '@angular/compiler';
-import {
-  isResolvedModuleWithProviders,
-  ResolvedModuleWithProviders,
-} from '@angular/compiler-cli/src/ngtsc/annotations/ng_module';
-import {
-  ErrorCode,
-  FatalDiagnosticError,
-  makeDiagnostic,
-} from '@angular/compiler-cli/src/ngtsc/diagnostics';
+import {isResolvedModuleWithProviders, ResolvedModuleWithProviders} from '../../ng_module';
+import {ErrorCode, FatalDiagnosticError, makeDiagnostic} from '../../../diagnostics';
 import ts from 'typescript';
 
 import {Reference} from '../../../imports';

--- a/packages/compiler-cli/src/ngtsc/docs/src/enum_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/enum_extractor.ts
@@ -6,18 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  EntryType,
-  EnumEntry,
-  EnumMemberEntry,
-  MemberType,
-} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
-import {
-  extractJsDocDescription,
-  extractJsDocTags,
-  extractRawJsDoc,
-} from '@angular/compiler-cli/src/ngtsc/docs/src/jsdoc_extractor';
-import {extractResolvedTypeString} from '@angular/compiler-cli/src/ngtsc/docs/src/type_extractor';
+import {EntryType, EnumEntry, EnumMemberEntry, MemberType} from './entities';
+import {extractJsDocDescription, extractJsDocTags, extractRawJsDoc} from './jsdoc_extractor';
+import {extractResolvedTypeString} from './type_extractor';
 import ts from 'typescript';
 
 /** Extracts documentation entry for an enum. */

--- a/packages/compiler-cli/src/ngtsc/transform/jit/src/initializer_api_transforms/model_function.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/jit/src/initializer_api_transforms/model_function.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Decorator} from '@angular/compiler-cli/src/ngtsc/reflection';
+import {Decorator} from '../../../../reflection';
 import ts from 'typescript';
 
 import {isAngularDecorator, tryParseSignalModelMapping} from '../../../../annotations';

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/nullish_coalescing_not_nullable/nullish_coalescing_not_nullable_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/nullish_coalescing_not_nullable/nullish_coalescing_not_nullable_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DiagnosticCategoryLabel} from '@angular/compiler-cli/src/ngtsc/core/api';
+import {DiagnosticCategoryLabel} from '../../../../../core/api';
 import ts from 'typescript';
 
 import {ErrorCode, ExtendedTemplateDiagnosticName, ngErrorCode} from '../../../../../diagnostics';

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/optional_chain_not_nullable/optional_chain_not_nullable_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/optional_chain_not_nullable/optional_chain_not_nullable_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DiagnosticCategoryLabel} from '@angular/compiler-cli/src/ngtsc/core/api';
+import {DiagnosticCategoryLabel} from '../../../../../core/api';
 import ts from 'typescript';
 
 import {ErrorCode, ExtendedTemplateDiagnosticName, ngErrorCode} from '../../../../../diagnostics';

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/suffix_not_supported/suffix_not_supported_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/suffix_not_supported/suffix_not_supported_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DiagnosticCategoryLabel} from '@angular/compiler-cli/src/ngtsc/core/api';
+import {DiagnosticCategoryLabel} from '../../../../../core/api';
 import ts from 'typescript';
 
 import {ErrorCode, ExtendedTemplateDiagnosticName, ngErrorCode} from '../../../../../diagnostics';

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/text_attribute_not_binding/text_attribute_not_binding_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/text_attribute_not_binding/text_attribute_not_binding_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DiagnosticCategoryLabel} from '@angular/compiler-cli/src/ngtsc/core/api';
+import {DiagnosticCategoryLabel} from '../../../../../core/api';
 import ts from 'typescript';
 
 import {ErrorCode, ExtendedTemplateDiagnosticName, ngErrorCode} from '../../../../../diagnostics';

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/unparenthesized_nullish_coalescing/unparenthesized_nullish_coalescing_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/unparenthesized_nullish_coalescing/unparenthesized_nullish_coalescing_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DiagnosticCategoryLabel} from '@angular/compiler-cli/src/ngtsc/core/api';
+import {DiagnosticCategoryLabel} from '../../../../../core/api';
 import ts from 'typescript';
 import {ErrorCode, ExtendedTemplateDiagnosticName, ngErrorCode} from '../../../../../diagnostics';
 import {absoluteFrom, getSourceFileOrError} from '../../../../../file_system';

--- a/packages/compiler-cli/test/ngtsc/attach_source_location_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/attach_source_location_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
-import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+import {runInEachFileSystem} from '../../src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '../../src/ngtsc/testing';
 import {NgtscTestEnvironment} from './env';
 import {setEnableTemplateSourceLocations} from '@angular/compiler/src/render3/view/config';
 

--- a/packages/compiler-cli/test/ngtsc/component_indexing_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/component_indexing_spec.ts
@@ -5,18 +5,14 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {
-  AbsoluteFsPath,
-  getFileSystem,
-  PathManipulation,
-} from '@angular/compiler-cli/src/ngtsc/file_system';
-import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
+import {AbsoluteFsPath, getFileSystem, PathManipulation} from '../../src/ngtsc/file_system';
+import {runInEachFileSystem} from '../../src/ngtsc/file_system/testing';
 import {
   AbsoluteSourceSpan,
   IdentifierKind,
   IndexedComponent,
   TopLevelIdentifier,
-} from '@angular/compiler-cli/src/ngtsc/indexer';
+} from '../../src/ngtsc/indexer';
 import {ParseSourceFile} from '@angular/compiler/src/compiler';
 
 import {NgtscTestEnvironment} from './env';

--- a/packages/compiler-cli/test/ngtsc/defer_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/defer_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ErrorCode, ngErrorCode} from '@angular/compiler-cli/src/ngtsc/diagnostics';
+import {ErrorCode, ngErrorCode} from '../../src/ngtsc/diagnostics';
 
 import {runInEachFileSystem} from '../../src/ngtsc/file_system/testing';
 import {loadStandardTestFiles} from '../../src/ngtsc/testing';

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/class_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/class_doc_extraction_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
+import {DocEntry} from '../../../src/ngtsc/docs';
 import {
   ClassEntry,
   EntryType,
@@ -14,9 +14,9 @@ import {
   MemberType,
   MethodEntry,
   PropertyEntry,
-} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
-import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
-import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+} from '../../../src/ngtsc/docs/src/entities';
+import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '../../../src/ngtsc/testing';
 
 import {NgtscTestEnvironment} from '../env';
 

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/common_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/common_doc_extraction_spec.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
-import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
-import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+import {DocEntry} from '../../../src/ngtsc/docs';
+import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '../../../src/ngtsc/testing';
 
 import {NgtscTestEnvironment} from '../env';
 

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/constant_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/constant_doc_extraction_spec.ts
@@ -6,14 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
-import {
-  ConstantEntry,
-  EntryType,
-  EnumEntry,
-} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
-import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
-import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+import {DocEntry} from '../../../src/ngtsc/docs';
+import {ConstantEntry, EntryType, EnumEntry} from '../../../src/ngtsc/docs/src/entities';
+import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '../../../src/ngtsc/testing';
 
 import {NgtscTestEnvironment} from '../env';
 

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/decorator_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/decorator_doc_extraction_spec.ts
@@ -6,14 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
-import {
-  DecoratorEntry,
-  DecoratorType,
-  EntryType,
-} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
-import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
-import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+import {DocEntry} from '../../../src/ngtsc/docs';
+import {DecoratorEntry, DecoratorType, EntryType} from '../../../src/ngtsc/docs/src/entities';
+import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '../../../src/ngtsc/testing';
 
 import {NgtscTestEnvironment} from '../env';
 

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/directive_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/directive_doc_extraction_spec.ts
@@ -6,16 +6,16 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
+import {DocEntry} from '../../../src/ngtsc/docs';
 import {
   ClassEntry,
   DirectiveEntry,
   EntryType,
   MemberTags,
   PropertyEntry,
-} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
-import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
-import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+} from '../../../src/ngtsc/docs/src/entities';
+import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '../../../src/ngtsc/testing';
 
 import {NgtscTestEnvironment} from '../env';
 

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/doc_extraction_filtering_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/doc_extraction_filtering_spec.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
-import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
-import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+import {DocEntry} from '../../../src/ngtsc/docs';
+import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '../../../src/ngtsc/testing';
 
 import {NgtscTestEnvironment} from '../env';
 

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/docs_private_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/docs_private_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
-import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
+import {DocEntry} from '../../../src/ngtsc/docs/src/entities';
+import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
 
 import {NgtscTestEnvironment} from '../env';
 

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/enum_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/enum_doc_extraction_spec.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
-import {EntryType, EnumEntry} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
-import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
-import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+import {DocEntry} from '../../../src/ngtsc/docs';
+import {EntryType, EnumEntry} from '../../../src/ngtsc/docs/src/entities';
+import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '../../../src/ngtsc/testing';
 
 import {NgtscTestEnvironment} from '../env';
 

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/function_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/function_doc_extraction_spec.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
-import {EntryType, FunctionEntry} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
-import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
-import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+import {DocEntry} from '../../../src/ngtsc/docs';
+import {EntryType, FunctionEntry} from '../../../src/ngtsc/docs/src/entities';
+import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '../../../src/ngtsc/testing';
 
 import {NgtscTestEnvironment} from '../env';
 

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/import_extractor_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/import_extractor_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
-import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '../../../src/ngtsc/testing';
 
 import {NgtscTestEnvironment} from '../env';
 

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/initializer_api_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/initializer_api_extraction_spec.ts
@@ -11,9 +11,9 @@ import {
   FunctionSignatureMetadata,
   InitializerApiFunctionEntry,
   ParameterEntry,
-} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
-import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
-import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+} from '../../../src/ngtsc/docs/src/entities';
+import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '../../../src/ngtsc/testing';
 
 import {NgtscTestEnvironment} from '../env';
 

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/interface_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/interface_doc_extraction_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
+import {DocEntry} from '../../../src/ngtsc/docs';
 import {
   ClassEntry,
   EntryType,
@@ -15,9 +15,9 @@ import {
   MemberType,
   MethodEntry,
   PropertyEntry,
-} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
-import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
-import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+} from '../../../src/ngtsc/docs/src/entities';
+import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '../../../src/ngtsc/testing';
 
 import {NgtscTestEnvironment} from '../env';
 

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/jsdoc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/jsdoc_extraction_spec.ts
@@ -6,15 +6,15 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
+import {DocEntry} from '../../../src/ngtsc/docs';
 import {
   ClassEntry,
   FunctionEntry,
   FunctionSignatureMetadata,
   MethodEntry,
-} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
-import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
-import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+} from '../../../src/ngtsc/docs/src/entities';
+import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '../../../src/ngtsc/testing';
 
 import {NgtscTestEnvironment} from '../env';
 

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/ng_module_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/ng_module_doc_extraction_spec.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
-import {ClassEntry, EntryType} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
-import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
-import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+import {DocEntry} from '../../../src/ngtsc/docs';
+import {ClassEntry, EntryType} from '../../../src/ngtsc/docs/src/entities';
+import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '../../../src/ngtsc/testing';
 
 import {NgtscTestEnvironment} from '../env';
 

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/pipe_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/pipe_doc_extraction_spec.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
-import {EntryType, PipeEntry} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
-import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
-import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+import {DocEntry} from '../../../src/ngtsc/docs';
+import {EntryType, PipeEntry} from '../../../src/ngtsc/docs/src/entities';
+import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '../../../src/ngtsc/testing';
 
 import {NgtscTestEnvironment} from '../env';
 

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/reexport_docs_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/reexport_docs_extraction_spec.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
-import {EntryType} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
-import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
-import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+import {DocEntry} from '../../../src/ngtsc/docs';
+import {EntryType} from '../../../src/ngtsc/docs/src/entities';
+import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '../../../src/ngtsc/testing';
 
 import {NgtscTestEnvironment} from '../env';
 

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/type_alias_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/type_alias_doc_extraction_spec.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
-import {EntryType, TypeAliasEntry} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
-import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
-import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+import {DocEntry} from '../../../src/ngtsc/docs';
+import {EntryType, TypeAliasEntry} from '../../../src/ngtsc/docs/src/entities';
+import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '../../../src/ngtsc/testing';
 
 import {NgtscTestEnvironment} from '../env';
 

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -6,12 +6,17 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CustomTransformers, defaultGatherDiagnostics, Program} from '@angular/compiler-cli';
-import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
-import * as api from '@angular/compiler-cli/src/transformers/api';
+import {
+  CustomTransformers,
+  defaultGatherDiagnostics,
+  Program,
+  createCompilerHost,
+  createProgram,
+} from '../../index';
+import {DocEntry} from '../../src/ngtsc/docs';
+import * as api from '../../src/transformers/api';
 import ts from 'typescript';
 
-import {createCompilerHost, createProgram} from '../../index';
 import {mainXi18n} from '../../src/extract_i18n';
 import {main, mainDiagnosticsForTest, readNgcCommandLineAndConfiguration} from '../../src/main';
 import {

--- a/packages/compiler-cli/test/ngtsc/hmr_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/hmr_spec.ts
@@ -9,9 +9,9 @@
 import {runInEachFileSystem} from '../../src/ngtsc/file_system/testing';
 import {loadStandardTestFiles} from '../../src/ngtsc/testing';
 import {NgtscTestEnvironment} from './env';
-import {CompilerOptions} from '@angular/compiler-cli/src/transformers/api';
-import {createCompilerHost} from '@angular/compiler-cli/src/transformers/compiler_host';
-import {NgtscProgram} from '@angular/compiler-cli/src/ngtsc/program';
+import {CompilerOptions} from '../../src/transformers/api';
+import {createCompilerHost} from '../../src/transformers/compiler_host';
+import {NgtscProgram} from '../../src/ngtsc/program';
 import ts from 'typescript';
 
 runInEachFileSystem(() => {

--- a/packages/compiler-cli/test/ngtsc/host_bindings_type_check_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/host_bindings_type_check_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
-import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+import {runInEachFileSystem} from '../../src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '../../src/ngtsc/testing';
 import {NgtscTestEnvironment} from './env';
 import ts from 'typescript';
 

--- a/packages/compiler-cli/test/ngtsc/ls_typecheck_helpers_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ls_typecheck_helpers_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {PotentialImportMode} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
+import {PotentialImportMode} from '../../src/ngtsc/typecheck/api';
 import ts from 'typescript';
 
 import {DiagnosticCategoryLabel} from '../../src/ngtsc/core/api';

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {NgtscProgram} from '@angular/compiler-cli/src/ngtsc/program';
-import {CompilerOptions} from '@angular/compiler-cli/src/transformers/api';
-import {createCompilerHost} from '@angular/compiler-cli/src/transformers/compiler_host';
+import {NgtscProgram} from '../../src/ngtsc/program';
+import {CompilerOptions} from '../../src/transformers/api';
+import {createCompilerHost} from '../../src/transformers/compiler_host';
 import {platform} from 'os';
 import ts from 'typescript';
 

--- a/packages/compiler-cli/test/ngtsc/util.ts
+++ b/packages/compiler-cli/test/ngtsc/util.ts
@@ -5,10 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {
-  ClassDeclaration,
-  isNamedClassDeclaration,
-} from '@angular/compiler-cli/src/ngtsc/reflection';
+import {ClassDeclaration, isNamedClassDeclaration} from '../../src/ngtsc/reflection';
 import ts from 'typescript';
 
 export function getClass(sf: ts.SourceFile, name: string): ClassDeclaration<ts.ClassDeclaration> {

--- a/packages/compiler-cli/test/ngtsc/xi18n_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/xi18n_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
-import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+import {runInEachFileSystem} from '../../src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '../../src/ngtsc/testing';
 import {platform} from 'os';
 
 import {NgtscTestEnvironment} from './env';

--- a/packages/compiler/test/expression_parser/ast_spec.ts
+++ b/packages/compiler/test/expression_parser/ast_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {AST, Lexer, Parser, RecursiveAstVisitor} from '@angular/compiler';
-import {Call, ImplicitReceiver, PropertyRead} from '@angular/compiler/src/compiler';
+import {AST, Lexer, Parser, RecursiveAstVisitor} from '../../index';
+import {Call, ImplicitReceiver, PropertyRead} from '../../src/compiler';
 
 describe('RecursiveAstVisitor', () => {
   it('should visit every node', () => {

--- a/packages/compiler/test/expression_parser/lexer_spec.ts
+++ b/packages/compiler/test/expression_parser/lexer_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Lexer, StringTokenKind, Token} from '@angular/compiler/src/expression_parser/lexer';
+import {Lexer, StringTokenKind, Token} from '../../src/expression_parser/lexer';
 
 function lex(text: string): any[] {
   return new Lexer().tokenize(text);

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -19,9 +19,9 @@ import {
   TemplateBinding,
   VariableBinding,
   TemplateLiteral,
-} from '@angular/compiler/src/expression_parser/ast';
-import {Lexer} from '@angular/compiler/src/expression_parser/lexer';
-import {Parser, SplitInterpolation} from '@angular/compiler/src/expression_parser/parser';
+} from '../../src/expression_parser/ast';
+import {Lexer} from '../../src/expression_parser/lexer';
+import {Parser, SplitInterpolation} from '../../src/expression_parser/parser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 import {unparse, unparseWithSpan} from './utils/unparser';

--- a/packages/compiler/test/i18n/extractor_merger_spec.ts
+++ b/packages/compiler/test/i18n/extractor_merger_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DEFAULT_INTERPOLATION_CONFIG, HtmlParser} from '@angular/compiler';
+import {DEFAULT_INTERPOLATION_CONFIG, HtmlParser} from '../../index';
 import {MissingTranslationStrategy} from '@angular/core';
 
 import {digest, serializeNodes as serializeI18nNodes} from '../../src/i18n/digest';

--- a/packages/compiler/test/i18n/i18n_html_parser_spec.ts
+++ b/packages/compiler/test/i18n/i18n_html_parser_spec.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {I18NHtmlParser} from '@angular/compiler/src/i18n/i18n_html_parser';
-import {TranslationBundle} from '@angular/compiler/src/i18n/translation_bundle';
-import {HtmlParser} from '@angular/compiler/src/ml_parser/html_parser';
+import {I18NHtmlParser} from '../../src/i18n/i18n_html_parser';
+import {TranslationBundle} from '../../src/i18n/translation_bundle';
+import {HtmlParser} from '../../src/ml_parser/html_parser';
 
 describe('I18N html parser', () => {
   // https://github.com/angular/angular/issues/14322

--- a/packages/compiler/test/i18n/i18n_parser_spec.ts
+++ b/packages/compiler/test/i18n/i18n_parser_spec.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {digest, serializeNodes} from '@angular/compiler/src/i18n/digest';
-import {extractMessages} from '@angular/compiler/src/i18n/extractor_merger';
-import {Message} from '@angular/compiler/src/i18n/i18n_ast';
-import {DEFAULT_INTERPOLATION_CONFIG} from '@angular/compiler/src/ml_parser/defaults';
-import {HtmlParser} from '@angular/compiler/src/ml_parser/html_parser';
+import {digest, serializeNodes} from '../../src/i18n/digest';
+import {extractMessages} from '../../src/i18n/extractor_merger';
+import {Message} from '../../src/i18n/i18n_ast';
+import {DEFAULT_INTERPOLATION_CONFIG} from '../../src/ml_parser/defaults';
+import {HtmlParser} from '../../src/ml_parser/html_parser';
 
 describe('I18nParser', () => {
   describe('elements', () => {

--- a/packages/compiler/test/i18n/integration_common.ts
+++ b/packages/compiler/test/i18n/integration_common.ts
@@ -7,11 +7,11 @@
  */
 
 import {NgLocalization} from '@angular/common';
-import {Serializer} from '@angular/compiler/src/i18n';
-import {MessageBundle} from '@angular/compiler/src/i18n/message_bundle';
-import {DEFAULT_INTERPOLATION_CONFIG} from '@angular/compiler/src/ml_parser/defaults';
-import {HtmlParser} from '@angular/compiler/src/ml_parser/html_parser';
-import {ResourceLoader} from '@angular/compiler/src/resource_loader';
+import {Serializer} from '../../src/i18n';
+import {MessageBundle} from '../../src/i18n/message_bundle';
+import {DEFAULT_INTERPOLATION_CONFIG} from '../../src/ml_parser/defaults';
+import {HtmlParser} from '../../src/ml_parser/html_parser';
+import {ResourceLoader} from '../../src/resource_loader';
 import {Component, DebugElement, TRANSLATIONS, TRANSLATIONS_FORMAT} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';

--- a/packages/compiler/test/i18n/integration_xliff2_spec.ts
+++ b/packages/compiler/test/i18n/integration_xliff2_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Xliff2} from '@angular/compiler/src/i18n/serializers/xliff2';
+import {Xliff2} from '../../src/i18n/serializers/xliff2';
 import {waitForAsync} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 

--- a/packages/compiler/test/i18n/integration_xliff_spec.ts
+++ b/packages/compiler/test/i18n/integration_xliff_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Xliff} from '@angular/compiler/src/i18n/serializers/xliff';
+import {Xliff} from '../../src/i18n/serializers/xliff';
 import {waitForAsync} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 

--- a/packages/compiler/test/i18n/integration_xmb_xtb_spec.ts
+++ b/packages/compiler/test/i18n/integration_xmb_xtb_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Xmb} from '@angular/compiler/src/i18n/serializers/xmb';
+import {Xmb} from '../../src/i18n/serializers/xmb';
 import {waitForAsync} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 

--- a/packages/compiler/test/i18n/serializers/i18n_ast_spec.ts
+++ b/packages/compiler/test/i18n/serializers/i18n_ast_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import * as i18n from '@angular/compiler/src/i18n/i18n_ast';
+import * as i18n from '../../../src/i18n/i18n_ast';
 
 import {serializeNodes} from '../../../src/i18n/digest';
 import {_extractMessages} from '../i18n_parser_spec';

--- a/packages/compiler/test/i18n/serializers/xliff2_spec.ts
+++ b/packages/compiler/test/i18n/serializers/xliff2_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {escapeRegExp} from '@angular/compiler/src/util';
+import {escapeRegExp} from '../../../src/util';
 
 import {serializeNodes} from '../../../src/i18n/digest';
 import {MessageBundle} from '../../../src/i18n/message_bundle';

--- a/packages/compiler/test/i18n/serializers/xliff_spec.ts
+++ b/packages/compiler/test/i18n/serializers/xliff_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {escapeRegExp} from '@angular/compiler/src/util';
+import {escapeRegExp} from '../../../src/util';
 
 import {serializeNodes} from '../../../src/i18n/digest';
 import {MessageBundle} from '../../../src/i18n/message_bundle';

--- a/packages/compiler/test/i18n/serializers/xmb_spec.ts
+++ b/packages/compiler/test/i18n/serializers/xmb_spec.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {MessageBundle} from '@angular/compiler/src/i18n/message_bundle';
-import {Xmb} from '@angular/compiler/src/i18n/serializers/xmb';
-import {DEFAULT_INTERPOLATION_CONFIG} from '@angular/compiler/src/ml_parser/defaults';
-import {HtmlParser} from '@angular/compiler/src/ml_parser/html_parser';
+import {MessageBundle} from '../../../src/i18n/message_bundle';
+import {Xmb} from '../../../src/i18n/serializers/xmb';
+import {DEFAULT_INTERPOLATION_CONFIG} from '../../../src/ml_parser/defaults';
+import {HtmlParser} from '../../../src/ml_parser/html_parser';
 
 describe('XMB serializer', () => {
   const HTML = `

--- a/packages/compiler/test/i18n/serializers/xtb_spec.ts
+++ b/packages/compiler/test/i18n/serializers/xtb_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {escapeRegExp} from '@angular/compiler/src/util';
+import {escapeRegExp} from '../../../src/util';
 
 import {serializeNodes} from '../../../src/i18n/digest';
 import * as i18n from '../../../src/i18n/i18n_ast';

--- a/packages/compiler/test/ml_parser/ast_serializer_spec.ts
+++ b/packages/compiler/test/ml_parser/ast_serializer_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {HtmlParser} from '@angular/compiler/src/ml_parser/html_parser';
+import {HtmlParser} from '../../src/ml_parser/html_parser';
 
 import {serializeNodes} from './util/util';
 

--- a/packages/compiler/test/ml_parser/util/util.ts
+++ b/packages/compiler/test/ml_parser/util/util.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import * as html from '@angular/compiler/src/ml_parser/ast';
-import {getHtmlTagDefinition} from '@angular/compiler/src/ml_parser/html_tags';
+import * as html from '../../../src/ml_parser/ast';
+import {getHtmlTagDefinition} from '../../../src/ml_parser/html_tags';
 
 class _SerializerVisitor implements html.Visitor {
   visitElement(element: html.Element, context: any): any {

--- a/packages/compiler/test/output/abstract_emitter_node_only_spec.ts
+++ b/packages/compiler/test/output/abstract_emitter_node_only_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '@angular/compiler';
-import {EmitterVisitorContext} from '@angular/compiler/src/output/abstract_emitter';
+import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '../..';
+import {EmitterVisitorContext} from '../../src/output/abstract_emitter';
 
 import {originalPositionFor} from './source_map_util';
 

--- a/packages/compiler/test/output/abstract_emitter_spec.ts
+++ b/packages/compiler/test/output/abstract_emitter_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {escapeIdentifier} from '@angular/compiler/src/output/abstract_emitter';
+import {escapeIdentifier} from '../../src/output/abstract_emitter';
 
 describe('AbstractEmitter', () => {
   describe('escapeIdentifier', () => {

--- a/packages/compiler/test/output/output_jit_spec.ts
+++ b/packages/compiler/test/output/output_jit_spec.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {EmitterVisitorContext} from '@angular/compiler/src/output/abstract_emitter';
-import * as o from '@angular/compiler/src/output/output_ast';
-import {JitEmitterVisitor, JitEvaluator} from '@angular/compiler/src/output/output_jit';
-import {R3JitReflector} from '@angular/compiler/src/render3/r3_jit';
-import {newArray} from '@angular/compiler/src/util';
+import {EmitterVisitorContext} from '../../src/output/abstract_emitter';
+import * as o from '../../src/output/output_ast';
+import {JitEmitterVisitor, JitEvaluator} from '../../src/output/output_jit';
+import {R3JitReflector} from '../../src/render3/r3_jit';
+import {newArray} from '../../src/util';
 
 describe('Output JIT', () => {
   describe('regression', () => {

--- a/packages/compiler/test/output/source_map_spec.ts
+++ b/packages/compiler/test/output/source_map_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {SourceMapGenerator, toBase64String} from '@angular/compiler/src/output/source_map';
+import {SourceMapGenerator, toBase64String} from '../../src/output/source_map';
 
 describe('source map generation', () => {
   describe('generation', () => {

--- a/packages/compiler/test/output/source_map_util.ts
+++ b/packages/compiler/test/output/source_map_util.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {SourceMap} from '@angular/compiler';
+import {SourceMap} from '../../index';
 import {SourceMapConsumer} from 'source-map';
 
 export interface SourceLocation {

--- a/packages/compiler/test/render3/r3_ast_absolute_span_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_absolute_span_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {AbsoluteSourceSpan} from '@angular/compiler';
+import {AbsoluteSourceSpan} from '../../index';
 
 import {humanizeExpressionSource} from './util/expression';
 import {parseR3 as parse} from './view/util';

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {AbsoluteSourceSpan} from '@angular/compiler';
+import {AbsoluteSourceSpan} from '../../../index';
 
 import * as e from '../../../src/expression_parser/ast';
 import * as t from '../../../src/render3/r3_ast';

--- a/packages/compiler/test/schema/dom_element_schema_registry_spec.ts
+++ b/packages/compiler/test/schema/dom_element_schema_registry_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DomElementSchemaRegistry} from '@angular/compiler/src/schema/dom_element_schema_registry';
+import {DomElementSchemaRegistry} from '../../src/schema/dom_element_schema_registry';
 import {CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA, SecurityContext} from '@angular/core';
 
 import {Element} from '../../src/ml_parser/ast';

--- a/packages/compiler/test/schema/trusted_types_sinks_spec.ts
+++ b/packages/compiler/test/schema/trusted_types_sinks_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {isTrustedTypesSink} from '@angular/compiler/src/schema/trusted_types_sinks';
+import {isTrustedTypesSink} from '../../src/schema/trusted_types_sinks';
 
 describe('isTrustedTypesSink', () => {
   it('should classify Trusted Types sinks', () => {

--- a/packages/compiler/test/selector/selector_spec.ts
+++ b/packages/compiler/test/selector/selector_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CssSelector, SelectorMatcher} from '@angular/compiler/src/selector';
+import {CssSelector, SelectorMatcher} from '../../src/selector';
 import {el} from '@angular/platform-browser/testing/src/browser_util';
 
 describe('SelectorMatcher', () => {

--- a/packages/compiler/test/shadow_css/process_rules_spec.ts
+++ b/packages/compiler/test/shadow_css/process_rules_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CssRule, processRules} from '@angular/compiler/src/shadow_css';
+import {CssRule, processRules} from '../../src/shadow_css';
 
 describe('ShadowCss, processRules', () => {
   describe('parse rules', () => {

--- a/packages/compiler/test/shadow_css/repeat_groups_spec.ts
+++ b/packages/compiler/test/shadow_css/repeat_groups_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {repeatGroups} from '@angular/compiler/src/shadow_css';
+import {repeatGroups} from '../../src/shadow_css';
 
 describe('ShadowCss, repeatGroups()', () => {
   it('should do nothing if `multiples` is 0', () => {

--- a/packages/compiler/test/shadow_css/utils.ts
+++ b/packages/compiler/test/shadow_css/utils.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ShadowCss} from '@angular/compiler/src/shadow_css';
+import {ShadowCss} from '../../src/shadow_css';
 
 export function shim(css: string, contentAttr: string, hostAttr: string = '') {
   const shadowCss = new ShadowCss();

--- a/packages/compiler/test/style_url_resolver_spec.ts
+++ b/packages/compiler/test/style_url_resolver_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {isStyleUrlResolvable} from '@angular/compiler/src/style_url_resolver';
+import {isStyleUrlResolvable} from '../src/style_url_resolver';
 
 describe('isStyleUrlResolvable', () => {
   it('should resolve relative urls', () => {


### PR DESCRIPTION
This PR updates scripts within `packages/compiler` and `packages/compiler-cli` to relative imports as a prep work to the upcoming infra updates.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No