### PR TITLE
refactor(core): promote `pendingUntilEvent` to developerPreview

### DIFF
--- a/packages/core/rxjs-interop/src/pending_until_event.ts
+++ b/packages/core/rxjs-interop/src/pending_until_event.ts
@@ -16,7 +16,7 @@ import {MonoTypeOperatorFunction, Observable} from 'rxjs';
  *
  * @param injector The `Injector` to use during creation. If this is not provided, the current injection context will be used instead (via `inject`).
  *
- * @experimental
+ * @developerPreview
  */
 export function pendingUntilEvent<T>(injector?: Injector): MonoTypeOperatorFunction<T> {
   if (injector === undefined) {


### PR DESCRIPTION
`pendingUntilEvent` is now in developerPreview in v20.
