### PR TITLE
test(router): This commit removes ZoneJS from the router tests

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
@@ -3,6 +3,6 @@
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=-203833057
 package.json=1896764724
-pnpm-lock.yaml=-141829712
+pnpm-lock.yaml=506935828
 pnpm-workspace.yaml=1711114604
-yarn.lock=-1888396006
+yarn.lock=1439972262

--- a/packages/common/testing/src/navigation/provide_fake_platform_navigation.ts
+++ b/packages/common/testing/src/navigation/provide_fake_platform_navigation.ts
@@ -26,9 +26,9 @@ const FAKE_NAVIGATION = new InjectionToken<FakeNavigation>('fakeNavigation', {
     const config = inject(MOCK_PLATFORM_LOCATION_CONFIG, {optional: true});
     const baseFallback = 'http://_empty_/';
     const startUrl = new URL(config?.startUrl || baseFallback, baseFallback);
-    // TODO(atscott): If we want to replace MockPlatformLocation with FakeNavigationPlatformLocation
-    // as the default in TestBed, we will likely need to use setSynchronousTraversalsForTesting(true);
-    return new FakeNavigation(inject(DOCUMENT), startUrl.href as `http${string}`);
+    const fakeNavigation = new FakeNavigation(inject(DOCUMENT), startUrl.href as `http${string}`);
+    fakeNavigation.setSynchronousTraversalsForTesting(true);
+    return fakeNavigation;
   },
 });
 

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -321,6 +321,9 @@ export class Router {
 
     const urlTree = this.parseUrl(url);
     this.scheduleNavigation(urlTree, source, restoredState, extras).catch((e) => {
+      if (this.disposed) {
+        return;
+      }
       this.injector.get(ɵINTERNAL_APPLICATION_ERROR_HANDLER)(e);
     });
   }

--- a/packages/router/test/BUILD.bazel
+++ b/packages/router/test/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "karma_web_test_suite", "ts_library", "zone_compatible_jasmine_node_test")
+load("//tools:defaults.bzl", "jasmine_node_test", "karma_web_test_suite", "ts_library")
 load("//tools/circular_dependency_test:index.bzl", "circular_dependency_test")
 
 circular_dependency_test(
@@ -35,11 +35,9 @@ ts_library(
     ],
 )
 
