### PR TITLE
feat(core): move DOCUMENT token into core

### DIFF
--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -6,6 +6,7 @@
 
 import { ChangeDetectorRef } from '@angular/core';
 import { DoCheck } from '@angular/core';
+import { DOCUMENT } from '@angular/core';
 import { ElementRef } from '@angular/core';
 import * as i0 from '@angular/core';
 import { ɵIMAGE_CONFIG as IMAGE_CONFIG } from '@angular/core';
@@ -163,8 +164,7 @@ export class DecimalPipe implements PipeTransform {
     static ɵpipe: i0.ɵɵPipeDeclaration<DecimalPipe, "number", true>;
 }
 
-// @public
-export const DOCUMENT: InjectionToken<Document>;
+export { DOCUMENT }
 
 // @public
 export function formatCurrency(value: number, locale: string, currency: string, currencyCode?: string, digitsInfo?: string): string;

--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -649,6 +649,9 @@ export interface DoCheck {
 }
 
 // @public
+export const DOCUMENT: InjectionToken<Document>;
+
+// @public
 export function effect(effectFn: (onCleanup: EffectCleanupRegisterFn) => void, options?: CreateEffectOptions): EffectRef;
 
 // @public

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -66,7 +66,6 @@ export {
   NgTemplateOutlet,
   NgComponentOutlet,
 } from './directives/index';
-export {DOCUMENT} from './dom_tokens';
 export {
   AsyncPipe,
   DatePipe,
@@ -111,3 +110,6 @@ export {
   provideNetlifyLoader,
 } from './directives/ng_optimized_image';
 export {normalizeQueryParams as ɵnormalizeQueryParams} from './location/util';
+
+// Backwards compatibility re-export.
+export {DOCUMENT} from '@angular/core';

--- a/packages/common/src/directives/ng_optimized_image/lcp_image_observer.ts
+++ b/packages/common/src/directives/ng_optimized_image/lcp_image_observer.ts
@@ -12,9 +12,9 @@ import {
   OnDestroy,
   ɵformatRuntimeError as formatRuntimeError,
   PLATFORM_ID,
+  DOCUMENT,
 } from '@angular/core';
 
-import {DOCUMENT} from '../../dom_tokens';
 import {RuntimeErrorCode} from '../../errors';
 
 import {assertDevMode} from './asserts';

--- a/packages/common/src/directives/ng_optimized_image/preconnect_link_checker.ts
+++ b/packages/common/src/directives/ng_optimized_image/preconnect_link_checker.ts
@@ -11,9 +11,9 @@ import {
   Injectable,
   InjectionToken,
   ɵformatRuntimeError as formatRuntimeError,
+  DOCUMENT,
 } from '@angular/core';
 
-import {DOCUMENT} from '../../dom_tokens';
 import {RuntimeErrorCode} from '../../errors';
 
 import {assertDevMode} from './asserts';

--- a/packages/common/src/directives/ng_optimized_image/preload-link-creator.ts
+++ b/packages/common/src/directives/ng_optimized_image/preload-link-creator.ts
@@ -6,9 +6,14 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {inject, Injectable, Renderer2, ɵRuntimeError as RuntimeError} from '@angular/core';
+import {
+  inject,
+  Injectable,
+  Renderer2,
+  ɵRuntimeError as RuntimeError,
+  DOCUMENT,
+} from '@angular/core';
 
-import {DOCUMENT} from '../../dom_tokens';
 import {RuntimeErrorCode} from '../../errors';
 
 import {DEFAULT_PRELOADED_IMAGES_LIMIT, PRELOADED_IMAGES} from './tokens';

--- a/packages/common/src/location/location_strategy.ts
+++ b/packages/common/src/location/location_strategy.ts
@@ -6,9 +6,15 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Inject, inject, Injectable, InjectionToken, OnDestroy, Optional} from '@angular/core';
-
-import {DOCUMENT} from '../dom_tokens';
+import {
+  Inject,
+  inject,
+  Injectable,
+  InjectionToken,
+  OnDestroy,
+  Optional,
+  DOCUMENT,
+} from '@angular/core';
 
 import {LocationChangeListener, PlatformLocation} from './platform_location';
 import {joinWithSlash, normalizeQueryParams} from './util';

--- a/packages/common/src/location/platform_location.ts
+++ b/packages/common/src/location/platform_location.ts
@@ -6,10 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {inject, Injectable, InjectionToken} from '@angular/core';
+import {inject, Injectable, InjectionToken, DOCUMENT} from '@angular/core';
 
 import {getDOM} from '../dom_adapter';
