### PR TITLE
ci: change `action: review` to `action: merge` in update docs

### DIFF
--- a/.github/workflows/update-cdk-apis-and-cli-help.yml
+++ b/.github/workflows/update-cdk-apis-and-cli-help.yml
@@ -50,7 +50,7 @@ jobs:
           body: |
             Updated Angular CDK api files.
           labels: |
-            action: review
+            action: merge
             area: docs
           commit-message: |
             docs: update Angular CDK apis
@@ -79,7 +79,7 @@ jobs:
           body: |
             Updated Angular CLI help contents.
           labels: |
-            action: review
+            action: merge
             area: docs
           commit-message: |
             docs: update Angular CLI help


### PR DESCRIPTION
Simplifies the workflow by reducing the number of required actions for the caretaker or reviewer, similar to Renovate PRs.
