### PR TITLE
refactor(router): Remove `inject` helper from router tests

### DIFF
--- a/packages/router/test/integration/duplicate_in_flight_navigations.spec.ts
+++ b/packages/router/test/integration/duplicate_in_flight_navigations.spec.ts
@@ -6,13 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Injectable, inject as coreInject} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {Location} from '@angular/common';
 import {TestBed, fakeAsync, tick} from '@angular/core/testing';
 import {
   Router,
-  ActivatedRouteSnapshot,
-  RouterStateSnapshot,
   provideRouter,
   withRouterConfig,
   NavigationStart,
@@ -77,7 +75,7 @@ export function duplicateInFlightNavigationsIntegrationSuite() {
         {
           path: 'blocked',
           component: BlankCmp,
-          canActivate: [() => coreInject(RedirectingGuard).canActivate()],
+          canActivate: [() => inject(RedirectingGuard).canActivate()],
         },
         {path: 'simple', component: SimpleCmp},
       ]);
@@ -106,7 +104,7 @@ export function duplicateInFlightNavigationsIntegrationSuite() {
         {
           path: 'blocked',
           component: BlankCmp,
-          canActivate: [() => coreInject(RedirectingGuard).canActivate()],
+          canActivate: [() => inject(RedirectingGuard).canActivate()],
         },
         {path: 'simple', component: SimpleCmp},
       ]);
@@ -139,7 +137,7 @@ export function duplicateInFlightNavigationsIntegrationSuite() {
         {
           path: 'blocked',
           component: BlankCmp,
-          canActivate: [() => coreInject(RedirectingGuard).canActivate()],
+          canActivate: [() => inject(RedirectingGuard).canActivate()],
         },
         {path: 'simple', redirectTo: '404'},
         {path: '404', component: SimpleCmp},

--- a/packages/router/test/integration/guards.spec.ts
+++ b/packages/router/test/integration/guards.spec.ts
@@ -10,13 +10,13 @@ import {LocationStrategy, HashLocationStrategy, Location} from '@angular/common'
 import {
   Injectable,
   DestroyRef,
-  inject as coreInject,
+  inject,
   Component,
   NgModule,
   InjectionToken,
   EnvironmentInjector,
 } from '@angular/core';
-import {inject, fakeAsync, TestBed, tick, ComponentFixture} from '@angular/core/testing';
+import {fakeAsync, TestBed, tick, ComponentFixture} from '@angular/core/testing';
 import {Subject, Observable, of, concat} from 'rxjs';
 import {delay, tap, mapTo, first, takeWhile, last} from 'rxjs/operators';
 import {
@@ -92,94 +92,91 @@ export function guardsIntegrationSuite() {
           }
         }
 
-        it('should not thrown an unhandled promise rejection', fakeAsync(
-          inject([Router], async (router: Router) => {
-            const fixture = createRoot(router, RootCmp);
+        it('should not thrown an unhandled promise rejection', fakeAsync(async () => {
+          const router = TestBed.inject(Router);
+          const fixture = createRoot(router, RootCmp);
 
-            const onUnhandledrejection = jasmine.createSpy();
-            window.addEventListener('unhandledrejection', onUnhandledrejection);
+          const onUnhandledrejection = jasmine.createSpy();
+          window.addEventListener('unhandledrejection', onUnhandledrejection);
 
-            router.resetConfig([
-              {path: 'team/:id', component: TeamCmp, canActivate: [CompletesBeforeEmitting]},
-            ]);
+          router.resetConfig([
+            {path: 'team/:id', component: TeamCmp, canActivate: [CompletesBeforeEmitting]},
+          ]);
 
-            router.navigateByUrl('/team/22');
+          router.navigateByUrl('/team/22');
 
-            // This was previously throwing an error `NG0205: Injector has already been destroyed`.
-            fixture.destroy();
+          // This was previously throwing an error `NG0205: Injector has already been destroyed`.
+          fixture.destroy();
 
-            // Wait until the event task is dispatched.
-            await new Promise((resolve) => setTimeout(resolve, 10));
-            window.removeEventListener('unhandledrejection', onUnhandledrejection);
+          // Wait until the event task is dispatched.
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          window.removeEventListener('unhandledrejection', onUnhandledrejection);
 
-            expect(onUnhandledrejection).not.toHaveBeenCalled();
-          }),
-        ));
+          expect(onUnhandledrejection).not.toHaveBeenCalled();
+        }));
       });
 
       describe('should not activate a route when CanActivate returns false', () => {
-        it('works', fakeAsync(
-          inject([Router, Location], (router: Router, location: Location) => {
-            const fixture = createRoot(router, RootCmp);
+        it('works', fakeAsync(() => {
+          const router = TestBed.inject(Router);
+          const location = TestBed.inject(Location);
+          const fixture = createRoot(router, RootCmp);
 
-            const recordedEvents: Event[] = [];
-            router.events.forEach((e) => recordedEvents.push(e));
+          const recordedEvents: Event[] = [];
+          router.events.forEach((e) => recordedEvents.push(e));
 
-            router.resetConfig([
-              {path: 'team/:id', component: TeamCmp, canActivate: [() => false]},
-            ]);
+          router.resetConfig([{path: 'team/:id', component: TeamCmp, canActivate: [() => false]}]);
 
-            router.navigateByUrl('/team/22');
-            advance(fixture);
+          router.navigateByUrl('/team/22');
+          advance(fixture);
 
-            expect(location.path()).toEqual('');
-            expectEvents(recordedEvents, [
-              [NavigationStart, '/team/22'],
-              [RoutesRecognized, '/team/22'],
-              [GuardsCheckStart, '/team/22'],
-              [ChildActivationStart],
-              [ActivationStart],
-              [GuardsCheckEnd, '/team/22'],
-              [NavigationCancel, '/team/22'],
-            ]);
-            expect((recordedEvents[5] as GuardsCheckEnd).shouldActivate).toBe(false);
-          }),
-        ));
+          expect(location.path()).toEqual('');
+          expectEvents(recordedEvents, [
+            [NavigationStart, '/team/22'],
+            [RoutesRecognized, '/team/22'],
+            [GuardsCheckStart, '/team/22'],
+            [ChildActivationStart],
+            [ActivationStart],
+            [GuardsCheckEnd, '/team/22'],
+            [NavigationCancel, '/team/22'],
+          ]);
+          expect((recordedEvents[5] as GuardsCheckEnd).shouldActivate).toBe(false);
+        }));
       });
 
       describe('should not activate a route when CanActivate returns false (componentless route)', () => {
-        it('works', fakeAsync(
-          inject([Router, Location], (router: Router, location: Location) => {
-            const fixture = createRoot(router, RootCmp);
+        it('works', fakeAsync(() => {
+          const router = TestBed.inject(Router);
+          const location = TestBed.inject(Location);
+          const fixture = createRoot(router, RootCmp);
 
-            router.resetConfig([
-              {
-                path: 'parent',
-                canActivate: [() => false],
-                children: [{path: 'team/:id', component: TeamCmp}],
-              },
-            ]);
+          router.resetConfig([
+            {
+              path: 'parent',
+              canActivate: [() => false],
+              children: [{path: 'team/:id', component: TeamCmp}],
+            },
+          ]);
 
-            router.navigateByUrl('parent/team/22');
-            advance(fixture);
+          router.navigateByUrl('parent/team/22');
+          advance(fixture);
 
-            expect(location.path()).toEqual('');
-          }),
-        ));
+          expect(location.path()).toEqual('');
+        }));
       });
 
       describe('should activate a route when CanActivate returns true', () => {
-        it('works', fakeAsync(
-          inject([Router, Location], (router: Router, location: Location) => {
-            const fixture = createRoot(router, RootCmp);
+        it('works', fakeAsync(() => {
+          const router = TestBed.inject(Router);
+          const location = TestBed.inject(Location);
+          const fixture = createRoot(router, RootCmp);
 
-            router.resetConfig([{path: 'team/:id', component: TeamCmp, canActivate: [() => true]}]);
+          router.resetConfig([{path: 'team/:id', component: TeamCmp, canActivate: [() => true]}]);
 
-            router.navigateByUrl('/team/22');
-            advance(fixture);
-            expect(location.path()).toEqual('/team/22');
-          }),
-        ));
+          router.navigateByUrl('/team/22');
+          advance(fixture);
+          expect(location.path()).toEqual('/team/22');
+        }));
       });
 
       describe('should work when given a class', () => {
@@ -193,75 +190,75 @@ export function guardsIntegrationSuite() {
           TestBed.configureTestingModule({providers: [AlwaysTrue]});
         });
 
-        it('works', fakeAsync(
-          inject([Router, Location], (router: Router, location: Location) => {
-            const fixture = createRoot(router, RootCmp);
+        it('works', fakeAsync(() => {
+          const router = TestBed.inject(Router);
+          const location = TestBed.inject(Location);
+          const fixture = createRoot(router, RootCmp);
 
-            router.resetConfig([{path: 'team/:id', component: TeamCmp, canActivate: [AlwaysTrue]}]);
+          router.resetConfig([{path: 'team/:id', component: TeamCmp, canActivate: [AlwaysTrue]}]);
 
-            router.navigateByUrl('/team/22');
-            advance(fixture);
+          router.navigateByUrl('/team/22');
+          advance(fixture);
 
-            expect(location.path()).toEqual('/team/22');
-          }),
-        ));
+          expect(location.path()).toEqual('/team/22');
+        }));
       });
 
       describe('should work when returns an observable', () => {
-        it('works', fakeAsync(
-          inject([Router, Location], (router: Router, location: Location) => {
-            const fixture = createRoot(router, RootCmp);
+        it('works', fakeAsync(() => {
+          const router = TestBed.inject(Router);
+          const location = TestBed.inject(Location);
+          const fixture = createRoot(router, RootCmp);
 
-            router.resetConfig([
-              {
-                path: 'team/:id',
-                component: TeamCmp,
-                canActivate: [
-                  () =>
-                    new Observable<boolean>((observer) => {
-                      observer.next(false);
-                    }),
-                ],
-              },
-            ]);
+          router.resetConfig([
+            {
+              path: 'team/:id',
+              component: TeamCmp,
+              canActivate: [
+                () =>
+                  new Observable<boolean>((observer) => {
+                    observer.next(false);
+                  }),
+              ],
+            },
+          ]);
 
-            router.navigateByUrl('/team/22');
-            advance(fixture);
-            expect(location.path()).toEqual('');
-          }),
-        ));
+          router.navigateByUrl('/team/22');
+          advance(fixture);
+          expect(location.path()).toEqual('');
+        }));
       });
 
       describe('should work when returns a promise', () => {
-        it('works', fakeAsync(
-          inject([Router, Location], (router: Router, location: Location) => {
-            const fixture = createRoot(router, RootCmp);
+        it('works', fakeAsync(() => {
+          const router = TestBed.inject(Router);
+          const location = TestBed.inject(Location);
+          const fixture = createRoot(router, RootCmp);
 
-            router.resetConfig([
-              {
-                path: 'team/:id',
-                component: TeamCmp,
-                canActivate: [
-                  (a) => {
-                    if (a.params['id'] === '22') {
-                      return Promise.resolve(true);
-                    } else {
-                      return Promise.resolve(false);
-                    }
-                  },
-                ],
-              },
-            ]);
+          router.resetConfig([
+            {
+              path: 'team/:id',
+              component: TeamCmp,
+              canActivate: [
+                (a) => {
+                  if (a.params['id'] === '22') {
+                    return Promise.resolve(true);
+                  } else {
+                    return Promise.resolve(false);
+                  }
+                },
+              ],
+            },
+          ]);
 
-            router.navigateByUrl('/team/22');
-            advance(fixture);
-            expect(location.path()).toEqual('/team/22');
+          router.navigateByUrl('/team/22');
+          advance(fixture);
+          expect(location.path()).toEqual('/team/22');
 
-            router.navigateByUrl('/team/33');
-            advance(fixture);
-            expect(location.path()).toEqual('/team/22');
-          }),
-        ));
+          router.navigateByUrl('/team/33');
+          advance(fixture);
+          expect(location.path()).toEqual('/team/22');
+        }));
       });
 
       describe('should reset the location when cancelling a navigation', () => {
@@ -271,155 +268,155 @@ export function guardsIntegrationSuite() {
           });
         });
 
-        it('works', fakeAsync(
-          inject([Router, Location], (router: Router, location: Location) => {
-            const fixture = createRoot(router, RootCmp);
+        it('works', fakeAsync(() => {
+          const router = TestBed.inject(Router);
+          const location = TestBed.inject(Location);
+          const fixture = createRoot(router, RootCmp);
 
-            router.resetConfig([
-              {path: 'one', component: SimpleCmp},
-              {path: 'two', component: SimpleCmp, canActivate: [() => false]},
-            ]);
+          router.resetConfig([
+            {path: 'one', component: SimpleCmp},
+            {path: 'two', component: SimpleCmp, canActivate: [() => false]},
+          ]);
 
-            router.navigateByUrl('/one');
-            advance(fixture);
-            expect(location.path()).toEqual('/one');
+          router.navigateByUrl('/one');
+          advance(fixture);
+          expect(location.path()).toEqual('/one');
 
-            location.go('/two');
-            location.historyGo(0);
-            advance(fixture);
-            expect(location.path()).toEqual('/one');
-          }),
-        ));
+          location.go('/two');
+          location.historyGo(0);
+          advance(fixture);
+          expect(location.path()).toEqual('/one');
+        }));
       });
 
       describe('should redirect to / when guard returns false', () => {
-        it('works', fakeAsync(
-          inject([Router, Location], (router: Router, location: Location) => {
-            router.resetConfig([
-              {
-                path: '',
-                component: SimpleCmp,
-              },
-              {
-                path: 'one',
-                component: RouteCmp,
-                canActivate: [
-                  () => {
-                    coreInject(Router).navigate(['/']);
-                    return false;
-                  },
-                ],
-              },
-            ]);
+        it('works', fakeAsync(() => {
+          const router = TestBed.inject(Router);
+          const location = TestBed.inject(Location);
+          router.resetConfig([
+            {
+              path: '',
+              component: SimpleCmp,
+            },
+            {
+              path: 'one',
+              component: RouteCmp,
+              canActivate: [
+                () => {
+                  inject(Router).navigate(['/']);
+                  return false;
+                },
+              ],
+            },
+          ]);
 
-            const fixture = TestBed.createComponent(RootCmp);
-            router.navigateByUrl('/one');
-            advance(fixture);
-            expect(location.path()).toEqual('');
-            expect(fixture.nativeElement).toHaveText('simple');
-          }),
-        ));
+          const fixture = TestBed.createComponent(RootCmp);
+          router.navigateByUrl('/one');
+          advance(fixture);
+          expect(location.path()).toEqual('');
+          expect(fixture.nativeElement).toHaveText('simple');
+        }));
       });
 
       describe('should redirect when guard returns UrlTree', () => {
-        it('works', fakeAsync(
-          inject([Router, Location], (router: Router, location: Location) => {
-            const recordedEvents: Event[] = [];
-            let cancelEvent: NavigationCancel = null!;
-            router.events.forEach((e) => {
-              recordedEvents.push(e);
-              if (e instanceof NavigationCancel) cancelEvent = e;
-            });
-            router.resetConfig([
-              {path: '', component: SimpleCmp},
-              {
-                path: 'one',
-                component: RouteCmp,
-                canActivate: [() => coreInject(Router).parseUrl('/redirected')],
-              },
-              {path: 'redirected', component: SimpleCmp},
-            ]);
+        it('works', fakeAsync(() => {
+          const router = TestBed.inject(Router);
+          const location = TestBed.inject(Location);
+          const recordedEvents: Event[] = [];
+          let cancelEvent: NavigationCancel = null!;
+          router.events.forEach((e) => {
+            recordedEvents.push(e);
+            if (e instanceof NavigationCancel) cancelEvent = e;
+          });
+          router.resetConfig([
+            {path: '', component: SimpleCmp},
+            {
+              path: 'one',
+              component: RouteCmp,
+              canActivate: [() => inject(Router).parseUrl('/redirected')],
+            },
+            {path: 'redirected', component: SimpleCmp},
+          ]);
 
-            const fixture = TestBed.createComponent(RootCmp);
-            router.navigateByUrl('/one');
+          const fixture = TestBed.createComponent(RootCmp);
+          router.navigateByUrl('/one');
 
-            advance(fixture);
+          advance(fixture);
 
-            expect(location.path()).toEqual('/redirected');
-            expect(fixture.nativeElement).toHaveText('simple');
-            expect(cancelEvent && cancelEvent.reason).toBe(
-              'NavigationCancelingError: Redirecting to "/redirected"',
-            );
-            expectEvents(recordedEvents, [
-              [NavigationStart, '/one'],
-              [RoutesRecognized, '/one'],
-              [GuardsCheckStart, '/one'],
-              [ChildActivationStart, undefined],
-              [ActivationStart, undefined],
-              [NavigationCancel, '/one'],
-              [NavigationStart, '/redirected'],
-              [RoutesRecognized, '/redirected'],
-              [GuardsCheckStart, '/redirected'],
-              [ChildActivationStart, undefined],
-              [ActivationStart, undefined],
-              [GuardsCheckEnd, '/redirected'],
-              [ResolveStart, '/redirected'],
-              [ResolveEnd, '/redirected'],
-              [ActivationEnd, undefined],
-              [ChildActivationEnd, undefined],
-              [NavigationEnd, '/redirected'],
-            ]);
-          }),
-        ));
+          expect(location.path()).toEqual('/redirected');
+          expect(fixture.nativeElement).toHaveText('simple');
+          expect(cancelEvent && cancelEvent.reason).toBe(
+            'NavigationCancelingError: Redirecting to "/redirected"',
+          );
+          expectEvents(recordedEvents, [
+            [NavigationStart, '/one'],
+            [RoutesRecognized, '/one'],
+            [GuardsCheckStart, '/one'],
+            [ChildActivationStart, undefined],
+            [ActivationStart, undefined],
+            [NavigationCancel, '/one'],
+            [NavigationStart, '/redirected'],
+            [RoutesRecognized, '/redirected'],
+            [GuardsCheckStart, '/redirected'],
+            [ChildActivationStart, undefined],
+            [ActivationStart, undefined],
+            [GuardsCheckEnd, '/redirected'],
+            [ResolveStart, '/redirected'],
+            [ResolveEnd, '/redirected'],
+            [ActivationEnd, undefined],
+            [ChildActivationEnd, undefined],
+            [NavigationEnd, '/redirected'],
+          ]);
+        }));
 
-        it('works with root url', fakeAsync(
-          inject([Router, Location], (router: Router, location: Location) => {
-            const recordedEvents: Event[] = [];
-            let cancelEvent: NavigationCancel = null!;
-            router.events.forEach((e: any) => {
-              recordedEvents.push(e);
-              if (e instanceof NavigationCancel) cancelEvent = e;
-            });
-            router.resetConfig([
-              {path: '', component: SimpleCmp},
-              {
-                path: 'one',
-                component: RouteCmp,
-                canActivate: [() => coreInject(Router).parseUrl('/')],
-              },
-            ]);
+        it('works with root url', fakeAsync(() => {
+          const router = TestBed.inject(Router);
+          const location = TestBed.inject(Location);
+          const recordedEvents: Event[] = [];
+          let cancelEvent: NavigationCancel = null!;
+          router.events.forEach((e: any) => {
+            recordedEvents.push(e);
+            if (e instanceof NavigationCancel) cancelEvent = e;
+          });
+          router.resetConfig([
+            {path: '', component: SimpleCmp},
+            {
+              path: 'one',
+              component: RouteCmp,
+              canActivate: [() => inject(Router).parseUrl('/')],
+            },
+          ]);
 
-            const fixture = TestBed.createComponent(RootCmp);
-            router.navigateByUrl('/one');
+          const fixture = TestBed.createComponent(RootCmp);
+          router.navigateByUrl('/one');
 
-            advance(fixture);
+          advance(fixture);
 
-            expect(location.path()).toEqual('');
-            expect(fixture.nativeElement).toHaveText('simple');
-            expect(cancelEvent && cancelEvent.reason).toBe(
-              'NavigationCancelingError: Redirecting to "/"',
-            );
-            expectEvents(recordedEvents, [
-              [NavigationStart, '/one'],
-              [RoutesRecognized, '/one'],
-              [GuardsCheckStart, '/one'],
-              [ChildActivationStart, undefined],
-              [ActivationStart, undefined],
-              [NavigationCancel, '/one'],
-              [NavigationStart, '/'],
-              [RoutesRecognized, '/'],
-              [GuardsCheckStart, '/'],
-              [ChildActivationStart, undefined],
-              [ActivationStart, undefined],
-              [GuardsCheckEnd, '/'],
-              [ResolveStart, '/'],
-              [ResolveEnd, '/'],
-              [ActivationEnd, undefined],
-              [ChildActivationEnd, undefined],
-              [NavigationEnd, '/'],
-            ]);
-          }),
-        ));
+          expect(location.path()).toEqual('');
+          expect(fixture.nativeElement).toHaveText('simple');
+          expect(cancelEvent && cancelEvent.reason).toBe(
+            'NavigationCancelingError: Redirecting to "/"',
+          );
+          expectEvents(recordedEvents, [
+            [NavigationStart, '/one'],
+            [RoutesRecognized, '/one'],
+            [GuardsCheckStart, '/one'],
+            [ChildActivationStart, undefined],
+            [ActivationStart, undefined],
+            [NavigationCancel, '/one'],
+            [NavigationStart, '/'],
+            [RoutesRecognized, '/'],
+            [GuardsCheckStart, '/'],
+            [ChildActivationStart, undefined],
+            [ActivationStart, undefined],
+            [GuardsCheckEnd, '/'],
+            [ResolveStart, '/'],
+            [ResolveEnd, '/'],
+            [ActivationEnd, undefined],
+            [ChildActivationEnd, undefined],
+            [NavigationEnd, '/'],
+          ]);
+        }));
 
         it('replaces URL when URL is updated eagerly so back button can still work', fakeAsync(() => {
           TestBed.configureTestingModule({
@@ -432,7 +429,7 @@ export function guardsIntegrationSuite() {
             {
               path: 'one',
               component: RouteCmp,
-              canActivate: [() => coreInject(Router).parseUrl('/redirected')],
+              canActivate: [() => inject(Router).parseUrl('/redirected')],
             },
             {path: 'redirected', component: SimpleCmp},
           ]);
@@ -464,7 +461,7 @@ export function guardsIntegrationSuite() {
             {
               path: 'one',
               component: RouteCmp,
-              canActivate: [() => coreInject(Router).parseUrl('/redirected')],
+              canActivate: [() => inject(Router).parseUrl('/redirected')],
             },
             {path: 'redirected', component: SimpleCmp},
           ]);
@@ -539,7 +536,7 @@ export function guardsIntegrationSuite() {
                 component: RouteCmp,
                 canActivate: [
                   () => {
-                    const router = coreInject(Router);
+                    const router = inject(Router);
                     router.navigateByUrl('/404', {
                       browserUrl: router.getCurrentNavigation()?.finalUrl,
                     });
@@ -578,7 +575,7 @@ export function guardsIntegrationSuite() {
               {
                 path: 'one',
                 component: RouteCmp,
-                canActivate: [() => coreInject(Router).parseUrl('/404')],
+                canActivate: [() => inject(Router).parseUrl('/404')],
               },
               {path: '404', component: SimpleCmp},
             ]),
@@ -674,260 +671,253 @@ export function guardsIntegrationSuite() {
           return fixture;
         }
 
-        it('should rerun guards and resolvers when params change', fakeAsync(
-          inject([Router], (router: Router) => {
-            const fixture = configureRouter(router, 'paramsChange');
+        it('should rerun guards and resolvers when params change', fakeAsync(() => {
+          const router = TestBed.inject(Router);
+          const fixture = configureRouter(router, 'paramsChange');
 
-            const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
-            const recordedData: Data[] = [];
-            cmp.route.data.subscribe((data) => recordedData.push(data));
+          const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
+          const recordedData: Data[] = [];
+          cmp.route.data.subscribe((data) => recordedData.push(data));
 
-            expect(guardRunCount).toEqual(1);
-            expect(recordedData).toEqual([{data: 0}]);
+          expect(guardRunCount).toEqual(1);
+          expect(recordedData).toEqual([{data: 0}]);
 
+          router.navigateByUrl('/a;p=1');
+          advance(fixture);
+          expect(guardRunCount).toEqual(2);
+          expect(recordedData).toEqual([{data: 0}, {data: 1}]);
+
+          router.navigateByUrl('/a;p=2');
+          advance(fixture);
+          expect(guardRunCount).toEqual(3);
+          expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}]);
+
+          router.navigateByUrl('/a;p=2?q=1');
+          advance(fixture);
+          expect(guardRunCount).toEqual(3);
+          expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}]);
+        }));
+
+        it('should rerun guards and resolvers when query params change', fakeAsync(() => {
+          const router = TestBed.inject(Router);
+          const fixture = configureRouter(router, 'paramsOrQueryParamsChange');
+
+          const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
+          const recordedData: Data[] = [];
+          cmp.route.data.subscribe((data) => recordedData.push(data));
+
+          expect(guardRunCount).toEqual(1);
+          expect(recordedData).toEqual([{data: 0}]);
+
+          router.navigateByUrl('/a;p=1');
+          advance(fixture);
+          expect(guardRunCount).toEqual(2);
+          expect(recordedData).toEqual([{data: 0}, {data: 1}]);
+
+          router.navigateByUrl('/a;p=2');
+          advance(fixture);
+          expect(guardRunCount).toEqual(3);
+          expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}]);
+
+          router.navigateByUrl('/a;p=2?q=1');
+          advance(fixture);
+          expect(guardRunCount).toEqual(4);
+          expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}, {data: 3}]);
+
+          router.navigateByUrl('/a;p=2(right:b)?q=1');
+          advance(fixture);
+          expect(guardRunCount).toEqual(4);
+          expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}, {data: 3}]);
+        }));
+
+        it('should always rerun guards and resolvers', fakeAsync(() => {
+          const router = TestBed.inject(Router);
+          const fixture = configureRouter(router, 'always');
+
+          const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
+          const recordedData: Data[] = [];
+          cmp.route.data.subscribe((data) => recordedData.push(data));
+
+          expect(guardRunCount).toEqual(1);
+          expect(recordedData).toEqual([{data: 0}]);
+
+          router.navigateByUrl('/a;p=1');
+          advance(fixture);
+          expect(guardRunCount).toEqual(2);
+          expect(recordedData).toEqual([{data: 0}, {data: 1}]);
+
+          router.navigateByUrl('/a;p=2');
+          advance(fixture);
+          expect(guardRunCount).toEqual(3);
+          expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}]);
+
+          router.navigateByUrl('/a;p=2?q=1');
+          advance(fixture);
+          expect(guardRunCount).toEqual(4);
+          expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}, {data: 3}]);
+
+          router.navigateByUrl('/a;p=2(right:b)?q=1');
+          advance(fixture);
+          expect(guardRunCount).toEqual(5);
+          expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}, {data: 3}, {data: 4}]);
+
+          // Issue #39030, always running guards and resolvers should not throw
+          // when navigating away from a component with a throwing constructor.
+          expect(() => {
+            router.navigateByUrl('/throwing').catch(() => {});
+            advance(fixture);
             router.navigateByUrl('/a;p=1');
             advance(fixture);
-            expect(guardRunCount).toEqual(2);
-            expect(recordedData).toEqual([{data: 0}, {data: 1}]);
+          }).not.toThrow();
+        }));
 
-            router.navigateByUrl('/a;p=2');
-            advance(fixture);
-            expect(guardRunCount).toEqual(3);
-            expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}]);
+        it('should rerun rerun guards and resolvers when path params change', fakeAsync(() => {
+          const router = TestBed.inject(Router);
+          const fixture = configureRouter(router, 'pathParamsChange');
 
-            router.navigateByUrl('/a;p=2?q=1');
-            advance(fixture);
-            expect(guardRunCount).toEqual(3);
-            expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}]);
-          }),
-        ));
+          const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
+          const recordedData: Data[] = [];
+          cmp.route.data.subscribe((data) => recordedData.push(data));
 
-        it('should rerun guards and resolvers when query params change', fakeAsync(
-          inject([Router], (router: Router) => {
-            const fixture = configureRouter(router, 'paramsOrQueryParamsChange');
+          // First navigation has already run
+          expect(guardRunCount).toEqual(1);
+          expect(recordedData).toEqual([{data: 0}]);
 
-            const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
-            const recordedData: Data[] = [];
-            cmp.route.data.subscribe((data) => recordedData.push(data));
+          // Changing any optional params will not result in running guards or resolvers
+          router.navigateByUrl('/a;p=1');
+          advance(fixture);
+          expect(guardRunCount).toEqual(1);
+          expect(recordedData).toEqual([{data: 0}]);
 
-            expect(guardRunCount).toEqual(1);
-            expect(recordedData).toEqual([{data: 0}]);
+          router.navigateByUrl('/a;p=2');
+          advance(fixture);
+          expect(guardRunCount).toEqual(1);
+          expect(recordedData).toEqual([{data: 0}]);
 
-            router.navigateByUrl('/a;p=1');
-            advance(fixture);
-            expect(guardRunCount).toEqual(2);
-            expect(recordedData).toEqual([{data: 0}, {data: 1}]);
+          router.navigateByUrl('/a;p=2?q=1');
+          advance(fixture);
+          expect(guardRunCount).toEqual(1);
+          expect(recordedData).toEqual([{data: 0}]);
 
-            router.navigateByUrl('/a;p=2');
-            advance(fixture);
-            expect(guardRunCount).toEqual(3);
-            expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}]);
+          router.navigateByUrl('/a;p=2(right:b)?q=1');
+          advance(fixture);
+          expect(guardRunCount).toEqual(1);
+          expect(recordedData).toEqual([{data: 0}]);
 
-            router.navigateByUrl('/a;p=2?q=1');
-            advance(fixture);
-            expect(guardRunCount).toEqual(4);
-            expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}, {data: 3}]);
+          // Change to new route with path param should run guards and resolvers
+          router.navigateByUrl('/c/paramValue');
+          advance(fixture);
 
-            router.navigateByUrl('/a;p=2(right:b)?q=1');
-            advance(fixture);
-            expect(guardRunCount).toEqual(4);
-            expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}, {data: 3}]);
-          }),
-        ));
+          expect(guardRunCount).toEqual(2);
 
