### PR TITLE
refactor(router): produce error message when `canMatch` is used with `redirectTo`

### DIFF
--- a/packages/router/src/utils/config.ts
+++ b/packages/router/src/utils/config.ts
@@ -141,25 +141,29 @@ function validateNode(route: Route, fullPath: string, requireStandaloneComponent
         `Invalid configuration of route '${fullPath}': children and loadChildren cannot be used together`,
       );
     }
-    if (route.redirectTo && (route.component || route.loadComponent)) {
-      throw new RuntimeError(
-        RuntimeErrorCode.INVALID_ROUTE_CONFIG,
-        `Invalid configuration of route '${fullPath}': redirectTo and component/loadComponent cannot be used together`,
-      );
-    }
     if (route.component && route.loadComponent) {
       throw new RuntimeError(
         RuntimeErrorCode.INVALID_ROUTE_CONFIG,
         `Invalid configuration of route '${fullPath}': component and loadComponent cannot be used together`,
       );
     }
-    if (route.redirectTo && route.canActivate) {
-      throw new RuntimeError(
-        RuntimeErrorCode.INVALID_ROUTE_CONFIG,
-        `Invalid configuration of route '${fullPath}': redirectTo and canActivate cannot be used together. Redirects happen before activation ` +
-          `so canActivate will never be executed.`,
-      );
+
+    if (route.redirectTo) {
+      if (route.component || route.loadComponent) {
+        throw new RuntimeError(
+          RuntimeErrorCode.INVALID_ROUTE_CONFIG,
+          `Invalid configuration of route '${fullPath}': redirectTo and component/loadComponent cannot be used together`,
+        );
+      }
+      if (route.canMatch || route.canActivate) {
+        throw new RuntimeError(
+          RuntimeErrorCode.INVALID_ROUTE_CONFIG,
+          `Invalid configuration of route '${fullPath}': redirectTo and ${route.canMatch ? 'canMatch' : 'canActivate'} cannot be used together.` +
+            `Redirects happen before guards are executed.`,
+        );
+      }
     }
+
     if (route.path && route.matcher) {
       throw new RuntimeError(
         RuntimeErrorCode.INVALID_ROUTE_CONFIG,


### PR DESCRIPTION


Redirects in the router are handled before `canMatch` guards are evaluated. As a result, `canMatch` will not run for routes that include a redirect. Instead of silently ignoring this misconfiguration, developers should be alerted to help them understand why it doesn't behave as expected.

Closes: #60957
