### PR TITLE
fix(compiler-cli): avoid ECMAScript private field metadata emit

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/common/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/src/metadata.ts
@@ -19,6 +19,7 @@ import {
 import ts from 'typescript';
 
 import {
+  ClassMemberAccessLevel,
   CtorParameter,
   DeclarationNode,
   Decorator,
@@ -84,11 +85,14 @@ export function extractClassMetadata(
 
   // Do the same for property decorators.
   let metaPropDecorators: Expression | null = null;
-  const classMembers = reflection
-    .getMembersOfClass(clazz)
-    .filter(
-      (member) => !member.isStatic && member.decorators !== null && member.decorators.length > 0,
-    );
+  const classMembers = reflection.getMembersOfClass(clazz).filter(
+    (member) =>
+      !member.isStatic &&
+      member.decorators !== null &&
+      member.decorators.length > 0 &&
+      // Private fields are not supported in the metadata emit
+      member.accessLevel !== ClassMemberAccessLevel.EcmaScriptPrivate,
+  );
   const duplicateDecoratedMembers = classMembers.filter(
     (member, i, arr) => arr.findIndex((arrayMember) => arrayMember.name === member.name) < i,
   );


### PR DESCRIPTION
The Angular class metadata emit structure does not support the use of private fields. If the class metadata emit is enabled and an ECMAScript private (i.e., `#` prefixed) member contains a decorator, the member will now be excluded from the emitting `setClassMetadata` call. This prevents runtime errors due to invalid syntax. This class member usage is only permitted if standard ECMAScript decorators are used.

Closes #61228