### PR TITLE
docs: add Security-DomSanitizer link in ElemnetRef&Renderer2

### DIFF
--- a/adev/shared-docs/styles/docs/_alert.scss
+++ b/adev/shared-docs/styles/docs/_alert.scss
@@ -26,9 +26,11 @@
       font-size: 1.3rem;
     }
 
-    p {
+    p, header {
       margin-inline-start: 1.65rem;
+    }
 
+    p {
       &:first-child {
         margin-block-start: 0;
       }

--- a/packages/core/src/linker/element_ref.ts
+++ b/packages/core/src/linker/element_ref.ts
@@ -49,12 +49,13 @@ export function createElementRef(tNode: TNode, lView: LView): ElementRef {
 // and could do better codegen in the future.
 export class ElementRef<T = any> {
   /**
-   * <div class="callout is-critical">
+   * <div class="docs-alert docs-alert-important">
    *   <header>Use with caution</header>
    *   <p>
    *    Use this API as the last resort when direct access to DOM is needed. Use templating and
-   *    data-binding provided by Angular instead. Alternatively you can take a look at
-   *    {@link Renderer2} which provides an API that can be safely used.
+   *    data-binding provided by Angular instead. If used, it is recommended in combination with
+   *    {@link /best-practices/security#direct-use-of-the-dom-apis-and-explicit-sanitization-calls}
+   *    for maxiumum security;
    *   </p>
    * </div>
    */

--- a/packages/core/src/linker/element_ref.ts
+++ b/packages/core/src/linker/element_ref.ts
@@ -54,7 +54,7 @@ export class ElementRef<T = any> {
    *   <p>
    *    Use this API as the last resort when direct access to DOM is needed. Use templating and
    *    data-binding provided by Angular instead. If used, it is recommended in combination with
-   *    {@link /best-practices/security#direct-use-of-the-dom-apis-and-explicit-sanitization-calls}
+   *    {@link /best-practices/security#direct-use-of-the-dom-apis-and-explicit-sanitization-calls DomSanitizer}
    *    for maxiumum security;
    *   </p>
    * </div>

--- a/packages/core/src/render/api.ts
+++ b/packages/core/src/render/api.ts
@@ -46,6 +46,12 @@ export abstract class RendererFactory2 {
  * renders a template into DOM. You can use custom rendering to intercept
  * rendering calls, or to render to something other than DOM.
  *
+ * <div class="docs-alert docs-alert-important">
+ * Please be aware that usage of `Renderer2`, in context of accessing DOM elements, provides no
+ * extra security which makes it equivalent to
+ * {@link /best-practices/security#direct-use-of-the-dom-apis-and-explicit-sanitization-calls}.
+ * </div>
+ *
  * Create your custom renderer using `RendererFactory2`.
  *
  * Use a custom renderer to bypass Angular's templating and

--- a/packages/core/src/render/api.ts
+++ b/packages/core/src/render/api.ts
@@ -47,9 +47,11 @@ export abstract class RendererFactory2 {
  * rendering calls, or to render to something other than DOM.
  *
  * <div class="docs-alert docs-alert-important">
+ * <p>
  * Please be aware that usage of `Renderer2`, in context of accessing DOM elements, provides no
  * extra security which makes it equivalent to
- * {@link /best-practices/security#direct-use-of-the-dom-apis-and-explicit-sanitization-calls}.
+ * {@link /best-practices/security#direct-use-of-the-dom-apis-and-explicit-sanitization-calls Security vulnerabilities}.
+ * </p>
  * </div>
  *
  * Create your custom renderer using `RendererFactory2`.


### PR DESCRIPTION
Renderer2 and ElementRef didn't mention the Security-DomSanitizer method, this will add clarity for potential user what to expect. Also swap deprecated "callout" class to docs-alert

Fixes #51208 , #46904

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #51208 , #46904


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
