### PR TITLE
docs: fix fallback content example in content projection guide

### DIFF
--- a/adev/src/content/guide/components/content-projection.md
+++ b/adev/src/content/guide/components/content-projection.md
@@ -172,9 +172,7 @@ Angular can show *fallback content* for a component's `<ng-content>` placeholder
 ```angular-html
 <!-- Rendered DOM -->
 <custom-card>
-  <div class="card-shadow">
-    Hello
-    <div class="card-divider"></div>
+  <ng-content select="span"><span>Hello</span></ng-content>
     Default Body
   </div>
 </custom-card>


### PR DESCRIPTION
## docs: fix fallback content example for content projection with select="span"

## What this PR does

This PR fixes a minor issue in the Content Projection guide on the Angular documentation site. Specifically, in the section about fallback content, the example:

```html
 <div class="card-shadow">
    Hello
    <div class="card-divider"></div>

## Fix 
<ng-content select="span"><span>Hello</span></ng-content>

## Why this is important
This small fix avoids confusion for beginners trying to understand how select works with <ng-content>. It provides a more accurate and functional example of how fallback content should be structured.

This is my first PR if any mistake happens with understanding the problem or with the solution feel free to correct 
ThankYou.