### PR TITLE
ci: temporarily disable saucelabs for push jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,18 +178,18 @@ jobs:
       - run: yarn --cwd packages/zone.js/test/typings install --frozen-lockfile --non-interactive
       - run: yarn --cwd packages/zone.js/test/typings test
 
-  saucelabs:
-    runs-on: ubuntu-latest-4core
-    env:
-      SAUCE_TUNNEL_IDENTIFIER: angular-framework-${{ github.run_number }}
-    steps:
-      - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@b5a3609f89c06eb4037dce22a93641213a5d1508
-        with:
-          cache-node-modules: true
-      - name: Install node modules
-        run: yarn install --frozen-lockfile
-      - uses: ./.github/actions/saucelabs-legacy
+  # saucelabs:
+  #   runs-on: ubuntu-latest-4core
+  #   env:
+  #     SAUCE_TUNNEL_IDENTIFIER: angular-framework-${{ github.run_number }}
+  #   steps:
+  #     - name: Initialize environment
+  #       uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@b5a3609f89c06eb4037dce22a93641213a5d1508
+  #       with:
+  #         cache-node-modules: true
+  #     - name: Install node modules
+  #       run: yarn install --frozen-lockfile
+  #     - uses: ./.github/actions/saucelabs-legacy
 
   adev-deploy:
     needs: [adev]


### PR DESCRIPTION
This also disables saucelabs for the CI (push) jobs.


