### PR TITLE
docs(docs-infra): fix mat-tab colors

### DIFF
--- a/adev/shared-docs/styles/_resets.scss
+++ b/adev/shared-docs/styles/_resets.scss
@@ -164,6 +164,9 @@
     --mat-tab-header-active-focus-label-text-color: var(--primary-contrast);
     --mat-tab-header-active-hover-label-text-color: var(--primary-contrast);
     --mat-tab-header-active-focus-indicator-color: var(--bright-blue);
+    --mat-tab-active-focus-label-text-color: transparent;
+    --mat-tab-inactive-label-text-color: var(--tertiary-contrast);
+    --mat-tab-inactive-hover-label-text-color: var(--primary-contrast);
     --mat-tab-header-active-hover-indicator-color: color-mix(
       in srgb,
       var(--bright-blue) 40%,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the new behavior?

Fix the regressed text colors on `main` of Material tabs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No