### PR TITLE
refactor(compiler): account for pipes without names

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -1677,7 +1677,7 @@ export class ComponentDecoratorHandler
       const scopeDeps = isModuleScope ? scope.compilation.dependencies : scope.dependencies;
       for (const dep of scopeDeps) {
         // Outside of selectorless the pipes are referred to by their defined name.
-        if (dep.kind === MetaKind.Pipe) {
+        if (dep.kind === MetaKind.Pipe && dep.name !== null) {
           pipes.set(dep.name, dep);
         }
         dependencies.push(dep);
@@ -1725,7 +1725,7 @@ export class ComponentDecoratorHandler
 
       const deferBlockMatcher = new SelectorMatcher<DirectiveMeta[]>();
       for (const dep of allDependencies) {
-        if (dep.kind === MetaKind.Pipe) {
+        if (dep.kind === MetaKind.Pipe && dep.name !== null) {
           pipes.set(dep.name, dep);
         } else if (dep.kind === MetaKind.Directive && dep.selector !== null) {
           deferBlockMatcher.addSelectables(CssSelector.parse(dep.selector), [dep]);

--- a/packages/compiler-cli/src/ngtsc/docs/src/entities.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/entities.ts
@@ -137,7 +137,7 @@ export interface DirectiveEntry extends ClassEntry {
 }
 
 export interface PipeEntry extends ClassEntry {
-  pipeName: string;
+  pipeName: string | null;
   isStandalone: boolean;
   usage: string;
   isPure: boolean;

--- a/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
@@ -358,7 +358,7 @@ export interface TemplateGuardMeta {
 export interface PipeMeta {
   kind: MetaKind.Pipe;
   ref: Reference<ClassDeclaration>;
-  name: string;
+  name: string | null;
   nameExpr: ts.Expression | null;
   isStandalone: boolean;
   isPure: boolean;

--- a/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
@@ -246,11 +246,15 @@ export class DtsMetadataReader implements MetadataReader {
       return null;
     }
     const type = def.type.typeArguments[1];
-    if (!ts.isLiteralTypeNode(type) || !ts.isStringLiteral(type.literal)) {
+
+    if (
+      !ts.isLiteralTypeNode(type) ||
+      (!ts.isStringLiteral(type.literal) && type.literal.kind !== ts.SyntaxKind.NullKeyword)
+    ) {
       // The type metadata was the wrong type.
       return null;
     }
-    const name = type.literal.text;
+    const name = ts.isStringLiteral(type.literal) ? type.literal.text : null;
 
     const isStandalone =
       def.type.typeArguments.length > 2 && (readBooleanType(def.type.typeArguments[2]) ?? false);

--- a/packages/compiler-cli/src/ngtsc/scope/src/typecheck.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/typecheck.ts
@@ -138,7 +138,7 @@ export class TypeCheckScopeRegistry {
       for (const dep of allDependencies) {
         if (dep.kind === MetaKind.Directive) {
           directives.push(dep);
-        } else if (dep.kind === MetaKind.Pipe) {
+        } else if (dep.kind === MetaKind.Pipe && dep.name !== null) {
           pipes.set(dep.name, dep);
         }
       }

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/scope.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/scope.ts
@@ -83,7 +83,7 @@ export interface PotentialPipe {
   /**
    * Name of the pipe.
    */
-  name: string;
+  name: string | null;
 
   /**
    * Whether or not this pipe is in scope.

--- a/packages/compiler-cli/src/ngtsc/validation/src/rules/unused_standalone_imports_rule.ts
+++ b/packages/compiler-cli/src/ngtsc/validation/src/rules/unused_standalone_imports_rule.ts
@@ -138,6 +138,7 @@ export class UnusedStandaloneImportsRule implements SourceFileValidatorRule {
       if (
         pipeMeta !== null &&
         pipeMeta.isStandalone &&
+        pipeMeta.name !== null &&
         !usedPipes.has(pipeMeta.name) &&
         !this.isPotentialSharedReference(current, rawImports)
       ) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/pipes/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/pipes/GOLDEN_PARTIAL.js
@@ -243,3 +243,32 @@ export declare class MyModule {
     static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: nameless_pipe.js
+ ****************************************************************************************************/
+import { Pipe } from '@angular/core';
+import * as i0 from "@angular/core";
+// TODO(crisbeto): remove `null!` from the pipes when public API is updated.
+export class PipeWithoutName {
+    transform(value) {
+        return value;
+    }
+}
+PipeWithoutName.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: PipeWithoutName, deps: [], target: i0.ɵɵFactoryTarget.Pipe });
+PipeWithoutName.ɵpipe = i0.ɵɵngDeclarePipe({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: PipeWithoutName, isStandalone: true, name: "PipeWithoutName" });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: PipeWithoutName, decorators: [{
+            type: Pipe,
+            args: [null]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: nameless_pipe.d.ts
+ ****************************************************************************************************/
+import { PipeTransform } from '@angular/core';
+import * as i0 from "@angular/core";
+export declare class PipeWithoutName implements PipeTransform {
+    transform(value: unknown): unknown;
+    static ɵfac: i0.ɵɵFactoryDeclaration<PipeWithoutName, never>;
+    static ɵpipe: i0.ɵɵPipeDeclaration<PipeWithoutName, null, true>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/pipes/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/pipes/TEST_CASES.json
@@ -111,6 +111,20 @@
           ]
         }
       ]
+    },
+    {
+      "description": "should handle a pipe that does not have a name",
+      "inputFiles": [
+        "nameless_pipe.ts"
+      ],
+      "expectations": [
+        {
+          "failureMessage": "Invalid definition",
+          "files": [
+            "nameless_pipe.js"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/pipes/nameless_pipe.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/pipes/nameless_pipe.js
@@ -1,0 +1,1 @@
+ɵɵdefinePipe({name: "PipeWithoutName", type: PipeWithoutName, pure: true});

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/pipes/nameless_pipe.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/pipes/nameless_pipe.ts
@@ -1,0 +1,9 @@
+import {Pipe, PipeTransform} from '@angular/core';
+
+// TODO(crisbeto): remove `null!` from the pipes when public API is updated.
+@Pipe(null!)
+export class PipeWithoutName implements PipeTransform {
+  transform(value: unknown) {
+    return value;
+  }
+}

--- a/packages/compiler-cli/test/ngtsc/selectorless_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/selectorless_spec.ts
@@ -747,12 +747,13 @@ runInEachFileSystem(() => {
     });
 
     it('should import capitalized pipes implicitly', () => {
+      // TODO(crisbeto): remove `null!` from the pipes when public API is updated.
       env.write(
         'pipe.ts',
         `
           import {Pipe} from '@angular/core';
 
-          @Pipe({name: 'Foo'})
+          @Pipe(null!)
           export class FooPipe {
             transform(value: number) {
               return value + 1;
@@ -779,7 +780,40 @@ runInEachFileSystem(() => {
       );
     });
 
+    it('should import capitalized pipes from external modules implicitly', () => {
+      env.write(
+        'node_modules/external/index.d.ts',
+        `
+          import * as i0 from "@angular/core";
+
+          export declare class FooPipe {
+            transform(value: number): number;
+            static ɵfac: i0.ɵɵFactoryDeclaration<FooPipe, never>;
+            static ɵpipe: i0.ɵɵPipeDeclaration<FooPipe, null, true>;
+          }
+        `,
+      );
+
+      env.write(
+        'test.ts',
+        `
+          import {Component} from '@angular/core';
+          import {FooPipe} from 'external';
+
+          @Component({template: '<div>{{ "hello" | FooPipe }}</div>'})
+          export class Comp {}
+        `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(
+        `Argument of type 'string' is not assignable to parameter of type 'number'.`,
+      );
+    });
+
     it('should be able to alias imports of selectorless dependencies', () => {
+      // TODO(crisbeto): remove `null!` from the pipes when public API is updated.
       env.write(
         'dep.ts',
         `
@@ -791,7 +825,7 @@ runInEachFileSystem(() => {
           @Directive()
           export class DepDir {}
 
-          @Pipe({name: 'dep'})
+          @Pipe(null!)
           export class DepPipe {
             transform(value: number) {
               return value;
@@ -840,12 +874,13 @@ runInEachFileSystem(() => {
         `,
       );
 
+      // TODO(crisbeto): remove `null!` from the pipes when public API is updated.
       env.write(
         'pipe.ts',
         `
           import {Pipe} from '@angular/core';
 
-          @Pipe({name: 'dep'})
+          @Pipe(null!)
           export default class DepPipe {
             transform(value: number) {
               return value;
@@ -918,6 +953,7 @@ runInEachFileSystem(() => {
     });
 
     it('should emit references to selectorless symbols', () => {
+      // TODO(crisbeto): remove `null!` from the pipes when public API is updated.
       env.write(
         'dep.ts',
         `
@@ -929,7 +965,7 @@ runInEachFileSystem(() => {
           @Directive()
           export class DepDir {}
 
-          @Pipe({name: 'dep'})
+          @Pipe(null!)
           export class DepPipe {
             transform(value: number) {
               return value;
@@ -1042,12 +1078,13 @@ runInEachFileSystem(() => {
         `,
       );
 
+      // TODO(crisbeto): remove `null!` from the pipes when public API is updated.
       env.write(
         'dep-pipe.ts',
         `
           import { Pipe } from '@angular/core';
 
-          @Pipe({name: 'dep'})
+          @Pipe(null!)
           export class DepPipe {
             transform(value: number) {
               return value;
@@ -1081,6 +1118,68 @@ runInEachFileSystem(() => {
           'import("./dep-pipe").then(m => m.DepPipe)];',
       );
       expect(jsContents).toContain('ɵɵdefer(1, 0, Comp_Defer_1_DepsFn);');
+    });
+
+    it('should generate metadata for a pipe without a name', () => {
+      // TODO(crisbeto): remove `null!` from the pipes when public API is updated.
+      env.write(
+        'pipe.ts',
+        `
+          import {Pipe} from '@angular/core';
+
+          @Pipe(null!)
+          export class FooPipe {
+            transform(value: any) {
+              return value;
+            }
+          }
+        `,
+      );
+
+      env.driveMain();
+
+      const jsContents = env.getContents('pipe.js');
+      const dtsContents = env.getContents('pipe.d.ts');
+
+      expect(jsContents).toContain('ɵɵdefinePipe({ name: "FooPipe", type: FooPipe, pure: true });');
+      expect(dtsContents).toContain('ɵɵPipeDeclaration<FooPipe, null, true>;');
+    });
+
+    it('should not expose pipe under its class name if selectorless is disabled', () => {
+      env.tsconfig({
+        _enableSelectorless: false,
+        strictTemplates: true,
+      });
+
+      // TODO(crisbeto): remove `null!` from the pipes when public API is updated.
+      env.write(
+        'pipe.ts',
+        `
+          import {Pipe} from '@angular/core';
+
+          @Pipe(null!)
+          export class FooPipe {
+            transform(value: number) {
+              return value;
+            }
+          }
+        `,
+      );
+
+      env.write(
+        'test.ts',
+        `
+          import { Component } from '@angular/core';
+          import { FooPipe } from './pipe';
+
+          @Component({template: '{{"hello" | FooPipe}}', imports: [FooPipe]})
+          export class Comp {}
+        `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(`No pipe found with name 'FooPipe'.`);
     });
   });
 });

--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -146,7 +146,7 @@ export interface R3DeclareDependencyMetadataFacade {
 export interface R3PipeMetadataFacade {
   name: string;
   type: Type;
-  pipeName: string;
+  pipeName: string | null;
   pure: boolean;
   isStandalone: boolean;
 }

--- a/packages/compiler/src/render3/partial/pipe.ts
+++ b/packages/compiler/src/render3/partial/pipe.ts
@@ -54,7 +54,7 @@ export function createPipeDefinitionMap(
   }
 
   // e.g. `name: "myPipe"`
-  definitionMap.set('name', o.literal(meta.pipeName));
+  definitionMap.set('name', o.literal(meta.pipeName ?? meta.name));
 
   if (meta.pure === false) {
     // e.g. `pure: false`

--- a/packages/compiler/src/render3/r3_pipe_compiler.ts
+++ b/packages/compiler/src/render3/r3_pipe_compiler.ts
@@ -30,7 +30,7 @@ export interface R3PipeMetadata {
   /**
    * Name of the pipe.
    */
-  pipeName: string;
+  pipeName: string | null;
 
   /**
    * Dependencies of the pipe's constructor.
@@ -52,7 +52,11 @@ export function compilePipeFromMetadata(metadata: R3PipeMetadata): R3CompiledExp
   const definitionMapValues: {key: string; quoted: boolean; value: o.Expression}[] = [];
 
   // e.g. `name: 'myPipe'`
-  definitionMapValues.push({key: 'name', value: o.literal(metadata.pipeName), quoted: false});
+  definitionMapValues.push({
+    key: 'name',
+    value: o.literal(metadata.pipeName ?? metadata.name),
+    quoted: false,
+  });
 
   // e.g. `type: MyPipe`
   definitionMapValues.push({key: 'type', value: metadata.type.value, quoted: false});

--- a/packages/core/src/compiler/compiler_facade_interface.ts
+++ b/packages/core/src/compiler/compiler_facade_interface.ts
@@ -146,7 +146,7 @@ export interface R3DeclareDependencyMetadataFacade {
 export interface R3PipeMetadataFacade {
   name: string;
   type: Type;
-  pipeName: string;
+  pipeName: string | null;
   pure: boolean;
   isStandalone: boolean;
 }

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -1179,13 +1179,19 @@ export class CompletionBuilder<N extends TmplAstNode | AST> {
     }
 
     const replacementSpan = makeReplacementSpanFromAst(this.node);
+    const entries: ts.CompletionEntry[] = [];
 
-    const entries: ts.CompletionEntry[] = pipes.map((pipe) => ({
-      name: pipe.name,
-      sortText: pipe.name,
-      kind: unsafeCastDisplayInfoKindToScriptElementKind(DisplayInfoKind.PIPE),
-      replacementSpan,
-    }));
+    for (const pipe of pipes) {
+      if (pipe.name !== null) {
+        entries.push({
+          name: pipe.name,
+          sortText: pipe.name,
+          kind: unsafeCastDisplayInfoKindToScriptElementKind(DisplayInfoKind.PIPE),
+          replacementSpan,
+        });
+      }
+    }
+
     return {
       entries,
       isGlobalCompletion: false,


### PR DESCRIPTION
Updates the compiler logic to account for pipe definitions that may not have names.