### PR TITLE
docs(docs-infra): fix home animation text width on small devices; fix snackbar colors

### DIFF
--- a/adev/shared-docs/styles/_colors.scss
+++ b/adev/shared-docs/styles/_colors.scss
@@ -1,3 +1,5 @@
+@use '@angular/material' as mat;
+
 // Colors
 // Using OKLCH color space for better color reproduction on P3 displays,
 // as well as better human-readability
@@ -186,9 +188,6 @@
   // for the "unfilled" portion of the word that hasn't
   // been highlighted by the gradient
   --gray-unfilled: var(--gray-400);
-  // TODO: convert oklch to hex at build time
-  --webgl-page-background: #ffffff;
-  --webgl-gray-unfilled: #a39fa9;
 }
 
 @mixin dark-mode-definitions() {
@@ -254,9 +253,6 @@
 
   // Home page - dark mode
   --gray-unfilled: var(--gray-700);
-  // TODO: convert oklch to hex at build time
-  --webgl-page-background: #0f0f11;
-  --webgl-gray-unfilled: #413e46;
 
   .docs-toggle {
     input {
@@ -268,9 +264,13 @@
 }
 
 @mixin mdc-definitions() {
-  --mdc-snackbar-container-shape: 0.25rem;
-  --mdc-snackbar-container-color: var(--page-background);
-  --mdc-snackbar-supporting-text-color: var(--primary-contrast);
+  @include mat.snack-bar-overrides(
+    (
+      container-shape: 0.25rem,
+      container-color: var(--page-background),
+      supporting-text-color: var(--primary-contrast),
+    )
+  );
 }
 
 // LIGHT MODE (Explicit)

--- a/adev/src/app/features/home/components/home-animation/home-animation.component.scss
+++ b/adev/src/app/features/home/components/home-animation/home-animation.component.scss
@@ -49,7 +49,7 @@ $transition: 200ms linear;
         color: var(--quaternary-contrast);
         font-size: clamp(1rem, 1vw, 2rem);
         line-height: 1.5;
-        width: clamp(375px, 50%, 600px);
+        width: clamp(345px, 50%, 600px);
         margin: 0 auto;
       }
 
@@ -91,6 +91,8 @@ $transition: 200ms linear;
           & {
             top: 6rem;
             left: var(--layout-padding);
+            /* Assuming the container width is identical to the viewport width (mobile device). */
+            max-width: calc(100% - var(--layout-padding) * 2);
           }
         }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The text exceeds the viewport width.

<img width="358" alt="Screenshot 2025-04-04 at 16 25 31" src="https://github.com/user-attachments/assets/717f2031-f71e-4f7e-9dd9-39054990dee1" /> &nbsp;&nbsp; <img width="360" alt="Screenshot 2025-04-04 at 16 25 47" src="https://github.com/user-attachments/assets/de476fd8-ef15-48fe-933d-f8e025aad150" /> 

## What is the new behavior?

The min `clamp` value has been updated. Additionally, the Material snackbar colors have been fixed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No