-import {DOCUMENT} from '../dom_tokens';
 
 /**
  * This class should not be used directly by an application developer. Instead, use

--- a/packages/common/src/viewport_scroller.ts
+++ b/packages/common/src/viewport_scroller.ts
@@ -6,9 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {inject, ɵɵdefineInjectable} from '@angular/core';
-
-import {DOCUMENT} from './dom_tokens';
+import {inject, ɵɵdefineInjectable, DOCUMENT} from '@angular/core';
 
 /**
  * Defines a scroll position manager. Implemented by `BrowserViewportScroller`.

--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -45,6 +45,7 @@ rollup_bundle(
         "//packages/core/schematics/ng-generate/self-closing-tags-migration:index.ts": "self-closing-tags-migration",
         "//packages/core/schematics/migrations/inject-flags:index.ts": "inject-flags",
         "//packages/core/schematics/migrations/test-bed-get:index.ts": "test-bed-get",
+        "//packages/core/schematics/migrations/document-core:index.ts": "document-core",
         "//packages/core/schematics/migrations/control-flow-migration:index.ts": "control-flow-migration",
     },
     format = "cjs",
@@ -56,6 +57,7 @@ rollup_bundle(
     ],
     deps = [
         "//packages/core/schematics/migrations/control-flow-migration",
+        "//packages/core/schematics/migrations/document-core",
         "//packages/core/schematics/migrations/inject-flags",
         "//packages/core/schematics/migrations/test-bed-get",
         "//packages/core/schematics/ng-generate/cleanup-unused-imports",

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -15,6 +15,11 @@
       "description": "Converts the entire application to block control flow syntax",
       "factory": "./bundles/control-flow-migration#migrate",
       "optional": true
+    },
+    "document-core": {
+      "version": "20.0.0",
+      "description": "Moves imports of `DOCUMENT` from `@angular/common` to `@angular/core`",
+      "factory": "./bundles/document-core#migrate"
     }
   }
 }

--- a/packages/core/schematics/migrations/document-core/BUILD.bazel
+++ b/packages/core/schematics/migrations/document-core/BUILD.bazel
@@ -1,0 +1,25 @@
+load("//tools:defaults.bzl", "ts_library")
+
+package(
+    default_visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/migrations/google3:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+)
+
+ts_library(
+    name = "document-core",
+    srcs = glob(["**/*.ts"]),
+    tsconfig = "//packages/core/schematics:tsconfig.json",
+    deps = [
+        "//packages/compiler-cli/private",
+        "//packages/compiler-cli/src/ngtsc/file_system",
+        "//packages/core/schematics/utils",
+        "//packages/core/schematics/utils/tsurge",
+        "//packages/core/schematics/utils/tsurge/helpers/angular_devkit",
+        "@npm//@angular-devkit/schematics",
+        "@npm//@types/node",
+        "@npm//typescript",
+    ],
+)

--- a/packages/core/schematics/migrations/document-core/README.md
+++ b/packages/core/schematics/migrations/document-core/README.md
@@ -1,0 +1,23 @@
+## Move `DOCUMENT` migration
+Replaces imports of `DOCUMENT` from `@angular/core` to `@angular/common`:
+
+### Before
+```typescript
+import { Component, inject } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+
+@Component()
+export class MyComp {
+  document = inject(DOCUMENT);
+}
+```
+
+### After
+```typescript
+import { Component, inject, DOCUMENT } from '@angular/core';
+
+@Component()
+export class MyComp {
+  document = inject(DOCUMENT);
+}
+```

