### PR TITLE
build: `--config=debug` should not disable sandbox for all actions

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,5 @@
 # Enable debugging tests with --config=debug
-test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test_strategy=exclusive --test_timeout=9999 --nocache_test_results --spawn_strategy=local
+test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test_strategy=exclusive --test_timeout=9999 --nocache_test_results --strategy=TestRunner=standalone
 
 # Do not attempt to de-flake locally.
 # On CI we might set this to `3` to run with deflaking.


### PR DESCRIPTION
Instead of disabling sandbox/workers for every action; which also could slow-down development turnaround significantly, the flag should only disable sandboxing for the test actions; allowing for e.g. DevTools to connect to them, even if they are inside the sandbox.

Arguably, this strategy isn't seemingly necessary in all environments, but given that we enable network sandboxing in this repo, it seems reasonable. Ideally we'd also expose `_debug` targets for e.g. Node tests that have the proper no-sandbox, or requires-network tag.

https://github.com/angular/angular/pull/54167 ended up turning off sandbox for all tests because `--test_strategy=local` was the wrong flag while the intent was to only disable test actions.