### PR TITLE
docs: update v17 as EOL for current documentation

### DIFF
--- a/adev/src/content/reference/releases.md
+++ b/adev/src/content/reference/releases.md
@@ -95,9 +95,8 @@ The following table provides the status for Angular versions under support.
 |:--------|:-------|:-----------|:------------|:-----------|
 | ^19.0.0 | Active | 2024-11-19 | 2025-05-19  | 2026-05-19 |
 | ^18.0.0 | LTS    | 2024-05-22 | 2024-11-19  | 2025-11-19 |
-| ^17.0.0 | LTS    | 2023-11-08 | 2024-05-08  | 2025-05-15 |
 
-Angular versions v2 to v16 are no longer supported.
+Angular versions v2 to v17 are no longer supported.
 
 ### LTS fixes
 


### PR DESCRIPTION
The versioning reference documentation now shows that Angular v17 has reached EOL and is no longer supported.