--- a/packages/core/schematics/migrations/document-core/document_core_migration.ts
+++ b/packages/core/schematics/migrations/document-core/document_core_migration.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {ImportManager} from '@angular/compiler-cli/private/migrations';
+import {applyImportManagerChanges} from '../../utils/tsurge/helpers/apply_import_manager';
+import {
+  confirmAsSerializable,
+  ProgramInfo,
+  Replacement,
+  Serializable,
+  TsurgeFunnelMigration,
+} from '../../utils/tsurge';
+import {getImportSpecifier} from '../../utils/typescript/imports';
+
+export interface CompilationUnitData {
+  replacements: Replacement[];
+}
+
+/** Migration that moves the import of `DOCUMENT` from `core` to `common`. */
+export class DocumentCoreMigration extends TsurgeFunnelMigration<
+  CompilationUnitData,
+  CompilationUnitData
+> {
+  override async analyze(info: ProgramInfo): Promise<Serializable<CompilationUnitData>> {
+    const replacements: Replacement[] = [];
+    let importManager: ImportManager | null = null;
+
+    for (const sourceFile of info.sourceFiles) {
+      const specifier = getImportSpecifier(sourceFile, '@angular/common', 'DOCUMENT');
+
+      if (specifier === null) {
+        continue;
+      }
+
+      importManager ??= new ImportManager({
+        // Prevent the manager from trying to generate a non-conflicting import.
+        generateUniqueIdentifier: () => null,
+        shouldUseSingleQuotes: () => true,
+      });
+      importManager.removeImport(sourceFile, 'DOCUMENT', '@angular/common');
+      importManager.addImport({
+        exportSymbolName: 'DOCUMENT',
+        exportModuleSpecifier: '@angular/core',
+        requestedFile: sourceFile,
+        unsafeAliasOverride: specifier.propertyName ? specifier.name.text : undefined,
+      });
+    }
+
+    if (importManager !== null) {
+      applyImportManagerChanges(importManager, replacements, info.sourceFiles, info);
+    }
+
+    return confirmAsSerializable({replacements});
+  }
+
+  override async migrate(globalData: CompilationUnitData) {
+    return confirmAsSerializable(globalData);
+  }
+
+  override async combine(
+    unitA: CompilationUnitData,
+    unitB: CompilationUnitData,
+  ): Promise<Serializable<CompilationUnitData>> {
+    const seen = new Set<string>();
+    const combined: Replacement[] = [];
+
+    [unitA.replacements, unitB.replacements].forEach((replacements) => {
+      replacements.forEach((current) => {
+        const {position, end, toInsert} = current.update.data;
+        const key = current.projectFile.id + '/' + position + '/' + end + '/' + toInsert;
+
+        if (!seen.has(key)) {
+          seen.add(key);
+          combined.push(current);
+        }
+      });
+    });
+
+    return confirmAsSerializable({replacements: combined});
+  }
+
+  override async globalMeta(
+    combinedData: CompilationUnitData,
+  ): Promise<Serializable<CompilationUnitData>> {
+    return confirmAsSerializable(combinedData);
+  }
+
+  override async stats() {
+    return {counters: {}};
+  }
+}

--- a/packages/core/schematics/migrations/document-core/index.ts
+++ b/packages/core/schematics/migrations/document-core/index.ts
@@ -1,0 +1,20 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Rule} from '@angular-devkit/schematics';
+import {DocumentCoreMigration} from './document_core_migration';
+import {runMigrationInDevkit} from '../../utils/tsurge/helpers/angular_devkit';
+
+export function migrate(): Rule {
+  return async (tree) => {
+    await runMigrationInDevkit({
+      tree,
+      getMigration: () => new DocumentCoreMigration(),
+    });
+  };
+}

