### PR TITLE
refactor(core): Remove use of private export PendingTasksInternal where possible

### DIFF
--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
@@ -25,7 +25,7 @@ import {
   Type,
   ViewContainerRef,
   ViewEncapsulation,
-  ɵPendingTasksInternal as PendingTasks,
+  PendingTasks,
   output,
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
@@ -84,11 +84,11 @@ export class DocViewer implements OnChanges {
   private countOfExamples = 0;
 
   async ngOnChanges(changes: SimpleChanges): Promise<void> {
-    const taskId = this.pendingTasks.add();
+    const removeTask = this.pendingTasks.add();
     if ('docContent' in changes) {
       await this.renderContentsAndRunClientSetup(this.docContent!);
     }
-    this.pendingTasks.remove(taskId);
+    removeTask();
   }
 
   async renderContentsAndRunClientSetup(content?: string): Promise<void> {

--- a/packages/core/rxjs-interop/test/pending_until_event_spec.ts
+++ b/packages/core/rxjs-interop/test/pending_until_event_spec.ts
@@ -6,11 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  EnvironmentInjector,
-  ɵPendingTasksInternal as PendingTasks,
-  ApplicationRef,
-} from '../../src/core';
+import {EnvironmentInjector, ApplicationRef} from '../../src/core';
+import {PendingTasksInternal} from '../../src/pending_tasks';
 import {
   BehaviorSubject,
   EMPTY,
@@ -28,11 +25,11 @@ import {pendingUntilEvent} from '../src';
 import {TestBed} from '../../testing';
 
 describe('pendingUntilEvent', () => {
-  let taskService: PendingTasks;
+  let taskService: PendingTasksInternal;
   let injector: EnvironmentInjector;
   let appRef: ApplicationRef;
   beforeEach(() => {
-    taskService = TestBed.inject(PendingTasks);
+    taskService = TestBed.inject(PendingTasksInternal);
     injector = TestBed.inject(EnvironmentInjector);
     appRef = TestBed.inject(ApplicationRef);
   });

--- a/packages/core/test/defer_fixture_spec.ts
+++ b/packages/core/test/defer_fixture_spec.ts
@@ -7,7 +7,8 @@
  */
 
 import {ɵPLATFORM_BROWSER_ID as PLATFORM_BROWSER_ID} from '@angular/common';
-import {Component, PLATFORM_ID, ɵPendingTasksInternal as PendingTasks} from '../src/core';
+import {Component, PLATFORM_ID} from '../src/core';
+import {PendingTasksInternal} from '../src/pending_tasks';
 import {DeferBlockBehavior, DeferBlockState, TestBed} from '../testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
@@ -177,7 +178,7 @@ describe('DeferFixture', () => {
       `,
     })
     class DeferComp {
-      constructor(taskService: PendingTasks) {
+      constructor(taskService: PendingTasksInternal) {
         // Add a task and never remove it. Keeps application unstable forever
         taskService.add();
       }

--- a/packages/core/testing/src/component_fixture.ts
+++ b/packages/core/testing/src/component_fixture.ts
@@ -23,9 +23,9 @@ import {
   ɵgetDeferBlocks as getDeferBlocks,
   ɵNoopNgZone as NoopNgZone,
   ɵZONELESS_ENABLED as ZONELESS_ENABLED,
-  ɵPendingTasksInternal as PendingTasks,
   ɵEffectScheduler as EffectScheduler,
 } from '../../src/core';
+import {PendingTasksInternal} from '../../src/pending_tasks';
 import {Subscription} from 'rxjs';
 
 import {DeferBlockFixture} from './defer';
@@ -83,7 +83,7 @@ export class ComponentFixture<T> {
   /** @internal */
   protected readonly _appRef = inject(ApplicationRef);
   private readonly _testAppRef = this._appRef as unknown as TestAppRef;
-  private readonly pendingTasks = inject(PendingTasks);
+  private readonly pendingTasks = inject(PendingTasksInternal);
   private readonly appErrorHandler = inject(TestBedApplicationErrorHandler);
   private readonly zonelessEnabled = inject(ZONELESS_ENABLED);
   private readonly scheduler = inject(ɵChangeDetectionScheduler);

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -40,7 +40,7 @@ import {
   TransferState,
   Type,
   ViewEncapsulation,
-  ɵPendingTasksInternal as PendingTasks,
+  PendingTasks,
   APP_INITIALIZER,
   inject,
   getPlatform,
@@ -115,9 +115,9 @@ function createAppWithPendingTask(standalone: boolean) {
 
     constructor() {
       const pendingTasks = coreInject(PendingTasks);
-      const taskId = pendingTasks.add();
+      const removeTask = pendingTasks.add();
       setTimeout(() => {
-        pendingTasks.remove(taskId);
+        removeTask();
         this.completed = 'Yes';
       });
     }


### PR DESCRIPTION
This commit removes the use of the privately exported PendingTasksInternal everywhere except for Router. A follow-up change will be done to remove that one as well and delete the private export.
