### PR TITLE
feat(core): Stabilize PendingTasks Injectable

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1391,7 +1391,7 @@ export const PACKAGE_ROOT_URL: InjectionToken<string>;
 // @public
 export class PendingTasks {
     add(): () => void;
-    run<T>(fn: () => Promise<T>): void;
+    run(fn: () => Promise<unknown>): void;
     // (undocumented)
     static ɵprov: unknown;
 }

--- a/packages/core/src/pending_tasks.ts
+++ b/packages/core/src/pending_tasks.ts
@@ -83,7 +83,6 @@ export class PendingTasksInternal implements OnDestroy {
  * ```
  *
  * @publicApi
- * @developerPreview
  */
 export class PendingTasks {
   private readonly internalPendingTasks = inject(PendingTasksInternal);
@@ -117,8 +116,9 @@ export class PendingTasks {
    * ```
    *
    * @param fn The asynchronous function to execute
+   * @developerPreview
    */
-  run<T>(fn: () => Promise<T>): void {
+  run(fn: () => Promise<unknown>): void {
     const removeTask = this.add();
     fn().catch(this.errorHandler).finally(removeTask);
   }


### PR DESCRIPTION
This PR marks `PendingTasks` as stable, though the `run` function remains in dev preview. There are still questions around its return value, error handling, and whether it will be replaced by a different `task` API that would better track context through the injector/injection context.
