### PR TITLE
build: ensure material dependencies are properly linked for devtools

### DIFF
--- a/devtools/tools/linking/BUILD.bazel
+++ b/devtools/tools/linking/BUILD.bazel
@@ -12,6 +12,7 @@ nodejs_binary(
         ":linker_srcs",
         "//packages/compiler-cli/linker/babel",
         "@npm//@babel/core",
+        "@npm//@nginfra/angular-linking",
         "@npm//tinyglobby",
     ],
     entry_point = ":index.mjs",

--- a/devtools/tools/linking/index.mjs
+++ b/devtools/tools/linking/index.mjs
@@ -35,33 +35,13 @@ async function main() {
     }),
   );
 
-  const fesmBundles = globSync('fesm2022/**/*.mjs', {cwd: outDir});
-  const tasks = [];
-  const babelOptions = {
-    plugins: [
-      [
-        linkerBabelPlugin,
-        {
-          // We compile with an unstamped version of the compiler, so ignore.
-          unknownDeclarationVersionHandling: 'ignore',
-        },
-      ],
-    ],
-  };
+  process.chdir(outDir);
 
-  for (const bundleFile of fesmBundles) {
-    tasks.push(
-      (async () => {
-        const filePath = path.join(outDir, bundleFile);
-        const content = await readFile(filePath, 'utf8');
-        const result = await transformAsync(content, {...babelOptions, filename: filePath});
+  // We compile with an unstamped version of the compiler, so ignore.
+  process.env['LINKER_UNKNOWN_DECLARATION_VERSION_HANDLING'] = 'ignore';
 
-        await writeFile(path.join(outDir, bundleFile), result.code);
-      })(),
-    );
-  }
-
-  await Promise.all(tasks);
+  // Run linking in cwd.
+  import('@nginfra/angular-linking');
 }
 
 main().catch((e) => {

--- a/package.json
+++ b/package.json
@@ -183,6 +183,7 @@
     "@lezer/common": "^1.1.2",
     "@lezer/highlight": "^1.2.0",
     "@lezer/javascript": "^1.4.10",
+    "@nginfra/angular-linking": "^1.0.10",
     "@octokit/graphql": "^8.0.0",
     "@types/adm-zip": "^0.5.0",
     "@types/cldrjs": "^0.4.22",

--- a/yarn.lock
+++ b/yarn.lock
@@ -465,7 +465,6 @@
 
 "@angular/ng-dev@https://github.com/angular/dev-infra-private-ng-dev-builds.git#78c7e244442d09fad1d880658da3c88f4627b14e":
   version "0.0.0-77fb8b4387755a887550b2e5c3fe1206ae130007"
-  uid "78c7e244442d09fad1d880658da3c88f4627b14e"
   resolved "https://github.com/angular/dev-infra-private-ng-dev-builds.git#78c7e244442d09fad1d880658da3c88f4627b14e"
   dependencies:
     "@google-cloud/spanner" "7.19.1"
@@ -2863,6 +2862,17 @@
     "@napi-rs/nice-win32-ia32-msvc" "1.0.1"
     "@napi-rs/nice-win32-x64-msvc" "1.0.1"
 
+"@nginfra/angular-linking@^1.0.10":
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/@nginfra/angular-linking/-/angular-linking-1.0.10.tgz#ce3de5310605eb1c1bb3712980dd71dc169b3b32"
+  integrity sha512-31zx+PCN8tBlC0FYUuCxS4uVPJLAlBhi4UVp6QgoQG44RsOHKTmcRORMVSJdPLRgRuCJkY45kj+PE3AxsgiUKA==
+  dependencies:
+    "@babel/core" "7.26.10"
+    "@types/babel__core" "^7.20.5"
+    "@types/node" "^22.14.0"
+    tinyglobby "0.2.12"
+    typescript "^5.8.3"
+
 "@ngtools/webpack@20.0.0-next.5":
   version "20.0.0-next.5"
   resolved "https://registry.yarnpkg.com/@ngtools/webpack/-/webpack-20.0.0-next.5.tgz#e11814b47262d3e3065535097917f2f20c48ddb6"
@@ -4107,7 +4117,7 @@
   resolved "https://registry.yarnpkg.com/@types/argparse/-/argparse-1.0.38.tgz#a81fd8606d481f873a3800c6ebae4f1d768a56a9"
   integrity sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==
 
-"@types/babel__core@7.20.5":
+"@types/babel__core@7.20.5", "@types/babel__core@^7.20.5":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
   integrity sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==
@@ -4705,6 +4715,13 @@
   integrity sha512-ACYy2HGcZPHxEeWTqowTF7dhXN+JU1o7Gr4b41klnn6pj2LD6rsiGqSZojMdk1Jh2ys3m76ap+ae1vvE4+5+vg==
   dependencies:
     undici-types "~5.26.4"
+
+"@types/node@^22.14.0":
+  version "22.14.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.14.0.tgz#d3bfa3936fef0dbacd79ea3eb17d521c628bb47e"
+  integrity sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==
+  dependencies:
+    undici-types "~6.21.0"
 
 "@types/normalize-package-data@^2.4.3":
   version "2.4.4"
@@ -17390,6 +17407,11 @@ typescript@5.8.2, typescript@^5.7.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.2.tgz#8170b3702f74b79db2e5a96207c15e65807999e4"
   integrity sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==
 
+typescript@^5.8.3:
+  version "5.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
+  integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
+
 typescript@~4.9.0:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
@@ -17462,6 +17484,11 @@ undici-types@~6.20.0:
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
   integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
+
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 undici@^5.25.4:
   version "5.29.0"


### PR DESCRIPTION
This is a follow-up to the recent devtools linking change, leveraging the dedicated package that we are also using in the components repository; avoiding future duplication.

The latest version of that package contains a fix for an issue where the linked bundles did not rewrite imports to shared chunks.

Such imports need to also point to their linked variants.