### PR TITLE
docs(docs-infra): use a custom scrollbar for the examples using HighlightTypeScript

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/highlight-ts.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/highlight-ts.tsx
@@ -11,8 +11,9 @@ import {RawHtml} from './raw-html';
 import {codeToHtml} from '../shiki/shiki';
 
 /** Component to render a header of the CLI page. */
-export function HighlightTypeScript(props: {code: string; }) {
+export function HighlightTypeScript(props: {code: string}) {
   const result = codeToHtml(props.code, 'typescript');
+  const withScrollTrack = result.replace(/^(<pre class="shiki)/, '$1 docs-mini-scroll-track');
 
-  return <RawHtml value={result} />;
+  return <RawHtml value={withScrollTrack} />;
 }

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/raw-html.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/raw-html.tsx
@@ -9,8 +9,8 @@
 import {h} from 'preact';
 
 /** Convenience component to render raw html */
-export function RawHtml(props: {value: string, className?: string}) {
+export function RawHtml(props: {value: string; className?: string}) {
   // Unfortunately, there does not seem to be a way to render the raw html
   // into a text node without introducing a div.
-  return <div className={props.className} dangerouslySetInnerHTML={({__html: props.value})}></div>;
+  return <div className={props.className} dangerouslySetInnerHTML={{__html: props.value}}></div>;
 }

--- a/adev/shared-docs/styles/_colors.scss
+++ b/adev/shared-docs/styles/_colors.scss
@@ -290,6 +290,7 @@
 // LIGHT MODE (Explicit)
 .docs-light-mode {
   background-color: #ffffff;
+  color-scheme: light;
   @include root-definitions();
   .docs-invert-mode {
     @include dark-mode-definitions();
@@ -299,6 +300,7 @@
 // DARK MODE (Explicit)
 .docs-dark-mode {
   background-color: oklch(16.93% 0.004 285.95);
+  color-scheme: dark;
   @include root-definitions();
   @include dark-mode-definitions();
   .docs-invert-mode {

--- a/adev/shared-docs/styles/_reference.scss
+++ b/adev/shared-docs/styles/_reference.scss
@@ -140,13 +140,10 @@
 
         code {
           font-size: 0.875rem;
+          overflow: hidden;
 
           &:has(pre) {
             padding: 0;
-          }
-
-          &:not(pre *) {
-            padding: 0 0.3rem;
           }
         }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

Some examples use the native horizontal scrollbar: https://angular.dev/api/core/afterNextRender
This PR changes this to the custom scrollbar that  the majority of the UI uses: https://ng-dev-previews-fw--pr-angular-angular-60981-adev-prev-hvz9vmu5.web.app/api/core/afterRenderEffect

Since this is a very minor change, `color-scheme` property has been added as part of this PR to each theme class so any native HTML control, if used, will match the theme.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
