### PR TITLE
Disable PNPM auto installs (main)

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
@@ -1,8 +1,8 @@
 # @generated
 # Input hashes for repository rule npm_translate_lock(name = "npm2", pnpm_lock = "@//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
-.npmrc=-203833057
+.npmrc=-1406867100
 package.json=-443660789
-pnpm-lock.yaml=-575151497
+pnpm-lock.yaml=-492509462
 pnpm-workspace.yaml=1711114604
 yarn.lock=-1986212688

--- a/.npmrc
+++ b/.npmrc
@@ -5,3 +5,8 @@ engine-strict = false
 # projects using rules_js so that pnpm outside of Bazel lays out a node_modules tree similar to what
 # rules_js lays out under Bazel (without a hidden node_modules/.pnpm/node_modules)
 hoist=false
+
+# Avoid pnpm auto-installing peer dependencies. We want to be explicit about our versions used
+# for peer dependencies, avoiding potential mismatches. In addition, it ensures we can continue
+# to rely on peer dependency placeholders substituted via Bazel.
+auto-install-peers=false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '6.0'
 
 settings:
-  autoInstallPeers: true
+  autoInstallPeers: false
   excludeLinksFromLockfile: false
 
 onlyBuiltDependencies: []
@@ -17,7 +17,7 @@ importers:
     dependencies:
       '@angular-devkit/build-angular':
         specifier: 20.0.0-rc.0
-        version: 20.0.0-rc.0(@angular/core@20.0.0-rc.0)(@angular/platform-browser@20.0.0-rc.0)(@angular/ssr@20.0.0-rc.0)(@types/node@18.19.87)(chokidar@4.0.3)(karma@6.4.4)(protractor@7.0.0)(tsx@4.19.3)(typescript@5.8.2)(vite@6.3.5)
+        version: 20.0.0-rc.0(@angular/ssr@20.0.0-rc.0)(@types/node@18.19.87)(chokidar@4.0.3)(karma@6.4.4)(protractor@7.0.0)(tsx@4.19.3)(typescript@5.8.2)
       '@angular-devkit/core':
         specifier: 20.0.0-rc.0
         version: 20.0.0-rc.0(chokidar@4.0.3)
@@ -26,19 +26,19 @@ importers:
         version: 20.0.0-rc.0(chokidar@4.0.3)
       '@angular/build':
         specifier: 20.0.0-rc.0
-        version: 20.0.0-rc.0(@angular/core@20.0.0-rc.0)(@angular/platform-browser@20.0.0-rc.0)(@angular/ssr@20.0.0-rc.0)(@types/node@18.19.87)(chokidar@4.0.3)(karma@6.4.4)(less@4.3.0)(postcss@8.5.3)(terser@5.39.0)(tslib@2.8.1)(tsx@4.19.3)(typescript@5.8.2)
+        version: 20.0.0-rc.0(@angular/ssr@20.0.0-rc.0)(@types/node@18.19.87)(chokidar@4.0.3)(karma@6.4.4)(less@4.3.0)(postcss@8.5.3)(terser@5.39.0)(tslib@2.8.1)(tsx@4.19.3)(typescript@5.8.2)
       '@angular/cdk':
         specifier: 20.0.0-rc.0
-        version: 20.0.0-rc.0(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)(rxjs@7.8.2)
+        version: 20.0.0-rc.0(rxjs@7.8.2)
       '@angular/cli':
         specifier: 20.0.0-rc.0
         version: 20.0.0-rc.0(@types/node@18.19.87)(chokidar@4.0.3)
       '@angular/material':
         specifier: 20.0.0-rc.0
-        version: 20.0.0-rc.0(@angular/cdk@20.0.0-rc.0)(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)(@angular/forms@20.0.0-rc.0)(@angular/platform-browser@20.0.0-rc.0)(rxjs@7.8.2)
+        version: 20.0.0-rc.0(@angular/cdk@20.0.0-rc.0)(rxjs@7.8.2)
       '@angular/ssr':
         specifier: 20.0.0-rc.0
-        version: 20.0.0-rc.0(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)(@angular/router@20.0.0-rc.0)
+        version: 20.0.0-rc.0
       '@babel/cli':
         specifier: 7.27.0
         version: 7.27.0(@babel/core@7.26.10)
@@ -50,7 +50,7 @@ importers:
         version: 7.27.0
       '@bazel/concatjs':
         specifier: 5.8.1
