### PR TITLE
feat(core): rename afterRender to afterEveryRender and stabilize

### DIFF
--- a/adev/src/content/guide/components/dom-apis.md
+++ b/adev/src/content/guide/components/dom-apis.md
@@ -19,7 +19,7 @@ export class ProfilePhoto {
 The `nativeElement` property references the
 host [Element](https://developer.mozilla.org/docs/Web/API/Element) instance.
 
-You can use Angular's `afterRender` and `afterNextRender` functions to register a **render
+You can use Angular's `afterEveryRender` and `afterNextRender` functions to register a **render
 callback** that runs when Angular has finished rendering the page.
 
 ```ts
@@ -27,7 +27,7 @@ callback** that runs when Angular has finished rendering the page.
 export class ProfilePhoto {
   constructor() {
     const elementRef = inject(ElementRef);
-    afterRender(() => {
+    afterEveryRender(() => {
       // Focus the first input element in this component.
       elementRef.nativeElement.querySelector('input')?.focus();
     });
@@ -35,7 +35,7 @@ export class ProfilePhoto {
 }
 ```
 
-`afterRender` and `afterNextRender` must be called in an _injection context_, typically a
+`afterEveryRender` and `afterNextRender` must be called in an _injection context_, typically a
 component's constructor.
 
 **Avoid direct DOM manipulation whenever possible.** Always prefer expressing your DOM's structure

--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -25,6 +25,17 @@ export interface AfterContentInit {
 }
 
 // @public
+export function afterEveryRender<E = never, W = never, M = never>(spec: {
+    earlyRead?: () => E;
+    write?: (...args: ɵFirstAvailable<[E]>) => W;
+    mixedReadWrite?: (...args: ɵFirstAvailable<[W, E]>) => M;
+    read?: (...args: ɵFirstAvailable<[M, W, E]>) => void;
+}, options?: Omit<AfterRenderOptions, 'phase'>): AfterRenderRef;
+
+// @public
+export function afterEveryRender(callback: VoidFunction, options?: AfterRenderOptions): AfterRenderRef;
+
+// @public
 export function afterNextRender<E = never, W = never, M = never>(spec: {
     earlyRead?: () => E;
     write?: (...args: ɵFirstAvailable<[E]>) => W;
@@ -34,19 +45,6 @@ export function afterNextRender<E = never, W = never, M = never>(spec: {
 
 // @public
 export function afterNextRender(callback: VoidFunction, options?: AfterRenderOptions): AfterRenderRef;
-
-// @public
-function afterRender<E = never, W = never, M = never>(spec: {
-    earlyRead?: () => E;
-    write?: (...args: ɵFirstAvailable<[E]>) => W;
-    mixedReadWrite?: (...args: ɵFirstAvailable<[W, E]>) => M;
-    read?: (...args: ɵFirstAvailable<[M, W, E]>) => void;
-}, options?: Omit<AfterRenderOptions, 'phase'>): AfterRenderRef;
-
-// @public
-function afterRender(callback: VoidFunction, options?: AfterRenderOptions): AfterRenderRef;
-export { afterRender as afterEveryRender }
-export { afterRender }
 
 // @public
 export function afterRenderEffect(callback: (onCleanup: EffectCleanupRegisterFn) => void, options?: Omit<AfterRenderOptions, 'phase'>): AfterRenderRef;

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -112,11 +112,10 @@ export {AfterRenderRef} from './render3/after_render/api';
 export {publishExternalGlobalUtil as ɵpublishExternalGlobalUtil} from './render3/util/global_utils';
 export {
   AfterRenderOptions,
-  afterRender,
+  afterEveryRender,
   afterNextRender,
   ɵFirstAvailable,
 } from './render3/after_render/hooks';
-export {afterRender as afterEveryRender} from './render3/after_render/hooks';
 export {inputBinding, outputBinding, twoWayBinding} from './render3/dynamic_bindings';
 export {ApplicationConfig, mergeApplicationConfig} from './application/application_config';
 export {makeStateKey, StateKey, TransferState} from './transfer_state';

--- a/packages/core/src/defer/dom_triggers.ts
+++ b/packages/core/src/defer/dom_triggers.ts
@@ -8,7 +8,7 @@
 
 import type {Injector} from '../di';
 import {AfterRenderRef} from '../render3/after_render/api';
-import {afterRender} from '../render3/after_render/hooks';
+import {afterEveryRender} from '../render3/after_render/hooks';
 import {assertLContainer, assertLView} from '../render3/assert';
 import {CONTAINER_HEADER_OFFSET} from '../render3/interfaces/container';
 import {TNode} from '../render3/interfaces/node';
@@ -345,5 +345,5 @@ export function registerDomTrigger(
   }
 
   // Begin polling for the trigger.
-  poll = afterRender({read: pollDomTrigger}, {injector});
+  poll = afterEveryRender({read: pollDomTrigger}, {injector});
 }

--- a/packages/core/src/render3/after_render/hooks.ts
+++ b/packages/core/src/render3/after_render/hooks.ts
@@ -33,7 +33,7 @@ export type ɵFirstAvailable<T extends unknown[]> = T extends [infer H, ...infer
   : [];
 
 /**
- * Options passed to `afterRender` and `afterNextRender`.
+ * Options passed to `afterEveryRender` and `afterNextRender`.
  *
  * @publicApi
  */
@@ -108,7 +108,7 @@ export interface AfterRenderOptions {
  *
  * @usageNotes
  *
- * Use `afterRender` to read or write the DOM after each render.
+ * Use `afterEveryRender` to read or write the DOM after each render.
  *
  * ### Example
  * ```angular-ts
@@ -120,7 +120,7 @@ export interface AfterRenderOptions {
  *   @ViewChild('content') contentRef: ElementRef;
  *
  *   constructor() {
- *     afterRender({
+ *     afterEveryRender({
  *       read: () => {
  *         console.log('content height: ' + this.contentRef.nativeElement.scrollHeight);
  *       }
@@ -131,7 +131,7 @@ export interface AfterRenderOptions {
  *
  * @developerPreview
  */
-export function afterRender<E = never, W = never, M = never>(
+export function afterEveryRender<E = never, W = never, M = never>(
   spec: {
     earlyRead?: () => E;
     write?: (...args: ɵFirstAvailable<[E]>) => W;
@@ -170,7 +170,7 @@ export function afterRender<E = never, W = never, M = never>(
  *
  * @usageNotes
  *
- * Use `afterRender` to read or write the DOM after each render.
+ * Use `afterEveryRender` to read or write the DOM after each render.
  *
  * ### Example
  * ```angular-ts
@@ -182,7 +182,7 @@ export function afterRender<E = never, W = never, M = never>(
  *   @ViewChild('content') contentRef: ElementRef;
  *
  *   constructor() {
- *     afterRender({
+ *     afterEveryRender({
  *       read: () => {
  *         console.log('content height: ' + this.contentRef.nativeElement.scrollHeight);
  *       }
@@ -191,11 +191,14 @@ export function afterRender<E = never, W = never, M = never>(
  * }
  * ```
  *
- * @developerPreview
+ * @publicApi
  */
-export function afterRender(callback: VoidFunction, options?: AfterRenderOptions): AfterRenderRef;
+export function afterEveryRender(
+  callback: VoidFunction,
+  options?: AfterRenderOptions,
+): AfterRenderRef;
 
-export function afterRender(
+export function afterEveryRender(
   callbackOrSpec:
     | VoidFunction
     | {
@@ -208,12 +211,12 @@ export function afterRender(
 ): AfterRenderRef {
   ngDevMode &&
     assertNotInReactiveContext(
-      afterRender,
-      'Call `afterRender` outside of a reactive context. For example, schedule the render ' +
+      afterEveryRender,
+      'Call `afterEveryRender` outside of a reactive context. For example, schedule the render ' +
         'callback inside the component constructor`.',
     );
 
-  !options?.injector && assertInInjectionContext(afterRender);
+  !options?.injector && assertInInjectionContext(afterEveryRender);
   const injector = options?.injector ?? inject(Injector);
 
   if (typeof ngServerMode !== 'undefined' && ngServerMode) {
@@ -222,7 +225,7 @@ export function afterRender(
 
   performanceMarkFeature('NgAfterRender');
 
-  return afterRenderImpl(callbackOrSpec, injector, options, /* once */ false);
+  return afterEveryRenderImpl(callbackOrSpec, injector, options, /* once */ false);
 }
 
 /**
@@ -392,7 +395,7 @@ export function afterNextRender(
 
   performanceMarkFeature('NgAfterNextRender');
 
-  return afterRenderImpl(callbackOrSpec, injector, options, /* once */ true);
+  return afterEveryRenderImpl(callbackOrSpec, injector, options, /* once */ true);
 }
 
 function getHooks(
@@ -418,9 +421,9 @@ function getHooks(
 }
 
 /**
- * Shared implementation for `afterRender` and `afterNextRender`.
+ * Shared implementation for `afterEveryRender` and `afterNextRender`.
  */
-function afterRenderImpl(
+function afterEveryRenderImpl(
   callbackOrSpec:
     | VoidFunction
     | {
@@ -435,7 +438,7 @@ function afterRenderImpl(
 ): AfterRenderRef {
   const manager = injector.get(AfterRenderManager);
   // Lazily initialize the handler implementation, if necessary. This is so that it can be
-  // tree-shaken if `afterRender` and `afterNextRender` aren't used.
+  // tree-shaken if `afterEveryRender` and `afterNextRender` aren't used.
   manager.impl ??= injector.get(AfterRenderImpl);
 
   const tracing = injector.get(TracingService, null, {optional: true});

--- a/packages/core/test/acceptance/after_render_hook_spec.ts
+++ b/packages/core/test/acceptance/after_render_hook_spec.ts
@@ -20,7 +20,7 @@ import {
   Type,
   ViewContainerRef,
   afterNextRender,
-  afterRender,
+  afterEveryRender,
   computed,
   createComponent,
   effect,
@@ -61,7 +61,7 @@ describe('after render hooks', () => {
           afterRenderCount = 0;
 
           constructor() {
-            afterRender(() => {
+            afterEveryRender(() => {
               this.afterRenderCount++;
             });
           }
@@ -77,7 +77,7 @@ describe('after render hooks', () => {
           viewContainerRef = inject(ViewContainerRef);
 
           constructor() {
-            afterRender(() => {
+            afterEveryRender(() => {
               this.afterRenderCount++;
             });
           }
@@ -127,7 +127,7 @@ describe('after render hooks', () => {
           afterRenderCount = 0;
 
           constructor() {
-            afterRender(() => {
+            afterEveryRender(() => {
               this.afterRenderCount++;
             });
           }
@@ -143,7 +143,7 @@ describe('after render hooks', () => {
           viewContainerRef = inject(ViewContainerRef);
 
           constructor() {
-            afterRender(() => {
+            afterEveryRender(() => {
               this.afterRenderCount++;
             });
           }
@@ -191,7 +191,7 @@ describe('after render hooks', () => {
         })
         class ChildComp {
           constructor() {
-            afterRender(() => {
+            afterEveryRender(() => {
               log.push('child-comp');
             });
           }
@@ -206,7 +206,7 @@ describe('after render hooks', () => {
           changeDetectorRef = inject(ChangeDetectorRef);
 
           constructor() {
-            afterRender(() => {
+            afterEveryRender(() => {
               log.push('parent-comp');
             });
           }
@@ -237,7 +237,7 @@ describe('after render hooks', () => {
         })
         class MyComp {
           constructor() {
-            afterRender(() => {
+            afterEveryRender(() => {
               log.push('render');
             });
           }
@@ -266,7 +266,7 @@ describe('after render hooks', () => {
         })
         class Comp {
           constructor() {
-            hookRef = afterRender(() => {
+            hookRef = afterEveryRender(() => {
               afterRenderCount++;
             });
           }
@@ -299,7 +299,7 @@ describe('after render hooks', () => {
         })
         class Comp {
           constructor() {
-            afterRender(() => {
+            afterEveryRender(() => {
               zoneLog.push(NgZone.isInAngularZone());
             });
           }
@@ -334,19 +334,19 @@ describe('after render hooks', () => {
         })
         class Comp {
           constructor() {
-            afterRender(() => {
+            afterEveryRender(() => {
               log.push('pass 1');
             });
 
-            afterRender(() => {
+            afterEveryRender(() => {
               throw new Error('fail 1');
             });
 
-            afterRender(() => {
+            afterEveryRender(() => {
               log.push('pass 2');
             });
 
-            afterRender(() => {
+            afterEveryRender(() => {
               throw new Error('fail 2');
             });
           }
@@ -379,25 +379,25 @@ describe('after render hooks', () => {
         })
         class CompA {
           constructor() {
-            afterRender({
+            afterEveryRender({
               earlyRead: () => {
                 log.push('early-read-1');
               },
             });
 
-            afterRender({
+            afterEveryRender({
               write: () => {
                 log.push('write-1');
               },
             });
 
-            afterRender({
+            afterEveryRender({
               mixedReadWrite: () => {
                 log.push('mixed-read-write-1');
               },
             });
 
-            afterRender({
+            afterEveryRender({
               read: () => {
                 log.push('read-1');
               },
@@ -411,25 +411,25 @@ describe('after render hooks', () => {
         })
         class CompB {
           constructor() {
-            afterRender({
+            afterEveryRender({
               read: () => {
                 log.push('read-2');
               },
             });
 
-            afterRender({
+            afterEveryRender({
               mixedReadWrite: () => {
                 log.push('mixed-read-write-2');
               },
             });
 
-            afterRender({
+            afterEveryRender({
               write: () => {
                 log.push('write-2');
               },
             });
 
-            afterRender({
+            afterEveryRender({
               earlyRead: () => {
                 log.push('early-read-2');
               },
@@ -466,7 +466,7 @@ describe('after render hooks', () => {
         })
         class Comp {
           constructor() {
-            afterRender({
+            afterEveryRender({
               earlyRead: () => {
                 log.push('early-read-1');
               },
@@ -481,7 +481,7 @@ describe('after render hooks', () => {
               },
             });
 
-            afterRender(() => {
+            afterEveryRender(() => {
               log.push('mixed-read-write-2');
             });
           }
@@ -513,7 +513,7 @@ describe('after render hooks', () => {
         })
         class Comp {
           constructor() {
-            afterRender({
+            afterEveryRender({
               earlyRead: () => 'earlyRead result',
               write: (results) => {
                 log.push(`results for write: ${results}`);
@@ -528,7 +528,7 @@ describe('after render hooks', () => {
               },
             });
 
-            afterRender({
+            afterEveryRender({
               earlyRead: () => 'earlyRead 2 result',
               read: (results) => {
                 log.push(`results for read 2: ${results}`);
@@ -561,23 +561,23 @@ describe('after render hooks', () => {
           })
           class TestCmp {
             someFn() {
-              afterRender(() => {});
+              afterEveryRender(() => {});
             }
           }
 
           const fixture = TestBed.createComponent(TestCmp);
           expect(() => fixture.detectChanges()).toThrowError(
-            /afterRender\(\) cannot be called from within a reactive context/,
+            /afterEveryRender\(\) cannot be called from within a reactive context/,
           );
         });
 
         it('inside computed', () => {
           const testComputed = computed(() => {
-            afterRender(() => {});
+            afterEveryRender(() => {});
           });
 
           expect(() => testComputed()).toThrowError(
-            /afterRender\(\) cannot be called from within a reactive context/,
+            /afterEveryRender\(\) cannot be called from within a reactive context/,
           );
         });
 
@@ -594,7 +594,7 @@ describe('after render hooks', () => {
             }
 
             someFnThatWillScheduleAfterRender() {
-              afterRender(() => {});
+              afterEveryRender(() => {});
             }
           }
 
@@ -613,7 +613,7 @@ describe('after render hooks', () => {
           const fixture = TestBed.createComponent(TestCmp);
 
           expect(() => fixture.detectChanges()).toThrowError(
-            /afterRender\(\) cannot be called from within a reactive context/,
+            /afterEveryRender\(\) cannot be called from within a reactive context/,
           );
         });
       });
@@ -625,7 +625,7 @@ describe('after render hooks', () => {
         @Component({selector: 'comp', template: '', standalone: false})
         class Comp {
           constructor() {
-            afterRenderRef = afterRender(() => count++, {manualCleanup: true});
+            afterRenderRef = afterEveryRender(() => count++, {manualCleanup: true});
           }
         }
 
@@ -1201,7 +1201,7 @@ describe('after render hooks', () => {
         })
         class Comp {
           constructor() {
-            afterRender({
+            afterEveryRender({
               earlyRead: () => {
                 log.push('early-read');
                 return 'early';
@@ -1361,7 +1361,7 @@ describe('after render hooks', () => {
         counter = counter;
         injector = inject(EnvironmentInjector);
         ngOnInit() {
-          afterRender(
+          afterEveryRender(
             () => {
               this.counter.update((v) => v + 1);
             },
@@ -1449,7 +1449,7 @@ describe('after render hooks', () => {
         })
         class Comp {
           constructor() {
-            afterRender(() => {
+            afterEveryRender(() => {
               afterRenderCount++;
             });
           }

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -7,10 +7,10 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {PLATFORM_BROWSER_ID} from '@angular/common/src/platform_id';
+import {expect} from '@angular/platform-browser/testing/src/matchers';
+import {BehaviorSubject} from 'rxjs';
 import {
   ApplicationRef,
-  NgZone,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -22,26 +22,21 @@ import {
   EventEmitter,
   inject,
   Input,
-  NgModule,
   OnInit,
   Output,
+  provideCheckNoChangesConfig,
+  provideZoneChangeDetection,
+  provideZonelessChangeDetection,
   QueryList,
+  ɵRuntimeError as RuntimeError,
+  ɵRuntimeErrorCode as RuntimeErrorCode,
   TemplateRef,
   Type,
   ViewChild,
   ViewChildren,
   ViewContainerRef,
-  provideCheckNoChangesConfig,
-  provideZonelessChangeDetection,
-  ɵRuntimeError as RuntimeError,
-  ɵRuntimeErrorCode as RuntimeErrorCode,
-  afterRender,
-  PLATFORM_ID,
-  provideZoneChangeDetection,
 } from '../../src/core';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '../../testing';
-import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {BehaviorSubject} from 'rxjs';
 
 describe('change detection', () => {
   it('can provide zone and zoneless (last one wins like any other provider) in TestBed', () => {

--- a/packages/core/test/acceptance/injector_profiler_spec.ts
+++ b/packages/core/test/acceptance/injector_profiler_spec.ts
@@ -8,7 +8,7 @@
 
 import {NgForOf, PercentPipe} from '@angular/common';
 import {
-  afterRender,
+  afterEveryRender,
   ClassProvider,
   Component,
   Directive,
@@ -475,7 +475,7 @@ describe('getInjectorMetadata', () => {
       elementRef = inject(ElementRef);
 
       constructor() {
-        afterRender(() => afterLazyComponentRendered(this));
+        afterEveryRender(() => afterLazyComponentRendered(this));
       }
     }
 

--- a/packages/core/test/acceptance/profiler_spec.ts
+++ b/packages/core/test/acceptance/profiler_spec.ts
@@ -13,7 +13,7 @@ import {TestBed} from '../../testing';
 import {
   AfterContentChecked,
   AfterContentInit,
-  afterRender,
+  afterEveryRender,
   AfterViewChecked,
   AfterViewInit,
   Component,
@@ -510,7 +510,7 @@ describe('profiler', () => {
         template: '',
       })
       class MyComponent {
-        arRef = afterRender(() => {});
+        arRef = afterEveryRender(() => {});
       }
 
       const fixture = TestBed.createComponent(MyComponent);

--- a/packages/core/test/acceptance/tracing_spec.ts
+++ b/packages/core/test/acceptance/tracing_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {
-  afterRender,
+  afterEveryRender,
   Component,
   ɵTracingAction as TracingAction,
   ɵTracingService as TracingService,
@@ -81,7 +81,7 @@ describe('TracingService', () => {
     @Component({template: ''})
     class App {
       constructor() {
-        afterRender(() => {});
+        afterEveryRender(() => {});
       }
     }
 

--- a/packages/core/test/change_detection_scheduler_spec.ts
+++ b/packages/core/test/change_detection_scheduler_spec.ts
@@ -10,7 +10,7 @@ import {AsyncPipe} from '@angular/common';
 import {PLATFORM_BROWSER_ID} from '@angular/common/src/platform_id';
 import {
   afterNextRender,
-  afterRender,
+  afterEveryRender,
   ApplicationRef,
   ChangeDetectorRef,
   Component,
@@ -303,7 +303,7 @@ describe('Angular with zoneless enabled', () => {
         })
         class App {
           @ViewChild('ref', {read: ViewContainerRef}) viewContainer!: ViewContainerRef;
-          unused = afterRender(() => {
+          unused = afterEveryRender(() => {
             renderHookCalls++;
           });
 
@@ -639,7 +639,7 @@ describe('Angular with zoneless enabled', () => {
   it('should not run change detection twice if manual tick called when CD was scheduled', async () => {
     let changeDetectionRuns = 0;
     TestBed.runInInjectionContext(() => {
-      afterRender(() => {
+      afterEveryRender(() => {
         changeDetectionRuns++;
       });
     });
@@ -787,7 +787,7 @@ describe('Angular with scheduler and ZoneJS', () => {
   it('will not schedule change detection if listener callback is outside the zone', async () => {
     let renders = 0;
     TestBed.runInInjectionContext(() => {
-      afterRender(() => {
+      afterEveryRender(() => {
         renders++;
       });
     });
@@ -902,7 +902,7 @@ describe('Angular with scheduler and ZoneJS', () => {
 
     let changeDetectionRuns = 0;
     TestBed.runInInjectionContext(() => {
-      afterRender(() => {
+      afterEveryRender(() => {
         changeDetectionRuns++;
       });
     });
@@ -945,7 +945,7 @@ describe('Angular with scheduler and ZoneJS', () => {
 
     let ticks = 0;
     TestBed.runInInjectionContext(() => {
-      afterRender(() => {
+      afterEveryRender(() => {
         ticks++;
       });
     });
@@ -973,7 +973,7 @@ describe('Angular with scheduler and ZoneJS', () => {
 
     let ticks = 0;
     TestBed.runInInjectionContext(() => {
-      afterRender(() => {
+      afterEveryRender(() => {
         ticks++;
       });
     });

--- a/packages/core/test/zone/ng_zone_spec.ts
+++ b/packages/core/test/zone/ng_zone_spec.ts
@@ -6,24 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  Component,
-  EventEmitter,
-  NgZone,
-  afterRender,
-  provideZoneChangeDetection,
-} from '../../src/core';
-import {
-  TestBed,
-  fakeAsync,
-  flush,
-  flushMicrotasks,
-  inject,
-  tick,
-  waitForAsync,
-} from '../../testing';
-import {Log} from '../../testing/src/testing_internal';
 import {firstValueFrom} from 'rxjs';
+import {Component, EventEmitter, NgZone, provideZoneChangeDetection} from '../../src/core';
+import {TestBed, fakeAsync, flush, flushMicrotasks, inject, waitForAsync} from '../../testing';
+import {Log} from '../../testing/src/testing_internal';
 
 import {scheduleCallbackWithRafRace as scheduler} from '../../src/util/callback_scheduler';
 import {global} from '../../src/util/global';

--- a/packages/platform-server/test/full_app_hydration_spec.ts
+++ b/packages/platform-server/test/full_app_hydration_spec.ts
@@ -24,7 +24,7 @@ import {
 import {MockPlatformLocation} from '@angular/common/testing';
 import {computeMsgId} from '@angular/compiler';
 import {
-  afterRender,
+  afterEveryRender,
   ApplicationRef,
   ChangeDetectorRef,
   Component,
@@ -4847,7 +4847,7 @@ describe('platform-server full application hydration integration', () => {
           elementRef = inject(ElementRef);
 
           constructor() {
-            afterRender(() => {
+            afterEveryRender(() => {
               observedChildCountLog.push(this.elementRef.nativeElement.childElementCount);
             });
           }
@@ -4890,7 +4890,7 @@ describe('platform-server full application hydration integration', () => {
           elementRef = inject(ElementRef);
 
           constructor() {
-            afterRender(() => {
+            afterEveryRender(() => {
               observedChildCountLog.push(this.elementRef.nativeElement.childElementCount);
             });
 


### PR DESCRIPTION
This change renames the afterRender to afterEveryRender and marks the renamed API as stable.

BREAKING CHANGE: afterRender was renamed to afterEveryRender.
