### PR TITLE
refactor(devtools): create highlight overlay on node selection

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
@@ -57,12 +57,16 @@ import {serializeDirectiveState} from './state-serializer/state-serializer';
 import {runOutsideAngular, unwrapSignal} from './utils';
 import {DirectiveForestHooks} from './hooks/hooks';
 
+type InspectorRef = {ref: ComponentInspector | null};
+
 export const subscribeToClientEvents = (
   messageBus: MessageBus<Events>,
   depsForTestOnly?: {
     directiveForestHooks?: typeof DirectiveForestHooks;
   },
 ): void => {
+  const inspector: InspectorRef = {ref: null};
+
   messageBus.on('shutdown', shutdownCallback(messageBus));
 
   messageBus.on(
@@ -75,7 +79,7 @@ export const subscribeToClientEvents = (
   messageBus.on('startProfiling', startProfilingCallback(messageBus));
   messageBus.on('stopProfiling', stopProfilingCallback(messageBus));
 
-  messageBus.on('setSelectedComponent', selectedComponentCallback);
+  messageBus.on('setSelectedComponent', selectedComponentCallback(inspector));
 
   messageBus.on('getNestedProperties', getNestedPropertiesCallback(messageBus));
   messageBus.on('getRoutes', getRoutesCallback(messageBus));
@@ -94,7 +98,8 @@ export const subscribeToClientEvents = (
   });
 
   if (appIsAngularInDevMode() && appIsSupportedAngularVersion() && appIsAngularIvy()) {
-    setupInspector(messageBus);
+    inspector.ref = setupInspector(messageBus);
+
     // Often websites have `scroll` event listener which triggers
     // Angular's change detection. We don't want to constantly send
     // update requests, instead we want to request an update at most
@@ -175,12 +180,13 @@ const stopProfilingCallback = (messageBus: MessageBus<Events>) => () => {
   messageBus.emit('profilerResults', [stopProfiling()]);
 };
 
-const selectedComponentCallback = (position: ElementPosition) => {
+const selectedComponentCallback = (inspector: InspectorRef) => (position: ElementPosition) => {
   const node = queryDirectiveForest(
     position,
     initializeOrGetDirectiveForestHooks().getIndexedDirectiveForest(),
   );
   setConsoleReference({node, position});
+  inspector.ref?.highlightByPosition(position);
 };
 
 const getNestedPropertiesCallback =
@@ -335,7 +341,7 @@ const checkForAngular = (messageBus: MessageBus<Events>): void => {
   ]);
 };
 
-const setupInspector = (messageBus: MessageBus<Events>) => {
+const setupInspector = (messageBus: MessageBus<Events>): ComponentInspector => {
   const inspector = new ComponentInspector({
     onComponentEnter: (id: number) => {
       messageBus.emit('highlightComponent', [id]);
@@ -358,6 +364,8 @@ const setupInspector = (messageBus: MessageBus<Events>) => {
 
   messageBus.on('createHydrationOverlay', inspector.highlightHydrationNodes);
   messageBus.on('removeHydrationOverlay', inspector.removeHydrationHighlights);
+
+  return inspector;
 };
 
 export interface SerializableDirectiveInstanceType extends DirectiveType {

--- a/devtools/projects/ng-devtools-backend/src/lib/highlighter.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/highlighter.ts
@@ -12,6 +12,7 @@ import {ngDebugClient} from './ng-debug-api/ng-debug-api';
 
 let hydrationOverlayItems: HTMLElement[] = [];
 let selectedElementOverlay: HTMLElement | null = null;
+let selectedElement: Node | null = null;
 
 const DEV_TOOLS_HIGHLIGHT_NODE_ID = '____ngDevToolsHighlight';
 
@@ -83,8 +84,12 @@ export function getDirectiveName(dir: Type<unknown> | undefined | null): string 
 }
 
 export function highlightSelectedElement(el: Node): void {
+  if (el === selectedElement) {
+    return;
+  }
   unHighlight();
   selectedElementOverlay = addHighlightForElement(el);
+  selectedElement = el;
 }
 
 export function highlightHydrationElement(el: Node, status: HydrationStatus) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Component highlighting works only when you hover a directive explorer node which is okay when you click on it but doesn't work when you use the keyboard to navigate through the tree.

## What is the new behavior?

The change enables this feature on node selection as well.

cc @dgp1130 

https://github.com/user-attachments/assets/6955c5aa-d684-4806-a6dd-8c7a39e690e9

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No