### PR TITLE
fix(core): ApplicationRef.tick should refresh ComponentFixture views

### DIFF
--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -597,7 +597,12 @@ export class ApplicationRef {
     if (!this.zonelessEnabled) {
       this.dirtyFlags |= ApplicationRefDirtyFlags.ViewTreeGlobal;
     }
-    this._tick();
+    try {
+      this.includeAllTestViews = true;
+      this._tick();
+    } finally {
+      this.includeAllTestViews = false;
+    }
   }
 
   /** @internal */

--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -318,12 +318,17 @@ export class ApplicationRef {
 
   // Needed for ComponentFixture temporarily during migration of autoDetect behavior
   // Eventually the hostView of the fixture should just attach to ApplicationRef.
-  private externalTestViews: Set<InternalViewRef<unknown>> = new Set();
+  private allTestViews: Set<InternalViewRef<unknown>> = new Set();
+  private autoDetectTestViews: Set<InternalViewRef<unknown>> = new Set();
+  private includeAllTestViews = false;
   /** @internal */
   afterTick = new Subject<void>();
   /** @internal */
   get allViews(): Array<InternalViewRef<unknown>> {
-    return [...this.externalTestViews.keys(), ...this._views];
+    return [
+      ...(this.includeAllTestViews ? this.allTestViews : this.autoDetectTestViews).keys(),
+      ...this._views,
+    ];
   }
 
   /**
@@ -648,6 +653,11 @@ export class ApplicationRef {
     }
 
     let runs = 0;
+    if (this.allTestViews.size) {
+      // Test views don't get attached to the application in the normal way so the dirty flags might not be present
+      // if the view has autoDetect off. We shouldn't ever actually skip any dirty views.
+      this.dirtyFlags |= ApplicationRefDirtyFlags.ViewTreeTraversal;
+    }
     while (this.dirtyFlags !== ApplicationRefDirtyFlags.None && runs++ < MAXIMUM_REFRESH_RERUNS) {
       profiler(ProfilerEvent.ChangeDetectionSyncStart);
       this.synchronizeOnce();

--- a/packages/core/src/change_detection/scheduling/ng_zone_scheduling.ts
+++ b/packages/core/src/change_detection/scheduling/ng_zone_scheduling.ts
@@ -8,7 +8,7 @@
 
 import {Subscription} from 'rxjs';
 
-import {ApplicationRef} from '../../application/application_ref';
+import {ApplicationRef, ApplicationRefDirtyFlags} from '../../application/application_ref';
 import {
   ENVIRONMENT_INITIALIZER,
   EnvironmentInjector,
@@ -58,7 +58,8 @@ export class NgZoneChangeDetectionScheduler {
         }
         this.zone.run(() => {
           try {
-            this.applicationRef.tick();
+            this.applicationRef.dirtyFlags |= ApplicationRefDirtyFlags.ViewTreeGlobal;
+            this.applicationRef._tick();
           } catch (e) {
             this.applicationErrorHandler(e);
           }

--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -15,6 +15,7 @@ import {
   Compiler,
   CompilerFactory,
   Component,
+  createComponent,
   EnvironmentInjector,
   InjectionToken,
   Injector,
@@ -751,32 +752,36 @@ describe('bootstrap', () => {
     });
 
     it('should dirty check attached views', () => {
-      const comp = TestBed.createComponent(MyComp);
+      const comp = createComponent(MyComp, {
+        environmentInjector: TestBed.inject(EnvironmentInjector),
+      });
       const appRef: ApplicationRef = TestBed.inject(ApplicationRef);
       expect(appRef.viewCount).toBe(0);
 
       appRef.tick();
-      expect(comp.nativeElement).toHaveText('');
+      expect(comp.location.nativeElement).toHaveText('');
 
-      appRef.attachView(comp.componentRef.hostView);
+      appRef.attachView(comp.hostView);
       appRef.tick();
       expect(appRef.viewCount).toBe(1);
-      expect(comp.nativeElement).toHaveText('Initial');
+      expect(comp.location.nativeElement).toHaveText('Initial');
     });
 
     it('should not dirty check detached views', () => {
-      const comp = TestBed.createComponent(MyComp);
+      const comp = createComponent(MyComp, {
+        environmentInjector: TestBed.inject(EnvironmentInjector),
+      });
       const appRef: ApplicationRef = TestBed.inject(ApplicationRef);
 
-      appRef.attachView(comp.componentRef.hostView);
+      appRef.attachView(comp.hostView);
       appRef.tick();
-      expect(comp.nativeElement).toHaveText('Initial');
+      expect(comp.location.nativeElement).toHaveText('Initial');
 
-      appRef.detachView(comp.componentRef.hostView);
-      comp.componentInstance.name = 'New';
+      appRef.detachView(comp.hostView);
+      comp.instance.name = 'New';
       appRef.tick();
       expect(appRef.viewCount).toBe(0);
-      expect(comp.nativeElement).toHaveText('Initial');
+      expect(comp.location.nativeElement).toHaveText('Initial');
     });
 
     it('should not dirty host bindings of views not marked for check', () => {

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -40,6 +40,8 @@ import {
   ɵɵsetNgModuleScope as setNgModuleScope,
   ɵɵtext as text,
   DOCUMENT,
+  signal,
+  provideZonelessChangeDetection,
 } from '../src/core';
 import {DeferBlockBehavior} from '../testing';
 import {TestBed, TestBedImpl} from '../testing/src/test_bed';
@@ -50,6 +52,7 @@ import {NgModuleType} from '../src/render3';
 import {depsTracker} from '../src/render3/deps_tracker/deps_tracker';
 import {setClassMetadataAsync} from '../src/render3/metadata';
 import {
+  ComponentFixtureAutoDetect,
   TEARDOWN_TESTING_MODULE_ON_DESTROY_DEFAULT,
   THROW_ON_UNKNOWN_ELEMENTS_DEFAULT,
   THROW_ON_UNKNOWN_PROPERTIES_DEFAULT,
@@ -2272,6 +2275,73 @@ describe('TestBed', () => {
     }
 
     expect(TestBed.runInInjectionContext(functionThatUsesInject)).toEqual(expectedValue);
+  });
+
+  describe('TestBed.tick', () => {
+    @Component({
+      template: '{{state()}}',
+    })
+    class Thing1 {
+      state = signal(1);
+    }
+
+    describe('with zone change detection', () => {
+      it('should update fixtures with autoDetect', () => {
+        TestBed.configureTestingModule({
+          providers: [{provide: ComponentFixtureAutoDetect, useValue: true}],
+        });
+        const {nativeElement, componentInstance} = TestBed.createComponent(Thing1);
+        expect(nativeElement.textContent).toBe('1');
+
+        componentInstance.state.set(2);
+        TestBed.tick();
+        expect(nativeElement.textContent).toBe('2');
+      });
+
+      it('should update fixtures without autoDetect', () => {
+        const {nativeElement, componentInstance} = TestBed.createComponent(Thing1);
+        expect(nativeElement.textContent).toBe(''); // change detection didn't run yet
+
+        componentInstance.state.set(2);
+        TestBed.tick();
+        expect(nativeElement.textContent).toBe('2');
+      });
+    });
+
+    describe('with zoneless change detection', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          providers: [provideZonelessChangeDetection()],
+        });
+      });
+
+      it('should update fixtures with autoDetect', async () => {
+        const fixture = TestBed.createComponent(Thing1);
+        await fixture.whenStable();
+
+        const {nativeElement, componentInstance} = fixture;
+        expect(nativeElement.textContent).toBe('1');
+
+        componentInstance.state.set(2);
+        TestBed.tick();
+        expect(nativeElement.textContent).toBe('2');
+      });
+
+      it('should update fixtures without autoDetect', async () => {
+        const fixture = TestBed.createComponent(Thing1);
+        fixture.autoDetectChanges(false);
+
+        const {nativeElement, componentInstance} = fixture;
+        expect(nativeElement.textContent).toBe('1');
+
+        componentInstance.state.set(2);
+        await fixture.whenStable();
+        expect(nativeElement.textContent).toBe('1');
+
+        TestBed.tick();
+        expect(nativeElement.textContent).toBe('2');
+      });
+    });
   });
 });
 

--- a/packages/core/testing/src/component_fixture.ts
+++ b/packages/core/testing/src/component_fixture.ts
@@ -33,8 +33,9 @@ import {DeferBlockFixture} from './defer';
 import {ComponentFixtureAutoDetect, ComponentFixtureNoNgZone} from './test_bed_common';
 
 interface TestAppRef {
-  externalTestViews: Set<ViewRef>;
-  skipCheckNoChangesForExternalTestViews: Set<ViewRef>;
+  allTestViews: Set<ViewRef>;
+  includeAllTestViews: boolean;
+  autoDetectTestViews: Set<ViewRef>;
 }
 
 /**
@@ -106,13 +107,15 @@ export class ComponentFixture<T> {
     this.nativeElement = this.elementRef.nativeElement;
     this.componentRef = componentRef;
 
+    this._testAppRef.allTestViews.add(this.componentRef.hostView);
     if (this.autoDetect) {
-      this._testAppRef.externalTestViews.add(this.componentRef.hostView);
+      this._testAppRef.autoDetectTestViews.add(this.componentRef.hostView);
       this.scheduler?.notify(ɵNotificationSource.ViewAttached);
       this.scheduler?.notify(ɵNotificationSource.MarkAncestorsForTraversal);
     }
     this.componentRef.hostView.onDestroy(() => {
-      this._testAppRef.externalTestViews.delete(this.componentRef.hostView);
+      this._testAppRef.allTestViews.delete(this.componentRef.hostView);
+      this._testAppRef.autoDetectTestViews.delete(this.componentRef.hostView);
     });
     // Create subscriptions outside the NgZone so that the callbacks run outside
     // of NgZone.
@@ -150,12 +153,10 @@ export class ComponentFixture<T> {
 
       if (this.zonelessEnabled) {
         try {
-          this._testAppRef.externalTestViews.add(this.componentRef.hostView);
+          this._testAppRef.includeAllTestViews = true;
           this._appRef.tick();
         } finally {
-          if (!this.autoDetect) {
-            this._testAppRef.externalTestViews.delete(this.componentRef.hostView);
-          }
+          this._testAppRef.includeAllTestViews = false;
         }
       } else {
         // Run the change detection inside the NgZone so that any async tasks as part of the change
@@ -191,12 +192,10 @@ export class ComponentFixture<T> {
       throw new Error('Cannot call autoDetectChanges when ComponentFixtureNoNgZone is set.');
     }
 
-    if (autoDetect !== this.autoDetect) {
-      if (autoDetect) {
-        this._testAppRef.externalTestViews.add(this.componentRef.hostView);
-      } else {
-        this._testAppRef.externalTestViews.delete(this.componentRef.hostView);
-      }
+    if (autoDetect) {
+      this._testAppRef.autoDetectTestViews.add(this.componentRef.hostView);
+    } else {
+      this._testAppRef.autoDetectTestViews.delete(this.componentRef.hostView);
     }
 
     this.autoDetect = autoDetect;
@@ -270,7 +269,8 @@ export class ComponentFixture<T> {
    */
   destroy(): void {
     this.subscriptions.unsubscribe();
-    this._testAppRef.externalTestViews.delete(this.componentRef.hostView);
+    this._testAppRef.autoDetectTestViews.delete(this.componentRef.hostView);
+    this._testAppRef.allTestViews.delete(this.componentRef.hostView);
     if (!this._isDestroyed) {
       this.componentRef.destroy();
       this._isDestroyed = true;

--- a/packages/core/testing/src/component_fixture.ts
+++ b/packages/core/testing/src/component_fixture.ts
@@ -152,12 +152,7 @@ export class ComponentFixture<T> {
       }
 
       if (this.zonelessEnabled) {
-        try {
-          this._testAppRef.includeAllTestViews = true;
-          this._appRef.tick();
-        } finally {
-          this._testAppRef.includeAllTestViews = false;
-        }
+        this._appRef.tick();
       } else {
         // Run the change detection inside the NgZone so that any async tasks as part of the change
         // detection are captured by the zone and can be waited for in isStable.

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -806,7 +806,17 @@ export class TestBedImpl implements TestBed {
    * @publicApi
    */
   tick(): void {
-    this.inject(ApplicationRef).tick();
+    const appRef = this.inject(ApplicationRef);
+    try {
+      // TODO(atscott): ApplicationRef.tick should set includeAllTestViews to true itself rather than doing this here and in ComponentFixture
+      // The behavior should be that TestBed.tick, ComponentFixture.detectChanges, and ApplicationRef.tick all result in the test fixtures
+      // getting synchronized, regardless of whether they are autoDetect: true.
+      // Automatic scheduling (zone or zoneless) will call _tick which will _not_ include fixtures with autoDetect: false
+      (appRef as any).includeAllTestViews = true;
+      appRef.tick();
+    } finally {
+      (appRef as any).includeAllTestViews = false;
+    }
   }
 }
 

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -806,17 +806,7 @@ export class TestBedImpl implements TestBed {
    * @publicApi
    */
   tick(): void {
-    const appRef = this.inject(ApplicationRef);
-    try {
-      // TODO(atscott): ApplicationRef.tick should set includeAllTestViews to true itself rather than doing this here and in ComponentFixture
-      // The behavior should be that TestBed.tick, ComponentFixture.detectChanges, and ApplicationRef.tick all result in the test fixtures
-      // getting synchronized, regardless of whether they are autoDetect: true.
-      // Automatic scheduling (zone or zoneless) will call _tick which will _not_ include fixtures with autoDetect: false
-      (appRef as any).includeAllTestViews = true;
-      appRef.tick();
-    } finally {
-      (appRef as any).includeAllTestViews = false;
-    }
+    this.inject(ApplicationRef).tick();
   }
 }
 


### PR DESCRIPTION
This aligns the behavior of `ApplicationRef.tick` with `TestBed.tick`.

First commit is part of https://github.com/angular/angular/pull/61382

This could be considered a breaking change. Should run TGP to determine whether this needs to wait for v21.