### PR TITLE
refactor(router): add return types to exported functions

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -5,7 +5,6 @@
 ```ts
 
 import { AfterContentInit } from '@angular/core';
-import * as _angular_router from '@angular/router';
 import { ChangeDetectorRef } from '@angular/core';
 import { ComponentRef } from '@angular/core';
 import { ElementRef } from '@angular/core';
@@ -728,7 +727,7 @@ export class Router {
     resetConfig(config: Routes): void;
     // @deprecated
     routeReuseStrategy: RouteReuseStrategy;
-    get routerState(): _angular_router.RouterState;
+    get routerState(): RouterState;
     serializeUrl(url: UrlTree): string;
     setUpLocationChangeListener(): void;
     get url(): string;

--- a/goldens/public-api/router/testing/index.api.md
+++ b/goldens/public-api/router/testing/index.api.md
@@ -5,7 +5,6 @@
 ```ts
 
 import { AfterContentInit } from '@angular/core';
-import * as _angular_router from '@angular/router';
 import { ChangeDetectorRef } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { ComponentRef } from '@angular/core';

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -322,7 +322,7 @@ export class RouterLink implements OnChanges, OnDestroy {
 
   /** @docs-private */
   // TODO(atscott): Remove changes parameter in major version as a breaking change.
-  ngOnChanges(changes?: SimpleChanges) {
+  ngOnChanges(changes?: SimpleChanges): void {
     if (
       ngDevMode &&
       isUrlTree(this.routerLinkInput) &&

--- a/packages/router/src/directives/router_link_active.ts
+++ b/packages/router/src/directives/router_link_active.ts
@@ -112,7 +112,7 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
   private linkInputChangesSubscription?: Subscription;
   private _isActive = false;
 
-  get isActive() {
+  get isActive(): boolean {
     return this._isActive;
   }
 

--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -247,7 +247,7 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
   readonly supportsBindingToComponentInputs = true;
 
   /** @docs-private */
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges): void {
     if (changes['name']) {
       const {firstChange, previousValue} = changes['name'];
       if (firstChange) {
@@ -357,7 +357,7 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
   /**
    * Called when the `RouteReuseStrategy` instructs to re-attach a previously detached subtree
    */
-  attach(ref: ComponentRef<any>, activatedRoute: ActivatedRoute) {
+  attach(ref: ComponentRef<any>, activatedRoute: ActivatedRoute): void {
     this.activated = ref;
     this._activatedRoute = activatedRoute;
     this.location.insert(ref.hostView);
@@ -375,7 +375,7 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
     }
   }
 
-  activateWith(activatedRoute: ActivatedRoute, environmentInjector: EnvironmentInjector) {
+  activateWith(activatedRoute: ActivatedRoute, environmentInjector: EnvironmentInjector): void {
     if (this.isActivated) {
       throw new RuntimeError(
         RuntimeErrorCode.OUTLET_ALREADY_ACTIVATED,
@@ -453,12 +453,12 @@ export const INPUT_BINDER = new InjectionToken<RoutedComponentInputBinder>('');
 export class RoutedComponentInputBinder {
   private outletDataSubscriptions = new Map<RouterOutlet, Subscription>();
 
-  bindActivatedRouteToOutletComponent(outlet: RouterOutlet) {
+  bindActivatedRouteToOutletComponent(outlet: RouterOutlet): void {
     this.unsubscribeFromRouteData(outlet);
     this.subscribeToRouteData(outlet);
   }
 
-  unsubscribeFromRouteData(outlet: RouterOutlet) {
+  unsubscribeFromRouteData(outlet: RouterOutlet): void {
     this.outletDataSubscriptions.get(outlet)?.unsubscribe();
     this.outletDataSubscriptions.delete(outlet);
   }

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -58,6 +58,7 @@ import {
 } from './url_tree';
 import {validateConfig} from './utils/config';
 import {afterNextNavigation} from './utils/navigations';
+import {RouterState} from './router_state';
 
 /**
  * The equivalent `IsActiveMatchOptions` options for `Router.isActive` is called with `true`
@@ -136,7 +137,7 @@ export class Router {
   /**
    * The current state of routing in this NgModule.
    */
-  get routerState() {
+  get routerState(): RouterState {
     return this.stateManager.getRouterState();
   }
 

--- a/packages/router/src/router_outlet_context.ts
+++ b/packages/router/src/router_outlet_context.ts
@@ -74,7 +74,7 @@ export class ChildrenOutletContexts {
     return contexts;
   }
 
-  onOutletReAttached(contexts: Map<string, OutletContext>) {
+  onOutletReAttached(contexts: Map<string, OutletContext>): void {
     this.contexts = contexts;
   }
 

--- a/packages/router/src/router_scroller.ts
+++ b/packages/router/src/router_scroller.ts
@@ -135,7 +135,7 @@ export class RouterScroller implements OnDestroy {
   }
 
   /** @docs-private */
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     this.routerEventsSubscription?.unsubscribe();
     this.scrollEventsSubscription?.unsubscribe();
   }

--- a/packages/router/src/statemanager/state_manager.ts
+++ b/packages/router/src/statemanager/state_manager.ts
@@ -91,7 +91,7 @@ export abstract class StateManager {
     return path;
   }
 
-  protected commitTransition({targetRouterState, finalUrl, initialUrl}: Navigation) {
+  protected commitTransition({targetRouterState, finalUrl, initialUrl}: Navigation): void {
     // If we are committing the transition after having a final URL and target state, we're updating
     // all pieces of the state. Otherwise, we likely skipped the transition (due to URL handling strategy)
     // and only want to update the rawUrlTree, which represents the browser URL (and doesn't necessarily match router state).
@@ -113,7 +113,7 @@ export abstract class StateManager {
 
   private stateMemento = this.createStateMemento();
 
-  protected updateStateMemento() {
+  protected updateStateMemento(): void {
     this.stateMemento = this.createStateMemento();
   }
 
@@ -209,7 +209,7 @@ export class HistoryStateManager extends StateManager {
     });
   }
 
-  override handleRouterEvent(e: Event | PrivateRouterEvents, currentTransition: Navigation) {
+  override handleRouterEvent(e: Event | PrivateRouterEvents, currentTransition: Navigation): void {
     if (e instanceof NavigationStart) {
       this.updateStateMemento();
     } else if (e instanceof NavigationSkipped) {

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -760,7 +760,7 @@ class UrlParser {
   }
 }
 
-export function createRoot(rootCandidate: UrlSegmentGroup) {
+export function createRoot(rootCandidate: UrlSegmentGroup): UrlSegmentGroup {
   return rootCandidate.segments.length > 0
     ? new UrlSegmentGroup([], {[PRIMARY_OUTLET]: rootCandidate})
     : rootCandidate;

--- a/packages/router/src/utils/collection.ts
+++ b/packages/router/src/utils/collection.ts
@@ -48,7 +48,10 @@ export function getDataKeys(obj: Object): Array<string | symbol> {
 /**
  * Test equality for arrays of strings or a string.
  */
-export function equalArraysOrString(a: string | readonly string[], b: string | readonly string[]) {
+export function equalArraysOrString(
+  a: string | readonly string[],
+  b: string | readonly string[],
+): boolean {
   if (Array.isArray(a) && Array.isArray(b)) {
     if (a.length !== b.length) return false;
     const aSorted = [...a].sort();

--- a/packages/router/src/utils/config.ts
+++ b/packages/router/src/utils/config.ts
@@ -31,7 +31,7 @@ import {PRIMARY_OUTLET} from '../shared';
 export function getOrCreateRouteInjectorIfNeeded(
   route: Route,
   currentInjector: EnvironmentInjector,
-) {
+): EnvironmentInjector {
   if (route.providers && !route._injector) {
     route._injector = createEnvironmentInjector(
       route.providers,
@@ -70,7 +70,7 @@ export function validateConfig(
   }
 }
 
-export function assertStandalone(fullPath: string, component: Type<unknown> | undefined) {
+export function assertStandalone(fullPath: string, component: Type<unknown> | undefined): void {
   if (component && isNgModule(component)) {
     throw new RuntimeError(
       RuntimeErrorCode.INVALID_ROUTE_CONFIG,

--- a/packages/router/src/utils/config_matching.ts
+++ b/packages/router/src/utils/config_matching.ts
@@ -115,7 +115,10 @@ export function split(
   consumedSegments: UrlSegment[],
   slicedSegments: UrlSegment[],
   config: Route[],
-) {
+): {
+  segmentGroup: UrlSegmentGroup;
+  slicedSegments: UrlSegment[];
+} {
   if (
     slicedSegments.length > 0 &&
     containsEmptyPathMatchesWithNamedOutlets(segmentGroup, slicedSegments, config)

--- a/packages/router/src/utils/navigations.ts
+++ b/packages/router/src/utils/navigations.ts
@@ -33,7 +33,7 @@ const enum NavigationResult {
  * redirecting/superseding navigation must finish.
  * - `NavigationError`, `NavigationEnd`, or `NavigationSkipped` event emits
  */
-export function afterNextNavigation(router: {events: Observable<Event>}, action: () => void) {
+export function afterNextNavigation(router: {events: Observable<Event>}, action: () => void): void {
   router.events
     .pipe(
       filter(

--- a/packages/router/src/utils/preactivation.ts
+++ b/packages/router/src/utils/preactivation.ts
@@ -42,7 +42,7 @@ export function getAllRouteGuards(
   future: RouterStateSnapshot,
   curr: RouterStateSnapshot,
   parentContexts: ChildrenOutletContexts,
-) {
+): Checks {
   const futureRoot = future._root;
   const currRoot = curr ? curr._root : null;
 

--- a/packages/router/src/utils/tree.ts
+++ b/packages/router/src/utils/tree.ts
@@ -100,7 +100,11 @@ export class TreeNode<T> {
 }
 
 // Return the list of T indexed by outlet name
-export function nodeChildrenAsMap<T extends {outlet: string}>(node: TreeNode<T> | null) {
+export function nodeChildrenAsMap<T extends {outlet: string}>(
+  node: TreeNode<T> | null,
+): {
+  [outlet: string]: TreeNode<T>;
+} {
   const map: {[outlet: string]: TreeNode<T>} = {};
 
   if (node) {

--- a/packages/router/upgrade/src/upgrade.ts
+++ b/packages/router/upgrade/src/upgrade.ts
@@ -70,7 +70,10 @@ export function locationSyncBootstrapListener(ngUpgrade: UpgradeModule) {
  *
  * @publicApi
  */
-export function setUpLocationSync(ngUpgrade: UpgradeModule, urlType: 'path' | 'hash' = 'path') {
+export function setUpLocationSync(
+  ngUpgrade: UpgradeModule,
+  urlType: 'path' | 'hash' = 'path',
+): void {
   if (!ngUpgrade.$injector) {
     throw new Error(`
         RouterUpgradeInitializer can be used only after UpgradeModule.bootstrap has been called.


### PR DESCRIPTION
Return types for exported functions from the router package have now been added. This provides preparation for the inclusion of additional linting rules which will eventually enforce the presence of return types for functions. It also improves readability and type correctness within the code. This is a type only change.