### PR TITLE
docs: document the use of `this` in template expression syntax

### DIFF
--- a/adev/src/content/guide/templates/expression-syntax.md
+++ b/adev/src/content/guide/templates/expression-syntax.md
@@ -98,7 +98,7 @@ Angular expressions additionally also support the following non-standard operato
 
 Angular expressions are evaluated within the context of the component class as well as any relevant [template variables](/guide/templates/variables), locals, and globals.
 
-When referring to class members, `this` is always implied.
+When referring to component class members, `this` is always implied. However, if a template declares a [template variables](guide/templates/variables) with the same name as a member, the variable shadows that member. You can unambiguously reference such a class member by explicitly using `this.`. This can be useful when creating an `@let` declaration that shadows a class member, e.g. for signal narrowing purposes.
 
 ## Declarations
 


### PR DESCRIPTION
As of Angular 19, `this` should consistently reference the given class property.

See: https://github.com/angular/angular/pull/55183