### PR TITLE
refactor(core): drop unused `ngDevMode` metrics

### DIFF
--- a/packages/core/src/render3/instructions/element_container.ts
+++ b/packages/core/src/render3/instructions/element_container.ts
@@ -58,8 +58,6 @@ function elementContainerStartFirstCreatePass(
   attrsIndex?: number | null,
   localRefsIndex?: number,
 ): TElementContainerNode {
-  ngDevMode && ngDevMode.firstCreatePass++;
-
   const tViewConsts = tView.consts;
   const attrs = getConstant<TAttributes>(tViewConsts, attrsIndex);
   const tNode = getOrCreateTNode(tView, index, TNodeType.ElementContainer, 'ng-container', attrs);

--- a/packages/core/src/render3/instructions/template.ts
+++ b/packages/core/src/render3/instructions/template.ts
@@ -67,7 +67,6 @@ function templateFirstCreatePass(
   localRefsIndex?: number | null,
 ): TContainerNode {
   ngDevMode && assertFirstCreatePass(tView);
-  ngDevMode && ngDevMode.firstCreatePass++;
   const tViewConsts = tView.consts;
 
   // TODO(pk): refactor getOrCreateTNode to have the "create" only version

--- a/packages/core/src/render3/tnode_manipulation.ts
+++ b/packages/core/src/render3/tnode_manipulation.ts
@@ -266,7 +266,6 @@ export function createTNode(
     // `view_engine_compatibility` for additional context.
     assertGreaterThanOrEqual(index, HEADER_OFFSET, "TNodes can't be in the LView header.");
   ngDevMode && assertNotSame(attrs, undefined, "'undefined' is not valid value for 'attrs'");
-  ngDevMode && ngDevMode.tNode++;
   ngDevMode && tParent && assertTNodeForTView(tParent, tView);
   let injectorIndex = tParent ? tParent.injectorIndex : -1;
   let flags = 0;

--- a/packages/core/src/render3/view/construction.ts
+++ b/packages/core/src/render3/view/construction.ts
@@ -77,7 +77,6 @@ export function createTView(
   constsOrFactory: TConstantsOrFactory | null,
   ssrId: string | null,
 ): TView {
-  ngDevMode && ngDevMode.tView++;
   const bindingStartIndex = HEADER_OFFSET + decls;
   // This length does not yet contain host bindings from child directives because at this point,
   // we don't know which directives are active on this template. As soon as a directive is matched

--- a/packages/core/src/render3/view/elements.ts
+++ b/packages/core/src/render3/view/elements.ts
@@ -28,7 +28,6 @@ export function elementStartFirstCreatePass(
   localRefsIndex?: number,
 ): TElementNode {
   ngDevMode && assertFirstCreatePass(tView);
-  ngDevMode && ngDevMode.firstCreatePass++;
 
   const tViewConsts = tView.consts;
   const attrs = getConstant<TAttributes>(tViewConsts, attrsIndex);

--- a/packages/core/src/util/ng_dev_mode.ts
+++ b/packages/core/src/util/ng_dev_mode.ts
@@ -26,10 +26,6 @@ declare global {
   const ngDevMode: null | NgDevModePerfCounters;
 
   interface NgDevModePerfCounters {
-    namedConstructors: boolean;
-    firstCreatePass: number;
-    tNode: number;
-    tView: number;
     hydratedNodes: number;
     hydratedComponents: number;
     dehydratedViewsRemoved: number;
@@ -39,13 +35,9 @@ declare global {
   }
 }
 
-export function ngDevModeResetPerfCounters(): NgDevModePerfCounters {
+function ngDevModeResetPerfCounters(): NgDevModePerfCounters {
   const locationString = typeof location !== 'undefined' ? location.toString() : '';
   const newCounters: NgDevModePerfCounters = {
-    namedConstructors: locationString.indexOf('ngDevMode=namedConstructors') != -1,
-    firstCreatePass: 0,
-    tNode: 0,
-    tView: 0,
     hydratedNodes: 0,
     hydratedComponents: 0,
     dehydratedViewsRemoved: 0,
@@ -84,9 +76,6 @@ export function ngDevModeResetPerfCounters(): NgDevModePerfCounters {
  *  get a `ReferenceError` like in https://github.com/angular/angular/issues/31595.
  *
  * Details on possible values for `ngDevMode` can be found on its docstring.
- *
- * NOTE:
- * - changes to the `ngDevMode` name must be synced with `compiler-cli/src/tooling.ts`.
  */
 export function initNgDevMode(): boolean {
   // The below checks are to ensure that calling `initNgDevMode` multiple times does not

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -35,11 +35,9 @@ import {getLViewById} from '../../src/render3/interfaces/lview_tracking';
 import {isLView} from '../../src/render3/interfaces/type_checks';
 import {ID, LView, PARENT, TVIEW} from '../../src/render3/interfaces/view';
 import {getLView} from '../../src/render3/state';
-import {ngDevModeResetPerfCounters} from '../../src/util/ng_dev_mode';
 import {fakeAsync, flushMicrotasks, TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {expectPerfCounters} from '@angular/private/testing';
 
 describe('acceptance integration tests', () => {
   function stripHtmlComments(str: string) {
@@ -58,44 +56,6 @@ describe('acceptance integration tests', () => {
       const fixture = TestBed.createComponent(App);
 
       expect(fixture.nativeElement.innerHTML).toEqual('<span title="Hello">Greetings</span>');
-    });
-
-    it('should render and update basic "Hello, World" template', () => {
-      ngDevModeResetPerfCounters();
-      @Component({
-        template: '<h1>Hello, {{name}}!</h1>',
-        standalone: false,
-      })
-      class App {
-        name = '';
-      }
-
-      expectPerfCounters({
-        tView: 0,
-        tNode: 0,
-      });
-
-      TestBed.configureTestingModule({declarations: [App]});
-      const fixture = TestBed.createComponent(App);
-
-      fixture.componentInstance.name = 'World';
-      fixture.detectChanges();
-
-      expect(fixture.nativeElement.innerHTML).toEqual('<h1>Hello, World!</h1>');
-      expectPerfCounters({
-        tView: 2, // Host view + App
-        tNode: 3, // Host Node + <h1> + #text
-      });
-
-      fixture.componentInstance.name = 'New World';
-      fixture.detectChanges();
-
-      expect(fixture.nativeElement.innerHTML).toEqual('<h1>Hello, New World!</h1>');
-      // Assert that the tView/tNode count does not increase (they are correctly cached)
-      expectPerfCounters({
-        tView: 2,
-        tNode: 3,
-      });
     });
   });
 

--- a/packages/core/test/acceptance/renderer_factory_spec.ts
+++ b/packages/core/test/acceptance/renderer_factory_spec.ts
@@ -26,7 +26,6 @@ import {
   ViewEncapsulation,
 } from '../../src/core';
 import {RElement} from '../../src/render3/interfaces/renderer_dom';
-import {ngDevModeResetPerfCounters} from '../../src/util/ng_dev_mode';
 import {NoopNgZone} from '../../src/zone/ng_zone';
 import {TestBed} from '../../testing';
 import {EventManager, ɵSharedStylesHost} from '@angular/platform-browser';
@@ -477,10 +476,6 @@ describe('Renderer2 destruction hooks', () => {
   }
 
   beforeEach(() => {
-    // Tests below depend on perf counters when running with Ivy. In order to have
-    // clean perf counters at the beginning of a test, we reset those here.
-    ngDevModeResetPerfCounters();
-
     TestBed.configureTestingModule({
       declarations: [SimpleApp, AppWithComponents, BasicComponent],
       providers: [

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -18,7 +18,6 @@ import {
   ViewContainerRef,
 } from '../../src/core';
 import {bypassSanitizationTrustStyle} from '../../src/sanitization/bypass';
-import {ngDevModeResetPerfCounters} from '../../src/util/ng_dev_mode';
 import {TestBed} from '../../testing';
 import {
   getElementClasses,
@@ -27,11 +26,8 @@ import {
   getSortedStyle,
 } from '../../testing/src/styling';
 import {By, DomSanitizer, SafeStyle} from '@angular/platform-browser';
-import {expectPerfCounters} from '@angular/private/testing';
 
 describe('styling', () => {
-  beforeEach(ngDevModeResetPerfCounters);
-
   describe('apply in prioritization order', () => {
     it('should perform static bindings', () => {
       @Component({
@@ -1917,9 +1913,6 @@ describe('styling', () => {
     expect(element.style.height).toEqual('900px');
     expect(element.style.fontSize).toEqual('100px');
 
-    // once for the template flush and again for the host bindings
-    ngDevModeResetPerfCounters();
-
     component.opacity = '0.6';
     component.compWithStyling!.height = '100px';
     component.compWithStyling!.width = '100px';
@@ -2217,7 +2210,6 @@ describe('styling', () => {
     const fixture = TestBed.createComponent(Cmp);
     const comp = fixture.componentInstance;
 
-    ngDevModeResetPerfCounters();
     fixture.detectChanges();
     const element = fixture.nativeElement.querySelector('div');
 
@@ -2225,21 +2217,18 @@ describe('styling', () => {
     assertStyle(element, 'height', '111px');
 
     comp.width = '222px';
-    ngDevModeResetPerfCounters();
     fixture.detectChanges();
 
     assertStyle(element, 'width', '222px');
     assertStyle(element, 'height', '111px');
 
     comp.height = '222px';
-    ngDevModeResetPerfCounters();
     fixture.detectChanges();
 
     assertStyle(element, 'width', '222px');
     assertStyle(element, 'height', '222px');
 
     comp.width = undefined;
-    ngDevModeResetPerfCounters();
     fixture.detectChanges();
 
     assertStyle(element, 'width', '555px');
@@ -2247,14 +2236,12 @@ describe('styling', () => {
 
     comp.width = '123px';
     comp.height = '123px';
-    ngDevModeResetPerfCounters();
     fixture.detectChanges();
 
     assertStyle(element, 'width', '123px');
     assertStyle(element, 'height', '123px');
 
     comp.map = {};
-    ngDevModeResetPerfCounters();
     fixture.detectChanges();
 
     // No change, hence no write
@@ -2262,14 +2249,12 @@ describe('styling', () => {
     assertStyle(element, 'height', '123px');
 
     comp.width = undefined;
-    ngDevModeResetPerfCounters();
     fixture.detectChanges();
 
     assertStyle(element, 'width', '999px');
     assertStyle(element, 'height', '123px');
 
     comp.dir.map = null;
-    ngDevModeResetPerfCounters();
     fixture.detectChanges();
 
     // the width is only applied once
@@ -2277,7 +2262,6 @@ describe('styling', () => {
     assertStyle(element, 'height', '123px');
 
     comp.dir.map = {width: '1000px', height: '1100px', color: 'red'};
-    ngDevModeResetPerfCounters();
     fixture.detectChanges();
 
     assertStyle(element, 'width', '1000px');
@@ -2285,7 +2269,6 @@ describe('styling', () => {
     assertStyle(element, 'color', 'red');
 
     comp.height = undefined;
-    ngDevModeResetPerfCounters();
     fixture.detectChanges();
 
     // height gets applied twice and all other
@@ -2295,7 +2278,6 @@ describe('styling', () => {
     assertStyle(element, 'color', 'red');
 
     comp.map = {color: 'blue', width: '2000px', opacity: '0.5'};
-    ngDevModeResetPerfCounters();
     fixture.detectChanges();
 
     assertStyle(element, 'width', '2000px');
@@ -2304,7 +2286,6 @@ describe('styling', () => {
     assertStyle(element, 'opacity', '0.5');
 
     comp.map = {color: 'blue', width: '2000px'};
-    ngDevModeResetPerfCounters();
     fixture.detectChanges();
 
     // all four are applied because the map was altered

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -43,7 +43,6 @@ import {
   ViewContainerRef,
   ɵsetDocument,
 } from '../../src/core';
-import {ngDevModeResetPerfCounters} from '../../src/util/ng_dev_mode';
 import {ComponentFixture, TestBed, TestComponentRenderer} from '../../testing';
 import {clearTranslations, loadTranslations} from '@angular/localize';
 import {By, DomSanitizer} from '@angular/platform-browser';
@@ -880,10 +879,6 @@ describe('ViewContainerRef', () => {
   describe('detach', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({declarations: [EmbeddedViewInsertionComp, VCRefDirective]});
-
-      // Tests depend on perf counters. In order to have clean perf counters at the beginning of a
-      // test, we reset those here.
-      ngDevModeResetPerfCounters();
     });
 
     it('should detach the right embedded view when an index is specified', () => {
@@ -978,10 +973,6 @@ describe('ViewContainerRef', () => {
         renderer.destroyNode = () => {};
         return renderer;
       };
-
-      // Tests depend on perf counters. In order to have clean perf counters at the beginning of a
-      // test, we reset those here.
-      ngDevModeResetPerfCounters();
     });
 
     it('should remove the right embedded view when an index is specified', () => {

--- a/packages/private/testing/src/utils.ts
+++ b/packages/private/testing/src/utils.ts
@@ -88,28 +88,6 @@ function wrapTestFn(
   };
 }
 
-/**
- * Runs jasmine expectations against the provided keys for `ngDevMode`.
- *
- * Will not perform expectations for keys that are not provided.
- *
- * ```ts
- * // Expect that `ngDevMode.styleMap` is `1`, and `ngDevMode.tNode` is `3`, but we don't care
- * // about the other values.
- * expectPerfCounters({
- *   stylingMap: 1,
- *   tNode: 3,
- * })
- * ```
- */
-export function expectPerfCounters(expectedCounters: Partial<NgDevModePerfCounters>): void {
-  Object.keys(expectedCounters).forEach((key) => {
-    const expected = (expectedCounters as any)[key];
-    const actual = (ngDevMode as any)[key];
-    expect(actual).toBe(expected, `ngDevMode.${key}`);
-  });
-}
-
 let savedDocument: Document | undefined = undefined;
 let savedRequestAnimationFrame: ((callback: FrameRequestCallback) => number) | undefined =
   undefined;


### PR DESCRIPTION
This commit updates the code to drop unused `ngDevMode` metrics and removes some related (and now unused) utility functions.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No