### PR TITLE
refactor: ensure tsurge migrations have clear ownership of files 

### DIFF
--- a/packages/core/schematics/migrations/self-closing-tags-migration/self-closing-tags-migration.ts
+++ b/packages/core/schematics/migrations/self-closing-tags-migration/self-closing-tags-migration.ts
@@ -109,12 +109,9 @@ export class SelfClosingTagsMigration extends TsurgeFunnelMigration<
     unitA: SelfClosingTagsCompilationUnitData,
     unitB: SelfClosingTagsCompilationUnitData,
   ): Promise<Serializable<SelfClosingTagsCompilationUnitData>> {
-    const uniqueReplacements = removeDuplicateReplacements([
-      ...unitA.tagReplacements,
-      ...unitB.tagReplacements,
-    ]);
-
-    return confirmAsSerializable({tagReplacements: uniqueReplacements});
+    return confirmAsSerializable({
+      tagReplacements: [...unitA.tagReplacements, ...unitB.tagReplacements],
+    });
   }
 
   override async globalMeta(
@@ -159,21 +156,4 @@ function prepareTextReplacement(
       toInsert: replacement,
     }),
   );
-}
-
-function removeDuplicateReplacements(
-  replacements: SelfClosingTagsMigrationData[],
-): SelfClosingTagsMigrationData[] {
-  const uniqueFiles = new Set<string>();
-  const result: SelfClosingTagsMigrationData[] = [];
-
-  for (const replacement of replacements) {
-    const fileId = replacement.file.id;
-    if (!uniqueFiles.has(fileId)) {
-      uniqueFiles.add(fileId);
-      result.push(replacement);
-    }
-  }
-
-  return result;
 }

--- a/packages/core/schematics/migrations/signal-migration/src/cli.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/cli.ts
@@ -11,6 +11,7 @@ import path from 'path';
 import assert from 'assert';
 import {SignalInputMigration} from './migration';
 import {writeMigrationReplacements} from './write_replacements';
+import {NodeJSFileSystem} from '../../../../../compiler-cli';
 
 main(
   path.resolve(process.argv[2]),
@@ -34,8 +35,7 @@ export async function main(
     insertTodosForSkippedFields,
     upgradeAnalysisPhaseToAvoidBatch: true,
   });
-  const baseInfo = migration.createProgram(absoluteTsconfigPath);
-  const info = migration.prepareProgram(baseInfo);
+  const info = migration.createProgram(absoluteTsconfigPath, new NodeJSFileSystem());
 
   await migration.analyze(info);
 

