### PR TITLE
refactor(devtools): improve components tab side pane UI

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.html
@@ -28,11 +28,15 @@
   </as-split-area>
   <as-split-area size="40" minSize="25" class="prop-split">
     <div class="property-tab-wrapper">
-      <ng-property-tab
-        [currentSelectedElement]="currentSelectedElement()!"
-        (inspect)="inspect($event)"
-        (viewSource)="viewSource($event)"
-      />
+      @if (currentSelectedElement(); as currentSelectedElement) {
+        <ng-property-tab
+          [currentSelectedElement]="currentSelectedElement"
+          (inspect)="inspect($event)"
+          (viewSource)="viewSource($event)"
+        />
+      } @else {
+        <p class="no-selected-element">No selected element</p>
+      }
     </div>
     @if (isHydrationEnabled) {
       <div class="hydration">

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.scss
@@ -21,6 +21,11 @@
   flex: 1;
   overflow: auto;
   width: 100%;
+
+  .no-selected-element {
+    text-align: center;
+    padding: 1rem;
+  }
 }
 
 .hydration {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/component-metadata.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/component-metadata.component.scss
@@ -1,7 +1,7 @@
 .meta-data-container {
   display: flex;
   flex-direction: column;
-  padding: 0.75rem;
+  padding: 0.25rem 0.75rem;
 }
 
 .meta-data-container a {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header.component.html
@@ -1,27 +1,21 @@
-@if (currentSelectedElement()) {
-  @let comp = currentSelectedElement().component;
-  @if (comp) {
-    <mat-accordion class="property-tab-header">
-      <div>
-        <mat-expansion-panel [hideToggle]="true">
-          <mat-expansion-panel-header collapsedHeight="32px" expandedHeight="32px">
-            <mat-panel-title>
-              <div class="element-header">
-                <div class="component-name">{{ comp.name }}</div>
-              </div>
-            </mat-panel-title>
-          </mat-expansion-panel-header>
-          <ng-component-metadata [currentSelectedComponent]="comp"></ng-component-metadata>
-        </mat-expansion-panel>
-      </div>
-    </mat-accordion>
-  } @else {
-    <div class="element-header">
-      <div class="element-name">{{ currentSelectedElement().element }}</div>
+@let comp = currentSelectedElement().component;
+@if (comp) {
+  <mat-accordion class="property-tab-header">
+    <div>
+      <mat-expansion-panel [hideToggle]="true">
+        <mat-expansion-panel-header collapsedHeight="32px" expandedHeight="32px">
+          <mat-panel-title>
+            <div class="element-header">
+              <div class="component-name">{{ comp.name }}</div>
+            </div>
+          </mat-panel-title>
+        </mat-expansion-panel-header>
+        <ng-component-metadata [currentSelectedComponent]="comp"></ng-component-metadata>
+      </mat-expansion-panel>
     </div>
-  }
+  </mat-accordion>
 } @else {
   <div class="element-header">
-    <div class="element-name">No selected Element</div>
+    <div class="element-name">{{ currentSelectedElement().element }}</div>
   </div>
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header.component.scss
@@ -1,16 +1,22 @@
 @use '../../../../styles/typography';
 
+:host {
+  border-bottom: 1px solid var(--color-separator);
+  display: block;
+}
+
 .element-header {
   display: flex;
   justify-content: space-between;
   width: 100%;
   align-items: center;
-  padding: 0.375rem 0;
   @extend %body-bold-01;
 
   .component-name,
   .element-name {
-    margin-left: 10px;
+    margin-left: 0.625rem;
+    font-weight: 700;
+    height: 32px; /* Same as mat-expansion-panel-header height */
   }
 }
 
@@ -22,6 +28,9 @@
 
     &.mat-accordion {
       .mat-expansion-panel {
+        border: none;
+        box-shadow: none;
+
         .mat-expansion-panel-header {
           padding: 0;
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header.component.scss
@@ -6,17 +6,16 @@
 }
 
 .element-header {
+  @extend %body-bold-01;
   display: flex;
   justify-content: space-between;
   width: 100%;
   align-items: center;
-  @extend %body-bold-01;
+  height: 32px; /* Same as mat-expansion-panel-header height */
 
   .component-name,
   .element-name {
     margin-left: 0.625rem;
-    font-weight: 700;
-    height: 32px; /* Same as mat-expansion-panel-header height */
   }
 }
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab.component.html
@@ -1,8 +1,6 @@
-<ng-property-tab-header [currentSelectedElement]="currentSelectedElement()">
-</ng-property-tab-header>
+<ng-property-tab-header [currentSelectedElement]="currentSelectedElement()" />
 <ng-property-tab-body
   (inspect)="inspect.emit($event)"
   (viewSource)="viewSource.emit($event)"
   [currentSelectedElement]="currentSelectedElement()"
->
-</ng-property-tab-body>
+/>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/BUILD.bazel
@@ -11,6 +11,7 @@ _STYLE_SRCS = [
     "property-view-body.component.scss",
     "property-view-header.component.scss",
     "property-view-tree.component.scss",
+    "dependency-viewer.component.scss",
 ]
 
 _STYLE_LABELS = [
@@ -32,6 +33,7 @@ _STYLE_LABELS = [
 ng_module(
     name = "property-view",
     srcs = [
+        "dependency-viewer.component.ts",
         "property-editor.component.ts",
         "property-preview.component.ts",
         "property-tab-body.component.ts",
@@ -48,6 +50,7 @@ ng_module(
         "property-preview.component.html",
         "property-editor.component.html",
         "property-tab-body.component.html",
+        "dependency-viewer.component.html",
     ] + _STYLE_LABELS,
     deps = [
         "//devtools/projects/ng-devtools/src/lib/application-environment",

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/dependency-viewer.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/dependency-viewer.component.html
@@ -1,0 +1,24 @@
+<mat-accordion class="example-headers-align" multi>
+  <mat-expansion-panel>
+    <mat-expansion-panel-header collapsedHeight="2.5rem" expandedHeight="2.5rem">
+      <div class="dep-data">
+        <div class="dep-pill" matTooltipPosition="left" matTooltip="Dependency injection token">
+          {{ dependency().token }}
+        </div>
+        @if (dependency().flags?.optional) {
+          <div class="dep-pill flagged">Optional</div>
+        }
+        @if (dependency().flags?.host) {
+          <div class="dep-pill flagged">Host</div>
+        }
+        @if (dependency().flags?.self) {
+          <div class="dep-pill flagged">Self</div>
+        }
+        @if (dependency().flags?.skipSelf) {
+          <div class="dep-pill flagged">SkipSelf</div>
+        }
+      </div>
+    </mat-expansion-panel-header>
+    <ng-resolution-path [path]="dependency().resolutionPath!"></ng-resolution-path>
+  </mat-expansion-panel>
+</mat-accordion>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/dependency-viewer.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/dependency-viewer.component.scss
@@ -1,0 +1,57 @@
+@import '../../../../../styles/typography';
+
+:host {
+  .dep-data {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 0.5rem;
+    width: 100%;
+    padding-right: 0.5rem;
+    box-sizing: border-box;
+
+    .dep-pill {
+      background: color-mix(in srgb, var(--quinary-contrast), var(--senary-contrast));
+      padding: 0.125rem 0.5rem;
+      border-radius: 1rem;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      @extend %body-01;
+
+      &.flagged {
+        background: var(--quinary-contrast);
+      }
+    }
+  }
+
+  .mat-expansion-panel {
+    position: relative;
+    border-bottom: none;
+    background: none;
+
+    mat-expansion-panel-header {
+      padding-right: 1.2rem;
+    }
+  }
+
+  &:not(:last-of-type) {
+    .mat-expansion-panel {
+      &::after {
+        content: '';
+        position: absolute;
+        width: calc(100% - 1rem);
+        height: 1px;
+        background: color-mix(in srgb, var(--quinary-contrast), var(--senary-contrast));
+        bottom: 0;
+        left: 0.5rem;
+      }
+
+      &.mat-expanded {
+        &::after {
+          width: 100%;
+          left: 0;
+        }
+      }
+    }
+  }
+}

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/dependency-viewer.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/dependency-viewer.component.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component, input} from '@angular/core';
+import {SerializedInjectedService} from 'protocol';
+import {ResolutionPathComponent} from '../../../dependency-injection/resolution-path/resolution-path.component';
+import {MatTooltip} from '@angular/material/tooltip';
+import {MatExpansionModule} from '@angular/material/expansion';
+
+@Component({
+  selector: 'ng-dependency-viewer',
+  templateUrl: './dependency-viewer.component.html',
+  styleUrl: './dependency-viewer.component.scss',
+  imports: [MatExpansionModule, MatTooltip, ResolutionPathComponent],
+})
+export class DependencyViewerComponent {
+  readonly dependency = input.required<SerializedInjectedService>();
+}

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-tab-body.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-tab-body.component.html
@@ -1,11 +1,9 @@
-@if (currentSelectedElement()) {
-  @for (directive of currentDirectives(); track $index) {
-    <div class="explorer-panel">
-      <ng-property-view
-        (inspect)="inspect.emit($event)"
-        (viewSource)="viewSource.emit(directive.name)"
-        [directive]="directive"
-      />
-    </div>
-  }
+@for (directive of currentDirectives(); track $index) {
+  <div class="explorer-panel">
+    <ng-property-view
+      (inspect)="inspect.emit($event)"
+      (viewSource)="viewSource.emit(directive.name)"
+      [directive]="directive"
+    />
+  </div>
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-tab-body.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-tab-body.component.scss
@@ -1,0 +1,6 @@
+::ng-deep {
+  .mat-expansion-panel {
+    border-bottom: 1px solid var(--color-separator);
+    box-shadow: none !important;
+  }
+}

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.html
@@ -4,7 +4,7 @@
     @if (deps && deps.length > 0) {
       <div class="mat-accordion-content">
         <mat-expansion-panel [expanded]="true">
-          <mat-expansion-panel-header collapsedHeight="25px" expandedHeight="25px">
+          <mat-expansion-panel-header collapsedHeight="28px" expandedHeight="28px">
             <mat-panel-title>
               Injected Services
               <a
@@ -26,7 +26,7 @@
       <div class="mat-accordion-content" cdkDrag>
         @if (panel.controls().dataSource.data.length > 0) {
           <mat-expansion-panel [expanded]="true">
-            <mat-expansion-panel-header collapsedHeight="25px" expandedHeight="25px">
+            <mat-expansion-panel-header collapsedHeight="28px" expandedHeight="28px">
               <mat-panel-title>{{ panel.title() }}</mat-panel-title>
             </mat-expansion-panel-header>
             <ng-property-view-tree

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.scss
@@ -6,12 +6,6 @@
       border-radius: unset !important;
     }
 
-    .mat-expansion-panel {
-      box-shadow:
-        0 -2px 5px -2px var(--dynamic-transparent-02),
-        0 2px 5px 0 var(--dynamic-transparent-02);
-    }
-
     .mat-expansion-panel-body {
       padding: 0;
     }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.ts
@@ -24,7 +24,6 @@ import {
 } from '../../property-resolver/directive-property-resolver';
 import {FlatNode} from '../../property-resolver/element-property-resolver';
 import {ResolutionPathComponent} from '../../../dependency-injection/resolution-path/resolution-path.component';
-import {MatChipsModule} from '@angular/material/chips';
 import {PropertyViewTreeComponent} from './property-view-tree.component';
 import {MatIcon} from '@angular/material/icon';
 import {MatTooltip} from '@angular/material/tooltip';
@@ -111,32 +110,23 @@ export class PropertyViewBodyComponent {
   template: `
     <mat-accordion class="example-headers-align" multi>
       <mat-expansion-panel>
-        <mat-expansion-panel-header collapsedHeight="35px" expandedHeight="35px">
-          <mat-panel-title>
-            <mat-chip-listbox>
-              <mat-chip
-                matTooltipPosition="left"
-                matTooltip="Dependency injection token"
-                (click)="$event.stopPropagation()"
-                >{{ dependency().token }}</mat-chip
-              >
-            </mat-chip-listbox>
-          </mat-panel-title>
-          <mat-panel-description>
-            <mat-chip-listbox>
-              <div class="di-flags">
-                @if (dependency().flags?.optional) {
-                <mat-chip [highlighted]="true" color="primary">Optional</mat-chip>
-                } @if (dependency().flags?.host) {
-                <mat-chip [highlighted]="true" color="primary">Host</mat-chip>
-                } @if (dependency().flags?.self) {
-                <mat-chip [highlighted]="true" color="primary">Self</mat-chip>
-                } @if (dependency().flags?.skipSelf) {
-                <mat-chip [highlighted]="true" color="primary">SkipSelf</mat-chip>
-                }
-              </div>
-            </mat-chip-listbox>
-          </mat-panel-description>
+        <mat-expansion-panel-header collapsedHeight="2.5rem" expandedHeight="2.5rem">
+          <div class="dep-data">
+            <div
+              class="dep-pill"
+              matTooltipPosition="left"
+              matTooltip="Dependency injection token"
+            >{{ dependency().token }}</div>
+              @if (dependency().flags?.optional) {
+                <div class="dep-pill flagged">Optional</div>
+              } @if (dependency().flags?.host) {
+                <div class="dep-pill flagged">Host</div>
+              } @if (dependency().flags?.self) {
+                <div class="dep-pill flagged">Self</div>
+              } @if (dependency().flags?.skipSelf) {
+                <div class="dep-pill flagged">SkipSelf</div>
+              }
+          </div>
         </mat-expansion-panel-header>
         <ng-resolution-path [path]="dependency().resolutionPath!"></ng-resolution-path>
       </mat-expansion-panel>
@@ -144,19 +134,57 @@ export class PropertyViewBodyComponent {
   `,
   styles: [
     `
-      .di-flags {
-        display: flex;
-        flex-wrap: nowrap;
-      }
-
       :host {
-        mat-chip {
-          --mdc-chip-container-height: 18px;
+        .dep-data {
+          display: flex;
+          flex-wrap: nowrap;
+          gap: 0.5rem;
+        }
+
+        .dep-pill {
+          background: color-mix(in srgb, var(--quinary-contrast), var(--senary-contrast));
+          padding: 0.125rem 0.5rem;
+          border-radius: 1rem;
+
+          &.flagged {
+            background: var(--quinary-contrast);
+          }
+        }
+
+        .mat-expansion-panel {
+          position: relative;
+          border-bottom: none;
+          background: none;
+
+          mat-expansion-panel-header {
+            padding-right: 1.2rem;
+          }
+        }
+
+        &:not(:last-of-type) {
+          .mat-expansion-panel {
+            &::after {
+              content: '';
+              position: absolute;
+              width: calc(100% - 1rem);
+              height: 1px;
+              background: color-mix(in srgb, var(--quinary-contrast), var(--senary-contrast));
+              bottom: 0;
+              left: 0.5rem;
+            }
+
+            &.mat-expanded {
+              &::after {
+                width: 100%;
+                left: 0;
+              }
+            }
+          }
         }
       }
     `,
   ],
-  imports: [MatExpansionModule, MatChipsModule, MatTooltip, ResolutionPathComponent],
+  imports: [MatExpansionModule, MatTooltip, ResolutionPathComponent],
 })
 export class DependencyViewerComponent {
   readonly dependency = input.required<SerializedInjectedService>();
@@ -164,14 +192,30 @@ export class DependencyViewerComponent {
 
 @Component({
   selector: 'ng-injected-services',
-  template: ` @for (dependency of dependencies(); track dependency.position[0]) {
-    <ng-dependency-viewer [dependency]="dependency" />
-    }`,
+  template: `
+    <div class="services">
+      @for (dependency of dependencies(); track dependency.position[0]) {
+        <ng-dependency-viewer [dependency]="dependency" />
+      }
+    </div>
+  `,
   styles: [
     `
-      ng-dependency-viewer {
+      :host {
         display: block;
-      }
+        padding: 0.5rem;
+
+        .services {
+          border-radius: 0.375rem;
+          background: color-mix(in srgb, var(--senary-contrast) 50%, var(--color-background) 50%);
+          overflow: hidden;
+
+          .wrapper {
+            ng-dependency-viewer {
+              display: block;
+            }
+          }
+        }
     `,
   ],
   imports: [DependencyViewerComponent],

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.ts
@@ -23,11 +23,11 @@ import {
   DirectiveTreeData,
 } from '../../property-resolver/directive-property-resolver';
 import {FlatNode} from '../../property-resolver/element-property-resolver';
-import {ResolutionPathComponent} from '../../../dependency-injection/resolution-path/resolution-path.component';
 import {PropertyViewTreeComponent} from './property-view-tree.component';
 import {MatIcon} from '@angular/material/icon';
 import {MatTooltip} from '@angular/material/tooltip';
 import {MatExpansionModule} from '@angular/material/expansion';
+import {DependencyViewerComponent} from './dependency-viewer.component';
 
 @Component({
   selector: 'ng-property-view-body',
@@ -103,91 +103,6 @@ export class PropertyViewBodyComponent {
       directivePosition: this.controller().directivePosition,
     });
   }
-}
-
-@Component({
-  selector: 'ng-dependency-viewer',
-  template: `
-    <mat-accordion class="example-headers-align" multi>
-      <mat-expansion-panel>
-        <mat-expansion-panel-header collapsedHeight="2.5rem" expandedHeight="2.5rem">
-          <div class="dep-data">
-            <div
-              class="dep-pill"
-              matTooltipPosition="left"
-              matTooltip="Dependency injection token"
-            >{{ dependency().token }}</div>
-              @if (dependency().flags?.optional) {
-                <div class="dep-pill flagged">Optional</div>
-              } @if (dependency().flags?.host) {
-                <div class="dep-pill flagged">Host</div>
-              } @if (dependency().flags?.self) {
-                <div class="dep-pill flagged">Self</div>
-              } @if (dependency().flags?.skipSelf) {
-                <div class="dep-pill flagged">SkipSelf</div>
-              }
-          </div>
-        </mat-expansion-panel-header>
-        <ng-resolution-path [path]="dependency().resolutionPath!"></ng-resolution-path>
-      </mat-expansion-panel>
-    </mat-accordion>
-  `,
-  styles: [
-    `
-      :host {
-        .dep-data {
-          display: flex;
-          flex-wrap: nowrap;
-          gap: 0.5rem;
-        }
-
-        .dep-pill {
-          background: color-mix(in srgb, var(--quinary-contrast), var(--senary-contrast));
-          padding: 0.125rem 0.5rem;
-          border-radius: 1rem;
-
-          &.flagged {
-            background: var(--quinary-contrast);
-          }
-        }
-
-        .mat-expansion-panel {
-          position: relative;
-          border-bottom: none;
-          background: none;
-
-          mat-expansion-panel-header {
-            padding-right: 1.2rem;
-          }
-        }
-
-        &:not(:last-of-type) {
-          .mat-expansion-panel {
-            &::after {
-              content: '';
-              position: absolute;
-              width: calc(100% - 1rem);
-              height: 1px;
-              background: color-mix(in srgb, var(--quinary-contrast), var(--senary-contrast));
-              bottom: 0;
-              left: 0.5rem;
-            }
-
-            &.mat-expanded {
-              &::after {
-                width: 100%;
-                left: 0;
-              }
-            }
-          }
-        }
-      }
-    `,
-  ],
-  imports: [MatExpansionModule, MatTooltip, ResolutionPathComponent],
-})
-export class DependencyViewerComponent {
-  readonly dependency = input.required<SerializedInjectedService>();
 }
 
 @Component({

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-header.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-header.component.scss
@@ -2,12 +2,13 @@
 
 mat-toolbar {
   @extend %body-medium-01;
-  padding-left: 10px;
+  padding: 0.25rem 0.625rem;
   justify-content: space-between;
   text-overflow: ellipsis;
   overflow: hidden;
   line-height: 25px;
   height: auto;
+  border-bottom: 1px solid var(--color-separator);
 }
 
 .mat-icon-button {

--- a/devtools/projects/ng-devtools/src/styles/_colors.scss
+++ b/devtools/projects/ng-devtools/src/styles/_colors.scss
@@ -49,6 +49,7 @@ $_colors: (
   transparent-02: oklch(0% 0 0 / 0.35),
   transparent-03: oklch(0% 0 0 / 0.2),
   transparent-04: oklch(0% 0 0 / 0.05),
+  transparent-05: oklch(0% 0 0 / 0),
 );
 
 @mixin _light-colors {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature



## What is the current behavior?

In general, the UI is a bit messy especially after the colors refactoring which made the shadows of the expandable containers very prominent. To name a few issues:

- Shadows do not match the overall look and feel of DevTools
- Material pills appear larger after the latest update, I believe
- Some inconsistencies in terms of paddings, margins and font sizes

## What is the new behavior?

<img width="617" alt="Screenshot 2025-04-17 at 16 51 23" src="https://github.com/user-attachments/assets/b0b954b6-d4de-4edd-9288-c8278d56b49b" />

- Shadows are substituted with borders
- Material pills are substituted with simple `div`s
- Injected services borders are shorter to imply that they are part of the parent expandable container (something that wasn't clear with the current/old UI)
- Other minor improvements
- Font sizes are handled by #60531 

The side pane might require a more thorough refactoring but this change should stabilize the UI for now.

cc @dgp1130 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
