### PR TITLE
refactor(devtools): add dagre-d3-es to prepare for the signal graph

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
@@ -2,10 +2,10 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm2", pnpm_lock = "@//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=-1406867100
-package.json=-454885126
+package.json=-987988389
 packages/compiler-cli/package.json=1094415146
 packages/compiler/package.json=1190056499
-pnpm-lock.yaml=1545759099
+pnpm-lock.yaml=604739839
 pnpm-workspace.yaml=353334404
 tools/bazel/rules_angular_store/package.json=-239561259
-yarn.lock=-647880827
+yarn.lock=-1336798803

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -84,6 +84,7 @@ yarn_install(
         "//:.yarnrc",
         "//:tools/npm-patches/@angular+ng-dev+0.0.0-a6dcd24107d12114198251ee5d20cda814a1986a.patch",
         "//:tools/npm-patches/@bazel+jasmine+5.8.1.patch",
+        "//:tools/npm-patches/dagre-d3-es+7.0.11.patch",
         "//tools:postinstall-patches.js",
         "//tools/esm-interop:patches/npm/@angular+build-tooling+0.0.0-2670abf637fa155971cdd1f7e570a7f234922a65.patch",
         "//tools/esm-interop:patches/npm/@bazel+concatjs+5.8.1.patch",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "chokidar": "^4.0.0",
     "convert-source-map": "^1.5.1",
     "d3": "^7.0.0",
+    "dagre-d3-es": "^7.0.11",
     "diff": "^8.0.0",
     "domino": "https://github.com/angular/domino.git#93e720f143d0296dd2726ffbcf4fc12283363a7b",
     "hammerjs": "~2.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       d3:
         specifier: ^7.0.0
         version: 7.9.0
+      dagre-d3-es:
+        specifier: ^7.0.11
+        version: 7.0.11
       diff:
         specifier: ^8.0.0
         version: 8.0.1
@@ -8910,7 +8913,6 @@ packages:
     dependencies:
       d3: 7.9.0
       lodash-es: 4.17.21
-    dev: true
 
   /dashdash@1.14.1:
     resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==, tarball: https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz}
@@ -12974,7 +12976,6 @@ packages:
 
   /lodash-es@4.17.21:
     resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==, tarball: https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz}
-    dev: true
 
   /lodash._objecttypes@2.4.1:
     resolution: {integrity: sha512-XpqGh1e7hhkOzftBfWE7zt+Yn9mVHFkDhicVttvKLsoCMLVVL+xTQjfjB4X4vtznauxv0QZ5ZAeqjvat0dh62Q==, tarball: https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz}

--- a/tools/npm-patches/dagre-d3-es+7.0.11.patch
+++ b/tools/npm-patches/dagre-d3-es+7.0.11.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/dagre-d3-es/src/dagre-js/label/add-html-label.js b/node_modules/dagre-d3-es/src/dagre-js/label/add-html-label.js
+index 94ee8a3..1983f45 100644
+--- a/node_modules/dagre-d3-es/src/dagre-js/label/add-html-label.js
++++ b/node_modules/dagre-d3-es/src/dagre-js/label/add-html-label.js
+@@ -28,8 +28,8 @@ function addHtmlLabel(root, node) {
+   // Fix for firefox
+   div.style('white-space', 'nowrap');
+ 
+-  var client = div.node().getBoundingClientRect();
+-  fo.attr('width', client.width).attr('height', client.height);
++  var client = div.node();
++  fo.attr('width', client.offsetWidth).attr('height', client.offsetHeight);
+ 
+   return fo;
+ }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7556,7 +7556,7 @@ d3@^7.0.0, d3@^7.9.0:
     d3-transition "3"
     d3-zoom "3"
 
-dagre-d3-es@7.0.11:
+dagre-d3-es@7.0.11, dagre-d3-es@^7.0.11:
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/dagre-d3-es/-/dagre-d3-es-7.0.11.tgz#2237e726c0577bfe67d1a7cfd2265b9ab2c15c40"
   integrity sha512-tvlJLyQf834SylNKax8Wkzco/1ias1OPw8DcUMDE7oUIoSEW25riQVuiu/0OWEFqT0cxHT3Pa9/D82Jr47IONw==
@@ -7952,8 +7952,7 @@ domhandler@^5.0.2, domhandler@^5.0.3:
     domelementtype "^2.3.0"
 
 "domino@https://github.com/angular/domino.git#93e720f143d0296dd2726ffbcf4fc12283363a7b":
-  version "2.1.6+git"
-  uid "93e720f143d0296dd2726ffbcf4fc12283363a7b"
+  version "2.1.6"
   resolved "https://github.com/angular/domino.git#93e720f143d0296dd2726ffbcf4fc12283363a7b"
 
 dompurify@^3.2.4:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

I've installed dagre-d3-es as a new package for use in devtools. 

This is the most popular fork of dagre, which still doesn't work with esm (and therefore is harder to integrate into our build pipeline). Dagre will allow us to layout the signals visualization in a compact graph

See #60478 for a more complete demo
 
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
