### PR TITLE
Initial language service support for selectorless

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
@@ -13,6 +13,8 @@ import {
   PropertyRead,
   SafePropertyRead,
   TemplateEntity,
+  TmplAstComponent,
+  TmplAstDirective,
   TmplAstElement,
   TmplAstHostElement,
   TmplAstNode,
@@ -30,7 +32,14 @@ import {ClassDeclaration} from '../../reflection';
 import {FullSourceMapping, NgTemplateDiagnostic, TypeCheckableDirectiveMeta} from './api';
 import {GlobalCompletion} from './completion';
 import {PotentialDirective, PotentialImport, PotentialImportMode, PotentialPipe} from './scope';
-import {ElementSymbol, Symbol, TcbLocation, TemplateSymbol} from './symbols';
+import {
+  ElementSymbol,
+  SelectorlessComponentSymbol,
+  SelectorlessDirectiveSymbol,
+  Symbol,
+  TcbLocation,
+  TemplateSymbol,
+} from './symbols';
 
 /**
  * Interface to the Angular Template Type Checker to extract diagnostics and intelligence from the
@@ -119,6 +128,14 @@ export interface TemplateTypeChecker {
    */
   getSymbolOfNode(node: TmplAstElement, component: ts.ClassDeclaration): ElementSymbol | null;
   getSymbolOfNode(node: TmplAstTemplate, component: ts.ClassDeclaration): TemplateSymbol | null;
+  getSymbolOfNode(
+    node: TmplAstComponent,
+    component: ts.ClassDeclaration,
+  ): SelectorlessComponentSymbol | null;
+  getSymbolOfNode(
+    node: TmplAstDirective,
+    component: ts.ClassDeclaration,
+  ): SelectorlessDirectiveSymbol | null;
   getSymbolOfNode(node: AST | TmplAstNode, component: ts.ClassDeclaration): Symbol | null;
 
   /**

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/symbols.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/symbols.ts
@@ -7,6 +7,8 @@
  */
 
 import {
+  TmplAstComponent,
+  TmplAstDirective,
   TmplAstElement,
   TmplAstLetDeclaration,
   TmplAstReference,
@@ -33,6 +35,8 @@ export enum SymbolKind {
   DomBinding,
   Pipe,
   LetDeclaration,
+  SelectorlessComponent,
+  SelectorlessDirective,
 }
 
 /**
@@ -49,7 +53,9 @@ export type Symbol =
   | TemplateSymbol
   | DomBindingSymbol
   | PipeSymbol
-  | LetDeclarationSymbol;
+  | LetDeclarationSymbol
+  | SelectorlessComponentSymbol
+  | SelectorlessDirectiveSymbol;
 
 /**
  * A `Symbol` which declares a new named entity in the template scope.
@@ -303,6 +309,52 @@ export interface TemplateSymbol {
   directives: DirectiveSymbol[];
 
   templateNode: TmplAstTemplate;
+}
+
+/** A representation of a selectorless component reference in a template. */
+export interface SelectorlessComponentSymbol {
+  kind: SymbolKind.SelectorlessComponent;
+
+  /** The `ts.Type` for the component class. */
+  tsType: ts.Type;
+
+  /** The `ts.Symbol` for the component class. */
+  tsSymbol: ts.Symbol | null;
+
+  /**
+   * Includes the component class itself and any host directives
+   * that may have been applied as a side-effect of it.
+   */
+  directives: DirectiveSymbol[];
+
+  /** The location in the shim file for the variable that holds the type of the component. */
+  tcbLocation: TcbLocation;
+
+  /** Template AST node defining the component. */
+  templateNode: TmplAstComponent;
+}
+
+/** A representation of a selectorless directive reference in a template. */
+export interface SelectorlessDirectiveSymbol {
+  kind: SymbolKind.SelectorlessDirective;
+
+  /** The `ts.Type` for the directive class. */
+  tsType: ts.Type;
+
+  /** The `ts.Symbol` for the directive class. */
+  tsSymbol: ts.Symbol | null;
+
+  /**
+   * Includes the directive class itself and any host directives
+   * that may have been applied as a side-effect of it.
+   */
+  directives: DirectiveSymbol[];
+
+  /** The location in the shim file for the variable that holds the type of the directive. */
+  tcbLocation: TcbLocation;
+
+  /** Template AST node defining the directive. */
+  templateNode: TmplAstDirective;
 }
 
 /** Interface shared between host and non-host directives. */

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -16,6 +16,8 @@ import {
   PropertyRead,
   SafePropertyRead,
   TemplateEntity,
+  TmplAstComponent,
+  TmplAstDirective,
   TmplAstElement,
   TmplAstHostElement,
   TmplAstNode,
@@ -68,6 +70,8 @@ import {
   PotentialImportMode,
   PotentialPipe,
   ProgramTypeCheckAdapter,
+  SelectorlessComponentSymbol,
+  SelectorlessDirectiveSymbol,
   Symbol,
   TcbLocation,
   TemplateDiagnostic,
@@ -670,6 +674,14 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
   }
   getSymbolOfNode(node: TmplAstTemplate, component: ts.ClassDeclaration): TemplateSymbol | null;
   getSymbolOfNode(node: TmplAstElement, component: ts.ClassDeclaration): ElementSymbol | null;
+  getSymbolOfNode(
+    node: TmplAstComponent,
+    component: ts.ClassDeclaration,
+  ): SelectorlessComponentSymbol | null;
+  getSymbolOfNode(
+    node: TmplAstDirective,
+    component: ts.ClassDeclaration,
+  ): SelectorlessDirectiveSymbol | null;
   getSymbolOfNode(node: AST | TmplAstNode, component: ts.ClassDeclaration): Symbol | null {
     const builder = this.getOrCreateSymbolBuilder(component);
     if (builder === null) {

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -477,7 +477,7 @@ export interface TypeCheckingTarget {
   /**
    * A map of component class names to string templates for that component.
    */
-  templates: {[className: string]: string};
+  templates?: {[className: string]: string};
 
   /**
    * Any declarations (e.g. directives) which should be considered as part of the scope for the
@@ -518,8 +518,10 @@ export function setup(
       contents = target.source;
     } else {
       contents = `// generated from templates\n\nexport const MODULE = true;\n\n`;
-      for (const className of Object.keys(target.templates)) {
-        contents += `export class ${className} {}\n`;
+      if (target.templates) {
+        for (const className of Object.keys(target.templates)) {
+          contents += `export class ${className} {}\n`;
+        }
       }
     }
 
@@ -582,15 +584,17 @@ export function setup(
       sfExtensionData(shimSf).fileShim = {extension: 'ngtypecheck', generatedFrom: target.fileName};
     }
 
-    for (const className of Object.keys(target.templates)) {
-      const classDecl = getClass(sf, className);
-      scopeMap.set(classDecl, scope);
+    if (target.templates) {
+      for (const className of Object.keys(target.templates)) {
+        const classDecl = getClass(sf, className);
+        scopeMap.set(classDecl, scope);
+      }
     }
   }
 
   const checkAdapter = createTypeCheckAdapter((sf, ctx) => {
     for (const target of targets) {
-      if (getSourceFileOrError(program, target.fileName) !== sf) {
+      if (getSourceFileOrError(program, target.fileName) !== sf || !target.templates) {
         continue;
       }
 

--- a/packages/language-service/src/definitions.ts
+++ b/packages/language-service/src/definitions.ts
@@ -22,6 +22,8 @@ import {
   DirectiveSymbol,
   DomBindingSymbol,
   ElementSymbol,
+  SelectorlessComponentSymbol,
+  SelectorlessDirectiveSymbol,
   Symbol,
   SymbolKind,
   TcbLocation,
@@ -118,6 +120,8 @@ export class DefinitionBuilder {
       case SymbolKind.Element:
       case SymbolKind.Template:
       case SymbolKind.DomBinding:
+      case SymbolKind.SelectorlessComponent:
+      case SymbolKind.SelectorlessDirective:
         // Though it is generally more appropriate for the above symbol definitions to be
         // associated with "type definitions" since the location in the template is the
         // actual definition location, the better user experience would be to allow
@@ -238,6 +242,8 @@ export class DefinitionBuilder {
         case SymbolKind.DomBinding:
         case SymbolKind.Element:
         case SymbolKind.Template:
+        case SymbolKind.SelectorlessComponent:
+        case SymbolKind.SelectorlessDirective:
           definitions.push(...this.getTypeDefinitionsForTemplateInstance(symbol, node));
           break;
         case SymbolKind.Output:
@@ -286,7 +292,13 @@ export class DefinitionBuilder {
   }
 
   private getTypeDefinitionsForTemplateInstance(
-    symbol: TemplateSymbol | ElementSymbol | DomBindingSymbol | DirectiveSymbol,
+    symbol:
+      | TemplateSymbol
+      | ElementSymbol
+      | DomBindingSymbol
+      | DirectiveSymbol
+      | SelectorlessComponentSymbol
+      | SelectorlessDirectiveSymbol,
     node: AST | TmplAstNode,
   ): ts.DefinitionInfo[] {
     switch (symbol.kind) {
@@ -313,6 +325,8 @@ export class DefinitionBuilder {
         );
         return this.getTypeDefinitionsForSymbols(...dirs);
       }
+      case SymbolKind.SelectorlessComponent:
+      case SymbolKind.SelectorlessDirective:
       case SymbolKind.Directive:
         return this.getTypeDefinitionsForSymbols(symbol);
     }

--- a/packages/language-service/src/quick_info.ts
+++ b/packages/language-service/src/quick_info.ts
@@ -23,6 +23,8 @@ import {
   OutputBindingSymbol,
   PipeSymbol,
   ReferenceSymbol,
+  SelectorlessComponentSymbol,
+  SelectorlessDirectiveSymbol,
   Symbol,
   SymbolKind,
   TcbLocation,
@@ -103,11 +105,13 @@ export class QuickInfoBuilder {
         return this.getQuickInfoForReferenceSymbol(symbol);
       case SymbolKind.DomBinding:
         return this.getQuickInfoForDomBinding(symbol);
-      case SymbolKind.Directive:
-        return this.getQuickInfoAtTcbLocation(symbol.tcbLocation);
       case SymbolKind.Pipe:
         return this.getQuickInfoForPipeSymbol(symbol);
+      case SymbolKind.SelectorlessComponent:
+      case SymbolKind.SelectorlessDirective:
+        return this.getQuickInfoForSelectorlessSymbol(symbol);
       case SymbolKind.Expression:
+      case SymbolKind.Directive:
         return this.getQuickInfoAtTcbLocation(symbol.tcbLocation);
     }
   }
@@ -231,6 +235,26 @@ export class QuickInfoBuilder {
       kind,
       getTextSpanOfNode(this.node),
       containerName,
+      undefined,
+      info?.documentation,
+      info?.tags,
+    );
+  }
+
+  private getQuickInfoForSelectorlessSymbol(
+    symbol: SelectorlessComponentSymbol | SelectorlessDirectiveSymbol,
+  ): ts.QuickInfo {
+    const kind =
+      symbol.kind === SymbolKind.SelectorlessComponent
+        ? DisplayInfoKind.COMPONENT
+        : DisplayInfoKind.DIRECTIVE;
+    const info = this.getQuickInfoFromTypeDefAtLocation(symbol.tcbLocation);
+
+    return createQuickInfo(
+      this.typeChecker.typeToString(symbol.tsType),
+      kind,
+      getTextSpanOfNode(this.node),
+      undefined,
       undefined,
       info?.documentation,
       info?.tags,

--- a/packages/language-service/src/template_target.ts
+++ b/packages/language-service/src/template_target.ts
@@ -105,7 +105,11 @@ export type SingleNodeTarget =
   | ElementInBodyContext
   | ElementInTagContext
   | AttributeInKeyContext
-  | AttributeInValueContext;
+  | AttributeInValueContext
+  | ComponentInBodyContext
+  | ComponentInTagContext
+  | DirectiveInNameContext
+  | DirectiveInBodyContext;
 
 /**
  * Contexts which logically target multiple nodes in the template AST, which cannot be
@@ -127,6 +131,10 @@ export enum TargetNodeKind {
   AttributeInKeyContext,
   AttributeInValueContext,
   TwoWayBindingContext,
+  ComponentInTagContext,
+  ComponentInBodyContext,
+  DirectiveInNameContext,
+  DirectiveInBodyContext,
 }
 
 /**
@@ -175,6 +183,42 @@ export interface ElementInTagContext {
 export interface ElementInBodyContext {
   kind: TargetNodeKind.ElementInBodyContext;
   node: TmplAstElement | TmplAstTemplate;
+}
+
+/**
+ * A `TmplAstComponent` element node that's targeted, where the given position is within the tag,
+ * e.g. `MyComp` in `<MyComp foo="bar"/>`.
+ */
+export interface ComponentInTagContext {
+  kind: TargetNodeKind.ComponentInTagContext;
+  node: TmplAstComponent;
+}
+
+/**
+ * A `TmplAstComponent` element node that's targeted, where the given position is within the body,
+ * e.g. `foo="bar"/>` in `<MyComp foo="bar"/>`.
+ */
+export interface ComponentInBodyContext {
+  kind: TargetNodeKind.ComponentInBodyContext;
+  node: TmplAstComponent;
+}
+
+/**
+ * A `TmplAstDirective` element node that's targeted, where the given position is within the
+ * directive's name (e.g. `MyDir` in `@MyDir`).
+ */
+export interface DirectiveInNameContext {
+  kind: TargetNodeKind.DirectiveInNameContext;
+  node: TmplAstDirective;
+}
+
+/**
+ * A `TmplAstDirective` element node that's targeted, where the given position is within the body,
+ * e.g. `(foo="bar")` in `@MyDir(foo="bar")`.
+ */
+export interface DirectiveInBodyContext {
+  kind: TargetNodeKind.DirectiveInBodyContext;
+  node: TmplAstDirective;
 }
 
 export interface AttributeInKeyContext {
@@ -267,22 +311,32 @@ export function getTargetAtPosition(
   } else if (candidate instanceof TmplAstElement) {
     // Elements have two contexts: the tag context (position is within the element tag) or the
     // element body context (position is outside of the tag name, but still in the element).
+    nodeInContext = {
+      kind: isWithinTagBody(position, candidate)
+        ? TargetNodeKind.ElementInBodyContext
+        : TargetNodeKind.ElementInTagContext,
+      node: candidate,
+    };
+  } else if (candidate instanceof TmplAstComponent) {
+    nodeInContext = {
+      kind: isWithinTagBody(position, candidate)
+        ? TargetNodeKind.ComponentInBodyContext
+        : TargetNodeKind.ComponentInTagContext,
+      node: candidate,
+    };
+  } else if (candidate instanceof TmplAstDirective) {
+    const startSpan = candidate.startSourceSpan;
 
-    // Calculate the end of the element tag name. Any position beyond this is in the element body.
-    const tagEndPos =
-      candidate.sourceSpan.start.offset + 1 /* '<' element open */ + candidate.name.length;
-    if (position > tagEndPos) {
-      // Position is within the element body
-      nodeInContext = {
-        kind: TargetNodeKind.ElementInBodyContext,
-        node: candidate,
-      };
-    } else {
-      nodeInContext = {
-        kind: TargetNodeKind.ElementInTagContext,
-        node: candidate,
-      };
-    }
+    // The start span includes the opening paren, if there is one which we have to account for.
+    const endOffset = startSpan.end.offset - (startSpan.toString().endsWith('(') ? 1 : 0);
+
+    nodeInContext = {
+      kind:
+        position >= startSpan.start.offset && position <= endOffset
+          ? TargetNodeKind.DirectiveInNameContext
+          : TargetNodeKind.DirectiveInBodyContext,
+      node: candidate,
+    };
   } else if (
     (candidate instanceof TmplAstBoundAttribute ||
       candidate instanceof TmplAstBoundEvent ||
@@ -474,20 +528,31 @@ class TemplateTargetVisitor implements TmplAstVisitor {
   }
 
   visitElement(element: TmplAstElement) {
-    this.visitElementOrTemplate(element);
+    this.visitDirectiveHost(element);
   }
 
   visitTemplate(template: TmplAstTemplate) {
-    this.visitElementOrTemplate(template);
+    this.visitDirectiveHost(template);
   }
 
-  visitElementOrTemplate(element: TmplAstTemplate | TmplAstElement) {
-    const isTemplate = element instanceof TmplAstTemplate;
-    this.visitAll(element.attributes);
-    if (!isTemplate) {
-      this.visitAll(element.directives);
+  visitComponent(component: TmplAstComponent) {
+    this.visitDirectiveHost(component);
+  }
+
+  visitDirective(directive: TmplAstDirective) {
+    this.visitDirectiveHost(directive);
+  }
+
+  private visitDirectiveHost(
+    node: TmplAstTemplate | TmplAstElement | TmplAstComponent | TmplAstDirective,
+  ) {
+    const isTemplate = node instanceof TmplAstTemplate;
+    const isDirective = node instanceof TmplAstDirective;
+    this.visitAll(node.attributes);
+    if (!isDirective) {
+      this.visitAll(node.directives);
     }
-    this.visitAll(element.inputs);
+    this.visitAll(node.inputs);
     // We allow the path to contain both the `TmplAstBoundAttribute` and `TmplAstBoundEvent` for
     // two-way bindings but do not want the path to contain both the `TmplAstBoundAttribute` with
     // its children when the position is in the value span because we would then logically create a
@@ -495,27 +560,29 @@ class TemplateTargetVisitor implements TmplAstVisitor {
     // condition ensures we target just `TmplAstBoundAttribute` for this case and exclude
     // `TmplAstBoundEvent` children.
     if (
-      this.path[this.path.length - 1] !== element &&
+      this.path[this.path.length - 1] !== node &&
       !(this.path[this.path.length - 1] instanceof TmplAstBoundAttribute)
     ) {
       return;
     }
-    this.visitAll(element.outputs);
+    this.visitAll(node.outputs);
     if (isTemplate) {
-      this.visitAll(element.templateAttrs);
+      this.visitAll(node.templateAttrs);
     }
-    this.visitAll(element.references);
+    this.visitAll(node.references);
     if (isTemplate) {
-      this.visitAll(element.variables);
+      this.visitAll(node.variables);
     }
 
     // If we get here and have not found a candidate node on the element itself, proceed with
     // looking for a more specific node on the element children.
-    if (this.path[this.path.length - 1] !== element) {
+    if (this.path[this.path.length - 1] !== node) {
       return;
     }
 
-    this.visitAll(element.children);
+    if (!isDirective) {
+      this.visitAll(node.children);
+    }
   }
 
   visitContent(content: TmplAstContent) {
@@ -626,14 +693,6 @@ class TemplateTargetVisitor implements TmplAstVisitor {
     this.visitBinding(decl.value);
   }
 
-  visitComponent(component: TmplAstComponent) {
-    // TODO(crisbeto): integrate selectorless
-  }
-
-  visitDirective(directive: TmplAstDirective) {
-    // TODO(crisbeto): integrate selectorless
-  }
-
   visitAll(nodes: TmplAstNode[]) {
     for (const node of nodes) {
       this.visit(node);
@@ -707,4 +766,13 @@ function isWithinNode(position: number, node: TmplAstNode): boolean {
     (node.listeners.length > 0 &&
       node.listeners.some((listener) => isWithin(position, listener.sourceSpan)))
   );
+}
+
+/** Checks whether a position is within the body or the start syntax of a node. */
+function isWithinTagBody(position: number, node: TmplAstElement | TmplAstComponent): boolean {
+  // Calculate the end of the element tag name. Any position beyond this is in the body.
+  const name = node instanceof TmplAstComponent ? node.fullName : node.name;
+  const tagEndPos =
+    node.sourceSpan.start.offset + 1 /* '<' is the opening character */ + name.length;
+  return position > tagEndPos;
 }

--- a/packages/language-service/test/definitions_spec.ts
+++ b/packages/language-service/test/definitions_spec.ts
@@ -13,6 +13,7 @@ import {
   assertFileNames,
   assertTextSpans,
   createModuleAndProjectWithDeclarations,
+  createProjectWithStandaloneDeclarations,
   humanizeDocumentSpanLike,
   LanguageServiceTestEnv,
   OpenBuffer,
@@ -470,6 +471,252 @@ describe('definitions', () => {
     expect(definitions[0].kind).toBe(ts.ScriptElementKind.variableElement);
     expect(definitions[0].textSpan).toBe('@let foo = {value: 123}');
     assertFileNames(Array.from(definitions), ['app.html']);
+  });
+
+  it('gets definition for selectorless component', () => {
+    initMockFileSystem('Native');
+    const files = {
+      'app.html': '',
+      'dep.ts': `
+         import {Component} from '@angular/core';
+
+         @Component({template: ''})
+         export class Dep {}
+       `,
+      'app.ts': `
+         import {Component} from '@angular/core';
+         import {Dep} from './dep';
+
+         @Component({
+          templateUrl: '/app.html',
+         })
+         export class AppCmp {}
+       `,
+    };
+    const env = LanguageServiceTestEnv.setup();
+
+    const project = createProjectWithStandaloneDeclarations(env, 'test', files, {
+      _enableSelectorless: true,
+    });
+    const template = project.openFile('app.html');
+    template.contents = '<Dep/>';
+    project.expectNoSourceDiagnostics();
+
+    template.moveCursorToText('<De¦p/>');
+    const {definitions} = getDefinitionsAndAssertBoundSpan(env, template);
+    expect(definitions[0].name).toEqual('Dep');
+    expect(definitions[0].kind).toBe(ts.ScriptElementKind.classElement);
+    expect(definitions[0].textSpan).toBe('Dep');
+    assertFileNames(Array.from(definitions), ['dep.ts']);
+  });
+
+  it('gets definition for selectorless directive', () => {
+    initMockFileSystem('Native');
+    const files = {
+      'app.html': '',
+      'dep.ts': `
+         import {Directive} from '@angular/core';
+
+         @Directive()
+         export class Dep {}
+       `,
+      'app.ts': `
+         import {Component} from '@angular/core';
+         import {Dep} from './dep';
+
+         @Component({
+          templateUrl: '/app.html',
+         })
+         export class AppCmp {}
+       `,
+    };
+    const env = LanguageServiceTestEnv.setup();
+
+    const project = createProjectWithStandaloneDeclarations(env, 'test', files, {
+      _enableSelectorless: true,
+    });
+    const template = project.openFile('app.html');
+    template.contents = '<div @Dep></div>';
+    project.expectNoSourceDiagnostics();
+
+    template.moveCursorToText('@De¦p');
+    const {definitions} = getDefinitionsAndAssertBoundSpan(env, template);
+    expect(definitions[0].name).toEqual('Dep');
+    expect(definitions[0].kind).toBe(ts.ScriptElementKind.classElement);
+    expect(definitions[0].textSpan).toBe('Dep');
+    assertFileNames(Array.from(definitions), ['dep.ts']);
+  });
+
+  it('gets definition of selectorless component input', () => {
+    initMockFileSystem('Native');
+    const files = {
+      'app.html': '',
+      'dep.ts': `
+         import {Component, Input} from '@angular/core';
+
+         @Component({template: ''})
+         export class Dep {
+          @Input() someInput: any;
+         }
+       `,
+      'app.ts': `
+         import {Component} from '@angular/core';
+         import {Dep} from './dep';
+
+         @Component({
+          templateUrl: '/app.html',
+         })
+         export class AppCmp {}
+       `,
+    };
+    const env = LanguageServiceTestEnv.setup();
+
+    const project = createProjectWithStandaloneDeclarations(env, 'test', files, {
+      _enableSelectorless: true,
+    });
+    const template = project.openFile('app.html');
+    template.contents = '<Dep [someInput]="123"/>';
+    project.expectNoSourceDiagnostics();
+
+    template.moveCursorToText('[some¦Input]');
+    const {textSpan, definitions} = getDefinitionsAndAssertBoundSpan(env, template);
+
+    expect(template.contents.slice(textSpan.start, textSpan.start + textSpan.length)).toEqual(
+      'someInput',
+    );
+    expect(definitions.length).toBe(1);
+    expect(definitions[0].textSpan).toContain('someInput');
+    assertFileNames(definitions, ['dep.ts']);
+  });
+
+  it('gets definition of selectorless directive input', () => {
+    initMockFileSystem('Native');
+    const files = {
+      'app.html': '',
+      'dep.ts': `
+         import {Directive, Input} from '@angular/core';
+
+         @Directive()
+         export class Dep {
+          @Input() someInput: any;
+         }
+       `,
+      'app.ts': `
+         import {Component} from '@angular/core';
+         import {Dep} from './dep';
+
+         @Component({
+          templateUrl: '/app.html',
+         })
+         export class AppCmp {}
+       `,
+    };
+    const env = LanguageServiceTestEnv.setup();
+
+    const project = createProjectWithStandaloneDeclarations(env, 'test', files, {
+      _enableSelectorless: true,
+    });
+    const template = project.openFile('app.html');
+    template.contents = '<div @Dep([someInput]="123")></div>';
+    project.expectNoSourceDiagnostics();
+
+    template.moveCursorToText('[some¦Input]');
+    const {textSpan, definitions} = getDefinitionsAndAssertBoundSpan(env, template);
+
+    expect(template.contents.slice(textSpan.start, textSpan.start + textSpan.length)).toEqual(
+      'someInput',
+    );
+    expect(definitions.length).toBe(1);
+    expect(definitions[0].textSpan).toContain('someInput');
+    assertFileNames(definitions, ['dep.ts']);
+  });
+
+  it('gets definition of selectorless component output', () => {
+    initMockFileSystem('Native');
+    const files = {
+      'app.html': '',
+      'dep.ts': `
+         import {Component, Output, EventEmitter} from '@angular/core';
+
+         @Component({template: ''})
+         export class Dep {
+          @Output() someEvent = new EventEmitter<void>();
+         }
+       `,
+      'app.ts': `
+         import {Component} from '@angular/core';
+         import {Dep} from './dep';
+
+         @Component({
+          templateUrl: '/app.html',
+         })
+         export class AppCmp {
+          handler() {}
+         }
+       `,
+    };
+    const env = LanguageServiceTestEnv.setup();
+
+    const project = createProjectWithStandaloneDeclarations(env, 'test', files, {
+      _enableSelectorless: true,
+    });
+    const template = project.openFile('app.html');
+    template.contents = '<Dep (someEvent)="handler()"/>';
+    project.expectNoSourceDiagnostics();
+
+    template.moveCursorToText('(some¦Event)');
+    const {textSpan, definitions} = getDefinitionsAndAssertBoundSpan(env, template);
+
+    expect(template.contents.slice(textSpan.start, textSpan.start + textSpan.length)).toEqual(
+      'someEvent',
+    );
+    expect(definitions.length).toBe(1);
+    expect(definitions[0].textSpan).toContain('someEvent');
+    assertFileNames(definitions, ['dep.ts']);
+  });
+
+  it('gets definition of selectorless directive output', () => {
+    initMockFileSystem('Native');
+    const files = {
+      'app.html': '',
+      'dep.ts': `
+         import {Directive, Output, EventEmitter} from '@angular/core';
+
+         @Directive()
+         export class Dep {
+          @Output() someEvent = new EventEmitter<void>();
+         }
+       `,
+      'app.ts': `
+         import {Component} from '@angular/core';
+         import {Dep} from './dep';
+
+         @Component({
+          templateUrl: '/app.html',
+         })
+         export class AppCmp {
+          handler() {}
+         }
+       `,
+    };
+    const env = LanguageServiceTestEnv.setup();
+
+    const project = createProjectWithStandaloneDeclarations(env, 'test', files, {
+      _enableSelectorless: true,
+    });
+    const template = project.openFile('app.html');
+    template.contents = '<div @Dep((someEvent)="handler()")></div>';
+    project.expectNoSourceDiagnostics();
+
+    template.moveCursorToText('(some¦Event)');
+    const {textSpan, definitions} = getDefinitionsAndAssertBoundSpan(env, template);
+
+    expect(template.contents.slice(textSpan.start, textSpan.start + textSpan.length)).toEqual(
+      'someEvent',
+    );
+    expect(definitions.length).toBe(1);
+    expect(definitions[0].textSpan).toContain('someEvent');
+    assertFileNames(definitions, ['dep.ts']);
   });
 
   it('gets definition for a method in a void expression', () => {

--- a/packages/language-service/test/quick_info_spec.ts
+++ b/packages/language-service/test/quick_info_spec.ts
@@ -1171,6 +1171,106 @@ describe('quick info', () => {
     });
   });
 
+  describe('selectorless', () => {
+    beforeEach(() => {
+      initMockFileSystem('Native');
+      env = LanguageServiceTestEnv.setup();
+      project = env.addProject(
+        'test',
+        {
+          'app.ts': `
+            import {Component, Directive, EventEmitter, Input, Output} from '@angular/core';
+
+            @Component({template: ''})
+            export class TestComponent {
+              @Input() name!: string;
+              @Output() testEvent = new EventEmitter<string>();
+            }
+
+            @Directive()
+            export class TestDirective {
+              @Input() value!: number;
+              @Output() dirEvent = new EventEmitter<number>();
+            }
+
+            @Component({templateUrl: './app.html'})
+            export class AppCmp {
+              stringValue = 'hello';
+              numberValue = 123;
+              handleEvent() {}
+            }
+          `,
+          'app.html': 'Will be overridden',
+        },
+        {_enableSelectorless: true},
+      );
+    });
+
+    it('should work for selectorless components', () => {
+      expectQuickInfo({
+        templateOverride: '<TestComp¦onent/>',
+        expectedSpanText: '<TestComponent/>',
+        expectedDisplayString: '(component) TestComponent',
+      });
+    });
+
+    it('should work for selectorless directives', () => {
+      expectQuickInfo({
+        templateOverride: '<div @Test¦Directive></div>',
+        expectedSpanText: '@TestDirective',
+        expectedDisplayString: '(directive) TestDirective',
+      });
+    });
+
+    it('should work for selectorless component input', () => {
+      expectQuickInfo({
+        templateOverride: '<TestComponent [na¦me]="stringValue"/>',
+        expectedSpanText: 'name',
+        expectedDisplayString: '(property) TestComponent.name: string',
+      });
+    });
+
+    it('should work for selectorless component output', () => {
+      expectQuickInfo({
+        templateOverride: '<TestComponent (testEv¦ent)="handleEvent()"/>',
+        expectedSpanText: 'testEvent',
+        expectedDisplayString: '(event) TestComponent.testEvent: EventEmitter<string>',
+      });
+    });
+
+    it('should work for selectorless directive input', () => {
+      expectQuickInfo({
+        templateOverride: '<div @TestDirective([val¦ue]="numberValue")></div>',
+        expectedSpanText: 'value',
+        expectedDisplayString: '(property) TestDirective.value: number',
+      });
+    });
+
+    it('should work for selectorless directive output', () => {
+      expectQuickInfo({
+        templateOverride: '<div @TestDirective((dirEv¦ent)="handleEvent()")></div>',
+        expectedSpanText: 'dirEvent',
+        expectedDisplayString: '(event) TestDirective.dirEvent: EventEmitter<number>',
+      });
+    });
+
+    it('should work for selectorless component references', () => {
+      expectQuickInfo({
+        templateOverride: '<TestComponent #r¦ef/>',
+        expectedSpanText: 'ref',
+        expectedDisplayString: '(reference) ref: TestComponent',
+      });
+    });
+
+    it('should work for selectorless directive references', () => {
+      expectQuickInfo({
+        templateOverride: '<div @TestDirective(#r¦ef)></div>',
+        expectedSpanText: 'ref',
+        expectedDisplayString: '(reference) ref: TestDirective',
+      });
+    });
+  });
+
   function expectQuickInfo({
     templateOverride,
     expectedSpanText,

--- a/packages/language-service/test/references_and_rename_spec.ts
+++ b/packages/language-service/test/references_and_rename_spec.ts
@@ -16,6 +16,7 @@ import {
   humanizeDocumentSpanLike,
   LanguageServiceTestEnv,
   OpenBuffer,
+  Project,
 } from '../testing';
 
 describe('find references and rename locations', () => {
@@ -2106,6 +2107,446 @@ describe('find references and rename locations', () => {
       expect(result.canRename).toEqual(true);
       expect(result.displayName).toEqual('dir');
       expect(result.kind).toEqual('property');
+    });
+  });
+
+  describe('selectorless components', () => {
+    let project: Project;
+
+    beforeEach(() => {
+      initMockFileSystem('Native');
+      env = LanguageServiceTestEnv.setup();
+      project = env.addProject(
+        'test',
+        {
+          'app.ts': `
+            import {Component} from '@angular/core';
+            import {TestComponent} from './test-component';
+
+            @Component({templateUrl: './app.html'})
+            export class AppCmp {
+              stringValue = 'hello';
+              handleEvent() {}
+            }
+          `,
+          'test-component.ts': `
+            import {Component, EventEmitter, Input, Output} from '@angular/core';
+
+            @Component({template: ''})
+            export class TestComponent {
+              @Input() name!: string;
+              @Output() testEvent = new EventEmitter<string>();
+            }
+          `,
+          'app.html': 'Will be overridden',
+        },
+        {_enableSelectorless: true},
+      );
+    });
+
+    describe('references', () => {
+      it('should find references to selectorless component from source file', () => {
+        const file = project.openFile('test-component.ts');
+        const template = project.openFile('app.html');
+        template.contents = '<TestComponent/>';
+        file.moveCursorToText('export class TestComp¦onent {');
+        const refs = getReferencesAtPosition(file)!;
+        expect(refs.length).toBe(3);
+        assertTextSpans(refs, ['TestComponent', '<TestComponent/>']);
+        assertFileNames(refs, ['test-component.ts', 'app.html', 'app.ts']);
+      });
+
+      it('should find references to selectorless component from template', () => {
+        const template = project.openFile('app.html');
+        template.contents = '<TestComponent/>';
+        template.moveCursorToText('<TestCom¦ponent/>');
+        const refs = getReferencesAtPosition(template)!;
+        expect(refs.length).toBe(3);
+        assertTextSpans(refs, ['TestComponent', '<TestComponent/>']);
+        assertFileNames(refs, ['test-component.ts', 'app.html', 'app.ts']);
+      });
+
+      it('should find references to selectorless component inputs from source file', () => {
+        const file = project.openFile('test-component.ts');
+        const template = project.openFile('app.html');
+        template.contents = '<TestComponent [name]="stringValue"/>';
+        file.moveCursorToText('@Input() na¦me!: string;');
+        const refs = getReferencesAtPosition(file)!;
+        expect(refs.length).toBe(2);
+        assertTextSpans(refs, ['name']);
+        assertFileNames(refs, ['test-component.ts', 'app.html']);
+      });
+
+      it('should find references to selectorless component inputs from template', () => {
+        const template = project.openFile('app.html');
+        template.contents = '<TestComponent [name]="stringValue"/>';
+        template.moveCursorToText('[na¦me]');
+        const refs = getReferencesAtPosition(template)!;
+        expect(refs.length).toBe(2);
+        assertTextSpans(refs, ['name']);
+        assertFileNames(refs, ['test-component.ts', 'app.html']);
+      });
+
+      it('should find references to selectorless component outputs from source file', () => {
+        const file = project.openFile('test-component.ts');
+        const template = project.openFile('app.html');
+        template.contents = '<TestComponent (testEvent)="handleEvent()"/>';
+        file.moveCursorToText('@Output() test¦Event = new EventEmitter<string>();');
+        const refs = getReferencesAtPosition(file)!;
+        expect(refs.length).toBe(2);
+        assertTextSpans(refs, ['testEvent']);
+        assertFileNames(refs, ['test-component.ts', 'app.html']);
+      });
+
+      it('should find references to selectorless component outputs from template', () => {
+        const template = project.openFile('app.html');
+        template.contents = '<TestComponent (testEvent)="handleEvent()"/>';
+        template.moveCursorToText('(tes¦tEvent)');
+        const refs = getReferencesAtPosition(template)!;
+        expect(refs.length).toBe(2);
+        assertTextSpans(refs, ['testEvent']);
+        assertFileNames(refs, ['test-component.ts', 'app.html']);
+      });
+    });
+
+    describe('rename locations', () => {
+      it('should find rename locations of selectorless component from template', () => {
+        const template = project.openFile('app.html');
+        template.contents = '<TestComponent/>';
+        template.moveCursorToText('<TestCom¦ponent/>');
+        const renameLocations = getRenameLocationsAtPosition(template)!;
+
+        // There are 3 locations that need to be renamed:
+        // - Source file where the component is defined.
+        // - Self-closing tag in the template.
+        // - Import in the app component.
+        expect(renameLocations.length).toBe(3);
+        assertTextSpans(renameLocations, ['TestComponent']);
+        assertFileNames(renameLocations, ['test-component.ts', 'app.html', 'app.ts']);
+      });
+
+      it('should find rename locations for complex selectorless component', () => {
+        const template = project.openFile('app.html');
+        template.contents = '<TestComponent:a hello="world">Hello</TestComponent:a>';
+        template.moveCursorToText('<TestCom¦ponent:a');
+        const renameLocations = getRenameLocationsAtPosition(template)!;
+
+        // There are 4 locations that need to be renamed:
+        // - Source file where the component is defined.
+        // - Opening tag in the template.
+        // - Closing tag in the template.
+        // - Import in the app component.
+        expect(renameLocations.length).toBe(4);
+        assertTextSpans(renameLocations, ['TestComponent']);
+        assertFileNames(renameLocations, ['test-component.ts', 'app.html', 'app.html', 'app.ts']);
+      });
+
+      it('should find rename locations to selectorless component inputs from source file', () => {
+        const file = project.openFile('test-component.ts');
+        const template = project.openFile('app.html');
+        template.contents = '<TestComponent [name]="stringValue"/>';
+        file.moveCursorToText('@Input() na¦me!: string;');
+        const refs = getRenameLocationsAtPosition(file)!;
+        expect(refs.length).toBe(2);
+        assertTextSpans(refs, ['name']);
+        assertFileNames(refs, ['test-component.ts', 'app.html']);
+      });
+
+      it('should find rename locations to selectorless component inputs from template', () => {
+        const template = project.openFile('app.html');
+        template.contents = '<TestComponent [name]="stringValue"/>';
+        template.moveCursorToText('[na¦me]');
+        const refs = getRenameLocationsAtPosition(template)!;
+        expect(refs.length).toBe(2);
+        assertTextSpans(refs, ['name']);
+        assertFileNames(refs, ['test-component.ts', 'app.html']);
+      });
+
+      it('should find rename locations to selectorless component outputs from source file', () => {
+        const file = project.openFile('test-component.ts');
+        const template = project.openFile('app.html');
+        template.contents = '<TestComponent (testEvent)="handleEvent()"/>';
+        file.moveCursorToText('@Output() test¦Event = new EventEmitter<string>();');
+        const refs = getRenameLocationsAtPosition(file)!;
+        expect(refs.length).toBe(2);
+        assertTextSpans(refs, ['testEvent']);
+        assertFileNames(refs, ['test-component.ts', 'app.html']);
+      });
+
+      it('should find rename locations to selectorless component outputs from template', () => {
+        const template = project.openFile('app.html');
+        template.contents = '<TestComponent (testEvent)="handleEvent()"/>';
+        template.moveCursorToText('(tes¦tEvent)');
+        const refs = getRenameLocationsAtPosition(template)!;
+        expect(refs.length).toBe(2);
+        assertTextSpans(refs, ['testEvent']);
+        assertFileNames(refs, ['test-component.ts', 'app.html']);
+      });
+
+      it('should handle rename request for selectorless component from source file', () => {
+        const file = project.openFile('test-component.ts');
+        const template = project.openFile('app.html');
+        template.contents = '<TestComponent/>';
+        file.moveCursorToText('export class TestCom¦ponent {');
+        const renameLocations = getRenameLocationsAtPosition(file)!;
+
+        expect(renameLocations).toBeUndefined();
+
+        // TODO(crisbeto): investigate if we can make this work.
+        // It would involve looking for all the component references and renaming them.
+        // expect(renameLocations.length).toBe(3);
+        // assertTextSpans(renameLocations, ['TestComponent']);
+        // assertFileNames(renameLocations, ['test-component.ts', 'app.html', 'app.ts']);
+      });
+    });
+  });
+
+  describe('selectorless directives', () => {
+    let project: Project;
+
+    beforeEach(() => {
+      initMockFileSystem('Native');
+      env = LanguageServiceTestEnv.setup();
+      project = env.addProject(
+        'test',
+        {
+          'app.ts': `
+            import {Component} from '@angular/core';
+            import {TestDirective} from './test-directive';
+
+            @Component({templateUrl: './app.html'})
+            export class AppCmp {
+              numberValue!: number;
+              handleEvent() {}
+            }
+          `,
+          'test-directive.ts': `
+            import {Directive, EventEmitter, Input, Output} from '@angular/core';
+
+            @Directive()
+            export class TestDirective {
+              @Input() value!: number;
+              @Output() testEvent = new EventEmitter<number>();
+            }
+          `,
+          'app.html': 'Will be overridden',
+        },
+        {_enableSelectorless: true},
+      );
+    });
+
+    describe('references', () => {
+      it('should find references to selectorless directive from source file', () => {
+        const file = project.openFile('test-directive.ts');
+        const template = project.openFile('app.html');
+        template.contents = '<div @TestDirective></div>';
+        file.moveCursorToText('export class TestDir¦ective {');
+        const refs = getReferencesAtPosition(file)!;
+        expect(refs.length).toBe(3);
+        assertTextSpans(refs, ['TestDirective', '@TestDirective']);
+        assertFileNames(refs, ['test-directive.ts', 'app.html', 'app.ts']);
+      });
+
+      it('should find references to selectorless directive from template', () => {
+        const template = project.openFile('app.html');
+        template.contents = '<div @TestDirective></div>';
+        template.moveCursorToText('<div @TestDir¦ective></div>');
+        const refs = getReferencesAtPosition(template)!;
+        expect(refs.length).toBe(3);
+        assertTextSpans(refs, ['TestDirective', '@TestDirective']);
+        assertFileNames(refs, ['test-directive.ts', 'app.html', 'app.ts']);
+      });
+
+      it('should find references to selectorless directive inputs from source file', () => {
+        const file = project.openFile('test-directive.ts');
+        const template = project.openFile('app.html');
+        template.contents = '<div @TestDirective([value]="numberValue")></div>';
+        file.moveCursorToText('@Input() val¦ue!: number;');
+        const refs = getReferencesAtPosition(file)!;
+        expect(refs.length).toBe(2);
+        assertTextSpans(refs, ['value']);
+        assertFileNames(refs, ['test-directive.ts', 'app.html']);
+      });
+
+      it('should find references to selectorless directive inputs from template', () => {
+        const template = project.openFile('app.html');
+        template.contents = '<div @TestDirective([value]="numberValue")></div>';
+        template.moveCursorToText('[val¦ue]');
+        const refs = getReferencesAtPosition(template)!;
+        expect(refs.length).toBe(2);
+        assertTextSpans(refs, ['value']);
+        assertFileNames(refs, ['test-directive.ts', 'app.html']);
+      });
+
+      it('should find references to selectorless directive outputs from source file', () => {
+        const file = project.openFile('test-directive.ts');
+        const template = project.openFile('app.html');
+        template.contents = '<div @TestDirective((testEvent)="handleEvent()")></div>';
+        file.moveCursorToText('@Output() test¦Event = new EventEmitter<number>();');
+        const refs = getReferencesAtPosition(file)!;
+        expect(refs.length).toBe(2);
+        assertTextSpans(refs, ['testEvent']);
+        assertFileNames(refs, ['test-directive.ts', 'app.html']);
+      });
+
+      it('should find references to selectorless directive outputs from template', () => {
+        const template = project.openFile('app.html');
+        template.contents = '<div @TestDirective((testEvent)="handleEvent()")></div>';
+        template.moveCursorToText('(tes¦tEvent)');
+        const refs = getReferencesAtPosition(template)!;
+        expect(refs.length).toBe(2);
+        assertTextSpans(refs, ['testEvent']);
+        assertFileNames(refs, ['test-directive.ts', 'app.html']);
+      });
+    });
+
+    describe('rename locations', () => {
+      it('should find rename locations of selectorless directive from template', () => {
+        const template = project.openFile('app.html');
+        template.contents = '<div @TestDirective></div>';
+        template.moveCursorToText('@TestDir¦ective');
+        const renameLocations = getRenameLocationsAtPosition(template)!;
+
+        // There are 3 locations that need to be renamed:
+        // - Source file where the directive is defined.
+        // - Reference on the `div` node.
+        // - Import in the app component.
+        expect(renameLocations.length).toBe(3);
+        assertTextSpans(renameLocations, ['TestDirective']);
+        assertFileNames(renameLocations, ['test-directive.ts', 'app.html', 'app.ts']);
+      });
+
+      it('should find rename locations for selectorless directive with bindings', () => {
+        const template = project.openFile('app.html');
+        template.contents = '<div @TestDirective([value]="123")>Hello</div>';
+        template.moveCursorToText('@TestDir¦ective(');
+        const renameLocations = getRenameLocationsAtPosition(template)!;
+
+        // There are 3 locations that need to be renamed:
+        // - Source file where the directive is defined.
+        // - Reference on the `div` node.
+        // - Import in the app component.
+        expect(renameLocations.length).toBe(3);
+        assertTextSpans(renameLocations, ['TestDirective']);
+        assertFileNames(renameLocations, ['test-directive.ts', 'app.html', 'app.ts']);
+      });
+
+      it('should find rename locations to selectorless directive inputs from source file', () => {
+        const file = project.openFile('test-directive.ts');
+        const template = project.openFile('app.html');
+        template.contents = '<div @TestDirective([value]="numberValue")></div>';
+        file.moveCursorToText('@Input() val¦ue!: number;');
+        const refs = getRenameLocationsAtPosition(file)!;
+        expect(refs.length).toBe(2);
+        assertTextSpans(refs, ['value']);
+        assertFileNames(refs, ['test-directive.ts', 'app.html']);
+      });
+
+      it('should find rename locations to selectorless directive inputs from template', () => {
+        const template = project.openFile('app.html');
+        template.contents = '<div @TestDirective([value]="numberValue")></div>';
+        template.moveCursorToText('[val¦ue]');
+        const refs = getRenameLocationsAtPosition(template)!;
+        expect(refs.length).toBe(2);
+        assertTextSpans(refs, ['value']);
+        assertFileNames(refs, ['test-directive.ts', 'app.html']);
+      });
+
+      it('should find rename locations to selectorless directive outputs from source file', () => {
+        const file = project.openFile('test-directive.ts');
+        const template = project.openFile('app.html');
+        template.contents = '<div @TestDirective((testEvent)="handleEvent()")></div>';
+        file.moveCursorToText('@Output() test¦Event = new EventEmitter<number>();');
+        const refs = getRenameLocationsAtPosition(file)!;
+        expect(refs.length).toBe(2);
+        assertTextSpans(refs, ['testEvent']);
+        assertFileNames(refs, ['test-directive.ts', 'app.html']);
+      });
+
+      it('should find rename locations to selectorless directive outputs from template', () => {
+        const template = project.openFile('app.html');
+        template.contents = '<div @TestDirective((testEvent)="handleEvent()")></div>';
+        template.moveCursorToText('(tes¦tEvent)');
+        const refs = getRenameLocationsAtPosition(template)!;
+        expect(refs.length).toBe(2);
+        assertTextSpans(refs, ['testEvent']);
+        assertFileNames(refs, ['test-directive.ts', 'app.html']);
+      });
+
+      it('should handle rename request for selectorless component from source file', () => {
+        const file = project.openFile('test-directive.ts');
+        const template = project.openFile('app.html');
+        template.contents = '<div @TestDirective></div>';
+        file.moveCursorToText('export class TestDir¦ective {');
+        const renameLocations = getRenameLocationsAtPosition(file)!;
+
+        expect(renameLocations).toBeUndefined();
+
+        // TODO(crisbeto): investigate if we can make this work.
+        // It would involve looking for all the component references and renaming them.
+        // expect(renameLocations.length).toBe(3);
+        // assertTextSpans(renameLocations, ['TestDirective']);
+        // assertFileNames(renameLocations, ['test-directive.ts', 'app.html', 'app.ts']);
+      });
+    });
+  });
+
+  describe('aliased selectorless', () => {
+    let project: Project;
+
+    beforeEach(() => {
+      initMockFileSystem('Native');
+      env = LanguageServiceTestEnv.setup();
+      project = env.addProject(
+        'test',
+        {
+          'app.ts': `
+            import {Component} from '@angular/core';
+            import {TestComponent as AliasedComponent} from './test-component';
+            import {TestDirective as AliasedDirective} from './test-directive';
+
+            @Component({templateUrl: './app.html'})
+            export class AppCmp {
+              numberValue!: number;
+              handleEvent() {}
+            }
+          `,
+          'test-component.ts': `
+            import {Component, EventEmitter, Input, Output} from '@angular/core';
+
+            @Component({template: ''})
+            export class TestComponent {
+              @Input() name!: string;
+              @Output() testEvent = new EventEmitter<string>();
+            }
+          `,
+          'test-directive.ts': `
+            import {Directive, EventEmitter, Input, Output} from '@angular/core';
+
+            @Directive()
+            export class TestDirective {
+              @Input() value!: number;
+              @Output() testEvent = new EventEmitter<number>();
+            }
+          `,
+          'app.html': 'Will be overridden',
+        },
+        {_enableSelectorless: true},
+      );
+    });
+
+    it('should not rename aliased selectorless component references', () => {
+      const template = project.openFile('app.html');
+      template.contents = '<AliasedComponent/>';
+      template.moveCursorToText('<AliasedCom¦ponent/>');
+      expect(getRenameLocationsAtPosition(template)).toBeUndefined();
+    });
+
+    it('should not rename aliased selectorless directive references', () => {
+      const template = project.openFile('app.html');
+      template.contents = '<div @AliasedDirective></div>';
+      template.moveCursorToText('@AliasedDir¦ective');
+      expect(getRenameLocationsAtPosition(template)).toBeUndefined();
     });
   });
 

--- a/packages/language-service/testing/src/project.ts
+++ b/packages/language-service/testing/src/project.ts
@@ -65,7 +65,10 @@ function writeTsconfig(
 
 export type TestableOptions = TypeCheckingOptions &
   InternalOptions &
-  Pick<LegacyNgcOptions, 'fullTemplateTypeCheck'>;
+  Pick<LegacyNgcOptions, 'fullTemplateTypeCheck'> & {
+    // This already exists in `InternalOptions`, but it's `internal` so it's stripped away.
+    _enableSelectorless?: boolean;
+  };
 
 export class Project {
   private tsProject: ts.server.Project;

--- a/packages/language-service/testing/src/util.ts
+++ b/packages/language-service/testing/src/util.ts
@@ -111,6 +111,26 @@ export function createModuleAndProjectWithDeclarations(
   return env.addProject(projectName, {...projectFiles, ...standaloneFiles}, angularCompilerOptions);
 }
 
+export function createProjectWithStandaloneDeclarations(
+  env: LanguageServiceTestEnv,
+  projectName: string,
+  projectFiles: ProjectFiles,
+  angularCompilerOptions: TestableOptions = {},
+  standaloneFiles: ProjectFiles = {},
+): Project {
+  const externalClasses: string[] = [];
+  const externalImports: string[] = [];
+  for (const [fileName, fileContents] of Object.entries(projectFiles)) {
+    if (!fileName.endsWith('.ts')) {
+      continue;
+    }
+    const className = getFirstClassDeclaration(fileContents);
+    externalClasses.push(className);
+    externalImports.push(`import {${className}} from './${fileName.replace('.ts', '')}';`);
+  }
+  return env.addProject(projectName, {...projectFiles, ...standaloneFiles}, angularCompilerOptions);
+}
+
 export function humanizeDocumentSpanLike<T extends ts.DocumentSpan>(
   item: T,
   env: LanguageServiceTestEnv,


### PR DESCRIPTION
Sets up some initial support for selectorless in the language service which handles things like resolving definitions and hover tooltips. We're still missing at least the following:
* Initiating a rename from a component/directive class. Currently it only works when initiated from the template.
* Completions in a selectorless. Both the directive name and its attributes.

Includes the following changes:
### fix(compiler-cli): symbol builder duplicating host directives 

The template symbol builder works by finding the variables referring to template AST nodes with specific offsets and resolving them to directives. Afterwards it goes through the directives and resolves their host directives.

The problem is that host directives are added with the exact same offsets as their host which means they get added once initially and again when resolving host directives.

These changes resolve the issue by de-duplicating them.

### refactor(compiler-cli): produce template symbols for selectorless nodes 

Updates the template type checker to produce symbols for selectorless nodes. This is necessary for integration into the language service.

### refactor(language-service): set up template targets for selectorless 

Adds the logic to resolve the template targets for the selectorless component and directive nodes. This is a prerequisite for other functionality.

### refactor(language-service): support definitions for selectorless 

Updates the language service to handle producing definition information for selectorless components and directives.

### refactor(language-service): support quick info selectorless symbols 

Updates the language service to produce quick info for selectorless components and directives.

### refactor(language-service): initial reference and rename implementation for selectorless
Adds an initial implementation for finding references and renaming to selectorless components/directives.

Finding references should work everywhere, whereas renaming only currently works when initiated from the template.