### PR TITLE
fix(core): fix ng generate @angular/core:output-migration

### DIFF
--- a/packages/core/schematics/migrations/output-migration/output-migration.spec.ts
+++ b/packages/core/schematics/migrations/output-migration/output-migration.spec.ts
@@ -33,6 +33,28 @@ describe('outputs', () => {
         });
       });
 
+      it('should keep type without initializer', async () => {
+        await verifyDeclaration({
+          before: '@Output() eventMovement: EventEmitter<IResponse> = new EventEmitter();',
+          after: 'readonly eventMovement = output<IResponse>();',
+        });
+      });
+
+      it('should keep type with initializer', async () => {
+        await verifyDeclaration({
+          before: '@Output() eventMovement: EventEmitter = new EventEmitter<IResponse>();',
+          after: 'readonly eventMovement = output<IResponse>();',
+        });
+      });
+
+      it('should keep type without initializer and with alias', async () => {
+        await verifyDeclaration({
+          before:
+            "@Output('customEvent') eventMovement: EventEmitter<IResponse> = new EventEmitter();",
+          after: "readonly eventMovement = output<IResponse>({ alias: 'customEvent' });",
+        });
+      });
+
       it('should migrate declaration without type hint', async () => {
         await verifyDeclaration({
           before: '@Output() readonly someChange = new EventEmitter();',

--- a/packages/core/schematics/migrations/output-migration/output-replacements.ts
+++ b/packages/core/schematics/migrations/output-migration/output-replacements.ts
@@ -28,10 +28,14 @@ export function calculateDeclarationReplacement(
   aliasParam?: string,
 ): Replacement {
   const sf = node.getSourceFile();
-  const payloadTypes =
-    node.initializer !== undefined && ts.isNewExpression(node.initializer)
-      ? node.initializer?.typeArguments
-      : undefined;
+
+  let payloadTypes: ts.NodeArray<ts.TypeNode> | undefined;
+
+  if (node.initializer && ts.isNewExpression(node.initializer) && node.initializer.typeArguments) {
+    payloadTypes = node.initializer.typeArguments;
+  } else if (node.type && ts.isTypeReferenceNode(node.type) && node.type.typeArguments) {
+    payloadTypes = ts.factory.createNodeArray(node.type.typeArguments);
+  }
 
   const outputCall = ts.factory.createCallExpression(
     ts.factory.createIdentifier('output'),


### PR DESCRIPTION
output-migration command not keep type if @Output declaring without initializer

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [X] Tests for the changes have been added (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [X] Bugfix


## What is the current behavior?

The output-migration command not keep type if @Output declaring without initializer


Issue Number: #59248 

## What is the new behavior?

The output-migration command keep type

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

