### PR TITLE
fix(core): reduce total memory usage of various migration schematics

### DIFF
--- a/packages/core/schematics/ng-generate/cleanup-unused-imports/index.ts
+++ b/packages/core/schematics/ng-generate/cleanup-unused-imports/index.ts
@@ -7,16 +7,20 @@
  */
 
 import {Rule} from '@angular-devkit/schematics';
+import {MigrationStage, runMigrationInDevkit} from '../../utils/tsurge/helpers/angular_devkit';
 import {UnusedImportsMigration} from './unused_imports_migration';
-import {runMigrationInDevkit} from '../../utils/tsurge/helpers/angular_devkit';
 
 export function migrate(): Rule {
   return async (tree, context) => {
     await runMigrationInDevkit({
       getMigration: () => new UnusedImportsMigration(),
       tree,
-      beforeProgramCreation: (tsconfigPath) => {
-        context.logger.info(`Preparing analysis for ${tsconfigPath}`);
+      beforeProgramCreation: (tsconfigPath, stage) => {
+        if (stage === MigrationStage.Analysis) {
+          context.logger.info(`Preparing analysis for: ${tsconfigPath}...`);
+        } else {
+          context.logger.info(`Running migration for: ${tsconfigPath}...`);
+        }
       },
       beforeUnitAnalysis: (tsconfigPath) => {
         context.logger.info(`Scanning for unused imports using ${tsconfigPath}`);

--- a/packages/core/schematics/ng-generate/output-migration/index.ts
+++ b/packages/core/schematics/ng-generate/output-migration/index.ts
@@ -8,7 +8,7 @@
 
 import {Rule} from '@angular-devkit/schematics';
 import {OutputMigration} from '../../migrations/output-migration/output-migration';
-import {runMigrationInDevkit} from '../../utils/tsurge/helpers/angular_devkit';
+import {MigrationStage, runMigrationInDevkit} from '../../utils/tsurge/helpers/angular_devkit';
 
 interface Options {
   path: string;
@@ -28,8 +28,12 @@ export function migrate(options: Options): Rule {
             );
           },
         }),
-      beforeProgramCreation: (tsconfigPath) => {
-        context.logger.info(`Preparing analysis for: ${tsconfigPath}...`);
+      beforeProgramCreation: (tsconfigPath, stage) => {
+        if (stage === MigrationStage.Analysis) {
+          context.logger.info(`Preparing analysis for: ${tsconfigPath}...`);
+        } else {
+          context.logger.info(`Running migration for: ${tsconfigPath}...`);
+        }
       },
       afterProgramCreation: (info, fs) => {
         const analysisPath = fs.resolve(options.analysisDir);

--- a/packages/core/schematics/ng-generate/self-closing-tags-migration/index.ts
+++ b/packages/core/schematics/ng-generate/self-closing-tags-migration/index.ts
@@ -8,7 +8,7 @@
 
 import {Rule} from '@angular-devkit/schematics';
 import {SelfClosingTagsMigration} from '../../migrations/self-closing-tags-migration/self-closing-tags-migration';
-import {runMigrationInDevkit} from '../../utils/tsurge/helpers/angular_devkit';
+import {MigrationStage, runMigrationInDevkit} from '../../utils/tsurge/helpers/angular_devkit';
 
 interface Options {
   path: string;
@@ -28,8 +28,12 @@ export function migrate(options: Options): Rule {
             );
           },
         }),
-      beforeProgramCreation: (tsconfigPath) => {
-        context.logger.info(`Preparing analysis for: ${tsconfigPath}...`);
+      beforeProgramCreation: (tsconfigPath, stage) => {
+        if (stage === MigrationStage.Analysis) {
+          context.logger.info(`Preparing analysis for: ${tsconfigPath}...`);
+        } else {
+          context.logger.info(`Running migration for: ${tsconfigPath}...`);
+        }
       },
       beforeUnitAnalysis: (tsconfigPath) => {
         context.logger.info(`Scanning for component tags: ${tsconfigPath}...`);

--- a/packages/core/schematics/ng-generate/signal-input-migration/index.ts
+++ b/packages/core/schematics/ng-generate/signal-input-migration/index.ts
@@ -8,7 +8,7 @@
 
 import {Rule} from '@angular-devkit/schematics';
 import {SignalInputMigration} from '../../migrations/signal-migration/src';
-import {runMigrationInDevkit} from '../../utils/tsurge/helpers/angular_devkit';
+import {MigrationStage, runMigrationInDevkit} from '../../utils/tsurge/helpers/angular_devkit';
 
 interface Options {
   path: string;
@@ -32,8 +32,12 @@ export function migrate(options: Options): Rule {
             );
           },
         }),
-      beforeProgramCreation: (tsconfigPath) => {
-        context.logger.info(`Preparing analysis for: ${tsconfigPath}...`);
+      beforeProgramCreation: (tsconfigPath, stage) => {
+        if (stage === MigrationStage.Analysis) {
+          context.logger.info(`Preparing analysis for: ${tsconfigPath}...`);
+        } else {
+          context.logger.info(`Running migration for: ${tsconfigPath}...`);
+        }
       },
       afterProgramCreation: (info, fs) => {
         const analysisPath = fs.resolve(options.analysisDir);

--- a/packages/core/schematics/ng-generate/signal-queries-migration/index.ts
+++ b/packages/core/schematics/ng-generate/signal-queries-migration/index.ts
@@ -8,7 +8,7 @@
 
 import {Rule} from '@angular-devkit/schematics';
 import {SignalQueriesMigration} from '../../migrations/signal-queries-migration/migration';
-import {runMigrationInDevkit} from '../../utils/tsurge/helpers/angular_devkit';
+import {MigrationStage, runMigrationInDevkit} from '../../utils/tsurge/helpers/angular_devkit';
 
 interface Options {
   path: string;
@@ -32,8 +32,12 @@ export function migrate(options: Options): Rule {
             );
           },
         }),
-      beforeProgramCreation: (tsconfigPath) => {
-        context.logger.info(`Preparing analysis for: ${tsconfigPath}...`);
+      beforeProgramCreation: (tsconfigPath, stage) => {
+        if (stage === MigrationStage.Analysis) {
+          context.logger.info(`Preparing analysis for: ${tsconfigPath}...`);
+        } else {
+          context.logger.info(`Running migration for: ${tsconfigPath}...`);
+        }
       },
       afterProgramCreation: (info, fs) => {
         const analysisPath = fs.resolve(options.analysisDir);


### PR DESCRIPTION
This commit changes Tsurge's operation within angular-devkit (i.e. the CLI) to no longer retain all programs across all migrations. This isn't necessary for so-called "funnel" migrations so not retaining the programs for those migrations is a pure performance win. The "complex" migrations may see increased execution time given that the program is now being recreated for the actual migration phase to run, although reduced memory pressure may help alleviate this overhead. Since this new approach should help prevent Node from running out of memory and failing entirely this is preferred over a potentially increased execution time.

Fixes #59813