### PR TITLE
fix(compiler-cli): typo in NG2026 message

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -797,7 +797,7 @@ export class ComponentDecoratorHandler
           makeDiagnostic(
             ErrorCode.UNSUPPORTED_SELECTORLESS_COMPONENT_FIELD,
             (rawImports || rawDeferredImports)!,
-            `Cannot use the "${rawImports === null ? 'deferredImports' : 'imports'}" field in a selectorless components`,
+            `Cannot use the "${rawImports === null ? 'deferredImports' : 'imports'}" field in a selectorless component`,
           ),
         );
       }

--- a/packages/compiler-cli/src/ngtsc/scope/src/selectorless_scope.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/selectorless_scope.ts
@@ -13,7 +13,7 @@ import {ComponentScopeKind, ComponentScopeReader, SelectorlessScope} from './api
 import ts from 'typescript';
 
 /**
- * Computes the scope for a selectorless components by looking at imports within the same
+ * Computes the scope for a selectorless component by looking at imports within the same
  * file and resolving them to metadata.
  */
 export class SelectorlessComponentScopeReader implements ComponentScopeReader {

--- a/packages/compiler-cli/test/ngtsc/selectorless_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/selectorless_spec.ts
@@ -288,7 +288,7 @@ runInEachFileSystem(() => {
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
       expect(diags[0].messageText).toBe(
-        'Cannot use the "imports" field in a selectorless components',
+        'Cannot use the "imports" field in a selectorless component',
       );
     });
 
@@ -313,7 +313,7 @@ runInEachFileSystem(() => {
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
       expect(diags[0].messageText).toBe(
-        'Cannot use the "deferredImports" field in a selectorless components',
+        'Cannot use the "deferredImports" field in a selectorless component',
       );
     });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The newly introduced NG2026 error for selectorless components had a typo in its message.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
