### PR TITLE
refactor(docs-infra): remove 'experimental' from cli entry

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/test/fake-cli-entries.json
+++ b/adev/shared-docs/pipeline/api-gen/rendering/test/fake-cli-entries.json
@@ -67,7 +67,7 @@
       "shortDescription": "Generates a new basic application definition in the \"projects\" subfolder of the workspace.",
       "options": [
         {
-          "name": "experimental-zoneless",
+          "name": "zoneless",
           "type": "boolean",
           "default": false,
           "description": "Create an application that does not utilize zone.js."


### PR DESCRIPTION
this removes the experimental prefix from zoneless entry in fake cli
