### PR TITLE
Selectorless template parsing

### DIFF
--- a/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
@@ -18,11 +18,13 @@ import {
   TmplAstBoundDeferredTrigger,
   TmplAstBoundEvent,
   TmplAstBoundText,
+  TmplAstComponent,
   TmplAstDeferredBlock,
   TmplAstDeferredBlockError,
   TmplAstDeferredBlockLoading,
   TmplAstDeferredBlockPlaceholder,
   TmplAstDeferredTrigger,
+  TmplAstDirective,
   TmplAstElement,
   TmplAstForLoopBlock,
   TmplAstForLoopBlockEmpty,
@@ -242,6 +244,7 @@ class TemplateVisitor extends TmplAstRecursiveVisitor {
     this.visitAll(element.references);
     this.visitAll(element.inputs);
     this.visitAll(element.attributes);
+    this.visitAll(element.directives);
     this.visitAll(element.children);
     this.visitAll(element.outputs);
   }
@@ -253,6 +256,7 @@ class TemplateVisitor extends TmplAstRecursiveVisitor {
       this.identifiers.add(templateIdentifier);
     }
 
+    this.visitAll(template.directives);
     this.visitAll(template.variables);
     this.visitAll(template.attributes);
     this.visitAll(template.templateAttrs);
@@ -361,6 +365,14 @@ class TemplateVisitor extends TmplAstRecursiveVisitor {
     }
 
     this.visitExpression(decl.value);
+  }
+
+  override visitComponent(component: TmplAstComponent): void {
+    throw new Error('TODO');
+  }
+
+  override visitDirective(directive: TmplAstDirective): void {
+    throw new Error('TODO');
   }
 
   /** Creates an identifier for a template element or template node. */

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/api/api.ts
@@ -15,12 +15,14 @@ import {
   TmplAstBoundDeferredTrigger,
   TmplAstBoundEvent,
   TmplAstBoundText,
+  TmplAstComponent,
   TmplAstContent,
   TmplAstDeferredBlock,
   TmplAstDeferredBlockError,
   TmplAstDeferredBlockLoading,
   TmplAstDeferredBlockPlaceholder,
   TmplAstDeferredTrigger,
+  TmplAstDirective,
   TmplAstElement,
   TmplAstForLoopBlock,
   TmplAstForLoopBlockEmpty,
@@ -185,6 +187,7 @@ class TemplateVisitor<Code extends ErrorCode>
     this.visitAllNodes(element.attributes);
     this.visitAllNodes(element.inputs);
     this.visitAllNodes(element.outputs);
+    this.visitAllNodes(element.directives);
     this.visitAllNodes(element.references);
     this.visitAllNodes(element.children);
   }
@@ -200,6 +203,8 @@ class TemplateVisitor<Code extends ErrorCode>
       this.visitAllNodes(template.inputs);
       this.visitAllNodes(template.outputs);
     }
