### PR TITLE
docs: rename `@nodoc` to `@docs-private`

### DIFF
--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -270,7 +270,6 @@ export class HashLocationStrategy extends LocationStrategy implements OnDestroy 
     getState(): unknown;
     // (undocumented)
     historyGo(relativePosition?: number): void;
-    // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
     onPopState(fn: LocationChangeListener): void;
@@ -396,7 +395,6 @@ class Location_2 implements OnDestroy {
     historyGo(relativePosition?: number): void;
     isCurrentPathEqualTo(path: string, query?: string): boolean;
     static joinWithSlash: (start: string, end: string) => string;
-    // (undocumented)
     ngOnDestroy(): void;
     normalize(url: string): string;
     static normalizeQueryParams: (params: string) => string;
@@ -504,11 +502,8 @@ export class NgComponentOutlet<T = any> implements OnChanges, DoCheck, OnDestroy
     ngComponentOutletNgModule?: Type<any>;
     // @deprecated (undocumented)
     ngComponentOutletNgModuleFactory?: NgModuleFactory<any>;
-    // (undocumented)
     ngDoCheck(): void;
-    // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
-    // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<NgComponentOutlet<any>, "[ngComponentOutlet]", ["ngComponentOutlet"], { "ngComponentOutlet": { "alias": "ngComponentOutlet"; "required": false; }; "ngComponentOutletInputs": { "alias": "ngComponentOutletInputs"; "required": false; }; "ngComponentOutletInjector": { "alias": "ngComponentOutletInjector"; "required": false; }; "ngComponentOutletContent": { "alias": "ngComponentOutletContent"; "required": false; }; "ngComponentOutletNgModule": { "alias": "ngComponentOutletNgModule"; "required": false; }; "ngComponentOutletNgModuleFactory": { "alias": "ngComponentOutletNgModuleFactory"; "required": false; }; }, {}, never, never, true, never>;
@@ -630,9 +625,7 @@ export class NgOptimizedImage implements OnInit, OnChanges {
     static ngAcceptInputType_priority: unknown;
     // (undocumented)
     static ngAcceptInputType_width: unknown;
-    // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
-    // (undocumented)
     ngOnInit(): void;
     ngSrc: string;
     ngSrcset: string;
@@ -778,7 +771,6 @@ export class PathLocationStrategy extends LocationStrategy implements OnDestroy 
     getState(): unknown;
     // (undocumented)
     historyGo(relativePosition?: number): void;
-    // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
     onPopState(fn: LocationChangeListener): void;

--- a/goldens/public-api/common/testing/index.api.md
+++ b/goldens/public-api/common/testing/index.api.md
@@ -121,7 +121,6 @@ export class SpyLocation implements Location_2 {
     historyGo(relativePosition?: number): void;
     // (undocumented)
     isCurrentPathEqualTo(path: string, query?: string): boolean;
-    // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
     normalize(url: string): string;

--- a/goldens/public-api/forms/index.api.md
+++ b/goldens/public-api/forms/index.api.md
@@ -143,9 +143,7 @@ export interface AbstractControlOptions {
 export class AbstractFormGroupDirective extends ControlContainer implements OnInit, OnDestroy {
     get control(): FormGroup;
     get formDirective(): Form | null;
-    // (undocumented)
     ngOnDestroy(): void;
-    // (undocumented)
     ngOnInit(): void;
     get path(): string[];
     // (undocumented)
@@ -225,7 +223,6 @@ export class DefaultValueAccessor extends BaseControlValueAccessor implements Co
 // @public
 export class EmailValidator extends AbstractValidatorDirective {
     email: boolean | string;
-    // (undocumented)
     enabled(input: boolean): boolean;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<EmailValidator, "[email][formControlName],[email][formControl],[email][ngModel]", never, { "email": { "alias": "email"; "required": false; }; }, {}, never, never, false, never>;
@@ -363,9 +360,7 @@ export class FormControlDirective extends NgControl implements OnChanges, OnDest
     set isDisabled(isDisabled: boolean);
     // @deprecated (undocumented)
     model: any;
-    // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
-    // (undocumented)
     ngOnDestroy(): void;
     get path(): string[];
     // @deprecated (undocumented)
@@ -387,9 +382,7 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
     // @deprecated (undocumented)
     model: any;
     name: string | number | null;
-    // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
-    // (undocumented)
     ngOnDestroy(): void;
     get path(): string[];
     // @deprecated (undocumented)
@@ -494,9 +487,7 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
     getControl(dir: FormControlName): FormControl;
     getFormArray(dir: FormArrayName): FormArray;
     getFormGroup(dir: FormGroupName): FormGroup;
-    // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
-    // (undocumented)
     ngOnDestroy(): void;
     ngSubmit: EventEmitter<any>;
     onReset(): void;
@@ -691,7 +682,6 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
     get formDirective(): Form;
     getControl(dir: NgModel): FormControl;
     getFormGroup(dir: NgModelGroup): FormGroup;
-    // (undocumented)
     ngAfterViewInit(): void;
     ngSubmit: EventEmitter<any>;
     onReset(): void;
@@ -723,11 +713,8 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
     isDisabled: boolean;
     model: any;
     name: string;
-    // (undocumented)
     static ngAcceptInputType_isDisabled: boolean | string;
-    // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
-    // (undocumented)
     ngOnDestroy(): void;
     options: {
         name?: string;
@@ -758,7 +745,6 @@ export class NgModelGroup extends AbstractFormGroupDirective implements OnInit, 
 export class NgSelectOption implements OnDestroy {
     constructor(_element: ElementRef, _renderer: Renderer2, _select: SelectControlValueAccessor);
     id: string;
-    // (undocumented)
     ngOnDestroy(): void;
     set ngValue(value: any);
     set value(value: any);
@@ -816,13 +802,10 @@ export class RadioControlValueAccessor extends BuiltInControlValueAccessor imple
     fireUncheck(value: any): void;
     formControlName: string;
     name: string;
-    // (undocumented)
     ngOnDestroy(): void;
-    // (undocumented)
     ngOnInit(): void;
     onChange: () => void;
     registerOnChange(fn: (_: any) => {}): void;
-    // (undocumented)
     setDisabledState(isDisabled: boolean): void;
     value: any;
     writeValue(value: any): void;
@@ -858,7 +841,6 @@ export class ReactiveFormsModule {
 
 // @public
 export class RequiredValidator extends AbstractValidatorDirective {
-    // (undocumented)
     enabled(input: boolean): boolean;
     required: boolean | string;
     // (undocumented)
@@ -871,7 +853,6 @@ export class RequiredValidator extends AbstractValidatorDirective {
 export class SelectControlValueAccessor extends BuiltInControlValueAccessor implements ControlValueAccessor {
     set compareWith(fn: (o1: any, o2: any) => boolean);
     registerOnChange(fn: (value: any) => any): void;
-    // (undocumented)
     value: any;
     writeValue(value: any): void;
     // (undocumented)

--- a/goldens/public-api/localize/index.api.md
+++ b/goldens/public-api/localize/index.api.md
@@ -19,7 +19,7 @@ export type TargetMessage = string;
 // @public
 export const ɵ$localize: ɵLocalizeFn;
 
-// @public (undocumented)
+// @public
 export interface ɵLocalizeFn {
     // (undocumented)
     (messageParts: TemplateStringsArray, ...expressions: readonly any[]): string;
@@ -27,7 +27,7 @@ export interface ɵLocalizeFn {
     translate?: ɵTranslateFn;
 }
 
-// @public (undocumented)
+// @public
 export interface ɵTranslateFn {
     // (undocumented)
     (messageParts: TemplateStringsArray, expressions: readonly any[]): [TemplateStringsArray, readonly any[]];

--- a/goldens/public-api/localize/init/index.api.md
+++ b/goldens/public-api/localize/init/index.api.md
@@ -8,7 +8,7 @@
 const $localize_2: LocalizeFn;
 export { $localize_2 as $localize }
 
-// @public (undocumented)
+// @public
 export interface LocalizeFn {
     // (undocumented)
     (messageParts: TemplateStringsArray, ...expressions: readonly any[]): string;
@@ -16,7 +16,7 @@ export interface LocalizeFn {
     translate?: TranslateFn;
 }
 
-// @public (undocumented)
+// @public
 export interface TranslateFn {
     // (undocumented)
     (messageParts: TemplateStringsArray, expressions: readonly any[]): [TemplateStringsArray, readonly any[]];

--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -721,7 +721,6 @@ export class Router {
     navigate(commands: readonly any[], extras?: NavigationExtras): Promise<boolean>;
     navigateByUrl(url: string | UrlTree, extras?: NavigationBehaviorOptions): Promise<boolean>;
     navigated: boolean;
-    // (undocumented)
     ngOnDestroy(): void;
     // @deprecated
     onSameUrlNavigation: OnSameUrlNavigation;
@@ -810,11 +809,8 @@ class RouterLink implements OnChanges, OnDestroy {
     static ngAcceptInputType_replaceUrl: unknown;
     // (undocumented)
     static ngAcceptInputType_skipLocationChange: unknown;
-    // (undocumented)
     ngOnChanges(changes?: SimpleChanges): void;
-    // (undocumented)
     ngOnDestroy(): any;
-    // (undocumented)
     onClick(button: number, ctrlKey: boolean, shiftKey: boolean, altKey: boolean, metaKey: boolean): boolean;
     preserveFragment: boolean;
     queryParams?: Params | null;
@@ -848,11 +844,8 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
     readonly isActiveChange: EventEmitter<boolean>;
     // (undocumented)
     links: QueryList<RouterLink>;
-    // (undocumented)
     ngAfterContentInit(): void;
-    // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
-    // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
     set routerLinkActive(data: string[] | string);
@@ -901,14 +894,10 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
     // (undocumented)
     get isActivated(): boolean;
     name: string;
-    // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
-    // (undocumented)
     ngOnDestroy(): void;
-    // (undocumented)
     ngOnInit(): void;
     readonly routerOutletData: i0.InputSignal<unknown>;
-    // (undocumented)
     readonly supportsBindingToComponentInputs = true;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<RouterOutlet, "router-outlet", ["outlet"], { "name": { "alias": "name"; "required": false; }; "routerOutletData": { "alias": "routerOutletData"; "required": false; "isSignal": true; }; }, { "activateEvents": "activate"; "deactivateEvents": "deactivate"; "attachEvents": "attach"; "detachEvents": "detach"; }, never, never, true, never>;
@@ -936,7 +925,6 @@ export interface RouterOutletContract {
 // @public
 export class RouterPreloader implements OnDestroy {
     constructor(router: Router, injector: EnvironmentInjector, preloadingStrategy: PreloadingStrategy, loader: RouterConfigLoader);
-    // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
     preload(): Observable<any>;

--- a/goldens/public-api/upgrade/static/index.api.md
+++ b/goldens/public-api/upgrade/static/index.api.md
@@ -54,13 +54,9 @@ export function setAngularLib(ng: any): void;
 // @public
 export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
     constructor(name: string, elementRef: ElementRef, injector: Injector);
-    // (undocumented)
     ngDoCheck(): void;
-    // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
-    // (undocumented)
     ngOnDestroy(): void;
-    // (undocumented)
     ngOnInit(): void;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<UpgradeComponent, never, never, {}, {}, never, never, true, never>;

--- a/packages/common/src/directives/ng_component_outlet.ts
+++ b/packages/common/src/directives/ng_component_outlet.ts
@@ -153,7 +153,7 @@ export class NgComponentOutlet<T = any> implements OnChanges, DoCheck, OnDestroy
     );
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnChanges(changes: SimpleChanges) {
     if (this._needToReCreateComponentInstance(changes)) {
       this._viewContainerRef.clear();
@@ -189,7 +189,7 @@ export class NgComponentOutlet<T = any> implements OnChanges, DoCheck, OnDestroy
     }
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngDoCheck() {
     if (this._componentRef) {
       if (this.ngComponentOutletInputs) {
@@ -202,7 +202,7 @@ export class NgComponentOutlet<T = any> implements OnChanges, DoCheck, OnDestroy
     }
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnDestroy() {
     this._moduleRef?.destroy();
   }

--- a/packages/common/src/directives/ng_for_of.ts
+++ b/packages/common/src/directives/ng_for_of.ts
@@ -16,10 +16,10 @@ import {
   IterableDiffer,
   IterableDiffers,
   NgIterable,
+  ɵRuntimeError as RuntimeError,
   TemplateRef,
   TrackByFunction,
   ViewContainerRef,
-  ɵRuntimeError as RuntimeError,
 } from '@angular/core';
 
 import {RuntimeErrorCode} from '../errors';
@@ -249,7 +249,7 @@ export class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> implements DoCh
 
   /**
    * Applies the changes when needed.
-   * @nodoc
+   * @docs-private
    */
   ngDoCheck(): void {
     if (this._ngForOfDirty) {

--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -7,9 +7,16 @@
  */
 
 import {
+  ApplicationRef,
   booleanAttribute,
+  ChangeDetectorRef,
+  DestroyRef,
   Directive,
   ElementRef,
+  ɵformatRuntimeError as formatRuntimeError,
+  ɵIMAGE_CONFIG as IMAGE_CONFIG,
+  ɵIMAGE_CONFIG_DEFAULTS as IMAGE_CONFIG_DEFAULTS,
+  ɵImageConfig as ImageConfig,
   inject,
   Injector,
   Input,
@@ -17,19 +24,12 @@ import {
   numberAttribute,
   OnChanges,
   OnInit,
-  Renderer2,
-  SimpleChanges,
-  ɵformatRuntimeError as formatRuntimeError,
-  ɵIMAGE_CONFIG as IMAGE_CONFIG,
-  ɵIMAGE_CONFIG_DEFAULTS as IMAGE_CONFIG_DEFAULTS,
-  ɵImageConfig as ImageConfig,
   ɵperformanceMarkFeature as performanceMarkFeature,
+  Renderer2,
   ɵRuntimeError as RuntimeError,
   ɵSafeValue as SafeValue,
+  SimpleChanges,
   ɵunwrapSafeValue as unwrapSafeValue,
-  ChangeDetectorRef,
-  ApplicationRef,
-  DestroyRef,
 } from '@angular/core';
 
 import {RuntimeErrorCode} from '../../errors';
@@ -408,7 +408,7 @@ export class NgOptimizedImage implements OnInit, OnChanges {
     }
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnInit() {
     performanceMarkFeature('NgOptimizedImage');
 
@@ -520,7 +520,7 @@ export class NgOptimizedImage implements OnInit, OnChanges {
     }
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnChanges(changes: SimpleChanges) {
     if (ngDevMode) {
       assertNoPostInitInputChange(this, changes, [

--- a/packages/common/src/directives/ng_switch.ts
+++ b/packages/common/src/directives/ng_switch.ts
@@ -12,9 +12,9 @@ import {
   Host,
   Input,
   Optional,
+  ɵRuntimeError as RuntimeError,
   TemplateRef,
   ViewContainerRef,
-  ɵRuntimeError as RuntimeError,
 } from '@angular/core';
 
 import {RuntimeErrorCode} from '../errors';
@@ -228,7 +228,7 @@ export class NgSwitchCase implements DoCheck {
 
   /**
    * Performs case matching. For internal use only.
-   * @nodoc
+   * @docs-private
    */
   ngDoCheck() {
     this._view.enforceState(this.ngSwitch._matchCase(this.ngSwitchCase));

--- a/packages/common/src/location/hash_location_strategy.ts
+++ b/packages/common/src/location/hash_location_strategy.ts
@@ -45,7 +45,7 @@ export class HashLocationStrategy extends LocationStrategy implements OnDestroy 
     }
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnDestroy(): void {
     while (this._removeListenerFns.length) {
       this._removeListenerFns.pop()!();

--- a/packages/common/src/location/location.ts
+++ b/packages/common/src/location/location.ts
@@ -84,7 +84,7 @@ export class Location implements OnDestroy {
     });
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnDestroy(): void {
     this._urlChangeSubscription?.unsubscribe();
     this._urlChangeListeners = [];

--- a/packages/common/src/location/location_strategy.ts
+++ b/packages/common/src/location/location_strategy.ts
@@ -7,13 +7,13 @@
  */
 
 import {
+  DOCUMENT,
   Inject,
   inject,
   Injectable,
   InjectionToken,
   OnDestroy,
   Optional,
-  DOCUMENT,
 } from '@angular/core';
 
 import {LocationChangeListener, PlatformLocation} from './platform_location';
@@ -126,7 +126,7 @@ export class PathLocationStrategy extends LocationStrategy implements OnDestroy 
       '';
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnDestroy(): void {
     while (this._removeListenerFns.length) {
       this._removeListenerFns.pop()!();

--- a/packages/common/testing/src/location_mock.ts
+++ b/packages/common/testing/src/location_mock.ts
@@ -36,7 +36,7 @@ export class SpyLocation implements Location {
   /** @internal */
   _urlChangeSubscription: SubscriptionLike | null = null;
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnDestroy(): void {
     this._urlChangeSubscription?.unsubscribe();
     this._urlChangeListeners = [];

--- a/packages/core/testing/src/component_fixture.ts
+++ b/packages/core/testing/src/component_fixture.ts
@@ -6,31 +6,31 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {Subscription} from 'rxjs';
 import {
   ApplicationRef,
   ChangeDetectorRef,
   ComponentRef,
-  ɵChangeDetectionScheduler,
-  ɵNotificationSource,
   DebugElement,
+  ɵDeferBlockDetails as DeferBlockDetails,
+  ɵEffectScheduler as EffectScheduler,
   ElementRef,
   getDebugNode,
+  ɵgetDeferBlocks as getDeferBlocks,
   inject,
   NgZone,
+  ɵNoopNgZone as NoopNgZone,
   RendererFactory2,
   ViewRef,
-  ɵDeferBlockDetails as DeferBlockDetails,
-  ɵgetDeferBlocks as getDeferBlocks,
-  ɵNoopNgZone as NoopNgZone,
   ɵZONELESS_ENABLED as ZONELESS_ENABLED,
-  ɵEffectScheduler as EffectScheduler,
+  ɵChangeDetectionScheduler,
+  ɵNotificationSource,
 } from '../../src/core';
 import {PendingTasksInternal} from '../../src/pending_tasks';
-import {Subscription} from 'rxjs';
 
+import {TestBedApplicationErrorHandler} from './application_error_handler';
 import {DeferBlockFixture} from './defer';
 import {ComponentFixtureAutoDetect, ComponentFixtureNoNgZone} from './test_bed_common';
-import {TestBedApplicationErrorHandler} from './application_error_handler';
 
 interface TestAppRef {
   externalTestViews: Set<ViewRef>;
@@ -97,7 +97,7 @@ export class ComponentFixture<T> {
   // TODO(atscott): Remove this from public API
   ngZone = this._noZoneOptionIsSet ? null : this._ngZone;
 
-  /** @nodoc */
+  /** @docs-private */
   constructor(public componentRef: ComponentRef<T>) {
     this.changeDetectorRef = componentRef.changeDetectorRef;
     this.elementRef = componentRef.location;

--- a/packages/core/testing/src/defer.ts
+++ b/packages/core/testing/src/defer.ts
@@ -23,7 +23,7 @@ import type {ComponentFixture} from './component_fixture';
  * @publicApi
  */
 export class DeferBlockFixture {
-  /** @nodoc */
+  /** @docs-private */
   constructor(
     private block: DeferBlockDetails,
     private componentFixture: ComponentFixture<unknown>,

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -11,33 +11,32 @@
 // this statement only.
 
 import {
+  ApplicationRef,
   Component,
+  ɵRender3ComponentFactory as ComponentFactory,
   ComponentRef,
+  ɵDeferBlockBehavior as DeferBlockBehavior,
   Directive,
   EnvironmentInjector,
-  InjectOptions,
-  Injector,
-  NgModule,
-  NgZone,
-  Pipe,
-  PlatformRef,
-  ProviderToken,
-  runInInjectionContext,
-  Type,
-  ɵDeferBlockBehavior as DeferBlockBehavior,
-  ɵEffectScheduler as EffectScheduler,
   ɵflushModuleScopingQueueAsMuchAsPossible as flushModuleScopingQueueAsMuchAsPossible,
   ɵgetAsyncClassMetadataFn as getAsyncClassMetadataFn,
   ɵgetUnknownElementStrictMode as getUnknownElementStrictMode,
   ɵgetUnknownPropertyStrictMode as getUnknownPropertyStrictMode,
-  ɵRender3ComponentFactory as ComponentFactory,
+  InjectOptions,
+  Injector,
+  NgModule,
   ɵRender3NgModuleRef as NgModuleRef,
+  NgZone,
+  Pipe,
+  PlatformRef,
+  ProviderToken,
   ɵresetCompiledComponents as resetCompiledComponents,
+  runInInjectionContext,
   ɵsetAllowDuplicateNgModuleIdsForTest as setAllowDuplicateNgModuleIdsForTest,
   ɵsetUnknownElementStrictMode as setUnknownElementStrictMode,
   ɵsetUnknownPropertyStrictMode as setUnknownPropertyStrictMode,
   ɵstringify as stringify,
-  ApplicationRef,
+  Type,
 } from '../../src/core';
 
 import {ComponentFixture} from './component_fixture';
@@ -408,7 +407,7 @@ export class TestBedImpl implements TestBed {
   /**
    * Internal-only flag to indicate whether a module
    * scoping queue has been checked and flushed already.
-   * @nodoc
+   * @docs-private
    */
   globalCompilationChecked = false;
 

--- a/packages/forms/src/directives/abstract_form_group_directive.ts
+++ b/packages/forms/src/directives/abstract_form_group_directive.ts
@@ -32,14 +32,14 @@ export class AbstractFormGroupDirective extends ControlContainer implements OnIn
    */
   _parent!: ControlContainer;
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnInit(): void {
     this._checkParentType();
     // Register the group with its parent group.
     this.formDirective!.addFormGroup(this);
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnDestroy(): void {
     if (this.formDirective) {
       // Remove the group from its parent group.

--- a/packages/forms/src/directives/checkbox_value_accessor.ts
+++ b/packages/forms/src/directives/checkbox_value_accessor.ts
@@ -56,7 +56,7 @@ export class CheckboxControlValueAccessor
 {
   /**
    * Sets the "checked" property on the input element.
-   * @nodoc
+   * @docs-private
    */
   writeValue(value: any): void {
     this.setProperty('checked', value);

--- a/packages/forms/src/directives/control_value_accessor.ts
+++ b/packages/forms/src/directives/control_value_accessor.ts
@@ -143,13 +143,13 @@ export class BaseControlValueAccessor {
   /**
    * The registered callback function called when a change or input event occurs on the input
    * element.
-   * @nodoc
+   * @docs-private
    */
   onChange = (_: any) => {};
 
   /**
    * The registered callback function called when a blur event occurs on the input element.
-   * @nodoc
+   * @docs-private
    */
   onTouched = () => {};
 
@@ -161,7 +161,7 @@ export class BaseControlValueAccessor {
   /**
    * Helper method that sets a property on a target element using the current Renderer
    * implementation.
-   * @nodoc
+   * @docs-private
    */
   protected setProperty(key: string, value: any): void {
     this._renderer.setProperty(this._elementRef.nativeElement, key, value);
@@ -169,7 +169,7 @@ export class BaseControlValueAccessor {
 
   /**
    * Registers a function called when the control is touched.
-   * @nodoc
+   * @docs-private
    */
   registerOnTouched(fn: () => void): void {
     this.onTouched = fn;
@@ -177,7 +177,7 @@ export class BaseControlValueAccessor {
 
   /**
    * Registers a function called when the control value changes.
-   * @nodoc
+   * @docs-private
    */
   registerOnChange(fn: (_: any) => {}): void {
     this.onChange = fn;
@@ -185,7 +185,7 @@ export class BaseControlValueAccessor {
 
   /**
    * Sets the "disabled" property on the range input element.
-   * @nodoc
+   * @docs-private
    */
   setDisabledState(isDisabled: boolean): void {
     this.setProperty('disabled', isDisabled);

--- a/packages/forms/src/directives/default_value_accessor.ts
+++ b/packages/forms/src/directives/default_value_accessor.ts
@@ -115,7 +115,7 @@ export class DefaultValueAccessor extends BaseControlValueAccessor implements Co
 
   /**
    * Sets the "value" property on the input element.
-   * @nodoc
+   * @docs-private
    */
   writeValue(value: any): void {
     const normalizedValue = value == null ? '' : value;

--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -185,7 +185,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
     );
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngAfterViewInit() {
     this._setUpdateStrategy();
   }

--- a/packages/forms/src/directives/ng_model.ts
+++ b/packages/forms/src/directives/ng_model.ts
@@ -173,7 +173,7 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
   // match the native "disabled attribute" semantics which can be observed on input elements.
   // This static member tells the compiler that values of type "string" can also be assigned
   // to the input in a template.
-  /** @nodoc */
+  /** @docs-private */
   static ngAcceptInputType_isDisabled: boolean | string;
 
   /** @internal */
@@ -181,7 +181,7 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
 
   /**
    * Internal reference to the view model value.
-   * @nodoc
+   * @docs-private
    */
   viewModel: any;
 
@@ -249,7 +249,7 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
     this.valueAccessor = selectValueAccessor(this, valueAccessors);
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnChanges(changes: SimpleChanges) {
     this._checkForErrors();
     if (!this._registered || 'name' in changes) {
@@ -276,7 +276,7 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
     }
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnDestroy(): void {
     this.formDirective && this.formDirective.removeControl(this);
   }

--- a/packages/forms/src/directives/number_value_accessor.ts
+++ b/packages/forms/src/directives/number_value_accessor.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Directive, ElementRef, forwardRef, Provider} from '@angular/core';
+import {Directive, forwardRef, Provider} from '@angular/core';
 
 import {
   BuiltInControlValueAccessor,
@@ -57,7 +57,7 @@ export class NumberValueAccessor
 {
   /**
    * Sets the "value" property on the input element.
-   * @nodoc
+   * @docs-private
    */
   writeValue(value: number): void {
     // The value needs to be normalized for IE9, otherwise it is set to 'null' when null
@@ -67,7 +67,7 @@ export class NumberValueAccessor
 
   /**
    * Registers a function called when the control value changes.
-   * @nodoc
+   * @docs-private
    */
   override registerOnChange(fn: (_: number | null) => void): void {
     this.onChange = (value) => {

--- a/packages/forms/src/directives/radio_control_value_accessor.ts
+++ b/packages/forms/src/directives/radio_control_value_accessor.ts
@@ -144,7 +144,7 @@ export class RadioControlValueAccessor
    * Note: we declare `onChange` here (also used as host listener) as a function with no arguments
    * to override the `onChange` function (which expects 1 argument) in the parent
    * `BaseControlValueAccessor` class.
-   * @nodoc
+   * @docs-private
    */
   override onChange = () => {};
 
@@ -179,21 +179,21 @@ export class RadioControlValueAccessor
     super(renderer, elementRef);
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnInit(): void {
     this._control = this._injector.get(NgControl);
     this._checkName();
     this._registry.add(this._control, this);
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnDestroy(): void {
     this._registry.remove(this);
   }
 
   /**
    * Sets the "checked" property value on the radio input element.
-   * @nodoc
+   * @docs-private
    */
   writeValue(value: any): void {
     this._state = value === this.value;
@@ -202,7 +202,7 @@ export class RadioControlValueAccessor
 
   /**
    * Registers a function called when the control value changes.
-   * @nodoc
+   * @docs-private
    */
   override registerOnChange(fn: (_: any) => {}): void {
     this._fn = fn;
@@ -212,7 +212,7 @@ export class RadioControlValueAccessor
     };
   }
 
-  /** @nodoc */
+  /** @docs-private */
   override setDisabledState(isDisabled: boolean): void {
     /**
      * `setDisabledState` is supposed to be called whenever the disabled state of a control changes,

--- a/packages/forms/src/directives/range_value_accessor.ts
+++ b/packages/forms/src/directives/range_value_accessor.ts
@@ -61,7 +61,7 @@ export class RangeValueAccessor
 {
   /**
    * Sets the "value" property on the input element.
-   * @nodoc
+   * @docs-private
    */
   writeValue(value: any): void {
     this.setProperty('value', parseFloat(value));
@@ -69,7 +69,7 @@ export class RangeValueAccessor
 
   /**
    * Registers a function called when the control value changes.
-   * @nodoc
+   * @docs-private
    */
   override registerOnChange(fn: (_: number | null) => void): void {
     this.onChange = (value) => {

--- a/packages/forms/src/directives/reactive_directives/form_control_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_directive.ts
@@ -80,7 +80,7 @@ const formControlBinding: Provider = {
 export class FormControlDirective extends NgControl implements OnChanges, OnDestroy {
   /**
    * Internal reference to the view model value.
-   * @nodoc
+   * @docs-private
    */
   viewModel: any;
 
@@ -147,7 +147,7 @@ export class FormControlDirective extends NgControl implements OnChanges, OnDest
     this.valueAccessor = selectValueAccessor(this, valueAccessors);
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnChanges(changes: SimpleChanges): void {
     if (this._isControlChanged(changes)) {
       const previousForm = changes['form'].previousValue;
@@ -166,7 +166,7 @@ export class FormControlDirective extends NgControl implements OnChanges, OnDest
     }
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnDestroy() {
     if (this.form) {
       cleanUpControl(this.form, this, /* validateControlPresenceOnChange */ false);

--- a/packages/forms/src/directives/reactive_directives/form_control_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_name.ts
@@ -165,7 +165,7 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
     this.valueAccessor = selectValueAccessor(this, valueAccessors);
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnChanges(changes: SimpleChanges) {
     if (!this._added) this._setUpControl();
     if (isPropertyUpdated(changes, this.viewModel)) {
@@ -177,7 +177,7 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
     }
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnDestroy(): void {
     if (this.formDirective) {
       this.formDirective.removeControl(this);

--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -46,9 +46,9 @@ import {
 } from '../shared';
 import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from '../validators';
 
+import {FormResetEvent, FormSubmittedEvent} from '../../model/abstract_model';
 import type {FormControlName} from './form_control_name';
 import type {FormArrayName, FormGroupName} from './form_group_name';
-import {FormResetEvent, FormSubmittedEvent} from '../../model/abstract_model';
 
 const formDirectiveProvider: Provider = {
   provide: ControlContainer,
@@ -147,7 +147,7 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
     this._setAsyncValidators(asyncValidators);
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnChanges(changes: SimpleChanges): void {
     if ((typeof ngDevMode === 'undefined' || ngDevMode) && !this.form) {
       throw missingFormException();
@@ -161,7 +161,7 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
     }
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnDestroy() {
     if (this.form) {
       cleanUpValidators(this.form, this);

--- a/packages/forms/src/directives/reactive_directives/form_group_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_name.ts
@@ -187,7 +187,7 @@ export class FormArrayName extends ControlContainer implements OnInit, OnDestroy
   /**
    * A lifecycle method called when the directive's inputs are initialized. For internal use only.
    * @throws If the directive does not have a valid parent.
-   * @nodoc
+   * @docs-private
    */
   ngOnInit(): void {
     if (hasInvalidParent(this._parent) && (typeof ngDevMode === 'undefined' || ngDevMode)) {
@@ -198,7 +198,7 @@ export class FormArrayName extends ControlContainer implements OnInit, OnDestroy
 
   /**
    * A lifecycle method called before the directive's instance is destroyed. For internal use only.
-   * @nodoc
+   * @docs-private
    */
   ngOnDestroy(): void {
     this.formDirective?.removeFormArray(this);

--- a/packages/forms/src/directives/select_control_value_accessor.ts
+++ b/packages/forms/src/directives/select_control_value_accessor.ts
@@ -110,7 +110,7 @@ export class SelectControlValueAccessor
   extends BuiltInControlValueAccessor
   implements ControlValueAccessor
 {
-  /** @nodoc */
+  /** @docs-private */
   value: any;
 
   /** @internal */
@@ -139,7 +139,7 @@ export class SelectControlValueAccessor
 
   /**
    * Sets the "value" property on the select element.
-   * @nodoc
+   * @docs-private
    */
   writeValue(value: any): void {
     this.value = value;
@@ -150,7 +150,7 @@ export class SelectControlValueAccessor
 
   /**
    * Registers a function called when the control value changes.
-   * @nodoc
+   * @docs-private
    */
   override registerOnChange(fn: (value: any) => any): void {
     this.onChange = (valueString: string) => {
@@ -237,7 +237,7 @@ export class NgSelectOption implements OnDestroy {
     this._renderer.setProperty(this._element.nativeElement, 'value', value);
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnDestroy(): void {
     if (this._select) {
       this._select._optionMap.delete(this.id);

--- a/packages/forms/src/directives/select_multiple_control_value_accessor.ts
+++ b/packages/forms/src/directives/select_multiple_control_value_accessor.ts
@@ -92,7 +92,7 @@ export class SelectMultipleControlValueAccessor
 {
   /**
    * The current value.
-   * @nodoc
+   * @docs-private
    */
   value: any;
 
@@ -122,7 +122,7 @@ export class SelectMultipleControlValueAccessor
 
   /**
    * Sets the "value" property on one or of more of the select's options.
-   * @nodoc
+   * @docs-private
    */
   writeValue(value: any): void {
     this.value = value;
@@ -144,7 +144,7 @@ export class SelectMultipleControlValueAccessor
   /**
    * Registers a function called when the control value changes
    * and writes an array of the selected options.
-   * @nodoc
+   * @docs-private
    */
   override registerOnChange(fn: (value: any) => any): void {
     this.onChange = (element: HTMLSelectElement) => {
@@ -266,7 +266,7 @@ export class ɵNgSelectMultipleOption implements OnDestroy {
     this._renderer.setProperty(this._element.nativeElement, 'selected', selected);
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnDestroy(): void {
     if (this._select) {
       this._select._optionMap.delete(this.id);

--- a/packages/forms/src/directives/validators.ts
+++ b/packages/forms/src/directives/validators.ts
@@ -154,7 +154,7 @@ abstract class AbstractValidatorDirective implements Validator, OnChanges {
    */
   abstract normalizeInput(input: unknown): unknown;
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnChanges(changes: SimpleChanges): void {
     if (this.inputName in changes) {
       const input = this.normalizeInput(changes[this.inputName].currentValue);
@@ -166,12 +166,12 @@ abstract class AbstractValidatorDirective implements Validator, OnChanges {
     }
   }
 
-  /** @nodoc */
+  /** @docs-private */
   validate(control: AbstractControl): ValidationErrors | null {
     return this._validator(control);
   }
 
-  /** @nodoc */
+  /** @docs-private */
   registerOnValidatorChange(fn: () => void): void {
     this._onChange = fn;
   }
@@ -397,7 +397,7 @@ export class RequiredValidator extends AbstractValidatorDirective {
   /** @internal */
   override createValidator = (input: boolean): ValidatorFn => requiredValidator;
 
-  /** @nodoc */
+  /** @docs-private */
   override enabled(input: boolean): boolean {
     return input;
   }
@@ -494,7 +494,7 @@ export class EmailValidator extends AbstractValidatorDirective {
   /** @internal */
   override createValidator = (input: number): ValidatorFn => emailValidator;
 
-  /** @nodoc */
+  /** @docs-private */
   override enabled(input: boolean): boolean {
     return input;
   }

--- a/packages/localize/src/localize/src/localize.ts
+++ b/packages/localize/src/localize/src/localize.ts
@@ -8,7 +8,7 @@
 
 import {findEndOfBlock} from '../../utils';
 
-/** @nodoc */
+/** @docs-private */
 export interface LocalizeFn {
   (messageParts: TemplateStringsArray, ...expressions: readonly any[]): string;
 
@@ -41,7 +41,7 @@ export interface LocalizeFn {
   locale?: string;
 }
 
-/** @nodoc */
+/** @docs-private */
 export interface TranslateFn {
   (
     messageParts: TemplateStringsArray,

--- a/packages/platform-browser/animations/async/src/async_animation_renderer.ts
+++ b/packages/platform-browser/animations/async/src/async_animation_renderer.ts
@@ -12,21 +12,21 @@ import {
   ɵAnimationRendererFactory as AnimationRendererFactory,
 } from '@angular/animations/browser';
 import {
+  ɵAnimationRendererType as AnimationRendererType,
+  ɵChangeDetectionScheduler as ChangeDetectionScheduler,
   inject,
   Injectable,
+  InjectionToken,
+  Injector,
   NgZone,
+  ɵNotificationSource as NotificationSource,
   OnDestroy,
   Renderer2,
   RendererFactory2,
   RendererStyleFlags2,
   RendererType2,
-  ɵAnimationRendererType as AnimationRendererType,
-  ɵChangeDetectionScheduler as ChangeDetectionScheduler,
-  ɵNotificationSource as NotificationSource,
   ɵRuntimeError as RuntimeError,
-  InjectionToken,
   type ListenerOptions,
-  Injector,
 } from '@angular/core';
 import {ɵRuntimeErrorCode as RuntimeErrorCode} from '../../../index';
 
@@ -57,7 +57,7 @@ export class AsyncAnimationRendererFactory implements OnDestroy, RendererFactory
     }>,
   ) {}
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnDestroy(): void {
     // When the root view is removed, the renderer defers the actual work to the
     // `TransitionAnimationEngine` to do this, and the `TransitionAnimationEngine` doesn't actually

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -12,30 +12,29 @@ import {
   booleanAttribute,
   Directive,
   ElementRef,
+  HostAttributeToken,
   HostBinding,
   HostListener,
+  inject,
   Input,
   OnChanges,
   OnDestroy,
   Renderer2,
   ɵRuntimeError as RuntimeError,
-  SimpleChanges,
-  ɵINTERNAL_APPLICATION_ERROR_HANDLER,
-  inject,
   signal,
+  SimpleChanges,
   untracked,
-  HostAttributeToken,
+  ɵINTERNAL_APPLICATION_ERROR_HANDLER,
 } from '@angular/core';
 import {Subject, Subscription} from 'rxjs';
-
+import {RuntimeErrorCode} from '../errors';
 import {Event, NavigationEnd} from '../events';
 import {QueryParamsHandling} from '../models';
 import {Router} from '../router';
+import {ROUTER_CONFIGURATION} from '../router_config';
 import {ActivatedRoute} from '../router_state';
 import {Params} from '../shared';
 import {isUrlTree, UrlTree} from '../url_tree';
-import {RuntimeErrorCode} from '../errors';
-import {ROUTER_CONFIGURATION} from '../router_config';
 
 /**
  * @description
@@ -321,7 +320,7 @@ export class RouterLink implements OnChanges, OnDestroy {
     this.applyAttributeValue('tabindex', newTabIndex);
   }
 
-  /** @nodoc */
+  /** @docs-private */
   // TODO(atscott): Remove changes parameter in major version as a breaking change.
   ngOnChanges(changes?: SimpleChanges) {
     if (
@@ -375,7 +374,7 @@ export class RouterLink implements OnChanges, OnDestroy {
     }
   }
 
-  /** @nodoc */
+  /** @docs-private */
   @HostListener('click', [
     '$event.button',
     '$event.ctrlKey',
@@ -423,7 +422,7 @@ export class RouterLink implements OnChanges, OnDestroy {
     return !this.isAnchorElement;
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnDestroy(): any {
     this.subscription?.unsubscribe();
   }
@@ -470,7 +469,8 @@ export class RouterLink implements OnChanges, OnDestroy {
  * An alias for the `RouterLink` directive.
  * Deprecated since v15, use `RouterLink` directive instead.
  *
- * @deprecated use `RouterLink` directive instead.
+export { RouterLink as RouterLinkWithHref };
+nstead.
  * @publicApi
  */
 export {RouterLink as RouterLinkWithHref};

--- a/packages/router/src/directives/router_link_active.ts
+++ b/packages/router/src/directives/router_link_active.ts
@@ -166,7 +166,7 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
     });
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngAfterContentInit(): void {
     // `of(null)` is used to force subscribe body to execute once immediately (like `startWith`).
     of(this.links.changes, of(null))
@@ -197,11 +197,11 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
     this.classes = classes.filter((c) => !!c);
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnChanges(changes: SimpleChanges): void {
     this.update();
   }
-  /** @nodoc */
+  /** @docs-private */
   ngOnDestroy(): void {
     this.routerEventsSubscription.unsubscribe();
     this.linkInputChangesSubscription?.unsubscribe();

--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -17,15 +17,15 @@ import {
   InjectionToken,
   Injector,
   Input,
+  input,
   OnDestroy,
   OnInit,
   Output,
   reflectComponentType,
-  SimpleChanges,
-  ViewContainerRef,
   ɵRuntimeError as RuntimeError,
   Signal,
-  input,
+  SimpleChanges,
+  ViewContainerRef,
 } from '@angular/core';
 import {combineLatest, of, Subscription} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
@@ -243,10 +243,10 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
   private location = inject(ViewContainerRef);
   private changeDetector = inject(ChangeDetectorRef);
   private inputBinder = inject(INPUT_BINDER, {optional: true});
-  /** @nodoc */
+  /** @docs-private */
   readonly supportsBindingToComponentInputs = true;
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnChanges(changes: SimpleChanges) {
     if (changes['name']) {
       const {firstChange, previousValue} = changes['name'];
@@ -266,7 +266,7 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
     }
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnDestroy(): void {
     // Ensure that the registered outlet is this one before removing it on the context.
     if (this.isTrackedInParentContexts(this.name)) {
@@ -279,7 +279,7 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
     return this.parentContexts.getContext(outletName)?.outlet === this;
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnInit(): void {
     this.initializeOutletWithName();
   }

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -8,17 +8,18 @@
 
 import {Location} from '@angular/common';
 import {
+  ɵConsole as Console,
+  EnvironmentInjector,
   inject,
   Injectable,
-  Type,
-  ɵConsole as Console,
   ɵPendingTasksInternal as PendingTasks,
   ɵRuntimeError as RuntimeError,
+  Type,
   ɵINTERNAL_APPLICATION_ERROR_HANDLER,
-  EnvironmentInjector,
 } from '@angular/core';
 import {Observable, Subject, Subscription, SubscriptionLike} from 'rxjs';
 
+import {standardizeConfig} from './components/empty_outlet';
 import {createSegmentGroupFromRoute, createUrlTreeFromSegmentGroup} from './create_url_tree';
 import {INPUT_BINDER} from './directives/router_outlet';
 import {RuntimeErrorCode} from './errors';
@@ -57,7 +58,6 @@ import {
 } from './url_tree';
 import {validateConfig} from './utils/config';
 import {afterNextNavigation} from './utils/navigations';
-import {standardizeConfig} from './components/empty_outlet';
 
 /**
  * The equivalent `IsActiveMatchOptions` options for `Router.isActive` is called with `true`
@@ -371,7 +371,7 @@ export class Router {
     this.navigated = false;
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnDestroy(): void {
     this.dispose();
   }

--- a/packages/router/src/router_outlet_context.ts
+++ b/packages/router/src/router_outlet_context.ts
@@ -41,7 +41,7 @@ export class ChildrenOutletContexts {
   // contexts for child outlets, by name.
   private contexts = new Map<string, OutletContext>();
 
-  /** @nodoc */
+  /** @docs-private */
   constructor(private rootInjector: EnvironmentInjector) {}
 
   /** Called when a `RouterOutlet` directive is instantiated */

--- a/packages/router/src/router_preloader.ts
+++ b/packages/router/src/router_preloader.ts
@@ -96,7 +96,7 @@ export class RouterPreloader implements OnDestroy {
     return this.processRoutes(this.injector, this.router.config);
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnDestroy(): void {
     if (this.subscription) {
       this.subscription.unsubscribe();

--- a/packages/router/src/router_scroller.ts
+++ b/packages/router/src/router_scroller.ts
@@ -34,7 +34,7 @@ export class RouterScroller implements OnDestroy {
   private restoredId = 0;
   private store: {[key: string]: [number, number]} = {};
 
-  /** @nodoc */
+  /** @docs-private */
   constructor(
     readonly urlSerializer: UrlSerializer,
     private transitions: NavigationTransitions,
@@ -134,7 +134,7 @@ export class RouterScroller implements OnDestroy {
     });
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnDestroy() {
     this.routerEventsSubscription?.unsubscribe();
     this.scrollEventsSubscription?.unsubscribe();

--- a/packages/upgrade/static/src/upgrade_component.ts
+++ b/packages/upgrade/static/src/upgrade_component.ts
@@ -123,7 +123,7 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
     this.initializeOutputs();
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnInit() {
     // Collect contents, insert and compile template
     const attachChildNodes: ɵangular1.ILinkFn | undefined = this.helper.prepareTransclusion();
@@ -196,7 +196,7 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
     }
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnChanges(changes: SimpleChanges) {
     if (!this.bindingDestination) {
       this.pendingChanges = changes;
@@ -205,7 +205,7 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
     }
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngDoCheck() {
     const twoWayBoundProperties = this.bindings.twoWayBoundProperties;
     const twoWayBoundLastValues = this.bindings.twoWayBoundLastValues;
@@ -225,7 +225,7 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
     });
   }
 
-  /** @nodoc */
+  /** @docs-private */
   ngOnDestroy() {
     if (ɵutil.isFunction(this.unregisterDoCheckWatcher)) {
       this.unregisterDoCheckWatcher();


### PR DESCRIPTION
This aligns with how angular/components marks their hidden APIs.
`@nodoc` has been broken since the switch to adev, this change should
properly hide the APIs again.