### PR TITLE
feat(devtools): add getSignalGraph api to devtools protocol

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.ts
@@ -116,6 +116,10 @@ export function serializeDirectiveState(instance: object): Record<string, Descri
   return result;
 }
 
+export function serializeValue(value: unknown): Descriptor {
+  return levelSerializer({value}, 'value', false, 0, 0);
+}
+
 export function deeplySerializeSelectedProperties(
   instance: object,
   props: NestedProp[],

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -16,6 +16,34 @@ import {
   ViewEncapsulation as AngularViewEncapsulation,
 } from '@angular/core';
 
+export interface DebugSignalGraphNode {
+  id: string;
+  kind: string;
+  epoch: number;
+  label?: string;
+  preview: Descriptor;
+}
+
+export interface DebugSignalGraphEdge {
+  /**
+   * Index of a signal node in the `nodes` array that is a consumer of the signal produced by the producer node.
+   */
+  consumer: number;
+
+  /**
+   * Index of a signal node in the `nodes` array that is a producer of the signal consumed by the consumer node.
+   */
+  producer: number;
+}
+
+/**
+ * A debug representation of the signal graph.
+ */
+export interface DebugSignalGraph {
+  nodes: DebugSignalGraphNode[];
+  edges: DebugSignalGraphEdge[];
+}
+
 export interface SignalNodePosition {
   element: ElementPosition;
   signalId: string;
@@ -306,11 +334,6 @@ export interface AngularDetection {
 
 export type Topic = keyof Events;
 
-export interface InjectorGraphViewQuery {
-  directivePosition: DirectivePosition;
-  paramIndex: number;
-}
-
 export interface SupportedApis {
   profiler: boolean;
   dependencyInjection: boolean;
@@ -331,6 +354,9 @@ export interface Events {
 
   inspectorStart: () => void;
   inspectorEnd: () => void;
+
+  getSignalGraph: (query: ElementPosition) => void;
+  latestSignalGraph: (graph: DebugSignalGraph) => void;
 
   getNestedProperties: (position: DirectivePosition, path: string[]) => void;
   nestedProperties: (position: DirectivePosition, data: Properties, path: string[]) => void;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

This allows the devtools frontend code to query the framework getSignalGraph API, which will enable us to visualize the signals graph in devtools

Related: #60772 (currently we'll get an error if we call getSignalGraph on a componentless injector)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
