### PR TITLE
refactor(common): Mark inputs of deprecated control flow directives a…

### DIFF
--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -520,7 +520,9 @@ export class NgComponentOutlet<T = any> implements OnChanges, DoCheck, OnDestroy
 class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> implements DoCheck {
     constructor(_viewContainer: ViewContainerRef, _template: TemplateRef<NgForOfContext<T, U>>, _differs: IterableDiffers);
     ngDoCheck(): void;
+    // @deprecated
     set ngForOf(ngForOf: (U & NgIterable<T>) | undefined | null);
+    // @deprecated
     set ngForTemplate(value: TemplateRef<NgForOfContext<T, U>>);
     set ngForTrackBy(fn: TrackByFunction<T>);
     // (undocumented)
@@ -558,8 +560,11 @@ export class NgForOfContext<T, U extends NgIterable<T> = NgIterable<T>> {
 // @public @deprecated
 export class NgIf<T = unknown> {
     constructor(_viewContainer: ViewContainerRef, templateRef: TemplateRef<NgIfContext<T>>);
+    // @deprecated
     set ngIf(condition: T);
+    // @deprecated
     set ngIfElse(templateRef: TemplateRef<NgIfContext<T>> | null);
+    // @deprecated
     set ngIfThen(templateRef: TemplateRef<NgIfContext<T>> | null);
     static ngTemplateContextGuard<T>(dir: NgIf<T>, ctx: any): ctx is NgIfContext<Exclude<T, false | 0 | '' | null | undefined>>;
     static ngTemplateGuard_ngIf: 'binding';
@@ -684,7 +689,7 @@ export class NgStyle implements DoCheck {
 
 // @public @deprecated
 export class NgSwitch {
-    // (undocumented)
+    // @deprecated (undocumented)
     set ngSwitch(newValue: any);
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<NgSwitch, "[ngSwitch]", never, { "ngSwitch": { "alias": "ngSwitch"; "required": false; }; }, {}, never, never, true, never>;
@@ -696,6 +701,7 @@ export class NgSwitch {
 export class NgSwitchCase implements DoCheck {
     constructor(viewContainer: ViewContainerRef, templateRef: TemplateRef<Object>, ngSwitch: NgSwitch);
     ngDoCheck(): void;
+    // @deprecated
     ngSwitchCase: any;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<NgSwitchCase, "[ngSwitchCase]", never, { "ngSwitchCase": { "alias": "ngSwitchCase"; "required": false; }; }, {}, never, never, true, never>;

--- a/packages/common/src/directives/ng_for_of.ts
+++ b/packages/common/src/directives/ng_for_of.ts
@@ -176,6 +176,7 @@ export class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> implements DoCh
   /**
    * The value of the iterable expression, which can be used as a
    * [template input variable](guide/directives/structural-directives#shorthand).
+   * @deprecated The `ngFor` directive is deprecated. Use the `@for` block instead.
    */
   @Input()
   set ngForOf(ngForOf: (U & NgIterable<T>) | undefined | null) {
@@ -199,6 +200,7 @@ export class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> implements DoCh
    * and the iterable is recreated and re-rendered, but most of the data is still the same).
    *
    * @see {@link TrackByFunction}
+   * @deprecated The `ngFor` directive is deprecated. Use the `@for` block instead.
    */
   @Input()
   set ngForTrackBy(fn: TrackByFunction<T>) {
@@ -231,6 +233,7 @@ export class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> implements DoCh
   /**
    * A reference to the template that is stamped out for each item in the iterable.
    * @see [template reference variable](guide/templates/variables#template-reference-variables)
+   * @deprecated The `ngFor` directive is deprecated. Use the `@for` block instead.
    */
   @Input()
   set ngForTemplate(value: TemplateRef<NgForOfContext<T, U>>) {

--- a/packages/common/src/directives/ng_if.ts
+++ b/packages/common/src/directives/ng_if.ts
@@ -178,6 +178,7 @@ export class NgIf<T = unknown> {
 
   /**
    * The Boolean expression to evaluate as the condition for showing a template.
+   * @deprecated Use the @if block instead. Intent to remove in v22
    */
   @Input()
   set ngIf(condition: T) {
@@ -187,6 +188,7 @@ export class NgIf<T = unknown> {
 
   /**
    * A template to show if the condition expression evaluates to true.
+   * @deprecated Use the @if block instead. Intent to remove in v22
    */
   @Input()
   set ngIfThen(templateRef: TemplateRef<NgIfContext<T>> | null) {
@@ -198,6 +200,7 @@ export class NgIf<T = unknown> {
 
   /**
    * A template to show if the condition expression evaluates to false.
+   * @deprecated Use the @if block instead. Intent to remove in v22
    */
   @Input()
   set ngIfElse(templateRef: TemplateRef<NgIfContext<T>> | null) {

--- a/packages/common/src/directives/ng_switch.ts
+++ b/packages/common/src/directives/ng_switch.ts
@@ -124,6 +124,7 @@ export class NgSwitch {
   private _lastCasesMatched = false;
   private _ngSwitch: any;
 
+  /** @deprecated Use the @switch block instead. Intent to remove in v22 */
   @Input()
   set ngSwitch(newValue: any) {
     this._ngSwitch = newValue;
@@ -206,6 +207,7 @@ export class NgSwitchCase implements DoCheck {
   private _view: SwitchView;
   /**
    * Stores the HTML template to be selected on match.
+   * @deprecated Use the @case block within a @switch block instead. Intent to remove in v22
    */
   @Input() ngSwitchCase: any;
 


### PR DESCRIPTION
…s deprecated

This updates the inputs of the deprecated control flow directives as also deprecated. Helpful for language services/tokenization tools
