### PR TITLE
refactor(core): drop injection context assertion in production

### DIFF
--- a/packages/core/rxjs-interop/src/pending_until_event.ts
+++ b/packages/core/rxjs-interop/src/pending_until_event.ts
@@ -20,7 +20,7 @@ import {MonoTypeOperatorFunction, Observable} from 'rxjs';
  */
 export function pendingUntilEvent<T>(injector?: Injector): MonoTypeOperatorFunction<T> {
   if (injector === undefined) {
-    assertInInjectionContext(pendingUntilEvent);
+    ngDevMode && assertInInjectionContext(pendingUntilEvent);
     injector = inject(Injector);
   }
   const taskService = injector.get(PendingTasks);

--- a/packages/core/rxjs-interop/src/take_until_destroyed.ts
+++ b/packages/core/rxjs-interop/src/take_until_destroyed.ts
@@ -22,7 +22,7 @@ import {takeUntil} from 'rxjs/operators';
  */
 export function takeUntilDestroyed<T>(destroyRef?: DestroyRef): MonoTypeOperatorFunction<T> {
   if (!destroyRef) {
-    assertInInjectionContext(takeUntilDestroyed);
+    ngDevMode && assertInInjectionContext(takeUntilDestroyed);
     destroyRef = inject(DestroyRef);
   }
 

--- a/packages/core/rxjs-interop/src/to_observable.ts
+++ b/packages/core/rxjs-interop/src/to_observable.ts
@@ -42,7 +42,9 @@ export interface ToObservableOptions {
  * @publicApi 20.0
  */
 export function toObservable<T>(source: Signal<T>, options?: ToObservableOptions): Observable<T> {
-  !options?.injector && assertInInjectionContext(toObservable);
+  if (ngDevMode && !options?.injector) {
+    assertInInjectionContext(toObservable);
+  }
   const injector = options?.injector ?? inject(Injector);
   const subject = new ReplaySubject<T>(1);
 


### PR DESCRIPTION
In other parts of the code, calls to the `assertInInjectionContext` function are guarded with `ngDevMode`. This change aligns these parts of the code with other implementations that drop such assertions in production.