### PR TITLE
[Patch port] fix(core): missing useExisting providers throwing for optional calls

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -659,7 +659,7 @@ function searchTokensOnInjector<T>(
     isHostSpecialCase,
   );
   if (injectableIdx !== null) {
-    return getNodeInjectable(lView, currentTView, injectableIdx, tNode as TElementNode);
+    return getNodeInjectable(lView, currentTView, injectableIdx, tNode as TElementNode, flags);
   } else {
     return NOT_FOUND;
   }
@@ -725,6 +725,7 @@ export function getNodeInjectable(
   tView: TView,
   index: number,
   tNode: TDirectiveHostNode,
+  flags?: InjectFlags,
 ): any {
   let value = lView[index];
   const tData = tView.data;
@@ -759,7 +760,7 @@ export function getNodeInjectable(
         "Because flags do not contain `SkipSelf' we expect this to always succeed.",
       );
     try {
-      value = lView[index] = factory.factory(undefined, tData, lView, tNode);
+      value = lView[index] = factory.factory(undefined, flags, tData, lView, tNode);
 
       ngDevMode && emitInstanceCreatedByInjectorEvent(value);
 

--- a/packages/core/src/render3/di_setup.ts
+++ b/packages/core/src/render3/di_setup.ts
@@ -7,6 +7,7 @@
  */
 
 import {resolveForwardRef} from '../di/forward_ref';
+import {InjectFlags, InternalInjectFlags} from '../di/interface/injector';
 import {ClassProvider, Provider} from '../di/interface/provider';
 import {isClassProvider, isTypeProvider, SingleProvider} from '../di/provider_collection';
 import {providerToFactory} from '../di/r3_injector';
@@ -319,6 +320,7 @@ function indexOf(item: any, arr: any[], begin: number, end: number) {
 function multiProvidersFactoryResolver(
   this: NodeInjectorFactory,
   _: undefined,
+  flags: InjectFlags | undefined,
   tData: TData,
   lData: LView,
   tNode: TDirectiveHostNode,
@@ -334,7 +336,8 @@ function multiProvidersFactoryResolver(
 function multiViewProvidersFactoryResolver(
   this: NodeInjectorFactory,
   _: undefined,
-  tData: TData,
+  _flags: InjectFlags | undefined,
+  _tData: TData,
   lView: LView,
   tNode: TDirectiveHostNode,
 ): any[] {
@@ -382,6 +385,7 @@ function multiFactory(
   factoryFn: (
     this: NodeInjectorFactory,
     _: undefined,
+    flags: InjectFlags | undefined,
     tData: TData,
     lData: LView,
     tNode: TDirectiveHostNode,

--- a/packages/core/src/render3/interfaces/injector.ts
+++ b/packages/core/src/render3/interfaces/injector.ts
@@ -261,6 +261,10 @@ export class NodeInjectorFactory {
       this: NodeInjectorFactory,
       _: undefined,
       /**
+       * Flags that control the injection behavior.
+       */
+      flags: InjectFlags | undefined,
+      /**
        * array where injectables tokens are stored. This is used in
        * case of an error reporting to produce friendlier errors.
        */

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -4469,6 +4469,94 @@ describe('di', () => {
     });
   });
 
+  describe('useExisting and optional', () => {
+    const token = new InjectionToken('token');
+    const existing = new InjectionToken('existing');
+
+    it('should return null when injecting a missing useExisting provider with optional: true in a node injector', () => {
+      let value: unknown;
+
+      @Directive({selector: '[dir]'})
+      class Dir {
+        constructor() {
+          value = inject(token, {optional: true});
+        }
+      }
+
+      @Component({
+        template: '<div dir></div>',
+        imports: [Dir],
+        providers: [{provide: token, useExisting: existing}],
+      })
+      class App {}
+
+      TestBed.createComponent(App);
+      expect(value).toBe(null);
+    });
+
+    it('should throw when injecting a missing useExisting provider in a node injector', () => {
+      @Directive({selector: '[dir]'})
+      class Dir {
+        constructor() {
+          inject(token, {optional: false});
+        }
+      }
+
+      @Component({
+        template: '<div dir></div>',
+        imports: [Dir],
+        providers: [{provide: token, useExisting: existing}],
+      })
+      class App {}
+
+      expect(() => TestBed.createComponent(App)).toThrowError(
+        /No provider for InjectionToken existing/,
+      );
+    });
+
+    it('should return null when injecting a missing useExisting provider with optional: true in a module injector', () => {
+      let value: unknown;
+
+      @Directive({selector: '[dir]', standalone: false})
+      class Dir {
+        constructor() {
+          value = inject(token, {optional: true});
+        }
+      }
+
+      @Component({template: '<div dir></div>', standalone: false})
+      class App {}
+
+      TestBed.configureTestingModule({
+        declarations: [App, Dir],
+        providers: [{provide: token, useExisting: existing}],
+      });
+      TestBed.createComponent(App);
+      expect(value).toBe(null);
+    });
+
+    it('should throw when injecting a missing useExisting provider in a module injector', () => {
+      @Directive({selector: '[dir]', standalone: false})
+      class Dir {
+        constructor() {
+          inject(token);
+        }
+      }
+
+      @Component({template: '<div dir></div>', standalone: false})
+      class App {}
+
+      TestBed.configureTestingModule({
+        declarations: [App, Dir],
+        providers: [{provide: token, useExisting: existing}],
+      });
+
+      expect(() => TestBed.createComponent(App)).toThrowError(
+        /No provider for InjectionToken existing/,
+      );
+    });
+  });
+
   it('should be able to use Host in `useFactory` dependency config', () => {
     // Scenario:
     // ---------


### PR DESCRIPTION
**Note:** this is a patch port of #61137.

Fixes that the runtime was throwing a DI error when attempting to inject a missing `useExisting` provider, despite the call being optional.

The problem was that when the provider has `useExisting`, we do a second `inject` call under the hood which didn't include the inject flags from the original call.

Fixes #61121.