-# Tests rely on `async/await` for change detection.
-# This syntax needs to be downleveled until ZoneJS supports it.
-zone_compatible_jasmine_node_test(
+jasmine_node_test(
     name = "test",
-    bootstrap = ["//tools/testing:node"],
+    bootstrap = ["//tools/testing:node_zoneless"],
     deps = [
         ":test_lib",
     ],
@@ -47,6 +45,7 @@ zone_compatible_jasmine_node_test(
 
 karma_web_test_suite(
     name = "test_web",
+    zoneless = True,
     deps = [
         ":test_lib",
     ],

--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -19,6 +19,7 @@ import {
   inject,
   Injectable,
   NgModule,
+  provideZonelessChangeDetection,
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {BrowserModule} from '@angular/platform-browser';
@@ -99,6 +100,7 @@ describe('bootstrap', () => {
     navigationEndPromise = promise;
     log = [];
     testProviders = [
+      provideZonelessChangeDetection(),
       {provide: DOCUMENT, useValue: doc},
       {provide: ViewportScroller, useClass: isNode ? NullViewportScroller : ViewportScroller},
       {provide: PlatformLocation, useClass: MockPlatformLocation},

--- a/packages/router/test/computed_state_restoration.spec.ts
+++ b/packages/router/test/computed_state_restoration.spec.ts
@@ -6,16 +6,17 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CommonModule, Location} from '@angular/common';
-import {provideLocationMocks, SpyLocation} from '@angular/common/testing';
+import {Location} from '@angular/common';
 import {Component, Injectable, NgModule, Type} from '@angular/core';
-import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {Router, RouterModule, RouterOutlet, UrlTree, withRouterConfig} from '../index';
 import {EMPTY, of} from 'rxjs';
 
 import {provideRouter} from '../src/provide_router';
 import {isUrlTree} from '../src/url_tree';
+import {timeout} from './helpers';
+import {afterNextNavigation} from '../src/utils/navigations';
 
 describe('`restoredState#ɵrouterPageId`', () => {
   @Injectable({providedIn: 'root'})
@@ -66,11 +67,9 @@ describe('`restoredState#ɵrouterPageId`', () => {
 
   let fixture: ComponentFixture<unknown>;
 
-  function createNavigationHistory(urlUpdateStrategy: 'eager' | 'deferred' = 'deferred') {
+  async function createNavigationHistory(urlUpdateStrategy: 'eager' | 'deferred' = 'deferred') {
     TestBed.configureTestingModule({
-      imports: [TestModule],
       providers: [
-        {provide: Location, useClass: SpyLocation},
         provideRouter(
           [
             {
@@ -118,34 +117,29 @@ describe('`restoredState#ɵrouterPageId`', () => {
     });
     const router = TestBed.inject(Router);
     const location = TestBed.inject(Location);
-    fixture = createRoot(router, RootCmp);
-    router.initialNavigation();
-    advance(fixture);
+    fixture = await createRoot(router, RootCmp);
     expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 0}));
 
-    router.navigateByUrl('/first');
-    advance(fixture);
+    await router.navigateByUrl('/first');
     expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
 
-    router.navigateByUrl('/second');
-    advance(fixture);
+    await router.navigateByUrl('/second');
     expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
-    router.navigateByUrl('/third');
-    advance(fixture);
+    await router.navigateByUrl('/third');
     expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
 
     location.back();
-    advance(fixture);
+    await nextNavigation();
     expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
   }
 
   describe('deferred url updates', () => {
-    beforeEach(fakeAsync(() => {
-      createNavigationHistory();
-    }));
+    beforeEach(async () => {
+      await createNavigationHistory();
+    });
 
-    it('should work when CanActivate returns false', fakeAsync(() => {
+    it('should work when CanActivate returns false', async () => {
       const location = TestBed.inject(Location);
       const router = TestBed.inject(Router);
       expect(location.path()).toEqual('/second');
@@ -153,99 +147,97 @@ describe('`restoredState#ɵrouterPageId`', () => {
 
       TestBed.inject(MyCanActivateGuard).allow = false;
       location.back();
-      advance(fixture);
+      await nextNavigation();
+      await timeout(5);
       expect(location.path()).toEqual('/second');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
       TestBed.inject(MyCanActivateGuard).allow = true;
       location.back();
-      advance(fixture);
+      await nextNavigation();
       expect(location.path()).toEqual('/first');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
 
       TestBed.inject(MyCanActivateGuard).allow = false;
       location.forward();
-      advance(fixture);
+      await nextNavigation();
+      await timeout(5);
       expect(location.path()).toEqual('/first');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
 
-      router.navigateByUrl('/second');
-      advance(fixture);
+      await router.navigateByUrl('/second');
       expect(location.path()).toEqual('/first');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
-    }));
+    });
 
-    it('should work when CanDeactivate returns false', fakeAsync(() => {
+    it('should work when CanDeactivate returns false', async () => {
       const location = TestBed.inject(Location);
       const router = TestBed.inject(Router);
 
       TestBed.inject(MyCanDeactivateGuard).allow = false;
       location.back();
-      advance(fixture);
+      await nextNavigation();
+      await timeout(5);
       expect(location.path()).toEqual('/second');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
       location.forward();
-      advance(fixture);
+      await nextNavigation();
+      await timeout(5);
       expect(location.path()).toEqual('/second');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
-      router.navigateByUrl('third');
-      advance(fixture);
+      await router.navigateByUrl('third');
       expect(location.path()).toEqual('/second');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
       TestBed.inject(MyCanDeactivateGuard).allow = true;
       location.forward();
-      advance(fixture);
+      await nextNavigation();
       expect(location.path()).toEqual('/third');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
-    }));
+    });
 
-    it('should work when using `NavigationExtras.skipLocationChange`', fakeAsync(() => {
+    it('should work when using `NavigationExtras.skipLocationChange`', async () => {
       const location = TestBed.inject(Location);
       const router = TestBed.inject(Router);
 
       expect(location.path()).toEqual('/second');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
-      router.navigateByUrl('/first', {skipLocationChange: true});
-      advance(fixture);
+      await router.navigateByUrl('/first', {skipLocationChange: true});
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
-      router.navigateByUrl('/third');
-      advance(fixture);
+      await router.navigateByUrl('/third');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
 
       location.back();
-      advance(fixture);
+      await nextNavigation();
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
-    }));
+    });
 
-    it('should work when using `NavigationExtras.replaceUrl`', fakeAsync(() => {
+    it('should work when using `NavigationExtras.replaceUrl`', async () => {
       const location = TestBed.inject(Location);
       const router = TestBed.inject(Router);
 
       expect(location.path()).toEqual('/second');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
-      router.navigateByUrl('/first', {replaceUrl: true});
-      advance(fixture);
+      await router.navigateByUrl('/first', {replaceUrl: true});
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
       expect(location.path()).toEqual('/first');
-    }));
+    });
 
-    it('should work when CanLoad returns false', fakeAsync(() => {
+    it('should work when CanLoad returns false', async () => {
       const location = TestBed.inject(Location);
       const router = TestBed.inject(Router);
 
-      router.navigateByUrl('/loaded');
-      advance(fixture);
+      await router.navigateByUrl('/loaded');
       expect(location.path()).toEqual('/second');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
-    }));
+    });
 
-    it('should work when resolve empty', fakeAsync(() => {
+    it('should work when resolve empty', async () => {
       const location = TestBed.inject(Location);
       const router = TestBed.inject(Router);
 
@@ -255,148 +247,146 @@ describe('`restoredState#ɵrouterPageId`', () => {
       TestBed.inject(MyResolve).myresolve = EMPTY;
 
       location.back();
-      advance(fixture);
+      await nextNavigation();
+      await timeout(5);
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
       expect(location.path()).toEqual('/second');
 
       TestBed.inject(MyResolve).myresolve = of(2);
 
       location.back();
-      advance(fixture);
+      await nextNavigation();
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
       expect(location.path()).toEqual('/first');
 
       TestBed.inject(MyResolve).myresolve = EMPTY;
 
       // We should cancel the navigation to `/third` when myresolve is empty
-      router.navigateByUrl('/third');
-      advance(fixture);
+      await router.navigateByUrl('/third');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
       expect(location.path()).toEqual('/first');
 
       location.historyGo(2);
-      advance(fixture);
+      await nextNavigation();
+      await timeout(5);
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
       expect(location.path()).toEqual('/first');
 
       TestBed.inject(MyResolve).myresolve = of(2);
       location.historyGo(2);
-      advance(fixture);
+      await nextNavigation();
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
       expect(location.path()).toEqual('/third');
 
       TestBed.inject(MyResolve).myresolve = EMPTY;
       location.historyGo(-2);
-      advance(fixture);
+      await nextNavigation();
+      await timeout(5);
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
       expect(location.path()).toEqual('/third');
-    }));
+    });
 
-    it('should work when an error occurred during navigation', fakeAsync(() => {
+    it('should work when an error occurred during navigation', async () => {
       const location = TestBed.inject(Location);
       const router = TestBed.inject(Router);
 
       expect(location.path()).toEqual('/second');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
-      router.navigateByUrl('/invalid').catch(() => null);
-      advance(fixture);
+      await router.navigateByUrl('/invalid').catch(() => null);
       expect(location.path()).toEqual('/second');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
       location.back();
-      advance(fixture);
+      await nextNavigation();
       expect(location.path()).toEqual('/first');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
-    }));
+    });
 
-    it('should work when CanActivate redirects', fakeAsync(() => {
+    it('should work when CanActivate redirects', async () => {
       const location = TestBed.inject(Location);
 
       TestBed.inject(MyCanActivateGuard).redirectTo = '/unguarded';
       location.back();
-      advance(fixture);
+      await nextNavigation();
       expect(location.path()).toEqual('/unguarded');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
       TestBed.inject(MyCanActivateGuard).redirectTo = null;
 
       location.back();
-      advance(fixture);
+      await nextNavigation();
       expect(location.path()).toEqual('/first');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
-    }));
+    });
 
-    it('restores history correctly when component throws error in constructor and replaceUrl=true', fakeAsync(() => {
+    it('restores history correctly when component throws error in constructor and replaceUrl=true', async () => {
       const location = TestBed.inject(Location);
       const router = TestBed.inject(Router);
 
-      router.navigateByUrl('/throwing', {replaceUrl: true}).catch(() => null);
-      advance(fixture);
+      await router.navigateByUrl('/throwing', {replaceUrl: true}).catch(() => null);
       expect(location.path()).toEqual('/second');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
       location.back();
-      advance(fixture);
+      await nextNavigation();
       expect(location.path()).toEqual('/first');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
-    }));
+    });
 
-    it('restores history correctly when component throws error in constructor and skipLocationChange=true', fakeAsync(() => {
+    it('restores history correctly when component throws error in constructor and skipLocationChange=true', async () => {
       const location = TestBed.inject(Location);
       const router = TestBed.inject(Router);
 
-      router.navigateByUrl('/throwing', {skipLocationChange: true}).catch(() => null);
-      advance(fixture);
+      await router.navigateByUrl('/throwing', {skipLocationChange: true}).catch(() => null);
       expect(location.path()).toEqual('/second');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
       location.back();
-      advance(fixture);
+      await nextNavigation();
       expect(location.path()).toEqual('/first');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
-    }));
+    });
   });
 
   describe('eager url updates', () => {
-    beforeEach(fakeAsync(() => {
-      createNavigationHistory('eager');
-    }));
-    it('should work', fakeAsync(() => {
-      const location = TestBed.inject(Location) as SpyLocation;
+    beforeEach(async () => {
+      await createNavigationHistory('eager');
+    });
+    it('should work', async () => {
+      const location = TestBed.inject(Location);
       const router = TestBed.inject(Router);
       expect(location.path()).toEqual('/second');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
       TestBed.inject(MyCanActivateGuard).allow = false;
-      router.navigateByUrl('/first');
-      advance(fixture);
+      await router.navigateByUrl('/first');
+      await nextNavigation();
       expect(location.path()).toEqual('/second');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
       location.back();
-      advance(fixture);
+      await nextNavigation();
       expect(location.path()).toEqual('/second');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
-    }));
-    it('should work when CanActivate redirects', fakeAsync(() => {
+    });
+    it('should work when CanActivate redirects', async () => {
       const location = TestBed.inject(Location);
       const router = TestBed.inject(Router);
 
       TestBed.inject(MyCanActivateGuard).redirectTo = '/unguarded';
-      router.navigateByUrl('/third');
-      advance(fixture);
+      await router.navigateByUrl('/third');
       expect(location.path()).toEqual('/unguarded');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 4}));
 
       TestBed.inject(MyCanActivateGuard).redirectTo = null;
 
       location.back();
-      advance(fixture);
+      await nextNavigation();
       expect(location.path()).toEqual('/third');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
-    }));
-    it('should work when CanActivate redirects with UrlTree', fakeAsync(() => {
+    });
+    it('should work when CanActivate redirects with UrlTree', async () => {
       // Note that this test is different from the above case because we are able to specifically
       // handle the `UrlTree` case as a proper redirect and set `replaceUrl: true` on the
       // follow-up navigation.
@@ -411,109 +401,103 @@ describe('`restoredState#ɵrouterPageId`', () => {
 
       // already at '2' from the `beforeEach` navigations
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
-      router.navigateByUrl('/initial');
-      advance(fixture);
+      await router.navigateByUrl('/initial');
       expect(location.path()).toEqual('/initial');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
 
       TestBed.inject(MyCanActivateGuard).redirectTo = null;
 
-      router.navigateByUrl('redirectTo');
-      advance(fixture);
+      await router.navigateByUrl('redirectTo');
       expect(location.path()).toEqual('/redirectTo');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 4}));
 
       // Navigate to different URL but get redirected to same URL should result in same page id
-      router.navigateByUrl('redirectFrom');
-      advance(fixture);
+      await router.navigateByUrl('redirectFrom');
       expect(location.path()).toEqual('/redirectTo');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 4}));
 
       // Back and forward should have page IDs 1 apart
       location.back();
-      advance(fixture);
+      await nextNavigation();
       expect(location.path()).toEqual('/initial');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
       location.forward();
-      advance(fixture);
+      await nextNavigation();
       expect(location.path()).toEqual('/redirectTo');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 4}));
 
       // Rejected navigation after redirect to same URL should have the same page ID
       allowNavigation = false;
-      router.navigateByUrl('redirectFrom');
-      advance(fixture);
+      await router.navigateByUrl('redirectFrom');
       expect(location.path()).toEqual('/redirectTo');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 4}));
-    }));
-    it('redirectTo with same url, and guard reject', fakeAsync(() => {
+    });
+    it('redirectTo with same url, and guard reject', async () => {
       const location = TestBed.inject(Location);
       const router = TestBed.inject(Router);
 
       TestBed.inject(MyCanActivateGuard).redirectTo = router.createUrlTree(['unguarded']);
-      router.navigateByUrl('/third');
-      advance(fixture);
+      await router.navigateByUrl('/third');
       expect(location.path()).toEqual('/unguarded');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
 
       TestBed.inject(MyCanActivateGuard).redirectTo = null;
 
       location.back();
-      advance(fixture);
+      await nextNavigation();
       expect(location.path()).toEqual('/second');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
-    }));
+    });
   });
 
   for (const urlUpdateStrategy of ['deferred', 'eager'] as const) {
-    it(`restores history correctly when an error is thrown in guard with urlUpdateStrategy ${urlUpdateStrategy}`, fakeAsync(() => {
-      createNavigationHistory(urlUpdateStrategy);
+    it(`restores history correctly when an error is thrown in guard with urlUpdateStrategy ${urlUpdateStrategy}`, async () => {
+      await createNavigationHistory(urlUpdateStrategy);
       const location = TestBed.inject(Location);
 
       TestBed.inject(ThrowingCanActivateGuard).throw = true;
 
       location.back();
-      advance(fixture);
+      await nextNavigation();
+      await timeout(5);
       expect(location.path()).toEqual('/second');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
       TestBed.inject(ThrowingCanActivateGuard).throw = false;
       location.back();
-      advance(fixture);
+      await nextNavigation();
       expect(location.path()).toEqual('/first');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
-    }));
+    });
 
-    it(`restores history correctly when component throws error in constructor with urlUpdateStrategy ${urlUpdateStrategy}`, fakeAsync(() => {
-      createNavigationHistory(urlUpdateStrategy);
+    it(`restores history correctly when component throws error in constructor with urlUpdateStrategy ${urlUpdateStrategy}`, async () => {
+      await createNavigationHistory(urlUpdateStrategy);
       const location = TestBed.inject(Location);
       const router = TestBed.inject(Router);
 
-      router.navigateByUrl('/throwing').catch(() => null);
-      advance(fixture);
+      await router.navigateByUrl('/throwing').catch(() => null);
+      await timeout(5);
       expect(location.path()).toEqual('/second');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
       location.back();
-      advance(fixture);
+      await nextNavigation();
       expect(location.path()).toEqual('/first');
       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
-    }));
+    });
   }
 });
 
-function createRoot<T>(router: Router, type: Type<T>): ComponentFixture<T> {
+async function createRoot<T>(router: Router, type: Type<T>): Promise<ComponentFixture<T>> {
   const f = TestBed.createComponent(type);
-  advance(f);
   router.initialNavigation();
-  advance(f);
+  await nextNavigation();
   return f;
 }
 
 @Component({
   selector: 'simple-cmp',
   template: `simple`,
-  standalone: false,
 })
 class SimpleCmp {}
 
@@ -523,14 +507,13 @@ class ModuleWithSimpleCmpAsRoute {}
 @Component({
   selector: 'root-cmp',
   template: `<router-outlet></router-outlet>`,
-  standalone: false,
+  imports: [RouterOutlet],
 })
 class RootCmp {}
 
 @Component({
   selector: 'throwing-cmp',
   template: '',
-  standalone: false,
 })
 class ThrowingCmp {
   constructor() {
@@ -538,15 +521,8 @@ class ThrowingCmp {
   }
 }
 
-function advance(fixture: ComponentFixture<unknown>, millis?: number): void {
-  tick(millis);
-  fixture.detectChanges();
+function nextNavigation(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    afterNextNavigation(TestBed.inject(Router), resolve);
+  });
 }
-
-@NgModule({
-  imports: [RouterOutlet, CommonModule],
-  providers: [provideLocationMocks()],
-  exports: [SimpleCmp, RootCmp, ThrowingCmp],
-  declarations: [SimpleCmp, RootCmp, ThrowingCmp],
-})
-class TestModule {}

--- a/packages/router/test/create_router_state.spec.ts
+++ b/packages/router/test/create_router_state.spec.ts
@@ -26,7 +26,7 @@ import {PRIMARY_OUTLET} from '../src/shared';
 import {DefaultUrlSerializer, UrlTree} from '../src/url_tree';
 import {TreeNode} from '../src/utils/tree';
 
-describe('create router state', async () => {
+describe('create router state', () => {
   let reuseStrategy: DefaultRouteReuseStrategy;
   beforeEach(() => {
     reuseStrategy = new DefaultRouteReuseStrategy();

--- a/packages/router/test/create_url_tree.spec.ts
+++ b/packages/router/test/create_url_tree.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {Component, Injectable} from '@angular/core';
-import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {createUrlTreeFromSnapshot} from '../src/create_url_tree';
@@ -18,8 +18,9 @@ import {ActivatedRoute, ActivatedRouteSnapshot} from '../src/router_state';
 import {Params, PRIMARY_OUTLET} from '../src/shared';
 import {DefaultUrlSerializer, UrlTree} from '../src/url_tree';
 import {provideRouter, withRouterConfig} from '../src';
+import {timeout} from './helpers';
 
-describe('createUrlTree', async () => {
+describe('createUrlTree', () => {
   const serializer = new DefaultUrlSerializer();
   let router: Router;
   beforeEach(() => {
@@ -47,7 +48,7 @@ describe('createUrlTree', async () => {
     ]);
   });
 
-  describe('query parameters', async () => {
+  describe('query parameters', () => {
     it('should support parameter with multiple values', async () => {
       const p1 = serializer.parse('/');
       const t1 = await createRoot(p1, ['/'], {m: ['v1', 'v2']});
@@ -115,7 +116,7 @@ describe('createUrlTree', async () => {
     expect(serializer.serialize(t)).toEqual('/%2Fone/two%2Fthree');
   });
 
-  describe('named outlets', async () => {
+  describe('named outlets', () => {
     it('should preserve secondary segments', async () => {
       const p = serializer.parse('/a/11/b(right:c)');
       const t = await createRoot(p, ['/a', 11, 'd']);
@@ -445,7 +446,7 @@ describe('createUrlTree', async () => {
     expect(segmentA.parameterMap.get('pp')).toEqual('33');
   });
 
-  describe('relative navigation', async () => {
+  describe('relative navigation', () => {
     it('should work', async () => {
       await router.navigateByUrl('/a/(c//left:cp)(left:ap)');
       const t = create(router.routerState.root.children[0], ['c2']);
@@ -638,8 +639,8 @@ function create(
   return TestBed.inject(Router).createUrlTree(commands, {relativeTo, queryParams, fragment});
 }
 
-describe('createUrlTreeFromSnapshot', async () => {
-  it('can create a UrlTree relative to empty path named parent', fakeAsync(() => {
+describe('createUrlTreeFromSnapshot', () => {
+  it('can create a UrlTree relative to empty path named parent', async () => {
     @Component({
       template: `<router-outlet></router-outlet>`,
       imports: [RouterModule],
@@ -683,13 +684,13 @@ describe('createUrlTreeFromSnapshot', async () => {
     const fixture = TestBed.createComponent(RootCmp);
 
     router.initialNavigation();
-    advance(fixture);
+    await advance(fixture);
     fixture.debugElement.query(By.directive(MainPageComponent)).componentInstance.navigate();
-    advance(fixture);
+    await advance(fixture);
     expect(fixture.nativeElement.innerHTML).toContain('child works!');
-  }));
+  });
 
-  it('can navigate to relative to `ActivatedRouteSnapshot` in guard', fakeAsync(() => {
+  it('can navigate to relative to `ActivatedRouteSnapshot` in guard', async () => {
     @Injectable({providedIn: 'root'})
     class Guard {
       constructor(private readonly router: Router) {}
@@ -736,12 +737,12 @@ describe('createUrlTreeFromSnapshot', async () => {
     const fixture = TestBed.createComponent(RootCmp);
 
     router.navigateByUrl('parent/guarded');
-    advance(fixture);
+    await advance(fixture);
     expect(router.url).toEqual('/parent/sibling');
-  }));
+  });
 });
 
-function advance(fixture: ComponentFixture<unknown>) {
-  tick();
+async function advance(fixture: ComponentFixture<unknown>) {
+  await timeout();
   fixture.detectChanges();
 }

--- a/packages/router/test/directives/router_outlet.spec.ts
+++ b/packages/router/test/directives/router_outlet.spec.ts
@@ -12,11 +12,11 @@ import {
   inject,
   provideZonelessChangeDetection,
   Input,
-  Signal,
   Type,
   NgModule,
+  signal,
 } from '@angular/core';
-import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {
   provideRouter,
   Router,
@@ -27,9 +27,10 @@ import {
 } from '../../index';
 import {RouterTestingHarness} from '../../testing';
 import {InjectionToken} from '../../../core/src/di';
+import {timeout} from '../helpers';
 
 describe('router outlet name', () => {
-  it('should support name binding', fakeAsync(() => {
+  it('should support name binding', async () => {
     @Component({
       template: '<router-outlet [name]="name"></router-outlet>',
       imports: [RouterOutlet],
@@ -47,17 +48,17 @@ describe('router outlet name', () => {
       imports: [RouterModule.forRoot([{path: '', outlet: 'popup', component: PopupCmp}])],
     });
     const router = TestBed.inject(Router);
-    const fixture = createRoot(router, RootCmp);
+    const fixture = await createRoot(router, RootCmp);
     expect(fixture.nativeElement.innerHTML).toContain('popup component');
-  }));
+  });
 
-  it('should be able to change the name of the outlet', fakeAsync(() => {
+  it('should be able to change the name of the outlet', async () => {
     @Component({
-      template: '<router-outlet [name]="name"></router-outlet>',
+      template: '<router-outlet [name]="name()"></router-outlet>',
       imports: [RouterOutlet],
     })
     class RootCmp {
-      name = '';
+      name = signal('');
     }
 
     @Component({
@@ -79,33 +80,33 @@ describe('router outlet name', () => {
       ],
     });
     const router = TestBed.inject(Router);
-    const fixture = createRoot(router, RootCmp);
+    const fixture = await createRoot(router, RootCmp);
 
     expect(fixture.nativeElement.innerHTML).not.toContain('goodbye');
     expect(fixture.nativeElement.innerHTML).not.toContain('hello');
 
-    fixture.componentInstance.name = 'greeting';
-    advance(fixture);
+    fixture.componentInstance.name.set('greeting');
+    await advance(fixture);
     expect(fixture.nativeElement.innerHTML).toContain('hello');
     expect(fixture.nativeElement.innerHTML).not.toContain('goodbye');
 
-    fixture.componentInstance.name = 'farewell';
-    advance(fixture);
+    fixture.componentInstance.name.set('farewell');
+    await advance(fixture);
     expect(fixture.nativeElement.innerHTML).toContain('goodbye');
     expect(fixture.nativeElement.innerHTML).not.toContain('hello');
-  }));
+  });
 
-  it('should support outlets in ngFor', fakeAsync(() => {
+  it('should support outlets in ngFor', async () => {
     @Component({
       template: `
-            <div *ngFor="let outlet of outlets">
+            <div *ngFor="let outlet of outlets()">
                 <router-outlet [name]="outlet"></router-outlet>
             </div>
             `,
       imports: [RouterOutlet, NgForOf],
     })
     class RootCmp {
-      outlets = ['outlet1', 'outlet2', 'outlet3'];
+      outlets = signal(['outlet1', 'outlet2', 'outlet3']);
     }
 
     @Component({
@@ -133,35 +134,35 @@ describe('router outlet name', () => {
       ],
     });
     const router = TestBed.inject(Router);
-    const fixture = createRoot(router, RootCmp);
+    const fixture = await createRoot(router, RootCmp);
 
     router.navigate([{outlets: {'outlet1': '1'}}]);
-    advance(fixture);
+    await advance(fixture);
     expect(fixture.nativeElement.innerHTML).toContain('component 1');
     expect(fixture.nativeElement.innerHTML).not.toContain('component 2');
     expect(fixture.nativeElement.innerHTML).not.toContain('component 3');
 
-    router.navigate([{outlets: {'outlet1': null, 'outlet2': '2', 'outlet3': '3'}}]);
-    advance(fixture);
+    await router.navigate([{outlets: {'outlet1': null, 'outlet2': '2', 'outlet3': '3'}}]);
+    await advance(fixture);
     expect(fixture.nativeElement.innerHTML).not.toContain('component 1');
     expect(fixture.nativeElement.innerHTML).toMatch('.*component 2.*component 3');
 
     // reverse the outlets
-    fixture.componentInstance.outlets = ['outlet3', 'outlet2', 'outlet1'];
-    router.navigate([{outlets: {'outlet1': '1', 'outlet2': '2', 'outlet3': '3'}}]);
-    advance(fixture);
+    fixture.componentInstance.outlets.set(['outlet3', 'outlet2', 'outlet1']);
+    await router.navigate([{outlets: {'outlet1': '1', 'outlet2': '2', 'outlet3': '3'}}]);
+    await advance(fixture);
     expect(fixture.nativeElement.innerHTML).toMatch('.*component 3.*component 2.*component 1');
-  }));
+  });
 
-  it('should not activate if route is changed', fakeAsync(() => {
+  it('should not activate if route is changed', async () => {
     @Component({
-      template: '<div *ngIf="initDone"><router-outlet></router-outlet></div>',
+      template: '<div *ngIf="initDone()"><router-outlet></router-outlet></div>',
       imports: [RouterOutlet, CommonModule],
     })
     class ParentCmp {
-      initDone = false;
+      initDone = signal(false);
       constructor() {
-        setTimeout(() => (this.initDone = true), 1000);
+        setTimeout(() => this.initDone.set(true), 1000);
       }
     }
 
@@ -178,20 +179,20 @@ describe('router outlet name', () => {
       ],
     });
     const router = TestBed.inject(Router);
-    const fixture = createRoot(router, ParentCmp);
+    const fixture = await createRoot(router, ParentCmp);
 
-    advance(fixture, 250);
+    await advance(fixture, 250);
     router.navigate(['parent/child']);
-    advance(fixture, 250);
+    await advance(fixture, 250);
     // Not contain because initDone is still false
     expect(fixture.nativeElement.innerHTML).not.toContain('child component');
 
-    advance(fixture, 1500);
+    await advance(fixture, 1500);
     router.navigate(['parent']);
-    advance(fixture, 1500);
+    await advance(fixture, 1500);
     // Not contain because route was changed back to parent
     expect(fixture.nativeElement.innerHTML).not.toContain('child component');
-  }));
+  });
 });
 
 describe('component input binding', () => {
@@ -572,15 +573,17 @@ describe('router outlet data', () => {
   });
 });
 
-function advance(fixture: ComponentFixture<unknown>, millis?: number): void {
-  tick(millis);
+async function advance(fixture: ComponentFixture<unknown>, millis?: number): Promise<void> {
+  if (millis) {
+    await timeout(millis);
+  }
   fixture.detectChanges();
 }
 
-function createRoot<T>(router: Router, type: Type<T>): ComponentFixture<T> {
+async function createRoot<T>(router: Router, type: Type<T>): Promise<ComponentFixture<T>> {
   const f = TestBed.createComponent(type);
-  advance(f);
+  await advance(f);
   router.initialNavigation();
-  advance(f);
+  await advance(f);
   return f;
 }

--- a/packages/router/test/helpers.ts
+++ b/packages/router/test/helpers.ts
@@ -48,3 +48,9 @@ export function createActivatedRouteSnapshot(args: ARSArgs): ActivatedRouteSnaps
     args.resolve || {},
   );
 }
+
+export async function timeout(ms?: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/packages/router/test/integration/integration.spec.ts
+++ b/packages/router/test/integration/integration.spec.ts
@@ -13,10 +13,9 @@ import {
   Component,
   NgModule,
   ɵConsole as Console,
-  provideZonelessChangeDetection,
   signal,
 } from '@angular/core';
-import {fakeAsync, TestBed} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {
   ActivationEnd,
@@ -38,11 +37,9 @@ import {
 
 import {provideRouter} from '../../src/provide_router';
 import {
-  advance,
   BlankCmp,
   CollectParamsCmp,
   ComponentRecordingRoutePathAndUrl,
-  createRoot,
   EmptyQueryParamsCmp,
   expectEvents,
   onlyNavigationStartAndEnd,
@@ -59,6 +56,8 @@ import {
   TestModule,
   TwoOutletsCmp,
   UserCmp,
+  createRoot,
+  advance,
 } from './integration_helpers';
 import {guardsIntegrationSuite} from './guards.spec';
 import {lazyLoadingIntegrationSuite} from './lazy_loading.spec';
@@ -83,24 +82,23 @@ for (const browserAPI of ['navigation', 'history'] as const) {
         providers: [
           {provide: Console, useValue: noopConsole},
           provideRouter([{path: 'simple', component: SimpleCmp}]),
-          provideZonelessChangeDetection(),
           browserAPI === 'navigation' ? ɵprovideFakePlatformNavigation() : [],
         ],
       });
     });
 
-    it('should navigate with a provided config', fakeAsync(() => {
+    it('should navigate with a provided config', async () => {
       const router: Router = TestBed.inject(Router);
       const location: Location = TestBed.inject(Location);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.navigateByUrl('/simple');
-      advance(fixture);
+      await advance(fixture);
 
       expect(location.path()).toEqual('/simple');
-    }));
+    });
 
-    it('should navigate from ngOnInit hook', fakeAsync(() => {
+    it('should navigate from ngOnInit hook', async () => {
       const router: Router = TestBed.inject(Router);
       const location: Location = TestBed.inject(Location);
       router.resetConfig([
@@ -108,12 +106,12 @@ for (const browserAPI of ['navigation', 'history'] as const) {
         {path: 'one', component: RouteCmp},
       ]);
 
-      const fixture = createRoot(router, RootCmpWithOnInit);
+      const fixture = await createRoot(router, RootCmpWithOnInit);
       expect(location.path()).toEqual('/one');
       expect(fixture.nativeElement).toHaveText('route');
-    }));
+    });
 
-    it('Should work inside ChangeDetectionStrategy.OnPush components', fakeAsync(() => {
+    it('Should work inside ChangeDetectionStrategy.OnPush components', async () => {
       @Component({
         selector: 'root-cmp',
         template: `<router-outlet></router-outlet>`,
@@ -138,7 +136,7 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       TestBed.configureTestingModule({imports: [TestModule]});
 
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -153,19 +151,19 @@ for (const browserAPI of ['navigation', 'history'] as const) {
         },
       ]);
 
-      advance(fixture);
+      await advance(fixture);
       router.navigateByUrl('on');
-      advance(fixture);
+      await advance(fixture);
       router.navigateByUrl('on/push');
-      advance(fixture);
+      await advance(fixture);
 
       expect(fixture.nativeElement).toHaveText('it works!');
-    }));
+    });
 
-    it('should not error when no url left and no children are matching', fakeAsync(() => {
+    it('should not error when no url left and no children are matching', async () => {
       const router: Router = TestBed.inject(Router);
       const location: Location = TestBed.inject(Location);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -176,22 +174,22 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       ]);
 
       router.navigateByUrl('/team/33/simple');
-      advance(fixture);
+      await advance(fixture);
 
       expect(location.path()).toEqual('/team/33/simple');
       expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
 
       router.navigateByUrl('/team/33');
-      advance(fixture);
+      await advance(fixture);
 
       expect(location.path()).toEqual('/team/33');
       expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
-    }));
+    });
 
-    it('should work when an outlet is in an ngIf', fakeAsync(() => {
+    it('should work when an outlet is in an ngIf', async () => {
       const router: Router = TestBed.inject(Router);
       const location: Location = TestBed.inject(Location);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -202,12 +200,12 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       ]);
 
       router.navigateByUrl('/child/simple');
-      advance(fixture);
+      await advance(fixture);
 
       expect(location.path()).toEqual('/child/simple');
-    }));
+    });
 
-    it('should work when an outlet is added/removed', fakeAsync(() => {
+    it('should work when an outlet is added/removed', async () => {
       @Component({
         selector: 'someRoot',
         template: `[<div *ngIf="cond()"><router-outlet></router-outlet></div>]`,
@@ -220,7 +218,7 @@ for (const browserAPI of ['navigation', 'history'] as const) {
 
       const router: Router = TestBed.inject(Router);
 
-      const fixture = createRoot(router, RootCmpWithLink);
+      const fixture = await createRoot(router, RootCmpWithLink);
 
       router.resetConfig([
         {path: 'simple', component: SimpleCmp},
@@ -228,19 +226,19 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       ]);
 
       router.navigateByUrl('/simple');
-      advance(fixture);
+      await advance(fixture);
       expect(fixture.nativeElement).toHaveText('[simple]');
 
       fixture.componentInstance.cond.set(false);
-      advance(fixture);
+      await advance(fixture);
       expect(fixture.nativeElement).toHaveText('[]');
 
       fixture.componentInstance.cond.set(true);
-      advance(fixture);
+      await advance(fixture);
       expect(fixture.nativeElement).toHaveText('[simple]');
-    }));
+    });
 
-    it('should update location when navigating', fakeAsync(() => {
+    it('should update location when navigating', async () => {
       @Component({
         template: `record`,
         standalone: false,
@@ -259,92 +257,92 @@ for (const browserAPI of ['navigation', 'history'] as const) {
 
       const router = TestBed.inject(Router);
       const location = TestBed.inject(Location);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([{path: 'record/:id', component: RecordLocationCmp}]);
 
       router.navigateByUrl('/record/22');
-      advance(fixture);
+      await advance(fixture);
 
       const c = fixture.debugElement.children[1].componentInstance;
       expect(location.path()).toEqual('/record/22');
       expect(c.storedPath).toEqual('/record/22');
 
       router.navigateByUrl('/record/33');
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/record/33');
-    }));
+    });
 
-    it('should skip location update when using NavigationExtras.skipLocationChange with navigateByUrl', fakeAsync(() => {
+    it('should skip location update when using NavigationExtras.skipLocationChange with navigateByUrl', async () => {
       const router: Router = TestBed.inject(Router);
       const location: Location = TestBed.inject(Location);
       const fixture = TestBed.createComponent(RootCmp);
-      advance(fixture);
+      await advance(fixture);
 
       router.resetConfig([{path: 'team/:id', component: TeamCmp}]);
 
       router.navigateByUrl('/team/22');
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/team/22');
 
       expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
 
       router.navigateByUrl('/team/33', {skipLocationChange: true});
-      advance(fixture);
+      await advance(fixture);
 
       expect(location.path()).toEqual('/team/22');
 
       expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
-    }));
+    });
 
-    it('should skip location update when using NavigationExtras.skipLocationChange with navigate', fakeAsync(() => {
+    it('should skip location update when using NavigationExtras.skipLocationChange with navigate', async () => {
       const router: Router = TestBed.inject(Router);
       const location: Location = TestBed.inject(Location);
       const fixture = TestBed.createComponent(RootCmp);
-      advance(fixture);
+      await advance(fixture);
 
       router.resetConfig([{path: 'team/:id', component: TeamCmp}]);
 
       router.navigate(['/team/22']);
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/team/22');
 
       expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
 
       router.navigate(['/team/33'], {skipLocationChange: true});
-      advance(fixture);
+      await advance(fixture);
 
       expect(location.path()).toEqual('/team/22');
 
       expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
-    }));
+    });
 
-    it('should navigate after navigation with skipLocationChange', fakeAsync(() => {
+    it('should navigate after navigation with skipLocationChange', async () => {
       const router: Router = TestBed.inject(Router);
       const location: Location = TestBed.inject(Location);
       const fixture = TestBed.createComponent(RootCmpWithNamedOutlet);
-      advance(fixture);
+      await advance(fixture);
 
       router.resetConfig([{path: 'show', outlet: 'main', component: SimpleCmp}]);
 
       router.navigate([{outlets: {main: 'show'}}], {skipLocationChange: true});
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('');
 
       expect(fixture.nativeElement).toHaveText('main [simple]');
 
       router.navigate([{outlets: {main: null}}], {skipLocationChange: true});
-      advance(fixture);
+      await advance(fixture);
 
       expect(location.path()).toEqual('');
 
       expect(fixture.nativeElement).toHaveText('main []');
-    }));
+    });
 
-    it('should navigate back and forward', fakeAsync(() => {
+    it('should navigate back and forward', async () => {
       const router: Router = TestBed.inject(Router);
       const location: Location = TestBed.inject(Location);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -365,51 +363,51 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       });
 
       router.navigateByUrl('/team/33/simple');
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/team/33/simple');
       const simpleNavStart = event!;
 
       router.navigateByUrl('/team/22/user/victor');
-      advance(fixture);
+      await advance(fixture);
       const userVictorNavStart = event!;
 
       location.back();
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/team/33/simple');
       expect(event!.navigationTrigger).toEqual('popstate');
       expect(event!.restoredState!.navigationId).toEqual(simpleNavStart.id);
 
       location.forward();
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/team/22/user/victor');
       expect(event!.navigationTrigger).toEqual('popstate');
       expect(event!.restoredState!.navigationId).toEqual(userVictorNavStart.id);
-    }));
+    });
 
-    it('should navigate to the same url when config changes', fakeAsync(() => {
+    it('should navigate to the same url when config changes', async () => {
       const router: Router = TestBed.inject(Router);
       const location: Location = TestBed.inject(Location);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([{path: 'a', component: SimpleCmp}]);
 
       router.navigate(['/a']);
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/a');
       expect(fixture.nativeElement).toHaveText('simple');
 
       router.resetConfig([{path: 'a', component: RouteCmp}]);
 
       router.navigate(['/a']);
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/a');
       expect(fixture.nativeElement).toHaveText('route');
-    }));
+    });
 
-    it('should navigate when locations changes', fakeAsync(() => {
+    it('should navigate when locations changes', async () => {
       const router: Router = TestBed.inject(Router);
       const location: Location = TestBed.inject(Location);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -423,15 +421,15 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       router.events.forEach((e) => onlyNavigationStartAndEnd(e) && recordedEvents.push(e));
 
       router.navigateByUrl('/team/22/user/victor');
-      advance(fixture);
+      await advance(fixture);
 
       location.go('/team/22/user/fedor');
       location.historyGo(0);
-      advance(fixture);
+      await advance(fixture);
 
       location.go('/team/22/user/fedor');
       location.historyGo(0);
-      advance(fixture);
+      await advance(fixture);
 
       expect(fixture.nativeElement).toHaveText('team 22 [ user fedor, right:  ]');
 
@@ -441,17 +439,17 @@ for (const browserAPI of ['navigation', 'history'] as const) {
         [NavigationStart, '/team/22/user/fedor'],
         [NavigationEnd, '/team/22/user/fedor'],
       ]);
-    }));
+    });
 
-    it('should update the location when the matched route does not change', fakeAsync(() => {
+    it('should update the location when the matched route does not change', async () => {
       const router: Router = TestBed.inject(Router);
       const location: Location = TestBed.inject(Location);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([{path: '**', component: CollectParamsCmp}]);
 
       router.navigateByUrl('/one/two');
-      advance(fixture);
+      await advance(fixture);
       const cmp = fixture.debugElement.children[1].componentInstance;
       expect(location.path()).toEqual('/one/two');
       expect(fixture.nativeElement).toHaveText('collect-params');
@@ -459,15 +457,15 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       expect(cmp.recordedUrls()).toEqual(['one/two']);
 
       router.navigateByUrl('/three/four');
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/three/four');
       expect(fixture.nativeElement).toHaveText('collect-params');
       expect(cmp.recordedUrls()).toEqual(['one/two', 'three/four']);
-    }));
+    });
 
-    it('should support secondary routes', fakeAsync(() => {
+    it('should support secondary routes', async () => {
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -481,14 +479,14 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       ]);
 
       router.navigateByUrl('/team/22/(user/victor//right:simple)');
-      advance(fixture);
+      await advance(fixture);
 
       expect(fixture.nativeElement).toHaveText('team 22 [ user victor, right: simple ]');
-    }));
+    });
 
-    it('should support secondary routes in separate commands', fakeAsync(() => {
+    it('should support secondary routes in separate commands', async () => {
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -502,16 +500,16 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       ]);
 
       router.navigateByUrl('/team/22/user/victor');
-      advance(fixture);
+      await advance(fixture);
       router.navigate(['team/22', {outlets: {right: 'simple'}}]);
-      advance(fixture);
+      await advance(fixture);
 
       expect(fixture.nativeElement).toHaveText('team 22 [ user victor, right: simple ]');
-    }));
+    });
 
-    it('should support secondary routes as child of empty path parent', fakeAsync(() => {
+    it('should support secondary routes as child of empty path parent', async () => {
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -522,14 +520,14 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       ]);
 
       router.navigateByUrl('/(right:simple)');
-      advance(fixture);
+      await advance(fixture);
 
       expect(fixture.nativeElement).toHaveText('team  [ , right: simple ]');
-    }));
+    });
 
-    it('should deactivate outlets', fakeAsync(() => {
+    it('should deactivate outlets', async () => {
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -543,17 +541,17 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       ]);
 
       router.navigateByUrl('/team/22/(user/victor//right:simple)');
-      advance(fixture);
+      await advance(fixture);
 
       router.navigateByUrl('/team/22/user/victor');
-      advance(fixture);
+      await advance(fixture);
 
       expect(fixture.nativeElement).toHaveText('team 22 [ user victor, right:  ]');
-    }));
+    });
 
-    it('should deactivate nested outlets', fakeAsync(() => {
+    it('should deactivate nested outlets', async () => {
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -568,59 +566,59 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       ]);
 
       router.navigateByUrl('/team/22/(user/victor//right:simple)');
-      advance(fixture);
+      await advance(fixture);
 
       router.navigateByUrl('/');
-      advance(fixture);
+      await advance(fixture);
 
       expect(fixture.nativeElement).toHaveText('');
-    }));
+    });
 
-    it('should set query params and fragment', fakeAsync(() => {
+    it('should set query params and fragment', async () => {
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([{path: 'query', component: QueryParamsAndFragmentCmp}]);
 
       router.navigateByUrl('/query?name=1#fragment1');
-      advance(fixture);
+      await advance(fixture);
       expect(fixture.nativeElement).toHaveText('query: 1 fragment: fragment1');
 
       router.navigateByUrl('/query?name=2#fragment2');
-      advance(fixture);
+      await advance(fixture);
       expect(fixture.nativeElement).toHaveText('query: 2 fragment: fragment2');
-    }));
+    });
 
-    it('should handle empty or missing fragments', fakeAsync(() => {
+    it('should handle empty or missing fragments', async () => {
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([{path: 'query', component: QueryParamsAndFragmentCmp}]);
 
       router.navigateByUrl('/query#');
-      advance(fixture);
+      await advance(fixture);
       expect(fixture.nativeElement).toHaveText('query:  fragment: ');
 
       router.navigateByUrl('/query');
-      advance(fixture);
+      await advance(fixture);
       expect(fixture.nativeElement).toHaveText('query:  fragment: null');
-    }));
+    });
 
-    it('should ignore null and undefined query params', fakeAsync(() => {
+    it('should ignore null and undefined query params', async () => {
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([{path: 'query', component: EmptyQueryParamsCmp}]);
 
       router.navigate(['query'], {queryParams: {name: 1, age: null, page: undefined}});
-      advance(fixture);
+      await advance(fixture);
       const cmp = fixture.debugElement.children[1].componentInstance;
       expect(cmp.recordedParams).toEqual([{name: '1'}]);
-    }));
+    });
 
-    it('should push params only when they change', fakeAsync(() => {
+    it('should push params only when they change', async () => {
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -631,7 +629,7 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       ]);
 
       router.navigateByUrl('/team/22/user/victor');
-      advance(fixture);
+      await advance(fixture);
       const team = fixture.debugElement.children[1].componentInstance;
       const user = fixture.debugElement.children[1].children[1].componentInstance;
 
@@ -641,17 +639,17 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       expect(user.snapshotParams).toEqual([{name: 'victor'}]);
 
       router.navigateByUrl('/team/22/user/fedor');
-      advance(fixture);
+      await advance(fixture);
 
       expect(team.recordedParams).toEqual([{id: '22'}]);
       expect(team.snapshotParams).toEqual([{id: '22'}]);
       expect(user.recordedParams).toEqual([{name: 'victor'}, {name: 'fedor'}]);
       expect(user.snapshotParams).toEqual([{name: 'victor'}, {name: 'fedor'}]);
-    }));
+    });
 
-    it('should work when navigating to /', fakeAsync(() => {
+    it('should work when navigating to /', async () => {
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {path: '', pathMatch: 'full', component: SimpleCmp},
@@ -659,19 +657,19 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       ]);
 
       router.navigateByUrl('/user/victor');
-      advance(fixture);
+      await advance(fixture);
 
       expect(fixture.nativeElement).toHaveText('user victor');
 
       router.navigateByUrl('/');
-      advance(fixture);
+      await advance(fixture);
 
       expect(fixture.nativeElement).toHaveText('simple');
-    }));
+    });
 
-    it('should cancel in-flight navigations', fakeAsync(() => {
+    it('should cancel in-flight navigations', async () => {
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([{path: 'user/:name', component: UserCmp}]);
 
@@ -679,14 +677,14 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       router.events.forEach((e) => recordedEvents.push(e));
 
       router.navigateByUrl('/user/init');
-      advance(fixture);
+      await advance(fixture);
 
       const user = fixture.debugElement.children[1].componentInstance;
 
       let r1: any, r2: any;
       router.navigateByUrl('/user/victor').then((_) => (r1 = _));
       router.navigateByUrl('/user/fedor').then((_) => (r2 = _));
-      advance(fixture);
+      await advance(fixture);
 
       expect(r1).toEqual(false); // returns false because it was canceled
       expect(r2).toEqual(true); // returns true because it was successful
@@ -722,16 +720,16 @@ for (const browserAPI of ['navigation', 'history'] as const) {
         [ChildActivationEnd],
         [NavigationEnd, '/user/fedor'],
       ]);
-    }));
+    });
 
-    it('should properly set currentNavigation when cancelling in-flight navigations', fakeAsync(() => {
+    it('should properly set currentNavigation when cancelling in-flight navigations', async () => {
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([{path: 'user/:name', component: UserCmp}]);
 
       router.navigateByUrl('/user/init');
-      advance(fixture);
+      await advance(fixture);
 
       router.navigateByUrl('/user/victor');
       expect(router.getCurrentNavigation()).not.toBe(null);
@@ -739,16 +737,16 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       // Due to https://github.com/angular/angular/issues/29389, this would be `false`
       // when running a second navigation.
       expect(router.getCurrentNavigation()).not.toBe(null);
-      advance(fixture);
+      await advance(fixture);
 
       expect(router.getCurrentNavigation()).toBe(null);
       expect(fixture.nativeElement).toHaveText('user fedor');
-    }));
+    });
 
-    it('should replace state when path is equal to current path', fakeAsync(() => {
+    it('should replace state when path is equal to current path', async () => {
       const router: Router = TestBed.inject(Router);
       const location: Location = TestBed.inject(Location);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -762,23 +760,23 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       ]);
 
       router.navigateByUrl('/team/33/simple');
-      advance(fixture);
+      await advance(fixture);
 
       router.navigateByUrl('/team/22/user/victor');
-      advance(fixture);
+      await advance(fixture);
 
       router.navigateByUrl('/team/22/user/victor');
-      advance(fixture);
+      await advance(fixture);
 
       location.back();
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/team/33/simple');
-    }));
+    });
 
-    it('should handle componentless paths', fakeAsync(() => {
+    it('should handle componentless paths', async () => {
       const router: Router = TestBed.inject(Router);
       const location: Location = TestBed.inject(Location);
-      const fixture = createRoot(router, RootCmpWithTwoOutlets);
+      const fixture = await createRoot(router, RootCmpWithTwoOutlets);
 
       router.resetConfig([
         {
@@ -793,33 +791,33 @@ for (const browserAPI of ['navigation', 'history'] as const) {
 
       // navigate to a componentless route
       router.navigateByUrl('/parent/11/(simple//right:user/victor)');
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/parent/11/(simple//right:user/victor)');
       expect(fixture.nativeElement).toHaveText('primary [simple] right [user victor]');
 
       // navigate to the same route with different params (reuse)
       router.navigateByUrl('/parent/22/(simple//right:user/fedor)');
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/parent/22/(simple//right:user/fedor)');
       expect(fixture.nativeElement).toHaveText('primary [simple] right [user fedor]');
 
       // navigate to a normal route (check deactivation)
       router.navigateByUrl('/user/victor');
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/user/victor');
       expect(fixture.nativeElement).toHaveText('primary [user victor] right []');
 
       // navigate back to a componentless route
       router.navigateByUrl('/parent/11/(simple//right:user/victor)');
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/parent/11/(simple//right:user/victor)');
       expect(fixture.nativeElement).toHaveText('primary [simple] right [user victor]');
-    }));
+    });
 
-    it('should not deactivate aux routes when navigating from a componentless routes', fakeAsync(() => {
+    it('should not deactivate aux routes when navigating from a componentless routes', async () => {
       const router: Router = TestBed.inject(Router);
       const location: Location = TestBed.inject(Location);
-      const fixture = createRoot(router, TwoOutletsCmp);
+      const fixture = await createRoot(router, TwoOutletsCmp);
 
       router.resetConfig([
         {path: 'simple', component: SimpleCmp},
@@ -828,17 +826,17 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       ]);
 
       router.navigateByUrl('/componentless/simple(aux:user/victor)');
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/componentless/simple(aux:user/victor)');
       expect(fixture.nativeElement).toHaveText('[ simple, aux: user victor ]');
 
       router.navigateByUrl('/simple(aux:user/victor)');
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/simple(aux:user/victor)');
       expect(fixture.nativeElement).toHaveText('[ simple, aux: user victor ]');
-    }));
+    });
 
-    it('should emit an event when an outlet gets activated', fakeAsync(() => {
+    it('should emit an event when an outlet gets activated', async () => {
       @Component({
         selector: 'container',
         template: `<router-outlet (activate)="recordActivate($event)" (deactivate)="recordDeactivate($event)"></router-outlet>`,
@@ -861,7 +859,7 @@ for (const browserAPI of ['navigation', 'history'] as const) {
 
       const router: Router = TestBed.inject(Router);
 
-      const fixture = createRoot(router, Container);
+      const fixture = await createRoot(router, Container);
       const cmp = fixture.componentInstance;
 
       router.resetConfig([
@@ -873,35 +871,35 @@ for (const browserAPI of ['navigation', 'history'] as const) {
       cmp.deactivations = [];
 
       router.navigateByUrl('/blank');
-      advance(fixture);
+      await advance(fixture);
 
       expect(cmp.activations.length).toEqual(1);
       expect(cmp.activations[0] instanceof BlankCmp).toBe(true);
 
       router.navigateByUrl('/simple');
-      advance(fixture);
+      await advance(fixture);
 
       expect(cmp.activations.length).toEqual(2);
       expect(cmp.activations[1] instanceof SimpleCmp).toBe(true);
       expect(cmp.deactivations.length).toEqual(1);
       expect(cmp.deactivations[0] instanceof BlankCmp).toBe(true);
-    }));
+    });
 
-    it('should update url and router state before activating components', fakeAsync(() => {
+    it('should update url and router state before activating components', async () => {
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([{path: 'cmp', component: ComponentRecordingRoutePathAndUrl}]);
 
       router.navigateByUrl('/cmp');
-      advance(fixture);
+      await advance(fixture);
 
       const cmp: ComponentRecordingRoutePathAndUrl =
         fixture.debugElement.children[1].componentInstance;
 
       expect(cmp.url).toBe('/cmp');
       expect(cmp.path.length).toEqual(2);
-    }));
+    });
 
     navigationErrorsIntegrationSuite();
     eagerUrlUpdateStrategyIntegrationSuite();

--- a/packages/router/test/integration/integration_helpers.ts
+++ b/packages/router/test/integration/integration_helpers.ts
@@ -7,7 +7,7 @@
  */
 import {CommonModule} from '@angular/common';
 import {Component, NgModule, Type, signal} from '@angular/core';
-import {ComponentFixture, tick, TestBed} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {
   ActivatedRoute,
   Event,
@@ -24,6 +24,7 @@ import {
 } from '../../index';
 import {Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
+import {timeout} from '../helpers';
 
 export const ROUTER_DIRECTIVES = [RouterLink, RouterLinkActive, RouterOutlet];
 
@@ -361,16 +362,19 @@ export class ConditionalThrowingCmp {
   }
 }
 
-export function advance(fixture: ComponentFixture<unknown>, millis?: number): void {
-  tick(millis);
+export async function advance(
+  fixture: ComponentFixture<unknown>,
+  millis: number = 1,
+): Promise<void> {
+  await timeout(millis);
   fixture.detectChanges();
 }
 
-export function createRoot<T>(router: Router, type: Type<T>): ComponentFixture<T> {
+export async function createRoot<T>(router: Router, type: Type<T>): Promise<ComponentFixture<T>> {
   const f = TestBed.createComponent<T>(type);
-  advance(f);
+  await advance(f);
   router.initialNavigation();
-  advance(f);
+  await advance(f);
   return f;
 }
 

--- a/packages/router/test/integration/lazy_loading.spec.ts
+++ b/packages/router/test/integration/lazy_loading.spec.ts
@@ -16,7 +16,7 @@ import {
   ViewChildren,
   QueryList,
 } from '@angular/core';
-import {fakeAsync, TestBed} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {
   Router,
@@ -48,19 +48,19 @@ import {
 } from '../../index';
 import {getLoadedRoutes} from '../../src/router_devtools';
 import {
-  createRoot,
   RootCmp,
   BlankCmp,
-  advance,
   TeamCmp,
   UserCmp,
   SimpleCmp,
   expectEvents,
+  createRoot,
+  advance,
 } from './integration_helpers';
 
 export function lazyLoadingIntegrationSuite() {
   describe('lazy loading', () => {
-    it('works', fakeAsync(() => {
+    it('works', async () => {
       const router = TestBed.inject(Router);
       const location = TestBed.inject(Location);
 
@@ -92,18 +92,18 @@ export function lazyLoadingIntegrationSuite() {
       })
       class LoadedModule {}
 
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([{path: 'lazy', loadChildren: () => LoadedModule}]);
 
       router.navigateByUrl('/lazy/loaded/child');
-      advance(fixture);
+      await advance(fixture);
 
       expect(location.path()).toEqual('/lazy/loaded/child');
       expect(fixture.nativeElement).toHaveText('lazy-loaded-parent [lazy-loaded-child]');
-    }));
+    });
 
-    it('should have 2 injector trees: module and element', fakeAsync(() => {
+    it('should have 2 injector trees: module and element', async () => {
       const router = TestBed.inject(Router);
       const location = TestBed.inject(Location);
 
@@ -151,10 +151,10 @@ export function lazyLoadingIntegrationSuite() {
       })
       class ChildModule {}
 
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
       router.resetConfig([{path: 'lazy', loadChildren: () => ParentModule}]);
       router.navigateByUrl('/lazy/parent/child');
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/lazy/parent/child');
       expect(fixture.nativeElement).toHaveText('parent[child]');
 
@@ -185,10 +185,10 @@ export function lazyLoadingIntegrationSuite() {
       expect(cmInj.get(Parent, '-')).toEqual('-');
       expect(pmInj.get(Child, '-')).toEqual('-');
       expect(cmInj.get(Child, '-')).toEqual('-');
-    }));
+    });
 
     // https://github.com/angular/angular/issues/12889
-    it('should create a single instance of lazy-loaded modules', fakeAsync(() => {
+    it('should create a single instance of lazy-loaded modules', async () => {
       const router = TestBed.inject(Router);
       const location = TestBed.inject(Location);
 
@@ -225,16 +225,16 @@ export function lazyLoadingIntegrationSuite() {
         }
       }
 
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
       router.resetConfig([{path: 'lazy', loadChildren: () => LoadedModule}]);
       router.navigateByUrl('/lazy/loaded/child');
-      advance(fixture);
+      await advance(fixture);
       expect(fixture.nativeElement).toHaveText('lazy-loaded-parent [lazy-loaded-child]');
       expect(LoadedModule.instances).toEqual(1);
-    }));
+    });
 
     // https://github.com/angular/angular/issues/13870
-    it('should create a single instance of guards for lazy-loaded modules', fakeAsync(() => {
+    it('should create a single instance of guards for lazy-loaded modules', async () => {
       const router = TestBed.inject(Router);
       const location = TestBed.inject(Location);
 
@@ -279,17 +279,17 @@ export function lazyLoadingIntegrationSuite() {
       })
       class LoadedModule {}
 
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
       router.resetConfig([{path: 'lazy', loadChildren: () => LoadedModule}]);
       router.navigateByUrl('/lazy/loaded');
-      advance(fixture);
+      await advance(fixture);
 
       expect(fixture.nativeElement).toHaveText('lazy');
       const lzc = fixture.debugElement.query(By.directive(LazyLoadedComponent)).componentInstance;
       expect(lzc.injectedService).toBe(lzc.resolvedService);
-    }));
+    });
 
-    it('should emit RouteConfigLoadStart and RouteConfigLoadEnd event when route is lazy loaded', fakeAsync(() => {
+    it('should emit RouteConfigLoadStart and RouteConfigLoadEnd event when route is lazy loaded', async () => {
       const router = TestBed.inject(Router);
       const location = TestBed.inject(Location);
 
@@ -329,18 +329,18 @@ export function lazyLoadingIntegrationSuite() {
         }
       });
 
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
       router.resetConfig([{path: 'lazy', loadChildren: () => LoadedModule}]);
 
       router.navigateByUrl('/lazy/loaded/child');
-      advance(fixture);
+      await advance(fixture);
 
       expect(events.length).toEqual(2);
       expect(events[0].toString()).toEqual('RouteConfigLoadStart(path: lazy)');
       expect(events[1].toString()).toEqual('RouteConfigLoadEnd(path: lazy)');
-    }));
+    });
 
-    it('throws an error when forRoot() is used in a lazy context', fakeAsync(() => {
+    it('throws an error when forRoot() is used in a lazy context', async () => {
       const router = TestBed.inject(Router);
       const location = TestBed.inject(Location);
 
@@ -357,17 +357,17 @@ export function lazyLoadingIntegrationSuite() {
       })
       class LoadedModule {}
 
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([{path: 'lazy', loadChildren: () => LoadedModule}]);
 
       let recordedError: any = null;
       router.navigateByUrl('/lazy/loaded')!.catch((err) => (recordedError = err));
-      advance(fixture);
+      await advance(fixture);
       expect(recordedError.message).toContain(`NG04007`);
-    }));
+    });
 
-    it('should combine routes from multiple modules into a single configuration', fakeAsync(() => {
+    it('should combine routes from multiple modules into a single configuration', async () => {
       const router = TestBed.inject(Router);
       const location = TestBed.inject(Location);
 
@@ -400,7 +400,7 @@ export function lazyLoadingIntegrationSuite() {
       })
       class LoadedModule {}
 
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {path: 'lazy1', loadChildren: () => LoadedModule},
@@ -408,15 +408,15 @@ export function lazyLoadingIntegrationSuite() {
       ]);
 
       router.navigateByUrl('/lazy1/loaded');
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/lazy1/loaded');
 
       router.navigateByUrl('/lazy2/loaded');
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/lazy2/loaded');
-    }));
+    });
 
-    it('should allow lazy loaded module in named outlet', fakeAsync(() => {
+    it('should allow lazy loaded module in named outlet', async () => {
       const router = TestBed.inject(Router);
 
       @Component({
@@ -432,7 +432,7 @@ export function lazyLoadingIntegrationSuite() {
       })
       class LazyLoadedModule {}
 
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -446,19 +446,19 @@ export function lazyLoadingIntegrationSuite() {
       ]);
 
       router.navigateByUrl('/team/22/user/john');
-      advance(fixture);
+      await advance(fixture);
 
       expect(fixture.nativeElement).toHaveText('team 22 [ user john, right:  ]');
 
       router.navigateByUrl('/team/22/(user/john//right:lazy)');
-      advance(fixture);
+      await advance(fixture);
 
       expect(fixture.nativeElement).toHaveText('team 22 [ user john, right: lazy-loaded ]');
-    }));
+    });
 
-    it('should allow componentless named outlet to render children', fakeAsync(() => {
+    it('should allow componentless named outlet to render children', async () => {
       const router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -472,19 +472,19 @@ export function lazyLoadingIntegrationSuite() {
       ]);
 
       router.navigateByUrl('/team/22/user/john');
-      advance(fixture);
+      await advance(fixture);
 
       expect(fixture.nativeElement).toHaveText('team 22 [ user john, right:  ]');
 
       router.navigateByUrl('/team/22/(user/john//right:simple)');
-      advance(fixture);
+      await advance(fixture);
 
       expect(fixture.nativeElement).toHaveText('team 22 [ user john, right: simple ]');
-    }));
+    });
 
-    it('should render loadComponent named outlet with children', fakeAsync(() => {
+    it('should render loadComponent named outlet with children', async () => {
       const router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       @Component({
         imports: [RouterModule],
@@ -515,7 +515,7 @@ export function lazyLoadingIntegrationSuite() {
       ]);
 
       router.navigateByUrl('/team/22/(user/john//right:simple)');
-      advance(fixture);
+      await advance(fixture);
 
       expect(fixture.nativeElement).toHaveText(
         'team 22 [ user john, right: [right outlet component: simple] ]',
@@ -528,14 +528,14 @@ export function lazyLoadingIntegrationSuite() {
 
       // Ensure we can navigate away and come back
       router.navigateByUrl('/');
-      advance(fixture);
+      await advance(fixture);
       router.navigateByUrl('/team/22/(user/john//right:simple)');
-      advance(fixture);
+      await advance(fixture);
       expect(fixture.nativeElement).toHaveText(
         'team 22 [ user john, right: [right outlet component: simple] ]',
       );
       expect(loadSpy.calls.count()).toEqual(1);
-    }));
+    });
 
     describe('should use the injector of the lazily-loaded configuration', () => {
       class LazyLoadedServiceDefinedInModule {}
@@ -597,10 +597,10 @@ export function lazyLoadingIntegrationSuite() {
         });
       });
 
-      it('should use the injector of the lazily-loaded configuration', fakeAsync(() => {
+      it('should use the injector of the lazily-loaded configuration', async () => {
         const router = TestBed.inject(Router);
         const location = TestBed.inject(Location);
-        const fixture = createRoot(router, RootCmp);
+        const fixture = await createRoot(router, RootCmp);
 
         router.resetConfig([
           {
@@ -611,14 +611,14 @@ export function lazyLoadingIntegrationSuite() {
         ]);
 
         router.navigateByUrl('/eager-parent/lazy/lazy-parent/lazy-child');
-        advance(fixture);
+        await advance(fixture);
 
         expect(location.path()).toEqual('/eager-parent/lazy/lazy-parent/lazy-child');
         expect(fixture.nativeElement).toHaveText('eager-parent lazy-parent lazy-child');
-      }));
+      });
     });
 
-    it('works when given a callback', fakeAsync(() => {
+    it('works when given a callback', async () => {
       const router = TestBed.inject(Router);
       const location = TestBed.inject(Location);
 
@@ -635,22 +635,22 @@ export function lazyLoadingIntegrationSuite() {
       })
       class LoadedModule {}
 
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([{path: 'lazy', loadChildren: () => LoadedModule}]);
 
       router.navigateByUrl('/lazy/loaded');
-      advance(fixture);
+      await advance(fixture);
 
       expect(location.path()).toEqual('/lazy/loaded');
       expect(fixture.nativeElement).toHaveText('lazy-loaded');
-    }));
+    });
 
-    it('error emit an error when cannot load a config', fakeAsync(() => {
+    it('error emit an error when cannot load a config', async () => {
       const router = TestBed.inject(Router);
       const location = TestBed.inject(Location);
 
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -665,7 +665,7 @@ export function lazyLoadingIntegrationSuite() {
       router.events.forEach((e) => recordedEvents.push(e));
 
       router.navigateByUrl('/lazy/loaded')!.catch((s) => {});
-      advance(fixture);
+      await advance(fixture);
 
       expect(location.path()).toEqual('');
 
@@ -674,26 +674,26 @@ export function lazyLoadingIntegrationSuite() {
         [RouteConfigLoadStart],
         [NavigationError, '/lazy/loaded'],
       ]);
-    }));
+    });
 
-    it('should emit an error when the lazily-loaded config is not valid', fakeAsync(() => {
+    it('should emit an error when the lazily-loaded config is not valid', async () => {
       const router = TestBed.inject(Router);
       @NgModule({imports: [RouterModule.forChild([{path: 'loaded'}])]})
       class LoadedModule {}
 
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
       router.resetConfig([{path: 'lazy', loadChildren: () => LoadedModule}]);
 
       let recordedError: any = null;
       router.navigateByUrl('/lazy/loaded').catch((err) => (recordedError = err));
-      advance(fixture);
+      await advance(fixture);
 
       expect(recordedError.message).toContain(
         `Invalid configuration of route 'lazy/loaded'. One of the following must be provided: component, loadComponent, redirectTo, children or loadChildren`,
       );
-    }));
+    });
 
-    it('should work with complex redirect rules', fakeAsync(() => {
+    it('should work with complex redirect rules', async () => {
       const router = TestBed.inject(Router);
       const location = TestBed.inject(Location);
 
@@ -710,7 +710,7 @@ export function lazyLoadingIntegrationSuite() {
       })
       class LoadedModule {}
 
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {path: 'lazy', loadChildren: () => LoadedModule},
@@ -718,12 +718,12 @@ export function lazyLoadingIntegrationSuite() {
       ]);
 
       router.navigateByUrl('/lazy/loaded');
-      advance(fixture);
+      await advance(fixture);
 
       expect(location.path()).toEqual('/lazy/loaded');
-    }));
+    });
 
-    it('should work with wildcard route', fakeAsync(() => {
+    it('should work with wildcard route', async () => {
       const router = TestBed.inject(Router);
       const location = TestBed.inject(Location);
 
@@ -740,16 +740,16 @@ export function lazyLoadingIntegrationSuite() {
       })
       class LazyLoadedModule {}
 
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([{path: '**', loadChildren: () => LazyLoadedModule}]);
 
       router.navigateByUrl('/lazy');
-      advance(fixture);
+      await advance(fixture);
 
       expect(location.path()).toEqual('/lazy');
       expect(fixture.nativeElement).toHaveText('lazy-loaded');
-    }));
+    });
 
     describe('preloading', () => {
       let log: string[] = [];
@@ -785,9 +785,9 @@ export function lazyLoadingIntegrationSuite() {
         preloader.setUpPreloading();
       });
 
-      it('should work', fakeAsync(() => {
+      it('should work', async () => {
         const router = TestBed.inject(Router);
-        const fixture = createRoot(router, RootCmp);
+        const fixture = await createRoot(router, RootCmp);
 
         router.resetConfig([
           {path: 'blank', component: BlankCmp},
@@ -795,7 +795,7 @@ export function lazyLoadingIntegrationSuite() {
         ]);
 
         router.navigateByUrl('/blank');
-        advance(fixture);
+        await advance(fixture);
 
         const config = router.config;
         const firstRoutes = getLoadedRoutes(config[1])!;
@@ -806,11 +806,11 @@ export function lazyLoadingIntegrationSuite() {
         const secondRoutes = getLoadedRoutes(firstRoutes[0])!;
         expect(secondRoutes).toBeDefined();
         expect(secondRoutes[0].path).toEqual('LoadedModule2');
-      }));
+      });
 
-      it('should not preload when canLoad is present and does not execute guard', fakeAsync(() => {
+      it('should not preload when canLoad is present and does not execute guard', async () => {
         const router = TestBed.inject(Router);
-        const fixture = createRoot(router, RootCmp);
+        const fixture = await createRoot(router, RootCmp);
 
         router.resetConfig([
           {path: 'blank', component: BlankCmp},
@@ -827,24 +827,24 @@ export function lazyLoadingIntegrationSuite() {
         ]);
 
         router.navigateByUrl('/blank');
-        advance(fixture);
+        await advance(fixture);
 
         const config = router.config;
         const firstRoutes = getLoadedRoutes(config[1])!;
 
         expect(firstRoutes).toBeUndefined();
         expect(log.length).toBe(0);
-      }));
+      });
 
-      it('should allow navigation to modules with no routes', fakeAsync(() => {
+      it('should allow navigation to modules with no routes', async () => {
         const router = TestBed.inject(Router);
-        const fixture = createRoot(router, RootCmp);
+        const fixture = await createRoot(router, RootCmp);
 
         router.resetConfig([{path: 'lazy', loadChildren: () => EmptyModule}]);
 
         router.navigateByUrl('/lazy');
-        advance(fixture);
-      }));
+        await advance(fixture);
+      });
     });
 
     describe('custom url handling strategies', () => {
@@ -891,11 +891,11 @@ export function lazyLoadingIntegrationSuite() {
         });
       });
 
-      it('should work', fakeAsync(() => {
+      it('should work', async () => {
         const router = TestBed.inject(Router);
         const location = TestBed.inject(Location);
 
-        const fixture = createRoot(router, RootCmp);
+        const fixture = await createRoot(router, RootCmp);
 
         router.resetConfig([
           {
@@ -913,7 +913,7 @@ export function lazyLoadingIntegrationSuite() {
 
         // supported URL
         router.navigateByUrl('/include/user/kate');
-        advance(fixture);
+        await advance(fixture);
 
         expect(location.path()).toEqual('/include/user/kate');
         expectEvents(events, [
@@ -930,7 +930,7 @@ export function lazyLoadingIntegrationSuite() {
 
         // unsupported URL
         router.navigateByUrl('/exclude/one');
-        advance(fixture);
+        await advance(fixture);
 
         expect(location.path()).toEqual('/exclude/one');
         expect(Object.keys(router.routerState.root.children).length).toEqual(0);
@@ -946,7 +946,7 @@ export function lazyLoadingIntegrationSuite() {
         // another unsupported URL
         location.go('/exclude/two');
         location.historyGo(0);
-        advance(fixture);
+        await advance(fixture);
 
         expect(location.path()).toEqual('/exclude/two');
         expectEvents(events, [[NavigationSkipped, '/exclude/two']]);
@@ -955,7 +955,7 @@ export function lazyLoadingIntegrationSuite() {
         // back to a supported URL
         location.go('/include/simple');
         location.historyGo(0);
-        advance(fixture);
+        await advance(fixture);
 
         expect(location.path()).toEqual('/include/simple');
         expect(fixture.nativeElement).toHaveText('team  [ simple, right:  ]');
@@ -969,13 +969,13 @@ export function lazyLoadingIntegrationSuite() {
           [ResolveEnd, '/include/simple'],
           [NavigationEnd, '/include/simple'],
         ]);
-      }));
+      });
 
-      it('should handle the case when the router takes only the primary url', fakeAsync(() => {
+      it('should handle the case when the router takes only the primary url', async () => {
         const router = TestBed.inject(Router);
         const location = TestBed.inject(Location);
 
-        const fixture = createRoot(router, RootCmp);
+        const fixture = await createRoot(router, RootCmp);
 
         router.resetConfig([
           {
@@ -993,7 +993,7 @@ export function lazyLoadingIntegrationSuite() {
 
         location.go('/include/user/kate(aux:excluded)');
         location.historyGo(0);
-        advance(fixture);
+        await advance(fixture);
 
         expect(location.path()).toEqual('/include/user/kate(aux:excluded)');
         expectEvents(events, [
@@ -1009,12 +1009,12 @@ export function lazyLoadingIntegrationSuite() {
 
         location.go('/include/user/kate(aux:excluded2)');
         location.historyGo(0);
-        advance(fixture);
+        await advance(fixture);
         expectEvents(events, [[NavigationSkipped, '/include/user/kate(aux:excluded2)']]);
         events.splice(0);
 
         router.navigateByUrl('/include/simple');
-        advance(fixture);
+        await advance(fixture);
 
         expect(location.path()).toEqual('/include/simple(aux:excluded2)');
         expectEvents(events, [
@@ -1026,15 +1026,15 @@ export function lazyLoadingIntegrationSuite() {
           [ResolveEnd, '/include/simple'],
           [NavigationEnd, '/include/simple'],
         ]);
-      }));
+      });
 
-      it('should not remove parts of the URL that are not handled by the router when "eager"', fakeAsync(() => {
+      it('should not remove parts of the URL that are not handled by the router when "eager"', async () => {
         TestBed.configureTestingModule({
           providers: [provideRouter([], withRouterConfig({urlUpdateStrategy: 'eager'}))],
         });
         const router = TestBed.inject(Router);
         const location = TestBed.inject(Location);
-        const fixture = createRoot(router, RootCmp);
+        const fixture = await createRoot(router, RootCmp);
 
         router.resetConfig([
           {
@@ -1046,13 +1046,13 @@ export function lazyLoadingIntegrationSuite() {
 
         location.go('/include/user/kate(aux:excluded)');
         location.historyGo(0);
-        advance(fixture);
+        await advance(fixture);
 
         expect(location.path()).toEqual('/include/user/kate(aux:excluded)');
-      }));
+      });
     });
 
-    it('can use `relativeTo` `route.parent` in `routerLink` to close secondary outlet', fakeAsync(() => {
+    it('can use `relativeTo` `route.parent` in `routerLink` to close secondary outlet', async () => {
       // Given
       @Component({
         template: '<router-outlet name="secondary"></router-outlet>',
@@ -1090,8 +1090,8 @@ export function lazyLoadingIntegrationSuite() {
 
       // When
       router.navigateByUrl('/root/childRoot/(secondary:popup)');
-      const fixture = createRoot(router, RootCmp);
-      advance(fixture);
+      const fixture = await createRoot(router, RootCmp);
+      await advance(fixture);
 
       // Then
       const relativeLinkCmp = fixture.debugElement.query(
@@ -1099,9 +1099,9 @@ export function lazyLoadingIntegrationSuite() {
       ).componentInstance;
       expect(relativeLinkCmp.links.first.urlTree.toString()).toEqual('/root/childRoot');
       expect(relativeLinkCmp.links.last.urlTree.toString()).toEqual('/root/childRoot');
-    }));
+    });
 
-    it('should ignore empty path for relative links', fakeAsync(() => {
+    it('should ignore empty path for relative links', async () => {
       const router = TestBed.inject(Router);
       @Component({
         selector: 'link-cmp',
@@ -1120,15 +1120,15 @@ export function lazyLoadingIntegrationSuite() {
       })
       class LazyLoadedModule {}
 
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([{path: 'lazy', loadChildren: () => LazyLoadedModule}]);
 
       router.navigateByUrl('/lazy/foo/bar');
-      advance(fixture);
+      await advance(fixture);
 
       const link = fixture.nativeElement.querySelector('a');
       expect(link.getAttribute('href')).toEqual('/lazy/foo/simple');
-    }));
+    });
   });
 }

--- a/packages/router/test/integration/redirects.spec.ts
+++ b/packages/router/test/integration/redirects.spec.ts
@@ -6,47 +6,45 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import {LocationStrategy, Location, HashLocationStrategy} from '@angular/common';
-import {fakeAsync, TestBed} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {Router, NavigationStart, RoutesRecognized} from '../../src';
 import {createRoot, RootCmp, BlankCmp, TeamCmp, advance} from './integration_helpers';
 
 export function redirectsIntegrationSuite() {
   describe('redirects', () => {
-    it('should work', fakeAsync(() => {
+    it('should work', async () => {
       const router = TestBed.inject(Router);
       const location = TestBed.inject(Location);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {path: 'old/team/:id', redirectTo: 'team/:id'},
         {path: 'team/:id', component: TeamCmp},
       ]);
 
-      router.navigateByUrl('old/team/22');
-      advance(fixture);
+      await router.navigateByUrl('old/team/22');
 
       expect(location.path()).toEqual('/team/22');
-    }));
+    });
 
-    it('can redirect from componentless named outlets', fakeAsync(() => {
+    it('can redirect from componentless named outlets', async () => {
       const router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {path: 'main', outlet: 'aux', component: BlankCmp},
         {path: '', pathMatch: 'full', outlet: 'aux', redirectTo: 'main'},
       ]);
 
-      router.navigateByUrl('');
-      advance(fixture);
+      await router.navigateByUrl('');
 
       expect(TestBed.inject(Location).path()).toEqual('/(aux:main)');
-    }));
+    });
 
-    it('should update Navigation object after redirects are applied', fakeAsync(() => {
+    it('should update Navigation object after redirects are applied', async () => {
       const router = TestBed.inject(Router);
       const location = TestBed.inject(Location);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
       let initialUrl, afterRedirectUrl;
 
       router.resetConfig([
@@ -65,21 +63,20 @@ export function redirectsIntegrationSuite() {
         }
       });
 
-      router.navigateByUrl('old/team/22');
-      advance(fixture);
+      await router.navigateByUrl('old/team/22');
 
       expect(initialUrl).toBeUndefined();
       expect(router.serializeUrl(afterRedirectUrl as any)).toBe('/team/22');
-    }));
+    });
 
-    it('should not break the back button when trigger by location change', fakeAsync(() => {
+    it('should not break the back button when trigger by location change', async () => {
       TestBed.configureTestingModule({
         providers: [{provide: LocationStrategy, useClass: HashLocationStrategy}],
       });
       const router = TestBed.inject(Router);
       const location = TestBed.inject(Location);
       const fixture = TestBed.createComponent(RootCmp);
-      advance(fixture);
+      await advance(fixture);
       router.resetConfig([
         {path: 'initial', component: BlankCmp},
         {path: 'old/team/:id', redirectTo: 'team/:id'},
@@ -93,23 +90,23 @@ export function redirectsIntegrationSuite() {
 
       // initial navigation
       router.initialNavigation();
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/team/22');
 
       location.back();
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/initial');
 
       // location change
       location.go('/old/team/33');
       location.historyGo(0);
 
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/team/33');
 
       location.back();
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/initial');
-    }));
+    });
   });
 }

--- a/packages/router/test/integration/route_data.spec.ts
+++ b/packages/router/test/integration/route_data.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import {Component, inject, NgModule, Injectable} from '@angular/core';
-import {TestBed, fakeAsync} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {Location} from '@angular/common';
 import {
   ActivatedRouteSnapshot,
@@ -29,16 +29,16 @@ import {map} from 'rxjs/operators';
 import {EMPTY, Observer, Observable, of} from 'rxjs';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {
-  createRoot,
   RootCmp,
   BlankCmp,
   RootCmpWithTwoOutlets,
   RouteCmp,
-  advance,
   SimpleCmp,
   expectEvents,
   CollectParamsCmp,
   WrapperCmp,
+  createRoot,
+  advance,
 } from './integration_helpers';
 
 export function routeDataIntegrationSuite() {
@@ -75,9 +75,9 @@ export function routeDataIntegrationSuite() {
       });
     });
 
-    it('should provide resolved data', fakeAsync(() => {
+    it('should provide resolved data', async () => {
       const router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmpWithTwoOutlets);
+      const fixture = await createRoot(router, RootCmpWithTwoOutlets);
 
       router.resetConfig([
         {
@@ -98,7 +98,7 @@ export function routeDataIntegrationSuite() {
       ]);
 
       router.navigateByUrl('/parent/1');
-      advance(fixture);
+      await advance(fixture);
 
       const primaryCmp = fixture.debugElement.children[1].componentInstance;
       const rightCmp = fixture.debugElement.children[3].componentInstance;
@@ -113,15 +113,15 @@ export function routeDataIntegrationSuite() {
       rightCmp.route.data.forEach((rec: any) => rightRecorded.push(rec));
 
       router.navigateByUrl('/parent/2');
-      advance(fixture);
+      await advance(fixture);
 
       expect(primaryRecorded).toEqual([{one: 1, three: 3, two: 2, four: 4}]);
       expect(rightRecorded).toEqual([{one: 1, five: 5, two: 2, six: 6}]);
-    }));
+    });
 
-    it('should handle errors', fakeAsync(() => {
+    it('should handle errors', async () => {
       const router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {path: 'simple', component: SimpleCmp, resolve: {error: 'resolveError'}},
@@ -132,7 +132,7 @@ export function routeDataIntegrationSuite() {
 
       let e: any = null;
       router.navigateByUrl('/simple')!.catch((error) => (e = error));
-      advance(fixture);
+      await advance(fixture);
 
       expectEvents(recordedEvents, [
         [NavigationStart, '/simple'],
@@ -144,11 +144,11 @@ export function routeDataIntegrationSuite() {
       ]);
 
       expect(e).toEqual('error');
-    }));
+    });
 
-    it('should handle empty errors', fakeAsync(() => {
+    it('should handle empty errors', async () => {
       const router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {path: 'simple', component: SimpleCmp, resolve: {error: 'resolveNullError'}},
@@ -159,14 +159,14 @@ export function routeDataIntegrationSuite() {
 
       let e: any = 'some value';
       router.navigateByUrl('/simple').catch((error) => (e = error));
-      advance(fixture);
+      await advance(fixture);
 
       expect(e).toEqual(null);
-    }));
+    });
 
-    it('should not navigate when all resolvers return empty result', fakeAsync(() => {
+    it('should not navigate when all resolvers return empty result', async () => {
       const router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -181,7 +181,7 @@ export function routeDataIntegrationSuite() {
 
       let e: any = null;
       router.navigateByUrl('/simple').catch((error) => (e = error));
-      advance(fixture);
+      await advance(fixture);
 
       expectEvents(recordedEvents, [
         [NavigationStart, '/simple'],
@@ -197,11 +197,11 @@ export function routeDataIntegrationSuite() {
       );
 
       expect(e).toEqual(null);
-    }));
+    });
 
-    it('should not navigate when at least one resolver returns empty result', fakeAsync(() => {
+    it('should not navigate when at least one resolver returns empty result', async () => {
       const router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {path: 'simple', component: SimpleCmp, resolve: {e1: 'resolveTwo', e2: 'resolveEmpty'}},
@@ -212,7 +212,7 @@ export function routeDataIntegrationSuite() {
 
       let e: any = null;
       router.navigateByUrl('/simple').catch((error) => (e = error));
-      advance(fixture);
+      await advance(fixture);
 
       expectEvents(recordedEvents, [
         [NavigationStart, '/simple'],
@@ -224,11 +224,11 @@ export function routeDataIntegrationSuite() {
       ]);
 
       expect(e).toEqual(null);
-    }));
+    });
 
-    it('should not navigate when all resolvers for a child route from forChild() returns empty result', fakeAsync(() => {
+    it('should not navigate when all resolvers for a child route from forChild() returns empty result', async () => {
       const router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       @Component({
         selector: 'lazy-cmp',
@@ -258,7 +258,7 @@ export function routeDataIntegrationSuite() {
 
       let e: any = null;
       router.navigateByUrl('lazy/loaded').catch((error) => (e = error));
-      advance(fixture);
+      await advance(fixture);
 
       expectEvents(recordedEvents, [
         [NavigationStart, '/lazy/loaded'],
@@ -270,11 +270,11 @@ export function routeDataIntegrationSuite() {
       ]);
 
       expect(e).toEqual(null);
-    }));
+    });
 
-    it('should not navigate when at least one resolver for a child route from forChild() returns empty result', fakeAsync(() => {
+    it('should not navigate when at least one resolver for a child route from forChild() returns empty result', async () => {
       const router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       @Component({
         selector: 'lazy-cmp',
@@ -304,7 +304,7 @@ export function routeDataIntegrationSuite() {
 
       let e: any = null;
       router.navigateByUrl('lazy/loaded').catch((error) => (e = error));
-      advance(fixture);
+      await advance(fixture);
 
       expectEvents(recordedEvents, [
         [NavigationStart, '/lazy/loaded'],
@@ -316,7 +316,7 @@ export function routeDataIntegrationSuite() {
       ]);
 
       expect(e).toEqual(null);
-    }));
+    });
 
     it('should include target snapshot in NavigationError when resolver throws', async () => {
       const router = TestBed.inject(Router);
@@ -348,9 +348,9 @@ export function routeDataIntegrationSuite() {
       expect(caughtError?.target).toBeDefined();
     });
 
-    it('should preserve resolved data', fakeAsync(() => {
+    it('should preserve resolved data', async () => {
       const router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -364,18 +364,18 @@ export function routeDataIntegrationSuite() {
       ]);
 
       router.navigateByUrl('/parent/child1');
-      advance(fixture);
+      await advance(fixture);
 
       router.navigateByUrl('/parent/child2');
-      advance(fixture);
+      await advance(fixture);
 
       const cmp: CollectParamsCmp = fixture.debugElement.children[1].componentInstance;
       expect(cmp.route.snapshot.data).toEqual({two: 2});
-    }));
+    });
 
-    it('should override route static data with resolved data', fakeAsync(() => {
+    it('should override route static data with resolved data', async () => {
       const router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -387,15 +387,15 @@ export function routeDataIntegrationSuite() {
       ]);
 
       router.navigateByUrl('/');
-      advance(fixture);
+      await advance(fixture);
       const cmp = fixture.debugElement.children[1].componentInstance;
 
       expect(cmp.data).toEqual([{prop: 2}]);
-    }));
+    });
 
-    it('should correctly override inherited route static data with resolved data', fakeAsync(() => {
+    it('should correctly override inherited route static data with resolved data', async () => {
       const router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -424,17 +424,17 @@ export function routeDataIntegrationSuite() {
       ]);
 
       router.navigateByUrl('/a/b/c');
-      advance(fixture);
+      await advance(fixture);
 
       const pInj = fixture.debugElement.queryAll(By.directive(NestedComponentWithData))[0]
         .injector!;
       const cmp = pInj.get(NestedComponentWithData);
       expect(cmp.data).toEqual([{prop: 'nested-b', prop3: 'nested'}]);
-    }));
+    });
 
-    it('should not override inherited resolved data with inherited static data', fakeAsync(() => {
+    it('should not override inherited resolved data with inherited static data', async () => {
       const router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -467,17 +467,17 @@ export function routeDataIntegrationSuite() {
       ]);
 
       router.navigateByUrl('/a/b/c');
-      advance(fixture);
+      await advance(fixture);
 
       const pInj = fixture.debugElement.queryAll(By.directive(NestedComponentWithData))[0]
         .injector!;
       const cmp = pInj.get(NestedComponentWithData);
       expect(cmp.data).toEqual([{prop: 'nested-d', prop2: 4}]);
-    }));
+    });
 
-    it('should not override nested route static data when both are using resolvers', fakeAsync(() => {
+    it('should not override nested route static data when both are using resolvers', async () => {
       const router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -496,16 +496,16 @@ export function routeDataIntegrationSuite() {
       ]);
 
       router.navigateByUrl('/child');
-      advance(fixture);
+      await advance(fixture);
 
       const pInj = fixture.debugElement.query(By.directive(NestedComponentWithData)).injector!;
       const cmp = pInj.get(NestedComponentWithData);
       expect(cmp.data).toEqual([{prop: 4}]);
-    }));
+    });
 
-    it("should not override child route's static data when both are using static data", fakeAsync(() => {
+    it("should not override child route's static data when both are using static data", async () => {
       const router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -524,16 +524,16 @@ export function routeDataIntegrationSuite() {
       ]);
 
       router.navigateByUrl('/child');
-      advance(fixture);
+      await advance(fixture);
 
       const pInj = fixture.debugElement.query(By.directive(NestedComponentWithData)).injector!;
       const cmp = pInj.get(NestedComponentWithData);
       expect(cmp.data).toEqual([{prop: 'inner'}]);
-    }));
+    });
 
-    it("should not override child route's static data when wrapper is using resolved data and the child route static data", fakeAsync(() => {
+    it("should not override child route's static data when wrapper is using resolved data and the child route static data", async () => {
       const router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -553,7 +553,7 @@ export function routeDataIntegrationSuite() {
       ]);
 
       router.navigateByUrl('/nested');
-      advance(fixture);
+      await advance(fixture);
 
       const pInj = fixture.debugElement.query(By.directive(NestedComponentWithData)).injector!;
       const cmp = pInj.get(NestedComponentWithData);
@@ -562,11 +562,11 @@ export function routeDataIntegrationSuite() {
       expect(cmp.data).toEqual([
         {prop: 'nested', prop2: 6, prop3: 'wrapper-static', prop4: 'nested-static'},
       ]);
-    }));
+    });
 
-    it('should allow guards alter data resolved by routes', fakeAsync(() => {
+    it('should allow guards alter data resolved by routes', async () => {
       const router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -582,17 +582,17 @@ export function routeDataIntegrationSuite() {
       ]);
 
       router.navigateByUrl('/route');
-      advance(fixture);
+      await advance(fixture);
 
       const pInj = fixture.debugElement.query(By.directive(NestedComponentWithData)).injector!;
       const cmp = pInj.get(NestedComponentWithData);
       expect(cmp.data).toEqual([{prop: 10}]);
-    }));
+    });
 
-    it('should rerun resolvers when the urls segments of a wildcard route change', fakeAsync(() => {
+    it('should rerun resolvers when the urls segments of a wildcard route change', async () => {
       const router = TestBed.inject(Router);
       const location = TestBed.inject(Location);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -603,16 +603,16 @@ export function routeDataIntegrationSuite() {
       ]);
 
       router.navigateByUrl('/one/two');
-      advance(fixture);
+      await advance(fixture);
       const cmp = fixture.debugElement.children[1].componentInstance;
 
       expect(cmp.route.snapshot.data).toEqual({numberOfUrlSegments: 2});
 
       router.navigateByUrl('/one/two/three');
-      advance(fixture);
+      await advance(fixture);
 
       expect(cmp.route.snapshot.data).toEqual({numberOfUrlSegments: 3});
-    }));
+    });
 
     describe('should run resolvers for the same route concurrently', () => {
       let log: string[];
@@ -648,9 +648,9 @@ export function routeDataIntegrationSuite() {
         });
       });
 
-      it('works', fakeAsync(() => {
+      it('works', async () => {
         const router = TestBed.inject(Router);
-        const fixture = createRoot(router, RootCmp);
+        const fixture = await createRoot(router, RootCmp);
 
         router.resetConfig([
           {
@@ -664,15 +664,15 @@ export function routeDataIntegrationSuite() {
         ]);
 
         router.navigateByUrl('/a');
-        advance(fixture);
+        await advance(fixture);
 
         expect(log).toEqual(['resolver2', 'resolver1']);
-      }));
+      });
     });
 
-    it('can resolve symbol keys', fakeAsync(() => {
+    it('can resolve symbol keys', async () => {
       const router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
       const symbolKey = Symbol('key');
 
       router.resetConfig([
@@ -680,14 +680,14 @@ export function routeDataIntegrationSuite() {
       ]);
 
       router.navigateByUrl('/simple');
-      advance(fixture);
+      await advance(fixture);
 
       expect(router.routerState.root.snapshot.firstChild!.data[symbolKey]).toEqual(4);
-    }));
+    });
 
-    it('should allow resolvers as pure functions', fakeAsync(() => {
+    it('should allow resolvers as pure functions', async () => {
       const router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
       const user = Symbol('user');
 
       const userResolver: ResolveFn<string> = (route: ActivatedRouteSnapshot) =>
@@ -695,14 +695,14 @@ export function routeDataIntegrationSuite() {
       router.resetConfig([{path: ':user', component: SimpleCmp, resolve: {[user]: userResolver}}]);
 
       router.navigateByUrl('/atscott');
-      advance(fixture);
+      await advance(fixture);
 
       expect(router.routerState.root.snapshot.firstChild!.data[user]).toEqual('atscott');
-    }));
+    });
 
-    it('should allow DI in resolvers as pure functions', fakeAsync(() => {
+    it('should allow DI in resolvers as pure functions', async () => {
       const router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
       const user = Symbol('user');
 
       @Injectable({providedIn: 'root'})
@@ -721,9 +721,9 @@ export function routeDataIntegrationSuite() {
       ]);
 
       router.navigateByUrl('/');
-      advance(fixture);
+      await advance(fixture);
 
       expect(router.routerState.root.snapshot.firstChild!.data[user]).toEqual('atscott');
-    }));
+    });
   });
 }

--- a/packages/router/test/integration/router_events.spec.ts
+++ b/packages/router/test/integration/router_events.spec.ts
@@ -7,7 +7,7 @@
  */
 import {filter, tap, first} from 'rxjs/operators';
 import {Event} from '../../index';
-import {fakeAsync, TestBed} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {
   Router,
@@ -28,9 +28,9 @@ import {createRoot, RootCmp, BlankCmp, UserCmp, advance, expectEvents} from './i
 
 export function routerEventsIntegrationSuite() {
   describe('route events', () => {
-    it('should fire matching (Child)ActivationStart/End events', fakeAsync(() => {
+    it('should fire matching (Child)ActivationStart/End events', async () => {
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([{path: 'user/:name', component: UserCmp}]);
 
@@ -38,7 +38,7 @@ export function routerEventsIntegrationSuite() {
       router.events.forEach((e) => recordedEvents.push(e));
 
       router.navigateByUrl('/user/fedor');
-      advance(fixture);
+      await advance(fixture);
 
       const event3 = recordedEvents[3] as ChildActivationStart;
       const event9 = recordedEvents[9] as ChildActivationEnd;
@@ -70,11 +70,11 @@ export function routerEventsIntegrationSuite() {
         [ChildActivationEnd],
         [NavigationEnd, '/user/fedor'],
       ]);
-    }));
+    });
 
-    it('should allow redirection in NavigationStart', fakeAsync(() => {
+    it('should allow redirection in NavigationStart', async () => {
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {path: 'blank', component: UserCmp},
@@ -99,54 +99,54 @@ export function routerEventsIntegrationSuite() {
       });
 
       router.navigate(['/user/:fedor']);
-      advance(fixture);
+      await advance(fixture);
 
       expect(navigateSpy.calls.mostRecent().args[1]!.queryParams);
-    }));
+    });
 
-    it('should stop emitting events after the router is destroyed', fakeAsync(() => {
+    it('should stop emitting events after the router is destroyed', async () => {
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
       router.resetConfig([{path: 'user/:name', component: UserCmp}]);
 
       let events = 0;
       const subscription = router.events.subscribe(() => events++);
 
       router.navigateByUrl('/user/frodo');
-      advance(fixture);
+      await advance(fixture);
       expect(events).toBeGreaterThan(0);
 
       const previousCount = events;
       router.dispose();
       router.navigateByUrl('/user/bilbo');
-      advance(fixture);
+      await advance(fixture);
 
       expect(events).toBe(previousCount);
       subscription.unsubscribe();
-    }));
+    });
 
-    it('should resolve navigation promise with false after the router is destroyed', fakeAsync(() => {
+    it('should resolve navigation promise with false after the router is destroyed', async () => {
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
       let result = null as boolean | null;
       const callback = (r: boolean) => (result = r);
       router.resetConfig([{path: 'user/:name', component: UserCmp}]);
 
       router.navigateByUrl('/user/frodo').then(callback);
-      advance(fixture);
+      await advance(fixture);
       expect(result).toBe(true);
       result = null as boolean | null;
 
       router.dispose();
 
       router.navigateByUrl('/user/bilbo').then(callback);
-      advance(fixture);
+      await advance(fixture);
       expect(result).toBe(false);
       result = null as boolean | null;
 
       router.navigate(['/user/bilbo']).then(callback);
-      advance(fixture);
+      await advance(fixture);
       expect(result).toBe(false);
-    }));
+    });
   });
 }

--- a/packages/router/test/integration/router_link_active.spec.ts
+++ b/packages/router/test/integration/router_link_active.spec.ts
@@ -7,27 +7,27 @@
  */
 import {Component, NgZone} from '@angular/core';
 import {Location} from '@angular/common';
-import {fakeAsync, TestBed} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {Router, provideRouter} from '../../src';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {
-  createRoot,
   RootCmp,
   BlankCmp,
   TeamCmp,
   DummyLinkCmp,
   SimpleCmp,
-  advance,
   DummyLinkWithParentCmp,
   ROUTER_DIRECTIVES,
+  createRoot,
+  advance,
 } from './integration_helpers';
 
 export function routerLinkActiveIntegrationSuite() {
   describe('routerLinkActive', () => {
-    it('should set the class when the link is active (a tag)', fakeAsync(() => {
+    it('should set the class when the link is active (a tag)', async () => {
       const router: Router = TestBed.inject(Router);
       const location: Location = TestBed.inject(Location);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -47,8 +47,8 @@ export function routerLinkActiveIntegrationSuite() {
       ]);
 
       router.navigateByUrl('/team/22/link;exact=true');
-      advance(fixture);
-      advance(fixture);
+      await advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/team/22/link;exact=true');
 
       const nativeLink = fixture.nativeElement.querySelector('a');
@@ -57,13 +57,13 @@ export function routerLinkActiveIntegrationSuite() {
       expect(nativeButton.className).toEqual('active');
 
       router.navigateByUrl('/team/22/link/simple');
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/team/22/link/simple');
       expect(nativeLink.className).toEqual('');
       expect(nativeButton.className).toEqual('');
-    }));
+    });
 
-    it('should not set the class until the first navigation succeeds', fakeAsync(() => {
+    it('should not set the class until the first navigation succeeds', async () => {
       @Component({
         template:
           '<router-outlet></router-outlet><a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" ></a>',
@@ -75,21 +75,21 @@ export function routerLinkActiveIntegrationSuite() {
       const router: Router = TestBed.inject(Router);
 
       const f = TestBed.createComponent(RootCmpWithLink);
-      advance(f);
+      await advance(f);
 
       const link = f.nativeElement.querySelector('a');
       expect(link.className).toEqual('');
 
       router.initialNavigation();
-      advance(f);
+      await advance(f);
 
       expect(link.className).toEqual('active');
-    }));
+    });
 
-    it('should set the class on a parent element when the link is active', fakeAsync(() => {
+    it('should set the class on a parent element when the link is active', async () => {
       const router: Router = TestBed.inject(Router);
       const location: Location = TestBed.inject(Location);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -109,23 +109,23 @@ export function routerLinkActiveIntegrationSuite() {
       ]);
 
       router.navigateByUrl('/team/22/link;exact=true');
-      advance(fixture);
-      advance(fixture);
+      await advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/team/22/link;exact=true');
 
       const native = fixture.nativeElement.querySelector('#link-parent');
       expect(native.className).toEqual('active');
 
       router.navigateByUrl('/team/22/link/simple');
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/team/22/link/simple');
       expect(native.className).toEqual('');
-    }));
+    });
 
-    it('should set the class when the link is active', fakeAsync(() => {
+    it('should set the class when the link is active', async () => {
       const router: Router = TestBed.inject(Router);
       const location: Location = TestBed.inject(Location);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -145,20 +145,20 @@ export function routerLinkActiveIntegrationSuite() {
       ]);
 
       router.navigateByUrl('/team/22/link');
-      advance(fixture);
-      advance(fixture);
+      await advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/team/22/link');
 
       const native = fixture.nativeElement.querySelector('a');
       expect(native.className).toEqual('active');
 
       router.navigateByUrl('/team/22/link/simple');
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/team/22/link/simple');
       expect(native.className).toEqual('active');
-    }));
+    });
 
-    it('should expose an isActive property', fakeAsync(() => {
+    it('should expose an isActive property', async () => {
       @Component({
         template: `<a routerLink="/team" routerLinkActive #rla="routerLinkActive"></a>
                <p>{{rla.isActive}}</p>
@@ -184,20 +184,19 @@ export function routerLinkActiveIntegrationSuite() {
       ]);
 
       const fixture = TestBed.createComponent(ComponentWithRouterLink);
-      router.navigateByUrl('/team');
-      expect(() => advance(fixture)).not.toThrow();
-      advance(fixture);
+      await expectAsync(router.navigateByUrl('/team')).toBeResolved();
+      await advance(fixture);
 
       const paragraph = fixture.nativeElement.querySelector('p');
       expect(paragraph.textContent).toEqual('true');
 
       router.navigateByUrl('/otherteam');
-      advance(fixture);
-      advance(fixture);
+      await advance(fixture);
+      await advance(fixture);
       expect(paragraph.textContent).toEqual('false');
-    }));
+    });
 
-    it('should not trigger change detection when active state has not changed', fakeAsync(() => {
+    it('should not trigger change detection when active state has not changed', async () => {
       @Component({
         template: `<div id="link" routerLinkActive="active" [routerLink]="link"></div>`,
         standalone: false,
@@ -218,16 +217,16 @@ export function routerLinkActiveIntegrationSuite() {
         declarations: [LinkComponent, SimpleComponent],
       });
 
-      const fixture = createRoot(TestBed.inject(Router), LinkComponent);
+      const fixture = await createRoot(TestBed.inject(Router), LinkComponent);
       fixture.componentInstance.link = 'stillnotactive';
       fixture.detectChanges(false /** checkNoChanges */);
       expect(TestBed.inject(NgZone).hasPendingMicrotasks).toBe(false);
-    }));
+    });
 
-    it('should emit on isActiveChange output when link is activated or inactivated', fakeAsync(() => {
+    it('should emit on isActiveChange output when link is activated or inactivated', async () => {
       const router: Router = TestBed.inject(Router);
       const location: Location = TestBed.inject(Location);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -247,8 +246,8 @@ export function routerLinkActiveIntegrationSuite() {
       ]);
 
       router.navigateByUrl('/team/22/link;exact=true');
-      advance(fixture);
-      advance(fixture);
+      await advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/team/22/link;exact=true');
 
       const linkComponent = fixture.debugElement.query(By.directive(DummyLinkCmp))
@@ -261,17 +260,17 @@ export function routerLinkActiveIntegrationSuite() {
       expect(nativeButton.className).toEqual('active');
 
       router.navigateByUrl('/team/22/link/simple');
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/team/22/link/simple');
       expect(linkComponent.isLinkActivated).toEqual(false);
       expect(nativeLink.className).toEqual('');
       expect(nativeButton.className).toEqual('');
-    }));
+    });
 
-    it('should set a provided aria-current attribute when the link is active (a tag)', fakeAsync(() => {
+    it('should set a provided aria-current attribute when the link is active (a tag)', async () => {
       const router: Router = TestBed.inject(Router);
       const location: Location = TestBed.inject(Location);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -291,8 +290,8 @@ export function routerLinkActiveIntegrationSuite() {
       ]);
 
       router.navigateByUrl('/team/22/link;exact=true');
-      advance(fixture);
-      advance(fixture);
+      await advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/team/22/link;exact=true');
 
       const nativeLink = fixture.nativeElement.querySelector('a');
@@ -301,10 +300,10 @@ export function routerLinkActiveIntegrationSuite() {
       expect(nativeButton.hasAttribute('aria-current')).toEqual(false);
 
       router.navigateByUrl('/team/22/link/simple');
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/team/22/link/simple');
       expect(nativeLink.hasAttribute('aria-current')).toEqual(false);
       expect(nativeButton.hasAttribute('aria-current')).toEqual(false);
-    }));
+    });
   });
 }

--- a/packages/router/test/integration/router_links.spec.ts
+++ b/packages/router/test/integration/router_links.spec.ts
@@ -7,16 +7,14 @@
  */
 import {Component} from '@angular/core';
 import {Location} from '@angular/common';
-import {fakeAsync, TestBed, ComponentFixture} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {Router} from '../../src';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {
-  advance,
   RootCmp,
   BlankCmp,
   TeamCmp,
-  createRoot,
   StringLinkCmp,
   SimpleCmp,
   StringLinkButtonCmp,
@@ -26,45 +24,48 @@ import {
   LinkWithQueryParamsAndFragment,
   LinkWithState,
   DivLinkWithState,
+  createRoot,
+  advance,
 } from './integration_helpers';
+import {timeout} from '../helpers';
 
 export function routerLinkIntegrationSpec() {
   describe('router links', () => {
-    it('should support skipping location update for anchor router links', fakeAsync(() => {
+    it('should support skipping location update for anchor router links', async () => {
       const router: Router = TestBed.inject(Router);
       const location: Location = TestBed.inject(Location);
-      const fixture = TestBed.createComponent(RootCmp);
-      advance(fixture);
+      const fixture = await createRoot(router, RootCmp);
+      await advance(fixture);
 
       router.resetConfig([{path: 'team/:id', component: TeamCmp}]);
 
       router.navigateByUrl('/team/22');
-      advance(fixture);
+      await advance(fixture);
       expect(location.path()).toEqual('/team/22');
       expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
 
       const teamCmp = fixture.debugElement.childNodes[1].componentInstance;
 
       teamCmp.routerLink.set(['/team/0']);
-      advance(fixture);
+      await advance(fixture);
       const anchor = fixture.debugElement.query(By.css('a')).nativeElement;
       anchor.click();
-      advance(fixture);
+      await advance(fixture);
       expect(fixture.nativeElement).toHaveText('team 0 [ , right:  ]');
       expect(location.path()).toEqual('/team/22');
 
       teamCmp.routerLink.set(['/team/1']);
-      advance(fixture);
+      await advance(fixture);
       const button = fixture.debugElement.query(By.css('button')).nativeElement;
       button.click();
-      advance(fixture);
+      await advance(fixture);
       expect(fixture.nativeElement).toHaveText('team 1 [ , right:  ]');
       expect(location.path()).toEqual('/team/22');
-    }));
+    });
 
-    it('should support string router links', fakeAsync(() => {
+    it('should support string router links', async () => {
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -78,19 +79,19 @@ export function routerLinkIntegrationSpec() {
       ]);
 
       router.navigateByUrl('/team/22/link');
-      advance(fixture);
+      await advance(fixture);
       expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
 
       const native = fixture.nativeElement.querySelector('a');
       expect(native.getAttribute('href')).toEqual('/team/33/simple');
       expect(native.getAttribute('target')).toEqual('_self');
       native.click();
-      advance(fixture);
+      await advance(fixture);
 
       expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
-    }));
+    });
 
-    it('should not preserve query params and fragment by default', fakeAsync(() => {
+    it('should not preserve query params and fragment by default', async () => {
       @Component({
         selector: 'someRoot',
         template: `<router-outlet></router-outlet><a routerLink="/home">Link</a>`,
@@ -101,18 +102,18 @@ export function routerLinkIntegrationSpec() {
       TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
       const router: Router = TestBed.inject(Router);
 
-      const fixture = createRoot(router, RootCmpWithLink);
+      const fixture = await createRoot(router, RootCmpWithLink);
 
       router.resetConfig([{path: 'home', component: SimpleCmp}]);
 
       const native = fixture.nativeElement.querySelector('a');
 
       router.navigateByUrl('/home?q=123#fragment');
-      advance(fixture);
+      await advance(fixture);
       expect(native.getAttribute('href')).toEqual('/home');
-    }));
+    });
 
-    it('should not throw when commands is null or undefined', fakeAsync(() => {
+    it('should not throw when commands is null or undefined', async () => {
       @Component({
         selector: 'someCmp',
         template: `<router-outlet></router-outlet>
@@ -128,7 +129,7 @@ export function routerLinkIntegrationSpec() {
       TestBed.configureTestingModule({declarations: [CmpWithLink]});
       const router: Router = TestBed.inject(Router);
 
-      let fixture: ComponentFixture<CmpWithLink> = createRoot(router, CmpWithLink);
+      let fixture: ComponentFixture<CmpWithLink> = await createRoot(router, CmpWithLink);
       router.resetConfig([{path: 'home', component: SimpleCmp}]);
       const anchors = fixture.nativeElement.querySelectorAll('a');
       const buttons = fixture.nativeElement.querySelectorAll('button');
@@ -136,9 +137,9 @@ export function routerLinkIntegrationSpec() {
       expect(() => anchors[1].click()).not.toThrow();
       expect(() => buttons[0].click()).not.toThrow();
       expect(() => buttons[1].click()).not.toThrow();
-    }));
+    });
 
-    it('should not throw when some command is null', fakeAsync(() => {
+    it('should not throw when some command is null', async () => {
       @Component({
         selector: 'someCmp',
         template: `<router-outlet></router-outlet><a [routerLink]="[null]">Link</a><button [routerLink]="[null]">Button</button>`,
@@ -149,10 +150,10 @@ export function routerLinkIntegrationSpec() {
       TestBed.configureTestingModule({declarations: [CmpWithLink]});
       const router: Router = TestBed.inject(Router);
 
-      expect(() => createRoot(router, CmpWithLink)).not.toThrow();
-    }));
+      expect(async () => await createRoot(router, CmpWithLink)).not.toThrow();
+    });
 
-    it('should not throw when some command is undefined', fakeAsync(() => {
+    it('should not throw when some command is undefined', async () => {
       @Component({
         selector: 'someCmp',
         template: `<router-outlet></router-outlet><a [routerLink]="[undefined]">Link</a><button [routerLink]="[undefined]">Button</button>`,
@@ -163,10 +164,10 @@ export function routerLinkIntegrationSpec() {
       TestBed.configureTestingModule({declarations: [CmpWithLink]});
       const router: Router = TestBed.inject(Router);
 
-      expect(() => createRoot(router, CmpWithLink)).not.toThrow();
-    }));
+      expect(async () => await createRoot(router, CmpWithLink)).not.toThrow();
+    });
 
-    it('should update hrefs when query params or fragment change', fakeAsync(() => {
+    it('should update hrefs when query params or fragment change', async () => {
       @Component({
         selector: 'someRoot',
         template: `<router-outlet></router-outlet><a routerLink="/home" queryParamsHandling="preserve" preserveFragment>Link</a>`,
@@ -175,26 +176,26 @@ export function routerLinkIntegrationSpec() {
       class RootCmpWithLink {}
       TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmpWithLink);
+      const fixture = await createRoot(router, RootCmpWithLink);
 
       router.resetConfig([{path: 'home', component: SimpleCmp}]);
 
       const native = fixture.nativeElement.querySelector('a');
 
       router.navigateByUrl('/home?q=123');
-      advance(fixture);
+      await advance(fixture);
       expect(native.getAttribute('href')).toEqual('/home?q=123');
 
       router.navigateByUrl('/home?q=456');
-      advance(fixture);
+      await advance(fixture);
       expect(native.getAttribute('href')).toEqual('/home?q=456');
 
       router.navigateByUrl('/home?q=456#1');
-      advance(fixture);
+      await advance(fixture);
       expect(native.getAttribute('href')).toEqual('/home?q=456#1');
-    }));
+    });
 
-    it('should correctly use the preserve strategy', fakeAsync(() => {
+    it('should correctly use the preserve strategy', async () => {
       @Component({
         selector: 'someRoot',
         template: `<router-outlet></router-outlet><a routerLink="/home" [queryParams]="{q: 456}" queryParamsHandling="preserve">Link</a>`,
@@ -203,18 +204,18 @@ export function routerLinkIntegrationSpec() {
       class RootCmpWithLink {}
       TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmpWithLink);
+      const fixture = await createRoot(router, RootCmpWithLink);
 
       router.resetConfig([{path: 'home', component: SimpleCmp}]);
 
       const native = fixture.nativeElement.querySelector('a');
 
       router.navigateByUrl('/home?a=123');
-      advance(fixture);
+      await advance(fixture);
       expect(native.getAttribute('href')).toEqual('/home?a=123');
-    }));
+    });
 
-    it('should correctly use the merge strategy', fakeAsync(() => {
+    it('should correctly use the merge strategy', async () => {
       @Component({
         selector: 'someRoot',
         template: `<router-outlet></router-outlet><a routerLink="/home" [queryParams]="{removeMe: null, q: 456}" queryParamsHandling="merge">Link</a>`,
@@ -223,20 +224,20 @@ export function routerLinkIntegrationSpec() {
       class RootCmpWithLink {}
       TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmpWithLink);
+      const fixture = await createRoot(router, RootCmpWithLink);
 
       router.resetConfig([{path: 'home', component: SimpleCmp}]);
 
       const native = fixture.nativeElement.querySelector('a');
 
       router.navigateByUrl('/home?a=123&removeMe=123');
-      advance(fixture);
+      await advance(fixture);
       expect(native.getAttribute('href')).toEqual('/home?a=123&q=456');
-    }));
+    });
 
-    it('should support using links on non-a tags', fakeAsync(() => {
+    it('should support using links on non-a tags', async () => {
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -250,20 +251,20 @@ export function routerLinkIntegrationSpec() {
       ]);
 
       router.navigateByUrl('/team/22/link');
-      advance(fixture);
+      await advance(fixture);
       expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
 
       const button = fixture.nativeElement.querySelector('button');
       expect(button.getAttribute('tabindex')).toEqual('0');
       button.click();
-      advance(fixture);
+      await advance(fixture);
 
       expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
-    }));
+    });
 
-    it('should support absolute router links', fakeAsync(() => {
+    it('should support absolute router links', async () => {
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -277,20 +278,20 @@ export function routerLinkIntegrationSpec() {
       ]);
 
       router.navigateByUrl('/team/22/link');
-      advance(fixture);
+      await advance(fixture);
       expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
 
       const native = fixture.nativeElement.querySelector('a');
       expect(native.getAttribute('href')).toEqual('/team/33/simple');
       native.click();
-      advance(fixture);
+      await advance(fixture);
 
       expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
-    }));
+    });
 
-    it('should support relative router links', fakeAsync(() => {
+    it('should support relative router links', async () => {
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -304,21 +305,21 @@ export function routerLinkIntegrationSpec() {
       ]);
 
       router.navigateByUrl('/team/22/link');
-      advance(fixture);
+      await advance(fixture);
       expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
 
       const native = fixture.nativeElement.querySelector('a');
       expect(native.getAttribute('href')).toEqual('/team/22/simple');
       native.click();
-      advance(fixture);
+      await advance(fixture);
 
       expect(fixture.nativeElement).toHaveText('team 22 [ simple, right:  ]');
-    }));
+    });
 
-    it('should support top-level link', fakeAsync(() => {
+    it('should support top-level link', async () => {
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RelativeLinkInIfCmp);
-      advance(fixture);
+      const fixture = await createRoot(router, RelativeLinkInIfCmp);
+      await advance(fixture);
 
       router.resetConfig([
         {path: 'simple', component: SimpleCmp},
@@ -326,27 +327,27 @@ export function routerLinkIntegrationSpec() {
       ]);
 
       router.navigateByUrl('/');
-      advance(fixture);
+      await advance(fixture);
       expect(fixture.nativeElement).toHaveText('');
       const cmp = fixture.componentInstance;
 
       cmp.show.set(true);
-      advance(fixture);
+      await advance(fixture);
 
       expect(fixture.nativeElement).toHaveText('link');
       const native = fixture.nativeElement.querySelector('a');
 
       expect(native.getAttribute('href')).toEqual('/simple');
       native.click();
-      advance(fixture);
+      await advance(fixture);
 
       expect(fixture.nativeElement).toHaveText('linksimple');
-    }));
+    });
 
-    it('should support query params and fragments', fakeAsync(() => {
+    it('should support query params and fragments', async () => {
       const router: Router = TestBed.inject(Router);
       const location: Location = TestBed.inject(Location);
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       router.resetConfig([
         {
@@ -360,17 +361,17 @@ export function routerLinkIntegrationSpec() {
       ]);
 
       router.navigateByUrl('/team/22/link');
-      advance(fixture);
+      await advance(fixture);
 
       const native = fixture.nativeElement.querySelector('a');
       expect(native.getAttribute('href')).toEqual('/team/22/simple?q=1#f');
       native.click();
-      advance(fixture);
+      await advance(fixture);
 
       expect(fixture.nativeElement).toHaveText('team 22 [ simple, right:  ]');
 
       expect(location.path(true)).toEqual('/team/22/simple?q=1#f');
-    }));
+    });
 
     describe('should support history and state', () => {
       let component: typeof LinkWithState | typeof DivLinkWithState;
@@ -384,10 +385,10 @@ export function routerLinkIntegrationSpec() {
         component = DivLinkWithState;
       });
 
-      afterEach(fakeAsync(() => {
+      afterEach(async () => {
         const router: Router = TestBed.inject(Router);
         const location: Location = TestBed.inject(Location);
-        const fixture = createRoot(router, RootCmp);
+        const fixture = await createRoot(router, RootCmp);
 
         router.resetConfig([
           {
@@ -401,20 +402,20 @@ export function routerLinkIntegrationSpec() {
         ]);
 
         router.navigateByUrl('/team/22/link');
-        advance(fixture);
+        await advance(fixture);
 
         const native = fixture.nativeElement.querySelector('#link');
         native.click();
-        advance(fixture);
+        await advance(fixture);
 
         expect(fixture.nativeElement).toHaveText('team 22 [ simple, right:  ]');
 
         // Check the history entry
         expect(location.getState()).toEqual({foo: 'bar', navigationId: 3});
-      }));
+      });
     });
 
-    it('should set href on area elements', fakeAsync(() => {
+    it('should set href on area elements', async () => {
       @Component({
         selector: 'someRoot',
         template: `<router-outlet></router-outlet><map><area routerLink="/home" /></map>`,
@@ -425,12 +426,12 @@ export function routerLinkIntegrationSpec() {
       TestBed.configureTestingModule({declarations: [RootCmpWithArea]});
       const router: Router = TestBed.inject(Router);
 
-      const fixture = createRoot(router, RootCmpWithArea);
+      const fixture = await createRoot(router, RootCmpWithArea);
 
       router.resetConfig([{path: 'home', component: SimpleCmp}]);
 
       const native = fixture.nativeElement.querySelector('area');
       expect(native.getAttribute('href')).toEqual('/home');
-    }));
+    });
   });
 }

--- a/packages/router/test/page_title_strategy_spec.ts
+++ b/packages/router/test/page_title_strategy_spec.ts
@@ -10,7 +10,7 @@ import {DOCUMENT} from '@angular/common';
 import {provideLocationMocks} from '@angular/common/testing';
 import {Component, inject, Inject, Injectable, NgModule} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
-import {fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {
   ActivatedRoute,
   provideRouter,
@@ -40,28 +40,25 @@ describe('title strategy', () => {
       document = TestBed.inject(DOCUMENT);
     });
 
-    it('sets page title from data', fakeAsync(() => {
+    it('sets page title from data', async () => {
       router.resetConfig([{path: 'home', title: 'My Application', component: BlankCmp}]);
-      router.navigateByUrl('home');
-      tick();
+      await router.navigateByUrl('home');
       expect(document.title).toBe('My Application');
-    }));
+    });
 
-    it('sets page title from resolved data', fakeAsync(() => {
+    it('sets page title from resolved data', async () => {
       router.resetConfig([{path: 'home', title: TitleResolver, component: BlankCmp}]);
-      router.navigateByUrl('home');
-      tick();
+      await router.navigateByUrl('home');
       expect(document.title).toBe('resolved title');
-    }));
+    });
 
-    it('sets page title from resolved data function', fakeAsync(() => {
+    it('sets page title from resolved data function', async () => {
       router.resetConfig([{path: 'home', title: () => 'resolved title', component: BlankCmp}]);
-      router.navigateByUrl('home');
-      tick();
+      await router.navigateByUrl('home');
       expect(document.title).toBe('resolved title');
-    }));
+    });
 
-    it('sets title with child routes', fakeAsync(() => {
+    it('sets title with child routes', async () => {
       router.resetConfig([
         {
           path: 'home',
@@ -69,12 +66,12 @@ describe('title strategy', () => {
           children: [{path: '', title: 'child title', component: BlankCmp}],
         },
       ]);
-      router.navigateByUrl('home');
-      tick();
-      expect(document.title).toBe('child title');
-    }));
+      await router.navigateByUrl('home');
 
-    it('sets title with child routes and named outlets', fakeAsync(() => {
+      expect(document.title).toBe('child title');
+    });
+
+    it('sets title with child routes and named outlets', async () => {
       router.resetConfig([
         {
           path: 'home',
@@ -86,12 +83,11 @@ describe('title strategy', () => {
         },
         {path: 'compose', component: BlankCmp, outlet: 'aux', title: 'compose'},
       ]);
-      router.navigateByUrl('home(aux:compose)');
-      tick();
+      await router.navigateByUrl('home(aux:compose)');
       expect(document.title).toBe('child title');
-    }));
+    });
 
-    it('sets page title with inherited params', fakeAsync(() => {
+    it('sets page title with inherited params', async () => {
       router.resetConfig([
         {
           path: 'home',
@@ -105,10 +101,9 @@ describe('title strategy', () => {
           ],
         },
       ]);
-      router.navigateByUrl('home');
-      tick();
+      await router.navigateByUrl('home');
       expect(document.title).toBe('resolved title');
-    }));
+    });
 
     it('can get the title from the ActivatedRouteSnapshot', async () => {
       router.resetConfig([
@@ -151,7 +146,7 @@ describe('title strategy', () => {
   });
 
   describe('custom strategies', () => {
-    it('overriding the setTitle method', fakeAsync(() => {
+    it('overriding the setTitle method', async () => {
       @Injectable({providedIn: 'root'})
       class TemplatePageTitleStrategy extends TitleStrategy {
         constructor(@Inject(DOCUMENT) private readonly document: Document) {
@@ -183,10 +178,9 @@ describe('title strategy', () => {
         },
       ]);
 
-      router.navigateByUrl('home');
-      tick();
+      await router.navigateByUrl('home');
       expect(document.title).toEqual('My Application | Child');
-    }));
+    });
   });
 });
 

--- a/packages/router/test/recognize.spec.ts
+++ b/packages/router/test/recognize.spec.ts
@@ -16,7 +16,7 @@ import {ActivatedRouteSnapshot, RouterStateSnapshot} from '../src/router_state';
 import {Params, PRIMARY_OUTLET} from '../src/shared';
 import {DefaultUrlSerializer, UrlTree} from '../src/url_tree';
 
-describe('recognize', async () => {
+describe('recognize', () => {
   it('should work', async () => {
     const s = await recognize([{path: 'a', component: ComponentA}], 'a');
     checkActivatedRoute(s.root, '', {}, RootComponent);
@@ -165,7 +165,7 @@ describe('recognize', async () => {
     checkActivatedRoute(c[1], 'c', {c1: '1111', c2: '2222'}, ComponentC, 'left');
   });
 
-  describe('data', async () => {
+  describe('data', () => {
     it('should set static data', async () => {
       const s = await recognize([{path: 'a', data: {one: 1}, component: ComponentA}], 'a');
       const r: ActivatedRouteSnapshot = s.root.firstChild!;
@@ -246,8 +246,8 @@ describe('recognize', async () => {
     });
   });
 
-  describe('empty path', async () => {
-    describe('root', async () => {
+  describe('empty path', () => {
+    describe('root', () => {
       it('should work', async () => {
         const s = await recognize([{path: '', component: ComponentA}], '');
         checkActivatedRoute(s.root.firstChild!, '', {}, ComponentA);
@@ -286,7 +286,7 @@ describe('recognize', async () => {
       });
     });
 
-    describe('aux split is in the middle', async () => {
+    describe('aux split is in the middle', () => {
       it('should match (non-terminal)', async () => {
         const s = await recognize(
           [
@@ -363,7 +363,7 @@ describe('recognize', async () => {
       });
     });
 
-    describe('aux split at the end (no right child)', async () => {
+    describe('aux split at the end (no right child)', () => {
       it('should match (non-terminal)', async () => {
         const s = await recognize(
           [
@@ -445,7 +445,7 @@ describe('recognize', async () => {
       });
     });
 
-    describe('split at the end (right child)', async () => {
+    describe('split at the end (right child)', () => {
       it('should match (non-terminal)', async () => {
         const s = await recognize(
           [
@@ -475,7 +475,7 @@ describe('recognize', async () => {
       });
     });
 
-    describe('with outlets', async () => {
+    describe('with outlets', () => {
       it('should work when outlet is a child of empty path parent', async () => {
         const s = await recognize(
           [
@@ -579,14 +579,14 @@ describe('recognize', async () => {
     });
   });
 
-  describe('wildcards', async () => {
+  describe('wildcards', () => {
     it('should support simple wildcards', async () => {
       const s = await recognize([{path: '**', component: ComponentA}], 'a/b/c/d;a1=11');
       checkActivatedRoute(s.root.firstChild!, 'a/b/c/d', {a1: '11'}, ComponentA);
     });
   });
 
-  describe('componentless routes', async () => {
+  describe('componentless routes', () => {
     it('should work', async () => {
       const s = await recognize(
         [
@@ -669,7 +669,7 @@ describe('recognize', async () => {
     });
   });
 
-  describe('empty URL leftovers', async () => {
+  describe('empty URL leftovers', () => {
     it('should not throw when no children matching', async () => {
       const s = await recognize(
         [{path: 'a', component: ComponentA, children: [{path: 'b', component: ComponentB}]}],
@@ -699,7 +699,7 @@ describe('recognize', async () => {
     });
   });
 
-  describe('custom path matchers', async () => {
+  describe('custom path matchers', () => {
     it('should run once', async () => {
       let calls = 0;
       const matcher: UrlMatcher = (s) => {
@@ -765,7 +765,7 @@ describe('recognize', async () => {
     });
   });
 
-  describe('query parameters', async () => {
+  describe('query parameters', () => {
     it('should support query params', async () => {
       const config = [{path: 'a', component: ComponentA}];
       const s = await recognize(config, 'a?q=11');
@@ -785,7 +785,7 @@ describe('recognize', async () => {
     });
   });
 
-  describe('fragment', async () => {
+  describe('fragment', () => {
     it('should support fragment', async () => {
       const config = [{path: 'a', component: ComponentA}];
       const s = await recognize(config, 'a#f1');

--- a/packages/router/test/regression_integration.spec.ts
+++ b/packages/router/test/regression_integration.spec.ts
@@ -19,8 +19,9 @@ import {
   ViewChild,
   ViewContainerRef,
   inject,
+  signal,
 } from '@angular/core';
-import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {
   ChildrenOutletContexts,
   DefaultUrlSerializer,
@@ -33,14 +34,15 @@ import {
   UrlTree,
 } from '../index';
 import {of} from 'rxjs';
-import {delay, filter, mapTo, take} from 'rxjs/operators';
+import {switchMap, filter, mapTo, take} from 'rxjs/operators';
 
 import {provideRouter, withRouterConfig} from '../src/provide_router';
 import {afterNextNavigation} from '../src/utils/navigations';
+import {timeout} from './helpers';
 
 describe('Integration', () => {
   describe('routerLinkActive', () => {
-    it('should update when the associated routerLinks change - #18469', fakeAsync(() => {
+    it('should update when the associated routerLinks change - #18469', async () => {
       @Component({
         template: `
           <a id="first-link" [routerLink]="[firstLink]" routerLinkActive="active">{{firstLink}}</a>
@@ -53,11 +55,13 @@ describe('Integration', () => {
       class LinkComponent {
         firstLink = 'link-a';
         secondLink = 'link-b';
+        cdr = inject(ChangeDetectorRef);
 
         changeLinks(): void {
           const temp = this.secondLink;
           this.secondLink = this.firstLink;
           this.firstLink = temp;
+          this.cdr.markForCheck();
         }
       }
 
@@ -78,24 +82,24 @@ describe('Integration', () => {
       });
 
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, LinkComponent);
+      const fixture = await createRoot(router, LinkComponent);
       const firstLink = fixture.debugElement.query((p) => p.nativeElement.id === 'first-link');
       const secondLink = fixture.debugElement.query((p) => p.nativeElement.id === 'second-link');
       router.navigateByUrl('/link-a');
-      advance(fixture);
+      await advance(fixture);
 
       expect(firstLink.nativeElement.classList).toContain('active');
       expect(secondLink.nativeElement.classList).not.toContain('active');
 
       fixture.componentInstance.changeLinks();
       fixture.detectChanges();
-      advance(fixture);
+      await advance(fixture);
 
       expect(firstLink.nativeElement.classList).not.toContain('active');
       expect(secondLink.nativeElement.classList).toContain('active');
-    }));
+    });
 
-    it('should not cause infinite loops in the change detection - #15825', fakeAsync(() => {
+    it('should not cause infinite loops in the change detection - #15825', async () => {
       @Component({
         selector: 'simple',
         template: 'simple',
@@ -128,18 +132,18 @@ describe('Integration', () => {
       TestBed.configureTestingModule({imports: [MyModule]});
 
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, MyCmp);
+      const fixture = await createRoot(router, MyCmp);
       router.resetConfig([{path: 'simple', component: SimpleCmp}]);
 
       router.navigateByUrl('/simple');
-      advance(fixture);
+      await advance(fixture);
 
       const instance = fixture.componentInstance;
       instance.show = true;
       expect(() => advance(fixture)).not.toThrow();
-    }));
+    });
 
-    it('should set isActive right after looking at its children -- #18983', fakeAsync(() => {
+    it('should set isActive right after looking at its children -- #18983', async () => {
       @Component({
         template: `
           <div #rla="routerLinkActive" routerLinkActive>
@@ -182,21 +186,21 @@ describe('Integration', () => {
       });
 
       const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, ComponentWithRouterLink);
+      const fixture = await createRoot(router, ComponentWithRouterLink);
       router.navigateByUrl('/simple');
-      advance(fixture);
+      await advance(fixture);
 
       fixture.componentInstance.addLink();
       fixture.detectChanges();
 
       fixture.componentInstance.removeLink();
-      advance(fixture);
-      advance(fixture);
+      await advance(fixture);
+      await advance(fixture);
 
       expect(fixture.nativeElement.innerHTML).toContain('isActive: false');
-    }));
+    });
 
-    it('should set isActive with OnPush change detection - #19934', fakeAsync(() => {
+    it('should set isActive with OnPush change detection - #19934', async () => {
       @Component({
         template: `
              <div routerLink="/simple" #rla="routerLinkActive" routerLinkActive>
@@ -220,15 +224,15 @@ describe('Integration', () => {
       });
 
       const router = TestBed.inject(Router);
-      const fixture = createRoot(router, OnPushComponent);
+      const fixture = await createRoot(router, OnPushComponent);
       router.navigateByUrl('/simple');
-      advance(fixture);
+      await advance(fixture);
 
       expect(fixture.nativeElement.innerHTML).toContain('isActive: true');
-    }));
+    });
   });
 
-  it('should not reactivate a deactivated outlet when destroyed and recreated - #41379', fakeAsync(() => {
+  it('should not reactivate a deactivated outlet when destroyed and recreated - #41379', async () => {
     @Component({
       template: 'simple',
       standalone: false,
@@ -249,15 +253,15 @@ describe('Integration', () => {
     });
 
     const router = TestBed.inject(Router);
-    const fixture = createRoot(router, AppComponent);
+    const fixture = await createRoot(router, AppComponent);
     const componentCdr = fixture.componentRef.injector.get<ChangeDetectorRef>(ChangeDetectorRef);
 
     router.navigate([{outlets: {aux: ['1234']}}]);
-    advance(fixture);
+    await advance(fixture);
     expect(fixture.nativeElement.innerHTML).toContain('simple');
 
     router.navigate([{outlets: {aux: null}}]);
-    advance(fixture);
+    await advance(fixture);
     expect(fixture.nativeElement.innerHTML).not.toContain('simple');
 
     fixture.componentInstance.outletVisible = false;
@@ -269,10 +273,10 @@ describe('Integration', () => {
     componentCdr.detectChanges();
     expect(fixture.nativeElement.innerHTML).toContain('router-outlet');
     expect(fixture.nativeElement.innerHTML).not.toContain('simple');
-  }));
+  });
 
   describe('useHash', () => {
-    it('should restore hash to match current route - #28561', fakeAsync(() => {
+    it('should restore hash to match current route - #28561', async () => {
       @Component({
         selector: 'root-cmp',
         template: `<router-outlet></router-outlet>`,
@@ -307,14 +311,14 @@ describe('Integration', () => {
 
       router.navigateByUrl('/');
       // Will setup location change listeners
-      const fixture = createRoot(router, RootCmp);
+      const fixture = await createRoot(router, RootCmp);
 
       location.simulateHashChange('/one');
-      advance(fixture);
+      await advance(fixture);
 
       expect(location.path()).toEqual('/');
       expect(fixture.nativeElement.innerHTML).toContain('one');
-    }));
+    });
   });
 
   describe('duplicate navigation handling (#43447, #43446)', () => {
@@ -322,11 +326,14 @@ describe('Integration', () => {
     let router: Router;
     let fixture: ComponentFixture<{}>;
 
-    beforeEach(fakeAsync(() => {
+    beforeEach(async () => {
       @Injectable()
       class DelayedResolve {
         resolve() {
-          return of('').pipe(delay(1000), mapTo(true));
+          return of('').pipe(
+            switchMap((v) => new Promise((r) => setTimeout(r, 10)).then(() => v)),
+            mapTo(true),
+          );
         }
       }
       @Component({
@@ -365,43 +372,43 @@ describe('Integration', () => {
 
       router.navigateByUrl('/');
       // Will setup location change listeners
-      fixture = createRoot(router, RootCmp);
-    }));
+      fixture = await createRoot(router, RootCmp);
+    });
 
-    it('duplicate navigation to same url', fakeAsync(() => {
+    it('duplicate navigation to same url', async () => {
       location.go('/one');
-      tick(100);
+      await timeout(1);
       location.go('/one');
-      tick(1000);
-      advance(fixture);
+      await timeout(10);
+      await advance(fixture);
 
       expect(location.path()).toEqual('/one');
       expect(fixture.nativeElement.innerHTML).toContain('one');
-    }));
+    });
 
-    it('works with a duplicate popstate/hashchange navigation (as seen in firefox)', fakeAsync(() => {
+    it('works with a duplicate popstate/hashchange navigation (as seen in firefox)', async () => {
       (location as any)._subject.next({'url': 'one', 'pop': true, 'type': 'popstate'});
-      tick(1);
+      await timeout(1);
       (location as any)._subject.next({'url': 'one', 'pop': true, 'type': 'hashchange'});
-      tick(1000);
-      advance(fixture);
+      await timeout(10);
+      await advance(fixture);
 
       expect(router.routerState.toString()).toContain(`url:'one'`);
       expect(fixture.nativeElement.innerHTML).toContain('one');
-    }));
+    });
   });
 
   it('should not unregister outlet if a different one already exists #36711, 32453', async () => {
     @Component({
       template: `
-      <router-outlet *ngIf="outlet1"></router-outlet>
-      <router-outlet *ngIf="outlet2"></router-outlet>
+      <router-outlet *ngIf="outlet1()"></router-outlet>
+      <router-outlet *ngIf="outlet2()"></router-outlet>
       `,
       standalone: false,
     })
     class TestCmp {
-      outlet1 = true;
-      outlet2 = false;
+      outlet1 = signal(true);
+      outlet2 = signal(false);
     }
 
     @Component({
@@ -426,11 +433,11 @@ describe('Integration', () => {
     // be timing issues between destroying and recreating a second one in some cases:
     // https://github.com/angular/angular/issues/36711,
     // https://github.com/angular/angular/issues/32453
-    fixture.componentInstance.outlet2 = true;
+    fixture.componentInstance.outlet2.set(true);
     fixture.detectChanges();
     expect(contexts.getContext('primary')?.outlet).not.toBeNull();
 
-    fixture.componentInstance.outlet1 = false;
+    fixture.componentInstance.outlet1.set(false);
     fixture.detectChanges();
     // Destroying the first one show not clear the outlet context because the second one takes over
     // as the registered outlet.
@@ -504,8 +511,8 @@ describe('Integration', () => {
   });
 });
 
-function advance<T>(fixture: ComponentFixture<T>): void {
-  tick();
+async function advance<T>(fixture: ComponentFixture<T>): Promise<void> {
+  await timeout();
   fixture.detectChanges();
 }
 

--- a/packages/router/test/router_devtools.spec.ts
+++ b/packages/router/test/router_devtools.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {Component} from '@angular/core';
-import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {Router, RouterModule} from '../index';
 import {getLoadedRoutes} from '../src/router_devtools';
 
@@ -22,7 +22,7 @@ export class RootCmp {}
 
 describe('router_devtools', () => {
   describe('getLoadedRoutes', () => {
-    it('should return loaded routes when called with load children', fakeAsync(() => {
+    it('should return loaded routes when called with load children', async () => {
       TestBed.configureTestingModule({
         imports: [
           RouterModule.forRoot([
@@ -38,17 +38,17 @@ describe('router_devtools', () => {
       const root = TestBed.createComponent(RootCmp);
 
       const router = TestBed.inject(Router);
-      router.navigateByUrl('/lazy/simple');
-      advance(root);
+      await router.navigateByUrl('/lazy/simple');
+      root.detectChanges();
       expect(root.nativeElement.innerHTML).toContain('simple standalone');
 
       const loadedRoutes = getLoadedRoutes(router.config[0]);
       const loadedPath = loadedRoutes && loadedRoutes[0].path;
       expect(loadedPath).toEqual('simple');
-    }));
+    });
   });
 
-  it('should return undefined when called without load children', fakeAsync(() => {
+  it('should return undefined when called without load children', async () => {
     TestBed.configureTestingModule({
       imports: [
         RouterModule.forRoot([
@@ -63,17 +63,12 @@ describe('router_devtools', () => {
     const root = TestBed.createComponent(RootCmp);
 
     const router = TestBed.inject(Router);
-    router.navigateByUrl('/lazy');
-    advance(root);
+    await router.navigateByUrl('/lazy');
+    root.detectChanges();
     expect(root.nativeElement.innerHTML).toContain('');
 
     const loadedRoutes = getLoadedRoutes(router.config[0]);
     const loadedPath = loadedRoutes && loadedRoutes[0].path;
     expect(loadedPath).toEqual(undefined);
-  }));
+  });
 });
-
-function advance(fixture: ComponentFixture<unknown>) {
-  tick();
-  fixture.detectChanges();
-}

--- a/packages/router/test/router_scroller.spec.ts
+++ b/packages/router/test/router_scroller.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {TestBed, fakeAsync, tick} from '@angular/core/testing';
+import {TestBed, tick} from '@angular/core/testing';
 import {DefaultUrlSerializer, Event, NavigationEnd, NavigationStart} from '../index';
 import {Subject} from 'rxjs';
 import {filter, switchMap, take} from 'rxjs/operators';
@@ -14,6 +14,7 @@ import {filter, switchMap, take} from 'rxjs/operators';
 import {Scroll} from '../src/events';
 import {RouterScroller} from '../src/router_scroller';
 import {ApplicationRef, ɵNoopNgZone as NoopNgZone} from '@angular/core';
+import {timeout} from './helpers';
 
 // TODO: add tests that exercise the `withInMemoryScrolling` feature of the provideRouter function
 describe('RouterScroller', () => {
@@ -150,7 +151,7 @@ describe('RouterScroller', () => {
   });
 
   describe('extending a scroll service', () => {
-    it('work', fakeAsync(() => {
+    it('work', async () => {
       const {events, viewportScroller} = createRouterScroller({
         scrollPositionRestoration: 'disabled',
         anchorScrolling: 'disabled',
@@ -165,7 +166,7 @@ describe('RouterScroller', () => {
             setTimeout(() => {
               r.next(p);
               r.complete();
-            }, 1000);
+            }, 10);
             return r;
           }),
         )
@@ -175,31 +176,31 @@ describe('RouterScroller', () => {
 
       events.next(new NavigationStart(1, '/a'));
       events.next(new NavigationEnd(1, '/a', '/a'));
-      tick();
+      await timeout();
       setScroll(viewportScroller, 10, 100);
 
       events.next(new NavigationStart(2, '/b'));
       events.next(new NavigationEnd(2, '/b', '/b'));
-      tick();
+      await timeout();
       setScroll(viewportScroller, 20, 200);
 
       events.next(new NavigationStart(3, '/c'));
       events.next(new NavigationEnd(3, '/c', '/c'));
-      tick();
+      await timeout();
       setScroll(viewportScroller, 30, 300);
 
       events.next(new NavigationStart(4, '/a', 'popstate', {navigationId: 1}));
       events.next(new NavigationEnd(4, '/a', '/a'));
 
-      tick(500);
+      await timeout(5);
       expect(viewportScroller.scrollToPosition).not.toHaveBeenCalled();
 
       events.next(new NavigationStart(5, '/a', 'popstate', {navigationId: 1}));
       events.next(new NavigationEnd(5, '/a', '/a'));
 
-      tick(5000);
+      await timeout(50);
       expect(viewportScroller.scrollToPosition).toHaveBeenCalledWith([10, 100]);
-    }));
+    });
   });
 
   function createRouterScroller({

--- a/packages/router/test/standalone.spec.ts
+++ b/packages/router/test/standalone.spec.ts
@@ -7,9 +7,10 @@
  */
 
 import {Component, Injectable, NgModule} from '@angular/core';
-import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {provideRoutes, Router, RouterModule, ROUTES} from '../index';
+import {timeout} from './helpers';
 
 @Component({template: '<div>simple standalone</div>'})
 export class SimpleStandaloneComponent {}
@@ -25,7 +26,7 @@ export class RootCmp {}
 
 describe('standalone in Router API', () => {
   describe('loadChildren => routes', () => {
-    it('can navigate to and render standalone component', fakeAsync(() => {
+    it('can navigate to and render standalone component', async () => {
       TestBed.configureTestingModule({
         imports: [
           RouterModule.forRoot([
@@ -42,11 +43,11 @@ describe('standalone in Router API', () => {
 
       const router = TestBed.inject(Router);
       router.navigateByUrl('/lazy');
-      advance(root);
+      await advanceAsync(root);
       expect(root.nativeElement.innerHTML).toContain('simple standalone');
-    }));
+    });
 
-    it('throws an error when loadChildren=>routes has a component that is not standalone', fakeAsync(() => {
+    it('throws an error when loadChildren=>routes has a component that is not standalone', async () => {
       TestBed.configureTestingModule({
         imports: [
           RouterModule.forRoot([
@@ -62,14 +63,13 @@ describe('standalone in Router API', () => {
       const root = TestBed.createComponent(RootCmp);
 
       const router = TestBed.inject(Router);
-      router.navigateByUrl('/lazy/notstandalone');
-      expect(() => advance(root)).toThrowError(
+      await expectAsync(router.navigateByUrl('/lazy/notstandalone')).toBeRejectedWithError(
         /.*lazy\/notstandalone.*component must be standalone/,
       );
-    }));
+    });
   });
   describe('route providers', () => {
-    it('can provide a guard on a route', fakeAsync(() => {
+    it('can provide a guard on a route', async () => {
       @Injectable()
       class ConfigurableGuard {
         static canActivateValue = false;
@@ -95,18 +95,18 @@ describe('standalone in Router API', () => {
       ConfigurableGuard.canActivateValue = false;
       const router = TestBed.inject(Router);
       router.navigateByUrl('/simple');
-      advance(root);
+      await advanceAsync(root);
       expect(root.nativeElement.innerHTML).not.toContain('simple standalone');
       expect(router.url).not.toContain('simple');
 
       ConfigurableGuard.canActivateValue = true;
       router.navigateByUrl('/simple');
-      advance(root);
+      await advanceAsync(root);
       expect(root.nativeElement.innerHTML).toContain('simple standalone');
       expect(router.url).toContain('simple');
-    }));
+    });
 
-    it('can inject provider on a route into component', fakeAsync(() => {
+    it('can inject provider on a route into component', async () => {
       @Injectable()
       class Service {
         value = 'my service';
@@ -130,12 +130,12 @@ describe('standalone in Router API', () => {
 
       const router = TestBed.inject(Router);
       router.navigateByUrl('/home');
-      advance(root);
+      await advanceAsync(root);
       expect(root.nativeElement.innerHTML).toContain('my service');
       expect(router.url).toContain('home');
-    }));
+    });
 
-    it('can not inject provider in lazy loaded ngModule from component on same level', fakeAsync(() => {
+    it('can not inject provider in lazy loaded ngModule from component on same level', async () => {
       @Injectable()
       class Service {
         value = 'my service';
@@ -160,14 +160,14 @@ describe('standalone in Router API', () => {
         ],
         declarations: [MyComponent],
       });
-      const root = TestBed.createComponent(RootCmp);
+      const fixture = TestBed.createComponent(RootCmp);
 
       const router = TestBed.inject(Router);
-      router.navigateByUrl('/home');
-      expect(() => advance(root)).toThrowError();
-    }));
+      await router.navigateByUrl('/home');
+      expect(fixture.detectChanges).toThrow();
+    });
 
-    it('component from lazy module can inject provider from parent route', fakeAsync(() => {
+    it('component from lazy module can inject provider from parent route', async () => {
       @Injectable()
       class Service {
         value = 'my service';
@@ -194,11 +194,11 @@ describe('standalone in Router API', () => {
 
       const router = TestBed.inject(Router);
       router.navigateByUrl('/home');
-      advance(root);
+      await advanceAsync(root);
       expect(root.nativeElement.innerHTML).toContain('my service');
-    }));
+    });
 
-    it('gets the correct injector for guards and components when combining lazy modules and route providers', fakeAsync(() => {
+    it('gets the correct injector for guards and components when combining lazy modules and route providers', async () => {
       const canActivateLog: string[] = [];
       abstract class ServiceBase {
         abstract name: string;
@@ -287,7 +287,7 @@ describe('standalone in Router API', () => {
 
       const router = TestBed.inject(Router);
       router.navigateByUrl('/home');
-      advance(root);
+      await advanceAsync(root);
       expect(canActivateLog).toEqual(['service1', 'service2']);
       expect(
         root.debugElement.query(By.directive(ParentCmp)).componentInstance.service.name,
@@ -297,16 +297,16 @@ describe('standalone in Router API', () => {
       ).toEqual('service2');
 
       router.navigateByUrl('/home/child2');
-      advance(root);
+      await advanceAsync(root);
       expect(canActivateLog).toEqual(['service1', 'service2', 'service3']);
       expect(
         root.debugElement.query(By.directive(ChildCmp2)).componentInstance.service.name,
       ).toEqual('service3');
-    }));
+    });
   });
 
   describe('loadComponent', () => {
-    it('does not load component when canActivate returns false', fakeAsync(() => {
+    it('does not load component when canActivate returns false', async () => {
       const loadComponentSpy = jasmine.createSpy();
       @Injectable({providedIn: 'root'})
       class Guard {
@@ -328,11 +328,11 @@ describe('standalone in Router API', () => {
       });
 
       TestBed.inject(Router).navigateByUrl('/home');
-      tick();
+      await timeout();
       expect(loadComponentSpy).not.toHaveBeenCalled();
-    }));
+    });
 
-    it('loads and renders lazy component', fakeAsync(() => {
+    it('loads and renders lazy component', async () => {
       TestBed.configureTestingModule({
         imports: [
           RouterModule.forRoot([
@@ -346,11 +346,11 @@ describe('standalone in Router API', () => {
 
       const root = TestBed.createComponent(RootCmp);
       TestBed.inject(Router).navigateByUrl('/home');
-      advance(root);
+      await advanceAsync(root);
       expect(root.nativeElement.innerHTML).toContain('simple standalone');
-    }));
+    });
 
-    it('throws error when loadComponent is not standalone', fakeAsync(() => {
+    it('throws error when loadComponent is not standalone', async () => {
       TestBed.configureTestingModule({
         imports: [
           RouterModule.forRoot([
@@ -363,11 +363,13 @@ describe('standalone in Router API', () => {
       });
 
       const root = TestBed.createComponent(RootCmp);
-      TestBed.inject(Router).navigateByUrl('/home');
-      expect(() => advance(root)).toThrowError(/.*home.*component must be standalone/);
-    }));
 
-    it('throws error when loadComponent is used with a module', fakeAsync(() => {
+      await expectAsync(TestBed.inject(Router).navigateByUrl('/home')).toBeRejectedWithError(
+        /.*home.*component must be standalone/,
+      );
+    });
+
+    it('throws error when loadComponent is used with a module', async () => {
       @NgModule()
       class LazyModule {}
 
@@ -383,9 +385,11 @@ describe('standalone in Router API', () => {
       });
 
       const root = TestBed.createComponent(RootCmp);
-      TestBed.inject(Router).navigateByUrl('/home');
-      expect(() => advance(root)).toThrowError(/.*home.*Use 'loadChildren' instead/);
-    }));
+
+      await expectAsync(TestBed.inject(Router).navigateByUrl('/home')).toBeRejectedWithError(
+        /.*home.*Use 'loadChildren' instead/,
+      );
+    });
   });
   describe('default export unwrapping', () => {
     it('should work for loadComponent', async () => {
@@ -437,7 +441,7 @@ describe('provideRoutes', () => {
   });
 });
 
-function advance(fixture: ComponentFixture<unknown>) {
-  tick();
+async function advanceAsync(fixture: ComponentFixture<unknown>) {
+  await timeout();
   fixture.detectChanges();
 }

--- a/packages/router/test/view_transitions.spec.ts
+++ b/packages/router/test/view_transitions.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {Component, destroyPlatform} from '@angular/core';
+import {Component, destroyPlatform, provideZonelessChangeDetection} from '@angular/core';
 import {bootstrapApplication} from '@angular/platform-browser';
 import {withBody} from '@angular/private/testing';
 import {
@@ -18,7 +18,6 @@ import {
   withDisabledInitialNavigation,
   withViewTransitions,
 } from '../index';
-import {TestBed} from '@angular/core/testing';
 
 describe('view transitions', () => {
   if (isNode) {
@@ -38,6 +37,7 @@ describe('view transitions', () => {
   it('should skip initial transition', async () => {
     const appRef = await bootstrapApplication(App, {
       providers: [
+        provideZonelessChangeDetection(),
         provideRouter(
           [{path: '**', component: App}],
           withDisabledInitialNavigation(),
@@ -66,7 +66,10 @@ describe('view transitions', () => {
     class ComponentB {}
 
     const res = await bootstrapApplication(App, {
-      providers: [provideRouter([{path: 'b', component: ComponentB}], withViewTransitions())],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideRouter([{path: 'b', component: ComponentB}], withViewTransitions()),
+      ],
     });
     const router = res.injector.get(Router);
     const eventLog = [] as Event[];
@@ -94,6 +97,7 @@ describe('view transitions', () => {
       const transitionSpy = jasmine.createSpy();
       const appRef = await bootstrapApplication(App, {
         providers: [
+          provideZonelessChangeDetection(),
           provideRouter(
             [{path: '**', component: App}],
             withDisabledInitialNavigation(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2586,6 +2586,7 @@ packages:
 
   /@bazel/typescript@5.8.1(typescript@5.7.3):
     resolution: {integrity: sha512-NAJ8WQHZL1WE1YmRoCrq/1hhG15Mvy/viWh6TkvFnBeEhNUiQUsA5GYyhU1ztnBIYW03nATO3vwhAEfO7Q0U5g==, tarball: https://registry.npmjs.org/@bazel/typescript/-/typescript-5.8.1.tgz}
+    deprecated: No longer maintained, https://github.com/aspect-build/rules_ts is the recommended replacement
     hasBin: true
     peerDependencies:
       typescript: '>=3.0.0'

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -263,6 +263,7 @@ def pkg_npm(name, deps = [], validate = True, **kwargs):
 def karma_web_test_suite(
         name,
         external = [],
+        zoneless = False,
         browsers = [
             "@npm//@angular/build-tooling/bazel/browsers/chromium:chromium",
             "@npm//@angular/build-tooling/bazel/browsers/firefox:firefox",
@@ -271,9 +272,8 @@ def karma_web_test_suite(
     """Default values for karma_web_test_suite"""
 
     # Default value for bootstrap
-    bootstrap = kwargs.pop("bootstrap", []) + [
-        "//tools/testing:browser",
-    ]
+    bootstrap = kwargs.pop("bootstrap", [])
+    bootstrap.extend(["//tools/testing:browser_zoneless"] if zoneless else ["//tools/testing:browser"])
 
     # Add common deps
     deps = kwargs.pop("deps", [])

--- a/tools/testing/BUILD.bazel
+++ b/tools/testing/BUILD.bazel
@@ -27,6 +27,35 @@ ts_library(
 )
 
 ts_library(
+    name = "browser_zoneless",
+    testonly = 1,
+    srcs = ["browser_zoneless_tests.init.ts"],
+    deps = [
+        "//packages/compiler",
+        "//packages/core",
+        "//packages/core/testing",
+        "//packages/platform-browser/animations",
+        "//packages/platform-browser/testing",
+        "@npm//reflect-metadata",
+    ],
+)
+
+ts_library(
+    name = "node_zoneless",
+    testonly = 1,
+    srcs = ["node_zoneless_tests.init.ts"],
+    deps = [
+        "//packages/compiler",
+        "//packages/core",
+        "//packages/core/testing",
+        "//packages/platform-server",
+        "//packages/platform-server:bundled_domino_lib",
+        "//packages/platform-server/testing",
+        "@npm//reflect-metadata",
+    ],
+)
+
+ts_library(
     name = "node",
     testonly = 1,
     srcs = ["node_tests.init.ts"],
@@ -38,6 +67,7 @@ ts_library(
         "//packages/platform-server:bundled_domino_lib",
         "//packages/platform-server/testing",
         "//packages/zone.js/lib",
+        "@npm//reflect-metadata",
     ],
 )
 

--- a/tools/testing/browser_zoneless_tests.init.ts
+++ b/tools/testing/browser_zoneless_tests.init.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import 'reflect-metadata';
+
+import '@angular/compiler'; // For JIT mode. Must be in front of any other @angular/* imports.
+
+import {TestBed} from '@angular/core/testing';
+import {BrowserTestingModule, platformBrowserTesting} from '@angular/platform-browser/testing';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {NgModule, provideZonelessChangeDetection} from '@angular/core';
+
+@NgModule({
+  providers: [provideZonelessChangeDetection()],
+})
+export class TestModule {}
+
+TestBed.initTestEnvironment(
+  [BrowserTestingModule, NoopAnimationsModule, TestModule],
+  platformBrowserTesting(),
+);
+
+(window as any).isNode = false;
+(window as any).isBrowser = true;
+(window as any).global = window;

--- a/tools/testing/node_zoneless_tests.init.ts
+++ b/tools/testing/node_zoneless_tests.init.ts
@@ -5,11 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-
 import 'reflect-metadata';
-
-import 'zone.js/lib/node/rollup-main';
-import './zone_base_setup';
 
 (global as any).isNode = true;
 (global as any).isBrowser = false;
@@ -17,6 +13,7 @@ import './zone_base_setup';
 import '@angular/compiler'; // For JIT mode. Must be in front of any other @angular/* imports.
 // Init TestBed
 import {TestBed} from '@angular/core/testing';
+import {NgModule, provideZonelessChangeDetection} from '@angular/core';
 import {
   ServerTestingModule,
   platformServerTesting,
@@ -24,7 +21,12 @@ import {
 import {DominoAdapter} from '@angular/platform-server/src/domino_adapter';
 import domino from '../../packages/platform-server/src/bundled-domino';
 
-TestBed.initTestEnvironment(ServerTestingModule, platformServerTesting());
+@NgModule({
+  providers: [provideZonelessChangeDetection()],
+})
+export class TestModule {}
+
+TestBed.initTestEnvironment([ServerTestingModule, TestModule], platformServerTesting());
 DominoAdapter.makeCurrent();
 (global as any).document =
   (DominoAdapter as any).defaultDoc ||

--- a/yarn.lock
+++ b/yarn.lock
@@ -317,7 +317,6 @@
 
 "@angular/build-tooling@https://github.com/angular/dev-infra-private-build-tooling-builds.git#ce04ec6cf7604014191821a637e60964a1a3bb4a":
   version "0.0.0-2670abf637fa155971cdd1f7e570a7f234922a65"
-  uid ce04ec6cf7604014191821a637e60964a1a3bb4a
   resolved "https://github.com/angular/dev-infra-private-build-tooling-builds.git#ce04ec6cf7604014191821a637e60964a1a3bb4a"
   dependencies:
     "@angular/benchpress" "0.3.0"
@@ -466,7 +465,6 @@
 
 "@angular/ng-dev@https://github.com/angular/dev-infra-private-ng-dev-builds.git#1a12d97905f4af88ccc0b582864907729d23e23e":
   version "0.0.0-a4538b2474d3c551f0217c3d1f5f3a99cf4f8eb7"
-  uid "1a12d97905f4af88ccc0b582864907729d23e23e"
   resolved "https://github.com/angular/dev-infra-private-ng-dev-builds.git#1a12d97905f4af88ccc0b582864907729d23e23e"
   dependencies:
     "@google-cloud/spanner" "7.19.1"
@@ -8102,8 +8100,7 @@ domhandler@^5.0.2, domhandler@^5.0.3:
     domelementtype "^2.3.0"
 
 "domino@https://github.com/angular/domino.git#8f228f8862540c6ccd14f76b5a1d9bb5458618af":
-  version "2.1.6+git"
-  uid "8f228f8862540c6ccd14f76b5a1d9bb5458618af"
+  version "2.1.6"
   resolved "https://github.com/angular/domino.git#8f228f8862540c6ccd14f76b5a1d9bb5458618af"
 
 dompurify@^3.2.4:


### PR DESCRIPTION
There is nothing in the Router that requires ZoneJS and we do not need `fakeAsync` as a mock clock. We can instead use any mock clock implementation to speed up test execution.

This removes ZoneJS completely from the bundle of the Router tests. ZoneJS causes the stacks to be unreadable when combined with the massive rxjs stack in the router transition.

This uses the new autoTick feature of jasmine's mock clock, allowing tests to be written without needing to have any knowledge of whether a clock is installed. This is also advantageous for debugging because all we need to do to remove the mock clock from the test is to comment out the install line and tests will then run with the real clock. This would clean up the stack even further and make execution entirely native.