### PR TITLE
Fixing the angular language service neovim docs

### DIFF
--- a/adev/src/content/tools/language-service.md
+++ b/adev/src/content/tools/language-service.md
@@ -131,7 +131,42 @@ Either directly install the "Eclipse IDE for Web and JavaScript developers" pack
 
 ### Neovim
 
-Angular language service can be used with Neovim by using the [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) plugin.
+#### Conquer of Completion with Node.js
+
+The Angular Language Service uses the tsserver, which doesn't follow the LSP specifications exactly. Therefore if you are using neovim or vim with JavaScript or TypeScript or Angular you may find that [Conquer of Completion](https://github.com/neoclide/coc.nvim) (COC) has the fullest implementation of the Angular Language Service and the tsserver. This is because COC ports the VSCode implementation of the tsserver which accommodates the tsserver's implementation.
+
+1. [Setup coc.nvim](https://github.com/neoclide/coc.nvim)
+   
+2. Configure the Angular Language Service
+
+    Once installed run the `CocConfig` vim command line command to open the config file `coc-settings.json` and add the angular property. 
+
+    Make sure to substitute the correct paths to your global `node_modules` such that they go to directories which contain `tsserver` and the `ngserver` respectively.
+
+    <docs-code header="CocConfig example file coc-settings.json" language="json">
+    {
+      "languageserver": {
+        "angular": {
+          "command": "ngserver",
+          "args": [
+            "--stdio",
+            "--tsProbeLocations",
+            "/usr/local/lib/node_modules/typescript/lib/CHANGE/THIS/TO/YOUR/GLOBAL/NODE_MODULES", 
+            "--ngProbeLocations",
+            "/usr/local/lib/node_modules/@angular/language-server/bin/CHANGE/THIS/TO/YOUR/GLOBAL/NODE_MODULES"
+          ],
+          "filetypes": ["ts", "typescript", "html"],
+          "trace.server.verbosity": "verbose"
+        }
+      }
+    }
+    </docs-code>
+
+HELPFUL: `/usr/local/lib/node_modules/typescript/lib` and `/usr/local/lib/node_modules/@angular/language-server/bin` above should point to the location of your global node modules, which may be different.
+
+
+#### Built In Neovim LSP
+Angular Language Service can be used with Neovim by using the [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) plugin.
 
 1. [Install nvim-lspconfig](https://github.com/neovim/nvim-lspconfig?tab=readme-ov-file#install)
 


### PR DESCRIPTION
Someone mistakenly (naively) removed the neovim angular language service documentation during one of the updates.

So this is a rendition of a commit that I made to prior version of the docs.

https://angular.dev/tools/language-service

https://v17.angular.io/guide/language-service#neovim

Update language-service.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
