### PR TITLE
docs(docs-infra): fix substitution regex

### DIFF
--- a/adev/shared-docs/BUILD.bazel
+++ b/adev/shared-docs/BUILD.bazel
@@ -91,6 +91,6 @@ pkg_npm(
     ],
     substitutions = {
         # Force the "unstamped" versions to be later than current so they are considered up to date.
-        "0.0.0": "99.99.99",
+        "0\\.0\\.0": "99.99.99",
     },
 )


### PR DESCRIPTION
It was replacing `rgba(0,0,0,0)` with `rgba(99.99.99, 0)`
