### PR TITLE
refactor(core): mark `makeEnvironmentProviders` as public.

### DIFF
--- a/packages/core/src/di/provider_collection.ts
+++ b/packages/core/src/di/provider_collection.ts
@@ -40,6 +40,8 @@ import {INJECTOR_DEF_TYPES} from './internal_tokens';
 /**
  * Wrap an array of `Provider`s into `EnvironmentProviders`, preventing them from being accidentally
  * referenced in `@Component` in a component injector.
+ *
+ * @publicApi
  */
 export function makeEnvironmentProviders(
   providers: (Provider | EnvironmentProviders)[],


### PR DESCRIPTION
`makeEnvironmentProviders` was already exported but didn't have the `@publicApi` tag.