-        it('should always rerun guards and resolvers', fakeAsync(
-          inject([Router], (router: Router) => {
-            const fixture = configureRouter(router, 'always');
+          // Modifying a path param should run guards and resolvers
+          router.navigateByUrl('/c/paramValueChanged');
+          advance(fixture);
+          expect(guardRunCount).toEqual(3);
 
-            const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
-            const recordedData: Data[] = [];
-            cmp.route.data.subscribe((data) => recordedData.push(data));
+          // Adding optional params should not cause guards/resolvers to run
+          router.navigateByUrl('/c/paramValueChanged;p=1?q=2');
+          advance(fixture);
+          expect(guardRunCount).toEqual(3);
+        }));
 
-            expect(guardRunCount).toEqual(1);
-            expect(recordedData).toEqual([{data: 0}]);
+        it('should rerun when a parent segment changes', fakeAsync(() => {
+          const router = TestBed.inject(Router);
+          const fixture = configureRouter(router, 'pathParamsChange');
 
-            router.navigateByUrl('/a;p=1');
-            advance(fixture);
-            expect(guardRunCount).toEqual(2);
-            expect(recordedData).toEqual([{data: 0}, {data: 1}]);
+          const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
 
-            router.navigateByUrl('/a;p=2');
-            advance(fixture);
-            expect(guardRunCount).toEqual(3);
-            expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}]);
+          // Land on an initial page
+          router.navigateByUrl('/d/1;dd=11/e/2;dd=22');
+          advance(fixture);
 
-            router.navigateByUrl('/a;p=2?q=1');
-            advance(fixture);
-            expect(guardRunCount).toEqual(4);
-            expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}, {data: 3}]);
+          expect(guardRunCount).toEqual(2);
 
-            router.navigateByUrl('/a;p=2(right:b)?q=1');
-            advance(fixture);
-            expect(guardRunCount).toEqual(5);
-            expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}, {data: 3}, {data: 4}]);
+          // Changes cause re-run on the config with the guard
+          router.navigateByUrl('/d/1;dd=11/e/3;ee=22');
+          advance(fixture);
 
-            // Issue #39030, always running guards and resolvers should not throw
-            // when navigating away from a component with a throwing constructor.
-            expect(() => {
-              router.navigateByUrl('/throwing').catch(() => {});
-              advance(fixture);
-              router.navigateByUrl('/a;p=1');
-              advance(fixture);
-            }).not.toThrow();
-          }),
-        ));
+          expect(guardRunCount).toEqual(3);
 
-        it('should rerun rerun guards and resolvers when path params change', fakeAsync(
-          inject([Router], (router: Router) => {
-            const fixture = configureRouter(router, 'pathParamsChange');
+          // Changes to the parent also cause re-run
+          router.navigateByUrl('/d/2;dd=11/e/3;ee=22');
+          advance(fixture);
 
-            const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
-            const recordedData: Data[] = [];
-            cmp.route.data.subscribe((data) => recordedData.push(data));
+          expect(guardRunCount).toEqual(4);
+        }));
 
-            // First navigation has already run
-            expect(guardRunCount).toEqual(1);
-            expect(recordedData).toEqual([{data: 0}]);
+        it('should rerun rerun guards and resolvers when path or query params change', fakeAsync(() => {
+          const router = TestBed.inject(Router);
+          const fixture = configureRouter(router, 'pathParamsOrQueryParamsChange');
 
-            // Changing any optional params will not result in running guards or resolvers
-            router.navigateByUrl('/a;p=1');
-            advance(fixture);
-            expect(guardRunCount).toEqual(1);
-            expect(recordedData).toEqual([{data: 0}]);
+          const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
+          const recordedData: Data[] = [];
+          cmp.route.data.subscribe((data) => recordedData.push(data));
 
-            router.navigateByUrl('/a;p=2');
-            advance(fixture);
-            expect(guardRunCount).toEqual(1);
-            expect(recordedData).toEqual([{data: 0}]);
+          // First navigation has already run
+          expect(guardRunCount).toEqual(1);
+          expect(recordedData).toEqual([{data: 0}]);
 
-            router.navigateByUrl('/a;p=2?q=1');
-            advance(fixture);
-            expect(guardRunCount).toEqual(1);
-            expect(recordedData).toEqual([{data: 0}]);
+          // Changing matrix params will not result in running guards or resolvers
+          router.navigateByUrl('/a;p=1');
+          advance(fixture);
+          expect(guardRunCount).toEqual(1);
+          expect(recordedData).toEqual([{data: 0}]);
 
-            router.navigateByUrl('/a;p=2(right:b)?q=1');
-            advance(fixture);
-            expect(guardRunCount).toEqual(1);
-            expect(recordedData).toEqual([{data: 0}]);
+          router.navigateByUrl('/a;p=2');
+          advance(fixture);
+          expect(guardRunCount).toEqual(1);
+          expect(recordedData).toEqual([{data: 0}]);
 
-            // Change to new route with path param should run guards and resolvers
-            router.navigateByUrl('/c/paramValue');
-            advance(fixture);
+          // Adding query params will re-run guards/resolvers
+          router.navigateByUrl('/a;p=2?q=1');
+          advance(fixture);
+          expect(guardRunCount).toEqual(2);
+          expect(recordedData).toEqual([{data: 0}, {data: 1}]);
 
-            expect(guardRunCount).toEqual(2);
+          // Changing query params will re-run guards/resolvers
+          router.navigateByUrl('/a;p=2?q=2');
+          advance(fixture);
+          expect(guardRunCount).toEqual(3);
+          expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}]);
+        }));
 
-            // Modifying a path param should run guards and resolvers
-            router.navigateByUrl('/c/paramValueChanged');
-            advance(fixture);
-            expect(guardRunCount).toEqual(3);
+        it('should allow a predicate function to determine when to run guards and resolvers', fakeAsync(() => {
+          const router = TestBed.inject(Router);
+          const fixture = configureRouter(router, (from, to) => to.paramMap.get('p') === '2');
 
-            // Adding optional params should not cause guards/resolvers to run
-            router.navigateByUrl('/c/paramValueChanged;p=1?q=2');
-            advance(fixture);
-            expect(guardRunCount).toEqual(3);
-          }),
-        ));
+          const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
+          const recordedData: Data[] = [];
+          cmp.route.data.subscribe((data) => recordedData.push(data));
 
-        it('should rerun when a parent segment changes', fakeAsync(
-          inject([Router], (router: Router) => {
-            const fixture = configureRouter(router, 'pathParamsChange');
+          // First navigation has already run
+          expect(guardRunCount).toEqual(1);
+          expect(recordedData).toEqual([{data: 0}]);
 
-            const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
+          // Adding `p` param shouldn't cause re-run
+          router.navigateByUrl('/a;p=1');
+          advance(fixture);
+          expect(guardRunCount).toEqual(1);
+          expect(recordedData).toEqual([{data: 0}]);
 
-            // Land on an initial page
-            router.navigateByUrl('/d/1;dd=11/e/2;dd=22');
-            advance(fixture);
+          // Re-run should trigger on p=2
+          router.navigateByUrl('/a;p=2');
+          advance(fixture);
+          expect(guardRunCount).toEqual(2);
+          expect(recordedData).toEqual([{data: 0}, {data: 1}]);
 
-            expect(guardRunCount).toEqual(2);
+          // Any other changes don't pass the predicate
+          router.navigateByUrl('/a;p=3?q=1');
+          advance(fixture);
+          expect(guardRunCount).toEqual(2);
+          expect(recordedData).toEqual([{data: 0}, {data: 1}]);
 
-            // Changes cause re-run on the config with the guard
-            router.navigateByUrl('/d/1;dd=11/e/3;ee=22');
-            advance(fixture);
-
-            expect(guardRunCount).toEqual(3);
-
-            // Changes to the parent also cause re-run
-            router.navigateByUrl('/d/2;dd=11/e/3;ee=22');
-            advance(fixture);
-
-            expect(guardRunCount).toEqual(4);
-          }),
-        ));
-
-        it('should rerun rerun guards and resolvers when path or query params change', fakeAsync(
-          inject([Router], (router: Router) => {
-            const fixture = configureRouter(router, 'pathParamsOrQueryParamsChange');
-
-            const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
-            const recordedData: Data[] = [];
-            cmp.route.data.subscribe((data) => recordedData.push(data));
-
-            // First navigation has already run
-            expect(guardRunCount).toEqual(1);
-            expect(recordedData).toEqual([{data: 0}]);
-
-            // Changing matrix params will not result in running guards or resolvers
-            router.navigateByUrl('/a;p=1');
-            advance(fixture);
-            expect(guardRunCount).toEqual(1);
-            expect(recordedData).toEqual([{data: 0}]);
-
-            router.navigateByUrl('/a;p=2');
-            advance(fixture);
-            expect(guardRunCount).toEqual(1);
-            expect(recordedData).toEqual([{data: 0}]);
-
-            // Adding query params will re-run guards/resolvers
-            router.navigateByUrl('/a;p=2?q=1');
-            advance(fixture);
-            expect(guardRunCount).toEqual(2);
-            expect(recordedData).toEqual([{data: 0}, {data: 1}]);
-
-            // Changing query params will re-run guards/resolvers
-            router.navigateByUrl('/a;p=2?q=2');
-            advance(fixture);
-            expect(guardRunCount).toEqual(3);
-            expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}]);
-          }),
-        ));
-
-        it('should allow a predicate function to determine when to run guards and resolvers', fakeAsync(
-          inject([Router], (router: Router) => {
-            const fixture = configureRouter(router, (from, to) => to.paramMap.get('p') === '2');
-
-            const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
-            const recordedData: Data[] = [];
-            cmp.route.data.subscribe((data) => recordedData.push(data));
-
-            // First navigation has already run
-            expect(guardRunCount).toEqual(1);
-            expect(recordedData).toEqual([{data: 0}]);
-
-            // Adding `p` param shouldn't cause re-run
-            router.navigateByUrl('/a;p=1');
-            advance(fixture);
-            expect(guardRunCount).toEqual(1);
-            expect(recordedData).toEqual([{data: 0}]);
-
-            // Re-run should trigger on p=2
-            router.navigateByUrl('/a;p=2');
-            advance(fixture);
-            expect(guardRunCount).toEqual(2);
-            expect(recordedData).toEqual([{data: 0}, {data: 1}]);
-
-            // Any other changes don't pass the predicate
-            router.navigateByUrl('/a;p=3?q=1');
-            advance(fixture);
-            expect(guardRunCount).toEqual(2);
-            expect(recordedData).toEqual([{data: 0}, {data: 1}]);
-
-            // Changing query params will re-run guards/resolvers
-            router.navigateByUrl('/a;p=3?q=2');
-            advance(fixture);
-            expect(guardRunCount).toEqual(2);
-            expect(recordedData).toEqual([{data: 0}, {data: 1}]);
-          }),
-        ));
+          // Changing query params will re-run guards/resolvers
+          router.navigateByUrl('/a;p=3?q=2');
+          advance(fixture);
+          expect(guardRunCount).toEqual(2);
+          expect(recordedData).toEqual([{data: 0}, {data: 1}]);
+        }));
       });
 
       describe('should wait for parent to complete', () => {
@@ -944,43 +934,42 @@ export function guardsIntegrationSuite() {
           return promise;
         }
 
-        it('works', fakeAsync(
-          inject([Router], (router: Router) => {
-            const fixture = createRoot(router, RootCmp);
+        it('works', fakeAsync(() => {
+          const router = TestBed.inject(Router);
+          const fixture = createRoot(router, RootCmp);
 
-            router.resetConfig([
-              {
-                path: 'parent',
-                canActivate: [
-                  () =>
-                    delayPromise(10).then(() => {
-                      log.push('parent');
-                      return true;
-                    }),
-                ],
-                children: [
-                  {
-                    path: 'child',
-                    component: SimpleCmp,
-                    canActivate: [
-                      () => {
-                        return delayPromise(5).then(() => {
-                          log.push('child');
-                          return true;
-                        });
-                      },
-                    ],
-                  },
-                ],
-              },
-            ]);
+          router.resetConfig([
+            {
+              path: 'parent',
+              canActivate: [
+                () =>
+                  delayPromise(10).then(() => {
+                    log.push('parent');
+                    return true;
+                  }),
+              ],
+              children: [
+                {
+                  path: 'child',
+                  component: SimpleCmp,
+                  canActivate: [
+                    () => {
+                      return delayPromise(5).then(() => {
+                        log.push('child');
+                        return true;
+                      });
+                    },
+                  ],
+                },
+              ],
+            },
+          ]);
 
-            router.navigateByUrl('/parent/child');
-            advance(fixture);
-            tick(15);
-            expect(log).toEqual(['parent', 'child']);
-          }),
-        ));
+          router.navigateByUrl('/parent/child');
+          advance(fixture);
+          tick(15);
+          expect(log).toEqual(['parent', 'child']);
+        }));
       });
     });
 
