### PR TITLE
refactor(devtools): Add support for @defer blocks

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.ts
@@ -99,7 +99,7 @@ export const getLatestComponentState = (
   directiveForest = directiveForest ?? buildDirectiveForest();
 
   const node = queryDirectiveForest(query.selectedElement, directiveForest);
-  if (!node) {
+  if (!node || !node.nativeElement) {
     return;
   }
 

--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/ltree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/ltree.ts
@@ -91,6 +91,7 @@ export class LTreeStrategy {
         directives: [],
         component: null,
         hydration: null, // We know there is no hydration if we use the LTreeStrategy
+        defer: null, // neither there will be any defer
       };
     }
     for (let i = tNode.directiveStart; i < tNode.directiveEnd; i++) {
@@ -116,6 +117,7 @@ export class LTreeStrategy {
       directives,
       component,
       hydration: null, // We know there is no hydration if we use the LTreeStrategy
+      defer: null, // neither there will be any defer
     };
   }
 

--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.ts
@@ -6,11 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import type {
+import {
   ɵFrameworkAgnosticGlobalUtils as FrameworkAgnosticGlobalUtils,
+  ɵDeferBlockData as DeferBlockData,
   ɵHydratedNode as HydrationNode,
 } from '@angular/core';
-import {HydrationStatus} from 'protocol';
+import {CurrentDeferBlock, HydrationStatus} from 'protocol';
 
 import {ComponentTreeNode} from '../interfaces';
 import {ngDebugClient} from '../ng-debug-api/ng-debug-api';
@@ -19,6 +20,7 @@ import {isCustomElement} from '../utils';
 const extractViewTree = (
   domNode: Node | Element,
   result: ComponentTreeNode[],
+  deferBlocks: DeferBlocksIterator,
   getComponent?: FrameworkAgnosticGlobalUtils['getComponent'],
   getDirectives?: FrameworkAgnosticGlobalUtils['getDirectives'],
   getDirectiveMetadata?: FrameworkAgnosticGlobalUtils['getDirectiveMetadata'],
@@ -43,12 +45,17 @@ const extractViewTree = (
     }),
     element: domNode.nodeName.toLowerCase(),
     nativeElement: domNode,
-    hydration: hydrationStatus(domNode as HydrationNode),
+    hydration: hydrationStatus(domNode),
+    defer: null,
   };
+
   if (!(domNode instanceof Element)) {
+    // In case we show the Comment nodes
     result.push(componentTreeNode);
     return result;
   }
+
+  const isDehydratedElement = componentTreeNode.hydration?.status === 'dehydrated';
   const component = getComponent?.(domNode);
   if (component) {
     componentTreeNode.component = {
@@ -57,29 +64,118 @@ const extractViewTree = (
       name: getDirectiveMetadata?.(component)?.name ?? domNode.nodeName.toLowerCase(),
     };
   }
-  if (component || componentTreeNode.directives.length) {
+
+  const isDisplayableNode = component || componentTreeNode.directives.length || isDehydratedElement;
+  if (isDisplayableNode) {
     result.push(componentTreeNode);
   }
-  if (componentTreeNode.component || componentTreeNode.directives.length) {
-    domNode.childNodes.forEach((node) =>
+
+  // Nodes that are part of a defer block will be added as children of the defer block
+  // and should be skipped from the regular code path
+  const deferredNodesToSkip = new Set<Node>();
+  const appendTo = isDisplayableNode ? componentTreeNode.children : result;
+
+  domNode.childNodes.forEach((node) => {
+    groupDeferChildrenIfNeeded(
+      node,
+      deferredNodesToSkip,
+      appendTo,
+      deferBlocks,
+      getComponent,
+      getDirectives,
+      getDirectiveMetadata,
+    );
+
+    if (!deferredNodesToSkip.has(node)) {
       extractViewTree(
         node,
-        componentTreeNode.children,
+        appendTo,
+        deferBlocks,
         getComponent,
         getDirectives,
         getDirectiveMetadata,
-      ),
-    );
-  } else {
-    domNode.childNodes.forEach((node) =>
-      extractViewTree(node, result, getComponent, getDirectives, getDirectiveMetadata),
-    );
-  }
+      );
+    }
+  });
+
   return result;
 };
 
-function hydrationStatus(node: HydrationNode): HydrationStatus {
-  switch (node.__ngDebugHydrationInfo__?.status) {
+/**
+ * Group Nodes under a defer block if they are part of it.
+ *
+ * @param node
+ * @param deferredNodesToSkip Will mutate the set with the nodes that are grouped into the created deferblock.
+ * @param deferBlocks
+ * @param appendTo
+ * @param getComponent
+ * @param getDirectives
+ * @param getDirectiveMetadata
+ */
+function groupDeferChildrenIfNeeded(
+  node: Node,
+  deferredNodesToSkip: Set<Node>,
+  appendTo: ComponentTreeNode[],
+  deferBlocks: DeferBlocksIterator,
+  getComponent?: FrameworkAgnosticGlobalUtils['getComponent'],
+  getDirectives?: FrameworkAgnosticGlobalUtils['getDirectives'],
+  getDirectiveMetadata?: FrameworkAgnosticGlobalUtils['getDirectiveMetadata'],
+) {
+  const currentDeferBlock = deferBlocks.currentBlock;
+  const isFirstDefferedChild = node === currentDeferBlock?.rootNodes[0];
+  if (isFirstDefferedChild) {
+    deferBlocks.advance();
+
+    // When encountering the first child of a defer block
+    // We create a synthetic TreeNode reprensenting the defer block
+    const childrenTree: ComponentTreeNode[] = [];
+    currentDeferBlock.rootNodes.forEach((child) => {
+      extractViewTree(
+        child,
+        childrenTree,
+        deferBlocks,
+        getComponent,
+        getDirectives,
+        getDirectiveMetadata,
+      );
+    });
+
+    const deferBlockTreeNode = {
+      children: childrenTree,
+      component: null,
+      directives: [],
+      element: '@defer',
+      nativeElement: undefined,
+      hydration: null,
+      defer: {
+        id: `deferId-${deferBlocks.currentIndex}`,
+        state: currentDeferBlock.state,
+        currentBlock: currentBlock(currentDeferBlock),
+        triggers: groupTriggers(currentDeferBlock.triggers),
+        blocks: {
+          hasErrorBlock: currentDeferBlock.hasErrorBlock,
+          placeholderBlock: currentDeferBlock.placeholderBlock,
+          loadingBlock: currentDeferBlock.loadingBlock,
+        },
+      },
+    } satisfies ComponentTreeNode;
+
+    currentDeferBlock?.rootNodes.forEach((child) => deferredNodesToSkip.add(child));
+    appendTo.push(deferBlockTreeNode);
+  }
+}
+
+function hydrationStatus(element: Node): HydrationStatus {
+  if (!(element instanceof Element)) {
+    return null;
+  }
+
+  if (!!element.getAttribute('ngh')) {
+    return {status: 'dehydrated'};
+  }
+
+  const hydrationInfo = (element as HydrationNode).__ngDebugHydrationInfo__;
+  switch (hydrationInfo?.status) {
     case 'hydrated':
       return {status: 'hydrated'};
     case 'skipped':
@@ -87,14 +183,37 @@ function hydrationStatus(node: HydrationNode): HydrationStatus {
     case 'mismatched':
       return {
         status: 'mismatched',
-        expectedNodeDetails: node.__ngDebugHydrationInfo__.expectedNodeDetails,
-        actualNodeDetails: node.__ngDebugHydrationInfo__.actualNodeDetails,
+        expectedNodeDetails: hydrationInfo.expectedNodeDetails,
+        actualNodeDetails: hydrationInfo.actualNodeDetails,
       };
     default:
       return null;
   }
 }
 
+function groupTriggers(triggers: string[]) {
+  const defer: string[] = [];
+  const hydrate: string[] = [];
+  const prefetch: string[] = [];
+
+  for (let trigger of triggers) {
+    if (trigger.startsWith('hydrate')) {
+      hydrate.push(trigger);
+    } else if (trigger.startsWith('prefetch')) {
+      prefetch.push(trigger);
+    } else {
+      defer.push(trigger);
+    }
+  }
+  return {defer, hydrate, prefetch};
+}
+
+function currentBlock(deferBlock: DeferBlockData): CurrentDeferBlock | null {
+  if (['placeholder', 'loading', 'error'].includes(deferBlock.state)) {
+    return deferBlock.state as 'placeholder' | 'loading' | 'error';
+  }
+  return null;
+}
 export class RTreeStrategy {
   supports(): boolean {
     return (['getDirectiveMetadata', 'getComponent'] as const).every(
@@ -103,13 +222,37 @@ export class RTreeStrategy {
   }
 
   build(element: Element): ComponentTreeNode[] {
+    const ng = ngDebugClient();
+    const deferBlocks = ng.ɵgetDeferBlocks?.(element) ?? [];
+
     // We want to start from the root element so that we can find components which are attached to
     // the application ref and which host elements have been inserted with DOM APIs.
-    while (element.parentElement) {
+    while (element.parentElement && element !== document.body) {
       element = element.parentElement;
     }
+    return extractViewTree(
+      element,
+      [],
+      new DeferBlocksIterator(deferBlocks),
+      ng.getComponent,
+      ng.getDirectives,
+      ng.getDirectiveMetadata,
+    );
+  }
+}
 
-    const ng = ngDebugClient();
-    return extractViewTree(element, [], ng.getComponent, ng.getDirectives, ng.getDirectiveMetadata);
+class DeferBlocksIterator {
+  public currentIndex = 0;
+  private blocks: DeferBlockData[] = [];
+  constructor(blocks: DeferBlockData[]) {
+    this.blocks = blocks;
+  }
+
+  advance() {
+    this.currentIndex++;
+  }
+
+  get currentBlock() {
+    return this.blocks[this.currentIndex];
   }
 }

--- a/devtools/projects/ng-devtools-backend/src/lib/hooks/capture.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/hooks/capture.ts
@@ -288,9 +288,10 @@ const prepareInitialFrame = (source: string, duration: number) => {
     let position: ElementPosition | undefined;
     if (node.component) {
       position = directiveForestHooks.getDirectivePosition(node.component.instance);
-    } else {
+    } else if (node.directives[0]) {
       position = directiveForestHooks.getDirectivePosition(node.directives[0].instance);
     }
+
     if (position === undefined) {
       return;
     }

--- a/devtools/projects/ng-devtools-backend/src/lib/hooks/identity-tracker.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/hooks/identity-tracker.ts
@@ -132,6 +132,7 @@ const indexTree = <T extends DevToolsNode<DirectiveInstanceType, ComponentInstan
     children: node.children.map((n, i) => indexTree(n, i, position)),
     nativeElement: node.nativeElement,
     hydration: node.hydration,
+    defer: node.defer,
   } as IndexedNode;
 };
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/component-data-source/component-data-source.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/component-data-source/component-data-source.spec.ts
@@ -33,9 +33,11 @@ const tree1: DevToolsNode = {
       element: 'bar',
       hydration: null,
       nativeElement: document.createElement('bar'),
+      defer: null,
     },
   ],
   nativeElement: document.createElement('foo'),
+  defer: null,
 };
 
 const tree2: DevToolsNode = {
@@ -60,6 +62,7 @@ const tree2: DevToolsNode = {
       element: 'bar',
       hydration: null,
       nativeElement: document.createElement('bar'),
+      defer: null,
     },
     {
       children: [],
@@ -72,9 +75,11 @@ const tree2: DevToolsNode = {
       element: 'qux',
       hydration: null,
       nativeElement: document.createElement('qux'),
+      defer: null,
     },
   ],
   nativeElement: document.createElement('foo'),
+  defer: null,
 };
 
 const tree3: DevToolsNode = {
@@ -98,6 +103,7 @@ const tree3: DevToolsNode = {
       directives: [],
       element: '#comment',
       hydration: null,
+      defer: null,
       nativeElement: document.createComment('bar'),
     },
     {
@@ -110,10 +116,12 @@ const tree3: DevToolsNode = {
       directives: [],
       element: '#comment',
       hydration: null,
+      defer: null,
       nativeElement: document.createComment('bar'),
     },
   ],
   nativeElement: document.createElement('foo'),
+  defer: null,
 };
 
 const tree4: DevToolsNode = {
@@ -145,6 +153,7 @@ const tree4: DevToolsNode = {
                       directives: [],
                       element: 'bar',
                       hydration: null,
+                      defer: null,
                       nativeElement: document.createComment('bar'),
                     },
                   ],
@@ -156,6 +165,7 @@ const tree4: DevToolsNode = {
                   directives: [],
                   element: '#comment',
                   hydration: null,
+                  defer: null,
                   nativeElement: document.createComment('bar'),
                 },
               ],
@@ -167,6 +177,7 @@ const tree4: DevToolsNode = {
               directives: [],
               element: '#comment',
               hydration: null,
+              defer: null,
               nativeElement: document.createComment('bar'),
             },
           ],
@@ -178,6 +189,7 @@ const tree4: DevToolsNode = {
           directives: [],
           element: '#comment',
           hydration: null,
+          defer: null,
           nativeElement: document.createComment('bar'),
         },
       ],
@@ -190,8 +202,10 @@ const tree4: DevToolsNode = {
       element: '#comment',
       hydration: null,
       nativeElement: document.createComment('bar'),
+      defer: null,
     },
   ],
+  defer: null,
   nativeElement: document.createElement('foo'),
 };
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/index-forest/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/index-forest/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//devtools/tools:typescript.bzl", "ts_library", "ts_test_library")
 load("//devtools/tools:defaults.bzl", "karma_web_test_suite")
+load("//devtools/tools:typescript.bzl", "ts_library", "ts_test_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -17,6 +17,7 @@ ts_test_library(
     srcs = glob(["**/*.spec.ts"]),
     deps = [
         ":index-forest",
+        "//devtools/projects/protocol",
     ],
 )
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/index-forest/index-forest.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/index-forest/index-forest.spec.ts
@@ -7,6 +7,7 @@
  */
 
 import {indexForest} from './';
