### PR TITLE
fix(core): attempt at annotation for projection case

### DIFF
--- a/packages/core/src/hydration/node_lookup_utils.ts
+++ b/packages/core/src/hydration/node_lookup_utils.ts
@@ -325,8 +325,9 @@ export function calcPathForNode(
   tNode: TNode,
   lView: LView,
   excludedParentNodes: Set<number> | null,
+  parent: TNode | null = null,
 ): string {
-  let parentTNode = tNode.parent;
+  let parentTNode = parent ?? tNode.parent;
   let parentIndex: number | string;
   let parentRNode: RNode;
   let referenceNodeName: string;

--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -817,6 +817,8 @@ function populateDehydratedViewsInLContainerImpl(
   tNode: TNode,
   hostLView: LView,
 ): boolean {
+  // This is failing during the hydration phase
+  debugger;
   // We already have a native element (anchor) set and the process
   // of finding dehydrated views happened (so the `lContainer[DEHYDRATED_VIEWS]`
   // is not null), exit early.

--- a/packages/core/src/render3/instructions/template.ts
+++ b/packages/core/src/render3/instructions/template.ts
@@ -296,8 +296,10 @@ function locateOrCreateContainerAnchorImpl(
 
   setSegmentHead(hydrationInfo, index, currentRNode);
   const viewContainerSize = calcSerializedContainerSize(hydrationInfo, index);
-  const comment = siblingAfter<RComment>(viewContainerSize, currentRNode)!;
-
+  let comment = siblingAfter<RComment>(viewContainerSize, currentRNode)!;
+  // this is just to see what happens. We need to adjust the container size here so that siblingAfter actually returns the real next sibling
+  // because it is a comment node, but viewContainerSize is 0 right now.
+  comment = comment.nextSibling! as RComment;
   if (ngDevMode) {
     validateMatchingNode(comment, Node.COMMENT_NODE, null, lView, tNode);
     markRNodeAsClaimedByHydration(comment);


### PR DESCRIPTION
In the case of an ng-template being projected via a ContentChild query, the nodes are disconnected at annotation time. We need to identify the connections and serialize the right path for hydration.
