### PR TITLE
refactor(platform-server): deprecate the testing entry point

### DIFF
--- a/goldens/public-api/platform-server/testing/index.api.md
+++ b/goldens/public-api/platform-server/testing/index.api.md
@@ -8,10 +8,10 @@ import * as i0 from '@angular/core';
 import * as i1 from '@angular/platform-browser-dynamic/testing';
 import { StaticProvider } from '@angular/core';
 
-// @public
+// @public @deprecated
 export const platformServerTesting: (extraProviders?: StaticProvider[]) => i0.PlatformRef;
 
-// @public
+// @public @deprecated
 export class ServerTestingModule {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<ServerTestingModule, never>;

--- a/packages/platform-server/testing/PACKAGE.md
+++ b/packages/platform-server/testing/PACKAGE.md
@@ -1,1 +1,5 @@
 Supplies a testing module for the Angular platform server subsystem.
+This secondary entry point is deprecated. Use e2e tests to verify SSR
+behavior instead of `TestBed`.
+
+See [Angular deprecation policy](reference/releases#deprecation-policy).

--- a/packages/platform-server/testing/src/server.ts
+++ b/packages/platform-server/testing/src/server.ts
@@ -23,6 +23,7 @@ const INTERNAL_SERVER_DYNAMIC_PLATFORM_TESTING_PROVIDERS: StaticProvider[] = [
  * Platform for testing
  *
  * @publicApi
+ * @deprecated from v20.0.0, use e2e testing to verify SSR behavior.
  */
 export const platformServerTesting = createPlatformFactory(
   platformCore,
@@ -34,6 +35,7 @@ export const platformServerTesting = createPlatformFactory(
  * NgModule for testing.
  *
  * @publicApi
+ * @deprecated from v20.0.0, use e2e testing to verify SSR behavior.
  */
 @NgModule({
   exports: [BrowserDynamicTestingModule],


### PR DESCRIPTION
DEPRECATED: `@angular/platform-server/testing`

Use e2e tests to verify SSR behavior instead.