### PR TITLE
build: add missing license

### DIFF
--- a/adev/src/app/main.component.ts
+++ b/adev/src/app/main.component.ts
@@ -1,3 +1,11 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
 import {Component, effect, inject, model, WritableSignal} from '@angular/core';
 import {IS_SEARCH_DIALOG_OPEN, Search} from '@angular/docs';
 import {RouterOutlet} from '@angular/router';


### PR DESCRIPTION
A file was missing a license. These changes add it.
