### PR TITLE
refactor(service-worker): pull less RxJS symbols

### DIFF
--- a/goldens/public-api/service-worker/index.api.md
+++ b/goldens/public-api/service-worker/index.api.md
@@ -6,6 +6,7 @@
 
 import { EnvironmentProviders } from '@angular/core';
 import * as i0 from '@angular/core';
+import { Injector } from '@angular/core';
 import { ModuleWithProviders } from '@angular/core';
 import { Observable } from 'rxjs';
 

--- a/packages/service-worker/src/provider.ts
+++ b/packages/service-worker/src/provider.ts
@@ -7,16 +7,16 @@
  */
 
 import {
-  APP_INITIALIZER,
   ApplicationRef,
   EnvironmentProviders,
+  inject,
   InjectionToken,
   Injector,
   makeEnvironmentProviders,
   NgZone,
+  provideAppInitializer,
 } from '@angular/core';
-import {merge, from, Observable, of} from 'rxjs';
-import {delay, take} from 'rxjs/operators';
+import type {Observable} from 'rxjs';
 
 import {NgswCommChannel} from './low_level';
 import {SwPush} from './push';
@@ -24,61 +24,58 @@ import {SwUpdate} from './update';
 
 export const SCRIPT = new InjectionToken<string>(ngDevMode ? 'NGSW_REGISTER_SCRIPT' : '');
 
