### PR TITLE
fix(core): unregister `onDestroy` in `toSignal`.

### DIFF
--- a/packages/core/rxjs-interop/src/to_signal.ts
+++ b/packages/core/rxjs-interop/src/to_signal.ts
@@ -152,6 +152,8 @@ export function toSignal<T, U = undefined>(
     );
   }
 
+  let destroyUnregisterFn: (() => void) | undefined;
+
   // Note: This code cannot run inside a reactive context (see assertion above). If we'd support
   // this, we would subscribe to the observable outside of the current reactive context, avoiding
   // that side-effect signal reads/writes are attribute to the current consumer. The current
@@ -162,6 +164,9 @@ export function toSignal<T, U = undefined>(
     next: (value) => state.set({kind: StateKind.Value, value}),
     error: (error) => {
       state.set({kind: StateKind.Error, error});
+    },
+    complete: () => {
+      destroyUnregisterFn?.();
     },
     // Completion of the Observable is meaningless to the signal. Signals don't have a concept of
     // "complete".
@@ -176,7 +181,7 @@ export function toSignal<T, U = undefined>(
   }
 
   // Unsubscribe when the current context is destroyed, if requested.
-  cleanupRef?.onDestroy(sub.unsubscribe.bind(sub));
+  destroyUnregisterFn = cleanupRef?.onDestroy(sub.unsubscribe.bind(sub));
 
   // The actual returned signal is a `computed` of the `State` signal, which maps the various states
   // to either values or errors.


### PR DESCRIPTION
We cleanup if the observable completes before the onDestroy fires.

fixes #61511
