### PR TITLE
refactor: explicitly ensure `ngDevMode` types are available

### DIFF
--- a/packages/core/primitives/event-dispatch/src/event_dispatcher.ts
+++ b/packages/core/primitives/event-dispatch/src/event_dispatcher.ts
@@ -13,6 +13,9 @@ import {isCaptureEventType} from './event_type';
 import {UnrenamedEventContract} from './eventcontract';
 import {Restriction} from './restriction';
 
+// Necessary to make the `ngDevMode` global types available.
+import '../../../src/util/ng_dev_mode';
+
 /**
  * A replayer is a function that is called when there are queued events, from the `EventContract`.
  */


### PR DESCRIPTION
This commit adds an import to the `ng_dev_mode.ts` file that augments `global` to have types for `ngDevMode`.

Notably this change is currently not needed because the file is loaded by `ts_library` through `tsconfig#files`— but in a separate PR we are switching the target to `ts_project` which no longer loads all Bazel dependency files via `tsconfig#files`; resulting in the ambient types no longer magically being available.