### PR TITLE
refactor(core): expose `getCleanupHook` via private exports

### DIFF
--- a/packages/core/testing/src/test_hooks.ts
+++ b/packages/core/testing/src/test_hooks.ts
@@ -27,7 +27,7 @@ globalThis.beforeEach?.(getCleanupHook(false));
 // afterEach is only defined when executing the tests
 globalThis.afterEach?.(getCleanupHook(true));
 
-export function getCleanupHook(expectedTeardownValue: boolean) {
+export function getCleanupHook(expectedTeardownValue: boolean): VoidFunction {
   return () => {
     const testBed = TestBedImpl.INSTANCE;
     if (testBed.shouldTearDownTestingModule() === expectedTeardownValue) {

--- a/packages/core/testing/src/test_hooks.ts
+++ b/packages/core/testing/src/test_hooks.ts
@@ -27,7 +27,7 @@ globalThis.beforeEach?.(getCleanupHook(false));
 // afterEach is only defined when executing the tests
 globalThis.afterEach?.(getCleanupHook(true));
 
-function getCleanupHook(expectedTeardownValue: boolean) {
+export function getCleanupHook(expectedTeardownValue: boolean) {
   return () => {
     const testBed = TestBedImpl.INSTANCE;
     if (testBed.shouldTearDownTestingModule() === expectedTeardownValue) {

--- a/packages/core/testing/src/testing.ts
+++ b/packages/core/testing/src/testing.ts
@@ -38,7 +38,7 @@ export {
   TestEnvironmentOptions,
   ModuleTeardownOptions,
 } from './test_bed_common';
-export * from './test_hooks';
+export {__core_private_testing_placeholder__} from './test_hooks';
 export * from './metadata_override';
 export {MetadataOverrider as ɵMetadataOverrider} from './metadata_overrider';
 export {

--- a/packages/core/testing/src/testing_private_export.ts
+++ b/packages/core/testing/src/testing_private_export.ts
@@ -7,3 +7,4 @@
  */
 
 export {FakeNavigation as ɵFakeNavigation} from '../../primitives/dom-navigation/testing';
+export {getCleanupHook as ɵgetCleanupHook} from './test_hooks';


### PR DESCRIPTION
Expose `getCleanupHook` as a private export to address integration issues with Vitest. In Vitest, `globalThis.beforeEach` and `globalThis.afterEach` are not available by default. Additionally, these hooks are patched during module evaluation, complicating seamless integration with Vitest.

See: https://github.com/angular/angular-cli/pull/30188
