### PR TITLE
refactor(core): Update Transition finished promise to not throw unhan…

### DIFF
--- a/packages/core/primitives/dom-navigation/testing/fake_navigation.ts
+++ b/packages/core/primitives/dom-navigation/testing/fake_navigation.ts
@@ -1145,6 +1145,8 @@ class InternalNavigationTransition implements NavigationTransition {
       this.finishedReject = reject;
       this.finishedResolve = resolve;
     });
+    // All rejections are handled.
+    this.finished.catch(() => {});
   }
 }
 


### PR DESCRIPTION
…dled rejection

As with `InternalNavigationResult`, this commit adds the `catch` to the `finished` promise on `InternalNavigationTransition` to avoid unhandled promise rejections.
