### PR TITLE
ci: restrict cross-repo updates to follow only the next tag on main

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -92,7 +92,18 @@
       "matchDepNames": ["/^@bazel/.*/", "/^build_bazel.*/"]
     },
     {
+      "matchBaseBranches": ["main"],
       "followTag": "next",
+      "groupName": "cross-repo Angular dependencies (next)",
+      "schedule": ["at any time"],
+      "matchPackageNames": [
+        "@angular/{/,}**",
+        "angular/{/,}**",
+        "@angular-devkit{/,}**",
+        "@schematics/{/,}**"
+      ]
+    },
+    {
       "groupName": "cross-repo Angular dependencies",
       "schedule": ["at any time"],
       "matchPackageNames": [


### PR DESCRIPTION
Limits automated cross-repo updates to only follow the 'next' tag when operating on the main branch. This helps avoid unintended updates from other tags and ensures a controlled release process.
