### PR TITLE
refactor(core): remove the `phase` prop from `AfterRenderOptions`

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -62,16 +62,6 @@ export function afterRenderEffect<E = never, W = never, M = never>(spec: {
 export interface AfterRenderOptions {
     injector?: Injector;
     manualCleanup?: boolean;
-    // @deprecated
-    phase?: AfterRenderPhase;
-}
-
-// @public @deprecated
-export enum AfterRenderPhase {
-    EarlyRead = 0,
-    MixedReadWrite = 2,
-    Read = 3,
-    Write = 1
 }
 
 // @public

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -104,7 +104,7 @@ export {
 } from './render3/ng_module_ref';
 export {createComponent, reflectComponentType, ComponentMirror} from './render3/component';
 export {isStandalone} from './render3/def_getters';
-export {AfterRenderPhase, AfterRenderRef} from './render3/after_render/api';
+export {AfterRenderRef} from './render3/after_render/api';
 export {publishExternalGlobalUtil as ɵpublishExternalGlobalUtil} from './render3/util/global_utils';
 export {
   AfterRenderOptions,

--- a/packages/core/src/render3/after_render/api.ts
+++ b/packages/core/src/render3/after_render/api.ts
@@ -23,11 +23,8 @@
  * so, Angular is better able to minimize the performance degradation associated with
  * manual DOM access, ensuring the best experience for the end users of your application
  * or library.
- *
- * @deprecated Specify the phase for your callback to run in by passing a spec-object as the first
- *   parameter to `afterRender` or `afterNextRender` instead of a function.
  */
-export enum AfterRenderPhase {
+export const enum AfterRenderPhase {
   /**
    * Use `AfterRenderPhase.EarlyRead` for callbacks that only need to **read** from the
    * DOM before a subsequent `AfterRenderPhase.Write` callback, for example to perform

--- a/packages/core/src/render3/after_render/hooks.ts
+++ b/packages/core/src/render3/after_render/hooks.ts
@@ -52,21 +52,6 @@ export interface AfterRenderOptions {
    * with the current `DestroyRef`.
    */
   manualCleanup?: boolean;
-
-  /**
-   * The phase the callback should be invoked in.
-   *
-   * <div class="docs-alert docs-alert-critical">
-   *
-   * Defaults to `AfterRenderPhase.MixedReadWrite`. You should choose a more specific
-   * phase instead. See `AfterRenderPhase` for more information.
-   *
-   * </div>
-   *
-   * @deprecated Specify the phase for your callback to run in by passing a spec-object as the first
-   *   parameter to `afterRender` or `afterNextRender` instead of a function.
-   */
-  phase?: AfterRenderPhase;
 }
 
 /**
@@ -419,12 +404,9 @@ function getHooks(
         mixedReadWrite?: (r?: unknown) => unknown;
         read?: (r?: unknown) => void;
       },
-  phase: AfterRenderPhase,
 ): AfterRenderHooks {
   if (callbackOrSpec instanceof Function) {
-    const hooks: AfterRenderHooks = [undefined, undefined, undefined, undefined];
-    hooks[phase] = callbackOrSpec;
-    return hooks;
+    return [undefined, undefined, /* MixedReadWrite */ callbackOrSpec, undefined];
   } else {
     return [
       callbackOrSpec.earlyRead,
@@ -458,12 +440,11 @@ function afterRenderImpl(
 
   const tracing = injector.get(TracingService, null, {optional: true});
 
-  const hooks = options?.phase ?? AfterRenderPhase.MixedReadWrite;
   const destroyRef = options?.manualCleanup !== true ? injector.get(DestroyRef) : null;
   const viewContext = injector.get(ViewContext, null, {optional: true});
   const sequence = new AfterRenderSequence(
     manager.impl,
-    getHooks(callbackOrSpec, hooks),
+    getHooks(callbackOrSpec),
     viewContext?.view,
     once,
     destroyRef,

--- a/packages/core/test/acceptance/after_render_hook_spec.ts
+++ b/packages/core/test/acceptance/after_render_hook_spec.ts
@@ -8,7 +8,6 @@
 
 import {PLATFORM_BROWSER_ID, PLATFORM_SERVER_ID} from '@angular/common/src/platform_id';
 import {
-  AfterRenderPhase,
   AfterRenderRef,
   ApplicationRef,
   ChangeDetectionStrategy,
@@ -435,108 +434,6 @@ describe('after render hooks', () => {
                 log.push('early-read-2');
               },
             });
-          }
-        }
-
-        TestBed.configureTestingModule({
-          declarations: [Root, CompA, CompB],
-          ...COMMON_CONFIGURATION,
-        });
-        createAndAttachComponent(Root);
-
-        expect(log).toEqual([]);
-        TestBed.inject(ApplicationRef).tick();
-        expect(log).toEqual([
-          'early-read-1',
-          'early-read-2',
-          'write-1',
-          'write-2',
-          'mixed-read-write-1',
-          'mixed-read-write-2',
-          'read-1',
-          'read-2',
-        ]);
-      });
-
-      it('should run callbacks in the correct phase and order when using deprecated phase flag', () => {
-        const log: string[] = [];
-
-        @Component({
-          selector: 'root',
-          template: `<comp-a></comp-a><comp-b></comp-b>`,
-          standalone: false,
-        })
-        class Root {}
-
-        @Component({
-          selector: 'comp-a',
-          standalone: false,
-        })
-        class CompA {
-          constructor() {
-            afterRender(
-              () => {
-                log.push('early-read-1');
-              },
-              {phase: AfterRenderPhase.EarlyRead},
-            );
-
-            afterRender(
-              () => {
-                log.push('write-1');
-              },
-              {phase: AfterRenderPhase.Write},
-            );
-
-            afterRender(
-              () => {
-                log.push('mixed-read-write-1');
-              },
-              {phase: AfterRenderPhase.MixedReadWrite},
-            );
-
-            afterRender(
-              () => {
-                log.push('read-1');
-              },
-              {phase: AfterRenderPhase.Read},
-            );
-          }
-        }
-
-        @Component({
-          selector: 'comp-b',
-          standalone: false,
-        })
-        class CompB {
-          constructor() {
-            afterRender(
-              () => {
-                log.push('read-2');
-              },
-              {phase: AfterRenderPhase.Read},
-            );
-
-            afterRender(
-              () => {
-                log.push('mixed-read-write-2');
-              },
-              {phase: AfterRenderPhase.MixedReadWrite},
-            );
-
-            afterRender(
-              () => {
-                log.push('write-2');
-              },
-              {phase: AfterRenderPhase.Write},
-            );
-
-            afterRender(
-              () => {
-                log.push('early-read-2');
-              },
-              {phase: AfterRenderPhase.EarlyRead},
-            );
           }
         }
 


### PR DESCRIPTION
The `AfterRenderPhase` enum now becomes private, it isn't exported anymore.
