### PR TITLE
refactor(core): Deprecate fixture.autoDetectChanges(true/false)

### DIFF
--- a/goldens/public-api/core/testing/index.api.md
+++ b/goldens/public-api/core/testing/index.api.md
@@ -11,7 +11,9 @@ import { Subscription } from 'rxjs';
 // @public
 export class ComponentFixture<T> {
     constructor(componentRef: ComponentRef<T>);
-    autoDetectChanges(autoDetect?: boolean): void;
+    // @deprecated
+    autoDetectChanges(autoDetect: boolean): void;
+    autoDetectChanges(): void;
     changeDetectorRef: ChangeDetectorRef;
     checkNoChanges(): void;
     componentInstance: T;

--- a/packages/core/testing/src/component_fixture.ts
+++ b/packages/core/testing/src/component_fixture.ts
@@ -185,7 +185,16 @@ export class ComponentFixture<T> {
    * Also runs detectChanges once so that any existing change is detected.
    *
    * @param autoDetect Whether to autodetect changes. By default, `true`.
+   * @deprecated For `autoDetect: true`, use `autoDetectChanges()`.
+   * We have not seen a use-case for `autoDetect: false` but `changeDetectorRef.detach()` is a close equivalent.
    */
+  autoDetectChanges(autoDetect: boolean): void;
+  /**
+   * Enables automatically synchronizing the view, as it would in an application.
+   *
+   * Also runs detectChanges once so that any existing change is detected.
+   */
+  autoDetectChanges(): void;
   autoDetectChanges(autoDetect = true): void {
     if (this._noZoneOptionIsSet && !this.zonelessEnabled) {
       throw new Error('Cannot call autoDetectChanges when ComponentFixtureNoNgZone is set.');


### PR DESCRIPTION
After nearly a decade of existence, there are 0 uses of `autoDetectChanges(false)` internally. All uses of `autoDetectChanges(true)` can be migrated directly to `autoDetectChanges()` instead.
