### PR TITLE
refactor(core): Promote `afterNextRender` to stable

### DIFF
--- a/packages/core/src/render3/after_render/api.ts
+++ b/packages/core/src/render3/after_render/api.ts
@@ -71,7 +71,7 @@ export const enum AfterRenderPhase {
 /**
  * A callback that runs after render.
  *
- * @developerPreview
+ * @publicApi
  */
 export interface AfterRenderRef {
   /**

--- a/packages/core/src/render3/after_render/hooks.ts
+++ b/packages/core/src/render3/after_render/hooks.ts
@@ -14,7 +14,7 @@ import {DestroyRef} from '../../linker/destroy_ref';
 import {performanceMarkFeature} from '../../util/performance';
 import {assertNotInReactiveContext} from '../reactivity/asserts';
 import {ViewContext} from '../view_context';
-import {AfterRenderPhase, AfterRenderRef} from './api';
+import {AfterRenderRef} from './api';
 import {
   AfterRenderHooks,
   AfterRenderImpl,
@@ -35,7 +35,7 @@ export type ɵFirstAvailable<T extends unknown[]> = T extends [infer H, ...infer
 /**
  * Options passed to `afterRender` and `afterNextRender`.
  *
- * @developerPreview
+ * @publicApi
  */
 export interface AfterRenderOptions {
   /**
@@ -365,7 +365,7 @@ export function afterNextRender<E = never, W = never, M = never>(
  * }
  * ```
  *
- * @developerPreview
+ * @publicApi
  */
 export function afterNextRender(
   callback: VoidFunction,


### PR DESCRIPTION
`afterRender` will not be promoted and is on its way out.