### PR TITLE
ci: update workflow to clone repo with history

### DIFF
--- a/.github/workflows/sync-angular-robot-forked-repo.yml
+++ b/.github/workflows/sync-angular-robot-forked-repo.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.ref }} # Checks out the branch that triggered the push
+          fetch-depth: 100
           persist-credentials: false
 
       - name: Push to angular-robot upstream remote
@@ -42,4 +43,4 @@ jobs:
           git remote -v
 
           echo "Pushing $CURRENT_BRANCH from origin to $UPSTREAM_OWNER upstream..."
-          git push upstream "$CURRENT_BRANCH" --force-with-lease
+          git push upstream "$CURRENT_BRANCH"


### PR DESCRIPTION
Tentative fix for:
```
Adding upstream remote: ***github.com/angular-robot/angular.git
origin	https://github.com/angular/angular (fetch)
origin	https://github.com/angular/angular (push)
upstream	***github.com/angular-robot/angular.git (fetch)
upstream	***github.com/angular-robot/angular.git (push)
Pushing 19.2.x from origin to angular-robot upstream...
To https://github.com/angular-robot/angular.git
 ! [rejected]        19.2.x -> 19.2.x (stale info)
error: failed to push some refs to 'https://github.com/angular-robot/angular.git'
```