### PR TITLE
docs: add a short redirect for HMR information [Patch]

### DIFF
--- a/adev/src/app/routes.ts
+++ b/adev/src/app/routes.ts
@@ -216,6 +216,10 @@ const REDIRECT_ROUTES: Route[] = [
     redirectTo: '/guide/components',
   },
   {
+    path: 'hmr',
+    redirectTo: '/tools/cli/build-system-migration#hot-module-replacement',
+  },
+  {
     path: 'guide',
     children: [
       {


### PR DESCRIPTION
The `https://angular.dev/hmr` URL will now redirect to the HMR information at the longer URL:
https://angular.dev/tools/cli/build-system-migration#hot-module-replacement This shorter URL will be used within console messages within the Angular CLI.

NOTE: 19.2.x patch version of #61545