### PR TITLE
docs: fix ngFor deprecation error message parsing

### DIFF
--- a/packages/common/src/directives/ng_for_of.ts
+++ b/packages/common/src/directives/ng_for_of.ts
@@ -167,7 +167,7 @@ export class NgForOfContext<T, U extends NgIterable<T> = NgIterable<T>> {
  * @ngModule CommonModule
  * @publicApi
  *
- * @deprecated Use the @for block instead. Intent to remove in v22
+ * @deprecated Use the `@for` block instead. Intent to remove in v22
  */
 @Directive({
   selector: '[ngFor][ngForOf]',


### PR DESCRIPTION
tslint parses the message incorrectly, causing the user-facing error to just say "Use the.": https://screenshot.googleplex.com/BNHP2iDMcayp326

The parser seems to consider `@` as a new decorator. The tick marks tells the parser otherwise.