+import {DevToolsNode} from 'protocol';
 
 describe('indexForest', () => {
   it('should work with an empty forest', () => {
@@ -42,7 +43,9 @@ describe('indexForest', () => {
               component: null,
               children: [],
               onPush: false,
-            },
+              defer: null,
+              hasNativeElement: true,
+            } as DevToolsNode & {hasNativeElement?: boolean},
             {
               element: 'Child1_2',
               directives: [],
@@ -54,9 +57,13 @@ describe('indexForest', () => {
               },
               children: [],
               onPush: false,
-            },
+              defer: null,
+              hasNativeElement: true,
+            } as DevToolsNode & {hasNativeElement?: boolean},
           ],
           onPush: false,
+          defer: null,
+          hasNativeElement: true,
         },
         {
           element: 'Parent2',
@@ -76,7 +83,9 @@ describe('indexForest', () => {
               component: null,
               children: [],
               onPush: true,
-            },
+              defer: null,
+              hasNativeElement: true,
+            } as DevToolsNode & {hasNativeElement?: boolean},
             {
               element: 'Child2_2',
               directives: [
@@ -93,9 +102,13 @@ describe('indexForest', () => {
               hydration: null,
               children: [],
               onPush: true,
-            },
+              defer: null,
+              hasNativeElement: true,
+            } as DevToolsNode & {hasNativeElement?: boolean},
           ],
           onPush: true,
+          defer: null,
+          hasNativeElement: true,
         },
       ]),
     ).toEqual([
@@ -127,6 +140,8 @@ describe('indexForest', () => {
             hydration: null,
             children: [],
             onPush: false,
+            defer: null,
+            hasNativeElement: true,
           },
           {
             element: 'Child1_2',
@@ -139,10 +154,14 @@ describe('indexForest', () => {
             },
             hydration: null,
             children: [],
+            defer: null,
             onPush: false,
+            hasNativeElement: true,
           },
         ],
+        defer: null,
         onPush: false,
+        hasNativeElement: true,
       },
       {
         element: 'Parent2',
@@ -164,6 +183,8 @@ describe('indexForest', () => {
             hydration: null,
             children: [],
             onPush: true,
+            defer: null,
+            hasNativeElement: true,
           },
           {
             element: 'Child2_2',
@@ -182,9 +203,13 @@ describe('indexForest', () => {
             children: [],
             hydration: null,
             onPush: true,
+            defer: null,
+            hasNativeElement: true,
           },
         ],
         onPush: true,
+        defer: null,
+        hasNativeElement: true,
       },
     ]);
   });

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/index-forest/index.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/index-forest/index.ts
@@ -11,10 +11,15 @@ import {DevToolsNode, ElementPosition} from 'protocol';
 export interface IndexedNode extends DevToolsNode {
   position: ElementPosition;
   children: IndexedNode[];
+
+  // native elements are not serializable and thus not accessible in this structure
+  nativeElement?: never;
+  // Instead we will have this boolean
+  hasNativeElement: boolean;
 }
 
 const indexTree = (
-  node: DevToolsNode,
+  node: DevToolsNode & {hasNativeElement?: boolean},
   idx: number,
   parentPosition: ElementPosition = [],
 ): IndexedNode => {
@@ -26,8 +31,11 @@ const indexTree = (
     directives: node.directives.map((d, i) => ({name: d.name, id: d.id})),
     children: node.children.map((n, i) => indexTree(n, i, position)),
     hydration: node.hydration,
+    defer: node.defer,
     onPush: node.onPush,
+    hasNativeElement: (node as any).hasNativeElement,
   };
 };
 
-export const indexForest = (forest: DevToolsNode[]) => forest.map((n, i) => indexTree(n, i));
+export const indexForest = (forest: (DevToolsNode & {hasNativeElement?: boolean})[]) =>
+  forest.map((n, i) => indexTree(n, i));

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/tree-node.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/tree-node.component.html
@@ -17,7 +17,12 @@
 
   <!-- The HTML should match directive-forest-utils/getFullNodeName output. -->
   <div class="node-name" #nodeName>
-    <span class="element-name" [class.angular-element]="isElement()">{{ node().name }}</span>
+    <span
+      class="element-name"
+      [class.non-element]="!node().original.hasNativeElement"
+      [class.angular-element]="isElement()"
+      >{{ node().name }}</span
+    >
     @if (node().directives) {
       <span class="dir-names">{{ directivesArrayString() }}</span>
     }
@@ -27,22 +32,34 @@
     <span class="on-push">OnPush</span>
   }
 
-  <!-- Shown/hidden via CSS -->
-  <span class="console-reference"> == $ng0 </span>
+  @let defer = node().defer;
+
+  @if (!defer && (!hydration || hydration.status !== 'dehydrated')) {
+    <!-- Shown/hidden via CSS -->
+    <span class="console-reference"> == $ng0 </span>
+  }
+
+  @if (defer && defer.currentBlock) {
+    <span class="on-push">(&#64;{{defer.currentBlock}})</span>
+  }
 
   @switch (hydration?.status) {
     @case ('hydrated') {
       <mat-icon matTooltip="Hydrated" class="hydration">water_drop</mat-icon>
     }
+    @case ('dehydrated') {
+      <mat-icon matTooltip="Dehydrated" class="hydration skipped">pending</mat-icon>
+    }
+
     @case ('skipped') {
-      <mat-icon matTooltip="Hydration skipped" class="hydration skipped"
-        >invert_colors_off</mat-icon
-      >
+      <mat-icon matTooltip="Hydration skipped" class="hydration skipped">
+        invert_colors_off
+      </mat-icon>
     }
     @case ('mismatched') {
-      <mat-icon matTooltip="Hydration mismatch" class="hydration mismatched"
-        >error_outline</mat-icon
-      >
+      <mat-icon matTooltip="Hydration mismatch" class="hydration mismatched">
+        error_outline
+      </mat-icon>
     }
   }
 </div>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/tree-node.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/tree-node.component.scss
@@ -22,6 +22,10 @@
     animation: appear 1.5s;
   }
 
