### PR TITLE
refactor(animations): mark non-default `new` expressions as pure

### DIFF
--- a/packages/animations/browser/src/render/timeline_animation_engine.ts
+++ b/packages/animations/browser/src/render/timeline_animation_engine.ts
@@ -38,7 +38,7 @@ import {
   optimizeGroupPlayer,
 } from './shared';
 
-const EMPTY_INSTRUCTION_MAP = new ElementInstructionMap();
+const EMPTY_INSTRUCTION_MAP = /* @__PURE__ */ new ElementInstructionMap();
 
 export class TimelineAnimationEngine {
   private _animations = new Map<string, Ast<AnimationMetadataType>>();

--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -141,7 +141,7 @@ class StateValue {
 }
 
 const VOID_VALUE = 'void';
-const DEFAULT_STATE_VALUE = new StateValue(VOID_VALUE);
+const DEFAULT_STATE_VALUE = /* @__PURE__ */ new StateValue(VOID_VALUE);
 
 class AnimationTransitionNamespace {
   public players: TransitionAnimationPlayer[] = [];


### PR DESCRIPTION
Adds `__PURE__` annotations to non-default `new` expressions to enable tree-shaking, even if they are not referenced. These variables are not dropped when Angular is imported from a module that has `sideEffects` set to `true`.

![image](https://github.com/user-attachments/assets/e5c887b7-ceb9-4e81-9497-5ea955b1383d)
