### PR TITLE
Internal compiler refactors

### DIFF
--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import {
-  BoundTarget,
   ChangeDetectionStrategy,
   compileComponentFromMetadata,
   ConstantPool,
@@ -17,6 +16,7 @@ import {
   InterpolationConfig,
   makeBindingParser,
   outputAst as o,
+  ParsedTemplate,
   parseTemplate,
   R3ComponentDeferMetadata,
   R3ComponentMetadata,
@@ -28,7 +28,6 @@ import {
   R3TargetBinder,
   R3TemplateDependencyKind,
   R3TemplateDependencyMetadata,
-  SelectorMatcher,
   TmplAstDeferredBlock,
   ViewEncapsulation,
 } from '@angular/compiler';
@@ -131,8 +130,6 @@ export class PartialComponentLinkerVersion1<TStatement, TExpression>
       );
     }
 
-    const binder = new R3TargetBinder(new SelectorMatcher());
-    const boundTarget = binder.bind({template: template.nodes});
     let declarationListEmitMode = DeclarationListEmitMode.Direct;
 
     const extractDeclarationTypeExpr = (
@@ -229,7 +226,7 @@ export class PartialComponentLinkerVersion1<TStatement, TExpression>
       styles: metaObj.has('styles')
         ? metaObj.getArray('styles').map((entry) => entry.getString())
         : [],
-      defer: this.createR3ComponentDeferMetadata(metaObj, boundTarget),
+      defer: this.createR3ComponentDeferMetadata(metaObj, template),
       encapsulation: metaObj.has('encapsulation')
         ? parseEncapsulation(metaObj.getValue('encapsulation'))
         : ViewEncapsulation.Emulated,
@@ -324,10 +321,22 @@ export class PartialComponentLinkerVersion1<TStatement, TExpression>
 
   private createR3ComponentDeferMetadata(
     metaObj: AstObject<R3DeclareComponentMetadata, TExpression>,
-    boundTarget: BoundTarget<any>,
+    template: ParsedTemplate,
   ): R3ComponentDeferMetadata {
+    const result: R3ComponentDeferMetadata = {
+      mode: DeferBlockDepsEmitMode.PerBlock,
+      blocks: new Map<TmplAstDeferredBlock, o.Expression | null>(),
+    };
+
+    // Exit early if the template is empty.
+    if (template.nodes.length === 0) {
+      return result;
+    }
+
+    // We're only using the bound target to find defer blocks
+    // so don't set up infrastructure for directive matching.
+    const boundTarget = new R3TargetBinder(null).bind({template: template.nodes});
     const deferredBlocks = boundTarget.getDeferBlocks();
-    const blocks = new Map<TmplAstDeferredBlock, o.Expression | null>();
     const dependencies = metaObj.has('deferBlockDependencies')
       ? metaObj.getArray('deferBlockDependencies')
       : null;
@@ -336,16 +345,16 @@ export class PartialComponentLinkerVersion1<TStatement, TExpression>
       const matchingDependencyFn = dependencies?.[i];
 
       if (matchingDependencyFn == null) {
-        blocks.set(deferredBlocks[i], null);
+        result.blocks.set(deferredBlocks[i], null);
       } else {
-        blocks.set(
+        result.blocks.set(
           deferredBlocks[i],
           matchingDependencyFn.isNull() ? null : matchingDependencyFn.getOpaque(),
         );
       }
     }
 
-    return {mode: DeferBlockDepsEmitMode.PerBlock, blocks};
+    return result;
   }
 }
 

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -1944,7 +1944,7 @@ export class ComponentDecoratorHandler
     template: ComponentTemplate,
   ): Map<TmplAstDeferredBlock, DeferredComponentDependency[]> {
     const deferBlocks = new Map<TmplAstDeferredBlock, DeferredComponentDependency[]>();
-    const directivelessBinder = new R3TargetBinder<DirectiveMeta>(new SelectorMatcher());
+    const directivelessBinder = new R3TargetBinder<DirectiveMeta>(null);
     const bound = directivelessBinder.bind({template: template.nodes});
     const deferredBlocks = bound.getDeferBlocks();
 

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -1086,7 +1086,6 @@ export class NgCompiler {
           this.options.extendedDiagnostics?.defaultCategory || DiagnosticCategoryLabel.Warning,
         allowSignalsInTwoWayBindings,
         checkTwoWayBoundEvents,
-        selectorlessEnabled: this.enableSelectorless,
       };
     } else {
       typeCheckingConfig = {
@@ -1122,7 +1121,6 @@ export class NgCompiler {
           this.options.extendedDiagnostics?.defaultCategory || DiagnosticCategoryLabel.Warning,
         allowSignalsInTwoWayBindings,
         checkTwoWayBoundEvents,
-        selectorlessEnabled: this.enableSelectorless,
       };
     }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
@@ -362,11 +362,6 @@ export interface TypeCheckingConfig {
    * Whether the event side of a two-way binding should be type checked.
    */
   checkTwoWayBoundEvents: boolean;
-
-  /**
-   * Whether selectorless syntax is enabled.
-   */
-  selectorlessEnabled: boolean;
 }
 
 export type SourceMapping =

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1050,7 +1050,6 @@ describe('type check blocks', () => {
       unusedStandaloneImports: 'warning',
       allowSignalsInTwoWayBindings: true,
       checkTwoWayBoundEvents: true,
-      selectorlessEnabled: false,
     };
 
     describe('config.applyTemplateContextGuards', () => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -285,7 +285,6 @@ export const ALL_ENABLED_CONFIG: Readonly<TypeCheckingConfig> = {
   unusedStandaloneImports: 'warning',
   allowSignalsInTwoWayBindings: true,
   checkTwoWayBoundEvents: true,
-  selectorlessEnabled: false,
 };
 
 // Remove 'ref' from TypeCheckableDirectiveMeta and add a 'selector' instead.
@@ -428,7 +427,6 @@ export function tcb(
     suggestionsForSuboptimalTypeInference: false,
     allowSignalsInTwoWayBindings: true,
     checkTwoWayBoundEvents: true,
-    selectorlessEnabled,
     ...config,
   };
   options = options || {emitSpans: false};

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -82,7 +82,6 @@ import {
   R3ComponentMetadata,
   R3DirectiveDependencyMetadata,
   R3DirectiveMetadata,
-  R3HostDirectiveMetadata,
   R3HostMetadata,
   R3InputMetadata,
   R3PipeDependencyMetadata,
@@ -104,7 +103,6 @@ import {R3TargetBinder} from './render3/view/t2_binder';
 import {makeBindingParser, parseTemplate} from './render3/view/template';
 import {ResourceLoader} from './resource_loader';
 import {DomElementSchemaRegistry} from './schema/dom_element_schema_registry';
-import {SelectorMatcher} from './directive_matching';
 import {getJitStandaloneDefaultForVersion} from './util';
 
 export class CompilerFacadeImpl implements CompilerFacade {
@@ -748,7 +746,7 @@ function parseJitTemplate(
     const errors = parsed.errors.map((err) => err.toString()).join(', ');
     throw new Error(`Errors during JIT compilation of template for ${typeName}: ${errors}`);
   }
-  const binder = new R3TargetBinder(new SelectorMatcher());
+  const binder = new R3TargetBinder(null);
   const boundTarget = binder.bind({template: parsed.nodes});
 
   return {

--- a/packages/compiler/src/render3/view/t2_api.ts
+++ b/packages/compiler/src/render3/view/t2_api.ts
@@ -48,15 +48,15 @@ export type ScopedNode =
 
 /** Possible values that a reference can be resolved to. */
 export type ReferenceTarget<DirectiveT> =
-  | {
-      directive: DirectiveT;
-      node: Element | Template | Component | Directive;
-    }
+  | {directive: DirectiveT; node: DirectiveOwner}
   | Element
   | Template;
 
 /** Entity that is local to the template and defined within the template. */
 export type TemplateEntity = Reference | Variable | LetDeclaration;
+
+/** Nodes that can have directives applied to them. */
+export type DirectiveOwner = Element | Template | Component | Directive;
 
 /*
  * t2 is the replacement for the `TemplateDefinitionBuilder`. It handles the operations of
@@ -183,7 +183,7 @@ export interface BoundTarget<DirectiveT extends DirectiveMeta> {
    * For a given template node (either an `Element` or a `Template`), get the set of directives
    * which matched the node, if any.
    */
-  getDirectivesOfNode(node: Element | Template | Component): DirectiveT[] | null;
+  getDirectivesOfNode(node: DirectiveOwner): DirectiveT[] | null;
 
   /**
    * For a given `Reference`, get the reference's target - either an `Element`, a `Template`, or
@@ -273,13 +273,6 @@ export interface BoundTarget<DirectiveT extends DirectiveMeta> {
    * Whether a given node is located in a `@defer` block.
    */
   isDeferred(node: Element): boolean;
-
-  /**
-   * Returns the directives that are owned by a specific component/directive node. This is either
-   * the directive being referenced itself or its host directives.
-   * @param node Node for which to retrieve the owned directives.
-   */
-  getOwnedDirectives(node: Component | Directive): DirectiveT[] | null;
 
   /**
    * Checks whether a component/directive that was referenced directly in the template exists.

--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -166,7 +166,7 @@ export type DirectiveMatcher<DirectiveT extends DirectiveMeta> =
  * target.
  */
 export class R3TargetBinder<DirectiveT extends DirectiveMeta> implements TargetBinder<DirectiveT> {
-  constructor(private directiveMatcher: DirectiveMatcher<DirectiveT>) {}
+  constructor(private directiveMatcher: DirectiveMatcher<DirectiveT> | null) {}
 
   /**
    * Perform a binding operation on the given `Target` and return a `BoundTarget` which contains
@@ -203,15 +203,17 @@ export class R3TargetBinder<DirectiveT extends DirectiveMeta> implements TargetB
       //   - bindings: Map of inputs, outputs, and attributes to the directive/element that claims
       //     them. TODO(alxhub): handle multiple directives claiming an input/output/etc.
       //   - references: Map of #references to their targets.
-      DirectiveBinder.apply(
-        target.template,
-        this.directiveMatcher,
-        directives,
-        eagerDirectives,
-        missingDirectives,
-        bindings,
-        references,
-      );
+      if (this.directiveMatcher !== null) {
+        DirectiveBinder.apply(
+          target.template,
+          this.directiveMatcher,
+          directives,
+          eagerDirectives,
+          missingDirectives,
+          bindings,
+          references,
+        );
+      }
 
       // Finally, run the TemplateBinder to bind references, variables, and other entities within the
       // template. This extracts all the metadata that doesn't depend on directive matching.


### PR DESCRIPTION
Includes a few refactors in the compiler to make the code a bit simpler and more manageable:

### refactor(compiler): simplify tracking of directives 
An earlier commit that introduced tracking of selectorless directives to the template binder made it so `getDirectivesOfNode` returns _all_ of the matched directives while a new method called `getOwnedDirectives` would return only the ones brought in by the specific node.

In hindsight, this is likely to cause bugs in the future, because it's unclear whether to reach for `getDirectivesOfNode` or `getOwnedDirectives`. These changes remove `getOwnedDirectives` and make it so in selectorless `getDirectivesOfNode` accepts the directive AST node itself.

Another goal of this refactor is that the TCB shouldn't have to check the `selectorlessEnabled` config option.

### refactor(compiler): allow binder to be created without matcher 
Currently to create an `R3TargetBinder`, we have to pass some sort of directive matcher, however we also have a couple of use cases where we use the binder to do analysis that's unrelated to directives (e.g. resolving the `@defer` blocks). In these cases having to create a dummy matcher adds some slight overhead and makes the code harder to reason about since it looks like directive matching may be happening.

These changes update the `R3TargetBinder` to allow for `null` to be passed as the directive matcher.

### refactor(compiler-cli): split up large method 
The `ComponentHandler.resolve` method is ~500 lines and is a bit hard to follow due to some very long `if` statements. These changes split the functionality across several smaller methods to make it easier to manage.