### PR TITLE
docs(docs-infra): fix algolia icon in the search dialog on safari

### DIFF
--- a/adev/shared-docs/components/search-dialog/search-dialog.component.scss
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.scss
@@ -51,9 +51,9 @@ dialog {
       padding-inline-end: 1rem;
       padding-block: 0.25rem;
 
-      /** 
+      /**
       * This rule needs ng-deep to be applied to elements that are created via a [innerHTML] binding
-      */ 
+      */
       ::ng-deep {
         mark {
           background: #e62600;
@@ -155,8 +155,8 @@ dialog {
   border-radius: 0 0 0.25rem 0.25rem;
 
   docs-algolia-icon {
-    display: inline-flex;
-    margin-block-start: 0.12rem;
+    display: block;
+    margin-block-start: 5px;
     margin-inline-start: 0.15rem;
     width: 4rem;
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The icon has zero height due to its display property on Safari.

<img width="759" alt="Screenshot 2025-04-02 at 19 04 45" src="https://github.com/user-attachments/assets/e1072e46-f410-4185-b76d-81115b719e63" />


## What is the new behavior?

Change the display property and align vertically the icon.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No