### PR TITLE
Revert "release: cut the v19.2.8 release"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,3 @@
-<a name="19.2.8"></a>
-# 19.2.8 (2025-04-23)
-### forms
-| Commit | Type | Description |
-| -- | -- | -- |
-| [ea4a211216](https://github.com/angular/angular/commit/ea4a21121681c78652f314c78c58390dca25f266) | fix | make NgForm emit FormSubmittedEvent and FormResetEvent ([#60887](https://github.com/angular/angular/pull/60887)) |
-
-<!-- CHANGELOG SPLIT MARKER -->
-
 <a name="19.2.7"></a>
 # 19.2.7 (2025-04-16)
 ### common

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-srcs",
-  "version": "19.2.8",
+  "version": "19.2.7",
   "private": true,
   "description": "Angular - a web framework for modern web apps",
   "homepage": "https://github.com/angular/angular",


### PR DESCRIPTION
This reverts commit 94b2a8cee0b9f7764424c3f133299049642f8a31.

Reverting due to release process aborting in the middle
