### PR TITLE
fix(common/http): allow HttpErrorResponse with successful status codes

### DIFF
--- a/packages/common/http/testing/src/request.ts
+++ b/packages/common/http/testing/src/request.ts
@@ -117,9 +117,6 @@ export class TestRequest {
     if (this.cancelled) {
       throw new Error(`Cannot return an error for a cancelled request.`);
     }
-    if (opts.status && opts.status >= 200 && opts.status < 300) {
-      throw new Error(`error() called with a successful status.`);
-    }
     const headers =
       opts.headers instanceof HttpHeaders ? opts.headers : new HttpHeaders(opts.headers);
     this.observer.error(

--- a/packages/common/http/testing/test/BUILD.bazel
+++ b/packages/common/http/testing/test/BUILD.bazel
@@ -7,6 +7,9 @@ ts_project(
     srcs = glob(
         ["**/*.ts"],
     ),
+    interop_deps = [
+        "//packages/private/testing",
+    ],
     # Visible to //:saucelabs_unit_tests_poc target
     visibility = ["//:__pkg__"],
     deps = [


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
Issue Number: #26161

Currently, `TestRequest.error()` throws an error when trying to mock an `HttpErrorResponse` with a successful status code (200-299).

## What is the new behavior?
The fix allows creating `HttpErrorResponse` with any status code, including successful ones, which is necessary for testing scenarios where the HTTP client might return an error response with a successful status code.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No