### PR TITLE
refactor(core): drop `frameworkDIDebugData`

### DIFF
--- a/packages/core/src/render3/debug/framework_injector_profiler.ts
+++ b/packages/core/src/render3/debug/framework_injector_profiler.ts
@@ -82,7 +82,7 @@ class DIDebugData {
   }
 }
 
-let frameworkDIDebugData = new DIDebugData();
+let frameworkDIDebugData = /* @__PURE__ */ new DIDebugData();
 
 export function getFrameworkDIDebugData(): DIDebugData {
   return frameworkDIDebugData;


### PR DESCRIPTION
Adds `__PURE__` annotations to `frameworkDIDebugData` expression to enable tree-shaking, even if it is not referenced. This variable is not dropped when Angular is imported from a module that has `sideEffects` set to `true`.

![image](https://github.com/user-attachments/assets/aaae14b8-6ee5-4b2b-89ab-cbcf956ef008)
