### PR TITLE
refactor(core): re-introduce TestBed.flushEffects()"

### DIFF
--- a/goldens/public-api/core/testing/index.api.md
+++ b/goldens/public-api/core/testing/index.api.md
@@ -117,6 +117,8 @@ export interface TestBed {
     createComponent<T>(component: Type<T>): ComponentFixture<T>;
     // (undocumented)
     execute(tokens: any[], fn: Function, context?: any): any;
+    // @deprecated
+    flushEffects(): void;
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, options?: TestEnvironmentOptions): void;
     // (undocumented)
     inject<T>(token: ProviderToken<T>, notFoundValue: undefined, options: InjectOptions & {

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -152,6 +152,13 @@ export interface TestBed {
   createComponent<T>(component: Type<T>): ComponentFixture<T>;
 
   /**
+   * Execute any pending effects.
+   *
+   * @deprecated use `TestBed.tick()` instead
+   */
+  flushEffects(): void;
+
+  /**
    * Execute any pending work required to synchronize model to the UI.
    *
    * @publicApi 20.0
@@ -388,6 +395,10 @@ export class TestBedImpl implements TestBed {
 
   static get ngModule(): Type<any> | Type<any>[] {
     return TestBedImpl.INSTANCE.ngModule;
+  }
+
+  static flushEffects(): void {
+    return TestBedImpl.INSTANCE.tick();
   }
 
   static tick(): void {
@@ -798,6 +809,15 @@ export class TestBedImpl implements TestBed {
     } finally {
       testRenderer.removeAllRootElements?.();
     }
+  }
+
+  /**
+   * Execute any pending effects by executing any pending work required to synchronize model to the UI.
+   *
+   * @deprecated use `TestBed.tick()` instead
+   */
+  flushEffects(): void {
+    this.tick();
   }
 
   /**


### PR DESCRIPTION
Our intention was to remove TestBed.flushEffects() in Angular v20 as it was a developer preview API that doesn't need to follow our deprecation policy. It turned out, though, that the angular.dev documentation wasn't displaying the @developerPreview annotation properly so some of the developers might have been unaware of the non-stable nature of this API.

This commits re-introduces the TestBed.flushEffects() API. This API call will delegate to TestBed.tick().