-        version: 5.8.1(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-junit-reporter@2.0.1)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(typescript@5.8.2)
+        version: 5.8.1(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(typescript@5.8.2)
       '@bazel/esbuild':
         specifier: 5.8.1
         version: 5.8.1
@@ -251,10 +251,10 @@ importers:
         version: 2.0.1
       ngx-flamegraph:
         specifier: 0.0.12
-        version: 0.0.12(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)
+        version: 0.0.12
       ngx-progressbar:
         specifier: ^14.0.0
-        version: 14.0.0(@angular/cdk@20.0.0-rc.0)(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)(rxjs@7.8.2)
+        version: 14.0.0(@angular/cdk@20.0.0-rc.0)(rxjs@7.8.2)
       open-in-idx:
         specifier: ^0.1.1
         version: 0.1.1
@@ -351,7 +351,7 @@ importers:
         version: 0.2000.0-rc.0(chokidar@4.0.3)
       '@angular/build-tooling':
         specifier: https://github.com/angular/dev-infra-private-build-tooling-builds.git#ce04ec6cf7604014191821a637e60964a1a3bb4a
-        version: github.com/angular/dev-infra-private-build-tooling-builds/ce04ec6cf7604014191821a637e60964a1a3bb4a(@angular/ssr@20.0.0-rc.0)(chokidar@4.0.3)(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-junit-reporter@2.0.1)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(less@4.3.0)(postcss@8.5.3)(rxjs@7.8.2)(terser@5.39.0)(tsx@4.19.3)(zone.js@0.15.0)
+        version: github.com/angular/dev-infra-private-build-tooling-builds/ce04ec6cf7604014191821a637e60964a1a3bb4a(@angular/ssr@20.0.0-rc.0)(chokidar@4.0.3)(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(rxjs@7.8.2)(terser@5.39.0)(tsx@4.19.3)
       '@angular/ng-dev':
         specifier: https://github.com/angular/dev-infra-private-ng-dev-builds.git#1c4ab5db67425dc52b9bff25660dbf5e105a4d75
         version: github.com/angular/dev-infra-private-ng-dev-builds/1c4ab5db67425dc52b9bff25660dbf5e105a4d75
@@ -453,7 +453,7 @@ importers:
         version: 0.5.16
       angular-split:
         specifier: ^19.0.0
-        version: 19.0.0(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)(rxjs@7.8.2)
+        version: 19.0.0(rxjs@7.8.2)
       check-side-effects:
         specifier: 0.0.23
         version: 0.0.23
@@ -745,7 +745,7 @@ packages:
     transitivePeerDependencies:
       - chokidar
 
-  /@angular-devkit/build-angular@20.0.0-rc.0(@angular/core@20.0.0-rc.0)(@angular/platform-browser@20.0.0-rc.0)(@angular/ssr@20.0.0-rc.0)(@types/node@18.19.87)(chokidar@4.0.3)(karma@6.4.4)(protractor@7.0.0)(tsx@4.19.3)(typescript@5.8.2)(vite@6.3.5):
+  /@angular-devkit/build-angular@20.0.0-rc.0(@angular/ssr@20.0.0-rc.0)(@types/node@18.19.87)(chokidar@4.0.3)(karma@6.4.4)(protractor@7.0.0)(tsx@4.19.3)(typescript@5.8.2):
     resolution: {integrity: sha512-dFiKXZTPV2Uiq938eHSxepCrZKPY3ZbS3L08Q6bgPTInq1hFIceaVty7Ujq90PD6DYEaY3bGKv+aynN8occcCw==, tarball: https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-20.0.0-rc.0.tgz}
     engines: {node: ^20.11.1 || ^22.11.0 || >=24.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     peerDependencies:
@@ -799,10 +799,8 @@ packages:
       '@angular-devkit/architect': 0.2000.0-rc.0(chokidar@4.0.3)
       '@angular-devkit/build-webpack': 0.2000.0-rc.0(chokidar@4.0.3)(webpack-dev-server@5.2.1)(webpack@5.99.8)
       '@angular-devkit/core': 20.0.0-rc.0(chokidar@4.0.3)
-      '@angular/build': 20.0.0-rc.0(@angular/core@20.0.0-rc.0)(@angular/platform-browser@20.0.0-rc.0)(@angular/ssr@20.0.0-rc.0)(@types/node@18.19.87)(chokidar@4.0.3)(karma@6.4.4)(less@4.3.0)(postcss@8.5.3)(terser@5.39.0)(tslib@2.8.1)(tsx@4.19.3)(typescript@5.8.2)
-      '@angular/core': 20.0.0-rc.0(rxjs@7.8.2)(zone.js@0.15.0)
-      '@angular/platform-browser': 20.0.0-rc.0(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)
-      '@angular/ssr': 20.0.0-rc.0(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)(@angular/router@20.0.0-rc.0)
+      '@angular/build': 20.0.0-rc.0(@angular/ssr@20.0.0-rc.0)(@types/node@18.19.87)(chokidar@4.0.3)(karma@6.4.4)(less@4.3.0)(postcss@8.5.3)(terser@5.39.0)(tslib@2.8.1)(tsx@4.19.3)(typescript@5.8.2)
+      '@angular/ssr': 20.0.0-rc.0
       '@babel/core': 7.27.1
       '@babel/generator': 7.27.1
       '@babel/helper-annotate-as-pure': 7.27.1
@@ -919,7 +917,7 @@ packages:
         optional: true
     dependencies:
       ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
+      ajv-formats: 3.0.1
       chokidar: 4.0.3
       jsonc-parser: 3.3.1
       picomatch: 4.0.2
@@ -937,7 +935,7 @@ packages:
         optional: true
     dependencies:
       ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
+      ajv-formats: 3.0.1
       chokidar: 4.0.3
       jsonc-parser: 3.3.1
       picomatch: 4.0.2
@@ -957,10 +955,10 @@ packages:
       - chokidar
     dev: false
 
-  /@angular/benchpress@0.3.0(rxjs@7.8.2)(zone.js@0.15.0):
+  /@angular/benchpress@0.3.0(rxjs@7.8.2):
     resolution: {integrity: sha512-ApxoY5lTj1S0QFLdq5ZdTfdkIds1m3tma9EJOZpNVHRU9eCj2D/5+VFb5tlWsv9NHQ2S0XXkJjauFOAdfzT8uw==, tarball: https://registry.npmjs.org/@angular/benchpress/-/benchpress-0.3.0.tgz}
     dependencies:
-      '@angular/core': 20.0.0-rc.0(rxjs@7.8.2)(zone.js@0.15.0)
+      '@angular/core': 20.0.0-rc.0(rxjs@7.8.2)
       reflect-metadata: 0.1.14
     transitivePeerDependencies:
       - '@angular/compiler'
@@ -968,7 +966,7 @@ packages:
       - zone.js
     dev: true
 
-  /@angular/build@19.1.0-rc.0(@angular/ssr@20.0.0-rc.0)(@types/node@18.19.87)(chokidar@4.0.3)(less@4.3.0)(postcss@8.5.3)(terser@5.39.0)(tsx@4.19.3)(typescript@5.7.3):
+  /@angular/build@19.1.0-rc.0(@angular/ssr@20.0.0-rc.0)(@types/node@18.19.87)(chokidar@4.0.3)(terser@5.39.0)(tsx@4.19.3)(typescript@5.7.3):
     resolution: {integrity: sha512-ALl+MVMYBF+E7HyAQ+1MtE6sNIOAX0o2Sfs0wdIQfM2unRl6jPsz/Ker4BjnNQIK4wRCcstyzBv5mZBDulfFIQ==, tarball: https://registry.npmjs.org/@angular/build/-/build-19.1.0-rc.0.tgz}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     peerDependencies:
@@ -1003,7 +1001,7 @@ packages:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1901.0-rc.0(chokidar@4.0.3)
-      '@angular/ssr': 20.0.0-rc.0(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)(@angular/router@20.0.0-rc.0)
+      '@angular/ssr': 20.0.0-rc.0
       '@babel/core': 7.26.0
       '@babel/helper-annotate-as-pure': 7.25.9
       '@babel/helper-split-export-declaration': 7.24.7
@@ -1016,19 +1014,17 @@ packages:
       fast-glob: 3.3.3
       https-proxy-agent: 7.0.6(supports-color@10.0.0)
       istanbul-lib-instrument: 6.0.3
-      less: 4.3.0
       listr2: 8.2.5
       magic-string: 0.30.17
       mrmime: 2.0.0
       parse5-html-rewriting-stream: 7.0.0
       picomatch: 4.0.2
       piscina: 4.8.0
-      postcss: 8.5.3
       rollup: 4.30.1
       sass: 1.83.1
       semver: 7.6.3
       typescript: 5.7.3
-      vite: 6.0.7(@types/node@18.19.87)(less@4.3.0)(sass@1.83.1)(terser@5.39.0)(tsx@4.19.3)
+      vite: 6.0.7(@types/node@18.19.87)(sass@1.83.1)(terser@5.39.0)(tsx@4.19.3)
       watchpack: 2.4.2
     optionalDependencies:
       lmdb: 3.2.2
@@ -1046,7 +1042,7 @@ packages:
       - yaml
     dev: true
 
-  /@angular/build@20.0.0-rc.0(@angular/core@20.0.0-rc.0)(@angular/platform-browser@20.0.0-rc.0)(@angular/ssr@20.0.0-rc.0)(@types/node@18.19.87)(chokidar@4.0.3)(karma@6.4.4)(less@4.3.0)(postcss@8.5.3)(terser@5.39.0)(tslib@2.8.1)(tsx@4.19.3)(typescript@5.8.2):
+  /@angular/build@20.0.0-rc.0(@angular/ssr@20.0.0-rc.0)(@types/node@18.19.87)(chokidar@4.0.3)(karma@6.4.4)(less@4.3.0)(postcss@8.5.3)(terser@5.39.0)(tslib@2.8.1)(tsx@4.19.3)(typescript@5.8.2):
     resolution: {integrity: sha512-cVKDaoloiiN06dMnsS0ARDP5QMKVpQSijTBHr2Fpvxi6615rTEQAhj/VgTECVYhkRRNm4cILP1RX1KvqWkawEA==, tarball: https://registry.npmjs.org/@angular/build/-/build-20.0.0-rc.0.tgz}
     engines: {node: ^20.11.1 || ^22.11.0 || >=24.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     peerDependencies:
@@ -1094,9 +1090,7 @@ packages:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2000.0-rc.0(chokidar@4.0.3)
-      '@angular/core': 20.0.0-rc.0(rxjs@7.8.2)(zone.js@0.15.0)
-      '@angular/platform-browser': 20.0.0-rc.0(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)
-      '@angular/ssr': 20.0.0-rc.0(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)(@angular/router@20.0.0-rc.0)
+      '@angular/ssr': 20.0.0-rc.0
       '@babel/core': 7.27.1
       '@babel/helper-annotate-as-pure': 7.27.1
       '@babel/helper-split-export-declaration': 7.24.7
@@ -1142,15 +1136,13 @@ packages:
       - yaml
     dev: false
 
-  /@angular/cdk@20.0.0-rc.0(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)(rxjs@7.8.2):
+  /@angular/cdk@20.0.0-rc.0(rxjs@7.8.2):
     resolution: {integrity: sha512-dvSacjyg5+6GCQiQpXIfguFcjrtR2R0uweUL8R9ZpGRi35jA0HqUYYY99asqyvhMS/G7F0etxRaPWu/d6sHpzg==, tarball: https://registry.npmjs.org/@angular/cdk/-/cdk-20.0.0-rc.0.tgz}
     peerDependencies:
       '@angular/common': ^20.0.0-0 || ^20.1.0-0 || ^20.2.0-0 || ^20.3.0-0 || ^21.0.0-0
       '@angular/core': 20.0.0-rc.0
       rxjs: ^6.5.3 || ^7.4.0
     dependencies:
-      '@angular/common': 20.0.0-rc.0(@angular/core@20.0.0-rc.0)(rxjs@7.8.2)
-      '@angular/core': 20.0.0-rc.0(rxjs@7.8.2)(zone.js@0.15.0)
       parse5: 7.3.0
       rxjs: 7.8.2
       tslib: 2.8.1
@@ -1183,18 +1175,7 @@ packages:
       - supports-color
     dev: false
 
-  /@angular/common@20.0.0-rc.0(@angular/core@20.0.0-rc.0)(rxjs@7.8.2):
-    resolution: {integrity: sha512-aaEjRPtVv0DF3q6wPHRfephY1kMYTefmFH35z+hzcUVIrVyYQdT/LIUX3L+C9ITfYyLmFWlENf3HxmVUILfXAg==, tarball: https://registry.npmjs.org/@angular/common/-/common-20.0.0-rc.0.tgz}
-    engines: {node: ^20.11.1 || ^22.11.0 || >=24.0.0}
-    peerDependencies:
-      '@angular/core': 20.0.0-rc.0
-      rxjs: ^6.5.3 || ^7.4.0
-    dependencies:
-      '@angular/core': 20.0.0-rc.0(rxjs@7.8.2)(zone.js@0.15.0)
-      rxjs: 7.8.2
-      tslib: 2.8.1
-
-  /@angular/core@20.0.0-rc.0(rxjs@7.8.2)(zone.js@0.15.0):
+  /@angular/core@20.0.0-rc.0(rxjs@7.8.2):
     resolution: {integrity: sha512-RKIXYA129vdrRKrnac2XOgpWuYusWqwM4KsQ7b5qKIMZabJ0a2GoOlezT6+NhPkOSsyygYuZtaia5wzQeU1acA==, tarball: https://registry.npmjs.org/@angular/core/-/core-20.0.0-rc.0.tgz}
     engines: {node: ^20.11.1 || ^22.11.0 || >=24.0.0}
     peerDependencies:
@@ -1207,25 +1188,9 @@ packages:
     dependencies:
       rxjs: 7.8.2
       tslib: 2.8.1
-      zone.js: 0.15.0
+    dev: true
 
-  /@angular/forms@20.0.0-rc.0(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)(@angular/platform-browser@20.0.0-rc.0)(rxjs@7.8.2):
-    resolution: {integrity: sha512-RH95gg+WBBHS+m6y2XDTCCUZMg6Xih1Y4G91tnBdzSxV32evqyNDrSA9IxOhC6Ztxcd+2aLg1S1hsaiMbF2Alw==, tarball: https://registry.npmjs.org/@angular/forms/-/forms-20.0.0-rc.0.tgz}
-    engines: {node: ^20.11.1 || ^22.11.0 || >=24.0.0}
-    peerDependencies:
-      '@angular/common': 20.0.0-rc.0
-      '@angular/core': 20.0.0-rc.0
-      '@angular/platform-browser': 20.0.0-rc.0
-      rxjs: ^6.5.3 || ^7.4.0
-    dependencies:
-      '@angular/common': 20.0.0-rc.0(@angular/core@20.0.0-rc.0)(rxjs@7.8.2)
-      '@angular/core': 20.0.0-rc.0(rxjs@7.8.2)(zone.js@0.15.0)
-      '@angular/platform-browser': 20.0.0-rc.0(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)
-      rxjs: 7.8.2
-      tslib: 2.8.1
-    dev: false
-
-  /@angular/material@20.0.0-rc.0(@angular/cdk@20.0.0-rc.0)(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)(@angular/forms@20.0.0-rc.0)(@angular/platform-browser@20.0.0-rc.0)(rxjs@7.8.2):
+  /@angular/material@20.0.0-rc.0(@angular/cdk@20.0.0-rc.0)(rxjs@7.8.2):
     resolution: {integrity: sha512-Z6uaTLaTdfMoT2RnL8GB1na/n2/0d9Dk5h2wSsymyZFJz/U20btCQuor9Cvb/mUlrPs/uu/5SWDMpigRXlaomg==, tarball: https://registry.npmjs.org/@angular/material/-/material-20.0.0-rc.0.tgz}
     peerDependencies:
       '@angular/cdk': 20.0.0-rc.0
@@ -1235,46 +1200,12 @@ packages:
       '@angular/platform-browser': ^20.0.0-0 || ^20.1.0-0 || ^20.2.0-0 || ^20.3.0-0 || ^21.0.0-0
       rxjs: ^6.5.3 || ^7.4.0
     dependencies:
-      '@angular/cdk': 20.0.0-rc.0(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)(rxjs@7.8.2)
-      '@angular/common': 20.0.0-rc.0(@angular/core@20.0.0-rc.0)(rxjs@7.8.2)
-      '@angular/core': 20.0.0-rc.0(rxjs@7.8.2)(zone.js@0.15.0)
-      '@angular/forms': 20.0.0-rc.0(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)(@angular/platform-browser@20.0.0-rc.0)(rxjs@7.8.2)
-      '@angular/platform-browser': 20.0.0-rc.0(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)
+      '@angular/cdk': 20.0.0-rc.0(rxjs@7.8.2)
       rxjs: 7.8.2
       tslib: 2.8.1
     dev: false
 
-  /@angular/platform-browser@20.0.0-rc.0(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0):
-    resolution: {integrity: sha512-mu2g1PNJkGCJxyCA366nGQt3abX9jx+VTcPR1PRaLqY/sGzA42sYJTG/M74CIpfnx9Sxb1hD3/XCB3xbN5rPhw==, tarball: https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.0.0-rc.0.tgz}
-    engines: {node: ^20.11.1 || ^22.11.0 || >=24.0.0}
-    peerDependencies:
-      '@angular/animations': 20.0.0-rc.0
-      '@angular/common': 20.0.0-rc.0
-      '@angular/core': 20.0.0-rc.0
-    peerDependenciesMeta:
-      '@angular/animations':
-        optional: true
-    dependencies:
-      '@angular/common': 20.0.0-rc.0(@angular/core@20.0.0-rc.0)(rxjs@7.8.2)
-      '@angular/core': 20.0.0-rc.0(rxjs@7.8.2)(zone.js@0.15.0)
-      tslib: 2.8.1
-
-  /@angular/router@20.0.0-rc.0(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)(@angular/platform-browser@20.0.0-rc.0)(rxjs@7.8.2):
-    resolution: {integrity: sha512-QkViBejo2xZwyGMHcM7NJh8QxhrAEeNq58Yoph6owzGb1/LMArVvZgoJAJC8HW3ojHN8xFUIfgxM4sFjjcw0dA==, tarball: https://registry.npmjs.org/@angular/router/-/router-20.0.0-rc.0.tgz}
-    engines: {node: ^20.11.1 || ^22.11.0 || >=24.0.0}
-    peerDependencies:
-      '@angular/common': 20.0.0-rc.0
-      '@angular/core': 20.0.0-rc.0
-      '@angular/platform-browser': 20.0.0-rc.0
-      rxjs: ^6.5.3 || ^7.4.0
-    dependencies:
-      '@angular/common': 20.0.0-rc.0(@angular/core@20.0.0-rc.0)(rxjs@7.8.2)
-      '@angular/core': 20.0.0-rc.0(rxjs@7.8.2)(zone.js@0.15.0)
-      '@angular/platform-browser': 20.0.0-rc.0(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)
-      rxjs: 7.8.2
-      tslib: 2.8.1
-
-  /@angular/ssr@20.0.0-rc.0(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)(@angular/router@20.0.0-rc.0):
+  /@angular/ssr@20.0.0-rc.0:
     resolution: {integrity: sha512-PqAXHxJvahRbEgDVpd8eYVqM0PEYd4kpvBtpoH532TQi173hoNQxYf9JY6O/ECADqe6ZEqiIgGWy41l1jt7XcA==, tarball: https://registry.npmjs.org/@angular/ssr/-/ssr-20.0.0-rc.0.tgz}
     peerDependencies:
       '@angular/common': ^20.0.0 || ^20.0.0-next.0
@@ -1285,9 +1216,6 @@ packages:
       '@angular/platform-server':
         optional: true
     dependencies:
-      '@angular/common': 20.0.0-rc.0(@angular/core@20.0.0-rc.0)(rxjs@7.8.2)
-      '@angular/core': 20.0.0-rc.0(rxjs@7.8.2)(zone.js@0.15.0)
-      '@angular/router': 20.0.0-rc.0(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)(@angular/platform-browser@20.0.0-rc.0)(rxjs@7.8.2)
       tslib: 2.8.1
 
   /@antfu/install-pkg@1.0.0:
@@ -2564,7 +2492,7 @@ packages:
     hasBin: true
     dev: true
 
-  /@bazel/concatjs@5.8.1(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-junit-reporter@2.0.1)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(typescript@5.7.3):
+  /@bazel/concatjs@5.8.1(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(typescript@5.7.3):
     resolution: {integrity: sha512-TkARsNUxgi3bjFeGwIGlffmQglNhuR9qK9uE7uKhdBZvQE5caAWVCjYiMTzo3viKDhwKn5QNRcHY5huuJMVFfA==, tarball: https://registry.npmjs.org/@bazel/concatjs/-/concatjs-5.8.1.tgz}
     hasBin: true
     peerDependencies:
@@ -2580,7 +2508,6 @@ packages:
       karma-chrome-launcher: 3.2.0
       karma-firefox-launcher: 2.1.3
       karma-jasmine: 5.1.0(karma@6.4.4)
-      karma-junit-reporter: 2.0.1(karma@6.4.4)
       karma-requirejs: 1.1.0(karma@6.4.4)(requirejs@2.3.7)
       karma-sourcemap-loader: 0.4.0
       protobufjs: 6.8.8
@@ -2590,7 +2517,7 @@ packages:
       - typescript
     dev: true
 
-  /@bazel/concatjs@5.8.1(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-junit-reporter@2.0.1)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(typescript@5.8.2):
+  /@bazel/concatjs@5.8.1(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(typescript@5.8.2):
     resolution: {integrity: sha512-TkARsNUxgi3bjFeGwIGlffmQglNhuR9qK9uE7uKhdBZvQE5caAWVCjYiMTzo3viKDhwKn5QNRcHY5huuJMVFfA==, tarball: https://registry.npmjs.org/@bazel/concatjs/-/concatjs-5.8.1.tgz}
     hasBin: true
     peerDependencies:
@@ -2606,7 +2533,6 @@ packages:
       karma-chrome-launcher: 3.2.0
       karma-firefox-launcher: 2.1.3
       karma-jasmine: 5.1.0(karma@6.4.4)
-      karma-junit-reporter: 2.0.1(karma@6.4.4)
       karma-requirejs: 1.1.0(karma@6.4.4)(requirejs@2.3.7)
       karma-sourcemap-loader: 0.4.0
       protobufjs: 6.8.8
@@ -5287,7 +5213,7 @@ packages:
       '@types/node': 18.19.87
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
-      ajv-formats: 3.0.1(ajv@8.13.0)
+      ajv-formats: 3.0.1
       fs-extra: 7.0.1
       import-lazy: 4.0.0
       jju: 1.4.0
@@ -5306,7 +5232,7 @@ packages:
       '@types/node': 18.19.87
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
-      ajv-formats: 3.0.1(ajv@8.13.0)
+      ajv-formats: 3.0.1
       fs-extra: 11.3.0
       import-lazy: 4.0.0
       jju: 1.4.0
@@ -6244,7 +6170,7 @@ packages:
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
     dependencies:
-      vite: 6.0.7(@types/node@18.19.87)(less@4.3.0)(sass@1.83.1)(terser@5.39.0)(tsx@4.19.3)
+      vite: 6.0.7(@types/node@18.19.87)(sass@1.83.1)(terser@5.39.0)(tsx@4.19.3)
     dev: true
 
   /@vitejs/plugin-basic-ssl@2.0.0(vite@6.3.5):
@@ -6532,23 +6458,8 @@ packages:
     dependencies:
       ajv: 8.17.1
 
-  /ajv-formats@3.0.1(ajv@8.13.0):
+  /ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==, tarball: https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-    dependencies:
-      ajv: 8.13.0
-
-  /ajv-formats@3.0.1(ajv@8.17.1):
-    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==, tarball: https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
     dependencies:
       ajv: 8.17.1
 
@@ -6628,15 +6539,13 @@ packages:
     resolution: {integrity: sha512-vqsT6zwu80cZ8RY7qRQBZuy6Fq5X7/N5hkV9LzNT0c8b546rw4ErGK6muW1u2JnDKYa7+jJuaGM702bWir4HGw==, tarball: https://registry.npmjs.org/angular-mocks/-/angular-mocks-1.8.3.tgz}
     dev: false
 
-  /angular-split@19.0.0(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)(rxjs@7.8.2):
+  /angular-split@19.0.0(rxjs@7.8.2):
     resolution: {integrity: sha512-vQqXWLcCimFmInu2lpGKIfS9FtYBgKmoWenPjeYkHSRdWmb7HLGlQoNPj1oALrwdhIWFPdySgp0BIXDe2IAepQ==, tarball: https://registry.npmjs.org/angular-split/-/angular-split-19.0.0.tgz}
     peerDependencies:
       '@angular/common': '>=19.0.0'
       '@angular/core': 20.0.0-rc.0
       rxjs: '>=7.0.0'
     dependencies:
-      '@angular/common': 20.0.0-rc.0(@angular/core@20.0.0-rc.0)(rxjs@7.8.2)
-      '@angular/core': 20.0.0-rc.0(rxjs@7.8.2)(zone.js@0.15.0)
       rxjs: 7.8.2
       tslib: 2.8.1
     dev: true
@@ -8419,6 +8328,7 @@ packages:
     resolution: {integrity: sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==, tarball: https://registry.npmjs.org/copy-anything/-/copy-anything-2.0.6.tgz}
     dependencies:
       is-what: 3.14.1
+    dev: false
 
   /copy-descriptor@0.1.1:
     resolution: {integrity: sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==, tarball: https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz}
@@ -9501,6 +9411,7 @@ packages:
     hasBin: true
     dependencies:
       prr: 1.0.1
+    dev: false
     optional: true
 
   /error-ex@1.3.2:
@@ -10207,7 +10118,7 @@ packages:
       '@google-cloud/pubsub': 4.11.0
       abort-controller: 3.0.0
       ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
+      ajv-formats: 3.0.1
       archiver: 7.0.1
       async-lock: 1.4.1
       body-parser: 1.20.3
@@ -11456,6 +11367,7 @@ packages:
     resolution: {integrity: sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==, tarball: https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz}
     engines: {node: '>=0.10.0'}
     hasBin: true
+    dev: false
     optional: true
 
   /immediate@3.0.6:
@@ -12071,6 +11983,7 @@ packages:
 
   /is-what@3.14.1:
     resolution: {integrity: sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==, tarball: https://registry.npmjs.org/is-what/-/is-what-3.14.1.tgz}
+    dev: false
 
   /is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==, tarball: https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz}
@@ -12546,16 +12459,6 @@ packages:
       jasmine-core: 4.6.1
       karma: 6.4.4
 
-  /karma-junit-reporter@2.0.1(karma@6.4.4):
-    resolution: {integrity: sha512-VtcGfE0JE4OE1wn0LK8xxDKaTP7slN8DO3I+4xg6gAi1IoAHAXOJ1V9G/y45Xg6sxdxPOR3THCFtDlAfBo9Afw==, tarball: https://registry.npmjs.org/karma-junit-reporter/-/karma-junit-reporter-2.0.1.tgz}
-    engines: {node: '>= 8'}
-    peerDependencies:
-      karma: '>=0.9'
-    dependencies:
-      karma: 6.4.4
-      path-is-absolute: 1.0.1
-      xmlbuilder: 12.0.0
-
   /karma-requirejs@1.1.0(karma@6.4.4)(requirejs@2.3.7):
     resolution: {integrity: sha512-MHTOYKdwwJBkvYid0TaYvBzOnFH3TDtzo6ie5E4o9SaUSXXsfMRLa/whUz6efVIgTxj1xnKYasNn/XwEgJeB/Q==, tarball: https://registry.npmjs.org/karma-requirejs/-/karma-requirejs-1.1.0.tgz}
     peerDependencies:
@@ -12751,6 +12654,7 @@ packages:
       mime: 1.6.0
       needle: 3.3.1
       source-map: 0.6.1
+    dev: false
 
   /leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==, tarball: https://registry.npmjs.org/leven/-/leven-3.1.0.tgz}
@@ -13158,6 +13062,7 @@ packages:
     dependencies:
       pify: 4.0.1
       semver: 5.7.2
+    dev: false
 
   /make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==, tarball: https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz}
@@ -13767,6 +13672,7 @@ packages:
     dependencies:
       iconv-lite: 0.6.3
       sax: 1.4.1
+    dev: false
     optional: true
 
   /negotiator@0.6.3:
@@ -13790,18 +13696,16 @@ packages:
     engines: {node: '>= 0.4.0'}
     dev: true
 
-  /ngx-flamegraph@0.0.12(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0):
+  /ngx-flamegraph@0.0.12:
     resolution: {integrity: sha512-YoxrqlL36Bg5Ca9fu10kuSUmaWHAvx7jkxINF4/4cXn9bBPRfu78FqnZ5LIULC0+iScZcSDSWDAnUdn8H7+wGw==, tarball: https://registry.npmjs.org/ngx-flamegraph/-/ngx-flamegraph-0.0.12.tgz}
     peerDependencies:
       '@angular/common': ^9.0.0
       '@angular/core': 20.0.0-rc.0
     dependencies:
-      '@angular/common': 20.0.0-rc.0(@angular/core@20.0.0-rc.0)(rxjs@7.8.2)
-      '@angular/core': 20.0.0-rc.0(rxjs@7.8.2)(zone.js@0.15.0)
       tslib: 2.8.1
     dev: false
 
-  /ngx-progressbar@14.0.0(@angular/cdk@20.0.0-rc.0)(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)(rxjs@7.8.2):
+  /ngx-progressbar@14.0.0(@angular/cdk@20.0.0-rc.0)(rxjs@7.8.2):
     resolution: {integrity: sha512-tDj7h5F2aSI4/XaJjs50FnELVe6qFqyz3vVq22acacd3oDW2EyJB4c+IYaxMf5972OdTw0WL4n6UwQ3dqC+gCA==, tarball: https://registry.npmjs.org/ngx-progressbar/-/ngx-progressbar-14.0.0.tgz}
     peerDependencies:
       '@angular/cdk': '>=17.3.0'
@@ -13809,9 +13713,7 @@ packages:
       '@angular/core': 20.0.0-rc.0
       rxjs: '>=7.0.0'
     dependencies:
-      '@angular/cdk': 20.0.0-rc.0(@angular/common@20.0.0-rc.0)(@angular/core@20.0.0-rc.0)(rxjs@7.8.2)
-      '@angular/common': 20.0.0-rc.0(@angular/core@20.0.0-rc.0)(rxjs@7.8.2)
-      '@angular/core': 20.0.0-rc.0(rxjs@7.8.2)(zone.js@0.15.0)
+      '@angular/cdk': 20.0.0-rc.0(rxjs@7.8.2)
       rxjs: 7.8.2
       tslib: 2.8.1
     dev: false
@@ -14436,6 +14338,7 @@ packages:
   /parse-node-version@1.0.1:
     resolution: {integrity: sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==, tarball: https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz}
     engines: {node: '>= 0.10'}
+    dev: false
 
   /parse-passwd@1.0.0:
     resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==, tarball: https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz}
@@ -14693,6 +14596,7 @@ packages:
   /pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==, tarball: https://registry.npmjs.org/pify/-/pify-4.0.1.tgz}
     engines: {node: '>=6'}
+    dev: false
 
   /pinkie-promise@2.0.1:
     resolution: {integrity: sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==, tarball: https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz}
@@ -15067,6 +14971,7 @@ packages:
 
   /prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==, tarball: https://registry.npmjs.org/prr/-/prr-1.0.1.tgz}
+    dev: false
     optional: true
 
   /psl@1.15.0:
@@ -17530,7 +17435,7 @@ packages:
       typescript: '>=3.9.2'
     dependencies:
       '@bazel/bazelisk': 1.26.0
-      '@bazel/concatjs': 5.8.1(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-junit-reporter@2.0.1)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(typescript@5.8.2)
+      '@bazel/concatjs': 5.8.1(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(typescript@5.8.2)
       glob: 7.2.3
       minimatch: 3.1.2
       typescript: 5.8.2
@@ -18257,7 +18162,7 @@ packages:
       teex: 1.0.1
     dev: true
 
-  /vite@6.0.7(@types/node@18.19.87)(less@4.3.0)(sass@1.83.1)(terser@5.39.0)(tsx@4.19.3):
+  /vite@6.0.7(@types/node@18.19.87)(sass@1.83.1)(terser@5.39.0)(tsx@4.19.3):
     resolution: {integrity: sha512-RDt8r/7qx9940f8FcOIAH9PTViRrghKaK2K1jY3RaAURrEUbm9Du1mJ72G+jlhtG3WwodnfzY8ORQZbBavZEAQ==, tarball: https://registry.npmjs.org/vite/-/vite-6.0.7.tgz}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -18299,7 +18204,6 @@ packages:
     dependencies:
       '@types/node': 18.19.87
       esbuild: 0.24.2
-      less: 4.3.0
       postcss: 8.5.3
       rollup: 4.40.2
       sass: 1.83.1
@@ -18966,10 +18870,6 @@ packages:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==, tarball: https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz}
     engines: {node: '>=4.0'}
 
-  /xmlbuilder@12.0.0:
-    resolution: {integrity: sha512-lMo8DJ8u6JRWp0/Y4XLa/atVDr75H9litKlb2E5j3V3MesoL50EBgZDWoLT3F/LztVnG67GjPXLZpqcky/UMnQ==, tarball: https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-12.0.0.tgz}
-    engines: {node: '>=6.0'}
-
   /xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==, tarball: https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz}
     dev: true
@@ -19114,25 +19014,22 @@ packages:
     resolution: {integrity: sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==, tarball: https://registry.npmjs.org/zod/-/zod-3.24.3.tgz}
     dev: true
 
-  /zone.js@0.15.0:
-    resolution: {integrity: sha512-9oxn0IIjbCZkJ67L+LkhYWRyAy7axphb3VgE2MBDlOqnmHMPWGYMxJxBYFueFq/JGY2GMwS0rU+UCLunEmy5UA==, tarball: https://registry.npmjs.org/zone.js/-/zone.js-0.15.0.tgz}
-
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==, tarball: https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz}
     dev: true
 
-  github.com/angular/dev-infra-private-build-tooling-builds/ce04ec6cf7604014191821a637e60964a1a3bb4a(@angular/ssr@20.0.0-rc.0)(chokidar@4.0.3)(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-junit-reporter@2.0.1)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(less@4.3.0)(postcss@8.5.3)(rxjs@7.8.2)(terser@5.39.0)(tsx@4.19.3)(zone.js@0.15.0):
+  github.com/angular/dev-infra-private-build-tooling-builds/ce04ec6cf7604014191821a637e60964a1a3bb4a(@angular/ssr@20.0.0-rc.0)(chokidar@4.0.3)(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(rxjs@7.8.2)(terser@5.39.0)(tsx@4.19.3):
     resolution: {tarball: https://codeload.github.com/angular/dev-infra-private-build-tooling-builds/tar.gz/ce04ec6cf7604014191821a637e60964a1a3bb4a}
     id: github.com/angular/dev-infra-private-build-tooling-builds/ce04ec6cf7604014191821a637e60964a1a3bb4a
     name: '@angular/build-tooling'
     version: 0.0.0-2670abf637fa155971cdd1f7e570a7f234922a65
     dependencies:
-      '@angular/benchpress': 0.3.0(rxjs@7.8.2)(zone.js@0.15.0)
-      '@angular/build': 19.1.0-rc.0(@angular/ssr@20.0.0-rc.0)(@types/node@18.19.87)(chokidar@4.0.3)(less@4.3.0)(postcss@8.5.3)(terser@5.39.0)(tsx@4.19.3)(typescript@5.7.3)
+      '@angular/benchpress': 0.3.0(rxjs@7.8.2)
+      '@angular/build': 19.1.0-rc.0(@angular/ssr@20.0.0-rc.0)(@types/node@18.19.87)(chokidar@4.0.3)(terser@5.39.0)(tsx@4.19.3)(typescript@5.7.3)
       '@babel/core': 7.27.1
       '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.27.1)
       '@bazel/buildifier': 6.3.3
-      '@bazel/concatjs': 5.8.1(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-junit-reporter@2.0.1)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(typescript@5.7.3)
+      '@bazel/concatjs': 5.8.1(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(typescript@5.7.3)
       '@bazel/esbuild': 5.8.1
       '@bazel/protractor': 5.8.1(protractor@7.0.0)
       '@bazel/runfiles': 5.8.1

--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,7 @@
     "executionMode": "branch"
   },
   "ignoreDeps": [
+    "@angular/build-tooling",
     "@types/selenium-webdriver",
     "angular-1.5",
     "angular-1.6",


### PR DESCRIPTION
Avoid pnpm auto-installing peer dependencies. We want to be explicit about our versions used for peer dependencies, avoiding potential mismatches. In addition, it ensures we can continue to rely on peer dependency placeholders substituted via Bazel.