### PR TITLE
refactor(docs-infra): Remove rethrowing error handler

### DIFF
--- a/adev/test-main.ts
+++ b/adev/test-main.ts
@@ -6,22 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ErrorHandler, NgModule, provideZonelessChangeDetection} from '@angular/core';
+import {NgModule, provideZonelessChangeDetection} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {BrowserTestingModule, platformBrowserTesting} from '@angular/platform-browser/testing';
 
 @NgModule({
-  providers: [
-    provideZonelessChangeDetection(),
-    {
-      provide: ErrorHandler,
-      useValue: {
-        handleError: (e: unknown) => {
-          throw e;
-        },
-      },
-    },
-  ],
+  providers: [provideZonelessChangeDetection()],
 })
 export class TestModule {}
 


### PR DESCRIPTION
This is no longer necessary since the work in the FW to rethrow in the TestBed error handler.
