### PR TITLE
refactor(devtools): switch to components tab whenever the inspector is used

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
@@ -95,6 +95,13 @@ export class DevToolsTabsComponent {
       this.routes.set(routes || []);
     });
 
+    // Change the tab to Components, if an element is selected via the inspector.
+    this._messageBus.on('selectComponent', () => {
+      if (this.activeTab() !== 'Components') {
+        this.changeTab('Components');
+      }
+    });
+
     if (typeof chrome !== 'undefined' && chrome.runtime !== undefined) {
       this.extensionVersion.set(chrome.runtime.getManifest().version);
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

Switch to the _Components_ tab, if on a different tab, when a component is selected via the inspector.

cc @dgp1130 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
