### PR TITLE
docs: fix missing card-title tag in example of fallback-content section

### DIFF
--- a/adev/src/content/guide/components/content-projection.md
+++ b/adev/src/content/guide/components/content-projection.md
@@ -173,7 +173,7 @@ Angular can show *fallback content* for a component's `<ng-content>` placeholder
 <!-- Rendered DOM -->
 <custom-card>
   <div class="card-shadow">
-    Hello
+    <card-title>Hello</card-title>
     <div class="card-divider"></div>
     Default Body
   </div>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular/issues/60823


## What is the new behavior?
Added missing `card-title` tags in example of fallback-content section

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
/