### PR TITLE
ci: remove redundant dash in workflow file

### DIFF
--- a/.github/workflows/sync-angular-robot-forked-repo.yml
+++ b/.github/workflows/sync-angular-robot-forked-repo.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout the repository
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.ref }} # Checks out the branch that triggered the push
           persist-credentials: false


### PR DESCRIPTION
This appears to the reason why the workflow is erroring out that each step is required to have `uses` or `run`

