### PR TITLE
fix(docs-infra): prevent processing node_modules .md files

### DIFF
--- a/adev/src/content/tutorials/BUILD.bazel
+++ b/adev/src/content/tutorials/BUILD.bazel
@@ -8,6 +8,7 @@ generate_guides(
         ],
         exclude = [
             "README.md",
+            "**/node_modules/**/*.md",
         ],
     ),
     data = [

--- a/adev/src/content/tutorials/deferrable-views/BUILD.bazel
+++ b/adev/src/content/tutorials/deferrable-views/BUILD.bazel
@@ -4,7 +4,14 @@ package(default_visibility = ["//adev:__subpackages__"])
 
 generate_guides(
     name = "deferrable-views-guides",
-    srcs = glob(["**/*.md"]),
+    srcs = glob(
+        [
+            "**/*.md",
+        ],
+        exclude = [
+            "**/node_modules/**/*.md",
+        ],
+    ),
 )
 
 filegroup(

--- a/adev/src/content/tutorials/first-app/BUILD.bazel
+++ b/adev/src/content/tutorials/first-app/BUILD.bazel
@@ -4,7 +4,14 @@ package(default_visibility = ["//adev:__subpackages__"])
 
 generate_guides(
     name = "first-app-guides",
-    srcs = glob(["**/*.md"]),
+    srcs = glob(
+        [
+            "**/*.md",
+        ],
+        exclude = [
+            "**/node_modules/**/*.md",
+        ],
+    ),
     data = [
         ":files",
     ],

--- a/adev/src/content/tutorials/homepage/BUILD.bazel
+++ b/adev/src/content/tutorials/homepage/BUILD.bazel
@@ -5,7 +5,12 @@ package(default_visibility = ["//adev:__subpackages__"])
 filegroup(
     name = "files",
     srcs = glob(
-        ["**/*"],
+        [
+            "**/*",
+        ],
+        exclude = [
+            "**/node_modules/**/*.md",
+        ],
     ),
 )
 

--- a/adev/src/content/tutorials/learn-angular/BUILD.bazel
+++ b/adev/src/content/tutorials/learn-angular/BUILD.bazel
@@ -4,7 +4,14 @@ package(default_visibility = ["//adev:__subpackages__"])
 
 generate_guides(
     name = "learn-angular-guides",
-    srcs = glob(["**/*.md"]),
+    srcs = glob(
+        [
+            "**/*.md",
+        ],
+        exclude = [
+            "**/node_modules/**/*.md",
+        ],
+    ),
 )
 
 filegroup(

--- a/adev/src/content/tutorials/playground/BUILD.bazel
+++ b/adev/src/content/tutorials/playground/BUILD.bazel
@@ -4,7 +4,14 @@ package(default_visibility = ["//adev:__subpackages__"])
 
 filegroup(
     name = "files",
-    srcs = glob(["**/*"]),
+    srcs = glob(
+        [
+            "**/*",
+        ],
+        exclude = [
+            "**/node_modules/**/*.md",
+        ],
+    ),
 )
 
 generate_playground(


### PR DESCRIPTION
If you happen to have node_modules installed for adev tutorials, there would be problems with trying to run adev tests. This excludes those node_modules folders.
