### PR TITLE
feat(core): support customization of `@defer`'s `on idle` behavior

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -64,6 +64,7 @@ export {
   ApplicationInitStatus,
   provideAppInitializer,
 } from './application/application_init';
+export {IdleService, provideIdleServiceWith} from './defer/idle_service';
 export * from './zone';
 export * from './render';
 export * from './linker';

--- a/packages/core/src/defer/idle_service.ts
+++ b/packages/core/src/defer/idle_service.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {AbstractType} from '../interface/type';
+import {InjectionToken} from '../di/injection_token';
+import type {EnvironmentProviders} from '../di/interface/provider';
+import {makeEnvironmentProviders} from '../di/provider_collection';
+
+/**
+ * Use shims for the `requestIdleCallback` and `cancelIdleCallback` functions for
+ * environments where those functions are not available (e.g. Node.js and Safari).
+ *
+ * Note: we wrap the `requestIdleCallback` call into a function, so that it can be
+ * overridden/mocked in test environment and picked up by the runtime code.
+ */
+const _requestIdleCallback = () =>
+  typeof requestIdleCallback !== 'undefined' ? requestIdleCallback : setTimeout;
+const _cancelIdleCallback = () =>
+  typeof requestIdleCallback !== 'undefined' ? cancelIdleCallback : clearTimeout;
+
+/**
+ * Service which configures custom 'on idle' behavior for Angular features like `@defer`.
+ *
+ * @publicApi
+ */
+export interface IdleService {
+  /**
+   * Schedule `callback` to be executed when the current application or browser is considered idle.
+   *
+   * @returns an id which allows the scheduled callback to be cancelled before it executes.
+   */
+  requestOnIdle(callback: () => void): number;
+
+  /**
+   * Cancel a previously scheduled callback using the id associated with it.
+   */
+  cancelOnIdle(id: number): void;
+}
+
+export const IDLE_SERVICE = new InjectionToken(ngDevMode ? 'IDLE_SERVICE' : '', {
+  providedIn: 'root',
+  factory: () => new RequestIdleCallbackService(_requestIdleCallback(), _cancelIdleCallback()),
+});
+
+/**
+ * Configures Angular to use the given DI token as its `IdleService`.
+ *
+ * The given token must be available for injection from the root injector, and the injected value
+ * must implement the `IdleService` interface.
+ *
+ * @publicApi
+ */
+export function provideIdleServiceWith(
+  useExisting: AbstractType<IdleService> | InjectionToken<IdleService>,
+): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    {
+      provide: IDLE_SERVICE,
+      useExisting,
+    },
+  ]);
+}
+
+/**
+ * Default implementation of `IDLE_SERVICE` which uses `requestIdleCallback` when available or
+ * `setTimeout` when not.
+ */
+class RequestIdleCallbackService implements IdleService {
+  constructor(
+    private readonly requestIdleCallback: (callback: () => void) => number,
+    private readonly cancelIdleCallback: (id: number) => void,
+  ) {}
+  requestOnIdle(callback: () => void): number {
+    return this.requestIdleCallback(callback);
+  }
+
+  cancelOnIdle(id: number): void {
+    return this.cancelIdleCallback(id);
+  }
+}

--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -34,6 +34,8 @@ import {
   Injector,
   ElementRef,
   ViewChild,
+  IdleService,
+  provideIdleServiceWith,
 } from '../../src/core';
 import {getComponentDef} from '../../src/render3/def_getters';
 import {ComponentFixture, DeferBlockBehavior, fakeAsync, flush, TestBed, tick} from '../../testing';
@@ -1815,6 +1817,105 @@ describe('@defer', () => {
       expect(loadingFnInvokedTimes).toBe(0);
 
       triggerIdleCallbacks();
+      await allPendingDynamicImports();
+      fixture.detectChanges();
+
+      // Expect that the loading resources function was invoked once.
+      expect(loadingFnInvokedTimes).toBe(1);
+
+      // Expect that placeholder content is still rendered.
+      expect(fixture.nativeElement.outerHTML).toContain('Placeholder');
+
+      // Trigger main content.
+      fixture.componentInstance.deferCond = true;
+      fixture.detectChanges();
+
+      await allPendingDynamicImports();
+      fixture.detectChanges();
+
+      // Verify primary block content.
+      const primaryBlockHTML = fixture.nativeElement.outerHTML;
+      expect(primaryBlockHTML).toContain(
+        '<nested-cmp ng-reflect-block="primary">Rendering primary block.</nested-cmp>',
+      );
+
+      // Expect that the loading resources function was not invoked again (counter remains 1).
+      expect(loadingFnInvokedTimes).toBe(1);
+    });
+
+    it('should use a custom `IdleService` for `prefetch on idle` condition', async () => {
+      @Component({
+        selector: 'nested-cmp',
+        template: 'Rendering {{ block }} block.',
+      })
+      class NestedCmp {
+        @Input() block!: string;
+      }
+
+      @Component({
+        selector: 'root-app',
+        imports: [NestedCmp],
+        template: `
+          @defer (when deferCond; prefetch on idle) {
+            <nested-cmp [block]="'primary'" />
+          } @placeholder {
+            Placeholder
+          }
+        `,
+      })
+      class RootCmp {
+        deferCond = false;
+      }
+
+      let loadingFnInvokedTimes = 0;
+      const deferDepsInterceptor = {
+        intercept() {
+          return () => {
+            loadingFnInvokedTimes++;
+            return [dynamicImportOf(NestedCmp)];
+          };
+        },
+      };
+
+      @Injectable({providedIn: 'root'})
+      class CustomIdleService implements IdleService {
+        private callbacks: Array<(() => void) | undefined> = [];
+
+        requestOnIdle(callback: () => void): number {
+          return this.callbacks.push(callback) - 1;
+        }
+
+        cancelOnIdle(id: number): void {
+          this.callbacks[id] = undefined;
+        }
+
+        trigger(): void {
+          for (const callback of this.callbacks) {
+            callback?.();
+          }
+          this.callbacks.length = 0;
+        }
+      }
+
+      TestBed.configureTestingModule({
+        providers: [
+          {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
+          provideIdleServiceWith(CustomIdleService),
+        ],
+      });
+
+      clearDirectiveDefs(RootCmp);
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.outerHTML).toContain('Placeholder');
+
+      // Make sure loading function is not yet invoked.
+      expect(loadingFnInvokedTimes).toBe(0);
+
+      TestBed.inject(CustomIdleService).trigger();
+
       await allPendingDynamicImports();
       fixture.detectChanges();
 


### PR DESCRIPTION
This commit makes the behavior of `on idle` in `@defer` configurable via DI. It defines an `IdleService` interface that an application can implement and provide to Angular:

```ts
@Injectable({providedIn: 'root'})
export class CustomIdleService implements IdleService {
  requestOnIdle(callback: () => void): number {...}
  cancelOnIdle(id: number): void {...}
}
```

Then in the app config `providers`:
```ts
// Configure Angular to use `CustomIdleService` instead of the browser API
// `requestIdleCallback` for detecting idleness.
provideIdleServiceWith(CustomIdleService),
```

