### PR TITLE
refactor(common): drop promise and subscribable strategies

### DIFF
--- a/packages/common/src/pipes/async_pipe.ts
+++ b/packages/common/src/pipes/async_pipe.ts
@@ -104,8 +104,8 @@ class PromiseStrategy implements SubscriptionStrategy {
   }
 }
 
-const _promiseStrategy = new PromiseStrategy();
-const _subscribableStrategy = new SubscribableStrategy();
+const _promiseStrategy = /* @__PURE__ */ new PromiseStrategy();
+const _subscribableStrategy = /* @__PURE__ */ new SubscribableStrategy();
 
 /**
  * @ngModule CommonModule


### PR DESCRIPTION
Adds `__PURE__` annotations to async pipe strategy expressions to enable tree-shaking, even if they are not referenced. These variables are not dropped when Angular is imported from a module that has `sideEffects` set to `true`.

![image](https://github.com/user-attachments/assets/829f8f61-b82f-4bbb-944d-f125f36cfefd)
