### PR TITLE
refactor(core): drop injection context assertion in production

### DIFF
--- a/packages/common/http/src/resource.ts
+++ b/packages/common/http/src/resource.ts
@@ -230,7 +230,9 @@ function makeHttpResourceFn<TRaw>(responseType: ResponseType) {
     request: RawRequestType,
     options?: HttpResourceOptions<TResult, TRaw>,
   ): HttpResourceRef<TResult> {
-    options?.injector || assertInInjectionContext(httpResource);
+    if (ngDevMode && !options?.injector) {
+      assertInInjectionContext(httpResource);
+    }
     const injector = options?.injector ?? inject(Injector);
     return new HttpResourceImpl(
       injector,

--- a/packages/core/rxjs-interop/src/rx_resource.ts
+++ b/packages/core/rxjs-interop/src/rx_resource.ts
@@ -44,7 +44,9 @@ export function rxResource<T, R>(
  */
 export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T | undefined>;
 export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T | undefined> {
-  opts?.injector || assertInInjectionContext(rxResource);
+  if (ngDevMode && !opts?.injector) {
+    assertInInjectionContext(rxResource);
+  }
   return resource<T, R>({
     ...opts,
     loader: undefined,

--- a/packages/core/rxjs-interop/src/to_signal.ts
+++ b/packages/core/rxjs-interop/src/to_signal.ts
@@ -131,7 +131,11 @@ export function toSignal<T, U = undefined>(
     );
 
   const requiresCleanup = !options?.manualCleanup;
-  requiresCleanup && !options?.injector && assertInInjectionContext(toSignal);
+
+  if (ngDevMode && requiresCleanup && !options?.injector) {
+    assertInInjectionContext(toSignal);
+  }
+
   const cleanupRef = requiresCleanup
     ? (options?.injector?.get(DestroyRef) ?? inject(DestroyRef))
     : null;

--- a/packages/core/src/render3/after_render/hooks.ts
+++ b/packages/core/src/render3/after_render/hooks.ts
@@ -216,7 +216,10 @@ export function afterEveryRender(
         'callback inside the component constructor`.',
     );
 
-  !options?.injector && assertInInjectionContext(afterEveryRender);
+  if (ngDevMode && !options?.injector) {
+    assertInInjectionContext(afterEveryRender);
+  }
+
   const injector = options?.injector ?? inject(Injector);
 
   if (typeof ngServerMode !== 'undefined' && ngServerMode) {

--- a/packages/core/src/render3/reactivity/after_render_effect.ts
+++ b/packages/core/src/render3/reactivity/after_render_effect.ts
@@ -366,7 +366,9 @@ export function afterRenderEffect<E = never, W = never, M = never>(
         'effect inside the component constructor`.',
     );
 
-  !options?.injector && assertInInjectionContext(afterRenderEffect);
+  if (ngDevMode && !options?.injector) {
+    assertInInjectionContext(afterRenderEffect);
+  }
 
   if (typeof ngServerMode !== 'undefined' && ngServerMode) {
     return NOOP_AFTER_RENDER_REF;

--- a/packages/core/src/render3/reactivity/effect.ts
+++ b/packages/core/src/render3/reactivity/effect.ts
@@ -140,7 +140,9 @@ export function effect(
         'effect inside the component constructor.',
     );
 
-  !options?.injector && assertInInjectionContext(effect);
+  if (ngDevMode && !options?.injector) {
+    assertInInjectionContext(effect);
+  }
 
   if (ngDevMode && options?.allowSignalWrites !== undefined) {
     console.warn(

--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -58,7 +58,10 @@ export function resource<T, R>(
  */
 export function resource<T, R>(options: ResourceOptions<T, R>): ResourceRef<T | undefined>;
 export function resource<T, R>(options: ResourceOptions<T, R>): ResourceRef<T | undefined> {
-  options?.injector || assertInInjectionContext(resource);
+  if (ngDevMode && !options?.injector) {
+    assertInInjectionContext(resource);
+  }
+
   const oldNameForParams = (
     options as ResourceOptions<T, R> & {request: ResourceOptions<T, R>['params']}
   ).request;


### PR DESCRIPTION
In other parts of the code, calls to the `assertInInjectionContext` function are guarded with `ngDevMode`. This change aligns these parts of the code with other implementations that drop such assertions in production.