### PR TITLE
refactor(devtools): introduce a more sophisticated directive forest filter

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/BUILD.bazel
@@ -28,6 +28,7 @@ ng_project(
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/diffing:diffing_rjs",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/breadcrumbs:breadcrumbs_rjs",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/component-data-source:component-data-source_rjs",
+        "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter:directive-forest-filter-fn-generator_rjs",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter:filter_rjs",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/index-forest:index-forest_rjs",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node:tree-node_rjs",

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.html
@@ -4,6 +4,7 @@
   (prevMatched)="navigateMatchedNode('prev')"
   [matchesCount]="matchesCount()"
   [currentMatch]="currentlyMatchedIndex() + 1"
+  [filterFnGenerator]="filterGenerator"
 />
 <cdk-virtual-scroll-viewport class="tree-wrapper" [itemSize]="itemHeight">
   <ng-tree-node
@@ -12,7 +13,7 @@
     [selectedNode]="selectedNode()"
     [highlightedId]="highlightIdInTreeFromElement()"
     [treeControl]="treeControl"
-    [textMatch]="matchedNodes().get(idx)"
+    [textMatches]="matchedNodes().get(idx) ?? []"
     (selectNode)="selectAndEnsureVisible($event)"
     (selectDomElement)="handleSelectDomElement($event)"
     (highlightNode)="highlightNode($event)"

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.ts
@@ -35,6 +35,7 @@ import {getFullNodeNameString, isChildOf, parentCollapsed} from './directive-for
 import {IndexedNode} from './index-forest';
 import {FilterComponent, FilterFn} from './filter/filter.component';
 import {TreeNodeComponent, NodeTextMatch} from './tree-node/tree-node.component';
+import {directiveForestFilterFnGenerator} from './filter/directive-forest-filter-fn-generator';
 
 const NODE_ITEM_HEIGHT = 18; // px; Required for CDK Virtual Scroll
 
@@ -72,7 +73,7 @@ export class DirectiveForestComponent {
 
   readonly selectedNode = signal<FlatNode | null>(null);
   readonly highlightIdInTreeFromElement = signal<number | null>(null);
-  readonly matchedNodes = signal<Map<number, NodeTextMatch>>(new Map()); // Node index, NodeTextMatch
+  readonly matchedNodes = signal<Map<number, NodeTextMatch[]>>(new Map()); // Node index, NodeTextMatch
   readonly matchesCount = computed(() => this.matchedNodes().size);
   readonly currentlyMatchedIndex = signal<number>(-1);
 
@@ -82,6 +83,7 @@ export class DirectiveForestComponent {
   );
   readonly dataSource = new ComponentDataSource(this.treeControl);
   readonly itemHeight = NODE_ITEM_HEIGHT;
+  readonly filterGenerator = directiveForestFilterFnGenerator;
 
   private parents!: FlatNode[];
   private initialized = false;
@@ -263,12 +265,12 @@ export class DirectiveForestComponent {
     for (let i = 0; i < this.dataSource.data.length; i++) {
       const node = this.dataSource.data[i];
       const fullName = getFullNodeNameString(node);
-      const match = filterFn(fullName);
+      const matches = filterFn(fullName);
 
-      if (match) {
+      if (matches.length) {
         this.matchedNodes.update((matched) => {
           const map = new Map(matched);
-          map.set(i, match);
+          map.set(i, matches);
           return map;
         });
       }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
 load("//devtools/tools:defaults.bzl", "karma_web_test_suite")
 load("//devtools/tools:ng_project.bzl", "ng_project")
-load("//devtools/tools:typescript.bzl", "ts_test_library")
+load("//devtools/tools:typescript.bzl", "ts_project", "ts_test_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -39,9 +39,26 @@ ts_test_library(
     ],
 )
 
+ts_project(
+    name = "directive-forest-filter-fn-generator",
+    srcs = ["directive-forest-filter-fn-generator.ts"],
+    interop_deps = [
+        ":filter",
+    ],
+)
+
+ts_test_library(
+    name = "directive-forest-filter-fn-generator_test",
+    srcs = ["directive-forest-filter-fn-generator.spec.ts"],
+    deps = [
+        ":directive-forest-filter-fn-generator_rjs",
+    ],
+)
+
 karma_web_test_suite(
     name = "test",
     deps = [
+        ":directive-forest-filter-fn-generator_test",
         ":filter_test",
     ],
 )

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/directive-forest-filter-fn-generator.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/directive-forest-filter-fn-generator.spec.ts
@@ -8,167 +8,302 @@
 
 import {
   directiveForestFilterFnGenerator,
-  directiveForestFilterParser,
-  FilterToken,
+  tokenizeDirectiveForestFilter,
+  parseDirectiveForestFilter,
+  ParsedFilter,
 } from './directive-forest-filter-fn-generator';
 
-function expectTokenToEqual(target: FilterToken, test: FilterToken) {
+function expectToMatchParsedFilter(target: ParsedFilter, test: ParsedFilter) {
   expect(target).toEqual(test);
 }
 
-describe('directive-forest-filter-fn-generator', () => {
-  describe('directiveForestParser', () => {
-    it('should parse an empty string to an empty tokens array', () => {
-      const tokens = directiveForestFilterParser('');
+function expectToMatchParsedElement(target: ParsedFilter, test: ParsedFilter['element']) {
+  expect(target.component).toBeUndefined();
+  expect(target.directives.length).toEqual(0);
+  expect(target.element).toEqual(test);
+}
 
-      expect(tokens.length).toEqual(0);
+function expectToMatchParsedComponent(target: ParsedFilter, test: ParsedFilter['component']) {
+  expect(target.element).toBeUndefined();
+  expect(target.directives.length).toEqual(0);
+  expect(target.component).toEqual(test);
+}
+
+function expectToMatchParsedDirectives(target: ParsedFilter, test: ParsedFilter['directives']) {
+  expect(target.element).toBeUndefined();
+  expect(target.component).toBeUndefined();
+  expect(target.directives).toEqual(test);
+}
+
+describe('directive-forest-filter-fn-generator', () => {
+  describe('tokenizeDirectiveForestFilter', () => {
+    it('should tokenize an empty string', () => {
+      const tokens = tokenizeDirectiveForestFilter('');
+      expect(tokens).toEqual([]);
+    });
+
+    it('should tokenize a component', () => {
+      const tokens = tokenizeDirectiveForestFilter('app-component');
+      expect(tokens).toEqual([{type: 'text', value: 'app-component', idx: 0}]);
+    });
+
+    it('should tokenize a directive', () => {
+      const tokens = tokenizeDirectiveForestFilter('[FooDirective]');
+      expect(tokens).toEqual([
+        {type: 'opening_bracket', value: '[', idx: 0},
+        {type: 'text', value: 'FooDirective', idx: 1},
+        {type: 'closing_bracket', value: ']', idx: 13},
+      ]);
+    });
+
+    it('should tokenize multiple directives', () => {
+      const tokens = tokenizeDirectiveForestFilter('[Foo][Bar]');
+      expect(tokens).toEqual([
+        {type: 'opening_bracket', value: '[', idx: 0},
+        {type: 'text', value: 'Foo', idx: 1},
+        {type: 'closing_bracket', value: ']', idx: 4},
+        {type: 'opening_bracket', value: '[', idx: 5},
+        {type: 'text', value: 'Bar', idx: 6},
+        {type: 'closing_bracket', value: ']', idx: 9},
+      ]);
+    });
+
+    it('should tokenize a component multiple directives', () => {
+      const tokens = tokenizeDirectiveForestFilter('app-cmp[Foo][Bar]');
+      expect(tokens).toEqual([
+        {type: 'text', value: 'app-cmp', idx: 0},
+        {type: 'opening_bracket', value: '[', idx: 7},
+        {type: 'text', value: 'Foo', idx: 8},
+        {type: 'closing_bracket', value: ']', idx: 11},
+        {type: 'opening_bracket', value: '[', idx: 12},
+        {type: 'text', value: 'Bar', idx: 13},
+        {type: 'closing_bracket', value: ']', idx: 16},
+      ]);
+    });
+
+    it('should tokenize an element', () => {
+      const tokens = tokenizeDirectiveForestFilter('<app-element />');
+      expect(tokens).toEqual([
+        {type: 'chevron_left', value: '<', idx: 0},
+        {type: 'text', value: 'app-element', idx: 1},
+        {type: 'space', value: ' ', idx: 12},
+        {type: 'slash', value: '/', idx: 13},
+        {type: 'chevron_right', value: '>', idx: 14},
+      ]);
+    });
+  });
+
+  describe('parseDirectiveForestFilter', () => {
+    it('should parse an empty string to an empty tokens array', () => {
+      const tokens = tokenizeDirectiveForestFilter('');
+      const parsed = parseDirectiveForestFilter(tokens);
+
+      expect(parsed.component).toBeUndefined();
+      expect(parsed.directives.length).toEqual(0);
     });
 
     it('should parse a standard string', () => {
-      const tokens = directiveForestFilterParser('app-random-component');
+      const tokens = tokenizeDirectiveForestFilter('app-random-component');
+      const parsed = parseDirectiveForestFilter(tokens);
 
-      expect(tokens.length).toEqual(1);
-
-      expectTokenToEqual(tokens[0], {
-        start: 0,
-        end: 20,
-        token: 'app-random-component',
-        type: 'generic',
+      expectToMatchParsedComponent(parsed, {
+        idx: 0,
+        value: 'app-random-component',
       });
     });
 
     it('should parse a directive', () => {
-      const tokens = directiveForestFilterParser('[AppDirective]');
+      const tokens = tokenizeDirectiveForestFilter('[AppDirective]');
+      const parsed = parseDirectiveForestFilter(tokens);
 
-      expect(tokens.length).toEqual(1);
-
-      expectTokenToEqual(tokens[0], {
-        start: 1,
-        end: 13,
-        token: 'AppDirective',
-        type: 'directive',
-      });
+      expectToMatchParsedDirectives(parsed, [
+        {
+          idx: 1,
+          value: 'AppDirective',
+        },
+      ]);
     });
 
     it('should parse multiple directives ([b][c] format)', () => {
-      const tokens = directiveForestFilterParser('[FooDir][BarDir]');
+      const tokens = tokenizeDirectiveForestFilter('[FooDir][BarDir]');
+      const parsed = parseDirectiveForestFilter(tokens);
 
-      expect(tokens.length).toEqual(2);
-
-      const [fooToken, barToken] = tokens;
-
-      expectTokenToEqual(fooToken, {
-        start: 1,
-        end: 7,
-        token: 'FooDir',
-        type: 'directive',
-      });
-      expectTokenToEqual(barToken, {
-        start: 9,
-        end: 15,
-        token: 'BarDir',
-        type: 'directive',
-      });
+      expectToMatchParsedDirectives(parsed, [
+        {
+          idx: 1,
+          value: 'FooDir',
+        },
+        {
+          idx: 9,
+          value: 'BarDir',
+        },
+      ]);
     });
 
     it('should parse multiple directives ([b c] format)', () => {
-      const tokens = directiveForestFilterParser('[FooDir BarDir]');
+      const tokens = tokenizeDirectiveForestFilter('[FooDir BarDir]');
+      const parsed = parseDirectiveForestFilter(tokens);
 
-      expect(tokens.length).toEqual(2);
-
-      const [fooToken, barToken] = tokens;
-
-      expectTokenToEqual(fooToken, {
-        start: 1,
-        end: 7,
-        token: 'FooDir',
-        type: 'directive',
-      });
-      expectTokenToEqual(barToken, {
-        start: 8,
-        end: 14,
-        token: 'BarDir',
-        type: 'directive',
-      });
+      expectToMatchParsedDirectives(parsed, [
+        {
+          idx: 1,
+          value: 'FooDir',
+        },
+        {
+          idx: 8,
+          value: 'BarDir',
+        },
+      ]);
     });
 
     it('should parse a component + directive', () => {
-      const tokens = directiveForestFilterParser('app-component[AppDirective]');
+      const tokens = tokenizeDirectiveForestFilter('app-component[AppDirective]');
+      const parsed = parseDirectiveForestFilter(tokens);
 
-      expect(tokens.length).toEqual(2);
-
-      const [cmpToken, dirToken] = tokens;
-
-      expectTokenToEqual(cmpToken, {
-        start: 0,
-        end: 13,
-        token: 'app-component',
-        type: 'component',
-      });
-      expectTokenToEqual(dirToken, {
-        start: 14,
-        end: 26,
-        token: 'AppDirective',
-        type: 'directive',
+      expectToMatchParsedFilter(parsed, {
+        component: {
+          idx: 0,
+          value: 'app-component',
+        },
+        directives: [
+          {
+            idx: 14,
+            value: 'AppDirective',
+          },
+        ],
       });
     });
 
     it('should parse a component + multiple directives (a[b][c] format)', () => {
-      const tokens = directiveForestFilterParser('app-foo[BarDir][BazDir]');
+      const tokens = tokenizeDirectiveForestFilter('app-foo[BarDir][BazDir]');
+      const parsed = parseDirectiveForestFilter(tokens);
 
-      expect(tokens.length).toEqual(3);
-
-      const [cmpToken, dirBarToken, dirBazToken] = tokens;
-
-      expectTokenToEqual(cmpToken, {
-        start: 0,
-        end: 7,
-        token: 'app-foo',
-        type: 'component',
-      });
-      expectTokenToEqual(dirBarToken, {
-        start: 8,
-        end: 14,
-        token: 'BarDir',
-        type: 'directive',
-      });
-      expectTokenToEqual(dirBazToken, {
-        start: 16,
-        end: 22,
-        token: 'BazDir',
-        type: 'directive',
+      expectToMatchParsedFilter(parsed, {
+        component: {
+          idx: 0,
+          value: 'app-foo',
+        },
+        directives: [
+          {
+            idx: 8,
+            value: 'BarDir',
+          },
+          {
+            idx: 16,
+            value: 'BazDir',
+          },
+        ],
       });
     });
 
     it('should parse a component + multiple directives (a[b c] format)', () => {
-      const tokens = directiveForestFilterParser('app-foo[BarDir BazDir]');
+      const tokens = tokenizeDirectiveForestFilter('app-foo[BarDir BazDir]');
+      const parsed = parseDirectiveForestFilter(tokens);
 
-      expect(tokens.length).toEqual(3);
-
-      const [cmpToken, dirBarToken, dirBazToken] = tokens;
-
-      expectTokenToEqual(cmpToken, {
-        start: 0,
-        end: 7,
-        token: 'app-foo',
-        type: 'component',
+      expectToMatchParsedFilter(parsed, {
+        component: {
+          idx: 0,
+          value: 'app-foo',
+        },
+        directives: [
+          {
+            idx: 8,
+            value: 'BarDir',
+          },
+          {
+            idx: 15,
+            value: 'BazDir',
+          },
+        ],
       });
-      expectTokenToEqual(dirBarToken, {
-        start: 8,
-        end: 14,
-        token: 'BarDir',
-        type: 'directive',
+    });
+
+    it('should parse a component with empty directive brackets (app-foo[)', () => {
+      const tokens = tokenizeDirectiveForestFilter('app-foo[');
+      const parsed = parseDirectiveForestFilter(tokens);
+
+      expectToMatchParsedFilter(parsed, {
+        component: {
+          idx: 0,
+          value: 'app-foo',
+        },
+        directives: [],
       });
-      expectTokenToEqual(dirBazToken, {
-        start: 15,
-        end: 21,
-        token: 'BazDir',
-        type: 'directive',
+    });
+
+    it('should parse a component with empty directive brackets (app-foo[])', () => {
+      const tokens = tokenizeDirectiveForestFilter('app-foo[]');
+      const parsed = parseDirectiveForestFilter(tokens);
+
+      expectToMatchParsedFilter(parsed, {
+        component: {
+          idx: 0,
+          value: 'app-foo',
+        },
+        directives: [],
+      });
+    });
+
+    it('should parse a component with empty directive brackets (app-foo])', () => {
+      const tokens = tokenizeDirectiveForestFilter('app-foo[]');
+      const parsed = parseDirectiveForestFilter(tokens);
+
+      expectToMatchParsedFilter(parsed, {
+        component: {
+          idx: 0,
+          value: 'app-foo',
+        },
+        directives: [],
+      });
+    });
+
+    it('should parse a component and a directive without closing bracket (app-foo[Foo)', () => {
+      const tokens = tokenizeDirectiveForestFilter('app-foo[Foo');
+      const parsed = parseDirectiveForestFilter(tokens);
+
+      expectToMatchParsedFilter(parsed, {
+        component: {
+          idx: 0,
+          value: 'app-foo',
+        },
+        directives: [
+          {
+            idx: 8,
+            value: 'Foo',
+          },
+        ],
+      });
+    });
+
+    it('should parse an element', () => {
+      const tokens = tokenizeDirectiveForestFilter('<app-element />');
+      const parsed = parseDirectiveForestFilter(tokens);
+
+      expectToMatchParsedElement(parsed, {
+        idx: 1,
+        value: 'app-element',
+      });
+    });
+
+    it('should parse an incomplete element', () => {
+      const tokens = tokenizeDirectiveForestFilter('<app-ele');
+      const parsed = parseDirectiveForestFilter(tokens);
+
+      expectToMatchParsedElement(parsed, {
+        idx: 1,
+        value: 'app-ele',
       });
     });
   });
 
   describe('directiveForestFilterFnGenerator', () => {
+    it('should NOT match an empty string input', () => {
+      const filterFn = directiveForestFilterFnGenerator('');
+      const matches = filterFn('app-foo-component');
+
+      expect(matches.length).toEqual(0);
+    });
+
     it('should match a standard string input', () => {
       const filterFn = directiveForestFilterFnGenerator('-foo-comp');
       const matches = filterFn('app-foo-component');
@@ -212,15 +347,15 @@ describe('directive-forest-filter-fn-generator', () => {
     });
 
     it('should match multiple directives irrespetive of order', () => {
-      const filterFn = directiveForestFilterFnGenerator('[Baz][Bar]');
+      const filterFn = directiveForestFilterFnGenerator('[Baz][BarDir]');
       const matches = filterFn('app-foo-cmp[BarDirective][BazDirective]');
 
       expect(matches.length).toEqual(2);
 
-      const [bar, baz] = matches;
+      const [barDir, baz] = matches;
 
-      expect(bar.startIdx).toEqual(12);
-      expect(bar.endIdx).toEqual(15);
+      expect(barDir.startIdx).toEqual(12);
+      expect(barDir.endIdx).toEqual(18);
 
       expect(baz.startIdx).toEqual(26);
       expect(baz.endIdx).toEqual(29);
@@ -228,6 +363,21 @@ describe('directive-forest-filter-fn-generator', () => {
 
     it('should match a component + directive', () => {
       const filterFn = directiveForestFilterFnGenerator('app-foo[Bar]');
+      const matches = filterFn('app-foo-cmp[BarDirective]');
+
+      expect(matches.length).toEqual(2);
+
+      const [foo, bar] = matches;
+
+      expect(foo.startIdx).toEqual(0);
+      expect(foo.endIdx).toEqual(7);
+
+      expect(bar.startIdx).toEqual(12);
+      expect(bar.endIdx).toEqual(15);
+    });
+
+    it('should match a component + directive (reversed order)', () => {
+      const filterFn = directiveForestFilterFnGenerator('[Bar]app-foo');
       const matches = filterFn('app-foo-cmp[BarDirective]');
 
       expect(matches.length).toEqual(2);
@@ -259,6 +409,54 @@ describe('directive-forest-filter-fn-generator', () => {
       expect(baz.endIdx).toEqual(38);
     });
 
+    it('should be able to distinguish between a component and a directive with the same name', () => {
+      const filterFn = directiveForestFilterFnGenerator('[app-foo]');
+      const matches = filterFn('app-foo[app-foo]');
+
+      expect(matches.length).toEqual(1);
+
+      const [match] = matches;
+
+      expect(match.startIdx).toEqual(8);
+      expect(match.endIdx).toEqual(15);
+    });
+
+    it('should match an element', () => {
+      const filterFn = directiveForestFilterFnGenerator('<app-element />');
+      const matches = filterFn('<app-element />');
+
+      expect(matches.length).toEqual(1);
+
+      const [match] = matches;
+
+      expect(match.startIdx).toEqual(1);
+      expect(match.endIdx).toEqual(12);
+    });
+
+    it('should match an element without a slash', () => {
+      const filterFn = directiveForestFilterFnGenerator('<app-element>');
+      const matches = filterFn('<app-element />');
+
+      expect(matches.length).toEqual(1);
+
+      const [match] = matches;
+
+      expect(match.startIdx).toEqual(1);
+      expect(match.endIdx).toEqual(12);
+    });
+
+    it('should match an incomplete element', () => {
+      const filterFn = directiveForestFilterFnGenerator('<app-ele');
+      const matches = filterFn('<app-ele');
+
+      expect(matches.length).toEqual(1);
+
+      const [match] = matches;
+
+      expect(match.startIdx).toEqual(1);
+      expect(match.endIdx).toEqual(8);
+    });
+
     it(`should NOT match, if a component matches but the directive doesn't`, () => {
       const filterFn = directiveForestFilterFnGenerator('app-foo[Baz]');
       const matches = filterFn('app-foo-cmp[BarDirective]');
@@ -278,6 +476,32 @@ describe('directive-forest-filter-fn-generator', () => {
       const matches = filterFn('app-foo-cmp[BarDirective][BazDirective]');
 
       expect(matches.length).toEqual(0);
+    });
+
+    it('should handle gracefully some gibberish cases', () => {
+      expect(() => directiveForestFilterFnGenerator('[')).not.toThrowError();
+
+      expect(() => directiveForestFilterFnGenerator('[]')).not.toThrowError();
+
+      expect(() => directiveForestFilterFnGenerator('][')).not.toThrowError();
+
+      expect(() => directiveForestFilterFnGenerator('<')).not.toThrowError();
+
+      expect(() => directiveForestFilterFnGenerator('<>')).not.toThrowError();
+
+      expect(() => directiveForestFilterFnGenerator('><')).not.toThrowError();
+
+      expect(() => directiveForestFilterFnGenerator('<<[[]][[][>></')).not.toThrowError();
+
+      expect(() => directiveForestFilterFnGenerator('[foo[bar[baz')).not.toThrowError();
+
+      expect(() => directiveForestFilterFnGenerator(']foo]bar]baz')).not.toThrowError();
+
+      expect(() => directiveForestFilterFnGenerator('<app-foo[Bar][Baz]/>')).not.toThrowError();
+
+      expect(() =>
+        directiveForestFilterFnGenerator('app-foo-cmp<element  [Foo][Bar][[/><baz '),
+      ).not.toThrowError();
     });
   });
 });

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/directive-forest-filter-fn-generator.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/directive-forest-filter-fn-generator.spec.ts
@@ -1,0 +1,283 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  directiveForestFilterFnGenerator,
+  directiveForestFilterParser,
+  FilterToken,
+} from './directive-forest-filter-fn-generator';
+
+function expectTokenToEqual(target: FilterToken, test: FilterToken) {
+  expect(target).toEqual(test);
+}
+
+describe('directive-forest-filter-fn-generator', () => {
+  describe('directiveForestParser', () => {
+    it('should parse an empty string to an empty tokens array', () => {
+      const tokens = directiveForestFilterParser('');
+
+      expect(tokens.length).toEqual(0);
+    });
+
+    it('should parse a standard string', () => {
+      const tokens = directiveForestFilterParser('app-random-component');
+
+      expect(tokens.length).toEqual(1);
+
+      expectTokenToEqual(tokens[0], {
+        start: 0,
+        end: 20,
+        token: 'app-random-component',
+        type: 'generic',
+      });
+    });
+
+    it('should parse a directive', () => {
+      const tokens = directiveForestFilterParser('[AppDirective]');
+
+      expect(tokens.length).toEqual(1);
+
+      expectTokenToEqual(tokens[0], {
+        start: 1,
+        end: 13,
+        token: 'AppDirective',
+        type: 'directive',
+      });
+    });
+
+    it('should parse multiple directives ([b][c] format)', () => {
+      const tokens = directiveForestFilterParser('[FooDir][BarDir]');
+
+      expect(tokens.length).toEqual(2);
+
+      const [fooToken, barToken] = tokens;
+
+      expectTokenToEqual(fooToken, {
+        start: 1,
+        end: 7,
+        token: 'FooDir',
+        type: 'directive',
+      });
+      expectTokenToEqual(barToken, {
+        start: 9,
+        end: 15,
+        token: 'BarDir',
+        type: 'directive',
+      });
+    });
+
+    it('should parse multiple directives ([b c] format)', () => {
+      const tokens = directiveForestFilterParser('[FooDir BarDir]');
+
+      expect(tokens.length).toEqual(2);
+
+      const [fooToken, barToken] = tokens;
+
+      expectTokenToEqual(fooToken, {
+        start: 1,
+        end: 7,
+        token: 'FooDir',
+        type: 'directive',
+      });
+      expectTokenToEqual(barToken, {
+        start: 8,
+        end: 14,
+        token: 'BarDir',
+        type: 'directive',
+      });
+    });
+
+    it('should parse a component + directive', () => {
+      const tokens = directiveForestFilterParser('app-component[AppDirective]');
+
+      expect(tokens.length).toEqual(2);
+
+      const [cmpToken, dirToken] = tokens;
+
+      expectTokenToEqual(cmpToken, {
+        start: 0,
+        end: 13,
+        token: 'app-component',
+        type: 'component',
+      });
+      expectTokenToEqual(dirToken, {
+        start: 14,
+        end: 26,
+        token: 'AppDirective',
+        type: 'directive',
+      });
+    });
+
+    it('should parse a component + multiple directives (a[b][c] format)', () => {
+      const tokens = directiveForestFilterParser('app-foo[BarDir][BazDir]');
+
+      expect(tokens.length).toEqual(3);
+
+      const [cmpToken, dirBarToken, dirBazToken] = tokens;
+
+      expectTokenToEqual(cmpToken, {
+        start: 0,
+        end: 7,
+        token: 'app-foo',
+        type: 'component',
+      });
+      expectTokenToEqual(dirBarToken, {
+        start: 8,
+        end: 14,
+        token: 'BarDir',
+        type: 'directive',
+      });
+      expectTokenToEqual(dirBazToken, {
+        start: 16,
+        end: 22,
+        token: 'BazDir',
+        type: 'directive',
+      });
+    });
+
+    it('should parse a component + multiple directives (a[b c] format)', () => {
+      const tokens = directiveForestFilterParser('app-foo[BarDir BazDir]');
+
+      expect(tokens.length).toEqual(3);
+
+      const [cmpToken, dirBarToken, dirBazToken] = tokens;
+
+      expectTokenToEqual(cmpToken, {
+        start: 0,
+        end: 7,
+        token: 'app-foo',
+        type: 'component',
+      });
+      expectTokenToEqual(dirBarToken, {
+        start: 8,
+        end: 14,
+        token: 'BarDir',
+        type: 'directive',
+      });
+      expectTokenToEqual(dirBazToken, {
+        start: 15,
+        end: 21,
+        token: 'BazDir',
+        type: 'directive',
+      });
+    });
+  });
+
+  describe('directiveForestFilterFnGenerator', () => {
+    it('should match a standard string input', () => {
+      const filterFn = directiveForestFilterFnGenerator('-foo-comp');
+      const matches = filterFn('app-foo-component');
+
+      expect(matches.length).toEqual(1);
+      expect(matches[0].startIdx).toEqual(3);
+      expect(matches[0].endIdx).toEqual(12);
+    });
+
+    it('should match the string fully', () => {
+      const filterFn = directiveForestFilterFnGenerator('app-foo-cmp');
+      const matches = filterFn('app-foo-cmp');
+
+      expect(matches.length).toEqual(1);
+      expect(matches[0].startIdx).toEqual(0);
+      expect(matches[0].endIdx).toEqual(11);
+    });
+
+    it('should match a directive', () => {
+      const filterFn = directiveForestFilterFnGenerator('[BarDir]');
+      const matches = filterFn('app-foo-cmp[BarDirective]');
+
+      expect(matches.length).toEqual(1);
+      expect(matches[0].startIdx).toEqual(12);
+      expect(matches[0].endIdx).toEqual(18);
+    });
+
+    it('should match multiple directives', () => {
+      const filterFn = directiveForestFilterFnGenerator('[Bar][Baz]');
+      const matches = filterFn('app-foo-cmp[BarDirective][BazDirective]');
+
+      expect(matches.length).toEqual(2);
+
+      const [bar, baz] = matches;
+
+      expect(bar.startIdx).toEqual(12);
+      expect(bar.endIdx).toEqual(15);
+
+      expect(baz.startIdx).toEqual(26);
+      expect(baz.endIdx).toEqual(29);
+    });
+
+    it('should match multiple directives irrespetive of order', () => {
+      const filterFn = directiveForestFilterFnGenerator('[Baz][Bar]');
+      const matches = filterFn('app-foo-cmp[BarDirective][BazDirective]');
+
+      expect(matches.length).toEqual(2);
+
+      const [bar, baz] = matches;
+
+      expect(bar.startIdx).toEqual(12);
+      expect(bar.endIdx).toEqual(15);
+
+      expect(baz.startIdx).toEqual(26);
+      expect(baz.endIdx).toEqual(29);
+    });
+
+    it('should match a component + directive', () => {
+      const filterFn = directiveForestFilterFnGenerator('app-foo[Bar]');
+      const matches = filterFn('app-foo-cmp[BarDirective]');
+
+      expect(matches.length).toEqual(2);
+
+      const [foo, bar] = matches;
+
+      expect(foo.startIdx).toEqual(0);
+      expect(foo.endIdx).toEqual(7);
+
+      expect(bar.startIdx).toEqual(12);
+      expect(bar.endIdx).toEqual(15);
+    });
+
+    it('should match a component + multiple directive', () => {
+      const filterFn = directiveForestFilterFnGenerator('app-foo[Bar][BazDirective]');
+      const matches = filterFn('app-foo-cmp[BarDirective][BazDirective]');
+
+      expect(matches.length).toEqual(3);
+
+      const [foo, bar, baz] = matches;
+
+      expect(foo.startIdx).toEqual(0);
+      expect(foo.endIdx).toEqual(7);
+
+      expect(bar.startIdx).toEqual(12);
+      expect(bar.endIdx).toEqual(15);
+
+      expect(baz.startIdx).toEqual(26);
+      expect(baz.endIdx).toEqual(38);
+    });
+
+    it(`should NOT match, if a component matches but the directive doesn't`, () => {
+      const filterFn = directiveForestFilterFnGenerator('app-foo[Baz]');
+      const matches = filterFn('app-foo-cmp[BarDirective]');
+
+      expect(matches.length).toEqual(0);
+    });
+
+    it(`should NOT match, if a directive matches but the component doesn't`, () => {
+      const filterFn = directiveForestFilterFnGenerator('app-baz[Bar]');
+      const matches = filterFn('app-foo-cmp[BarDirective]');
+
+      expect(matches.length).toEqual(0);
+    });
+
+    it(`should NOT match, if some of the directives doesn't match`, () => {
+      const filterFn = directiveForestFilterFnGenerator('app-foo-cmp[Bar][Qux]');
+      const matches = filterFn('app-foo-cmp[BarDirective][BazDirective]');
+
+      expect(matches.length).toEqual(0);
+    });
+  });
+});

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/directive-forest-filter-fn-generator.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/directive-forest-filter-fn-generator.ts
@@ -1,0 +1,146 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {FilterFn, FilterFnGenerator} from './filter.component';
+
+/**
+ * Represents the parsed token type
+ * - `directive` – matches only directive part of the string
+ * - `component` – matches only component part of the string
+ * - `generic` – a fallback; matches the whole string
+ */
+type TokenType = 'component' | 'directive' | 'generic';
+
+export type FilterToken = {
+  token: string;
+  type: TokenType;
+  start: number;
+  end: number;
+};
+
+/** Parse a directive-forest filter text to a `FilterToken`s */
+export function directiveForestFilterParser(text: string): FilterToken[] {
+  const tokens: FilterToken[] = [];
+  let buffer = '';
+
+  // Pushes a token (i.e. empties the buffer), if there is anything to push.
+  const pushToken = (type: TokenType, end: number) => {
+    if (buffer.length) {
+      tokens.push({
+        type,
+        token: buffer,
+        start: end - buffer.length,
+        end,
+      });
+      buffer = '';
+    }
+  };
+
+  let directiveOnly = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+
+    if (char === '[') {
+      pushToken('component', i);
+      directiveOnly = true;
+    } else if (directiveOnly && char === ' ') {
+      pushToken('directive', i);
+    } else if (char === ']') {
+      pushToken('directive', i);
+      directiveOnly = false;
+    } else {
+      buffer += char;
+    }
+  }
+
+  // Empty the buffer after the loop.
+  // A generic match can be only be a single match.
+  pushToken(
+    !tokens.length && !directiveOnly ? 'generic' : directiveOnly ? 'directive' : 'component',
+    text.length,
+  );
+
+  return tokens;
+}
+
+function checkForTokenMatch(
+  target: FilterToken,
+  filter: FilterToken,
+): {startIdx: number; endIdx: number} | null {
+  const startIdx = target.token.indexOf(filter.token);
+
+  if (startIdx > -1) {
+    const start = startIdx + target.start;
+    return {
+      startIdx: start,
+      endIdx: start + filter.token.length,
+    };
+  }
+  return null;
+}
+
+/** Generates a `FilterFn`, that performs token matching, for the directive-forest filter. */
+export const directiveForestFilterFnGenerator: FilterFnGenerator = (filter: string): FilterFn => {
+  const parsedFilter = directiveForestFilterParser(filter.toLowerCase());
+  const cmpFilterTokens = parsedFilter.filter((t) => t.type === 'component');
+  const dirFilterTokens = parsedFilter.filter((t) => t.type === 'directive');
+
+  return (target: string) => {
+    const isFirstGeneric = parsedFilter[0]?.type === 'generic';
+
+    if (!isFirstGeneric && parsedFilter.length) {
+      const matches = [];
+      const parsedTarget = directiveForestFilterParser(target.toLowerCase());
+      const typeMatchesCount: {[key in TokenType]: number} = {
+        component: 0,
+        directive: 0,
+        generic: 0, // Not a case but added as a safe guard, if the parser fails/has a bug.
+      };
+
+      for (const targetToken of parsedTarget) {
+        const isCmpToken = targetToken.type === 'component';
+        const isDirToken = targetToken.type === 'directive';
+        const filterTokens = isCmpToken ? cmpFilterTokens : isDirToken ? dirFilterTokens : [];
+
+        for (const filterToken of filterTokens) {
+          const match = checkForTokenMatch(targetToken, filterToken);
+          if (match) {
+            matches.push(match);
+            typeMatchesCount[filterToken.type]++;
+          }
+        }
+      }
+
+      // Do not register a match if the target doesn't completely match the filter.
+      // For example, if the search/filter string is `app-todo[Tooltip]`, it shouldn't
+      // match `app-menu[Tooltip]` nodes. Same for components: `app-todo[Tooltip]`
+      // shouldn't match `app-todo[CtxMenu]`.
+      if (
+        typeMatchesCount.component >= cmpFilterTokens.length &&
+        typeMatchesCount.directive >= dirFilterTokens.length
+      ) {
+        return matches;
+      }
+    } else if (isFirstGeneric) {
+      // Represents a standard string search. We don't have to parse the target.
+      const match = checkForTokenMatch(
+        {
+          type: 'generic',
+          token: target.toLowerCase(),
+          start: 0,
+          end: target.length,
+        },
+        parsedFilter[0],
+      );
+
+      return match ? [match] : [];
+    }
+    return [];
+  };
+};

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/filter.component.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/filter.component.spec.ts
@@ -59,47 +59,53 @@ describe('FilterComponent', () => {
     expect(getMatchesCountEl().nativeElement.innerText).toEqual('2 of 5');
   });
 
-  it('should emit a filter function that returns null, if no match', () => {
+  it('should emit a default filter function that returns an empty matches array, if no match', () => {
     component.filter.subscribe((filterFn) => {
       const match = filterFn('Foo Bar');
 
-      expect(match).toBeFalsy();
+      expect(match.length).toEqual(0);
     });
 
     emitFilterEvent('Baz');
   });
 
-  it('should emit a filter function that returns match indices, if there is a match', () => {
+  it('should emit a default filter function that returns match indices, if there is a match', () => {
     component.filter.subscribe((filterFn) => {
-      const match = filterFn('Foo Bar');
+      const matches = filterFn('Foo Bar');
 
-      expect(match).toBeTruthy();
-      expect(match?.startIdx).toEqual(4);
-      expect(match?.endIdx).toEqual(7);
+      expect(matches.length).toEqual(1);
+
+      const [match] = matches;
+      expect(match.startIdx).toEqual(4);
+      expect(match.endIdx).toEqual(7);
     });
 
     emitFilterEvent('Bar');
   });
 
-  it('should emit a filter function that returns match indices, if there is a full match', () => {
+  it('should emit a default filter function that returns match indices, if there is a full match', () => {
     component.filter.subscribe((filterFn) => {
-      const match = filterFn('Foo Bar');
+      const matches = filterFn('Foo Bar');
 
-      expect(match).toBeTruthy();
-      expect(match?.startIdx).toEqual(0);
-      expect(match?.endIdx).toEqual(7);
+      expect(matches.length).toEqual(1);
+
+      const [match] = matches;
+      expect(match.startIdx).toEqual(0);
+      expect(match.endIdx).toEqual(7);
     });
 
     emitFilterEvent('Foo Bar');
   });
 
-  it('should emit a filter function that returns match indices, if there is a match (case insensitive)', () => {
+  it('should emit a default filter function that returns match indices, if there is a match (case insensitive)', () => {
     component.filter.subscribe((filterFn) => {
-      const match = filterFn('Foo Bar Baz');
+      const matches = filterFn('Foo Bar Baz');
 
-      expect(match).toBeTruthy();
-      expect(match?.startIdx).toEqual(4);
-      expect(match?.endIdx).toEqual(7);
+      expect(matches.length).toEqual(1);
+
+      const [match] = matches;
+      expect(match.startIdx).toEqual(4);
+      expect(match.endIdx).toEqual(7);
     });
 
     emitFilterEvent('bar');

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/filter.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/filter.component.ts
@@ -10,10 +10,12 @@ import {Component, input, output} from '@angular/core';
 import {MatIcon} from '@angular/material/icon';
 import {MatCard} from '@angular/material/card';
 
-export type FilterFn = (source: string) => {
+export type FilterMatch = {
   startIdx: number;
   endIdx: number;
-}[];
+};
+
+export type FilterFn = (source: string) => FilterMatch[];
 
 /** Describes the filtering strategy of the `ng-filter` by providing a generator for the `FilterFn`. */
 export type FilterFnGenerator = (filter: string) => FilterFn;

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/tree-node.component.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/tree-node.component.spec.ts
@@ -10,7 +10,7 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {FlatTreeControl} from '@angular/cdk/tree';
 
-import {TreeNodeComponent} from './tree-node.component';
+import {NodeTextMatch, TreeNodeComponent} from './tree-node.component';
 import {FlatNode} from '../component-data-source';
 
 type DeepPartial<T> = T extends object ? {[P in keyof T]?: DeepPartial<T[P]>} : T;
@@ -56,7 +56,7 @@ describe('TreeNodeComponent', () => {
     fixture.componentRef.setInput('node', {
       ...srcNode,
       name: 'app-test',
-    } as FlatNode);
+    });
     fixture.detectChanges();
 
     const name = fixture.debugElement.query(By.css('.node-name'));
@@ -69,7 +69,7 @@ describe('TreeNodeComponent', () => {
       ...srcNode,
       name: 'app-test',
       directives: ['TooltipDirective'],
-    } as FlatNode);
+    });
     fixture.detectChanges();
 
     const name = fixture.debugElement.query(By.css('.node-name'));
@@ -82,7 +82,7 @@ describe('TreeNodeComponent', () => {
       ...srcNode,
       name: 'app-test',
       directives: ['TooltipDirective', 'CtxMenuDirective'],
-    } as FlatNode);
+    });
     fixture.detectChanges();
 
     const name = fixture.debugElement.query(By.css('.node-name'));
@@ -98,7 +98,7 @@ describe('TreeNodeComponent', () => {
       ...srcNode,
       name: 'app-test',
       onPush: true,
-    } as FlatNode);
+    });
     fixture.detectChanges();
 
     onPush = fixture.debugElement.query(By.css('.on-push'));
@@ -129,7 +129,7 @@ describe('TreeNodeComponent', () => {
     fixture.componentRef.setInput('node', {
       ...srcNode,
       newItem: true,
-    } as FlatNode);
+    });
     fixture.detectChanges();
 
     const classList = fixture.debugElement.nativeElement.classList;
@@ -137,11 +137,11 @@ describe('TreeNodeComponent', () => {
   });
 
   it('should mark the text that matches the filter', () => {
-    fixture.componentRef.setInput('textMatch', {startIdx: 3, endIdx: 27});
+    fixture.componentRef.setInput('textMatches', [{startIdx: 3, endIdx: 27}]);
     fixture.componentRef.setInput('node', {
       ...srcNode,
       name: 'my-long-component-name[WithADirective]',
-    } as FlatNode);
+    });
     fixture.detectChanges();
 
     const marked = fixture.debugElement.query(By.css('mark'));
@@ -149,11 +149,11 @@ describe('TreeNodeComponent', () => {
   });
 
   it('should mark the text that matches the filter (beginning of the string)', () => {
-    fixture.componentRef.setInput('textMatch', {startIdx: 0, endIdx: 9});
+    fixture.componentRef.setInput('textMatches', [{startIdx: 0, endIdx: 9}]);
     fixture.componentRef.setInput('node', {
       ...srcNode,
       name: 'app-large-component',
-    } as FlatNode);
+    });
     fixture.detectChanges();
 
     const marked = fixture.debugElement.query(By.css('mark'));
@@ -161,11 +161,11 @@ describe('TreeNodeComponent', () => {
   });
 
   it('should mark the text that matches the filter (end of the string)', () => {
-    fixture.componentRef.setInput('textMatch', {startIdx: 10, endIdx: 19});
+    fixture.componentRef.setInput('textMatches', [{startIdx: 10, endIdx: 19}]);
     fixture.componentRef.setInput('node', {
       ...srcNode,
       name: 'app-large-component',
-    } as FlatNode);
+    });
     fixture.detectChanges();
 
     const marked = fixture.debugElement.query(By.css('mark'));
@@ -173,14 +173,35 @@ describe('TreeNodeComponent', () => {
   });
 
   it('should mark the whole text, if it matches completely the filter', () => {
-    fixture.componentRef.setInput('textMatch', {startIdx: 0, endIdx: 8});
+    fixture.componentRef.setInput('textMatches', [{startIdx: 0, endIdx: 8}]);
     fixture.componentRef.setInput('node', {
       ...srcNode,
       name: 'app-test',
-    } as FlatNode);
+    });
     fixture.detectChanges();
 
     const marked = fixture.debugElement.query(By.css('mark'));
     expect(marked.nativeElement.innerText).toEqual('app-test');
+  });
+
+  it('should mark a sequence of matches', () => {
+    const matches: NodeTextMatch[] = [
+      {startIdx: 0, endIdx: 8}, // app-test
+      {startIdx: 13, endIdx: 16}, // Foo
+      {startIdx: 24, endIdx: 26}, // az
+    ];
+    fixture.componentRef.setInput('textMatches', matches);
+    fixture.componentRef.setInput('node', {
+      ...srcNode,
+      name: 'app-test-cmp[Foo][Bar][Baz]',
+    });
+    fixture.detectChanges();
+
+    const marked = fixture.debugElement.queryAll(By.css('mark'));
+
+    const [appTest, foo, az] = marked;
+    expect(appTest.nativeElement.innerText).toEqual('app-test');
+    expect(foo.nativeElement.innerText).toEqual('Foo');
+    expect(az.nativeElement.innerText).toEqual('az');
   });
 });

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/tree-node.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/tree-node.component.ts
@@ -102,50 +102,25 @@ export class TreeNodeComponent {
     }
 
     const textMatches = this.textMatches();
-
     if (textMatches.length) {
-      // Flatten all matches to an array where the even indices
-      // represent the match start whereas odd indices represent
-      // the match end.
-      const flattenedMatchesIndices = [];
-      for (const match of textMatches) {
-        flattenedMatchesIndices.push(match.startIdx, match.endIdx);
-      }
-
-      this.buildMatchedTextElement(flattenedMatchesIndices);
+      this.buildMatchedTextElement(textMatches);
     }
   }
 
-  private buildMatchedTextElement(flattenedMatchesIndices: number[]) {
+  private buildMatchedTextElement(textMatches: NodeTextMatch[]) {
     const matchedText = this.renderer.createElement('span');
     this.renderer.addClass(matchedText, 'matched-text');
 
     const name = this.nodeNameString();
-    let textBuffer = '';
-    let matchIdx = 0;
+    let lastMatchEndIdx = 0;
 
-    for (let i = 0; i < name.length; i++) {
-      if (i === flattenedMatchesIndices[matchIdx]) {
-        const isEvenMatchIdx = matchIdx % 2 === 0; // i.e. match start
-
-        if (isEvenMatchIdx && textBuffer) {
-          // Add any text that wraps the matched text.
-          this.appendText(matchedText, textBuffer);
-          textBuffer = '';
-        } else if (!isEvenMatchIdx) {
-          // Add the matched text.
-          this.appendText(matchedText, textBuffer, true);
-          textBuffer = '';
-        }
-
-        matchIdx++;
+    for (const {startIdx, endIdx} of textMatches) {
+      if (lastMatchEndIdx < startIdx) {
+        // Filler/non-marked text
+        this.appendText(matchedText, name.slice(lastMatchEndIdx, startIdx), false);
       }
-
-      textBuffer += name[i];
-    }
-
-    if (textBuffer && matchIdx === flattenedMatchesIndices.length - 1) {
-      this.appendText(matchedText, textBuffer, true);
+      this.appendText(matchedText, name.slice(startIdx, endIdx), true);
+      lastMatchEndIdx = endIdx;
     }
 
     this.matchedText = matchedText;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature

## What is the new behavior?

This is a continuation of #60672 and more specifically [this discussion](https://github.com/angular/angular/pull/60672#discussion_r2025547872).

<img width="559" alt="Screenshot 2025-05-06 at 17 10 11" src="https://github.com/user-attachments/assets/aa0b60ee-cfeb-46f8-ab47-d76bfca001c6" />

In other words, the filter text is now parsed which means that we support a more sophisticated filtering. To name a few:

- Directive-only search –  Wrapping the text in square brackets (i.e. `[MyDirective]`) will target only the directives
- Component + directive search – Currently, the filtering performs a generic string matching, so nodes like `app-todo[Tooltip][CtxMenu]` can only be matched if the the whole or part of the strings is matched. This update will allow for matching the given example with filters like `app-todo[CtxMenu]`, `todo[Menu]`, etc. Basically, each segment (directive of component) is filtered/checked individually.

cc @dgp1130 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No