### PR TITLE
build: update post-approval dev-infra action

### DIFF
--- a/.github/workflows/dev-infra.yml
+++ b/.github/workflows/dev-infra.yml
@@ -20,6 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: angular/dev-infra/github-actions/post-approval-changes@77fb8b4387755a887550b2e5c3fe1206ae130007
+      - uses: angular/dev-infra/github-actions/post-approval-changes@77b20173e6aee60aa43dd47cab8f2c3933651a1c
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}


### PR DESCRIPTION
This should fix errors with the suspended GitHub app installation.