### PR TITLE
refactor(devtools): fix resolution path viz padding

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/dependency-injection/resolution-path/resolution-path.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/dependency-injection/resolution-path/resolution-path.component.scss
@@ -4,7 +4,7 @@
   display: flex;
   flex-wrap: wrap;
   background: var(--octonary-contrast);
-  padding: 0.5rem 0.5rem 0.25rem 0.5rem;
+  padding: 0.5rem 1rem 0.25rem 0.5rem;
   border-top: 1px solid var(--senary-contrast);
 
   .node {


### PR DESCRIPTION
Adjusts the right padding appropriately.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
<img width="425" alt="Screenshot 2025-04-23 at 13 08 18" src="https://github.com/user-attachments/assets/70491740-de89-4d4c-b525-4aa870d452df" />


## What is the new behavior?

Fixes the right padding.

cc @dgp1130 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No