### PR TITLE
build: Run browsers tests without `platform-browser-dynamic`

### DIFF
--- a/packages/animations/test/browser_animation_builder_spec.ts
+++ b/packages/animations/test/browser_animation_builder_spec.ts
@@ -17,12 +17,9 @@ import {DOCUMENT} from '@angular/common';
 import {Component, NgZone, RendererFactory2, ViewChild} from '@angular/core';
 import {fakeAsync, flushMicrotasks, TestBed} from '@angular/core/testing';
 import {ɵDomRendererFactory2 as DomRendererFactory2} from '@angular/platform-browser';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {ɵAsyncAnimationRendererFactory as AsyncAnimationRendererFactory} from '@angular/platform-browser/animations/async';
+import {BrowserTestingModule, platformBrowserTesting} from '@angular/platform-browser/testing';
 
 describe('BrowserAnimationBuilder', () => {
   if (isNode) {
@@ -236,7 +233,7 @@ describe('BrowserAnimationBuilder', () => {
       // We need to reset the test environment because
       // browser_tests.init.ts inits the environment with the NoopAnimationsModule
       TestBed.resetTestEnvironment();
-      TestBed.initTestEnvironment([BrowserDynamicTestingModule], platformBrowserDynamicTesting());
+      TestBed.initTestEnvironment([BrowserTestingModule], platformBrowserTesting());
     });
 
     it('should throw an error when injecting AnimationBuilder without animation providers set', () => {
@@ -249,8 +246,8 @@ describe('BrowserAnimationBuilder', () => {
       // We're reset the test environment to their default values, cf browser_tests.init.ts
       TestBed.resetTestEnvironment();
       TestBed.initTestEnvironment(
-        [BrowserDynamicTestingModule, NoopAnimationsModule],
-        platformBrowserDynamicTesting(),
+        [BrowserTestingModule, NoopAnimationsModule],
+        platformBrowserTesting(),
       );
     });
   });

--- a/packages/core/test/BUILD.bazel
+++ b/packages/core/test/BUILD.bazel
@@ -75,7 +75,6 @@ ts_library(
         "//packages/core/testing",
         "//packages/localize/init",
         "//packages/platform-browser",
-        "//packages/platform-browser-dynamic",
         "//packages/platform-browser/animations",
         "//packages/platform-browser/testing",
         "//packages/platform-server",

--- a/packages/core/test/linker/regression_integration_spec.ts
+++ b/packages/core/test/linker/regression_integration_spec.ts
@@ -36,8 +36,7 @@ import {
   ViewContainerRef,
 } from '../../src/core';
 import {fakeAsync, inject, TestBed, tick} from '../../testing';
-import {BrowserModule, By} from '@angular/platform-browser';
-import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
+import {BrowserModule, By, platformBrowser} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 describe('regressions', () => {
@@ -485,7 +484,7 @@ describe('regressions using bootstrap', () => {
       })
       class TestModule {}
 
-      platformBrowserDynamic()
+      platformBrowser()
         .bootstrapModule(TestModule)
         .then((ref) => {
           NgZone.assertNotInAngularZone();

--- a/packages/platform-browser-dynamic/test/BUILD.bazel
+++ b/packages/platform-browser-dynamic/test/BUILD.bazel
@@ -18,6 +18,7 @@ ts_library(
         "//packages/core/testing",
         "//packages/platform-browser-dynamic",
         "//packages/platform-browser-dynamic/testing",
+        "//packages/platform-browser/animations",
         "//packages/platform-browser/testing",
         "//packages/private/testing",
     ],

--- a/packages/platform-browser-dynamic/test/testing_public_browser_spec.ts
+++ b/packages/platform-browser-dynamic/test/testing_public_browser_spec.ts
@@ -7,9 +7,12 @@
  */
 
 import {ResourceLoader} from '@angular/compiler';
-import {Compiler, Component, NgModule} from '@angular/core';
+import {Compiler, Component, getPlatform, NgModule, PlatformRef} from '@angular/core';
 import {fakeAsync, inject, TestBed, tick, waitForAsync} from '@angular/core/testing';
 import {ResourceLoaderImpl} from '../src/resource_loader/resource_loader_impl';
+import {BrowserDynamicTestingModule, platformBrowserDynamicTesting} from '../testing';
+import {BrowserTestingModule, platformBrowserTesting} from '@angular/platform-browser/testing';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 // Components for the tests.
 class FancyService {
@@ -54,6 +57,15 @@ if (isBrowser) {
     describe('using the test injector with the inject helper', () => {
       describe('setting up Providers', () => {
         beforeEach(() => {
+          getPlatform()?.destroy();
+          // We need to reset the test environment because
+          // browser_tests.init.ts doesn't use platformBrowserDynamicTesting
+          TestBed.resetTestEnvironment();
+          TestBed.initTestEnvironment(
+            [BrowserDynamicTestingModule],
+            platformBrowserDynamicTesting(),
+          );
+
           TestBed.configureTestingModule({
             providers: [{provide: FancyService, useValue: new FancyService()}],
           });
@@ -76,6 +88,17 @@ if (isBrowser) {
             expect(value).toEqual('async value');
           }),
         ));
+
+        afterEach(() => {
+          getPlatform()?.destroy();
+
+          // We're reset the test environment to their default values, cf browser_tests.init.ts
+          TestBed.resetTestEnvironment();
+          TestBed.initTestEnvironment(
+            [BrowserTestingModule, NoopAnimationsModule],
+            platformBrowserTesting(),
+          );
+        });
       });
     });
 

--- a/tools/testing/BUILD.bazel
+++ b/tools/testing/BUILD.bazel
@@ -20,8 +20,8 @@ ts_library(
         ":zone_base_setup_lib",
         "//packages/compiler",
         "//packages/core/testing",
-        "//packages/platform-browser-dynamic/testing",
         "//packages/platform-browser/animations",
+        "//packages/platform-browser/testing",
         "//packages/zone.js/lib",
     ],
 )

--- a/tools/testing/browser_tests.init.ts
+++ b/tools/testing/browser_tests.init.ts
@@ -11,16 +11,10 @@ import './zone_base_setup';
 import '@angular/compiler'; // For JIT mode. Must be in front of any other @angular/* imports.
 
 import {TestBed} from '@angular/core/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
+import {BrowserTestingModule, platformBrowserTesting} from '@angular/platform-browser/testing';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
-TestBed.initTestEnvironment(
-  [BrowserDynamicTestingModule, NoopAnimationsModule],
-  platformBrowserDynamicTesting(),
-);
+TestBed.initTestEnvironment([BrowserTestingModule, NoopAnimationsModule], platformBrowserTesting());
 
 (window as any).isNode = false;
 (window as any).isBrowser = true;


### PR DESCRIPTION
Use the regular `platform-browser` providers instead.

Previously at #60937, a `NoopAnimationModule` was missing after a `resetTestEnvironment `. 
