### PR TITLE
fix(compiler): lexer support for template literals in object literals

### DIFF
--- a/packages/compiler/test/expression_parser/lexer_spec.ts
+++ b/packages/compiler/test/expression_parser/lexer_spec.ts
@@ -588,6 +588,20 @@ describe('lexer', () => {
         expectStringToken(tokens[8], 29, 33, '!!!', StringTokenKind.TemplateLiteralEnd);
       });
 
+      it('should tokenize a template literal in an literal object value', () => {
+        const tokens: Token[] = lex('{foo: `${name}`}');
+        expect(tokens.length).toBe(9);
+        expectCharacterToken(tokens[0], 0, 1, '{');
+        expectIdentifierToken(tokens[1], 1, 4, 'foo');
+        expectCharacterToken(tokens[2], 4, 5, ':');
+        expectStringToken(tokens[3], 6, 7, '', StringTokenKind.TemplateLiteralPart);
+        expectOperatorToken(tokens[4], 7, 9, '${');
+        expectIdentifierToken(tokens[5], 9, 13, 'name');
+        expectOperatorToken(tokens[6], 13, 14, '}');
+        expectStringToken(tokens[7], 14, 15, '', StringTokenKind.TemplateLiteralEnd);
+        expectCharacterToken(tokens[8], 15, 16, '}');
+      });
+
       it('should produce an error if a template literal is not terminated', () => {
         expectErrorToken(
           lex('`hello')[0],

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -453,6 +453,13 @@ describe('parser', () => {
         checkBinding('`hello ${(name | capitalize)}!!!`', '`hello ${((name | capitalize))}!!!`');
       });
 
+      it('should parse template literals in objects literals', () => {
+        checkBinding('{"a": `${name}`}');
+        checkBinding('{"a": `hello ${name}!`}');
+        checkBinding('{"a": `hello ${`hello ${`hello`}`}!`}');
+        checkBinding('{"a": `hello ${{"b": `hello`}}`}');
+      });
+
       it('should report error if interpolation is empty', () => {
         expectBindingError(
           '`hello ${}`',


### PR DESCRIPTION
This commit fixes a shortcoming of the lexer with template literals

fixes #61572
