### PR TITLE
refactor(migrations): ensure tsurge configures file system properly

### DIFF
--- a/packages/core/schematics/utils/tsurge/base_migration.ts
+++ b/packages/core/schematics/utils/tsurge/base_migration.ts
@@ -6,13 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {absoluteFrom, FileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {NgCompilerOptions} from '@angular/compiler-cli/src/ngtsc/core/api';
-import {getRootDirs} from '@angular/compiler-cli/src/ngtsc/util/src/typescript';
-import {isShim} from '@angular/compiler-cli/src/ngtsc/shims';
-import {ProgramInfo} from './program_info';
-import {Serializable} from './helpers/serializable';
+import {FileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {createBaseProgramInfo, getProgramInfoFromBaseInfo} from './helpers/create_program';
+import {Serializable} from './helpers/serializable';
+import {ProgramInfo} from './program_info';
 
 /** Type helper extracting the stats type of a migration. */
 export type MigrationStats<T> =

--- a/packages/core/schematics/utils/tsurge/helpers/create_program.ts
+++ b/packages/core/schematics/utils/tsurge/helpers/create_program.ts
@@ -25,13 +25,13 @@ import {createPlainTsProgram} from './ts_program';
 /** Creates the base program info for the given tsconfig path. */
 export function createBaseProgramInfo(
   absoluteTsconfigPath: string,
-  fs?: FileSystem,
+  fs: FileSystem,
   optionOverrides: NgCompilerOptions = {},
 ): BaseProgramInfo {
-  if (fs === undefined) {
-    fs = new NodeJSFileSystem();
-    setFileSystem(fs);
-  }
+  // Make sure the FS becomes globally available. Some code paths
+  // of the Angular compiler, or tsconfig parsing aren't leveraging
+  // the specified file system.
+  setFileSystem(fs);
 
   const tsconfig = parseTsconfigOrDie(absoluteTsconfigPath, fs);
   const tsHost = new NgtscCompilerHost(fs, tsconfig.options);


### PR DESCRIPTION
Currently in 1P, without this commit, the tsconfig parsing picks up the default file system (InvalidFS) and results in runtime errors.