### PR TITLE
refactor(router): replace `first()`

### DIFF
--- a/packages/router/src/operators/check_guards.ts
+++ b/packages/router/src/operators/check_guards.ts
@@ -17,7 +17,7 @@ import {
   OperatorFunction,
   pipe,
 } from 'rxjs';
-import {concatMap, first, map, mergeMap, tap} from 'rxjs/operators';
+import {concatMap, defaultIfEmpty, filter, map, mergeMap, take, tap} from 'rxjs/operators';
 
 import {ActivationStart, ChildActivationStart, Event} from '../events';
 import {
@@ -92,9 +92,9 @@ function runCanDeactivateChecks(
     mergeMap((check) =>
       runCanDeactivate(check.component, check.route, currRSS, futureRSS, injector),
     ),
-    first((result) => {
-      return result !== true;
-    }, true),
+    filter((result) => result !== true),
+    take(1),
+    defaultIfEmpty(true),
   );
 }
 
@@ -113,9 +113,9 @@ function runCanActivateChecks(
         runCanActivate(futureSnapshot, check.route, injector),
       );
     }),
-    first((result) => {
-      return result !== true;
-    }, true),
+    filter((result) => result !== true),
+    take(1),
+    defaultIfEmpty(true),
   );
 }
 
@@ -175,7 +175,7 @@ function runCanActivate(
         : runInInjectionContext(closestInjector, () =>
             (guard as CanActivateFn)(futureARS, futureRSS),
           );
-      return wrapIntoObservable(guardVal).pipe(first());
+      return wrapIntoObservable(guardVal).pipe(take(1));
     });
   });
   return of(canActivateObservables).pipe(prioritizedGuardValue());
@@ -208,7 +208,7 @@ function runCanActivateChild(
             : runInInjectionContext(closestInjector, () =>
                 (guard as CanActivateChildFn)(futureARS, futureRSS),
               );
-          return wrapIntoObservable(guardVal).pipe(first());
+          return wrapIntoObservable(guardVal).pipe(take(1));
         },
       );
       return of(guardsMapped).pipe(prioritizedGuardValue());
@@ -234,7 +234,7 @@ function runCanDeactivate(
       : runInInjectionContext(closestInjector, () =>
           (guard as CanDeactivateFn<any>)(component, currARS, currRSS, futureRSS),
         );
-    return wrapIntoObservable(guardVal).pipe(first());
+    return wrapIntoObservable(guardVal).pipe(take(1));
   });
   return of(canDeactivateObservables).pipe(prioritizedGuardValue());
 }

--- a/packages/router/src/operators/resolve_data.ts
+++ b/packages/router/src/operators/resolve_data.ts
@@ -8,7 +8,7 @@
 
 import {EnvironmentInjector, ProviderToken, runInInjectionContext} from '@angular/core';
 import {defer, EMPTY, from, MonoTypeOperatorFunction, Observable, of, throwError} from 'rxjs';
-import {catchError, concatMap, first, map, mergeMap, takeLast, tap} from 'rxjs/operators';
+import {catchError, concatMap, map, mergeMap, take, takeLast, tap} from 'rxjs/operators';
 
 import {RedirectCommand, ResolveData} from '../models';
 import type {NavigationTransition} from '../navigation_transition';
@@ -115,7 +115,7 @@ function resolveNode(
   return from(keys).pipe(
     mergeMap((key) =>
       getResolver(resolve[key], futureARS, futureRSS, injector).pipe(
-        first(),
+        take(1),
         tap((value: any) => {
           if (value instanceof RedirectCommand) {
             throw redirectingNavigationError(new DefaultUrlSerializer(), value);

--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -12,12 +12,13 @@ import {
   catchError,
   concatMap,
   defaultIfEmpty,
-  first,
+  filter,
   last,
   map,
   mergeMap,
   scan,
   switchMap,
+  take,
   tap,
 } from 'rxjs/operators';
 
@@ -272,7 +273,8 @@ export class Recognizer {
           }),
         );
       }),
-      first((x): x is TreeNode<ActivatedRouteSnapshot> | NoLeftoversInUrl => !!x),
+      filter((x): x is TreeNode<ActivatedRouteSnapshot> | NoLeftoversInUrl => !!x),
+      take(1),
       catchError((e) => {
         if (isEmptyError(e)) {
           if (noLeftoversInUrl(segmentGroup, segments, outlet)) {


### PR DESCRIPTION
In most cases, we may not even need to use `first()` since it behaves slightly differently, especially when the observable completes without emitting a value (which would throw an error). We can safely replace most instances of `first()` with `take(1)`, and `first(predicate)` with `filter(predicate), take(1)`. This should also reduce the number of RxJS symbols pulled in if consumers never use `first` at all.