### PR TITLE
feat(core): support typed component ref setInput

### DIFF
--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
@@ -28,6 +28,7 @@ import {
   PendingTasks,
   output,
 } from '@angular/core';
+import type {ExtractedDirectiveInputValue} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {TOC_SKIP_CONTENT_MARKER, NavigationState} from '../../../services/index';
 import {TableOfContents} from '../../table-of-contents/table-of-contents.component';
@@ -287,7 +288,7 @@ export class DocViewer implements OnChanges {
 
     if (inputs) {
       for (const [name, value] of Object.entries(inputs)) {
-        componentRef.setInput(name, value);
+        componentRef.setInput(name, value as ExtractedDirectiveInputValue<T, string>);
       }
     }
 

--- a/packages/core/src/authoring/input/input_type_checking.ts
+++ b/packages/core/src/authoring/input/input_type_checking.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {InputSignalWithTransform} from './input_signal';
+import type {InputSignalWithTransform} from './input_signal';
 
 /** Retrieves the write type of an `InputSignal` and `InputSignalWithTransform`. */
 export type ɵUnwrapInputSignalWriteType<Field> =
@@ -19,3 +19,27 @@ export type ɵUnwrapInputSignalWriteType<Field> =
 export type ɵUnwrapDirectiveSignalInputs<Dir, Fields extends keyof Dir> = {
   [P in Fields]: ɵUnwrapInputSignalWriteType<Dir[P]>;
 };
+
+/**
+ * Extracts a type with only the input properties of `Dir`, where each property's
+ * type is extracted using `ɵUnwrapInputSignalWriteType`. Only fields of type
+ * `InputSignal`, `ModelSignal` and `InputSignalWithTransform` are extracted.
+ */
+export type ExtractDirectiveSignalInputs<Dir> = {
+  [Field in keyof Dir as ɵUnwrapInputSignalWriteType<Dir[Field]> extends never
+    ? never
+    : Field]: ɵUnwrapInputSignalWriteType<Dir[Field]>;
+};
+
+/**
+ * Determines the type of the input property `TKey` in `Dir`.
+ * If `TKey` is a known input, it uses the extracted input type.
+ * Otherwise, it defaults to `unknown`.
+ */
+export type ExtractedDirectiveInputValue<Dir, Field extends keyof any> =
+  ExtractDirectiveSignalInputs<Dir> extends Record<Field, unknown>
+    ? ExtractDirectiveSignalInputs<Dir>[Field]
+    : unknown;
+
+/** To require a string type and still provide the possibility of code completion */
+export type SomeInputPropertyName = string & NonNullable<unknown>;

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -17,6 +17,10 @@ export * from './authoring';
 // JSCompiler's conformance requirement for inferred const exports. See:
 // https://docs.google.com/document/d/1RXb1wYwsbJotO1KBgSDsAtKpduGmIHod9ADxuXcAvV4/edit?tab=t.0
 export {input} from './authoring/input/input';
+export type {
+  ExtractDirectiveSignalInputs,
+  ExtractedDirectiveInputValue,
+} from './authoring/input/input_type_checking';
 export {contentChild, contentChildren, viewChild, viewChildren} from './authoring/queries';
 export {model} from './authoring/model/model';
 

--- a/packages/core/src/linker/component_factory.ts
+++ b/packages/core/src/linker/component_factory.ts
@@ -6,6 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import type {
+  ExtractDirectiveSignalInputs,
+  ExtractedDirectiveInputValue,
+  SomeInputPropertyName,
+} from '../authoring/input/input_type_checking';
 import type {ChangeDetectorRef} from '../change_detection/change_detection';
 import type {Injector} from '../di/injector';
 import type {EnvironmentInjector} from '../di/r3_injector';
@@ -29,10 +34,21 @@ export abstract class ComponentRef<C> {
    * component using the `OnPush` change detection strategy. It will also assure that the
    * `OnChanges` lifecycle hook runs when a dynamically created component is change-detected.
    *
-   * @param name The name of an input.
-   * @param value The new value of an input.
+   * The method facilitates type-safe updates for input properties defined as `InputSignal`,
+   * `ModelSignal` or `InputSignalWithTransform` within the directives's type definition.
+   * The `name` parameter accepts either a known input property key or a custom string name.
+   * When a custom name does not correspond to a defined input property, the `value` type
+   * resolves to `unknown`.
+   *
+   * @param name The name of the input property to update, either a key of the component's input
+   * properties or a custom string identifier.
+   * @param value The new value to assign to the input property, type-inferred based on the
+   * specified `name`.
    */
-  abstract setInput(name: string, value: unknown): void;
+  abstract setInput<Field extends keyof ExtractDirectiveSignalInputs<C> | SomeInputPropertyName>(
+    name: Field | SomeInputPropertyName,
+    value: ExtractedDirectiveInputValue<C, Field>,
+  ): void;
 
   /**
    * The host or anchor element for this component instance.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

+ Tests for specified feature are already existent
+ Special documentation is not required since it is provided via jsdoc

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When setting input values via `setInput` in unit tests or when interacting with a `ComponentRef`, there is no guarantee that the provided value matches the expected type for the input. Additionally, the type information does not automatically update when the component or its associated types are refactored, leading to potential type mismatches and reduced developer confidence.

## What is the new behavior?

This change introduces type-safe handling for signal-based inputs. For each signal input defined on a component, the corresponding type is automatically extracted, enabling type checking and providing code completion for available input properties. This enhances developer productivity and reduces errors during input configuration.

Traditional `@Input` decorators, which rely on function-based type inference, cannot be typed in this manner. To maintain backward compatibility, the API continues to accept arbitrary string keys for inputs, falling back to the previous behavior where the type is resolved as unknown.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
- [x] Unsure

It could be a breaking change, but existing components and tests did not need to be updated. The only issue occured when using a generic `ComponentRef`.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

When using `setInput` on an `ComponentRef<T>` with an unspecified component/directive it is required to add `as ExtractedDirectiveInputValue<T, string>` to the value attribute. For example: `componentRef.setInput(name, value as ExtractedDirectiveInputValue<T, string>);`