### PR TITLE
fix(animations): add missing peer dependency on `@angular/common`

### DIFF
--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -11,7 +11,8 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@angular/core": "0.0.0-PLACEHOLDER"
+    "@angular/core": "0.0.0-PLACEHOLDER",
+    "@angular/common": "0.0.0-PLACEHOLDER"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
As of https://github.com/angular/angular/commit/1c4a3677eb4140435d27c0c873f719b7d8cdce58#diff-64131f78c9ae21421dc277debf9c8a16705a90fa649ddf580da3db434c295b11R7-R8, the animations package has a dependency on `@angular/common`. This commit adds this dependency to the `package.json`— as otherwise pnpm strict builds will fail.