### PR TITLE
refactor(core): expose enableProfiling() on from @angular/core

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -669,6 +669,9 @@ export abstract class EmbeddedViewRef<C> extends ViewRef {
 // @public
 export function enableProdMode(): void;
 
+// @public
+export function enableProfiling(): () => void;
+
 // @public @deprecated
 export const ENVIRONMENT_INITIALIZER: InjectionToken<readonly (() => void)[]>;
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -106,6 +106,7 @@ export {createComponent, reflectComponentType, ComponentMirror} from './render3/
 export {isStandalone} from './render3/def_getters';
 export {AfterRenderRef} from './render3/after_render/api';
 export {publishExternalGlobalUtil as ɵpublishExternalGlobalUtil} from './render3/util/global_utils';
+export {enableProfiling} from './render3/debug/chrome_dev_tools_performance';
 export {
   AfterRenderOptions,
   afterEveryRender,

--- a/packages/core/src/render3/debug/chrome_dev_tools_performance.ts
+++ b/packages/core/src/render3/debug/chrome_dev_tools_performance.ts
@@ -226,15 +226,22 @@ function getProviderTokenMeasureName<T>(token: any) {
  * Start listening to the Angular's internal performance-related events and route those to the Chrome DevTools performance panel.
  * This enables Angular-specific data visualization when recording a performance profile directly in the Chrome DevTools.
  *
+ * Note: integration is enabled in the development mode only, this operation is noop in the production mode.
+ *
+ * @experimental
+ *
  * @returns a function that can be invoked to stop sending profiling data.
  */
 export function enableProfiling() {
   performanceMarkFeature('Chrome DevTools profiling');
-  const removeInjectorProfiler = setInjectorProfiler(chromeDevToolsInjectorProfiler);
-  const removeProfiler = setProfiler(devToolsProfiler);
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+    const removeInjectorProfiler = setInjectorProfiler(chromeDevToolsInjectorProfiler);
+    const removeProfiler = setProfiler(devToolsProfiler);
 
-  return () => {
-    removeInjectorProfiler();
-    removeProfiler();
-  };
+    return () => {
+      removeInjectorProfiler();
+      removeProfiler();
+    };
+  }
+  return () => {};
 }


### PR DESCRIPTION
This commit exposes the experimental enableProfiling() API that enables Angular integration with the Chrome DevTools performance panel. Previously this integration was exposed on the ng. namespace only but there are legitimate cases where developers might want to expose the integration earlier (ex.: bootstrap profiling).
