### PR TITLE
58894/fix-ng-model-submit-reset-events

### DIFF
--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -78,6 +78,8 @@
   "EventManagerPlugin",
   "FormControl",
   "FormGroup",
+  "FormResetEvent",
+  "FormSubmittedEvent",
   "FormsExampleModule",
   "FormsModule",
   "INJECTOR",

--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -22,7 +22,12 @@ import {
   ɵWritable as Writable,
 } from '@angular/core';
 
-import {AbstractControl, FormHooks} from '../model/abstract_model';
+import {
+  AbstractControl,
+  FormHooks,
+  FormResetEvent,
+  FormSubmittedEvent,
+} from '../model/abstract_model';
 import {FormControl} from '../model/form_control';
 import {FormGroup} from '../model/form_group';
 import {
@@ -338,6 +343,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
     this.submittedReactive.set(true);
     syncPendingControls(this.form, this._directives);
     this.ngSubmit.emit($event);
+    this.form._events.next(new FormSubmittedEvent(this.control));
     // Forms with `method="dialog"` have some special behavior
     // that won't reload the page and that shouldn't be prevented.
     return ($event?.target as HTMLFormElement | null)?.method === 'dialog';
@@ -360,6 +366,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
   resetForm(value: any = undefined): void {
     this.form.reset(value);
     this.submittedReactive.set(false);
+    this.form._events.next(new FormResetEvent(this.form));
   }
 
   private _setUpdateStrategy() {

--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -11,6 +11,7 @@ import {fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
 import {
   AbstractControl,
   CheckboxControlValueAccessor,
+  ControlEvent,
   ControlValueAccessor,
   DefaultValueAccessor,
   FormArray,
@@ -21,15 +22,20 @@ import {
   FormGroup,
   FormGroupDirective,
   FormGroupName,
+  FormResetEvent,
+  FormSubmittedEvent,
   NgControl,
   NgForm,
   NgModel,
   NgModelGroup,
   SelectControlValueAccessor,
   SelectMultipleControlValueAccessor,
+  StatusChangeEvent,
+  TouchedChangeEvent,
   ValidationErrors,
   Validator,
   Validators,
+  ValueChangeEvent,
 } from '../index';
 import {selectValueAccessor} from '../src/directives/shared';
 import {composeValidators} from '../src/validators';
@@ -431,6 +437,37 @@ describe('Form Directives', () => {
 
       expect(f.form.errors).toEqual({'async': true});
     }));
+
+    describe('events emissions', () => {
+      it('formControl should emit an event when resetting a form', () => {
+        const f = new NgForm([], []);
+        const events: ControlEvent[] = [];
+
+        f.form.events.subscribe((event) => events.push(event));
+        f.resetForm();
+
+        expect(events.length).toBe(4);
+        expect(events[0]).toBeInstanceOf(TouchedChangeEvent);
+        expect(events[1]).toBeInstanceOf(ValueChangeEvent);
+        expect(events[2]).toBeInstanceOf(StatusChangeEvent);
+
+        // The event that matters
+        expect(events[3]).toBeInstanceOf(FormResetEvent);
+        expect(events[3].source).toBe(f.form);
+      });
+
+      it('formControl should emit an event when submitting a form', () => {
+        const f = new NgForm([], []);
+        const events: ControlEvent[] = [];
+
+        f.form.events.subscribe((event) => events.push(event));
+        f.onSubmit({} as any);
+
+        expect(events.length).toBe(1);
+        expect(events[0]).toBeInstanceOf(FormSubmittedEvent);
+        expect(events[0].source).toBe(f.form);
+      });
+    });
   });
 
   describe('FormGroupName', () => {


### PR DESCRIPTION
Currently, only forms created with `FormGroupDirective` emit events on form submission and resetting. This commit extends this behavior to Template-driven forms also.

Related to #58894

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Only Reactive Forms emit events FormSubmittedEvent and FormResetEvent.

Issue Number: #58894


## What is the new behavior?

Now Template-Driven Forms also emit FormSubmittedEvent and FormResetEvent.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Tests added, all tests passed.