### PR TITLE
ci: replace `yarn ng-dev misc update-generated-files` with separate update commands for specific targets

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,10 @@
       "git restore .yarn/releases/yarn-1.22.22.cjs pnpm-lock.yaml .npmrc",
       "yarn install --frozen-lockfile --non-interactive",
       "yarn bazel sync --only=repo || true",
-      "yarn ng-dev misc update-generated-files"
+      "yarn bazel run //.github/actions/deploy-docs-site:main.update",
+      "yarn bazel run //packages/common:base_currencies_file.update",
+      "yarn bazel run //packages/common/locales:closure_locale_file.update",
+      "yarn bazel run //packages/core:base_locale_file.update"
     ],
     "fileFilters": [
       ".aspect/rules/external_repository_action_cache/**/*",


### PR DESCRIPTION
Currently, `yarn ng-dev misc update-generated-files` attempts to update 67 targets, but only 4 actually require updating. Running the full script causes Renovate to slow down significantly, adding around 7 minutes per PR to the process. By replacing it with individual update commands for just the necessary targets, we improve performance and reduce Renovate’s runtime considerably.
