### PR TITLE
perf(core): avoid intermediate arrays in definition

### DIFF
--- a/packages/core/src/render3/scope.ts
+++ b/packages/core/src/render3/scope.ts
@@ -11,9 +11,9 @@ import {Type} from '../interface/type';
 import {flatten} from '../util/array_utils';
 import {noSideEffects} from '../util/closure';
 import {EMPTY_ARRAY} from '../util/empty';
-import {getNgModuleDefOrThrow} from './def_getters';
+import {getNgModuleDefOrThrow, getPipeDef} from './def_getters';
 
-import {extractDefListOrFactory} from './definition';
+import {extractDefListOrFactory, extractDirectiveDef} from './definition';
 import {depsTracker} from './deps_tracker/deps_tracker';
 import {
   ComponentDef,
@@ -38,8 +38,8 @@ export function ɵɵsetComponentScope(
   pipes: Type<any>[] | (() => Type<any>[]),
 ): void {
   const def = type.ɵcmp as ComponentDef<any>;
-  def.directiveDefs = extractDefListOrFactory(directives, /* pipeDef */ false);
-  def.pipeDefs = extractDefListOrFactory(pipes, /* pipeDef */ true);
+  def.directiveDefs = extractDefListOrFactory(directives, extractDirectiveDef);
+  def.pipeDefs = extractDefListOrFactory(pipes, getPipeDef);
 }
 
 /**

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -410,7 +410,6 @@
   "nextNgElementId",
   "ngOnChangesSetInput",
   "ngZoneInstanceId",
-  "nonNull",
   "noop",
   "noop2",
   "normalizeAnimationEntry",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -420,7 +420,6 @@
   "nextNgElementId",
   "ngOnChangesSetInput",
   "ngZoneInstanceId",
-  "nonNull",
   "noop",
   "noop2",
   "notFoundValueOrThrow",

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -527,7 +527,6 @@
   "ngOnChangesSetInput",
   "ngZoneInstanceId",
   "noSideEffects",
-  "nonNull",
   "noop",
   "noop2",
   "normalizeValidators",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -517,7 +517,6 @@
   "ngOnChangesSetInput",
   "ngZoneInstanceId",
   "noSideEffects",
-  "nonNull",
   "noop",
   "noop2",
   "normalizeValidators",

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -378,7 +378,6 @@
   "nextNgElementId",
   "ngOnChangesSetInput",
   "ngZoneInstanceId",
-  "nonNull",
   "noop",
   "noop2",
   "notFoundValueOrThrow",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -608,7 +608,6 @@
   "noMatch2",
   "noSideEffects",
   "nodeChildrenAsMap",
-  "nonNull",
   "noop",
   "noop2",
   "normalizeQueryParams",

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -316,7 +316,6 @@
   "nextNgElementId",
   "ngOnChangesSetInput",
   "ngZoneInstanceId",
-  "nonNull",
   "noop",
   "noop2",
   "notFoundValueOrThrow",


### PR DESCRIPTION
A minor performance improvement for `ɵɵdefineComponent` where the underlying `extractDefListOrFactory` call had a chain of `.map.filter` which meant that we were unnecessarily creating intermediate arrays just to filter out the null values. These changes switch to simple `for` loop to get around it.