### PR TITLE
ci: disable renovate run on `20.0.x`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "baseBranches": ["main", "20.0.x"],
+  "baseBranches": ["main"],
   "enabledManagers": ["npm", "bazel", "github-actions", "nvm"],
   "rangeStrategy": "replace",
   "pinDigests": true,

--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
   "lockFileMaintenance": {
     "enabled": true
   },
-  "labels": ["area: build & ci", "action: merge"],
+  "labels": ["target: minor", "area: build & ci", "action: merge"],
   "postUpgradeTasks": {
     "commands": [
       "git restore .yarn/releases/yarn-1.22.22.cjs pnpm-lock.yaml",


### PR DESCRIPTION
`baseBraches` is not supported when running Renovate in Fork mode.

See: https://docs.renovatebot.com/getting-started/running/#forking-renovate-app and https://github.com/renovatebot/renovate/issues/28700
