### PR TITLE
refactor(core): tree-shake `getDirectiveDef` error

### DIFF
--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -29,7 +29,7 @@ import {Sanitizer} from '../sanitization/sanitizer';
 
 import {assertComponentType} from './assert';
 import {attachPatchData} from './context_discovery';
-import {getComponentDef, getDirectiveDef} from './def_getters';
+import {getComponentDef, getDirectiveDef, getDirectiveDefOrThrow} from './def_getters';
 import {depsTracker} from './deps_tracker/deps_tracker';
 import {NodeInjector} from './di';
 import {reportUnknownPropertyError} from './instructions/element_validation';
@@ -387,8 +387,6 @@ function createRootTView(
     for (let i = 0; i < directives.length; i++) {
       const directive = directives[i];
       if (typeof directive !== 'function') {
-        const def: DirectiveDef<unknown> = getDirectiveDef(directive.type, true);
-
         for (const binding of directive.bindings) {
           varsToAllocate += binding[BINDING].requiredVars;
           const targetDirectiveIdx = i + 1;
@@ -410,7 +408,9 @@ function createRootTView(
   if (directives) {
     for (const directive of directives) {
       const directiveType = typeof directive === 'function' ? directive : directive.type;
-      const directiveDef = getDirectiveDef(directiveType, true);
+      const directiveDef = ngDevMode
+        ? getDirectiveDefOrThrow(directiveType)
+        : getDirectiveDef(directiveType)!;
 
       if (ngDevMode && !directiveDef.standalone) {
         throw new RuntimeError(

--- a/packages/core/src/render3/def_getters.ts
+++ b/packages/core/src/render3/def_getters.ts
@@ -39,11 +39,9 @@ export function getComponentDef<T>(type: any): ComponentDef<T> | null {
   return type[NG_COMP_DEF] || null;
 }
 
-export function getDirectiveDef<T>(type: any, throwIfNotFound: true): DirectiveDef<T>;
-export function getDirectiveDef<T>(type: any): DirectiveDef<T> | null;
-export function getDirectiveDef<T>(type: any, throwIfNotFound?: boolean): DirectiveDef<T> | null {
-  const def = type[NG_DIR_DEF] || null;
-  if (!def && throwIfNotFound) {
+export function getDirectiveDefOrThrow<T>(type: any): DirectiveDef<T> | never {
+  const def = getDirectiveDef<T>(type);
+  if (!def) {
     throw new RuntimeError(
       RuntimeErrorCode.MISSING_DIRECTIVE_DEFINITION,
       (typeof ngDevMode === 'undefined' || ngDevMode) &&
@@ -51,6 +49,10 @@ export function getDirectiveDef<T>(type: any, throwIfNotFound?: boolean): Direct
     );
   }
   return def;
+}
+
+export function getDirectiveDef<T>(type: any): DirectiveDef<T> | null {
+  return type[NG_DIR_DEF] || null;
 }
 
 export function getPipeDef<T>(type: any): PipeDef<T> | null {


### PR DESCRIPTION
This commit (https://github.com/angular/angular/commit/25cae4555abab4e5d9aa530a7996f90d8896ccb0) introduced an error throw when the directive definition is not defined. We can guard it with `ngDevMode` and throw the error only in development mode.