### PR TITLE
test: replace `platform-browser-dynamic` with  `platform-browser`

### DIFF
--- a/integration/animations/package.json
+++ b/integration/animations/package.json
@@ -17,7 +17,6 @@
     "@angular/compiler": "file:../../dist/packages-dist/compiler",
     "@angular/core": "file:../../dist/packages-dist/core",
     "@angular/platform-browser": "file:../../dist/packages-dist/platform-browser",
-    "@angular/platform-browser-dynamic": "file:../../dist/packages-dist/platform-browser-dynamic",
     "@angular/router": "file:../../dist/packages-dist/router",
     "rxjs": "file:../../node_modules/rxjs",
     "tslib": "file:../../node_modules/tslib",

--- a/integration/animations/yarn.lock
+++ b/integration/animations/yarn.lock
@@ -201,11 +201,6 @@
 "@angular/language-service@file:../../dist/packages-dist/language-service":
   version "20.0.0-next.4"
 
-"@angular/platform-browser-dynamic@file:../../dist/packages-dist/platform-browser-dynamic":
-  version "20.0.0-next.4"
-  dependencies:
-    tslib "^2.3.0"
-
 "@angular/platform-browser@file:../../dist/packages-dist/platform-browser":
   version "20.0.0-next.4"
   dependencies:

--- a/integration/cli-signal-inputs/package.json
+++ b/integration/cli-signal-inputs/package.json
@@ -18,7 +18,6 @@
     "@angular/core": "file:../../dist/packages-dist/core",
     "@angular/forms": "file:../../dist/packages-dist/forms",
     "@angular/platform-browser": "file:../../dist/packages-dist/platform-browser",
-    "@angular/platform-browser-dynamic": "file:../../dist/packages-dist/platform-browser-dynamic",
     "@angular/router": "file:../../dist/packages-dist/router",
     "rxjs": "file:../../node_modules/rxjs",
     "tslib": "file:../../node_modules/tslib",

--- a/integration/cli-signal-inputs/yarn.lock
+++ b/integration/cli-signal-inputs/yarn.lock
@@ -203,11 +203,6 @@
   dependencies:
     tslib "^2.3.0"
 
-"@angular/platform-browser-dynamic@file:../../dist/packages-dist/platform-browser-dynamic":
-  version "20.0.0-next.4"
-  dependencies:
-    tslib "^2.3.0"
-
 "@angular/platform-browser@file:../../dist/packages-dist/platform-browser":
   version "20.0.0-next.4"
   dependencies:

--- a/integration/ng-modules-importability/BUILD.bazel
+++ b/integration/ng-modules-importability/BUILD.bazel
@@ -23,7 +23,6 @@ module_test(
         "//packages/elements:npm_package": "packages/elements/npm_package",
         "//packages/forms:npm_package": "packages/forms/npm_package",
         "//packages/localize:npm_package": "packages/localize/npm_package",
-        "//packages/platform-browser-dynamic:npm_package": "packages/platform-browser-dynamic/npm_package",
         "//packages/platform-browser:npm_package": "packages/platform-browser/npm_package",
         "//packages/router:npm_package": "packages/router/npm_package",
         "//packages/service-worker:npm_package": "packages/service-worker/npm_package",

--- a/integration/ng_update_migrations/package.json
+++ b/integration/ng_update_migrations/package.json
@@ -15,7 +15,6 @@
     "@angular/compiler": "file:../../dist/packages-dist/compiler",
     "@angular/core": "file:../../dist/packages-dist/core",
     "@angular/platform-browser": "file:../../dist/packages-dist/platform-browser",
-    "@angular/platform-browser-dynamic": "file:../../dist/packages-dist/platform-browser-dynamic",
     "@angular/router": "file:../../dist/packages-dist/router",
     "rxjs": "file:../../node_modules/rxjs",
     "tslib": "file:../../node_modules/tslib",

--- a/integration/ng_update_migrations/src/test.ts
+++ b/integration/ng_update_migrations/src/test.ts
@@ -2,15 +2,12 @@
 
 import 'zone.js/testing';
 import {getTestBed} from '@angular/core/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
+import {BrowserTestingModule, platformBrowserTesting} from '@angular/platform-browser/testing';
 
 declare const require: any;
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+getTestBed().initTestEnvironment(BrowserTestingModule, platformBrowserTesting(), {
   teardown: {destroyAfterEach: false},
 });
 // Then we find all the tests.

--- a/integration/ng_update_migrations/src/test_expected.ts
+++ b/integration/ng_update_migrations/src/test_expected.ts
@@ -2,15 +2,12 @@
 
 import 'zone.js/testing';
 import {getTestBed} from '@angular/core/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
+import {BrowserTestingModule, platformBrowserTesting} from '@angular/platform-browser/testing';
 
 declare const require: any;
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+getTestBed().initTestEnvironment(BrowserTestingModule, platformBrowserTesting(), {
   teardown: {destroyAfterEach: false},
 });
 // Then we find all the tests.

--- a/integration/ng_update_migrations/yarn.lock
+++ b/integration/ng_update_migrations/yarn.lock
@@ -193,11 +193,6 @@
   dependencies:
     tslib "^2.3.0"
 
-"@angular/platform-browser-dynamic@file:../../dist/packages-dist/platform-browser-dynamic":
-  version "20.0.0-next.4"
-  dependencies:
-    tslib "^2.3.0"
-
 "@angular/platform-browser@file:../../dist/packages-dist/platform-browser":
   version "20.0.0-next.4"
   dependencies:

--- a/integration/trusted-types/package.json
+++ b/integration/trusted-types/package.json
@@ -18,7 +18,6 @@
     "@angular/core": "file:../../dist/packages-dist/core",
     "@angular/forms": "file:../../dist/packages-dist/forms",
     "@angular/platform-browser": "file:../../dist/packages-dist/platform-browser",
-    "@angular/platform-browser-dynamic": "file:../../dist/packages-dist/platform-browser-dynamic",
     "@angular/router": "file:../../dist/packages-dist/router",
     "@angular/ssr": "file:../../node_modules/@angular/ssr",
     "rxjs": "file:../../node_modules/rxjs",

--- a/integration/trusted-types/yarn.lock
+++ b/integration/trusted-types/yarn.lock
@@ -236,11 +236,6 @@
   dependencies:
     tslib "^2.3.0"
 
-"@angular/platform-browser-dynamic@file:../../dist/packages-dist/platform-browser-dynamic":
-  version "20.0.0-next.4"
-  dependencies:
-    tslib "^2.3.0"
-
 "@angular/platform-browser@file:../../dist/packages-dist/platform-browser":
   version "20.0.0-next.4"
   dependencies:


### PR DESCRIPTION
The former isn't needed anymore and is now deprecated.
