### PR TITLE
docs(docs-infra): prevent from resetting the search on navigation

### DIFF
--- a/adev/shared-docs/components/search-dialog/search-dialog.component.html
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.html
@@ -4,6 +4,7 @@
       [autofocus]="true"
       [hideIcon]="true"
       [(ngModel)]="searchQuery"
+      [resetLabel]="'Clear the search'"
       class="docs-search-input"
       placeholder="Search docs"
     />
@@ -57,15 +58,82 @@
       </div>
     }
 
-    <div class="docs-algolia">
-      <span>Search by</span>
-      <a
-        target="_blank"
-        rel="noopener"
-        href="https://www.algolia.com/developers/?utm_source=angular.dev&utm_medium=referral&utm_content=powered_by&utm_campaign=docsearch"
-      >
-        <docs-algolia-icon />
-      </a>
+    <div class="docs-search-footer">
+      <ul class="docs-search-commands">
+        <li>
+          <kbd class="docs-search-commands-key">
+            <svg width="15" height="15" aria-label="Enter key" role="img">
+              <g
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.2"
+              >
+                <path d="M12 3.53088v3c0 1-1 2-2 2H4M7 11.53088l-3-3 3-3"></path>
+              </g>
+            </svg>
+          </kbd>
+          <span>to select</span>
+        </li>
+        <li>
+          <kbd class="docs-search-commands-key">
+            <svg width="15" height="15" aria-label="Arrow down" role="img">
+              <g
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.2"
+              >
+                <path d="M7.5 3.5v8M10.5 8.5l-3 3-3-3"></path>
+              </g>
+            </svg>
+          </kbd>
+          <kbd class="docs-search-commands-key">
+            <svg width="15" height="15" aria-label="Arrow up" role="img">
+              <g
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.2"
+              >
+                <path d="M7.5 11.5v-8M10.5 6.5l-3-3-3 3"></path>
+              </g>
+            </svg>
+          </kbd>
+          <span>to navigate</span>
+        </li>
+        <li>
+          <kbd class="docs-search-commands-key"
+            ><svg width="15" height="15" aria-label="Escape key" role="img">
+              <g
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.2"
+              >
+                <path
+                  d="M13.6167 8.936c-.1065.3583-.6883.962-1.4875.962-.7993 0-1.653-.9165-1.653-2.1258v-.5678c0-1.2548.7896-2.1016 1.653-2.1016.8634 0 1.3601.4778 1.4875 1.0724M9 6c-.1352-.4735-.7506-.9219-1.46-.8972-.7092.0246-1.344.57-1.344 1.2166s.4198.8812 1.3445.9805C8.465 7.3992 8.968 7.9337 9 8.5c.032.5663-.454 1.398-1.4595 1.398C6.6593 9.898 6 9 5.963 8.4851m-1.4748.5368c-.2635.5941-.8099.876-1.5443.876s-1.7073-.6248-1.7073-2.204v-.4603c0-1.0416.721-2.131 1.7073-2.131.9864 0 1.6425 1.031 1.5443 2.2492h-2.956"
+                ></path>
+              </g>
+            </svg>
+          </kbd>
+          <span>to close</span>
+        </li>
+      </ul>
+      <div class="docs-algolia">
+        <span>Search by</span>
+        <a
+          target="_blank"
+          rel="noopener"
+          href="https://www.algolia.com/developers/?utm_source=angular.dev&utm_medium=referral&utm_content=powered_by&utm_campaign=docsearch"
+        >
+          <docs-algolia-icon />
+        </a>
+      </div>
     </div>
   </div>
 </dialog>

--- a/adev/shared-docs/components/search-dialog/search-dialog.component.scss
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.scss
@@ -25,23 +25,16 @@ dialog {
     height: 2.6875rem; // 43px;
     padding-inline-start: 1rem;
     position: relative;
-
-    &::after {
-      content: 'Esc';
-      position: absolute;
-      right: 1rem;
-      color: var(--gray-400);
-      font-size: 0.875rem;
-    }
   }
 
