### PR TITLE
refactor(core): Remove zoneless change detection re-export

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1478,9 +1478,7 @@ export type ProviderToken<T> = Type<T> | AbstractType<T> | InjectionToken<T>;
 export function provideZoneChangeDetection(options?: NgZoneOptions): EnvironmentProviders;
 
 // @public
-function provideZonelessChangeDetection(): EnvironmentProviders;
-export { provideZonelessChangeDetection as provideExperimentalZonelessChangeDetection }
-export { provideZonelessChangeDetection }
+export function provideZonelessChangeDetection(): EnvironmentProviders;
 
 // @public
 export interface Query {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -43,11 +43,7 @@ export {
   provideZoneChangeDetection,
   NgZoneOptions,
 } from './change_detection/scheduling/ng_zone_scheduling';
-export {
-  provideZonelessChangeDetection,
-  // TODO(atscott): Remove after internal LSC for name change
-  provideZonelessChangeDetection as provideExperimentalZonelessChangeDetection,
-} from './change_detection/scheduling/zoneless_scheduling_impl';
+export {provideZonelessChangeDetection} from './change_detection/scheduling/zoneless_scheduling_impl';
 export {PendingTasks} from './pending_tasks';
 export {provideCheckNoChangesConfig} from './change_detection/provide_check_no_changes_config';
 export {enableProdMode, isDevMode} from './util/is_dev_mode';


### PR DESCRIPTION
removes the experimental re-export from zoneless provider
