### PR TITLE
Compiler cleanups

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -1399,7 +1399,7 @@ export class ComponentDecoratorHandler
       removeDeferrableTypesFromComponentDecorator(analysis, perComponentDeferredDeps);
     }
 
-    const def = compileComponentFromMetadata(meta, pool, makeBindingParser());
+    const def = compileComponentFromMetadata(meta, pool, this.getNewBindingParser());
     const inputTransformFields = compileInputTransformFields(analysis.inputs);
     const classMetadata =
       analysis.classMetadata !== null
@@ -1529,7 +1529,7 @@ export class ComponentDecoratorHandler
     }
 
     const fac = compileNgFactoryDefField(toFactoryMetadata(meta, FactoryTarget.Component));
-    const def = compileComponentFromMetadata(meta, pool, makeBindingParser());
+    const def = compileComponentFromMetadata(meta, pool, this.getNewBindingParser());
     const inputTransformFields = compileInputTransformFields(analysis.inputs);
     const classMetadata =
       analysis.classMetadata !== null
@@ -1587,7 +1587,7 @@ export class ComponentDecoratorHandler
       defer,
     };
     const fac = compileNgFactoryDefField(toFactoryMetadata(meta, FactoryTarget.Component));
-    const def = compileComponentFromMetadata(meta, pool, makeBindingParser());
+    const def = compileComponentFromMetadata(meta, pool, this.getNewBindingParser());
     const classMetadata =
       analysis.classMetadata !== null
         ? compileComponentClassMetadata(analysis.classMetadata, null).toStmt()
@@ -2443,6 +2443,11 @@ export class ComponentDecoratorHandler
     }
 
     throw new Error(`Invalid deferBlockDepsEmitMode. Cannot compile deferred block metadata.`);
+  }
+
+  /** Creates a new binding parser. */
+  private getNewBindingParser() {
+    return makeBindingParser(undefined, this.enableSelectorless);
   }
 }
 

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/selectorless.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/selectorless.ts
@@ -8,34 +8,12 @@
 
 import {
   AST,
-  AstVisitor,
-  ASTWithSource,
-  RecursiveAstVisitor,
-  TmplAstBoundAttribute,
-  TmplAstBoundDeferredTrigger,
-  TmplAstBoundEvent,
-  TmplAstBoundText,
   TmplAstComponent,
-  TmplAstContent,
-  TmplAstDeferredBlock,
-  TmplAstDeferredBlockError,
-  TmplAstDeferredBlockLoading,
-  TmplAstDeferredBlockPlaceholder,
-  TmplAstDeferredTrigger,
   TmplAstDirective,
-  TmplAstElement,
-  TmplAstForLoopBlock,
-  TmplAstForLoopBlockEmpty,
-  TmplAstIcu,
-  TmplAstIfBlock,
-  TmplAstIfBlockBranch,
-  TmplAstLetDeclaration,
   TmplAstNode,
-  TmplAstSwitchBlock,
-  TmplAstSwitchBlockCase,
-  TmplAstTemplate,
-  tmplAstVisitAll,
   BindingPipe,
+  CombinedRecursiveAstVisitor,
+  tmplAstVisitAll,
 } from '@angular/compiler';
 
 /**
@@ -60,7 +38,7 @@ export function analyzeTemplateForSelectorless(template: TmplAstNode[]): {
  * Visitor that traverses all the template nodes and
  * expressions to look for selectorless references.
  */
