### PR TITLE
fix(core): enable stashing only when `withEventReplay()` is invoked

### DIFF
--- a/packages/core/src/render3/instructions/listener.ts
+++ b/packages/core/src/render3/instructions/listener.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import type {EventCallback, WrappedEventCallback} from '../../event_delegation_utils';
 import {TNode, TNodeType} from '../interfaces/node';
 import {GlobalTargetResolver, Renderer} from '../interfaces/renderer';
 import {LView, RENDERER, TView} from '../interfaces/view';
@@ -13,12 +14,7 @@ import {assertTNodeType} from '../node_assert';
 import {getCurrentDirectiveDef, getCurrentTNode, getLView, getTView} from '../state';
 
 import {listenToOutput} from '../view/directive_outputs';
-import {
-  EventCallback,
-  listenToDomEvent,
-  wrapListener,
-  WrappedEventCallback,
-} from '../view/listeners';
+import {listenToDomEvent, wrapListener} from '../view/listeners';
 import {loadComponentRenderer} from './shared';
 
 /**

--- a/packages/core/src/render3/instructions/two_way.ts
+++ b/packages/core/src/render3/instructions/two_way.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import type {EventCallback} from '../../event_delegation_utils';
 import {bindingUpdated} from '../bindings';
 import {SanitizerFn} from '../interfaces/sanitization';
 import {RENDERER} from '../interfaces/view';
 import {isWritableSignal, WritableSignal} from '../reactivity/signal';
 import {getCurrentTNode, getLView, getSelectedTNode, getTView, nextBindingIndex} from '../state';
-import {EventCallback} from '../view/listeners';
 
 import {listenerInternal} from './listener';
 import {setPropertyAndInputs, storePropertyBindingMetadata} from './shared';

--- a/packages/core/src/render3/view/directive_outputs.ts
+++ b/packages/core/src/render3/view/directive_outputs.ts
@@ -7,12 +7,13 @@
  */
 
 import {RuntimeError, RuntimeErrorCode} from '../../errors';
+import type {EventCallback, WrappedEventCallback} from '../../event_delegation_utils';
 import {assertIndexInRange} from '../../util/assert';
 import {DirectiveDef} from '../interfaces/definition';
 import {TNode} from '../interfaces/node';
 import {LView, TVIEW} from '../interfaces/view';
 import {stringifyForError} from '../util/stringify_utils';
-import {EventCallback, storeListenerCleanup, wrapListener, WrappedEventCallback} from './listeners';
+import {storeListenerCleanup, wrapListener} from './listeners';
 
 /** Describes a subscribable output field value. */
 interface SubscribableOutput<T> {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -611,7 +611,6 @@
   "signal",
   "signalAsReadonlyFn",
   "signalSetFn",
-  "stashEventListeners",
   "storeLViewOnDestroy",
   "storeListenerCleanup",
   "stringify",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -606,7 +606,6 @@
   "signal",
   "signalAsReadonlyFn",
   "signalSetFn",
-  "stashEventListeners",
   "storeLViewOnDestroy",
   "storeListenerCleanup",
   "stringify",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -692,7 +692,6 @@
   "split",
   "squashSegmentGroup",
   "standardizeConfig",
-  "stashEventListeners",
   "storeLViewOnDestroy",
   "storeListenerCleanup",
   "stringify",


### PR DESCRIPTION
This commit brings the necessary event replay code code in tree-shakable manner.