### PR TITLE
refactor: replace port `4206` usage with `4209`

### DIFF
--- a/integration/platform-server-zoneless/angular.json
+++ b/integration/platform-server-zoneless/angular.json
@@ -74,7 +74,7 @@
             "port": 0,
             "protractorConfig": "e2e/protractor.conf.js",
             "webdriverUpdate": false,
-            "baseUrl": "http://localhost:4206"
+            "baseUrl": "http://localhost:4209"
           }
         },
         "extract-i18n": {

--- a/integration/platform-server-zoneless/e2e/protractor.conf.js
+++ b/integration/platform-server-zoneless/e2e/protractor.conf.js
@@ -27,7 +27,7 @@ exports.config = {
     },
   },
   directConnect: true,
-  baseUrl: 'http://localhost:4206/',
+  baseUrl: 'http://localhost:4209/',
   framework: 'jasmine',
   jasmineNodeOpts: {
     showColors: true,

--- a/integration/platform-server-zoneless/projects/standalone/server.ts
+++ b/integration/platform-server-zoneless/projects/standalone/server.ts
@@ -50,6 +50,6 @@ app.get('*', (req, res) => {
   });
 });
 
-app.listen(4206, () => {
-  console.log('Server listening on port 4206!');
+app.listen(4209, () => {
+  console.log('Server listening on port 4209!');
 });

--- a/integration/platform-server-zoneless/projects/standalone/src/app/http-transferstate-lazy-on-init/http-transfer-state-on-init.component.ts
+++ b/integration/platform-server-zoneless/projects/standalone/src/app/http-transferstate-lazy-on-init/http-transfer-state-on-init.component.ts
@@ -23,7 +23,7 @@ export class TransferStateOnInitComponent implements OnInit {
 
   ngOnInit(): void {
     // Test that HTTP cache works when HTTP call is made in a lifecycle hook.
-    this.httpClient.get<any>('http://localhost:4206/api').subscribe((response) => {
+    this.httpClient.get<any>('http://localhost:4209/api').subscribe((response) => {
       this.responseOne = response.data;
       this.cdr.markForCheck();
     });

--- a/integration/platform-server-zoneless/projects/standalone/src/app/http-transferstate-lazy/http-transfer-state.component.ts
+++ b/integration/platform-server-zoneless/projects/standalone/src/app/http-transferstate-lazy/http-transfer-state.component.ts
@@ -27,7 +27,7 @@ export class TransferStateComponent implements OnInit {
 
   constructor() {
     // Test that HTTP cache works when HTTP call is made in the constructor.
-    this.httpClient.get<any>('http://localhost:4206/api').subscribe((response) => {
+    this.httpClient.get<any>('http://localhost:4209/api').subscribe((response) => {
       this.responseOne = response.data;
       this.cdr.markForCheck();
     });


### PR DESCRIPTION
Port `4206` is used by other tests which causes this test to be flakey example https://github.com/angular/angular/actions/runs/15038891642/job/42265813534