-class SelectorlessDirectivesAnalyzer extends RecursiveAstVisitor implements AstVisitor {
+class SelectorlessDirectivesAnalyzer extends CombinedRecursiveAstVisitor {
   symbols: Set<string> | null = null;
 
   override visit(node: AST | TmplAstNode) {
@@ -70,148 +48,21 @@ class SelectorlessDirectivesAnalyzer extends RecursiveAstVisitor implements AstV
       this.trackSymbol(node.name);
     }
 
-    node.visit(this);
+    super.visit(node);
+  }
+
+  override visitComponent(component: TmplAstComponent) {
+    this.trackSymbol(component.componentName);
+    super.visitComponent(component);
+  }
+
+  override visitDirective(directive: TmplAstDirective) {
+    this.trackSymbol(directive.name);
+    super.visitDirective(directive);
   }
 
   private trackSymbol(name: string) {
     this.symbols ??= new Set();
     this.symbols.add(name);
   }
-
-  visitAllNodes(nodes: TmplAstNode[]) {
-    for (const node of nodes) {
-      this.visit(node);
-    }
-  }
-
-  visitAst(ast: AST) {
-    if (ast instanceof ASTWithSource) {
-      ast = ast.ast;
-    }
-    this.visit(ast);
-  }
-
-  visitComponent(component: TmplAstComponent) {
-    this.trackSymbol(component.componentName);
-    this.visitAllNodes(component.attributes);
-    this.visitAllNodes(component.inputs);
-    this.visitAllNodes(component.outputs);
-    this.visitAllNodes(component.directives);
-    this.visitAllNodes(component.references);
-    this.visitAllNodes(component.children);
-  }
-
-  visitDirective(directive: TmplAstDirective) {
-    this.trackSymbol(directive.name);
-    this.visitAllNodes(directive.attributes);
-    this.visitAllNodes(directive.inputs);
-    this.visitAllNodes(directive.outputs);
-    this.visitAllNodes(directive.references);
-  }
-
-  visitElement(element: TmplAstElement) {
-    this.visitAllNodes(element.attributes);
-    this.visitAllNodes(element.inputs);
-    this.visitAllNodes(element.outputs);
-    this.visitAllNodes(element.directives);
-    this.visitAllNodes(element.references);
-    this.visitAllNodes(element.children);
-  }
-
-  visitTemplate(template: TmplAstTemplate) {
-    this.visitAllNodes(template.attributes);
-    this.visitAllNodes(template.inputs);
-    this.visitAllNodes(template.outputs);
-    this.visitAllNodes(template.directives);
-    this.visitAllNodes(template.templateAttrs);
-    this.visitAllNodes(template.variables);
-    this.visitAllNodes(template.references);
-    this.visitAllNodes(template.children);
-  }
-
-  visitContent(content: TmplAstContent): void {
-    this.visitAllNodes(content.children);
-  }
-
-  visitBoundAttribute(attribute: TmplAstBoundAttribute): void {
-    this.visitAst(attribute.value);
-  }
-
-  visitBoundEvent(attribute: TmplAstBoundEvent): void {
-    this.visitAst(attribute.handler);
-  }
-
-  visitBoundText(text: TmplAstBoundText): void {
-    this.visitAst(text.value);
-  }
-
-  visitIcu(icu: TmplAstIcu): void {
-    Object.keys(icu.vars).forEach((key) => this.visit(icu.vars[key]));
-    Object.keys(icu.placeholders).forEach((key) => this.visit(icu.placeholders[key]));
-  }
-
-  visitDeferredBlock(deferred: TmplAstDeferredBlock): void {
-    deferred.visitAll(this);
-  }
-
-  visitDeferredTrigger(trigger: TmplAstDeferredTrigger): void {
-    if (trigger instanceof TmplAstBoundDeferredTrigger) {
-      this.visitAst(trigger.value);
-    }
-  }
-
-  visitDeferredBlockPlaceholder(block: TmplAstDeferredBlockPlaceholder): void {
-    this.visitAllNodes(block.children);
-  }
-
-  visitDeferredBlockError(block: TmplAstDeferredBlockError): void {
-    this.visitAllNodes(block.children);
-  }
-
-  visitDeferredBlockLoading(block: TmplAstDeferredBlockLoading): void {
-    this.visitAllNodes(block.children);
-  }
-
-  visitSwitchBlock(block: TmplAstSwitchBlock): void {
-    this.visitAst(block.expression);
-    this.visitAllNodes(block.cases);
-  }
-
-  visitSwitchBlockCase(block: TmplAstSwitchBlockCase): void {
-    block.expression && this.visitAst(block.expression);
-    this.visitAllNodes(block.children);
-  }
-
-  visitForLoopBlock(block: TmplAstForLoopBlock): void {
-    block.item.visit(this);
-    this.visitAllNodes(block.contextVariables);
-    this.visitAst(block.expression);
-    this.visitAllNodes(block.children);
-    block.empty?.visit(this);
-  }
-
-  visitForLoopBlockEmpty(block: TmplAstForLoopBlockEmpty): void {
-    this.visitAllNodes(block.children);
-  }
-
-  visitIfBlock(block: TmplAstIfBlock): void {
-    this.visitAllNodes(block.branches);
-  }
-
-  visitIfBlockBranch(block: TmplAstIfBlockBranch): void {
-    block.expression && this.visitAst(block.expression);
-    block.expressionAlias?.visit(this);
-    this.visitAllNodes(block.children);
-  }
-
-  visitLetDeclaration(decl: TmplAstLetDeclaration): void {
-    this.visitAst(decl.value);
-  }
-
-  // Unused
-  visitText(): void {}
-  visitVariable(): void {}
-  visitReference(): void {}
-  visitTextAttribute(): void {}
-  visitUnknownBlock(): void {}
 }

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/selectorless.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/selectorless.ts
@@ -14,6 +14,7 @@ import {
   BindingPipe,
   CombinedRecursiveAstVisitor,
   tmplAstVisitAll,
+  BindingPipeType,
 } from '@angular/compiler';
 
 /**
@@ -42,9 +43,7 @@ class SelectorlessDirectivesAnalyzer extends CombinedRecursiveAstVisitor {
   symbols: Set<string> | null = null;
 
   override visit(node: AST | TmplAstNode) {
-    // TODO(crisbeto): consider capitalized pipes as "selectorless" for now.
-    // We should introduce a different AST node for them in the parser.
-    if (node instanceof BindingPipe && node.name[0].toUpperCase() === node.name[0]) {
+    if (node instanceof BindingPipe && node.type === BindingPipeType.ReferencedDirectly) {
       this.trackSymbol(node.name);
     }
 

--- a/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
@@ -22,6 +22,8 @@ export enum IdentifierKind {
   Reference,
   Variable,
   LetDeclaration,
+  Component,
+  Directive,
 }
 
 /**
@@ -66,8 +68,9 @@ interface DirectiveReference {
   node: ClassDeclaration;
   selector: string;
 }
+
 /** A base interface for element and template identifiers. */
