### PR TITLE
refactor(core): alias `afterRender` to `afterEveryRender`

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -37,7 +37,7 @@ export function afterNextRender<E = never, W = never, M = never>(spec: {
 export function afterNextRender(callback: VoidFunction, options?: AfterRenderOptions): AfterRenderRef;
 
 // @public
-export function afterRender<E = never, W = never, M = never>(spec: {
+function afterRender<E = never, W = never, M = never>(spec: {
     earlyRead?: () => E;
     write?: (...args: ɵFirstAvailable<[E]>) => W;
     mixedReadWrite?: (...args: ɵFirstAvailable<[W, E]>) => M;
@@ -45,7 +45,9 @@ export function afterRender<E = never, W = never, M = never>(spec: {
 }, options?: Omit<AfterRenderOptions, 'phase'>): AfterRenderRef;
 
 // @public
-export function afterRender(callback: VoidFunction, options?: AfterRenderOptions): AfterRenderRef;
+function afterRender(callback: VoidFunction, options?: AfterRenderOptions): AfterRenderRef;
+export { afterRender as afterEveryRender }
+export { afterRender }
 
 // @public
 export function afterRenderEffect(callback: (onCleanup: EffectCleanupRegisterFn) => void, options?: Omit<AfterRenderOptions, 'phase'>): AfterRenderRef;

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -112,6 +112,7 @@ export {
   afterNextRender,
   ɵFirstAvailable,
 } from './render3/after_render/hooks';
+export {afterRender as afterEveryRender} from './render3/after_render/hooks';
 export {inputBinding, outputBinding, twoWayBinding} from './render3/dynamic_bindings';
 export {ApplicationConfig, mergeApplicationConfig} from './application/application_config';
 export {makeStateKey, StateKey, TransferState} from './transfer_state';


### PR DESCRIPTION
Introduce an alias from afterRender to afterEveryRender in preparations for the the internal rename.
Opening this intermediate PR mostly to do G3 cleanups.
