### PR TITLE
Runtime refactor: move code out of instructions folder

### DIFF
--- a/packages/core/src/hydration/i18n.ts
+++ b/packages/core/src/hydration/i18n.ts
@@ -8,7 +8,7 @@
 
 import {inject, Injector} from '../di';
 import {isRootTemplateMessage} from '../render3/i18n/i18n_util';
-import {createIcuIterator} from '../render3/instructions/i18n_icu_container_visitor';
+import {createIcuIterator} from '../render3/i18n/i18n_icu_container_visitor';
 import {I18nNode, I18nNodeKind, I18nPlaceholderType, TI18n, TIcu} from '../render3/interfaces/i18n';
 import {isTNodeShape, TNode, TNodeType} from '../render3/interfaces/node';
 import type {Renderer} from '../render3/interfaces/renderer';

--- a/packages/core/src/render3/i18n/i18n_icu_container_visitor.ts
+++ b/packages/core/src/render3/i18n/i18n_icu_container_visitor.ts
@@ -9,7 +9,7 @@
 import {assertDomNode, assertNumber, assertNumberInRange} from '../../util/assert';
 import {EMPTY_ARRAY} from '../../util/empty';
 import {assertTIcu, assertTNodeForLView} from '../assert';
-import {getCurrentICUCaseIndex} from '../i18n/i18n_util';
+import {getCurrentICUCaseIndex} from './i18n_util';
 import {I18nRemoveOpCodes, TIcu} from '../interfaces/i18n';
 import {TIcuContainerNode} from '../interfaces/node';
 import {RNode} from '../interfaces/renderer_dom';

--- a/packages/core/src/render3/i18n/i18n_parse.ts
+++ b/packages/core/src/render3/i18n/i18n_parse.ts
@@ -25,7 +25,7 @@ import {
   assertString,
 } from '../../util/assert';
 import {CharCode} from '../../util/char_code';
-import {loadIcuContainerVisitor} from '../instructions/i18n_icu_container_visitor';
+import {loadIcuContainerVisitor} from './i18n_icu_container_visitor';
 
 import {getDocument} from '../interfaces/document';
 import {

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -52,7 +52,6 @@ export {ComponentFactory, ComponentFactoryResolver, ComponentRef} from './compon
 export {ɵɵgetInheritedFactory} from './di';
 export {getLocaleId, setLocaleId} from './i18n/i18n_locale_id';
 export {
-  store,
   ɵɵadvance,
   ɵɵattribute,
   ɵɵattributeInterpolate1,
@@ -229,6 +228,8 @@ export {ɵɵtemplateRefExtractor} from './view_engine_compatibility_prebound';
 export {ɵɵgetComponentDepsFactory} from './local_compilation';
 export {ɵsetClassDebugInfo} from './debug/set_debug_info';
 export {ɵɵreplaceMetadata} from './hmr';
+
+export {store} from './util/view_utils';
 
 export {
   ComponentDef,

--- a/packages/core/src/render3/instructions/let_declaration.ts
+++ b/packages/core/src/render3/instructions/let_declaration.ts
@@ -12,8 +12,7 @@ import {TNodeType} from '../interfaces/node';
 import {HEADER_OFFSET} from '../interfaces/view';
 import {getContextLView, getLView, getSelectedIndex, getTView, setCurrentTNode} from '../state';
 import {getOrCreateTNode} from '../tnode_manipulation';
-import {load} from '../util/view_utils';
-import {store} from './storage';
+import {load, store} from '../util/view_utils';
 
 /** Object that indicates the value of a `@let` declaration that hasn't been initialized yet. */
 const UNINITIALIZED_LET = {};

--- a/packages/core/src/render3/instructions/storage.ts
+++ b/packages/core/src/render3/instructions/storage.ts
@@ -9,17 +9,6 @@ import {HEADER_OFFSET, LView, TView} from '../interfaces/view';
 import {getContextLView} from '../state';
 import {load} from '../util/view_utils';
 
-/** Store a value in the `data` at a given `index`. */
-export function store<T>(tView: TView, lView: LView, index: number, value: T): void {
-  // We don't store any static data for local variables, so the first time
-  // we see the template, we should store as null to avoid a sparse array
-  if (index >= tView.data.length) {
-    tView.data[index] = null;
-    tView.blueprint[index] = null;
-  }
-  lView[index] = value;
-}
-
 /**
  * Retrieves a local reference from the current contextViewData.
  *

--- a/packages/core/src/render3/pipe.ts
+++ b/packages/core/src/render3/pipe.ts
@@ -14,7 +14,7 @@ import {Type} from '../interface/type';
 import {InjectorProfilerContext, setInjectorProfilerContext} from './debug/injector_profiler';
 import {getFactoryDef} from './definition_factory';
 import {NodeInjector, setIncludeViewProviders} from './di';
-import {store, ɵɵdirectiveInject} from './instructions/all';
+import {ɵɵdirectiveInject} from './instructions/all';
 import {isHostComponentStandalone} from './instructions/element_validation';
 import {PipeDef, PipeDefList} from './interfaces/definition';
 import {TTextNode} from './interfaces/node';
@@ -27,7 +27,7 @@ import {
   pureFunctionVInternal,
 } from './pure_function';
 import {getBindingRoot, getCurrentTNode, getLView, getTView} from './state';
-import {load} from './util/view_utils';
+import {load, store} from './util/view_utils';
 
 /**
  * Create a pipe.

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -138,6 +138,17 @@ export function load<T>(view: LView | TData, index: number): T {
   return view[index];
 }
 
+/** Store a value in the `data` at a given `index`. */
+export function store<T>(tView: TView, lView: LView, index: number, value: T): void {
+  // We don't store any static data for local variables, so the first time
+  // we see the template, we should store as null to avoid a sparse array
+  if (index >= tView.data.length) {
+    tView.data[index] = null;
+    tView.blueprint[index] = null;
+  }
+  lView[index] = value;
+}
+
 export function getComponentLViewByIndex(nodeIndex: number, hostView: LView): LView {
   // Could be an LView or an LContainer. If LContainer, unwrap to find LView.
   ngDevMode && assertIndexInRange(hostView, nodeIndex);


### PR DESCRIPTION
This is one of the many refactorings that tries to cleanup / re-dispatch code in the `instructions` folder. The general idea is that the `instructions` should only contain functions referenced in the generated code and the instructions functions should be, most of the time, delegating to the core framework logic / utility functions. 