-interface BaseElementOrTemplateIdentifier extends TemplateIdentifier {
+interface BaseDirectiveHostIdentifier extends TemplateIdentifier {
   /** Attributes on an element or template. */
   attributes: Set<AttributeIdentifier>;
 
@@ -79,13 +82,23 @@ interface BaseElementOrTemplateIdentifier extends TemplateIdentifier {
  * element tag, which can be parsed by an indexer to determine where used directives should be
  * referenced.
  */
-export interface ElementIdentifier extends BaseElementOrTemplateIdentifier {
+export interface ElementIdentifier extends BaseDirectiveHostIdentifier {
   kind: IdentifierKind.Element;
 }
 
 /** Describes an indexed template node in a component template file. */
-export interface TemplateNodeIdentifier extends BaseElementOrTemplateIdentifier {
+export interface TemplateNodeIdentifier extends BaseDirectiveHostIdentifier {
   kind: IdentifierKind.Template;
+}
+
+/** Describes a selectorless component node in a template file. */
+export interface ComponentNodeIdentifier extends BaseDirectiveHostIdentifier {
+  kind: IdentifierKind.Component;
+}
+
+/** Describes a selectorless directive node in a template file. */
+export interface DirectiveNodeIdentifier extends BaseDirectiveHostIdentifier {
+  kind: IdentifierKind.Directive;
 }
 
 /** Describes a reference in a template like "foo" in `<div #foo></div>`. */
@@ -95,7 +108,7 @@ export interface ReferenceIdentifier extends TemplateIdentifier {
   /** The target of this reference. If the target is not known, this is `null`. */
   target: {
     /** The template AST node that the reference targets. */
-    node: ElementIdentifier | TemplateIdentifier;
+    node: DirectiveHostIdentifier;
 
     /**
      * The directive on `node` that the reference targets. If no directive is targeted, this is
@@ -126,15 +139,24 @@ export type TopLevelIdentifier =
   | ReferenceIdentifier
   | VariableIdentifier
   | MethodIdentifier
-  | LetDeclarationIdentifier;
+  | LetDeclarationIdentifier
+  | ComponentNodeIdentifier
+  | DirectiveNodeIdentifier;
+
+/** Identifiers that can bring in directives to the template. */
+export type DirectiveHostIdentifier =
+  | ElementIdentifier
+  | TemplateNodeIdentifier
+  | ComponentNodeIdentifier
+  | DirectiveNodeIdentifier;
 
 /**
  * Describes the absolute byte offsets of a text anchor in a source code.
  */
 export class AbsoluteSourceSpan {
   constructor(
-    public start: number,
-    public end: number,
+    readonly start: number,
+    readonly end: number,
   ) {}
 }
 

--- a/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
@@ -9,35 +9,21 @@ import {
   AST,
   ASTWithSource,
   BoundTarget,
+  CombinedRecursiveAstVisitor,
   ImplicitReceiver,
   ParseSourceSpan,
   PropertyRead,
   PropertyWrite,
-  RecursiveAstVisitor,
   TmplAstBoundAttribute,
-  TmplAstBoundDeferredTrigger,
-  TmplAstBoundEvent,
-  TmplAstBoundText,
   TmplAstComponent,
-  TmplAstDeferredBlock,
-  TmplAstDeferredBlockError,
-  TmplAstDeferredBlockLoading,
-  TmplAstDeferredBlockPlaceholder,
-  TmplAstDeferredTrigger,
   TmplAstDirective,
   TmplAstElement,
-  TmplAstForLoopBlock,
-  TmplAstForLoopBlockEmpty,
-  TmplAstIfBlock,
-  TmplAstIfBlockBranch,
   TmplAstLetDeclaration,
   TmplAstNode,
-  TmplAstRecursiveVisitor,
   TmplAstReference,
-  TmplAstSwitchBlock,
-  TmplAstSwitchBlockCase,
   TmplAstTemplate,
   TmplAstVariable,
+  tmplAstVisitAll,
 } from '@angular/compiler';
 
 import {ClassDeclaration, DeclarationNode} from '../../reflection';
@@ -57,146 +43,20 @@ import {
 } from './api';
 import {ComponentMeta} from './context';
 
-/**
- * A parsed node in a template, which may have a name (if it is a selector) or
- * be anonymous (like a text span).
- */
-interface HTMLNode extends TmplAstNode {
-  tagName?: string;
-  name?: string;
-}
-
 type ExpressionIdentifier = PropertyIdentifier | MethodIdentifier;
 type TmplTarget = TmplAstReference | TmplAstVariable | TmplAstLetDeclaration;
 type TargetIdentifier = ReferenceIdentifier | VariableIdentifier | LetDeclarationIdentifier;
 type TargetIdentifierMap = Map<TmplTarget, TargetIdentifier>;
 
 /**
- * Visits the AST of an Angular template syntax expression, finding interesting
- * entities (variable references, etc.). Creates an array of Entities found in
- * the expression, with the location of the Entities being relative to the
- * expression.
- *
- * Visiting `text {{prop}}` will return
- * `[TopLevelIdentifier {name: 'prop', span: {start: 7, end: 11}}]`.
- */
-class ExpressionVisitor extends RecursiveAstVisitor {
-  readonly identifiers: ExpressionIdentifier[] = [];
-  readonly errors: Error[] = [];
-
-  private constructor(
-    private readonly expressionStr: string,
-    private readonly absoluteOffset: number,
-    private readonly boundTemplate: BoundTarget<ComponentMeta>,
-    private readonly targetToIdentifier: (target: TmplTarget) => TargetIdentifier | null,
-  ) {
-    super();
-  }
-
-  /**
-   * Returns identifiers discovered in an expression.
-   *
-   * @param ast expression AST to visit
-   * @param source expression AST source code
-   * @param absoluteOffset absolute byte offset from start of the file to the start of the AST
-   * source code.
-   * @param boundTemplate bound target of the entire template, which can be used to query for the
-   * entities expressions target.
-   * @param targetToIdentifier closure converting a template target node to its identifier.
-   */
-  static getIdentifiers(
-    ast: AST,
-    source: string,
-    absoluteOffset: number,
-    boundTemplate: BoundTarget<ComponentMeta>,
-    targetToIdentifier: (target: TmplTarget) => TargetIdentifier | null,
-  ): {identifiers: TopLevelIdentifier[]; errors: Error[]} {
-    const visitor = new ExpressionVisitor(
-      source,
-      absoluteOffset,
-      boundTemplate,
-      targetToIdentifier,
-    );
-    visitor.visit(ast);
-    return {identifiers: visitor.identifiers, errors: visitor.errors};
-  }
-
-  override visit(ast: AST) {
-    ast.visit(this);
-  }
-
-  override visitPropertyRead(ast: PropertyRead, context: {}) {
-    this.visitIdentifier(ast, IdentifierKind.Property);
-    super.visitPropertyRead(ast, context);
-  }
-
-  override visitPropertyWrite(ast: PropertyWrite, context: {}) {
-    this.visitIdentifier(ast, IdentifierKind.Property);
-    super.visitPropertyWrite(ast, context);
-  }
-
-  /**
-   * Visits an identifier, adding it to the identifier store if it is useful for indexing.
-   *
-   * @param ast expression AST the identifier is in
-   * @param kind identifier kind
-   */
-  private visitIdentifier(
-    ast: AST & {name: string; receiver: AST},
-    kind: ExpressionIdentifier['kind'],
-  ) {
-    // The definition of a non-top-level property such as `bar` in `{{foo.bar}}` is currently
-    // impossible to determine by an indexer and unsupported by the indexing module.
-    // The indexing module also does not currently support references to identifiers declared in the
-    // template itself, which have a non-null expression target.
-    if (!(ast.receiver instanceof ImplicitReceiver)) {
-      return;
-    }
-
-    // The source span of the requested AST starts at a location that is offset from the expression.
-    let identifierStart = ast.sourceSpan.start - this.absoluteOffset;
-
-    if (ast instanceof PropertyRead || ast instanceof PropertyWrite) {
-      // For `PropertyRead` and `PropertyWrite`, the identifier starts at the `nameSpan`, not
-      // necessarily the `sourceSpan`.
-      identifierStart = ast.nameSpan.start - this.absoluteOffset;
-    }
-
-    if (!this.expressionStr.substring(identifierStart).startsWith(ast.name)) {
-      this.errors.push(
-        new Error(
-          `Impossible state: "${ast.name}" not found in "${this.expressionStr}" at location ${identifierStart}`,
-        ),
-      );
-      return;
-    }
-
-    // Join the relative position of the expression within a node with the absolute position
-    // of the node to get the absolute position of the expression in the source code.
-    const absoluteStart = this.absoluteOffset + identifierStart;
-    const span = new AbsoluteSourceSpan(absoluteStart, absoluteStart + ast.name.length);
-
-    const targetAst = this.boundTemplate.getExpressionTarget(ast);
-    const target = targetAst ? this.targetToIdentifier(targetAst) : null;
-    const identifier = {
-      name: ast.name,
-      span,
-      kind,
-      target,
-    } as ExpressionIdentifier;
-
-    this.identifiers.push(identifier);
-  }
-}
-
-/**
  * Visits the AST of a parsed Angular template. Discovers and stores
  * identifiers of interest, deferring to an `ExpressionVisitor` as needed.
  */
-class TemplateVisitor extends TmplAstRecursiveVisitor {
+class TemplateVisitor extends CombinedRecursiveAstVisitor {
   // Identifiers of interest found in the template.
   readonly identifiers = new Set<TopLevelIdentifier>();
   readonly errors: Error[] = [];
+  private currentAstWithSource: {source: string | null; absoluteOffset: number} | null = null;
 
   // Map of targets in a template to their identifiers.
   private readonly targetIdentifierCache: TargetIdentifierMap = new Map();
@@ -218,19 +78,6 @@ class TemplateVisitor extends TmplAstRecursiveVisitor {
   }
 
   /**
-   * Visits a node in the template.
-   *
-   * @param node node to visit
-   */
-  visit(node: HTMLNode) {
-    node.visit(this);
-  }
-
-  visitAll(nodes: TmplAstNode[]) {
-    nodes.forEach((node) => this.visit(node));
-  }
-
-  /**
    * Add an identifier for an HTML element and visit its children recursively.
    *
    * @param element
@@ -240,131 +87,38 @@ class TemplateVisitor extends TmplAstRecursiveVisitor {
     if (elementIdentifier !== null) {
       this.identifiers.add(elementIdentifier);
     }
-
-    this.visitAll(element.references);
-    this.visitAll(element.inputs);
-    this.visitAll(element.attributes);
-    this.visitAll(element.directives);
-    this.visitAll(element.children);
-    this.visitAll(element.outputs);
+    super.visitElement(element);
   }
 
   override visitTemplate(template: TmplAstTemplate) {
     const templateIdentifier = this.elementOrTemplateToIdentifier(template);
-
     if (templateIdentifier !== null) {
       this.identifiers.add(templateIdentifier);
     }
-
-    this.visitAll(template.directives);
-    this.visitAll(template.variables);
-    this.visitAll(template.attributes);
-    this.visitAll(template.templateAttrs);
-    this.visitAll(template.children);
-    this.visitAll(template.references);
+    super.visitTemplate(template);
   }
 
-  override visitBoundAttribute(attribute: TmplAstBoundAttribute) {
-    // If the bound attribute has no value, it cannot have any identifiers in the value expression.
-    if (attribute.valueSpan === undefined) {
-      return;
-    }
-
-    const {identifiers, errors} = ExpressionVisitor.getIdentifiers(
-      attribute.value,
-      attribute.valueSpan.toString(),
-      attribute.valueSpan.start.offset,
-      this.boundTemplate,
-      this.targetToIdentifier.bind(this),
-    );
-    identifiers.forEach((id) => this.identifiers.add(id));
-    this.errors.push(...errors);
-  }
-  override visitBoundEvent(attribute: TmplAstBoundEvent) {
-    this.visitExpression(attribute.handler);
-  }
-  override visitBoundText(text: TmplAstBoundText) {
-    this.visitExpression(text.value);
-  }
   override visitReference(reference: TmplAstReference) {
     const referenceIdentifier = this.targetToIdentifier(reference);
-    if (referenceIdentifier === null) {
-      return;
+    if (referenceIdentifier !== null) {
+      this.identifiers.add(referenceIdentifier);
     }
-
-    this.identifiers.add(referenceIdentifier);
+    super.visitReference(reference);
   }
   override visitVariable(variable: TmplAstVariable) {
     const variableIdentifier = this.targetToIdentifier(variable);
-    if (variableIdentifier === null) {
-      return;
+    if (variableIdentifier !== null) {
+      this.identifiers.add(variableIdentifier);
     }
-
-    this.identifiers.add(variableIdentifier);
-  }
-
-  override visitDeferredBlock(deferred: TmplAstDeferredBlock) {
-    deferred.visitAll(this);
-  }
-
-  override visitDeferredBlockPlaceholder(block: TmplAstDeferredBlockPlaceholder) {
-    this.visitAll(block.children);
-  }
-
-  override visitDeferredBlockError(block: TmplAstDeferredBlockError) {
-    this.visitAll(block.children);
-  }
-
-  override visitDeferredBlockLoading(block: TmplAstDeferredBlockLoading) {
-    this.visitAll(block.children);
-  }
-
-  override visitDeferredTrigger(trigger: TmplAstDeferredTrigger) {
-    if (trigger instanceof TmplAstBoundDeferredTrigger) {
-      this.visitExpression(trigger.value);
-    }
-  }
-
-  override visitSwitchBlock(block: TmplAstSwitchBlock) {
-    this.visitExpression(block.expression);
-    this.visitAll(block.cases);
-  }
-
-  override visitSwitchBlockCase(block: TmplAstSwitchBlockCase) {
-    block.expression && this.visitExpression(block.expression);
-    this.visitAll(block.children);
-  }
-
-  override visitForLoopBlock(block: TmplAstForLoopBlock): void {
-    block.item.visit(this);
-    this.visitAll(block.contextVariables);
-    this.visitExpression(block.expression);
-    this.visitAll(block.children);
-    block.empty?.visit(this);
-  }
-
-  override visitForLoopBlockEmpty(block: TmplAstForLoopBlockEmpty): void {
-    this.visitAll(block.children);
-  }
-
-  override visitIfBlock(block: TmplAstIfBlock): void {
-    this.visitAll(block.branches);
-  }
-
-  override visitIfBlockBranch(block: TmplAstIfBlockBranch): void {
-    block.expression && this.visitExpression(block.expression);
-    block.expressionAlias?.visit(this);
-    this.visitAll(block.children);
+    super.visitVariable(variable);
   }
 
   override visitLetDeclaration(decl: TmplAstLetDeclaration): void {
     const identifier = this.targetToIdentifier(decl);
-
     if (identifier !== null) {
       this.identifiers.add(identifier);
     }
-
-    this.visitExpression(decl.value);
+    super.visitLetDeclaration(decl);
   }
 
   override visitComponent(component: TmplAstComponent): void {
@@ -373,6 +127,26 @@ class TemplateVisitor extends TmplAstRecursiveVisitor {
 
   override visitDirective(directive: TmplAstDirective): void {
     throw new Error('TODO');
+  }
+
+  override visitPropertyRead(ast: PropertyRead) {
+    this.visitIdentifier(ast, IdentifierKind.Property);
+    super.visitPropertyRead(ast, null);
+  }
+
+  override visitPropertyWrite(ast: PropertyWrite) {
+    this.visitIdentifier(ast, IdentifierKind.Property);
+    super.visitPropertyWrite(ast, null);
+  }
+
+  override visitBoundAttribute(attribute: TmplAstBoundAttribute): void {
+    const previous = this.currentAstWithSource;
+    this.currentAstWithSource = {
+      source: attribute.valueSpan?.toString() || null,
+      absoluteOffset: attribute.valueSpan ? attribute.valueSpan.start.offset : -1,
+    };
+    this.visit(attribute.value instanceof ASTWithSource ? attribute.value.ast : attribute.value);
+    this.currentAstWithSource = previous;
   }
 
   /** Creates an identifier for a template element or template node. */
@@ -530,22 +304,74 @@ class TemplateVisitor extends TmplAstRecursiveVisitor {
    *
    * @param node node whose expression to visit
    */
-  private visitExpression(ast: AST) {
-    // Only include ASTs that have information about their source and absolute source spans.
-    if (ast instanceof ASTWithSource && ast.source !== null) {
-      // Make target to identifier mapping closure stateful to this visitor instance.
-      const targetToIdentifier = this.targetToIdentifier.bind(this);
-      const absoluteOffset = ast.sourceSpan.start;
-      const {identifiers, errors} = ExpressionVisitor.getIdentifiers(
-        ast,
-        ast.source,
-        absoluteOffset,
-        this.boundTemplate,
-        targetToIdentifier,
-      );
-      identifiers.forEach((id) => this.identifiers.add(id));
-      this.errors.push(...errors);
+  override visit(node: TmplAstNode | AST): void {
+    if (node instanceof ASTWithSource) {
+      const previous = this.currentAstWithSource;
+      this.currentAstWithSource = {source: node.source, absoluteOffset: node.sourceSpan.start};
+      super.visit(node.ast);
+      this.currentAstWithSource = previous;
+    } else {
+      super.visit(node);
     }
+  }
+
+  /**
+   * Visits an identifier, adding it to the identifier store if it is useful for indexing.
+   *
+   * @param ast expression AST the identifier is in
+   * @param kind identifier kind
+   */
+  private visitIdentifier(
+    ast: AST & {name: string; receiver: AST},
+    kind: ExpressionIdentifier['kind'],
+  ) {
+    // Only handle identifiers in expressions that have a source location.
+    if (this.currentAstWithSource === null || this.currentAstWithSource.source === null) {
+      return;
+    }
+
+    // The definition of a non-top-level property such as `bar` in `{{foo.bar}}` is currently
+    // impossible to determine by an indexer and unsupported by the indexing module.
+    // The indexing module also does not currently support references to identifiers declared in the
+    // template itself, which have a non-null expression target.
+    if (!(ast.receiver instanceof ImplicitReceiver)) {
+      return;
+    }
+
+    const {absoluteOffset, source: expressionStr} = this.currentAstWithSource;
+
+    // The source span of the requested AST starts at a location that is offset from the expression.
+    let identifierStart = ast.sourceSpan.start - absoluteOffset;
+
+    if (ast instanceof PropertyRead || ast instanceof PropertyWrite) {
+      // For `PropertyRead` and `PropertyWrite`, the identifier starts at the `nameSpan`, not
+      // necessarily the `sourceSpan`.
+      identifierStart = ast.nameSpan.start - absoluteOffset;
+    }
+
+    if (!expressionStr.substring(identifierStart).startsWith(ast.name)) {
+      this.errors.push(
+        new Error(
+          `Impossible state: "${ast.name}" not found in "${expressionStr}" at location ${identifierStart}`,
+        ),
+      );
+      return;
+    }
+
+    // Join the relative position of the expression within a node with the absolute position
+    // of the node to get the absolute position of the expression in the source code.
+    const absoluteStart = absoluteOffset + identifierStart;
+    const span = new AbsoluteSourceSpan(absoluteStart, absoluteStart + ast.name.length);
+    const targetAst = this.boundTemplate.getExpressionTarget(ast);
+    const target = targetAst ? this.targetToIdentifier(targetAst) : null;
+    const identifier: ExpressionIdentifier = {
+      name: ast.name,
+      span,
+      kind,
+      target,
+    };
+
+    this.identifiers.add(identifier);
   }
 }
 
@@ -561,7 +387,7 @@ export function getTemplateIdentifiers(boundTemplate: BoundTarget<ComponentMeta>
 } {
   const visitor = new TemplateVisitor(boundTemplate);
   if (boundTemplate.target.template !== undefined) {
-    visitor.visitAll(boundTemplate.target.template);
+    tmplAstVisitAll(visitor, boundTemplate.target.template);
   }
   return {identifiers: visitor.identifiers, errors: visitor.errors};
 }

--- a/packages/compiler-cli/src/ngtsc/scope/src/selectorless_scope.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/selectorless_scope.ts
@@ -90,38 +90,28 @@ export class SelectorlessComponentScopeReader implements ComponentScopeReader {
       }
 
       for (const stmt of current.statements) {
-        switch (true) {
-          case ts.isImportDeclaration(stmt):
-            if (stmt.importClause !== undefined && !stmt.importClause.isTypeOnly) {
-              const clause = stmt.importClause;
-              if (clause.namedBindings !== undefined && ts.isNamedImports(clause.namedBindings)) {
-                for (const element of clause.namedBindings.elements) {
-                  if (!element.isTypeOnly) {
-                    result.set(element.name.text, element.name);
-                  }
-                }
-              }
-              if (clause.name !== undefined) {
-                result.set(clause.name.text, clause.name);
+        if (this.reflector.isClass(stmt)) {
+          result.set(stmt.name.text, stmt.name);
+          continue;
+        }
+
+        if (
+          ts.isImportDeclaration(stmt) &&
+          stmt.importClause !== undefined &&
+          !stmt.importClause.isTypeOnly
+        ) {
+          const clause = stmt.importClause;
+          if (clause.namedBindings !== undefined && ts.isNamedImports(clause.namedBindings)) {
+            for (const element of clause.namedBindings.elements) {
+              if (!element.isTypeOnly) {
+                result.set(element.name.text, element.name);
               }
             }
-            break;
-
-          case ts.isVariableStatement(stmt):
-            for (const decl of stmt.declarationList.declarations) {
-              if (
-                ts.isIdentifier(decl.name) &&
-                decl.initializer !== undefined &&
-                ts.isIdentifier(decl.initializer)
-              ) {
-                result.set(decl.name.text, decl.initializer);
-              }
-            }
-            break;
-
-          case this.reflector.isClass(stmt):
-            result.set(stmt.name.text, stmt.name);
-            break;
+          }
+          if (clause.name !== undefined) {
+            result.set(clause.name.text, clause.name);
+          }
+          continue;
         }
       }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/oob.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/oob.ts
@@ -697,7 +697,8 @@ export class OutOfBandDiagnosticRecorderImpl implements OutOfBandDiagnosticRecor
         ts.DiagnosticCategory.Error,
         ngErrorCode(ErrorCode.MISSING_NAMED_TEMPLATE_DEPENDENCY),
         // Wording is meant to mimic the wording TS uses in their diagnostic for missing symbols.
-        `Cannot find name "${node instanceof TmplAstDirective ? node.name : node.componentName}".`,
+        `Cannot find name "${node instanceof TmplAstDirective ? node.name : node.componentName}". ` +
+          `Selectorless references are only supported to classes or non-type import statements.`,
       ),
     );
   }

--- a/packages/compiler-cli/test/ngtsc/selectorless_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/selectorless_spec.ts
@@ -37,7 +37,9 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe('Cannot find name "Dep".');
+      expect(diags[0].messageText).toBe(
+        'Cannot find name "Dep". Selectorless references are only supported to classes or non-type import statements.',
+      );
     });
 
     it('should report a selectorless directive reference that is not imported', () => {
@@ -53,7 +55,67 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe('Cannot find name "Dep".');
+      expect(diags[0].messageText).toBe(
+        'Cannot find name "Dep". Selectorless references are only supported to classes or non-type import statements.',
+      );
+    });
+
+    it('should report a selectorless reference that is imported through a single type-only import', () => {
+      env.write(
+        'dep.ts',
+        `
+          import {Component} from '@angular/core';
+
+          @Component({template: ''})
+          export class Dep {}
+        `,
+      );
+
+      env.write(
+        'test.ts',
+        `
+          import {Component} from '@angular/core';
+          import {type Dep} from './dep';
+
+          @Component({template: '<Dep/>'})
+          export class Comp {}
+        `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(
+        'Cannot find name "Dep". Selectorless references are only supported to classes or non-type import statements.',
+      );
+    });
+
+    it('should report a selectorless reference that is imported through an entirely type-only import', () => {
+      env.write(
+        'dep.ts',
+        `
+          import {Component} from '@angular/core';
+
+          @Component({template: ''})
+          export class Dep {}
+        `,
+      );
+
+      env.write(
+        'test.ts',
+        `
+          import {Component} from '@angular/core';
+          import type {Dep} from './dep';
+
+          @Component({template: '<Dep/>'})
+          export class Comp {}
+        `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(
+        'Cannot find name "Dep". Selectorless references are only supported to classes or non-type import statements.',
+      );
     });
 
     it('should report a selectorless pipe reference that is not imported', () => {
@@ -801,46 +863,6 @@ runInEachFileSystem(() => {
           import DepPipe from './pipe';
 
           @Component({template: '<DepComp @DepDir>{{123 | DepPipe}}</DepComp>'})
-          export class Comp {}
-        `,
-      );
-
-      const diags = env.driveDiagnostics();
-      expect(diags.map((d) => d.messageText)).toEqual([]);
-    });
-
-    it('should be able to alias imports of selectorless dependencies through variables', () => {
-      env.write(
-        'dep.ts',
-        `
-          import {Directive, Component, Pipe} from '@angular/core';
-
-          @Component({template: ''})
-          export class DepComp {}
-
-          @Directive()
-          export class DepDir {}
-
-          @Pipe({name: 'dep'})
-          export class DepPipe {
-            transform(value: number) {
-              return value;
-            }
-          }
-        `,
-      );
-
-      env.write(
-        'test.ts',
-        `
-          import {Component} from '@angular/core';
-          import {DepComp, DepDir, DepPipe} from './dep';
-
-          const AliasedDepComp = DepComp;
-          const AliasedDepDir = DepDir;
-          const AliasedDepPipe = DepPipe;
-
-          @Component({template: '<AliasedDepComp @AliasedDepDir>{{123 | AliasedDepPipe}}</AliasedDepComp>'})
           export class Comp {}
         `,
       );

--- a/packages/compiler/src/combined_visitor.ts
+++ b/packages/compiler/src/combined_visitor.ts
@@ -1,0 +1,151 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {AST, ASTWithSource, RecursiveAstVisitor} from './expression_parser/ast';
+import * as t from './render3/r3_ast';
+
+/**
+ * Visitor that traverses all template and expression AST nodes in a template.
+ * Useful for cases where every single node needs to be visited.
+ */
+export class CombinedRecursiveAstVisitor extends RecursiveAstVisitor implements t.RecursiveVisitor {
+  override visit(node: AST | t.Node): void {
+    if (node instanceof ASTWithSource) {
+      this.visit(node.ast);
+    } else {
+      node.visit(this);
+    }
+  }
+
+  visitElement(element: t.Element): void {
+    this.visitAllTemplateNodes(element.attributes);
+    this.visitAllTemplateNodes(element.inputs);
+    this.visitAllTemplateNodes(element.outputs);
+    this.visitAllTemplateNodes(element.directives);
+    this.visitAllTemplateNodes(element.references);
+    this.visitAllTemplateNodes(element.children);
+  }
+
+  visitTemplate(template: t.Template): void {
+    this.visitAllTemplateNodes(template.attributes);
+    this.visitAllTemplateNodes(template.inputs);
+    this.visitAllTemplateNodes(template.outputs);
+    this.visitAllTemplateNodes(template.directives);
+    this.visitAllTemplateNodes(template.templateAttrs);
+    this.visitAllTemplateNodes(template.variables);
+    this.visitAllTemplateNodes(template.references);
+    this.visitAllTemplateNodes(template.children);
+  }
+
+  visitContent(content: t.Content): void {
+    this.visitAllTemplateNodes(content.children);
+  }
+
+  visitBoundAttribute(attribute: t.BoundAttribute): void {
+    this.visit(attribute.value);
+  }
+
+  visitBoundEvent(attribute: t.BoundEvent): void {
+    this.visit(attribute.handler);
+  }
+
+  visitBoundText(text: t.BoundText): void {
+    this.visit(text.value);
+  }
+
+  visitIcu(icu: t.Icu): void {
+    Object.keys(icu.vars).forEach((key) => this.visit(icu.vars[key]));
+    Object.keys(icu.placeholders).forEach((key) => this.visit(icu.placeholders[key]));
+  }
+
+  visitDeferredBlock(deferred: t.DeferredBlock): void {
+    deferred.visitAll(this);
+  }
+
+  visitDeferredTrigger(trigger: t.DeferredTrigger): void {
+    if (trigger instanceof t.BoundDeferredTrigger) {
+      this.visit(trigger.value);
+    }
+  }
+
+  visitDeferredBlockPlaceholder(block: t.DeferredBlockPlaceholder): void {
+    this.visitAllTemplateNodes(block.children);
+  }
+
+  visitDeferredBlockError(block: t.DeferredBlockError): void {
+    this.visitAllTemplateNodes(block.children);
+  }
+
+  visitDeferredBlockLoading(block: t.DeferredBlockLoading): void {
+    this.visitAllTemplateNodes(block.children);
+  }
+
+  visitSwitchBlock(block: t.SwitchBlock): void {
+    this.visit(block.expression);
+    this.visitAllTemplateNodes(block.cases);
+  }
+
+  visitSwitchBlockCase(block: t.SwitchBlockCase): void {
+    block.expression && this.visit(block.expression);
+    this.visitAllTemplateNodes(block.children);
+  }
+
+  visitForLoopBlock(block: t.ForLoopBlock): void {
+    block.item.visit(this);
+    this.visitAllTemplateNodes(block.contextVariables);
+    this.visit(block.expression);
+    this.visitAllTemplateNodes(block.children);
+    block.empty?.visit(this);
+  }
+
+  visitForLoopBlockEmpty(block: t.ForLoopBlockEmpty): void {
+    this.visitAllTemplateNodes(block.children);
+  }
+
+  visitIfBlock(block: t.IfBlock): void {
+    this.visitAllTemplateNodes(block.branches);
+  }
+
+  visitIfBlockBranch(block: t.IfBlockBranch): void {
+    block.expression && this.visit(block.expression);
+    block.expressionAlias?.visit(this);
+    this.visitAllTemplateNodes(block.children);
+  }
+
+  visitLetDeclaration(decl: t.LetDeclaration): void {
+    this.visit(decl.value);
+  }
+
+  visitComponent(component: t.Component): void {
+    this.visitAllTemplateNodes(component.attributes);
+    this.visitAllTemplateNodes(component.inputs);
+    this.visitAllTemplateNodes(component.outputs);
+    this.visitAllTemplateNodes(component.directives);
+    this.visitAllTemplateNodes(component.references);
+    this.visitAllTemplateNodes(component.children);
+  }
+
+  visitDirective(directive: t.Directive): void {
+    this.visitAllTemplateNodes(directive.attributes);
+    this.visitAllTemplateNodes(directive.inputs);
+    this.visitAllTemplateNodes(directive.outputs);
+    this.visitAllTemplateNodes(directive.references);
+  }
+
+  visitVariable(variable: t.Variable): void {}
+  visitReference(reference: t.Reference): void {}
+  visitTextAttribute(attribute: t.TextAttribute): void {}
+  visitText(text: t.Text): void {}
+  visitUnknownBlock(block: t.UnknownBlock): void {}
+
+  protected visitAllTemplateNodes(nodes: t.Node[]): void {
+    for (const node of nodes) {
+      this.visit(node);
+    }
+  }
+}

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -237,6 +237,7 @@ export {
   parseTemplate,
   ParseTemplateOptions,
 } from './render3/view/template';
+export {CombinedRecursiveAstVisitor} from './combined_visitor';
 
 // Note: BindingParser is intentionally exported as a type only, because it should
 // be constructed through `makeBindingParser`, rather than its constructor.

--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -203,6 +203,21 @@ export class KeyedWrite extends AST {
   }
 }
 
+/** Possible types for a pipe. */
+export enum BindingPipeType {
+  /**
+   * Pipe is being referenced by its name, for example:
+   * `@Pipe({name: 'foo'}) class FooPipe` and `{{123 | foo}}`.
+   */
+  ReferencedByName,
+
+  /**
+   * Pipe is being referenced by its class name, for example:
+   * `@Pipe() class FooPipe` and `{{123 | FooPipe}}`.
+   */
+  ReferencedDirectly,
+}
+
 export class BindingPipe extends ASTWithName {
   constructor(
     span: ParseSpan,
@@ -210,6 +225,7 @@ export class BindingPipe extends ASTWithName {
     public exp: AST,
     public name: string,
     public args: any[],
+    readonly type: BindingPipeType,
     nameSpan: AbsoluteSourceSpan,
   ) {
     super(span, sourceSpan, nameSpan);

--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -797,7 +797,7 @@ export function visitAll<Result>(visitor: Visitor<Result>, nodes: Node[]): Resul
   const result: Result[] = [];
   if (visitor.visit) {
     for (const node of nodes) {
-      visitor.visit(node) || node.visit(visitor);
+      visitor.visit(node);
     }
   } else {
     for (const node of nodes) {

--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -65,6 +65,7 @@ import {
 } from './t2_api';
 import {parseTemplate} from './template';
 import {createCssSelectorFromNode} from './util';
+import {CombinedRecursiveAstVisitor} from '../../combined_visitor';
 
 /**
  * Computes a difference between full list (first argument) and
@@ -779,8 +780,8 @@ class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
  * Expressions are visited by the superclass `RecursiveAstVisitor`, with custom logic provided
  * by overridden methods from that visitor.
  */
-class TemplateBinder extends RecursiveAstVisitor implements Visitor {
-  private visitNode: (node: Node) => void;
+class TemplateBinder extends CombinedRecursiveAstVisitor {
+  private visitNode = (node: Node) => node.visit(this);
 
   private constructor(
     private bindings: Map<AST, TemplateEntity>,
@@ -794,20 +795,6 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
     private level: number,
   ) {
     super();
-
-    // Save a bit of processing time by constructing this closure in advance.
-    this.visitNode = (node: Node) => node.visit(this);
-  }
-
-  // This method is defined to reconcile the type of TemplateBinder since both
-  // RecursiveAstVisitor and Visitor define the visit() method in their
-  // interfaces.
-  override visit(node: AST | Node, context?: any) {
-    if (node instanceof AST) {
-      node.visit(this, context);
-    } else {
-      node.visit(this);
-    }
   }
 
   /**
@@ -897,16 +884,7 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
     }
   }
 
-  visitElement(element: Element) {
-    // Visit the inputs, outputs, and children of the element.
-    element.inputs.forEach(this.visitNode);
-    element.outputs.forEach(this.visitNode);
-    element.directives.forEach(this.visitNode);
-    element.children.forEach(this.visitNode);
-    element.references.forEach(this.visitNode);
-  }
-
-  visitTemplate(template: Template) {
+  override visitTemplate(template: Template) {
     // First, visit inputs, outputs and template attributes of the template node.
     template.inputs.forEach(this.visitNode);
     template.outputs.forEach(this.visitNode);
@@ -918,55 +896,21 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
     this.ingestScopedNode(template);
   }
 
-  visitVariable(variable: Variable) {
+  override visitVariable(variable: Variable) {
     // Register the `Variable` as a symbol in the current `Template`.
     if (this.rootNode !== null) {
       this.symbols.set(variable, this.rootNode);
     }
   }
 
-  visitReference(reference: Reference) {
+  override visitReference(reference: Reference) {
     // Register the `Reference` as a symbol in the current `Template`.
     if (this.rootNode !== null) {
       this.symbols.set(reference, this.rootNode);
     }
   }
 
-  visitComponent(component: Component) {
-    component.inputs.forEach(this.visitNode);
-    component.outputs.forEach(this.visitNode);
-    component.directives.forEach(this.visitNode);
-    component.children.forEach(this.visitNode);
-    component.references.forEach(this.visitNode);
-  }
-
-  visitDirective(directive: Directive) {
-    directive.inputs.forEach(this.visitNode);
-    directive.outputs.forEach(this.visitNode);
-    directive.references.forEach(this.visitNode);
-  }
-
-  // Unused template visitors
-  visitText(text: Text) {}
-  visitTextAttribute(attribute: TextAttribute) {}
-  visitUnknownBlock(block: UnknownBlock) {}
-  visitDeferredTrigger(): void {}
-  visitIcu(icu: Icu): void {
-    Object.keys(icu.vars).forEach((key) => icu.vars[key].visit(this));
-    Object.keys(icu.placeholders).forEach((key) => icu.placeholders[key].visit(this));
-  }
-
-  // The remaining visitors are concerned with processing AST expressions within template bindings
-
-  visitBoundAttribute(attribute: BoundAttribute) {
-    attribute.value.visit(this);
-  }
-
-  visitBoundEvent(event: BoundEvent) {
-    event.handler.visit(this);
-  }
-
-  visitDeferredBlock(deferred: DeferredBlock) {
+  override visitDeferredBlock(deferred: DeferredBlock) {
     this.ingestScopedNode(deferred);
     deferred.triggers.when?.value.visit(this);
     deferred.prefetchTriggers.when?.value.visit(this);
@@ -977,57 +921,44 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
     deferred.error && this.visitNode(deferred.error);
   }
 
-  visitDeferredBlockPlaceholder(block: DeferredBlockPlaceholder) {
+  override visitDeferredBlockPlaceholder(block: DeferredBlockPlaceholder) {
     this.ingestScopedNode(block);
   }
 
-  visitDeferredBlockError(block: DeferredBlockError) {
+  override visitDeferredBlockError(block: DeferredBlockError) {
     this.ingestScopedNode(block);
   }
 
-  visitDeferredBlockLoading(block: DeferredBlockLoading) {
+  override visitDeferredBlockLoading(block: DeferredBlockLoading) {
     this.ingestScopedNode(block);
   }
 
-  visitSwitchBlock(block: SwitchBlock) {
-    block.expression.visit(this);
-    block.cases.forEach(this.visitNode);
-  }
-
-  visitSwitchBlockCase(block: SwitchBlockCase) {
+  override visitSwitchBlockCase(block: SwitchBlockCase) {
     block.expression?.visit(this);
     this.ingestScopedNode(block);
   }
 
-  visitForLoopBlock(block: ForLoopBlock) {
+  override visitForLoopBlock(block: ForLoopBlock) {
     block.expression.visit(this);
     this.ingestScopedNode(block);
     block.empty?.visit(this);
   }
 
-  visitForLoopBlockEmpty(block: ForLoopBlockEmpty) {
+  override visitForLoopBlockEmpty(block: ForLoopBlockEmpty) {
     this.ingestScopedNode(block);
   }
 
-  visitIfBlock(block: IfBlock) {
-    block.branches.forEach((node) => node.visit(this));
-  }
-
-  visitIfBlockBranch(block: IfBlockBranch) {
+  override visitIfBlockBranch(block: IfBlockBranch) {
     block.expression?.visit(this);
     this.ingestScopedNode(block);
   }
 
-  visitContent(content: Content) {
+  override visitContent(content: Content) {
     this.ingestScopedNode(content);
   }
 
-  visitBoundText(text: BoundText) {
-    text.value.visit(this);
-  }
-
-  visitLetDeclaration(decl: LetDeclaration) {
-    decl.value.visit(this);
+  override visitLetDeclaration(decl: LetDeclaration) {
+    super.visitLetDeclaration(decl);
 
     if (this.rootNode !== null) {
       this.symbols.set(decl, this.rootNode);

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -148,7 +148,8 @@ export function parseTemplate(
   options: ParseTemplateOptions = {},
 ): ParsedTemplate {
   const {interpolationConfig, preserveWhitespaces, enableI18nLegacyMessageIdFormat} = options;
-  const bindingParser = makeBindingParser(interpolationConfig);
+  const selectorlessEnabled = options.enableSelectorless ?? false;
+  const bindingParser = makeBindingParser(interpolationConfig, selectorlessEnabled);
   const htmlParser = new HtmlParser();
   const parseResult = htmlParser.parse(template, templateUrl, {
     leadingTriviaChars: LEADING_TRIVIA_CHARS,
@@ -156,7 +157,7 @@ export function parseTemplate(
     tokenizeExpansionForms: true,
     tokenizeBlocks: options.enableBlockSyntax ?? true,
     tokenizeLet: options.enableLetSyntax ?? true,
-    selectorlessEnabled: options.enableSelectorless ?? false,
+    selectorlessEnabled,
   });
 
   if (
@@ -293,8 +294,14 @@ const elementRegistry = new DomElementSchemaRegistry();
  */
 export function makeBindingParser(
   interpolationConfig: InterpolationConfig = DEFAULT_INTERPOLATION_CONFIG,
+  selectorlessEnabled = false,
 ): BindingParser {
-  return new BindingParser(new Parser(new Lexer()), interpolationConfig, elementRegistry, []);
+  return new BindingParser(
+    new Parser(new Lexer(), selectorlessEnabled),
+    interpolationConfig,
+    elementRegistry,
+    [],
+  );
 }
 
 /**

--- a/packages/language-service/src/outlining_spans.ts
+++ b/packages/language-service/src/outlining_spans.ts
@@ -93,5 +93,6 @@ class BlockVisitor extends TmplAstRecursiveVisitor {
     ) {
       this.blocks.push(node);
     }
+    node.visit(this);
   }
 }

--- a/packages/language-service/src/template_target.ts
+++ b/packages/language-service/src/template_target.ts
@@ -627,11 +627,11 @@ class TemplateTargetVisitor implements TmplAstVisitor {
   }
 
   visitComponent(component: TmplAstComponent) {
-    throw new Error('TODO');
+    // TODO(crisbeto): integrate selectorless
   }
 
   visitDirective(directive: TmplAstDirective) {
-    throw new Error('TODO');
+    // TODO(crisbeto): integrate selectorless
   }
 
   visitAll(nodes: TmplAstNode[]) {


### PR DESCRIPTION
Includes the following cleanups in the compiler:

### refactor(compiler): consolidate combined recursive visitors 
We have several cases where we need a visitor that traverses both the template and expression ASTs fully. Currently we're re-implementing the visitor each time which means that we need to update multiple visitors every time something changes.

These changes add a single base class that we can reuse to simplify such cases in the future.

### refactor(compiler): detect directly referenced pipes during parsing 
Moves the logic to detect directly referenced pipes into the compiler so that we don't have to do it ad-hoc.

### refactor(compiler-cli): support selectorless in the template indexer 
Handles the new selectorless nodes when indexing a template.

### refactor(compiler-cli): do not resolve selectorless references from variables
Based on some recent discussions, these changes remove the logic that resolves selectorless references from variables. It also updates the wording so it's clearer where selectorless references are supported.