### PR TITLE
refactor(core): Disallow autoDetectChanges(false) in zoneless

### DIFF
--- a/packages/core/test/component_fixture_spec.ts
+++ b/packages/core/test/component_fixture_spec.ts
@@ -634,7 +634,7 @@ describe('ComponentFixture with zoneless', () => {
     expect(() => fixture.detectChanges()).toThrowError(/ExpressionChanged/);
   });
 
-  it('runs change detection when autoDetect is false', () => {
+  it('disallows autoDetect: false', () => {
     @Component({
       template: '{{thing()}}',
     })
@@ -643,9 +643,6 @@ describe('ComponentFixture with zoneless', () => {
     }
 
     const fixture = TestBed.createComponent(App);
-    fixture.autoDetectChanges(false);
-    fixture.componentInstance.thing.set(2);
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).toBe('2');
+    expect(() => fixture.autoDetectChanges(false)).toThrow();
   });
 });

--- a/packages/core/testing/src/component_fixture.ts
+++ b/packages/core/testing/src/component_fixture.ts
@@ -196,6 +196,9 @@ export class ComponentFixture<T> {
    */
   autoDetectChanges(): void;
   autoDetectChanges(autoDetect = true): void {
+    if (!autoDetect && this.zonelessEnabled) {
+      throw new Error('Cannot set autoDetect to false with zoneless change detection.');
+    }
     if (this._noZoneOptionIsSet && !this.zonelessEnabled) {
       throw new Error('Cannot call autoDetectChanges when ComponentFixtureNoNgZone is set.');
     }


### PR DESCRIPTION
This removes the ability to use `autoDetectChanges(false)` when
`provideZonelessChangeDetection` is used.