### PR TITLE
docs(docs-infra): fix API query filtering.

### DIFF
--- a/adev/shared-docs/components/text-field/text-field.component.ts
+++ b/adev/shared-docs/components/text-field/text-field.component.ts
@@ -63,8 +63,8 @@ export class TextField implements ControlValueAccessor {
   }
 
   // Implemented as part of ControlValueAccessor.
-  writeValue(value: string): void {
-    this.value.set(value);
+  writeValue(value: unknown): void {
+    this.value.set(typeof value === 'string' ? value : null);
   }
 
   // Implemented as part of ControlValueAccessor.


### PR DESCRIPTION
On `19.2`  we pass an undefined value to the text-field. But more generaly, the CVA should protect itself if it doesn't recieve an `undefined` value.

fixes #61299
