### PR TITLE
docs: remove top level heading for ai guide

### DIFF
--- a/adev/src/content/ai/overview.md
+++ b/adev/src/content/ai/overview.md
@@ -3,7 +3,6 @@
 Build AI-powered apps. Develop faster with AI.
 </docs-decorative-header>
 
-# Overview
 Generative AI (GenAI) with large language models (LLMs) enables the creation of sophisticated and engaging application experiences, including personalized content, intelligent recommendations, media generation and comprehension, information summarization, and dynamic functionality.
 
 Developing features like these would have previously required deep domain expertise and significant engineering effort. However, new products and SDKs are lowering the barrier to entry. Angular is well-suited for integrating AI into your web application as a result of:


### PR DESCRIPTION
It interferes with `docs-decorative-header`
