### PR TITLE
refactor(core): drop `rxResource` error messages

### DIFF
--- a/goldens/public-api/core/errors.api.md
+++ b/goldens/public-api/core/errors.api.md
@@ -122,6 +122,8 @@ export const enum RuntimeErrorCode {
     // (undocumented)
     MULTIPLE_PLATFORMS = 400,
     // (undocumented)
+    MUST_PROVIDE_STREAM_OPTION = 990,
+    // (undocumented)
     NO_BINDING_TARGET = 315,
     // (undocumented)
     NO_COMPONENT_FACTORY_FOUND = 917,
@@ -153,6 +155,8 @@ export const enum RuntimeErrorCode {
     REQUIRED_MODEL_NO_VALUE = 952,
     // (undocumented)
     REQUIRED_QUERY_NO_VALUE = -951,
+    // (undocumented)
+    RESOURCE_COMPLETED_BEFORE_PRODUCING_VALUE = 991,
     // (undocumented)
     RUNTIME_DEPS_INVALID_IMPORTED_TYPE = 980,
     // (undocumented)

--- a/packages/core/rxjs-interop/src/rx_resource.ts
+++ b/packages/core/rxjs-interop/src/rx_resource.ts
@@ -14,6 +14,8 @@ import {
   Signal,
   signal,
   BaseResourceOptions,
+  ɵRuntimeError,
+  ɵRuntimeErrorCode,
 } from '../../src/core';
 import {Observable, Subscription} from 'rxjs';
 
@@ -70,7 +72,10 @@ export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T |
       // TODO(alxhub): remove after g3 updated to rename loader -> stream
       const streamFn = opts.stream ?? (opts as {loader?: RxResourceOptions<T, R>['stream']}).loader;
       if (streamFn === undefined) {
-        throw new Error(`Must provide \`stream\` option.`);
+        throw new ɵRuntimeError(
+          ɵRuntimeErrorCode.MUST_PROVIDE_STREAM_OPTION,
+          ngDevMode && `Must provide \`stream\` option.`,
+        );
       }
 
       sub = streamFn(params).subscribe({
@@ -78,7 +83,12 @@ export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T |
         error: (error) => send({error}),
         complete: () => {
           if (resolve) {
-            send({error: new Error('Resource completed before producing a value')});
+            send({
+              error: new ɵRuntimeError(
+                ɵRuntimeErrorCode.RESOURCE_COMPLETED_BEFORE_PRODUCING_VALUE,
+                ngDevMode && 'Resource completed before producing a value',
+              ),
+            });
           }
           params.abortSignal.removeEventListener('abort', onAbort);
         },

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -143,6 +143,10 @@ export const enum RuntimeErrorCode {
   RUNTIME_DEPS_INVALID_IMPORTED_TYPE = 980,
   RUNTIME_DEPS_ORPHAN_COMPONENT = 981,
 
+  // Resource errors
+  MUST_PROVIDE_STREAM_OPTION = 990,
+  RESOURCE_COMPLETED_BEFORE_PRODUCING_VALUE = 991,
+
   // Upper bounds for core runtime errors is 999
 }
 


### PR DESCRIPTION
Drops `rxResource` error messages in production and replaces with error codes.