### PR TITLE
docs: remove unused imports in examples

### DIFF
--- a/adev/src/content/examples/animations/src/app/hero-list-auto.component.ts
+++ b/adev/src/content/examples/animations/src/app/hero-list-auto.component.ts
@@ -2,13 +2,11 @@ import {Component, Input, Output, EventEmitter} from '@angular/core';
 import {trigger, state, style, animate, transition} from '@angular/animations';
 
 import {Hero} from './hero';
-import {NgFor} from '@angular/common';
 
 @Component({
   selector: 'app-hero-list-auto',
   templateUrl: 'hero-list-auto.component.html',
   styleUrls: ['./hero-list-page.component.css'],
-  imports: [NgFor],
   // #docregion auto-calc
   animations: [
     trigger('shrinkOut', [

--- a/adev/src/content/examples/animations/src/app/hero-list-enter-leave.component.ts
+++ b/adev/src/content/examples/animations/src/app/hero-list-enter-leave.component.ts
@@ -2,7 +2,6 @@ import {Component, Input, Output, EventEmitter} from '@angular/core';
 import {trigger, state, style, animate, transition} from '@angular/animations';
 
 import {Hero} from './hero';
-import {NgFor} from '@angular/common';
 
 @Component({
   selector: 'app-hero-list-enter-leave',
@@ -19,7 +18,6 @@ import {NgFor} from '@angular/common';
     </ul>
   `,
   styleUrls: ['./hero-list-page.component.css'],
-  imports: [NgFor],
   // #docregion animationdef
   animations: [
     trigger('flyInOut', [

--- a/adev/src/content/examples/animations/src/app/hero-list-groups.component.ts
+++ b/adev/src/content/examples/animations/src/app/hero-list-groups.component.ts
@@ -2,7 +2,6 @@ import {Component, Input, Output, EventEmitter} from '@angular/core';
 import {trigger, state, style, animate, transition, group} from '@angular/animations';
 
 import {Hero} from './hero';
-import {NgFor} from '@angular/common';
 
 @Component({
   selector: 'app-hero-list-groups',
@@ -19,7 +18,6 @@ import {NgFor} from '@angular/common';
     </ul>
   `,
   styleUrls: ['./hero-list-page.component.css'],
-  imports: [NgFor],
   // #docregion animationdef
   animations: [
     trigger('flyInOut', [

--- a/adev/src/content/examples/animations/src/app/hero-list-page.component.ts
+++ b/adev/src/content/examples/animations/src/app/hero-list-page.component.ts
@@ -4,12 +4,10 @@ import {Component, HostBinding, OnInit} from '@angular/core';
 import {trigger, transition, animate, style, query, stagger} from '@angular/animations';
 import {HEROES} from './mock-heroes';
 import {Hero} from './hero';
-import {NgFor} from '@angular/common';
 
 // #docregion filter-animations
 @Component({
   // #enddocregion filter-animations
-  imports: [NgFor],
   selector: 'app-hero-list-page',
   templateUrl: 'hero-list-page.component.html',
   styleUrls: ['hero-list-page.component.css'],

--- a/adev/src/content/examples/animations/src/app/insert-remove.component.ts
+++ b/adev/src/content/examples/animations/src/app/insert-remove.component.ts
@@ -1,11 +1,9 @@
 // #docplaster
 import {Component} from '@angular/core';
 import {trigger, transition, animate, style} from '@angular/animations';
-import {NgIf} from '@angular/common';
 
 @Component({
   selector: 'app-insert-remove',
-  imports: [NgIf],
   animations: [
     // #docregion enter-leave-trigger
     trigger('myInsertRemoveTrigger', [

--- a/adev/src/content/examples/animations/src/app/querying.component.ts
+++ b/adev/src/content/examples/animations/src/app/querying.component.ts
@@ -11,7 +11,6 @@ import {
 } from '@angular/animations';
 
 import {HEROES} from './mock-heroes';
-import {NgIf} from '@angular/common';
 
 @Component({
   selector: 'app-querying',
@@ -34,7 +33,6 @@ import {NgIf} from '@angular/common';
     }
   `,
   styleUrls: ['./querying.component.css'],
-  imports: [NgIf],
   animations: [
     trigger('query', [
       transition(':enter', [

--- a/adev/src/content/examples/inputs-outputs/src/app/app.component.ts
+++ b/adev/src/content/examples/inputs-outputs/src/app/app.component.ts
@@ -1,6 +1,5 @@
 // #docplaster
 import {Component} from '@angular/core';
-import {NgFor} from '@angular/common';
 
 import {AliasingComponent} from './aliasing.component';
 import {InputOutputComponent} from './input-output.component';
@@ -19,7 +18,6 @@ import {ItemOutputComponent} from './item-output.component';
     ItemDetailComponent,
     ItemDetailMetadataComponent,
     ItemOutputComponent,
-    NgFor,
   ],
 })
 


### PR DESCRIPTION
These unused imports were triggering warnings in the adev builds.
