### PR TITLE
fix(core): `linkedSignal.update` should propagate errors

### DIFF
--- a/packages/core/primitives/signals/src/linked_signal.ts
+++ b/packages/core/primitives/signals/src/linked_signal.ts
@@ -112,6 +112,10 @@ export function linkedSignalUpdateFn<S, D>(
   updater: (value: D) => D,
 ): void {
   producerUpdateValueVersion(node);
+  // update() on a linked signal can't work if the current state is ERRORED, as there's no value.
+  if (node.value === ERRORED) {
+    throw node.error;
+  }
   signalUpdateFn(node, updater);
   producerMarkClean(node);
 }

--- a/packages/core/test/signals/linked_signal_spec.ts
+++ b/packages/core/test/signals/linked_signal_spec.ts
@@ -148,6 +148,27 @@ describe('linkedSignal', () => {
     expect(choice()).toBe(0);
   });
 
+  it('should throw error from update if current computation state is an error', () => {
+    const source = linkedSignal<number>(() => {
+      // Initial computation fails.
+      throw new Error('failure');
+    });
+
+    let updaterRan = false;
+    expect(() =>
+      source.update(() => {
+        // Note: we explicitly do _not_ interact with the previous value here. That's because in the
+        // failure mode, the previous value is an internal `Symbol` from `linkedSignal`, and we want
+        // to avoid throwing any errors related to this `Symbol` and causing the test to incorrectly
+        // pass.
+
+        updaterRan = true;
+        return 0;
+      }),
+    ).toThrowError(/failure/);
+    expect(updaterRan).toBeFalse();
+  });
+
   it('should not recompute downstream dependencies when computed value is equal to the currently set value', () => {
     const source = signal(0);
     const isEven = linkedSignal(() => source() % 2 === 0);


### PR DESCRIPTION
Unlike a normal `signal()`, a `linkedSignal()` can be in an error state when its computation fails. Currently, there's a bug where `linkedSignal.update` does not account for this error state, and will pass the internal `ERRORED` `Symbol` as the current value to the updater function.

This commit fixes the issue by having `update()` check and throw the error instead of calling the updater function.
