### PR TITLE
feat(core): Add provider which reports unhandled errors on window t…

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1455,6 +1455,9 @@ export interface PromiseResourceOptions<T, R> extends BaseResourceOptions<T, R> 
 export function provideAppInitializer(initializerFn: () => Observable<unknown> | Promise<unknown> | void): EnvironmentProviders;
 
 // @public
+export function provideBrowserGlobalErrorListeners(): EnvironmentProviders;
+
+// @public
 export function provideEnvironmentInitializer(initializerFn: () => void): EnvironmentProviders;
 
 // @public

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -90,7 +90,7 @@ export {
 export {ApplicationModule} from './application/application_module';
 export {AbstractType, Type} from './interface/type';
 export {EventEmitter} from './event_emitter';
-export {ErrorHandler} from './error_handler';
+export {ErrorHandler, provideBrowserGlobalErrorListeners} from './error_handler';
 export * from './core_private_export';
 export * from './core_render3_private_export';
 export * from './core_reactivity_export';

--- a/packages/core/test/error_handler_spec.ts
+++ b/packages/core/test/error_handler_spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ErrorHandler} from '../src/error_handler';
+import {TestBed} from '../testing';
+import {ErrorHandler, provideBrowserGlobalErrorListeners} from '../src/error_handler';
 
 class MockConsole {
   res: any[][] = [];
@@ -37,5 +38,30 @@ describe('ErrorHandler', () => {
     expect(errorToString(false)).toBe('ERROR#false');
     expect(errorToString(null)).toBe('ERROR#null');
     expect(errorToString(undefined)).toBe('ERROR#undefined');
+  });
+
+  it('installs global error handler once', async () => {
+    if (isNode) {
+      return;
+    }
+    // override global.onerror to prevent jasmine report error
+    let originalWindowOnError = window.onerror;
+    window.onerror = function () {};
+    TestBed.configureTestingModule({
+      rethrowApplicationErrors: false,
+      providers: [provideBrowserGlobalErrorListeners(), provideBrowserGlobalErrorListeners()],
+    });
+
+    const spy = spyOn(TestBed.inject(ErrorHandler), 'handleError');
+    await new Promise((resolve) => {
+      setTimeout(() => {
+        throw new Error('abc');
+      });
+      setTimeout(resolve, 1);
+    });
+
+    expect(spy).toHaveBeenCalledWith(jasmine.objectContaining({message: 'abc'}));
+    expect(spy.calls.count()).toBe(1);
+    window.onerror = originalWindowOnError;
   });
 });


### PR DESCRIPTION
…o ErrorHandler

This commit adds a provider that installs listeners on the browser window to forward unhandled promise rejections and uncaught errors to the `ErrorHandler`. This is useful for both ZoneJS and Zoneless applications. For apps using ZoneJS, errors can reach the window when they happen outside the Angular Zone. For Zoneless apps, any errors not explicitly caught by the framework can reach the window. Without this provider, these errors would otherwise not be reported to `ErrorHandler`.

We will/should consider adding this provider to apps by default in the cli. In addition, it should be mentioned in the (to be created) documentation page on error handling in Angular.
