### PR TITLE
docs: fix button styling on the profiler frame selector

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/frame-selector.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/frame-selector.component.ts
@@ -30,6 +30,7 @@ import {MatIcon} from '@angular/material/icon';
 import {MatTooltip} from '@angular/material/tooltip';
 import {MatCard} from '@angular/material/card';
 import {NgStyle} from '@angular/common';
+import {MatIconButton} from '@angular/material/button';
 
 const ITEM_WIDTH = 30;
 
@@ -41,6 +42,7 @@ const ITEM_WIDTH = 30;
     MatCard,
     MatTooltip,
     MatIcon,
+    MatIconButton,
     CdkVirtualScrollViewport,
     CdkFixedSizeVirtualScroll,
     CdkVirtualForOf,


### PR DESCRIPTION
Missing standalone import.
