### PR TITLE
fix(core): fix ng generate @angular/core:signal-queries-migration

### DIFF
--- a/packages/core/schematics/migrations/signal-queries-migration/convert_query_property.ts
+++ b/packages/core/schematics/migrations/signal-queries-migration/convert_query_property.ts
@@ -150,8 +150,17 @@ export function computeReplacementsToMigrateQuery(
     resolvedReadType === null && type !== undefined ? [type] : undefined,
     args,
   );
+
+  const accessibilityModifier = getAccessibilityModifier(node);
+  let modifiers: (ts.ModifierLike | ts.ModifierToken<ts.SyntaxKind.ReadonlyKeyword>)[] = [
+    ts.factory.createModifier(ts.SyntaxKind.ReadonlyKeyword),
+  ];
+  if (accessibilityModifier) {
+    modifiers = [accessibilityModifier, ...modifiers];
+  }
+
   const updated = ts.factory.createPropertyDeclaration(
-    [ts.factory.createModifier(ts.SyntaxKind.ReadonlyKeyword)],
+    modifiers,
     node.name,
     undefined,
     undefined,
@@ -168,4 +177,13 @@ export function computeReplacementsToMigrateQuery(
       }),
     ),
   ];
+}
+
+function getAccessibilityModifier(node: ts.PropertyDeclaration): ts.ModifierLike | undefined {
+  return node.modifiers?.find(
+    (mod) =>
+      mod.kind === ts.SyntaxKind.PublicKeyword ||
+      mod.kind === ts.SyntaxKind.PrivateKeyword ||
+      mod.kind === ts.SyntaxKind.ProtectedKeyword,
+  );
 }

--- a/packages/core/schematics/migrations/signal-queries-migration/migration.spec.ts
+++ b/packages/core/schematics/migrations/signal-queries-migration/migration.spec.ts
@@ -55,6 +55,11 @@ const declarationTestCases: TestCase[] = [
     before: `@ViewChild('myBtn', {read: ElementRef}) buttonEl!: ElementRef;`,
     after: `readonly buttonEl = viewChild.required('myBtn', { read: ElementRef });`,
   },
+  {
+    id: 'viewChild retain accessibility modifier',
+    before: `@ViewChild('sidenav') public sidenav: HTMLElement;`,
+    after: `public readonly sidenav = viewChild<HTMLElement>('sidenav');`,
+  },
   // Content Child
   {
     id: 'contentChild with string locator and nullable',
@@ -136,6 +141,11 @@ const declarationTestCases: TestCase[] = [
     id: 'viewChildren with query list as initializer value, and descendants option but same as default',
     before: `@ViewChildren('myBtn', {descendants: true}) buttonEl = new QueryList<ElementRef>()`,
     after: `readonly buttonEl = viewChildren<ElementRef>('myBtn');`,
+  },
+  {
+    id: 'viewChildren retain accessibility modifier',
+    before: `@ViewChildren('sidenav') public sidenav: HTMLElement;`,
+    after: `public readonly sidenav = viewChildren('sidenav');`,
   },
   // ContentChildren
   {


### PR DESCRIPTION
retain accessibility modifier if it's already present for signal migrations

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [X] Tests for the changes have been added (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [X] Bugfix


## What is the current behavior?
The command `@angular/core:signal-queries-migration` not retain accessibility modifier if it's already present for signal migrations

Issue Number: #59882 


## What is the new behavior?
Retain accessibility modifier if it's already present for signal migrations

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


## Other information
