### PR TITLE
refactor(core): Remove _cdRefInjectingView from markForRefresh

### DIFF
--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -370,5 +370,6 @@ export function isViewDirty(view: ViewRef<unknown>): boolean {
 }
 
 export function markForRefresh(view: ViewRef<unknown>): void {
-  markViewForRefresh(view['_cdRefInjectingView'] || view._lView);
+  // This function is only used by elements where _cdRefInjectingView is the same as _lView
+  markViewForRefresh(view._lView);
 }


### PR DESCRIPTION
The code was not compatible with property renaming so it was always using _lView. This didn't matter because they're always the same for the only place the function is used. Casting to any would fix the renaming problem but introduce a risk of getting "broken" by a refactor that changes the private variable name. This change removes the private member access entirely.
