### PR TITLE
refactor(devtools): use a ResizeObserver for the responsive split

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/shared/responsive-split/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/shared/responsive-split/BUILD.bazel
@@ -11,6 +11,8 @@ ng_project(
         "//packages/core",
     ],
     deps = [
+        "//devtools/projects/ng-devtools/src/lib/application-providers:window_rjs",
+        "//devtools/projects/ng-devtools/src/lib/shared/utils:utils_rjs",
         "//devtools/projects/ng-devtools/src/lib/vendor/angular-split:angular-split_rjs",
     ],
 )
@@ -25,6 +27,7 @@ ts_test_library(
     ],
     deps = [
         ":responsive-split_rjs",
+        "//devtools/projects/ng-devtools/src/lib/application-providers:window_rjs",
         "//devtools/projects/ng-devtools/src/lib/vendor/angular-split:angular-split_rjs",
     ],
 )

--- a/devtools/projects/ng-devtools/src/lib/shared/responsive-split/responsive-split.directive.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/responsive-split/responsive-split.directive.ts
@@ -24,10 +24,6 @@ export type ResponsiveSplitConfig = {
   breakpointDirection: Direction;
 };
 
-interface ExtendedWindow extends Window {
-  ResizeObserver: typeof ResizeObserver;
-}
-
 /** Make as-split direction responsive. */
 @Directive({
   selector: 'as-split[ngResponsiveSplit]',
@@ -36,7 +32,7 @@ export class ResponsiveSplitDirective implements OnDestroy {
   private readonly host = inject(SplitComponent);
   private readonly elementRef = inject(ElementRef);
   private readonly zone = inject(NgZone);
-  private readonly window = inject<ExtendedWindow>(WINDOW);
+  private readonly window = inject<typeof globalThis>(WINDOW);
   private resizeObserver: ResizeObserver;
   private debouncer: Debouncer;
 

--- a/devtools/projects/ng-devtools/src/lib/shared/responsive-split/responsive-split.directive.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/responsive-split/responsive-split.directive.ts
@@ -6,22 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  afterNextRender,
-  computed,
-  Directive,
-  ElementRef,
-  inject,
-  input,
-  NgZone,
-  OnDestroy,
-  OnInit,
-  output,
-  Renderer2,
-} from '@angular/core';
+import {Directive, ElementRef, inject, input, NgZone, OnDestroy, output} from '@angular/core';
 import {SplitComponent} from '../../vendor/angular-split/public_api';
+import {WINDOW} from '../../application-providers/window_provider';
+import {Debouncer} from '../utils/debouncer';
 
-const RESIZE_DEBOUNCE = 50; // in milliseconds
+export const RESIZE_DEBOUNCE = 50; // in milliseconds
 
 export type Direction = 'vertical' | 'horizontal';
 
@@ -34,17 +24,21 @@ export type ResponsiveSplitConfig = {
   breakpointDirection: Direction;
 };
 
+interface ExtendedWindow extends Window {
+  ResizeObserver: typeof ResizeObserver;
+}
+
 /** Make as-split direction responsive. */
 @Directive({
   selector: 'as-split[ngResponsiveSplit]',
 })
-export class ResponsiveSplitDirective implements OnInit, OnDestroy {
+export class ResponsiveSplitDirective implements OnDestroy {
   private readonly host = inject(SplitComponent);
   private readonly elementRef = inject(ElementRef);
-  private readonly renderer = inject(Renderer2);
   private readonly zone = inject(NgZone);
-  private resizeTimeout?: ReturnType<typeof setTimeout>;
-  private resizeUnlisten?: () => void;
+  private readonly window = inject<ExtendedWindow>(WINDOW);
+  private resizeObserver: ResizeObserver;
+  private debouncer: Debouncer;
 
   protected readonly config = input.required<ResponsiveSplitConfig>({
     alias: 'ngResponsiveSplit',
@@ -53,31 +47,30 @@ export class ResponsiveSplitDirective implements OnInit, OnDestroy {
   protected readonly directionChange = output<Direction>();
 
   constructor() {
-    afterNextRender({
-      write: () => this.applyDirection(),
-    });
-  }
+    this.debouncer = new Debouncer();
+    this.resizeObserver = new this.window.ResizeObserver(
+      this.debouncer.debounce(([entry]) => {
+        // Since used in a ResizeObserver which is not
+        // patched by zone.js, run inside a zone.
+        this.zone.run(() => {
+          if (entry.contentBoxSize) {
+            const [{inlineSize, blockSize}] = entry.contentBoxSize;
+            this.applyDirection(inlineSize, blockSize);
+          }
+        });
+      }, RESIZE_DEBOUNCE),
+    );
 
-  ngOnInit() {
-    this.zone.runOutsideAngular(() => {
-      this.resizeUnlisten = this.renderer.listen('window', 'resize', () => this.onWindowResize());
-    });
+    this.resizeObserver.observe(this.elementRef.nativeElement);
   }
 
   ngOnDestroy() {
-    this.resizeUnlisten?.();
+    this.debouncer.cancel();
+    this.resizeObserver.unobserve(this.elementRef.nativeElement);
   }
 
-  protected onWindowResize() {
-    if (this.resizeTimeout) {
-      clearTimeout(this.resizeTimeout);
-    }
-    this.resizeTimeout = setTimeout(() => this.applyDirection(), RESIZE_DEBOUNCE);
-  }
-
-  private applyDirection() {
-    const {clientWidth, clientHeight} = this.elementRef.nativeElement;
-    const ratio = clientWidth / clientHeight;
+  private applyDirection(width: number, height: number) {
+    const ratio = width / height;
     const {defaultDirection, breakpointDirection, aspectRatioBreakpoint} = this.config();
     let newDir: Direction = defaultDirection;
 

--- a/devtools/projects/ng-devtools/src/lib/shared/utils/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/shared/utils/BUILD.bazel
@@ -1,0 +1,8 @@
+load("//devtools/tools:typescript.bzl", "ts_project")
+
+package(default_visibility = ["//devtools:__subpackages__"])
+
+ts_project(
+    name = "utils",
+    srcs = ["debouncer.ts"],
+)

--- a/devtools/projects/ng-devtools/src/lib/shared/utils/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/shared/utils/BUILD.bazel
@@ -1,8 +1,24 @@
-load("//devtools/tools:typescript.bzl", "ts_project")
+load("//devtools/tools:defaults.bzl", "karma_web_test_suite")
+load("//devtools/tools:typescript.bzl", "ts_project", "ts_test_library")
 
 package(default_visibility = ["//devtools:__subpackages__"])
 
 ts_project(
     name = "utils",
     srcs = ["debouncer.ts"],
+)
+
+ts_test_library(
+    name = "utils_tests",
+    srcs = glob(["*.spec.ts"]),
+    deps = [
+        ":utils_rjs",
+    ],
+)
+
+karma_web_test_suite(
+    name = "test",
+    deps = [
+        ":utils_tests",
+    ],
 )

--- a/devtools/projects/ng-devtools/src/lib/shared/utils/debouncer.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/utils/debouncer.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Debouncer} from './debouncer';
+
+/** Runs the provided callback with an `ng` string argument. */
+function run(cb: (arg: string) => void) {
+  cb('ng');
+}
+
+describe('Debouncer', () => {
+  let debouncer: Debouncer;
+
+  beforeEach(() => {
+    jasmine.clock().uninstall();
+    jasmine.clock().install();
+    debouncer = new Debouncer();
+  });
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
+  });
+
+  it('should exist', () => {
+    expect(debouncer).toBeTruthy();
+  });
+
+  it('should debounce the callback', () => {
+    const callback = jasmine.createSpy();
+    run(debouncer.debounce(callback, 1000));
+
+    expect(callback).not.toHaveBeenCalled();
+
+    jasmine.clock().tick(990);
+    expect(callback).not.toHaveBeenCalled();
+
+    jasmine.clock().tick(1010);
+    expect(callback).toHaveBeenCalledOnceWith('ng');
+  });
+
+  it('should cancel the debounce', () => {
+    const callback = jasmine.createSpy();
+    run(debouncer.debounce(callback, 1000));
+
+    expect(callback).not.toHaveBeenCalled();
+
+    jasmine.clock().tick(990);
+    expect(callback).not.toHaveBeenCalled();
+
+    debouncer.cancel();
+
+    jasmine.clock().tick(1010);
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/devtools/projects/ng-devtools/src/lib/shared/utils/debouncer.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/utils/debouncer.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+type Callable = (...args: any) => void;
+
+export class Debouncer {
+  private timeout?: ReturnType<typeof setTimeout>;
+  private initialized: boolean = false;
+
+  debounce<T = any>(handler: T, timeout: number): T {
+    if (this.initialized) {
+      throw new Error('The debouncer is already initialized and running.');
+    }
+    this.initialized = true;
+
+    return ((...args: any) => {
+      this.cancel();
+      this.timeout = setTimeout(() => (handler as Callable)(...args), timeout);
+    }) as T;
+  }
+
+  cancel() {
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+    }
+  }
+}


### PR DESCRIPTION
Do not rely on `window:resize` since the split can be resized by other split panels as well.

cc @dgp1130 