### PR TITLE
Fix for document overflow issue on template-driven-forms page

### DIFF
--- a/adev/shared-docs/styles/_resets.scss
+++ b/adev/shared-docs/styles/_resets.scss
@@ -9,7 +9,7 @@
       'Segoe UI Symbol', 'Noto Color Emoji';
     --page-width: 80ch;
     --layout-padding: 3.12rem; // a common padding value throughout the layout
-    --primary-nav-width: 110px;
+    --primary-nav-width: 6.875rem;
     --secondary-nav-width: 16.25rem;
     --fixed-content-height: calc(100vh - var(--layout-padding) * 2);
 
@@ -277,6 +277,9 @@
 
   // Tabs inside Example Viewer Header
   .docs-example-viewer-actions {
+    // Adjusted width - as tabs were overflowing when they were too many
+    max-width: calc(100vw - var(--secondary-nav-width) - var(--primary-nav-width) - var(--layout-padding)*2 );
+
     .mat-mdc-tab-labels {
       width: 100%;
     }


### PR DESCRIPTION
Fix for document overflow issue on template-driven-forms page

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Text overflow issue on https://angular.dev/guide/forms/template-driven-forms


Issue Number: https://github.com/angular/angular/issues/61359


## What is the new behavior?
This issue seem to be happening because of `.mat-mdc-tab-label-container` div element being overflowed out of it's view -

![Image](https://github.com/user-attachments/assets/6e232cd6-0a3e-4404-93a7-ec0531012e6e)

When we remove this element from DOM it works! But offcourse we cannot do that. 

In order to fix it, I tried to restrict it's width and its works -

![Image](https://github.com/user-attachments/assets/26e2c7c4-9c0d-4645-8116-0a98692e6ed3)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
