### PR TITLE
refactor(core): cleanup `after*` option types

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -30,7 +30,7 @@ export function afterEveryRender<E = never, W = never, M = never>(spec: {
     write?: (...args: ɵFirstAvailable<[E]>) => W;
     mixedReadWrite?: (...args: ɵFirstAvailable<[W, E]>) => M;
     read?: (...args: ɵFirstAvailable<[M, W, E]>) => void;
-}, options?: Omit<AfterRenderOptions, 'phase'>): AfterRenderRef;
+}, options?: AfterRenderOptions): AfterRenderRef;
 
 // @public
 export function afterEveryRender(callback: VoidFunction, options?: AfterRenderOptions): AfterRenderRef;
@@ -41,13 +41,13 @@ export function afterNextRender<E = never, W = never, M = never>(spec: {
     write?: (...args: ɵFirstAvailable<[E]>) => W;
     mixedReadWrite?: (...args: ɵFirstAvailable<[W, E]>) => M;
     read?: (...args: ɵFirstAvailable<[M, W, E]>) => void;
-}, options?: Omit<AfterRenderOptions, 'phase'>): AfterRenderRef;
+}, options?: AfterRenderOptions): AfterRenderRef;
 
 // @public
 export function afterNextRender(callback: VoidFunction, options?: AfterRenderOptions): AfterRenderRef;
 
 // @public
-export function afterRenderEffect(callback: (onCleanup: EffectCleanupRegisterFn) => void, options?: Omit<AfterRenderOptions, 'phase'>): AfterRenderRef;
+export function afterRenderEffect(callback: (onCleanup: EffectCleanupRegisterFn) => void, options?: AfterRenderOptions): AfterRenderRef;
 
 // @public
 export function afterRenderEffect<E = never, W = never, M = never>(spec: {
@@ -55,7 +55,7 @@ export function afterRenderEffect<E = never, W = never, M = never>(spec: {
     write?: (...args: [...ɵFirstAvailableSignal<[E]>, EffectCleanupRegisterFn]) => W;
     mixedReadWrite?: (...args: [...ɵFirstAvailableSignal<[W, E]>, EffectCleanupRegisterFn]) => M;
     read?: (...args: [...ɵFirstAvailableSignal<[M, W, E]>, EffectCleanupRegisterFn]) => void;
-}, options?: Omit<AfterRenderOptions, 'phase'>): AfterRenderRef;
+}, options?: AfterRenderOptions): AfterRenderRef;
 
 // @public
 export interface AfterRenderOptions {

--- a/packages/core/src/render3/after_render/hooks.ts
+++ b/packages/core/src/render3/after_render/hooks.ts
@@ -138,7 +138,7 @@ export function afterEveryRender<E = never, W = never, M = never>(
     mixedReadWrite?: (...args: ɵFirstAvailable<[W, E]>) => M;
     read?: (...args: ɵFirstAvailable<[M, W, E]>) => void;
   },
-  options?: Omit<AfterRenderOptions, 'phase'>,
+  options?: AfterRenderOptions,
 ): AfterRenderRef;
 
 /**
@@ -314,7 +314,7 @@ export function afterNextRender<E = never, W = never, M = never>(
     mixedReadWrite?: (...args: ɵFirstAvailable<[W, E]>) => M;
     read?: (...args: ɵFirstAvailable<[M, W, E]>) => void;
   },
-  options?: Omit<AfterRenderOptions, 'phase'>,
+  options?: AfterRenderOptions,
 ): AfterRenderRef;
 
 /**

--- a/packages/core/src/render3/reactivity/after_render_effect.ts
+++ b/packages/core/src/render3/reactivity/after_render_effect.ts
@@ -271,7 +271,7 @@ export type ɵFirstAvailableSignal<T extends unknown[]> = T extends [infer H, ..
  */
 export function afterRenderEffect(
   callback: (onCleanup: EffectCleanupRegisterFn) => void,
-  options?: Omit<AfterRenderOptions, 'phase'>,
+  options?: AfterRenderOptions,
 ): AfterRenderRef;
 /**
  * Register effects that, when triggered, are invoked when the application finishes rendering,
@@ -340,7 +340,7 @@ export function afterRenderEffect<E = never, W = never, M = never>(
     mixedReadWrite?: (...args: [...ɵFirstAvailableSignal<[W, E]>, EffectCleanupRegisterFn]) => M;
     read?: (...args: [...ɵFirstAvailableSignal<[M, W, E]>, EffectCleanupRegisterFn]) => void;
   },
-  options?: Omit<AfterRenderOptions, 'phase'>,
+  options?: AfterRenderOptions,
 ): AfterRenderRef;
 
 /**
@@ -357,7 +357,7 @@ export function afterRenderEffect<E = never, W = never, M = never>(
         ) => M;
         read?: (...args: [...ɵFirstAvailableSignal<[M, W, E]>, EffectCleanupRegisterFn]) => void;
       },
-  options?: Omit<AfterRenderOptions, 'phase'>,
+  options?: AfterRenderOptions,
 ): AfterRenderRef {
   ngDevMode &&
     assertNotInReactiveContext(


### PR DESCRIPTION
The `phase` property of `AfterRenderOptions`  was removed in #60641.
