### PR TITLE
refactor(zone.js): drop `copySymbolProperties` for browser bundles

### DIFF
--- a/packages/zone.js/lib/common/utils.ts
+++ b/packages/zone.js/lib/common/utils.ts
@@ -390,34 +390,29 @@ export function patchClass(className: string) {
   }
 }
 
-export function copySymbolProperties(src: any, dest: any) {
-  if (typeof (Object as any).getOwnPropertySymbols !== 'function') {
-    return;
-  }
-  const symbols: any = (Object as any).getOwnPropertySymbols(src);
-  symbols.forEach((symbol: any) => {
-    const desc = Object.getOwnPropertyDescriptor(src, symbol);
-    Object.defineProperty(dest, symbol, {
-      get: function () {
-        return src[symbol];
-      },
-      set: function (value: any) {
-        if (desc && (!desc.writable || typeof desc.set !== 'function')) {
-          // if src[symbol] is not writable or not have a setter, just return
-          return;
-        }
-        src[symbol] = value;
-      },
-      enumerable: desc ? desc.enumerable : true,
-      configurable: desc ? desc.configurable : true,
+let copySymbolProperties: ((source: any, destination: any) => void) | null = null;
+
+export function setCopySymbolPropertiesImpl() {
+  copySymbolProperties = (source: any, destination: any) => {
+    const symbols = Object.getOwnPropertySymbols(source);
+    symbols.forEach((symbol) => {
+      const desc = Object.getOwnPropertyDescriptor(source, symbol);
+      Object.defineProperty(destination, symbol, {
+        get: function () {
+          return source[symbol];
+        },
+        set: function (value: any) {
+          if (desc && (!desc.writable || typeof desc.set !== 'function')) {
+            // if source[symbol] is not writable or not have a setter, just return
+            return;
+          }
+          source[symbol] = value;
+        },
+        enumerable: desc ? desc.enumerable : true,
+        configurable: desc ? desc.configurable : true,
+      });
     });
-  });
-}
-
-let shouldCopySymbolProperties = false;
-
-export function setShouldCopySymbolProperties(flag: boolean) {
-  shouldCopySymbolProperties = flag;
+  };
 }
 
 export function patchMethod(
@@ -451,9 +446,7 @@ export function patchMethod(
         return patchDelegate(this, arguments as any);
       };
       attachOriginToPatched(proto[name], delegate);
-      if (shouldCopySymbolProperties) {
-        copySymbolProperties(delegate, proto[name]);
-      }
+      copySymbolProperties?.(delegate, proto[name]);
     }
   }
   return delegate;

--- a/packages/zone.js/lib/node/node_util.ts
+++ b/packages/zone.js/lib/node/node_util.ts
@@ -11,7 +11,7 @@ import {
   patchMacroTask,
   patchMethod,
   patchOnProperties,
-  setShouldCopySymbolProperties,
+  setCopySymbolPropertiesImpl,
 } from '../common/utils';
 import {ZoneType} from '../zone-impl';
 
@@ -21,6 +21,6 @@ export function patchNodeUtil(Zone: ZoneType): void {
     api.patchMethod = patchMethod;
     api.bindArguments = bindArguments;
     api.patchMacroTask = patchMacroTask;
-    setShouldCopySymbolProperties(true);
+    setCopySymbolPropertiesImpl();
   });
 }


### PR DESCRIPTION
The `copySymbolProperties` implementation is now tree-shaken for browser bundles, because its implementation is only set in Node.js patch.