### PR TITLE
fix(core): properly handle the case where getSignalGraph is called on a componentless NodeInjector

### DIFF
--- a/packages/core/src/render3/util/signal_debug.ts
+++ b/packages/core/src/render3/util/signal_debug.ts
@@ -25,6 +25,7 @@ import {
   SIGNAL_NODE,
   SignalNode,
 } from '../../../primitives/signals';
+import {isLView} from '../interfaces/type_checks';
 
 export interface DebugSignalGraphNode {
   kind: string;
@@ -82,9 +83,10 @@ function getTemplateConsumer(injector: NodeInjector): ReactiveLViewConsumer | nu
   const lView = getNodeInjectorLView(injector)!;
   assertLView(lView);
   const templateLView = lView[tNode.index]!;
-  assertLView(templateLView);
-
-  return templateLView[REACTIVE_TEMPLATE_CONSUMER];
+  if (isLView(templateLView)) {
+    return templateLView[REACTIVE_TEMPLATE_CONSUMER] ?? null;
+  }
+  return null;
 }
 
 const signalDebugMap = new WeakMap<ReactiveNode, string>();


### PR DESCRIPTION
Previously this would throw an error on the assertLView when we try to discover the templateLView.

Now this properly returns null for the template consumer and continues discovering other effects on the injector.