### PR TITLE
refactor(compiler): add `selectedcontent` to the DOM element schema r…

### DIFF
--- a/packages/compiler/src/schema/dom_element_schema_registry.ts
+++ b/packages/compiler/src/schema/dom_element_schema_registry.ts
@@ -141,6 +141,7 @@ const SCHEMA: string[] = [
   'q,blockquote,cite^[HTMLElement]|',
   'script^[HTMLElement]|!async,charset,%crossOrigin,!defer,event,htmlFor,integrity,!noModule,%referrerPolicy,src,text,type',
   'select^[HTMLElement]|autocomplete,!disabled,#length,!multiple,name,!required,#selectedIndex,#size,value',
+  'selectedcontent^[HTMLElement]|',
   'slot^[HTMLElement]|name',
   'source^[HTMLElement]|#height,media,sizes,src,srcset,type,#width',
   'span^[HTMLElement]|',


### PR DESCRIPTION
…egistry

This is only adding support for `selectedcontent` at the compiler level. At runtime it doesn't behave as expected see #60636

fixes #60679
