### PR TITLE
fix(core): Testing should not throw when Zone does not patch test FW …

### DIFF
--- a/packages/core/testing/src/fake_async.ts
+++ b/packages/core/testing/src/fake_async.ts
@@ -25,7 +25,7 @@ export function resetFakeAsyncZone(): void {
 }
 
 export function resetFakeAsyncZoneIfExists(): void {
-  if (fakeAsyncTestModule) {
+  if (fakeAsyncTestModule && (Zone as any)['ProxyZoneSpec']?.isLoaded()) {
     fakeAsyncTestModule.resetFakeAsyncZone();
   }
 }


### PR DESCRIPTION
…APIs

This prevents `core/testing` from throwing an error if ZoneJS is present but does not patch the test FW APIs such that `fakeAsync` works automatically. For example, there is currently no patching of the vitest APIs, so if you try to use Vitest with Zone on the page, it will throw.
