### PR TITLE
refactor: add a new version of the logic node

### DIFF
--- a/packages/forms/experimental/src/api/types.ts
+++ b/packages/forms/experimental/src/api/types.ts
@@ -54,7 +54,13 @@ export interface ServerError {
  * The result of running a validation function. The result may be `undefined` to indicate no errors,
  * a single `FormError`, or a list of `FormError` which can be used to indicate multiple errors.
  */
-export type ValidationResult = FormError | readonly FormError[] | undefined;
+export type ValidationResult = readonly FormError[] | FormError | undefined;
+
+export type AsyncValidationResult =
+  | readonly FormTreeError[]
+  | FormTreeError
+  | 'pending'
+  | undefined;
 
 /**
  * An object that represents a single field in a form. This includes both primitive value fields

--- a/packages/forms/experimental/src/logic_node.ts
+++ b/packages/forms/experimental/src/logic_node.ts
@@ -136,7 +136,7 @@ export abstract class AbstractLogic<TReturn, TValue = TReturn> {
   }
 }
 
-class BooleanOrLogic extends AbstractLogic<boolean> {
+export class BooleanOrLogic extends AbstractLogic<boolean> {
   override get defaultValue() {
     return false;
   }
@@ -146,7 +146,7 @@ class BooleanOrLogic extends AbstractLogic<boolean> {
   }
 }
 
-class ArrayMergeLogic<TElement> extends AbstractLogic<
+export class ArrayMergeLogic<TElement> extends AbstractLogic<
   readonly TElement[],
   TElement | readonly TElement[] | undefined
 > {
@@ -169,7 +169,7 @@ class ArrayMergeLogic<TElement> extends AbstractLogic<
   }
 }
 
-class MetadataMergeLogic<T> extends AbstractLogic<T> {
+export class MetadataMergeLogic<T> extends AbstractLogic<T> {
   override get defaultValue() {
     return this.key.defaultValue();
   }

--- a/packages/forms/experimental/src/logic_node_2.ts
+++ b/packages/forms/experimental/src/logic_node_2.ts
@@ -134,7 +134,7 @@ export class Logic {
     if (this.metadata.has(key as MetadataKey<unknown>)) {
       return this.metadata.get(key as MetadataKey<unknown>)!.compute(arg) as T;
     } else {
-      return key.defaultValue;
+      return key.defaultValue();
     }
   }
 

--- a/packages/forms/experimental/src/logic_node_2.ts
+++ b/packages/forms/experimental/src/logic_node_2.ts
@@ -1,0 +1,230 @@
+import {FieldContext, FormError, LogicFn, MetadataKey, ValidationResult} from '../public_api';
+import {
+  AbstractLogic,
+  ArrayMergeLogic,
+  BooleanOrLogic,
+  MetadataMergeLogic,
+  Predicate,
+} from './logic_node';
+
+/**
+ * Container for all the different types of logic that can be applied to a field
+ * (disabled, hidden, errors, etc.)
+ */
+export class Logic {
+  readonly hidden: BooleanOrLogic;
+  readonly disabled: BooleanOrLogic;
+  readonly errors: ArrayMergeLogic<FormError>;
+  private readonly metadata = new Map<MetadataKey<unknown>, AbstractLogic<unknown>>();
+
+  constructor(private predicate: Predicate | undefined) {
+    this.hidden = new BooleanOrLogic(predicate);
+    this.disabled = new BooleanOrLogic(predicate);
+    this.errors = new ArrayMergeLogic<FormError>(predicate);
+  }
+
+  getMetadata<T>(key: MetadataKey<T>): AbstractLogic<T> {
+    if (!this.metadata.has(key as MetadataKey<unknown>)) {
+      this.metadata.set(key as MetadataKey<unknown>, new MetadataMergeLogic(this.predicate, key));
+    }
+    return this.metadata.get(key as MetadataKey<unknown>)! as AbstractLogic<T>;
+  }
+
+  readMetadata<T>(key: MetadataKey<T>, arg: FieldContext<unknown>): T {
+    if (this.metadata.has(key as MetadataKey<unknown>)) {
+      return this.metadata.get(key as MetadataKey<unknown>)!.compute(arg) as T;
+    } else {
+      return key.defaultValue;
+    }
+  }
+
+  getMetadataKeys() {
+    return this.metadata.keys();
+  }
+}
+
+/**
+ * A tree structure of `Logic` corresponding to a tree of fields.
+ */
+export class LogicNode {
+  readonly logic: Logic;
+
+  constructor(private builder: LogicNodeBuilder | undefined) {
+    this.logic = builder ? createLogic(builder) : new Logic(undefined);
+  }
+
+  getChild(key: PropertyKey): LogicNode {
+    // The logic for a particular child may be spread across multiple builders. We lazily combine
+    // this logic at the time the child logic node is requested to be created.
+    const childBuilders = this.builder ? getAllChildren(this.builder, key) : [];
+    if (childBuilders.length === 0) {
+      return new LogicNode(undefined);
+    } else {
+      // If there are child builders, merge them under a new builder to ensure the predicate is
+      // propagated.
+      const combined = LogicNodeBuilder.newRoot(this.builder?.predicate);
+      for (const child of childBuilders) {
+        combined.mergeIn(child);
+      }
+      return new LogicNode(combined);
+    }
+  }
+}
+
+/**
+ * A builder for `LogicNode`, which itself is a tree.
+ */
+export abstract class LogicNodeBuilder {
+  protected constructor(readonly predicate: Predicate | undefined) {}
+
+  abstract addHiddenRule(logic: LogicFn<unknown, boolean>): void;
+  abstract addDisabledRule(logic: LogicFn<unknown, boolean>): void;
+  abstract addErrorRule(logic: LogicFn<unknown, ValidationResult>): void;
+  abstract addMetadataRule<T>(key: MetadataKey<T>, logic: LogicFn<unknown, T>): void;
+  abstract getChild(key: PropertyKey): MergableLogicNodeBuilder;
+
+  build(): LogicNode {
+    return new LogicNode(this);
+  }
+
+  static newRoot(predicate: Predicate | undefined): MergableLogicNodeBuilder {
+    return new CompositeLogicNodeBuilder(predicate);
+  }
+}
+
+/**
+ * A subclass of `LogicNodeBuilder` that supports merging with other logic trees.
+ */
+export interface MergableLogicNodeBuilder extends LogicNodeBuilder {
+  mergeIn(other: MergableLogicNodeBuilder): void;
+}
+
+/**
+ * A `MergableLogicNodeBuilder` that delegates to its "current" builder and creates a new current
+ * builder after another builder tree is merged in.
+ */
+class CompositeLogicNodeBuilder extends LogicNodeBuilder implements MergableLogicNodeBuilder {
+  private current: SimpleLogicNodeBuilder | undefined;
+  readonly all: LogicNodeBuilder[] = [];
+
+  override addHiddenRule(logic: LogicFn<unknown, boolean>): void {
+    this.getCurrent().addHiddenRule(logic);
+  }
+
+  override addDisabledRule(logic: LogicFn<unknown, boolean>): void {
+    this.getCurrent().addDisabledRule(logic);
+  }
+
+  override addErrorRule(logic: LogicFn<unknown, FormError>): void {
+    this.getCurrent().addErrorRule(logic);
+  }
+
+  override addMetadataRule<T>(key: MetadataKey<T>, logic: LogicFn<unknown, T>): void {
+    this.getCurrent().addMetadataRule(key, logic);
+  }
+
+  override getChild(key: PropertyKey): MergableLogicNodeBuilder {
+    return this.getCurrent().getChild(key);
+  }
+
+  mergeIn(other: MergableLogicNodeBuilder): void {
+    // Add the other builder to our collection, we'll defer the actual merging of the logic until
+    // the logic node is requested to be created. In order to preserve the original ordering of the
+    // rules, we close off the current builder to any further edits. If additional logic is added,
+    // a new current builder will be created to capture it.
+    this.all.push(other);
+    this.current = undefined;
+  }
+
+  private getCurrent(): SimpleLogicNodeBuilder {
+    // All rules added to this builder get added on to the current builder. If there is no current
+    // builder, a new one is created. In order to preserve the original ordering of the rules, we
+    // clear the current builder whenever a separate builder tree is merged in.
+    if (this.current === undefined) {
+      this.current = new SimpleLogicNodeBuilder(this.predicate);
+      this.all.push(this.current);
+    }
+    return this.current;
+  }
+}
+
+/**
+ * A `LogicNodeBuilder` that directly adds logic to its backing `Logic` instance.
+ *
+ * The user should not be given a reference to this class, it is used internally to keep track of
+ * concrete tree chunks within the `CompositeLogicNodeBuilder`. When handing a `LogicNodeBuilder`
+ * to the user it should always be a `CompositeLogicNodeBuilder`.
+ */
+class SimpleLogicNodeBuilder extends LogicNodeBuilder {
+  readonly logic = new Logic(undefined);
+  readonly children = new Map<PropertyKey, MergableLogicNodeBuilder>();
+
+  override addHiddenRule(logic: LogicFn<unknown, boolean>): void {
+    this.logic.hidden.push(logic);
+  }
+
+  override addDisabledRule(logic: LogicFn<unknown, boolean>): void {
+    this.logic.disabled.push(logic);
+  }
+
+  override addErrorRule(logic: LogicFn<unknown, ValidationResult>): void {
+    this.logic.errors.push(logic);
+  }
+
+  override addMetadataRule<T>(key: MetadataKey<T>, logic: LogicFn<unknown, T>): void {
+    this.logic.getMetadata(key).push(logic);
+  }
+
+  override getChild(key: PropertyKey): MergableLogicNodeBuilder {
+    // We always create a `CompositeLogicNodeBuilder` for children since someone may call `apply` on
+    // the child.
+    if (!this.children.has(key)) {
+      this.children.set(key, new CompositeLogicNodeBuilder(this.predicate));
+    }
+    return this.children.get(key)!;
+  }
+}
+
+/**
+ * Gets all of the builders that contribute logic to the given child of the parent builder.
+ */
+function getAllChildren(builder: LogicNodeBuilder, key: PropertyKey): MergableLogicNodeBuilder[] {
+  if (builder instanceof CompositeLogicNodeBuilder) {
+    return builder.all.flatMap((node) => getAllChildren(node, key));
+  } else if (builder instanceof SimpleLogicNodeBuilder) {
+    if (builder.children.has(key)) {
+      return [builder.children.get(key)!];
+    }
+  } else {
+    throw new Error('Unknown LogicNodeBuilder type');
+  }
+  return [];
+}
+
+/**
+ * Creates the full `Logic` for a given builder.
+ */
+function createLogic(builder: LogicNodeBuilder): Logic {
+  const logic = new Logic(builder.predicate);
+  if (builder instanceof CompositeLogicNodeBuilder) {
+    const builtNodes = builder.all.map((b) => b.build());
+    for (const node of builtNodes) {
+      logic.disabled.mergeIn(node.logic.disabled);
+      logic.hidden.mergeIn(node.logic.hidden);
+      logic.errors.mergeIn(node.logic.errors);
+      for (const key of node.logic.getMetadataKeys()) {
+        logic.getMetadata(key).mergeIn(node.logic.getMetadata(key));
+      }
+    }
+  } else if (builder instanceof SimpleLogicNodeBuilder) {
+    logic.disabled.mergeIn(builder.logic.disabled);
+    logic.hidden.mergeIn(builder.logic.hidden);
+    logic.errors.mergeIn(builder.logic.errors);
+    for (const key of builder.logic.getMetadataKeys()) {
+      logic.getMetadata(key).mergeIn(builder.logic.getMetadata(key));
+    }
+  } else {
+    throw new Error('Unknown LogicNodeBuilder type');
+  }
+  return logic;
+}

--- a/packages/forms/experimental/src/logic_node_2.ts
+++ b/packages/forms/experimental/src/logic_node_2.ts
@@ -7,6 +7,135 @@ import {
   Predicate,
 } from './logic_node';
 
+abstract class AbstractLogicNodeBuilder {
+  constructor(readonly predicates: ReadonlyArray<Predicate>) {}
+
+  abstract addHiddenRule(logic: LogicFn<unknown, boolean>): void;
+  abstract addDisabledRule(logic: LogicFn<unknown, boolean>): void;
+  abstract addErrorRule(logic: LogicFn<unknown, ValidationResult>): void;
+  abstract addMetadataRule<T>(key: MetadataKey<T>, logic: LogicFn<unknown, T>): void;
+  abstract getChild(key: PropertyKey): LogicNodeBuilder;
+  abstract predicate(predicates: ReadonlyArray<Predicate>): AbstractLogicNodeBuilder;
+
+  build(): LogicNode {
+    return new LogicNode(this);
+  }
+}
+
+/**
+ * A builder for `LogicNode`. Used to add logic to the final `LogicNode` tree.
+ */
+export class LogicNodeBuilder extends AbstractLogicNodeBuilder {
+  private current: NonMergableLogicNodeBuilder | undefined;
+  readonly all: AbstractLogicNodeBuilder[] = [];
+
+  constructor(predicates: ReadonlyArray<Predicate>) {
+    super(predicates);
+  }
+
+  addHiddenRule(logic: LogicFn<unknown, boolean>): void {
+    this.getCurrent().addHiddenRule(logic);
+  }
+
+  addDisabledRule(logic: LogicFn<unknown, boolean>): void {
+    this.getCurrent().addDisabledRule(logic);
+  }
+
+  addErrorRule(logic: LogicFn<unknown, ValidationResult>): void {
+    this.getCurrent().addErrorRule(logic);
+  }
+
+  addMetadataRule<T>(key: MetadataKey<T>, logic: LogicFn<unknown, T>): void {
+    this.getCurrent().addMetadataRule(key, logic);
+  }
+
+  getChild(key: PropertyKey): LogicNodeBuilder {
+    return this.getCurrent().getChild(key);
+  }
+
+  predicate(predicates: ReadonlyArray<Predicate>) {
+    const newPredicates = [...this.predicates, ...predicates];
+    const clone = new LogicNodeBuilder(newPredicates);
+    clone.all.push(...this.all.map((b) => b.predicate(newPredicates)));
+    clone.current = this.current?.predicate(newPredicates);
+    return clone;
+  }
+
+  mergeIn(other: LogicNodeBuilder, predicate?: Predicate): void {
+    // Add the other builder to our collection, we'll defer the actual merging of the logic until
+    // the logic node is requested to be created. In order to preserve the original ordering of the
+    // rules, we close off the current builder to any further edits. If additional logic is added,
+    // a new current builder will be created to capture it.
+    const predicates = [...this.predicates];
+    if (predicate) {
+      predicates.push(predicate);
+    }
+    if (predicates.length !== 0) {
+      this.all.push(other.predicate(predicates));
+    } else {
+      this.all.push(other);
+    }
+    this.current = undefined;
+  }
+
+  private getCurrent(): NonMergableLogicNodeBuilder {
+    // All rules added to this builder get added on to the current builder. If there is no current
+    // builder, a new one is created. In order to preserve the original ordering of the rules, we
+    // clear the current builder whenever a separate builder tree is merged in.
+    if (this.current === undefined) {
+      this.current = new NonMergableLogicNodeBuilder(this.predicates);
+      this.all.push(this.current);
+    }
+    return this.current;
+  }
+
+  static newRoot(): LogicNodeBuilder {
+    return new LogicNodeBuilder([]);
+  }
+}
+
+/**
+ * A type of `AbstractLogicNodeBuilder` used internally by the `LogicNodeBuilder` to record "pure"
+ * chunks of logic that do not require merging in other builders.
+ */
+class NonMergableLogicNodeBuilder extends AbstractLogicNodeBuilder {
+  logic = new Logic([]);
+  readonly children = new Map<PropertyKey, LogicNodeBuilder>();
+
+  override addHiddenRule(logic: LogicFn<unknown, boolean>): void {
+    this.logic.hidden.push(logic);
+  }
+
+  override addDisabledRule(logic: LogicFn<unknown, boolean>): void {
+    this.logic.disabled.push(logic);
+  }
+
+  override addErrorRule(logic: LogicFn<unknown, ValidationResult>): void {
+    this.logic.errors.push(logic);
+  }
+
+  override addMetadataRule<T>(key: MetadataKey<T>, logic: LogicFn<unknown, T>): void {
+    this.logic.getMetadata(key).push(logic);
+  }
+
+  override predicate(predicates: ReadonlyArray<Predicate>) {
+    const newPredicates = [...this.predicates, ...predicates];
+    const clone = new NonMergableLogicNodeBuilder(newPredicates);
+    for (const [prop, child] of this.children) {
+      clone.children.set(prop, child.predicate(newPredicates));
+    }
+    clone.logic = this.logic;
+    return clone;
+  }
+
+  override getChild(key: PropertyKey): LogicNodeBuilder {
+    if (!this.children.has(key)) {
+      this.children.set(key, new LogicNodeBuilder(this.predicates));
+    }
+    return this.children.get(key)!;
+  }
+}
+
 /**
  * Container for all the different types of logic that can be applied to a field
  * (disabled, hidden, errors, etc.)
@@ -49,10 +178,11 @@ export class Logic {
 export class LogicNode {
   readonly logic: Logic;
 
-  constructor(private builder: LogicNodeBuilder | undefined) {
+  constructor(private builder: AbstractLogicNodeBuilder | undefined) {
     this.logic = builder ? createLogic(builder) : new Logic([]);
   }
 
+  // TODO: cache here, or just rely on the user of this API to do caching?
   getChild(key: PropertyKey): LogicNode {
     // The logic for a particular child may be spread across multiple builders. We lazily combine
     // this logic at the time the child logic node is requested to be created.
@@ -72,154 +202,12 @@ export class LogicNode {
 }
 
 /**
- * A builder for `LogicNode`, which itself is a tree.
- */
-export abstract class LogicNodeBuilder {
-  protected constructor(readonly predicates: ReadonlyArray<Predicate>) {}
-
-  abstract addHiddenRule(logic: LogicFn<unknown, boolean>): void;
-  abstract addDisabledRule(logic: LogicFn<unknown, boolean>): void;
-  abstract addErrorRule(logic: LogicFn<unknown, ValidationResult>): void;
-  abstract addMetadataRule<T>(key: MetadataKey<T>, logic: LogicFn<unknown, T>): void;
-  abstract getChild(key: PropertyKey): MergableLogicNodeBuilder;
-  abstract predicate(predicates: ReadonlyArray<Predicate>): LogicNodeBuilder;
-
-  build(): LogicNode {
-    return new LogicNode(this);
-  }
-
-  static newRoot(): MergableLogicNodeBuilder {
-    return new CompositeLogicNodeBuilder([]);
-  }
-}
-
-/**
- * A subclass of `LogicNodeBuilder` that supports merging with other logic trees.
- */
-export interface MergableLogicNodeBuilder extends LogicNodeBuilder {
-  mergeIn(other: MergableLogicNodeBuilder, predicate?: Predicate): void;
-  predicate(predicates: ReadonlyArray<Predicate>): MergableLogicNodeBuilder;
-}
-
-/**
- * A `MergableLogicNodeBuilder` that delegates to its "current" builder and creates a new current
- * builder after another builder tree is merged in.
- */
-class CompositeLogicNodeBuilder extends LogicNodeBuilder implements MergableLogicNodeBuilder {
-  private current: SimpleLogicNodeBuilder | undefined;
-  readonly all: LogicNodeBuilder[] = [];
-
-  override addHiddenRule(logic: LogicFn<unknown, boolean>): void {
-    this.getCurrent().addHiddenRule(logic);
-  }
-
-  override addDisabledRule(logic: LogicFn<unknown, boolean>): void {
-    this.getCurrent().addDisabledRule(logic);
-  }
-
-  override addErrorRule(logic: LogicFn<unknown, FormError>): void {
-    this.getCurrent().addErrorRule(logic);
-  }
-
-  override addMetadataRule<T>(key: MetadataKey<T>, logic: LogicFn<unknown, T>): void {
-    this.getCurrent().addMetadataRule(key, logic);
-  }
-
-  override getChild(key: PropertyKey): MergableLogicNodeBuilder {
-    return this.getCurrent().getChild(key);
-  }
-
-  override predicate(predicates: ReadonlyArray<Predicate>) {
-    const newPredicates = [...this.predicates, ...predicates];
-    const clone = new CompositeLogicNodeBuilder(newPredicates);
-    clone.all.push(...this.all.map((b) => b.predicate(newPredicates)));
-    clone.current = this.current?.predicate(newPredicates);
-    return clone;
-  }
-
-  mergeIn(other: MergableLogicNodeBuilder, predicate?: Predicate): void {
-    // Add the other builder to our collection, we'll defer the actual merging of the logic until
-    // the logic node is requested to be created. In order to preserve the original ordering of the
-    // rules, we close off the current builder to any further edits. If additional logic is added,
-    // a new current builder will be created to capture it.
-    const predicates = [...this.predicates];
-    if (predicate) {
-      predicates.push(predicate);
-    }
-    if (predicates.length !== 0) {
-      this.all.push(other.predicate(predicates));
-    } else {
-      this.all.push(other);
-    }
-    this.current = undefined;
-  }
-
-  private getCurrent(): SimpleLogicNodeBuilder {
-    // All rules added to this builder get added on to the current builder. If there is no current
-    // builder, a new one is created. In order to preserve the original ordering of the rules, we
-    // clear the current builder whenever a separate builder tree is merged in.
-    if (this.current === undefined) {
-      this.current = new SimpleLogicNodeBuilder(this.predicates);
-      this.all.push(this.current);
-    }
-    return this.current;
-  }
-}
-
-/**
- * A `LogicNodeBuilder` that directly adds logic to its backing `Logic` instance.
- *
- * The user should not be given a reference to this class, it is used internally to keep track of
- * concrete tree chunks within the `CompositeLogicNodeBuilder`. When handing a `LogicNodeBuilder`
- * to the user it should always be a `CompositeLogicNodeBuilder`.
- */
-class SimpleLogicNodeBuilder extends LogicNodeBuilder {
-  logic = new Logic([]);
-  readonly children = new Map<PropertyKey, MergableLogicNodeBuilder>();
-
-  override addHiddenRule(logic: LogicFn<unknown, boolean>): void {
-    this.logic.hidden.push(logic);
-  }
-
-  override addDisabledRule(logic: LogicFn<unknown, boolean>): void {
-    this.logic.disabled.push(logic);
-  }
-
-  override addErrorRule(logic: LogicFn<unknown, ValidationResult>): void {
-    this.logic.errors.push(logic);
-  }
-
-  override addMetadataRule<T>(key: MetadataKey<T>, logic: LogicFn<unknown, T>): void {
-    this.logic.getMetadata(key).push(logic);
-  }
-
-  override predicate(predicates: ReadonlyArray<Predicate>) {
-    const newPredicates = [...this.predicates, ...predicates];
-    const clone = new SimpleLogicNodeBuilder(newPredicates);
-    for (const [prop, child] of this.children) {
-      clone.children.set(prop, child.predicate(newPredicates));
-    }
-    clone.logic = this.logic;
-    return clone;
-  }
-
-  override getChild(key: PropertyKey): MergableLogicNodeBuilder {
-    // We always create a `CompositeLogicNodeBuilder` for children since someone may call `apply` on
-    // the child.
-    if (!this.children.has(key)) {
-      this.children.set(key, new CompositeLogicNodeBuilder(this.predicates));
-    }
-    return this.children.get(key)!;
-  }
-}
-
-/**
  * Gets all of the builders that contribute logic to the given child of the parent builder.
  */
-function getAllChildren(builder: LogicNodeBuilder, key: PropertyKey): MergableLogicNodeBuilder[] {
-  if (builder instanceof CompositeLogicNodeBuilder) {
+function getAllChildren(builder: AbstractLogicNodeBuilder, key: PropertyKey): LogicNodeBuilder[] {
+  if (builder instanceof LogicNodeBuilder) {
     return builder.all.flatMap((node) => getAllChildren(node, key));
-  } else if (builder instanceof SimpleLogicNodeBuilder) {
+  } else if (builder instanceof NonMergableLogicNodeBuilder) {
     if (builder.children.has(key)) {
       return [builder.children.get(key)!];
     }
@@ -232,9 +220,10 @@ function getAllChildren(builder: LogicNodeBuilder, key: PropertyKey): MergableLo
 /**
  * Creates the full `Logic` for a given builder.
  */
-function createLogic(builder: LogicNodeBuilder): Logic {
-  const logic = new Logic(builder.predicates);
-  if (builder instanceof CompositeLogicNodeBuilder) {
+function createLogic(builder: AbstractLogicNodeBuilder): Logic {
+  if (builder instanceof LogicNodeBuilder) {
+    // Build the logic for all sub-builders, and merge them into one.
+    const logic = new Logic([]);
     const builtNodes = builder.all.map((b) => b.build());
     for (const node of builtNodes) {
       logic.disabled.mergeIn(node.logic.disabled);
@@ -244,15 +233,17 @@ function createLogic(builder: LogicNodeBuilder): Logic {
         logic.getMetadata(key).mergeIn(node.logic.getMetadata(key));
       }
     }
-  } else if (builder instanceof SimpleLogicNodeBuilder) {
+    return logic;
+  } else if (builder instanceof NonMergableLogicNodeBuilder) {
+    const logic = new Logic(builder.predicates);
     logic.disabled.mergeIn(builder.logic.disabled);
     logic.hidden.mergeIn(builder.logic.hidden);
     logic.errors.mergeIn(builder.logic.errors);
     for (const key of builder.logic.getMetadataKeys()) {
       logic.getMetadata(key).mergeIn(builder.logic.getMetadata(key));
     }
+    return logic;
   } else {
     throw new Error('Unknown LogicNodeBuilder type');
   }
-  return logic;
 }

--- a/packages/forms/experimental/src/logic_node_2.ts
+++ b/packages/forms/experimental/src/logic_node_2.ts
@@ -17,17 +17,40 @@ import {
   Predicate,
 } from './logic_node';
 
+/**
+ * Abstract base class for building a `LogicNode`.
+ * This class defines the interface for adding various logic rules (e.g., hidden, disabled)
+ * and data factories to a node in the logic tree.
+ * LogicNodeBuilders are 1:1 with nodes in the Schema tree.
+ */
 abstract class AbstractLogicNodeBuilder {
+  /** Adds a rule to determine if a field should be hidden. */
   abstract addHiddenRule(logic: LogicFn<any, boolean>): void;
+  /** Adds a rule to determine if a field should be disabled, and for what reason. */
   abstract addDisabledReasonRule(logic: LogicFn<any, DisabledReason | undefined>): void;
+  /** Adds a rule to determine if a field should be read-only. */
   abstract addReadonlyRule(logic: LogicFn<any, boolean>): void;
+  /** Adds a rule for synchronous validation errors for a field. */
   abstract addSyncErrorRule(logic: LogicFn<any, ValidationResult>): void;
+  /** Adds a rule for synchronous validation errors that apply to a subtree. */
   abstract addSyncTreeErrorRule(logic: LogicFn<any, FormTreeError[]>): void;
+  /** Adds a rule for asynchronous validation errors for a field. */
   abstract addAsyncErrorRule(logic: LogicFn<any, AsyncValidationResult>): void;
+  /** Adds a rule to compute metadata for a field. */
   abstract addMetadataRule<M>(key: MetadataKey<M>, logic: LogicFn<any, M>): void;
+  /** Adds a factory function to produce a data value associated with a field. */
   abstract addDataFactory<D>(key: DataKey<D>, factory: (ctx: FieldContext<any>) => D): void;
+  /**
+   * Gets a builder for a child node associated with the given property key.
+   * @param key The property key of the child.
+   * @returns A `LogicNodeBuilder` for the child.
+   */
   abstract getChild(key: PropertyKey): LogicNodeBuilder;
 
+  /**
+   * Builds the `LogicNode` from the accumulated rules and child builders.
+   * @returns The constructed `LogicNode`.
+   */
   build(): LogicNode {
     return new LeafLogicNode(this, []);
   }
@@ -35,9 +58,20 @@ abstract class AbstractLogicNodeBuilder {
 
 /**
  * A builder for `LogicNode`. Used to add logic to the final `LogicNode` tree.
+ * This builder supports merging multiple sources of logic, potentially with predicates,
+ * preserving the order of rule application.
  */
 export class LogicNodeBuilder extends AbstractLogicNodeBuilder {
+  /**
+   * The current `NonMergableLogicNodeBuilder` being used to add rules directly to this
+   * `LogicNodeBuilder`. Do not use this directly, call `getCurrent()` which will create a current
+   * builder if there is none.
+   */
   private current: NonMergableLogicNodeBuilder | undefined;
+  /**
+   * Stores all builders that contribute to this node, along with any predicates
+   * that gate their application.
+   */
   readonly all: {builder: AbstractLogicNodeBuilder; predicate?: Predicate}[] = [];
 
   override addHiddenRule(logic: LogicFn<any, boolean>): void {
@@ -76,6 +110,13 @@ export class LogicNodeBuilder extends AbstractLogicNodeBuilder {
     return this.getCurrent().getChild(key);
   }
 
+  /**
+   * Merges logic from another `LogicNodeBuilder` into this one.
+   * If a `predicate` is provided, all logic from the `other` builder will only apply
+   * when the predicate evaluates to true.
+   * @param other The `LogicNodeBuilder` to merge in.
+   * @param predicate An optional predicate to gate the merged logic.
+   */
   mergeIn(other: LogicNodeBuilder, predicate?: Predicate): void {
     // Add the other builder to our collection, we'll defer the actual merging of the logic until
     // the logic node is requested to be created. In order to preserve the original ordering of the
@@ -89,10 +130,14 @@ export class LogicNodeBuilder extends AbstractLogicNodeBuilder {
     this.current = undefined;
   }
 
+  /**
+   * Gets the current `NonMergableLogicNodeBuilder` for adding rules directly to this
+   * `LogicNodeBuilder`. If no current builder exists, a new one is created.
+   * The current builder is cleared whenever `mergeIn` is called to preserve the order
+   * of rules when merging separate builder trees.
+   * @returns The current `NonMergableLogicNodeBuilder`.
+   */
   private getCurrent(): NonMergableLogicNodeBuilder {
-    // All rules added to this builder get added on to the current builder. If there is no current
-    // builder, a new one is created. In order to preserve the original ordering of the rules, we
-    // clear the current builder whenever a separate builder tree is merged in.
     if (this.current === undefined) {
       this.current = new NonMergableLogicNodeBuilder();
       this.all.push({builder: this.current});
@@ -100,6 +145,10 @@ export class LogicNodeBuilder extends AbstractLogicNodeBuilder {
     return this.current;
   }
 
+  /**
+   * Creates a new root `LogicNodeBuilder`.
+   * @returns A new instance of `LogicNodeBuilder`.
+   */
   static newRoot(): LogicNodeBuilder {
     return new LogicNodeBuilder();
   }
@@ -110,7 +159,12 @@ export class LogicNodeBuilder extends AbstractLogicNodeBuilder {
  * chunks of logic that do not require merging in other builders.
  */
 class NonMergableLogicNodeBuilder extends AbstractLogicNodeBuilder {
-  readonly logic = new Logic([]);
+  /** The collection of logic rules directly added to this builder. */
+  readonly logic = new LogicContainer([]);
+  /**
+   * A map of child property keys to their corresponding `LogicNodeBuilder` instances.
+   * This allows for building a tree of logic.
+   */
   readonly children = new Map<PropertyKey, LogicNodeBuilder>();
 
   override addHiddenRule(logic: LogicFn<any, boolean>): void {
@@ -157,36 +211,62 @@ class NonMergableLogicNodeBuilder extends AbstractLogicNodeBuilder {
  * Container for all the different types of logic that can be applied to a field
  * (disabled, hidden, errors, etc.)
  */
-export class Logic {
+export class LogicContainer {
+  /** Logic that determines if the field is hidden. */
   readonly hidden: BooleanOrLogic;
+  /** Logic that determines reasons for the field being disabled. */
   readonly disabledReasons: ArrayMergeLogic<DisabledReason>;
+  /** Logic that determines if the field is read-only. */
   readonly readonly: BooleanOrLogic;
+  /** Logic that produces synchronous validation errors for the field. */
   readonly syncErrors: ArrayMergeLogic<FormError>;
+  /** Logic that produces synchronous validation errors for the field's subtree. */
   readonly syncTreeErrors: ArrayMergeLogic<FormTreeError>;
+  /** Logic that produces asynchronous validation results (errors or 'pending'). */
   readonly asyncErrors: ArrayMergeLogic<FormTreeError | 'pending'>;
+  /** A map of metadata keys to the `AbstractLogic` instances that compute their values. */
   private readonly metadata = new Map<MetadataKey<unknown>, AbstractLogic<unknown>>();
+  /** A map of data keys to the factory functions that create their values. */
   private readonly dataFactories = new Map<
     DataKey<unknown>,
     (ctx: FieldContext<unknown>) => unknown
   >();
 
+  /**
+   * Constructs a new `Logic` container.
+   * @param predicates An array of predicates that must all be true for the logic
+   *   functions within this container to be active.
+   */
   constructor(private predicates: ReadonlyArray<Predicate>) {
     this.hidden = new BooleanOrLogic(predicates);
-    this.disabledReasons = new ArrayMergeLogic(this.predicates);
-    this.readonly = new BooleanOrLogic(this.predicates);
+    this.disabledReasons = new ArrayMergeLogic(predicates);
+    this.readonly = new BooleanOrLogic(predicates);
     this.syncErrors = new ArrayMergeLogic<FormError>(predicates);
     this.syncTreeErrors = new ArrayMergeLogic<FormTreeError>(predicates);
     this.asyncErrors = new ArrayMergeLogic<FormTreeError | 'pending'>(predicates);
   }
 
+  /**
+   * Gets an iterable of [metadata key, metadata logic] pairs.
+   * @returns An iterable of metadata entries.
+   */
   getMetadataEntries() {
     return this.metadata.entries();
   }
 
+  /**
+   * Gets an iterable of [data key, data factory function] pairs.
+   * @returns An iterable of data factory entries.
+   */
   getDataFactoryEntries() {
     return this.dataFactories.entries();
   }
 
+  /**
+   * Retrieves or creates the `AbstractLogic` for a given metadata key.
+   * @param key The `MetadataKey` for which to get the logic.
+   * @returns The `AbstractLogic` associated with the key.
+   */
   getMetadata<T>(key: MetadataKey<T>): AbstractLogic<T> {
     if (!this.metadata.has(key as MetadataKey<unknown>)) {
       this.metadata.set(key as MetadataKey<unknown>, new MetadataMergeLogic(this.predicates, key));
@@ -194,6 +274,12 @@ export class Logic {
     return this.metadata.get(key as MetadataKey<unknown>)! as AbstractLogic<T>;
   }
 
+  /**
+   * Adds a data factory function for a given data key.
+   * @param key The `DataKey` to associate the factory with.
+   * @param factory The factory function.
+   * @throws If a factory is already defined for the given key.
+   */
   addDataFactory(key: DataKey<unknown>, factory: (ctx: FieldContext<unknown>) => unknown) {
     if (this.dataFactories.has(key)) {
       // TODO: name of the key?
@@ -202,7 +288,11 @@ export class Logic {
     this.dataFactories.set(key, factory);
   }
 
-  mergeIn(other: Logic) {
+  /**
+   * Merges logic from another `Logic` instance into this one.
+   * @param other The `Logic` instance to merge from.
+   */
+  mergeIn(other: LogicContainer) {
     this.hidden.mergeIn(other.hidden);
     this.disabledReasons.mergeIn(other.disabledReasons);
     this.readonly.mergeIn(other.readonly);
@@ -218,25 +308,50 @@ export class Logic {
   }
 }
 
+/**
+ * Represents a node in the logic tree, containing all logic applicable
+ * to a specific field or path in the form structure.
+ * LogicNodes are 1:1 with nodes in the Field tree.
+ */
 export interface LogicNode {
-  readonly logic: Logic;
+  /** The collection of logic rules (hidden, disabled, errors, etc.) for this node. */
+  readonly logic: LogicContainer;
+  /**
+   * Retrieves the `LogicNode` for a child identified by the given property key.
+   * @param key The property key of the child.
+   * @returns The `LogicNode` for the specified child.
+   */
   getChild(key: PropertyKey): LogicNode;
 }
 
 /**
  * A tree structure of `Logic` corresponding to a tree of fields.
+ * This implementation represents a leaf in the sense that its logic is derived
+ * from a single builder.
  */
 class LeafLogicNode implements LogicNode {
-  readonly logic: Logic;
+  /** The computed logic for this node. */
+  readonly logic: LogicContainer;
 
+  /**
+   * Constructs a `LeafLogicNode`.
+   * @param builder The `AbstractLogicNodeBuilder` from which to derive the logic.
+   *   If undefined, an empty `Logic` instance is created.
+   * @param predicates An array of predicates that gate the logic from the builder.
+   */
   constructor(
     private builder: AbstractLogicNodeBuilder | undefined,
     private predicates: Predicate[],
   ) {
-    this.logic = builder ? createLogic(builder, predicates) : new Logic([]);
+    this.logic = builder ? createLogic(builder, predicates) : new LogicContainer([]);
   }
 
   // TODO: cache here, or just rely on the user of this API to do caching?
+  /**
+   * Retrieves the `LogicNode` for a child identified by the given property key.
+   * @param key The property key of the child.
+   * @returns The `LogicNode` for the specified child.
+   */
   getChild(key: PropertyKey): LogicNode {
     // The logic for a particular child may be spread across multiple builders. We lazily combine
     // this logic at the time the child logic node is requested to be created.
@@ -253,16 +368,32 @@ class LeafLogicNode implements LogicNode {
   }
 }
 
+/**
+ * A `LogicNode` that represents the composition of multiple `LogicNode` instances.
+ * This is used when logic for a particular path is contributed by several distinct
+ * builder branches that need to be merged.
+ */
 class CompositeLogicNode implements LogicNode {
-  readonly logic: Logic;
+  /** The merged logic from all composed nodes. */
+  readonly logic: LogicContainer;
 
+  /**
+   * Constructs a `CompositeLogicNode`.
+   * @param all An array of `LogicNode` instances to compose.
+   */
   constructor(private all: LogicNode[]) {
-    this.logic = new Logic([]);
+    this.logic = new LogicContainer([]);
     for (const node of all) {
       this.logic.mergeIn(node.logic);
     }
   }
 
+  /**
+   * Retrieves the child `LogicNode` by composing the results of `getChild` from all
+   * underlying `LogicNode` instances.
+   * @param key The property key of the child.
+   * @returns A `CompositeLogicNode` representing the composed child.
+   */
   getChild(key: PropertyKey): LogicNode {
     return new CompositeLogicNode(this.all.flatMap((child) => child.getChild(key)));
   }
@@ -270,6 +401,10 @@ class CompositeLogicNode implements LogicNode {
 
 /**
  * Gets all of the builders that contribute logic to the given child of the parent builder.
+ * This function recursively traverses the builder hierarchy.
+ * @param builder The parent `AbstractLogicNodeBuilder`.
+ * @param key The property key of the child.
+ * @returns An array of objects, each containing a `LogicNodeBuilder` for the child and any associated predicates.
  */
 function getAllChildBuilders(
   builder: AbstractLogicNodeBuilder,
@@ -298,9 +433,14 @@ function getAllChildBuilders(
 
 /**
  * Creates the full `Logic` for a given builder.
+ * This function handles different types of builders (`LogicNodeBuilder`, `NonMergableLogicNodeBuilder`)
+ * and applies the provided predicates.
+ * @param builder The `AbstractLogicNodeBuilder` to process.
+ * @param predicates Predicates to apply to the logic derived from the builder.
+ * @returns The `Logic` instance.
  */
-function createLogic(builder: AbstractLogicNodeBuilder, predicates: Predicate[]): Logic {
-  const logic = new Logic(predicates);
+function createLogic(builder: AbstractLogicNodeBuilder, predicates: Predicate[]): LogicContainer {
+  const logic = new LogicContainer(predicates);
   if (builder instanceof LogicNodeBuilder) {
     // TODO: do we need to bind predicate to a specific field here?
     // Specifically I think we need to split the idea of a predicate in the LogicNodeBuilder from

--- a/packages/forms/experimental/test/logic_node_2.spec.ts
+++ b/packages/forms/experimental/test/logic_node_2.spec.ts
@@ -1,13 +1,14 @@
 import {signal} from '@angular/core';
-import {FieldContext} from '../public_api';
+import {FieldContext, FieldState} from '../public_api';
 import {DYNAMIC} from '../src/logic_node';
 import {LogicNodeBuilder} from '../src/logic_node_2';
 
 const fakeFieldContext: FieldContext<unknown> = {
-  resolve: () =>
-    ({
-      $state: {fieldContext: fakeFieldContext},
-    }) as any,
+  fieldOf: () => undefined!,
+  stateOf: <P>() => ({context: undefined}) as unknown as FieldState<P>,
+  valueOf: () => undefined!,
+  field: undefined!,
+  state: undefined!,
   value: undefined!,
 };
 

--- a/packages/forms/experimental/test/logic_node_2.spec.ts
+++ b/packages/forms/experimental/test/logic_node_2.spec.ts
@@ -19,10 +19,10 @@ describe('LogicNodeBuilder', () => {
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.addErrorRule(() => [{kind: 'root-err'}]);
+    builder.addSyncErrorRule(() => [{kind: 'root-err'}]);
 
     const logicNode = builder.build();
-    expect(logicNode.logic.errors.compute(fakeFieldContext)).toEqual([{kind: 'root-err'}]);
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'root-err'}]);
   });
 
   it('should build child logic', () => {
@@ -31,10 +31,10 @@ describe('LogicNodeBuilder', () => {
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.getChild('a').addErrorRule(() => [{kind: 'root-err'}]);
+    builder.getChild('a').addSyncErrorRule(() => [{kind: 'root-err'}]);
 
     const logicNode = builder.build();
-    expect(logicNode.getChild('a').logic.errors.compute(fakeFieldContext)).toEqual([
+    expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
       {kind: 'root-err'},
     ]);
   });
@@ -46,14 +46,14 @@ describe('LogicNodeBuilder', () => {
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.addErrorRule(() => [{kind: 'err-1'}]);
+    builder.addSyncErrorRule(() => [{kind: 'err-1'}]);
 
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.addErrorRule(() => [{kind: 'err-2'}]);
+    builder2.addSyncErrorRule(() => [{kind: 'err-2'}]);
     builder.mergeIn(builder2);
 
     const logicNode = builder.build();
-    expect(logicNode.logic.errors.compute(fakeFieldContext)).toEqual([
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
       {kind: 'err-1'},
       {kind: 'err-2'},
     ]);
@@ -66,14 +66,14 @@ describe('LogicNodeBuilder', () => {
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.getChild('a').addErrorRule(() => [{kind: 'err-1'}]);
+    builder.getChild('a').addSyncErrorRule(() => [{kind: 'err-1'}]);
 
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.getChild('a').addErrorRule(() => [{kind: 'err-2'}]);
+    builder2.getChild('a').addSyncErrorRule(() => [{kind: 'err-2'}]);
     builder.mergeIn(builder2);
 
     const logicNode = builder.build();
-    expect(logicNode.getChild('a').logic.errors.compute(fakeFieldContext)).toEqual([
+    expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
       {kind: 'err-1'},
       {kind: 'err-2'},
     ]);
@@ -90,14 +90,14 @@ describe('LogicNodeBuilder', () => {
 
     const pred = signal(true);
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.addErrorRule(() => [{kind: 'err-1'}]);
+    builder2.addSyncErrorRule(() => [{kind: 'err-1'}]);
     builder.mergeIn(builder2, {fn: pred, path: undefined!});
 
     const logicNode = builder.build();
-    expect(logicNode.logic.errors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
 
     pred.set(false);
-    expect(logicNode.logic.errors.compute(fakeFieldContext)).toEqual([]);
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([]);
   });
 
   it('should apply predicate to merged in logic', () => {
@@ -115,16 +115,16 @@ describe('LogicNodeBuilder', () => {
     const builder2 = LogicNodeBuilder.newRoot();
 
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.addErrorRule(() => [{kind: 'err-1'}]);
+    builder3.addSyncErrorRule(() => [{kind: 'err-1'}]);
 
     builder2.mergeIn(builder3);
     builder.mergeIn(builder2, {fn: pred, path: undefined!});
 
     const logicNode = builder.build();
-    expect(logicNode.logic.errors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
 
     pred.set(false);
-    expect(logicNode.logic.errors.compute(fakeFieldContext)).toEqual([]);
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([]);
   });
 
   it('should apply predicate to merged in child logic', () => {
@@ -142,18 +142,18 @@ describe('LogicNodeBuilder', () => {
     const builder2 = LogicNodeBuilder.newRoot();
 
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.getChild('a').addErrorRule(() => [{kind: 'err-1'}]);
+    builder3.getChild('a').addSyncErrorRule(() => [{kind: 'err-1'}]);
 
     builder2.mergeIn(builder3);
     builder.mergeIn(builder2, {fn: pred, path: undefined!});
 
     const logicNode = builder.build();
-    expect(logicNode.getChild('a').logic.errors.compute(fakeFieldContext)).toEqual([
+    expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
       {kind: 'err-1'},
     ]);
 
     pred.set(false);
-    expect(logicNode.getChild('a').logic.errors.compute(fakeFieldContext)).toEqual([]);
+    expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([]);
   });
 
   it('should combine predicates', () => {
@@ -172,23 +172,23 @@ describe('LogicNodeBuilder', () => {
 
     const pred2 = signal(true);
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.addErrorRule(() => [{kind: 'err-1'}]);
+    builder3.addSyncErrorRule(() => [{kind: 'err-1'}]);
 
     builder2.getChild('a').mergeIn(builder3, {fn: pred2, path: undefined!});
     builder.mergeIn(builder2, {fn: pred, path: undefined!});
 
     const logicNode = builder.build();
-    expect(logicNode.getChild('a').logic.errors.compute(fakeFieldContext)).toEqual([
+    expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
       {kind: 'err-1'},
     ]);
 
     pred.set(false);
     pred2.set(true);
-    expect(logicNode.getChild('a').logic.errors.compute(fakeFieldContext)).toEqual([]);
+    expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([]);
 
     pred.set(true);
     pred2.set(false);
-    expect(logicNode.getChild('a').logic.errors.compute(fakeFieldContext)).toEqual([]);
+    expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([]);
   });
 
   it('should propagate predicates through deep application', () => {
@@ -211,47 +211,44 @@ describe('LogicNodeBuilder', () => {
     builder2
       .getChild('a')
       .getChild('b')
-      .addErrorRule(() => [{kind: 'err-1'}]);
+      .addSyncErrorRule(() => [{kind: 'err-1'}]);
 
     const pred2 = signal(true);
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.getChild('b').addErrorRule(() => [{kind: 'err-2'}]);
+    builder3.getChild('b').addSyncErrorRule(() => [{kind: 'err-2'}]);
 
     const pred3 = signal(true);
     const builder4 = LogicNodeBuilder.newRoot();
-    builder4.addErrorRule(() => [{kind: 'err-3'}]);
+    builder4.addSyncErrorRule(() => [{kind: 'err-3'}]);
     builder3.getChild('b').mergeIn(builder4, {fn: pred3, path: undefined!});
     builder2.getChild('a').mergeIn(builder3, {fn: pred2, path: undefined!});
     builder.mergeIn(builder2, {fn: pred, path: undefined!});
 
     const logicNode = builder.build();
-    expect(logicNode.getChild('a').getChild('b').logic.errors.compute(fakeFieldContext)).toEqual([
-      {kind: 'err-1'},
-      {kind: 'err-2'},
-      {kind: 'err-3'},
-    ]);
+    expect(
+      logicNode.getChild('a').getChild('b').logic.syncErrors.compute(fakeFieldContext),
+    ).toEqual([{kind: 'err-1'}, {kind: 'err-2'}, {kind: 'err-3'}]);
 
     pred.set(true);
     pred2.set(true);
     pred3.set(false);
-    expect(logicNode.getChild('a').getChild('b').logic.errors.compute(fakeFieldContext)).toEqual([
-      {kind: 'err-1'},
-      {kind: 'err-2'},
-    ]);
+    expect(
+      logicNode.getChild('a').getChild('b').logic.syncErrors.compute(fakeFieldContext),
+    ).toEqual([{kind: 'err-1'}, {kind: 'err-2'}]);
 
     pred.set(true);
     pred2.set(false);
     pred3.set(true);
-    expect(logicNode.getChild('a').getChild('b').logic.errors.compute(fakeFieldContext)).toEqual([
-      {kind: 'err-1'},
-    ]);
+    expect(
+      logicNode.getChild('a').getChild('b').logic.syncErrors.compute(fakeFieldContext),
+    ).toEqual([{kind: 'err-1'}]);
 
     pred.set(false);
     pred2.set(true);
     pred3.set(true);
-    expect(logicNode.getChild('a').getChild('b').logic.errors.compute(fakeFieldContext)).toEqual(
-      [],
-    );
+    expect(
+      logicNode.getChild('a').getChild('b').logic.syncErrors.compute(fakeFieldContext),
+    ).toEqual([]);
   });
 
   it('should propagate predicates through deep child access', () => {
@@ -269,7 +266,7 @@ describe('LogicNodeBuilder', () => {
     const builder2 = LogicNodeBuilder.newRoot();
 
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.getChild('last').addErrorRule(() => [{kind: 'err-1'}]);
+    builder3.getChild('last').addSyncErrorRule(() => [{kind: 'err-1'}]);
 
     builder2.getChild('items').getChild(DYNAMIC).mergeIn(builder3);
     builder.mergeIn(builder2, {fn: pred, path: undefined!});
@@ -280,7 +277,7 @@ describe('LogicNodeBuilder', () => {
         .getChild('items')
         .getChild(DYNAMIC)
         .getChild('last')
-        .logic.errors.compute(fakeFieldContext),
+        .logic.syncErrors.compute(fakeFieldContext),
     ).toEqual([{kind: 'err-1'}]);
 
     pred.set(false);
@@ -289,7 +286,7 @@ describe('LogicNodeBuilder', () => {
         .getChild('items')
         .getChild(DYNAMIC)
         .getChild('last')
-        .logic.errors.compute(fakeFieldContext),
+        .logic.syncErrors.compute(fakeFieldContext),
     ).toEqual([]);
   });
 
@@ -303,16 +300,16 @@ describe('LogicNodeBuilder', () => {
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.addErrorRule(() => [{kind: 'err-1'}]);
+    builder.addSyncErrorRule(() => [{kind: 'err-1'}]);
 
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.addErrorRule(() => [{kind: 'err-2'}]);
+    builder2.addSyncErrorRule(() => [{kind: 'err-2'}]);
     builder.mergeIn(builder2);
 
-    builder.addErrorRule(() => [{kind: 'err-3'}]);
+    builder.addSyncErrorRule(() => [{kind: 'err-3'}]);
 
     const logicNode = builder.build();
-    expect(logicNode.logic.errors.compute(fakeFieldContext)).toEqual([
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
       {kind: 'err-1'},
       {kind: 'err-2'},
       {kind: 'err-3'},
@@ -329,16 +326,16 @@ describe('LogicNodeBuilder', () => {
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.getChild('a').addErrorRule(() => [{kind: 'err-1'}]);
+    builder.getChild('a').addSyncErrorRule(() => [{kind: 'err-1'}]);
 
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.getChild('a').addErrorRule(() => [{kind: 'err-2'}]);
+    builder2.getChild('a').addSyncErrorRule(() => [{kind: 'err-2'}]);
     builder.mergeIn(builder2);
 
-    builder.getChild('a').addErrorRule(() => [{kind: 'err-3'}]);
+    builder.getChild('a').addSyncErrorRule(() => [{kind: 'err-3'}]);
 
     const logicNode = builder.build();
-    expect(logicNode.getChild('a').logic.errors.compute(fakeFieldContext)).toEqual([
+    expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
       {kind: 'err-1'},
       {kind: 'err-2'},
       {kind: 'err-3'},
@@ -352,16 +349,16 @@ describe('LogicNodeBuilder', () => {
     // }));
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.addErrorRule(() => [{kind: 'err-1'}]);
+    builder.addSyncErrorRule(() => [{kind: 'err-1'}]);
     builder.getChild('next').mergeIn(builder);
 
     const logicNode = builder.build();
-    expect(logicNode.logic.errors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
-    expect(logicNode.getChild('next').logic.errors.compute(fakeFieldContext)).toEqual([
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
+    expect(logicNode.getChild('next').logic.syncErrors.compute(fakeFieldContext)).toEqual([
       {kind: 'err-1'},
     ]);
     expect(
-      logicNode.getChild('next').getChild('next').logic.errors.compute(fakeFieldContext),
+      logicNode.getChild('next').getChild('next').logic.syncErrors.compute(fakeFieldContext),
     ).toEqual([{kind: 'err-1'}]);
   });
 
@@ -373,25 +370,25 @@ describe('LogicNodeBuilder', () => {
 
     const pred = signal(true);
     const builder = LogicNodeBuilder.newRoot();
-    builder.addErrorRule(() => [{kind: 'err-1'}]);
+    builder.addSyncErrorRule(() => [{kind: 'err-1'}]);
     builder.getChild('next').mergeIn(builder, {fn: pred, path: undefined!});
 
     const logicNode = builder.build();
-    expect(logicNode.logic.errors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
-    expect(logicNode.getChild('next').logic.errors.compute(fakeFieldContext)).toEqual([
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
+    expect(logicNode.getChild('next').logic.syncErrors.compute(fakeFieldContext)).toEqual([
       {kind: 'err-1'},
     ]);
     expect(
-      logicNode.getChild('next').getChild('next').logic.errors.compute(fakeFieldContext),
+      logicNode.getChild('next').getChild('next').logic.syncErrors.compute(fakeFieldContext),
     ).toEqual([{kind: 'err-1'}]);
 
     // TODO: test that verifies that the same predicate can resolve with a different field context
     // on `.next` vs on `.next.next`
     pred.set(false);
-    expect(logicNode.logic.errors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
-    expect(logicNode.getChild('next').logic.errors.compute(fakeFieldContext)).toEqual([]);
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
+    expect(logicNode.getChild('next').logic.syncErrors.compute(fakeFieldContext)).toEqual([]);
     expect(
-      logicNode.getChild('next').getChild('next').logic.errors.compute(fakeFieldContext),
+      logicNode.getChild('next').getChild('next').logic.syncErrors.compute(fakeFieldContext),
     ).toEqual([]);
   });
 });

--- a/packages/forms/experimental/test/logic_node_2.spec.ts
+++ b/packages/forms/experimental/test/logic_node_2.spec.ts
@@ -1,0 +1,279 @@
+import {signal} from '@angular/core';
+import {FieldContext} from '../public_api';
+import {LogicNodeBuilder} from '../src/logic_node_2';
+
+const fakeFieldContext: FieldContext<unknown> = {
+  resolve: () =>
+    ({
+      $state: {fieldContext: fakeFieldContext},
+    }) as any,
+  value: undefined!,
+};
+
+describe('LogicNodeBuilder', () => {
+  it('should build logic', () => {
+    // (p) => {
+    //   validate(p, () => ({kind: 'root-err'}));
+    // };
+
+    const builder = LogicNodeBuilder.newRoot(undefined);
+    builder.addErrorRule(() => [{kind: 'root-err'}]);
+
+    const logicNode = builder.build();
+    expect(logicNode.logic.errors.compute(fakeFieldContext)).toEqual([{kind: 'root-err'}]);
+  });
+
+  it('should build child logic', () => {
+    // (p) => {
+    //   validate(p.a, () => ({kind: 'child-err'}));
+    // };
+
+    const builder = LogicNodeBuilder.newRoot(undefined);
+    builder.getChild('a').addErrorRule(() => [{kind: 'root-err'}]);
+
+    const logicNode = builder.build();
+    expect(logicNode.getChild('a').logic.errors.compute(fakeFieldContext)).toEqual([
+      {kind: 'root-err'},
+    ]);
+  });
+
+  it('should build merged logic', () => {
+    // (p) => {
+    //   validate(p, () => ({kind: 'err-1'}));
+    //   validate(p, () => ({kind: 'err-2'}));
+    // };
+
+    const builder = LogicNodeBuilder.newRoot(undefined);
+    builder.addErrorRule(() => [{kind: 'err-1'}]);
+
+    const builder2 = LogicNodeBuilder.newRoot(undefined);
+    builder2.addErrorRule(() => [{kind: 'err-2'}]);
+    builder.mergeIn(builder2);
+
+    const logicNode = builder.build();
+    expect(logicNode.logic.errors.compute(fakeFieldContext)).toEqual([
+      {kind: 'err-1'},
+      {kind: 'err-2'},
+    ]);
+  });
+
+  it('should build merged child logic', () => {
+    // (p) => {
+    //   validate(p.a, () => ({kind: 'err-1'}));
+    //   validate(p.a, () => ({kind: 'err-2'}));
+    // };
+
+    const builder = LogicNodeBuilder.newRoot(undefined);
+    builder.getChild('a').addErrorRule(() => [{kind: 'err-1'}]);
+
+    const builder2 = LogicNodeBuilder.newRoot(undefined);
+    builder2.getChild('a').addErrorRule(() => [{kind: 'err-2'}]);
+    builder.mergeIn(builder2);
+
+    const logicNode = builder.build();
+    expect(logicNode.getChild('a').logic.errors.compute(fakeFieldContext)).toEqual([
+      {kind: 'err-1'},
+      {kind: 'err-2'},
+    ]);
+  });
+
+  it('should build logic with predicate', () => {
+    // applyWhen(p, pred, (p) => {
+    //   validate(p, () => ({kind: 'err-1'}));
+    // };
+
+    const pred = signal(true);
+    const builder = LogicNodeBuilder.newRoot({fn: pred, path: undefined!});
+    builder.addErrorRule(() => [{kind: 'err-1'}]);
+
+    const logicNode = builder.build();
+    expect(logicNode.logic.errors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
+
+    pred.set(false);
+    expect(logicNode.logic.errors.compute(fakeFieldContext)).toEqual([]);
+  });
+
+  it('should apply predicate to merged in logic', () => {
+    // applyWhen(p, pred, (p) => {
+    //   apply(p, (p) => {
+    //     validate(p, () => ({kind: 'err-1'}));
+    //   });
+    // };
+
+    const pred = signal(true);
+    const builder = LogicNodeBuilder.newRoot({fn: pred, path: undefined!});
+
+    const builder2 = LogicNodeBuilder.newRoot(undefined);
+    builder2.addErrorRule(() => [{kind: 'err-1'}]);
+    builder.mergeIn(builder2);
+
+    const logicNode = builder.build();
+    expect(logicNode.logic.errors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
+
+    pred.set(false);
+    expect(logicNode.logic.errors.compute(fakeFieldContext)).toEqual([]);
+  });
+
+  it('should apply predicate to merged in child logic', () => {
+    // applyWhen(p, pred, (p) => {
+    //   apply(p, (p) => {
+    //     validate(p.a, () => ({kind: 'err-1'}));
+    //   });
+    // });
+
+    const pred = signal(true);
+    const builder = LogicNodeBuilder.newRoot({fn: pred, path: undefined!});
+
+    const builder2 = LogicNodeBuilder.newRoot(undefined);
+    builder2.getChild('a').addErrorRule(() => [{kind: 'err-1'}]);
+    builder.mergeIn(builder2);
+
+    const logicNode = builder.build();
+    expect(logicNode.getChild('a').logic.errors.compute(fakeFieldContext)).toEqual([
+      {kind: 'err-1'},
+    ]);
+
+    pred.set(false);
+    expect(logicNode.getChild('a').logic.errors.compute(fakeFieldContext)).toEqual([]);
+  });
+
+  it('should combine predicates', () => {
+    // applyWhen(p, pred, (p) => {
+    //   applyWhen(p.a, pred2, (a) => {
+    //     validate(a, () => ({kind: 'err-1'}));
+    //   });
+    // });
+
+    const pred = signal(true);
+    const builder = LogicNodeBuilder.newRoot({fn: pred, path: undefined!});
+
+    const pred2 = signal(true);
+    const builder2 = LogicNodeBuilder.newRoot({fn: pred2, path: undefined!});
+    builder2.addErrorRule(() => [{kind: 'err-1'}]);
+    builder.getChild('a').mergeIn(builder2);
+
+    const logicNode = builder.build();
+    expect(logicNode.getChild('a').logic.errors.compute(fakeFieldContext)).toEqual([
+      {kind: 'err-1'},
+    ]);
+
+    pred.set(false);
+    pred2.set(true);
+    expect(logicNode.getChild('a').logic.errors.compute(fakeFieldContext)).toEqual([]);
+
+    pred.set(true);
+    pred2.set(false);
+    expect(logicNode.getChild('a').logic.errors.compute(fakeFieldContext)).toEqual([]);
+  });
+
+  it('should deeply propagate predicates', () => {
+    // applyWhen(p, pred, (p) => {
+    //   validate(p.a.b, () => ({kind: 'err-1'}));
+    //   applyWhen(p.a, pred2, (a) => {
+    //     validate(a.b, () => ({kind: 'err-2'}));
+    //     applyWhen(a.b, pred3, (b) => {
+    //       validate(b, () => ({kind: 'err-3'}));
+    //     });
+    //   });
+    // });
+
+    const pred = signal(true);
+    const builder = LogicNodeBuilder.newRoot({fn: pred, path: undefined!});
+    builder
+      .getChild('a')
+      .getChild('b')
+      .addErrorRule(() => [{kind: 'err-1'}]);
+
+    const pred2 = signal(true);
+    const builder2 = LogicNodeBuilder.newRoot({fn: pred2, path: undefined!});
+    builder2.getChild('b').addErrorRule(() => [{kind: 'err-2'}]);
+
+    const pred3 = signal(true);
+    const builder3 = LogicNodeBuilder.newRoot({fn: pred3, path: undefined!});
+    builder3.addErrorRule(() => [{kind: 'err-3'}]);
+
+    builder2.getChild('b').mergeIn(builder3);
+    builder.getChild('a').mergeIn(builder2);
+
+    const logicNode = builder.build();
+    expect(logicNode.getChild('a').getChild('b').logic.errors.compute(fakeFieldContext)).toEqual([
+      {kind: 'err-1'},
+      {kind: 'err-2'},
+      {kind: 'err-3'},
+    ]);
+
+    pred.set(true);
+    pred2.set(true);
+    pred3.set(false);
+    expect(logicNode.getChild('a').getChild('b').logic.errors.compute(fakeFieldContext)).toEqual([
+      {kind: 'err-1'},
+      {kind: 'err-2'},
+    ]);
+
+    pred.set(true);
+    pred2.set(false);
+    pred3.set(true);
+    expect(logicNode.getChild('a').getChild('b').logic.errors.compute(fakeFieldContext)).toEqual([
+      {kind: 'err-1'},
+    ]);
+
+    pred.set(false);
+    pred2.set(true);
+    pred3.set(true);
+    expect(logicNode.getChild('a').getChild('b').logic.errors.compute(fakeFieldContext)).toEqual(
+      [],
+    );
+  });
+
+  it('should preserve ordering across merges', () => {
+    // (p) => {
+    //   validate(p, () => ({kind: 'err-1'}));
+    //   apply(p, (p) => {
+    //     validate(p, () => ({kind: 'err-2'}));
+    //   })
+    //   validate(p, () => ({kind: 'err-3'}));
+    // };
+
+    const builder = LogicNodeBuilder.newRoot(undefined);
+    builder.addErrorRule(() => [{kind: 'err-1'}]);
+
+    const builder2 = LogicNodeBuilder.newRoot(undefined);
+    builder2.addErrorRule(() => [{kind: 'err-2'}]);
+    builder.mergeIn(builder2);
+
+    builder.addErrorRule(() => [{kind: 'err-3'}]);
+
+    const logicNode = builder.build();
+    expect(logicNode.logic.errors.compute(fakeFieldContext)).toEqual([
+      {kind: 'err-1'},
+      {kind: 'err-2'},
+      {kind: 'err-3'},
+    ]);
+  });
+
+  it('should preserve child ordering across merges', () => {
+    // (p) => {
+    //   validate(p.a, () => ({kind: 'err-1'}));
+    //   apply(p, (p) => {
+    //     validate(p.a, () => ({kind: 'err-2'}));
+    //   })
+    //   validate(p.a, () => ({kind: 'err-3'}));
+    // };
+
+    const builder = LogicNodeBuilder.newRoot(undefined);
+    builder.getChild('a').addErrorRule(() => [{kind: 'err-1'}]);
+
+    const builder2 = LogicNodeBuilder.newRoot(undefined);
+    builder2.getChild('a').addErrorRule(() => [{kind: 'err-2'}]);
+    builder.mergeIn(builder2);
+
+    builder.getChild('a').addErrorRule(() => [{kind: 'err-3'}]);
+
+    const logicNode = builder.build();
+    expect(logicNode.getChild('a').logic.errors.compute(fakeFieldContext)).toEqual([
+      {kind: 'err-1'},
+      {kind: 'err-2'},
+      {kind: 'err-3'},
+    ]);
+  });
+});


### PR DESCRIPTION
Adds a new version of logic node that is created via builders. The builder / actual logic node split allows the final logic for a node to be lazily merged together.

My plan is to eventually swap this in for FieldLogicNode and have the schema methods (`validate`, `apply`, etc.) work with the builders. The FieldNode will then build its logic when it is first created.

This should be the other main piece aside from relative paths which is needed to make self-referential logic work.