@@ -996,316 +985,310 @@ export function guardsIntegrationSuite() {
       });
 
       describe('should not deactivate a route when CanDeactivate returns false', () => {
-        it('works', fakeAsync(
-          inject([Router, Location], (router: Router, location: Location) => {
-            const fixture = createRoot(router, RootCmp);
-
-            router.resetConfig([
-              {
-                path: 'team/:id',
-                component: TeamCmp,
-                canDeactivate: [
-                  (c, a) => {
-                    return a.params['id'] === '22';
-                  },
-                ],
-              },
-            ]);
-
-            router.navigateByUrl('/team/22');
-            advance(fixture);
-            expect(location.path()).toEqual('/team/22');
-
-            let successStatus: boolean = false;
-            router.navigateByUrl('/team/33')!.then((res) => (successStatus = res));
-            advance(fixture);
-            expect(location.path()).toEqual('/team/33');
-            expect(successStatus).toEqual(true);
-
-            let canceledStatus: boolean = false;
-            router.navigateByUrl('/team/44')!.then((res) => (canceledStatus = res));
-            advance(fixture);
-            expect(location.path()).toEqual('/team/33');
-            expect(canceledStatus).toEqual(false);
-          }),
-        ));
-
-        it('works with componentless routes', fakeAsync(
-          inject([Router, Location], (router: Router, location: Location) => {
-            const fixture = createRoot(router, RootCmp);
-
-            router.resetConfig([
-              {
-                path: 'grandparent',
-                canDeactivate: [recordingDeactivate],
-                children: [
-                  {
-                    path: 'parent',
-                    canDeactivate: [recordingDeactivate],
-                    children: [
-                      {
-                        path: 'child',
-                        canDeactivate: [recordingDeactivate],
-                        children: [
-                          {
-                            path: 'simple',
-                            component: SimpleCmp,
-                            canDeactivate: [recordingDeactivate],
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              },
-              {path: 'simple', component: SimpleCmp},
-            ]);
-
-            router.navigateByUrl('/grandparent/parent/child/simple');
-            advance(fixture);
-            expect(location.path()).toEqual('/grandparent/parent/child/simple');
-
-            router.navigateByUrl('/simple');
-            advance(fixture);
-
-            const child = fixture.debugElement.children[1].componentInstance;
-
-            expect(log.map((a: any) => a.path)).toEqual([
-              'simple',
-              'child',
-              'parent',
-              'grandparent',
-            ]);
-            expect(log[0].component instanceof SimpleCmp).toBeTruthy();
-            [1, 2, 3].forEach((i) => expect(log[i].component).toBeNull());
-            expect(child instanceof SimpleCmp).toBeTruthy();
-            expect(child).not.toBe(log[0].component);
-          }),
-        ));
-
-        it('works with aux routes', fakeAsync(
-          inject([Router, Location], (router: Router, location: Location) => {
-            const fixture = createRoot(router, RootCmp);
-
-            router.resetConfig([
-              {
-                path: 'two-outlets',
-                component: TwoOutletsCmp,
-                children: [
-                  {path: 'a', component: BlankCmp},
-                  {
-                    path: 'b',
-                    canDeactivate: [recordingDeactivate],
-                    component: SimpleCmp,
-                    outlet: 'aux',
-                  },
-                ],
-              },
-            ]);
-
-            router.navigateByUrl('/two-outlets/(a//aux:b)');
-            advance(fixture);
-            expect(location.path()).toEqual('/two-outlets/(a//aux:b)');
-
-            router.navigate(['two-outlets', {outlets: {aux: null}}]);
-            advance(fixture);
-
-            expect(log.map((a: any) => a.path)).toEqual(['b']);
-            expect(location.path()).toEqual('/two-outlets/a');
-          }),
-        ));
-
-        it('works with a nested route', fakeAsync(
-          inject([Router, Location], (router: Router, location: Location) => {
-            const fixture = createRoot(router, RootCmp);
-
-            router.resetConfig([
-              {
-                path: 'team/:id',
-                component: TeamCmp,
-                children: [
-                  {path: '', pathMatch: 'full', component: SimpleCmp},
-                  {
-                    path: 'user/:name',
-                    component: UserCmp,
-                    canDeactivate: [
-                      (c: any, a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
-                        return a.params['name'] === 'victor';
-                      },
-                    ],
-                  },
-                ],
-              },
-            ]);
-
-            router.navigateByUrl('/team/22/user/victor');
-            advance(fixture);
-
-            // this works because we can deactivate victor
-            router.navigateByUrl('/team/33');
-            advance(fixture);
-            expect(location.path()).toEqual('/team/33');
-
-            router.navigateByUrl('/team/33/user/fedor');
-            advance(fixture);
-
-            // this doesn't work cause we cannot deactivate fedor
-            router.navigateByUrl('/team/44');
-            advance(fixture);
-            expect(location.path()).toEqual('/team/33/user/fedor');
-          }),
-        ));
-      });
-
-      it('should use correct component to deactivate forChild route', fakeAsync(
-        inject([Router], (router: Router) => {
-          @Component({
-            selector: 'admin',
-            template: '',
-            standalone: false,
-          })
-          class AdminComponent {}
-
-          @NgModule({
-            declarations: [AdminComponent],
-            imports: [
-              RouterModule.forChild([
-                {
-                  path: '',
-                  component: AdminComponent,
-                  canDeactivate: [recordingDeactivate],
-                },
-              ]),
-            ],
-          })
-          class LazyLoadedModule {}
-
+        it('works', fakeAsync(() => {
+          const router: Router = TestBed.inject(Router);
+          const location: Location = TestBed.inject(Location);
           const fixture = createRoot(router, RootCmp);
 
           router.resetConfig([
             {
-              path: 'a',
-              component: WrapperCmp,
-              children: [{path: '', pathMatch: 'full', loadChildren: () => LazyLoadedModule}],
-            },
-            {path: 'b', component: SimpleCmp},
-          ]);
-
-          router.navigateByUrl('/a');
-          advance(fixture);
-          router.navigateByUrl('/b');
-          advance(fixture);
-
-          expect(log[0].component).toBeInstanceOf(AdminComponent);
-        }),
-      ));
-
-      it('should not create a route state if navigation is canceled', fakeAsync(
-        inject([Router, Location], (router: Router, location: Location) => {
-          const fixture = createRoot(router, RootCmp);
-
-          router.resetConfig([
-            {
-              path: 'main',
+              path: 'team/:id',
               component: TeamCmp,
-              children: [
-                {path: 'component1', component: SimpleCmp, canDeactivate: [() => false]},
-                {path: 'component2', component: SimpleCmp},
-              ],
-            },
-          ]);
-
-          router.navigateByUrl('/main/component1');
-          advance(fixture);
-
-          router.navigateByUrl('/main/component2');
-          advance(fixture);
-
-          const teamCmp = fixture.debugElement.children[1].componentInstance;
-          expect(teamCmp.route.firstChild.url.value[0].path).toEqual('component1');
-          expect(location.path()).toEqual('/main/component1');
-        }),
-      ));
-
-      it('should not run CanActivate when CanDeactivate returns false', fakeAsync(
-        inject([Router, Location], (router: Router, location: Location) => {
-          const fixture = createRoot(router, RootCmp);
-
-          router.resetConfig([
-            {
-              path: 'main',
-              component: TeamCmp,
-              children: [
-                {
-                  path: 'component1',
-                  component: SimpleCmp,
-                  canDeactivate: [
-                    () => {
-                      log.push('called');
-                      let resolve: (result: boolean) => void;
-                      const promise = new Promise((res) => (resolve = res));
-                      setTimeout(() => resolve(false), 0);
-                      return promise;
-                    },
-                  ],
-                },
-                {
-                  path: 'component2',
-                  component: SimpleCmp,
-                  canActivate: [
-                    () => {
-                      log.push('canActivate called');
-                      return true;
-                    },
-                  ],
-                },
-              ],
-            },
-          ]);
-
-          router.navigateByUrl('/main/component1');
-          advance(fixture);
-          expect(location.path()).toEqual('/main/component1');
-
-          router.navigateByUrl('/main/component2');
-          advance(fixture);
-          expect(location.path()).toEqual('/main/component1');
-          expect(log).toEqual(['called']);
-        }),
-      ));
-
-      it('should call guards every time when navigating to the same url over and over again', fakeAsync(
-        inject([Router, Location], (router: Router, location: Location) => {
-          const fixture = createRoot(router, RootCmp);
-
-          router.resetConfig([
-            {
-              path: 'simple',
-              component: SimpleCmp,
               canDeactivate: [
-                () => {
-                  log.push('called');
-                  return false;
+                (c, a) => {
+                  return a.params['id'] === '22';
                 },
               ],
             },
-            {path: 'blank', component: BlankCmp},
           ]);
+
+          router.navigateByUrl('/team/22');
+          advance(fixture);
+          expect(location.path()).toEqual('/team/22');
+
+          let successStatus: boolean = false;
+          router.navigateByUrl('/team/33')!.then((res) => (successStatus = res));
+          advance(fixture);
+          expect(location.path()).toEqual('/team/33');
+          expect(successStatus).toEqual(true);
+
+          let canceledStatus: boolean = false;
+          router.navigateByUrl('/team/44')!.then((res) => (canceledStatus = res));
+          advance(fixture);
+          expect(location.path()).toEqual('/team/33');
+          expect(canceledStatus).toEqual(false);
+        }));
+
+        it('works with componentless routes', fakeAsync(() => {
+          const router: Router = TestBed.inject(Router);
+          const location: Location = TestBed.inject(Location);
+          const fixture = createRoot(router, RootCmp);
+
+          router.resetConfig([
+            {
+              path: 'grandparent',
+              canDeactivate: [recordingDeactivate],
+              children: [
+                {
+                  path: 'parent',
+                  canDeactivate: [recordingDeactivate],
+                  children: [
+                    {
+                      path: 'child',
+                      canDeactivate: [recordingDeactivate],
+                      children: [
+                        {
+                          path: 'simple',
+                          component: SimpleCmp,
+                          canDeactivate: [recordingDeactivate],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {path: 'simple', component: SimpleCmp},
+          ]);
+
+          router.navigateByUrl('/grandparent/parent/child/simple');
+          advance(fixture);
+          expect(location.path()).toEqual('/grandparent/parent/child/simple');
 
           router.navigateByUrl('/simple');
           advance(fixture);
 
-          router.navigateByUrl('/blank');
-          advance(fixture);
-          expect(log).toEqual(['called']);
-          expect(location.path()).toEqual('/simple');
+          const child = fixture.debugElement.children[1].componentInstance;
 
-          router.navigateByUrl('/blank');
+          expect(log.map((a: any) => a.path)).toEqual(['simple', 'child', 'parent', 'grandparent']);
+          expect(log[0].component instanceof SimpleCmp).toBeTruthy();
+          [1, 2, 3].forEach((i) => expect(log[i].component).toBeNull());
+          expect(child instanceof SimpleCmp).toBeTruthy();
+          expect(child).not.toBe(log[0].component);
+        }));
+
+        it('works with aux routes', fakeAsync(() => {
+          const router: Router = TestBed.inject(Router);
+          const location: Location = TestBed.inject(Location);
+          const fixture = createRoot(router, RootCmp);
+
+          router.resetConfig([
+            {
+              path: 'two-outlets',
+              component: TwoOutletsCmp,
+              children: [
+                {path: 'a', component: BlankCmp},
+                {
+                  path: 'b',
+                  canDeactivate: [recordingDeactivate],
+                  component: SimpleCmp,
+                  outlet: 'aux',
+                },
+              ],
+            },
+          ]);
+
+          router.navigateByUrl('/two-outlets/(a//aux:b)');
           advance(fixture);
-          expect(log).toEqual(['called', 'called']);
-          expect(location.path()).toEqual('/simple');
-        }),
-      ));
+          expect(location.path()).toEqual('/two-outlets/(a//aux:b)');
+
+          router.navigate(['two-outlets', {outlets: {aux: null}}]);
+          advance(fixture);
+
+          expect(log.map((a: any) => a.path)).toEqual(['b']);
+          expect(location.path()).toEqual('/two-outlets/a');
+        }));
+
+        it('works with a nested route', fakeAsync(() => {
+          const router: Router = TestBed.inject(Router);
+          const location: Location = TestBed.inject(Location);
+          const fixture = createRoot(router, RootCmp);
+
+          router.resetConfig([
+            {
+              path: 'team/:id',
+              component: TeamCmp,
+              children: [
+                {path: '', pathMatch: 'full', component: SimpleCmp},
+                {
+                  path: 'user/:name',
+                  component: UserCmp,
+                  canDeactivate: [
+                    (c: any, a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
+                      return a.params['name'] === 'victor';
+                    },
+                  ],
+                },
+              ],
+            },
+          ]);
+
+          router.navigateByUrl('/team/22/user/victor');
+          advance(fixture);
+
+          // this works because we can deactivate victor
+          router.navigateByUrl('/team/33');
+          advance(fixture);
+          expect(location.path()).toEqual('/team/33');
+
+          router.navigateByUrl('/team/33/user/fedor');
+          advance(fixture);
+
+          // this doesn't work cause we cannot deactivate fedor
+          router.navigateByUrl('/team/44');
+          advance(fixture);
+          expect(location.path()).toEqual('/team/33/user/fedor');
+        }));
+      });
+
+      it('should use correct component to deactivate forChild route', fakeAsync(() => {
+        const router: Router = TestBed.inject(Router);
+        @Component({
+          selector: 'admin',
+          template: '',
+          standalone: false,
+        })
+        class AdminComponent {}
+
+        @NgModule({
+          declarations: [AdminComponent],
+          imports: [
+            RouterModule.forChild([
+              {
+                path: '',
+                component: AdminComponent,
+                canDeactivate: [recordingDeactivate],
+              },
+            ]),
+          ],
+        })
+        class LazyLoadedModule {}
+
+        const fixture = createRoot(router, RootCmp);
+
+        router.resetConfig([
+          {
+            path: 'a',
+            component: WrapperCmp,
+            children: [{path: '', pathMatch: 'full', loadChildren: () => LazyLoadedModule}],
+          },
+          {path: 'b', component: SimpleCmp},
+        ]);
+
+        router.navigateByUrl('/a');
+        advance(fixture);
+        router.navigateByUrl('/b');
+        advance(fixture);
+
+        expect(log[0].component).toBeInstanceOf(AdminComponent);
+      }));
+
+      it('should not create a route state if navigation is canceled', fakeAsync(() => {
+        const router: Router = TestBed.inject(Router);
+        const location: Location = TestBed.inject(Location);
+        const fixture = createRoot(router, RootCmp);
+
+        router.resetConfig([
+          {
+            path: 'main',
+            component: TeamCmp,
+            children: [
+              {path: 'component1', component: SimpleCmp, canDeactivate: [() => false]},
+              {path: 'component2', component: SimpleCmp},
+            ],
+          },
+        ]);
+
+        router.navigateByUrl('/main/component1');
+        advance(fixture);
+
+        router.navigateByUrl('/main/component2');
+        advance(fixture);
+
+        const teamCmp = fixture.debugElement.children[1].componentInstance;
+        expect(teamCmp.route.firstChild.url.value[0].path).toEqual('component1');
+        expect(location.path()).toEqual('/main/component1');
+      }));
+
+      it('should not run CanActivate when CanDeactivate returns false', fakeAsync(() => {
+        const router: Router = TestBed.inject(Router);
+        const location: Location = TestBed.inject(Location);
+        const fixture = createRoot(router, RootCmp);
+
+        router.resetConfig([
+          {
+            path: 'main',
+            component: TeamCmp,
+            children: [
+              {
+                path: 'component1',
+                component: SimpleCmp,
+                canDeactivate: [
+                  () => {
+                    log.push('called');
+                    let resolve: (result: boolean) => void;
+                    const promise = new Promise((res) => (resolve = res));
+                    setTimeout(() => resolve(false), 0);
+                    return promise;
+                  },
+                ],
+              },
+              {
+                path: 'component2',
+                component: SimpleCmp,
+                canActivate: [
+                  () => {
+                    log.push('canActivate called');
+                    return true;
+                  },
+                ],
+              },
+            ],
+          },
+        ]);
+
+        router.navigateByUrl('/main/component1');
+        advance(fixture);
+        expect(location.path()).toEqual('/main/component1');
+
+        router.navigateByUrl('/main/component2');
+        advance(fixture);
+        expect(location.path()).toEqual('/main/component1');
+        expect(log).toEqual(['called']);
+      }));
+
+      it('should call guards every time when navigating to the same url over and over again', fakeAsync(() => {
+        const router: Router = TestBed.inject(Router);
+        const location: Location = TestBed.inject(Location);
+        const fixture = createRoot(router, RootCmp);
+
+        router.resetConfig([
+          {
+            path: 'simple',
+            component: SimpleCmp,
+            canDeactivate: [
+              () => {
+                log.push('called');
+                return false;
+              },
+            ],
+          },
+          {path: 'blank', component: BlankCmp},
+        ]);
+
+        router.navigateByUrl('/simple');
+        advance(fixture);
+
+        router.navigateByUrl('/blank');
+        advance(fixture);
+        expect(log).toEqual(['called']);
+        expect(location.path()).toEqual('/simple');
+
+        router.navigateByUrl('/blank');
+        advance(fixture);
+        expect(log).toEqual(['called', 'called']);
+        expect(location.path()).toEqual('/simple');
+      }));
 
       describe('next state', () => {
         let log: string[];
@@ -1329,69 +1312,69 @@ export function guardsIntegrationSuite() {
           });
         });
 
-        it('should pass next state as the 4 argument when guard is a class', fakeAsync(
-          inject([Router, Location], (router: Router, location: Location) => {
-            const fixture = createRoot(router, RootCmp);
+        it('should pass next state as the 4 argument when guard is a class', fakeAsync(() => {
+          const router: Router = TestBed.inject(Router);
+          const location: Location = TestBed.inject(Location);
+          const fixture = createRoot(router, RootCmp);
 
-            router.resetConfig([
-              {
-                path: 'team/:id',
-                component: TeamCmp,
-                canDeactivate: [
-                  (
-                    component: TeamCmp,
-                    currentRoute: ActivatedRouteSnapshot,
-                    currentState: RouterStateSnapshot,
-                    nextState: RouterStateSnapshot,
-                  ) =>
-                    coreInject(ClassWithNextState).canDeactivate(
-                      component,
-                      currentRoute,
-                      currentState,
-                      nextState,
-                    ),
-                ],
-              },
-            ]);
+          router.resetConfig([
+            {
+              path: 'team/:id',
+              component: TeamCmp,
+              canDeactivate: [
+                (
+                  component: TeamCmp,
+                  currentRoute: ActivatedRouteSnapshot,
+                  currentState: RouterStateSnapshot,
+                  nextState: RouterStateSnapshot,
+                ) =>
+                  inject(ClassWithNextState).canDeactivate(
+                    component,
+                    currentRoute,
+                    currentState,
+                    nextState,
+                  ),
+              ],
+            },
+          ]);
 
-            router.navigateByUrl('/team/22');
-            advance(fixture);
-            expect(location.path()).toEqual('/team/22');
+          router.navigateByUrl('/team/22');
+          advance(fixture);
+          expect(location.path()).toEqual('/team/22');
 
-            router.navigateByUrl('/team/33');
-            advance(fixture);
-            expect(location.path()).toEqual('/team/33');
-            expect(log).toEqual(['/team/22', '/team/33']);
-          }),
-        ));
+          router.navigateByUrl('/team/33');
+          advance(fixture);
+          expect(location.path()).toEqual('/team/33');
+          expect(log).toEqual(['/team/22', '/team/33']);
+        }));
 
-        it('should pass next state as the 4 argument when guard is a function', fakeAsync(
-          inject([Router, Location], (router: Router, location: Location) => {
-            const fixture = createRoot(router, RootCmp);
+        it('should pass next state as the 4 argument when guard is a function', fakeAsync(() => {
+          const router: Router = TestBed.inject(Router);
+          const location: Location = TestBed.inject(Location);
+          const fixture = createRoot(router, RootCmp);
 
-            router.resetConfig([
-              {
-                path: 'team/:id',
-                component: TeamCmp,
-                canDeactivate: [
-                  (cmp, currentRoute, currentState, nextState) => {
-                    log.push(currentState.url, nextState.url);
-                    return true;
-                  },
-                ],
-              },
-            ]);
+          router.resetConfig([
+            {
+              path: 'team/:id',
+              component: TeamCmp,
+              canDeactivate: [
+                (cmp, currentRoute, currentState, nextState) => {
+                  log.push(currentState.url, nextState.url);
+                  return true;
+                },
+              ],
+            },
+          ]);
 
-            router.navigateByUrl('/team/22');
-            advance(fixture);
-            expect(location.path()).toEqual('/team/22');
+          router.navigateByUrl('/team/22');
+          advance(fixture);
+          expect(location.path()).toEqual('/team/22');
 
-            router.navigateByUrl('/team/33');
-            advance(fixture);
-            expect(location.path()).toEqual('/team/33');
-            expect(log).toEqual(['/team/22', '/team/33']);
-          }),
-        ));
+          router.navigateByUrl('/team/33');
+          advance(fixture);
+          expect(location.path()).toEqual('/team/33');
+          expect(log).toEqual(['/team/22', '/team/33']);
+        }));
       });
 
       describe('should work when given a class', () => {
@@ -1405,134 +1388,134 @@ export function guardsIntegrationSuite() {
           TestBed.configureTestingModule({providers: [AlwaysTrue]});
         });
 
-        it('works', fakeAsync(
-          inject([Router, Location], (router: Router, location: Location) => {
-            const fixture = createRoot(router, RootCmp);
+        it('works', fakeAsync(() => {
+          const router: Router = TestBed.inject(Router);
+          const location: Location = TestBed.inject(Location);
+          const fixture = createRoot(router, RootCmp);
 
-            router.resetConfig([
-              {
-                path: 'team/:id',
-                component: TeamCmp,
-                canDeactivate: [() => coreInject(AlwaysTrue).canDeactivate()],
-              },
-            ]);
+          router.resetConfig([
+            {
+              path: 'team/:id',
+              component: TeamCmp,
+              canDeactivate: [() => inject(AlwaysTrue).canDeactivate()],
+            },
+          ]);
 
-            router.navigateByUrl('/team/22');
-            advance(fixture);
-            expect(location.path()).toEqual('/team/22');
+          router.navigateByUrl('/team/22');
+          advance(fixture);
+          expect(location.path()).toEqual('/team/22');
 
-            router.navigateByUrl('/team/33');
-            advance(fixture);
-            expect(location.path()).toEqual('/team/33');
-          }),
-        ));
+          router.navigateByUrl('/team/33');
+          advance(fixture);
+          expect(location.path()).toEqual('/team/33');
+        }));
       });
 
       describe('should work when returns an observable', () => {
-        it('works', fakeAsync(
-          inject([Router, Location], (router: Router, location: Location) => {
-            const fixture = createRoot(router, RootCmp);
+        it('works', fakeAsync(() => {
+          const router: Router = TestBed.inject(Router);
+          const location: Location = TestBed.inject(Location);
+          const fixture = createRoot(router, RootCmp);
 
-            router.resetConfig([
-              {
-                path: 'team/:id',
-                component: TeamCmp,
-                canDeactivate: [
-                  () => {
-                    return new Observable<boolean>((observer) => {
-                      observer.next(false);
-                    });
-                  },
-                ],
-              },
-            ]);
+          router.resetConfig([
+            {
+              path: 'team/:id',
+              component: TeamCmp,
+              canDeactivate: [
+                () => {
+                  return new Observable<boolean>((observer) => {
+                    observer.next(false);
+                  });
+                },
+              ],
+            },
+          ]);
 
-            router.navigateByUrl('/team/22');
-            advance(fixture);
-            expect(location.path()).toEqual('/team/22');
+          router.navigateByUrl('/team/22');
+          advance(fixture);
+          expect(location.path()).toEqual('/team/22');
 
-            router.navigateByUrl('/team/33');
-            advance(fixture);
-            expect(location.path()).toEqual('/team/22');
-          }),
-        ));
+          router.navigateByUrl('/team/33');
+          advance(fixture);
+          expect(location.path()).toEqual('/team/22');
+        }));
       });
     });
 
     describe('CanActivateChild', () => {
       describe('should be invoked when activating a child', () => {
-        it('works', fakeAsync(
-          inject([Router, Location], (router: Router, location: Location) => {
-            const fixture = createRoot(router, RootCmp);
-
-            router.resetConfig([
-              {
-                path: '',
-                canActivateChild: [(a: any) => a.paramMap.get('id') === '22'],
-                children: [{path: 'team/:id', component: TeamCmp}],
-              },
-            ]);
-
-            router.navigateByUrl('/team/22');
-            advance(fixture);
-
-            expect(location.path()).toEqual('/team/22');
-
-            router.navigateByUrl('/team/33')!.catch(() => {});
-            advance(fixture);
-
-            expect(location.path()).toEqual('/team/22');
-          }),
-        ));
-      });
-
-      it('should find the guard provided in lazy loaded module', fakeAsync(
-        inject([Router, Location], (router: Router, location: Location) => {
-          @Component({
-            selector: 'admin',
-            template: '<router-outlet></router-outlet>',
-            standalone: false,
-          })
-          class AdminComponent {}
-
-          @Component({
-            selector: 'lazy',
-            template: 'lazy-loaded',
-            standalone: false,
-          })
-          class LazyLoadedComponent {}
-
-          @NgModule({
-            declarations: [AdminComponent, LazyLoadedComponent],
-            imports: [
-              RouterModule.forChild([
-                {
-                  path: '',
-                  component: AdminComponent,
-                  children: [
-                    {
-                      path: '',
-                      canActivateChild: [() => true],
-                      children: [{path: '', component: LazyLoadedComponent}],
-                    },
-                  ],
-                },
-              ]),
-            ],
-          })
-          class LazyLoadedModule {}
-
+        it('works', fakeAsync(() => {
+          const router: Router = TestBed.inject(Router);
+          const location: Location = TestBed.inject(Location);
           const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig([{path: 'admin', loadChildren: () => LazyLoadedModule}]);
+          router.resetConfig([
+            {
+              path: '',
+              canActivateChild: [(a: any) => a.paramMap.get('id') === '22'],
+              children: [{path: 'team/:id', component: TeamCmp}],
+            },
+          ]);
 
-          router.navigateByUrl('/admin');
+          router.navigateByUrl('/team/22');
           advance(fixture);
 
-          expect(location.path()).toEqual('/admin');
-          expect(fixture.nativeElement).toHaveText('lazy-loaded');
-        }),
-      ));
+          expect(location.path()).toEqual('/team/22');
+
+          router.navigateByUrl('/team/33')!.catch(() => {});
+          advance(fixture);
+
+          expect(location.path()).toEqual('/team/22');
+        }));
+      });
+
+      it('should find the guard provided in lazy loaded module', fakeAsync(() => {
+        const router: Router = TestBed.inject(Router);
+        const location: Location = TestBed.inject(Location);
+        @Component({
+          selector: 'admin',
+          template: '<router-outlet></router-outlet>',
+          standalone: false,
+        })
+        class AdminComponent {}
+
+        @Component({
+          selector: 'lazy',
+          template: 'lazy-loaded',
+          standalone: false,
+        })
+        class LazyLoadedComponent {}
+
+        @NgModule({
+          declarations: [AdminComponent, LazyLoadedComponent],
+          imports: [
+            RouterModule.forChild([
+              {
+                path: '',
+                component: AdminComponent,
+                children: [
+                  {
+                    path: '',
+                    canActivateChild: [() => true],
+                    children: [{path: '', component: LazyLoadedComponent}],
+                  },
+                ],
+              },
+            ]),
+          ],
+        })
+        class LazyLoadedModule {}
+
+        const fixture = createRoot(router, RootCmp);
+
+        router.resetConfig([{path: 'admin', loadChildren: () => LazyLoadedModule}]);
+
+        router.navigateByUrl('/admin');
+        advance(fixture);
+
+        expect(location.path()).toEqual('/admin');
+        expect(fixture.nativeElement).toHaveText('lazy-loaded');
+      }));
     });
 
     describe('CanLoad', () => {
@@ -1552,259 +1535,260 @@ export function guardsIntegrationSuite() {
         });
       });
 
-      it('should not load children when CanLoad returns false', fakeAsync(
-        inject([Router, Location], (router: Router, location: Location) => {
-          @Component({
-            selector: 'lazy',
-            template: 'lazy-loaded',
-            standalone: false,
-          })
-          class LazyLoadedComponent {}
+      it('should not load children when CanLoad returns false', fakeAsync(() => {
+        const router = TestBed.inject(Router);
+        const location = TestBed.inject(Location);
 
-          @NgModule({
-            declarations: [LazyLoadedComponent],
-            imports: [RouterModule.forChild([{path: 'loaded', component: LazyLoadedComponent}])],
-          })
-          class LoadedModule {}
+        @Component({
+          selector: 'lazy',
+          template: 'lazy-loaded',
+          standalone: false,
+        })
+        class LazyLoadedComponent {}
 
-          const fixture = createRoot(router, RootCmp);
+        @NgModule({
+          declarations: [LazyLoadedComponent],
+          imports: [RouterModule.forChild([{path: 'loaded', component: LazyLoadedComponent}])],
+        })
+        class LoadedModule {}
 
-          router.resetConfig([
-            {path: 'lazyFalse', canLoad: [() => false], loadChildren: () => LoadedModule},
-            {path: 'lazyTrue', canLoad: [() => true], loadChildren: () => LoadedModule},
-          ]);
+        const fixture = createRoot(router, RootCmp);
 
-          const recordedEvents: Event[] = [];
-          router.events.forEach((e) => recordedEvents.push(e));
+        router.resetConfig([
+          {path: 'lazyFalse', canLoad: [() => false], loadChildren: () => LoadedModule},
+          {path: 'lazyTrue', canLoad: [() => true], loadChildren: () => LoadedModule},
+        ]);
 
-          // failed navigation
-          router.navigateByUrl('/lazyFalse/loaded');
-          advance(fixture);
+        const recordedEvents: Event[] = [];
+        router.events.forEach((e) => recordedEvents.push(e));
 
-          expect(location.path()).toEqual('');
+        // failed navigation
+        router.navigateByUrl('/lazyFalse/loaded');
+        advance(fixture);
 
-          expectEvents(recordedEvents, [
-            [NavigationStart, '/lazyFalse/loaded'],
-            //  [GuardsCheckStart, '/lazyFalse/loaded'],
-            [NavigationCancel, '/lazyFalse/loaded'],
-          ]);
+        expect(location.path()).toEqual('');
 
-          expect((recordedEvents[1] as NavigationCancel).code).toBe(
-            NavigationCancellationCode.GuardRejected,
-          );
+        expectEvents(recordedEvents, [
+          [NavigationStart, '/lazyFalse/loaded'],
+          //  [GuardsCheckStart, '/lazyFalse/loaded'],
+          [NavigationCancel, '/lazyFalse/loaded'],
+        ]);
 
-          recordedEvents.splice(0);
+        expect((recordedEvents[1] as NavigationCancel).code).toBe(
+          NavigationCancellationCode.GuardRejected,
+        );
 
-          // successful navigation
-          router.navigateByUrl('/lazyTrue/loaded');
-          advance(fixture);
+        recordedEvents.splice(0);
 
-          expect(location.path()).toEqual('/lazyTrue/loaded');
+        // successful navigation
+        router.navigateByUrl('/lazyTrue/loaded');
+        advance(fixture);
 
-          expectEvents(recordedEvents, [
-            [NavigationStart, '/lazyTrue/loaded'],
-            [RouteConfigLoadStart],
-            [RouteConfigLoadEnd],
-            [RoutesRecognized, '/lazyTrue/loaded'],
-            [GuardsCheckStart, '/lazyTrue/loaded'],
-            [ChildActivationStart],
-            [ActivationStart],
-            [ChildActivationStart],
-            [ActivationStart],
-            [GuardsCheckEnd, '/lazyTrue/loaded'],
-            [ResolveStart, '/lazyTrue/loaded'],
-            [ResolveEnd, '/lazyTrue/loaded'],
-            [ActivationEnd],
-            [ChildActivationEnd],
-            [ActivationEnd],
-            [ChildActivationEnd],
-            [NavigationEnd, '/lazyTrue/loaded'],
-          ]);
-        }),
-      ));
+        expect(location.path()).toEqual('/lazyTrue/loaded');
 
-      it('should support navigating from within the guard', fakeAsync(
-        inject([Router, Location], (router: Router, location: Location) => {
-          const fixture = createRoot(router, RootCmp);
+        expectEvents(recordedEvents, [
+          [NavigationStart, '/lazyTrue/loaded'],
+          [RouteConfigLoadStart],
+          [RouteConfigLoadEnd],
+          [RoutesRecognized, '/lazyTrue/loaded'],
+          [GuardsCheckStart, '/lazyTrue/loaded'],
+          [ChildActivationStart],
+          [ActivationStart],
+          [ChildActivationStart],
+          [ActivationStart],
+          [GuardsCheckEnd, '/lazyTrue/loaded'],
+          [ResolveStart, '/lazyTrue/loaded'],
+          [ResolveEnd, '/lazyTrue/loaded'],
+          [ActivationEnd],
+          [ChildActivationEnd],
+          [ActivationEnd],
+          [ChildActivationEnd],
+          [NavigationEnd, '/lazyTrue/loaded'],
+        ]);
+      }));
 
-          router.resetConfig([
-            {
-              path: 'lazyFalse',
-              canLoad: [
-                () => {
-                  router.navigate(['blank']);
-                  return false;
-                },
-              ],
-              loadChildren: jasmine.createSpy('lazyFalse'),
-            },
-            {path: 'blank', component: BlankCmp},
-          ]);
+      it('should support navigating from within the guard', fakeAsync(() => {
+        const router = TestBed.inject(Router);
+        const location = TestBed.inject(Location);
+        const fixture = createRoot(router, RootCmp);
 
-          const recordedEvents: Event[] = [];
-          router.events.forEach((e) => recordedEvents.push(e));
+        router.resetConfig([
+          {
+            path: 'lazyFalse',
+            canLoad: [
+              () => {
+                router.navigate(['blank']);
+                return false;
+              },
+            ],
+            loadChildren: jasmine.createSpy('lazyFalse'),
+          },
+          {path: 'blank', component: BlankCmp},
+        ]);
 
-          router.navigateByUrl('/lazyFalse/loaded');
-          advance(fixture);
+        const recordedEvents: Event[] = [];
+        router.events.forEach((e) => recordedEvents.push(e));
 
-          expect(location.path()).toEqual('/blank');
+        router.navigateByUrl('/lazyFalse/loaded');
+        advance(fixture);
 
-          expectEvents(recordedEvents, [
-            [NavigationStart, '/lazyFalse/loaded'],
-            // No GuardCheck events as `canLoad` is a special guard that's not actually part of
-            // the guard lifecycle.
-            [NavigationCancel, '/lazyFalse/loaded'],
+        expect(location.path()).toEqual('/blank');
 
-            [NavigationStart, '/blank'],
-            [RoutesRecognized, '/blank'],
-            [GuardsCheckStart, '/blank'],
-            [ChildActivationStart],
-            [ActivationStart],
-            [GuardsCheckEnd, '/blank'],
-            [ResolveStart, '/blank'],
-            [ResolveEnd, '/blank'],
-            [ActivationEnd],
-            [ChildActivationEnd],
-            [NavigationEnd, '/blank'],
-          ]);
+        expectEvents(recordedEvents, [
+          [NavigationStart, '/lazyFalse/loaded'],
+          // No GuardCheck events as `canLoad` is a special guard that's not actually part of
+          // the guard lifecycle.
+          [NavigationCancel, '/lazyFalse/loaded'],
 
-          expect((recordedEvents[1] as NavigationCancel).code).toBe(
-            NavigationCancellationCode.SupersededByNewNavigation,
-          );
-        }),
-      ));
+          [NavigationStart, '/blank'],
+          [RoutesRecognized, '/blank'],
+          [GuardsCheckStart, '/blank'],
+          [ChildActivationStart],
+          [ActivationStart],
+          [GuardsCheckEnd, '/blank'],
+          [ResolveStart, '/blank'],
+          [ResolveEnd, '/blank'],
+          [ActivationEnd],
+          [ChildActivationEnd],
+          [NavigationEnd, '/blank'],
+        ]);
 
-      it('should support returning UrlTree from within the guard', fakeAsync(
-        inject([Router, Location], (router: Router, location: Location) => {
-          const fixture = createRoot(router, RootCmp);
+        expect((recordedEvents[1] as NavigationCancel).code).toBe(
+          NavigationCancellationCode.SupersededByNewNavigation,
+        );
+      }));
 
-          router.resetConfig([
-            {
-              path: 'lazyFalse',
-              canLoad: [() => coreInject(Router).createUrlTree(['blank'])],
-              loadChildren: jasmine.createSpy('lazyFalse'),
-            },
-            {path: 'blank', component: BlankCmp},
-          ]);
+      it('should support returning UrlTree from within the guard', fakeAsync(() => {
+        const router = TestBed.inject(Router);
+        const location = TestBed.inject(Location);
+        const fixture = createRoot(router, RootCmp);
 
-          const recordedEvents: Event[] = [];
-          router.events.forEach((e) => recordedEvents.push(e));
+        router.resetConfig([
+          {
+            path: 'lazyFalse',
+            canLoad: [() => inject(Router).createUrlTree(['blank'])],
+            loadChildren: jasmine.createSpy('lazyFalse'),
+          },
+          {path: 'blank', component: BlankCmp},
+        ]);
 
-          router.navigateByUrl('/lazyFalse/loaded');
-          advance(fixture);
+        const recordedEvents: Event[] = [];
+        router.events.forEach((e) => recordedEvents.push(e));
 
-          expect(location.path()).toEqual('/blank');
+        router.navigateByUrl('/lazyFalse/loaded');
+        advance(fixture);
 
-          expectEvents(recordedEvents, [
-            [NavigationStart, '/lazyFalse/loaded'],
-            // No GuardCheck events as `canLoad` is a special guard that's not actually part of
-            // the guard lifecycle.
-            [NavigationCancel, '/lazyFalse/loaded'],
+        expect(location.path()).toEqual('/blank');
 
-            [NavigationStart, '/blank'],
-            [RoutesRecognized, '/blank'],
-            [GuardsCheckStart, '/blank'],
-            [ChildActivationStart],
-            [ActivationStart],
-            [GuardsCheckEnd, '/blank'],
-            [ResolveStart, '/blank'],
-            [ResolveEnd, '/blank'],
-            [ActivationEnd],
-            [ChildActivationEnd],
-            [NavigationEnd, '/blank'],
-          ]);
+        expectEvents(recordedEvents, [
+          [NavigationStart, '/lazyFalse/loaded'],
+          // No GuardCheck events as `canLoad` is a special guard that's not actually part of
+          // the guard lifecycle.
+          [NavigationCancel, '/lazyFalse/loaded'],
 
-          expect((recordedEvents[1] as NavigationCancel).code).toBe(
-            NavigationCancellationCode.Redirect,
-          );
-        }),
-      ));
+          [NavigationStart, '/blank'],
+          [RoutesRecognized, '/blank'],
+          [GuardsCheckStart, '/blank'],
+          [ChildActivationStart],
+          [ActivationStart],
+          [GuardsCheckEnd, '/blank'],
+          [ResolveStart, '/blank'],
+          [ResolveEnd, '/blank'],
+          [ActivationEnd],
+          [ChildActivationEnd],
+          [NavigationEnd, '/blank'],
+        ]);
+
+        expect((recordedEvents[1] as NavigationCancel).code).toBe(
+          NavigationCancellationCode.Redirect,
+        );
+      }));
 
       // Regression where navigateByUrl with false CanLoad no longer resolved `false` value on
       // navigateByUrl promise: https://github.com/angular/angular/issues/26284
-      it('should resolve navigateByUrl promise after CanLoad executes', fakeAsync(
-        inject([Router], (router: Router) => {
-          @Component({
-            selector: 'lazy',
-            template: 'lazy-loaded',
-            standalone: false,
-          })
-          class LazyLoadedComponent {}
+      it('should resolve navigateByUrl promise after CanLoad executes', fakeAsync(() => {
+        const router = TestBed.inject(Router);
 
-          @NgModule({
-            declarations: [LazyLoadedComponent],
-            imports: [RouterModule.forChild([{path: 'loaded', component: LazyLoadedComponent}])],
-          })
-          class LazyLoadedModule {}
+        @Component({
+          selector: 'lazy',
+          template: 'lazy-loaded',
+          standalone: false,
+        })
+        class LazyLoadedComponent {}
 
-          const fixture = createRoot(router, RootCmp);
+        @NgModule({
+          declarations: [LazyLoadedComponent],
+          imports: [RouterModule.forChild([{path: 'loaded', component: LazyLoadedComponent}])],
+        })
+        class LazyLoadedModule {}
 
-          router.resetConfig([
-            {path: 'lazy-false', canLoad: [() => false], loadChildren: () => LazyLoadedModule},
-            {path: 'lazy-true', canLoad: [() => true], loadChildren: () => LazyLoadedModule},
-          ]);
+        const fixture = createRoot(router, RootCmp);
 
-          let navFalseResult = true;
-          let navTrueResult = false;
-          router.navigateByUrl('/lazy-false').then((v) => {
-            navFalseResult = v;
-          });
-          advance(fixture);
-          router.navigateByUrl('/lazy-true').then((v) => {
-            navTrueResult = v;
-          });
-          advance(fixture);
+        router.resetConfig([
+          {path: 'lazy-false', canLoad: [() => false], loadChildren: () => LazyLoadedModule},
+          {path: 'lazy-true', canLoad: [() => true], loadChildren: () => LazyLoadedModule},
+        ]);
 
-          expect(navFalseResult).toBe(false);
-          expect(navTrueResult).toBe(true);
-        }),
-      ));
+        let navFalseResult = true;
+        let navTrueResult = false;
+        router.navigateByUrl('/lazy-false').then((v) => {
+          navFalseResult = v;
+        });
+        advance(fixture);
+        router.navigateByUrl('/lazy-true').then((v) => {
+          navTrueResult = v;
+        });
+        advance(fixture);
 
-      it('should execute CanLoad only once', fakeAsync(
-        inject([Router, Location], (router: Router, location: Location) => {
-          @Component({
-            selector: 'lazy',
-            template: 'lazy-loaded',
-            standalone: false,
-          })
-          class LazyLoadedComponent {}
+        expect(navFalseResult).toBe(false);
+        expect(navTrueResult).toBe(true);
+      }));
 
-          @NgModule({
-            declarations: [LazyLoadedComponent],
-            imports: [RouterModule.forChild([{path: 'loaded', component: LazyLoadedComponent}])],
-          })
-          class LazyLoadedModule {}
+      it('should execute CanLoad only once', fakeAsync(() => {
+        const router = TestBed.inject(Router);
+        const location = TestBed.inject(Location);
+        @Component({
+          selector: 'lazy',
+          template: 'lazy-loaded',
+          standalone: false,
+        })
+        class LazyLoadedComponent {}
 
-          const fixture = createRoot(router, RootCmp);
+        @NgModule({
+          declarations: [LazyLoadedComponent],
+          imports: [RouterModule.forChild([{path: 'loaded', component: LazyLoadedComponent}])],
+        })
+        class LazyLoadedModule {}
 
-          router.resetConfig([
-            {
-              path: 'lazy',
-              canLoad: [
-                () => {
-                  canLoadRunCount++;
-                  return true;
-                },
-              ],
-              loadChildren: () => LazyLoadedModule,
-            },
-          ]);
+        const fixture = createRoot(router, RootCmp);
 
-          router.navigateByUrl('/lazy/loaded');
-          advance(fixture);
-          expect(location.path()).toEqual('/lazy/loaded');
-          expect(canLoadRunCount).toEqual(1);
+        router.resetConfig([
+          {
+            path: 'lazy',
+            canLoad: [
+              () => {
+                canLoadRunCount++;
+                return true;
+              },
+            ],
+            loadChildren: () => LazyLoadedModule,
+          },
+        ]);
 
-          router.navigateByUrl('/');
-          advance(fixture);
-          expect(location.path()).toEqual('');
+        router.navigateByUrl('/lazy/loaded');
+        advance(fixture);
+        expect(location.path()).toEqual('/lazy/loaded');
+        expect(canLoadRunCount).toEqual(1);
 
-          router.navigateByUrl('/lazy/loaded');
-          advance(fixture);
-          expect(location.path()).toEqual('/lazy/loaded');
-          expect(canLoadRunCount).toEqual(1);
-        }),
-      ));
+        router.navigateByUrl('/');
+        advance(fixture);
+        expect(location.path()).toEqual('');
+
+        router.navigateByUrl('/lazy/loaded');
+        advance(fixture);
+        expect(location.path()).toEqual('/lazy/loaded');
+        expect(canLoadRunCount).toEqual(1);
+      }));
 
       it('cancels guard execution when a new navigation happens', fakeAsync(() => {
         @Injectable({providedIn: 'root'})
@@ -1859,11 +1843,11 @@ export function guardsIntegrationSuite() {
       };
       const returnFalseAndNavigate = () => {
         log.push('returnFalseAndNavigate');
-        coreInject(Router).navigateByUrl('/redirected');
+        inject(Router).navigateByUrl('/redirected');
         return false;
       };
       const returnUrlTree = () => {
-        const router = coreInject(Router);
+        const router = inject(Router);
         return delayObservable(15).pipe(
           mapTo(router.parseUrl('/redirected')),
           tap({next: () => log.push('returnUrlTree')}),
@@ -1898,63 +1882,65 @@ export function guardsIntegrationSuite() {
         expect(log).toEqual(['guard1']);
       }));
 
-      it('should execute canLoad guards', fakeAsync(
-        inject([Router], (router: Router) => {
-          router.resetConfig([
-            {
-              path: 'lazy',
-              canLoad: [guard1, guard2],
-              loadChildren: () => ModuleWithBlankCmpAsRoute,
-            },
-          ]);
+      it('should execute canLoad guards', fakeAsync(() => {
+        const router = TestBed.inject(Router);
 
-          router.navigateByUrl('/lazy');
-          tick(5);
+        router.resetConfig([
+          {
+            path: 'lazy',
+            canLoad: [guard1, guard2],
+            loadChildren: () => ModuleWithBlankCmpAsRoute,
+          },
+        ]);
 
-          expect(log.length).toEqual(2);
-          expect(log).toEqual(['guard2', 'guard1']);
-        }),
-      ));
+        router.navigateByUrl('/lazy');
+        tick(5);
 
-      it('should redirect with UrlTree if higher priority guards have resolved', fakeAsync(
-        inject([Router, Location], (router: Router, location: Location) => {
-          router.resetConfig([
-            {
-              path: 'lazy',
-              canLoad: [returnUrlTree, guard1, guard2],
-              loadChildren: () => ModuleWithBlankCmpAsRoute,
-            },
-            {path: 'redirected', component: SimpleCmp},
-          ]);
+        expect(log.length).toEqual(2);
+        expect(log).toEqual(['guard2', 'guard1']);
+      }));
 
-          router.navigateByUrl('/lazy');
-          tick(15);
+      it('should redirect with UrlTree if higher priority guards have resolved', fakeAsync(() => {
+        const router = TestBed.inject(Router);
+        const location = TestBed.inject(Location);
 
-          expect(log.length).toEqual(3);
-          expect(log).toEqual(['guard2', 'guard1', 'returnUrlTree']);
-          expect(location.path()).toEqual('/redirected');
-        }),
-      ));
+        router.resetConfig([
+          {
+            path: 'lazy',
+            canLoad: [returnUrlTree, guard1, guard2],
+            loadChildren: () => ModuleWithBlankCmpAsRoute,
+          },
+          {path: 'redirected', component: SimpleCmp},
+        ]);
 
-      it('should redirect with UrlTree if UrlTree is lower priority', fakeAsync(
-        inject([Router, Location], (router: Router, location: Location) => {
-          router.resetConfig([
-            {
-              path: 'lazy',
-              canLoad: [guard1, returnUrlTree],
-              loadChildren: () => ModuleWithBlankCmpAsRoute,
-            },
-            {path: 'redirected', component: SimpleCmp},
-          ]);
+        router.navigateByUrl('/lazy');
+        tick(15);
 
-          router.navigateByUrl('/lazy');
-          tick(15);
+        expect(log.length).toEqual(3);
+        expect(log).toEqual(['guard2', 'guard1', 'returnUrlTree']);
+        expect(location.path()).toEqual('/redirected');
+      }));
 
-          expect(log.length).toEqual(2);
-          expect(log).toEqual(['guard1', 'returnUrlTree']);
-          expect(location.path()).toEqual('/redirected');
-        }),
-      ));
+      it('should redirect with UrlTree if UrlTree is lower priority', fakeAsync(() => {
+        const router = TestBed.inject(Router);
+        const location = TestBed.inject(Location);
+
+        router.resetConfig([
+          {
+            path: 'lazy',
+            canLoad: [guard1, returnUrlTree],
+            loadChildren: () => ModuleWithBlankCmpAsRoute,
+          },
+          {path: 'redirected', component: SimpleCmp},
+        ]);
+
+        router.navigateByUrl('/lazy');
+        tick(15);
+
+        expect(log.length).toEqual(2);
+        expect(log).toEqual(['guard1', 'returnUrlTree']);
+        expect(location.path()).toEqual('/redirected');
+      }));
     });
 
     describe('order', () => {
@@ -1970,75 +1956,75 @@ export function guardsIntegrationSuite() {
         });
       });
 
-      it('should call guards in the right order', fakeAsync(
-        inject([Router, Logger], (router: Router, logger: Logger) => {
-          const fixture = createRoot(router, RootCmp);
+      it('should call guards in the right order', fakeAsync(() => {
+        const router = TestBed.inject(Router);
+        const logger = TestBed.inject(Logger);
+        const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig([
-            {
-              path: '',
-              canActivateChild: [() => (logger.add('canActivateChild_parent'), true)],
-              children: [
-                {
-                  path: 'team/:id',
-                  canActivate: [() => (logger.add('canActivate_team'), true)],
-                  canDeactivate: [() => (logger.add('canDeactivate_team'), true)],
-                  component: TeamCmp,
-                },
-              ],
-            },
-          ]);
+        router.resetConfig([
+          {
+            path: '',
+            canActivateChild: [() => (logger.add('canActivateChild_parent'), true)],
+            children: [
+              {
+                path: 'team/:id',
+                canActivate: [() => (logger.add('canActivate_team'), true)],
+                canDeactivate: [() => (logger.add('canDeactivate_team'), true)],
+                component: TeamCmp,
+              },
+            ],
+          },
+        ]);
 
-          router.navigateByUrl('/team/22');
-          advance(fixture);
+        router.navigateByUrl('/team/22');
+        advance(fixture);
 
-          router.navigateByUrl('/team/33');
-          advance(fixture);
+        router.navigateByUrl('/team/33');
+        advance(fixture);
 
-          expect(logger.logs).toEqual([
-            'canActivateChild_parent',
-            'canActivate_team',
+        expect(logger.logs).toEqual([
+          'canActivateChild_parent',
+          'canActivate_team',
 
-            'canDeactivate_team',
-            'canActivateChild_parent',
-            'canActivate_team',
-          ]);
-        }),
-      ));
+          'canDeactivate_team',
+          'canActivateChild_parent',
+          'canActivate_team',
+        ]);
+      }));
 
-      it('should call deactivate guards from bottom to top', fakeAsync(
-        inject([Router, Logger], (router: Router, logger: Logger) => {
-          const fixture = createRoot(router, RootCmp);
+      it('should call deactivate guards from bottom to top', fakeAsync(() => {
+        const router = TestBed.inject(Router);
+        const logger = TestBed.inject(Logger);
+        const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig([
-            {
-              path: '',
-              children: [
-                {
-                  path: 'team/:id',
-                  canDeactivate: [() => (logger.add('canDeactivate_team'), true)],
-                  children: [
-                    {
-                      path: '',
-                      component: SimpleCmp,
-                      canDeactivate: [() => (logger.add('canDeactivate_simple'), true)],
-                    },
-                  ],
-                  component: TeamCmp,
-                },
-              ],
-            },
-          ]);
+        router.resetConfig([
+          {
+            path: '',
+            children: [
+              {
+                path: 'team/:id',
+                canDeactivate: [() => (logger.add('canDeactivate_team'), true)],
+                children: [
+                  {
+                    path: '',
+                    component: SimpleCmp,
+                    canDeactivate: [() => (logger.add('canDeactivate_simple'), true)],
+                  },
+                ],
+                component: TeamCmp,
+              },
+            ],
+          },
+        ]);
 
-          router.navigateByUrl('/team/22');
-          advance(fixture);
+        router.navigateByUrl('/team/22');
+        advance(fixture);
 
-          router.navigateByUrl('/team/33');
-          advance(fixture);
+        router.navigateByUrl('/team/33');
+        advance(fixture);
 
-          expect(logger.logs).toEqual(['canDeactivate_simple', 'canDeactivate_team']);
-        }),
-      ));
+        expect(logger.logs).toEqual(['canDeactivate_simple', 'canDeactivate_team']);
+      }));
     });
 
     describe('canMatch', () => {
@@ -2056,7 +2042,7 @@ export function guardsIntegrationSuite() {
         router.resetConfig([
           {
             path: 'a',
-            canMatch: [() => coreInject(ConfigurableGuard).canMatch()],
+            canMatch: [() => inject(ConfigurableGuard).canMatch()],
             component: BlankCmp,
           },
           {path: 'a', component: SimpleCmp},
@@ -2074,7 +2060,7 @@ export function guardsIntegrationSuite() {
         router.resetConfig([
           {
             path: 'a',
-            canMatch: [() => coreInject(ConfigurableGuard).canMatch()],
+            canMatch: [() => inject(ConfigurableGuard).canMatch()],
             component: SimpleCmp,
           },
           {path: 'a', component: BlankCmp},
@@ -2094,7 +2080,7 @@ export function guardsIntegrationSuite() {
         router.resetConfig([
           {
             path: 'a',
-            canMatch: [() => coreInject(ConfigurableGuard).canMatch()],
+            canMatch: [() => inject(ConfigurableGuard).canMatch()],
             component: SimpleCmp,
           },
           {path: 'team/:id', component: TeamCmp},
@@ -2303,19 +2289,19 @@ export function guardsIntegrationSuite() {
       const fixture = createRoot(router, RootCmp);
       const guards = {
         canActivate() {
-          return coreInject(State).value;
+          return inject(State).value;
         },
         canDeactivate() {
-          return coreInject(State).value;
+          return inject(State).value;
         },
         canActivateChild() {
-          return coreInject(State).value;
+          return inject(State).value;
         },
         canMatch() {
-          return coreInject(State).value;
+          return inject(State).value;
         },
         canLoad() {
-          return coreInject(State).value;
+          return inject(State).value;
         },
       };
       spyOn(guards, 'canActivate').and.callThrough();
@@ -2357,7 +2343,7 @@ export function guardsIntegrationSuite() {
         guards: CanActivateFn[] | CanActivateChildFn[],
       ): CanActivateFn | CanActivateChildFn {
         return (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
-          const injector = coreInject(EnvironmentInjector);
+          const injector = inject(EnvironmentInjector);
           const observables = guards.map((guard) => {
             const guardResult = injector.runInContext(() => guard(route, state));
             return wrapIntoObservable(guardResult).pipe(first());

--- a/packages/router/test/integration/integration.spec.ts
+++ b/packages/router/test/integration/integration.spec.ts
@@ -8,15 +8,8 @@
 
 import {Location} from '@angular/common';
 import {ɵprovideFakePlatformNavigation} from '@angular/common/testing';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  inject as coreInject,
-  Injectable,
-  NgModule,
-  ɵConsole as Console,
-} from '@angular/core';
-import {fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
+import {ChangeDetectionStrategy, Component, NgModule, ɵConsole as Console} from '@angular/core';
+import {fakeAsync, TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {
   ActivationEnd,
@@ -27,9 +20,7 @@ import {
   GuardsCheckEnd,
   GuardsCheckStart,
   NavigationCancel,
-  NavigationCancellationCode,
   NavigationEnd,
-  NavigationError,
   NavigationStart,
   ResolveEnd,
   ResolveStart,
@@ -37,20 +28,13 @@ import {
   RouterModule,
   RoutesRecognized,
 } from '../../index';
-import {RouterTestingHarness} from '../../testing';
 
-import {RedirectCommand} from '../../src/models';
-import {
-  provideRouter,
-  withNavigationErrorHandler,
-  withRouterConfig,
-} from '../../src/provide_router';
+import {provideRouter} from '../../src/provide_router';
 import {
   advance,
   BlankCmp,
   CollectParamsCmp,
   ComponentRecordingRoutePathAndUrl,
-  ConditionalThrowingCmp,
   createRoot,
   EmptyQueryParamsCmp,
   expectEvents,
@@ -66,7 +50,6 @@ import {
   SimpleCmp,
   TeamCmp,
   TestModule,
-  ThrowingCmp,
   TwoOutletsCmp,
   UserCmp,
 } from './integration_helpers';
@@ -98,29 +81,29 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       });
     });
 
-    it('should navigate with a provided config', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmp);
+    it('should navigate with a provided config', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const location: Location = TestBed.inject(Location);
+      const fixture = createRoot(router, RootCmp);
 
-        router.navigateByUrl('/simple');
-        advance(fixture);
+      router.navigateByUrl('/simple');
+      advance(fixture);
 
-        expect(location.path()).toEqual('/simple');
-      }),
-    ));
+      expect(location.path()).toEqual('/simple');
+    }));
 
-    it('should navigate from ngOnInit hook', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        router.resetConfig([
-          {path: '', component: SimpleCmp},
-          {path: 'one', component: RouteCmp},
-        ]);
+    it('should navigate from ngOnInit hook', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const location: Location = TestBed.inject(Location);
+      router.resetConfig([
+        {path: '', component: SimpleCmp},
+        {path: 'one', component: RouteCmp},
+      ]);
 
-        const fixture = createRoot(router, RootCmpWithOnInit);
-        expect(location.path()).toEqual('/one');
-        expect(fixture.nativeElement).toHaveText('route');
-      }),
-    ));
+      const fixture = createRoot(router, RootCmpWithOnInit);
+      expect(location.path()).toEqual('/one');
+      expect(fixture.nativeElement).toHaveText('route');
+    }));
 
     it('Should work inside ChangeDetectionStrategy.OnPush components', fakeAsync(() => {
       @Component({
@@ -171,50 +154,50 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       expect(fixture.nativeElement).toHaveText('it works!');
     }));
 
-    it('should not error when no url left and no children are matching', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmp);
+    it('should not error when no url left and no children are matching', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const location: Location = TestBed.inject(Location);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([
-          {
-            path: 'team/:id',
-            component: TeamCmp,
-            children: [{path: 'simple', component: SimpleCmp}],
-          },
-        ]);
+      router.resetConfig([
+        {
+          path: 'team/:id',
+          component: TeamCmp,
+          children: [{path: 'simple', component: SimpleCmp}],
+        },
+      ]);
 
-        router.navigateByUrl('/team/33/simple');
-        advance(fixture);
+      router.navigateByUrl('/team/33/simple');
+      advance(fixture);
 
-        expect(location.path()).toEqual('/team/33/simple');
-        expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
+      expect(location.path()).toEqual('/team/33/simple');
+      expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
 
-        router.navigateByUrl('/team/33');
-        advance(fixture);
+      router.navigateByUrl('/team/33');
+      advance(fixture);
 
-        expect(location.path()).toEqual('/team/33');
-        expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
-      }),
-    ));
+      expect(location.path()).toEqual('/team/33');
+      expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
+    }));
 
-    it('should work when an outlet is in an ngIf', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmp);
+    it('should work when an outlet is in an ngIf', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const location: Location = TestBed.inject(Location);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([
-          {
-            path: 'child',
-            component: OutletInNgIf,
-            children: [{path: 'simple', component: SimpleCmp}],
-          },
-        ]);
+      router.resetConfig([
+        {
+          path: 'child',
+          component: OutletInNgIf,
+          children: [{path: 'simple', component: SimpleCmp}],
+        },
+      ]);
 
-        router.navigateByUrl('/child/simple');
-        advance(fixture);
+      router.navigateByUrl('/child/simple');
+      advance(fixture);
 
-        expect(location.path()).toEqual('/child/simple');
-      }),
-    ));
+      expect(location.path()).toEqual('/child/simple');
+    }));
 
     it('should work when an outlet is added/removed', fakeAsync(() => {
       @Component({
@@ -284,580 +267,568 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       expect(location.path()).toEqual('/record/33');
     }));
 
-    it('should skip location update when using NavigationExtras.skipLocationChange with navigateByUrl', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = TestBed.createComponent(RootCmp);
-        advance(fixture);
+    it('should skip location update when using NavigationExtras.skipLocationChange with navigateByUrl', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const location: Location = TestBed.inject(Location);
+      const fixture = TestBed.createComponent(RootCmp);
+      advance(fixture);
 
-        router.resetConfig([{path: 'team/:id', component: TeamCmp}]);
+      router.resetConfig([{path: 'team/:id', component: TeamCmp}]);
 
-        router.navigateByUrl('/team/22');
-        advance(fixture);
-        expect(location.path()).toEqual('/team/22');
-
-        expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
+      router.navigateByUrl('/team/22');
+      advance(fixture);
+      expect(location.path()).toEqual('/team/22');
 
-        router.navigateByUrl('/team/33', {skipLocationChange: true});
-        advance(fixture);
+      expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
+
+      router.navigateByUrl('/team/33', {skipLocationChange: true});
+      advance(fixture);
 
-        expect(location.path()).toEqual('/team/22');
+      expect(location.path()).toEqual('/team/22');
 
-        expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
-      }),
-    ));
-
-    it('should skip location update when using NavigationExtras.skipLocationChange with navigate', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = TestBed.createComponent(RootCmp);
-        advance(fixture);
+      expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
+    }));
+
+    it('should skip location update when using NavigationExtras.skipLocationChange with navigate', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const location: Location = TestBed.inject(Location);
+      const fixture = TestBed.createComponent(RootCmp);
+      advance(fixture);
 
-        router.resetConfig([{path: 'team/:id', component: TeamCmp}]);
+      router.resetConfig([{path: 'team/:id', component: TeamCmp}]);
+
+      router.navigate(['/team/22']);
+      advance(fixture);
+      expect(location.path()).toEqual('/team/22');
+
+      expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
+
+      router.navigate(['/team/33'], {skipLocationChange: true});
+      advance(fixture);
+
+      expect(location.path()).toEqual('/team/22');
+
+      expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
+    }));
+
+    it('should navigate after navigation with skipLocationChange', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const location: Location = TestBed.inject(Location);
+      const fixture = TestBed.createComponent(RootCmpWithNamedOutlet);
+      advance(fixture);
+
+      router.resetConfig([{path: 'show', outlet: 'main', component: SimpleCmp}]);
+
+      router.navigate([{outlets: {main: 'show'}}], {skipLocationChange: true});
+      advance(fixture);
+      expect(location.path()).toEqual('');
+
+      expect(fixture.nativeElement).toHaveText('main [simple]');
+
+      router.navigate([{outlets: {main: null}}], {skipLocationChange: true});
+      advance(fixture);
 
-        router.navigate(['/team/22']);
-        advance(fixture);
-        expect(location.path()).toEqual('/team/22');
-
-        expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
-
-        router.navigate(['/team/33'], {skipLocationChange: true});
-        advance(fixture);
-
-        expect(location.path()).toEqual('/team/22');
-
-        expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
-      }),
-    ));
-
-    it('should navigate after navigation with skipLocationChange', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = TestBed.createComponent(RootCmpWithNamedOutlet);
-        advance(fixture);
-
-        router.resetConfig([{path: 'show', outlet: 'main', component: SimpleCmp}]);
-
-        router.navigate([{outlets: {main: 'show'}}], {skipLocationChange: true});
-        advance(fixture);
-        expect(location.path()).toEqual('');
-
-        expect(fixture.nativeElement).toHaveText('main [simple]');
-
-        router.navigate([{outlets: {main: null}}], {skipLocationChange: true});
-        advance(fixture);
-
-        expect(location.path()).toEqual('');
-
-        expect(fixture.nativeElement).toHaveText('main []');
-      }),
-    ));
-
-    it('should navigate back and forward', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmp);
-
-        router.resetConfig([
-          {
-            path: 'team/:id',
-            component: TeamCmp,
-            children: [
-              {path: 'simple', component: SimpleCmp},
-              {path: 'user/:name', component: UserCmp},
-            ],
-          },
-        ]);
-
-        let event: NavigationStart;
-        router.events.subscribe((e) => {
-          if (e instanceof NavigationStart) {
-            event = e;
-          }
-        });
-
-        router.navigateByUrl('/team/33/simple');
-        advance(fixture);
-        expect(location.path()).toEqual('/team/33/simple');
-        const simpleNavStart = event!;
-
-        router.navigateByUrl('/team/22/user/victor');
-        advance(fixture);
-        const userVictorNavStart = event!;
-
-        location.back();
-        advance(fixture);
-        expect(location.path()).toEqual('/team/33/simple');
-        expect(event!.navigationTrigger).toEqual('popstate');
-        expect(event!.restoredState!.navigationId).toEqual(simpleNavStart.id);
-
-        location.forward();
-        advance(fixture);
-        expect(location.path()).toEqual('/team/22/user/victor');
-        expect(event!.navigationTrigger).toEqual('popstate');
-        expect(event!.restoredState!.navigationId).toEqual(userVictorNavStart.id);
-      }),
-    ));
-
-    it('should navigate to the same url when config changes', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmp);
-
-        router.resetConfig([{path: 'a', component: SimpleCmp}]);
-
-        router.navigate(['/a']);
-        advance(fixture);
-        expect(location.path()).toEqual('/a');
-        expect(fixture.nativeElement).toHaveText('simple');
-
-        router.resetConfig([{path: 'a', component: RouteCmp}]);
-
-        router.navigate(['/a']);
-        advance(fixture);
-        expect(location.path()).toEqual('/a');
-        expect(fixture.nativeElement).toHaveText('route');
-      }),
-    ));
-
-    it('should navigate when locations changes', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmp);
-
-        router.resetConfig([
-          {
-            path: 'team/:id',
-            component: TeamCmp,
-            children: [{path: 'user/:name', component: UserCmp}],
-          },
-        ]);
-
-        const recordedEvents: (NavigationStart | NavigationEnd)[] = [];
-        router.events.forEach((e) => onlyNavigationStartAndEnd(e) && recordedEvents.push(e));
-
-        router.navigateByUrl('/team/22/user/victor');
-        advance(fixture);
-
-        location.go('/team/22/user/fedor');
-        location.historyGo(0);
-        advance(fixture);
-
-        location.go('/team/22/user/fedor');
-        location.historyGo(0);
-        advance(fixture);
-
-        expect(fixture.nativeElement).toHaveText('team 22 [ user fedor, right:  ]');
-
-        expectEvents(recordedEvents, [
-          [NavigationStart, '/team/22/user/victor'],
-          [NavigationEnd, '/team/22/user/victor'],
-          [NavigationStart, '/team/22/user/fedor'],
-          [NavigationEnd, '/team/22/user/fedor'],
-        ]);
-      }),
-    ));
-
-    it('should update the location when the matched route does not change', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmp);
-
-        router.resetConfig([{path: '**', component: CollectParamsCmp}]);
-
-        router.navigateByUrl('/one/two');
-        advance(fixture);
-        const cmp = fixture.debugElement.children[1].componentInstance;
-        expect(location.path()).toEqual('/one/two');
-        expect(fixture.nativeElement).toHaveText('collect-params');
-
-        expect(cmp.recordedUrls()).toEqual(['one/two']);
-
-        router.navigateByUrl('/three/four');
-        advance(fixture);
-        expect(location.path()).toEqual('/three/four');
-        expect(fixture.nativeElement).toHaveText('collect-params');
-        expect(cmp.recordedUrls()).toEqual(['one/two', 'three/four']);
-      }),
-    ));
-
-    it('should support secondary routes', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
-
-        router.resetConfig([
-          {
-            path: 'team/:id',
-            component: TeamCmp,
-            children: [
-              {path: 'user/:name', component: UserCmp},
-              {path: 'simple', component: SimpleCmp, outlet: 'right'},
-            ],
-          },
-        ]);
-
-        router.navigateByUrl('/team/22/(user/victor//right:simple)');
-        advance(fixture);
-
-        expect(fixture.nativeElement).toHaveText('team 22 [ user victor, right: simple ]');
-      }),
-    ));
-
-    it('should support secondary routes in separate commands', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
-
-        router.resetConfig([
-          {
-            path: 'team/:id',
-            component: TeamCmp,
-            children: [
-              {path: 'user/:name', component: UserCmp},
-              {path: 'simple', component: SimpleCmp, outlet: 'right'},
-            ],
-          },
-        ]);
-
-        router.navigateByUrl('/team/22/user/victor');
-        advance(fixture);
-        router.navigate(['team/22', {outlets: {right: 'simple'}}]);
-        advance(fixture);
-
-        expect(fixture.nativeElement).toHaveText('team 22 [ user victor, right: simple ]');
-      }),
-    ));
-
-    it('should support secondary routes as child of empty path parent', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
-
-        router.resetConfig([
-          {
-            path: '',
-            component: TeamCmp,
-            children: [{path: 'simple', component: SimpleCmp, outlet: 'right'}],
-          },
-        ]);
-
-        router.navigateByUrl('/(right:simple)');
-        advance(fixture);
-
-        expect(fixture.nativeElement).toHaveText('team  [ , right: simple ]');
-      }),
-    ));
-
-    it('should deactivate outlets', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
-
-        router.resetConfig([
-          {
-            path: 'team/:id',
-            component: TeamCmp,
-            children: [
-              {path: 'user/:name', component: UserCmp},
-              {path: 'simple', component: SimpleCmp, outlet: 'right'},
-            ],
-          },
-        ]);
-
-        router.navigateByUrl('/team/22/(user/victor//right:simple)');
-        advance(fixture);
-
-        router.navigateByUrl('/team/22/user/victor');
-        advance(fixture);
-
-        expect(fixture.nativeElement).toHaveText('team 22 [ user victor, right:  ]');
-      }),
-    ));
-
-    it('should deactivate nested outlets', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
-
-        router.resetConfig([
-          {
-            path: 'team/:id',
-            component: TeamCmp,
-            children: [
-              {path: 'user/:name', component: UserCmp},
-              {path: 'simple', component: SimpleCmp, outlet: 'right'},
-            ],
-          },
-          {path: '', component: BlankCmp},
-        ]);
-
-        router.navigateByUrl('/team/22/(user/victor//right:simple)');
-        advance(fixture);
-
-        router.navigateByUrl('/');
-        advance(fixture);
-
-        expect(fixture.nativeElement).toHaveText('');
-      }),
-    ));
-
-    it('should set query params and fragment', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
-
-        router.resetConfig([{path: 'query', component: QueryParamsAndFragmentCmp}]);
-
-        router.navigateByUrl('/query?name=1#fragment1');
-        advance(fixture);
-        expect(fixture.nativeElement).toHaveText('query: 1 fragment: fragment1');
-
-        router.navigateByUrl('/query?name=2#fragment2');
-        advance(fixture);
-        expect(fixture.nativeElement).toHaveText('query: 2 fragment: fragment2');
-      }),
-    ));
-
-    it('should handle empty or missing fragments', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
-
-        router.resetConfig([{path: 'query', component: QueryParamsAndFragmentCmp}]);
-
-        router.navigateByUrl('/query#');
-        advance(fixture);
-        expect(fixture.nativeElement).toHaveText('query:  fragment: ');
-
-        router.navigateByUrl('/query');
-        advance(fixture);
-        expect(fixture.nativeElement).toHaveText('query:  fragment: null');
-      }),
-    ));
-
-    it('should ignore null and undefined query params', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
-
-        router.resetConfig([{path: 'query', component: EmptyQueryParamsCmp}]);
-
-        router.navigate(['query'], {queryParams: {name: 1, age: null, page: undefined}});
-        advance(fixture);
-        const cmp = fixture.debugElement.children[1].componentInstance;
-        expect(cmp.recordedParams).toEqual([{name: '1'}]);
-      }),
-    ));
-
-    it('should push params only when they change', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
-
-        router.resetConfig([
-          {
-            path: 'team/:id',
-            component: TeamCmp,
-            children: [{path: 'user/:name', component: UserCmp}],
-          },
-        ]);
-
-        router.navigateByUrl('/team/22/user/victor');
-        advance(fixture);
-        const team = fixture.debugElement.children[1].componentInstance;
-        const user = fixture.debugElement.children[1].children[1].componentInstance;
-
-        expect(team.recordedParams).toEqual([{id: '22'}]);
-        expect(team.snapshotParams).toEqual([{id: '22'}]);
-        expect(user.recordedParams).toEqual([{name: 'victor'}]);
-        expect(user.snapshotParams).toEqual([{name: 'victor'}]);
-
-        router.navigateByUrl('/team/22/user/fedor');
-        advance(fixture);
-
-        expect(team.recordedParams).toEqual([{id: '22'}]);
-        expect(team.snapshotParams).toEqual([{id: '22'}]);
-        expect(user.recordedParams).toEqual([{name: 'victor'}, {name: 'fedor'}]);
-        expect(user.snapshotParams).toEqual([{name: 'victor'}, {name: 'fedor'}]);
-      }),
-    ));
-
-    it('should work when navigating to /', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
-
-        router.resetConfig([
-          {path: '', pathMatch: 'full', component: SimpleCmp},
-          {path: 'user/:name', component: UserCmp},
-        ]);
-
-        router.navigateByUrl('/user/victor');
-        advance(fixture);
-
-        expect(fixture.nativeElement).toHaveText('user victor');
-
-        router.navigateByUrl('/');
-        advance(fixture);
-
-        expect(fixture.nativeElement).toHaveText('simple');
-      }),
-    ));
-
-    it('should cancel in-flight navigations', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
-
-        router.resetConfig([{path: 'user/:name', component: UserCmp}]);
-
-        const recordedEvents: Event[] = [];
-        router.events.forEach((e) => recordedEvents.push(e));
-
-        router.navigateByUrl('/user/init');
-        advance(fixture);
-
-        const user = fixture.debugElement.children[1].componentInstance;
-
-        let r1: any, r2: any;
-        router.navigateByUrl('/user/victor').then((_) => (r1 = _));
-        router.navigateByUrl('/user/fedor').then((_) => (r2 = _));
-        advance(fixture);
-
-        expect(r1).toEqual(false); // returns false because it was canceled
-        expect(r2).toEqual(true); // returns true because it was successful
-
-        expect(fixture.nativeElement).toHaveText('user fedor');
-        expect(user.recordedParams).toEqual([{name: 'init'}, {name: 'fedor'}]);
-
-        expectEvents(recordedEvents, [
-          [NavigationStart, '/user/init'],
-          [RoutesRecognized, '/user/init'],
-          [GuardsCheckStart, '/user/init'],
-          [ChildActivationStart],
-          [ActivationStart],
-          [GuardsCheckEnd, '/user/init'],
-          [ResolveStart, '/user/init'],
-          [ResolveEnd, '/user/init'],
-          [ActivationEnd],
-          [ChildActivationEnd],
-          [NavigationEnd, '/user/init'],
-
-          [NavigationStart, '/user/victor'],
-          [NavigationCancel, '/user/victor'],
-
-          [NavigationStart, '/user/fedor'],
-          [RoutesRecognized, '/user/fedor'],
-          [GuardsCheckStart, '/user/fedor'],
-          [ChildActivationStart],
-          [ActivationStart],
-          [GuardsCheckEnd, '/user/fedor'],
-          [ResolveStart, '/user/fedor'],
-          [ResolveEnd, '/user/fedor'],
-          [ActivationEnd],
-          [ChildActivationEnd],
-          [NavigationEnd, '/user/fedor'],
-        ]);
-      }),
-    ));
-
-    it('should properly set currentNavigation when cancelling in-flight navigations', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
-
-        router.resetConfig([{path: 'user/:name', component: UserCmp}]);
-
-        router.navigateByUrl('/user/init');
-        advance(fixture);
-
-        router.navigateByUrl('/user/victor');
-        expect(router.getCurrentNavigation()).not.toBe(null);
-        router.navigateByUrl('/user/fedor');
-        // Due to https://github.com/angular/angular/issues/29389, this would be `false`
-        // when running a second navigation.
-        expect(router.getCurrentNavigation()).not.toBe(null);
-        advance(fixture);
-
-        expect(router.getCurrentNavigation()).toBe(null);
-        expect(fixture.nativeElement).toHaveText('user fedor');
-      }),
-    ));
-
-    it('should replace state when path is equal to current path', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmp);
-
-        router.resetConfig([
-          {
-            path: 'team/:id',
-            component: TeamCmp,
-            children: [
-              {path: 'simple', component: SimpleCmp},
-              {path: 'user/:name', component: UserCmp},
-            ],
-          },
-        ]);
-
-        router.navigateByUrl('/team/33/simple');
-        advance(fixture);
-
-        router.navigateByUrl('/team/22/user/victor');
-        advance(fixture);
-
-        router.navigateByUrl('/team/22/user/victor');
-        advance(fixture);
-
-        location.back();
-        advance(fixture);
-        expect(location.path()).toEqual('/team/33/simple');
-      }),
-    ));
-
-    it('should handle componentless paths', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmpWithTwoOutlets);
-
-        router.resetConfig([
-          {
-            path: 'parent/:id',
-            children: [
-              {path: 'simple', component: SimpleCmp},
-              {path: 'user/:name', component: UserCmp, outlet: 'right'},
-            ],
-          },
-          {path: 'user/:name', component: UserCmp},
-        ]);
-
-        // navigate to a componentless route
-        router.navigateByUrl('/parent/11/(simple//right:user/victor)');
-        advance(fixture);
-        expect(location.path()).toEqual('/parent/11/(simple//right:user/victor)');
-        expect(fixture.nativeElement).toHaveText('primary [simple] right [user victor]');
-
-        // navigate to the same route with different params (reuse)
-        router.navigateByUrl('/parent/22/(simple//right:user/fedor)');
-        advance(fixture);
-        expect(location.path()).toEqual('/parent/22/(simple//right:user/fedor)');
-        expect(fixture.nativeElement).toHaveText('primary [simple] right [user fedor]');
-
-        // navigate to a normal route (check deactivation)
-        router.navigateByUrl('/user/victor');
-        advance(fixture);
-        expect(location.path()).toEqual('/user/victor');
-        expect(fixture.nativeElement).toHaveText('primary [user victor] right []');
-
-        // navigate back to a componentless route
-        router.navigateByUrl('/parent/11/(simple//right:user/victor)');
-        advance(fixture);
-        expect(location.path()).toEqual('/parent/11/(simple//right:user/victor)');
-        expect(fixture.nativeElement).toHaveText('primary [simple] right [user victor]');
-      }),
-    ));
-
-    it('should not deactivate aux routes when navigating from a componentless routes', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, TwoOutletsCmp);
-
-        router.resetConfig([
-          {path: 'simple', component: SimpleCmp},
-          {path: 'componentless', children: [{path: 'simple', component: SimpleCmp}]},
-          {path: 'user/:name', outlet: 'aux', component: UserCmp},
-        ]);
-
-        router.navigateByUrl('/componentless/simple(aux:user/victor)');
-        advance(fixture);
-        expect(location.path()).toEqual('/componentless/simple(aux:user/victor)');
-        expect(fixture.nativeElement).toHaveText('[ simple, aux: user victor ]');
-
-        router.navigateByUrl('/simple(aux:user/victor)');
-        advance(fixture);
-        expect(location.path()).toEqual('/simple(aux:user/victor)');
-        expect(fixture.nativeElement).toHaveText('[ simple, aux: user victor ]');
-      }),
-    ));
+      expect(location.path()).toEqual('');
+
+      expect(fixture.nativeElement).toHaveText('main []');
+    }));
+
+    it('should navigate back and forward', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const location: Location = TestBed.inject(Location);
+      const fixture = createRoot(router, RootCmp);
+
+      router.resetConfig([
+        {
+          path: 'team/:id',
+          component: TeamCmp,
+          children: [
+            {path: 'simple', component: SimpleCmp},
+            {path: 'user/:name', component: UserCmp},
+          ],
+        },
+      ]);
+
+      let event: NavigationStart;
+      router.events.subscribe((e) => {
+        if (e instanceof NavigationStart) {
+          event = e;
+        }
+      });
+
+      router.navigateByUrl('/team/33/simple');
+      advance(fixture);
+      expect(location.path()).toEqual('/team/33/simple');
+      const simpleNavStart = event!;
+
+      router.navigateByUrl('/team/22/user/victor');
+      advance(fixture);
+      const userVictorNavStart = event!;
+
+      location.back();
+      advance(fixture);
+      expect(location.path()).toEqual('/team/33/simple');
+      expect(event!.navigationTrigger).toEqual('popstate');
+      expect(event!.restoredState!.navigationId).toEqual(simpleNavStart.id);
+
+      location.forward();
+      advance(fixture);
+      expect(location.path()).toEqual('/team/22/user/victor');
+      expect(event!.navigationTrigger).toEqual('popstate');
+      expect(event!.restoredState!.navigationId).toEqual(userVictorNavStart.id);
+    }));
+
+    it('should navigate to the same url when config changes', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const location: Location = TestBed.inject(Location);
+      const fixture = createRoot(router, RootCmp);
+
+      router.resetConfig([{path: 'a', component: SimpleCmp}]);
+
+      router.navigate(['/a']);
+      advance(fixture);
+      expect(location.path()).toEqual('/a');
+      expect(fixture.nativeElement).toHaveText('simple');
+
+      router.resetConfig([{path: 'a', component: RouteCmp}]);
+
+      router.navigate(['/a']);
+      advance(fixture);
+      expect(location.path()).toEqual('/a');
+      expect(fixture.nativeElement).toHaveText('route');
+    }));
+
+    it('should navigate when locations changes', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const location: Location = TestBed.inject(Location);
+      const fixture = createRoot(router, RootCmp);
+
+      router.resetConfig([
+        {
+          path: 'team/:id',
+          component: TeamCmp,
+          children: [{path: 'user/:name', component: UserCmp}],
+        },
+      ]);
+
+      const recordedEvents: (NavigationStart | NavigationEnd)[] = [];
+      router.events.forEach((e) => onlyNavigationStartAndEnd(e) && recordedEvents.push(e));
+
+      router.navigateByUrl('/team/22/user/victor');
+      advance(fixture);
+
+      location.go('/team/22/user/fedor');
+      location.historyGo(0);
+      advance(fixture);
+
+      location.go('/team/22/user/fedor');
+      location.historyGo(0);
+      advance(fixture);
+
+      expect(fixture.nativeElement).toHaveText('team 22 [ user fedor, right:  ]');
+
+      expectEvents(recordedEvents, [
+        [NavigationStart, '/team/22/user/victor'],
+        [NavigationEnd, '/team/22/user/victor'],
+        [NavigationStart, '/team/22/user/fedor'],
+        [NavigationEnd, '/team/22/user/fedor'],
+      ]);
+    }));
+
+    it('should update the location when the matched route does not change', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const location: Location = TestBed.inject(Location);
+      const fixture = createRoot(router, RootCmp);
+
+      router.resetConfig([{path: '**', component: CollectParamsCmp}]);
+
+      router.navigateByUrl('/one/two');
+      advance(fixture);
+      const cmp = fixture.debugElement.children[1].componentInstance;
+      expect(location.path()).toEqual('/one/two');
+      expect(fixture.nativeElement).toHaveText('collect-params');
+
+      expect(cmp.recordedUrls()).toEqual(['one/two']);
+
+      router.navigateByUrl('/three/four');
+      advance(fixture);
+      expect(location.path()).toEqual('/three/four');
+      expect(fixture.nativeElement).toHaveText('collect-params');
+      expect(cmp.recordedUrls()).toEqual(['one/two', 'three/four']);
+    }));
+
+    it('should support secondary routes', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
+
+      router.resetConfig([
+        {
+          path: 'team/:id',
+          component: TeamCmp,
+          children: [
+            {path: 'user/:name', component: UserCmp},
+            {path: 'simple', component: SimpleCmp, outlet: 'right'},
+          ],
+        },
+      ]);
+
+      router.navigateByUrl('/team/22/(user/victor//right:simple)');
+      advance(fixture);
+
+      expect(fixture.nativeElement).toHaveText('team 22 [ user victor, right: simple ]');
+    }));
+
+    it('should support secondary routes in separate commands', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
+
+      router.resetConfig([
+        {
+          path: 'team/:id',
+          component: TeamCmp,
+          children: [
+            {path: 'user/:name', component: UserCmp},
+            {path: 'simple', component: SimpleCmp, outlet: 'right'},
+          ],
+        },
+      ]);
+
+      router.navigateByUrl('/team/22/user/victor');
+      advance(fixture);
+      router.navigate(['team/22', {outlets: {right: 'simple'}}]);
+      advance(fixture);
+
+      expect(fixture.nativeElement).toHaveText('team 22 [ user victor, right: simple ]');
+    }));
+
+    it('should support secondary routes as child of empty path parent', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
+
+      router.resetConfig([
+        {
+          path: '',
+          component: TeamCmp,
+          children: [{path: 'simple', component: SimpleCmp, outlet: 'right'}],
+        },
+      ]);
+
+      router.navigateByUrl('/(right:simple)');
+      advance(fixture);
+
+      expect(fixture.nativeElement).toHaveText('team  [ , right: simple ]');
+    }));
+
+    it('should deactivate outlets', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
+
+      router.resetConfig([
+        {
+          path: 'team/:id',
+          component: TeamCmp,
+          children: [
+            {path: 'user/:name', component: UserCmp},
+            {path: 'simple', component: SimpleCmp, outlet: 'right'},
+          ],
+        },
+      ]);
+
+      router.navigateByUrl('/team/22/(user/victor//right:simple)');
+      advance(fixture);
+
+      router.navigateByUrl('/team/22/user/victor');
+      advance(fixture);
+
+      expect(fixture.nativeElement).toHaveText('team 22 [ user victor, right:  ]');
+    }));
+
+    it('should deactivate nested outlets', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
+
+      router.resetConfig([
+        {
+          path: 'team/:id',
+          component: TeamCmp,
+          children: [
+            {path: 'user/:name', component: UserCmp},
+            {path: 'simple', component: SimpleCmp, outlet: 'right'},
+          ],
+        },
+        {path: '', component: BlankCmp},
+      ]);
+
+      router.navigateByUrl('/team/22/(user/victor//right:simple)');
+      advance(fixture);
+
+      router.navigateByUrl('/');
+      advance(fixture);
+
+      expect(fixture.nativeElement).toHaveText('');
+    }));
+
+    it('should set query params and fragment', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
+
+      router.resetConfig([{path: 'query', component: QueryParamsAndFragmentCmp}]);
+
+      router.navigateByUrl('/query?name=1#fragment1');
+      advance(fixture);
+      expect(fixture.nativeElement).toHaveText('query: 1 fragment: fragment1');
+
+      router.navigateByUrl('/query?name=2#fragment2');
+      advance(fixture);
+      expect(fixture.nativeElement).toHaveText('query: 2 fragment: fragment2');
+    }));
+
+    it('should handle empty or missing fragments', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
+
+      router.resetConfig([{path: 'query', component: QueryParamsAndFragmentCmp}]);
+
+      router.navigateByUrl('/query#');
+      advance(fixture);
+      expect(fixture.nativeElement).toHaveText('query:  fragment: ');
+
+      router.navigateByUrl('/query');
+      advance(fixture);
+      expect(fixture.nativeElement).toHaveText('query:  fragment: null');
+    }));
+
+    it('should ignore null and undefined query params', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
+
+      router.resetConfig([{path: 'query', component: EmptyQueryParamsCmp}]);
+
+      router.navigate(['query'], {queryParams: {name: 1, age: null, page: undefined}});
+      advance(fixture);
+      const cmp = fixture.debugElement.children[1].componentInstance;
+      expect(cmp.recordedParams).toEqual([{name: '1'}]);
+    }));
+
+    it('should push params only when they change', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
+
+      router.resetConfig([
+        {
+          path: 'team/:id',
+          component: TeamCmp,
+          children: [{path: 'user/:name', component: UserCmp}],
+        },
+      ]);
+
+      router.navigateByUrl('/team/22/user/victor');
+      advance(fixture);
+      const team = fixture.debugElement.children[1].componentInstance;
+      const user = fixture.debugElement.children[1].children[1].componentInstance;
+
+      expect(team.recordedParams).toEqual([{id: '22'}]);
+      expect(team.snapshotParams).toEqual([{id: '22'}]);
+      expect(user.recordedParams).toEqual([{name: 'victor'}]);
+      expect(user.snapshotParams).toEqual([{name: 'victor'}]);
+
+      router.navigateByUrl('/team/22/user/fedor');
+      advance(fixture);
+
+      expect(team.recordedParams).toEqual([{id: '22'}]);
+      expect(team.snapshotParams).toEqual([{id: '22'}]);
+      expect(user.recordedParams).toEqual([{name: 'victor'}, {name: 'fedor'}]);
+      expect(user.snapshotParams).toEqual([{name: 'victor'}, {name: 'fedor'}]);
+    }));
+
+    it('should work when navigating to /', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
+
+      router.resetConfig([
+        {path: '', pathMatch: 'full', component: SimpleCmp},
+        {path: 'user/:name', component: UserCmp},
+      ]);
+
+      router.navigateByUrl('/user/victor');
+      advance(fixture);
+
+      expect(fixture.nativeElement).toHaveText('user victor');
+
+      router.navigateByUrl('/');
+      advance(fixture);
+
+      expect(fixture.nativeElement).toHaveText('simple');
+    }));
+
+    it('should cancel in-flight navigations', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
+
+      router.resetConfig([{path: 'user/:name', component: UserCmp}]);
+
+      const recordedEvents: Event[] = [];
+      router.events.forEach((e) => recordedEvents.push(e));
+
+      router.navigateByUrl('/user/init');
+      advance(fixture);
+
+      const user = fixture.debugElement.children[1].componentInstance;
+
+      let r1: any, r2: any;
+      router.navigateByUrl('/user/victor').then((_) => (r1 = _));
+      router.navigateByUrl('/user/fedor').then((_) => (r2 = _));
+      advance(fixture);
+
+      expect(r1).toEqual(false); // returns false because it was canceled
+      expect(r2).toEqual(true); // returns true because it was successful
+
+      expect(fixture.nativeElement).toHaveText('user fedor');
+      expect(user.recordedParams).toEqual([{name: 'init'}, {name: 'fedor'}]);
+
+      expectEvents(recordedEvents, [
+        [NavigationStart, '/user/init'],
+        [RoutesRecognized, '/user/init'],
+        [GuardsCheckStart, '/user/init'],
+        [ChildActivationStart],
+        [ActivationStart],
+        [GuardsCheckEnd, '/user/init'],
+        [ResolveStart, '/user/init'],
+        [ResolveEnd, '/user/init'],
+        [ActivationEnd],
+        [ChildActivationEnd],
+        [NavigationEnd, '/user/init'],
+
+        [NavigationStart, '/user/victor'],
+        [NavigationCancel, '/user/victor'],
+
+        [NavigationStart, '/user/fedor'],
+        [RoutesRecognized, '/user/fedor'],
+        [GuardsCheckStart, '/user/fedor'],
+        [ChildActivationStart],
+        [ActivationStart],
+        [GuardsCheckEnd, '/user/fedor'],
+        [ResolveStart, '/user/fedor'],
+        [ResolveEnd, '/user/fedor'],
+        [ActivationEnd],
+        [ChildActivationEnd],
+        [NavigationEnd, '/user/fedor'],
+      ]);
+    }));
+
+    it('should properly set currentNavigation when cancelling in-flight navigations', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
+
+      router.resetConfig([{path: 'user/:name', component: UserCmp}]);
+
+      router.navigateByUrl('/user/init');
+      advance(fixture);
+
+      router.navigateByUrl('/user/victor');
+      expect(router.getCurrentNavigation()).not.toBe(null);
+      router.navigateByUrl('/user/fedor');
+      // Due to https://github.com/angular/angular/issues/29389, this would be `false`
+      // when running a second navigation.
+      expect(router.getCurrentNavigation()).not.toBe(null);
+      advance(fixture);
+
+      expect(router.getCurrentNavigation()).toBe(null);
+      expect(fixture.nativeElement).toHaveText('user fedor');
+    }));
+
+    it('should replace state when path is equal to current path', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const location: Location = TestBed.inject(Location);
+      const fixture = createRoot(router, RootCmp);
+
+      router.resetConfig([
+        {
+          path: 'team/:id',
+          component: TeamCmp,
+          children: [
+            {path: 'simple', component: SimpleCmp},
+            {path: 'user/:name', component: UserCmp},
+          ],
+        },
+      ]);
+
+      router.navigateByUrl('/team/33/simple');
+      advance(fixture);
+
+      router.navigateByUrl('/team/22/user/victor');
+      advance(fixture);
+
+      router.navigateByUrl('/team/22/user/victor');
+      advance(fixture);
+
+      location.back();
+      advance(fixture);
+      expect(location.path()).toEqual('/team/33/simple');
+    }));
+
+    it('should handle componentless paths', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const location: Location = TestBed.inject(Location);
+      const fixture = createRoot(router, RootCmpWithTwoOutlets);
+
+      router.resetConfig([
+        {
+          path: 'parent/:id',
+          children: [
+            {path: 'simple', component: SimpleCmp},
+            {path: 'user/:name', component: UserCmp, outlet: 'right'},
+          ],
+        },
+        {path: 'user/:name', component: UserCmp},
+      ]);
+
+      // navigate to a componentless route
+      router.navigateByUrl('/parent/11/(simple//right:user/victor)');
+      advance(fixture);
+      expect(location.path()).toEqual('/parent/11/(simple//right:user/victor)');
+      expect(fixture.nativeElement).toHaveText('primary [simple] right [user victor]');
+
+      // navigate to the same route with different params (reuse)
+      router.navigateByUrl('/parent/22/(simple//right:user/fedor)');
+      advance(fixture);
+      expect(location.path()).toEqual('/parent/22/(simple//right:user/fedor)');
+      expect(fixture.nativeElement).toHaveText('primary [simple] right [user fedor]');
+
+      // navigate to a normal route (check deactivation)
+      router.navigateByUrl('/user/victor');
+      advance(fixture);
+      expect(location.path()).toEqual('/user/victor');
+      expect(fixture.nativeElement).toHaveText('primary [user victor] right []');
+
+      // navigate back to a componentless route
+      router.navigateByUrl('/parent/11/(simple//right:user/victor)');
+      advance(fixture);
+      expect(location.path()).toEqual('/parent/11/(simple//right:user/victor)');
+      expect(fixture.nativeElement).toHaveText('primary [simple] right [user victor]');
+    }));
+
+    it('should not deactivate aux routes when navigating from a componentless routes', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const location: Location = TestBed.inject(Location);
+      const fixture = createRoot(router, TwoOutletsCmp);
+
+      router.resetConfig([
+        {path: 'simple', component: SimpleCmp},
+        {path: 'componentless', children: [{path: 'simple', component: SimpleCmp}]},
+        {path: 'user/:name', outlet: 'aux', component: UserCmp},
+      ]);
+
+      router.navigateByUrl('/componentless/simple(aux:user/victor)');
+      advance(fixture);
+      expect(location.path()).toEqual('/componentless/simple(aux:user/victor)');
+      expect(fixture.nativeElement).toHaveText('[ simple, aux: user victor ]');
+
+      router.navigateByUrl('/simple(aux:user/victor)');
+      advance(fixture);
+      expect(location.path()).toEqual('/simple(aux:user/victor)');
+      expect(fixture.nativeElement).toHaveText('[ simple, aux: user victor ]');
+    }));
 
     it('should emit an event when an outlet gets activated', fakeAsync(() => {
       @Component({
@@ -908,22 +879,21 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       expect(cmp.deactivations[0] instanceof BlankCmp).toBe(true);
     }));
 
-    it('should update url and router state before activating components', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
+    it('should update url and router state before activating components', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([{path: 'cmp', component: ComponentRecordingRoutePathAndUrl}]);
+      router.resetConfig([{path: 'cmp', component: ComponentRecordingRoutePathAndUrl}]);
 
-        router.navigateByUrl('/cmp');
-        advance(fixture);
+      router.navigateByUrl('/cmp');
+      advance(fixture);
 
-        const cmp: ComponentRecordingRoutePathAndUrl =
-          fixture.debugElement.children[1].componentInstance;
+      const cmp: ComponentRecordingRoutePathAndUrl =
+        fixture.debugElement.children[1].componentInstance;
 
-        expect(cmp.url).toBe('/cmp');
-        expect(cmp.path.length).toEqual(2);
-      }),
-    ));
+      expect(cmp.url).toBe('/cmp');
+      expect(cmp.path.length).toEqual(2);
+    }));
 
     navigationErrorsIntegrationSuite();
     eagerUrlUpdateStrategyIntegrationSuite();

