### PR TITLE
fix(core): unregister `onDestroy` when observable errors in `toSignal`

### DIFF
--- a/packages/core/rxjs-interop/src/to_signal.ts
+++ b/packages/core/rxjs-interop/src/to_signal.ts
@@ -168,6 +168,7 @@ export function toSignal<T, U = undefined>(
     next: (value) => state.set({kind: StateKind.Value, value}),
     error: (error) => {
       state.set({kind: StateKind.Error, error});
+      destroyUnregisterFn?.();
     },
     complete: () => {
       destroyUnregisterFn?.();


### PR DESCRIPTION
The observable terminates immediately when `error` is called, and no further emissions or completion notifications occur. Thus, we have to remove the listener in both the `error` and `complete` notifications.