+  .non-element {
+    color: var(--color-tree-node-non-element-name);
+  }
+
   .tree-node-info {
     display: flex;
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/tree-node.component.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/tree-node.component.spec.ts
@@ -13,6 +13,8 @@ import {FlatTreeControl} from '@angular/cdk/tree';
 import {TreeNodeComponent} from './tree-node.component';
 import {FlatNode} from '../component-data-source';
 
+type DeepPartial<T> = T extends object ? {[P in keyof T]?: DeepPartial<T[P]>} : T;
+
 const srcNode = {
   id: 'node',
   original: {
@@ -20,7 +22,7 @@ const srcNode = {
       id: 1337,
     },
   },
-};
+} as DeepPartial<FlatNode>;
 
 describe('TreeNodeComponent', () => {
   let component: TreeNodeComponent;

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/element-property-resolver.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/element-property-resolver.spec.ts
@@ -29,6 +29,8 @@ const mockIndexedNode: IndexedNode = {
       name: 'BazDir',
     },
   ],
+  defer: null,
+  hasNativeElement: true,
   children: [],
   element: 'foo',
   position: [0],

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/BUILD.bazel
@@ -40,6 +40,7 @@ ng_module(
     deps = [
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/index-forest",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver",
+        "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/defer-view",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view",
         "//devtools/projects/protocol",
         "//packages/common",

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/defer-view/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/defer-view/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//devtools/tools:ng_module.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
+
+sass_binary(
+    name = "defer_view.component.scss_styles",
+    src = "defer-view.component.scss",
+    deps = ["//devtools/projects/ng-devtools/src/styles:typography"],
+)
+
+ng_module(
+    name = "defer-view",
+    srcs = [
+        "defer-view.component.ts",
+    ],
+    angular_assets = [
+        "defer-view.component.html",
+    ] + ["defer_view.component.scss_styles"],
+    deps = [
+        "//devtools/projects/protocol",
+        "//packages/core",
+        "@npm//@angular/material",
+        "@npm//@types",
+        "@npm//rxjs",
+    ],
+)

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/defer-view/defer-view.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/defer-view/defer-view.component.html
@@ -1,0 +1,44 @@
+<mat-toolbar>Current block</mat-toolbar>
+<div class="defer-details">
+  <span class="pill"> &#64;{{defer().currentBlock ?? 'defer'}}</span>
+</div>
+
+@let triggers = defer().triggers;
+@let blocks = defer().blocks;
+<mat-toolbar>Declared blocks</mat-toolbar>
+<div class="defer-details">
+  @if (blocks.placeholderBlock) {
+    <span class="pill">
+      &#64;placeholder<!--
+      -->{{blocks.placeholderBlock.minimumTime ? `(minimum ${blocks.placeholderBlock.minimumTime} ms)` : ''}}</span
+    >
+  }
+  @if (blocks.loadingBlock) {
+    <span class="pill">&#64;loading{{loadingBlockInfo()}}</span>
+  }
+  @if (blocks.hasErrorBlock) {
+    <span class="pill">&#64;error</span>
+  }
+</div>
+
+<mat-toolbar>Triggers</mat-toolbar>
+<div class="defer-details">
+  <h3>Defer triggers</h3>
+  @for (trigger of triggers.defer; track $index) {
+    <span class="trigger">{{trigger}}</span>
+  }
+  @if (triggers.hydrate.length > 0) {
+    <h3>Hydration triggers</h3>
+    @for (trigger of triggers.hydrate; track $index) {
+      <span class="trigger">{{trigger}}</span>
+    }
+  }
+  @if (triggers.prefetch.length > 0) {
+    <h3>Prefetch triggers</h3>
+    @for (trigger of triggers.prefetch; track $index) {
+      <span class="trigger">{{trigger}}</span>
+    }
+  }
+
+  <!--TODO(mri) What additional details would we want in sidepanel for defer blocks  -->
+</div>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/defer-view/defer-view.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/defer-view/defer-view.component.scss
@@ -1,0 +1,50 @@
+@use '../../../../../styles/typography';
+
+.defer-details {
+  padding: 12px;
+
+  h3 {
+    @extend %heading-400;
+    margin: 0;
+
+    &:not(:first-child) {
+      margin-top: 1rem;
+    }
+  }
+
+  .trigger {
+    font-family: monospace;
+    padding-inline-start: 1rem;
+  }
+
+  .pill {
+    font-family: monospace;
+    background: color-mix(in srgb, var(--quinary-contrast), var(--senary-contrast));
+    padding: 0.125rem 0.5rem;
+    margin: 0.125rem;
+    border-radius: 1rem;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    @extend %body-01;
+
+    &.flagged {
+      background: var(--quinary-contrast);
+    }
+  }
+}
+
+mat-toolbar {
+  @extend %body-medium-01;
+  padding: 0.25rem 0.625rem;
+  justify-content: space-between;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  line-height: 25px;
+  height: auto;
+  border-bottom: 1px solid var(--color-separator);
+
+  &:not(:first-child) {
+    border-top: 1px solid var(--color-separator);
+  }
+}

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/defer-view/defer-view.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/defer-view/defer-view.component.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component, computed, input} from '@angular/core';
+import {MatToolbar} from '@angular/material/toolbar';
+import {DeferInfo} from 'protocol';
+
+@Component({
+  templateUrl: './defer-view.component.html',
+  selector: 'ng-defer-view',
+  styleUrls: ['./defer-view.component.scss'],
+  imports: [MatToolbar],
+})
+export class DeferViewComponent {
+  readonly defer = input.required<NonNullable<DeferInfo>>();
+
+  readonly loadingBlockInfo = computed(() => {
+    const loadingBlock = this.defer().blocks.loadingBlock;
+    if (!loadingBlock) {
+      return null;
+    }
+
+    const info: string[] = [];
+    if (loadingBlock.minimumTime) {
+      info.push(`minimum ${loadingBlock.minimumTime}ms`);
+    }
+    if (loadingBlock.afterTime) {
+      info.push(`after ${loadingBlock.afterTime}ms`);
+    }
+    return info.length ? `(${info.join(', ')})` : null;
+  });
+}

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab.component.html
@@ -1,6 +1,19 @@
-<ng-property-tab-header [currentSelectedElement]="currentSelectedElement()" />
-<ng-property-tab-body
-  (inspect)="inspect.emit($event)"
-  (viewSource)="viewSource.emit($event)"
-  [currentSelectedElement]="currentSelectedElement()"
-/>
+@let currentSelectedElement = this.currentSelectedElement();
+
+@if (currentSelectedElement) {
+  <ng-property-tab-header [currentSelectedElement]="currentSelectedElement" />
+  <ng-property-tab-body
+    (inspect)="inspect.emit($event)"
+    (viewSource)="viewSource.emit($event)"
+    [currentSelectedElement]="currentSelectedElement"
+  />
+
+  @let hydration = currentSelectedElement.hydration;
+  @if (hydration && hydration.status === 'dehydrated') {
+    <div class="dehydrated-component">This component is dehydrated</div>
+  }
+
+  @if (currentSelectedElement.defer) {
+    <ng-defer-view [defer]="currentSelectedElement.defer" />
+  }
+}

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab.component.scss
@@ -1,4 +1,3 @@
-ng-property-view-body {
-  width: 100%;
-  overflow: auto;
+.dehydrated-component {
+  padding: 12px;
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab.component.ts
@@ -13,14 +13,16 @@ import {IndexedNode} from '../directive-forest/index-forest';
 import {FlatNode} from '../property-resolver/element-property-resolver';
 import {PropertyTabBodyComponent} from './property-view/property-tab-body.component';
 import {PropertyTabHeaderComponent} from './property-tab-header.component';
+import {DeferViewComponent} from './defer-view/defer-view.component';
 
 @Component({
-  templateUrl: './property-tab.component.html',
   selector: 'ng-property-tab',
-  imports: [PropertyTabHeaderComponent, PropertyTabBodyComponent],
+  templateUrl: './property-tab.component.html',
+  styleUrls: ['./property-tab.component.scss'],
+  imports: [PropertyTabHeaderComponent, PropertyTabBodyComponent, DeferViewComponent],
 })
 export class PropertyTabComponent {
-  readonly currentSelectedElement = input.required<IndexedNode>();
+  readonly currentSelectedElement = input.required<IndexedNode | null>();
   readonly viewSource = output<string>();
   readonly inspect = output<{node: FlatNode; directivePosition: DirectivePosition}>();
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree-fns.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree-fns.spec.ts
@@ -111,6 +111,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
           'component': {'name': 'app-root', 'isElement': false, 'id': 0},
           'directives': [],
           'hydration': null,
+          'defer': null,
           'children': [
             {
               'element': 'router-outlet',
@@ -125,11 +126,13 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                 {'id': '4', 'type': 'null', 'name': 'Null Injector'},
               ],
               'hydration': null,
+              'defer': null,
             },
             {
               'element': 'app-demo-component',
               'component': {'name': 'app-demo-component', 'isElement': false, 'id': 2},
               'hydration': null,
+              'defer': null,
               'directives': [],
               'children': [
                 {
@@ -148,12 +151,14 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                     {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                   ],
                   'hydration': null,
+                  'defer': null,
                 },
                 {
                   'element': 'app-todo-demo',
                   'component': {'name': 'app-todo-demo', 'isElement': false, 'id': 4},
                   'directives': [],
                   'hydration': null,
+                  'defer': null,
                   'children': [
                     {
                       'element': 'a',
@@ -174,6 +179,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                         {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                       ],
                       'hydration': null,
+                      'defer': null,
                     },
                     {
                       'element': 'a',
@@ -194,6 +200,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                         {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                       ],
                       'hydration': null,
+                      'defer': null,
                     },
                     {
                       'element': 'router-outlet',
@@ -214,11 +221,13 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                         {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                       ],
                       'hydration': null,
+                      'defer': null,
                     },
                     {
                       'element': 'app-todos',
                       'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
                       'hydration': null,
+                      'defer': null,
                       'directives': [],
                       'children': [
                         {
@@ -243,6 +252,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                             {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                           ],
                           'hydration': null,
+                          'defer': null,
                         },
                         {
                           'element': 'a',
@@ -266,6 +276,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                             {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                           ],
                           'hydration': null,
+                          'defer': null,
                         },
                         {
                           'element': 'a',
@@ -289,6 +300,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                             {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                           ],
                           'hydration': null,
+                          'defer': null,
                         },
                         {
                           'element': 'app-todo',
@@ -319,6 +331,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                                 {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                               ],
                               'hydration': null,
+                              'defer': null,
                             },
                           ],
                           'resolutionPath': [
@@ -339,12 +352,14 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                             {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                           ],
                           'hydration': null,
+                          'defer': null,
                         },
                         {
                           'element': 'app-todo',
                           'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
                           'directives': [{'name': '_TooltipDirective', 'id': 16}],
                           'hydration': null,
+                          'defer': null,
                           'children': [
                             {
                               'element': 'div',
@@ -370,6 +385,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                                 {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                               ],
                               'hydration': null,
+                              'defer': null,
                             },
                           ],
                           'resolutionPath': [
@@ -412,6 +428,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                             {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                           ],
                           'hydration': null,
+                          'defer': null,
                         },
                       ],
                       'resolutionPath': [
@@ -460,6 +477,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                     {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                   ],
                   'hydration': null,
+                  'defer': null,
                 },
               ],
               'resolutionPath': [
@@ -487,6 +505,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
           'element': 'router-outlet',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterOutlet', 'id': 1}],
           'children': [],
           'resolutionPath': [
@@ -504,6 +523,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
           'element': 'app-demo-component',
           'component': {'name': 'app-demo-component', 'isElement': false, 'id': 2},
           'hydration': null,
+          'defer': null,
           'directives': [],
           'children': [
             {
@@ -522,11 +542,13 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                 {'id': '4', 'type': 'null', 'name': 'Null Injector'},
               ],
               'hydration': null,
+              'defer': null,
             },
             {
               'element': 'app-todo-demo',
               'component': {'name': 'app-todo-demo', 'isElement': false, 'id': 4},
               'hydration': null,
+              'defer': null,
               'directives': [],
               'children': [
                 {
@@ -548,6 +570,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                     {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                   ],
                   'hydration': null,
+                  'defer': null,
                 },
                 {
                   'element': 'a',
@@ -568,6 +591,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                     {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                   ],
                   'hydration': null,
+                  'defer': null,
                 },
                 {
                   'element': 'router-outlet',
@@ -588,11 +612,13 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                     {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                   ],
                   'hydration': null,
+                  'defer': null,
                 },
                 {
                   'element': 'app-todos',
                   'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
                   'hydration': null,
+                  'defer': null,
                   'directives': [],
                   'children': [
                     {
@@ -617,6 +643,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                         {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                       ],
                       'hydration': null,
+                      'defer': null,
                     },
                     {
                       'element': 'a',
@@ -640,6 +667,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                         {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                       ],
                       'hydration': null,
+                      'defer': null,
                     },
                     {
                       'element': 'a',
@@ -663,12 +691,14 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                         {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                       ],
                       'hydration': null,
+                      'defer': null,
                     },
                     {
                       'element': 'app-todo',
                       'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
                       'directives': [{'name': '_TooltipDirective', 'id': 13}],
                       'hydration': null,
+                      'defer': null,
                       'children': [
                         {
                           'element': 'div',
@@ -694,6 +724,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                             {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                           ],
                           'hydration': null,
+                          'defer': null,
                         },
                       ],
                       'resolutionPath': [
@@ -719,6 +750,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                       'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
                       'directives': [{'name': '_TooltipDirective', 'id': 16}],
                       'hydration': null,
+                      'defer': null,
 
                       'children': [
                         {
@@ -745,6 +777,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                             {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                           ],
                           'hydration': null,
+                          'defer': null,
                         },
                       ],
                       'resolutionPath': [
@@ -787,6 +820,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                         {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                       ],
                       'hydration': null,
+                      'defer': null,
                     },
                   ],
                   'resolutionPath': [
@@ -835,6 +869,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                 {'id': '4', 'type': 'null', 'name': 'Null Injector'},
               ],
               'hydration': null,
+              'defer': null,
             },
           ],
           'resolutionPath': [
@@ -858,6 +893,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
           'component': null,
           'directives': [{'name': '_RouterOutlet', 'id': 3}],
           'hydration': null,
+          'defer': null,
           'children': [],
           'resolutionPath': [
             {'id': '5', 'type': 'element', 'name': '_RouterOutlet'},
@@ -880,6 +916,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
           'element': 'app-todo-demo',
           'component': {'name': 'app-todo-demo', 'isElement': false, 'id': 4},
           'hydration': null,
+          'defer': null,
           'directives': [],
           'children': [
             {
@@ -901,6 +938,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                 {'id': '4', 'type': 'null', 'name': 'Null Injector'},
               ],
               'hydration': null,
+              'defer': null,
             },
             {
               'element': 'a',
@@ -921,6 +959,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                 {'id': '4', 'type': 'null', 'name': 'Null Injector'},
               ],
               'hydration': null,
+              'defer': null,
             },
             {
               'element': 'router-outlet',
@@ -941,12 +980,14 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                 {'id': '4', 'type': 'null', 'name': 'Null Injector'},
               ],
               'hydration': null,
+              'defer': null,
             },
             {
               'element': 'app-todos',
               'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
               'directives': [],
               'hydration': null,
+              'defer': null,
               'children': [
                 {
                   'element': 'a',
@@ -970,6 +1011,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                     {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                   ],
                   'hydration': null,
+                  'defer': null,
                 },
                 {
                   'element': 'a',
@@ -993,6 +1035,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                     {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                   ],
                   'hydration': null,
+                  'defer': null,
                 },
                 {
                   'element': 'a',
@@ -1016,12 +1059,14 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                     {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                   ],
                   'hydration': null,
+                  'defer': null,
                 },
                 {
                   'element': 'app-todo',
                   'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
                   'directives': [{'name': '_TooltipDirective', 'id': 13}],
                   'hydration': null,
+                  'defer': null,
                   'children': [
                     {
                       'element': 'div',
@@ -1047,6 +1092,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                         {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                       ],
                       'hydration': null,
+                      'defer': null,
                     },
                   ],
                   'resolutionPath': [
@@ -1072,6 +1118,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                   'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
                   'directives': [{'name': '_TooltipDirective', 'id': 16}],
                   'hydration': null,
+                  'defer': null,
                   'children': [
                     {
                       'element': 'div',
@@ -1097,6 +1144,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                         {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                       ],
                       'hydration': null,
+                      'defer': null,
                     },
                   ],
                   'resolutionPath': [
@@ -1139,6 +1187,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                     {'id': '4', 'type': 'null', 'name': 'Null Injector'},
                   ],
                   'hydration': null,
+                  'defer': null,
                 },
               ],
               'resolutionPath': [
@@ -1182,6 +1231,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
           'element': 'a',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterLink', 'id': 5}],
           'children': [],
           'resolutionPath': [
@@ -1224,6 +1274,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
             {'id': '4', 'type': 'null', 'name': 'Null Injector'},
           ],
           'hydration': null,
+          'defer': null,
         },
         'path': [
           {'id': '1', 'type': 'element', 'name': '_AppComponent'},
@@ -1236,6 +1287,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
           'element': 'router-outlet',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterOutlet', 'id': 7}],
           'children': [],
           'resolutionPath': [
@@ -1264,11 +1316,13 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
           'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
           'directives': [],
           'hydration': null,
+          'defer': null,
           'children': [
             {
               'element': 'a',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterLink', 'id': 9}],
               'children': [],
               'resolutionPath': [
@@ -1292,6 +1346,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
               'element': 'a',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterLink', 'id': 10}],
               'children': [],
               'resolutionPath': [
@@ -1315,6 +1370,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
               'element': 'a',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterLink', 'id': 11}],
               'children': [],
               'resolutionPath': [
@@ -1339,12 +1395,14 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
               'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
               'directives': [{'name': '_TooltipDirective', 'id': 13}],
               'hydration': null,
+              'defer': null,
               'children': [
                 {
                   'element': 'div',
                   'component': null,
                   'directives': [{'name': '_TooltipDirective', 'id': 14}],
                   'hydration': null,
+                  'defer': null,
                   'children': [],
                   'resolutionPath': [
                     {'id': '18', 'type': 'element', 'name': '_TooltipDirective'},
@@ -1389,12 +1447,14 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
               'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
               'directives': [{'name': '_TooltipDirective', 'id': 16}],
               'hydration': null,
+              'defer': null,
               'children': [
                 {
                   'element': 'div',
                   'component': null,
                   'directives': [{'name': '_TooltipDirective', 'id': 17}],
                   'hydration': null,
+                  'defer': null,
                   'children': [],
                   'resolutionPath': [
                     {'id': '21', 'type': 'element', 'name': '_TooltipDirective'},
@@ -1439,6 +1499,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
               'component': null,
               'directives': [{'name': '_NgForOf', 'id': 18}],
               'hydration': null,
+              'defer': null,
               'children': [],
               'resolutionPath': [
                 {'id': '20', 'type': 'element', 'name': '_NgForOf'},
@@ -1486,6 +1547,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
           'element': 'a',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterLink', 'id': 9}],
           'children': [],
           'resolutionPath': [
@@ -1517,6 +1579,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
           'element': 'a',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterLink', 'id': 10}],
           'children': [],
           'resolutionPath': [
@@ -1548,6 +1611,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
           'element': 'a',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterLink', 'id': 11}],
           'children': [],
           'resolutionPath': [
@@ -1580,12 +1644,14 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
           'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
           'directives': [{'name': '_TooltipDirective', 'id': 13}],
           'hydration': null,
+          'defer': null,
           'children': [
             {
               'element': 'div',
               'component': null,
               'directives': [{'name': '_TooltipDirective', 'id': 14}],
               'hydration': null,
+              'defer': null,
               'children': [],
               'resolutionPath': [
                 {'id': '18', 'type': 'element', 'name': '_TooltipDirective'},
@@ -1638,6 +1704,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
           'element': 'div',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_TooltipDirective', 'id': 14}],
           'children': [],
           'resolutionPath': [
@@ -1674,6 +1741,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
           'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
           'directives': [{'name': '_TooltipDirective', 'id': 16}],
           'hydration': null,
+          'defer': null,
           'children': [
             {
               'element': 'div',
@@ -1681,6 +1749,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
               'directives': [{'name': '_TooltipDirective', 'id': 17}],
               'children': [],
               'hydration': null,
+              'defer': null,
               'resolutionPath': [
                 {'id': '21', 'type': 'element', 'name': '_TooltipDirective'},
                 {'id': '22', 'type': 'element', 'name': '_TodoComponent'},
@@ -1732,6 +1801,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
           'element': 'div',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_TooltipDirective', 'id': 17}],
           'children': [],
           'resolutionPath': [
@@ -1767,6 +1837,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
           'element': '#comment',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_NgForOf', 'id': 18}],
           'children': [],
           'resolutionPath': [
@@ -1797,6 +1868,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
         'node': {
           'element': 'app-heavy',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-heavy', 'isElement': false, 'id': 20},
           'directives': [],
           'children': [],
@@ -1830,6 +1902,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
             'node': {
               'element': 'app-root',
               'hydration': null,
+              'defer': null,
               'component': {'name': 'app-root', 'isElement': false, 'id': 0},
               'directives': [],
               'children': [
@@ -1837,6 +1910,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                   'element': 'router-outlet',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterOutlet', 'id': 1}],
                   'children': [],
                   'resolutionPath': [
@@ -1852,11 +1926,13 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                   'component': {'name': 'app-demo-component', 'isElement': false, 'id': 2},
                   'directives': [],
                   'hydration': null,
+                  'defer': null,
                   'children': [
                     {
                       'element': 'router-outlet',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterOutlet', 'id': 3}],
                       'children': [],
                       'resolutionPath': [
@@ -1875,11 +1951,13 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                       'component': {'name': 'app-todo-demo', 'isElement': false, 'id': 4},
                       'directives': [],
                       'hydration': null,
+                      'defer': null,
                       'children': [
                         {
                           'element': 'a',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_RouterLink', 'id': 5}],
                           'children': [],
                           'resolutionPath': [
@@ -1900,6 +1978,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                           'element': 'a',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_RouterLink', 'id': 6}],
                           'children': [],
                           'resolutionPath': [
@@ -1920,6 +1999,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                           'element': 'router-outlet',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_RouterOutlet', 'id': 7}],
                           'children': [],
                           'resolutionPath': [
@@ -1941,11 +2021,13 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                           'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
                           'directives': [],
                           'hydration': null,
+                          'defer': null,
                           'children': [
                             {
                               'element': 'a',
                               'component': null,
                               'hydration': null,
+                              'defer': null,
                               'directives': [{'name': '_RouterLink', 'id': 9}],
                               'children': [],
                               'resolutionPath': [
@@ -1969,6 +2051,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                               'element': 'a',
                               'component': null,
                               'hydration': null,
+                              'defer': null,
                               'directives': [{'name': '_RouterLink', 'id': 10}],
                               'children': [],
                               'resolutionPath': [
@@ -1992,6 +2075,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                               'element': 'a',
                               'component': null,
                               'hydration': null,
+                              'defer': null,
                               'directives': [{'name': '_RouterLink', 'id': 11}],
                               'children': [],
                               'resolutionPath': [
@@ -2016,11 +2100,13 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                               'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
                               'directives': [{'name': '_TooltipDirective', 'id': 13}],
                               'hydration': null,
+                              'defer': null,
                               'children': [
                                 {
                                   'element': 'div',
                                   'component': null,
                                   'hydration': null,
+                                  'defer': null,
                                   'directives': [{'name': '_TooltipDirective', 'id': 14}],
                                   'children': [],
                                   'resolutionPath': [
@@ -2066,11 +2152,13 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                               'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
                               'directives': [{'name': '_TooltipDirective', 'id': 16}],
                               'hydration': null,
+                              'defer': null,
                               'children': [
                                 {
                                   'element': 'div',
                                   'component': null,
                                   'hydration': null,
+                                  'defer': null,
                                   'directives': [{'name': '_TooltipDirective', 'id': 17}],
                                   'children': [],
                                   'resolutionPath': [
@@ -2116,6 +2204,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                               'component': null,
                               'directives': [{'name': '_NgForOf', 'id': 18}],
                               'hydration': null,
+                              'defer': null,
                               'children': [],
                               'resolutionPath': [
                                 {'id': '20', 'type': 'element', 'name': '_NgForOf'},
@@ -2171,6 +2260,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                       'directives': [],
                       'children': [],
                       'hydration': null,
+                      'defer': null,
                       'resolutionPath': [
                         {'id': '24', 'type': 'element', 'name': '_HeavyComponent'},
                         {'id': '6', 'type': 'element', 'name': '_DemoAppComponent'},
@@ -2213,6 +2303,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                   'component': {'name': 'app-demo-component', 'isElement': false, 'id': 2},
                   'directives': [],
                   'hydration': null,
+                  'defer': null,
                   'children': [
                     {
                       'element': 'router-outlet',
@@ -2220,6 +2311,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                       'directives': [{'name': '_RouterOutlet', 'id': 3}],
                       'children': [],
                       'hydration': null,
+                      'defer': null,
                       'resolutionPath': [
                         {'id': '5', 'type': 'element', 'name': '_RouterOutlet'},
                         {'id': '6', 'type': 'element', 'name': '_DemoAppComponent'},
@@ -2236,11 +2328,13 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                       'component': {'name': 'app-todo-demo', 'isElement': false, 'id': 4},
                       'directives': [],
                       'hydration': null,
+                      'defer': null,
                       'children': [
                         {
                           'element': 'a',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_RouterLink', 'id': 5}],
                           'children': [],
                           'resolutionPath': [
@@ -2263,6 +2357,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                           'directives': [{'name': '_RouterLink', 'id': 6}],
                           'children': [],
                           'hydration': null,
+                          'defer': null,
                           'resolutionPath': [
                             {'id': '11', 'type': 'element', 'name': '_RouterLink'},
                             {'id': '9', 'type': 'element', 'name': '_AppTodoComponent'},
@@ -2283,6 +2378,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                           'directives': [{'name': '_RouterOutlet', 'id': 7}],
                           'children': [],
                           'hydration': null,
+                          'defer': null,
                           'resolutionPath': [
                             {'id': '12', 'type': 'element', 'name': '_RouterOutlet'},
                             {'id': '9', 'type': 'element', 'name': '_AppTodoComponent'},
@@ -2302,6 +2398,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                           'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
                           'directives': [],
                           'hydration': null,
+                          'defer': null,
                           'children': [
                             {
                               'element': 'a',
@@ -2309,6 +2406,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                               'directives': [{'name': '_RouterLink', 'id': 9}],
                               'children': [],
                               'hydration': null,
+                              'defer': null,
                               'resolutionPath': [
                                 {'id': '13', 'type': 'element', 'name': '_RouterLink'},
                                 {'id': '14', 'type': 'element', 'name': '_TodosComponent'},
@@ -2332,6 +2430,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                               'directives': [{'name': '_RouterLink', 'id': 10}],
                               'children': [],
                               'hydration': null,
+                              'defer': null,
                               'resolutionPath': [
                                 {'id': '16', 'type': 'element', 'name': '_RouterLink'},
                                 {'id': '14', 'type': 'element', 'name': '_TodosComponent'},
@@ -2355,6 +2454,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                               'directives': [{'name': '_RouterLink', 'id': 11}],
                               'children': [],
                               'hydration': null,
+                              'defer': null,
                               'resolutionPath': [
                                 {'id': '17', 'type': 'element', 'name': '_RouterLink'},
                                 {'id': '14', 'type': 'element', 'name': '_TodosComponent'},
@@ -2377,6 +2477,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                               'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
                               'directives': [{'name': '_TooltipDirective', 'id': 13}],
                               'hydration': null,
+                              'defer': null,
                               'children': [
                                 {
                                   'element': 'div',
@@ -2384,6 +2485,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                                   'directives': [{'name': '_TooltipDirective', 'id': 14}],
                                   'children': [],
                                   'hydration': null,
+                                  'defer': null,
                                   'resolutionPath': [
                                     {'id': '18', 'type': 'element', 'name': '_TooltipDirective'},
                                     {'id': '19', 'type': 'element', 'name': '_TodoComponent'},
@@ -2427,11 +2529,13 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                               'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
                               'directives': [{'name': '_TooltipDirective', 'id': 16}],
                               'hydration': null,
+                              'defer': null,
                               'children': [
                                 {
                                   'element': 'div',
                                   'component': null,
                                   'hydration': null,
+                                  'defer': null,
                                   'directives': [{'name': '_TooltipDirective', 'id': 17}],
                                   'children': [],
                                   'resolutionPath': [
@@ -2478,6 +2582,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                               'directives': [{'name': '_NgForOf', 'id': 18}],
                               'children': [],
                               'hydration': null,
+                              'defer': null,
                               'resolutionPath': [
                                 {'id': '20', 'type': 'element', 'name': '_NgForOf'},
                                 {'id': '14', 'type': 'element', 'name': '_TodosComponent'},
@@ -2530,6 +2635,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                       'element': 'app-heavy',
                       'component': {'name': 'app-heavy', 'isElement': false, 'id': 20},
                       'hydration': null,
+                      'defer': null,
                       'directives': [],
                       'children': [],
                       'resolutionPath': [
@@ -2565,6 +2671,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                       'element': 'app-todo-demo',
                       'component': {'name': 'app-todo-demo', 'isElement': false, 'id': 4},
                       'hydration': null,
+                      'defer': null,
                       'directives': [],
                       'children': [
                         {
@@ -2573,6 +2680,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                           'directives': [{'name': '_RouterLink', 'id': 5}],
                           'children': [],
                           'hydration': null,
+                          'defer': null,
                           'resolutionPath': [
                             {'id': '8', 'type': 'element', 'name': '_RouterLink'},
                             {'id': '9', 'type': 'element', 'name': '_AppTodoComponent'},
@@ -2593,6 +2701,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                           'directives': [{'name': '_RouterLink', 'id': 6}],
                           'children': [],
                           'hydration': null,
+                          'defer': null,
                           'resolutionPath': [
                             {'id': '11', 'type': 'element', 'name': '_RouterLink'},
                             {'id': '9', 'type': 'element', 'name': '_AppTodoComponent'},
@@ -2611,6 +2720,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                           'element': 'router-outlet',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_RouterOutlet', 'id': 7}],
                           'children': [],
                           'resolutionPath': [
@@ -2632,11 +2742,13 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                           'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
                           'directives': [],
                           'hydration': null,
+                          'defer': null,
                           'children': [
                             {
                               'element': 'a',
                               'component': null,
                               'hydration': null,
+                              'defer': null,
                               'directives': [{'name': '_RouterLink', 'id': 9}],
                               'children': [],
                               'resolutionPath': [
@@ -2660,6 +2772,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                               'element': 'a',
                               'component': null,
                               'hydration': null,
+                              'defer': null,
                               'directives': [{'name': '_RouterLink', 'id': 10}],
                               'children': [],
                               'resolutionPath': [
@@ -2684,6 +2797,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                               'component': null,
                               'directives': [{'name': '_RouterLink', 'id': 11}],
                               'hydration': null,
+                              'defer': null,
                               'children': [],
                               'resolutionPath': [
                                 {'id': '17', 'type': 'element', 'name': '_RouterLink'},
@@ -2707,11 +2821,13 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                               'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
                               'directives': [{'name': '_TooltipDirective', 'id': 13}],
                               'hydration': null,
+                              'defer': null,
                               'children': [
                                 {
                                   'element': 'div',
                                   'component': null,
                                   'hydration': null,
+                                  'defer': null,
                                   'directives': [{'name': '_TooltipDirective', 'id': 14}],
                                   'children': [],
                                   'resolutionPath': [
@@ -2757,11 +2873,13 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                               'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
                               'directives': [{'name': '_TooltipDirective', 'id': 16}],
                               'hydration': null,
+                              'defer': null,
                               'children': [
                                 {
                                   'element': 'div',
                                   'component': null,
                                   'hydration': null,
+                                  'defer': null,
                                   'directives': [{'name': '_TooltipDirective', 'id': 17}],
                                   'children': [],
                                   'resolutionPath': [
@@ -2807,6 +2925,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                               'component': null,
                               'directives': [{'name': '_NgForOf', 'id': 18}],
                               'hydration': null,
+                              'defer': null,
                               'children': [],
                               'resolutionPath': [
                                 {'id': '20', 'type': 'element', 'name': '_NgForOf'},
@@ -2866,6 +2985,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                         'node': {
                           'element': 'app-todos',
                           'hydration': null,
+                          'defer': null,
                           'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
                           'directives': [],
                           'children': [
@@ -2873,6 +2993,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                               'element': 'a',
                               'component': null,
                               'hydration': null,
+                              'defer': null,
                               'directives': [{'name': '_RouterLink', 'id': 9}],
                               'children': [],
                               'resolutionPath': [
@@ -2896,6 +3017,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                               'element': 'a',
                               'component': null,
                               'hydration': null,
+                              'defer': null,
                               'directives': [{'name': '_RouterLink', 'id': 10}],
                               'children': [],
                               'resolutionPath': [
@@ -2919,6 +3041,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                               'element': 'a',
                               'component': null,
                               'hydration': null,
+                              'defer': null,
                               'directives': [{'name': '_RouterLink', 'id': 11}],
                               'children': [],
                               'resolutionPath': [
@@ -2943,11 +3066,13 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                               'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
                               'directives': [{'name': '_TooltipDirective', 'id': 13}],
                               'hydration': null,
+                              'defer': null,
                               'children': [
                                 {
                                   'element': 'div',
                                   'component': null,
                                   'hydration': null,
+                                  'defer': null,
                                   'directives': [{'name': '_TooltipDirective', 'id': 14}],
                                   'children': [],
                                   'resolutionPath': [
@@ -2993,11 +3118,13 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                               'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
                               'directives': [{'name': '_TooltipDirective', 'id': 16}],
                               'hydration': null,
+                              'defer': null,
                               'children': [
                                 {
                                   'element': 'div',
                                   'component': null,
                                   'hydration': null,
+                                  'defer': null,
                                   'directives': [{'name': '_TooltipDirective', 'id': 17}],
                                   'children': [],
                                   'resolutionPath': [
@@ -3042,6 +3169,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                               'element': '#comment',
                               'component': null,
                               'hydration': null,
+                              'defer': null,
                               'directives': [{'name': '_NgForOf', 'id': 18}],
                               'children': [],
                               'resolutionPath': [
@@ -3088,6 +3216,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                             'node': {
                               'element': 'app-todo',
                               'hydration': null,
+                              'defer': null,
                               'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
                               'directives': [{'name': '_TooltipDirective', 'id': 13}],
                               'children': [
@@ -3095,6 +3224,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                                   'element': 'div',
                                   'component': null,
                                   'hydration': null,
+                                  'defer': null,
                                   'directives': [{'name': '_TooltipDirective', 'id': 14}],
                                   'children': [],
                                   'resolutionPath': [
@@ -3146,6 +3276,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                                   'element': 'div',
                                   'component': null,
                                   'hydration': null,
+                                  'defer': null,
                                   'directives': [{'name': '_TooltipDirective', 'id': 14}],
                                   'children': [],
                                   'resolutionPath': [
@@ -3180,6 +3311,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                             'node': {
                               'element': 'app-todo',
                               'hydration': null,
+                              'defer': null,
                               'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
                               'directives': [{'name': '_TooltipDirective', 'id': 16}],
                               'children': [
@@ -3187,6 +3319,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                                   'element': 'div',
                                   'component': null,
                                   'hydration': null,
+                                  'defer': null,
                                   'directives': [{'name': '_TooltipDirective', 'id': 17}],
                                   'children': [],
                                   'resolutionPath': [
@@ -3238,6 +3371,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                                   'element': 'div',
                                   'component': null,
                                   'hydration': null,
+                                  'defer': null,
                                   'directives': [{'name': '_TooltipDirective', 'id': 17}],
                                   'children': [],
                                   'resolutionPath': [
@@ -3276,6 +3410,7 @@ describe('transformInjectorResolutionPathsIntoTree', () => {
                     'node': {
                       'element': 'app-heavy',
                       'hydration': null,
+                      'defer': null,
                       'component': {'name': 'app-heavy', 'isElement': false, 'id': 20},
                       'directives': [],
                       'children': [],
@@ -3311,6 +3446,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'app-root',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-root', 'isElement': false, 'id': 0},
           'directives': [],
           'children': [
@@ -3319,6 +3455,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'component': null,
               'directives': [{'name': '_RouterOutlet', 'id': 1}],
               'hydration': null,
+              'defer': null,
               'children': [],
               'resolutionPath': [
                 {'id': '0', 'type': 'element', 'name': '_RouterOutlet'},
@@ -3331,6 +3468,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
             {
               'element': 'app-demo-component',
               'hydration': null,
+              'defer': null,
               'component': {'name': 'app-demo-component', 'isElement': false, 'id': 2},
               'directives': [],
               'children': [
@@ -3340,6 +3478,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'directives': [{'name': '_RouterOutlet', 'id': 3}],
                   'children': [],
                   'hydration': null,
+                  'defer': null,
                   'resolutionPath': [
                     {'id': '5', 'type': 'element', 'name': '_RouterOutlet'},
                     {'id': '6', 'type': 'element', 'name': '_DemoAppComponent'},
@@ -3354,6 +3493,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                 {
                   'element': 'app-todo-demo',
                   'hydration': null,
+                  'defer': null,
                   'component': {'name': 'app-todo-demo', 'isElement': false, 'id': 4},
                   'directives': [],
                   'children': [
@@ -3361,6 +3501,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': 'a',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterLink', 'id': 5}],
                       'children': [],
                       'resolutionPath': [
@@ -3381,6 +3522,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': 'a',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterLink', 'id': 6}],
                       'children': [],
                       'resolutionPath': [
@@ -3401,6 +3543,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': 'router-outlet',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterOutlet', 'id': 7}],
                       'children': [],
                       'resolutionPath': [
@@ -3420,6 +3563,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                     {
                       'element': 'app-todos',
                       'hydration': null,
+                      'defer': null,
                       'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
                       'directives': [],
                       'children': [
@@ -3427,6 +3571,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                           'element': 'a',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_RouterLink', 'id': 9}],
                           'children': [],
                           'resolutionPath': [
@@ -3450,6 +3595,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                           'element': 'a',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_RouterLink', 'id': 10}],
                           'children': [],
                           'resolutionPath': [
@@ -3473,6 +3619,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                           'element': 'a',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_RouterLink', 'id': 11}],
                           'children': [],
                           'resolutionPath': [
@@ -3495,6 +3642,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                         {
                           'element': 'app-todo',
                           'hydration': null,
+                          'defer': null,
                           'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
                           'directives': [{'name': '_TooltipDirective', 'id': 13}],
                           'children': [
@@ -3502,6 +3650,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                               'element': 'div',
                               'component': null,
                               'hydration': null,
+                              'defer': null,
                               'directives': [{'name': '_TooltipDirective', 'id': 14}],
                               'children': [],
                               'resolutionPath': [
@@ -3545,6 +3694,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                         {
                           'element': 'app-todo',
                           'hydration': null,
+                          'defer': null,
                           'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
                           'directives': [{'name': '_TooltipDirective', 'id': 16}],
                           'children': [
@@ -3552,6 +3702,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                               'element': 'div',
                               'component': null,
                               'hydration': null,
+                              'defer': null,
                               'directives': [{'name': '_TooltipDirective', 'id': 17}],
                               'children': [],
                               'resolutionPath': [
@@ -3596,6 +3747,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                           'element': '#comment',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_NgForOf', 'id': 18}],
                           'children': [],
                           'resolutionPath': [
@@ -3649,6 +3801,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                 {
                   'element': 'app-zippy',
                   'hydration': null,
+                  'defer': null,
                   'component': {'name': 'app-zippy', 'isElement': true, 'id': 19},
                   'directives': [],
                   'children': [],
@@ -3663,6 +3816,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                 {
                   'element': 'app-heavy',
                   'hydration': null,
+                  'defer': null,
                   'component': {'name': 'app-heavy', 'isElement': false, 'id': 20},
                   'directives': [],
                   'children': [],
@@ -3706,6 +3860,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'router-outlet',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterOutlet', 'id': 1}],
           'children': [],
           'resolutionPath': [
@@ -3725,6 +3880,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'app-demo-component',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-demo-component', 'isElement': false, 'id': 2},
           'directives': [],
           'children': [
@@ -3732,6 +3888,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'router-outlet',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterOutlet', 'id': 3}],
               'children': [],
               'resolutionPath': [
@@ -3748,6 +3905,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
             {
               'element': 'app-todo-demo',
               'hydration': null,
+              'defer': null,
               'component': {'name': 'app-todo-demo', 'isElement': false, 'id': 4},
               'directives': [],
               'children': [
@@ -3755,6 +3913,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': 'a',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterLink', 'id': 5}],
                   'children': [],
                   'resolutionPath': [
@@ -3775,6 +3934,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': 'a',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterLink', 'id': 6}],
                   'children': [],
                   'resolutionPath': [
@@ -3795,6 +3955,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': 'router-outlet',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterOutlet', 'id': 7}],
                   'children': [],
                   'resolutionPath': [
@@ -3814,6 +3975,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                 {
                   'element': 'app-todos',
                   'hydration': null,
+                  'defer': null,
                   'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
                   'directives': [],
                   'children': [
@@ -3821,6 +3983,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': 'a',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterLink', 'id': 9}],
                       'children': [],
                       'resolutionPath': [
@@ -3844,6 +4007,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': 'a',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterLink', 'id': 10}],
                       'children': [],
                       'resolutionPath': [
@@ -3867,6 +4031,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': 'a',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterLink', 'id': 11}],
                       'children': [],
                       'resolutionPath': [
@@ -3889,6 +4054,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                     {
                       'element': 'app-todo',
                       'hydration': null,
+                      'defer': null,
                       'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
                       'directives': [{'name': '_TooltipDirective', 'id': 13}],
                       'children': [
@@ -3896,6 +4062,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                           'element': 'div',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_TooltipDirective', 'id': 14}],
                           'children': [],
                           'resolutionPath': [
@@ -3939,6 +4106,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                     {
                       'element': 'app-todo',
                       'hydration': null,
+                      'defer': null,
                       'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
                       'directives': [{'name': '_TooltipDirective', 'id': 16}],
                       'children': [
@@ -3946,6 +4114,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                           'element': 'div',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_TooltipDirective', 'id': 17}],
                           'children': [],
                           'resolutionPath': [
@@ -3990,6 +4159,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': '#comment',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_NgForOf', 'id': 18}],
                       'children': [],
                       'resolutionPath': [
@@ -4043,6 +4213,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
             {
               'element': 'app-zippy',
               'hydration': null,
+              'defer': null,
               'component': {'name': 'app-zippy', 'isElement': true, 'id': 19},
               'directives': [],
               'children': [],
@@ -4057,6 +4228,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
             {
               'element': 'app-heavy',
               'hydration': null,
+              'defer': null,
               'component': {'name': 'app-heavy', 'isElement': false, 'id': 20},
               'directives': [],
               'children': [],
@@ -4094,6 +4266,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'router-outlet',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterOutlet', 'id': 3}],
           'children': [],
           'resolutionPath': [
@@ -4118,6 +4291,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'app-todo-demo',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-todo-demo', 'isElement': false, 'id': 4},
           'directives': [],
           'children': [
@@ -4125,6 +4299,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'a',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterLink', 'id': 5}],
               'children': [],
               'resolutionPath': [
@@ -4145,6 +4320,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'a',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterLink', 'id': 6}],
               'children': [],
               'resolutionPath': [
@@ -4165,6 +4341,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'router-outlet',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterOutlet', 'id': 7}],
               'children': [],
               'resolutionPath': [
@@ -4186,11 +4363,13 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
               'directives': [],
               'hydration': null,
+              'defer': null,
               'children': [
                 {
                   'element': 'a',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterLink', 'id': 9}],
                   'children': [],
                   'resolutionPath': [
@@ -4214,6 +4393,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': 'a',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterLink', 'id': 10}],
                   'children': [],
                   'resolutionPath': [
@@ -4237,6 +4417,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': 'a',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterLink', 'id': 11}],
                   'children': [],
                   'resolutionPath': [
@@ -4259,6 +4440,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                 {
                   'element': 'app-todo',
                   'hydration': null,
+                  'defer': null,
                   'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
                   'directives': [{'name': '_TooltipDirective', 'id': 13}],
                   'children': [
@@ -4266,6 +4448,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': 'div',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_TooltipDirective', 'id': 14}],
                       'children': [],
                       'resolutionPath': [
@@ -4309,6 +4492,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                 {
                   'element': 'app-todo',
                   'hydration': null,
+                  'defer': null,
 
                   'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
                   'directives': [{'name': '_TooltipDirective', 'id': 16}],
@@ -4317,6 +4501,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': 'div',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_TooltipDirective', 'id': 17}],
                       'children': [],
                       'resolutionPath': [
@@ -4361,6 +4546,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': '#comment',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_NgForOf', 'id': 18}],
                   'children': [],
                   'resolutionPath': [
@@ -4425,6 +4611,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'a',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterLink', 'id': 5}],
           'children': [],
           'resolutionPath': [
@@ -4455,6 +4642,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'a',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterLink', 'id': 6}],
           'children': [],
           'resolutionPath': [
@@ -4485,6 +4673,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'router-outlet',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterOutlet', 'id': 7}],
           'children': [],
           'resolutionPath': [
@@ -4514,6 +4703,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'app-todos',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
           'directives': [],
           'children': [
@@ -4521,6 +4711,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'a',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterLink', 'id': 9}],
               'children': [],
               'resolutionPath': [
@@ -4544,6 +4735,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'a',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterLink', 'id': 10}],
               'children': [],
               'resolutionPath': [
@@ -4567,6 +4759,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'a',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterLink', 'id': 11}],
               'children': [],
               'resolutionPath': [
@@ -4589,6 +4782,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
             {
               'element': 'app-todo',
               'hydration': null,
+              'defer': null,
               'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
               'directives': [{'name': '_TooltipDirective', 'id': 13}],
               'children': [
@@ -4596,6 +4790,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': 'div',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_TooltipDirective', 'id': 14}],
                   'children': [],
                   'resolutionPath': [
@@ -4639,6 +4834,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
             {
               'element': 'app-todo',
               'hydration': null,
+              'defer': null,
               'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
               'directives': [{'name': '_TooltipDirective', 'id': 16}],
               'children': [
@@ -4646,6 +4842,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': 'div',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_TooltipDirective', 'id': 17}],
                   'children': [],
                   'resolutionPath': [
@@ -4690,6 +4887,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': '#comment',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_NgForOf', 'id': 18}],
               'children': [],
               'resolutionPath': [
@@ -4742,6 +4940,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'a',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterLink', 'id': 9}],
           'children': [],
           'resolutionPath': [
@@ -4777,6 +4976,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'a',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterLink', 'id': 10}],
           'children': [],
           'resolutionPath': [
@@ -4812,6 +5012,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'a',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterLink', 'id': 11}],
           'children': [],
           'resolutionPath': [
@@ -4846,6 +5047,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'app-todo',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
           'directives': [{'name': '_TooltipDirective', 'id': 13}],
           'children': [
@@ -4853,6 +5055,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'div',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_TooltipDirective', 'id': 14}],
               'children': [],
               'resolutionPath': [
@@ -4910,6 +5113,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'div',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_TooltipDirective', 'id': 14}],
           'children': [],
           'resolutionPath': [
@@ -4948,6 +5152,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'app-todo',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
           'directives': [{'name': '_TooltipDirective', 'id': 16}],
           'children': [
@@ -4955,6 +5160,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'div',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_TooltipDirective', 'id': 17}],
               'children': [],
               'resolutionPath': [
@@ -5012,6 +5218,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'div',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_TooltipDirective', 'id': 17}],
           'children': [],
           'resolutionPath': [
@@ -5051,6 +5258,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': '#comment',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_NgForOf', 'id': 18}],
           'children': [],
           'resolutionPath': [
@@ -5085,6 +5293,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'app-zippy',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-zippy', 'isElement': true, 'id': 19},
           'directives': [],
           'children': [],
@@ -5106,6 +5315,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'app-heavy',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-heavy', 'isElement': false, 'id': 20},
           'directives': [],
           'children': [],
@@ -5135,6 +5345,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'app-root',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-root', 'isElement': false, 'id': 0},
           'directives': [],
           'children': [
@@ -5142,6 +5353,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'router-outlet',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterOutlet', 'id': 1}],
               'children': [],
               'resolutionPath': [
@@ -5155,6 +5367,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
             {
               'element': 'app-demo-component',
               'hydration': null,
+              'defer': null,
               'component': {'name': 'app-demo-component', 'isElement': false, 'id': 2},
               'directives': [],
               'children': [
@@ -5162,6 +5375,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': 'router-outlet',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterOutlet', 'id': 3}],
                   'children': [],
                   'resolutionPath': [
@@ -5178,6 +5392,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                 {
                   'element': 'app-todo-demo',
                   'hydration': null,
+                  'defer': null,
                   'component': {'name': 'app-todo-demo', 'isElement': false, 'id': 4},
                   'directives': [],
                   'children': [
@@ -5185,6 +5400,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': 'a',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterLink', 'id': 5}],
                       'children': [],
                       'resolutionPath': [
@@ -5205,6 +5421,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': 'a',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterLink', 'id': 6}],
                       'children': [],
                       'resolutionPath': [
@@ -5225,6 +5442,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': 'router-outlet',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterOutlet', 'id': 7}],
                       'children': [],
                       'resolutionPath': [
@@ -5244,6 +5462,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                     {
                       'element': 'app-todos',
                       'hydration': null,
+                      'defer': null,
                       'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
                       'directives': [],
                       'children': [
@@ -5251,6 +5470,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                           'element': 'a',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_RouterLink', 'id': 9}],
                           'children': [],
                           'resolutionPath': [
@@ -5274,6 +5494,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                           'element': 'a',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_RouterLink', 'id': 10}],
                           'children': [],
                           'resolutionPath': [
@@ -5297,6 +5518,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                           'element': 'a',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_RouterLink', 'id': 11}],
                           'children': [],
                           'resolutionPath': [
@@ -5319,6 +5541,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                         {
                           'element': 'app-todo',
                           'hydration': null,
+                          'defer': null,
                           'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
                           'directives': [{'name': '_TooltipDirective', 'id': 13}],
                           'children': [
@@ -5326,6 +5549,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                               'element': 'div',
                               'component': null,
                               'hydration': null,
+                              'defer': null,
                               'directives': [{'name': '_TooltipDirective', 'id': 14}],
                               'children': [],
                               'resolutionPath': [
@@ -5369,6 +5593,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                         {
                           'element': 'app-todo',
                           'hydration': null,
+                          'defer': null,
                           'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
                           'directives': [{'name': '_TooltipDirective', 'id': 16}],
                           'children': [
@@ -5376,6 +5601,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                               'element': 'div',
                               'component': null,
                               'hydration': null,
+                              'defer': null,
                               'directives': [{'name': '_TooltipDirective', 'id': 17}],
                               'children': [],
                               'resolutionPath': [
@@ -5420,6 +5646,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                           'element': '#comment',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_NgForOf', 'id': 18}],
                           'children': [],
                           'resolutionPath': [
@@ -5473,6 +5700,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                 {
                   'element': 'app-zippy',
                   'hydration': null,
+                  'defer': null,
                   'component': {'name': 'app-zippy', 'isElement': true, 'id': 19},
                   'directives': [],
                   'children': [],
@@ -5487,6 +5715,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                 {
                   'element': 'app-heavy',
                   'hydration': null,
+                  'defer': null,
                   'component': {'name': 'app-heavy', 'isElement': false, 'id': 20},
                   'directives': [],
                   'children': [],
@@ -5527,6 +5756,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'router-outlet',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterOutlet', 'id': 1}],
           'children': [],
           'resolutionPath': [
@@ -5545,11 +5775,13 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'component': {'name': 'app-demo-component', 'isElement': false, 'id': 2},
           'directives': [],
           'hydration': null,
+          'defer': null,
           'children': [
             {
               'element': 'router-outlet',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterOutlet', 'id': 3}],
               'children': [],
               'resolutionPath': [
@@ -5567,12 +5799,14 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'app-todo-demo',
               'component': {'name': 'app-todo-demo', 'isElement': false, 'id': 4},
               'hydration': null,
+              'defer': null,
               'directives': [],
               'children': [
                 {
                   'element': 'a',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterLink', 'id': 5}],
                   'children': [],
                   'resolutionPath': [
@@ -5593,6 +5827,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': 'a',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterLink', 'id': 6}],
                   'children': [],
                   'resolutionPath': [
@@ -5613,6 +5848,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': 'router-outlet',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterOutlet', 'id': 7}],
                   'children': [],
                   'resolutionPath': [
@@ -5633,12 +5869,14 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': 'app-todos',
                   'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
                   'hydration': null,
+                  'defer': null,
                   'directives': [],
                   'children': [
                     {
                       'element': 'a',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterLink', 'id': 9}],
                       'children': [],
                       'resolutionPath': [
@@ -5662,6 +5900,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': 'a',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterLink', 'id': 10}],
                       'children': [],
                       'resolutionPath': [
@@ -5685,6 +5924,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': 'a',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterLink', 'id': 11}],
                       'children': [],
                       'resolutionPath': [
@@ -5707,6 +5947,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                     {
                       'element': 'app-todo',
                       'hydration': null,
+                      'defer': null,
                       'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
                       'directives': [{'name': '_TooltipDirective', 'id': 13}],
                       'children': [
@@ -5714,6 +5955,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                           'element': 'div',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_TooltipDirective', 'id': 14}],
                           'children': [],
                           'resolutionPath': [
@@ -5757,6 +5999,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                     {
                       'element': 'app-todo',
                       'hydration': null,
+                      'defer': null,
                       'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
                       'directives': [{'name': '_TooltipDirective', 'id': 16}],
                       'children': [
@@ -5764,6 +6007,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                           'element': 'div',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_TooltipDirective', 'id': 17}],
                           'children': [],
                           'resolutionPath': [
@@ -5808,6 +6052,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': '#comment',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_NgForOf', 'id': 18}],
                       'children': [],
                       'resolutionPath': [
@@ -5864,6 +6109,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'directives': [],
               'children': [],
               'hydration': null,
+              'defer': null,
               'resolutionPath': [
                 {'id': '23', 'type': 'element', 'name': '_ZippyComponent'},
                 {'id': '7', 'type': 'environment', 'name': '_DemoAppModule'},
@@ -5878,6 +6124,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'directives': [],
               'children': [],
               'hydration': null,
+              'defer': null,
               'resolutionPath': [
                 {'id': '24', 'type': 'element', 'name': '_HeavyComponent'},
                 {'id': '6', 'type': 'element', 'name': '_DemoAppComponent'},
@@ -5909,6 +6156,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'router-outlet',
           'hydration': null,
+          'defer': null,
           'component': null,
           'directives': [{'name': '_RouterOutlet', 'id': 3}],
           'children': [],
@@ -5932,6 +6180,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'app-todo-demo',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-todo-demo', 'isElement': false, 'id': 4},
           'directives': [],
           'children': [
@@ -5939,6 +6188,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'a',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterLink', 'id': 5}],
               'children': [],
               'resolutionPath': [
@@ -5959,6 +6209,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'a',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterLink', 'id': 6}],
               'children': [],
               'resolutionPath': [
@@ -5979,6 +6230,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'router-outlet',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterOutlet', 'id': 7}],
               'children': [],
               'resolutionPath': [
@@ -5998,6 +6250,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
             {
               'element': 'app-todos',
               'hydration': null,
+              'defer': null,
               'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
               'directives': [],
               'children': [
@@ -6005,6 +6258,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': 'a',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterLink', 'id': 9}],
                   'children': [],
                   'resolutionPath': [
@@ -6028,6 +6282,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': 'a',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterLink', 'id': 10}],
                   'children': [],
                   'resolutionPath': [
@@ -6051,6 +6306,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': 'a',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterLink', 'id': 11}],
                   'children': [],
                   'resolutionPath': [
@@ -6073,6 +6329,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                 {
                   'element': 'app-todo',
                   'hydration': null,
+                  'defer': null,
                   'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
                   'directives': [{'name': '_TooltipDirective', 'id': 13}],
                   'children': [
@@ -6080,6 +6337,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': 'div',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_TooltipDirective', 'id': 14}],
                       'children': [],
                       'resolutionPath': [
@@ -6123,6 +6381,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                 {
                   'element': 'app-todo',
                   'hydration': null,
+                  'defer': null,
                   'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
                   'directives': [{'name': '_TooltipDirective', 'id': 16}],
                   'children': [
@@ -6130,6 +6389,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': 'div',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_TooltipDirective', 'id': 17}],
                       'children': [],
                       'resolutionPath': [
@@ -6174,6 +6434,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': '#comment',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_NgForOf', 'id': 18}],
                   'children': [],
                   'resolutionPath': [
@@ -6234,6 +6495,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'a',
           'hydration': null,
+          'defer': null,
           'component': null,
           'directives': [{'name': '_RouterLink', 'id': 5}],
           'children': [],
@@ -6262,6 +6524,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'a',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterLink', 'id': 6}],
           'children': [],
           'resolutionPath': [
@@ -6289,6 +6552,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'router-outlet',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterOutlet', 'id': 7}],
           'children': [],
           'resolutionPath': [
@@ -6315,6 +6579,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'app-todos',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
           'directives': [],
           'children': [
@@ -6322,6 +6587,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'a',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterLink', 'id': 9}],
               'children': [],
               'resolutionPath': [
@@ -6345,6 +6611,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'a',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterLink', 'id': 10}],
               'children': [],
               'resolutionPath': [
@@ -6368,6 +6635,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'a',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterLink', 'id': 11}],
               'children': [],
               'resolutionPath': [
@@ -6392,11 +6660,13 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
               'directives': [{'name': '_TooltipDirective', 'id': 13}],
               'hydration': null,
+              'defer': null,
               'children': [
                 {
                   'element': 'div',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_TooltipDirective', 'id': 14}],
                   'children': [],
                   'resolutionPath': [
@@ -6442,12 +6712,14 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
               'directives': [{'name': '_TooltipDirective', 'id': 16}],
               'hydration': null,
+              'defer': null,
               'children': [
                 {
                   'element': 'div',
                   'component': null,
                   'directives': [{'name': '_TooltipDirective', 'id': 17}],
                   'hydration': null,
+                  'defer': null,
                   'children': [],
                   'resolutionPath': [
                     {'id': '21', 'type': 'element', 'name': '_TooltipDirective'},
@@ -6492,6 +6764,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'component': null,
               'directives': [{'name': '_NgForOf', 'id': 18}],
               'hydration': null,
+              'defer': null,
               'children': [],
               'resolutionPath': [
                 {'id': '20', 'type': 'element', 'name': '_NgForOf'},
@@ -6539,6 +6812,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'a',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterLink', 'id': 9}],
           'children': [],
           'resolutionPath': [
@@ -6570,6 +6844,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'a',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterLink', 'id': 10}],
           'children': [],
           'resolutionPath': [
@@ -6601,6 +6876,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'a',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterLink', 'id': 11}],
           'children': [],
           'resolutionPath': [
@@ -6631,6 +6907,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'app-todo',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
           'directives': [{'name': '_TooltipDirective', 'id': 13}],
           'children': [
@@ -6638,6 +6915,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'div',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_TooltipDirective', 'id': 14}],
               'children': [],
               'resolutionPath': [
@@ -6691,6 +6969,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'div',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_TooltipDirective', 'id': 14}],
           'children': [],
           'resolutionPath': [
@@ -6727,11 +7006,13 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
           'directives': [{'name': '_TooltipDirective', 'id': 16}],
           'hydration': null,
+          'defer': null,
           'children': [
             {
               'element': 'div',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_TooltipDirective', 'id': 17}],
               'children': [],
               'resolutionPath': [
@@ -6785,6 +7066,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'div',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_TooltipDirective', 'id': 17}],
           'children': [],
           'resolutionPath': [
@@ -6820,6 +7102,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': '#comment',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_NgForOf', 'id': 18}],
           'children': [],
           'resolutionPath': [
@@ -6850,6 +7133,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'app-zippy',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-zippy', 'isElement': true, 'id': 19},
           'directives': [],
           'children': [],
@@ -6867,6 +7151,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'app-heavy',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-heavy', 'isElement': false, 'id': 20},
           'directives': [],
           'children': [],
@@ -6894,6 +7179,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'app-root',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-root', 'isElement': false, 'id': 0},
           'directives': [],
           'children': [
@@ -6901,6 +7187,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'router-outlet',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterOutlet', 'id': 1}],
               'children': [],
               'resolutionPath': [
@@ -6915,6 +7202,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'app-demo-component',
               'component': {'name': 'app-demo-component', 'isElement': false, 'id': 2},
               'hydration': null,
+              'defer': null,
               'directives': [],
               'children': [
                 {
@@ -6922,6 +7210,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'component': null,
                   'directives': [{'name': '_RouterOutlet', 'id': 3}],
                   'hydration': null,
+                  'defer': null,
                   'children': [],
                   'resolutionPath': [
                     {'id': '5', 'type': 'element', 'name': '_RouterOutlet'},
@@ -6937,6 +7226,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                 {
                   'element': 'app-todo-demo',
                   'hydration': null,
+                  'defer': null,
                   'component': {'name': 'app-todo-demo', 'isElement': false, 'id': 4},
                   'directives': [],
                   'children': [
@@ -6944,6 +7234,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': 'a',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterLink', 'id': 5}],
                       'children': [],
                       'resolutionPath': [
@@ -6964,6 +7255,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': 'a',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterLink', 'id': 6}],
                       'children': [],
                       'resolutionPath': [
@@ -6984,6 +7276,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': 'router-outlet',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterOutlet', 'id': 7}],
                       'children': [],
                       'resolutionPath': [
@@ -7003,6 +7296,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                     {
                       'element': 'app-todos',
                       'hydration': null,
+                      'defer': null,
                       'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
                       'directives': [],
                       'children': [
@@ -7010,6 +7304,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                           'element': 'a',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_RouterLink', 'id': 9}],
                           'children': [],
                           'resolutionPath': [
@@ -7033,6 +7328,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                           'element': 'a',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_RouterLink', 'id': 10}],
                           'children': [],
                           'resolutionPath': [
@@ -7056,6 +7352,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                           'element': 'a',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_RouterLink', 'id': 11}],
                           'children': [],
                           'resolutionPath': [
@@ -7078,6 +7375,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                         {
                           'element': 'app-todo',
                           'hydration': null,
+                          'defer': null,
                           'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
                           'directives': [{'name': '_TooltipDirective', 'id': 13}],
                           'children': [
@@ -7085,6 +7383,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                               'element': 'div',
                               'component': null,
                               'hydration': null,
+                              'defer': null,
                               'directives': [{'name': '_TooltipDirective', 'id': 14}],
                               'children': [],
                               'resolutionPath': [
@@ -7130,11 +7429,13 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                           'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
                           'directives': [{'name': '_TooltipDirective', 'id': 16}],
                           'hydration': null,
+                          'defer': null,
                           'children': [
                             {
                               'element': 'div',
                               'component': null,
                               'hydration': null,
+                              'defer': null,
                               'directives': [{'name': '_TooltipDirective', 'id': 17}],
                               'children': [],
                               'resolutionPath': [
@@ -7179,6 +7480,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                           'element': '#comment',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_NgForOf', 'id': 18}],
                           'children': [],
                           'resolutionPath': [
@@ -7232,6 +7534,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                 {
                   'element': 'app-zippy',
                   'hydration': null,
+                  'defer': null,
                   'component': {'name': 'app-zippy', 'isElement': true, 'id': 19},
                   'directives': [],
                   'children': [],
@@ -7247,6 +7550,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': 'app-heavy',
                   'component': {'name': 'app-heavy', 'isElement': false, 'id': 20},
                   'hydration': null,
+                  'defer': null,
                   'directives': [],
                   'children': [],
                   'resolutionPath': [
@@ -7286,6 +7590,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'router-outlet',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterOutlet', 'id': 1}],
           'children': [],
           'resolutionPath': [
@@ -7302,6 +7607,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'app-demo-component',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-demo-component', 'isElement': false, 'id': 2},
           'directives': [],
           'children': [
@@ -7309,6 +7615,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'router-outlet',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterOutlet', 'id': 3}],
               'children': [],
               'resolutionPath': [
@@ -7325,6 +7632,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
             {
               'element': 'app-todo-demo',
               'hydration': null,
+              'defer': null,
               'component': {'name': 'app-todo-demo', 'isElement': false, 'id': 4},
               'directives': [],
               'children': [
@@ -7332,6 +7640,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': 'a',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterLink', 'id': 5}],
                   'children': [],
                   'resolutionPath': [
@@ -7352,6 +7661,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': 'a',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterLink', 'id': 6}],
                   'children': [],
                   'resolutionPath': [
@@ -7372,6 +7682,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': 'router-outlet',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterOutlet', 'id': 7}],
                   'children': [],
                   'resolutionPath': [
@@ -7392,12 +7703,14 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': 'app-todos',
                   'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
                   'hydration': null,
+                  'defer': null,
                   'directives': [],
                   'children': [
                     {
                       'element': 'a',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterLink', 'id': 9}],
                       'children': [],
                       'resolutionPath': [
@@ -7421,6 +7734,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': 'a',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterLink', 'id': 10}],
                       'children': [],
                       'resolutionPath': [
@@ -7444,6 +7758,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': 'a',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterLink', 'id': 11}],
                       'children': [],
                       'resolutionPath': [
@@ -7466,6 +7781,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                     {
                       'element': 'app-todo',
                       'hydration': null,
+                      'defer': null,
                       'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
                       'directives': [{'name': '_TooltipDirective', 'id': 13}],
                       'children': [
@@ -7473,6 +7789,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                           'element': 'div',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_TooltipDirective', 'id': 14}],
                           'children': [],
                           'resolutionPath': [
@@ -7516,6 +7833,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                     {
                       'element': 'app-todo',
                       'hydration': null,
+                      'defer': null,
                       'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
                       'directives': [{'name': '_TooltipDirective', 'id': 16}],
                       'children': [
@@ -7523,6 +7841,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                           'element': 'div',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_TooltipDirective', 'id': 17}],
                           'children': [],
                           'resolutionPath': [
@@ -7567,6 +7886,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': '#comment',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_NgForOf', 'id': 18}],
                       'children': [],
                       'resolutionPath': [
@@ -7620,6 +7940,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
             {
               'element': 'app-zippy',
               'hydration': null,
+              'defer': null,
               'component': {'name': 'app-zippy', 'isElement': true, 'id': 19},
               'directives': [],
               'children': [],
@@ -7634,6 +7955,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
             {
               'element': 'app-heavy',
               'hydration': null,
+              'defer': null,
               'component': {'name': 'app-heavy', 'isElement': false, 'id': 20},
               'directives': [],
               'children': [],
@@ -7668,6 +7990,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'router-outlet',
           'hydration': null,
+          'defer': null,
           'component': null,
           'directives': [{'name': '_RouterOutlet', 'id': 3}],
           'children': [],
@@ -7691,6 +8014,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'app-todo-demo',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-todo-demo', 'isElement': false, 'id': 4},
           'directives': [],
           'children': [
@@ -7698,6 +8022,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'a',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterLink', 'id': 5}],
               'children': [],
               'resolutionPath': [
@@ -7718,6 +8043,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'a',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterLink', 'id': 6}],
               'children': [],
               'resolutionPath': [
@@ -7738,6 +8064,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'router-outlet',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterOutlet', 'id': 7}],
               'children': [],
               'resolutionPath': [
@@ -7757,6 +8084,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
             {
               'element': 'app-todos',
               'hydration': null,
+              'defer': null,
               'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
               'directives': [],
               'children': [
@@ -7764,6 +8092,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': 'a',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterLink', 'id': 9}],
                   'children': [],
                   'resolutionPath': [
@@ -7787,6 +8116,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': 'a',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterLink', 'id': 10}],
                   'children': [],
                   'resolutionPath': [
@@ -7810,6 +8140,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': 'a',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterLink', 'id': 11}],
                   'children': [],
                   'resolutionPath': [
@@ -7832,6 +8163,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                 {
                   'element': 'app-todo',
                   'hydration': null,
+                  'defer': null,
                   'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
                   'directives': [{'name': '_TooltipDirective', 'id': 13}],
                   'children': [
@@ -7839,6 +8171,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': 'div',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_TooltipDirective', 'id': 14}],
                       'children': [],
                       'resolutionPath': [
@@ -7882,6 +8215,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                 {
                   'element': 'app-todo',
                   'hydration': null,
+                  'defer': null,
                   'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
                   'directives': [{'name': '_TooltipDirective', 'id': 16}],
                   'children': [
@@ -7889,6 +8223,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                       'element': 'div',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_TooltipDirective', 'id': 17}],
                       'children': [],
                       'resolutionPath': [
@@ -7933,6 +8268,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': '#comment',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_NgForOf', 'id': 18}],
                   'children': [],
                   'resolutionPath': [
@@ -7994,6 +8330,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'a',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterLink', 'id': 5}],
           'children': [],
           'resolutionPath': [
@@ -8021,6 +8358,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'a',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterLink', 'id': 6}],
           'children': [],
           'resolutionPath': [
@@ -8047,6 +8385,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'router-outlet',
           'hydration': null,
+          'defer': null,
           'component': null,
           'directives': [{'name': '_RouterOutlet', 'id': 7}],
           'children': [],
@@ -8074,6 +8413,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'app-todos',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
           'directives': [],
           'children': [
@@ -8081,6 +8421,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'a',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterLink', 'id': 9}],
               'children': [],
               'resolutionPath': [
@@ -8104,6 +8445,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'a',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterLink', 'id': 10}],
               'children': [],
               'resolutionPath': [
@@ -8127,6 +8469,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'a',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterLink', 'id': 11}],
               'children': [],
               'resolutionPath': [
@@ -8149,6 +8492,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
             {
               'element': 'app-todo',
               'hydration': null,
+              'defer': null,
               'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
               'directives': [{'name': '_TooltipDirective', 'id': 13}],
               'children': [
@@ -8156,6 +8500,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': 'div',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_TooltipDirective', 'id': 14}],
                   'children': [],
                   'resolutionPath': [
@@ -8199,6 +8544,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
             {
               'element': 'app-todo',
               'hydration': null,
+              'defer': null,
               'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
               'directives': [{'name': '_TooltipDirective', 'id': 16}],
               'children': [
@@ -8206,6 +8552,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
                   'element': 'div',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_TooltipDirective', 'id': 17}],
                   'children': [],
                   'resolutionPath': [
@@ -8250,6 +8597,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': '#comment',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_NgForOf', 'id': 18}],
               'children': [],
               'resolutionPath': [
@@ -8298,6 +8646,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'a',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterLink', 'id': 9}],
           'children': [],
           'resolutionPath': [
@@ -8329,6 +8678,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'a',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterLink', 'id': 10}],
           'children': [],
           'resolutionPath': [
@@ -8360,6 +8710,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'a',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterLink', 'id': 11}],
           'children': [],
           'resolutionPath': [
@@ -8390,6 +8741,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'app-todo',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
           'directives': [{'name': '_TooltipDirective', 'id': 13}],
           'children': [
@@ -8397,6 +8749,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'div',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_TooltipDirective', 'id': 14}],
               'children': [],
               'resolutionPath': [
@@ -8449,6 +8802,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'div',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_TooltipDirective', 'id': 14}],
           'children': [],
           'resolutionPath': [
@@ -8481,6 +8835,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'app-todo',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
           'directives': [{'name': '_TooltipDirective', 'id': 16}],
           'children': [
@@ -8488,6 +8843,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
               'element': 'div',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_TooltipDirective', 'id': 17}],
               'children': [],
               'resolutionPath': [
@@ -8540,6 +8896,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': 'div',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_TooltipDirective', 'id': 17}],
           'children': [],
           'resolutionPath': [
@@ -8573,6 +8930,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
           'element': '#comment',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_NgForOf', 'id': 18}],
           'children': [],
           'resolutionPath': [
@@ -8603,6 +8961,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'app-zippy',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-zippy', 'isElement': true, 'id': 19},
           'directives': [],
           'children': [],
@@ -8623,6 +8982,7 @@ describe('splitInjectorPathsIntoElementAndEnvironmentPaths', () => {
         'node': {
           'element': 'app-heavy',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-heavy', 'isElement': false, 'id': 20},
           'directives': [],
           'children': [],
@@ -8737,6 +9097,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
       {
         'element': 'app-root',
         'hydration': null,
+        'defer': null,
         'component': {'name': 'app-root', 'isElement': false, 'id': 0},
         'directives': [],
         'children': [
@@ -8744,6 +9105,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
             'element': 'router-outlet',
             'component': null,
             'hydration': null,
+            'defer': null,
             'directives': [{'name': '_RouterOutlet', 'id': 1}],
             'children': [],
             'resolutionPath': [
@@ -8757,6 +9119,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
           {
             'element': 'app-demo-component',
             'hydration': null,
+            'defer': null,
             'component': {'name': 'app-demo-component', 'isElement': false, 'id': 2},
             'directives': [],
             'children': [
@@ -8764,6 +9127,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                 'element': 'router-outlet',
                 'component': null,
                 'hydration': null,
+                'defer': null,
                 'directives': [{'name': '_RouterOutlet', 'id': 3}],
                 'children': [],
                 'resolutionPath': [
@@ -8780,6 +9144,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
               {
                 'element': 'app-todo-demo',
                 'hydration': null,
+                'defer': null,
                 'component': {'name': 'app-todo-demo', 'isElement': false, 'id': 4},
                 'directives': [],
                 'children': [
@@ -8787,6 +9152,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                     'element': 'a',
                     'component': null,
                     'hydration': null,
+                    'defer': null,
                     'directives': [{'name': '_RouterLink', 'id': 5}],
                     'children': [],
                     'resolutionPath': [
@@ -8807,6 +9173,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                     'element': 'a',
                     'component': null,
                     'hydration': null,
+                    'defer': null,
                     'directives': [{'name': '_RouterLink', 'id': 6}],
                     'children': [],
                     'resolutionPath': [
@@ -8827,6 +9194,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                     'element': 'router-outlet',
                     'component': null,
                     'hydration': null,
+                    'defer': null,
                     'directives': [{'name': '_RouterOutlet', 'id': 7}],
                     'children': [],
                     'resolutionPath': [
@@ -8848,11 +9216,13 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                     'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
                     'directives': [],
                     'hydration': null,
+                    'defer': null,
                     'children': [
                       {
                         'element': 'a',
                         'component': null,
                         'hydration': null,
+                        'defer': null,
                         'directives': [{'name': '_RouterLink', 'id': 9}],
                         'children': [],
                         'resolutionPath': [
@@ -8876,6 +9246,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                         'element': 'a',
                         'component': null,
                         'hydration': null,
+                        'defer': null,
                         'directives': [{'name': '_RouterLink', 'id': 10}],
                         'children': [],
                         'resolutionPath': [
@@ -8899,6 +9270,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                         'element': 'a',
                         'component': null,
                         'hydration': null,
+                        'defer': null,
                         'directives': [{'name': '_RouterLink', 'id': 11}],
                         'children': [],
                         'resolutionPath': [
@@ -8921,6 +9293,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                       {
                         'element': 'app-todo',
                         'hydration': null,
+                        'defer': null,
                         'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
                         'directives': [{'name': '_TooltipDirective', 'id': 13}],
                         'children': [
@@ -8928,6 +9301,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                             'element': 'div',
                             'component': null,
                             'hydration': null,
+                            'defer': null,
                             'directives': [{'name': '_TooltipDirective', 'id': 14}],
                             'children': [],
                             'resolutionPath': [
@@ -8971,6 +9345,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                       {
                         'element': 'app-todo',
                         'hydration': null,
+                        'defer': null,
                         'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
                         'directives': [{'name': '_TooltipDirective', 'id': 16}],
                         'children': [
@@ -8978,6 +9353,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                             'element': 'div',
                             'component': null,
                             'hydration': null,
+                            'defer': null,
                             'directives': [{'name': '_TooltipDirective', 'id': 17}],
                             'children': [],
                             'resolutionPath': [
@@ -9022,6 +9398,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                         'element': '#comment',
                         'component': null,
                         'hydration': null,
+                        'defer': null,
                         'directives': [{'name': '_NgForOf', 'id': 18}],
                         'children': [],
                         'resolutionPath': [
@@ -9075,6 +9452,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
               {
                 'element': 'app-zippy',
                 'hydration': null,
+                'defer': null,
                 'component': {'name': 'app-zippy', 'isElement': true, 'id': 19},
                 'directives': [],
                 'children': [],
@@ -9089,6 +9467,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
               {
                 'element': 'app-heavy',
                 'hydration': null,
+                'defer': null,
                 'component': {'name': 'app-heavy', 'isElement': false, 'id': 20},
                 'directives': [],
                 'children': [],
@@ -9129,6 +9508,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
         'node': {
           'element': 'app-root',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-root', 'isElement': false, 'id': 0},
           'directives': [],
           'children': [
@@ -9136,6 +9516,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
               'element': 'router-outlet',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterOutlet', 'id': 1}],
               'children': [],
               'resolutionPath': [
@@ -9149,6 +9530,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
             {
               'element': 'app-demo-component',
               'hydration': null,
+              'defer': null,
               'component': {'name': 'app-demo-component', 'isElement': false, 'id': 2},
               'directives': [],
               'children': [
@@ -9156,6 +9538,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                   'element': 'router-outlet',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterOutlet', 'id': 3}],
                   'children': [],
                   'resolutionPath': [
@@ -9172,6 +9555,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                 {
                   'element': 'app-todo-demo',
                   'hydration': null,
+                  'defer': null,
                   'component': {'name': 'app-todo-demo', 'isElement': false, 'id': 4},
                   'directives': [],
                   'children': [
@@ -9179,6 +9563,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                       'element': 'a',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterLink', 'id': 5}],
                       'children': [],
                       'resolutionPath': [
@@ -9199,6 +9584,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                       'element': 'a',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterLink', 'id': 6}],
                       'children': [],
                       'resolutionPath': [
@@ -9219,6 +9605,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                       'element': 'router-outlet',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterOutlet', 'id': 7}],
                       'children': [],
                       'resolutionPath': [
@@ -9238,6 +9625,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                     {
                       'element': 'app-todos',
                       'hydration': null,
+                      'defer': null,
                       'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
                       'directives': [],
                       'children': [
@@ -9245,6 +9633,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                           'element': 'a',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_RouterLink', 'id': 9}],
                           'children': [],
                           'resolutionPath': [
@@ -9268,6 +9657,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                           'element': 'a',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_RouterLink', 'id': 10}],
                           'children': [],
                           'resolutionPath': [
@@ -9291,6 +9681,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                           'element': 'a',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_RouterLink', 'id': 11}],
                           'children': [],
                           'resolutionPath': [
@@ -9313,6 +9704,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                         {
                           'element': 'app-todo',
                           'hydration': null,
+                          'defer': null,
                           'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
                           'directives': [{'name': '_TooltipDirective', 'id': 13}],
                           'children': [
@@ -9320,6 +9712,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                               'element': 'div',
                               'component': null,
                               'hydration': null,
+                              'defer': null,
                               'directives': [{'name': '_TooltipDirective', 'id': 14}],
                               'children': [],
                               'resolutionPath': [
@@ -9363,6 +9756,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                         {
                           'element': 'app-todo',
                           'hydration': null,
+                          'defer': null,
                           'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
                           'directives': [{'name': '_TooltipDirective', 'id': 16}],
                           'children': [
@@ -9370,6 +9764,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                               'element': 'div',
                               'component': null,
                               'hydration': null,
+                              'defer': null,
                               'directives': [{'name': '_TooltipDirective', 'id': 17}],
                               'children': [],
                               'resolutionPath': [
@@ -9414,6 +9809,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                           'element': '#comment',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_NgForOf', 'id': 18}],
                           'children': [],
                           'resolutionPath': [
@@ -9467,6 +9863,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                 {
                   'element': 'app-zippy',
                   'hydration': null,
+                  'defer': null,
                   'component': {'name': 'app-zippy', 'isElement': true, 'id': 19},
                   'directives': [],
                   'children': [],
@@ -9481,6 +9878,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                 {
                   'element': 'app-heavy',
                   'hydration': null,
+                  'defer': null,
                   'component': {'name': 'app-heavy', 'isElement': false, 'id': 20},
                   'directives': [],
                   'children': [],
@@ -9525,6 +9923,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
         'node': {
           'element': 'router-outlet',
           'hydration': null,
+          'defer': null,
           'component': null,
           'directives': [{'name': '_RouterOutlet', 'id': 1}],
           'children': [],
@@ -9548,6 +9947,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
         'node': {
           'element': 'app-demo-component',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-demo-component', 'isElement': false, 'id': 2},
           'directives': [],
           'children': [
@@ -9555,6 +9955,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
               'element': 'router-outlet',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterOutlet', 'id': 3}],
               'children': [],
               'resolutionPath': [
@@ -9571,6 +9972,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
             {
               'element': 'app-todo-demo',
               'hydration': null,
+              'defer': null,
               'component': {'name': 'app-todo-demo', 'isElement': false, 'id': 4},
               'directives': [],
               'children': [
@@ -9578,6 +9980,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                   'element': 'a',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterLink', 'id': 5}],
                   'children': [],
                   'resolutionPath': [
@@ -9598,6 +10001,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                   'element': 'a',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterLink', 'id': 6}],
                   'children': [],
                   'resolutionPath': [
@@ -9618,6 +10022,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                   'element': 'router-outlet',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterOutlet', 'id': 7}],
                   'children': [],
                   'resolutionPath': [
@@ -9637,6 +10042,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                 {
                   'element': 'app-todos',
                   'hydration': null,
+                  'defer': null,
                   'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
                   'directives': [],
                   'children': [
@@ -9644,6 +10050,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                       'element': 'a',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterLink', 'id': 9}],
                       'children': [],
                       'resolutionPath': [
@@ -9667,6 +10074,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                       'element': 'a',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterLink', 'id': 10}],
                       'children': [],
                       'resolutionPath': [
@@ -9690,6 +10098,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                       'element': 'a',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_RouterLink', 'id': 11}],
                       'children': [],
                       'resolutionPath': [
@@ -9712,6 +10121,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                     {
                       'element': 'app-todo',
                       'hydration': null,
+                      'defer': null,
                       'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
                       'directives': [{'name': '_TooltipDirective', 'id': 13}],
                       'children': [
@@ -9719,6 +10129,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                           'element': 'div',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_TooltipDirective', 'id': 14}],
                           'children': [],
                           'resolutionPath': [
@@ -9762,6 +10173,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                     {
                       'element': 'app-todo',
                       'hydration': null,
+                      'defer': null,
                       'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
                       'directives': [{'name': '_TooltipDirective', 'id': 16}],
                       'children': [
@@ -9769,6 +10181,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                           'element': 'div',
                           'component': null,
                           'hydration': null,
+                          'defer': null,
                           'directives': [{'name': '_TooltipDirective', 'id': 17}],
                           'children': [],
                           'resolutionPath': [
@@ -9813,6 +10226,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                       'element': '#comment',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_NgForOf', 'id': 18}],
                       'children': [],
                       'resolutionPath': [
@@ -9866,6 +10280,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
             {
               'element': 'app-zippy',
               'hydration': null,
+              'defer': null,
               'component': {'name': 'app-zippy', 'isElement': true, 'id': 19},
               'directives': [],
               'children': [],
@@ -9880,6 +10295,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
             {
               'element': 'app-heavy',
               'hydration': null,
+              'defer': null,
               'component': {'name': 'app-heavy', 'isElement': false, 'id': 20},
               'directives': [],
               'children': [],
@@ -9920,6 +10336,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
           'element': 'router-outlet',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterOutlet', 'id': 3}],
           'children': [],
           'resolutionPath': [
@@ -9948,6 +10365,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
         'node': {
           'element': 'app-todo-demo',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-todo-demo', 'isElement': false, 'id': 4},
           'directives': [],
           'children': [
@@ -9955,6 +10373,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
               'element': 'a',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterLink', 'id': 5}],
               'children': [],
               'resolutionPath': [
@@ -9975,6 +10394,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
               'element': 'a',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterLink', 'id': 6}],
               'children': [],
               'resolutionPath': [
@@ -9995,6 +10415,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
               'element': 'router-outlet',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterOutlet', 'id': 7}],
               'children': [],
               'resolutionPath': [
@@ -10014,6 +10435,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
             {
               'element': 'app-todos',
               'hydration': null,
+              'defer': null,
               'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
               'directives': [],
               'children': [
@@ -10021,6 +10443,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                   'element': 'a',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterLink', 'id': 9}],
                   'children': [],
                   'resolutionPath': [
@@ -10044,6 +10467,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                   'element': 'a',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterLink', 'id': 10}],
                   'children': [],
                   'resolutionPath': [
@@ -10067,6 +10491,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                   'element': 'a',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_RouterLink', 'id': 11}],
                   'children': [],
                   'resolutionPath': [
@@ -10089,6 +10514,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                 {
                   'element': 'app-todo',
                   'hydration': null,
+                  'defer': null,
                   'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
                   'directives': [{'name': '_TooltipDirective', 'id': 13}],
                   'children': [
@@ -10096,6 +10522,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                       'element': 'div',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_TooltipDirective', 'id': 14}],
                       'children': [],
                       'resolutionPath': [
@@ -10139,6 +10566,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                 {
                   'element': 'app-todo',
                   'hydration': null,
+                  'defer': null,
                   'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
                   'directives': [{'name': '_TooltipDirective', 'id': 16}],
                   'children': [
@@ -10146,6 +10574,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                       'element': 'div',
                       'component': null,
                       'hydration': null,
+                      'defer': null,
                       'directives': [{'name': '_TooltipDirective', 'id': 17}],
                       'children': [],
                       'resolutionPath': [
@@ -10190,6 +10619,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                   'element': '#comment',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_NgForOf', 'id': 18}],
                   'children': [],
                   'resolutionPath': [
@@ -10257,6 +10687,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
         'node': {
           'element': 'a',
           'hydration': null,
+          'defer': null,
           'component': null,
           'directives': [{'name': '_RouterLink', 'id': 5}],
           'children': [],
@@ -10293,6 +10724,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
           'element': 'a',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterLink', 'id': 6}],
           'children': [],
           'resolutionPath': [
@@ -10328,6 +10760,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
           'element': 'router-outlet',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterOutlet', 'id': 7}],
           'children': [],
           'resolutionPath': [
@@ -10362,6 +10795,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
         'node': {
           'element': 'app-todos',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-todos', 'isElement': false, 'id': 8},
           'directives': [],
           'children': [
@@ -10369,6 +10803,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
               'element': 'a',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterLink', 'id': 9}],
               'children': [],
               'resolutionPath': [
@@ -10392,6 +10827,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
               'element': 'a',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterLink', 'id': 10}],
               'children': [],
               'resolutionPath': [
@@ -10415,6 +10851,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
               'element': 'a',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_RouterLink', 'id': 11}],
               'children': [],
               'resolutionPath': [
@@ -10437,6 +10874,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
             {
               'element': 'app-todo',
               'hydration': null,
+              'defer': null,
               'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
               'directives': [{'name': '_TooltipDirective', 'id': 13}],
               'children': [
@@ -10444,6 +10882,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                   'element': 'div',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_TooltipDirective', 'id': 14}],
                   'children': [],
                   'resolutionPath': [
@@ -10487,6 +10926,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
             {
               'element': 'app-todo',
               'hydration': null,
+              'defer': null,
               'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
               'directives': [{'name': '_TooltipDirective', 'id': 16}],
               'children': [
@@ -10494,6 +10934,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                   'element': 'div',
                   'component': null,
                   'hydration': null,
+                  'defer': null,
                   'directives': [{'name': '_TooltipDirective', 'id': 17}],
                   'children': [],
                   'resolutionPath': [
@@ -10516,6 +10957,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
                   ],
                 },
               ],
+
               'resolutionPath': [
                 {'id': '22', 'type': 'element', 'name': '_TodoComponent'},
                 {'id': '20', 'type': 'element', 'name': '_NgForOf'},
@@ -10538,6 +10980,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
               'element': '#comment',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_NgForOf', 'id': 18}],
               'children': [],
               'resolutionPath': [
@@ -10595,6 +11038,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
           'element': 'a',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterLink', 'id': 9}],
           'children': [],
           'resolutionPath': [
@@ -10636,6 +11080,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
           'element': 'a',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterLink', 'id': 10}],
           'children': [],
           'resolutionPath': [
@@ -10677,6 +11122,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
           'element': 'a',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_RouterLink', 'id': 11}],
           'children': [],
           'resolutionPath': [
@@ -10717,6 +11163,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
         'node': {
           'element': 'app-todo',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-todo', 'isElement': false, 'id': 12},
           'directives': [{'name': '_TooltipDirective', 'id': 13}],
           'children': [
@@ -10724,8 +11171,10 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
               'element': 'div',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_TooltipDirective', 'id': 14}],
               'children': [],
+
               'resolutionPath': [
                 {'id': '18', 'type': 'element', 'name': '_TooltipDirective'},
                 {'id': '19', 'type': 'element', 'name': '_TodoComponent'},
@@ -10787,6 +11236,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
           'element': 'div',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_TooltipDirective', 'id': 14}],
           'children': [],
           'resolutionPath': [
@@ -10831,6 +11281,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
         'node': {
           'element': 'app-todo',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-todo', 'isElement': false, 'id': 15},
           'directives': [{'name': '_TooltipDirective', 'id': 16}],
           'children': [
@@ -10838,6 +11289,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
               'element': 'div',
               'component': null,
               'hydration': null,
+              'defer': null,
               'directives': [{'name': '_TooltipDirective', 'id': 17}],
               'children': [],
               'resolutionPath': [
@@ -10900,6 +11352,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
         'node': {
           'element': 'div',
           'hydration': null,
+          'defer': null,
           'component': null,
           'directives': [{'name': '_TooltipDirective', 'id': 17}],
           'children': [],
@@ -10946,6 +11399,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
           'element': '#comment',
           'component': null,
           'hydration': null,
+          'defer': null,
           'directives': [{'name': '_NgForOf', 'id': 18}],
           'children': [],
           'resolutionPath': [
@@ -10986,6 +11440,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
         'node': {
           'element': 'app-zippy',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-zippy', 'isElement': true, 'id': 19},
           'directives': [],
           'children': [],
@@ -11009,6 +11464,7 @@ describe('grabInjectorPathsFromDirectiveForest', () => {
         'node': {
           'element': 'app-heavy',
           'hydration': null,
+          'defer': null,
           'component': {'name': 'app-heavy', 'isElement': false, 'id': 20},
           'directives': [],
           'children': [],

--- a/devtools/projects/ng-devtools/src/styles/_colors.scss
+++ b/devtools/projects/ng-devtools/src/styles/_colors.scss
@@ -122,6 +122,7 @@ $_colors: (
 
   /* Special colors – usually a single-use colors meant for specific elements */
   --color-tree-node-element-name: #71a2f7;
+  --color-tree-node-non-element-name: #71f7b6;
   --color-tree-node-dir-name: #9ec0f9;
   --color-tree-node-ng-element: #fe824f;
   --color-tree-node-console-ref: #a1a1a1;

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -28,14 +28,37 @@ export interface ComponentType {
 }
 
 export type HydrationStatus =
+  // null represent the absence of hydration status (a node created via CSR)
   | null
-  | {status: 'hydrated' | 'skipped'}
+  | {status: 'hydrated' | 'skipped' | 'dehydrated'}
   | {
       status: 'mismatched';
       expectedNodeDetails: string | null;
       actualNodeDetails: string | null;
     };
 
+export type CurrentDeferBlock = 'placeholder' | 'loading' | 'error';
+
+export interface DeferInfo {
+  id: string;
+  state: 'placeholder' | 'loading' | 'complete' | 'error' | 'initial';
+  currentBlock: CurrentDeferBlock | null;
+  triggers: {
+    defer: string[];
+    hydrate: string[];
+    prefetch: string[];
+  };
+  blocks: BlockDetails;
+}
+
+export interface BlockDetails {
+  hasErrorBlock: boolean;
+  placeholderBlock: null | {minimumTime: number | null};
+  loadingBlock: null | {minimumTime: number | null; afterTime: number | null};
+}
+
+// TODO: refactor to remove nativeElement as it is not serializable
+// and only really exists on the ng-devtools-backend
 export interface DevToolsNode<DirType = DirectiveType, CmpType = ComponentType> {
   element: string;
   directives: DirType[];
@@ -44,6 +67,7 @@ export interface DevToolsNode<DirType = DirectiveType, CmpType = ComponentType> 
   nativeElement?: Node;
   resolutionPath?: SerializedInjector[];
   hydration: HydrationStatus;
+  defer: DeferInfo | null;
   onPush?: boolean;
 }
 

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -326,3 +326,4 @@ export {
 } from './render3/deps_tracker/deps_tracker';
 export {generateStandaloneInDeclarationsError as ɵgenerateStandaloneInDeclarationsError} from './render3/jit/module';
 export {getAsyncClassMetadataFn as ɵgetAsyncClassMetadataFn} from './render3/metadata';
+export {DeferBlockData as ɵDeferBlockData} from './render3/util/defer';

--- a/packages/core/src/hydration/utils.ts
+++ b/packages/core/src/hydration/utils.ts
@@ -301,7 +301,7 @@ const HYDRATION_INFO_KEY = '__ngDebugHydrationInfo__';
 
 export type HydratedNode = {
   [HYDRATION_INFO_KEY]?: HydrationInfo;
-};
+} & Element;
 
 function patchHydrationInfo(node: RNode, info: HydrationInfo) {
   (node as HydratedNode)[HYDRATION_INFO_KEY] = info;


### PR DESCRIPTION
This commit adds the support for defer block in the Angular DevTools.

@defer block are now visible in the directive tree and give access to defer & hydration details.

This feature also brings support of incrementation hydration.
