### PR TITLE
refactor(router): remove dependency on `@types/dom-view-transitions`

### DIFF
--- a/adev/shared-docs/components/viewers/BUILD.bazel
+++ b/adev/shared-docs/components/viewers/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//tools:defaults.bzl", "karma_web_test_suite", "ng_module", "ts_library")
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+load("//tools:defaults.bzl", "karma_web_test_suite", "ng_module", "ts_library")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -28,7 +28,6 @@ ng_module(
         "//packages/router",
         "@npm//@angular/cdk",
         "@npm//@angular/material",
-        "@npm//@types/dom-view-transitions",
     ],
 )
 

--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
@@ -41,8 +41,6 @@ import {Breadcrumb} from '../../breadcrumb/breadcrumb.component';
 import {CopySourceCodeButton} from '../../copy-source-code-button/copy-source-code-button.component';
 import {ExampleViewer} from '../example-viewer/example-viewer.component';
 
-/// <reference types="@types/dom-view-transitions" />
-
 const TOC_HOST_ELEMENT_NAME = 'docs-table-of-contents';
 export const ASSETS_EXAMPLES_PATH = 'assets/content/examples';
 export const DOCS_VIEWER_SELECTOR = 'docs-viewer';

--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -1114,13 +1114,7 @@ export const VERSION: Version;
 export interface ViewTransitionInfo {
     from: ActivatedRouteSnapshot;
     to: ActivatedRouteSnapshot;
-    transition: {
-        finished: Promise<void>;
-        ready: Promise<void>;
-        updateCallbackDone: Promise<void>;
-        skipTransition(): void;
-        readonly types: Set<string>;
-    };
+    transition: ViewTransition;
 }
 
 // @public

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "@types/chrome": "^0.0.313",
     "@types/convert-source-map": "^2.0.0",
     "@types/diff": "^7.0.0",
-    "@types/dom-view-transitions": "^1.0.1",
     "@types/dom-navigation": "^1.0.5",
     "@types/hammerjs": "2.0.46",
     "@types/jasmine": "^5.0.0",

--- a/packages/router/BUILD.bazel
+++ b/packages/router/BUILD.bazel
@@ -14,7 +14,6 @@ ng_module(
         "//packages/common",
         "//packages/core",
         "//packages/platform-browser",
-        "@npm//@types/dom-view-transitions",
         "@npm//rxjs",
     ],
 )
@@ -81,7 +80,6 @@ generate_api_docs(
         "//packages:common_files_and_deps_for_docs",
         "//packages/common:files_for_docgen",
         "//packages/common/http:files_for_docgen",
-        "@npm//@types/dom-view-transitions",
     ],
     entry_point = ":index.ts",
     module_name = "@angular/router",

--- a/packages/router/src/utils/view_transition.ts
+++ b/packages/router/src/utils/view_transition.ts
@@ -6,8 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-/// <reference types="dom-view-transitions" />
-
 import {DOCUMENT} from '@angular/common';
 import {
   afterNextRender,
@@ -56,37 +54,11 @@ export interface ViewTransitionsFeatureOptions {
  * @experimental
  */
 export interface ViewTransitionInfo {
-  // TODO(atscott): This type can/should be the built-in `ViewTransition` type
-  // from @types/dom-view-transitions but exporting that type from the public API is currently not
-  // supported by tooling.
   /**
    * The `ViewTransition` returned by the call to `startViewTransition`.
    * @see https://developer.mozilla.org/en-US/docs/Web/API/ViewTransition
    */
-  transition: {
-    /**
-     * @see https://developer.mozilla.org/en-US/docs/Web/API/ViewTransition/finished
-     */
-    finished: Promise<void>;
-    /**
-     * @see https://developer.mozilla.org/en-US/docs/Web/API/ViewTransition/ready
-     */
-    ready: Promise<void>;
-    /**
-     * @see https://developer.mozilla.org/en-US/docs/Web/API/ViewTransition/updateCallbackDone
-     */
-    updateCallbackDone: Promise<void>;
-    /**
-     * @see https://developer.mozilla.org/en-US/docs/Web/API/ViewTransition/skipTransition
-     */
-    skipTransition(): void;
-
-    /**
-     * @see https://developer.mozilla.org/en-US/docs/Web/API/ViewTransition#browser_compatibility
-     * @see https://developer.chrome.com/docs/web-platform/view-transitions/same-document#default_style_and_transition_reference
-     */
-    readonly types: Set<string>;
-  };
+  transition: ViewTransition;
   /**
    * The `ActivatedRouteSnapshot` that the navigation is transitioning from.
    */
@@ -131,8 +103,7 @@ export function createViewTransition(
       // routes (the DOM update). This view transition waits for the next change detection to
       // complete (below), which includes the update phase of the routed components.
       return createRenderPromise(injector);
-      // TODO(atscott): Types in DefinitelyTyped are not up-to-date
-    }) as ViewTransition & {readonly types: Set<string>};
+    });
     const {onViewTransitionCreated} = transitionOptions;
     if (onViewTransitionCreated) {
       runInInjectionContext(injector, () => onViewTransitionCreated({transition, from, to}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -4329,11 +4329,6 @@
   resolved "https://registry.yarnpkg.com/@types/dom-navigation/-/dom-navigation-1.0.5.tgz#5fd6ed014d3ee66b53b0733b6c50994c105b542d"
   integrity sha512-aM1Mr488jX62+6b9zdEtPHFnI7ILgvbII4BaBJMaqhhbDBupJJJ8+nXFVyQT1ptujOUAg6Sojkjk3j6rU73Bwg==
 
-"@types/dom-view-transitions@^1.0.1":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@types/dom-view-transitions/-/dom-view-transitions-1.0.6.tgz#e6c53f17826be079fafe6df03623f37fcd1b86ac"
-  integrity sha512-Q5IoDouTOcZKEs4nDpmUti2MXP48MQDBkS2nUQKFrsDeTFIaArVmhWUon28vlDfNkbbaK4EROu4Fv0iKObWjSg==
-
 "@types/duplexify@*":
   version "3.6.4"
   resolved "https://registry.yarnpkg.com/@types/duplexify/-/duplexify-3.6.4.tgz#aa7e916c33fcc05be8769546fd0441d9b368613e"


### PR DESCRIPTION
The types have been shipped in TS 5.6
