### PR TITLE
refactor: remove redundant renovate settings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,6 @@
   "baseBranches": ["main", "20.0.x"],
   "enabledManagers": ["npm", "bazel", "github-actions", "nvm"],
   "rangeStrategy": "replace",
-  "pinDigests": true,
   "semanticCommits": "enabled",
   "semanticCommitScope": "",
   "semanticCommitType": "build",


### PR DESCRIPTION
Remove `pinDigests` as we do update docker images, also remove `rangeStrategy` and let renovate handle the update strategy.
