### PR TITLE
refactor(core): export markViewForRefresh for elements

### DIFF
--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -295,11 +295,8 @@ export {
   FrameworkAgnosticGlobalUtils as ɵFrameworkAgnosticGlobalUtils,
   GlobalDevModeUtils as ɵGlobalDevModeUtils,
 } from './render3/util/global_utils';
-export {
-  ViewRef as ɵViewRef,
-  isViewDirty as ɵisViewDirty,
-  markForRefresh as ɵmarkForRefresh,
-} from './render3/view_ref';
+export {ViewRef as ɵViewRef, isViewDirty as ɵisViewDirty} from './render3/view_ref';
+export {markViewForRefresh as ɵmarkViewForRefresh} from './render3/util/view_utils';
 export {
   bypassSanitizationTrustHtml as ɵbypassSanitizationTrustHtml,
   bypassSanitizationTrustResourceUrl as ɵbypassSanitizationTrustResourceUrl,

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -368,7 +368,3 @@ export class ViewRef<T> implements EmbeddedViewRef<T>, ChangeDetectorRefInterfac
 export function isViewDirty(view: ViewRef<unknown>): boolean {
   return requiresRefreshOrTraversal(view._lView) || !!(view._lView[FLAGS] & LViewFlags.Dirty);
 }
-
-export function markForRefresh(view: ViewRef<unknown>): void {
-  markViewForRefresh(view['_cdRefInjectingView'] || view._lView);
-}

--- a/packages/elements/src/component-factory-strategy.ts
+++ b/packages/elements/src/component-factory-strategy.ts
@@ -19,7 +19,7 @@ import {
   ɵNotificationSource as NotificationSource,
   ɵViewRef as ViewRef,
   ɵisViewDirty as isViewDirty,
-  ɵmarkForRefresh as markForRefresh,
+  ɵmarkViewForRefresh as markViewForRefresh,
   OutputRef,
 } from '@angular/core';
 import {merge, Observable, ReplaySubject} from 'rxjs';
@@ -181,7 +181,7 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
         // guarantees the view will be checked even if the input is being set from within change
         // detection. This provides backwards compatibility, since we used to unconditionally
         // schedule change detection in addition to the current zone run.
-        markForRefresh(this.componentRef!.changeDetectorRef as ViewRef<unknown>);
+        markViewForRefresh((this.componentRef!.changeDetectorRef as ViewRef<unknown>)._lView);
 
         // Notifying the scheduler with `NotificationSource.CustomElement` causes a `tick()` to be
         // scheduled unconditionally, even if the scheduler is otherwise disabled.


### PR DESCRIPTION
`markForRefresh` calls in to `markViewForRefresh`. The only place this
function is used is for elements when _cdRefInjectionView is always the
same as _lView.