### PR TITLE
Binder support for selectorless

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -1047,6 +1047,8 @@ export class ComponentDecoratorHandler
         }
       }
     }
+
+    // TODO(crisbeto): implement for selectorless.
     const binder = new R3TargetBinder(matcher);
     const boundTemplate = binder.bind({template: analysis.template.diagNodes});
 
@@ -1076,6 +1078,7 @@ export class ComponentDecoratorHandler
       return;
     }
 
+    // TODO(crisbeto): implement for selectorless.
     const binder = new R3TargetBinder<TypeCheckableDirectiveMeta>(scope.matcher);
     const templateContext: TemplateContext = {
       nodes: meta.template.diagNodes,
@@ -2266,6 +2269,8 @@ function createTargetBinder(dependencies: Array<PipeMeta | DirectiveMeta | NgMod
       matcher.addSelectables(CssSelector.parse(dep.selector), [dep]);
     }
   }
+
+  // TODO(crisbeto): implement for selectorless.
   return new R3TargetBinder(matcher);
 }
 

--- a/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
@@ -377,8 +377,12 @@ class TemplateVisitor extends TmplAstRecursiveVisitor {
 
   /** Creates an identifier for a template element or template node. */
   private elementOrTemplateToIdentifier(
-    node: TmplAstElement | TmplAstTemplate,
+    node: TmplAstElement | TmplAstTemplate | TmplAstComponent | TmplAstDirective,
   ): ElementIdentifier | TemplateNodeIdentifier | null {
+    if (node instanceof TmplAstComponent || node instanceof TmplAstDirective) {
+      throw new Error('TODO');
+    }
+
     // If this node has already been seen, return the cached result.
     if (this.elementAndTemplateIdentifierCache.has(node)) {
       return this.elementAndTemplateIdentifierCache.get(node)!;
@@ -465,7 +469,12 @@ class TemplateVisitor extends TmplAstRecursiveVisitor {
       if (refTarget) {
         let node: ElementIdentifier | TemplateNodeIdentifier | null = null;
         let directive: ClassDeclaration<DeclarationNode> | null = null;
-        if (refTarget instanceof TmplAstElement || refTarget instanceof TmplAstTemplate) {
+        if (
+          refTarget instanceof TmplAstElement ||
+          refTarget instanceof TmplAstTemplate ||
+          refTarget instanceof TmplAstComponent ||
+          refTarget instanceof TmplAstDirective
+        ) {
           node = this.elementOrTemplateToIdentifier(refTarget);
         } else {
           node = this.elementOrTemplateToIdentifier(refTarget.node);

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -245,7 +245,7 @@ export {createCssSelectorFromNode} from './render3/view/util';
 export * from './resource_loader';
 export * from './schema/dom_element_schema_registry';
 export * from './schema/element_schema_registry';
-export * from './selector';
+export * from './directive_matching';
 export {Version} from './util';
 export * from './version';
 export {outputAst};

--- a/packages/compiler/src/core.ts
+++ b/packages/compiler/src/core.ts
@@ -12,7 +12,7 @@
 // This is important to prevent a build cycle, as @angular/core needs to
 // be compiled with the compiler.
 
-import {CssSelector} from './selector';
+import {CssSelector} from './directive_matching';
 
 // Stores the default value of `emitDistinctChangesOnly` when the `emitDistinctChangesOnly` is not
 // explicitly set.

--- a/packages/compiler/src/directive_matching.ts
+++ b/packages/compiler/src/directive_matching.ts
@@ -472,3 +472,11 @@ export class SelectorContext<T = any> {
     return result;
   }
 }
+
+export class SelectorlessMatcher<T = unknown> {
+  constructor(private registry: Map<string, T>) {}
+
+  match(name: string): T | null {
+    return this.registry.get(name) ?? null;
+  }
+}

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -104,7 +104,7 @@ import {R3TargetBinder} from './render3/view/t2_binder';
 import {makeBindingParser, parseTemplate} from './render3/view/template';
 import {ResourceLoader} from './resource_loader';
 import {DomElementSchemaRegistry} from './schema/dom_element_schema_registry';
-import {SelectorMatcher} from './selector';
+import {SelectorMatcher} from './directive_matching';
 import {getJitStandaloneDefaultForVersion} from './util';
 
 export class CompilerFacadeImpl implements CompilerFacade {

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -10,7 +10,7 @@ import {ConstantPool} from '../../constant_pool';
 import * as core from '../../core';
 import * as o from '../../output/output_ast';
 import {ParseError, ParseSourceSpan} from '../../parse_util';
-import {CssSelector} from '../../selector';
+import {CssSelector} from '../../directive_matching';
 import {ShadowCss} from '../../shadow_css';
 import {CompilationJobKind} from '../../template/pipeline/src/compilation';
 import {emitHostBindingFunction, emitTemplateFn, transform} from '../../template/pipeline/src/emit';

--- a/packages/compiler/src/render3/view/t2_api.ts
+++ b/packages/compiler/src/render3/view/t2_api.ts
@@ -10,12 +10,14 @@ import {AST} from '../../expression_parser/ast';
 import {
   BoundAttribute,
   BoundEvent,
+  Component,
   Content,
   DeferredBlock,
   DeferredBlockError,
   DeferredBlockLoading,
   DeferredBlockPlaceholder,
   DeferredTrigger,
+  Directive,
   Element,
   ForLoopBlock,
   ForLoopBlockEmpty,
@@ -48,7 +50,7 @@ export type ScopedNode =
 export type ReferenceTarget<DirectiveT> =
   | {
       directive: DirectiveT;
-      node: Element | Template;
+      node: Element | Template | Component | Directive;
     }
   | Element
   | Template;
@@ -181,7 +183,7 @@ export interface BoundTarget<DirectiveT extends DirectiveMeta> {
    * For a given template node (either an `Element` or a `Template`), get the set of directives
    * which matched the node, if any.
    */
-  getDirectivesOfNode(node: Element | Template): DirectiveT[] | null;
+  getDirectivesOfNode(node: Element | Template | Component): DirectiveT[] | null;
 
   /**
    * For a given `Reference`, get the reference's target - either an `Element`, a `Template`, or
@@ -270,5 +272,5 @@ export interface BoundTarget<DirectiveT extends DirectiveMeta> {
   /**
    * Whether a given node is located in a `@defer` block.
    */
-  isDeferred(node: Element): boolean;
+  isDeferred(node: Element | Component): boolean;
 }

--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -88,12 +88,12 @@ type ReferenceMap<DirectiveT> = Map<
   | Element
   | {
       directive: DirectiveT;
-      node: Element | Template;
+      node: Element | Template | Component | Directive;
     }
 >;
 
 /** Mapping between AST nodes and the directives that have been matched on them. */
-type MatchedDirectives<DirectiveT> = Map<Template | Element, DirectiveT[]>;
+type MatchedDirectives<DirectiveT> = Map<Template | Element | Component, DirectiveT[]>;
 
 /**
  * Mapping between a scoped not and the template entities that exist in it.
@@ -275,9 +275,9 @@ class Scope implements Visitor {
   readonly namedEntities = new Map<string, TemplateEntity>();
 
   /**
-   * Set of elements that belong to this scope.
+   * Set of element-like nodes that belong to this scope.
    */
-  readonly elementsInScope = new Set<Element>();
+  readonly elementLikeInScope = new Set<Element | Component>();
 
   /**
    * Child `Scope`s for immediately nested `ScopedNode`s.
@@ -345,15 +345,7 @@ class Scope implements Visitor {
   }
 
   visitElement(element: Element) {
-    element.directives.forEach((node) => node.visit(this));
-
-    // `Element`s in the template may have `Reference`s which are captured in the scope.
-    element.references.forEach((node) => this.visitReference(node));
-
-    // Recurse into the `Element`'s children.
-    element.children.forEach((node) => node.visit(this));
-
-    this.elementsInScope.add(element);
+    this.visitElementLike(element);
   }
 
   visitTemplate(template: Template) {
@@ -430,11 +422,11 @@ class Scope implements Visitor {
   }
 
   visitComponent(component: Component) {
-    throw new Error('TODO');
+    this.visitElementLike(component);
   }
 
   visitDirective(directive: Directive) {
-    throw new Error('TODO');
+    directive.references.forEach((current) => this.visitReference(current));
   }
 
   // Unused visitors.
@@ -446,6 +438,13 @@ class Scope implements Visitor {
   visitIcu(icu: Icu) {}
   visitDeferredTrigger(trigger: DeferredTrigger) {}
   visitUnknownBlock(block: UnknownBlock) {}
+
+  private visitElementLike(node: Element | Component) {
+    node.directives.forEach((current) => current.visit(this));
+    node.references.forEach((current) => this.visitReference(current));
+    node.children.forEach((current) => current.visit(this));
+    this.elementLikeInScope.add(node);
+  }
 
   private maybeDeclare(thing: TemplateEntity) {
     // Declare something with a name, as long as that name isn't taken.
@@ -551,84 +550,6 @@ class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
     this.visitElementOrTemplate(template);
   }
 
-  visitElementOrTemplate(node: Element | Template): void {
-    const directives: DirectiveT[] = [];
-
-    if (this.directiveMatcher instanceof SelectorMatcher) {
-      // First, determine the HTML shape of the node for the purpose of directive matching.
-      // Do this by building up a `CssSelector` for the node.
-      const cssSelector = createCssSelectorFromNode(node);
-
-      this.directiveMatcher.match(cssSelector, (_selector, results) => directives.push(...results));
-
-      if (directives.length > 0) {
-        this.directives.set(node, directives);
-        if (!this.isInDeferBlock) {
-          this.eagerDirectives.push(...directives);
-        }
-      }
-    } else {
-      throw new Error('TODO');
-    }
-
-    // Resolve any references that are created on this node.
-    node.references.forEach((ref) => {
-      let dirTarget: DirectiveT | null = null;
-
-      // If the reference expression is empty, then it matches the "primary" directive on the node
-      // (if there is one). Otherwise it matches the host node itself (either an element or
-      // <ng-template> node).
-      if (ref.value.trim() === '') {
-        // This could be a reference to a component if there is one.
-        dirTarget = directives.find((dir) => dir.isComponent) || null;
-      } else {
-        // This should be a reference to a directive exported via exportAs.
-        dirTarget =
-          directives.find(
-            (dir) => dir.exportAs !== null && dir.exportAs.some((value) => value === ref.value),
-          ) || null;
-        // Check if a matching directive was found.
-        if (dirTarget === null) {
-          // No matching directive was found - this reference points to an unknown target. Leave it
-          // unmapped.
-          return;
-        }
-      }
-
-      if (dirTarget !== null) {
-        // This reference points to a directive.
-        this.references.set(ref, {directive: dirTarget, node});
-      } else {
-        // This reference points to the node itself.
-        this.references.set(ref, node);
-      }
-    });
-
-    // Associate attributes/bindings on the node with directives or with the node itself.
-    type BoundNode = BoundAttribute | BoundEvent | TextAttribute;
-    const setAttributeBinding = (
-      attribute: BoundNode,
-      ioType: keyof Pick<DirectiveMeta, 'inputs' | 'outputs'>,
-    ) => {
-      const dir = directives.find((dir) => dir[ioType].hasBindingPropertyName(attribute.name));
-      const binding = dir !== undefined ? dir : node;
-      this.bindings.set(attribute, binding);
-    };
-
-    // Node inputs (bound attributes) and text attributes can be bound to an
-    // input on a directive.
-    node.inputs.forEach((input) => setAttributeBinding(input, 'inputs'));
-    node.attributes.forEach((attr) => setAttributeBinding(attr, 'inputs'));
-    if (node instanceof Template) {
-      node.templateAttrs.forEach((attr) => setAttributeBinding(attr, 'inputs'));
-    }
-    // Node outputs (bound events) can be bound to an output on a directive.
-    node.outputs.forEach((output) => setAttributeBinding(output, 'outputs'));
-
-    // Recurse into the node's children.
-    node.children.forEach((child) => child.visit(this));
-  }
-
   visitDeferredBlock(deferred: DeferredBlock): void {
     const wasInDeferBlock = this.isInDeferBlock;
     this.isInDeferBlock = true;
@@ -684,12 +605,165 @@ class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
     content.children.forEach((child) => child.visit(this));
   }
 
-  visitComponent(component: Component) {
-    throw new Error('TODO');
+  visitComponent(node: Component): void {
+    const directives: DirectiveT[] = [];
+    let componentMetas: DirectiveT[] | null = null;
+
+    if (this.directiveMatcher instanceof SelectorlessMatcher) {
+      componentMetas = this.directiveMatcher.match(node.componentName);
+
+      if (componentMetas !== null) {
+        directives.push(...componentMetas);
+      }
+
+      for (const directive of node.directives) {
+        const directiveMetas = this.directiveMatcher.match(directive.name);
+
+        if (directiveMetas !== null) {
+          directives.push(...directiveMetas);
+        }
+      }
+    }
+
+    this.trackMatchedDirectives(node, directives);
+
+    if (componentMetas !== null) {
+      this.trackSelectorlessBindings(node, componentMetas);
+    }
+
+    node.directives.forEach((directive) => directive.visit(this));
+    node.children.forEach((child) => child.visit(this));
   }
 
-  visitDirective(directive: Directive) {
-    throw new Error('TODO');
+  visitDirective(node: Directive): void {
+    const directives =
+      this.directiveMatcher instanceof SelectorlessMatcher
+        ? this.directiveMatcher.match(node.name)
+        : null;
+
+    if (directives !== null) {
+      this.trackSelectorlessBindings(node, directives);
+    }
+  }
+
+  private visitElementOrTemplate(node: Element | Template): void {
+    const directives: DirectiveT[] = [];
+
+    if (this.directiveMatcher instanceof SelectorMatcher) {
+      // First, determine the HTML shape of the node for the purpose of directive matching.
+      // Do this by building up a `CssSelector` for the node.
+      const cssSelector = createCssSelectorFromNode(node);
+
+      this.directiveMatcher.match(cssSelector, (_selector, results) => {
+        directives.push(...results);
+      });
+
+      this.trackSelectorMatchedBindings(node, directives);
+    } else {
+      for (const directive of node.directives) {
+        const matchedDirectives = this.directiveMatcher.match(directive.name);
+
+        if (matchedDirectives !== null) {
+          directives.push(...matchedDirectives);
+        }
+      }
+    }
+
+    this.trackMatchedDirectives(node, directives);
+    node.directives.forEach((directive) => directive.visit(this));
+    node.children.forEach((child) => child.visit(this));
+  }
+
+  private trackMatchedDirectives(
+    node: Template | Element | Component,
+    directives: DirectiveT[],
+  ): void {
+    if (directives.length > 0) {
+      this.directives.set(node, directives);
+      if (!this.isInDeferBlock) {
+        this.eagerDirectives.push(...directives);
+      }
+    }
+  }
+
+  private trackSelectorlessBindings(node: Component | Directive, metas: DirectiveT[]): void {
+    const setBinding = (
+      meta: DirectiveT,
+      attribute: BoundAttribute | BoundEvent | TextAttribute,
+      ioType: keyof Pick<DirectiveMeta, 'inputs' | 'outputs'>,
+    ) => {
+      if (meta[ioType].hasBindingPropertyName(attribute.name)) {
+        this.bindings.set(attribute, meta);
+      }
+    };
+
+    for (const meta of metas) {
+      node.inputs.forEach((input) => setBinding(meta, input, 'inputs'));
+      node.attributes.forEach((attr) => setBinding(meta, attr, 'inputs'));
+      node.outputs.forEach((output) => setBinding(meta, output, 'outputs'));
+    }
+
+    // TODO(crisbeto): currently it's unclear how references should behave under selectorless,
+    // given that there's one named class which can bring in multiple host directives.
+    // For the time being only register the first directive as the reference target.
+    if (metas.length > 0) {
+      node.references.forEach((ref) => this.references.set(ref, {directive: metas[0], node: node}));
+    }
+  }
+
+  private trackSelectorMatchedBindings(node: Element | Template, directives: DirectiveT[]): void {
+    // Resolve any references that are created on this node.
+    node.references.forEach((ref) => {
+      let dirTarget: DirectiveT | null = null;
+
+      // If the reference expression is empty, then it matches the "primary" directive on the node
+      // (if there is one). Otherwise it matches the host node itself (either an element or
+      // <ng-template> node).
+      if (ref.value.trim() === '') {
+        // This could be a reference to a component if there is one.
+        dirTarget = directives.find((dir) => dir.isComponent) || null;
+      } else {
+        // This should be a reference to a directive exported via exportAs.
+        dirTarget =
+          directives.find(
+            (dir) => dir.exportAs !== null && dir.exportAs.some((value) => value === ref.value),
+          ) || null;
+        // Check if a matching directive was found.
+        if (dirTarget === null) {
+          // No matching directive was found - this reference points to an unknown target. Leave it
+          // unmapped.
+          return;
+        }
+      }
+
+      if (dirTarget !== null) {
+        // This reference points to a directive.
+        this.references.set(ref, {directive: dirTarget, node});
+      } else {
+        // This reference points to the node itself.
+        this.references.set(ref, node);
+      }
+    });
+
+    // Associate attributes/bindings on the node with directives or with the node itself.
+    const setAttributeBinding = (
+      attribute: BoundAttribute | BoundEvent | TextAttribute,
+      ioType: keyof Pick<DirectiveMeta, 'inputs' | 'outputs'>,
+    ) => {
+      const dir = directives.find((dir) => dir[ioType].hasBindingPropertyName(attribute.name));
+      const binding = dir !== undefined ? dir : node;
+      this.bindings.set(attribute, binding);
+    };
+
+    // Node inputs (bound attributes) and text attributes can be bound to an
+    // input on a directive.
+    node.inputs.forEach((input) => setAttributeBinding(input, 'inputs'));
+    node.attributes.forEach((attr) => setAttributeBinding(attr, 'inputs'));
+    if (node instanceof Template) {
+      node.templateAttrs.forEach((attr) => setAttributeBinding(attr, 'inputs'));
+    }
+    // Node outputs (bound events) can be bound to an output on a directive.
+    node.outputs.forEach((output) => setAttributeBinding(output, 'outputs'));
   }
 
   // Unused visitors.
@@ -870,11 +944,17 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
   }
 
   visitComponent(component: Component) {
-    throw new Error('TODO');
+    component.inputs.forEach(this.visitNode);
+    component.outputs.forEach(this.visitNode);
+    component.directives.forEach(this.visitNode);
+    component.children.forEach(this.visitNode);
+    component.references.forEach(this.visitNode);
   }
 
   visitDirective(directive: Directive) {
-    throw new Error('TODO');
+    directive.inputs.forEach(this.visitNode);
+    directive.outputs.forEach(this.visitNode);
+    directive.references.forEach(this.visitNode);
   }
 
   // Unused template visitors
@@ -1171,7 +1251,7 @@ class R3BoundTarget<DirectiveT extends DirectiveMeta> implements BoundTarget<Dir
     return null;
   }
 
-  isDeferred(element: Element): boolean {
+  isDeferred(element: Element | Component): boolean {
     for (const block of this.deferredBlocks) {
       if (!this.deferredScopes.has(block)) {
         continue;
@@ -1182,7 +1262,7 @@ class R3BoundTarget<DirectiveT extends DirectiveMeta> implements BoundTarget<Dir
       while (stack.length > 0) {
         const current = stack.pop()!;
 
-        if (current.elementsInScope.has(element)) {
+        if (current.elementLikeInScope.has(element)) {
           return true;
         }
 
@@ -1216,7 +1296,11 @@ class R3BoundTarget<DirectiveT extends DirectiveMeta> implements BoundTarget<Dir
       return target;
     }
 
-    if (target instanceof Template) {
+    if (
+      target instanceof Template ||
+      target.node instanceof Component ||
+      target.node instanceof Directive
+    ) {
       return null;
     }
 

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -130,6 +130,9 @@ export interface ParseTemplateOptions {
 
   /** Whether the `@let` syntax is enabled. */
   enableLetSyntax?: boolean;
+
+  /** Whether the selectorless syntax is enabled. */
+  enableSelectorless?: boolean;
 }
 
 /**
@@ -153,6 +156,7 @@ export function parseTemplate(
     tokenizeExpansionForms: true,
     tokenizeBlocks: options.enableBlockSyntax ?? true,
     tokenizeLet: options.enableLetSyntax ?? true,
+    selectorlessEnabled: options.enableSelectorless ?? false,
   });
 
   if (

--- a/packages/compiler/src/render3/view/util.ts
+++ b/packages/compiler/src/render3/view/util.ts
@@ -10,7 +10,7 @@ import {InputFlags} from '../../core';
 import {BindingType} from '../../expression_parser/ast';
 import {splitNsName} from '../../ml_parser/tags';
 import * as o from '../../output/output_ast';
-import {CssSelector} from '../../selector';
+import {CssSelector} from '../../directive_matching';
 import * as t from '../r3_ast';
 
 import {isI18nAttribute} from './i18n/util';

--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -37,7 +37,7 @@ import {mergeNsAndName} from '../ml_parser/tags';
 import {InterpolatedAttributeToken, InterpolatedTextToken} from '../ml_parser/tokens';
 import {ParseError, ParseErrorLevel, ParseSourceSpan} from '../parse_util';
 import {ElementSchemaRegistry} from '../schema/element_schema_registry';
-import {CssSelector} from '../selector';
+import {CssSelector} from '../directive_matching';
 import {splitAtColon, splitAtPeriod} from '../util';
 
 const PROPERTY_PARTS_SEPARATOR = '.';

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -2646,6 +2646,18 @@ describe('R3 template transform', () => {
           /Binding is not supported in a directive context/,
         );
       });
+
+      it('should not allow named references', () => {
+        const pattern = /Cannot specify a value for a local reference in this context/;
+        expect(() => parseSelectorless('<MyComp #foo="bar"/>')).toThrowError(pattern);
+        expect(() => parseSelectorless('<div @Dir(#foo="bar")></div>')).toThrowError(pattern);
+      });
+
+      it('should not allow duplicate references', () => {
+        const pattern = /Duplicate reference names are not allowed/;
+        expect(() => parseSelectorless('<MyComp #foo #foo/>')).toThrowError(pattern);
+        expect(() => parseSelectorless('<div @Dir(#foo #foo)></div>')).toThrowError(pattern);
+      });
     });
   });
 });

--- a/packages/compiler/test/render3/view/binding_spec.ts
+++ b/packages/compiler/test/render3/view/binding_spec.ts
@@ -9,9 +9,13 @@
 import * as e from '../../../src/expression_parser/ast';
 import * as a from '../../../src/render3/r3_ast';
 import {DirectiveMeta, InputOutputPropertySet} from '../../../src/render3/view/t2_api';
-import {findMatchingDirectivesAndPipes, R3TargetBinder} from '../../../src/render3/view/t2_binder';
-import {parseTemplate} from '../../../src/render3/view/template';
-import {CssSelector, SelectorMatcher} from '../../../src/selector';
+import {
+  DirectiveMatcher,
+  findMatchingDirectivesAndPipes,
+  R3TargetBinder,
+} from '../../../src/render3/view/t2_binder';
+import {parseTemplate, ParseTemplateOptions} from '../../../src/render3/view/template';
+import {CssSelector, SelectorMatcher} from '../../../src/directive_matching';
 
 import {findExpression} from './util';
 

--- a/packages/compiler/test/selector/selector_spec.ts
+++ b/packages/compiler/test/selector/selector_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CssSelector, SelectorMatcher} from '../../src/selector';
+import {CssSelector, SelectorMatcher} from '../../src/directive_matching';
 import {el} from '@angular/platform-browser/testing/src/browser_util';
 
 describe('SelectorMatcher', () => {


### PR DESCRIPTION
These changes update the template binder to account for selectorless. This is necessary for further compiler work. Includes the following commits:

### refactor(compiler): allow different kinds of directive matchers to be passed to binder
Updates the target binder to allow either a selector-based or selectorless matcher to be passed in. This will allow us to skip some of the overhead when matching directives to nodes.

### refactor(compiler): add flag to enable selectorless parsing 
Adds a flag to `parseTemplate` to enable selectorless.

### refactor(compiler): validate references in selectorless 
Adds the following validations to the selectorless template parsing:
* Local references with values are not allowed (e.g. `#foo="bar"`).
* Multiple local references with the same on a component or directive are not allowed.

### refactor(compiler): account for selectorless in template binder 
Updates the template binder to account for the new selectorless AST nodes. This is a prerequisite to supporting template type checking of the new syntax.