### PR TITLE
[19.2.x] refactor(forms): convert scripts within `packages/forms` to relative imports

### DIFF
--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -30,9 +30,9 @@ import {
   ValidationErrors,
   Validator,
   Validators,
-} from '@angular/forms';
-import {selectValueAccessor} from '@angular/forms/src/directives/shared';
-import {composeValidators} from '@angular/forms/src/validators';
+} from '../index';
+import {selectValueAccessor} from '../src/directives/shared';
+import {composeValidators} from '../src/validators';
 
 import {asyncValidator} from './util';
 

--- a/packages/forms/test/form_array_spec.ts
+++ b/packages/forms/test/form_array_spec.ts
@@ -14,8 +14,8 @@ import {
   FormGroup,
   ValidationErrors,
   ValidatorFn,
-} from '@angular/forms';
-import {Validators} from '@angular/forms/src/validators';
+} from '../index';
+import {Validators} from '../src/validators';
 import {of} from 'rxjs';
 
 import {asyncValidator} from './util';

--- a/packages/forms/test/form_builder_spec.ts
+++ b/packages/forms/test/form_builder_spec.ts
@@ -13,7 +13,7 @@ import {
   ReactiveFormsModule,
   UntypedFormBuilder,
   Validators,
-} from '@angular/forms';
+} from '../index';
 import {of} from 'rxjs';
 
 (function () {

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {fakeAsync, tick} from '@angular/core/testing';
-import {AsyncValidatorFn, FormArray, FormControl, FormGroup, Validators} from '@angular/forms';
+import {AsyncValidatorFn, FormArray, FormControl, FormGroup, Validators} from '../index';
 
 import {asyncValidator, asyncValidatorReturningObservable} from './util';
 

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -16,7 +16,7 @@ import {
   ValidationErrors,
   Validators,
   ValueChangeEvent,
-} from '@angular/forms';
+} from '../index';
 import {of} from 'rxjs';
 
 import {

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -40,7 +40,7 @@ import {
   ReactiveFormsModule,
   Validator,
   Validators,
-} from '@angular/forms';
+} from '../index';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {dispatchEvent, sortedClassList} from '@angular/platform-browser/testing/src/browser_util';
 import {expect} from '@angular/platform-browser/testing/src/matchers';

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -24,7 +24,7 @@ import {
   NgForm,
   NgModel,
   Validator,
-} from '@angular/forms';
+} from '../index';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {dispatchEvent, sortedClassList} from '@angular/platform-browser/testing/src/browser_util';
 import {merge} from 'rxjs';

--- a/packages/forms/test/typed_integration_spec.ts
+++ b/packages/forms/test/typed_integration_spec.ts
@@ -9,7 +9,7 @@
 // These tests mainly check the types of strongly typed form controls, which is generally enforced
 // at compile time.
 
-import {ɵRawValue} from '@angular/forms';
+import {ɵRawValue} from '../index';
 import {FormBuilder, NonNullableFormBuilder, UntypedFormBuilder} from '../src/form_builder';
 import {
   AbstractControl,

--- a/packages/forms/test/util.ts
+++ b/packages/forms/test/util.ts
@@ -7,7 +7,7 @@
  */
 
 import {EventEmitter} from '@angular/core';
-import {AbstractControl, AsyncValidatorFn, ValidationErrors} from '@angular/forms';
+import {AbstractControl, AsyncValidatorFn, ValidationErrors} from '../index';
 import {of} from 'rxjs';
 
 function createValidationPromise(

--- a/packages/forms/test/validators_spec.ts
+++ b/packages/forms/test/validators_spec.ts
@@ -16,7 +16,7 @@ import {
   ValidationErrors,
   ValidatorFn,
   Validators,
-} from '@angular/forms';
+} from '../index';
 import {Observable, of, timer} from 'rxjs';
 import {first, map} from 'rxjs/operators';
 

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -31,7 +31,7 @@ import {
   NgModel,
   ReactiveFormsModule,
   Validators,
-} from '@angular/forms';
+} from '../index';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util';
 


### PR DESCRIPTION
This is a cherry-pick version of PR #60624, which has landed in the main branch.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No