### PR TITLE
refactor(zone.js): drop IE code paths

### DIFF
--- a/packages/zone.js/lib/browser/property-descriptor.ts
+++ b/packages/zone.js/lib/browser/property-descriptor.ts
@@ -87,7 +87,7 @@ export function propertyDescriptorPatch(api: _ZonePrivate, _global: any) {
       'Worker',
     ]);
     const ignoreErrorProperties: IgnoreProperty[] = [];
-    // In older browsers like IE or Edge, event handler properties (e.g., `onclick`)
+    // In older browsers like Edge, event handler properties (e.g., `onclick`)
     // may not be defined directly on the `window` object but on its prototype (`WindowPrototype`).
     // To ensure complete coverage, we use the prototype when checking
     // for and patching these properties.

--- a/packages/zone.js/lib/common/events.ts
+++ b/packages/zone.js/lib/common/events.ts
@@ -245,9 +245,6 @@ export function patchEventTarget(
   };
 
   function globalCallback(context: unknown, event: Event, isCapture: boolean) {
-    // https://github.com/angular/zone.js/issues/911, in IE, sometimes
-    // event will be undefined, so we need to use window.event
-    event = event || _global.event;
     if (!event) {
       return;
     }
@@ -324,10 +321,6 @@ export function patchEventTarget(
     let proto = obj;
     while (proto && !proto.hasOwnProperty(ADD_EVENT_LISTENER)) {
       proto = ObjectGetPrototypeOf(proto);
-    }
-    if (!proto && obj[ADD_EVENT_LISTENER]) {
-      // somehow we did not find it, but we can see it. This happens on IE for Window properties.
-      proto = obj;
     }
 
     if (!proto) {


### PR DESCRIPTION
Code paths containing special handling for IE have been removed because we no longer support IE.