### PR TITLE
refactor(platform-browser): Deprecate the `platform-browser-dynamic` package

### DIFF
--- a/goldens/public-api/platform-browser-dynamic/index.api.md
+++ b/goldens/public-api/platform-browser-dynamic/index.api.md
@@ -17,7 +17,7 @@ export class JitCompilerFactory implements CompilerFactory {
     createCompiler(options?: CompilerOptions[]): Compiler;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const platformBrowserDynamic: (extraProviders?: StaticProvider[]) => PlatformRef;
 
 // @public (undocumented)

--- a/goldens/public-api/platform-browser-dynamic/testing/index.api.md
+++ b/goldens/public-api/platform-browser-dynamic/testing/index.api.md
@@ -9,7 +9,7 @@ import * as i1 from '@angular/platform-browser/testing';
 import { PlatformRef } from '@angular/core';
 import { StaticProvider } from '@angular/core';
 
-// @public
+// @public @deprecated
 export class BrowserDynamicTestingModule {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<BrowserDynamicTestingModule, never>;
@@ -19,7 +19,7 @@ export class BrowserDynamicTestingModule {
     static ɵmod: i0.ɵɵNgModuleDeclaration<BrowserDynamicTestingModule, never, never, [typeof i1.BrowserTestingModule]>;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const platformBrowserDynamicTesting: (extraProviders?: StaticProvider[]) => PlatformRef;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/platform-browser-dynamic/src/platform_providers.ts
+++ b/packages/platform-browser-dynamic/src/platform_providers.ts
@@ -28,7 +28,8 @@ export const INTERNAL_BROWSER_DYNAMIC_PLATFORM_PROVIDERS: StaticProvider[] = [
 ];
 
 /**
- * @publicApi
+ * @deprecated Use the `platformBrowser` function instead from `@angular/platform-browser`.
+ * In case you are not in a CLI app and rely on JIT compilation, you will also need to import `@angular/compiler`
  */
 export const platformBrowserDynamic: (extraProviders?: StaticProvider[]) => PlatformRef =
   createPlatformFactory(

--- a/packages/platform-browser-dynamic/testing/src/testing.ts
+++ b/packages/platform-browser-dynamic/testing/src/testing.ts
@@ -11,7 +11,8 @@ import {platformBrowserDynamic} from '../../index';
 import {BrowserTestingModule} from '@angular/platform-browser/testing';
 
 /**
- * @publicApi
+ * @deprecated Use the `platformBrowserTesting` function instead from `@angular/platform-browser/testing`.
+ * In case you are not in a CLI app and rely on JIT compilation, you might also need to import `@angular/compiler`
  */
 export const platformBrowserDynamicTesting: (extraProviders?: StaticProvider[]) => PlatformRef =
   createPlatformFactory(platformBrowserDynamic, 'browserDynamicTesting');
@@ -19,7 +20,7 @@ export const platformBrowserDynamicTesting: (extraProviders?: StaticProvider[]) 
 /**
  * NgModule for testing.
  *
- * @publicApi
+ * @deprecated Use the `BrowserTestingModule` from `@angular/platform-browser/testing` instead.
  */
 @NgModule({
   exports: [BrowserTestingModule],


### PR DESCRIPTION
All entries of the `@angular/platform-browser-dynamic` package are now deprecated. We now recommend using the `@angular/platform-browser` package instead. In case a JIT application/testing environment is complaining about missing the compiler also add `import '@angular/compiler'`

Note: JIT compilation remains supported as before. 