### PR TITLE
test: set the `noCheck` TS compiler option in declaration-only emission compliance tests

### DIFF
--- a/packages/compiler-cli/test/compliance/declaration-only/declaration_only_emit_spec.ts
+++ b/packages/compiler-cli/test/compliance/declaration-only/declaration_only_emit_spec.ts
@@ -40,6 +40,7 @@ function emitDeclarationOnlyTest(fs: FileSystem, test: ComplianceTest): CompileR
     {
       ...test.compilerOptions,
       emitDeclarationOnly: true,
+      noCheck: true,
     },
     {
       ...test.angularCompilerOptions,


### PR DESCRIPTION
No type-checking is performed in declaration-only emission mode so we should explicitly disable it in the compliance tests.

This also aligns the compiler configuration with the setup used in `packages/compiler-cli/test/ngtsc/declaration_only_emission_spec.ts`: https://github.com/angular/angular/blob/2b3c89dba228f55e90e298e6a1fca5850b7f40eb/packages/compiler-cli/test/ngtsc/declaration_only_emission_spec.ts#L31