### PR TITLE
refactor(core): replace `TestBed.flushEffects` with `tick`

### DIFF
--- a/goldens/public-api/core/testing/index.api.md
+++ b/goldens/public-api/core/testing/index.api.md
@@ -118,6 +118,7 @@ export interface TestBed {
     createComponent<T>(component: Type<T>): ComponentFixture<T>;
     // (undocumented)
     execute(tokens: any[], fn: Function, context?: any): any;
+    // @deprecated
     flushEffects(): void;
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, options?: TestEnvironmentOptions): void;
     // (undocumented)
@@ -165,6 +166,7 @@ export interface TestBed {
     // (undocumented)
     resetTestingModule(): TestBed;
     runInInjectionContext<T>(fn: () => T): T;
+    tick(): void;
 }
 
 // @public

--- a/packages/common/http/test/resource_spec.ts
+++ b/packages/common/http/test/resource_spec.ts
@@ -25,7 +25,7 @@ describe('httpResource', () => {
   it('should send a basic request', async () => {
     const backend = TestBed.inject(HttpTestingController);
     const res = httpResource(() => '/data', {injector: TestBed.inject(Injector)});
-    TestBed.flushEffects();
+    TestBed.tick();
     const req = backend.expectOne('/data');
     req.flush([]);
     await TestBed.inject(ApplicationRef).whenStable();
@@ -36,14 +36,14 @@ describe('httpResource', () => {
     const id = signal(0);
     const backend = TestBed.inject(HttpTestingController);
     const res = httpResource(() => `/data/${id()}`, {injector: TestBed.inject(Injector)});
-    TestBed.flushEffects();
+    TestBed.tick();
     const req1 = backend.expectOne('/data/0');
     req1.flush(0);
     await TestBed.inject(ApplicationRef).whenStable();
     expect(res.value()).toEqual(0);
 
     id.set(1);
-    TestBed.flushEffects();
+    TestBed.tick();
     const req2 = backend.expectOne('/data/1');
     req2.flush(1);
     await TestBed.inject(ApplicationRef).whenStable();
@@ -56,13 +56,13 @@ describe('httpResource', () => {
     const res = httpResource(() => (id() !== 1 ? `/data/${id()}` : undefined), {
       injector: TestBed.inject(Injector),
     });
-    TestBed.flushEffects();
+    TestBed.tick();
     backend.expectOne('/data/0').flush(0);
     await TestBed.inject(ApplicationRef).whenStable();
     expect(res.value()).toEqual(0);
 
     id.set(1);
-    TestBed.flushEffects();
+    TestBed.tick();
 
     // Verify no requests have been made.
     backend.verify({ignoreCancelled: false});
@@ -70,7 +70,7 @@ describe('httpResource', () => {
     backend.verify({ignoreCancelled: false});
 
     id.set(2);
-    TestBed.flushEffects();
+    TestBed.tick();
     backend.expectOne('/data/2').flush(2);
     await TestBed.inject(ApplicationRef).whenStable();
     expect(res.value()).toBe(2);
@@ -93,7 +93,7 @@ describe('httpResource', () => {
       }),
       {injector: TestBed.inject(Injector)},
     );
-    TestBed.flushEffects();
+    TestBed.tick();
     const req = backend.expectOne('/data?fast=yes');
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual({message: 'Hello, backend!'});
@@ -109,7 +109,7 @@ describe('httpResource', () => {
   it('should return response headers & status when resolved', async () => {
     const backend = TestBed.inject(HttpTestingController);
     const res = httpResource(() => '/data', {injector: TestBed.inject(Injector)});
-    TestBed.flushEffects();
+    TestBed.tick();
     const req = backend.expectOne('/data');
     req.flush([], {
       headers: {
@@ -125,7 +125,7 @@ describe('httpResource', () => {
   it('should return response headers & status when request errored', async () => {
     const backend = TestBed.inject(HttpTestingController);
     const res = httpResource(() => '/data', {injector: TestBed.inject(Injector)});
-    TestBed.flushEffects();
+    TestBed.tick();
     const req = backend.expectOne('/data');
     req.flush([], {
       headers: {
@@ -149,7 +149,7 @@ describe('httpResource', () => {
       }),
       {injector: TestBed.inject(Injector)},
     );
-    TestBed.flushEffects();
+    TestBed.tick();
     const req = backend.expectOne('/data');
     req.event({
       type: HttpEventType.DownloadProgress,
@@ -192,7 +192,7 @@ describe('httpResource', () => {
         injector: TestBed.inject(Injector),
       },
     );
-    TestBed.flushEffects();
+    TestBed.tick();
 
     const req = TestBed.inject(HttpTestingController).expectOne('/data?fast=yes');
     expect(req.request.headers.get('X-Tag')).toEqual('alpha,beta');
@@ -215,7 +215,7 @@ describe('httpResource', () => {
         parse: (value) => JSON.stringify(value),
       },
     );
-    TestBed.flushEffects();
+    TestBed.tick();
     const req = backend.expectOne('/data');
     req.flush([1, 2, 3]);
 
@@ -229,7 +229,7 @@ describe('httpResource', () => {
       injector: TestBed.inject(Injector),
       equal: (_a, _b) => true,
     });
-    TestBed.flushEffects();
+    TestBed.tick();
     const req = backend.expectOne('/data');
     req.flush(1);
 
@@ -249,7 +249,7 @@ describe('httpResource', () => {
       }),
       {injector: TestBed.inject(Injector)},
     );
-    TestBed.flushEffects();
+    TestBed.tick();
     const req = backend.expectOne('/data');
     req.flush('[1,2,3]');
 
@@ -266,7 +266,7 @@ describe('httpResource', () => {
       }),
       {injector: TestBed.inject(Injector)},
     );
-    TestBed.flushEffects();
+    TestBed.tick();
     const req = backend.expectOne('/data');
     const buffer = new ArrayBuffer();
     req.flush(buffer);

--- a/packages/core/test/render3/reactive_safety_spec.ts
+++ b/packages/core/test/render3/reactive_safety_spec.ts
@@ -236,5 +236,5 @@ function expectNotToThrowInReactiveContext(fn: () => void): void {
     },
     {injector},
   );
-  TestBed.flushEffects();
+  TestBed.tick();
 }

--- a/packages/core/test/render3/reactivity_spec.ts
+++ b/packages/core/test/render3/reactivity_spec.ts
@@ -268,11 +268,11 @@ describe('reactivity', () => {
       const log: number[] = [];
       TestBed.runInInjectionContext(() => effect(() => log.push(counter())));
 
-      TestBed.flushEffects();
+      TestBed.tick();
       expect(log).toEqual([0]);
 
       counter.set(1);
-      TestBed.flushEffects();
+      TestBed.tick();
       expect(log).toEqual([0, 1]);
     });
 
@@ -282,11 +282,11 @@ describe('reactivity', () => {
       const log: number[] = [];
       effect(() => log.push(counter()), {injector: TestBed.inject(Injector)});
 
-      TestBed.flushEffects();
+      TestBed.tick();
       expect(log).toEqual([0]);
 
       counter.set(1);
-      TestBed.flushEffects();
+      TestBed.tick();
       expect(log).toEqual([0, 1]);
     });
 
@@ -300,16 +300,16 @@ describe('reactivity', () => {
         injector: TestBed.inject(Injector),
       });
 
-      TestBed.flushEffects();
+      TestBed.tick();
       expect(log).toEqual([0]);
 
       counter.set(1);
-      TestBed.flushEffects();
+      TestBed.tick();
       expect(log).toEqual([0, 1]);
 
       ref.destroy();
       counter.set(2);
-      TestBed.flushEffects();
+      TestBed.tick();
       expect(log).toEqual([0, 1]);
     });
 
@@ -518,11 +518,11 @@ describe('reactivity', () => {
         );
         expect(effectCounter).toBe(0);
         effectRef.destroy();
-        TestBed.flushEffects();
+        TestBed.tick();
         expect(effectCounter).toBe(0);
 
         counter.set(2);
-        TestBed.flushEffects();
+        TestBed.tick();
         expect(effectCounter).toBe(0);
       });
 
@@ -543,11 +543,11 @@ describe('reactivity', () => {
         fixture.detectChanges();
         expect(effectCounter).toBe(0);
 
-        TestBed.flushEffects();
+        TestBed.tick();
         expect(effectCounter).toBe(0);
 
         fixture.componentInstance.counter.set(2);
-        TestBed.flushEffects();
+        TestBed.tick();
         expect(effectCounter).toBe(0);
       });
     });
@@ -558,7 +558,7 @@ describe('reactivity', () => {
       const counter = signal(0);
 
       effect(() => counter.set(1), {injector: TestBed.inject(Injector)});
-      TestBed.flushEffects();
+      TestBed.tick();
       expect(counter()).toBe(1);
     });
 
@@ -804,7 +804,7 @@ describe('reactivity', () => {
         }
 
         const fixture = TestBed.createComponent(TestCmp);
-        TestBed.flushEffects();
+        TestBed.tick();
         expect(log).toEqual([]);
         fixture.detectChanges();
         expect(log).toEqual(['init', 'effect']);
@@ -882,7 +882,7 @@ describe('reactivity', () => {
         fixture.componentInstance.vcr.createComponent(TestCmp);
 
         // Verify that simply creating the component didn't schedule the effect.
-        TestBed.flushEffects();
+        TestBed.tick();
         expect(log).toEqual([]);
 
         // Running change detection should schedule and run the effect.
@@ -914,7 +914,7 @@ describe('reactivity', () => {
         }
 
         const fixture = TestBed.createComponent(TestCmp);
-        TestBed.flushEffects();
+        TestBed.tick();
         expect(log).toEqual([]);
         fixture.detectChanges();
         expect(log).toEqual(['init', 'effect']);

--- a/packages/core/test/resource/resource_spec.ts
+++ b/packages/core/test/resource/resource_spec.ts
@@ -89,7 +89,7 @@ describe('resource', () => {
     expect(echoResource.hasValue()).toBeFalse();
     expect(echoResource.value()).toBeUndefined();
     expect(echoResource.error()).toBe(undefined);
-    TestBed.flushEffects();
+    TestBed.tick();
     await backend.flush();
     expect(echoResource.status()).toBe(ResourceStatus.Resolved);
     expect(echoResource.isLoading()).toBeFalse();
@@ -98,7 +98,7 @@ describe('resource', () => {
     expect(echoResource.error()).toBe(undefined);
 
     counter.update((c) => c + 1);
-    TestBed.flushEffects();
+    TestBed.tick();
     await backend.flush();
     expect(echoResource.status()).toBe(ResourceStatus.Resolved);
     expect(echoResource.isLoading()).toBeFalse();
@@ -120,7 +120,7 @@ describe('resource', () => {
       injector: TestBed.inject(Injector),
     });
 
-    TestBed.flushEffects();
+    TestBed.tick();
     await flushMicrotasks();
 
     expect(prevStatus).toBe(ResourceStatus.Idle);
@@ -135,7 +135,7 @@ describe('resource', () => {
       injector: TestBed.inject(Injector),
     });
 
-    TestBed.flushEffects();
+    TestBed.tick();
     await backend.reject(requestParam, 'Something went wrong....');
 
     expect(echoResource.status()).toBe(ResourceStatus.Error);
@@ -160,7 +160,7 @@ describe('resource', () => {
       injector: TestBed.inject(Injector),
     });
 
-    TestBed.flushEffects();
+    TestBed.tick();
     await backend.flush();
 
     expect(echoResource.status()).toBe(ResourceStatus.Resolved);
@@ -170,7 +170,7 @@ describe('resource', () => {
     expect(echoResource.error()).toBe(undefined);
 
     counter.update((value) => value + 1);
-    TestBed.flushEffects();
+    TestBed.tick();
     await backend.flush();
 
     expect(echoResource.status()).toBe(ResourceStatus.Error);
@@ -261,12 +261,12 @@ describe('resource', () => {
       injector: TestBed.inject(Injector),
     });
 
-    TestBed.flushEffects();
+    TestBed.tick();
     expect(echoResource.status()).toBe(ResourceStatus.Idle);
     expect(echoResource.isLoading()).toBeFalse();
 
     counter.set(10);
-    TestBed.flushEffects();
+    TestBed.tick();
     expect(echoResource.isLoading()).toBeTrue();
   });
 
@@ -289,12 +289,12 @@ describe('resource', () => {
     });
 
     // start a request without resolving the previous one
-    TestBed.flushEffects();
+    TestBed.tick();
     await Promise.resolve();
 
     // start a new request and resolve all
     counter.update((c) => c + 1);
-    TestBed.flushEffects();
+    TestBed.tick();
     await backend.flush();
     expect(echoResource.status()).toBe(ResourceStatus.Resolved);
     expect(echoResource.value()).toEqual({counter: 1});
@@ -323,7 +323,7 @@ describe('resource', () => {
     });
 
     // start a request without resolving the previous one
-    TestBed.flushEffects();
+    TestBed.tick();
     await Promise.resolve();
 
     injector.destroy();
@@ -355,7 +355,7 @@ describe('resource', () => {
     });
 
     // start a request without resolving the previous one
-    TestBed.flushEffects();
+    TestBed.tick();
     await Promise.resolve();
 
     echoResource.destroy();
@@ -381,12 +381,12 @@ describe('resource', () => {
       injector: TestBed.inject(Injector),
     });
 
-    TestBed.flushEffects();
+    TestBed.tick();
     await backend.flush();
     expect(res.value()).toBe('0:0');
 
     unrelated.set('b');
-    TestBed.flushEffects();
+    TestBed.tick();
     // there is no chang in the status
     expect(res.status()).toBe(ResourceStatus.Resolved);
     await backend.flush();
@@ -403,7 +403,7 @@ describe('resource', () => {
       injector: TestBed.inject(Injector),
     });
 
-    TestBed.flushEffects();
+    TestBed.tick();
     await backend.flush();
 
     expect(echoResource.status()).toBe(ResourceStatus.Resolved);
@@ -419,7 +419,7 @@ describe('resource', () => {
     expect(echoResource.error()).toBe(undefined);
 
     counter.set(1);
-    TestBed.flushEffects();
+    TestBed.tick();
     await backend.flush();
     expect(echoResource.status()).toBe(ResourceStatus.Resolved);
     expect(echoResource.value()).toEqual({counter: 1});
@@ -440,7 +440,7 @@ describe('resource', () => {
       injector: TestBed.inject(Injector),
     });
 
-    TestBed.flushEffects();
+    TestBed.tick();
     await backend.flush();
     expect(res.status()).toBe(ResourceStatus.Resolved);
     expect(res.value()).toBe('0:0');
@@ -450,7 +450,7 @@ describe('resource', () => {
     expect(res.status()).toBe(ResourceStatus.Reloading);
     expect(res.value()).toBe('0:0');
 
-    TestBed.flushEffects();
+    TestBed.tick();
     await backend.flush();
     expect(res.status()).toBe(ResourceStatus.Resolved);
     expect(res.isLoading()).toBeFalse();
@@ -459,9 +459,9 @@ describe('resource', () => {
 
     // calling refresh multiple times should _not_ result in multiple requests
     res.reload();
-    TestBed.flushEffects();
+    TestBed.tick();
     res.reload();
-    TestBed.flushEffects();
+    TestBed.tick();
     await backend.flush();
     expect(res.value()).toBe('0:2');
   });
@@ -518,7 +518,7 @@ describe('resource', () => {
     expect(echoResource.status()).toBe(ResourceStatus.Idle);
     // Allow the load to proceed.
     request.set(2);
-    TestBed.flushEffects();
+    TestBed.tick();
     await backend.flush();
     expect(echoResource.status()).toBe(ResourceStatus.Resolved);
     // Reload state should be synchronous.
@@ -538,7 +538,7 @@ describe('resource', () => {
     });
     const appRef = TestBed.inject(ApplicationRef);
     // Fully resolve the resource to start.
-    TestBed.flushEffects();
+    TestBed.tick();
     await backend.flush();
     expect(echoResource.status()).toBe(ResourceStatus.Resolved);
     // Trigger loading state.
@@ -547,7 +547,7 @@ describe('resource', () => {
     // Set the resource to a new value.
     echoResource.set(3);
     // Now run the effect, which should be a no-op as the resource was set to a local value.
-    TestBed.flushEffects();
+    TestBed.tick();
     // We should still be in local state.
     expect(echoResource.status()).toBe(ResourceStatus.Local);
     expect(echoResource.value()).toBe(3);
@@ -569,7 +569,7 @@ describe('resource', () => {
     });
     const appRef = TestBed.inject(ApplicationRef);
     // Fully resolve the resource to start.
-    TestBed.flushEffects();
+    TestBed.tick();
     await backend.flush();
     expect(echoResource.status()).toBe(ResourceStatus.Resolved);
     // Trigger reloading state.
@@ -578,7 +578,7 @@ describe('resource', () => {
     // Set the resource to a new value.
     echoResource.set(3);
     // Now run the effect, which should be a no-op as the resource was set to a local value.
-    TestBed.flushEffects();
+    TestBed.tick();
     // We should still be in local state.
     expect(echoResource.status()).toBe(ResourceStatus.Local);
     expect(echoResource.value()).toBe(3);
@@ -686,7 +686,7 @@ describe('resource', () => {
     });
 
     // Start the initial load.
-    TestBed.flushEffects();
+    TestBed.tick();
     await Promise.resolve();
     expect(echoResource.status()).toBe(ResourceStatus.Loading);
     expect(echoResource.value()).toBe(undefined);
@@ -695,7 +695,7 @@ describe('resource', () => {
 
     // Interrupt by setting a value before the request has resolved.
     echoResource.set(null);
-    TestBed.flushEffects();
+    TestBed.tick();
     await backend.flush();
     expect(echoResource.status()).toBe(ResourceStatus.Local);
     expect(echoResource.value()).toBe(null);
@@ -704,7 +704,7 @@ describe('resource', () => {
 
     // Reload the resource to trigger another request.
     echoResource.reload();
-    TestBed.flushEffects();
+    TestBed.tick();
     await Promise.resolve();
     expect(echoResource.status()).toBe(ResourceStatus.Reloading);
     expect(echoResource.value()).toBe(null);

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -37,6 +37,7 @@ import {
   ɵsetUnknownElementStrictMode as setUnknownElementStrictMode,
   ɵsetUnknownPropertyStrictMode as setUnknownPropertyStrictMode,
   ɵstringify as stringify,
+  ApplicationRef,
 } from '../../src/core';
 
 import {ComponentFixture} from './component_fixture';
@@ -154,9 +155,16 @@ export interface TestBed {
   /**
    * Execute any pending effects.
    *
-   * @developerPreview
+   * @deprecated use `TestBed.tick()` instead
    */
   flushEffects(): void;
+
+  /**
+   * Execute any pending work required to synchronize model to the UI.
+   *
+   * @publicApi
+   */
+  tick(): void;
 }
 
 let _nextRootElementId = 0;
@@ -392,6 +400,10 @@ export class TestBedImpl implements TestBed {
 
   static flushEffects(): void {
     return TestBedImpl.INSTANCE.flushEffects();
+  }
+
+  static tick(): void {
+    return TestBedImpl.INSTANCE.tick();
   }
 
   // Properties
@@ -803,10 +815,19 @@ export class TestBedImpl implements TestBed {
   /**
    * Execute any pending effects.
    *
-   * @developerPreview
+   * @deprecated use `TestBed.tick()` instead
    */
   flushEffects(): void {
     this.inject(EffectScheduler).flush();
+  }
+
+  /**
+   * Execute any pending work required to synchronize model to the UI.
+   *
+   * @publicApi
+   */
+  tick(): void {
+    this.inject(ApplicationRef).tick();
   }
 }
 


### PR DESCRIPTION
Instead of stabilizing the `TestBed.flushEffects()` API we intend to replace it with the `tick()` method (equivalent of `ApplicationRef.tick()`. The reasoning here is that we prefer tests running the entire synchronization process (as in production apps) instead of invoking parts of the synchronization process in a way that would naver happen in a running application.
