### PR TITLE
fix(devtools): fix profiler support with @defer blocks

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/hooks/identity-tracker.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/hooks/identity-tracker.ts
@@ -129,7 +129,8 @@ const indexTree = <T extends DevToolsNode<DirectiveInstanceType, ComponentInstan
     element: node.element,
     component: node.component,
     directives: node.directives.map((d) => ({position, ...d})),
-    children: node.children.map((n, i) => indexTree(n, i, position)),
+    // Not every node represents a DOM element (ex @defer blocks), we shouldn't account for them
+    children: node.children.filter((n) => n.nativeElement).map((n, i) => indexTree(n, i, position)),
     nativeElement: node.nativeElement,
     hydration: node.hydration,
     defer: node.defer,
@@ -138,4 +139,5 @@ const indexTree = <T extends DevToolsNode<DirectiveInstanceType, ComponentInstan
 
 export const indexForest = <T extends DevToolsNode<DirectiveInstanceType, ComponentInstanceType>>(
   forest: T[],
-): IndexedNode[] => forest.map((n, i) => indexTree(n, i));
+  // Not every node represents a DOM element (ex @defer blocks), we shouldn't account for them
+): IndexedNode[] => forest.filter((n) => n.nativeElement).map((n, i) => indexTree(n, i));

--- a/devtools/projects/ng-devtools-backend/src/lib/hooks/identity-tracker.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/hooks/identity-tracker.ts
@@ -124,13 +124,21 @@ const indexTree = <T extends DevToolsNode<DirectiveInstanceType, ComponentInstan
   parentPosition: number[] = [],
 ): IndexedNode => {
   const position = parentPosition.concat([idx]);
+
+  // Not every node represents a DOM element (ex @defer blocks), we shouldn't account for them
+  const children: IndexedNode[] = [];
+  node.children.forEach((n, i) => {
+    if (n.nativeElement) {
+      children.push(indexTree(n, i, position));
+    }
+  });
+
   return {
     position,
     element: node.element,
     component: node.component,
     directives: node.directives.map((d) => ({position, ...d})),
-    // Not every node represents a DOM element (ex @defer blocks), we shouldn't account for them
-    children: node.children.filter((n) => n.nativeElement).map((n, i) => indexTree(n, i, position)),
+    children,
     nativeElement: node.nativeElement,
     hydration: node.hydration,
     defer: node.defer,


### PR DESCRIPTION
Prior to this change, the devtools profile logged warnings "Unable to find parent node for ...".
