### PR TITLE
fix(core): inject migration should treat @Attribute as optional

### DIFF
--- a/packages/core/schematics/test/inject_migration_spec.ts
+++ b/packages/core/schematics/test/inject_migration_spec.ts
@@ -194,7 +194,7 @@ describe('inject migration', () => {
       ``,
       `@Directive()`,
       `class MyDir {`,
-      `  private foo = inject(new HostAttributeToken('foo'));`,
+      `  private foo = inject(new HostAttributeToken('foo'), { optional: true });`,
       `}`,
     ]);
   });
@@ -1252,6 +1252,31 @@ describe('inject migration', () => {
       `  readonly f = inject(F, { optional: true });`,
       `  protected g = inject(G, { optional: true });`,
       `  h = inject(H, { optional: true });`,
+      `}`,
+    ]);
+  });
+
+  it('should add non-null assertion for @Attribute injections when enabled', async () => {
+    writeFile(
+      '/dir.ts',
+      [
+        `import { Attribute, Directive } from '@angular/core';`,
+        ``,
+        `@Directive()`,
+        `class MyDir {`,
+        `  constructor(@Attribute('tabindex') private foo: string) {}`,
+        `}`,
+      ].join('\n'),
+    );
+
+    await runMigration({nonNullableOptional: true});
+
+    expect(tree.readContent('/dir.ts').split('\n')).toEqual([
+      `import { Directive, HostAttributeToken, inject } from '@angular/core';`,
+      ``,
+      `@Directive()`,
+      `class MyDir {`,
+      `  private foo = inject(new HostAttributeToken('tabindex'), { optional: true })!;`,
       `}`,
     ]);
   });


### PR DESCRIPTION
The @Attribute decorator will inject null if a host attribute is missing, but `inject(new HostAttributeToken(...))` will throw a no provider error. We should set {optional: true} when migrating an @Attribute decorator. Also allow nonNullableOptional to add `!` to those declarations if enabled.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
