### PR TITLE
refactor(router): drop `defer`

### DIFF
--- a/packages/router/src/operators/check_guards.ts
+++ b/packages/router/src/operators/check_guards.ts
@@ -7,16 +7,7 @@
  */
 
 import {EnvironmentInjector, ProviderToken, runInInjectionContext} from '@angular/core';
-import {
-  concat,
-  defer,
-  from,
-  MonoTypeOperatorFunction,
-  Observable,
-  of,
-  OperatorFunction,
-  pipe,
-} from 'rxjs';
+import {concat, from, MonoTypeOperatorFunction, Observable, of, OperatorFunction, pipe} from 'rxjs';
 import {concatMap, first, map, mergeMap, tap} from 'rxjs/operators';
 
 import {ActivationStart, ChildActivationStart, Event} from '../events';
@@ -33,6 +24,7 @@ import {redirectingNavigationError} from '../navigation_canceling_error';
 import type {NavigationTransition} from '../navigation_transition';
 import type {ActivatedRouteSnapshot, RouterStateSnapshot} from '../router_state';
 import {UrlSegment, UrlSerializer} from '../url_tree';
+import {defer} from '../utils/defer';
 import {wrapIntoObservable} from '../utils/collection';
 import {getClosestRouteInjector} from '../utils/config';
 import {

--- a/packages/router/src/operators/resolve_data.ts
+++ b/packages/router/src/operators/resolve_data.ts
@@ -7,7 +7,7 @@
  */
 
 import {EnvironmentInjector, ProviderToken, runInInjectionContext} from '@angular/core';
-import {defer, EMPTY, from, MonoTypeOperatorFunction, Observable, of, throwError} from 'rxjs';
+import {EMPTY, from, MonoTypeOperatorFunction, Observable, of, throwError} from 'rxjs';
 import {catchError, concatMap, first, map, mergeMap, takeLast, tap} from 'rxjs/operators';
 
 import {RedirectCommand, ResolveData} from '../models';
@@ -25,6 +25,7 @@ import {getTokenOrFunctionIdentity} from '../utils/preactivation';
 import {isEmptyError} from '../utils/type_guards';
 import {redirectingNavigationError} from '../navigation_canceling_error';
 import {DefaultUrlSerializer} from '../url_tree';
+import {defer} from '../utils/defer';
 
 export function resolveData(
   paramsInheritanceStrategy: 'emptyOnly' | 'always',

--- a/packages/router/src/utils/defer.ts
+++ b/packages/router/src/utils/defer.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Observable} from 'rxjs';
+
+// `defer` from RxJS pulls in `from()` internally.
+export const defer = <T>(observableFactory: () => Observable<T>) =>
+  new Observable<T>((subscriber) => observableFactory().subscribe(subscriber));


### PR DESCRIPTION
RxJS `defer` pulls in `from()` internally.