--- a/packages/router/test/integration/navigation.spec.ts
+++ b/packages/router/test/integration/navigation.spec.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, inject as coreInject, NgModule} from '@angular/core';
+import {Component, inject, NgModule} from '@angular/core';
 import {Location} from '@angular/common';
-import {fakeAsync, TestBed, tick, inject} from '@angular/core/testing';
+import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {
   Event,
   provideRouter,
@@ -135,7 +135,7 @@ export function navigationIntegrationTestSuite() {
           component: SimpleCmp,
           canActivate: [
             () => {
-              observedInfo = coreInject(Router).getCurrentNavigation()?.extras?.info;
+              observedInfo = inject(Router).getCurrentNavigation()?.extras?.info;
               return true;
             },
           ],
@@ -155,7 +155,7 @@ export function navigationIntegrationTestSuite() {
           component: SimpleCmp,
           canActivate: [
             () => {
-              observedInfo = coreInject(Router).getCurrentNavigation()?.extras?.info;
+              observedInfo = inject(Router).getCurrentNavigation()?.extras?.info;
               return true;
             },
           ],
@@ -185,14 +185,14 @@ export function navigationIntegrationTestSuite() {
         {
           path: 'redirect',
           component: SimpleCmp,
-          canActivate: [() => coreInject(Router).parseUrl('/simple')],
+          canActivate: [() => inject(Router).parseUrl('/simple')],
         },
         {
           path: 'simple',
           component: SimpleCmp,
           canActivate: [
             () => {
-              observedInfo = coreInject(Router).getCurrentNavigation()?.extras?.info;
+              observedInfo = inject(Router).getCurrentNavigation()?.extras?.info;
               return true;
             },
           ],
@@ -204,249 +204,247 @@ export function navigationIntegrationTestSuite() {
       expect(router.url).toEqual('/simple');
     });
 
-    it('should ignore empty paths in relative links', fakeAsync(
-      inject([Router], (router: Router) => {
-        router.resetConfig([
-          {
-            path: 'foo',
-            children: [{path: 'bar', children: [{path: '', component: RelativeLinkCmp}]}],
-          },
-        ]);
+    it('should ignore empty paths in relative links', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      router.resetConfig([
+        {
+          path: 'foo',
+          children: [{path: 'bar', children: [{path: '', component: RelativeLinkCmp}]}],
+        },
+      ]);
 
-        const fixture = createRoot(router, RootCmp);
+      const fixture = createRoot(router, RootCmp);
 
-        router.navigateByUrl('/foo/bar');
-        advance(fixture);
+      router.navigateByUrl('/foo/bar');
+      advance(fixture);
 
-        const link = fixture.nativeElement.querySelector('a');
-        expect(link.getAttribute('href')).toEqual('/foo/simple');
-      }),
-    ));
+      const link = fixture.nativeElement.querySelector('a');
+      expect(link.getAttribute('href')).toEqual('/foo/simple');
+    }));
 
-    it('should set the restoredState to null when executing imperative navigations', fakeAsync(
-      inject([Router], (router: Router) => {
-        router.resetConfig([
-          {path: '', component: SimpleCmp},
-          {path: 'simple', component: SimpleCmp},
-        ]);
+    it('should set the restoredState to null when executing imperative navigations', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      router.resetConfig([
+        {path: '', component: SimpleCmp},
+        {path: 'simple', component: SimpleCmp},
+      ]);
 
-        const fixture = createRoot(router, RootCmp);
-        let event: NavigationStart;
-        router.events.subscribe((e) => {
-          if (e instanceof NavigationStart) {
-            event = e;
-          }
-        });
+      const fixture = createRoot(router, RootCmp);
+      let event: NavigationStart;
+      router.events.subscribe((e) => {
+        if (e instanceof NavigationStart) {
+          event = e;
+        }
+      });
 
-        router.navigateByUrl('/simple');
-        tick();
+      router.navigateByUrl('/simple');
+      tick();
 
-        expect(event!.navigationTrigger).toEqual('imperative');
-        expect(event!.restoredState).toEqual(null);
-      }),
-    ));
+      expect(event!.navigationTrigger).toEqual('imperative');
+      expect(event!.restoredState).toEqual(null);
+    }));
 
