### PR TITLE
refactor(router): Use `NavigationTrigger` more consistently and move …

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -408,7 +408,7 @@ export interface Navigation {
     id: number;
     initialUrl: UrlTree;
     previousNavigation: Navigation | null;
-    trigger: 'imperative' | 'popstate' | 'hashchange';
+    trigger: NavigationTrigger;
 }
 
 // @public

--- a/packages/router/src/events.ts
+++ b/packages/router/src/events.ts
@@ -624,6 +624,9 @@ export class RedirectRequest {
   ) {}
 }
 export type PrivateRouterEvents = BeforeActivateRoutes | RedirectRequest;
+export function isPublicRouterEvent(e: Event | PrivateRouterEvents): e is Event {
+  return !(e instanceof BeforeActivateRoutes) && !(e instanceof RedirectRequest);
+}
 
 /**
  * Router events that allow you to track the lifecycle of the router.

--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -281,12 +281,8 @@ export interface Navigation {
   targetRouterState?: RouterState;
   /**
    * Identifies how this navigation was triggered.
-   *
-   * * 'imperative'--Triggered by `router.navigateByUrl` or `router.navigate`.
-   * * 'popstate'--Triggered by a popstate event.
-   * * 'hashchange'--Triggered by a hashchange event.
    */
-  trigger: 'imperative' | 'popstate' | 'hashchange';
+  trigger: NavigationTrigger;
   /**
    * Options that controlled the strategy used for this navigation.
    * See `NavigationExtras`.

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -23,14 +23,13 @@ import {createSegmentGroupFromRoute, createUrlTreeFromSegmentGroup} from './crea
 import {INPUT_BINDER} from './directives/router_outlet';
 import {RuntimeErrorCode} from './errors';
 import {
-  BeforeActivateRoutes,
   Event,
   IMPERATIVE_NAVIGATION,
+  isPublicRouterEvent,
   NavigationCancel,
   NavigationCancellationCode,
   NavigationEnd,
   NavigationTrigger,
-  PrivateRouterEvents,
   RedirectRequest,
 } from './events';
 import {NavigationBehaviorOptions, OnSameUrlNavigation, Routes} from './models';
@@ -685,8 +684,4 @@ function validateCommands(commands: string[]): void {
       );
     }
   }
-}
-
-function isPublicRouterEvent(e: Event | PrivateRouterEvents): e is Event {
-  return !(e instanceof BeforeActivateRoutes) && !(e instanceof RedirectRequest);
 }

--- a/packages/router/src/router_scroller.ts
+++ b/packages/router/src/router_scroller.ts
@@ -7,21 +7,16 @@
  */
 
 import {ViewportScroller} from '@angular/common';
-import {
-  EnvironmentInjector,
-  inject,
-  Injectable,
-  InjectionToken,
-  NgZone,
-  OnDestroy,
-} from '@angular/core';
+import {Injectable, InjectionToken, NgZone, OnDestroy} from '@angular/core';
 import {Unsubscribable} from 'rxjs';
 
 import {
+  IMPERATIVE_NAVIGATION,
   NavigationEnd,
   NavigationSkipped,
   NavigationSkippedCode,
   NavigationStart,
+  NavigationTrigger,
   Scroll,
 } from './events';
 import {NavigationTransitions} from './navigation_transition';
@@ -35,7 +30,7 @@ export class RouterScroller implements OnDestroy {
   private scrollEventsSubscription?: Unsubscribable;
 
   private lastId = 0;
-  private lastSource: 'imperative' | 'popstate' | 'hashchange' | undefined = 'imperative';
+  private lastSource: NavigationTrigger | undefined = IMPERATIVE_NAVIGATION;
   private restoredId = 0;
   private store: {[key: string]: [number, number]} = {};
 


### PR DESCRIPTION
…events helper next to definitions

This adjusts code to use `NavigationTrigger` type where appropriate and moves the `isPublicRouterEvent` next to the private event type union to make it more obvious that it should be updated along with any updates to the private type union.
