### PR TITLE
docs(docs-infra): fix function api ref header width

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/function-reference.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/function-reference.tsx
@@ -38,16 +38,14 @@ export const signatureCard = (
     <div id={opts.id} class={REFERENCE_MEMBER_CARD}>
       <header class={REFERENCE_MEMBER_CARD_HEADER}>
         {printSignaturesAsHeader ? (
-          <code>
-            <HighlightTypeScript
-              code={printInitializerFunctionSignatureLine(
-                name,
-                signature,
-                // Always omit types in signature headers, to keep them short.
-                true,
-              )}
-            />
-          </code>
+          <HighlightTypeScript
+            code={printInitializerFunctionSignatureLine(
+              name,
+              signature,
+              // Always omit types in signature headers, to keep them short.
+              true,
+            )}
+          />
         ) : (
           <>
             <h3>{name}</h3>

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/highlight-ts.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/highlight-ts.tsx
@@ -15,5 +15,5 @@ export function HighlightTypeScript(props: {code: string}) {
   const result = codeToHtml(props.code, 'typescript');
   const withScrollTrack = result.replace(/^(<pre class="shiki)/, '$1 docs-mini-scroll-track');
 
-  return <RawHtml value={withScrollTrack} />;
+  return <RawHtml value={withScrollTrack} className="docs-code" />;
 }

--- a/adev/shared-docs/styles/_reference.scss
+++ b/adev/shared-docs/styles/_reference.scss
@@ -138,20 +138,16 @@
           border-radius: 0.25rem;
         }
 
-        code {
-          font-size: 0.875rem;
-          overflow: hidden;
+        .docs-code {
+          flex: 1;
 
-          &:has(pre) {
-            padding: 0;
+          button[docs-copy-source-code] {
+            display: none;
           }
         }
 
-        pre {
-          margin: 0;
-
-          /* Do we have a better alternative ? */
-          overflow: auto;
+        code {
+          font-size: 0.875rem;
         }
 
         h3 {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

<img width="667" alt="Screenshot 2025-04-28 at 19 10 14" src="https://github.com/user-attachments/assets/d4219130-7417-4e54-9921-7b722892506c" />

Reproducible for function references.

## What is the new behavior?

Fix the width of the function API reference header when the viewport width is for-desktop-down.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
