### PR TITLE
fix(compiler-cli): rename flag for enabling fast type declaration emission

### DIFF
--- a/goldens/public-api/compiler-cli/compiler_options.api.md
+++ b/goldens/public-api/compiler-cli/compiler_options.api.md
@@ -7,7 +7,7 @@
 // @public
 export interface BazelAndG3Options {
     annotateForClosureCompiler?: boolean;
-    _geminiAllowEmitDeclarationOnly?: boolean;
+    _experimentalAllowEmitDeclarationOnly?: boolean;
     generateDeepReexports?: boolean;
     generateExtraImportsInLocalMode?: boolean;
     onlyExplicitDeferDependencyImports?: boolean;

--- a/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
@@ -353,9 +353,9 @@ export interface BazelAndG3Options {
    * references.
    *
    * The mode is experimental and specifically tailored to support fast type declaration emission
-   * for the Gemini app in g3.
+   * for the Gemini app in g3 for the initial phase of the experiment.
    */
-  _geminiAllowEmitDeclarationOnly?: boolean;
+  _experimentalAllowEmitDeclarationOnly?: boolean;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -468,7 +468,7 @@ export class NgCompiler {
     this.enableLetSyntax = options['_enableLetSyntax'] ?? true;
     this.enableSelectorless = options['_enableSelectorless'] ?? false;
     this.emitDeclarationOnly =
-      !!options.emitDeclarationOnly && !!options._geminiAllowEmitDeclarationOnly;
+      !!options.emitDeclarationOnly && !!options._experimentalAllowEmitDeclarationOnly;
     // Standalone by default is enabled since v19. We need to toggle it here,
     // because the language service extension may be running with the latest
     // version of the compiler against an older version of Angular.

--- a/packages/compiler-cli/test/compliance/declaration-only/declaration_only_emit_spec.ts
+++ b/packages/compiler-cli/test/compliance/declaration-only/declaration_only_emit_spec.ts
@@ -43,7 +43,7 @@ function emitDeclarationOnlyTest(fs: FileSystem, test: ComplianceTest): CompileR
     },
     {
       ...test.angularCompilerOptions,
-      _geminiAllowEmitDeclarationOnly: true,
+      _experimentalAllowEmitDeclarationOnly: true,
     },
   );
 }

--- a/packages/compiler-cli/test/ngtsc/declaration_only_emission_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/declaration_only_emission_spec.ts
@@ -31,7 +31,7 @@ runInEachFileSystem(() => {
           noCheck: true,
         },
         angularCompilerOptions: {
-          _geminiAllowEmitDeclarationOnly: true,
+          _experimentalAllowEmitDeclarationOnly: true,
         },
       };
       env.write('tsconfig.json', JSON.stringify(tsconfig, null, 2));


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Enabling fast type declaration emission is controlled by the flag `_geminiAllowEmitDeclarationOnly`.

## What is the new behavior?
Renamed the flag `_geminiAllowEmitDeclarationOnly` to `_experimentalAllowEmitDeclarationOnly` as a follow-up on a comment in PR #61334.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
