### PR TITLE
refactor(core): tree-shake `NOT_SET` and `EMPTY_CLEANUP_SET`

### DIFF
--- a/packages/core/src/render3/reactivity/after_render_effect.ts
+++ b/packages/core/src/render3/reactivity/after_render_effect.ts
@@ -40,8 +40,8 @@ import {LView} from '../interfaces/view';
 import {ViewContext} from '../view_context';
 import {assertNotInReactiveContext} from './asserts';
 
-const NOT_SET = Symbol('NOT_SET');
-const EMPTY_CLEANUP_SET = new Set<() => void>();
+const NOT_SET = /* @__PURE__ */ Symbol('NOT_SET');
+const EMPTY_CLEANUP_SET = /* @__PURE__ */ new Set<() => void>();
 
 /** Callback type for an `afterRenderEffect` phase effect */
 type AfterRenderPhaseEffectHook = (


### PR DESCRIPTION
Adds `__PURE__` annotations to `NOT_SET` and `EMPTY_CLEANUP_SET` to enable tree-shaking, even if they are not referenced. These variables are not dropped when Angular is imported from a module that has `sideEffects` set to `true`.