### PR TITLE
refactor(core): remove `USE_RUNTIME_DEPS_TRACKER_FOR_JIT` flag.

### DIFF
--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -320,10 +320,7 @@ export {
 export {ɵɵvalidateIframeAttribute} from './sanitization/iframe_attrs_validation';
 export {noSideEffects as ɵnoSideEffects} from './util/closure';
 export {AfterRenderManager as ɵAfterRenderManager} from './render3/after_render/manager';
-export {
-  depsTracker as ɵdepsTracker,
-  USE_RUNTIME_DEPS_TRACKER_FOR_JIT as ɵUSE_RUNTIME_DEPS_TRACKER_FOR_JIT,
-} from './render3/deps_tracker/deps_tracker';
+export {depsTracker as ɵdepsTracker} from './render3/deps_tracker/deps_tracker';
 export {generateStandaloneInDeclarationsError as ɵgenerateStandaloneInDeclarationsError} from './render3/jit/module';
 export {getAsyncClassMetadataFn as ɵgetAsyncClassMetadataFn} from './render3/metadata';
 export {DeferBlockData as ɵDeferBlockData} from './render3/util/defer';

--- a/packages/core/src/render3/deps_tracker/deps_tracker.ts
+++ b/packages/core/src/render3/deps_tracker/deps_tracker.ts
@@ -28,15 +28,6 @@ import {
 } from './api';
 
 /**
- * Indicates whether to use the runtime dependency tracker for scope calculation in JIT compilation.
- * The value "false" means the old code path based on patching scope info into the types will be
- * used.
- *
- * @deprecated For migration purposes only, to be removed soon.
- */
-export const USE_RUNTIME_DEPS_TRACKER_FOR_JIT = true;
-
-/**
  * An implementation of DepsTrackerApi which will be used for JIT and local compilation.
  */
 class DepsTracker implements DepsTrackerApi {

--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -35,7 +35,7 @@ import {
   getPipeDef,
   isStandalone,
 } from '../def_getters';
-import {depsTracker, USE_RUNTIME_DEPS_TRACKER_FOR_JIT} from '../deps_tracker/deps_tracker';
+import {depsTracker} from '../deps_tracker/deps_tracker';
 import {NG_COMP_DEF, NG_DIR_DEF, NG_FACTORY_DEF, NG_MOD_DEF, NG_PIPE_DEF} from '../fields';
 import type {ComponentDef} from '../interfaces/definition';
 import {maybeUnwrapFn} from '../util/misc_utils';
@@ -552,16 +552,12 @@ export function patchComponentDefWithScope<C>(
  */
 export function transitiveScopesFor<T>(type: Type<T>): NgModuleTransitiveScopes {
   if (isNgModule(type)) {
-    if (USE_RUNTIME_DEPS_TRACKER_FOR_JIT) {
-      const scope = depsTracker.getNgModuleScope(type);
-      const def = getNgModuleDefOrThrow(type);
-      return {
-        schemas: def.schemas || null,
-        ...scope,
-      };
-    } else {
-      return transitiveScopesForNgModule(type);
-    }
+    const scope = depsTracker.getNgModuleScope(type);
+    const def = getNgModuleDefOrThrow(type);
+    return {
+      schemas: def.schemas || null,
+      ...scope,
+    };
   } else if (isStandalone(type)) {
     const directiveDef = getComponentDef(type) || getDirectiveDef(type);
     if (directiveDef !== null) {

--- a/packages/core/testing/src/test_bed_compiler.ts
+++ b/packages/core/testing/src/test_bed_compiler.ts
@@ -61,7 +61,6 @@ import {
   ɵrestoreComponentResolutionQueue,
   ɵsetLocaleId as setLocaleId,
   ɵtransitiveScopesFor as transitiveScopesFor,
-  ɵUSE_RUNTIME_DEPS_TRACKER_FOR_JIT as USE_RUNTIME_DEPS_TRACKER_FOR_JIT,
   ɵɵInjectableDeclaration as InjectableDeclaration,
   NgZone,
   ErrorHandler,
@@ -238,9 +237,7 @@ export class TestBedCompiler {
   }
 
   overrideModule(ngModule: Type<any>, override: MetadataOverride<NgModule>): void {
-    if (USE_RUNTIME_DEPS_TRACKER_FOR_JIT) {
-      depsTracker.clearScopeCacheFor(ngModule);
-    }
+    depsTracker.clearScopeCacheFor(ngModule);
     this.overriddenModules.add(ngModule as NgModuleType<any>);
 
     // Compile the module right away.
@@ -512,9 +509,7 @@ export class TestBedCompiler {
       }
 
       this.maybeStoreNgDef(NG_COMP_DEF, declaration);
-      if (USE_RUNTIME_DEPS_TRACKER_FOR_JIT) {
-        depsTracker.clearScopeCacheFor(declaration);
-      }
+      depsTracker.clearScopeCacheFor(declaration);
       compileComponent(declaration, metadata);
     });
     this.pendingComponents.clear();
@@ -551,12 +546,7 @@ export class TestBedCompiler {
       const affectedModules = this.collectModulesAffectedByOverrides(testingModuleDef.imports);
       if (affectedModules.size > 0) {
         affectedModules.forEach((moduleType) => {
-          if (!USE_RUNTIME_DEPS_TRACKER_FOR_JIT) {
-            this.storeFieldOfDefOnType(moduleType as any, NG_MOD_DEF, 'transitiveCompileScopes');
-            (moduleType as any)[NG_MOD_DEF].transitiveCompileScopes = null;
-          } else {
-            depsTracker.clearScopeCacheFor(moduleType);
-          }
+          depsTracker.clearScopeCacheFor(moduleType);
         });
       }
     }
@@ -911,9 +901,7 @@ export class TestBedCompiler {
     // Restore initial component/directive/pipe defs
     this.initialNgDefs.forEach(
       (defs: Map<string, PropertyDescriptor | undefined>, type: Type<any>) => {
-        if (USE_RUNTIME_DEPS_TRACKER_FOR_JIT) {
-          depsTracker.clearScopeCacheFor(type);
-        }
+        depsTracker.clearScopeCacheFor(type);
         defs.forEach((descriptor, prop) => {
           if (!descriptor) {
             // Delete operations are generally undesirable since they have performance


### PR DESCRIPTION
The code has been migrated in G3, this flag is no longer necessary.
