### PR TITLE
refactor(core): Add createSignalTuple

### DIFF
--- a/goldens/public-api/core/primitives/signals/index.api.md
+++ b/goldens/public-api/core/primitives/signals/index.api.md
@@ -43,6 +43,9 @@ export function createLinkedSignal<S, D>(sourceFn: () => S, computationFn: Compu
 // @public
 export function createSignal<T>(initialValue: T, equal?: ValueEqualityFn<T>): SignalGetter<T>;
 
+// @public
+export function createSignalTuple<T>(initialValue: T, equal?: ValueEqualityFn<T>): [SignalGetter<T>, SignalSetter<T>, SignalUpdater<T>];
+
 // @public (undocumented)
 export function createWatch(fn: (onCleanup: WatchCleanupRegisterFn) => void, schedule: (watch: Watch) => void, allowSignalWrites: boolean): Watch;
 

--- a/packages/core/primitives/signals/index.ts
+++ b/packages/core/primitives/signals/index.ts
@@ -51,6 +51,7 @@ export {
   signalGetFn,
   signalSetFn,
   signalUpdateFn,
+  createSignalTuple,
 } from './src/signal';
 export {Watch, WatchCleanupFn, WatchCleanupRegisterFn, createWatch} from './src/watch';
 export {setAlternateWeakRefImpl} from './src/weak_ref';

--- a/packages/core/primitives/signals/src/signal.ts
+++ b/packages/core/primitives/signals/src/signal.ts
@@ -38,6 +38,8 @@ export interface SignalNode<T> extends ReactiveNode {
 }
 
 export type SignalBaseGetter<T> = (() => T) & {readonly [SIGNAL]: unknown};
+type SignalSetter<T> = (newValue: T) => void;
+type SignalUpdater<T> = (updateFn: (value: T) => T) => void;
 
 // Note: Closure *requires* this to be an `interface` and not a type, which is why the
 // `SignalBaseGetter` type exists to provide the correct shape.
@@ -64,6 +66,22 @@ export function createSignal<T>(initialValue: T, equal?: ValueEqualityFn<T>): Si
   runPostProducerCreatedFn(node);
 
   return getter;
+}
+
+/**
+ * Creates a `Signal` getter, setter, and updater function.
+ */
+export function createSignalTuple<T>(
+  initialValue: T,
+  equal?: ValueEqualityFn<T>,
+): [SignalGetter<T>, SignalSetter<T>, SignalUpdater<T>] {
+  const getter = createSignal(initialValue, equal);
+  const node = getter[SIGNAL];
+  return [
+    getter,
+    (newValue: T) => signalSetFn(node, newValue),
+    (updateFn: (value: T) => T) => signalUpdateFn(node, updateFn),
+  ];
 }
 
 export function setPostSignalSetFn(fn: ReactiveHookFn | null): ReactiveHookFn | null {

--- a/packages/core/primitives/signals/src/signal.ts
+++ b/packages/core/primitives/signals/src/signal.ts
@@ -59,16 +59,13 @@ export function createSignal<T>(initialValue: T, equal?: ValueEqualityFn<T>): Si
   const getter = (() => signalGetFn(node)) as SignalGetter<T>;
   (getter as any)[SIGNAL] = node;
   if (typeof ngDevMode !== 'undefined' && ngDevMode) {
-    getter.toString = () => `[${createSignalDebugName(node)}: ${node.value}]`;
+    const debugName = node.debugName ? ' (' + node.debugName + ')' : '';
+    getter.toString = () => `[Signal${debugName}: ${node.value}]`;
   }
 
   runPostProducerCreatedFn(node);
 
   return getter;
-}
-
-function createSignalDebugName<T>(node: SignalNode<T>) {
-  return `Signal${node.debugName ? ' (' + node.debugName + ')' : ''}`;
 }
 
 /**
@@ -80,13 +77,8 @@ export function createSignalTuple<T>(
 ): [SignalGetter<T>, SignalSetter<T>, SignalUpdater<T>] {
   const getter = createSignal(initialValue, equal);
   const node = getter[SIGNAL];
-  const debugName = node.debugName;
   const set = (newValue: T) => signalSetFn(node, newValue);
   const update = (updateFn: (value: T) => T) => signalUpdateFn(node, updateFn);
-  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
-    set.toString = () => `[${createSignalDebugName} Setter:${node.value}]`;
-    update.toString = () => `[${createSignalDebugName} Updater:${node.value}]`;
-  }
   return [getter, set, update];
 }
 

--- a/packages/core/test/signals/signal_spec.ts
+++ b/packages/core/test/signals/signal_spec.ts
@@ -12,6 +12,7 @@ import {
   ReactiveNode,
   setPostProducerCreatedFn,
   setPostSignalSetFn,
+  createSignalTuple,
   SIGNAL,
 } from '../../primitives/signals';
 
@@ -223,5 +224,24 @@ describe('signals', () => {
 
     expect(producerKindsCreated).toEqual(['signal']);
     setPostProducerCreatedFn(prev);
+  });
+});
+
+describe('createSignalTuple', () => {
+  it('get returns the signal value', () => {
+    const [get] = createSignalTuple(0);
+    expect(get()).toBe(0);
+  });
+
+  it('set sets the signal value', () => {
+    const [get, set] = createSignalTuple(0);
+    set(1);
+    expect(get()).toBe(1);
+  });
+
+  it('update updates the values based on the previous value', () => {
+    const [get, , update] = createSignalTuple(0);
+    update((prev) => prev + 2);
+    expect(get()).toBe(2);
   });
 });


### PR DESCRIPTION
Add createSignalTuple function to match Wiz array destructuring signal return. This will be the implementation for createSignal once createSignal usages in google3 are migrated to createSignalTuple.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is the create signal function that only returns the signal getter. Each caller of createSignal must then create their own setter and update functions.

Issue Number: N/A


## What is the new behavior?
A `createSignalTuple` function that returns a tuple containing a getter, setter, and update function.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
