### PR TITLE
build: migrate forms to rules_js 

### DIFF
--- a/packages/compiler-cli/BUILD.bazel
+++ b/packages/compiler-cli/BUILD.bazel
@@ -148,14 +148,14 @@ pkg_npm(
 # Long-term, `pkg_npm` will be migrated to `npm_package` in general.
 npm_package(
     name = "pkg",
-    srcs = [":npm_package_nosub"],
+    srcs = [":npm_package"],
     data = [
         # Needed because compiler is a dev dependency (to satisfy the peer dependency)
         # and `rules_js` only makes transitive production dependencies available.
         ":node_modules/@angular/compiler",
     ],
     replace_prefixes = {
-        "npm_package_nosub/": "",
+        "npm_package/": "",
     },
 )
 

--- a/packages/compiler/BUILD.bazel
+++ b/packages/compiler/BUILD.bazel
@@ -48,9 +48,9 @@ ng_package(
 # Long-term, `pkg_npm` will be migrated to `npm_package` in general.
 npm_package(
     name = "pkg",
-    srcs = [":npm_package"],
+    srcs = [":npm_package_nosub"],
     replace_prefixes = {
-        "npm_package/": "",
+        "npm_package_nosub/": "",
     },
 )
 

--- a/packages/forms/BUILD.bazel
+++ b/packages/forms/BUILD.bazel
@@ -1,8 +1,9 @@
-load("//tools:defaults.bzl", "api_golden_test", "api_golden_test_npm_package", "generate_api_docs", "ng_module", "ng_package")
+load("//tools:defaults.bzl", "api_golden_test", "api_golden_test_npm_package", "generate_api_docs", "ng_package")
+load("//tools:defaults2.bzl", "ng_project")
 
 package(default_visibility = ["//visibility:public"])
 
-ng_module(
+ng_project(
     name = "forms",
     srcs = glob(
         [
@@ -10,10 +11,12 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
-    deps = [
-        "//packages/core",
+    interop_deps = [
         "//packages/platform-browser",
-        "@npm//rxjs",
+    ],
+    deps = [
+        "//:node_modules/rxjs",
+        "//packages/core:core_rjs",
     ],
 )
 

--- a/packages/forms/test/BUILD.bazel
+++ b/packages/forms/test/BUILD.bazel
@@ -1,20 +1,23 @@
-load("//tools:defaults.bzl", "karma_web_test_suite", "ts_library", "zone_compatible_jasmine_node_test")
+load("//tools:defaults.bzl", "karma_web_test_suite", "zone_compatible_jasmine_node_test")
+load("//tools:defaults2.bzl", "ts_project")
 
-ts_library(
+ts_project(
     name = "test_lib",
     testonly = True,
     srcs = glob(["**/*.ts"]),
-    # Visible to //:saucelabs_unit_tests_poc target
-    visibility = ["//:__pkg__"],
-    deps = [
-        "//packages/common",
-        "//packages/core",
-        "//packages/core/testing",
-        "//packages/forms",
+    interop_deps = [
         "//packages/platform-browser",
         "//packages/platform-browser/testing",
         "//packages/private/testing",
-        "@npm//rxjs",
+    ],
+    # Visible to //:saucelabs_unit_tests_poc target
+    visibility = ["//:__pkg__"],
+    deps = [
+        "//:node_modules/rxjs",
+        "//packages/common:common_rjs",
+        "//packages/core:core_rjs",
+        "//packages/core/testing:testing_rjs",
+        "//packages/forms:forms_rjs",
     ],
 )
 

--- a/packages/forms/test/ng_control_status_spec.ts
+++ b/packages/forms/test/ng_control_status_spec.ts
@@ -6,10 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component, provideZonelessChangeDetection} from '@angular/core';
 import {FormControl, FormsModule, ReactiveFormsModule, Validators} from '../public_api';
 import {TestBed} from '@angular/core/testing';
-import {provideZonelessChangeDetection} from '@angular/core/src/change_detection/scheduling/zoneless_scheduling_impl';
 
 describe('status host binding classes', () => {
   beforeEach(() => {

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -18,7 +18,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
-import {By} from '@angular/platform-browser/src/dom/debug/by';
+import {By} from '@angular/platform-browser';
 import {dispatchEvent, isNode, sortedClassList} from '@angular/private/testing';
 import {expect} from '@angular/private/testing/matchers';
 import {merge, NEVER, Observable, of, Subject, Subscription, timer} from 'rxjs';

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -25,7 +25,7 @@ import {
   NgModel,
   Validator,
 } from '../index';
-import {By} from '@angular/platform-browser/src/dom/debug/by';
+import {By} from '@angular/platform-browser';
 import {dispatchEvent, sortedClassList} from '@angular/private/testing';
 import {merge} from 'rxjs';
 

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -32,7 +32,7 @@ import {
   ReactiveFormsModule,
   Validators,
 } from '../index';
-import {By} from '@angular/platform-browser/src/dom/debug/by';
+import {By} from '@angular/platform-browser';
 import {dispatchEvent, isNode} from '@angular/private/testing';
 
 describe('value accessors', () => {

--- a/packages/language-service/test/legacy/BUILD.bazel
+++ b/packages/language-service/test/legacy/BUILD.bazel
@@ -19,6 +19,7 @@ filegroup(
     srcs = [
         "//packages/common:common_rjs",
         "//packages/core:core_rjs",
+        "//packages/forms:forms_rjs",
     ],
     output_group = "types",
 )

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -174,6 +174,7 @@ def ng_package(name, readme_md = None, license_banner = None, license = None, de
     if not license:
         license = "//:LICENSE"
     visibility = kwargs.pop("visibility", None)
+    tags = kwargs.pop("tags", [])
 
     common_substitutions = dict(kwargs.pop("substitutions", {}), **PKG_GROUP_REPLACEMENTS)
     substitutions = dict(common_substitutions, **{
@@ -198,6 +199,23 @@ def ng_package(name, readme_md = None, license_banner = None, license = None, de
         rollup_config_tmpl = _INTERNAL_NG_PACKAGE_DEFAULT_ROLLUP_CONFIG_TMPL,
         rollup = _INTERNAL_NG_PACKAGE_DEFAULT_ROLLUP,
         visibility = visibility,
+        tags = tags,
+        **kwargs
+    )
+
+    _ng_package(
+        name = "%s_nosub" % name,
+        deps = deps,
+        validate = True,
+        readme_md = readme_md,
+        license = license,
+        license_banner = license_banner,
+        substitutions = common_substitutions,
+        ng_packager = _INTERNAL_NG_PACKAGE_PACKAGER,
+        rollup_config_tmpl = _INTERNAL_NG_PACKAGE_DEFAULT_ROLLUP_CONFIG_TMPL,
+        rollup = _INTERNAL_NG_PACKAGE_DEFAULT_ROLLUP,
+        visibility = visibility,
+        tags = ["manual"],
         **kwargs
     )
 
@@ -214,7 +232,6 @@ def ng_package(name, readme_md = None, license_banner = None, license = None, de
 def pkg_npm(name, deps = [], validate = True, **kwargs):
     """Default values for pkg_npm"""
     visibility = kwargs.pop("visibility", None)
-    tags = kwargs.pop("tags", [])
 
     common_substitutions = dict(kwargs.pop("substitutions", {}), **PKG_GROUP_REPLACEMENTS)
     substitutions = dict(common_substitutions, **{
@@ -248,18 +265,6 @@ def pkg_npm(name, deps = [], validate = True, **kwargs):
         }),
         deps = [":%s_js_module_output" % name],
         visibility = visibility,
-        tags = tags,
-        **kwargs
-    )
-
-    _pkg_npm(
-        name = "%s_nosub" % name,
-        validate = validate,
-        substitutions = common_substitutions,
-        deps = [":%s_js_module_output" % name],
-        visibility = visibility,
-        # should not be built unless it is a dependency of another rule
-        tags = ["manual"],
         **kwargs
     )
 


### PR DESCRIPTION
Looks like my previous change didn't actually change the version stamping as expected as seen [here](https://github.com/angular/common-builds/blob/950eb4792f5225f3ef96efc5f67dd18a24d88eda/fesm2022/common.mjs#L649)

This should be corrected with this changed.