### PR TITLE
fix(core): do not run change detection on global error events

### DIFF
--- a/packages/core/src/error_handler.ts
+++ b/packages/core/src/error_handler.ts
@@ -104,8 +104,19 @@ const globalErrorListeners = new InjectionToken<void>(ngDevMode ? 'GlobalErrorLi
       e.preventDefault();
     };
 
-    window.addEventListener('unhandledrejection', rejectionListener);
-    window.addEventListener('error', errorListener);
+    const setupEventListeners = () => {
+      window.addEventListener('unhandledrejection', rejectionListener);
+      window.addEventListener('error', errorListener);
+    };
+
+    // Angular doesn't have to run change detection whenever any asynchronous tasks are invoked in
+    // the scope of this functionality.
+    if (typeof Zone !== 'undefined') {
+      Zone.root.run(setupEventListeners);
+    } else {
+      setupEventListeners();
+    }
+
     inject(DestroyRef).onDestroy(() => {
       window.removeEventListener('error', errorListener);
       window.removeEventListener('unhandledrejection', rejectionListener);


### PR DESCRIPTION
This commit wraps the `error` and `unhandledrejection` event listeners so they are installed outside of the Angular zone, because otherwise they trigger change detection whenever the event callbacks are invoked.