### PR TITLE
fix(http): Include HTTP status code and headers when HTTP requests errored in `httpResource`

### DIFF
--- a/packages/common/http/src/resource.ts
+++ b/packages/common/http/src/resource.ts
@@ -25,7 +25,7 @@ import {Subscription} from 'rxjs';
 
 import {HttpRequest} from './request';
 import {HttpClient} from './client';
-import {HttpEventType, HttpProgressEvent, HttpResponseBase} from './response';
+import {HttpErrorResponse, HttpEventType, HttpProgressEvent, HttpResponseBase} from './response';
 import {HttpHeaders} from './headers';
 import {HttpParams} from './params';
 import {HttpResourceRef, HttpResourceOptions, HttpResourceRequest} from './resource_api';
@@ -353,7 +353,14 @@ class HttpResourceImpl<T>
                 break;
             }
           },
-          error: (error) => send({error}),
+          error: (error) => {
+            if (error instanceof HttpErrorResponse) {
+              this._headers.set(error.headers);
+              this._statusCode.set(error.status);
+            }
+
+            send({error});
+          },
           complete: () => {
             if (resolve) {
               send({error: new Error('Resource completed before producing a value')});

--- a/packages/common/http/test/resource_spec.ts
+++ b/packages/common/http/test/resource_spec.ts
@@ -122,6 +122,24 @@ describe('httpResource', () => {
     expect(res.statusCode()).toBe(200);
   });
 
+  it('should return response headers & status when request errored', async () => {
+    const backend = TestBed.inject(HttpTestingController);
+    const res = httpResource(() => '/data', {injector: TestBed.inject(Injector)});
+    TestBed.flushEffects();
+    const req = backend.expectOne('/data');
+    req.flush([], {
+      headers: {
+        'X-Special': '123',
+      },
+      status: 429,
+      statusText: 'Too many requests',
+    });
+    await TestBed.inject(ApplicationRef).whenStable();
+    expect((res.error() as any).error).toEqual([]);
+    expect(res.headers()?.get('X-Special')).toBe('123');
+    expect(res.statusCode()).toBe(429);
+  });
+
   it('should support progress events', async () => {
     const backend = TestBed.inject(HttpTestingController);
     const res = httpResource(


### PR DESCRIPTION
Currently the HTTP status code and headers are only included if the request succeeded. Given status codes convey more information in case of a request error vs. success, this makes it more useful than inspecting what is contained in `.error()`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I'm not sure if the current behaviour is actually intended, but I don't really see why statusCode would exist if it was not meant to contain something else than 200 (or 204, but you get my point).