--- a/packages/core/schematics/ng-generate/cleanup-unused-imports/unused_imports_migration.ts
+++ b/packages/core/schematics/ng-generate/cleanup-unused-imports/unused_imports_migration.ts
@@ -8,7 +8,6 @@
 
 import ts from 'typescript';
 import {
-  BaseProgramInfo,
   confirmAsSerializable,
   ProgramInfo,
   projectFile,
@@ -19,7 +18,7 @@ import {
   TsurgeFunnelMigration,
 } from '../../utils/tsurge';
 import {ErrorCode, FileSystem, ngErrorCode} from '@angular/compiler-cli';
-import {DiagnosticCategoryLabel} from '@angular/compiler-cli/src/ngtsc/core/api';
+import {DiagnosticCategoryLabel, NgCompilerOptions} from '@angular/compiler-cli/src/ngtsc/core/api';
 import {ImportManager} from '@angular/compiler-cli/private/migrations';
 import {applyImportManagerChanges} from '../../utils/tsurge/helpers/apply_import_manager';
 
@@ -70,7 +69,7 @@ export class UnusedImportsMigration extends TsurgeFunnelMigration<
 > {
   private printer = ts.createPrinter();
 
-  override createProgram(tsconfigAbsPath: string, fs?: FileSystem): BaseProgramInfo {
+  override createProgram(tsconfigAbsPath: string, fs: FileSystem): ProgramInfo {
     return super.createProgram(tsconfigAbsPath, fs, {
       extendedDiagnostics: {
         checks: {

--- a/packages/core/schematics/ng-generate/cleanup-unused-imports/unused_imports_migration.ts
+++ b/packages/core/schematics/ng-generate/cleanup-unused-imports/unused_imports_migration.ts
@@ -11,7 +11,6 @@ import {
   confirmAsSerializable,
   ProgramInfo,
   projectFile,
-  ProjectFileID,
   Replacement,
   Serializable,
   TextUpdate,
@@ -27,8 +26,8 @@ export interface CompilationUnitData {
   /** Text changes that should be performed. */
   replacements: Replacement[];
 
-  /** Identifiers that have been removed from each file. */
-  removedIdentifiers: NodeID[];
+  /** Total number of imports that were removed. */
+  removedImports: number;
 
   /** Total number of files that were changed. */
   changedFiles: number;
@@ -43,7 +42,7 @@ interface RemovalLocations {
   partialRemovals: Map<ts.ArrayLiteralExpression, Set<ts.Expression>>;
 
   /** Text of all identifiers that have been removed. */
-  allRemovedIdentifiers: Set<ts.Identifier>;
+  allRemovedIdentifiers: Set<string>;
 }
 
 /** Tracks how identifiers are used across a single file. */
@@ -58,9 +57,6 @@ interface UsageAnalysis {
   /** Number of times each identifier string is seen within a file. */
   identifierCounts: Map<string, number>;
 }
-
-/** ID of a node based on its location. */
-type NodeID = string & {__nodeID: true};
 
 /** Migration that cleans up unused imports from a project. */
 export class UnusedImportsMigration extends TsurgeFunnelMigration<
@@ -83,7 +79,7 @@ export class UnusedImportsMigration extends TsurgeFunnelMigration<
   override async analyze(info: ProgramInfo): Promise<Serializable<CompilationUnitData>> {
     const nodePositions = new Map<ts.SourceFile, Set<string>>();
     const replacements: Replacement[] = [];
-    const removedIdentifiers: NodeID[] = [];
+    let removedImports = 0;
     let changedFiles = 0;
 
     info.ngCompiler?.getDiagnostics().forEach((diag) => {
@@ -101,7 +97,7 @@ export class UnusedImportsMigration extends TsurgeFunnelMigration<
         if (!nodePositions.has(diag.file)) {
           nodePositions.set(diag.file, new Set());
         }
-        nodePositions.get(diag.file)!.add(this.getNodeID(diag.start, diag.length));
+        nodePositions.get(diag.file)!.add(this.getNodeKey(diag.start, diag.length));
       }
     });
 
@@ -110,15 +106,14 @@ export class UnusedImportsMigration extends TsurgeFunnelMigration<
       const usageAnalysis = this.analyzeUsages(sourceFile, resolvedLocations);
 
       if (resolvedLocations.allRemovedIdentifiers.size > 0) {
+        removedImports += resolvedLocations.allRemovedIdentifiers.size;
         changedFiles++;
-        resolvedLocations.allRemovedIdentifiers.forEach((identifier) => {
-          removedIdentifiers.push(this.getNodeID(identifier.getStart(), identifier.getWidth()));
-        });
       }
+
       this.generateReplacements(sourceFile, resolvedLocations, usageAnalysis, info, replacements);
     });
 
-    return confirmAsSerializable({replacements, removedIdentifiers, changedFiles});
+    return confirmAsSerializable({replacements, removedImports, changedFiles});
   }
 
   override async migrate(globalData: CompilationUnitData) {
@@ -129,34 +124,10 @@ export class UnusedImportsMigration extends TsurgeFunnelMigration<
     unitA: CompilationUnitData,
     unitB: CompilationUnitData,
   ): Promise<Serializable<CompilationUnitData>> {
-    const combinedReplacements: Replacement[] = [];
-    const combinedRemovedIdentifiers: NodeID[] = [];
-    const seenReplacements = new Set<string>();
-    const seenIdentifiers = new Set<NodeID>();
-    const changedFileIds = new Set<ProjectFileID>();
-
-    [unitA, unitB].forEach((unit) => {
-      for (const replacement of unit.replacements) {
-        const key = this.getReplacementID(replacement);
-        changedFileIds.add(replacement.projectFile.id);
-        if (!seenReplacements.has(key)) {
-          seenReplacements.add(key);
-          combinedReplacements.push(replacement);
-        }
-      }
-
-      for (const identifier of unit.removedIdentifiers) {
-        if (!seenIdentifiers.has(identifier)) {
-          seenIdentifiers.add(identifier);
-          combinedRemovedIdentifiers.push(identifier);
-        }
-      }
-    });
-
     return confirmAsSerializable({
-      replacements: combinedReplacements,
-      removedIdentifiers: combinedRemovedIdentifiers,
-      changedFiles: changedFileIds.size,
+      replacements: [...unitA.replacements, ...unitB.replacements],
+      removedImports: unitA.removedImports + unitB.removedImports,
+      changedFiles: unitA.changedFiles + unitB.changedFiles,
     });
   }
 
@@ -168,20 +139,14 @@ export class UnusedImportsMigration extends TsurgeFunnelMigration<
 
   override async stats(globalMetadata: CompilationUnitData) {
     return confirmAsSerializable({
-      removedImports: globalMetadata.removedIdentifiers.length,
+      removedImports: globalMetadata.removedImports,
       changedFiles: globalMetadata.changedFiles,
     });
   }
 
-  /** Gets an ID that can be used to look up a node based on its location. */
-  private getNodeID(start: number, length: number): NodeID {
-    return `${start}/${length}` as NodeID;
-  }
-
-  /** Gets a unique ID for a replacement. */
-  private getReplacementID(replacement: Replacement): string {
-    const {position, end, toInsert} = replacement.update.data;
-    return replacement.projectFile.id + '/' + position + '/' + end + '/' + toInsert;
+  /** Gets a key that can be used to look up a node based on its location. */
+  private getNodeKey(start: number, length: number): string {
+    return `${start}/${length}`;
   }
 
   /**
@@ -212,7 +177,7 @@ export class UnusedImportsMigration extends TsurgeFunnelMigration<
         return;
       }
 
-      if (locations.has(this.getNodeID(node.getStart(), node.getWidth()))) {
+      if (locations.has(this.getNodeKey(node.getStart(), node.getWidth()))) {
         // When the entire array needs to be cleared, the diagnostic is
         // reported on the property assignment, rather than an array element.
         if (
@@ -223,7 +188,7 @@ export class UnusedImportsMigration extends TsurgeFunnelMigration<
           result.fullRemovals.add(parent.initializer);
           parent.initializer.elements.forEach((element) => {
             if (ts.isIdentifier(element)) {
-              result.allRemovedIdentifiers.add(element);
+              result.allRemovedIdentifiers.add(element.text);
             }
           });
         } else if (ts.isArrayLiteralExpression(parent)) {
@@ -231,7 +196,7 @@ export class UnusedImportsMigration extends TsurgeFunnelMigration<
             result.partialRemovals.set(parent, new Set());
           }
           result.partialRemovals.get(parent)!.add(node);
-          result.allRemovedIdentifiers.add(node);
+          result.allRemovedIdentifiers.add(node.text);
         }
       }
     };
@@ -362,13 +327,8 @@ export class UnusedImportsMigration extends TsurgeFunnelMigration<
       names.forEach((symbolName, localName) => {
         // Note that in the `identifierCounts` lookup both zero and undefined
         // are valid and mean that the identifiers isn't being used anymore.
-        if (!identifierCounts.get(localName)) {
-          for (const identifier of allRemovedIdentifiers) {
-            if (identifier.text === localName) {
-              importManager.removeImport(sourceFile, symbolName, moduleName);
-              break;
-            }
-          }
+        if (allRemovedIdentifiers.has(localName) && !identifierCounts.get(localName)) {
+          importManager.removeImport(sourceFile, symbolName, moduleName);
         }
       });
     });

--- a/packages/core/schematics/ng-generate/cleanup-unused-imports/unused_imports_migration.ts
+++ b/packages/core/schematics/ng-generate/cleanup-unused-imports/unused_imports_migration.ts
@@ -93,6 +93,11 @@ export class UnusedImportsMigration extends TsurgeFunnelMigration<
         diag.length !== undefined &&
         diag.code === ngErrorCode(ErrorCode.UNUSED_STANDALONE_IMPORTS)
       ) {
+        // Skip files that aren't owned by this compilation unit.
+        if (!info.sourceFiles.includes(diag.file)) {
+          return;
+        }
+
         if (!nodePositions.has(diag.file)) {
           nodePositions.set(diag.file, new Set());
         }

--- a/packages/core/schematics/utils/tsurge/base_migration.ts
+++ b/packages/core/schematics/utils/tsurge/base_migration.ts
@@ -10,9 +10,9 @@ import {absoluteFrom, FileSystem} from '@angular/compiler-cli/src/ngtsc/file_sys
 import {NgCompilerOptions} from '@angular/compiler-cli/src/ngtsc/core/api';
 import {getRootDirs} from '@angular/compiler-cli/src/ngtsc/util/src/typescript';
 import {isShim} from '@angular/compiler-cli/src/ngtsc/shims';
-import {BaseProgramInfo, ProgramInfo} from './program_info';
+import {ProgramInfo} from './program_info';
 import {Serializable} from './helpers/serializable';
-import {createBaseProgramInfo} from './helpers/create_program';
+import {createBaseProgramInfo, getProgramInfoFromBaseInfo} from './helpers/create_program';
 
 /** Type helper extracting the stats type of a migration. */
 export type MigrationStats<T> =
@@ -33,8 +33,7 @@ export abstract class TsurgeBaseMigration<
   Stats = unknown,
 > {
   /**
-   * Advanced Tsurge users can override this method, but most of the time,
-   * overriding {@link prepareProgram} is more desirable.
+   * Creates the TypeScript program for a given compilation unit.
    *
    * By default:
    *  - In 3P: Ngtsc programs are being created.
@@ -42,43 +41,10 @@ export abstract class TsurgeBaseMigration<
    */
   createProgram(
     tsconfigAbsPath: string,
-    fs?: FileSystem,
-    optionOverrides?: NgCompilerOptions,
-  ): BaseProgramInfo {
-    return createBaseProgramInfo(tsconfigAbsPath, fs, optionOverrides);
-  }
-
-  // Optional function to prepare the base `ProgramInfo` even further,
-  // for the analyze and migrate phases. E.g. determining source files.
-  prepareProgram(info: BaseProgramInfo): ProgramInfo {
-    const fullProgramSourceFiles = [...info.program.getSourceFiles()];
-    const sourceFiles = fullProgramSourceFiles.filter(
-      (f) =>
-        !f.isDeclarationFile &&
-        // Note `isShim` will work for the initial program, but for TCB programs, the shims are no longer annotated.
-        !isShim(f) &&
-        !f.fileName.endsWith('.ngtypecheck.ts'),
-    );
-
-    // Sort it by length in reverse order (longest first). This speeds up lookups,
-    // since there's no need to keep going through the array once a match is found.
-    const sortedRootDirs = getRootDirs(info.host, info.userOptions).sort(
-      (a, b) => b.length - a.length,
-    );
-
-    // TODO: Consider also following TS's logic here, finding the common source root.
-    // See: Program#getCommonSourceDirectory.
-    const primaryRoot = absoluteFrom(
-      info.userOptions.rootDir ?? sortedRootDirs.at(-1) ?? info.program.getCurrentDirectory(),
-    );
-
-    return {
-      ...info,
-      sourceFiles,
-      fullProgramSourceFiles,
-      sortedRootDirs,
-      projectRoot: primaryRoot,
-    };
+    fs: FileSystem,
+    optionsOverride?: NgCompilerOptions,
+  ): ProgramInfo {
+    return getProgramInfoFromBaseInfo(createBaseProgramInfo(tsconfigAbsPath, fs, optionsOverride));
   }
 
   /** Analyzes the given TypeScript project and returns serializable compilation unit data. */

--- a/packages/core/schematics/utils/tsurge/executors/analyze_exec.ts
+++ b/packages/core/schematics/utils/tsurge/executors/analyze_exec.ts
@@ -6,11 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {NodeJSFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {TsurgeMigration} from '../migration';
 import {Serializable} from '../helpers/serializable';
 
 /**
- * Executes the analyze phase of the given migration against
+ * 1P Logic: Executes the analyze phase of the given migration against
  * the specified TypeScript project.
  *
  * @returns the serializable migration unit data.
@@ -19,8 +20,7 @@ export async function executeAnalyzePhase<UnitData, GlobalData>(
   migration: TsurgeMigration<UnitData, GlobalData, unknown>,
   tsconfigAbsolutePath: string,
 ): Promise<Serializable<UnitData>> {
-  const baseInfo = migration.createProgram(tsconfigAbsolutePath);
-  const info = migration.prepareProgram(baseInfo);
+  const info = migration.createProgram(tsconfigAbsolutePath, new NodeJSFileSystem());
 
   return await migration.analyze(info);
 }

--- a/packages/core/schematics/utils/tsurge/executors/combine_exec.ts
+++ b/packages/core/schematics/utils/tsurge/executors/combine_exec.ts
@@ -10,7 +10,7 @@ import {Serializable} from '../helpers/serializable';
 import {TsurgeMigration} from '../migration';
 
 /**
- * Executes the combine phase for the given migration against
+ * 1P Logic: Executes the combine phase for the given migration against
  * two unit analyses.
  *
  * @returns the serializable combined unit data.

--- a/packages/core/schematics/utils/tsurge/executors/global_meta_exec.ts
+++ b/packages/core/schematics/utils/tsurge/executors/global_meta_exec.ts
@@ -10,7 +10,7 @@ import {Serializable} from '../helpers/serializable';
 import {TsurgeMigration} from '../migration';
 
 /**
- * Executes the `globalMeta` stage for the given migration
+ * 1P Logic: Executes the `globalMeta` stage for the given migration
  * to convert the combined unit data into global meta.
  *
  * @returns the serializable global meta.

--- a/packages/core/schematics/utils/tsurge/executors/migrate_exec.ts
+++ b/packages/core/schematics/utils/tsurge/executors/migrate_exec.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {AbsoluteFsPath, NodeJSFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {TsurgeMigration} from '../migration';
 import {Replacement} from '../replacement';
 
 /**
- * Executes the migrate phase of the given migration against
+ * 1P Logic: Executes the migrate phase of the given migration against
  * the specified TypeScript project.
  *
  * This requires the global migration data, computed by the
@@ -25,8 +25,8 @@ export async function executeMigratePhase<UnitData, GlobalData>(
   globalMetadata: GlobalData,
   tsconfigAbsolutePath: string,
 ): Promise<{replacements: Replacement[]; projectRoot: AbsoluteFsPath}> {
-  const baseInfo = migration.createProgram(tsconfigAbsolutePath);
-  const info = migration.prepareProgram(baseInfo);
+  // In 1P, we never need to use a virtual file system.
+  const info = migration.createProgram(tsconfigAbsolutePath, new NodeJSFileSystem());
 
   return {
     ...(await migration.migrate(globalMetadata, info)),

--- a/packages/core/schematics/utils/tsurge/helpers/angular_devkit/BUILD.bazel
+++ b/packages/core/schematics/utils/tsurge/helpers/angular_devkit/BUILD.bazel
@@ -13,5 +13,6 @@ ts_project(
     deps = [
         "//:node_modules/@angular-devkit/core",
         "//:node_modules/@angular-devkit/schematics",
+        "//:node_modules/typescript",
     ],
 )

--- a/packages/core/schematics/utils/tsurge/helpers/angular_devkit/run_in_devkit.ts
+++ b/packages/core/schematics/utils/tsurge/helpers/angular_devkit/run_in_devkit.ts
@@ -12,11 +12,11 @@ import {DevkitMigrationFilesystem} from './devkit_filesystem';
 import {groupReplacementsByFile} from '../group_replacements';
 import {synchronouslyCombineUnitData} from '../combine_units';
 import {TsurgeFunnelMigration, TsurgeMigration} from '../../migration';
-import {MigrationStats} from '../../base_migration';
 import {Replacement, TextUpdate} from '../../replacement';
 import {ProjectRootRelativePath} from '../../project_paths';
 import {ProgramInfo} from '../../program_info';
 import {getProjectTsConfigPaths} from '../../../../utils/project_tsconfig_paths';
+import ts from 'typescript';
 
 export enum MigrationStage {
   /** The migration is analyzing an entrypoint */
@@ -74,13 +74,17 @@ export async function runMigrationInDevkit<Stats>(
   const unitResults: unknown[] = [];
 
   const isFunnelMigration = migration instanceof TsurgeFunnelMigration;
+  const compilationUnitAssignments = new Map<string, string>();
+
   for (const tsconfigPath of tsconfigPaths) {
     config.beforeProgramCreation?.(tsconfigPath, MigrationStage.Analysis);
-    const baseInfo = migration.createProgram(tsconfigPath, fs);
-    const info = migration.prepareProgram(baseInfo);
-    config.afterProgramCreation?.(info, fs, MigrationStage.Analysis);
+    const info = migration.createProgram(tsconfigPath, fs);
 
+    modifyProgramInfoToEnsureNonOverlappingFiles(tsconfigPath, info, compilationUnitAssignments);
+
+    config.afterProgramCreation?.(info, fs, MigrationStage.Analysis);
     config.beforeUnitAnalysis?.(tsconfigPath);
+
     unitResults.push(await migration.analyze(info));
   }
 
@@ -102,8 +106,9 @@ export async function runMigrationInDevkit<Stats>(
 
     for (const tsconfigPath of tsconfigPaths) {
       config.beforeProgramCreation?.(tsconfigPath, MigrationStage.Migrate);
-      const baseInfo = migration.createProgram(tsconfigPath, fs);
-      const info = migration.prepareProgram(baseInfo);
+      const info = migration.createProgram(tsconfigPath, fs);
+      modifyProgramInfoToEnsureNonOverlappingFiles(tsconfigPath, info, compilationUnitAssignments);
+
       config.afterProgramCreation?.(info, fs, MigrationStage.Migrate);
 
       const result = await migration.migrate(globalMeta, info);
@@ -131,4 +136,38 @@ export async function runMigrationInDevkit<Stats>(
   }
 
   config.whenDone?.(await migration.stats(globalMeta));
+}
+
+/**
+ * Special logic for devkit migrations. In the Angular CLI, or in 3P precisely,
+ * projects can have tsconfigs with overlapping source files. i.e. two tsconfigs
+ * like e.g. build or test include the same `ts.SourceFile` (`.ts`). Migrations
+ * should never have 2+ compilation units with overlapping source files as this
+ * can result in duplicated replacements or analysis— hence we only ever assign a
+ * source file to a compilation unit *once*.
+ *
+ * Note that this is fine as we expect Tsurge migrations to work together as
+ * isolated compilation units— so it shouldn't matter if worst case a `.ts`
+ * file ends up in the e.g. test program.
+ */
+function modifyProgramInfoToEnsureNonOverlappingFiles(
+  tsconfigPath: string,
+  info: ProgramInfo,
+  compilationUnitAssignments: Map<string, string>,
+) {
+  const sourceFiles: ts.SourceFile[] = [];
+
+  for (const sf of info.sourceFiles) {
+    const assignment = compilationUnitAssignments.get(sf.fileName);
+
+    // File is already assigned to a different compilation unit.
+    if (assignment !== undefined && assignment !== tsconfigPath) {
+      continue;
+    }
+
+    compilationUnitAssignments.set(sf.fileName, tsconfigPath);
+    sourceFiles.push(sf);
+  }
+
+  info.sourceFiles = sourceFiles;
 }

--- a/packages/core/schematics/utils/tsurge/helpers/create_program.ts
+++ b/packages/core/schematics/utils/tsurge/helpers/create_program.ts
@@ -8,12 +8,15 @@
 
 import {NgCompilerOptions} from '@angular/compiler-cli/src/ngtsc/core/api';
 import {
+  absoluteFrom,
   FileSystem,
   NgtscCompilerHost,
   NodeJSFileSystem,
   setFileSystem,
 } from '@angular/compiler-cli/src/ngtsc/file_system';
-import {BaseProgramInfo} from '../program_info';
+import {isShim} from '@angular/compiler-cli/src/ngtsc/shims';
+import {getRootDirs} from '@angular/compiler-cli/src/ngtsc/util/src/typescript';
+import {BaseProgramInfo, ProgramInfo} from '../program_info';
 import {google3UsePlainTsProgramIfNoKnownAngularOption} from './google3/target_detection';
 import {createNgtscProgram} from './ngtsc_program';
 import {parseTsconfigOrDie} from './ts_parse_config';
@@ -43,4 +46,42 @@ export function createBaseProgramInfo(
   }
 
   return createNgtscProgram(tsHost, tsconfig, optionOverrides);
+}
+
+/**
+ * Creates the {@link ProgramInfo} from the given base information.
+ *
+ * This function purely exists to support custom programs that are
+ * intended to be injected into Tsurge migrations. e.g. for language
+ * service refactorings.
+ */
+export function getProgramInfoFromBaseInfo(baseInfo: BaseProgramInfo): ProgramInfo {
+  const fullProgramSourceFiles = [...baseInfo.program.getSourceFiles()];
+  const sourceFiles = fullProgramSourceFiles.filter(
+    (f) =>
+      !f.isDeclarationFile &&
+      // Note `isShim` will work for the initial program, but for TCB programs, the shims are no longer annotated.
+      !isShim(f) &&
+      !f.fileName.endsWith('.ngtypecheck.ts'),
+  );
+
+  // Sort it by length in reverse order (longest first). This speeds up lookups,
+  // since there's no need to keep going through the array once a match is found.
+  const sortedRootDirs = getRootDirs(baseInfo.host, baseInfo.userOptions).sort(
+    (a, b) => b.length - a.length,
+  );
+
+  // TODO: Consider also following TS's logic here, finding the common source root.
+  // See: Program#getCommonSourceDirectory.
+  const primaryRoot = absoluteFrom(
+    baseInfo.userOptions.rootDir ?? sortedRootDirs.at(-1) ?? baseInfo.program.getCurrentDirectory(),
+  );
+
+  return {
+    ...baseInfo,
+    sourceFiles,
+    fullProgramSourceFiles,
+    sortedRootDirs,
+    projectRoot: primaryRoot,
+  };
 }

--- a/packages/core/schematics/utils/tsurge/helpers/ngtsc_program.ts
+++ b/packages/core/schematics/utils/tsurge/helpers/ngtsc_program.ts
@@ -43,7 +43,7 @@ export function createNgtscProgram(
     ngCompiler: ngtscProgram.compiler,
     program: ngtscProgram.getTsProgram(),
     userOptions: tsconfig.options,
-    programAbsoluteRootFileNames: tsconfig.rootNames,
+    __programAbsoluteRootFileNames: tsconfig.rootNames,
     host: tsHost,
   };
 }

--- a/packages/core/schematics/utils/tsurge/helpers/ts_program.ts
+++ b/packages/core/schematics/utils/tsurge/helpers/ts_program.ts
@@ -42,7 +42,7 @@ export function createPlainTsProgram(
     ngCompiler: null,
     program,
     userOptions: tsconfig.options,
-    programAbsoluteRootFileNames: tsconfig.rootNames,
+    __programAbsoluteRootFileNames: tsconfig.rootNames,
     host: tsHost,
   };
 }

--- a/packages/core/schematics/utils/tsurge/index.ts
+++ b/packages/core/schematics/utils/tsurge/index.ts
@@ -12,4 +12,5 @@ export * from './program_info';
 export * from './replacement';
 export * from './helpers/unique_id';
 export * from './helpers/serializable';
+export {getProgramInfoFromBaseInfo} from './helpers/create_program';
 export * from './project_paths';

--- a/packages/core/schematics/utils/tsurge/migration.ts
+++ b/packages/core/schematics/utils/tsurge/migration.ts
@@ -37,7 +37,7 @@ interface MigrateResult {
  *   - {@link TsurgeFunnelMigration}
  *   - {@link TsurgeComplexMigration}
  *
- *  TODO: Link design doc
+ *  http://go/tsurge-design
  */
 export type TsurgeMigration<UnitAnalysisMetadata, CombinedGlobalMetadata, Stats> =
   | TsurgeComplexMigration<UnitAnalysisMetadata, CombinedGlobalMetadata, Stats>

--- a/packages/core/schematics/utils/tsurge/program_info.ts
+++ b/packages/core/schematics/utils/tsurge/program_info.ts
@@ -14,27 +14,43 @@ import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
 
 /**
  * Base information for a TypeScript project, including an instantiated
- * TypeScript program. Base information may be extended by user-overridden
- * migration preparation methods to extend the stages with more data.
+ * TypeScript program.
  */
 export interface BaseProgramInfo {
   ngCompiler: NgCompiler | null;
   program: ts.Program;
   userOptions: NgCompilerOptions;
-  programAbsoluteRootFileNames: string[];
   host: Pick<ts.CompilerHost, 'getCanonicalFileName' | 'getCurrentDirectory'>;
+
+  // Legacy field that shouldn't be used in the new migrations.
+  __programAbsoluteRootFileNames: string[];
 }
 
 /**
- * Full program information for a TypeScript project. This is the default "extension"
- * of the {@link BaseProgramInfo} with additional commonly accessed information.
- *
- * A different interface may be used as full program information, configured via a
- * {@link TsurgeMigration.prepareProgram} override.
+ * Full program information for a TypeScript project.
  */
 export interface ProgramInfo extends BaseProgramInfo {
+  /**
+   * All source files owned by this program / compilation unit.
+   *
+   * These are the files owned by the compilation unit and the migration
+   * can make modifications to.
+   *
+   * *Note for 3P*: It intentionally might be that more files would technically be
+   * part of this program, but aren't listed here. This can happen when Tsurge
+   * detects an overlap of multiple programs (e.g. tsconfig.build and tsconfig.test)
+   * and smartly coordinates which compilation unit should own the source file.
+   */
   sourceFiles: ts.SourceFile[];
+
+  /**
+   * All source files in the program, including transitively loaded `.d.ts`.
+   *
+   * Use {@link sourceFiles} for a convenient way to finding source files that
+   * can be migrated. This field is useful when full program analysis is performed.
+   */
   fullProgramSourceFiles: readonly ts.SourceFile[];
+
   /**
    * Root directories of the project.
    * Sorted longest first for easy lookups.

--- a/packages/core/schematics/utils/tsurge/testing/run_single.ts
+++ b/packages/core/schematics/utils/tsurge/testing/run_single.ts
@@ -58,8 +58,7 @@ export async function runTsurgeMigration<Stats>(
     }),
   );
 
-  const baseInfo = migration.createProgram('/tsconfig.json', mockFs);
-  const info = migration.prepareProgram(baseInfo);
+  const info = migration.createProgram('/tsconfig.json', mockFs);
 
   const unitData = await migration.analyze(info);
   const globalMeta = await migration.globalMeta(unitData);

--- a/packages/language-service/src/refactorings/convert_to_signal_input/apply_input_refactoring.ts
+++ b/packages/language-service/src/refactorings/convert_to_signal_input/apply_input_refactoring.ts
@@ -19,6 +19,7 @@ import {
   nonIgnorableFieldIncompatibilities,
   SignalInputMigration,
 } from '@angular/core/schematics/migrations/signal-migration/src';
+import {getProgramInfoFromBaseInfo} from '@angular/core/schematics/utils/tsurge';
 import {groupReplacementsByFile} from '@angular/core/schematics/utils/tsurge/helpers/group_replacements';
 import {ApplyRefactoringProgressFn, ApplyRefactoringResult} from '../../../api';
 
@@ -42,15 +43,15 @@ export async function applySignalInputRefactoring(
   });
 
   await migration.analyze(
-    migration.prepareProgram({
+    getProgramInfoFromBaseInfo({
       ngCompiler: compiler,
       program: compiler.getCurrentProgram(),
       userOptions: compilerOptions,
-      programAbsoluteRootFileNames: [],
       host: {
         getCanonicalFileName: (file) => project.projectService.toCanonicalFileName(file),
         getCurrentDirectory: () => project.getCurrentDirectory(),
       },
+      __programAbsoluteRootFileNames: [],
     }),
   );
 

--- a/packages/language-service/src/refactorings/convert_to_signal_queries/apply_query_refactoring.ts
+++ b/packages/language-service/src/refactorings/convert_to_signal_queries/apply_query_refactoring.ts
@@ -17,7 +17,7 @@ import {
   SignalQueriesMigration,
 } from '@angular/core/schematics/migrations/signal-queries-migration';
 import assert from 'assert';
-import {projectFile} from '../../../../core/schematics/utils/tsurge';
+import {projectFile, getProgramInfoFromBaseInfo} from '../../../../core/schematics/utils/tsurge';
 import {FieldIncompatibilityReason} from '../../../../core/schematics/migrations/signal-migration/src';
 import {
   isFieldIncompatibility,
@@ -43,15 +43,15 @@ export async function applySignalQueriesRefactoring(
     shouldMigrateQuery,
   });
 
-  const programInfo = migration.prepareProgram({
+  const programInfo = getProgramInfoFromBaseInfo({
     ngCompiler: compiler,
     program: compiler.getCurrentProgram(),
     userOptions: compilerOptions,
-    programAbsoluteRootFileNames: [],
     host: {
       getCanonicalFileName: (file) => project.projectService.toCanonicalFileName(file),
       getCurrentDirectory: () => project.getCurrentDirectory(),
     },
+    __programAbsoluteRootFileNames: [],
   });
 
   const unitData = await migration.analyze(programInfo);


### PR DESCRIPTION
Currently there can be cases, exclusively in 3P, where multiple tsconfig
projects have overlap of source files. This is the default setup of new
CLI applications as well.

When this is the case, Tsurge will treat each tsconfig as an isolated
compilation unit (given the concepts and mental model to support
scalable batching). This is wrong though, and the same `.ts` source file
can appear in two migration invocations; resulting in duplicate
replacements or analysis (depending on the migration).

We've worked around this problem in the past by deduplicating
replacements, or migrating to an ID-based approach with natural
deduplication. This worked, but it's just working around the root cause.

This commit attempts to fix the root cause by adjusting Tsurge to ensure
that no source file ever appears in two compilation units. This is
naively achieved by not adding a source file to a migration unit, if it
was part of a previous one. This is expected to be fine given the nature
of Tsurge migrations that are built to operate on isolated pieces
anyway— so it shouldn't be problematic if e.g. `app.component.ts` ends
up being part of the test tsconfig compilation unit (we avoid this order
though by visiting build targets first).

Related #61337 