### PR TITLE
feat(zone.js): Allow fakeAsync to be used outside of ProxyZone with warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,7 @@ jobs:
       - run: yarn --cwd packages/zone.js promisefinallytest
       - run: yarn --cwd packages/zone.js jest:test
       - run: yarn --cwd packages/zone.js jest:nodetest
+      - run: yarn --cwd packages/zone.js vitest:test
       - run: yarn --cwd packages/zone.js electrontest
       - run: yarn --cwd packages/zone.js/test/typings install --frozen-lockfile --non-interactive
       - run: yarn --cwd packages/zone.js/test/typings test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -185,6 +185,7 @@ jobs:
       - run: yarn --cwd packages/zone.js promisefinallytest
       - run: yarn --cwd packages/zone.js jest:test
       - run: yarn --cwd packages/zone.js jest:nodetest
+      - run: yarn --cwd packages/zone.js vitest:test
       - run: yarn --cwd packages/zone.js electrontest
       - run: yarn --cwd packages/zone.js/test/typings install --frozen-lockfile --non-interactive
       - run: yarn --cwd packages/zone.js/test/typings test

--- a/goldens/public-api/core/testing/index.api.md
+++ b/goldens/public-api/core/testing/index.api.md
@@ -62,18 +62,10 @@ export enum DeferBlockState {
 // @public
 export function discardPeriodicTasks(): void;
 
-// @public (undocumented)
-export const fakeAsync: FakeAsyncFn;
-
-// @public (undocumented)
-export interface FakeAsyncFn {
-    (fn: Function, options?: {
-        flush?: boolean;
-    }): (...args: any[]) => any;
-    allowNewProxyZone(fn: Function, options?: {
-        flush?: boolean;
-    }): (...args: any[]) => any;
-}
+// @public
+export function fakeAsync(fn: Function, options?: {
+    flush?: boolean;
+}): (...args: any[]) => any;
 
 // @public
 export function flush(maxTurns?: number): number;
@@ -231,6 +223,9 @@ export function withModule(moduleDef: TestModuleMetadata): InjectSetupWrapper;
 
 // @public (undocumented)
 export function withModule(moduleDef: TestModuleMetadata, fn: Function): () => any;
+
+// @public
+export function withProxyZone(fn: Function): (...args: any[]) => any;
 
 // (No @packageDocumentation comment for this package)
 

--- a/goldens/public-api/core/testing/index.api.md
+++ b/goldens/public-api/core/testing/index.api.md
@@ -62,10 +62,18 @@ export enum DeferBlockState {
 // @public
 export function discardPeriodicTasks(): void;
 
-// @public
-export function fakeAsync(fn: Function, options?: {
-    flush?: boolean;
-}): (...args: any[]) => any;
+// @public (undocumented)
+export const fakeAsync: FakeAsyncFn;
+
+// @public (undocumented)
+export interface FakeAsyncFn {
+    (fn: Function, options?: {
+        flush?: boolean;
+    }): (...args: any[]) => any;
+    allowNewProxyZone(fn: Function, options?: {
+        flush?: boolean;
+    }): (...args: any[]) => any;
+}
 
 // @public
 export function flush(maxTurns?: number): number;

--- a/packages/core/testing/src/testing.ts
+++ b/packages/core/testing/src/testing.ts
@@ -18,6 +18,7 @@ export {
   resetFakeAsyncZone,
   discardPeriodicTasks,
   fakeAsync,
+  FakeAsyncFn,
   flush,
   flushMicrotasks,
   tick,

--- a/packages/core/testing/src/testing.ts
+++ b/packages/core/testing/src/testing.ts
@@ -18,7 +18,7 @@ export {
   resetFakeAsyncZone,
   discardPeriodicTasks,
   fakeAsync,
-  FakeAsyncFn,
+  withProxyZone,
   flush,
   flushMicrotasks,
   tick,

--- a/packages/zone.js/lib/jasmine/jasmine.ts
+++ b/packages/zone.js/lib/jasmine/jasmine.ts
@@ -9,6 +9,7 @@
 /// <reference types="jasmine"/>
 
 import {ZoneType} from '../zone-impl';
+import {type ProxyZoneSpec} from '../zone-spec/proxy';
 
 ('use strict');
 declare let jest: any;
@@ -37,9 +38,9 @@ export function patchJasmine(Zone: ZoneType): void {
     (jasmine as any)['__zone_patch__'] = true;
 
     const SyncTestZoneSpec: {new (name: string): ZoneSpec} = (Zone as any)['SyncTestZoneSpec'];
-    const ProxyZoneSpec: {new (): ZoneSpec} = (Zone as any)['ProxyZoneSpec'];
+    const ProxyZoneSpecType: typeof ProxyZoneSpec = (Zone as any)['ProxyZoneSpec'];
     if (!SyncTestZoneSpec) throw new Error('Missing: SyncTestZoneSpec');
-    if (!ProxyZoneSpec) throw new Error('Missing: ProxyZoneSpec');
+    if (!ProxyZoneSpecType) throw new Error('Missing: ProxyZoneSpec');
 
     const ambientZone = Zone.current;
 
@@ -268,7 +269,7 @@ export function patchJasmine(Zone: ZoneType): void {
     }
     interface QueueRunner {
       execute(): void;
-      testProxyZoneSpec: ZoneSpec | null;
+      testProxyZoneSpec: ProxyZoneSpec | null;
       testProxyZone: Zone | null;
     }
     interface QueueRunnerAttrs {
@@ -331,7 +332,7 @@ export function patchJasmine(Zone: ZoneType): void {
           ) {
             // jasmine timeout, we can make the error message more
             // reasonable to tell what tasks are pending
-            const proxyZoneSpec: any = this && this.testProxyZoneSpec;
+            const proxyZoneSpec = this && this.testProxyZoneSpec;
             if (proxyZoneSpec) {
               const pendingTasksInfo = proxyZoneSpec.getAndClearPendingTasksInfo();
               try {
@@ -370,7 +371,7 @@ export function patchJasmine(Zone: ZoneType): void {
         //   - Because ProxyZone is parent fo `childZone` fakeAsync can retroactively add
         //     fakeAsync behavior to the childZone.
 
-        this.testProxyZoneSpec = new ProxyZoneSpec();
+        this.testProxyZoneSpec = new ProxyZoneSpecType();
         this.testProxyZone = ambientZone.fork(this.testProxyZoneSpec);
         if (!Zone.currentTask) {
           // if we are not running in a task then if someone would register a

--- a/packages/zone.js/lib/zone-spec/proxy.ts
+++ b/packages/zone.js/lib/zone-spec/proxy.ts
@@ -21,7 +21,7 @@ export class ProxyZoneSpec implements ZoneSpec {
 
   private tasks: Task[] = [];
 
-  static get(): ProxyZoneSpec {
+  static get(): ProxyZoneSpec | undefined {
     return Zone.current.get('ProxyZoneSpec');
   }
 
@@ -30,10 +30,11 @@ export class ProxyZoneSpec implements ZoneSpec {
   }
 
   static assertPresent(): ProxyZoneSpec {
-    if (!ProxyZoneSpec.isLoaded()) {
+    const spec = ProxyZoneSpec.get();
+    if (spec === undefined) {
       throw new Error(`Expected to be running in 'ProxyZone', but it was not found.`);
     }
-    return ProxyZoneSpec.get();
+    return spec;
   }
 
   constructor(private defaultSpecDelegate: ZoneSpec | null = null) {

--- a/packages/zone.js/package.json
+++ b/packages/zone.js/package.json
@@ -17,12 +17,14 @@
     "jest-environment-node": "^29.0.3",
     "mocha": "^11.0.0",
     "mock-require": "3.0.3",
-    "tslib": "^2.3.0"
+    "tslib": "^2.3.0",
+    "vitest": "^3.1.3"
   },
   "scripts": {
     "electrontest": "cd test/extra && node electron.js",
     "jest:test": "jest --config ./test/jest/jest.config.js ./test/jest/jest.spec.js",
     "jest:nodetest": "jest --config ./test/jest/jest.node.config.js ./test/jest/jest.spec.js",
+    "vitest:test": "vitest ./test/vitest/vitest.spec.js",
     "promisefinallytest": "mocha ./test/promise/promise.finally.spec.mjs"
   },
   "repository": {

--- a/packages/zone.js/test/vitest/vitest.spec.js
+++ b/packages/zone.js/test/vitest/vitest.spec.js
@@ -3,41 +3,114 @@ require('../../../../dist/bin/packages/zone.js/npm_package/bundles/zone-testing.
 
 import {expect, test, describe, beforeEach} from 'vitest';
 
-const {tick, fakeAsyncWithAutoProxy, withAutoProxy, fakeAsync} = Zone[Zone.__symbol__('fakeAsyncTest')];
+const {tick, withProxyZone, fakeAsync} = Zone[Zone.__symbol__('fakeAsyncTest')];
+
+describe('proxy zone behavior', () => {
+  const spec = new Zone['ProxyZoneSpec']();
+  const proxyZone = Zone.root.fork(spec);
+
+  function createForkedZone() {
+    const AsyncTestZoneSpec = Zone['AsyncTestZoneSpec'];
+    return Zone.current.fork(
+      new AsyncTestZoneSpec(
+        () => {},
+        () => {},
+        'asyncTest',
+      ),
+    );
+  }
+
+  test('cannot run fakeAsync outside proxy zone', () => {
+    expect(fakeAsync(() => {})).toThrow();
+  });
+
+  test('can run fakeAsync inside proxy zone', () => {
+    expect(() => {
+      proxyZone.run(fakeAsync(() => {}));
+    }).not.toThrow();
+  });
+
+  test('can flush timeouts in forked zone if created in proxy', () => {
+    let forkedZone;
+    proxyZone.run(() => {
+      forkedZone = createForkedZone();
+    });
+
+    proxyZone.run(
+      fakeAsync(() => {
+        let x = 1;
+        forkedZone.run(() => {
+          setTimeout(() => void (x = 2), 5000);
+        });
+
+        tick(5000);
+        expect(x).toBe(2);
+      }),
+    );
+  });
+
+  test('cannot flush timeouts in forked zone if created outside proxy', () => {
+    // This test is similar to creating a component in a beforeEach, which forks the zone to create the Angular NgZone
+    const forkedZone = createForkedZone();
+    proxyZone.run(() => {
+      fakeAsync(() => {
+        let x = 1;
+        forkedZone.run(() => {
+          setTimeout(() => void (x = 2), 5000);
+        });
+
+        tick(5000);
+        expect(x).toBe(1);
+      })();
+    });
+  });
+});
 
 test(
-  'can use fakeAsync in the test body',
-  fakeAsyncWithAutoProxy(() => {
-    let x = 1;
-    setTimeout(() => void (x = 2), 5000);
-    tick(5000);
-    expect(x).toBe(2);
+  'withProxyZone runs inside proxy zone',
+  withProxyZone(() => {
+    expect(Zone.current.name).toEqual('ProxyZone');
   }),
 );
-function assertInsideProxyZone() {
-  expect(Zone.current.name).toEqual('ProxyZone');
-}
 
-describe('can use withAutoProxy and beforeEach', () => {
-  let forkedZoneInBeforeEach;
-  let syncZone;
-  beforeEach(withAutoProxy(() => {
-    assertInsideProxyZone();
-        const SyncTestZoneSpec = Zone['SyncTestZoneSpec'];
-    syncZone = Zone.current.fork(new SyncTestZoneSpec('jest.describe'));
-  }));
+test(
+  'can use fakeAsync in proxy zone in test body',
+  withProxyZone(
+    fakeAsync(() => {
+      let x = 1;
+      setTimeout(() => void (x = 2), 5000);
+      tick(5000);
+      expect(x).toBe(2);
+    }),
+  ),
+);
 
-  test('withAutoProxy(fakeAsync)', withAutoProxy(fakeAsync(() => {
-    let x = 1;
-    syncZone.run(() => {
-    setTimeout(() => void (x = 2), 5000);
-    });
-    tick(5000);
-    expect(x).toBe(2);
-    assertInsideProxyZone();
-  })));
+describe('can use withProxyZone and beforeEach', () => {
+  let forkedZone;
+  beforeEach(
+    withProxyZone(() => {
+      const AsyncTestZoneSpec = Zone['AsyncTestZoneSpec'];
+      forkedZone = Zone.current.fork(
+        new AsyncTestZoneSpec(
+          () => {},
+          () => {},
+          'asyncTest',
+        ),
+      );
+    }),
+  );
 
-  test('fakeAsync.withAutoProxy', fakeAsyncWithAutoProxy(() => {
-    assertInsideProxyZone();
-  }));
+  test(
+    'withProxyZone(fakeAsync)',
+    withProxyZone(
+      fakeAsync(() => {
+        let x = 1;
+        forkedZone.run(() => {
+          setTimeout(() => void (x = 2), 5000);
+        });
+        tick(5000);
+        expect(x).toBe(2);
+      }),
+    ),
+  );
 });

--- a/packages/zone.js/test/vitest/vitest.spec.js
+++ b/packages/zone.js/test/vitest/vitest.spec.js
@@ -1,16 +1,43 @@
 require('../../../../dist/bin/packages/zone.js/npm_package/bundles/zone.umd.js');
 require('../../../../dist/bin/packages/zone.js/npm_package/bundles/zone-testing.umd.js');
 
-import {expect, test} from 'vitest';
+import {expect, test, describe, beforeEach} from 'vitest';
 
-const {tick, fakeAsyncAllowNewProxyZone} = Zone[Zone.__symbol__('fakeAsyncTest')];
+const {tick, fakeAsyncWithAutoProxy, withAutoProxy, fakeAsync} = Zone[Zone.__symbol__('fakeAsyncTest')];
 
 test(
   'can use fakeAsync in the test body',
-  fakeAsyncAllowNewProxyZone(() => {
+  fakeAsyncWithAutoProxy(() => {
     let x = 1;
     setTimeout(() => void (x = 2), 5000);
     tick(5000);
     expect(x).toBe(2);
   }),
 );
+function assertInsideProxyZone() {
+  expect(Zone.current.name).toEqual('ProxyZone');
+}
+
+describe('can use withAutoProxy and beforeEach', () => {
+  let forkedZoneInBeforeEach;
+  let syncZone;
+  beforeEach(withAutoProxy(() => {
+    assertInsideProxyZone();
+        const SyncTestZoneSpec = Zone['SyncTestZoneSpec'];
+    syncZone = Zone.current.fork(new SyncTestZoneSpec('jest.describe'));
+  }));
+
+  test('withAutoProxy(fakeAsync)', withAutoProxy(fakeAsync(() => {
+    let x = 1;
+    syncZone.run(() => {
+    setTimeout(() => void (x = 2), 5000);
+    });
+    tick(5000);
+    expect(x).toBe(2);
+    assertInsideProxyZone();
+  })));
+
+  test('fakeAsync.withAutoProxy', fakeAsyncWithAutoProxy(() => {
+    assertInsideProxyZone();
+  }));
+});

--- a/packages/zone.js/test/vitest/vitest.spec.js
+++ b/packages/zone.js/test/vitest/vitest.spec.js
@@ -1,0 +1,16 @@
+require('../../../../dist/bin/packages/zone.js/npm_package/bundles/zone.umd.js');
+require('../../../../dist/bin/packages/zone.js/npm_package/bundles/zone-testing.umd.js');
+
+import {expect, test} from 'vitest';
+
+const {tick, fakeAsyncAllowNewProxyZone} = Zone[Zone.__symbol__('fakeAsyncTest')];
+
+test(
+  'can use fakeAsync in the test body',
+  fakeAsyncAllowNewProxyZone(() => {
+    let x = 1;
+    setTimeout(() => void (x = 2), 5000);
+    tick(5000);
+    expect(x).toBe(2);
+  }),
+);


### PR DESCRIPTION
As an alternative to monkey patching vitest, this change updates `fakeAsync` to allow uses outside of a `ProxyZone`. This would mean that the `fakeAsync` closure may not capture all timers and microtasks if it invokes things created in a zone that was already forked (e.g. creating a component in a beforeEach):
https://github.com/angular/angular/blob/2699dd65558d70fadeac1e9b420841f3dfc3a059/packages/zone.js/lib/jasmine/jasmine.ts#L363-L371
