### PR TITLE
docs(docs-infra): integrate the new layout with the new changes

### DIFF
--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.scss
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.scss
@@ -21,16 +21,14 @@
     max-width: var(--page-width);
   }
 
-  // check if TOC component present in the page and has more than one elenment
-  &.docs-with-TOC:has(docs-table-of-contents ul > li:nth-child(2)) {
 
-    //applying styles when TOC position got translated to the top right 
-    @media only screen and (min-width: 1431px) {
-      // take the available space except a reserved area for TOC
-      margin-left: -16rem;
-      width: calc(100% - 16rem);
-    }
+  //applying styles when TOC position got translated to the top right 
+  @media only screen and (min-width: 1431px) {
+    // take the available space except a reserved area for TOC
+    margin-left: -16rem;
+    width: calc(100% - 16rem);
   }
+
 
   pre {
     margin-block: 0;

--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.scss
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.scss
@@ -11,18 +11,21 @@
   flex-direction: column;
   padding: 0px;
   box-sizing: border-box;
+  padding-inline: var(--layout-padding);
 
   @media only screen and (max-width: 1430px) {
     container: docs-content / inline-size;
   }
 
-  @include mq.for-big-desktop-up{
+  @include mq.for-big-desktop-up {
     max-width: var(--page-width);
   }
 
   // check if TOC component present in the page and has more than one elenment
   &.docs-with-TOC:has(docs-table-of-contents ul > li:nth-child(2)) {
-    @media only screen and (min-width: 1430px) {
+
+    //applying styles when TOC position got translated to the top right 
+    @media only screen and (min-width: 1431px) {
       // take the available space except a reserved area for TOC
       margin-left: -16rem;
       width: calc(100% - 16rem);
@@ -83,6 +86,7 @@
   }
 
   a:not(.docs-github-links):not(.docs-card):not(.docs-pill):not(.docs-example-github-link) {
+
     &[href^='http:'],
     &[href^='https:'] {
       @include links.external-link-with-icon();
@@ -90,6 +94,7 @@
   }
 
   &-scroll-margin-large {
+
     h2,
     h3 {
       scroll-margin: 5em;
@@ -99,7 +104,8 @@
 
 .docs-header {
   margin-block-end: 1rem;
-  & > p:first-child {
+
+  &>p:first-child {
     color: var(--quaternary-contrast);
     font-weight: 500;
     margin: 0;

--- a/adev/src/app/features/docs/docs.component.scss
+++ b/adev/src/app/features/docs/docs.component.scss
@@ -1,12 +1,16 @@
 :host {
+  display: block;
+  padding-top: var(--layout-padding);
+  padding-bottom: var(--layout-padding);
+
   .docs-viewer {
     &.docs-animate-content {
       animation: fade-in 500ms;
     }
   }
-  padding: var(--layout-padding);
-  
-  @media only screen and (min-width: 1430px) {
+
+  //applying styles when TOC position got translated to the top right 
+  @media only screen and (min-width: 1431px) {
     display: flex;
     justify-content: center;
   }

--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
@@ -9,16 +9,13 @@
   padding-top: var(--layout-padding);
   padding-bottom: var(--layout-padding);
 
-  &:has(> docs-viewer.docs-with-TOC) {
-    &:has(docs-table-of-contents ul > li:nth-child(2)) {
 
-      //applying styles when TOC position got translated to the top right 
-      @media only screen and (min-width: 1431px) {
-        // take the available space except a reserved area for TOC
-        width: calc(100% - 16rem);
-      }
-    }
+  //applying styles when TOC position got translated to the top right 
+  @media only screen and (min-width: 1431px) {
+    // take the available space except a reserved area for TOC
+    width: calc(100% - 16rem);
   }
+
 
   docs-viewer {
     display: block;

--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
@@ -2,15 +2,35 @@
 @use '@angular/docs/styles/reference' as ref;
 
 :host {
-  display: block;
+  display: flex;
+  justify-content: center;
   width: 100%;
-  max-width: var(--page-width);
-  padding: var(--layout-padding) 0 1rem var(--layout-padding);
-  box-sizing: border-box;
 
-  @include mq.for-desktop-down {
-    padding: var(--layout-padding);
-    max-width: none;
+  padding-top: var(--layout-padding);
+  padding-bottom: var(--layout-padding);
+
+  &:has(> docs-viewer.docs-with-TOC) {
+    &:has(docs-table-of-contents ul > li:nth-child(2)) {
+
+      //applying styles when TOC position got translated to the top right 
+      @media only screen and (min-width: 1431px) {
+        // take the available space except a reserved area for TOC
+        width: calc(100% - 16rem);
+      }
+    }
+  }
+
+  docs-viewer {
+    display: block;
+    padding-inline: var(--layout-padding);
+    width: 100%;
+
+    //applying styles when TOC position got translated to the top right 
+    @media only screen and (min-width: 1431px) {
+      // take the available space except a reserved area for TOC
+      max-width: var(--page-width);
+    }
+
   }
 
   &::-webkit-scrollbar-thumb {
@@ -19,31 +39,39 @@
     transition: background-color 0.3s ease;
   }
 
-  & > *{
+  &>* {
     padding-inline: 0px;
-    @include mq.for-big-desktop-up{
+
+    @include mq.for-big-desktop-up {
       width: var(--page-width);
     }
   }
-  
+
   h1 {
     font-size: 1.5rem;
   }
+
   h2 {
     font-size: 1.25rem;
   }
+
   h3 {
     font-size: 1rem;
   }
+
   h4 {
     font-size: 0.95rem;
   }
+
   h5 {
     font-size: 0.875rem;
   }
+
   h6 {
     font-size: 0.6rem;
   }
+
+
 }
 
 ::ng-deep {

--- a/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.scss
+++ b/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.scss
@@ -10,16 +10,13 @@
   padding-bottom: var(--layout-padding);
 
 
-  &:has(> docs-viewer.docs-with-TOC) {
-    &:has(docs-table-of-contents ul > li:nth-child(2)) {
 
-      //applying styles when TOC position got translated to the top right 
-      @media only screen and (min-width: 1431px) {
-        // take the available space except a reserved area for TOC
-        width: calc(100% - 16rem);
-      }
-    }
+  //applying styles when TOC position got translated to the top right 
+  @media only screen and (min-width: 1431px) {
+    // take the available space except a reserved area for TOC
+    width: calc(100% - 16rem);
   }
+
 
   docs-viewer {
     display: block;

--- a/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.scss
+++ b/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.scss
@@ -2,15 +2,44 @@
 @use '@angular/docs/styles/reference' as ref;
 
 :host {
-  display: block;
+  display: flex;
+  justify-content: center;
   width: 100%;
-  max-width: var(--page-width);
-  padding: var(--layout-padding) 0 1rem var(--layout-padding);
   box-sizing: border-box;
+  padding-top: var(--layout-padding);
+  padding-bottom: var(--layout-padding);
 
-  @include mq.for-desktop-down {
-    padding: var(--layout-padding);
-    max-width: none;
+
+  &:has(> docs-viewer.docs-with-TOC) {
+    &:has(docs-table-of-contents ul > li:nth-child(2)) {
+
+      //applying styles when TOC position got translated to the top right 
+      @media only screen and (min-width: 1431px) {
+        // take the available space except a reserved area for TOC
+        width: calc(100% - 16rem);
+      }
+    }
+  }
+
+  docs-viewer {
+    display: block;
+    padding-inline: var(--layout-padding);
+    width: 100%;
+
+    //applying styles when TOC position got translated to the top right 
+    @media only screen and (min-width: 1431px) {
+      // take the available space except a reserved area for TOC
+      max-width: var(--page-width);
+    }
+  }
+
+  &>* {
+    width: 100%;
+
+    @include mq.for-desktop-up {
+      padding-inline: 0px;
+      width: var(--page-width);
+    }
   }
 }
 
@@ -18,20 +47,4 @@
 ::ng-deep {
   @include ref.reference-common();
   @include ref.cli-reference();
-}
-
-:host{
-  display: flex;
-  flex-flow: row wrap;
-  justify-content: center;
-  padding: var(--layout-padding);
-
-  & > *{
-    width: 100%;
-    
-    @include mq.for-desktop-up{
-      padding-inline: 0px;
-      width: var(--page-width);
-    }
-  }
 }

--- a/adev/src/app/features/tutorial/tutorial.component.scss
+++ b/adev/src/app/features/tutorial/tutorial.component.scss
@@ -18,7 +18,7 @@ $column-width: calc(50% - #{$resizer-width} - var(--layout-padding));
 
   // Tablet / Mobile Tutorial Nav
   @include mq.for-tablet-landscape-up {
-    > .adev-tutorial-nav-container {
+    >.adev-tutorial-nav-container {
       display: none;
     }
   }
@@ -75,7 +75,7 @@ $column-width: calc(50% - #{$resizer-width} - var(--layout-padding));
 
   // Desktop Tutorial Nav
   @include mq.for-tablet-landscape-down {
-    > .adev-tutorial-nav-container {
+    >.adev-tutorial-nav-container {
       display: none;
     }
   }
@@ -88,6 +88,16 @@ $column-width: calc(50% - #{$resizer-width} - var(--layout-padding));
       width: 100%;
       height: 100%;
       backdrop-filter: blur(3px);
+    }
+  }
+
+  .docs-viewer {
+
+    //applying styles when TOC position got translated to the top right 
+    @media only screen and (min-width: 1431px) {
+      // take the available space except a reserved area for TOC
+      margin-left: 0rem;
+      width: unset;
     }
   }
 }

--- a/adev/src/app/features/update/update.component.html
+++ b/adev/src/app/features/update/update.component.html
@@ -1,5 +1,5 @@
 <div class="page docs-viewer">
-  <h1 tabindex="-1">Update Guide</h1>
+  <h1 class="page-header" tabindex="-1">Update Guide</h1>
   <div class="wizard">
     <div>
       <h2>Select the options that match your update</h2>

--- a/adev/src/app/features/update/update.component.scss
+++ b/adev/src/app/features/update/update.component.scss
@@ -1,21 +1,39 @@
 @use '@angular/docs/styles/media-queries' as mq;
 
-::ng-deep adev-update-guide{
+:host {
   display: flex;
   flex-flow: column;
   align-items: center;
-  padding: var(--layout-padding);
+  padding: var(--layout-padding) 0px;
   container: update-guide-page / inline-size;
+
+  .docs-viewer {
+    padding-inline: var(--layout-padding);
+
+    //applying styles when TOC position got translated to the top right 
+    @media only screen and (min-width: 1431px) {
+      // take the available space except a reserved area for TOC
+      margin-left: -16rem;
+      width: calc(100% - 16rem);
+      box-sizing: border-box;
+    }
+
+    .page-header {
+      margin-top: 0px;
+    }
+  }
 }
+
 .page {
   max-width: var(--page-width);
-  & > *{
-    @include mq.for-big-desktop-up{
+
+  &>* {
+    @include mq.for-big-desktop-up {
       padding-inline: 0px;
     }
   }
 
-  @include mq.for-tablet-landscape-down{
+  @include mq.for-tablet-landscape-down {
     width: 100%;
   }
 }
@@ -87,6 +105,7 @@ h4 {
     padding-block: 0.5rem;
     font-weight: 400;
     transition: border 0.3s ease;
+
     span {
       color: var(--primary-contrast);
       transition: color 0.3s ease;
@@ -105,7 +124,7 @@ h4 {
   display: flex;
   align-items: center;
 
-  > div {
+  >div {
     margin-inline-start: 2rem;
   }
 


### PR DESCRIPTION
fix new global layout issues, and make other pages adhere to the new centered layout like cli ref page, cli ref details, api ref details pages

I've execluded the api ref list page from the new centered layout as it's a big long and wide list with long names so it's better to leave it on left  in my opinion ..... please let me know if we want to change it as well 

