### PR TITLE
ci: restore `.npmrc` before executing `postUpgradeTasks`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,7 @@
   "labels": ["area: build & ci", "action: merge"],
   "postUpgradeTasks": {
     "commands": [
-      "git restore .yarn/releases/yarn-1.22.22.cjs pnpm-lock.yaml",
+      "git restore .yarn/releases/yarn-1.22.22.cjs pnpm-lock.yaml .npmrc",
       "yarn install --frozen-lockfile --non-interactive",
       "yarn bazel sync --only=repo || true",
       "yarn ng-dev misc update-generated-files"


### PR DESCRIPTION
Renovate temporarily modifies the `.npmrc` file during its operations and reverts these changes afterward. However, during `postUpgradeTasks`, the non reverted `.npmrc` will lead to errors when running `yarn bazel sync --only=repo`

See: https://github.com/renovatebot/renovate/discussions/14897