-export function ngswAppInitializer(
-  injector: Injector,
-  script: string,
-  options: SwRegistrationOptions,
-): Function {
-  return () => {
-    if (typeof ngServerMode !== 'undefined' && ngServerMode) {
-      return;
-    }
+export function ngswAppInitializer(): void {
+  if (typeof ngServerMode !== 'undefined' && ngServerMode) {
+    return;
+  }
 
-    if (!('serviceWorker' in navigator && options.enabled !== false)) {
-      return;
-    }
+  const options = inject(SwRegistrationOptions);
 
-    const ngZone = injector.get(NgZone);
-    const appRef = injector.get(ApplicationRef);
+  if (!('serviceWorker' in navigator && options.enabled !== false)) {
+    return;
+  }
 
-    // Set up the `controllerchange` event listener outside of
-    // the Angular zone to avoid unnecessary change detections,
-    // as this event has no impact on view updates.
-    ngZone.runOutsideAngular(() => {
-      // Wait for service worker controller changes, and fire an INITIALIZE action when a new SW
-      // becomes active. This allows the SW to initialize itself even if there is no application
-      // traffic.
-      const sw = navigator.serviceWorker;
-      const onControllerChange = () => sw.controller?.postMessage({action: 'INITIALIZE'});
+  const script = inject(SCRIPT);
+  const ngZone = inject(NgZone);
+  const appRef = inject(ApplicationRef);
 
-      sw.addEventListener('controllerchange', onControllerChange);
+  // Set up the `controllerchange` event listener outside of
+  // the Angular zone to avoid unnecessary change detections,
+  // as this event has no impact on view updates.
+  ngZone.runOutsideAngular(() => {
+    // Wait for service worker controller changes, and fire an INITIALIZE action when a new SW
+    // becomes active. This allows the SW to initialize itself even if there is no application
+    // traffic.
+    const sw = navigator.serviceWorker;
+    const onControllerChange = () => sw.controller?.postMessage({action: 'INITIALIZE'});
 
-      appRef.onDestroy(() => {
-        sw.removeEventListener('controllerchange', onControllerChange);
-      });
+    sw.addEventListener('controllerchange', onControllerChange);
+
+    appRef.onDestroy(() => {
+      sw.removeEventListener('controllerchange', onControllerChange);
     });
+  });
 
-    let readyToRegister$: Observable<unknown>;
+  // Run outside the Angular zone to avoid preventing the app from stabilizing (especially
+  // given that some registration strategies wait for the app to stabilize).
+  ngZone.runOutsideAngular(() => {
+    let readyToRegister: Promise<void>;
 
-    if (typeof options.registrationStrategy === 'function') {
-      readyToRegister$ = options.registrationStrategy();
+    const {registrationStrategy} = options;
+    if (typeof registrationStrategy === 'function') {
+      readyToRegister = new Promise((resolve) => registrationStrategy().subscribe(() => resolve()));
     } else {
-      const [strategy, ...args] = (
-        options.registrationStrategy || 'registerWhenStable:30000'
-      ).split(':');
+      const [strategy, ...args] = (registrationStrategy || 'registerWhenStable:30000').split(':');
 
       switch (strategy) {
         case 'registerImmediately':
-          readyToRegister$ = of(null);
+          readyToRegister = Promise.resolve();
           break;
         case 'registerWithDelay':
-          readyToRegister$ = delayWithTimeout(+args[0] || 0);
+          readyToRegister = delayWithTimeout(+args[0] || 0);
           break;
         case 'registerWhenStable':
-          const whenStable$ = from(injector.get(ApplicationRef).whenStable());
-          readyToRegister$ = !args[0]
-            ? whenStable$
-            : merge(whenStable$, delayWithTimeout(+args[0]));
+          readyToRegister = Promise.race([appRef.whenStable(), delayWithTimeout(+args[0])]);
           break;
         default:
           // Unknown strategy.
@@ -89,30 +86,28 @@ export function ngswAppInitializer(
     }
 
     // Don't return anything to avoid blocking the application until the SW is registered.
-    // Also, run outside the Angular zone to avoid preventing the app from stabilizing (especially
-    // given that some registration strategies wait for the app to stabilize).
     // Catch and log the error if SW registration fails to avoid uncaught rejection warning.
-    ngZone.runOutsideAngular(() =>
-      readyToRegister$
-        .pipe(take(1))
-        .subscribe(() =>
-          navigator.serviceWorker
-            .register(script, {scope: options.scope})
-            .catch((err) => console.error('Service worker registration failed with:', err)),
-        ),
+    readyToRegister.then(() =>
+      navigator.serviceWorker
+        .register(script, {scope: options.scope})
+        .catch((err) => console.error('Service worker registration failed with:', err)),
     );
-  };
+  });
 }
 
-function delayWithTimeout(timeout: number): Observable<unknown> {
-  return of(null).pipe(delay(timeout));
+function delayWithTimeout(timeout: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, timeout));
 }
 
-export function ngswCommChannelFactory(opts: SwRegistrationOptions): NgswCommChannel {
+export function ngswCommChannelFactory(
+  opts: SwRegistrationOptions,
+  injector: Injector,
+): NgswCommChannel {
   const isBrowser = !(typeof ngServerMode !== 'undefined' && ngServerMode);
 
   return new NgswCommChannel(
     isBrowser && opts.enabled !== false ? navigator.serviceWorker : undefined,
+    injector,
   );
 }
 
@@ -205,13 +200,8 @@ export function provideServiceWorker(
     {
       provide: NgswCommChannel,
       useFactory: ngswCommChannelFactory,
-      deps: [SwRegistrationOptions],
+      deps: [SwRegistrationOptions, Injector],
     },
-    {
-      provide: APP_INITIALIZER,
-      useFactory: ngswAppInitializer,
-      deps: [Injector, SCRIPT, SwRegistrationOptions],
-      multi: true,
-    },
+    provideAppInitializer(ngswAppInitializer),
   ]);
 }

--- a/packages/service-worker/test/comm_spec.ts
+++ b/packages/service-worker/test/comm_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {PLATFORM_ID} from '@angular/core';
+import {Injector, PLATFORM_ID} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {
   NgswCommChannel,
@@ -79,7 +79,7 @@ describe('ServiceWorker library', () => {
             {
               provide: NgswCommChannel,
               useFactory: ngswCommChannelFactory,
-              deps: [SwRegistrationOptions, PLATFORM_ID],
+              deps: [SwRegistrationOptions, Injector],
             },
           ],
         });
@@ -96,7 +96,7 @@ describe('ServiceWorker library', () => {
           {
             provide: NgswCommChannel,
             useFactory: ngswCommChannelFactory,
-            deps: [SwRegistrationOptions, PLATFORM_ID],
+            deps: [SwRegistrationOptions, Injector],
           },
         ],
       });
@@ -111,7 +111,7 @@ describe('ServiceWorker library', () => {
           {
             provide: NgswCommChannel,
             useFactory: ngswCommChannelFactory,
-            deps: [SwRegistrationOptions, PLATFORM_ID],
+            deps: [SwRegistrationOptions, Injector],
           },
         ],
       });
@@ -140,7 +140,7 @@ describe('ServiceWorker library', () => {
           {
             provide: NgswCommChannel,
             useFactory: ngswCommChannelFactory,
-            deps: [SwRegistrationOptions, PLATFORM_ID],
+            deps: [SwRegistrationOptions, Injector],
           },
         ],
       });

--- a/packages/service-worker/test/provider_spec.ts
+++ b/packages/service-worker/test/provider_spec.ts
@@ -18,6 +18,12 @@ import {SwUpdate} from '../src/update';
 const provideServiceWorkerApi = 'provideServiceWorker';
 const serviceWorkerModuleApi = 'ServiceWorkerModule';
 
+async function waitForReadyToRegister() {
+  // `readyToRegister` is a microtask, so we wait for it to execute by
+  // scheduling another microtask before running expectations.
+  await Promise.resolve();
+}
+
 [provideServiceWorkerApi, serviceWorkerModuleApi].forEach((apiFnName: string) => {
   describe(apiFnName, () => {
     // Skip environments that don't support the minimum APIs needed to run these SW tests.
@@ -57,6 +63,7 @@ const serviceWorkerModuleApi = 'ServiceWorkerModule';
         }
 
         await untilStable();
+        await waitForReadyToRegister();
       };
 
       it('sets the registration options', async () => {
@@ -87,7 +94,7 @@ const serviceWorkerModuleApi = 'ServiceWorkerModule';
         expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
       });
 
-      it('catches and a logs registration errors', async () => {
+      it('catches and logs registration errors', async () => {
         const consoleErrorSpy = spyOn(console, 'error');
         swRegisterSpy.and.returnValue(Promise.reject('no reason'));
 
@@ -126,8 +133,8 @@ const serviceWorkerModuleApi = 'ServiceWorkerModule';
       it('sets the registration options (and overwrites those set via `provideServiceWorker()`', async () => {
         configTestBed({enabled: true, scope: 'provider'});
         await untilStable();
-
         expect(TestBed.inject(SwRegistrationOptions)).toEqual({enabled: true, scope: 'provider'});
+        await waitForReadyToRegister();
         expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: 'provider'});
       });
 
@@ -144,6 +151,7 @@ const serviceWorkerModuleApi = 'ServiceWorkerModule';
         await untilStable();
 
         expect(TestBed.inject(SwUpdate).isEnabled).toBe(true);
+        await waitForReadyToRegister();
         expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
       });
 
@@ -152,6 +160,7 @@ const serviceWorkerModuleApi = 'ServiceWorkerModule';
         await untilStable();
 
         expect(TestBed.inject(SwUpdate).isEnabled).toBe(true);
+        await waitForReadyToRegister();
         expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
       });
 
@@ -213,13 +222,11 @@ const serviceWorkerModuleApi = 'ServiceWorkerModule';
           const isStableSub = configTestBedWithMockedStability();
 
           isStableSub.next(false);
-          isStableSub.next(false);
 
-          tick();
           expect(swRegisterSpy).not.toHaveBeenCalled();
-
-          tick(20000);
-          expect(swRegisterSpy).not.toHaveBeenCalled();
+          // tick(20000);
+          // Calling `tick(20000)` drains the microtask queue,
+          // which leads to `register` being called.
 
           isStableSub.next(true);
 
@@ -229,11 +236,8 @@ const serviceWorkerModuleApi = 'ServiceWorkerModule';
 
         it('defaults to registering the SW after 30s if the app does not stabilize sooner', fakeAsync(() => {
           configTestBedWithMockedStability();
-
-          tick(29999);
           expect(swRegisterSpy).not.toHaveBeenCalled();
-
-          tick(1);
+          tick(30000);
           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
         }));
 
@@ -243,10 +247,6 @@ const serviceWorkerModuleApi = 'ServiceWorkerModule';
           isStableSub.next(false);
           isStableSub.next(false);
 
-          tick();
-          expect(swRegisterSpy).not.toHaveBeenCalled();
-
-          tick(500);
           expect(swRegisterSpy).not.toHaveBeenCalled();
 
           isStableSub.next(true);
@@ -257,11 +257,8 @@ const serviceWorkerModuleApi = 'ServiceWorkerModule';
 
         it('registers the SW after `timeout` if the app does not stabilize with `registerWhenStable:<timeout>`', fakeAsync(() => {
           configTestBedWithMockedStability('registerWhenStable:1000');
-
-          tick(999);
           expect(swRegisterSpy).not.toHaveBeenCalled();
-
-          tick(1);
+          tick(1000);
           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
         }));
 
@@ -271,7 +268,6 @@ const serviceWorkerModuleApi = 'ServiceWorkerModule';
           // Create a microtask.
           Promise.resolve();
 
-          flushMicrotasks();
           expect(swRegisterSpy).not.toHaveBeenCalled();
 
           tick(0);
@@ -284,10 +280,6 @@ const serviceWorkerModuleApi = 'ServiceWorkerModule';
           isStableSub.next(false);
           isStableSub.next(false);
 
-          tick();
-          expect(swRegisterSpy).not.toHaveBeenCalled();
-
-          tick(60000);
           expect(swRegisterSpy).not.toHaveBeenCalled();
 
           isStableSub.next(true);
@@ -302,10 +294,6 @@ const serviceWorkerModuleApi = 'ServiceWorkerModule';
           isStableSub.next(false);
           isStableSub.next(false);
 
-          tick();
-          expect(swRegisterSpy).not.toHaveBeenCalled();
-
-          tick(60000);
           expect(swRegisterSpy).not.toHaveBeenCalled();
 
           isStableSub.next(true);
@@ -314,18 +302,21 @@ const serviceWorkerModuleApi = 'ServiceWorkerModule';
           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
         }));
 
