### PR TITLE
refactor(core): drop computation error messages in production

### DIFF
--- a/packages/core/primitives/signals/src/computed.ts
+++ b/packages/core/primitives/signals/src/computed.ts
@@ -133,7 +133,9 @@ const COMPUTED_NODE = /* @__PURE__ */ (() => {
     producerRecomputeValue(node: ComputedNode<unknown>): void {
       if (node.value === COMPUTING) {
         // Our computation somehow led to a cyclic read of itself.
-        throw new Error('Detected cycle in computations.');
+        throw new Error(
+          typeof ngDevMode !== 'undefined' && ngDevMode ? 'Detected cycle in computations.' : '',
+        );
       }
 
       const oldValue = node.value;

--- a/packages/core/primitives/signals/src/linked_signal.ts
+++ b/packages/core/primitives/signals/src/linked_signal.ts
@@ -137,7 +137,9 @@ export const LINKED_SIGNAL_NODE = /* @__PURE__ */ (() => {
     producerRecomputeValue(node: LinkedSignalNode<unknown, unknown>): void {
       if (node.value === COMPUTING) {
         // Our computation somehow led to a cyclic read of itself.
-        throw new Error('Detected cycle in computations.');
+        throw new Error(
+          typeof ngDevMode !== 'undefined' && ngDevMode ? 'Detected cycle in computations.' : '',
+        );
       }
 
       const oldValue = node.value;

--- a/packages/core/primitives/signals/src/watch.ts
+++ b/packages/core/primitives/signals/src/watch.ts
@@ -18,6 +18,10 @@ import {
   SIGNAL,
 } from './graph';
 
+// Required as the signals library is in a separate package, so we need to explicitly ensure the
+// global `ngDevMode` type is defined.
+declare const ngDevMode: boolean | undefined;
+
 /**
  * A cleanup function that can be optionally registered from the watch logic. If registered, the
  * cleanup logic runs before the next watch execution.
@@ -99,7 +103,11 @@ export function createWatch(
     }
 
     if (isInNotificationPhase()) {
-      throw new Error(`Schedulers cannot synchronously execute watches while scheduling.`);
+      throw new Error(
+        typeof ngDevMode !== 'undefined' && ngDevMode
+          ? 'Schedulers cannot synchronously execute watches while scheduling.'
+          : '',
+      );
     }
 
     node.dirty = false;


### PR DESCRIPTION
Some of the error messages in `core/primitives` are already guarded with `ngDevMode`; this change guards the remaining ones.