### PR TITLE
docs(docs-infra): fix nav items active status is shown for multiple i…

### DIFF
--- a/adev/shared-docs/components/navigation-list/navigation-list.component.html
+++ b/adev/shared-docs/components/navigation-list/navigation-list.component.html
@@ -31,6 +31,7 @@
               
               
               routerLinkActive="docs-faceted-list-item-active"
+              [routerLinkActiveOptions]="{ exact: true }"
               (click)="emitClickOnLink()"
               [matTooltip]="item.label"
               [matTooltipDisabled]="item.label.length < 27"


### PR DESCRIPTION
fix secondnav active status is shown for multiple items due to the matching algo is not "exact" 

so both "/essentials" and "/essentials/signals" will show essentials page as active

![image](https://github.com/user-attachments/assets/9b433510-847f-424d-b234-1ab8eba97849)


 