-    it('should set history.state if passed using imperative navigation', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        router.resetConfig([
-          {path: '', component: SimpleCmp},
-          {path: 'simple', component: SimpleCmp},
-        ]);
+    it('should set history.state if passed using imperative navigation', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const location = TestBed.inject(Location);
+      router.resetConfig([
+        {path: '', component: SimpleCmp},
+        {path: 'simple', component: SimpleCmp},
+      ]);
 
-        const fixture = createRoot(router, RootCmp);
-        let navigation: Navigation = null!;
-        router.events.subscribe((e) => {
-          if (e instanceof NavigationStart) {
-            navigation = router.getCurrentNavigation()!;
-          }
-        });
+      const fixture = createRoot(router, RootCmp);
+      let navigation: Navigation = null!;
+      router.events.subscribe((e) => {
+        if (e instanceof NavigationStart) {
+          navigation = router.getCurrentNavigation()!;
+        }
+      });
 
-        router.navigateByUrl('/simple', {state: {foo: 'bar'}});
-        tick();
+      router.navigateByUrl('/simple', {state: {foo: 'bar'}});
+      tick();
 
-        const state = location.getState() as any;
-        expect(state.foo).toBe('bar');
-        expect(state).toEqual({foo: 'bar', navigationId: 2});
-        expect(navigation.extras.state).toBeDefined();
-        expect(navigation.extras.state).toEqual({foo: 'bar'});
-      }),
-    ));
+      const state = location.getState() as any;
+      expect(state.foo).toBe('bar');
+      expect(state).toEqual({foo: 'bar', navigationId: 2});
+      expect(navigation.extras.state).toBeDefined();
+      expect(navigation.extras.state).toEqual({foo: 'bar'});
+    }));
 
-    it('should set history.state when navigation with browser back and forward', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        router.resetConfig([
-          {path: '', component: SimpleCmp},
-          {path: 'simple', component: SimpleCmp},
-        ]);
+    it('should set history.state when navigation with browser back and forward', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const location = TestBed.inject(Location);
+      router.resetConfig([
+        {path: '', component: SimpleCmp},
+        {path: 'simple', component: SimpleCmp},
+      ]);
 
-        const fixture = createRoot(router, RootCmp);
-        let navigation: Navigation = null!;
-        router.events.subscribe((e) => {
-          if (e instanceof NavigationStart) {
-            navigation = <Navigation>router.getCurrentNavigation()!;
-          }
-        });
+      const fixture = createRoot(router, RootCmp);
+      let navigation: Navigation = null!;
+      router.events.subscribe((e) => {
+        if (e instanceof NavigationStart) {
+          navigation = <Navigation>router.getCurrentNavigation()!;
+        }
+      });
 
-        let state: Record<string, string> = {foo: 'bar'};
-        router.navigateByUrl('/simple', {state});
-        tick();
-        location.back();
-        tick();
-        location.forward();
-        tick();
+      let state: Record<string, string> = {foo: 'bar'};
+      router.navigateByUrl('/simple', {state});
+      tick();
+      location.back();
+      tick();
+      location.forward();
+      tick();
 
-        expect(navigation.extras.state).toBeDefined();
-        expect(navigation.extras.state).toEqual(state);
+      expect(navigation.extras.state).toBeDefined();
+      expect(navigation.extras.state).toEqual(state);
 
-        // Manually set state rather than using navigate()
-        state = {bar: 'foo'};
-        location.replaceState(location.path(), '', state);
-        location.back();
-        tick();
-        location.forward();
-        tick();
+      // Manually set state rather than using navigate()
+      state = {bar: 'foo'};
+      location.replaceState(location.path(), '', state);
+      location.back();
+      tick();
+      location.forward();
+      tick();
 
-        expect(navigation.extras.state).toBeDefined();
-        expect(navigation.extras.state).toEqual(state);
-      }),
-    ));
+      expect(navigation.extras.state).toBeDefined();
+      expect(navigation.extras.state).toEqual(state);
+    }));
 
-    it('should navigate correctly when using `Location#historyGo', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        router.resetConfig([
-          {path: 'first', component: SimpleCmp},
-          {path: 'second', component: SimpleCmp},
-        ]);
+    it('should navigate correctly when using `Location#historyGo', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const location = TestBed.inject(Location);
+      router.resetConfig([
+        {path: 'first', component: SimpleCmp},
+        {path: 'second', component: SimpleCmp},
+      ]);
 
-        createRoot(router, RootCmp);
+      createRoot(router, RootCmp);
 
-        router.navigateByUrl('/first');
-        tick();
-        router.navigateByUrl('/second');
-        tick();
-        expect(router.url).toEqual('/second');
+      router.navigateByUrl('/first');
+      tick();
+      router.navigateByUrl('/second');
+      tick();
+      expect(router.url).toEqual('/second');
 
-        location.historyGo(-1);
-        tick();
-        expect(router.url).toEqual('/first');
+      location.historyGo(-1);
+      tick();
+      expect(router.url).toEqual('/first');
 
-        location.historyGo(1);
-        tick();
-        expect(router.url).toEqual('/second');
+      location.historyGo(1);
+      tick();
+      expect(router.url).toEqual('/second');
 
-        location.historyGo(-100);
-        tick();
-        expect(router.url).toEqual('/second');
+      location.historyGo(-100);
+      tick();
+      expect(router.url).toEqual('/second');
 
-        location.historyGo(100);
-        tick();
-        expect(router.url).toEqual('/second');
+      location.historyGo(100);
+      tick();
+      expect(router.url).toEqual('/second');
 
-        location.historyGo(0);
-        tick();
-        expect(router.url).toEqual('/second');
+      location.historyGo(0);
+      tick();
+      expect(router.url).toEqual('/second');
 
-        location.historyGo();
-        tick();
-        expect(router.url).toEqual('/second');
-      }),
-    ));
+      location.historyGo();
+      tick();
+      expect(router.url).toEqual('/second');
+    }));
 
-    it('should not error if state is not {[key: string]: any}', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        router.resetConfig([
-          {path: '', component: SimpleCmp},
-          {path: 'simple', component: SimpleCmp},
-        ]);
+    it('should not error if state is not {[key: string]: any}', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const location = TestBed.inject(Location);
+      router.resetConfig([
+        {path: '', component: SimpleCmp},
+        {path: 'simple', component: SimpleCmp},
+      ]);
 
-        const fixture = createRoot(router, RootCmp);
-        let navigation: Navigation = null!;
-        router.events.subscribe((e) => {
-          if (e instanceof NavigationStart) {
-            navigation = <Navigation>router.getCurrentNavigation()!;
-          }
-        });
+      const fixture = createRoot(router, RootCmp);
+      let navigation: Navigation = null!;
+      router.events.subscribe((e) => {
+        if (e instanceof NavigationStart) {
+          navigation = <Navigation>router.getCurrentNavigation()!;
+        }
+      });
 
-        location.replaceState('', '', 42);
-        router.navigateByUrl('/simple');
-        tick();
-        location.back();
-        advance(fixture);
+      location.replaceState('', '', 42);
+      router.navigateByUrl('/simple');
+      tick();
+      location.back();
+      advance(fixture);
 
-        // Angular does not support restoring state to the primitive.
-        expect(navigation.extras.state).toEqual(undefined);
-        expect(location.getState()).toEqual({navigationId: 3});
-      }),
-    ));
+      // Angular does not support restoring state to the primitive.
+      expect(navigation.extras.state).toEqual(undefined);
+      expect(location.getState()).toEqual({navigationId: 3});
+    }));
 
-    it('should not pollute browser history when replaceUrl is set to true', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        router.resetConfig([
-          {path: '', component: SimpleCmp},
-          {path: 'a', component: SimpleCmp},
-          {path: 'b', component: SimpleCmp},
-        ]);
+    it('should not pollute browser history when replaceUrl is set to true', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const location = TestBed.inject(Location);
+      router.resetConfig([
+        {path: '', component: SimpleCmp},
+        {path: 'a', component: SimpleCmp},
+        {path: 'b', component: SimpleCmp},
+      ]);
 
-        createRoot(router, RootCmp);
+      createRoot(router, RootCmp);
 
-        const replaceSpy = spyOn(location, 'replaceState');
-        router.navigateByUrl('/a', {replaceUrl: true});
-        router.navigateByUrl('/b', {replaceUrl: true});
-        tick();
+      const replaceSpy = spyOn(location, 'replaceState');
+      router.navigateByUrl('/a', {replaceUrl: true});
+      router.navigateByUrl('/b', {replaceUrl: true});
+      tick();
 
-        expect(replaceSpy.calls.count()).toEqual(1);
-      }),
-    ));
+      expect(replaceSpy.calls.count()).toEqual(1);
+    }));
 