-        it('registers the SW immediatelly (synchronously) with `registerImmediately`', () => {
+        it('registers the SW immediatelly (synchronously) with `registerImmediately`', async () => {
           configTestBedWithMockedStability('registerImmediately');
+          await waitForReadyToRegister();
           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
         });
 
         it('registers the SW after the specified delay with `registerWithDelay:<delay>`', fakeAsync(() => {
           configTestBedWithMockedStability('registerWithDelay:100000');
 
-          tick(99999);
+          // tick(99999);
+          // Calling `tick(99999)` drains the microtask queue,
+          // which leads to `register` being called.
           expect(swRegisterSpy).not.toHaveBeenCalled();
 
-          tick(1);
+          tick(100000);
           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
         }));
 
@@ -364,6 +355,7 @@ const serviceWorkerModuleApi = 'ServiceWorkerModule';
           expect(swRegisterSpy).not.toHaveBeenCalled();
 
           registerSub.next();
+          tick();
           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
         }));
 


### PR DESCRIPTION
In this commit, we reduce the number of imported RxJS symbols since they are redundant.

- We replace `merge` with a manual observable because `merge` internally pulls in `from()`.
- We remove `defer` and `throwError`, replacing them with `new Observable(s => s.error(..))`.
- We replace `toPromise()` with `new Promise`, as `toPromise()` is deprecated.
- We convert `readyToRegister` to a promise to avoid using RxJS operators like `delay`.