### PR TITLE
fix(http): Delay stabilization until next app synchronization

### DIFF
--- a/packages/common/http/src/interceptor.ts
+++ b/packages/common/http/src/interceptor.ts
@@ -16,7 +16,7 @@ import {
   runInInjectionContext,
   ɵConsole as Console,
   ɵformatRuntimeError as formatRuntimeError,
-  ɵPendingTasksInternal as PendingTasks,
+  PendingTasks,
 } from '@angular/core';
 import {Observable} from 'rxjs';
 import {finalize} from 'rxjs/operators';
@@ -244,8 +244,8 @@ export function legacyInterceptorFnFactory(): HttpInterceptorFn {
     const pendingTasks = inject(PendingTasks);
     const contributeToStability = inject(REQUESTS_CONTRIBUTE_TO_STABILITY);
     if (contributeToStability) {
-      const taskId = pendingTasks.add();
-      return chain(req, handler).pipe(finalize(() => pendingTasks.remove(taskId)));
+      const removeTask = pendingTasks.add();
+      return chain(req, handler).pipe(finalize(removeTask));
     } else {
       return chain(req, handler);
     }
@@ -323,10 +323,10 @@ export class HttpInterceptorHandler extends HttpHandler {
     }
 
     if (this.contributeToStability) {
-      const taskId = this.pendingTasks.add();
+      const removeTask = this.pendingTasks.add();
       return this.chain(initialRequest, (downstreamRequest) =>
         this.backend.handle(downstreamRequest),
-      ).pipe(finalize(() => this.pendingTasks.remove(taskId)));
+      ).pipe(finalize(removeTask));
     } else {
       return this.chain(initialRequest, (downstreamRequest) =>
         this.backend.handle(downstreamRequest),


### PR DESCRIPTION
This commit updates the `HttpClient` internals to use the public `PendingTasks` API which delays stability until the next `ApplicationRef.tick` instead of causing the application to become stable synchronously. This is helpful to resolve unexpected issues where computations happen as follow-up work to the value coming out of the response.

fixes https://github.com/angular/angular/issues/59352