-  ul {
+  .docs-search-results {
     max-height: 50vh;
     overflow-y: auto;
     overscroll-behavior: contain;
     list-style-type: none;
     padding-inline: 0;
     padding-block-start: 1rem;
+    padding-block-end: 1rem;
     margin: 0;
     border-block-end: 1px solid var(--senary-contrast);
 
@@ -142,17 +135,48 @@ dialog {
   }
 }
 
-.docs-algolia {
+.docs-search-footer {
   display: flex;
   align-items: center;
-  justify-content: end;
+  justify-content: space-between;
   color: var(--gray-400);
   padding: 1rem;
   font-size: 0.75rem;
   font-weight: 500;
-  gap: 0.25rem;
   background-color: var(--page-background);
   border-radius: 0 0 0.25rem 0.25rem;
+  container-type: inline-size;
+  container-name: footer;
+
+  .docs-search-commands {
+    display: flex;
+    list-style: none;
+    gap: 1rem;
+    margin: 0;
+    padding: 0;
+
+    li {
+      display: flex;
+      gap: 0.25rem;
+    }
+
+    .docs-search-commands-key {
+      display: flex;
+      align-items: center;
+    }
+  }
+
+  @container footer (max-width: 600px) {
+    .docs-search-commands li {
+      display: none;
+    }
+  }
+
+  .docs-algolia {
+    display: flex;
+    gap: 0.25rem;
+    align-items: center;
+  }
 
   docs-algolia-icon {
     display: block;

--- a/adev/shared-docs/components/text-field/text-field.component.html
+++ b/adev/shared-docs/components/text-field/text-field.component.html
@@ -10,3 +10,24 @@
   (ngModelChange)="setValue($event)"
   class="docs-text-field"
 />
+
+@if (resetLabel()) {
+  <button
+    type="reset"
+    [title]="resetLabel()"
+    class="docs-text-reset"
+    [attr.aria-label]="resetLabel()"
+    (click)="clearTextField()"
+  >
+    <svg width="20" height="20" viewBox="0 0 20 20">
+      <path
+        d="M10 10l5.09-5.09L10 10l5.09 5.09L10 10zm0 0L4.91 4.91 10 10l-5.09 5.09L10 10z"
+        stroke="currentColor"
+        fill="none"
+        fill-rule="evenodd"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      ></path>
+    </svg>
+  </button>
+}

--- a/adev/shared-docs/components/text-field/text-field.component.scss
+++ b/adev/shared-docs/components/text-field/text-field.component.scss
@@ -7,3 +7,11 @@
 docs-icon + .docs-text-field {
   font-size: 1rem;
 }
+
+button {
+  color: var(--secondary-contrast);
+
+  &:hover {
+    color: var(--vivid-pink);
+  }
+}

--- a/adev/shared-docs/components/text-field/text-field.component.ts
+++ b/adev/shared-docs/components/text-field/text-field.component.ts
@@ -46,6 +46,7 @@ export class TextField implements ControlValueAccessor {
   readonly disabled = model<boolean>(false);
   readonly hideIcon = input<boolean>(false);
   readonly autofocus = input<boolean>(false);
+  readonly resetLabel = input<string | null>(null);
 
   // Implemented as part of ControlValueAccessor.
   private onChange: (value: string) => void = (_: string) => {};
@@ -89,5 +90,9 @@ export class TextField implements ControlValueAccessor {
     this.value.set(value);
     this.onChange(value);
     this.onTouched();
+  }
+
+  clearTextField() {
+    this.setValue('');
   }
 }

--- a/adev/shared-docs/services/search.service.ts
+++ b/adev/shared-docs/services/search.service.ts
@@ -6,26 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  DestroyRef,
-  Injectable,
-  InjectionToken,
-  Provider,
-  ResourceRef,
-  inject,
-  resource,
-  signal,
-} from '@angular/core';
-import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
-import {NavigationEnd, Router} from '@angular/router';
+import {Injectable, InjectionToken, Provider, inject, resource, signal} from '@angular/core';
 import {ENVIRONMENT} from '../providers/index';
 import type {Environment, SearchResult, SearchResultItem, SnippetResult} from '../interfaces/index';
-import {filter} from 'rxjs';
 import {
   liteClient as algoliasearch,
   SearchResponses,
   SearchResult as AlgoliaSearchResult,
-  Hit,
 } from 'algoliasearch/lite';
 
 export const SEARCH_DELAY = 200;
@@ -49,8 +36,6 @@ export const provideAlgoliaSearchClient = (config: Environment): Provider => {
 export class Search {
   readonly searchQuery = signal('');
 
-  private readonly destroyRef = inject(DestroyRef);
-  private readonly router = inject(Router);
   private readonly config = inject(ENVIRONMENT);
   private readonly client = inject(ALGOLIA_CLIENT);
 
@@ -103,10 +88,6 @@ export class Search {
     },
   });
 
-  constructor() {
-    this.resetSearchQueryOnNavigationEnd();
-  }
-
   private getUniqueSearchResultItems(items: SearchResult[]): SearchResult[] {
     const uniqueUrls = new Set<string>();
 
@@ -132,15 +113,6 @@ export class Search {
       }
       return false;
     });
-  }
-
-  private resetSearchQueryOnNavigationEnd(): void {
-    this.router.events
-      .pipe(filter((event) => event instanceof NavigationEnd))
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => {
-        this.searchQuery.set('');
-      });
   }
 
   private parseResult(response: SearchResponses<unknown>): SearchResultItem[] | undefined {


### PR DESCRIPTION
By keeping the search well allow developers to navigate through multiple results without having to re-type the search
