### PR TITLE
ci: clean untracked files before running `postUpgradeTasks`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "baseBranches": ["main", "20.0.x"],
   "postUpgradeTasks": {
     "commands": [
-      "git restore .yarn/releases/yarn-1.22.22.cjs pnpm-lock.yaml .npmrc",
+      "git clean -f && git restore .yarn/releases/yarn-1.22.22.cjs pnpm-lock.yaml .npmrc",
       "yarn install --frozen-lockfile --non-interactive",
       "yarn bazel sync --only=repo || true",
       "yarn bazel run //.github/actions/deploy-docs-site:main.update",


### PR DESCRIPTION
Not sure what changed overnight, but Renovate is now committing .npmrc files that we didn't generate. Example: https://github.com/angular/angular/pull/61492/files

We should revisit this once we transition away from Yarn.
