### PR TITLE
build: remove resolution for `@angular/core`

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
@@ -2,10 +2,10 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm2", pnpm_lock = "@//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=-1406867100
-package.json=-993231271
+package.json=-898135277
 packages/compiler-cli/package.json=-1767555217
 packages/compiler/package.json=-426903429
-pnpm-lock.yaml=-932788537
+pnpm-lock.yaml=-1965451272
 pnpm-workspace.yaml=353334404
 tools/bazel/rules_angular_store/package.json=-239561259
-yarn.lock=1015632261
+yarn.lock=-827526745

--- a/package.json
+++ b/package.json
@@ -234,8 +234,7 @@
   },
   "resolutions": {
     "https-proxy-agent": "7.0.6",
-    "saucelabs": "9.0.2",
-    "@angular/core": "20.0.0-rc.0"
+    "saucelabs": "9.0.2"
   },
   "pnpm": {
     "onlyBuiltDependencies": []

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,6 @@ onlyBuiltDependencies: []
 overrides:
   https-proxy-agent: 7.0.6
   saucelabs: 9.0.2
-  '@angular/core': 20.0.0-rc.0
 
 importers:
 
@@ -796,7 +795,7 @@ packages:
     engines: {node: ^20.11.1 || ^22.11.0 || >=24.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     peerDependencies:
       '@angular/compiler-cli': ^20.0.0 || ^20.0.0-next.0
-      '@angular/core': 20.0.0-rc.0
+      '@angular/core': ^20.0.0 || ^20.0.0-next.0
       '@angular/localize': ^20.0.0 || ^20.0.0-next.0
       '@angular/platform-browser': ^20.0.0 || ^20.0.0-next.0
       '@angular/platform-server': ^20.0.0 || ^20.0.0-next.0
@@ -1004,10 +1003,9 @@ packages:
   /@angular/benchpress@0.3.0(rxjs@7.8.2):
     resolution: {integrity: sha512-ApxoY5lTj1S0QFLdq5ZdTfdkIds1m3tma9EJOZpNVHRU9eCj2D/5+VFb5tlWsv9NHQ2S0XXkJjauFOAdfzT8uw==, tarball: https://registry.npmjs.org/@angular/benchpress/-/benchpress-0.3.0.tgz}
     dependencies:
-      '@angular/core': 20.0.0-rc.0(rxjs@7.8.2)
+      '@angular/core': 14.3.0(rxjs@7.8.2)
       reflect-metadata: 0.1.14
     transitivePeerDependencies:
-      - '@angular/compiler'
       - rxjs
       - zone.js
     dev: true
@@ -1094,7 +1092,7 @@ packages:
     peerDependencies:
       '@angular/compiler': ^20.0.0 || ^20.0.0-next.0
       '@angular/compiler-cli': ^20.0.0 || ^20.0.0-next.0
-      '@angular/core': 20.0.0-rc.0
+      '@angular/core': ^20.0.0 || ^20.0.0-next.0
       '@angular/localize': ^20.0.0 || ^20.0.0-next.0
       '@angular/platform-browser': ^20.0.0 || ^20.0.0-next.0
       '@angular/platform-server': ^20.0.0 || ^20.0.0-next.0
@@ -1186,7 +1184,7 @@ packages:
     resolution: {integrity: sha512-dvSacjyg5+6GCQiQpXIfguFcjrtR2R0uweUL8R9ZpGRi35jA0HqUYYY99asqyvhMS/G7F0etxRaPWu/d6sHpzg==, tarball: https://registry.npmjs.org/@angular/cdk/-/cdk-20.0.0-rc.0.tgz}
     peerDependencies:
       '@angular/common': ^20.0.0-0 || ^20.1.0-0 || ^20.2.0-0 || ^20.3.0-0 || ^21.0.0-0
-      '@angular/core': 20.0.0-rc.0
+      '@angular/core': ^20.0.0-0 || ^20.1.0-0 || ^20.2.0-0 || ^20.3.0-0 || ^21.0.0-0
       rxjs: ^6.5.3 || ^7.4.0
     dependencies:
       parse5: 7.3.0
@@ -1221,16 +1219,12 @@ packages:
       - supports-color
     dev: false
 
-  /@angular/core@20.0.0-rc.0(rxjs@7.8.2):
-    resolution: {integrity: sha512-RKIXYA129vdrRKrnac2XOgpWuYusWqwM4KsQ7b5qKIMZabJ0a2GoOlezT6+NhPkOSsyygYuZtaia5wzQeU1acA==, tarball: https://registry.npmjs.org/@angular/core/-/core-20.0.0-rc.0.tgz}
-    engines: {node: ^20.11.1 || ^22.11.0 || >=24.0.0}
+  /@angular/core@14.3.0(rxjs@7.8.2):
+    resolution: {integrity: sha512-wYiwItc0Uyn4FWZ/OAx/Ubp2/WrD3EgUJ476y1XI7yATGPF8n9Ld5iCXT08HOvc4eBcYlDfh90kTXR6/MfhzdQ==, tarball: https://registry.npmjs.org/@angular/core/-/core-14.3.0.tgz}
+    engines: {node: ^14.15.0 || >=16.10.0}
     peerDependencies:
-      '@angular/compiler': 20.0.0-rc.0
       rxjs: ^6.5.3 || ^7.4.0
-      zone.js: ~0.15.0
-    peerDependenciesMeta:
-      '@angular/compiler':
-        optional: true
+      zone.js: ~0.11.4 || ~0.12.0
     dependencies:
       rxjs: 7.8.2
       tslib: 2.8.1
@@ -1241,7 +1235,7 @@ packages:
     peerDependencies:
       '@angular/cdk': 20.0.0-rc.0
       '@angular/common': ^20.0.0-0 || ^20.1.0-0 || ^20.2.0-0 || ^20.3.0-0 || ^21.0.0-0
-      '@angular/core': 20.0.0-rc.0
+      '@angular/core': ^20.0.0-0 || ^20.1.0-0 || ^20.2.0-0 || ^20.3.0-0 || ^21.0.0-0
       '@angular/forms': ^20.0.0-0 || ^20.1.0-0 || ^20.2.0-0 || ^20.3.0-0 || ^21.0.0-0
       '@angular/platform-browser': ^20.0.0-0 || ^20.1.0-0 || ^20.2.0-0 || ^20.3.0-0 || ^21.0.0-0
       rxjs: ^6.5.3 || ^7.4.0
@@ -1255,7 +1249,7 @@ packages:
     resolution: {integrity: sha512-PqAXHxJvahRbEgDVpd8eYVqM0PEYd4kpvBtpoH532TQi173hoNQxYf9JY6O/ECADqe6ZEqiIgGWy41l1jt7XcA==, tarball: https://registry.npmjs.org/@angular/ssr/-/ssr-20.0.0-rc.0.tgz}
     peerDependencies:
       '@angular/common': ^20.0.0 || ^20.0.0-next.0
-      '@angular/core': 20.0.0-rc.0
+      '@angular/core': ^20.0.0 || ^20.0.0-next.0
       '@angular/platform-server': ^20.0.0 || ^20.0.0-next.0
       '@angular/router': ^20.0.0 || ^20.0.0-next.0
     peerDependenciesMeta:
@@ -6612,7 +6606,7 @@ packages:
     resolution: {integrity: sha512-vQqXWLcCimFmInu2lpGKIfS9FtYBgKmoWenPjeYkHSRdWmb7HLGlQoNPj1oALrwdhIWFPdySgp0BIXDe2IAepQ==, tarball: https://registry.npmjs.org/angular-split/-/angular-split-19.0.0.tgz}
     peerDependencies:
       '@angular/common': '>=19.0.0'
-      '@angular/core': 20.0.0-rc.0
+      '@angular/core': '>=19.0.0'
       rxjs: '>=7.0.0'
     dependencies:
       rxjs: 7.8.2
@@ -13748,7 +13742,7 @@ packages:
     resolution: {integrity: sha512-YoxrqlL36Bg5Ca9fu10kuSUmaWHAvx7jkxINF4/4cXn9bBPRfu78FqnZ5LIULC0+iScZcSDSWDAnUdn8H7+wGw==, tarball: https://registry.npmjs.org/ngx-flamegraph/-/ngx-flamegraph-0.0.12.tgz}
     peerDependencies:
       '@angular/common': ^9.0.0
-      '@angular/core': 20.0.0-rc.0
+      '@angular/core': ^9.0.0
     dependencies:
       tslib: 2.8.1
     dev: false
@@ -13758,7 +13752,7 @@ packages:
     peerDependencies:
       '@angular/cdk': '>=17.3.0'
       '@angular/common': '>=17.3.0'
-      '@angular/core': 20.0.0-rc.0
+      '@angular/core': '>=17.3.0'
       rxjs: '>=7.0.0'
     dependencies:
       '@angular/cdk': 20.0.0-rc.0(rxjs@7.8.2)

--- a/yarn.lock
+++ b/yarn.lock
@@ -320,7 +320,6 @@
 
 "@angular/build-tooling@https://github.com/angular/dev-infra-private-build-tooling-builds.git#ce04ec6cf7604014191821a637e60964a1a3bb4a":
   version "0.0.0-2670abf637fa155971cdd1f7e570a7f234922a65"
-  uid ce04ec6cf7604014191821a637e60964a1a3bb4a
   resolved "https://github.com/angular/dev-infra-private-build-tooling-builds.git#ce04ec6cf7604014191821a637e60964a1a3bb4a"
   dependencies:
     "@angular/benchpress" "0.3.0"
@@ -453,10 +452,10 @@
     semver "7.7.1"
     yargs "17.7.2"
 
-"@angular/core@20.0.0-rc.0", "@angular/core@^13.0.0 || ^14.0.0-0":
-  version "20.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@angular/core/-/core-20.0.0-rc.0.tgz#ea02d6f7a0a582adfd617e5a77377b8fb30981ec"
-  integrity sha512-RKIXYA129vdrRKrnac2XOgpWuYusWqwM4KsQ7b5qKIMZabJ0a2GoOlezT6+NhPkOSsyygYuZtaia5wzQeU1acA==
+"@angular/core@^13.0.0 || ^14.0.0-0":
+  version "14.3.0"
+  resolved "https://registry.yarnpkg.com/@angular/core/-/core-14.3.0.tgz#7f44c59b6e866fa4cee7221495040c1ead433895"
+  integrity sha512-wYiwItc0Uyn4FWZ/OAx/Ubp2/WrD3EgUJ476y1XI7yATGPF8n9Ld5iCXT08HOvc4eBcYlDfh90kTXR6/MfhzdQ==
   dependencies:
     tslib "^2.3.0"
 
@@ -469,7 +468,6 @@
 
 "@angular/ng-dev@https://github.com/angular/dev-infra-private-ng-dev-builds.git#a871c115e04a76587fcd418107ad985752610ccf":
   version "0.0.0-892760b7f6cf0d08a51778674a9b13ebc1a809a7"
-  uid a871c115e04a76587fcd418107ad985752610ccf
   resolved "https://github.com/angular/dev-infra-private-ng-dev-builds.git#a871c115e04a76587fcd418107ad985752610ccf"
   dependencies:
     "@google-cloud/spanner" "7.21.0"
@@ -7957,8 +7955,7 @@ domhandler@^5.0.2, domhandler@^5.0.3:
     domelementtype "^2.3.0"
 
 "domino@https://github.com/angular/domino.git#93e720f143d0296dd2726ffbcf4fc12283363a7b":
-  version "2.1.6+git"
-  uid "93e720f143d0296dd2726ffbcf4fc12283363a7b"
+  version "2.1.6"
   resolved "https://github.com/angular/domino.git#93e720f143d0296dd2726ffbcf4fc12283363a7b"
 
 dompurify@^3.2.4:


### PR DESCRIPTION
This causes running `pnpm import` directly to fail

```
Scope: all 4 workspace projects
Progress: resolved 1, reused 0, downloaded 0, added 0
.                                        |  WARN  deprecated @babel/plugin-proposal-async-generator-functions@7.20.7
.                                        |  WARN  deprecated gulp-conventional-changelog@5.0.0
.                                        |  WARN  deprecated angular@1.5.11
.                                        |  WARN  deprecated angular@1.6.10
.                                        |  WARN  deprecated angular@1.7.9
.                                        |  WARN  deprecated angular@1.8.3
.                                        |  WARN  deprecated protractor@7.0.0
.                                        |  WARN  deprecated tslint@6.1.3
Progress: resolved 177, reused 1, downloaded 0, added 0
Packages are hard linked from the content-addressable store to the virtual store.
  Content-addressable store is at: /tmp/renovate/cache/others/pnpm-store/v3
  Virtual store is at:             node_modules/.pnpm
Progress: resolved 323, reused 2, downloaded 1, added 0
Progress: resolved 833, reused 2, downloaded 1, added 0
Progress: resolved 1565, reused 2, downloaded 1, added 0
Progress: resolved 2264, reused 2, downloaded 1, added 0
 ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @angular/compiler@0.0.0-PLACEHOLDER

This error happened while installing a direct dependency of /tmp/renovate/repos/github/angular/angular

The latest release of @angular/compiler is "19.2.10".

Other releases are:
  * v4-lts: 4.4.7
  * v5-lts: 5.2.11
  * v6-lts: 6.1.10
  * v7-lts: 7.2.15
  * v8-lts: 8.2.14
  * v9-lts: 9.1.13
  * v10-lts: 10.2.5
  * v11-lts: 11.2.14
  * v12-lts: 12.2.17
  * v14-lts: 14.3.0
  * v13-lts: 13.4.0
  * v15-lts: 15.2.10
  * v16-lts: 16.2.12
  * v17-lts: 17.3.12
  * v18-lts: 18.2.13
  * next: 20.0.0-rc.0

If you need the full list of all 906 published versions run "$ pnpm view @angular/compiler versions".

```
