### PR TITLE
fix(platform-server): less aggressive ngServerMode cleanup

### DIFF
--- a/packages/platform-server/src/server.ts
+++ b/packages/platform-server/src/server.ts
@@ -116,7 +116,8 @@ function _document(injector: Injector) {
  * @publicApi
  */
 export function platformServer(extraProviders?: StaticProvider[] | undefined): PlatformRef {
-  if (typeof ngServerMode === 'undefined') {
+  const noServerModeSet = typeof ngServerMode === 'undefined';
+  if (noServerModeSet) {
     globalThis['ngServerMode'] = true;
   }
 
@@ -126,9 +127,11 @@ export function platformServer(extraProviders?: StaticProvider[] | undefined): P
     INTERNAL_SERVER_PLATFORM_PROVIDERS,
   )(extraProviders);
 
-  platform.onDestroy(() => {
-    globalThis['ngServerMode'] = undefined;
-  });
+  if (noServerModeSet) {
+    platform.onDestroy(() => {
+      globalThis['ngServerMode'] = undefined;
+    });
+  }
 
   return platform;
 }


### PR DESCRIPTION
Other code may depend on `ngServerMode` and it might have been set globally / via a bundler. Forcing it to `undefined` in those situations can lead to hard debug issues where the only symptom is that "suddenly" browser-specific code paths run on the server and (obviously) break.

---

Note: This is the less aggressive version that still forces `ngServerMode` to undefined if that's how we found it. I think it would also be reasonable to remove this cleanup all together but I tried to err on the side of caution.