### PR TITLE
docs: generate api pages for cdk

### DIFF
--- a/adev/src/assets/BUILD.bazel
+++ b/adev/src/assets/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
+load("//adev/shared-docs/pipeline/api-gen/manifest:generate_api_manifest.bzl", "generate_api_manifest")
 
 package(default_visibility = ["//adev:__subpackages__"])
 
@@ -8,6 +9,7 @@ copy_to_directory(
         "//adev/src/content",
         "//adev/src/content/best-practices",
         "//adev/src/content/best-practices/runtime-performance",
+        "//adev/src/content/cdk:cdk_docs",
         "//adev/src/content/cli/help:cli_docs",
         "//adev/src/content/ecosystem",
         "//adev/src/content/ecosystem/rxjs-interop",
@@ -81,6 +83,7 @@ copy_to_directory(
     ],
     replace_prefixes = {
         "adev/src/content/cli/help/cli_docs_html": "cli/",
+        "adev/src/content/cdk/cdk_docs_html": "api/",
         "adev/src/content": "",
         "packages/**/": "api/",
         "tools/**/": "api/",
@@ -101,10 +104,18 @@ copy_to_directory(
     },
 )
 
+generate_api_manifest(
+    name = "docs_api_manifest",
+    srcs = [
+        "//adev/src/content/cdk:cdk_extracted_apis",
+        "//packages:docs_extracted_apis",
+    ],
+)
+
 copy_to_directory(
     name = "api",
     srcs = [
-        "//packages:docs_api_manifest",
+        ":docs_api_manifest",
     ],
     replace_prefixes = {
         "**/": "",

--- a/adev/src/content/cdk/BUILD.bazel
+++ b/adev/src/content/cdk/BUILD.bazel
@@ -1,0 +1,25 @@
+load("//adev/shared-docs/pipeline/api-gen/manifest:generate_api_manifest.bzl", "generate_api_manifest")
+load("//adev/shared-docs/pipeline/api-gen/rendering:render_api_to_html.bzl", "render_api_to_html")
+
+filegroup(
+    name = "cdk_extracted_apis",
+    srcs = glob(
+        ["*.json"],
+        exclude = ["_*.json"],
+    ),
+    visibility = ["//visibility:public"],
+)
+
+render_api_to_html(
+    name = "cdk_docs",
+    srcs = [":cdk_extracted_apis"],
+    visibility = ["//visibility:public"],
+)
+
+generate_api_manifest(
+    name = "docs_api_manifest",
+    srcs = [
+        ":cdk_extracted_apis",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/adev/src/content/guide/testing/component-harnesses-overview.md
+++ b/adev/src/content/guide/testing/component-harnesses-overview.md
@@ -3,6 +3,7 @@
 A <strong>component harness</strong> is a class that allows tests to interact with components the way an end user does via a supported API. You can create test harnesses for any component, ranging from small reusable widgets to full pages.
 
 Harnesses offer several benefits:
+
 - They make tests less brittle by insulating themselves against implementation details of a component, such as its DOM structure
 - They make tests become more readable and easier to maintain
 - They can be used across multiple testing environments
@@ -21,10 +22,10 @@ Component harnesses support multiple testing environments. You can use the same 
 
 Many developers can be categorized by one of the following developer type categories: test authors, component harness authors, and harness environment authors. Use the table below to find the most relevant section in this guide based on these categories:
 
-| Developer Type              | Description           | Relevant Section      |
-|:---                         | :---                  | :---                  |
-| Test Authors                | Developers that use component harnesses written by someone else to test their application. For example, this could be an app developer who uses a third-party menu component and needs to interact with the menu in a unit test. | [Using component harnesses in tests](guide/testing/using-component-harnesses) |
-| Component harness authors   | Developers who maintain some reusable Angular components and want to create a test harness for its users to use in their tests. For example, an author of a third party Angular component library or a developer who maintains a set of common components for a large Angular application. | [Creating component harnesses for your components](guide/testing/creating-component-harnesses ) |
+| Developer Type              | Description                                                                                                                                                                                                                                                                                            | Relevant Section                                                                                             |
+| :-------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------- |
+| Test Authors                | Developers that use component harnesses written by someone else to test their application. For example, this could be an app developer who uses a third-party menu component and needs to interact with the menu in a unit test.                                                                       | [Using component harnesses in tests](guide/testing/using-component-harnesses)                                |
+| Component harness authors   | Developers who maintain some reusable Angular components and want to create a test harness for its users to use in their tests. For example, an author of a third party Angular component library or a developer who maintains a set of common components for a large Angular application.             | [Creating component harnesses for your components](guide/testing/creating-component-harnesses)               |
 | Harness environment authors | Developers who want to add support for using component harnesses in additional testing environments. For information on supported testing environments out-of-the-box, see the [test harness environments and loaders](guide/testing/using-component-harnesses#test-harness-environments-and-loaders). | [Adding support for additional testing environments](guide/testing/component-harnesses-testing-environments) |
 
-For the full API reference, please see the [Angular CDK's component harness API reference page](https://material.angular.io/cdk/testing/api).
+For the full API reference, please see the [Angular CDK's component harness API reference page](/api/cdk/testing/AsyncOptionPredicate).

--- a/adev/src/content/guide/testing/component-harnesses-testing-environments.md
+++ b/adev/src/content/guide/testing/component-harnesses-testing-environments.md
@@ -7,6 +7,7 @@ TIP: This guide assumes you've already read the [component harnesses overview gu
 ### When does adding support for a test environment make sense?
 
 To use component harnesses in the following environments, you can use Angular CDK's two built-in environments:
+
 - Unit tests
 - WebDriver end-to-end tests
 
@@ -26,34 +27,36 @@ The [Component Dev Kit (CDK)](https://material.angular.io/cdk/categories) is a s
 
 Every test environment must define a `TestElement` implementation. The `TestElement` interface serves as an environment-agnostic representation of a DOM element. It enables harnesses to interact with DOM elements regardless of the underlying environment. Because some environments don't support interacting with DOM elements synchronously (e.g. WebDriver), all `TestElement` methods are asynchronous, returning a `Promise` with the result of the operation.
 
-`TestElement` offers a number of methods to interact with the underlying DOM such as `blur()`, `click()`, `getAttribute()`, and more. See the [TestElement API reference page](https://material.angular.io/cdk/testing/api#TestElement) for the full list of methods.
+`TestElement` offers a number of methods to interact with the underlying DOM such as `blur()`, `click()`, `getAttribute()`, and more. See the [TestElement API reference page](/api/cdk/testing/TestElement) for the full list of methods.
 
 The `TestElement` interface consists largely of methods that resemble methods available on `HTMLElement`. Similar methods exist in most test environments, which makes implementing the methods fairly straightforward. However, one important difference to note when implementing the `sendKeys` method, is that the key codes in the `TestKey` enum likely differ from the key codes used in the test environment. Environment authors should maintain a mapping from `TestKey` codes to the codes used in the particular testing environment.
 
-The [UnitTestElement](https://github.com/angular/components/blob/main/src/cdk/testing/testbed/unit-test-element.ts#L33) and [SeleniumWebDriverElement](https://github.com/angular/components/blob/main/src/cdk/testing/selenium-webdriver/selenium-webdriver-keys.ts#L16) implementations in Angular CDK serve as good examples of implementations of this interface.
+The [UnitTestElement](/api/cdk/testing/testbed/UnitTestElement) and [SeleniumWebDriverElement](/api/cdk/testing/selenium-webdriver/SeleniumWebDriverElement) implementations in Angular CDK serve as good examples of implementations of this interface.
 
 ## Creating a `HarnessEnvironment` implementation
+
 Test authors use `HarnessEnvironment` to create component harness instances for use in tests. `HarnessEnvironment` is an abstract class that must be extended to create a concrete subclass for the new environment. When supporting a new test environment, create a `HarnessEnvironment` subclass that adds concrete implementations for all abstract members.
 
 `HarnessEnvironment` has a generic type parameter: `HarnessEnvironment<E>`. This parameter, `E`, represents the raw element type of the environment. For example, this parameter is Element for unit test environments.
 
 The following are the abstract methods that must be implemented:
 
-| Method                                                        | Description           |
-|:---                                                           | :---                  |
-| `abstract getDocumentRoot(): E`                               | Gets the root element for the environment (e.g. `document.body`). |
-| `abstract createTestElement(element: E): TestElement`         | Creates a `TestElement` for the given raw element. |
-| `abstract createEnvironment(element: E): HarnessEnvironment`  | Creates a `HarnessEnvironment` rooted at the given raw element. |
-| `abstract getAllRawElements(selector: string): Promise<E[]>`  | Gets all of the raw elements under the root element of the environment matching the given selector. |
-| `abstract forceStabilize(): Promise<void>`                    | Gets a `Promise` that resolves when the `NgZone` is stable. Additionally, if applicable, tells `NgZone` to stabilize (e.g. calling `flush()` in a `fakeAsync` test). |
-| `abstract waitForTasksOutsideAngular(): Promise<void>`        | Gets a `Promise` that resolves when the parent zone of `NgZone` is stable. |
+| Method                                                       | Description                                                                                                                                                          |
+| :----------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `abstract getDocumentRoot(): E`                              | Gets the root element for the environment (e.g. `document.body`).                                                                                                    |
+| `abstract createTestElement(element: E): TestElement`        | Creates a `TestElement` for the given raw element.                                                                                                                   |
+| `abstract createEnvironment(element: E): HarnessEnvironment` | Creates a `HarnessEnvironment` rooted at the given raw element.                                                                                                      |
+| `abstract getAllRawElements(selector: string): Promise<E[]>` | Gets all of the raw elements under the root element of the environment matching the given selector.                                                                  |
+| `abstract forceStabilize(): Promise<void>`                   | Gets a `Promise` that resolves when the `NgZone` is stable. Additionally, if applicable, tells `NgZone` to stabilize (e.g. calling `flush()` in a `fakeAsync` test). |
+| `abstract waitForTasksOutsideAngular(): Promise<void>`       | Gets a `Promise` that resolves when the parent zone of `NgZone` is stable.                                                                                           |
 
 In addition to implementing the missing methods, this class should provide a way for test authors to get `ComponentHarness` instances. You should define a protected constructor and provide a static method called `loader` that returns a `HarnessLoader` instance. This allows test authors to write code like: `SomeHarnessEnvironment.loader().getHarness(...)`. Depending on the needs of the particular environment, the class may provide several different static methods or require arguments to be passed. (e.g. the `loader` method on `TestbedHarnessEnvironment` takes a `ComponentFixture`, and the class provides additional static methods called `documentRootLoader` and `harnessForFixture`).
 
-The [`TestbedHarnessEnvironment`](https://github.com/angular/components/blob/main/src/cdk/testing/testbed/testbed-harness-environment.ts#L89) and [SeleniumWebDriverHarnessEnvironment](https://github.com/angular/components/blob/main/src/cdk/testing/selenium-webdriver/selenium-web-driver-harness-environment.ts#L71) implementations in Angular CDK serve as good examples of implementations of this interface.
+The [`TestbedHarnessEnvironment`](/api/cdk/testing/testbed/TestbedHarnessEnvironment) and [SeleniumWebDriverHarnessEnvironment](/api/cdk/testing/selenium-webdriver/SeleniumWebDriverHarnessEnvironment) implementations in Angular CDK serve as good examples of implementations of this interface.
 
 ## Handling auto change detection
+
 In order to support the `manualChangeDetection` and parallel APIs, your environment should install a handler for the auto change detection status.
 
-When your environment wants to start handling the auto change detection status it can call `handleAutoChangeDetectionStatus(handler)`. The handler function will receive a `AutoChangeDetectionStatus` which has two properties `isDisabled` and `onDetectChangesNow()`. See the [AutoChangeDetectionStatus API reference page](https://material.angular.io/cdk/testing/api#AutoChangeDetectionStatus) for more information.
+When your environment wants to start handling the auto change detection status it can call `handleAutoChangeDetectionStatus(handler)`. The handler function will receive a `AutoChangeDetectionStatus` which has two properties `isDisabled` and `onDetectChangesNow()`. See the [AutoChangeDetectionStatus API reference page](/api/cdk/testing/AutoChangeDetectionStatus) for more information.
 If your environment wants to stop handling auto change detection status it can call `stopHandlingAutoChangeDetectionStatus()`.

--- a/adev/src/content/guide/testing/creating-component-harnesses.md
+++ b/adev/src/content/guide/testing/creating-component-harnesses.md
@@ -37,11 +37,11 @@ The `hostSelector` property identifies elements in the DOM that match this harne
 class MyPopup {
   triggerText = input('');
 
-  isOpen = signal(false);
+isOpen = signal(false);
 
-  toggle() {
-    this.isOpen.update((value) => !value);
-  }
+toggle() {
+this.isOpen.update((value) => !value);
+}
 }
 </docs-code>
 
@@ -61,7 +61,7 @@ Each instance of a `ComponentHarness` subclass represents a particular instance 
 
 `ComponentHarness` also offers several methods for locating elements within the component's DOM. These methods are `locatorFor()`, `locatorForOptional()`, and `locatorForAll()`. These methods create functions that find elements, they do not directly find elements. This approach safeguards against caching references to out-of-date elements. For example, when an `ngIf` hides and then shows an element, the result is a new DOM element; using functions ensures that tests always reference the current state of the DOM.
 
-See the [ComponentHarness API reference page](https://material.angular.io/cdk/testing/api#ComponentHarness) for the full list details of the different `locatorFor` methods.
+See the [ComponentHarness API reference page](/api/cdk/testing/ComponentHarness) for the full list details of the different `locatorFor` methods.
 
 For example, the `MyPopupHarness` example discussed above could provide methods to get the trigger and content elements as follows:
 
@@ -69,11 +69,11 @@ For example, the `MyPopupHarness` example discussed above could provide methods 
 class MyPopupHarness extends ComponentHarness {
   static hostSelector = 'my-popup';
 
-  /** Gets the trigger element */
-  getTriggerElement = this.locatorFor('button');
+/\*_ Gets the trigger element _/
+getTriggerElement = this.locatorFor('button');
 
-  /** Gets the content element. */
-  getContentElement = this.locatorForOptional('.my-popup-content');
+/\*_ Gets the content element. _/
+getContentElement = this.locatorForOptional('.my-popup-content');
 }
 </docs-code>
 
@@ -81,7 +81,7 @@ class MyPopupHarness extends ComponentHarness {
 
 `TestElement` is an abstraction designed to work across different test environments (Unit tests, WebDriver, etc). When using harnesses, you should perform all DOM interaction via this interface. Other means of accessing DOM elements, such as `document.querySelector()`, do not work in all test environments.
 
-`TestElement` has a number of methods to interact with the underlying DOM, such as `blur()`, `click()`, `getAttribute()`, and more. See the [TestElement API reference page](https://material.angular.io/cdk/testing/api#TestElement) for the full list of methods.
+`TestElement` has a number of methods to interact with the underlying DOM, such as `blur()`, `click()`, `getAttribute()`, and more. See the [TestElement API reference page](/api/cdk/testing/TestElement) for the full list of methods.
 
 Do not expose `TestElement` instances to harness users unless it's an element the component consumer defines directly, such as the component's host element. Exposing `TestElement` instances for internal elements leads users to depend on a component's internal DOM structure.
 
@@ -91,20 +91,20 @@ Instead, provide more narrow-focused methods for specific actions the end-user m
 class MyPopupHarness extends ComponentHarness {
   static hostSelector = 'my-popup';
 
-  protected getTriggerElement = this.locatorFor('button');
-  protected getContentElement = this.locatorForOptional('.my-popup-content');
+protected getTriggerElement = this.locatorFor('button');
+protected getContentElement = this.locatorForOptional('.my-popup-content');
 
-  /** Toggles the open state of the popup. */
-  async toggle() {
-    const trigger = await this.getTriggerElement();
-    return trigger.click();
-  }
+/\*_ Toggles the open state of the popup. _/
+async toggle() {
+const trigger = await this.getTriggerElement();
+return trigger.click();
+}
 
-  /** Checks if the popup us open. */
-  async isOpen() {
-    const content = await this.getContentElement();
-    return !!content;
-  }
+/\*_ Checks if the popup us open. _/
+async isOpen() {
+const content = await this.getContentElement();
+return !!content;
+}
 }
 </docs-code>
 
@@ -112,7 +112,7 @@ class MyPopupHarness extends ComponentHarness {
 
 Larger components often compose sub-components. You can reflect this structure in a component's harness as well. Each of the `locatorFor` methods on `ComponentHarness` has an alternate signature that can be used for locating sub-harnesses rather than elements.
 
-See the [ComponentHarness API reference page](https://material.angular.io/cdk/testing/api#ComponentHarness) for the full list of the different locatorFor methods.
+See the [ComponentHarness API reference page](/api/cdk/testing/ComponentHarness) for the full list of the different locatorFor methods.
 
 For example, consider a menu build using the popup from above:
 
@@ -123,17 +123,16 @@ For example, consider a menu build using the popup from above:
 class MyMenuItem {}
 
 @Component({
-  selector: 'my-menu',
-  template: `
-    <my-popup>
+selector: 'my-menu',
+template: `     <my-popup>
       <ng-content></ng-content>
     </my-popup>
   `
 })
 class MyMenu {
-  triggerText = input('');
+triggerText = input('');
 
-  @ContentChildren(MyMenuItem) items: QueryList<MyMenuItem>;
+@ContentChildren(MyMenuItem) items: QueryList<MyMenuItem>;
 }
 </docs-code>
 
@@ -143,29 +142,30 @@ The harness for `MyMenu` can then take advantage of other harnesses for `MyPopup
 class MyMenuHarness extends ComponentHarness {
   static hostSelector = 'my-menu';
 
-  protected getPopupHarness = this.locatorFor(MyPopupHarness);
+protected getPopupHarness = this.locatorFor(MyPopupHarness);
 
-  /** Gets the currently shown menu items (empty list if menu is closed). */
-  getItems = this.locatorForAll(MyMenuItemHarness);
+/\*_ Gets the currently shown menu items (empty list if menu is closed). _/
+getItems = this.locatorForAll(MyMenuItemHarness);
 
-  /** Toggles open state of the menu. */
-  async toggle() {
-    const popupHarness = await this.getPopupHarness();
-    return popupHarness.toggle();
-  }
+/\*_ Toggles open state of the menu. _/
+async toggle() {
+const popupHarness = await this.getPopupHarness();
+return popupHarness.toggle();
+}
 }
 
 class MyMenuItemHarness extends ComponentHarness {
-  static hostSelector = 'my-menu-item';
+static hostSelector = 'my-menu-item';
 }
 </docs-code>
 
 ## Filtering harness instances with `HarnessPredicate`
+
 When a page contains multiple instances of a particular component, you may want to filter based on some property of the component to get a particular component instance. For example, you may want a button with some specific text, or a menu with a specific ID. The `HarnessPredicate` class can capture criteria like this for a `ComponentHarness` subclass. While the test author is able to construct `HarnessPredicate` instances manually, it's easier when the `ComponentHarness` subclass provides a helper method to construct predicates for common filters.
 
 You should create a static `with()` method on each `ComponentHarness` subclass that returns a `HarnessPredicate` for that class. This allows test authors to write easily understandable code, e.g. `loader.getHarness(MyMenuHarness.with({selector: '#menu1'}))`. In addition to the standard selector and ancestor options, the `with` method should add any other options that make sense for the particular subclass.
 
-Harnesses that need to add additional options should extend the `BaseHarnessFilters` interface and additional optional properties as needed. `HarnessPredicate` provides several convenience methods for adding options: `stringMatches()`, `addOption()`, and `add()`. See the [HarnessPredicate API page](https://material.angular.io/cdk/testing/api#HarnessPredicate) for the full description.
+Harnesses that need to add additional options should extend the `BaseHarnessFilters` interface and additional optional properties as needed. `HarnessPredicate` provides several convenience methods for adding options: `stringMatches()`, `addOption()`, and `add()`. See the [HarnessPredicate API page](/api/cdk/testing/HarnessPredicate) for the full description.
 
 For example, when working with a menu it is useful to filter based on trigger text and to filter menu items based on their text:
 
@@ -176,45 +176,45 @@ interface MyMenuHarnessFilters extends BaseHarnessFilters {
 }
 
 interface MyMenuItemHarnessFilters extends BaseHarnessFilters {
-  /** Filters based on the text of the menu item. */
-  text?: string | RegExp;
+/\*_ Filters based on the text of the menu item. _/
+text?: string | RegExp;
 }
 
 class MyMenuHarness extends ComponentHarness {
-  static hostSelector = 'my-menu';
+static hostSelector = 'my-menu';
 
-  /** Creates a `HarnessPredicate` used to locate a particular `MyMenuHarness`. */
-  static with(options: MyMenuHarnessFilters): HarnessPredicate<MyMenuHarness> {
-    return new HarnessPredicate(MyMenuHarness, options)
-        .addOption('trigger text', options.triggerText,
-            (harness, text) => HarnessPredicate.stringMatches(harness.getTriggerText(), text));
-  }
+/\*_ Creates a `HarnessPredicate` used to locate a particular `MyMenuHarness`. _/
+static with(options: MyMenuHarnessFilters): HarnessPredicate<MyMenuHarness> {
+return new HarnessPredicate(MyMenuHarness, options)
+.addOption('trigger text', options.triggerText,
+(harness, text) => HarnessPredicate.stringMatches(harness.getTriggerText(), text));
+}
 
-  protected getPopupHarness = this.locatorFor(MyPopupHarness);
+protected getPopupHarness = this.locatorFor(MyPopupHarness);
 
-  /** Gets the text of the menu trigger. */
-  async getTriggerText(): Promise<string> {
-    const popupHarness = await this.getPopupHarness();
-    return popupHarness.getTriggerText();
-  }
-  ...
+/\*_ Gets the text of the menu trigger. _/
+async getTriggerText(): Promise<string> {
+const popupHarness = await this.getPopupHarness();
+return popupHarness.getTriggerText();
+}
+...
 }
 
 class MyMenuItemHarness extends ComponentHarness {
-  static hostSelector = 'my-menu-item';
+static hostSelector = 'my-menu-item';
 
-  /** Creates a `HarnessPredicate` used to locate a particular `MyMenuItemHarness`. */
-  static with(options: MyMenuItemHarnessFilters): HarnessPredicate<MyMenuItemHarness> {
-    return new HarnessPredicate(MyMenuItemHarness, options)
-        .addOption('text', options.text,
-            (harness, text) => HarnessPredicate.stringMatches(harness.getText(), text));
-  }
+/\*_ Creates a `HarnessPredicate` used to locate a particular `MyMenuItemHarness`. _/
+static with(options: MyMenuItemHarnessFilters): HarnessPredicate<MyMenuItemHarness> {
+return new HarnessPredicate(MyMenuItemHarness, options)
+.addOption('text', options.text,
+(harness, text) => HarnessPredicate.stringMatches(harness.getText(), text));
+}
 
-  /** Gets the text of the menu item. */
-  async getText(): Promise<string> {
-    const host = await this.host();
-    return host.text();
-  }
+/\*_ Gets the text of the menu item. _/
+async getText(): Promise<string> {
+const host = await this.host();
+return host.text();
+}
 }
 </docs-code>
 
@@ -224,12 +224,12 @@ You can pass a `HarnessPredicate` instead of a `ComponentHarness` class to any o
 class MyMenuHarness extends ComponentHarness {
   static hostSelector = 'my-menu';
 
-  /** Gets a list of items in the menu, optionally filtered based on the given criteria. */
-  async getItems(filters: MyMenuItemHarnessFilters = {}): Promise<MyMenuItemHarness[]> {
-    const getFilteredItems = this.locatorForAll(MyMenuItemHarness.with(filters));
-    return getFilteredItems();
-  }
-  ...
+/\*_ Gets a list of items in the menu, optionally filtered based on the given criteria. _/
+async getItems(filters: MyMenuItemHarnessFilters = {}): Promise<MyMenuItemHarness[]> {
+const getFilteredItems = this.locatorForAll(MyMenuItemHarness.with(filters));
+return getFilteredItems();
+}
+...
 }
 </docs-code>
 
@@ -237,7 +237,7 @@ class MyMenuHarness extends ComponentHarness {
 
 Some components project additional content into the component's template. See the [content projection guide](guide/components/content-projection) for more information.
 
-Add a `HarnessLoader` instance scoped to the element containing the `<ng-content>` when you create a harness for a component that uses content projection. This allows the user of the harness to load additional harnesses for whatever components were passed in as content. `ComponentHarness` has several methods that can be used to create HarnessLoader instances for cases like this: `harnessLoaderFor()`, `harnessLoaderForOptional()`, `harnessLoaderForAll()`. See the [HarnessLoader interface API reference page](https://material.angular.io/cdk/testing/api#HarnessLoader) for more details.
+Add a `HarnessLoader` instance scoped to the element containing the `<ng-content>` when you create a harness for a component that uses content projection. This allows the user of the harness to load additional harnesses for whatever components were passed in as content. `ComponentHarness` has several methods that can be used to create HarnessLoader instances for cases like this: `harnessLoaderFor()`, `harnessLoaderForOptional()`, `harnessLoaderForAll()`. See the [HarnessLoader interface API reference page](/api/cdk/testing/HarnessLoader) for more details.
 
 For example, the `MyPopupHarness` example from above can extend `ContentContainerComponentHarness` to add support to load harnesses within the `<ng-content>` of the component.
 
@@ -259,11 +259,11 @@ Consider if the `MyPopup` component above used the CDK overlay for the popup con
 class MyPopupHarness extends ComponentHarness {
   static hostSelector = 'my-popup';
 
-  /** Gets a `HarnessLoader` whose root element is the popup's content element. */
-  async getHarnessLoaderForContent(): Promise<HarnessLoader> {
-    const rootLocator = this.documentRootLocatorFactory();
-    return rootLocator.harnessLoaderFor('my-popup-content');
-  }
+/\*_ Gets a `HarnessLoader` whose root element is the popup's content element. _/
+async getHarnessLoaderForContent(): Promise<HarnessLoader> {
+const rootLocator = this.documentRootLocatorFactory();
+return rootLocator.harnessLoaderFor('my-popup-content');
+}
 }
 </docs-code>
 

--- a/adev/src/content/guide/testing/using-component-harnesses.md
+++ b/adev/src/content/guide/testing/using-component-harnesses.md
@@ -15,9 +15,9 @@ The [Component Dev Kit (CDK)](https://material.angular.io/cdk/categories) is a s
 ## Test harness environments and loaders
 
 You can use component test harnesses in different test environments. Angular CDK supports two built-in environments:
+
 - Unit tests with Angular's `TestBed`
 - End-to-end tests with [WebDriver](https://developer.mozilla.org/en-US/docs/Web/WebDriver)
-
 
 Each environment provides a <strong>harness loader</strong>. The loader creates the harness instances you use throughout your tests. See below for more specific guidance on supported testing environments.
 
@@ -25,7 +25,7 @@ Additional testing environments require custom bindings. See the [adding harness
 
 ### Using the loader from `TestbedHarnessEnvironment` for unit tests
 
-For unit tests you can create a harness loader from [TestbedHarnessEnvironment](https://material.angular.io/cdk/testing/api#TestbedHarnessEnvironment). This environment uses a [component fixture](api/core/testing/ComponentFixture) created by Angular's `TestBed`.
+For unit tests you can create a harness loader from [TestbedHarnessEnvironment](/api/cdk/testing/TestbedHarnessEnvironment). This environment uses a [component fixture](api/core/testing/ComponentFixture) created by Angular's `TestBed`.
 
 To create a harness loader rooted at the fixture's root element, use the `loader()` method:
 
@@ -72,6 +72,7 @@ const myComponentHarnesses = await loader.getHarnesses(MyComponent);
 </docs-code>
 
 As an example, consider a reusable dialog-button component that opens a dialog on click. It contains the following components, each with a corresponding harness:
+
 - `MyDialogButton` (composes the `MyButton` and `MyDialog` with a convenient API)
 - `MyButton` (a standard button component)
 - `MyDialog` (a dialog appended to `document.body` by `MyDialogButton` upon click)
@@ -84,23 +85,23 @@ let loader: HarnessLoader;
 let rootLoader: HarnessLoader;
 
 beforeEach(() => {
-  fixture = TestBed.createComponent(MyDialogButton);
-  loader = TestbedHarnessEnvironment.loader(fixture);
-  rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+fixture = TestBed.createComponent(MyDialogButton);
+loader = TestbedHarnessEnvironment.loader(fixture);
+rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
 });
 
 it('loads harnesses', async () => {
-  // Load a harness for the bootstrapped component with `harnessForFixture`
-  dialogButtonHarness =
-      await TestbedHarnessEnvironment.harnessForFixture(fixture, MyDialogButtonHarness);
-  // The button element is inside the fixture's root element, so we use `loader`.
-  const buttonHarness = await loader.getHarness(MyButtonHarness);
-  // Click the button to open the dialog
-  await buttonHarness.click();
-  // The dialog is appended to `document.body`, outside of the fixture's root element,
-  // so we use `rootLoader` in this case.
-  const dialogHarness = await rootLoader.getHarness(MyDialogHarness);
-  // ... make some assertions
+// Load a harness for the bootstrapped component with `harnessForFixture`
+dialogButtonHarness =
+await TestbedHarnessEnvironment.harnessForFixture(fixture, MyDialogButtonHarness);
+// The button element is inside the fixture's root element, so we use `loader`.
+const buttonHarness = await loader.getHarness(MyButtonHarness);
+// Click the button to open the dialog
+await buttonHarness.click();
+// The dialog is appended to `document.body`, outside of the fixture's root element,
+// so we use `rootLoader` in this case.
+const dialogHarness = await rootLoader.getHarness(MyDialogHarness);
+// ... make some assertions
 });
 </docs-code>
 
@@ -127,6 +128,7 @@ const allChildLoaders = await myComponentHarness.getAllChildLoaders('.child');
 When a page contains multiple instances of a particular component, you may want to filter based on some property of the component to get a particular component instance. You can use a <strong>harness predicate</strong>, a class used to associate a `ComponentHarness` class with predicates functions that can be used to filter component instances, to do so.
 
 When you ask a `HarnessLoader` for a harness, you're actually providing a HarnessQuery. A query can be one of two things:
+
 - A harness constructor. This just gets that harness
 - A `HarnessPredicate`, which gets harnesses that are filtered based on one or more conditions
 
@@ -149,7 +151,7 @@ For more details refer to the specific harness documentation since additional fi
 
 ## Using test harness APIs
 
-While every harness defines an API specific to its corresponding component, they all share a common base class, [ComponentHarness](https://material.angular.io/cdk/testing/api#ComponentHarness). This base class defines a static property, `hostSelector`, that matches the harness class to instances of the component in the DOM.
+While every harness defines an API specific to its corresponding component, they all share a common base class, [ComponentHarness](/api/cdk/testing/ComponentHarness). This base class defines a static property, `hostSelector`, that matches the harness class to instances of the component in the DOM.
 
 Beyond that, the API of any given harness is specific to its corresponding component; refer to the component's documentation to learn how to use a specific harness.
 
@@ -185,6 +187,7 @@ it('checks state while async action is in progress', async () => {
 </docs-code>
 
 Almost all harness methods are asynchronous and return a `Promise` to support the following:
+
 - Support for unit tests
 - Support for end-to-end tests
 - Insulate tests against changes in asynchronous behavior

--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_ts//ts:defs.bzl", rules_js_tsconfig = "ts_config")
 load("//:packages.bzl", "DOCS_ENTRYPOINTS")
-load("//adev/shared-docs/pipeline/api-gen/manifest:generate_api_manifest.bzl", "generate_api_manifest")
 load("//tools:defaults.bzl", "ts_config", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
@@ -92,8 +91,8 @@ filegroup(
     ],
 )
 
-generate_api_manifest(
-    name = "docs_api_manifest",
+filegroup(
+    name = "docs_extracted_apis",
     srcs = [
         "//packages/animations:animations_docs_extraction",
         "//packages/animations/browser:animations_browser_docs_extraction",
@@ -131,4 +130,5 @@ generate_api_manifest(
         "//tools/manual_api_docs/blocks",
         "//tools/manual_api_docs/elements",
     ],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Generates html for the cdk api pages based on the json files imported
from angular/cdk-builds