### PR TITLE
feat(router) ✨ Adds Asynchrounous Redirects

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -606,7 +606,7 @@ export class RedirectCommand {
 }
 
 // @public
-export type RedirectFunction = (redirectData: Pick<ActivatedRouteSnapshot, 'routeConfig' | 'url' | 'params' | 'queryParams' | 'fragment' | 'data' | 'outlet' | 'title'>) => string | UrlTree;
+export type RedirectFunction = (redirectData: Pick<ActivatedRouteSnapshot, 'routeConfig' | 'url' | 'params' | 'queryParams' | 'fragment' | 'data' | 'outlet' | 'title'>) => MaybeAsync<string | UrlTree>;
 
 // @public
 export interface Resolve<T> {

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -316,7 +316,7 @@ export type RedirectFunction = (
     ActivatedRouteSnapshot,
     'routeConfig' | 'url' | 'params' | 'queryParams' | 'fragment' | 'data' | 'outlet' | 'title'
   >,
-) => string | UrlTree;
+) => MaybeAsync<string | UrlTree>;
 
 /**
  * A policy for when to run guards and resolvers on a route.

--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -382,7 +382,7 @@ export class Recognizer {
     const inherited = getInherited(currentSnapshot, parentRoute, this.paramsInheritanceStrategy);
     currentSnapshot.params = Object.freeze(inherited.params);
     currentSnapshot.data = Object.freeze(inherited.data);
-    const newTree = this.applyRedirects.applyRedirectCommands(
+    const newTree$: Observable<UrlTree> = this.applyRedirects.applyRedirectCommands(
       consumedSegments,
       route.redirectTo!,
       positionalParamSegments,
@@ -390,7 +390,8 @@ export class Recognizer {
       injector,
     );
 
-    return this.applyRedirects.lineralizeSegments(route, newTree).pipe(
+    return newTree$.pipe(
+      switchMap((newTree) => this.applyRedirects.lineralizeSegments(route, newTree)),
       mergeMap((newSegments: UrlSegment[]) => {
         return this.processSegment(
           injector,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently the angular router only allows a string or a synchronous function for the redirectTo field of the router.


## What is the new behavior?
Currently the angular router now allows also asynchronous functions that return a Promise or an Observable.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

I had to change one of the tests whose assertion was unreachable for it to fail. There might be a bug in the redirection strategy. I don't know if it's done on purpose, but if the path that has the redirectTo is a subpath of the redirected to url. The redirectTo function returns it as a UrlTree, which causes an infinite loop. I have been able to reproduce it here:
https://stackblitz.com/edit/angular-vakejq-tmlfa9gy?file=src%2Fapp.routes.ts


I have added a test to lock this behaviour, but I suspect it should be modified, at least throwing an error in devMode telling the user that there might be an infinite loop. I'd gladly do it in another PR once a decision on what should be done is made. In the meantime, this PR adds async management of redirection, keeping all the current behaviours of the simple functional redirection. All tests pass locally.