--- a/packages/core/schematics/test/document_core_spec.ts
+++ b/packages/core/schematics/test/document_core_spec.ts
@@ -1,0 +1,137 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {getSystemPath, normalize, virtualFs} from '@angular-devkit/core';
+import {TempScopedNodeJsSyncHost} from '@angular-devkit/core/node/testing';
+import {HostTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
+import {runfiles} from '@bazel/runfiles';
+import shx from 'shelljs';
+
+describe('document-core migration', () => {
+  let runner: SchematicTestRunner;
+  let host: TempScopedNodeJsSyncHost;
+  let tree: UnitTestTree;
+  let tmpDirPath: string;
+
+  function writeFile(filePath: string, contents: string) {
+    host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
+  }
+
+  function runMigration() {
+    return runner.runSchematic('document-core', {}, tree);
+  }
+
+  beforeEach(() => {
+    runner = new SchematicTestRunner('test', runfiles.resolvePackageRelative('../migrations.json'));
+    host = new TempScopedNodeJsSyncHost();
+    tree = new UnitTestTree(new HostTree(host));
+    tmpDirPath = getSystemPath(host.root);
+
+    writeFile('/tsconfig.json', '{}');
+    writeFile(
+      '/angular.json',
+      JSON.stringify({
+        version: 1,
+        projects: {t: {root: '', architect: {build: {options: {tsConfig: './tsconfig.json'}}}}},
+      }),
+    );
+
+    shx.cd(tmpDirPath);
+  });
+
+  it('should migrate an import of DOCUMENT', async () => {
+    writeFile(
+      '/dir.ts',
+      `
+        import { Directive, inject } from '@angular/core';
+        import { DOCUMENT } from '@angular/common';
+
+        @Directive()
+        export class Dir {
+          protected doc = inject(DOCUMENT);
+        }
+      `,
+    );
+
+    await runMigration();
+    const content = tree.readContent('/dir.ts');
+    expect(content).toContain(`import { Directive, inject, DOCUMENT } from '@angular/core';`);
+    expect(content).not.toContain(`@angular/common`);
+  });
+
+  it('should migrate an aliased import of DOCUMENT', async () => {
+    writeFile(
+      '/dir.ts',
+      `
+        import { Directive, inject } from '@angular/core';
+        import { DOCUMENT as MY_DOC } from '@angular/common';
+
+        @Directive()
+        export class Dir {
+          protected doc = inject(MY_DOC);
+        }
+      `,
+    );
+
+    await runMigration();
+    const content = tree.readContent('/dir.ts');
+    expect(content).toContain(
+      `import { Directive, inject, DOCUMENT as MY_DOC } from '@angular/core';`,
+    );
+    expect(content).not.toContain(`@angular/common`);
+  });
+
+  it('should migrate a file that does not import @angular/core', async () => {
+    writeFile(
+      '/dir.ts',
+      `
+        import { DOCUMENT } from '@angular/common';
+
+        console.log(DOCUMENT);
+      `,
+    );
+
+    await runMigration();
+    const content = tree.readContent('/dir.ts');
+    expect(content).toContain(`import { DOCUMENT } from '@angular/core';`);
+    expect(content).not.toContain(`@angular/common`);
+  });
+
+  it('should handle a file that is present in multiple projects', async () => {
+    writeFile('/tsconfig-2.json', '{}');
+    writeFile(
+      '/angular.json',
+      JSON.stringify({
+        version: 1,
+        projects: {
+          a: {root: '', architect: {build: {options: {tsConfig: './tsconfig.json'}}}},
+          b: {root: '', architect: {build: {options: {tsConfig: './tsconfig-2.json'}}}},
+        },
+      }),
+    );
+
+    writeFile(
+      'dir.ts',
+      `
+        import { Directive, inject } from '@angular/core';
+        import { DOCUMENT } from '@angular/common';
+
+        @Directive()
+        export class Dir {
+          protected doc = inject(DOCUMENT);
+        }
+      `,
+    );
+
+    await runMigration();
+    const content = tree.readContent('/dir.ts');
+    expect(content).toContain(`import { Directive, inject, DOCUMENT } from '@angular/core';`);
+    expect(content).not.toContain(`@angular/common`);
+  });
+});

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -117,6 +117,7 @@ export {ApplicationConfig, mergeApplicationConfig} from './application/applicati
 export {makeStateKey, StateKey, TransferState} from './transfer_state';
 export {booleanAttribute, numberAttribute} from './util/coercion';
 export {REQUEST, REQUEST_CONTEXT, RESPONSE_INIT} from './application/platform_tokens';
+export {DOCUMENT} from './document';
 
 import {global} from './util/global';
 if (typeof ngDevMode !== 'undefined' && ngDevMode) {

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {InjectionToken} from '@angular/core';
+import {InjectionToken} from './di';
 
 /**
  * A DI Token representing the main rendering context.

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -39,6 +39,7 @@ import {
   ɵɵelementStart as elementStart,
   ɵɵsetNgModuleScope as setNgModuleScope,
   ɵɵtext as text,
+  DOCUMENT,
 } from '../src/core';
 import {DeferBlockBehavior} from '../testing';
 import {TestBed, TestBedImpl} from '../testing/src/test_bed';
@@ -53,7 +54,6 @@ import {
   THROW_ON_UNKNOWN_ELEMENTS_DEFAULT,
   THROW_ON_UNKNOWN_PROPERTIES_DEFAULT,
 } from '../testing/src/test_bed_common';
-import {DOCUMENT} from '@angular/common/src/dom_tokens';
 
 const NAME = new InjectionToken<string>('name');
 


### PR DESCRIPTION
Moves the `DOCUMENT` token from `common` into `core` since it's relevant for lots of SSR use cases and users shouldn't have to install `common` for it. The token is still exported through `common` for backwards compatibility.