### PR TITLE
feat(core): introduce TestBed.tick()

### DIFF
--- a/goldens/public-api/core/testing/index.api.md
+++ b/goldens/public-api/core/testing/index.api.md
@@ -118,8 +118,6 @@ export interface TestBed {
     createComponent<T>(component: Type<T>): ComponentFixture<T>;
     // (undocumented)
     execute(tokens: any[], fn: Function, context?: any): any;
-    // @deprecated
-    flushEffects(): void;
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, options?: TestEnvironmentOptions): void;
     // (undocumented)
     inject<T>(token: ProviderToken<T>, notFoundValue: undefined, options: InjectOptions & {

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -153,13 +153,6 @@ export interface TestBed {
   createComponent<T>(component: Type<T>): ComponentFixture<T>;
 
   /**
-   * Execute any pending effects.
-   *
-   * @deprecated use `TestBed.tick()` instead
-   */
-  flushEffects(): void;
-
-  /**
    * Execute any pending work required to synchronize model to the UI.
    *
    * @publicApi
@@ -396,10 +389,6 @@ export class TestBedImpl implements TestBed {
 
   static get ngModule(): Type<any> | Type<any>[] {
     return TestBedImpl.INSTANCE.ngModule;
-  }
-
-  static flushEffects(): void {
-    return TestBedImpl.INSTANCE.flushEffects();
   }
 
   static tick(): void {
@@ -810,15 +799,6 @@ export class TestBedImpl implements TestBed {
     } finally {
       testRenderer.removeAllRootElements?.();
     }
-  }
-
-  /**
-   * Execute any pending effects.
-   *
-   * @deprecated use `TestBed.tick()` instead
-   */
-  flushEffects(): void {
-    this.inject(EffectScheduler).flush();
   }
 
   /**


### PR DESCRIPTION
This commit introduces the `TestBed.tick()` method that, similarly to the `ApplicationRef.tick()`, synchronizes state with the DOM. It can be used in unit tests to mimic framework's logic executed in production applications. The `TestBed.tick()` should be used instead of the removed `TestBed.flushEffects()`.

BREAKING CHANGE: the `TestBed.flushEffects()` was removed - use the `TestBed.tick()` instead.
