### PR TITLE
ci: move cross-repo Angular dependencies (next)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -91,9 +91,7 @@
       "matchDepNames": ["/^@bazel/.*/", "/^build_bazel.*/"]
     },
     {
-      "matchBaseBranches": ["main"],
-      "followTag": "next",
-      "groupName": "cross-repo Angular dependencies (next)",
+      "groupName": "cross-repo Angular dependencies",
       "schedule": ["at any time"],
       "matchPackageNames": [
         "@angular/{/,}**",
@@ -103,7 +101,9 @@
       ]
     },
     {
-      "groupName": "cross-repo Angular dependencies",
+      "matchBaseBranches": ["main"],
+      "followTag": "next",
+      "groupName": "cross-repo Angular dependencies (next)",
       "schedule": ["at any time"],
       "matchPackageNames": [
         "@angular/{/,}**",


### PR DESCRIPTION
Renovate `packageRules` are applied and it’s the last matching group that takes effect.
