### PR TITLE
refactor(core): remove private `__core_private_testing_placeholder__` API

### DIFF
--- a/goldens/public-api/core/testing/index.api.md
+++ b/goldens/public-api/core/testing/index.api.md
@@ -9,9 +9,6 @@ import { Subject } from 'rxjs';
 import { Subscription } from 'rxjs';
 
 // @public
-export const __core_private_testing_placeholder__ = "";
-
-// @public
 export class ComponentFixture<T> {
     constructor(componentRef: ComponentRef<T>);
     autoDetectChanges(autoDetect?: boolean): void;

--- a/packages/core/testing/src/test_hooks.ts
+++ b/packages/core/testing/src/test_hooks.ts
@@ -36,14 +36,3 @@ export function getCleanupHook(expectedTeardownValue: boolean): VoidFunction {
     }
   };
 }
-
-/**
- * This API should be removed. But doing so seems to break `google3` and so it requires a bit of
- * investigation.
- *
- * A work around is to mark it as `@codeGenApi` for now and investigate later.
- *
- * @codeGenApi
- */
-// TODO(iminar): Remove this code in a safe way.
-export const __core_private_testing_placeholder__ = '';

--- a/packages/core/testing/src/testing.ts
+++ b/packages/core/testing/src/testing.ts
@@ -38,7 +38,6 @@ export {
   TestEnvironmentOptions,
   ModuleTeardownOptions,
 } from './test_bed_common';
-export {__core_private_testing_placeholder__} from './test_hooks';
 export * from './metadata_override';
 export {MetadataOverrider as ɵMetadataOverrider} from './metadata_overrider';
 export {


### PR DESCRIPTION

This API is no longer used in G3