### PR TITLE
docs: expand Angular's browser policy by adopting the "widely available" Baseline

### DIFF
--- a/adev/src/content/reference/versions.md
+++ b/adev/src/content/reference/versions.md
@@ -69,8 +69,21 @@ Until Angular v9, Angular and Angular CLI versions were not synced.
 
 ## Browser support
 
-Angular supports most recent browsers.
-This includes the following specific versions:
+Angular uses the ["widely available" Baseline](https://web.dev/baseline) to define browser
+support. For each major version, Angular supports browsers included in the Baseline of a
+chosen date near the release date for that major.
+
+The "widely available" Baseline includes browsers released less than 30 months (2.5 years)
+of the chosen date within Baseline's core browser set (Chrome, Edge, Firefox, Safari) and
+targets supporting approximately 95% of web users.
+
+| Angular | Baseline Date | Browser Set                 |
+| ------- | ------------- | --------------------------- |
+| v20     | 2025-03-31    | [Browser Set][browsers-v20] |
+
+[browsers-v20]: https://browsersl.ist/#q=Chrome+%3E%3D+105%0AChromeAndroid+%3E%3D+105%0AEdge+%3E%3D+105%0AFirefox+%3E%3D+104%0AFirefoxAndroid+%3E%3D+104%0ASafari+%3E%3D+16%0AiOS+%3E%3D+16
+
+Angular versions prior to v20 support the following specific browser versions:
 
 | Browser | Supported versions                          |
 | :------ | :------------------------------------------ |
@@ -80,8 +93,6 @@ This includes the following specific versions:
 | Safari  | 2 most recent major versions                |
 | iOS     | 2 most recent major versions                |
 | Android | 2 most recent major versions                |
-
-HELPFUL: Angular's continuous integration process runs unit tests of the framework on all of these browsers for every pull request, using [Sauce Labs](https://saucelabs.com).
 
 ## Polyfills
 

--- a/adev/src/content/tools/cli/build.md
+++ b/adev/src/content/tools/cli/build.md
@@ -132,21 +132,9 @@ If the best option is to use a CommonJS dependency, you can disable these warnin
 The Angular CLI uses [Browserslist](https://github.com/browserslist/browserslist) to ensure compatibility with different browser versions.
 Depending on supported browsers, Angular will automatically transform certain JavaScript and CSS features to ensure the built application does not use a feature which has not been implemented by a supported browser. However, the Angular CLI will not automatically add polyfills to supplement missing Web APIs. Use the `polyfills` option in `angular.json` to add polyfills.
 
-Internally, the Angular CLI uses the below default `browserslist` configuration which matches the [browsers that are supported](reference/versions#browser-support) by Angular.
+By default, the Angular CLI uses a `browserslist` configuration which [matches browsers supported by Angular](reference/versions#browser-support) for the current major version.
 
-<docs-code language="text">
-
-last 2 Chrome versions
-last 1 Firefox version
-last 2 Edge major versions
-last 2 Safari major versions
-last 2 iOS major versions
-last 2 Android major versions
-Firefox ESR
-
-</docs-code>
-
-To override the internal configuration, run [`ng generate config browserslist`](cli/generate/config), which generates a `.browserslistrc` configuration file in the project directory.
+To override the internal configuration, run [`ng generate config browserslist`](cli/generate/config), which generates a `.browserslistrc` configuration file in the project directory matching Angular's supported browsers.
 
 See the [browserslist repository](https://github.com/browserslist/browserslist) for more examples of how to target specific browsers and versions.
 Avoid expanding this list to more browsers. Even if your application code more broadly compatible, Angular itself might not be.


### PR DESCRIPTION
This effectively expands Angular's existing browser support policy to be defined as browsers covered by the ["widely available" Baseline](https://web.dev/baseline) (effectively browsers released <30 months ago). Each major version will choose a date shortly before release and pin its version support to the "widely available" Baseline of that date.

There's a few motivations behind this policy change:
1. This gives a more explicit and well-defined browser support policy.
2. This pins the support policy for each major version. Historically, "2 most recent versions" is vague about what date it is most recent to. Is it the release date of a particular major version, a particular patch version, the current date?
3. This aligns us with the rest of the web ecosystem, which is moving towards Baseline as a mechanism for defining feature/browser support.
4. This increases overall browser coverage to more accurately reflect the team's stance. It's highly unlikely we would have ever been comfortable breaking a Chrome browser only three versions old, even though that was technically allowed by the old policy.

Related PRs updating Angular CLI and `ng-packagr` to use this policy in its default `.browserslistrc` configuration: https://github.com/angular/angular-cli/pull/30036, https://github.com/ng-packagr/ng-packagr/pull/3034