### PR TITLE
feat(devtools): inspect signals

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/application-operations/index.ts
+++ b/devtools/projects/ng-devtools/src/lib/application-operations/index.ts
@@ -7,11 +7,12 @@
  */
 
 import {Frame} from '../application-environment';
-import {DirectivePosition, ElementPosition} from '../../../../protocol';
+import {DirectivePosition, ElementPosition, SignalNodePosition} from '../../../../protocol';
 
 export abstract class ApplicationOperations {
   abstract viewSource(position: ElementPosition, target: Frame, directiveIndex?: number): void;
   abstract selectDomElement(position: ElementPosition, target: Frame): void;
   abstract inspect(directivePosition: DirectivePosition, objectPath: string[], target: Frame): void;
+  abstract inspectSignal(position: SignalNodePosition, target: Frame): void;
   abstract viewSourceFromRouter(name: string, type: string, target: Frame): void;
 }

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -16,6 +16,11 @@ import {
   ViewEncapsulation as AngularViewEncapsulation,
 } from '@angular/core';
 
+export interface SignalNodePosition {
+  element: ElementPosition;
+  signalId: string;
+}
+
 export interface DirectiveType {
   name: string;
   id: number;

--- a/devtools/projects/shell-browser/src/app/BUILD.bazel
+++ b/devtools/projects/shell-browser/src/app/BUILD.bazel
@@ -63,8 +63,13 @@ ts_project(
         "//devtools/projects/ng-devtools-backend/src/lib/component-tree",
     ],
     deps = [
+        "//devtools/projects/ng-devtools-backend",
         "//devtools/projects/ng-devtools-backend:ng-devtools-backend_rjs",
+        "//devtools/projects/ng-devtools-backend/src/lib/component-tree",
+        "//devtools/projects/ng-devtools-backend/src/lib/ng-debug-api",
+        "//devtools/projects/protocol",
         "//devtools/projects/protocol:protocol_rjs",
+        "@npm//@types",
     ],
 )
 

--- a/devtools/projects/shell-browser/src/app/chrome-application-operations.ts
+++ b/devtools/projects/shell-browser/src/app/chrome-application-operations.ts
@@ -11,7 +11,7 @@
 import {Platform} from '@angular/cdk/platform';
 import {inject} from '@angular/core';
 import {ApplicationOperations, Frame, TOP_LEVEL_FRAME_ID} from '../../../ng-devtools';
-import {DirectivePosition, ElementPosition} from '../../../protocol';
+import {DirectivePosition, ElementPosition, SignalNodePosition} from '../../../protocol';
 
 export class ChromeApplicationOperations extends ApplicationOperations {
   platform = inject(Platform);
@@ -54,6 +54,13 @@ export class ChromeApplicationOperations extends ApplicationOperations {
       args,
     )}'))`;
     this.runInInspectedWindow(inspect, target);
+  }
+
+  override inspectSignal(position: SignalNodePosition, target: Frame): void {
+    const inspectSignal = `inspect(inspectedApplication.findSignalNodeByPosition('${JSON.stringify(
+      position,
+    )}'))`;
+    this.runInInspectedWindow(inspectSignal, target);
   }
 
   override viewSourceFromRouter(name: string, type: string, target: Frame): void {

--- a/devtools/src/demo-application-operations.ts
+++ b/devtools/src/demo-application-operations.ts
@@ -7,7 +7,7 @@
  */
 
 import {ApplicationOperations} from '../projects/ng-devtools';
-import {DirectivePosition, ElementPosition} from '../projects/protocol';
+import {DirectivePosition, ElementPosition, SignalNodePosition} from '../projects/protocol';
 
 export class DemoApplicationOperations extends ApplicationOperations {
   override viewSource(position: ElementPosition): void {
@@ -20,6 +20,10 @@ export class DemoApplicationOperations extends ApplicationOperations {
   }
   override inspect(directivePosition: DirectivePosition, keyPath: string[]): void {
     console.warn('inspect() is not implemented because the demo app runs in an Iframe');
+    return;
+  }
+  override inspectSignal(position: SignalNodePosition): void {
+    console.warn('inspectSignal() is not implemented because the demo app runs in an Iframe');
     return;
   }
   override viewSourceFromRouter(name: string, type: string): void {


### PR DESCRIPTION
add a new global api for the devtools connector to jump to the source of a computed or effect

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

We can now call `ApplicationOperations.inspectSignal` from chrome devtools and it will jump to the source of a computed or effect 

See https://github.com/angular/angular/pull/60478 for a more complete demo

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
