### PR TITLE
docs(docs-infra): workaround the NG203 issue

### DIFF
--- a/adev/shared-docs/components/search-dialog/search-dialog.component.ts
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.ts
@@ -9,6 +9,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   ElementRef,
   Injector,
   OnDestroy,
@@ -55,6 +56,7 @@ export class SearchDialog implements OnDestroy {
   items = viewChildren(SearchItem);
 
   private readonly search = inject(Search);
+  private readonly destroyRef = inject(DestroyRef);
   private readonly relativeLink = new RelativeLink();
   private readonly router = inject(Router);
   private readonly window = inject(WINDOW);
@@ -91,7 +93,7 @@ export class SearchDialog implements OnDestroy {
     });
 
     fromEvent<KeyboardEvent>(this.window, 'keydown')
-      .pipe(takeUntilDestroyed())
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((event) => {
         // When user presses Enter we can navigate to currently selected item in the search result list.
         if (event.key === 'Enter') {


### PR DESCRIPTION
Currently Shared-docs pulls a different bundle of core which means that `assertInInjectionContext` throws NG203. We work around it but injecting manually `DestroyRef` into `takeUntilDestroy`.
