### PR TITLE
refactor(compiler-cli): Extract type predicates from type guards.

### DIFF
--- a/packages/compiler-cli/test/ngtsc/doc_extraction/function_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/function_doc_extraction_spec.ts
@@ -145,5 +145,19 @@ runInEachFileSystem(() => {
       expect(genericEntry.constraint).toBeUndefined();
       expect(genericEntry.default).toBeUndefined();
     });
+
+    it('should extract type predicates as return type of type guards', () => {
+      env.write(
+        'index.ts',
+        `export function isSignal(value: unknown): value is Signal<unknown> {}`,
+      );
+
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
+      expect(docs.length).toBe(1);
+
+      const [functionEntry] = docs as FunctionEntry[];
+      expect(functionEntry.implementation.returnType).toBe('value is Signal<unknown>');
+      expect(functionEntry.signatures[0].returnType).toBe('value is Signal<unknown>');
+    });
   });
 });


### PR DESCRIPTION
Previously they were extracted as `boolean`.

Example: https://ng-dev-previews-fw--pr-angular-angular-60934-adev-prev-ezptkitm.web.app/api/core/isSignal
