### PR TITLE
fix(core): fakeAsync should not depend on module import order

### DIFF
--- a/packages/core/testing/src/fake_async.ts
+++ b/packages/core/testing/src/fake_async.ts
@@ -10,10 +10,18 @@
 import type {} from 'zone.js';
 
 const _Zone: any = typeof Zone !== 'undefined' ? Zone : null;
-const fakeAsyncTestModule = _Zone && _Zone[_Zone.__symbol__('fakeAsyncTest')];
+function getFakeAsyncTestModule() {
+  return _Zone && _Zone[_Zone.__symbol__('fakeAsyncTest')];
+}
 
-const fakeAsyncTestModuleNotLoadedErrorMessage = `zone-testing.js is needed for the fakeAsync() test helper but could not be found.
-        Please make sure that your environment includes zone.js/testing`;
+function withFakeAsyncTestModule(fn: (fakeAsyncTestModule: any) => any): any {
+  const fakeAsyncTestModule = getFakeAsyncTestModule();
+  if (!fakeAsyncTestModule) {
+    throw new Error(`zone-testing.js is needed for the fakeAsync() test helper but could not be found.
+        Please make sure that your environment includes zone.js/testing`);
+  }
+  return fn(fakeAsyncTestModule);
+}
 
 /**
  * Clears out the shared fake async zone for a test.
@@ -22,15 +30,12 @@ const fakeAsyncTestModuleNotLoadedErrorMessage = `zone-testing.js is needed for 
  * @publicApi
  */
 export function resetFakeAsyncZone(): void {
-  if (fakeAsyncTestModule) {
-    return fakeAsyncTestModule.resetFakeAsyncZone();
-  }
-  throw new Error(fakeAsyncTestModuleNotLoadedErrorMessage);
+  withFakeAsyncTestModule((v) => v.resetFakeAsyncZone());
 }
 
 export function resetFakeAsyncZoneIfExists(): void {
-  if (fakeAsyncTestModule && (Zone as any)['ProxyZoneSpec']?.isLoaded()) {
-    fakeAsyncTestModule.resetFakeAsyncZone();
+  if (getFakeAsyncTestModule() && (Zone as any)['ProxyZoneSpec']?.isLoaded()) {
+    getFakeAsyncTestModule().resetFakeAsyncZone();
   }
 }
 
@@ -59,10 +64,7 @@ export function resetFakeAsyncZoneIfExists(): void {
  * @publicApi
  */
 export function fakeAsync(fn: Function, options?: {flush?: boolean}): (...args: any[]) => any {
-  if (fakeAsyncTestModule) {
-    return fakeAsyncTestModule.fakeAsync(fn, options);
-  }
-  throw new Error(fakeAsyncTestModuleNotLoadedErrorMessage);
+  return withFakeAsyncTestModule((v) => v.fakeAsync(fn, options));
 }
 
 /**
@@ -135,10 +137,7 @@ export function tick(
     processNewMacroTasksSynchronously: true,
   },
 ): void {
-  if (fakeAsyncTestModule) {
-    return fakeAsyncTestModule.tick(millis, tickOptions);
-  }
-  throw new Error(fakeAsyncTestModuleNotLoadedErrorMessage);
+  return withFakeAsyncTestModule((m) => m.tick(millis, tickOptions));
 }
 
 /**
@@ -153,10 +152,7 @@ export function tick(
  * @publicApi
  */
 export function flush(maxTurns?: number): number {
-  if (fakeAsyncTestModule) {
-    return fakeAsyncTestModule.flush(maxTurns);
-  }
-  throw new Error(fakeAsyncTestModuleNotLoadedErrorMessage);
+  return withFakeAsyncTestModule((m) => m.flush(maxTurns));
 }
 
 /**
@@ -165,10 +161,7 @@ export function flush(maxTurns?: number): number {
  * @publicApi
  */
 export function discardPeriodicTasks(): void {
-  if (fakeAsyncTestModule) {
-    return fakeAsyncTestModule.discardPeriodicTasks();
-  }
-  throw new Error(fakeAsyncTestModuleNotLoadedErrorMessage);
+  return withFakeAsyncTestModule((m) => m.discardPeriodicTasks());
 }
 
 /**
@@ -177,8 +170,5 @@ export function discardPeriodicTasks(): void {
  * @publicApi
  */
 export function flushMicrotasks(): void {
-  if (fakeAsyncTestModule) {
-    return fakeAsyncTestModule.flushMicrotasks();
-  }
-  throw new Error(fakeAsyncTestModuleNotLoadedErrorMessage);
+  return withFakeAsyncTestModule((m) => m.flushMicrotasks());
 }


### PR DESCRIPTION
`fakeAsync` does not work if the zone-testing polyfill is included after
@angular/core/testing is loaded. This allows fakeAsync to work
even if the zone-testing is included later.