+
+    this.visitAllNodes(template.directives);
 
     // TODO(crisbeto): remove this condition when deleting `canVisitStructuralAttributes`.
     if (this.check.canVisitStructuralAttributes || isInlineTemplate) {
@@ -289,6 +294,22 @@ class TemplateVisitor<Code extends ErrorCode>
 
   visitLetDeclaration(decl: TmplAstLetDeclaration): void {
     this.visitAst(decl.value);
+  }
+
+  visitComponent(component: TmplAstComponent) {
+    this.visitAllNodes(component.attributes);
+    this.visitAllNodes(component.inputs);
+    this.visitAllNodes(component.outputs);
+    this.visitAllNodes(component.directives);
+    this.visitAllNodes(component.references);
+    this.visitAllNodes(component.children);
+  }
+
+  visitDirective(directive: TmplAstDirective) {
+    this.visitAllNodes(directive.attributes);
+    this.visitAllNodes(directive.inputs);
+    this.visitAllNodes(directive.outputs);
+    this.visitAllNodes(directive.references);
   }
 
   getDiagnostics(template: TmplAstNode[]): NgTemplateDiagnostic<Code>[] {

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -175,6 +175,8 @@ export {
   Variable as TmplAstVariable,
   ViewportDeferredTrigger as TmplAstViewportDeferredTrigger,
   HostElement as TmplAstHostElement,
+  Component as TmplAstComponent,
+  Directive as TmplAstDirective,
   visitAll as tmplAstVisitAll,
   Visitor as TmplAstVisitor,
 } from './render3/r3_ast';

--- a/packages/compiler/src/i18n/extractor_merger.ts
+++ b/packages/compiler/src/i18n/extractor_merger.ts
@@ -130,7 +130,7 @@ class _Visitor implements html.Visitor {
     this._translations = translations;
 
     // Construct a single fake root element
-    const wrapper = new html.Element('wrapper', [], nodes, undefined!, undefined!, undefined);
+    const wrapper = new html.Element('wrapper', [], [], nodes, undefined!, undefined!, undefined);
 
     const translatedNode = wrapper.visit(this, null);
 
@@ -247,82 +247,7 @@ class _Visitor implements html.Visitor {
   }
 
   visitElement(el: html.Element, context: any): html.Element | null {
-    this._mayBeAddBlockChildren(el);
-    this._depth++;
-    const wasInI18nNode = this._inI18nNode;
-    const wasInImplicitNode = this._inImplicitNode;
-    let childNodes: html.Node[] = [];
-    let translatedChildNodes: html.Node[] = undefined!;
-
-    // Extract:
-    // - top level nodes with the (implicit) "i18n" attribute if not already in a section
-    // - ICU messages
-    const i18nAttr = _getI18nAttr(el);
-    const i18nMeta = i18nAttr ? i18nAttr.value : '';
-    const isImplicit =
-      this._implicitTags.some((tag) => el.name === tag) &&
-      !this._inIcu &&
-      !this._isInTranslatableSection;
-    const isTopLevelImplicit = !wasInImplicitNode && isImplicit;
-    this._inImplicitNode = wasInImplicitNode || isImplicit;
-
-    if (!this._isInTranslatableSection && !this._inIcu) {
-      if (i18nAttr || isTopLevelImplicit) {
-        this._inI18nNode = true;
-        const message = this._addMessage(el.children, i18nMeta)!;
-        translatedChildNodes = this._translateMessage(el, message);
-      }
-
-      if (this._mode == _VisitorMode.Extract) {
-        const isTranslatable = i18nAttr || isTopLevelImplicit;
-        if (isTranslatable) this._openTranslatableSection(el);
-        html.visitAll(this, el.children);
-        if (isTranslatable) this._closeTranslatableSection(el, el.children);
-      }
-    } else {
-      if (i18nAttr || isTopLevelImplicit) {
-        this._reportError(
-          el,
-          'Could not mark an element as translatable inside a translatable section',
-        );
-      }
-
-      if (this._mode == _VisitorMode.Extract) {
-        // Descend into child nodes for extraction
-        html.visitAll(this, el.children);
-      }
-    }
-
-    if (this._mode === _VisitorMode.Merge) {
-      const visitNodes = translatedChildNodes || el.children;
-      visitNodes.forEach((child) => {
-        const visited = child.visit(this, context);
-        if (visited && !this._isInTranslatableSection) {
-          // Do not add the children from translatable sections (= i18n blocks here)
-          // They will be added later in this loop when the block closes (i.e. on `<!-- /i18n -->`)
-          childNodes = childNodes.concat(visited);
-        }
-      });
-    }
-
-    this._visitAttributesOf(el);
-
-    this._depth--;
-    this._inI18nNode = wasInI18nNode;
-    this._inImplicitNode = wasInImplicitNode;
-
-    if (this._mode === _VisitorMode.Merge) {
-      const translatedAttrs = this._translateAttributes(el);
-      return new html.Element(
-        el.name,
-        translatedAttrs,
-        childNodes,
-        el.sourceSpan,
-        el.startSourceSpan,
-        el.endSourceSpan,
-      );
-    }
-    return null;
+    return this._visitElementLike(el, context);
   }
 
   visitAttribute(attribute: html.Attribute, context: any): any {
@@ -336,6 +261,14 @@ class _Visitor implements html.Visitor {
   visitBlockParameter(parameter: html.BlockParameter, context: any) {}
 
   visitLetDeclaration(decl: html.LetDeclaration, context: any) {}
+
+  visitComponent(component: html.Component, context: any): html.Component | null {
+    return this._visitElementLike(component, context);
+  }
+
+  visitDirective(directive: html.Directive, context: any) {
+    throw new Error('unreachable code');
+  }
 
   private _init(mode: _VisitorMode, interpolationConfig: InterpolationConfig): void {
     this._mode = mode;
@@ -358,16 +291,116 @@ class _Visitor implements html.Visitor {
     );
   }
 
+  private _visitElementLike<T extends html.Element | html.Component>(
+    node: T,
+    context: any,
+  ): T | null {
+    this._mayBeAddBlockChildren(node);
+    this._depth++;
+    const wasInI18nNode = this._inI18nNode;
+    const wasInImplicitNode = this._inImplicitNode;
+    let childNodes: html.Node[] = [];
+    let translatedChildNodes: html.Node[] = undefined!;
+
+    // Extract:
+    // - top level nodes with the (implicit) "i18n" attribute if not already in a section
+    // - ICU messages
+    const nodeName = node instanceof html.Component ? node.tagName : node.name;
+    const i18nAttr = _getI18nAttr(node);
+    const i18nMeta = i18nAttr ? i18nAttr.value : '';
+    const isImplicit =
+      this._implicitTags.some((tag) => nodeName === tag) &&
+      !this._inIcu &&
+      !this._isInTranslatableSection;
+    const isTopLevelImplicit = !wasInImplicitNode && isImplicit;
+    this._inImplicitNode = wasInImplicitNode || isImplicit;
+
+    if (!this._isInTranslatableSection && !this._inIcu) {
+      if (i18nAttr || isTopLevelImplicit) {
+        this._inI18nNode = true;
+        const message = this._addMessage(node.children, i18nMeta)!;
+        translatedChildNodes = this._translateMessage(node, message);
+      }
+
+      if (this._mode == _VisitorMode.Extract) {
+        const isTranslatable = i18nAttr || isTopLevelImplicit;
+        if (isTranslatable) this._openTranslatableSection(node);
+        html.visitAll(this, node.children);
+        if (isTranslatable) this._closeTranslatableSection(node, node.children);
+      }
+    } else {
+      if (i18nAttr || isTopLevelImplicit) {
+        this._reportError(
+          node,
+          'Could not mark an element as translatable inside a translatable section',
+        );
+      }
+
+      if (this._mode == _VisitorMode.Extract) {
+        // Descend into child nodes for extraction
+        html.visitAll(this, node.children);
+      }
+    }
+
+    if (this._mode === _VisitorMode.Merge) {
+      const visitNodes = translatedChildNodes || node.children;
+      visitNodes.forEach((child) => {
+        const visited = child.visit(this, context);
+        if (visited && !this._isInTranslatableSection) {
+          // Do not add the children from translatable sections (= i18n blocks here)
+          // They will be added later in this loop when the block closes (i.e. on `<!-- /i18n -->`)
+          childNodes = childNodes.concat(visited);
+        }
+      });
+    }
+
+    this._visitAttributesOf(node);
+
+    this._depth--;
+    this._inI18nNode = wasInI18nNode;
+    this._inImplicitNode = wasInImplicitNode;
+
+    if (this._mode === _VisitorMode.Merge) {
+      if (node instanceof html.Element) {
+        return new html.Element(
+          node.name,
+          this._translateAttributes(node),
+          this._translateDirectives(node),
+          childNodes,
+          node.sourceSpan,
+          node.startSourceSpan,
+          node.endSourceSpan,
+        ) as T;
+      } else {
+        return new html.Component(
+          node.componentName,
+          node.tagName,
+          node.fullName,
+          this._translateAttributes(node),
+          this._translateDirectives(node),
+          childNodes,
+          node.sourceSpan,
+          node.startSourceSpan,
+          node.endSourceSpan,
+        ) as T;
+      }
+    }
+    return null;
+  }
+
   // looks for translatable attributes
-  private _visitAttributesOf(el: html.Element): void {
+  private _visitAttributesOf(el: html.Element | html.Component): void {
     const explicitAttrNameToValue: {[k: string]: string} = {};
-    const implicitAttrNames: string[] = this._implicitAttrs[el.name] || [];
+    const implicitAttrNames: string[] =
+      this._implicitAttrs[el instanceof html.Component ? el.tagName || '' : el.name] || [];
 
     el.attrs
-      .filter((attr) => attr.name.startsWith(_I18N_ATTR_PREFIX))
-      .forEach(
-        (attr) => (explicitAttrNameToValue[attr.name.slice(_I18N_ATTR_PREFIX.length)] = attr.value),
-      );
+      .filter((attr) => attr instanceof html.Attribute && attr.name.startsWith(_I18N_ATTR_PREFIX))
+      .forEach((attr) => {
+        explicitAttrNameToValue[attr.name.slice(_I18N_ATTR_PREFIX.length)] = (
+          attr as html.Attribute
+        ).value;
+      });
 
     el.attrs.forEach((attr) => {
       if (attr.name in explicitAttrNameToValue) {
@@ -459,13 +492,15 @@ class _Visitor implements html.Visitor {
   }
 
   // translate the attributes of an element and remove i18n specific attributes
-  private _translateAttributes(el: html.Element): html.Attribute[] {
-    const attributes = el.attrs;
+  private _translateAttributes(
+    node: html.Element | html.Component | html.Directive,
+  ): html.Attribute[] {
     const i18nParsedMessageMeta: {
       [name: string]: {meaning: string; description: string; id: string};
     } = {};
+    const translatedAttributes: html.Attribute[] = [];
 
-    attributes.forEach((attr) => {
+    node.attrs.forEach((attr) => {
       if (attr.name.startsWith(_I18N_ATTR_PREFIX)) {
         i18nParsedMessageMeta[attr.name.slice(_I18N_ATTR_PREFIX.length)] = _parseMessageMeta(
           attr.value,
@@ -473,9 +508,7 @@ class _Visitor implements html.Visitor {
       }
     });
 
-    const translatedAttributes: html.Attribute[] = [];
-
-    attributes.forEach((attr) => {
+    node.attrs.forEach((attr) => {
       if (attr.name === _I18N_ATTR || attr.name.startsWith(_I18N_ATTR_PREFIX)) {
         // strip i18n specific attributes
         return;
@@ -513,7 +546,7 @@ class _Visitor implements html.Visitor {
             );
           } else {
             this._reportError(
-              el,
+              node,
               `Unexpected translation for attribute "${attr.name}" (id="${
                 id || this._translations.digest(message)
               }")`,
@@ -521,7 +554,7 @@ class _Visitor implements html.Visitor {
           }
         } else {
           this._reportError(
-            el,
+            node,
             `Translation unavailable for attribute "${attr.name}" (id="${
               id || this._translations.digest(message)
             }")`,
@@ -533,6 +566,19 @@ class _Visitor implements html.Visitor {
     });
 
     return translatedAttributes;
+  }
+
+  private _translateDirectives(node: html.Element | html.Component): html.Directive[] {
+    return node.directives.map(
+      (dir) =>
+        new html.Directive(
+          dir.name,
+          this._translateAttributes(dir),
+          dir.sourceSpan,
+          dir.startSourceSpan,
+          dir.endSourceSpan,
+        ),
+    );
   }
 
   /**
@@ -621,8 +667,12 @@ function _isClosingComment(n: html.Node): boolean {
   return !!(n instanceof html.Comment && n.value && n.value === '/i18n');
 }
 
-function _getI18nAttr(p: html.Element): html.Attribute | null {
-  return p.attrs.find((attr) => attr.name === _I18N_ATTR) || null;
+function _getI18nAttr(p: html.Element | html.Component): html.Attribute | null {
+  return (
+    (p.attrs.find((attr) => attr instanceof html.Attribute && attr.name === _I18N_ATTR) as
+      | html.Attribute
+      | undefined) || null
+  );
 }
 
 function _parseMessageMeta(i18n?: string): {meaning: string; description: string; id: string} {

--- a/packages/compiler/src/i18n/serializers/xliff.ts
+++ b/packages/compiler/src/i18n/serializers/xliff.ts
@@ -305,6 +305,10 @@ class XliffParser implements ml.Visitor {
 
   visitLetDeclaration(decl: ml.LetDeclaration, context: any) {}
 
+  visitComponent(component: ml.Component, context: any) {}
+
+  visitDirective(directive: ml.Directive, context: any) {}
+
   private _addError(node: ml.Node, message: string): void {
     this._errors.push(new I18nError(node.sourceSpan, message));
   }
@@ -379,6 +383,14 @@ class XmlToI18n implements ml.Visitor {
   visitBlockParameter(parameter: ml.BlockParameter, context: any) {}
 
   visitLetDeclaration(decl: ml.LetDeclaration, context: any) {}
+
+  visitComponent(component: ml.Component, context: any) {
+    this._addError(component, 'Unexpected node');
+  }
+
+  visitDirective(directive: ml.Directive, context: any) {
+    this._addError(directive, 'Unexpected node');
+  }
 
   private _addError(node: ml.Node, message: string): void {
     this._errors.push(new I18nError(node.sourceSpan, message));

--- a/packages/compiler/src/i18n/serializers/xliff2.ts
+++ b/packages/compiler/src/i18n/serializers/xliff2.ts
@@ -336,6 +336,10 @@ class Xliff2Parser implements ml.Visitor {
 
   visitLetDeclaration(decl: ml.LetDeclaration, context: any) {}
 
+  visitComponent(component: ml.Component, context: any) {}
+
+  visitDirective(directive: ml.Directive, context: any) {}
+
   private _addError(node: ml.Node, message: string): void {
     this._errors.push(new I18nError(node.sourceSpan, message));
   }
@@ -431,6 +435,14 @@ class XmlToI18n implements ml.Visitor {
   visitBlockParameter(parameter: ml.BlockParameter, context: any) {}
 
   visitLetDeclaration(decl: ml.LetDeclaration, context: any) {}
+
+  visitComponent(component: ml.Component, context: any) {
+    this._addError(component, 'Unexpected node');
+  }
+
+  visitDirective(directive: ml.Directive, context: any) {
+    this._addError(directive, 'Unexpected node');
+  }
 
   private _addError(node: ml.Node, message: string): void {
     this._errors.push(new I18nError(node.sourceSpan, message));

--- a/packages/compiler/src/i18n/serializers/xtb.ts
+++ b/packages/compiler/src/i18n/serializers/xtb.ts
@@ -160,6 +160,14 @@ class XtbParser implements ml.Visitor {
 
   visitLetDeclaration(decl: ml.LetDeclaration, context: any) {}
 
+  visitComponent(component: ml.Component, context: any) {
+    this._addError(component, 'Unexpected node');
+  }
+
+  visitDirective(directive: ml.Directive, context: any) {
+    this._addError(directive, 'Unexpected node');
+  }
+
   private _addError(node: ml.Node, message: string): void {
     this._errors.push(new I18nError(node.sourceSpan, message));
   }
@@ -229,6 +237,14 @@ class XmlToI18n implements ml.Visitor {
   visitBlockParameter(block: ml.BlockParameter, context: any) {}
 
   visitLetDeclaration(decl: ml.LetDeclaration, context: any) {}
+
+  visitComponent(component: ml.Component, context: any) {
+    this._addError(component, 'Unexpected node');
+  }
+
+  visitDirective(directive: ml.Directive, context: any) {
+    this._addError(directive, 'Unexpected node');
+  }
 
   private _addError(node: ml.Node, message: string): void {
     this._errors.push(new I18nError(node.sourceSpan, message));

--- a/packages/compiler/src/ml_parser/ast.ts
+++ b/packages/compiler/src/ml_parser/ast.ts
@@ -24,7 +24,9 @@ export type Node =
   | ExpansionCase
   | Text
   | Block
-  | BlockParameter;
+  | BlockParameter
+  | Component
+  | Directive;
 
 export abstract class NodeWithI18n implements BaseNode {
   constructor(
@@ -99,6 +101,7 @@ export class Element extends NodeWithI18n {
   constructor(
     public name: string,
     public attrs: Attribute[],
+    readonly directives: Directive[],
     public children: Node[],
     sourceSpan: ParseSourceSpan,
     public startSourceSpan: ParseSourceSpan,
@@ -141,6 +144,41 @@ export class Block extends NodeWithI18n {
   }
 }
 
+export class Component extends NodeWithI18n {
+  constructor(
+    readonly componentName: string,
+    readonly tagName: string | null,
+    readonly fullName: string,
+    public attrs: Attribute[],
+    readonly directives: Directive[],
+    readonly children: Node[],
+    sourceSpan: ParseSourceSpan,
+    readonly startSourceSpan: ParseSourceSpan,
+    public endSourceSpan: ParseSourceSpan | null = null,
+    i18n?: I18nMeta,
+  ) {
+    super(sourceSpan, i18n);
+  }
+
+  override visit(visitor: Visitor, context: any): any {
+    return visitor.visitComponent(this, context);
+  }
+}
+
+export class Directive implements BaseNode {
+  constructor(
+    readonly name: string,
+    readonly attrs: Attribute[],
+    readonly sourceSpan: ParseSourceSpan,
+    readonly startSourceSpan: ParseSourceSpan,
+    readonly endSourceSpan: ParseSourceSpan | null = null,
+  ) {}
+
+  visit(visitor: Visitor, context: any): any {
+    return visitor.visitDirective(this, context);
+  }
+}
+
 export class BlockParameter implements BaseNode {
   constructor(
     public expression: string,
@@ -180,6 +218,8 @@ export interface Visitor {
   visitBlock(block: Block, context: any): any;
   visitBlockParameter(parameter: BlockParameter, context: any): any;
   visitLetDeclaration(decl: LetDeclaration, context: any): any;
+  visitComponent(component: Component, context: any): any;
+  visitDirective(directive: Directive, context: any): any;
 }
 
 export function visitAll(visitor: Visitor, nodes: Node[], context: any = null): any[] {
@@ -203,6 +243,7 @@ export class RecursiveVisitor implements Visitor {
   visitElement(ast: Element, context: any): any {
     this.visitChildren(context, (visit) => {
       visit(ast.attrs);
+      visit(ast.directives);
       visit(ast.children);
     });
   }
@@ -230,7 +271,20 @@ export class RecursiveVisitor implements Visitor {
 
   visitLetDeclaration(decl: LetDeclaration, context: any) {}
 
-  private visitChildren<T extends Node>(
+  visitComponent(component: Component, context: any) {
+    this.visitChildren(context, (visit) => {
+      visit(component.attrs);
+      visit(component.children);
+    });
+  }
+
+  visitDirective(directive: Directive, context: any) {
+    this.visitChildren(context, (visit) => {
+      visit(directive.attrs);
+    });
+  }
+
+  private visitChildren(
     context: any,
     cb: (visit: <V extends Node>(children: V[] | undefined) => void) => void,
   ) {

--- a/packages/compiler/src/ml_parser/html_whitespaces.ts
+++ b/packages/compiler/src/ml_parser/html_whitespaces.ts
@@ -73,6 +73,7 @@ export class WhitespaceVisitor implements html.Visitor {
       const newElement = new html.Element(
         element.name,
         visitAllWithSiblings(this, element.attrs),
+        visitAllWithSiblings(this, element.directives),
         element.children,
         element.sourceSpan,
         element.startSourceSpan,
@@ -86,6 +87,7 @@ export class WhitespaceVisitor implements html.Visitor {
     const newElement = new html.Element(
       element.name,
       element.attrs,
+      element.directives,
       visitAllWithSiblings(this, element.children),
       element.sourceSpan,
       element.startSourceSpan,
@@ -202,6 +204,49 @@ export class WhitespaceVisitor implements html.Visitor {
 
   visitLetDeclaration(decl: html.LetDeclaration, context: any) {
     return decl;
+  }
+
+  visitComponent(node: html.Component, context: any): any {
+    if (
+      (node.tagName && SKIP_WS_TRIM_TAGS.has(node.tagName)) ||
+      hasPreserveWhitespacesAttr(node.attrs)
+    ) {
+      // don't descent into elements where we need to preserve whitespaces
+      // but still visit all attributes to eliminate one used as a market to preserve WS
+      const newElement = new html.Component(
+        node.componentName,
+        node.tagName,
+        node.fullName,
+        visitAllWithSiblings(this, node.attrs),
+        visitAllWithSiblings(this, node.directives),
+        node.children,
+        node.sourceSpan,
+        node.startSourceSpan,
+        node.endSourceSpan,
+        node.i18n,
+      );
+      this.originalNodeMap?.set(newElement, node);
+      return newElement;
+    }
+
+    const newElement = new html.Component(
+      node.componentName,
+      node.tagName,
+      node.fullName,
+      node.attrs,
+      node.directives,
+      visitAllWithSiblings(this, node.children),
+      node.sourceSpan,
+      node.startSourceSpan,
+      node.endSourceSpan,
+      node.i18n,
+    );
+    this.originalNodeMap?.set(newElement, node);
+    return newElement;
+  }
+
+  visitDirective(directive: html.Directive, context: any) {
+    return directive;
   }
 
   visit(_node: html.Node, context: any) {

--- a/packages/compiler/src/ml_parser/icu_ast_expander.ts
+++ b/packages/compiler/src/ml_parser/icu_ast_expander.ts
@@ -68,6 +68,7 @@ class _Expander implements html.Visitor {
     return new html.Element(
       element.name,
       element.attrs,
+      element.directives,
       html.visitAll(this, element.children),
       element.sourceSpan,
       element.startSourceSpan,
@@ -117,6 +118,24 @@ class _Expander implements html.Visitor {
   visitLetDeclaration(decl: html.LetDeclaration, context: any) {
     return decl;
   }
+
+  visitComponent(node: html.Component, context: any): any {
+    return new html.Component(
+      node.componentName,
+      node.tagName,
+      node.fullName,
+      node.attrs,
+      node.directives,
+      html.visitAll(this, node.children),
+      node.sourceSpan,
+      node.startSourceSpan,
+      node.endSourceSpan,
+    );
+  }
+
+  visitDirective(directive: html.Directive, context: any) {
+    return directive;
+  }
 }
 
 // Plural forms are expanded to `NgPlural` and `NgPluralCase`s
@@ -147,6 +166,7 @@ function _expandPluralForm(ast: html.Expansion, errors: ParseError[]): html.Elem
           undefined /* i18n */,
         ),
       ],
+      [],
       expansionResult.nodes,
       c.sourceSpan,
       c.sourceSpan,
@@ -165,6 +185,7 @@ function _expandPluralForm(ast: html.Expansion, errors: ParseError[]): html.Elem
   return new html.Element(
     'ng-container',
     [switchAttr],
+    [],
     children,
     ast.sourceSpan,
     ast.sourceSpan,
@@ -193,6 +214,7 @@ function _expandDefaultForm(ast: html.Expansion, errors: ParseError[]): html.Ele
             undefined /* i18n */,
           ),
         ],
+        [],
         expansionResult.nodes,
         c.sourceSpan,
         c.sourceSpan,
@@ -213,6 +235,7 @@ function _expandDefaultForm(ast: html.Expansion, errors: ParseError[]): html.Ele
           undefined /* i18n */,
         ),
       ],
+      [],
       expansionResult.nodes,
       c.sourceSpan,
       c.sourceSpan,
@@ -232,6 +255,7 @@ function _expandDefaultForm(ast: html.Expansion, errors: ParseError[]): html.Ele
     'ng-container',
     [switchAttr],
     children,
+    [],
     ast.sourceSpan,
     ast.sourceSpan,
     ast.sourceSpan,

--- a/packages/compiler/src/ml_parser/parser.ts
+++ b/packages/compiler/src/ml_parser/parser.ts
@@ -20,11 +20,15 @@ import {
   BlockParameterToken,
   CdataStartToken,
   CommentStartToken,
+  ComponentCloseToken,
+  ComponentOpenStartToken,
+  DirectiveNameToken,
   ExpansionCaseExpressionEndToken,
   ExpansionCaseExpressionStartToken,
   ExpansionCaseValueToken,
   ExpansionFormStartToken,
   IncompleteBlockOpenToken,
+  IncompleteComponentOpenToken,
   IncompleteLetToken,
   IncompleteTagOpenToken,
   InterpolatedAttributeToken,
@@ -40,7 +44,7 @@ import {
 } from './tokens';
 
 /** Nodes that can contain other nodes. */
-type NodeContainer = html.Element | html.Block;
+type NodeContainer = html.Element | html.Block | html.Component;
 
 /** Class that can construct a `NodeContainer`. */
 interface NodeContainerConstructor extends Function {
@@ -93,7 +97,7 @@ class _TreeBuilder {
 
   constructor(
     private tokens: Token[],
-    private getTagDefinition: (tagName: string) => TagDefinition,
+    private tagDefinitionResolver: (tagName: string) => TagDefinition,
   ) {
     this._advance();
   }
@@ -104,9 +108,9 @@ class _TreeBuilder {
         this._peek.type === TokenType.TAG_OPEN_START ||
         this._peek.type === TokenType.INCOMPLETE_TAG_OPEN
       ) {
-        this._consumeStartTag(this._advance());
+        this._consumeElementStartTag(this._advance());
       } else if (this._peek.type === TokenType.TAG_CLOSE) {
-        this._consumeEndTag(this._advance());
+        this._consumeElementEndTag(this._advance());
       } else if (this._peek.type === TokenType.CDATA_START) {
         this._closeVoidElement();
         this._consumeCdata(this._advance());
@@ -137,6 +141,13 @@ class _TreeBuilder {
       } else if (this._peek.type === TokenType.INCOMPLETE_LET) {
         this._closeVoidElement();
         this._consumeIncompleteLet(this._advance());
+      } else if (
+        this._peek.type === TokenType.COMPONENT_OPEN_START ||
+        this._peek.type === TokenType.INCOMPLETE_COMPONENT_OPEN
+      ) {
+        this._consumeComponentStartTag(this._advance());
+      } else if (this._peek.type === TokenType.COMPONENT_CLOSE) {
+        this._consumeComponentEndTag(this._advance());
       } else {
         // Skip all other tokens...
         this._advance();
@@ -253,7 +264,7 @@ class _TreeBuilder {
     exp.push({type: TokenType.EOF, parts: [], sourceSpan: end.sourceSpan});
 
     // parse everything in between { and }
-    const expansionCaseParser = new _TreeBuilder(exp, this.getTagDefinition);
+    const expansionCaseParser = new _TreeBuilder(exp, this.tagDefinitionResolver);
     expansionCaseParser.build();
     if (expansionCaseParser.errors.length > 0) {
       this.errors = this.errors.concat(expansionCaseParser.errors);
@@ -335,7 +346,7 @@ class _TreeBuilder {
       if (
         parent != null &&
         parent.children.length === 0 &&
-        this.getTagDefinition(parent.name).ignoreFirstLf
+        this._getTagDefinition(parent)?.ignoreFirstLf
       ) {
         text = text.substring(1);
         tokens[0] = {type: token.type, sourceSpan: token.sourceSpan, parts: [text]} as typeof token;
@@ -376,26 +387,25 @@ class _TreeBuilder {
 
   private _closeVoidElement(): void {
     const el = this._getContainer();
-    if (el instanceof html.Element && this.getTagDefinition(el.name).isVoid) {
+    if (el !== null && this._getTagDefinition(el)?.isVoid) {
       this._containerStack.pop();
     }
   }
 
-  private _consumeStartTag(startTagToken: TagOpenStartToken | IncompleteTagOpenToken) {
-    const [prefix, name] = startTagToken.parts;
+  private _consumeElementStartTag(startTagToken: TagOpenStartToken | IncompleteTagOpenToken) {
     const attrs: html.Attribute[] = [];
-    while (this._peek.type === TokenType.ATTR_NAME) {
-      attrs.push(this._consumeAttr(this._advance<AttributeNameToken>()));
-    }
-    const fullName = this._getElementFullName(prefix, name, this._getClosestParentElement());
+    const directives: html.Directive[] = [];
+    this._consumeAttributesAndDirectives(attrs, directives);
+
+    const fullName = this._getElementFullName(startTagToken, this._getClosestElementLikeParent());
     let selfClosing = false;
     // Note: There could have been a tokenizer error
     // so that we don't get a token for the end tag...
     if (this._peek.type === TokenType.TAG_OPEN_END_VOID) {
       this._advance();
       selfClosing = true;
-      const tagDef = this.getTagDefinition(fullName);
-      if (!(tagDef.canSelfClose || getNsPrefix(fullName) !== null || tagDef.isVoid)) {
+      const tagDef = this._getTagDefinition(fullName);
+      if (!(tagDef?.canSelfClose || getNsPrefix(fullName) !== null || tagDef?.isVoid)) {
         this.errors.push(
           TreeError.create(
             fullName,
@@ -420,14 +430,12 @@ class _TreeBuilder {
       end,
       startTagToken.sourceSpan.fullStart,
     );
-    // TODO: capture directives.
-    const el = new html.Element(fullName, attrs, [], [], span, startSpan, undefined);
-    const parentEl = this._getContainer();
-    this._pushContainer(
-      el,
-      parentEl instanceof html.Element &&
-        this.getTagDefinition(parentEl.name).isClosedByChild(el.name),
-    );
+    const el = new html.Element(fullName, attrs, directives, [], span, startSpan, undefined);
+    const parent = this._getContainer();
+    const isClosedByChild =
+      parent !== null && !!this._getTagDefinition(parent)?.isClosedByChild(el.name);
+    this._pushContainer(el, isClosedByChild);
+
     if (selfClosing) {
       // Elements that are self-closed have their `endSourceSpan` set to the full span, as the
       // element start tag also represents the end tag.
@@ -442,6 +450,105 @@ class _TreeBuilder {
     }
   }
 
+  private _consumeComponentStartTag(
+    startToken: ComponentOpenStartToken | IncompleteComponentOpenToken,
+  ) {
+    const componentName = startToken.parts[0];
+    const attrs: html.Attribute[] = [];
+    const directives: html.Directive[] = [];
+    this._consumeAttributesAndDirectives(attrs, directives);
+
+    const closestElement = this._getClosestElementLikeParent();
+    const tagName = this._getComponentTagName(startToken, closestElement);
+    const fullName = this._getComponentFullName(startToken, closestElement);
+    const selfClosing = this._peek.type === TokenType.COMPONENT_OPEN_END_VOID;
+    this._advance();
+
+    const end = this._peek.sourceSpan.fullStart;
+    const span = new ParseSourceSpan(
+      startToken.sourceSpan.start,
+      end,
+      startToken.sourceSpan.fullStart,
+    );
+    const startSpan = new ParseSourceSpan(
+      startToken.sourceSpan.start,
+      end,
+      startToken.sourceSpan.fullStart,
+    );
+    const node = new html.Component(
+      componentName,
+      tagName,
+      fullName,
+      attrs,
+      directives,
+      [],
+      span,
+      startSpan,
+      undefined,
+    );
+    const parent = this._getContainer();
+    const isClosedByChild =
+      parent !== null &&
+      node.tagName !== null &&
+      !!this._getTagDefinition(parent)?.isClosedByChild(node.tagName);
+    this._pushContainer(node, isClosedByChild);
+
+    if (selfClosing) {
+      this._popContainer(fullName, html.Component, span);
+    } else if (startToken.type === TokenType.INCOMPLETE_COMPONENT_OPEN) {
+      this._popContainer(fullName, html.Component, null);
+      this.errors.push(
+        TreeError.create(fullName, span, `Opening tag "${fullName}" not terminated.`),
+      );
+    }
+  }
+
+  private _consumeAttributesAndDirectives(
+    attributesResult: html.Attribute[],
+    directivesResult: html.Directive[],
+  ) {
+    while (
+      this._peek.type === TokenType.ATTR_NAME ||
+      this._peek.type === TokenType.DIRECTIVE_NAME
+    ) {
+      if (this._peek.type === TokenType.DIRECTIVE_NAME) {
+        directivesResult.push(this._consumeDirective(this._peek));
+      } else {
+        attributesResult.push(this._consumeAttr(this._advance<AttributeNameToken>()));
+      }
+    }
+  }
+
+  private _consumeComponentEndTag(endToken: ComponentCloseToken) {
+    const fullName = this._getComponentFullName(endToken, this._getClosestElementLikeParent());
+
+    if (!this._popContainer(fullName, html.Component, endToken.sourceSpan)) {
+      const container = this._containerStack[this._containerStack.length - 1];
+      let suffix: string;
+
+      if (container instanceof html.Component && container.componentName === endToken.parts[0]) {
+        suffix = `, did you mean "${container.fullName}"?`;
+      } else {
+        suffix = '. It may happen when the tag has already been closed by another tag.';
+      }
+
+      const errMsg = `Unexpected closing tag "${fullName}"${suffix}`;
+      this.errors.push(TreeError.create(fullName, endToken.sourceSpan, errMsg));
+    }
+  }
+
+  private _getTagDefinition(nodeOrName: html.Node | string): TagDefinition | null {
+    if (typeof nodeOrName === 'string') {
+      return this.tagDefinitionResolver(nodeOrName);
+    } else if (nodeOrName instanceof html.Element) {
+      return this.tagDefinitionResolver(nodeOrName.name);
+    } else if (nodeOrName instanceof html.Component && nodeOrName.tagName !== null) {
+      return this.tagDefinitionResolver(nodeOrName.tagName);
+    } else {
+      return null;
+    }
+  }
+
   private _pushContainer(node: NodeContainer, isClosedByChild: boolean) {
     if (isClosedByChild) {
       this._containerStack.pop();
@@ -451,14 +558,10 @@ class _TreeBuilder {
     this._containerStack.push(node);
   }
 
-  private _consumeEndTag(endTagToken: TagCloseToken) {
-    const fullName = this._getElementFullName(
-      endTagToken.parts[0],
-      endTagToken.parts[1],
-      this._getClosestParentElement(),
-    );
+  private _consumeElementEndTag(endTagToken: TagCloseToken) {
+    const fullName = this._getElementFullName(endTagToken, this._getClosestElementLikeParent());
 
-    if (this.getTagDefinition(fullName).isVoid) {
+    if (this._getTagDefinition(fullName)?.isVoid) {
       this.errors.push(
         TreeError.create(
           fullName,
@@ -486,8 +589,9 @@ class _TreeBuilder {
     let unexpectedCloseTagDetected = false;
     for (let stackIndex = this._containerStack.length - 1; stackIndex >= 0; stackIndex--) {
       const node = this._containerStack[stackIndex];
+      const nodeName = node instanceof html.Component ? node.fullName : node.name;
 
-      if ((node.name === expectedName || expectedName === null) && node instanceof expectedType) {
+      if ((nodeName === expectedName || expectedName === null) && node instanceof expectedType) {
         // Record the parse span with the element that is being closed. Any elements that are
         // removed from the element stack at this point are closed implicitly, so they won't get
         // an end source span (as there is no explicit closing element).
@@ -498,10 +602,7 @@ class _TreeBuilder {
       }
 
       // Blocks and most elements are not self closing.
-      if (
-        node instanceof html.Block ||
-        (node instanceof html.Element && !this.getTagDefinition(node.name).closedByParent)
-      ) {
+      if (node instanceof html.Block || !this._getTagDefinition(node)?.closedByParent) {
         // Note that we encountered an unexpected close tag but continue processing the element
         // stack so we can assign an `endSourceSpan` if there is a corresponding start tag for this
         // end tag in the stack.
@@ -573,6 +674,53 @@ class _TreeBuilder {
       valueSpan,
       valueTokens.length > 0 ? valueTokens : undefined,
       undefined,
+    );
+  }
+
+  private _consumeDirective(nameToken: DirectiveNameToken): html.Directive {
+    const attributes: html.Attribute[] = [];
+    let startSourceSpanEnd: ParseLocation = nameToken.sourceSpan.end;
+    let endSourceSpan: ParseSourceSpan | null = null;
+    this._advance();
+
+    if (this._peek.type === TokenType.DIRECTIVE_OPEN) {
+      // Capture the opening token in the start span.
+      startSourceSpanEnd = this._peek.sourceSpan.end;
+      this._advance();
+
+      // Cast here is necessary, because TS doesn't know that `_advance` changed `_peek`.
+      while ((this._peek as Token).type === TokenType.ATTR_NAME) {
+        attributes.push(this._consumeAttr(this._advance<AttributeNameToken>()));
+      }
+
+      if ((this._peek as Token).type === TokenType.DIRECTIVE_CLOSE) {
+        endSourceSpan = this._peek.sourceSpan;
+        this._advance();
+      } else {
+        this.errors.push(
+          TreeError.create(null, nameToken.sourceSpan, 'Unterminated directive definition'),
+        );
+      }
+    }
+
+    const startSourceSpan = new ParseSourceSpan(
+      nameToken.sourceSpan.start,
+      startSourceSpanEnd,
+      nameToken.sourceSpan.fullStart,
+    );
+
+    const sourceSpan = new ParseSourceSpan(
+      startSourceSpan.start,
+      endSourceSpan === null ? nameToken.sourceSpan.end : endSourceSpan.end,
+      startSourceSpan.fullStart,
+    );
+
+    return new html.Directive(
+      nameToken.parts[0],
+      attributes,
+      sourceSpan,
+      startSourceSpan,
+      endSourceSpan,
     );
   }
 
@@ -727,10 +875,11 @@ class _TreeBuilder {
       : null;
   }
 
-  private _getClosestParentElement(): html.Element | null {
+  private _getClosestElementLikeParent(): html.Element | html.Component | null {
     for (let i = this._containerStack.length - 1; i > -1; i--) {
-      if (this._containerStack[i] instanceof html.Element) {
-        return this._containerStack[i] as html.Element;
+      const current = this._containerStack[i];
+      if (current instanceof html.Element || current instanceof html.Component) {
+        return current;
       }
     }
 
@@ -748,22 +897,83 @@ class _TreeBuilder {
   }
 
   private _getElementFullName(
-    prefix: string,
-    localName: string,
-    parentElement: html.Element | null,
+    token: TagOpenStartToken | IncompleteTagOpenToken | TagCloseToken,
+    parent: html.Element | html.Component | null,
   ): string {
-    if (prefix === '') {
-      prefix = this.getTagDefinition(localName).implicitNamespacePrefix || '';
-      if (prefix === '' && parentElement != null) {
-        const parentTagName = splitNsName(parentElement.name)[1];
-        const parentTagDefinition = this.getTagDefinition(parentTagName);
-        if (!parentTagDefinition.preventNamespaceInheritance) {
-          prefix = getNsPrefix(parentElement.name);
+    const prefix = this._getPrefix(token, parent);
+    return mergeNsAndName(prefix, token.parts[1]);
+  }
+
+  private _getComponentFullName(
+    token: ComponentOpenStartToken | IncompleteComponentOpenToken | ComponentCloseToken,
+    parent: html.Element | html.Component | null,
+  ): string {
+    const componentName = token.parts[0];
+    const tagName = this._getComponentTagName(token, parent);
+
+    if (tagName === null) {
+      return componentName;
+    }
+
+    return tagName.startsWith(':') ? componentName + tagName : `${componentName}:${tagName}`;
+  }
+
+  private _getComponentTagName(
+    token: ComponentOpenStartToken | IncompleteComponentOpenToken | ComponentCloseToken,
+    parent: html.Element | html.Component | null,
+  ): string | null {
+    const prefix = this._getPrefix(token, parent);
+    const tagName = token.parts[2];
+
+    if (!prefix && !tagName) {
+      return null;
+    } else if (!prefix && tagName) {
+      return tagName;
+    } else {
+      // TODO(crisbeto): re-evaluate this fallback. Maybe base it off the class name?
+      return mergeNsAndName(prefix, tagName || 'ng-component');
+    }
+  }
+
+  private _getPrefix(
+    token:
+      | TagOpenStartToken
+      | IncompleteTagOpenToken
+      | ComponentOpenStartToken
+      | IncompleteComponentOpenToken
+      | TagCloseToken
+      | ComponentCloseToken,
+    parent: html.Element | html.Component | null,
+  ): string {
+    let prefix: string;
+    let tagName: string;
+
+    if (
+      token.type === TokenType.COMPONENT_OPEN_START ||
+      token.type === TokenType.INCOMPLETE_COMPONENT_OPEN ||
+      token.type === TokenType.COMPONENT_CLOSE
+    ) {
+      prefix = token.parts[1];
+      tagName = token.parts[2];
+    } else {
+      prefix = token.parts[0];
+      tagName = token.parts[1];
+    }
+
+    prefix = prefix || this._getTagDefinition(tagName)?.implicitNamespacePrefix || '';
+
+    if (!prefix && parent) {
+      const parentName = parent instanceof html.Element ? parent.name : parent.tagName;
+      if (parentName !== null) {
+        const parentTagName = splitNsName(parentName)[1];
+        const parentTagDefinition = this._getTagDefinition(parentTagName);
+        if (parentTagDefinition !== null && !parentTagDefinition.preventNamespaceInheritance) {
+          prefix = getNsPrefix(parentName);
         }
       }
     }
 
-    return mergeNsAndName(prefix, localName);
+    return prefix;
   }
 }
 

--- a/packages/compiler/src/ml_parser/parser.ts
+++ b/packages/compiler/src/ml_parser/parser.ts
@@ -420,7 +420,8 @@ class _TreeBuilder {
       end,
       startTagToken.sourceSpan.fullStart,
     );
-    const el = new html.Element(fullName, attrs, [], span, startSpan, undefined);
+    // TODO: capture directives.
+    const el = new html.Element(fullName, attrs, [], [], span, startSpan, undefined);
     const parentEl = this._getContainer();
     this._pushContainer(
       el,

--- a/packages/compiler/src/ml_parser/tokens.ts
+++ b/packages/compiler/src/ml_parser/tokens.ts
@@ -42,6 +42,11 @@ export const enum TokenType {
   LET_VALUE,
   LET_END,
   INCOMPLETE_LET,
+  COMPONENT_OPEN_START,
+  COMPONENT_OPEN_END,
+  COMPONENT_OPEN_END_VOID,
+  COMPONENT_CLOSE,
+  INCOMPLETE_COMPONENT_OPEN,
   EOF,
 }
 
@@ -77,7 +82,12 @@ export type Token =
   | LetStartToken
   | LetValueToken
   | LetEndToken
-  | IncompleteLetToken;
+  | IncompleteLetToken
+  | ComponentOpenStartToken
+  | ComponentOpenEndToken
+  | ComponentOpenEndVoidToken
+  | ComponentCloseToken
+  | IncompleteComponentOpenToken;
 
 export type InterpolatedTextToken = TextToken | InterpolationToken | EncodedEntityToken;
 
@@ -254,4 +264,29 @@ export interface LetEndToken extends TokenBase {
 export interface IncompleteLetToken extends TokenBase {
   type: TokenType.INCOMPLETE_LET;
   parts: [name: string];
+}
+
+export interface ComponentOpenStartToken extends TokenBase {
+  type: TokenType.COMPONENT_OPEN_START;
+  parts: [componentName: string, prefix: string, tagName: string];
+}
+
+export interface ComponentOpenEndToken extends TokenBase {
+  type: TokenType.COMPONENT_OPEN_END;
+  parts: [];
+}
+
+export interface ComponentOpenEndVoidToken extends TokenBase {
+  type: TokenType.COMPONENT_OPEN_END_VOID;
+  parts: [];
+}
+
+export interface ComponentCloseToken extends TokenBase {
+  type: TokenType.COMPONENT_CLOSE;
+  parts: [componentName: string, prefix: string, tagName: string];
+}
+
+export interface IncompleteComponentOpenToken extends TokenBase {
+  type: TokenType.INCOMPLETE_COMPONENT_OPEN;
+  parts: [componentName: string, prefix: string, tagName: string];
 }

--- a/packages/compiler/src/ml_parser/tokens.ts
+++ b/packages/compiler/src/ml_parser/tokens.ts
@@ -47,6 +47,9 @@ export const enum TokenType {
   COMPONENT_OPEN_END_VOID,
   COMPONENT_CLOSE,
   INCOMPLETE_COMPONENT_OPEN,
+  DIRECTIVE_NAME,
+  DIRECTIVE_OPEN,
+  DIRECTIVE_CLOSE,
   EOF,
 }
 
@@ -87,7 +90,10 @@ export type Token =
   | ComponentOpenEndToken
   | ComponentOpenEndVoidToken
   | ComponentCloseToken
-  | IncompleteComponentOpenToken;
+  | IncompleteComponentOpenToken
+  | DirectiveNameToken
+  | DirectiveOpenToken
+  | DirectiveCloseToken;
 
 export type InterpolatedTextToken = TextToken | InterpolationToken | EncodedEntityToken;
 
@@ -289,4 +295,19 @@ export interface ComponentCloseToken extends TokenBase {
 export interface IncompleteComponentOpenToken extends TokenBase {
   type: TokenType.INCOMPLETE_COMPONENT_OPEN;
   parts: [componentName: string, prefix: string, tagName: string];
+}
+
+export interface DirectiveNameToken extends TokenBase {
+  type: TokenType.DIRECTIVE_NAME;
+  parts: [name: string];
+}
+
+export interface DirectiveOpenToken extends TokenBase {
+  type: TokenType.DIRECTIVE_OPEN;
+  parts: [];
+}
+
+export interface DirectiveCloseToken extends TokenBase {
+  type: TokenType.DIRECTIVE_CLOSE;
+  parts: [];
 }

--- a/packages/compiler/src/ml_parser/xml_parser.ts
+++ b/packages/compiler/src/ml_parser/xml_parser.ts
@@ -17,6 +17,11 @@ export class XmlParser extends Parser {
 
   override parse(source: string, url: string, options: TokenizeOptions = {}): ParseTreeResult {
     // Blocks and let declarations aren't supported in an XML context.
-    return super.parse(source, url, {...options, tokenizeBlocks: false, tokenizeLet: false});
+    return super.parse(source, url, {
+      ...options,
+      tokenizeBlocks: false,
+      tokenizeLet: false,
+      selectorlessEnabled: false,
+    });
   }
 }

--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -162,6 +162,7 @@ export class Element implements Node {
     public attributes: TextAttribute[],
     public inputs: BoundAttribute[],
     public outputs: BoundEvent[],
+    public directives: Directive[],
     public children: Node[],
     public references: Reference[],
     public sourceSpan: ParseSourceSpan,
@@ -538,6 +539,44 @@ export class LetDeclaration implements Node {
   }
 }
 
+export class Component implements Node {
+  constructor(
+    public componentName: string,
+    public tagName: string | null,
+    public fullName: string,
+    public attributes: TextAttribute[],
+    public inputs: BoundAttribute[],
+    public outputs: BoundEvent[],
+    public directives: Directive[],
+    public children: Node[],
+    public references: Reference[],
+    public sourceSpan: ParseSourceSpan,
+    public startSourceSpan: ParseSourceSpan,
+    public endSourceSpan: ParseSourceSpan | null,
+    public i18n?: I18nMeta,
+  ) {}
+  visit<Result>(visitor: Visitor<Result>): Result {
+    return visitor.visitComponent(this);
+  }
+}
+
+export class Directive implements Node {
+  constructor(
+    public name: string,
+    public attributes: TextAttribute[],
+    public inputs: BoundAttribute[],
+    public outputs: BoundEvent[],
+    public references: Reference[],
+    public sourceSpan: ParseSourceSpan,
+    public startSourceSpan: ParseSourceSpan,
+    public endSourceSpan: ParseSourceSpan | null,
+    public i18n?: I18nMeta,
+  ) {}
+  visit<Result>(visitor: Visitor<Result>): Result {
+    return visitor.visitDirective(this);
+  }
+}
+
 export class Template implements Node {
   constructor(
     // tagName is the name of the container element, if applicable.
@@ -548,6 +587,7 @@ export class Template implements Node {
     public attributes: TextAttribute[],
     public inputs: BoundAttribute[],
     public outputs: BoundEvent[],
+    public directives: Directive[],
     public templateAttrs: (BoundAttribute | TextAttribute)[],
     public children: Node[],
     public references: Reference[],
@@ -665,6 +705,8 @@ export interface Visitor<Result = any> {
   visitIfBlockBranch(block: IfBlockBranch): Result;
   visitUnknownBlock(block: UnknownBlock): Result;
   visitLetDeclaration(decl: LetDeclaration): Result;
+  visitComponent(component: Component): Result;
+  visitDirective(directive: Directive): Result;
 }
 
 export class RecursiveVisitor implements Visitor<void> {
@@ -672,6 +714,7 @@ export class RecursiveVisitor implements Visitor<void> {
     visitAll(this, element.attributes);
     visitAll(this, element.inputs);
     visitAll(this, element.outputs);
+    visitAll(this, element.directives);
     visitAll(this, element.children);
     visitAll(this, element.references);
   }
@@ -679,6 +722,7 @@ export class RecursiveVisitor implements Visitor<void> {
     visitAll(this, template.attributes);
     visitAll(this, template.inputs);
     visitAll(this, template.outputs);
+    visitAll(this, template.directives);
     visitAll(this, template.children);
     visitAll(this, template.references);
     visitAll(this, template.variables);
@@ -719,6 +763,20 @@ export class RecursiveVisitor implements Visitor<void> {
   }
   visitContent(content: Content): void {
     visitAll(this, content.children);
+  }
+  visitComponent(component: Component): void {
+    visitAll(this, component.attributes);
+    visitAll(this, component.inputs);
+    visitAll(this, component.outputs);
+    visitAll(this, component.directives);
+    visitAll(this, component.children);
+    visitAll(this, component.references);
+  }
+  visitDirective(directive: Directive): void {
+    visitAll(this, directive.attributes);
+    visitAll(this, directive.inputs);
+    visitAll(this, directive.outputs);
+    visitAll(this, directive.references);
   }
   visitVariable(variable: Variable): void {}
   visitReference(reference: Reference): void {}

--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -610,6 +610,8 @@ export class Content implements Node {
     public attributes: TextAttribute[],
     public children: Node[],
     public sourceSpan: ParseSourceSpan,
+    public startSourceSpan: ParseSourceSpan,
+    public endSourceSpan: ParseSourceSpan | null,
     public i18n?: I18nMeta,
   ) {}
   visit<Result>(visitor: Visitor<Result>): Result {

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -406,6 +406,14 @@ class HtmlAstToIvyAst implements html.Visitor {
     return new t.LetDeclaration(decl.name, value, decl.sourceSpan, decl.nameSpan, decl.valueSpan);
   }
 
+  visitComponent(component: html.Component, context: any) {
+    throw new Error('TODO');
+  }
+
+  visitDirective(directive: html.Directive, context: any) {
+    throw new Error('TODO');
+  }
+
   visitBlockParameter() {
     return null;
   }
@@ -913,6 +921,14 @@ class NonBindableVisitor implements html.Visitor {
 
   visitLetDeclaration(decl: html.LetDeclaration, context: any) {
     return new t.Text(`@let ${decl.name} = ${decl.value};`, decl.sourceSpan);
+  }
+
+  visitComponent(ast: html.Component, context: any) {
+    throw new Error('TODO');
+  }
+
+  visitDirective(directive: html.Directive, context: any) {
+    throw new Error('TODO');
   }
 }
 

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -239,7 +239,15 @@ class HtmlAstToIvyAst implements html.Visitor {
     if (preparsedElement.type === PreparsedElementType.NG_CONTENT) {
       const selector = preparsedElement.selectAttr;
       const attrs: t.TextAttribute[] = element.attrs.map((attr) => this.visitAttribute(attr));
-      parsedElement = new t.Content(selector, attrs, children, element.sourceSpan, element.i18n);
+      parsedElement = new t.Content(
+        selector,
+        attrs,
+        children,
+        element.sourceSpan,
+        element.startSourceSpan,
+        element.endSourceSpan,
+        element.i18n,
+      );
       this.ngContentSelectors.push(selector);
     } else if (isTemplateElement) {
       // `<ng-template>`

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -6,7 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {EmptyExpr, ParsedEvent, ParsedProperty, ParsedVariable} from '../expression_parser/ast';
+import {
+  BindingType,
+  EmptyExpr,
+  ParsedEvent,
+  ParsedProperty,
+  ParsedVariable,
+} from '../expression_parser/ast';
 import * as i18n from '../i18n/i18n_ast';
 import * as html from '../ml_parser/ast';
 import {replaceNgsp} from '../ml_parser/html_whitespaces';
@@ -53,6 +59,19 @@ const BINDING_DELIMS = {
 };
 
 const TEMPLATE_ATTR_PREFIX = '*';
+
+// TODO(crisbeto): any other tag names that shouldn't be allowed here?
+const UNSUPPORTED_SELECTORLESS_TAGS = new Set([
+  'link',
+  'style',
+  'script',
+  'ng-template',
+  'ng-container',
+  'ng-content',
+]);
+
+// TODO(crisbeto): any other attributes that should not be allowed here?
+const UNSUPPORTED_SELECTORLESS_DIRECTIVE_ATTRS = new Set(['ngProjectAs', 'ngNonBindable']);
 
 // Result of the html AST to Ivy AST transformation
 export interface Render3ParseResult {
@@ -144,86 +163,19 @@ class HtmlAstToIvyAst implements html.Visitor {
 
     // Whether the element is a `<ng-template>`
     const isTemplateElement = isNgTemplate(element.name);
+    const {
+      attributes,
+      boundEvents,
+      references,
+      variables,
+      templateVariables,
+      elementHasInlineTemplate,
+      parsedProperties,
+      templateParsedProperties,
+      i18nAttrsMeta,
+    } = this.prepareAttributes(element.attrs, isTemplateElement);
 
-    const parsedProperties: ParsedProperty[] = [];
-    const boundEvents: t.BoundEvent[] = [];
-    const variables: t.Variable[] = [];
-    const references: t.Reference[] = [];
-    const attributes: t.TextAttribute[] = [];
-    const i18nAttrsMeta: {[key: string]: i18n.I18nMeta} = {};
-
-    const templateParsedProperties: ParsedProperty[] = [];
-    const templateVariables: t.Variable[] = [];
-
-    // Whether the element has any *-attribute
-    let elementHasInlineTemplate = false;
-
-    for (const attribute of element.attrs) {
-      let hasBinding = false;
-      const normalizedName = normalizeAttributeName(attribute.name);
-
-      // `*attr` defines template bindings
-      let isTemplateBinding = false;
-
-      if (attribute.i18n) {
-        i18nAttrsMeta[attribute.name] = attribute.i18n;
-      }
-
-      if (normalizedName.startsWith(TEMPLATE_ATTR_PREFIX)) {
-        // *-attributes
-        if (elementHasInlineTemplate) {
-          this.reportError(
-            `Can't have multiple template bindings on one element. Use only one attribute prefixed with *`,
-            attribute.sourceSpan,
-          );
-        }
-        isTemplateBinding = true;
-        elementHasInlineTemplate = true;
-        const templateValue = attribute.value;
-        const templateKey = normalizedName.substring(TEMPLATE_ATTR_PREFIX.length);
-
-        const parsedVariables: ParsedVariable[] = [];
-        const absoluteValueOffset = attribute.valueSpan
-          ? attribute.valueSpan.start.offset
-          : // If there is no value span the attribute does not have a value, like `attr` in
-            //`<div attr></div>`. In this case, point to one character beyond the last character of
-            // the attribute name.
-            attribute.sourceSpan.start.offset + attribute.name.length;
-
-        this.bindingParser.parseInlineTemplateBinding(
-          templateKey,
-          templateValue,
-          attribute.sourceSpan,
-          absoluteValueOffset,
-          [],
-          templateParsedProperties,
-          parsedVariables,
-          true /* isIvyAst */,
-        );
-        templateVariables.push(
-          ...parsedVariables.map(
-            (v) => new t.Variable(v.name, v.value, v.sourceSpan, v.keySpan, v.valueSpan),
-          ),
-        );
-      } else {
-        // Check for variables, events, property bindings, interpolation
-        hasBinding = this.parseAttribute(
-          isTemplateElement,
-          attribute,
-          [],
-          parsedProperties,
-          boundEvents,
-          variables,
-          references,
-        );
-      }
-
-      if (!hasBinding && !isTemplateBinding) {
-        // don't include the bindings as attributes as well in the AST
-        attributes.push(this.visitAttribute(attribute));
-      }
-    }
-
+    const directives = this.extractDirectives(element);
     let children: t.Node[];
 
     if (preparsedElement.nonBindable) {
@@ -251,13 +203,18 @@ class HtmlAstToIvyAst implements html.Visitor {
       this.ngContentSelectors.push(selector);
     } else if (isTemplateElement) {
       // `<ng-template>`
-      const attrs = this.extractAttributes(element.name, parsedProperties, i18nAttrsMeta);
+      const attrs = this.categorizePropertyAttributes(
+        element.name,
+        parsedProperties,
+        i18nAttrsMeta,
+      );
 
       parsedElement = new t.Template(
         element.name,
         attributes,
         attrs.bound,
         boundEvents,
+        directives,
         [
           /* no template attributes */
         ],
@@ -270,12 +227,17 @@ class HtmlAstToIvyAst implements html.Visitor {
         element.i18n,
       );
     } else {
-      const attrs = this.extractAttributes(element.name, parsedProperties, i18nAttrsMeta);
+      const attrs = this.categorizePropertyAttributes(
+        element.name,
+        parsedProperties,
+        i18nAttrsMeta,
+      );
       parsedElement = new t.Element(
         element.name,
         attributes,
         attrs.bound,
         boundEvents,
+        directives,
         children,
         references,
         element.sourceSpan,
@@ -288,42 +250,13 @@ class HtmlAstToIvyAst implements html.Visitor {
     if (elementHasInlineTemplate) {
       // If this node is an inline-template (e.g. has *ngFor) then we need to create a template
       // node that contains this node.
-      // Moreover, if the node is an element, then we need to hoist its attributes to the template
-      // node for matching against content projection selectors.
-      const attrs = this.extractAttributes('ng-template', templateParsedProperties, i18nAttrsMeta);
-      const templateAttrs: (t.TextAttribute | t.BoundAttribute)[] = [];
-      attrs.literal.forEach((attr) => templateAttrs.push(attr));
-      attrs.bound.forEach((attr) => templateAttrs.push(attr));
-      const hoistedAttrs =
-        parsedElement instanceof t.Element
-          ? {
-              attributes: parsedElement.attributes,
-              inputs: parsedElement.inputs,
-              outputs: parsedElement.outputs,
-            }
-          : {attributes: [], inputs: [], outputs: []};
-
-      // For <ng-template>s with structural directives on them, avoid passing i18n information to
-      // the wrapping template to prevent unnecessary i18n instructions from being generated. The
-      // necessary i18n meta information will be extracted from child elements.
-      const i18n = isTemplateElement && isI18nRootElement ? undefined : element.i18n;
-      const name = parsedElement instanceof t.Template ? null : parsedElement.name;
-
-      parsedElement = new t.Template(
-        name,
-        hoistedAttrs.attributes,
-        hoistedAttrs.inputs,
-        hoistedAttrs.outputs,
-        templateAttrs,
-        [parsedElement],
-        [
-          /* no references */
-        ],
+      parsedElement = this.wrapInTemplate(
+        parsedElement,
+        templateParsedProperties,
         templateVariables,
-        element.sourceSpan,
-        element.startSourceSpan,
-        element.endSourceSpan,
-        i18n,
+        i18nAttrsMeta,
+        isTemplateElement,
+        isI18nRootElement,
       );
     }
     if (isI18nRootElement) {
@@ -414,12 +347,89 @@ class HtmlAstToIvyAst implements html.Visitor {
     return new t.LetDeclaration(decl.name, value, decl.sourceSpan, decl.nameSpan, decl.valueSpan);
   }
 
-  visitComponent(component: html.Component, context: any) {
-    throw new Error('TODO');
+  visitComponent(component: html.Component) {
+    const isI18nRootElement = isI18nRootNode(component.i18n);
+    if (isI18nRootElement) {
+      if (this.inI18nBlock) {
+        this.reportError(
+          'Cannot mark a component as translatable inside of a translatable section. Please remove the nested i18n marker.',
+          component.sourceSpan,
+        );
+      }
+      this.inI18nBlock = true;
+    }
+
+    if (component.tagName !== null && UNSUPPORTED_SELECTORLESS_TAGS.has(component.tagName)) {
+      this.reportError(
+        `Tag name "${component.tagName}" cannot be used as a component tag`,
+        component.startSourceSpan,
+      );
+      return null;
+    }
+
+    const {
+      attributes,
+      boundEvents,
+      references,
+      templateVariables,
+      elementHasInlineTemplate,
+      parsedProperties,
+      templateParsedProperties,
+      i18nAttrsMeta,
+    } = this.prepareAttributes(component.attrs, false);
+
+    const directives = this.extractDirectives(component);
+    let children: t.Node[];
+
+    if (component.attrs.find((attr) => attr.name === 'ngNonBindable')) {
+      // The `NonBindableVisitor` may need to return an array of nodes for blocks so we need
+      // to flatten the array here. Avoid doing this for the `HtmlAstToIvyAst` since `flat` creates
+      // a new array.
+      children = html.visitAll(NON_BINDABLE_VISITOR, component.children).flat(Infinity);
+    } else {
+      children = html.visitAll(this, component.children, component.children);
+    }
+
+    const attrs = this.categorizePropertyAttributes(
+      component.tagName,
+      parsedProperties,
+      i18nAttrsMeta,
+    );
+
+    let node: t.Component | t.Template = new t.Component(
+      component.componentName,
+      component.tagName,
+      component.fullName,
+      attributes,
+      attrs.bound,
+      boundEvents,
+      directives,
+      children,
+      references,
+      component.sourceSpan,
+      component.startSourceSpan,
+      component.endSourceSpan,
+      component.i18n,
+    );
+
+    if (elementHasInlineTemplate) {
+      node = this.wrapInTemplate(
+        node,
+        templateParsedProperties,
+        templateVariables,
+        i18nAttrsMeta,
+        false,
+        isI18nRootElement,
+      );
+    }
+    if (isI18nRootElement) {
+      this.inI18nBlock = false;
+    }
+    return node;
   }
 
-  visitDirective(directive: html.Directive, context: any) {
-    throw new Error('TODO');
+  visitDirective() {
+    return null;
   }
 
   visitBlockParameter() {
@@ -536,9 +546,9 @@ class HtmlAstToIvyAst implements html.Visitor {
     return relatedBlocks;
   }
 
-  // convert view engine `ParsedProperty` to a format suitable for IVY
-  private extractAttributes(
-    elementName: string,
+  /** Splits up the property attributes depending on whether they're static or bound. */
+  private categorizePropertyAttributes(
+    elementName: string | null,
     properties: ParsedProperty[],
     i18nPropsMeta: {[key: string]: i18n.I18nMeta},
   ): {bound: t.BoundAttribute[]; literal: t.TextAttribute[]} {
@@ -573,6 +583,98 @@ class HtmlAstToIvyAst implements html.Visitor {
     });
 
     return {bound, literal};
+  }
+
+  private prepareAttributes(attrs: html.Attribute[], isTemplateElement: boolean) {
+    const parsedProperties: ParsedProperty[] = [];
+    const boundEvents: t.BoundEvent[] = [];
+    const variables: t.Variable[] = [];
+    const references: t.Reference[] = [];
+    const attributes: t.TextAttribute[] = [];
+    const i18nAttrsMeta: Record<string, i18n.I18nMeta> = {};
+    const templateParsedProperties: ParsedProperty[] = [];
+    const templateVariables: t.Variable[] = [];
+
+    // Whether the element has any *-attribute
+    let elementHasInlineTemplate = false;
+
+    for (const attribute of attrs) {
+      let hasBinding = false;
+      const normalizedName = normalizeAttributeName(attribute.name);
+
+      // `*attr` defines template bindings
+      let isTemplateBinding = false;
+
+      if (attribute.i18n) {
+        i18nAttrsMeta[attribute.name] = attribute.i18n;
+      }
+
+      if (normalizedName.startsWith(TEMPLATE_ATTR_PREFIX)) {
+        // *-attributes
+        if (elementHasInlineTemplate) {
+          this.reportError(
+            `Can't have multiple template bindings on one element. Use only one attribute prefixed with *`,
+            attribute.sourceSpan,
+          );
+        }
+        isTemplateBinding = true;
+        elementHasInlineTemplate = true;
+        const templateValue = attribute.value;
+        const templateKey = normalizedName.substring(TEMPLATE_ATTR_PREFIX.length);
+
+        const parsedVariables: ParsedVariable[] = [];
+        const absoluteValueOffset = attribute.valueSpan
+          ? attribute.valueSpan.start.offset
+          : // If there is no value span the attribute does not have a value, like `attr` in
+            //`<div attr></div>`. In this case, point to one character beyond the last character of
+            // the attribute name.
+            attribute.sourceSpan.start.offset + attribute.name.length;
+
+        this.bindingParser.parseInlineTemplateBinding(
+          templateKey,
+          templateValue,
+          attribute.sourceSpan,
+          absoluteValueOffset,
+          [],
+          templateParsedProperties,
+          parsedVariables,
+          true /* isIvyAst */,
+        );
+        templateVariables.push(
+          ...parsedVariables.map(
+            (v) => new t.Variable(v.name, v.value, v.sourceSpan, v.keySpan, v.valueSpan),
+          ),
+        );
+      } else {
+        // Check for variables, events, property bindings, interpolation
+        hasBinding = this.parseAttribute(
+          isTemplateElement,
+          attribute,
+          [],
+          parsedProperties,
+          boundEvents,
+          variables,
+          references,
+        );
+      }
+
+      if (!hasBinding && !isTemplateBinding) {
+        // don't include the bindings as attributes as well in the AST
+        attributes.push(this.visitAttribute(attribute));
+      }
+    }
+
+    return {
+      attributes,
+      boundEvents,
+      references,
+      variables,
+      templateVariables,
+      elementHasInlineTemplate,
+      parsedProperties,
+      templateParsedProperties,
+      i18nAttrsMeta,
+    };
   }
 
   private parseAttribute(
@@ -774,6 +876,145 @@ class HtmlAstToIvyAst implements html.Visitor {
     return hasBinding;
   }
 
+  private extractDirectives(node: html.Element | html.Component): t.Directive[] {
+    const elementName = node instanceof html.Component ? node.tagName : node.name;
+    const directives: t.Directive[] = [];
+    const seenDirectives = new Set<string>();
+
+    for (const directive of node.directives) {
+      let invalid = false;
+
+      for (const attr of directive.attrs) {
+        if (attr.name.startsWith(TEMPLATE_ATTR_PREFIX)) {
+          invalid = true;
+          this.reportError(
+            `Shorthand template syntax "${attr.name}" is not supported inside a directive context`,
+            attr.sourceSpan,
+          );
+        } else if (UNSUPPORTED_SELECTORLESS_DIRECTIVE_ATTRS.has(attr.name)) {
+          invalid = true;
+          this.reportError(
+            `Attribute "${attr.name}" is not supported in a directive context`,
+            attr.sourceSpan,
+          );
+        }
+      }
+
+      if (!invalid && seenDirectives.has(directive.name)) {
+        invalid = true;
+        this.reportError(
+          `Cannot apply directive "${directive.name}" multiple times on the same element`,
+          directive.sourceSpan,
+        );
+      }
+
+      if (invalid) {
+        continue;
+      }
+
+      const {attributes, parsedProperties, boundEvents, references, i18nAttrsMeta} =
+        this.prepareAttributes(directive.attrs, false);
+      const {bound: inputs} = this.categorizePropertyAttributes(
+        elementName,
+        parsedProperties,
+        i18nAttrsMeta,
+      );
+
+      for (const input of inputs) {
+        if (input.type !== BindingType.Property && input.type !== BindingType.TwoWay) {
+          invalid = true;
+          this.reportError('Binding is not supported in a directive context', input.sourceSpan);
+        }
+      }
+
+      if (invalid) {
+        continue;
+      }
+
+      seenDirectives.add(directive.name);
+      directives.push(
+        new t.Directive(
+          directive.name,
+          attributes,
+          inputs,
+          boundEvents,
+          references,
+          directive.sourceSpan,
+          directive.startSourceSpan,
+          directive.endSourceSpan,
+          undefined,
+        ),
+      );
+    }
+
+    return directives;
+  }
+
+  private wrapInTemplate(
+    node: t.Element | t.Component | t.Content | t.Template,
+    templateProperties: ParsedProperty[],
+    templateVariables: t.Variable[],
+    i18nAttrsMeta: Record<string, i18n.I18nMeta>,
+    isTemplateElement: boolean,
+    isI18nRootElement: boolean,
+  ) {
+    // We need to hoist the attributes of the node to the template for content projection purposes.
+    const attrs = this.categorizePropertyAttributes(
+      'ng-template',
+      templateProperties,
+      i18nAttrsMeta,
+    );
+    const templateAttrs: (t.TextAttribute | t.BoundAttribute)[] = [];
+    attrs.literal.forEach((attr) => templateAttrs.push(attr));
+    attrs.bound.forEach((attr) => templateAttrs.push(attr));
+
+    const hoistedAttrs = {
+      attributes: [] as t.TextAttribute[],
+      inputs: [] as t.BoundAttribute[],
+      outputs: [] as t.BoundEvent[],
+    };
+
+    if (node instanceof t.Element || node instanceof t.Component) {
+      hoistedAttrs.attributes.push(...node.attributes);
+      hoistedAttrs.inputs.push(...node.inputs);
+      hoistedAttrs.outputs.push(...node.outputs);
+    }
+
+    // For <ng-template>s with structural directives on them, avoid passing i18n information to
+    // the wrapping template to prevent unnecessary i18n instructions from being generated. The
+    // necessary i18n meta information will be extracted from child elements.
+    const i18n = isTemplateElement && isI18nRootElement ? undefined : node.i18n;
+    let name: string | null;
+
+    if (node instanceof t.Component) {
+      name = node.tagName;
+    } else if (node instanceof t.Template) {
+      name = null;
+    } else {
+      name = node.name;
+    }
+
+    return new t.Template(
+      name,
+      hoistedAttrs.attributes,
+      hoistedAttrs.inputs,
+      hoistedAttrs.outputs,
+      [
+        // Do not copy over the directives.
+      ],
+      templateAttrs,
+      [node],
+      [
+        // Do not copy over the references.
+      ],
+      templateVariables,
+      node.sourceSpan,
+      node.startSourceSpan,
+      node.endSourceSpan,
+      i18n,
+    );
+  }
+
   private _visitTextWithInterpolation(
     value: string,
     sourceSpan: ParseSourceSpan,
@@ -873,6 +1114,7 @@ class NonBindableVisitor implements html.Visitor {
       html.visitAll(this, ast.attrs) as t.TextAttribute[],
       /* inputs */ [],
       /* outputs */ [],
+      /* directives */ [],
       children,
       /* references */ [],
       ast.sourceSpan,
@@ -932,11 +1174,23 @@ class NonBindableVisitor implements html.Visitor {
   }
 
   visitComponent(ast: html.Component, context: any) {
-    throw new Error('TODO');
+    const children: t.Node[] = html.visitAll(this, ast.children, null);
+    return new t.Element(
+      ast.fullName,
+      html.visitAll(this, ast.attrs) as t.TextAttribute[],
+      /* inputs */ [],
+      /* outputs */ [],
+      /* directives */ [],
+      children,
+      /* references */ [],
+      ast.sourceSpan,
+      ast.startSourceSpan,
+      ast.endSourceSpan,
+    );
   }
 
   visitDirective(directive: html.Directive, context: any) {
-    throw new Error('TODO');
+    return null;
   }
 }
 

--- a/packages/compiler/src/render3/view/i18n/util.ts
+++ b/packages/compiler/src/render3/view/i18n/util.ts
@@ -21,8 +21,8 @@ export function isI18nAttribute(name: string): boolean {
   return name === I18N_ATTR || name.startsWith(I18N_ATTR_PREFIX);
 }
 
-export function hasI18nAttrs(element: html.Element): boolean {
-  return element.attrs.some((attr: html.Attribute) => isI18nAttribute(attr.name));
+export function hasI18nAttrs(node: html.Element | html.Component): boolean {
+  return node.attrs.some((attr: html.Attribute) => isI18nAttribute(attr.name));
 }
 
 export function icuFromI18nMessage(message: i18n.Message) {

--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -22,12 +22,14 @@ import {
   BoundEvent,
   BoundText,
   Comment,
+  Component,
   Content,
   DeferredBlock,
   DeferredBlockError,
   DeferredBlockLoading,
   DeferredBlockPlaceholder,
   DeferredTrigger,
+  Directive,
   Element,
   ForLoopBlock,
   ForLoopBlockEmpty,
@@ -338,6 +340,8 @@ class Scope implements Visitor {
   }
 
   visitElement(element: Element) {
+    element.directives.forEach((node) => node.visit(this));
+
     // `Element`s in the template may have `Reference`s which are captured in the scope.
     element.references.forEach((node) => this.visitReference(node));
 
@@ -348,6 +352,8 @@ class Scope implements Visitor {
   }
 
   visitTemplate(template: Template) {
+    template.directives.forEach((node) => node.visit(this));
+
     // References on a <ng-template> are defined in the outer scope, so capture them before
     // processing the template's child scope.
     template.references.forEach((node) => this.visitReference(node));
@@ -416,6 +422,14 @@ class Scope implements Visitor {
 
   visitLetDeclaration(decl: LetDeclaration) {
     this.maybeDeclare(decl);
+  }
+
+  visitComponent(component: Component) {
+    throw new Error('TODO');
+  }
+
+  visitDirective(directive: Directive) {
+    throw new Error('TODO');
   }
 
   // Unused visitors.
@@ -536,6 +550,11 @@ class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
     // First, determine the HTML shape of the node for the purpose of directive matching.
     // Do this by building up a `CssSelector` for the node.
     const cssSelector = createCssSelectorFromNode(node);
+
+    // TODO(crisbeto): account for selectorless directives here.
+    if (node.directives.length > 0) {
+      throw new Error('TODO');
+    }
 
     // Next, use the `SelectorMatcher` to get the list of directives on the node.
     const directives: DirectiveT[] = [];
@@ -658,6 +677,14 @@ class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
 
   visitContent(content: Content): void {
     content.children.forEach((child) => child.visit(this));
+  }
+
+  visitComponent(component: Component) {
+    throw new Error('TODO');
+  }
+
+  visitDirective(directive: Directive) {
+    throw new Error('TODO');
   }
 
   // Unused visitors.
@@ -806,6 +833,7 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
     // Visit the inputs, outputs, and children of the element.
     element.inputs.forEach(this.visitNode);
     element.outputs.forEach(this.visitNode);
+    element.directives.forEach(this.visitNode);
     element.children.forEach(this.visitNode);
     element.references.forEach(this.visitNode);
   }
@@ -814,6 +842,7 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
     // First, visit inputs, outputs and template attributes of the template node.
     template.inputs.forEach(this.visitNode);
     template.outputs.forEach(this.visitNode);
+    template.directives.forEach(this.visitNode);
     template.templateAttrs.forEach(this.visitNode);
     template.references.forEach(this.visitNode);
 
@@ -833,6 +862,14 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
     if (this.rootNode !== null) {
       this.symbols.set(reference, this.rootNode);
     }
+  }
+
+  visitComponent(component: Component) {
+    throw new Error('TODO');
+  }
+
+  visitDirective(directive: Directive) {
+    throw new Error('TODO');
   }
 
   // Unused template visitors

--- a/packages/compiler/test/ml_parser/ast_spec_utils.ts
+++ b/packages/compiler/test/ml_parser/ast_spec_utils.ts
@@ -39,7 +39,7 @@ class _Humanizer implements html.Visitor {
 
   constructor(private includeSourceSpan: boolean) {}
 
-  visitElement(element: html.Element, context: any): any {
+  visitElement(element: html.Element): any {
     const res = this._appendContext(element, [html.Element, element.name, this.elDepth++]);
     if (this.includeSourceSpan) {
       res.push(element.startSourceSpan.toString() ?? null);
@@ -47,11 +47,12 @@ class _Humanizer implements html.Visitor {
     }
     this.result.push(res);
     html.visitAll(this, element.attrs);
+    html.visitAll(this, element.directives);
     html.visitAll(this, element.children);
     this.elDepth--;
   }
 
-  visitAttribute(attribute: html.Attribute, context: any): any {
+  visitAttribute(attribute: html.Attribute): any {
     const valueTokens = attribute.valueTokens ?? [];
     const res = this._appendContext(attribute, [
       html.Attribute,
@@ -62,7 +63,7 @@ class _Humanizer implements html.Visitor {
     this.result.push(res);
   }
 
-  visitText(text: html.Text, context: any): any {
+  visitText(text: html.Text): any {
     const res = this._appendContext(text, [
       html.Text,
       text.value,
@@ -72,12 +73,12 @@ class _Humanizer implements html.Visitor {
     this.result.push(res);
   }
 
-  visitComment(comment: html.Comment, context: any): any {
+  visitComment(comment: html.Comment): any {
     const res = this._appendContext(comment, [html.Comment, comment.value, this.elDepth]);
     this.result.push(res);
   }
 
-  visitExpansion(expansion: html.Expansion, context: any): any {
+  visitExpansion(expansion: html.Expansion): any {
     const res = this._appendContext(expansion, [
       html.Expansion,
       expansion.switchValue,
@@ -89,7 +90,7 @@ class _Humanizer implements html.Visitor {
     this.elDepth--;
   }
 
-  visitExpansionCase(expansionCase: html.ExpansionCase, context: any): any {
+  visitExpansionCase(expansionCase: html.ExpansionCase): any {
     const res = this._appendContext(expansionCase, [
       html.ExpansionCase,
       expansionCase.value,
@@ -98,7 +99,7 @@ class _Humanizer implements html.Visitor {
     this.result.push(res);
   }
 
-  visitBlock(block: html.Block, context: any) {
+  visitBlock(block: html.Block) {
     const res = this._appendContext(block, [html.Block, block.name, this.elDepth++]);
     if (this.includeSourceSpan) {
       res.push(block.startSourceSpan.toString() ?? null);
@@ -110,11 +111,11 @@ class _Humanizer implements html.Visitor {
     this.elDepth--;
   }
 
-  visitBlockParameter(parameter: html.BlockParameter, context: any) {
+  visitBlockParameter(parameter: html.BlockParameter) {
     this.result.push(this._appendContext(parameter, [html.BlockParameter, parameter.expression]));
   }
 
-  visitLetDeclaration(decl: html.LetDeclaration, context: any) {
+  visitLetDeclaration(decl: html.LetDeclaration) {
     const res = this._appendContext(decl, [html.LetDeclaration, decl.name, decl.value]);
 
     if (this.includeSourceSpan) {
@@ -123,6 +124,33 @@ class _Humanizer implements html.Visitor {
     }
 
     this.result.push(res);
+  }
+
+  visitComponent(node: html.Component): any {
+    const res = this._appendContext(node, [
+      html.Component,
+      node.componentName,
+      node.tagName,
+      node.fullName,
+      this.elDepth++,
+    ]);
+    if (this.includeSourceSpan) {
+      res.push(node.startSourceSpan.toString() ?? null, node.endSourceSpan?.toString() ?? null);
+    }
+    this.result.push(res);
+    html.visitAll(this, node.attrs);
+    html.visitAll(this, node.directives);
+    html.visitAll(this, node.children);
+    this.elDepth--;
+  }
+
+  visitDirective(directive: html.Directive) {
+    const res = this._appendContext(directive, [html.Directive, directive.name]);
+    if (this.includeSourceSpan) {
+      res.push(directive.startSourceSpan.toString(), directive.endSourceSpan?.toString() ?? null);
+    }
+    this.result.push(res);
+    html.visitAll(this, directive.attrs);
   }
 
   private _appendContext(ast: html.Node, input: any[]): any[] {

--- a/packages/compiler/test/ml_parser/util/util.ts
+++ b/packages/compiler/test/ml_parser/util/util.ts
@@ -11,13 +11,13 @@ import {getHtmlTagDefinition} from '../../../src/ml_parser/html_tags';
 
 class _SerializerVisitor implements html.Visitor {
   visitElement(element: html.Element, context: any): any {
+    const attrs = `${this._visitAll(element.attrs, ' ', ' ')}${this._visitAll(element.directives, ' ', ' ')}`;
+
     if (getHtmlTagDefinition(element.name).isVoid) {
-      return `<${element.name}${this._visitAll(element.attrs, ' ', ' ')}/>`;
+      return `<${element.name}${attrs}/>`;
     }
 
-    return `<${element.name}${this._visitAll(element.attrs, ' ', ' ')}>${this._visitAll(
-      element.children,
-    )}</${element.name}>`;
+    return `<${element.name}${attrs}>${this._visitAll(element.children)}</${element.name}>`;
   }
 
   visitAttribute(attribute: html.Attribute, context: any): any {
@@ -52,6 +52,15 @@ class _SerializerVisitor implements html.Visitor {
 
   visitLetDeclaration(decl: html.LetDeclaration, context: any) {
     return `@let ${decl.name} = ${decl.value};`;
+  }
+
+  visitComponent(node: html.Component, context: any): any {
+    const attrs = `${this._visitAll(node.attrs, ' ', ' ')}${this._visitAll(node.directives, ' ', ' ')}`;
+    return `<${node.fullName}${attrs}>${this._visitAll(node.children)}</${node.fullName}>`;
+  }
+
+  visitDirective(directive: html.Directive, context: any) {
+    return `@${directive.name}${this._visitAll(directive.attrs, ' ', ' ')}`;
   }
 
   private _visitAll(nodes: html.Node[], separator = '', prefix = ''): string {

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -137,10 +137,12 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
   }
 
   visitTemplate(ast: t.Template) {
+    t.visitAll(this, ast.directives);
     t.visitAll(this, ast.children);
     t.visitAll(this, ast.templateAttrs);
   }
   visitElement(ast: t.Element) {
+    t.visitAll(this, ast.directives);
     t.visitAll(this, ast.children);
     t.visitAll(this, ast.inputs);
     t.visitAll(this, ast.outputs);
@@ -230,6 +232,18 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
 
   visitLetDeclaration(decl: t.LetDeclaration) {
     decl.value.visit(this);
+  }
+
+  visitComponent(ast: t.Component) {
+    t.visitAll(this, ast.children);
+    t.visitAll(this, ast.directives);
+    t.visitAll(this, ast.inputs);
+    t.visitAll(this, ast.outputs);
+  }
+
+  visitDirective(ast: t.Directive) {
+    t.visitAll(this, ast.inputs);
+    t.visitAll(this, ast.outputs);
   }
 }
 

--- a/packages/compiler/test/render3/view/util.ts
+++ b/packages/compiler/test/render3/view/util.ts
@@ -105,11 +105,13 @@ export function findExpression(tmpl: a.Node[], expr: string): e.AST | null {
 }
 
 function findExpressionInNode(node: a.Node, expr: string): e.AST | null {
-  if (node instanceof a.Element || node instanceof a.Template) {
+  if (node instanceof a.Element || node instanceof a.Template || node instanceof a.Component) {
     return findExpression([...node.inputs, ...node.outputs, ...node.children], expr);
+  } else if (node instanceof a.Directive) {
+    return findExpression([...node.inputs, ...node.outputs], expr);
   } else if (node instanceof a.BoundAttribute || node instanceof a.BoundText) {
     const ts = toStringExpression(node.value);
-    return toStringExpression(node.value) === expr ? node.value : null;
+    return ts === expr ? node.value : null;
   } else if (node instanceof a.BoundEvent) {
     return toStringExpression(node.handler) === expr ? node.handler : null;
   } else {
@@ -148,12 +150,14 @@ export function parseR3(
     preserveWhitespaces?: boolean;
     leadingTriviaChars?: string[];
     ignoreError?: boolean;
+    selectorlessEnabled?: boolean;
   } = {},
 ): Render3ParseResult {
   const htmlParser = new HtmlParser();
   const parseResult = htmlParser.parse(input, 'path:://to/template', {
     tokenizeExpansionForms: true,
     leadingTriviaChars: options.leadingTriviaChars ?? LEADING_TRIVIA_CHARS,
+    selectorlessEnabled: options.selectorlessEnabled,
   });
 
   if (parseResult.errors.length > 0 && !options.ignoreError) {

--- a/packages/core/schematics/utils/template_ast_visitor.ts
+++ b/packages/core/schematics/utils/template_ast_visitor.ts
@@ -33,6 +33,8 @@ import type {
   TmplAstVariable,
   TmplAstUnknownBlock,
   TmplAstLetDeclaration,
+  TmplAstComponent,
+  TmplAstDirective,
 } from '@angular/compiler';
 
 /**
@@ -81,6 +83,8 @@ export class TemplateAstVisitor implements TmplAstRecursiveVisitor {
   visitIfBlock(block: TmplAstIfBlock): void {}
   visitIfBlockBranch(block: TmplAstIfBlockBranch): void {}
   visitLetDeclaration(decl: TmplAstLetDeclaration): void {}
+  visitComponent(component: TmplAstComponent): void {}
+  visitDirective(directive: TmplAstDirective): void {}
 
   /**
    * Visits all the provided nodes in order using this Visitor's visit methods.

--- a/packages/language-service/src/template_target.ts
+++ b/packages/language-service/src/template_target.ts
@@ -21,12 +21,14 @@ import {
   TmplAstBoundDeferredTrigger,
   TmplAstBoundEvent,
   TmplAstBoundText,
+  TmplAstComponent,
   TmplAstContent,
   TmplAstDeferredBlock,
   TmplAstDeferredBlockError,
   TmplAstDeferredBlockLoading,
   TmplAstDeferredBlockPlaceholder,
   TmplAstDeferredTrigger,
+  TmplAstDirective,
   TmplAstElement,
   TmplAstForLoopBlock,
   TmplAstForLoopBlockEmpty,
@@ -480,7 +482,11 @@ class TemplateTargetVisitor implements TmplAstVisitor {
   }
 
   visitElementOrTemplate(element: TmplAstTemplate | TmplAstElement) {
+    const isTemplate = element instanceof TmplAstTemplate;
     this.visitAll(element.attributes);
+    if (!isTemplate) {
+      this.visitAll(element.directives);
+    }
     this.visitAll(element.inputs);
     // We allow the path to contain both the `TmplAstBoundAttribute` and `TmplAstBoundEvent` for
     // two-way bindings but do not want the path to contain both the `TmplAstBoundAttribute` with
@@ -495,11 +501,11 @@ class TemplateTargetVisitor implements TmplAstVisitor {
       return;
     }
     this.visitAll(element.outputs);
-    if (element instanceof TmplAstTemplate) {
+    if (isTemplate) {
       this.visitAll(element.templateAttrs);
     }
     this.visitAll(element.references);
-    if (element instanceof TmplAstTemplate) {
+    if (isTemplate) {
       this.visitAll(element.variables);
     }
 
@@ -618,6 +624,14 @@ class TemplateTargetVisitor implements TmplAstVisitor {
 
   visitLetDeclaration(decl: TmplAstLetDeclaration) {
     this.visitBinding(decl.value);
+  }
+
+  visitComponent(component: TmplAstComponent) {
+    throw new Error('TODO');
+  }
+
+  visitDirective(directive: TmplAstDirective) {
+    throw new Error('TODO');
   }
 
   visitAll(nodes: TmplAstNode[]) {

--- a/packages/localize/tools/src/translate/translation_files/base_visitor.ts
+++ b/packages/localize/tools/src/translate/translation_files/base_visitor.ts
@@ -10,6 +10,8 @@ import {
   Block,
   BlockParameter,
   Comment,
+  Component,
+  Directive,
   Element,
   Expansion,
   ExpansionCase,
@@ -33,4 +35,6 @@ export class BaseVisitor implements Visitor {
   visitBlock(_block: Block, _context: any) {}
   visitBlockParameter(_parameter: BlockParameter, _context: any) {}
   visitLetDeclaration(_decl: LetDeclaration, _context: any) {}
+  visitComponent(_component: Component, _context: any) {}
+  visitDirective(_directive: Directive, _context: any) {}
 }


### PR DESCRIPTION
⚠️ Disclaimer ⚠️ this PR implements syntax that is still being designed and discussed. It's an initial prototype that will allow us experiment with the runtime and run user studies.

These changes are an initial implementation of the template parsing for selectorless templates. Here's an example showing most of the syntax where we create a `MatButton` component as a link, we apply the `HasRipple` directive without any inputs and set a tooltip that's only enabled if the user doesn't have permissions to go to the admin page:

```html
<MatButton:a href="/admin" @HasRipple @Tooltip(message="Cannot navigate" [disabled]="hasPermissions")>Admin</MatButton:a>
```
