### PR TITLE
refactor(forms): drop `resolvedPromise`

### DIFF
--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -56,7 +56,7 @@ const formDirectiveProvider: Provider = {
   useExisting: forwardRef(() => NgForm),
 };
 
-const resolvedPromise = (() => Promise.resolve())();
+const resolvedPromise = /* @__PURE__ */ (() => Promise.resolve())();
 
 /**
  * @description

--- a/packages/forms/src/directives/ng_model.ts
+++ b/packages/forms/src/directives/ng_model.ts
@@ -71,7 +71,7 @@ const formControlBinding: Provider = {
  * - this is just one extra run no matter how many `ngModel`s have been changed.
  * - this is a general problem when using `exportAs` for directives!
  */
-const resolvedPromise = (() => Promise.resolve())();
+const resolvedPromise = /* @__PURE__ */ (() => Promise.resolve())();
 
 /**
  * @description


### PR DESCRIPTION
Adds `__PURE__` annotations to `resolvedPromise` expressions to enable tree-shaking, even if they are not referenced. These variables are not dropped when Angular is imported from a module that has `sideEffects` set to `true`.

![image](https://github.com/user-attachments/assets/6ad164fb-9818-4156-8294-4727befcd981)
