### PR TITLE
refactor(zone.js): additional cleanups to reduce code size

### DIFF
--- a/packages/zone.js/lib/browser/browser-util.ts
+++ b/packages/zone.js/lib/browser/browser-util.ts
@@ -18,7 +18,7 @@ export function patchCallbacks(
   }
   const nativeDelegate = (target[symbol] = target[method]);
   target[method] = function (name: any, opts: any, options?: any) {
-    if (opts && opts.prototype) {
+    if (opts?.prototype) {
       callbacks.forEach(function (callback) {
         const source = `${targetName}.${method}::` + callback;
         const prototype = opts.prototype;
@@ -33,7 +33,7 @@ export function patchCallbacks(
         try {
           if (prototype.hasOwnProperty(callback)) {
             const descriptor = api.ObjectGetOwnPropertyDescriptor(prototype, callback);
-            if (descriptor && descriptor.value) {
+            if (descriptor?.value) {
               descriptor.value = api.wrapWithCurrentZone(descriptor.value, source);
               api._redefineProperty(opts.prototype, callback, descriptor);
             } else if (prototype[callback]) {

--- a/packages/zone.js/lib/browser/browser.ts
+++ b/packages/zone.js/lib/browser/browser.ts
@@ -67,7 +67,7 @@ export function patchBrowser(Zone: ZoneType): void {
     eventTargetPatch(global, api);
     // patch XMLHttpRequestEventTarget's addEventListener/removeEventListener
     const XMLHttpRequestEventTarget = (global as any)['XMLHttpRequestEventTarget'];
-    if (XMLHttpRequestEventTarget && XMLHttpRequestEventTarget.prototype) {
+    if (XMLHttpRequestEventTarget?.prototype) {
       api.patchEventTarget(global, api, [XMLHttpRequestEventTarget.prototype]);
     }
   });
@@ -255,8 +255,7 @@ export function patchBrowser(Zone: ZoneType): void {
                 clearTask,
               );
               if (
-                self &&
-                self[XHR_ERROR_BEFORE_SCHEDULED] === true &&
+                self?.[XHR_ERROR_BEFORE_SCHEDULED] === true &&
                 !options.aborted &&
                 task.state === SCHEDULED
               ) {
@@ -275,12 +274,12 @@ export function patchBrowser(Zone: ZoneType): void {
         () =>
           function (self: any, args: any[]) {
             const task: Task = findPendingTask(self);
-            if (task && typeof task.type == 'string') {
+            if (typeof task?.type == 'string') {
               // If the XHR has already completed, do nothing.
               // If the XHR has already been aborted, do nothing.
               // Fix #569, call abort multiple times before done will cause
               // macroTask task count be negative number
-              if (task.cancelFn == null || (task.data && (<XHROptions>task.data).aborted)) {
+              if (task.cancelFn == null || (<XHROptions>task.data)?.aborted) {
                 return;
               }
               task.zone.cancelTask(task);
@@ -298,8 +297,9 @@ export function patchBrowser(Zone: ZoneType): void {
 
   Zone.__load_patch('geolocation', (global: any) => {
     /// GEO_LOCATION
-    if (global['navigator'] && global['navigator'].geolocation) {
-      patchPrototype(global['navigator'].geolocation, ['getCurrentPosition', 'watchPosition']);
+    const geolocation = global['navigator']?.geolocation;
+    if (geolocation) {
+      patchPrototype(geolocation, ['getCurrentPosition', 'watchPosition']);
     }
   });
 

--- a/packages/zone.js/lib/browser/canvas.ts
+++ b/packages/zone.js/lib/browser/canvas.ts
@@ -11,11 +11,7 @@ import {ZoneType} from '../zone-impl';
 export function patchCanvas(Zone: ZoneType): void {
   Zone.__load_patch('canvas', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
     const HTMLCanvasElement = global['HTMLCanvasElement'];
-    if (
-      typeof HTMLCanvasElement !== 'undefined' &&
-      HTMLCanvasElement.prototype &&
-      HTMLCanvasElement.prototype.toBlob
-    ) {
+    if (HTMLCanvasElement?.prototype?.toBlob) {
       api.patchMacroTask(HTMLCanvasElement.prototype, 'toBlob', (self: any, args: any[]) => {
         return {name: 'HTMLCanvasElement.toBlob', target: self, cbIdx: 0, args: args};
       });

--- a/packages/zone.js/lib/browser/define-property.ts
+++ b/packages/zone.js/lib/browser/define-property.ts
@@ -86,7 +86,7 @@ export function _redefineProperty(obj: any, prop: string, desc: any) {
 }
 
 function isUnconfigurable(obj: any, prop: any) {
-  return obj && obj[unconfigurablesKey] && obj[unconfigurablesKey][prop];
+  return obj?.[unconfigurablesKey]?.[prop];
 }
 
 function rewriteDescriptor(obj: any, prop: string, desc: any) {

--- a/packages/zone.js/lib/browser/event-target.ts
+++ b/packages/zone.js/lib/browser/event-target.ts
@@ -13,23 +13,21 @@ export function eventTargetPatch(_global: any, api: _ZonePrivate) {
   }
   const {eventNames, zoneSymbolEventNames, TRUE_STR, FALSE_STR, ZONE_SYMBOL_PREFIX} =
     api.getGlobalObjects()!;
-  //  predefine all __zone_symbol__ + eventName + true/false string
-  for (let i = 0; i < eventNames.length; i++) {
-    const eventName = eventNames[i];
+  // Predefine all zone symbol event name mappings for both `capture = false` and `true`.
+  // This avoids recomputing symbol strings at runtime and improves performance.
+  for (const eventName of eventNames) {
     const falseEventName = eventName + FALSE_STR;
     const trueEventName = eventName + TRUE_STR;
     const symbol = ZONE_SYMBOL_PREFIX + falseEventName;
     const symbolCapture = ZONE_SYMBOL_PREFIX + trueEventName;
-    zoneSymbolEventNames[eventName] = {};
-    zoneSymbolEventNames[eventName][FALSE_STR] = symbol;
-    zoneSymbolEventNames[eventName][TRUE_STR] = symbolCapture;
+    zoneSymbolEventNames[eventName] = {[FALSE_STR]: symbol, [TRUE_STR]: symbolCapture};
   }
 
-  const EVENT_TARGET = _global['EventTarget'];
-  if (!EVENT_TARGET || !EVENT_TARGET.prototype) {
+  const EventTarget = _global['EventTarget'];
+  if (!EventTarget?.prototype) {
     return;
   }
-  api.patchEventTarget(_global, api, [EVENT_TARGET && EVENT_TARGET.prototype]);
+  api.patchEventTarget(_global, api, [EventTarget.prototype]);
 
   return true;
 }

--- a/packages/zone.js/lib/browser/message-port.ts
+++ b/packages/zone.js/lib/browser/message-port.ts
@@ -15,7 +15,7 @@ export function patchMessagePort(Zone: ZoneType): void {
    */
   Zone.__load_patch('MessagePort', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
     const MessagePort = global['MessagePort'];
-    if (typeof MessagePort !== 'undefined' && MessagePort.prototype) {
+    if (MessagePort?.prototype) {
       api.patchOnProperties(MessagePort.prototype, ['message', 'messageerror']);
     }
   });

--- a/packages/zone.js/lib/browser/property-descriptor.ts
+++ b/packages/zone.js/lib/browser/property-descriptor.ts
@@ -87,7 +87,7 @@ export function propertyDescriptorPatch(api: _ZonePrivate, _global: any) {
       'Worker',
     ]);
     const ignoreErrorProperties: IgnoreProperty[] = [];
-    // In older browsers like IE or Edge, event handler properties (e.g., `onclick`)
+    // In older browsers like Edge, event handler properties (e.g., `onclick`)
     // may not be defined directly on the `window` object but on its prototype (`WindowPrototype`).
     // To ensure complete coverage, we use the prototype when checking
     // for and patching these properties.

--- a/packages/zone.js/lib/node/node_util.ts
+++ b/packages/zone.js/lib/node/node_util.ts
@@ -11,7 +11,7 @@ import {
   patchMacroTask,
   patchMethod,
   patchOnProperties,
-  setShouldCopySymbolProperties,
+  setCopySymbolPropertiesForNodeJS,
 } from '../common/utils';
 import {ZoneType} from '../zone-impl';
 
@@ -21,6 +21,6 @@ export function patchNodeUtil(Zone: ZoneType): void {
     api.patchMethod = patchMethod;
     api.bindArguments = bindArguments;
     api.patchMacroTask = patchMacroTask;
-    setShouldCopySymbolProperties(true);
+    setCopySymbolPropertiesForNodeJS();
   });
 }

--- a/packages/zone.js/lib/zone-impl.ts
+++ b/packages/zone.js/lib/zone-impl.ts
@@ -774,10 +774,10 @@ export function initZone(): ZoneType {
   const performance: {mark(name: string): void; measure(name: string, label: string): void} =
     global['performance'];
   function mark(name: string) {
-    performance && performance['mark'] && performance['mark'](name);
+    performance?.['mark']?.(name);
   }
   function performanceMeasure(name: string, label: string) {
-    performance && performance['measure'] && performance['measure'](name, label);
+    performance?.['measure']?.(name, label);
   }
   mark('Zone');
 
@@ -845,12 +845,8 @@ export function initZone(): ZoneType {
     constructor(parent: ZoneImpl | null, zoneSpec: ZoneSpec | null) {
       this._parent = parent as ZoneImpl;
       this._name = zoneSpec ? zoneSpec.name || 'unnamed' : '<root>';
-      this._properties = (zoneSpec && zoneSpec.properties) || {};
-      this._zoneDelegate = new _ZoneDelegate(
-        this,
-        this._parent && this._parent._zoneDelegate,
-        zoneSpec,
-      );
+      this._properties = zoneSpec?.properties || {};
+      this._zoneDelegate = new _ZoneDelegate(this, this._parent?._zoneDelegate, zoneSpec);
     }
 
     public get(key: string): any {
@@ -1222,8 +1218,8 @@ export function initZone(): ZoneType {
       this._hasTaskDlgtOwner = null;
       this._hasTaskCurrZone = null;
 
-      const zoneSpecHasTask = zoneSpec && zoneSpec.onHasTask;
-      const parentHasTask = parentDelegate && parentDelegate._hasTaskZS;
+      const zoneSpecHasTask = zoneSpec?.onHasTask;
+      const parentHasTask = parentDelegate?._hasTaskZS;
       if (zoneSpecHasTask || parentHasTask) {
         // If we need to report hasTask, than this ZS needs to do ref counting on tasks. In such
         // a case all task related interceptors must go through this ZD. We can't short circuit it.
@@ -1358,13 +1354,12 @@ export function initZone(): ZoneType {
       // hasTask should not throw error so other ZoneDelegate
       // can still trigger hasTask callback
       try {
-        this._hasTaskZS &&
-          this._hasTaskZS.onHasTask!(
-            this._hasTaskDlgt!,
-            this._hasTaskCurrZone!,
-            targetZone,
-            isEmpty,
-          );
+        this._hasTaskZS?.onHasTask!(
+          this._hasTaskDlgt!,
+          this._hasTaskCurrZone!,
+          targetZone,
+          isEmpty,
+        );
       } catch (err) {
         this.handleError(targetZone, err);
       }
@@ -1421,7 +1416,7 @@ export function initZone(): ZoneType {
       this.callback = callback;
       const self = this;
       // TODO: @JiaLiPassion options should have interface
-      if (type === eventTask && options && (options as any).useG) {
+      if (type === eventTask && (options as any)?.useG) {
         this.invoke = ZoneTask.invokeTask;
       } else {
         this.invoke = function () {
@@ -1476,7 +1471,7 @@ export function initZone(): ZoneType {
     }
 
     public toString() {
-      if (this.data && typeof this.data.handleId !== 'undefined') {
+      if (this.data?.handleId) {
         return this.data.handleId.toString();
       } else {
         return Object.prototype.toString.call(this);


### PR DESCRIPTION
NOTE: Some code paths containing special handling for IE have been removed because we no longer support IE.

In this commit, we perform separate cleanups inside the zone.js package to reduce the number of `&&` operations by using optional chaining, as it makes the code smaller and more readable.

The `copySymbolProperties` function is now tree-shakable in browser bundles because its implementation is only set in Node.js.