### PR TITLE
fix(core): cleanup testability subscriptions

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -1,8 +1,8 @@
 {
   "cli-hello-world": {
     "uncompressed": {
-      "main": 132425,
-      "polyfills": 33792
+      "main": 137461,
+      "polyfills": 34579
     }
   },
   "cli-hello-world-ivy-i18n": {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -461,6 +461,7 @@
   "isFormControlState",
   "isForwardRef",
   "isFunction",
+  "isInInjectionContext",
   "isInlineTemplate",
   "isInputBinding",
   "isInteropObservable",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -448,6 +448,7 @@
   "isFormControlState",
   "isForwardRef",
   "isFunction",
+  "isInInjectionContext",
   "isInlineTemplate",
   "isInputBinding",
   "isInteropObservable",


### PR DESCRIPTION
This commit prevents leaking memory when the application is destroyed and subscriptions are still alive.