### PR TITLE
fix(core): eliminate InjectionToken in closure compiler

### DIFF
--- a/packages/core/src/di/injection_token.ts
+++ b/packages/core/src/di/injection_token.ts
@@ -7,7 +7,6 @@
  */
 
 import {Type} from '../interface/type';
-import {assertLessThan} from '../util/assert';
 
 import {ɵɵdefineInjectable} from './interface/defs';
 
@@ -79,13 +78,7 @@ export class InjectionToken<T> {
     },
   ) {
     this.ɵprov = undefined;
-    if (typeof options == 'number') {
-      (typeof ngDevMode === 'undefined' || ngDevMode) &&
-        assertLessThan(options, 0, 'Only negative numbers are supported here');
-      // This is a special hack to assign __NG_ELEMENT_ID__ to this instance.
-      // See `InjectorMarkers`
-      (this as any).__NG_ELEMENT_ID__ = options;
-    } else if (options !== undefined) {
+    if (options !== undefined) {
       this.ɵprov = ɵɵdefineInjectable({
         token: this,
         providedIn: options.providedIn || 'root',

--- a/packages/core/src/di/injector_token.ts
+++ b/packages/core/src/di/injector_token.ts
@@ -6,9 +6,28 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {Type} from '../interface/type';
+import {assertLessThan} from '../util/assert';
+
 import {InjectionToken} from './injection_token';
 import type {Injector} from './injector';
 import {InjectorMarkers} from './injector_marker';
+
+function createTokenWithInjectionMarker<T>(
+  desc: string,
+  marker: number,
+  options?: {
+    providedIn?: Type<any> | 'root' | 'platform' | 'any' | null;
+    factory: () => T;
+  },
+): InjectionToken<T> {
+  if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    assertLessThan(marker, 0, 'Only negative numbers are supported here');
+  }
+  const token = new InjectionToken<T>(desc, options);
+  (token as any).__NG_ELEMENT_ID__ = marker;
+  return token;
+}
 
 /**
  * An InjectionToken that gets the current `Injector` for `createInjector()`-style injectors.
@@ -18,9 +37,9 @@ import {InjectorMarkers} from './injector_marker';
  *
  * @publicApi
  */
-export const INJECTOR = new InjectionToken<Injector>(
+export const INJECTOR = createTokenWithInjectionMarker<Injector>(
   ngDevMode ? 'INJECTOR' : '',
   // Disable tslint because this is const enum which gets inlined not top level prop access.
   // tslint:disable-next-line: no-toplevel-property-access
-  InjectorMarkers.Injector as any, // Special value used by Ivy to identify `Injector`.
+  InjectorMarkers.Injector, // Special value used by Ivy to identify `Injector`.
 );

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -259,6 +259,7 @@
   "createStyleElement",
   "createTView",
   "createTimelineInstruction",
+  "createTokenWithInjectionMarker",
   "createTransitionInstruction",
   "dashCaseToCamelCase",
   "deepForEach",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -258,6 +258,7 @@
   "createNotification",
   "createStyleElement",
   "createTView",
+  "createTokenWithInjectionMarker",
   "declareTemplate",
   "deepForEach",
   "deepForEachProvider",

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -310,6 +310,7 @@
   "createPlatformFactory",
   "createStyleElement",
   "createTView",
+  "createTokenWithInjectionMarker",
   "deepForEach",
   "deepForEachProvider",
   "defaultEquals",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -301,6 +301,7 @@
   "createPlatformFactory",
   "createStyleElement",
   "createTView",
+  "createTokenWithInjectionMarker",
   "deepForEach",
   "deepForEachProvider",
   "defaultEquals",

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -224,6 +224,7 @@
   "createStyleElement",
   "createTView",
   "createTextNode",
+  "createTokenWithInjectionMarker",
   "deepForEach",
   "deepForEachProvider",
   "detachMovedView",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -361,6 +361,7 @@
   "createStyleElement",
   "createTView",
   "createTemplateRef",
+  "createTokenWithInjectionMarker",
   "createUrlTreeFromSegmentGroup",
   "deactivateRouteAndItsChildren",
   "decode",

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -193,6 +193,7 @@
   "createNotification",
   "createStyleElement",
   "createTView",
+  "createTokenWithInjectionMarker",
   "deepForEach",
   "deepForEachProvider",
   "detachMovedView",


### PR DESCRIPTION
At least today, the `throw` in the assertion affected the constructor even when the exception itself gets eliminated in dev mode.

Since making the change here doesn't really reduce clarity (maybe even enhances it), I'm fixing it on the Angular end for this case. Allowing elimination of unused DI tokens should be worth it.

Longer term, this can hopefully be fixed on the closure side.