### PR TITLE
ci: use bash syntax for `CURRENT_BRANCH` in GitHub Actions

### DIFF
--- a/.github/workflows/sync-angular-robot-forked-repo.yml
+++ b/.github/workflows/sync-angular-robot-forked-repo.yml
@@ -41,5 +41,5 @@ jobs:
           git remote add upstream "$UPSTREAM_URL"
           git remote -v
 
-          echo "Pushing ${{ CURRENT_BRANCH }} from origin to $UPSTREAM_OWNER upstream..."
+          echo "Pushing $CURRENT_BRANCH from origin to $UPSTREAM_OWNER upstream..."
           git push upstream "${CURRENT_BRANCH}"

--- a/.github/workflows/sync-angular-robot-forked-repo.yml
+++ b/.github/workflows/sync-angular-robot-forked-repo.yml
@@ -42,4 +42,4 @@ jobs:
           git remote -v
 
           echo "Pushing $CURRENT_BRANCH from origin to $UPSTREAM_OWNER upstream..."
-          git push upstream "${CURRENT_BRANCH}"
+          git push upstream "$CURRENT_BRANCH"


### PR DESCRIPTION


Replaces incorrect use of GitHub Actions expression syntax `${{CURRENT_BRANCH }}` inside a run block with proper bash variablesyntax `$CURRENT_BRANCH`, preventing 'Unrecognized named-value' errors.
