### PR TITLE
fix(core): fix ng generate @angular/core:output-migration.

### DIFF
--- a/packages/core/schematics/migrations/output-migration/output-migration.spec.ts
+++ b/packages/core/schematics/migrations/output-migration/output-migration.spec.ts
@@ -169,6 +169,65 @@ describe('outputs', () => {
         });
       });
 
+      it('should not insert a TODO comment for emit function with no type', async () => {
+        await verify({
+          before: `
+              import {Directive, Output, EventEmitter} from '@angular/core';
+
+              @Directive()
+              export class TestDir {
+                @Output() someChange = new EventEmitter();
+
+                someMethod(): void {
+                  this.someChange.emit();
+                }
+              }
+            `,
+          after: `
+              import {Directive, output} from '@angular/core';
+
+              @Directive()
+              export class TestDir {
+                readonly someChange = output();
+
+                someMethod(): void {
+                  this.someChange.emit();
+                }
+              }
+            `,
+        });
+      });
+
+      it('should insert a TODO comment for emit function with type', async () => {
+        await verify({
+          before: `
+              import {Directive, Output, EventEmitter} from '@angular/core';
+
+              @Directive()
+              export class TestDir {
+                @Output() someChange = new EventEmitter<string>();
+
+                someMethod(): void {
+                  this.someChange.emit();
+                }
+              }
+            `,
+          after: `
+              import {Directive, output} from '@angular/core';
+
+              @Directive()
+              export class TestDir {
+                readonly someChange = output<string>();
+
+                someMethod(): void {
+                  // TODO: The 'emit' function requires a mandatory string argument
+                  this.someChange.emit();
+                }
+              }
+            `,
+        });
+      });
+
       it('should migrate multiple outputs', async () => {
         await verifyDeclaration({
           before:


### PR DESCRIPTION
insert a TODO comment for emit function with no parameters

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [X] Tests for the changes have been added (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

After migration, event emitters of type @Output that have a function with empty 'emit' (without any parameters) report an error because the 'emit' function expects a mandatory parameter.

Issue Number: #58650 


## What is the new behavior?

Insert a TODO comment for empty emit (without parameter).

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
