### PR TITLE
Docs: Fix Property Binding

### DIFF
--- a/adev/src/content/tutorials/learn-angular/steps/6-property-binding/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/6-property-binding/README.md
@@ -34,7 +34,7 @@ Next, bind the `contentEditable` attribute of the `div` to the `isEditable` prop
 <docs-code highlight="[3]" language="angular-ts">
 @Component({
     ...
-    template: `<div [contentEditable]="{{isEditable}}"></div>`,
+    template: `<div [contentEditable]="isEditable"></div>`,
 })
 </docs-code>
 </docs-step>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
[Bind to contentEditable](https://angular.dev/tutorials/learn-angular/6-property-binding#bind-to-contenteditable) contains an error where {{isEditable}} is incorrectly wrapped in curly braces, leading to a parser error.

Issue Number: N/A


## What is the new behavior?
```[contentEditable]="isEditable"``` code functions correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
<img width="1309" alt="Screenshot 2025-04-03 at 09 43 36" src="https://github.com/user-attachments/assets/c72e83bb-0507-4820-944e-c08f26295388" />
