### PR TITLE
refactor(compiler-cli): Don't extract constructors with no parameters

### DIFF
--- a/packages/compiler-cli/src/ngtsc/docs/src/class_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/class_extractor.ts
@@ -117,7 +117,10 @@ class ClassExtractor {
       return this.extractClassProperty(memberDeclaration);
     } else if (ts.isAccessor(memberDeclaration)) {
       return this.extractGetterSetter(memberDeclaration);
-    } else if (ts.isConstructorDeclaration(memberDeclaration)) {
+    } else if (
+      ts.isConstructorDeclaration(memberDeclaration) &&
+      memberDeclaration.parameters.length > 0
+    ) {
       return this.extractConstructor(memberDeclaration);
     }
 

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/class_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/class_doc_extraction_spec.ts
@@ -723,6 +723,25 @@ runInEachFileSystem(() => {
       expect((fooEntry as PropertyEntry).type).toBe('string');
     });
 
+    it('should not extract a constructor without parameters', () => {
+      env.write(
+        'index.ts',
+        `
+        export class MyClass {
+          constructor() {}
+
+          foo: string;
+        }`,
+      );
+
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
+      expect(docs.length).toBe(1);
+      const classEntry = docs[0] as ClassEntry;
+      expect(classEntry.members.length).toBe(1); // only foo, no constructor
+      const [fooEntry] = classEntry.members as PropertyEntry[];
+      expect(fooEntry.name).toBe('foo');
+    });
+
     it('should extract members of a class from .d.ts', () => {
       env.write(
         'index.d.ts',


### PR DESCRIPTION
This will prevent usesless paramters in the docs, ex: https://angular.dev/api/core/ApplicationInitStatus#constructor

This improves #60302

Demo: https://ng-dev-previews-fw--pr-angular-angular-60928-adev-prev-tzgprluj.web.app/api/core/ApplicationInitStatus
