### PR TITLE
refactor(core): tree-shake `PROPAGATION_STOPPED_SYMBOL`

### DIFF
--- a/packages/core/primitives/event-dispatch/src/event_dispatcher.ts
+++ b/packages/core/primitives/event-dispatch/src/event_dispatcher.ts
@@ -19,7 +19,7 @@ import {Restriction} from './restriction';
 export type Replayer = (eventInfoWrappers: Event[]) => void;
 
 /** An internal symbol used to indicate whether propagation should be stopped or not. */
-export const PROPAGATION_STOPPED_SYMBOL = Symbol.for('propagationStopped');
+export const PROPAGATION_STOPPED_SYMBOL = /* @__PURE__ */ Symbol.for('propagationStopped');
 
 /** Extra event phases beyond what the browser provides. */
 export const EventPhase = {


### PR DESCRIPTION
Adds `__PURE__` annotations to `PROPAGATION_STOPPED_SYMBOL` to enable tree-shaking, even if is is not referenced. This variable is not dropped when Angular is imported from a module that has `sideEffects` set to `true`.

![image](https://github.com/user-attachments/assets/1083280b-342c-424e-88b9-7b5a74b28b01)