-    it('should skip navigation if another navigation is already scheduled', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        router.resetConfig([
-          {path: '', component: SimpleCmp},
-          {path: 'a', component: SimpleCmp},
-          {path: 'b', component: SimpleCmp},
-        ]);
+    it('should skip navigation if another navigation is already scheduled', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const location = TestBed.inject(Location);
+      router.resetConfig([
+        {path: '', component: SimpleCmp},
+        {path: 'a', component: SimpleCmp},
+        {path: 'b', component: SimpleCmp},
+      ]);
 
-        const fixture = createRoot(router, RootCmp);
+      const fixture = createRoot(router, RootCmp);
 
-        router.navigate(['/a'], {
-          queryParams: {a: true},
-          queryParamsHandling: 'merge',
-          replaceUrl: true,
-        });
-        router.navigate(['/b'], {
-          queryParams: {b: true},
-          queryParamsHandling: 'merge',
-          replaceUrl: true,
-        });
-        tick();
+      router.navigate(['/a'], {
+        queryParams: {a: true},
+        queryParamsHandling: 'merge',
+        replaceUrl: true,
+      });
+      router.navigate(['/b'], {
+        queryParams: {b: true},
+        queryParamsHandling: 'merge',
+        replaceUrl: true,
+      });
+      tick();
 
-        /**
-         * Why do we have '/b?b=true' and not '/b?a=true&b=true'?
-         *
-         * This is because the router has the right to stop a navigation mid-flight if another
-         * navigation has been already scheduled. This is why we can use a top-level guard
-         * to perform redirects. Calling `navigate` in such a guard will stop the navigation, and
-         * the components won't be instantiated.
-         *
-         * This is a fundamental property of the router: it only cares about its latest state.
-         *
-         * This means that components should only map params to something else, not reduce them.
-         * In other words, the following component is asking for trouble:
-         *
-         * ```
-         * class MyComponent {
-         *  constructor(a: ActivatedRoute) {
-         *    a.params.scan(...)
-         *  }
-         * }
-         * ```
-         *
-         * This also means "queryParamsHandling: 'merge'" should only be used to merge with
-         * long-living query parameters (e.g., debug).
-         */
-        expect(router.url).toEqual('/b?b=true');
-      }),
-    ));
+      /**
+       * Why do we have '/b?b=true' and not '/b?a=true&b=true'?
+       *
+       * This is because the router has the right to stop a navigation mid-flight if another
+       * navigation has been already scheduled. This is why we can use a top-level guard
+       * to perform redirects. Calling `navigate` in such a guard will stop the navigation, and
+       * the components won't be instantiated.
+       *
+       * This is a fundamental property of the router: it only cares about its latest state.
+       *
+       * This means that components should only map params to something else, not reduce them.
+       * In other words, the following component is asking for trouble:
+       *
+       * ```
+       * class MyComponent {
+       *  constructor(a: ActivatedRoute) {
+       *    a.params.scan(...)
+       *  }
+       * }
+       * ```
+       *
+       * This also means "queryParamsHandling: 'merge'" should only be used to merge with
+       * long-living query parameters (e.g., debug).
+       */
+      expect(router.url).toEqual('/b?b=true');
+    }));
   });
 
   describe('should execute navigations serially', () => {
@@ -661,55 +659,55 @@ export function navigationIntegrationTestSuite() {
       }));
     });
 
-    it('should not wait for prior navigations to start a new navigation', fakeAsync(
-      inject([Router, Location], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
-        const trueRightAway = () => {
-          log.push('trueRightAway');
-          return true;
-        };
-        const trueIn2Seconds = () => {
-          log.push('trueIn2Seconds-start');
-          return new Promise<boolean>((res) => {
-            setTimeout(() => {
-              log.push('trueIn2Seconds-end');
-              res(true);
-            }, 2000);
-          });
-        };
-        router.resetConfig([
-          {path: 'a', component: SimpleCmp, canActivate: [trueRightAway, trueIn2Seconds]},
-          {path: 'b', component: SimpleCmp, canActivate: [trueRightAway, trueIn2Seconds]},
-        ]);
+    it('should not wait for prior navigations to start a new navigation', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const location = TestBed.inject(Location);
+      const fixture = createRoot(router, RootCmp);
+      const trueRightAway = () => {
+        log.push('trueRightAway');
+        return true;
+      };
+      const trueIn2Seconds = () => {
+        log.push('trueIn2Seconds-start');
+        return new Promise<boolean>((res) => {
+          setTimeout(() => {
+            log.push('trueIn2Seconds-end');
+            res(true);
+          }, 2000);
+        });
+      };
+      router.resetConfig([
+        {path: 'a', component: SimpleCmp, canActivate: [trueRightAway, trueIn2Seconds]},
+        {path: 'b', component: SimpleCmp, canActivate: [trueRightAway, trueIn2Seconds]},
+      ]);
 
-        router.navigateByUrl('/a');
-        tick(100);
-        fixture.detectChanges();
+      router.navigateByUrl('/a');
+      tick(100);
+      fixture.detectChanges();
 
-        router.navigateByUrl('/b');
-        tick(100); // 200
-        fixture.detectChanges();
+      router.navigateByUrl('/b');
+      tick(100); // 200
+      fixture.detectChanges();
 
-        expect(log).toEqual([
-          'trueRightAway',
-          'trueIn2Seconds-start',
-          'trueRightAway',
-          'trueIn2Seconds-start',
-        ]);
+      expect(log).toEqual([
+        'trueRightAway',
+        'trueIn2Seconds-start',
+        'trueRightAway',
+        'trueIn2Seconds-start',
+      ]);
 
-        tick(2000); // 2200
-        fixture.detectChanges();
+      tick(2000); // 2200
+      fixture.detectChanges();
 
-        expect(log).toEqual([
-          'trueRightAway',
-          'trueIn2Seconds-start',
-          'trueRightAway',
-          'trueIn2Seconds-start',
-          'trueIn2Seconds-end',
-          'trueIn2Seconds-end',
-        ]);
-      }),
-    ));
+      expect(log).toEqual([
+        'trueRightAway',
+        'trueIn2Seconds-start',
+        'trueRightAway',
+        'trueIn2Seconds-start',
+        'trueIn2Seconds-end',
+        'trueIn2Seconds-end',
+      ]);
+    }));
   });
 
   describe('abort an ongoing navigation', () => {
@@ -747,7 +745,7 @@ export function navigationIntegrationTestSuite() {
       @Component({template: ''})
       class Aborting {
         constructor() {
-          coreInject(Router).getCurrentNavigation()!.abort();
+          inject(Router).getCurrentNavigation()!.abort();
         }
       }
       setup([{path: '**', component: Aborting}]);
@@ -799,7 +797,7 @@ export function navigationIntegrationTestSuite() {
           component: class {},
           canActivate: [
             () => {
-              coreInject(Router).getCurrentNavigation()!.abort();
+              inject(Router).getCurrentNavigation()!.abort();
               return false;
             },
           ],
@@ -821,7 +819,7 @@ export function navigationIntegrationTestSuite() {
           component: class {},
           canMatch: [
             () => {
-              coreInject(Router).getCurrentNavigation()!.abort();
+              inject(Router).getCurrentNavigation()!.abort();
               return false;
             },
           ],

--- a/packages/router/test/integration/navigation_errors.spec.ts
+++ b/packages/router/test/integration/navigation_errors.spec.ts
@@ -5,10 +5,10 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {inject as coreInject, Injectable} from '@angular/core';
+import {inject, Injectable} from '@angular/core';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {Location} from '@angular/common';
-import {fakeAsync, TestBed, tick, inject} from '@angular/core/testing';
+import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {
   Router,
   NavigationStart,
@@ -47,43 +47,42 @@ import {
 } from './integration_helpers';
 
 export function navigationErrorsIntegrationSuite() {
-  it('should handle failed navigations gracefully', fakeAsync(
-    inject([Router], (router: Router) => {
-      const fixture = createRoot(router, RootCmp);
+  it('should handle failed navigations gracefully', fakeAsync(() => {
+    const router = TestBed.inject(Router);
+    const fixture = createRoot(router, RootCmp);
 
-      router.resetConfig([{path: 'user/:name', component: UserCmp}]);
+    router.resetConfig([{path: 'user/:name', component: UserCmp}]);
 
-      const recordedEvents: Event[] = [];
-      router.events.forEach((e) => recordedEvents.push(e));
+    const recordedEvents: Event[] = [];
+    router.events.forEach((e) => recordedEvents.push(e));
 
-      let e: any;
-      router.navigateByUrl('/invalid').catch((_) => (e = _));
-      advance(fixture);
-      expect(e.message).toContain('Cannot match any routes');
+    let e: any;
+    router.navigateByUrl('/invalid').catch((_) => (e = _));
+    advance(fixture);
+    expect(e.message).toContain('Cannot match any routes');
 
-      router.navigateByUrl('/user/fedor');
-      advance(fixture);
+    router.navigateByUrl('/user/fedor');
+    advance(fixture);
 
-      expect(fixture.nativeElement).toHaveText('user fedor');
+    expect(fixture.nativeElement).toHaveText('user fedor');
 
-      expectEvents(recordedEvents, [
-        [NavigationStart, '/invalid'],
-        [NavigationError, '/invalid'],
+    expectEvents(recordedEvents, [
+      [NavigationStart, '/invalid'],
+      [NavigationError, '/invalid'],
 
-        [NavigationStart, '/user/fedor'],
-        [RoutesRecognized, '/user/fedor'],
-        [GuardsCheckStart, '/user/fedor'],
-        [ChildActivationStart],
-        [ActivationStart],
-        [GuardsCheckEnd, '/user/fedor'],
-        [ResolveStart, '/user/fedor'],
-        [ResolveEnd, '/user/fedor'],
-        [ActivationEnd],
-        [ChildActivationEnd],
-        [NavigationEnd, '/user/fedor'],
-      ]);
-    }),
-  ));
+      [NavigationStart, '/user/fedor'],
+      [RoutesRecognized, '/user/fedor'],
+      [GuardsCheckStart, '/user/fedor'],
+      [ChildActivationStart],
+      [ActivationStart],
+      [GuardsCheckEnd, '/user/fedor'],
+      [ResolveStart, '/user/fedor'],
+      [ResolveEnd, '/user/fedor'],
+      [ActivationEnd],
+      [ChildActivationEnd],
+      [NavigationEnd, '/user/fedor'],
+    ]);
+  }));
 
   it('should be able to provide an error handler with DI dependencies', async () => {
     @Injectable({providedIn: 'root'})
@@ -105,7 +104,7 @@ export function navigationErrorsIntegrationSuite() {
             },
           ],
           withRouterConfig({resolveNavigationPromiseOnError: true}),
-          withNavigationErrorHandler(() => (coreInject(Handler).handlerCalled = true)),
+          withNavigationErrorHandler(() => (inject(Handler).handlerCalled = true)),
         ),
       ],
     });
@@ -132,7 +131,7 @@ export function navigationErrorsIntegrationSuite() {
           ],
           {
             resolveNavigationPromiseOnError: true,
-            errorHandler: () => new RedirectCommand(coreInject(Router).parseUrl('/error')),
+            errorHandler: () => new RedirectCommand(inject(Router).parseUrl('/error')),
           },
         ),
       ],
@@ -171,9 +170,7 @@ export function navigationErrorsIntegrationSuite() {
             {path: 'error', component: BlankCmp},
           ],
           withRouterConfig({resolveNavigationPromiseOnError: true}),
-          withNavigationErrorHandler(
-            () => new RedirectCommand(coreInject(Router).parseUrl('/error')),
-          ),
+          withNavigationErrorHandler(() => new RedirectCommand(inject(Router).parseUrl('/error'))),
         ),
       ],
     });
@@ -226,7 +223,7 @@ export function navigationErrorsIntegrationSuite() {
       TestBed.configureTestingModule({
         providers: [provideRouter([], withRouterConfig({urlUpdateStrategy}))],
       });
-      const router: Router = TestBed.inject(Router);
+      const router = TestBed.inject(Router);
       const location = TestBed.inject(Location);
       const fixture = createRoot(router, RootCmp);
 
@@ -286,7 +283,7 @@ export function navigationErrorsIntegrationSuite() {
       TestBed.configureTestingModule({
         providers: [provideRouter([], withRouterConfig({urlUpdateStrategy}))],
       });
-      const router: Router = TestBed.inject(Router);
+      const router = TestBed.inject(Router);
       const location = TestBed.inject(Location);
       const fixture = createRoot(router, RootCmp);
 
@@ -352,7 +349,7 @@ export function navigationErrorsIntegrationSuite() {
   });
 
   it('should dispatch NavigationCancel after the url has been reset back', fakeAsync(() => {
-    const router: Router = TestBed.inject(Router);
+    const router = TestBed.inject(Router);
     const location = TestBed.inject(Location);
 
     const fixture = createRoot(router, RootCmp);
@@ -387,29 +384,28 @@ export function navigationErrorsIntegrationSuite() {
     expect(locationUrlBeforeEmittingError).toEqual('/simple');
   }));
 
-  it('should recover from malformed uri errors', fakeAsync(
-    inject([Router, Location], (router: Router, location: Location) => {
-      router.resetConfig([{path: 'simple', component: SimpleCmp}]);
-      const fixture = createRoot(router, RootCmp);
-      router.navigateByUrl('/invalid/url%with%percent');
-      advance(fixture);
-      expect(location.path()).toEqual('');
-    }),
-  ));
+  it('should recover from malformed uri errors', fakeAsync(() => {
+    const router = TestBed.inject(Router);
+    const location = TestBed.inject(Location);
+    router.resetConfig([{path: 'simple', component: SimpleCmp}]);
+    const fixture = createRoot(router, RootCmp);
+    router.navigateByUrl('/invalid/url%with%percent');
+    advance(fixture);
+    expect(location.path()).toEqual('');
+  }));
 
-  it('should not swallow errors', fakeAsync(
-    inject([Router], (router: Router) => {
-      const fixture = createRoot(router, RootCmp);
+  it('should not swallow errors', fakeAsync(() => {
+    const router = TestBed.inject(Router);
+    const fixture = createRoot(router, RootCmp);
 
-      router.resetConfig([{path: 'simple', component: SimpleCmp}]);
+    router.resetConfig([{path: 'simple', component: SimpleCmp}]);
 
-      router.navigateByUrl('/invalid');
-      expect(() => advance(fixture)).toThrow();
+    router.navigateByUrl('/invalid');
+    expect(() => advance(fixture)).toThrow();
 
-      router.navigateByUrl('/invalid2');
-      expect(() => advance(fixture)).toThrow();
-    }),
-  ));
+    router.navigateByUrl('/invalid2');
+    expect(() => advance(fixture)).toThrow();
+  }));
 
   it('should not swallow errors from browser state update', async () => {
     const routerEvents: Event[] = [];
@@ -431,15 +427,14 @@ export function navigationErrorsIntegrationSuite() {
     expect(routerEvents[routerEvents.length - 1]).toBeInstanceOf(NavigationError);
   });
 
-  it('should throw an error when one of the commands is null/undefined', fakeAsync(
-    inject([Router], (router: Router) => {
-      createRoot(router, RootCmp);
+  it('should throw an error when one of the commands is null/undefined', fakeAsync(() => {
+    const router = TestBed.inject(Router);
+    createRoot(router, RootCmp);
 
-      router.resetConfig([{path: 'query', component: EmptyQueryParamsCmp}]);
+    router.resetConfig([{path: 'query', component: EmptyQueryParamsCmp}]);
 
-      expect(() => router.navigate([undefined, 'query'])).toThrowError(
-        /The requested path contains undefined segment at index 0/,
-      );
-    }),
-  ));
+    expect(() => router.navigate([undefined, 'query'])).toThrowError(
+      /The requested path contains undefined segment at index 0/,
+    );
+  }));
 }

--- a/packages/router/test/integration/redirects.spec.ts
+++ b/packages/router/test/integration/redirects.spec.ts
@@ -6,27 +6,27 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import {LocationStrategy, Location, HashLocationStrategy} from '@angular/common';
-import {fakeAsync, TestBed, inject} from '@angular/core/testing';
+import {fakeAsync, TestBed} from '@angular/core/testing';
 import {Router, NavigationStart, RoutesRecognized} from '../../src';
 import {createRoot, RootCmp, BlankCmp, TeamCmp, advance} from './integration_helpers';
 
 export function redirectsIntegrationSuite() {
   describe('redirects', () => {
-    it('should work', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmp);
+    it('should work', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const location = TestBed.inject(Location);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([
-          {path: 'old/team/:id', redirectTo: 'team/:id'},
-          {path: 'team/:id', component: TeamCmp},
-        ]);
+      router.resetConfig([
+        {path: 'old/team/:id', redirectTo: 'team/:id'},
+        {path: 'team/:id', component: TeamCmp},
+      ]);
 
-        router.navigateByUrl('old/team/22');
-        advance(fixture);
+      router.navigateByUrl('old/team/22');
+      advance(fixture);
 
-        expect(location.path()).toEqual('/team/22');
-      }),
-    ));
+      expect(location.path()).toEqual('/team/22');
+    }));
 
     it('can redirect from componentless named outlets', fakeAsync(() => {
       const router = TestBed.inject(Router);
@@ -43,34 +43,34 @@ export function redirectsIntegrationSuite() {
       expect(TestBed.inject(Location).path()).toEqual('/(aux:main)');
     }));
 
-    it('should update Navigation object after redirects are applied', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmp);
-        let initialUrl, afterRedirectUrl;
+    it('should update Navigation object after redirects are applied', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const location = TestBed.inject(Location);
+      const fixture = createRoot(router, RootCmp);
+      let initialUrl, afterRedirectUrl;
 
-        router.resetConfig([
-          {path: 'old/team/:id', redirectTo: 'team/:id'},
-          {path: 'team/:id', component: TeamCmp},
-        ]);
+      router.resetConfig([
+        {path: 'old/team/:id', redirectTo: 'team/:id'},
+        {path: 'team/:id', component: TeamCmp},
+      ]);
 
-        router.events.subscribe((e) => {
-          if (e instanceof NavigationStart) {
-            const navigation = router.getCurrentNavigation();
-            initialUrl = navigation && navigation.finalUrl;
-          }
-          if (e instanceof RoutesRecognized) {
-            const navigation = router.getCurrentNavigation();
-            afterRedirectUrl = navigation && navigation.finalUrl;
-          }
-        });
+      router.events.subscribe((e) => {
+        if (e instanceof NavigationStart) {
+          const navigation = router.getCurrentNavigation();
+          initialUrl = navigation && navigation.finalUrl;
+        }
+        if (e instanceof RoutesRecognized) {
+          const navigation = router.getCurrentNavigation();
+          afterRedirectUrl = navigation && navigation.finalUrl;
+        }
+      });
 
-        router.navigateByUrl('old/team/22');
-        advance(fixture);
+      router.navigateByUrl('old/team/22');
+      advance(fixture);
 
-        expect(initialUrl).toBeUndefined();
-        expect(router.serializeUrl(afterRedirectUrl as any)).toBe('/team/22');
-      }),
-    ));
+      expect(initialUrl).toBeUndefined();
+      expect(router.serializeUrl(afterRedirectUrl as any)).toBe('/team/22');
+    }));
 
     it('should not break the back button when trigger by location change', fakeAsync(() => {
       TestBed.configureTestingModule({

--- a/packages/router/test/integration/route_data.spec.ts
+++ b/packages/router/test/integration/route_data.spec.ts
@@ -5,8 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {Component, inject as coreInject, NgModule, Injectable} from '@angular/core';
-import {TestBed, fakeAsync, inject} from '@angular/core/testing';
+import {Component, inject, NgModule, Injectable} from '@angular/core';
+import {TestBed, fakeAsync} from '@angular/core/testing';
 import {Location} from '@angular/common';
 import {
   ActivatedRouteSnapshot,
@@ -75,255 +75,248 @@ export function routeDataIntegrationSuite() {
       });
     });
 
-    it('should provide resolved data', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmpWithTwoOutlets);
+    it('should provide resolved data', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmpWithTwoOutlets);
 
-        router.resetConfig([
-          {
-            path: 'parent/:id',
-            data: {one: 1},
-            resolve: {two: 'resolveTwo'},
-            children: [
-              {path: '', data: {three: 3}, resolve: {four: 'resolveFour'}, component: RouteCmp},
-              {
-                path: '',
-                data: {five: 5},
-                resolve: {six: 'resolveSix'},
-                component: RouteCmp,
-                outlet: 'right',
-              },
-            ],
-          },
-        ]);
-
-        router.navigateByUrl('/parent/1');
-        advance(fixture);
-
-        const primaryCmp = fixture.debugElement.children[1].componentInstance;
-        const rightCmp = fixture.debugElement.children[3].componentInstance;
-
-        expect(primaryCmp.route.snapshot.data).toEqual({one: 1, two: 2, three: 3, four: 4});
-        expect(rightCmp.route.snapshot.data).toEqual({one: 1, two: 2, five: 5, six: 6});
-
-        const primaryRecorded: any[] = [];
-        primaryCmp.route.data.forEach((rec: any) => primaryRecorded.push(rec));
-
-        const rightRecorded: any[] = [];
-        rightCmp.route.data.forEach((rec: any) => rightRecorded.push(rec));
-
-        router.navigateByUrl('/parent/2');
-        advance(fixture);
-
-        expect(primaryRecorded).toEqual([{one: 1, three: 3, two: 2, four: 4}]);
-        expect(rightRecorded).toEqual([{one: 1, five: 5, two: 2, six: 6}]);
-      }),
-    ));
-
-    it('should handle errors', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
-
-        router.resetConfig([
-          {path: 'simple', component: SimpleCmp, resolve: {error: 'resolveError'}},
-        ]);
-
-        const recordedEvents: any[] = [];
-        router.events.subscribe((e) => e instanceof RouterEvent && recordedEvents.push(e));
-
-        let e: any = null;
-        router.navigateByUrl('/simple')!.catch((error) => (e = error));
-        advance(fixture);
-
-        expectEvents(recordedEvents, [
-          [NavigationStart, '/simple'],
-          [RoutesRecognized, '/simple'],
-          [GuardsCheckStart, '/simple'],
-          [GuardsCheckEnd, '/simple'],
-          [ResolveStart, '/simple'],
-          [NavigationError, '/simple'],
-        ]);
-
-        expect(e).toEqual('error');
-      }),
-    ));
-
-    it('should handle empty errors', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
-
-        router.resetConfig([
-          {path: 'simple', component: SimpleCmp, resolve: {error: 'resolveNullError'}},
-        ]);
-
-        const recordedEvents: any[] = [];
-        router.events.subscribe((e) => e instanceof RouterEvent && recordedEvents.push(e));
-
-        let e: any = 'some value';
-        router.navigateByUrl('/simple').catch((error) => (e = error));
-        advance(fixture);
-
-        expect(e).toEqual(null);
-      }),
-    ));
-
-    it('should not navigate when all resolvers return empty result', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
-
-        router.resetConfig([
-          {
-            path: 'simple',
-            component: SimpleCmp,
-            resolve: {e1: 'resolveEmpty', e2: 'resolveEmpty'},
-          },
-        ]);
-
-        const recordedEvents: any[] = [];
-        router.events.subscribe((e) => e instanceof RouterEvent && recordedEvents.push(e));
-
-        let e: any = null;
-        router.navigateByUrl('/simple').catch((error) => (e = error));
-        advance(fixture);
-
-        expectEvents(recordedEvents, [
-          [NavigationStart, '/simple'],
-          [RoutesRecognized, '/simple'],
-          [GuardsCheckStart, '/simple'],
-          [GuardsCheckEnd, '/simple'],
-          [ResolveStart, '/simple'],
-          [NavigationCancel, '/simple'],
-        ]);
-
-        expect((recordedEvents[recordedEvents.length - 1] as NavigationCancel).code).toBe(
-          NavigationCancellationCode.NoDataFromResolver,
-        );
-
-        expect(e).toEqual(null);
-      }),
-    ));
-
-    it('should not navigate when at least one resolver returns empty result', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
-
-        router.resetConfig([
-          {path: 'simple', component: SimpleCmp, resolve: {e1: 'resolveTwo', e2: 'resolveEmpty'}},
-        ]);
-
-        const recordedEvents: any[] = [];
-        router.events.subscribe((e) => e instanceof RouterEvent && recordedEvents.push(e));
-
-        let e: any = null;
-        router.navigateByUrl('/simple').catch((error) => (e = error));
-        advance(fixture);
-
-        expectEvents(recordedEvents, [
-          [NavigationStart, '/simple'],
-          [RoutesRecognized, '/simple'],
-          [GuardsCheckStart, '/simple'],
-          [GuardsCheckEnd, '/simple'],
-          [ResolveStart, '/simple'],
-          [NavigationCancel, '/simple'],
-        ]);
-
-        expect(e).toEqual(null);
-      }),
-    ));
-
-    it('should not navigate when all resolvers for a child route from forChild() returns empty result', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
-
-        @Component({
-          selector: 'lazy-cmp',
-          template: 'lazy-loaded-1',
-          standalone: false,
-        })
-        class LazyComponent1 {}
-
-        @NgModule({
-          declarations: [LazyComponent1],
-          imports: [
-            RouterModule.forChild([
-              {
-                path: 'loaded',
-                component: LazyComponent1,
-                resolve: {e1: 'resolveEmpty', e2: 'resolveEmpty'},
-              },
-            ]),
+      router.resetConfig([
+        {
+          path: 'parent/:id',
+          data: {one: 1},
+          resolve: {two: 'resolveTwo'},
+          children: [
+            {path: '', data: {three: 3}, resolve: {four: 'resolveFour'}, component: RouteCmp},
+            {
+              path: '',
+              data: {five: 5},
+              resolve: {six: 'resolveSix'},
+              component: RouteCmp,
+              outlet: 'right',
+            },
           ],
-        })
-        class LoadedModule {}
+        },
+      ]);
 
-        router.resetConfig([{path: 'lazy', loadChildren: () => LoadedModule}]);
+      router.navigateByUrl('/parent/1');
+      advance(fixture);
 
-        const recordedEvents: any[] = [];
-        router.events.subscribe((e) => e instanceof RouterEvent && recordedEvents.push(e));
+      const primaryCmp = fixture.debugElement.children[1].componentInstance;
+      const rightCmp = fixture.debugElement.children[3].componentInstance;
 
-        let e: any = null;
-        router.navigateByUrl('lazy/loaded').catch((error) => (e = error));
-        advance(fixture);
+      expect(primaryCmp.route.snapshot.data).toEqual({one: 1, two: 2, three: 3, four: 4});
+      expect(rightCmp.route.snapshot.data).toEqual({one: 1, two: 2, five: 5, six: 6});
 
-        expectEvents(recordedEvents, [
-          [NavigationStart, '/lazy/loaded'],
-          [RoutesRecognized, '/lazy/loaded'],
-          [GuardsCheckStart, '/lazy/loaded'],
-          [GuardsCheckEnd, '/lazy/loaded'],
-          [ResolveStart, '/lazy/loaded'],
-          [NavigationCancel, '/lazy/loaded'],
-        ]);
+      const primaryRecorded: any[] = [];
+      primaryCmp.route.data.forEach((rec: any) => primaryRecorded.push(rec));
 
-        expect(e).toEqual(null);
-      }),
-    ));
+      const rightRecorded: any[] = [];
+      rightCmp.route.data.forEach((rec: any) => rightRecorded.push(rec));
 
-    it('should not navigate when at least one resolver for a child route from forChild() returns empty result', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
+      router.navigateByUrl('/parent/2');
+      advance(fixture);
 
-        @Component({
-          selector: 'lazy-cmp',
-          template: 'lazy-loaded-1',
-          standalone: false,
-        })
-        class LazyComponent1 {}
+      expect(primaryRecorded).toEqual([{one: 1, three: 3, two: 2, four: 4}]);
+      expect(rightRecorded).toEqual([{one: 1, five: 5, two: 2, six: 6}]);
+    }));
 
