### PR TITLE
Revert "refactor(router): produce error message when `canMatch` is used with `redirectTo` (#60958)"

### DIFF
--- a/packages/router/src/utils/config.ts
+++ b/packages/router/src/utils/config.ts
@@ -141,29 +141,25 @@ function validateNode(route: Route, fullPath: string, requireStandaloneComponent
         `Invalid configuration of route '${fullPath}': children and loadChildren cannot be used together`,
       );
     }
+    if (route.redirectTo && (route.component || route.loadComponent)) {
+      throw new RuntimeError(
+        RuntimeErrorCode.INVALID_ROUTE_CONFIG,
+        `Invalid configuration of route '${fullPath}': redirectTo and component/loadComponent cannot be used together`,
+      );
+    }
     if (route.component && route.loadComponent) {
       throw new RuntimeError(
         RuntimeErrorCode.INVALID_ROUTE_CONFIG,
         `Invalid configuration of route '${fullPath}': component and loadComponent cannot be used together`,
       );
     }
-
-    if (route.redirectTo) {
-      if (route.component || route.loadComponent) {
-        throw new RuntimeError(
-          RuntimeErrorCode.INVALID_ROUTE_CONFIG,
-          `Invalid configuration of route '${fullPath}': redirectTo and component/loadComponent cannot be used together`,
-        );
-      }
-      if (route.canMatch || route.canActivate) {
-        throw new RuntimeError(
-          RuntimeErrorCode.INVALID_ROUTE_CONFIG,
-          `Invalid configuration of route '${fullPath}': redirectTo and ${route.canMatch ? 'canMatch' : 'canActivate'} cannot be used together.` +
-            `Redirects happen before guards are executed.`,
-        );
-      }
+    if (route.redirectTo && route.canActivate) {
+      throw new RuntimeError(
+        RuntimeErrorCode.INVALID_ROUTE_CONFIG,
+        `Invalid configuration of route '${fullPath}': redirectTo and canActivate cannot be used together. Redirects happen before activation ` +
+          `so canActivate will never be executed.`,
+      );
     }
-
     if (route.path && route.matcher) {
       throw new RuntimeError(
         RuntimeErrorCode.INVALID_ROUTE_CONFIG,


### PR DESCRIPTION
This reverts commit 907f9bd3b871ef9f7320a62eeae291e5d2c1d2e1.

This change is reverted due to some failing tests in g3 that would require a cleanup.
