### PR TITLE
refactor(core): replace `DOCUMENT` imports from common to core.

### DIFF
--- a/packages/animations/src/animation_builder.ts
+++ b/packages/animations/src/animation_builder.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {DOCUMENT} from '@angular/common';
+import {DOCUMENT} from '@angular/core';
 import {
   ANIMATION_MODULE_TYPE,
   Inject,

--- a/packages/platform-browser/animations/async/src/providers.ts
+++ b/packages/platform-browser/animations/async/src/providers.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT} from '@angular/common';
 import {
   ANIMATION_MODULE_TYPE,
+  DOCUMENT,
   EnvironmentProviders,
   makeEnvironmentProviders,
   NgZone,

--- a/packages/platform-browser/animations/src/providers.ts
+++ b/packages/platform-browser/animations/src/providers.ts
@@ -15,10 +15,9 @@ import {
   ɵWebAnimationsDriver as WebAnimationsDriver,
   ɵWebAnimationsStyleNormalizer as WebAnimationsStyleNormalizer,
 } from '@angular/animations/browser';
-import {DOCUMENT} from '@angular/common';
 import {
   ANIMATION_MODULE_TYPE,
-  inject,
+  DOCUMENT,
   Inject,
   Injectable,
   NgZone,

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -8,7 +8,6 @@
 
 import {
   CommonModule,
-  DOCUMENT,
   XhrFactory,
   ɵPLATFORM_BROWSER_ID as PLATFORM_BROWSER_ID,
 } from '@angular/common';
@@ -17,6 +16,7 @@ import {
   ApplicationModule,
   ApplicationRef,
   createPlatformFactory,
+  DOCUMENT,
   ErrorHandler,
   InjectionToken,
   NgModule,

--- a/packages/platform-browser/src/browser/meta.ts
+++ b/packages/platform-browser/src/browser/meta.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT, ɵDomAdapter as DomAdapter, ɵgetDOM as getDOM} from '@angular/common';
-import {Inject, Injectable} from '@angular/core';
+import {ɵDomAdapter as DomAdapter, ɵgetDOM as getDOM} from '@angular/common';
+import {Inject, Injectable, DOCUMENT} from '@angular/core';
 
 /**
  * Represents the attributes of an HTML `<meta>` element. The element itself is

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -6,10 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT, isPlatformServer, ɵgetDOM as getDOM} from '@angular/common';
+import {isPlatformServer, ɵgetDOM as getDOM} from '@angular/common';
 import {
   APP_ID,
   CSP_NONCE,
+  DOCUMENT,
   Inject,
   Injectable,
   InjectionToken,

--- a/packages/platform-browser/src/dom/events/dom_events.ts
+++ b/packages/platform-browser/src/dom/events/dom_events.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT} from '@angular/common';
+import {DOCUMENT} from '@angular/core';
 import {Inject, Injectable, type ListenerOptions} from '@angular/core';
 
 import {EventManagerPlugin} from './event_manager';

--- a/packages/platform-browser/src/dom/events/hammer_gestures.ts
+++ b/packages/platform-browser/src/dom/events/hammer_gestures.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT} from '@angular/common';
 import {
+  DOCUMENT,
   Inject,
   Injectable,
   InjectionToken,

--- a/packages/platform-browser/src/dom/shared_styles_host.ts
+++ b/packages/platform-browser/src/dom/shared_styles_host.ts
@@ -6,10 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT, isPlatformServer} from '@angular/common';
+import {isPlatformServer} from '@angular/common';
 import {
   APP_ID,
   CSP_NONCE,
+  DOCUMENT,
   Inject,
   Injectable,
   OnDestroy,

--- a/packages/platform-browser/src/security/dom_sanitization_service.ts
+++ b/packages/platform-browser/src/security/dom_sanitization_service.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT} from '@angular/common';
 import {
+  DOCUMENT,
   forwardRef,
   Inject,
   Injectable,

--- a/packages/platform-browser/testing/src/dom_test_component_renderer.ts
+++ b/packages/platform-browser/testing/src/dom_test_component_renderer.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT, ɵgetDOM as getDOM} from '@angular/common';
-import {Inject, Injectable} from '@angular/core';
+import {ɵgetDOM as getDOM} from '@angular/common';
+import {DOCUMENT, Inject, Injectable} from '@angular/core';
 import {TestComponentRenderer} from '@angular/core/testing';
 
 /**

--- a/packages/platform-server/src/location.ts
+++ b/packages/platform-server/src/location.ts
@@ -7,13 +7,12 @@
  */
 
 import {
-  DOCUMENT,
   LocationChangeEvent,
   LocationChangeListener,
   PlatformLocation,
   ɵgetDOM as getDOM,
 } from '@angular/common';
-import {Inject, Injectable, Optional, ɵWritable as Writable} from '@angular/core';
+import {DOCUMENT, Inject, Injectable, Optional, ɵWritable as Writable} from '@angular/core';
 import {Subject} from 'rxjs';
 
 import {INITIAL_CONFIG, PlatformConfig} from './tokens';

--- a/packages/platform-server/src/platform_state.ts
+++ b/packages/platform-server/src/platform_state.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT} from '@angular/common';
 import {
+  DOCUMENT,
   inject,
   Inject,
   Injectable,

--- a/packages/platform-server/src/server_events.ts
+++ b/packages/platform-server/src/server_events.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT, ɵgetDOM as getDOM} from '@angular/common';
-import {Inject, Injectable, type ListenerOptions} from '@angular/core';
+import {ɵgetDOM as getDOM} from '@angular/common';
+import {DOCUMENT, Inject, Injectable, type ListenerOptions} from '@angular/core';
 import {EventManagerPlugin} from '@angular/platform-browser';
 
 @Injectable()

--- a/packages/platform-server/src/transfer_state.ts
+++ b/packages/platform-server/src/transfer_state.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT} from '@angular/common';
 import {
   APP_ID,
+  DOCUMENT,
   inject,
   InjectionToken,
   Injector,

--- a/packages/router/src/utils/view_transition.ts
+++ b/packages/router/src/utils/view_transition.ts
@@ -8,8 +8,8 @@
 
 /// <reference types="dom-view-transitions" />
 
-import {DOCUMENT} from '@angular/common';
 import {
+  DOCUMENT,
   afterNextRender,
   InjectionToken,
   Injector,


### PR DESCRIPTION
In some platforms, the previous imports could lead to `DOCUMENT` being undefined.