-        @NgModule({
-          declarations: [LazyComponent1],
-          imports: [
-            RouterModule.forChild([
-              {
-                path: 'loaded',
-                component: LazyComponent1,
-                resolve: {e1: 'resolveTwo', e2: 'resolveEmpty'},
-              },
-            ]),
-          ],
-        })
-        class LoadedModule {}
+    it('should handle errors', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([{path: 'lazy', loadChildren: () => LoadedModule}]);
+      router.resetConfig([
+        {path: 'simple', component: SimpleCmp, resolve: {error: 'resolveError'}},
+      ]);
 
-        const recordedEvents: any[] = [];
-        router.events.subscribe((e) => e instanceof RouterEvent && recordedEvents.push(e));
+      const recordedEvents: any[] = [];
+      router.events.subscribe((e) => e instanceof RouterEvent && recordedEvents.push(e));
 
-        let e: any = null;
-        router.navigateByUrl('lazy/loaded').catch((error) => (e = error));
-        advance(fixture);
+      let e: any = null;
+      router.navigateByUrl('/simple')!.catch((error) => (e = error));
+      advance(fixture);
 
-        expectEvents(recordedEvents, [
-          [NavigationStart, '/lazy/loaded'],
-          [RoutesRecognized, '/lazy/loaded'],
-          [GuardsCheckStart, '/lazy/loaded'],
-          [GuardsCheckEnd, '/lazy/loaded'],
-          [ResolveStart, '/lazy/loaded'],
-          [NavigationCancel, '/lazy/loaded'],
-        ]);
+      expectEvents(recordedEvents, [
+        [NavigationStart, '/simple'],
+        [RoutesRecognized, '/simple'],
+        [GuardsCheckStart, '/simple'],
+        [GuardsCheckEnd, '/simple'],
+        [ResolveStart, '/simple'],
+        [NavigationError, '/simple'],
+      ]);
 
-        expect(e).toEqual(null);
-      }),
-    ));
+      expect(e).toEqual('error');
+    }));
+
+    it('should handle empty errors', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
+
+      router.resetConfig([
+        {path: 'simple', component: SimpleCmp, resolve: {error: 'resolveNullError'}},
+      ]);
+
+      const recordedEvents: any[] = [];
+      router.events.subscribe((e) => e instanceof RouterEvent && recordedEvents.push(e));
+
+      let e: any = 'some value';
+      router.navigateByUrl('/simple').catch((error) => (e = error));
+      advance(fixture);
+
+      expect(e).toEqual(null);
+    }));
+
+    it('should not navigate when all resolvers return empty result', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
+
+      router.resetConfig([
+        {
+          path: 'simple',
+          component: SimpleCmp,
+          resolve: {e1: 'resolveEmpty', e2: 'resolveEmpty'},
+        },
+      ]);
+
+      const recordedEvents: any[] = [];
+      router.events.subscribe((e) => e instanceof RouterEvent && recordedEvents.push(e));
+
+      let e: any = null;
+      router.navigateByUrl('/simple').catch((error) => (e = error));
+      advance(fixture);
+
+      expectEvents(recordedEvents, [
+        [NavigationStart, '/simple'],
+        [RoutesRecognized, '/simple'],
+        [GuardsCheckStart, '/simple'],
+        [GuardsCheckEnd, '/simple'],
+        [ResolveStart, '/simple'],
+        [NavigationCancel, '/simple'],
+      ]);
+
+      expect((recordedEvents[recordedEvents.length - 1] as NavigationCancel).code).toBe(
+        NavigationCancellationCode.NoDataFromResolver,
+      );
+
+      expect(e).toEqual(null);
+    }));
+
+    it('should not navigate when at least one resolver returns empty result', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
+
+      router.resetConfig([
+        {path: 'simple', component: SimpleCmp, resolve: {e1: 'resolveTwo', e2: 'resolveEmpty'}},
+      ]);
+
+      const recordedEvents: any[] = [];
+      router.events.subscribe((e) => e instanceof RouterEvent && recordedEvents.push(e));
+
+      let e: any = null;
+      router.navigateByUrl('/simple').catch((error) => (e = error));
+      advance(fixture);
+
+      expectEvents(recordedEvents, [
+        [NavigationStart, '/simple'],
+        [RoutesRecognized, '/simple'],
+        [GuardsCheckStart, '/simple'],
+        [GuardsCheckEnd, '/simple'],
+        [ResolveStart, '/simple'],
+        [NavigationCancel, '/simple'],
+      ]);
+
+      expect(e).toEqual(null);
+    }));
+
+    it('should not navigate when all resolvers for a child route from forChild() returns empty result', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
+
+      @Component({
+        selector: 'lazy-cmp',
+        template: 'lazy-loaded-1',
+        standalone: false,
+      })
+      class LazyComponent1 {}
+
+      @NgModule({
+        declarations: [LazyComponent1],
+        imports: [
+          RouterModule.forChild([
+            {
+              path: 'loaded',
+              component: LazyComponent1,
+              resolve: {e1: 'resolveEmpty', e2: 'resolveEmpty'},
+            },
+          ]),
+        ],
+      })
+      class LoadedModule {}
+
+      router.resetConfig([{path: 'lazy', loadChildren: () => LoadedModule}]);
+
+      const recordedEvents: any[] = [];
+      router.events.subscribe((e) => e instanceof RouterEvent && recordedEvents.push(e));
+
+      let e: any = null;
+      router.navigateByUrl('lazy/loaded').catch((error) => (e = error));
+      advance(fixture);
+
+      expectEvents(recordedEvents, [
+        [NavigationStart, '/lazy/loaded'],
+        [RoutesRecognized, '/lazy/loaded'],
+        [GuardsCheckStart, '/lazy/loaded'],
+        [GuardsCheckEnd, '/lazy/loaded'],
+        [ResolveStart, '/lazy/loaded'],
+        [NavigationCancel, '/lazy/loaded'],
+      ]);
+
+      expect(e).toEqual(null);
+    }));
+
+    it('should not navigate when at least one resolver for a child route from forChild() returns empty result', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
+
+      @Component({
+        selector: 'lazy-cmp',
+        template: 'lazy-loaded-1',
+        standalone: false,
+      })
+      class LazyComponent1 {}
+
+      @NgModule({
+        declarations: [LazyComponent1],
+        imports: [
+          RouterModule.forChild([
+            {
+              path: 'loaded',
+              component: LazyComponent1,
+              resolve: {e1: 'resolveTwo', e2: 'resolveEmpty'},
+            },
+          ]),
+        ],
+      })
+      class LoadedModule {}
+
+      router.resetConfig([{path: 'lazy', loadChildren: () => LoadedModule}]);
+
+      const recordedEvents: any[] = [];
+      router.events.subscribe((e) => e instanceof RouterEvent && recordedEvents.push(e));
+
+      let e: any = null;
+      router.navigateByUrl('lazy/loaded').catch((error) => (e = error));
+      advance(fixture);
+
+      expectEvents(recordedEvents, [
+        [NavigationStart, '/lazy/loaded'],
+        [RoutesRecognized, '/lazy/loaded'],
+        [GuardsCheckStart, '/lazy/loaded'],
+        [GuardsCheckEnd, '/lazy/loaded'],
+        [ResolveStart, '/lazy/loaded'],
+        [NavigationCancel, '/lazy/loaded'],
+      ]);
+
+      expect(e).toEqual(null);
+    }));
 
     it('should include target snapshot in NavigationError when resolver throws', async () => {
       const router = TestBed.inject(Router);
@@ -355,282 +348,271 @@ export function routeDataIntegrationSuite() {
       expect(caughtError?.target).toBeDefined();
     });
 
-    it('should preserve resolved data', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
+    it('should preserve resolved data', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([
-          {
-            path: 'parent',
-            resolve: {two: 'resolveTwo'},
-            children: [
-              {path: 'child1', component: CollectParamsCmp},
-              {path: 'child2', component: CollectParamsCmp},
-            ],
-          },
-        ]);
+      router.resetConfig([
+        {
+          path: 'parent',
+          resolve: {two: 'resolveTwo'},
+          children: [
+            {path: 'child1', component: CollectParamsCmp},
+            {path: 'child2', component: CollectParamsCmp},
+          ],
+        },
+      ]);
 
-        router.navigateByUrl('/parent/child1');
-        advance(fixture);
+      router.navigateByUrl('/parent/child1');
+      advance(fixture);
 
-        router.navigateByUrl('/parent/child2');
-        advance(fixture);
+      router.navigateByUrl('/parent/child2');
+      advance(fixture);
 
-        const cmp: CollectParamsCmp = fixture.debugElement.children[1].componentInstance;
-        expect(cmp.route.snapshot.data).toEqual({two: 2});
-      }),
-    ));
+      const cmp: CollectParamsCmp = fixture.debugElement.children[1].componentInstance;
+      expect(cmp.route.snapshot.data).toEqual({two: 2});
+    }));
 
-    it('should override route static data with resolved data', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
+    it('should override route static data with resolved data', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([
-          {
-            path: '',
-            component: NestedComponentWithData,
-            resolve: {prop: 'resolveTwo'},
-            data: {prop: 'static'},
-          },
-        ]);
+      router.resetConfig([
+        {
+          path: '',
+          component: NestedComponentWithData,
+          resolve: {prop: 'resolveTwo'},
+          data: {prop: 'static'},
+        },
+      ]);
 
-        router.navigateByUrl('/');
-        advance(fixture);
-        const cmp = fixture.debugElement.children[1].componentInstance;
+      router.navigateByUrl('/');
+      advance(fixture);
+      const cmp = fixture.debugElement.children[1].componentInstance;
 
-        expect(cmp.data).toEqual([{prop: 2}]);
-      }),
-    ));
+      expect(cmp.data).toEqual([{prop: 2}]);
+    }));
 
-    it('should correctly override inherited route static data with resolved data', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
+    it('should correctly override inherited route static data with resolved data', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([
-          {
-            path: 'a',
-            component: WrapperCmp,
-            resolve: {prop2: 'resolveTwo'},
-            data: {prop: 'wrapper-a'},
-            children: [
-              // will inherit data from this child route because it has `path` and its parent has
-              // component
-              {
-                path: 'b',
-                data: {prop: 'nested-b'},
-                resolve: {prop3: 'resolveFour'},
-                children: [
-                  {
-                    path: 'c',
-                    children: [
-                      {path: '', component: NestedComponentWithData, data: {prop3: 'nested'}},
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        ]);
+      router.resetConfig([
+        {
+          path: 'a',
+          component: WrapperCmp,
+          resolve: {prop2: 'resolveTwo'},
+          data: {prop: 'wrapper-a'},
+          children: [
+            // will inherit data from this child route because it has `path` and its parent has
+            // component
+            {
+              path: 'b',
+              data: {prop: 'nested-b'},
+              resolve: {prop3: 'resolveFour'},
+              children: [
+                {
+                  path: 'c',
+                  children: [
+                    {path: '', component: NestedComponentWithData, data: {prop3: 'nested'}},
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]);
 
-        router.navigateByUrl('/a/b/c');
-        advance(fixture);
+      router.navigateByUrl('/a/b/c');
+      advance(fixture);
 
-        const pInj = fixture.debugElement.queryAll(By.directive(NestedComponentWithData))[0]
-          .injector!;
-        const cmp = pInj.get(NestedComponentWithData);
-        expect(cmp.data).toEqual([{prop: 'nested-b', prop3: 'nested'}]);
-      }),
-    ));
+      const pInj = fixture.debugElement.queryAll(By.directive(NestedComponentWithData))[0]
+        .injector!;
+      const cmp = pInj.get(NestedComponentWithData);
+      expect(cmp.data).toEqual([{prop: 'nested-b', prop3: 'nested'}]);
+    }));
 
-    it('should not override inherited resolved data with inherited static data', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
+    it('should not override inherited resolved data with inherited static data', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([
-          {
-            path: 'a',
-            component: WrapperCmp,
-            resolve: {prop2: 'resolveTwo'},
-            data: {prop: 'wrapper-a'},
-            children: [
-              // will inherit data from this child route because it has `path` and its parent has
-              // component
-              {
-                path: 'b',
-                data: {prop2: 'parent-b', prop: 'parent-b'},
-                children: [
-                  {
-                    path: 'c',
-                    resolve: {prop2: 'resolveFour'},
-                    children: [
-                      {
-                        path: '',
-                        component: NestedComponentWithData,
-                        data: {prop: 'nested-d'},
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        ]);
+      router.resetConfig([
+        {
+          path: 'a',
+          component: WrapperCmp,
+          resolve: {prop2: 'resolveTwo'},
+          data: {prop: 'wrapper-a'},
+          children: [
+            // will inherit data from this child route because it has `path` and its parent has
+            // component
+            {
+              path: 'b',
+              data: {prop2: 'parent-b', prop: 'parent-b'},
+              children: [
+                {
+                  path: 'c',
+                  resolve: {prop2: 'resolveFour'},
+                  children: [
+                    {
+                      path: '',
+                      component: NestedComponentWithData,
+                      data: {prop: 'nested-d'},
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]);
 
-        router.navigateByUrl('/a/b/c');
-        advance(fixture);
+      router.navigateByUrl('/a/b/c');
+      advance(fixture);
 
-        const pInj = fixture.debugElement.queryAll(By.directive(NestedComponentWithData))[0]
-          .injector!;
-        const cmp = pInj.get(NestedComponentWithData);
-        expect(cmp.data).toEqual([{prop: 'nested-d', prop2: 4}]);
-      }),
-    ));
+      const pInj = fixture.debugElement.queryAll(By.directive(NestedComponentWithData))[0]
+        .injector!;
+      const cmp = pInj.get(NestedComponentWithData);
+      expect(cmp.data).toEqual([{prop: 'nested-d', prop2: 4}]);
+    }));
 
-    it('should not override nested route static data when both are using resolvers', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
+    it('should not override nested route static data when both are using resolvers', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([
-          {
-            path: 'child',
-            component: WrapperCmp,
-            resolve: {prop: 'resolveTwo'},
-            children: [
-              {
-                path: '',
-                pathMatch: 'full',
-                component: NestedComponentWithData,
-                resolve: {prop: 'resolveFour'},
-              },
-            ],
-          },
-        ]);
+      router.resetConfig([
+        {
+          path: 'child',
+          component: WrapperCmp,
+          resolve: {prop: 'resolveTwo'},
+          children: [
+            {
+              path: '',
+              pathMatch: 'full',
+              component: NestedComponentWithData,
+              resolve: {prop: 'resolveFour'},
+            },
+          ],
+        },
+      ]);
 
-        router.navigateByUrl('/child');
-        advance(fixture);
+      router.navigateByUrl('/child');
+      advance(fixture);
 
-        const pInj = fixture.debugElement.query(By.directive(NestedComponentWithData)).injector!;
-        const cmp = pInj.get(NestedComponentWithData);
-        expect(cmp.data).toEqual([{prop: 4}]);
-      }),
-    ));
+      const pInj = fixture.debugElement.query(By.directive(NestedComponentWithData)).injector!;
+      const cmp = pInj.get(NestedComponentWithData);
+      expect(cmp.data).toEqual([{prop: 4}]);
+    }));
 
-    it("should not override child route's static data when both are using static data", fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
+    it("should not override child route's static data when both are using static data", fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([
-          {
-            path: 'child',
-            component: WrapperCmp,
-            data: {prop: 'wrapper'},
-            children: [
-              {
-                path: '',
-                pathMatch: 'full',
-                component: NestedComponentWithData,
-                data: {prop: 'inner'},
-              },
-            ],
-          },
-        ]);
+      router.resetConfig([
+        {
+          path: 'child',
+          component: WrapperCmp,
+          data: {prop: 'wrapper'},
+          children: [
+            {
+              path: '',
+              pathMatch: 'full',
+              component: NestedComponentWithData,
+              data: {prop: 'inner'},
+            },
+          ],
+        },
+      ]);
 
-        router.navigateByUrl('/child');
-        advance(fixture);
+      router.navigateByUrl('/child');
+      advance(fixture);
 
-        const pInj = fixture.debugElement.query(By.directive(NestedComponentWithData)).injector!;
-        const cmp = pInj.get(NestedComponentWithData);
-        expect(cmp.data).toEqual([{prop: 'inner'}]);
-      }),
-    ));
+      const pInj = fixture.debugElement.query(By.directive(NestedComponentWithData)).injector!;
+      const cmp = pInj.get(NestedComponentWithData);
+      expect(cmp.data).toEqual([{prop: 'inner'}]);
+    }));
 
-    it("should not override child route's static data when wrapper is using resolved data and the child route static data", fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
+    it("should not override child route's static data when wrapper is using resolved data and the child route static data", fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([
-          {
-            path: 'nested',
-            component: WrapperCmp,
-            resolve: {prop: 'resolveTwo', prop2: 'resolveSix'},
-            data: {prop3: 'wrapper-static', prop4: 'another-static'},
-            children: [
-              {
-                path: '',
-                pathMatch: 'full',
-                component: NestedComponentWithData,
-                data: {prop: 'nested', prop4: 'nested-static'},
-              },
-            ],
-          },
-        ]);
+      router.resetConfig([
+        {
+          path: 'nested',
+          component: WrapperCmp,
+          resolve: {prop: 'resolveTwo', prop2: 'resolveSix'},
+          data: {prop3: 'wrapper-static', prop4: 'another-static'},
+          children: [
+            {
+              path: '',
+              pathMatch: 'full',
+              component: NestedComponentWithData,
+              data: {prop: 'nested', prop4: 'nested-static'},
+            },
+          ],
+        },
+      ]);
 
-        router.navigateByUrl('/nested');
-        advance(fixture);
+      router.navigateByUrl('/nested');
+      advance(fixture);
 
-        const pInj = fixture.debugElement.query(By.directive(NestedComponentWithData)).injector!;
-        const cmp = pInj.get(NestedComponentWithData);
-        // Issue 34361 - `prop` should contain value defined in `data` object from the nested
-        // route.
-        expect(cmp.data).toEqual([
-          {prop: 'nested', prop2: 6, prop3: 'wrapper-static', prop4: 'nested-static'},
-        ]);
-      }),
-    ));
+      const pInj = fixture.debugElement.query(By.directive(NestedComponentWithData)).injector!;
+      const cmp = pInj.get(NestedComponentWithData);
+      // Issue 34361 - `prop` should contain value defined in `data` object from the nested
+      // route.
+      expect(cmp.data).toEqual([
+        {prop: 'nested', prop2: 6, prop3: 'wrapper-static', prop4: 'nested-static'},
+      ]);
+    }));
 
-    it('should allow guards alter data resolved by routes', fakeAsync(
-      inject([Router], (router: Router) => {
-        // This is not documented or recommended behavior but is here to prevent unexpected
-        // regressions. This behavior isn't necessary 'by design' but it was discovered during a
-        // refactor that some teams depend on it.
-        const fixture = createRoot(router, RootCmp);
+    it('should allow guards alter data resolved by routes', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([
-          {
-            path: 'route',
-            component: NestedComponentWithData,
-            canActivate: [
-              (route: ActivatedRouteSnapshot) => {
-                route.data = {prop: 10};
-                return true;
-              },
-            ],
-          },
-        ]);
+      router.resetConfig([
+        {
+          path: 'route',
+          component: NestedComponentWithData,
+          canActivate: [
+            (route: ActivatedRouteSnapshot) => {
+              route.data = {prop: 10};
+              return true;
+            },
+          ],
+        },
+      ]);
 
-        router.navigateByUrl('/route');
-        advance(fixture);
+      router.navigateByUrl('/route');
+      advance(fixture);
 
-        const pInj = fixture.debugElement.query(By.directive(NestedComponentWithData)).injector!;
-        const cmp = pInj.get(NestedComponentWithData);
-        expect(cmp.data).toEqual([{prop: 10}]);
-      }),
-    ));
+      const pInj = fixture.debugElement.query(By.directive(NestedComponentWithData)).injector!;
+      const cmp = pInj.get(NestedComponentWithData);
+      expect(cmp.data).toEqual([{prop: 10}]);
+    }));
 
-    it('should rerun resolvers when the urls segments of a wildcard route change', fakeAsync(
-      inject([Router, Location], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
+    it('should rerun resolvers when the urls segments of a wildcard route change', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const location = TestBed.inject(Location);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([
-          {
-            path: '**',
-            component: CollectParamsCmp,
-            resolve: {numberOfUrlSegments: 'numberOfUrlSegments'},
-          },
-        ]);
+      router.resetConfig([
+        {
+          path: '**',
+          component: CollectParamsCmp,
+          resolve: {numberOfUrlSegments: 'numberOfUrlSegments'},
+        },
+      ]);
 
-        router.navigateByUrl('/one/two');
-        advance(fixture);
-        const cmp = fixture.debugElement.children[1].componentInstance;
+      router.navigateByUrl('/one/two');
+      advance(fixture);
+      const cmp = fixture.debugElement.children[1].componentInstance;
 
-        expect(cmp.route.snapshot.data).toEqual({numberOfUrlSegments: 2});
+      expect(cmp.route.snapshot.data).toEqual({numberOfUrlSegments: 2});
 
-        router.navigateByUrl('/one/two/three');
-        advance(fixture);
+      router.navigateByUrl('/one/two/three');
+      advance(fixture);
 
-        expect(cmp.route.snapshot.data).toEqual({numberOfUrlSegments: 3});
-      }),
-    ));
+      expect(cmp.route.snapshot.data).toEqual({numberOfUrlSegments: 3});
+    }));
 
     describe('should run resolvers for the same route concurrently', () => {
       let log: string[];
@@ -666,27 +648,26 @@ export function routeDataIntegrationSuite() {
         });
       });
 
-      it('works', fakeAsync(
-        inject([Router], (router: Router) => {
-          const fixture = createRoot(router, RootCmp);
+      it('works', fakeAsync(() => {
+        const router = TestBed.inject(Router);
+        const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig([
-            {
-              path: 'a',
-              resolve: {
-                one: 'resolver1',
-                two: 'resolver2',
-              },
-              component: SimpleCmp,
+        router.resetConfig([
+          {
+            path: 'a',
+            resolve: {
+              one: 'resolver1',
+              two: 'resolver2',
             },
-          ]);
+            component: SimpleCmp,
+          },
+        ]);
 
-          router.navigateByUrl('/a');
-          advance(fixture);
+        router.navigateByUrl('/a');
+        advance(fixture);
 
-          expect(log).toEqual(['resolver2', 'resolver1']);
-        }),
-      ));
+        expect(log).toEqual(['resolver2', 'resolver1']);
+      }));
     });
 
     it('can resolve symbol keys', fakeAsync(() => {
@@ -734,7 +715,7 @@ export function routeDataIntegrationSuite() {
           path: '**',
           component: SimpleCmp,
           resolve: {
-            [user]: () => coreInject(LoginState).user,
+            [user]: () => inject(LoginState).user,
           },
         },
       ]);

--- a/packages/router/test/integration/route_reuse_strategy.spec.ts
+++ b/packages/router/test/integration/route_reuse_strategy.spec.ts
@@ -8,7 +8,7 @@
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {CommonModule, Location} from '@angular/common';
 import {Component, OnDestroy, NgModule, InjectionToken, Inject} from '@angular/core';
-import {TestBed, fakeAsync, inject} from '@angular/core/testing';
+import {TestBed, fakeAsync} from '@angular/core/testing';
 import {
   RouteReuseStrategy,
   DetachedRouteHandle,
@@ -155,76 +155,76 @@ export function routeReuseIntegrationSuite() {
       expect(cmp.detachedComponents[0] instanceof BlankCmp).toBe(true);
     }));
 
-    it('should support attaching & detaching fragments', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmp);
+    it('should support attaching & detaching fragments', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const location = TestBed.inject(Location);
+      const fixture = createRoot(router, RootCmp);
 
-        router.routeReuseStrategy = new AttachDetachReuseStrategy();
-        (router.routeReuseStrategy as AttachDetachReuseStrategy).pathsToDetach = ['a', 'b'];
-        spyOn(router.routeReuseStrategy, 'retrieve').and.callThrough();
+      router.routeReuseStrategy = new AttachDetachReuseStrategy();
+      (router.routeReuseStrategy as AttachDetachReuseStrategy).pathsToDetach = ['a', 'b'];
+      spyOn(router.routeReuseStrategy, 'retrieve').and.callThrough();
 
-        router.resetConfig([
-          {
-            path: 'a',
-            component: TeamCmp,
-            children: [{path: 'b', component: SimpleCmp}],
-          },
-          {path: 'c', component: UserCmp},
-        ]);
+      router.resetConfig([
+        {
+          path: 'a',
+          component: TeamCmp,
+          children: [{path: 'b', component: SimpleCmp}],
+        },
+        {path: 'c', component: UserCmp},
+      ]);
 
-        router.navigateByUrl('/a/b');
-        advance(fixture);
-        const teamCmp = fixture.debugElement.children[1].componentInstance;
-        const simpleCmp = fixture.debugElement.children[1].children[1].componentInstance;
-        expect(location.path()).toEqual('/a/b');
-        expect(teamCmp).toBeDefined();
-        expect(simpleCmp).toBeDefined();
-        expect(router.routeReuseStrategy.retrieve).not.toHaveBeenCalled();
+      router.navigateByUrl('/a/b');
+      advance(fixture);
+      const teamCmp = fixture.debugElement.children[1].componentInstance;
+      const simpleCmp = fixture.debugElement.children[1].children[1].componentInstance;
+      expect(location.path()).toEqual('/a/b');
+      expect(teamCmp).toBeDefined();
+      expect(simpleCmp).toBeDefined();
+      expect(router.routeReuseStrategy.retrieve).not.toHaveBeenCalled();
 
-        router.navigateByUrl('/c');
-        advance(fixture);
-        expect(location.path()).toEqual('/c');
-        expect(fixture.debugElement.children[1].componentInstance).toBeInstanceOf(UserCmp);
-        // We have still not encountered a route that should be reattached
-        expect(router.routeReuseStrategy.retrieve).not.toHaveBeenCalled();
+      router.navigateByUrl('/c');
+      advance(fixture);
+      expect(location.path()).toEqual('/c');
+      expect(fixture.debugElement.children[1].componentInstance).toBeInstanceOf(UserCmp);
+      // We have still not encountered a route that should be reattached
+      expect(router.routeReuseStrategy.retrieve).not.toHaveBeenCalled();
 
-        router.navigateByUrl('/a;p=1/b;p=2');
-        advance(fixture);
-        // We retrieve both the stored route snapshots
-        expect(router.routeReuseStrategy.retrieve).toHaveBeenCalledTimes(4);
-        const teamCmp2 = fixture.debugElement.children[1].componentInstance;
-        const simpleCmp2 = fixture.debugElement.children[1].children[1].componentInstance;
-        expect(location.path()).toEqual('/a;p=1/b;p=2');
-        expect(teamCmp2).toBe(teamCmp);
-        expect(simpleCmp2).toBe(simpleCmp);
+      router.navigateByUrl('/a;p=1/b;p=2');
+      advance(fixture);
+      // We retrieve both the stored route snapshots
+      expect(router.routeReuseStrategy.retrieve).toHaveBeenCalledTimes(4);
+      const teamCmp2 = fixture.debugElement.children[1].componentInstance;
+      const simpleCmp2 = fixture.debugElement.children[1].children[1].componentInstance;
+      expect(location.path()).toEqual('/a;p=1/b;p=2');
+      expect(teamCmp2).toBe(teamCmp);
+      expect(simpleCmp2).toBe(simpleCmp);
 
-        expect(teamCmp.route).toBe(router.routerState.root.firstChild);
-        expect(teamCmp.route.snapshot).toBe(router.routerState.snapshot.root.firstChild);
-        expect(teamCmp.route.snapshot.params).toEqual({p: '1'});
-        expect(teamCmp.route.firstChild.snapshot.params).toEqual({p: '2'});
-        expect(teamCmp.recordedParams).toEqual([{}, {p: '1'}]);
-      }),
-    ));
+      expect(teamCmp.route).toBe(router.routerState.root.firstChild);
+      expect(teamCmp.route.snapshot).toBe(router.routerState.snapshot.root.firstChild);
+      expect(teamCmp.route.snapshot.params).toEqual({p: '1'});
+      expect(teamCmp.route.firstChild.snapshot.params).toEqual({p: '2'});
+      expect(teamCmp.recordedParams).toEqual([{}, {p: '1'}]);
+    }));
 
-    it('should support shorter lifecycles', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmp);
-        router.routeReuseStrategy = new ShortLifecycle();
+    it('should support shorter lifecycles', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      const location = TestBed.inject(Location);
+      const fixture = createRoot(router, RootCmp);
+      router.routeReuseStrategy = new ShortLifecycle();
 
-        router.resetConfig([{path: 'a', component: SimpleCmp}]);
+      router.resetConfig([{path: 'a', component: SimpleCmp}]);
 
-        router.navigateByUrl('/a');
-        advance(fixture);
-        const simpleCmp1 = fixture.debugElement.children[1].componentInstance;
-        expect(location.path()).toEqual('/a');
+      router.navigateByUrl('/a');
+      advance(fixture);
+      const simpleCmp1 = fixture.debugElement.children[1].componentInstance;
+      expect(location.path()).toEqual('/a');
 
-        router.navigateByUrl('/a;p=1');
-        advance(fixture);
-        expect(location.path()).toEqual('/a;p=1');
-        const simpleCmp2 = fixture.debugElement.children[1].componentInstance;
-        expect(simpleCmp1).not.toBe(simpleCmp2);
-      }),
-    ));
+      router.navigateByUrl('/a;p=1');
+      advance(fixture);
+      expect(location.path()).toEqual('/a;p=1');
+      const simpleCmp2 = fixture.debugElement.children[1].componentInstance;
+      expect(simpleCmp1).not.toBe(simpleCmp2);
+    }));
 
     it('should not mount the component of the previously reused route when the outlet was not instantiated at the time of route activation', fakeAsync(() => {
       @Component({

--- a/packages/router/test/integration/router_events.spec.ts
+++ b/packages/router/test/integration/router_events.spec.ts
@@ -7,7 +7,7 @@
  */
 import {filter, tap, first} from 'rxjs/operators';
 import {Event} from '../../index';
-import {fakeAsync, inject} from '@angular/core/testing';
+import {fakeAsync, TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {
   Router,
@@ -28,129 +28,125 @@ import {createRoot, RootCmp, BlankCmp, UserCmp, advance, expectEvents} from './i
 
 export function routerEventsIntegrationSuite() {
   describe('route events', () => {
-    it('should fire matching (Child)ActivationStart/End events', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
+    it('should fire matching (Child)ActivationStart/End events', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([{path: 'user/:name', component: UserCmp}]);
+      router.resetConfig([{path: 'user/:name', component: UserCmp}]);
 
-        const recordedEvents: Event[] = [];
-        router.events.forEach((e) => recordedEvents.push(e));
+      const recordedEvents: Event[] = [];
+      router.events.forEach((e) => recordedEvents.push(e));
 
-        router.navigateByUrl('/user/fedor');
-        advance(fixture);
+      router.navigateByUrl('/user/fedor');
+      advance(fixture);
 
-        const event3 = recordedEvents[3] as ChildActivationStart;
-        const event9 = recordedEvents[9] as ChildActivationEnd;
+      const event3 = recordedEvents[3] as ChildActivationStart;
+      const event9 = recordedEvents[9] as ChildActivationEnd;
 
-        expect(fixture.nativeElement).toHaveText('user fedor');
-        expect(event3 instanceof ChildActivationStart).toBe(true);
-        expect(event3.snapshot).toBe(event9.snapshot.root);
-        expect(event9 instanceof ChildActivationEnd).toBe(true);
-        expect(event9.snapshot).toBe(event9.snapshot.root);
+      expect(fixture.nativeElement).toHaveText('user fedor');
+      expect(event3 instanceof ChildActivationStart).toBe(true);
+      expect(event3.snapshot).toBe(event9.snapshot.root);
+      expect(event9 instanceof ChildActivationEnd).toBe(true);
+      expect(event9.snapshot).toBe(event9.snapshot.root);
 
-        const event4 = recordedEvents[4] as ActivationStart;
-        const event8 = recordedEvents[8] as ActivationEnd;
+      const event4 = recordedEvents[4] as ActivationStart;
+      const event8 = recordedEvents[8] as ActivationEnd;
 
-        expect(event4 instanceof ActivationStart).toBe(true);
-        expect(event4.snapshot.routeConfig?.path).toBe('user/:name');
-        expect(event8 instanceof ActivationEnd).toBe(true);
-        expect(event8.snapshot.routeConfig?.path).toBe('user/:name');
+      expect(event4 instanceof ActivationStart).toBe(true);
+      expect(event4.snapshot.routeConfig?.path).toBe('user/:name');
+      expect(event8 instanceof ActivationEnd).toBe(true);
+      expect(event8.snapshot.routeConfig?.path).toBe('user/:name');
 
-        expectEvents(recordedEvents, [
-          [NavigationStart, '/user/fedor'],
-          [RoutesRecognized, '/user/fedor'],
-          [GuardsCheckStart, '/user/fedor'],
-          [ChildActivationStart],
-          [ActivationStart],
-          [GuardsCheckEnd, '/user/fedor'],
-          [ResolveStart, '/user/fedor'],
-          [ResolveEnd, '/user/fedor'],
-          [ActivationEnd],
-          [ChildActivationEnd],
-          [NavigationEnd, '/user/fedor'],
-        ]);
-      }),
-    ));
+      expectEvents(recordedEvents, [
+        [NavigationStart, '/user/fedor'],
+        [RoutesRecognized, '/user/fedor'],
+        [GuardsCheckStart, '/user/fedor'],
+        [ChildActivationStart],
+        [ActivationStart],
+        [GuardsCheckEnd, '/user/fedor'],
+        [ResolveStart, '/user/fedor'],
+        [ResolveEnd, '/user/fedor'],
+        [ActivationEnd],
+        [ChildActivationEnd],
+        [NavigationEnd, '/user/fedor'],
+      ]);
+    }));
 
-    it('should allow redirection in NavigationStart', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
+    it('should allow redirection in NavigationStart', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([
-          {path: 'blank', component: UserCmp},
-          {path: 'user/:name', component: BlankCmp},
-        ]);
+      router.resetConfig([
+        {path: 'blank', component: UserCmp},
+        {path: 'user/:name', component: BlankCmp},
+      ]);
 
-        const navigateSpy = spyOn(router, 'navigate').and.callThrough();
-        const recordedEvents: Event[] = [];
+      const navigateSpy = spyOn(router, 'navigate').and.callThrough();
+      const recordedEvents: Event[] = [];
 
-        const navStart$ = router.events.pipe(
-          tap((e) => recordedEvents.push(e)),
-          filter((e): e is NavigationStart => e instanceof NavigationStart),
-          first(),
-        );
+      const navStart$ = router.events.pipe(
+        tap((e) => recordedEvents.push(e)),
+        filter((e): e is NavigationStart => e instanceof NavigationStart),
+        first(),
+      );
 
-        navStart$.subscribe((e: NavigationStart | NavigationError) => {
-          router.navigate(['/blank'], {
-            queryParams: {state: 'redirected'},
-            queryParamsHandling: 'merge',
-          });
-          advance(fixture);
+      navStart$.subscribe((e: NavigationStart | NavigationError) => {
+        router.navigate(['/blank'], {
+          queryParams: {state: 'redirected'},
+          queryParamsHandling: 'merge',
         });
-
-        router.navigate(['/user/:fedor']);
         advance(fixture);
+      });
 
-        expect(navigateSpy.calls.mostRecent().args[1]!.queryParams);
-      }),
-    ));
+      router.navigate(['/user/:fedor']);
+      advance(fixture);
 
-    it('should stop emitting events after the router is destroyed', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
-        router.resetConfig([{path: 'user/:name', component: UserCmp}]);
+      expect(navigateSpy.calls.mostRecent().args[1]!.queryParams);
+    }));
 
-        let events = 0;
-        const subscription = router.events.subscribe(() => events++);
+    it('should stop emitting events after the router is destroyed', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
+      router.resetConfig([{path: 'user/:name', component: UserCmp}]);
 
-        router.navigateByUrl('/user/frodo');
-        advance(fixture);
-        expect(events).toBeGreaterThan(0);
+      let events = 0;
+      const subscription = router.events.subscribe(() => events++);
 
-        const previousCount = events;
-        router.dispose();
-        router.navigateByUrl('/user/bilbo');
-        advance(fixture);
+      router.navigateByUrl('/user/frodo');
+      advance(fixture);
+      expect(events).toBeGreaterThan(0);
 
-        expect(events).toBe(previousCount);
-        subscription.unsubscribe();
-      }),
-    ));
+      const previousCount = events;
+      router.dispose();
+      router.navigateByUrl('/user/bilbo');
+      advance(fixture);
 
-    it('should resolve navigation promise with false after the router is destroyed', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
-        let result = null as boolean | null;
-        const callback = (r: boolean) => (result = r);
-        router.resetConfig([{path: 'user/:name', component: UserCmp}]);
+      expect(events).toBe(previousCount);
+      subscription.unsubscribe();
+    }));
 
-        router.navigateByUrl('/user/frodo').then(callback);
-        advance(fixture);
-        expect(result).toBe(true);
-        result = null as boolean | null;
+    it('should resolve navigation promise with false after the router is destroyed', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
+      let result = null as boolean | null;
+      const callback = (r: boolean) => (result = r);
+      router.resetConfig([{path: 'user/:name', component: UserCmp}]);
 
-        router.dispose();
+      router.navigateByUrl('/user/frodo').then(callback);
+      advance(fixture);
+      expect(result).toBe(true);
+      result = null as boolean | null;
 
-        router.navigateByUrl('/user/bilbo').then(callback);
-        advance(fixture);
-        expect(result).toBe(false);
-        result = null as boolean | null;
+      router.dispose();
 
-        router.navigate(['/user/bilbo']).then(callback);
-        advance(fixture);
-        expect(result).toBe(false);
-      }),
-    ));
+      router.navigateByUrl('/user/bilbo').then(callback);
+      advance(fixture);
+      expect(result).toBe(false);
+      result = null as boolean | null;
+
+      router.navigate(['/user/bilbo']).then(callback);
+      advance(fixture);
+      expect(result).toBe(false);
+    }));
   });
 }

--- a/packages/router/test/integration/router_link_active.spec.ts
+++ b/packages/router/test/integration/router_link_active.spec.ts
@@ -7,7 +7,7 @@
  */
 import {Component, NgZone} from '@angular/core';
 import {Location} from '@angular/common';
-import {fakeAsync, TestBed, inject} from '@angular/core/testing';
+import {fakeAsync, TestBed} from '@angular/core/testing';
 import {Router, provideRouter} from '../../src';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {
@@ -24,44 +24,44 @@ import {
 
 export function routerLinkActiveIntegrationSuite() {
   describe('routerLinkActive', () => {
-    it('should set the class when the link is active (a tag)', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmp);
+    it('should set the class when the link is active (a tag)', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const location: Location = TestBed.inject(Location);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([
-          {
-            path: 'team/:id',
-            component: TeamCmp,
-            children: [
-              {
-                path: 'link',
-                component: DummyLinkCmp,
-                children: [
-                  {path: 'simple', component: SimpleCmp},
-                  {path: '', component: BlankCmp},
-                ],
-              },
-            ],
-          },
-        ]);
+      router.resetConfig([
+        {
+          path: 'team/:id',
+          component: TeamCmp,
+          children: [
+            {
+              path: 'link',
+              component: DummyLinkCmp,
+              children: [
+                {path: 'simple', component: SimpleCmp},
+                {path: '', component: BlankCmp},
+              ],
+            },
+          ],
+        },
+      ]);
 
-        router.navigateByUrl('/team/22/link;exact=true');
-        advance(fixture);
-        advance(fixture);
-        expect(location.path()).toEqual('/team/22/link;exact=true');
+      router.navigateByUrl('/team/22/link;exact=true');
+      advance(fixture);
+      advance(fixture);
+      expect(location.path()).toEqual('/team/22/link;exact=true');
 
-        const nativeLink = fixture.nativeElement.querySelector('a');
-        const nativeButton = fixture.nativeElement.querySelector('button');
-        expect(nativeLink.className).toEqual('active');
-        expect(nativeButton.className).toEqual('active');
+      const nativeLink = fixture.nativeElement.querySelector('a');
+      const nativeButton = fixture.nativeElement.querySelector('button');
+      expect(nativeLink.className).toEqual('active');
+      expect(nativeButton.className).toEqual('active');
 
-        router.navigateByUrl('/team/22/link/simple');
-        advance(fixture);
-        expect(location.path()).toEqual('/team/22/link/simple');
-        expect(nativeLink.className).toEqual('');
-        expect(nativeButton.className).toEqual('');
-      }),
-    ));
+      router.navigateByUrl('/team/22/link/simple');
+      advance(fixture);
+      expect(location.path()).toEqual('/team/22/link/simple');
+      expect(nativeLink.className).toEqual('');
+      expect(nativeButton.className).toEqual('');
+    }));
 
     it('should not set the class until the first navigation succeeds', fakeAsync(() => {
       @Component({
@@ -86,77 +86,77 @@ export function routerLinkActiveIntegrationSuite() {
       expect(link.className).toEqual('active');
     }));
 
-    it('should set the class on a parent element when the link is active', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmp);
+    it('should set the class on a parent element when the link is active', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const location: Location = TestBed.inject(Location);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([
-          {
-            path: 'team/:id',
-            component: TeamCmp,
-            children: [
-              {
-                path: 'link',
-                component: DummyLinkWithParentCmp,
-                children: [
-                  {path: 'simple', component: SimpleCmp},
-                  {path: '', component: BlankCmp},
-                ],
-              },
-            ],
-          },
-        ]);
+      router.resetConfig([
+        {
+          path: 'team/:id',
+          component: TeamCmp,
+          children: [
+            {
+              path: 'link',
+              component: DummyLinkWithParentCmp,
+              children: [
+                {path: 'simple', component: SimpleCmp},
+                {path: '', component: BlankCmp},
+              ],
+            },
+          ],
+        },
+      ]);
 
-        router.navigateByUrl('/team/22/link;exact=true');
-        advance(fixture);
-        advance(fixture);
-        expect(location.path()).toEqual('/team/22/link;exact=true');
+      router.navigateByUrl('/team/22/link;exact=true');
+      advance(fixture);
+      advance(fixture);
+      expect(location.path()).toEqual('/team/22/link;exact=true');
 
-        const native = fixture.nativeElement.querySelector('#link-parent');
-        expect(native.className).toEqual('active');
+      const native = fixture.nativeElement.querySelector('#link-parent');
+      expect(native.className).toEqual('active');
 
-        router.navigateByUrl('/team/22/link/simple');
-        advance(fixture);
-        expect(location.path()).toEqual('/team/22/link/simple');
-        expect(native.className).toEqual('');
-      }),
-    ));
+      router.navigateByUrl('/team/22/link/simple');
+      advance(fixture);
+      expect(location.path()).toEqual('/team/22/link/simple');
+      expect(native.className).toEqual('');
+    }));
 
-    it('should set the class when the link is active', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmp);
+    it('should set the class when the link is active', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const location: Location = TestBed.inject(Location);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([
-          {
-            path: 'team/:id',
-            component: TeamCmp,
-            children: [
-              {
-                path: 'link',
-                component: DummyLinkCmp,
-                children: [
-                  {path: 'simple', component: SimpleCmp},
-                  {path: '', component: BlankCmp},
-                ],
-              },
-            ],
-          },
-        ]);
+      router.resetConfig([
+        {
+          path: 'team/:id',
+          component: TeamCmp,
+          children: [
+            {
+              path: 'link',
+              component: DummyLinkCmp,
+              children: [
+                {path: 'simple', component: SimpleCmp},
+                {path: '', component: BlankCmp},
+              ],
+            },
+          ],
+        },
+      ]);
 
-        router.navigateByUrl('/team/22/link');
-        advance(fixture);
-        advance(fixture);
-        expect(location.path()).toEqual('/team/22/link');
+      router.navigateByUrl('/team/22/link');
+      advance(fixture);
+      advance(fixture);
+      expect(location.path()).toEqual('/team/22/link');
 
-        const native = fixture.nativeElement.querySelector('a');
-        expect(native.className).toEqual('active');
+      const native = fixture.nativeElement.querySelector('a');
+      expect(native.className).toEqual('active');
 
-        router.navigateByUrl('/team/22/link/simple');
-        advance(fixture);
-        expect(location.path()).toEqual('/team/22/link/simple');
-        expect(native.className).toEqual('active');
-      }),
-    ));
+      router.navigateByUrl('/team/22/link/simple');
+      advance(fixture);
+      expect(location.path()).toEqual('/team/22/link/simple');
+      expect(native.className).toEqual('active');
+    }));
 
     it('should expose an isActive property', fakeAsync(() => {
       @Component({
@@ -224,87 +224,87 @@ export function routerLinkActiveIntegrationSuite() {
       expect(TestBed.inject(NgZone).hasPendingMicrotasks).toBe(false);
     }));
 
-    it('should emit on isActiveChange output when link is activated or inactivated', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmp);
+    it('should emit on isActiveChange output when link is activated or inactivated', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const location: Location = TestBed.inject(Location);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([
-          {
-            path: 'team/:id',
-            component: TeamCmp,
-            children: [
-              {
-                path: 'link',
-                component: DummyLinkCmp,
-                children: [
-                  {path: 'simple', component: SimpleCmp},
-                  {path: '', component: BlankCmp},
-                ],
-              },
-            ],
-          },
-        ]);
+      router.resetConfig([
+        {
+          path: 'team/:id',
+          component: TeamCmp,
+          children: [
+            {
+              path: 'link',
+              component: DummyLinkCmp,
+              children: [
+                {path: 'simple', component: SimpleCmp},
+                {path: '', component: BlankCmp},
+              ],
+            },
+          ],
+        },
+      ]);
 
-        router.navigateByUrl('/team/22/link;exact=true');
-        advance(fixture);
-        advance(fixture);
-        expect(location.path()).toEqual('/team/22/link;exact=true');
+      router.navigateByUrl('/team/22/link;exact=true');
+      advance(fixture);
+      advance(fixture);
+      expect(location.path()).toEqual('/team/22/link;exact=true');
 
-        const linkComponent = fixture.debugElement.query(By.directive(DummyLinkCmp))
-          .componentInstance as DummyLinkCmp;
+      const linkComponent = fixture.debugElement.query(By.directive(DummyLinkCmp))
+        .componentInstance as DummyLinkCmp;
 
-        expect(linkComponent.isLinkActivated).toEqual(true);
-        const nativeLink = fixture.nativeElement.querySelector('a');
-        const nativeButton = fixture.nativeElement.querySelector('button');
-        expect(nativeLink.className).toEqual('active');
-        expect(nativeButton.className).toEqual('active');
+      expect(linkComponent.isLinkActivated).toEqual(true);
+      const nativeLink = fixture.nativeElement.querySelector('a');
+      const nativeButton = fixture.nativeElement.querySelector('button');
+      expect(nativeLink.className).toEqual('active');
+      expect(nativeButton.className).toEqual('active');
 
-        router.navigateByUrl('/team/22/link/simple');
-        advance(fixture);
-        expect(location.path()).toEqual('/team/22/link/simple');
-        expect(linkComponent.isLinkActivated).toEqual(false);
-        expect(nativeLink.className).toEqual('');
-        expect(nativeButton.className).toEqual('');
-      }),
-    ));
+      router.navigateByUrl('/team/22/link/simple');
+      advance(fixture);
+      expect(location.path()).toEqual('/team/22/link/simple');
+      expect(linkComponent.isLinkActivated).toEqual(false);
+      expect(nativeLink.className).toEqual('');
+      expect(nativeButton.className).toEqual('');
+    }));
 
-    it('should set a provided aria-current attribute when the link is active (a tag)', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmp);
+    it('should set a provided aria-current attribute when the link is active (a tag)', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const location: Location = TestBed.inject(Location);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([
-          {
-            path: 'team/:id',
-            component: TeamCmp,
-            children: [
-              {
-                path: 'link',
-                component: DummyLinkCmp,
-                children: [
-                  {path: 'simple', component: SimpleCmp},
-                  {path: '', component: BlankCmp},
-                ],
-              },
-            ],
-          },
-        ]);
+      router.resetConfig([
+        {
+          path: 'team/:id',
+          component: TeamCmp,
+          children: [
+            {
+              path: 'link',
+              component: DummyLinkCmp,
+              children: [
+                {path: 'simple', component: SimpleCmp},
+                {path: '', component: BlankCmp},
+              ],
+            },
+          ],
+        },
+      ]);
 
-        router.navigateByUrl('/team/22/link;exact=true');
-        advance(fixture);
-        advance(fixture);
-        expect(location.path()).toEqual('/team/22/link;exact=true');
+      router.navigateByUrl('/team/22/link;exact=true');
+      advance(fixture);
+      advance(fixture);
+      expect(location.path()).toEqual('/team/22/link;exact=true');
 
-        const nativeLink = fixture.nativeElement.querySelector('a');
-        const nativeButton = fixture.nativeElement.querySelector('button');
-        expect(nativeLink.getAttribute('aria-current')).toEqual('page');
-        expect(nativeButton.hasAttribute('aria-current')).toEqual(false);
+      const nativeLink = fixture.nativeElement.querySelector('a');
+      const nativeButton = fixture.nativeElement.querySelector('button');
+      expect(nativeLink.getAttribute('aria-current')).toEqual('page');
+      expect(nativeButton.hasAttribute('aria-current')).toEqual(false);
 
-        router.navigateByUrl('/team/22/link/simple');
-        advance(fixture);
-        expect(location.path()).toEqual('/team/22/link/simple');
-        expect(nativeLink.hasAttribute('aria-current')).toEqual(false);
-        expect(nativeButton.hasAttribute('aria-current')).toEqual(false);
-      }),
-    ));
+      router.navigateByUrl('/team/22/link/simple');
+      advance(fixture);
+      expect(location.path()).toEqual('/team/22/link/simple');
+      expect(nativeLink.hasAttribute('aria-current')).toEqual(false);
+      expect(nativeButton.hasAttribute('aria-current')).toEqual(false);
+    }));
   });
 }

--- a/packages/router/test/integration/router_links.spec.ts
+++ b/packages/router/test/integration/router_links.spec.ts
@@ -7,7 +7,7 @@
  */
 import {Component} from '@angular/core';
 import {Location} from '@angular/common';
-import {fakeAsync, TestBed, inject, ComponentFixture} from '@angular/core/testing';
+import {fakeAsync, TestBed, ComponentFixture} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {Router} from '../../src';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
@@ -30,66 +30,65 @@ import {
 
 export function routerLinkIntegrationSpec() {
   describe('router links', () => {
-    it('should support skipping location update for anchor router links', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = TestBed.createComponent(RootCmp);
-        advance(fixture);
+    it('should support skipping location update for anchor router links', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const location: Location = TestBed.inject(Location);
+      const fixture = TestBed.createComponent(RootCmp);
+      advance(fixture);
 
-        router.resetConfig([{path: 'team/:id', component: TeamCmp}]);
+      router.resetConfig([{path: 'team/:id', component: TeamCmp}]);
 
-        router.navigateByUrl('/team/22');
-        advance(fixture);
-        expect(location.path()).toEqual('/team/22');
-        expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
+      router.navigateByUrl('/team/22');
+      advance(fixture);
+      expect(location.path()).toEqual('/team/22');
+      expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
 
-        const teamCmp = fixture.debugElement.childNodes[1].componentInstance;
+      const teamCmp = fixture.debugElement.childNodes[1].componentInstance;
 
-        teamCmp.routerLink = ['/team/0'];
-        advance(fixture);
-        const anchor = fixture.debugElement.query(By.css('a')).nativeElement;
-        anchor.click();
-        advance(fixture);
-        expect(fixture.nativeElement).toHaveText('team 0 [ , right:  ]');
-        expect(location.path()).toEqual('/team/22');
+      teamCmp.routerLink = ['/team/0'];
+      advance(fixture);
+      const anchor = fixture.debugElement.query(By.css('a')).nativeElement;
+      anchor.click();
+      advance(fixture);
+      expect(fixture.nativeElement).toHaveText('team 0 [ , right:  ]');
+      expect(location.path()).toEqual('/team/22');
 
-        teamCmp.routerLink = ['/team/1'];
-        advance(fixture);
-        const button = fixture.debugElement.query(By.css('button')).nativeElement;
-        button.click();
-        advance(fixture);
-        expect(fixture.nativeElement).toHaveText('team 1 [ , right:  ]');
-        expect(location.path()).toEqual('/team/22');
-      }),
-    ));
+      teamCmp.routerLink = ['/team/1'];
+      advance(fixture);
+      const button = fixture.debugElement.query(By.css('button')).nativeElement;
+      button.click();
+      advance(fixture);
+      expect(fixture.nativeElement).toHaveText('team 1 [ , right:  ]');
+      expect(location.path()).toEqual('/team/22');
+    }));
 
-    it('should support string router links', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
+    it('should support string router links', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([
-          {
-            path: 'team/:id',
-            component: TeamCmp,
-            children: [
-              {path: 'link', component: StringLinkCmp},
-              {path: 'simple', component: SimpleCmp},
-            ],
-          },
-        ]);
+      router.resetConfig([
+        {
+          path: 'team/:id',
+          component: TeamCmp,
+          children: [
+            {path: 'link', component: StringLinkCmp},
+            {path: 'simple', component: SimpleCmp},
+          ],
+        },
+      ]);
 
-        router.navigateByUrl('/team/22/link');
-        advance(fixture);
-        expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
+      router.navigateByUrl('/team/22/link');
+      advance(fixture);
+      expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
 
-        const native = fixture.nativeElement.querySelector('a');
-        expect(native.getAttribute('href')).toEqual('/team/33/simple');
-        expect(native.getAttribute('target')).toEqual('_self');
-        native.click();
-        advance(fixture);
+      const native = fixture.nativeElement.querySelector('a');
+      expect(native.getAttribute('href')).toEqual('/team/33/simple');
+      expect(native.getAttribute('target')).toEqual('_self');
+      native.click();
+      advance(fixture);
 
-        expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
-      }),
-    ));
+      expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
+    }));
 
     it('should not preserve query params and fragment by default', fakeAsync(() => {
       @Component({
@@ -235,147 +234,143 @@ export function routerLinkIntegrationSpec() {
       expect(native.getAttribute('href')).toEqual('/home?a=123&q=456');
     }));
 
-    it('should support using links on non-a tags', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
+    it('should support using links on non-a tags', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([
-          {
-            path: 'team/:id',
-            component: TeamCmp,
-            children: [
-              {path: 'link', component: StringLinkButtonCmp},
-              {path: 'simple', component: SimpleCmp},
-            ],
-          },
-        ]);
+      router.resetConfig([
+        {
+          path: 'team/:id',
+          component: TeamCmp,
+          children: [
+            {path: 'link', component: StringLinkButtonCmp},
+            {path: 'simple', component: SimpleCmp},
+          ],
+        },
+      ]);
 
-        router.navigateByUrl('/team/22/link');
-        advance(fixture);
-        expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
+      router.navigateByUrl('/team/22/link');
+      advance(fixture);
+      expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
 
-        const button = fixture.nativeElement.querySelector('button');
-        expect(button.getAttribute('tabindex')).toEqual('0');
-        button.click();
-        advance(fixture);
+      const button = fixture.nativeElement.querySelector('button');
+      expect(button.getAttribute('tabindex')).toEqual('0');
+      button.click();
+      advance(fixture);
 
-        expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
-      }),
-    ));
+      expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
+    }));
 
-    it('should support absolute router links', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
+    it('should support absolute router links', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([
-          {
-            path: 'team/:id',
-            component: TeamCmp,
-            children: [
-              {path: 'link', component: AbsoluteLinkCmp},
-              {path: 'simple', component: SimpleCmp},
-            ],
-          },
-        ]);
+      router.resetConfig([
+        {
+          path: 'team/:id',
+          component: TeamCmp,
+          children: [
+            {path: 'link', component: AbsoluteLinkCmp},
+            {path: 'simple', component: SimpleCmp},
+          ],
+        },
+      ]);
 
-        router.navigateByUrl('/team/22/link');
-        advance(fixture);
-        expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
+      router.navigateByUrl('/team/22/link');
+      advance(fixture);
+      expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
 
-        const native = fixture.nativeElement.querySelector('a');
-        expect(native.getAttribute('href')).toEqual('/team/33/simple');
-        native.click();
-        advance(fixture);
+      const native = fixture.nativeElement.querySelector('a');
+      expect(native.getAttribute('href')).toEqual('/team/33/simple');
+      native.click();
+      advance(fixture);
 
-        expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
-      }),
-    ));
+      expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
+    }));
 
-    it('should support relative router links', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
+    it('should support relative router links', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([
-          {
-            path: 'team/:id',
-            component: TeamCmp,
-            children: [
-              {path: 'link', component: RelativeLinkCmp},
-              {path: 'simple', component: SimpleCmp},
-            ],
-          },
-        ]);
+      router.resetConfig([
+        {
+          path: 'team/:id',
+          component: TeamCmp,
+          children: [
+            {path: 'link', component: RelativeLinkCmp},
+            {path: 'simple', component: SimpleCmp},
+          ],
+        },
+      ]);
 
-        router.navigateByUrl('/team/22/link');
-        advance(fixture);
-        expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
+      router.navigateByUrl('/team/22/link');
+      advance(fixture);
+      expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
 
-        const native = fixture.nativeElement.querySelector('a');
-        expect(native.getAttribute('href')).toEqual('/team/22/simple');
-        native.click();
-        advance(fixture);
+      const native = fixture.nativeElement.querySelector('a');
+      expect(native.getAttribute('href')).toEqual('/team/22/simple');
+      native.click();
+      advance(fixture);
 
-        expect(fixture.nativeElement).toHaveText('team 22 [ simple, right:  ]');
-      }),
-    ));
+      expect(fixture.nativeElement).toHaveText('team 22 [ simple, right:  ]');
+    }));
 
-    it('should support top-level link', fakeAsync(
-      inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RelativeLinkInIfCmp);
-        advance(fixture);
+    it('should support top-level link', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const fixture = createRoot(router, RelativeLinkInIfCmp);
+      advance(fixture);
 
-        router.resetConfig([
-          {path: 'simple', component: SimpleCmp},
-          {path: '', component: BlankCmp},
-        ]);
+      router.resetConfig([
+        {path: 'simple', component: SimpleCmp},
+        {path: '', component: BlankCmp},
+      ]);
 
-        router.navigateByUrl('/');
-        advance(fixture);
-        expect(fixture.nativeElement).toHaveText('');
-        const cmp = fixture.componentInstance;
+      router.navigateByUrl('/');
+      advance(fixture);
+      expect(fixture.nativeElement).toHaveText('');
+      const cmp = fixture.componentInstance;
 
-        cmp.show = true;
-        advance(fixture);
+      cmp.show = true;
+      advance(fixture);
 
-        expect(fixture.nativeElement).toHaveText('link');
-        const native = fixture.nativeElement.querySelector('a');
+      expect(fixture.nativeElement).toHaveText('link');
+      const native = fixture.nativeElement.querySelector('a');
 
-        expect(native.getAttribute('href')).toEqual('/simple');
-        native.click();
-        advance(fixture);
+      expect(native.getAttribute('href')).toEqual('/simple');
+      native.click();
+      advance(fixture);
 
-        expect(fixture.nativeElement).toHaveText('linksimple');
-      }),
-    ));
+      expect(fixture.nativeElement).toHaveText('linksimple');
+    }));
 
-    it('should support query params and fragments', fakeAsync(
-      inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmp);
+    it('should support query params and fragments', fakeAsync(() => {
+      const router: Router = TestBed.inject(Router);
+      const location: Location = TestBed.inject(Location);
+      const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([
-          {
-            path: 'team/:id',
-            component: TeamCmp,
-            children: [
-              {path: 'link', component: LinkWithQueryParamsAndFragment},
-              {path: 'simple', component: SimpleCmp},
-            ],
-          },
-        ]);
+      router.resetConfig([
+        {
+          path: 'team/:id',
+          component: TeamCmp,
+          children: [
+            {path: 'link', component: LinkWithQueryParamsAndFragment},
+            {path: 'simple', component: SimpleCmp},
+          ],
+        },
+      ]);
 
-        router.navigateByUrl('/team/22/link');
-        advance(fixture);
+      router.navigateByUrl('/team/22/link');
+      advance(fixture);
 
-        const native = fixture.nativeElement.querySelector('a');
-        expect(native.getAttribute('href')).toEqual('/team/22/simple?q=1#f');
-        native.click();
-        advance(fixture);
+      const native = fixture.nativeElement.querySelector('a');
+      expect(native.getAttribute('href')).toEqual('/team/22/simple?q=1#f');
+      native.click();
+      advance(fixture);
 
-        expect(fixture.nativeElement).toHaveText('team 22 [ simple, right:  ]');
+      expect(fixture.nativeElement).toHaveText('team 22 [ simple, right:  ]');
 
-        expect(location.path(true)).toEqual('/team/22/simple?q=1#f');
-      }),
-    ));
+      expect(location.path(true)).toEqual('/team/22/simple?q=1#f');
+    }));
 
     describe('should support history and state', () => {
       let component: typeof LinkWithState | typeof DivLinkWithState;
@@ -389,34 +384,34 @@ export function routerLinkIntegrationSpec() {
         component = DivLinkWithState;
       });
 
-      afterEach(fakeAsync(
-        inject([Router, Location], (router: Router, location: Location) => {
-          const fixture = createRoot(router, RootCmp);
+      afterEach(fakeAsync(() => {
+        const router: Router = TestBed.inject(Router);
+        const location: Location = TestBed.inject(Location);
+        const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig([
-            {
-              path: 'team/:id',
-              component: TeamCmp,
-              children: [
-                {path: 'link', component},
-                {path: 'simple', component: SimpleCmp},
-              ],
-            },
-          ]);
+        router.resetConfig([
+          {
+            path: 'team/:id',
+            component: TeamCmp,
+            children: [
+              {path: 'link', component},
+              {path: 'simple', component: SimpleCmp},
+            ],
+          },
+        ]);
 
-          router.navigateByUrl('/team/22/link');
-          advance(fixture);
+        router.navigateByUrl('/team/22/link');
+        advance(fixture);
 
-          const native = fixture.nativeElement.querySelector('#link');
-          native.click();
-          advance(fixture);
+        const native = fixture.nativeElement.querySelector('#link');
+        native.click();
+        advance(fixture);
 
-          expect(fixture.nativeElement).toHaveText('team 22 [ simple, right:  ]');
+        expect(fixture.nativeElement).toHaveText('team 22 [ simple, right:  ]');
 
-          // Check the history entry
-          expect(location.getState()).toEqual({foo: 'bar', navigationId: 3});
-        }),
-      ));
+        // Check the history entry
+        expect(location.getState()).toEqual({foo: 'bar', navigationId: 3});
+      }));
     });
 
     it('should set href on area elements', fakeAsync(() => {

--- a/packages/router/test/router.spec.ts
+++ b/packages/router/test/router.spec.ts
@@ -7,8 +7,8 @@
  */
 
 import {Location} from '@angular/common';
-import {EnvironmentInjector, inject as coreInject} from '@angular/core';
-import {inject, TestBed} from '@angular/core/testing';
+import {EnvironmentInjector, inject} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
 import {RouterModule} from '../index';
 import {of} from 'rxjs';
 
@@ -90,7 +90,9 @@ describe('Router', () => {
       TestBed.configureTestingModule({imports: [RouterModule.forRoot([])]});
     });
 
-    it('should be idempotent', inject([Router, Location], (r: Router, location: Location) => {
+    it('should be idempotent', () => {
+      const r: Router = TestBed.inject(Router);
+      const location: Location = TestBed.inject(Location);
       r.setUpLocationChangeListener();
       const a = (<any>r).nonRouterCurrentEntryChangeSubscription;
       r.setUpLocationChangeListener();
@@ -103,7 +105,7 @@ describe('Router', () => {
       const c = (<any>r).nonRouterCurrentEntryChangeSubscription;
 
       expect(c).not.toBe(b);
-    }));
+    });
   });
 
   describe('PreActivation', () => {
@@ -113,7 +115,7 @@ describe('Router', () => {
 
     function createLoggerGuard(token: string, returnValue = true as boolean | UrlTree) {
       return () => {
-        coreInject(Logger).add(token);
+        inject(Logger).add(token);
         return returnValue;
       };
     }
@@ -151,11 +153,12 @@ describe('Router', () => {
       });
     });
 
-    beforeEach(inject([Logger], (_logger: Logger) => {
+    beforeEach(() => {
+      const _logger: Logger = TestBed.inject(Logger);
       empty = createEmptyStateSnapshot(null);
       logger = _logger;
       events = [];
-    }));
+    });
 
     describe('ChildActivation', () => {
       it('should run', () => {

--- a/packages/router/test/view_transitions.spec.ts
+++ b/packages/router/test/view_transitions.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {Component, destroyPlatform, inject} from '@angular/core';
+import {Component, destroyPlatform} from '@angular/core';
 import {bootstrapApplication} from '@angular/platform-browser';
 import {withBody} from '@angular/private/testing';
 import {


### PR DESCRIPTION
This removes the `inject` helper from core/testing in the router tests.
