### PR TITLE
refactor(common): use `ngServerMode` in `HttpInterceptorHandler`

### DIFF
--- a/packages/common/http/src/interceptor.ts
+++ b/packages/common/http/src/interceptor.ts
@@ -6,13 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {isPlatformServer} from '../../index';
 import {
   EnvironmentInjector,
   inject,
   Injectable,
   InjectionToken,
-  PLATFORM_ID,
   runInInjectionContext,
   ɵConsole as Console,
   ɵformatRuntimeError as formatRuntimeError,
@@ -275,15 +273,18 @@ export class HttpInterceptorHandler extends HttpHandler {
     // for an application. The logic below checks if that's the case and produces
     // a warning otherwise.
     if ((typeof ngDevMode === 'undefined' || ngDevMode) && !fetchBackendWarningDisplayed) {
-      const isServer = isPlatformServer(injector.get(PLATFORM_ID));
-
       // This flag is necessary because provideHttpClientTesting() overrides the backend
       // even if `withFetch()` is used within the test. When the testing HTTP backend is provided,
       // no HTTP calls are actually performed during the test, so producing a warning would be
       // misleading.
       const isTestingBackend = (this.backend as any).isTestingBackend;
 
-      if (isServer && !(this.backend instanceof FetchBackend) && !isTestingBackend) {
+      if (
+        typeof ngServerMode !== 'undefined' &&
+        ngServerMode &&
+        !(this.backend instanceof FetchBackend) &&
+        !isTestingBackend
+      ) {
         fetchBackendWarningDisplayed = true;
         injector
           .get(Console)

--- a/packages/common/http/test/provider_spec.ts
+++ b/packages/common/http/test/provider_spec.ts
@@ -489,13 +489,7 @@ describe('provideHttpClient', () => {
 
       TestBed.resetTestingModule();
       TestBed.configureTestingModule({
-        providers: [
-          // Setting this flag to verify that there are no
-          // `console.warn` produced for cases when `fetch`
-          // is enabled and we are running in a browser.
-          {provide: PLATFORM_ID, useValue: 'browser'},
-          provideHttpClient(withFetch()),
-        ],
+        providers: [provideHttpClient(withFetch())],
       });
       const fetchBackend = TestBed.inject(HttpBackend);
       expect(fetchBackend).toBeInstanceOf(FetchBackend);
@@ -540,13 +534,7 @@ describe('provideHttpClient', () => {
 
       TestBed.resetTestingModule();
       TestBed.configureTestingModule({
-        providers: [
-          // Setting this flag to verify that there are no
-          // `console.warn` produced for cases when `fetch`
-          // is enabled and we are running in a browser.
-          {provide: PLATFORM_ID, useValue: 'browser'},
-          provideHttpClient(),
-        ],
+        providers: [provideHttpClient()],
       });
 
       TestBed.inject(HttpHandler);
@@ -556,19 +544,15 @@ describe('provideHttpClient', () => {
     });
 
     it('should warn during SSR if fetch is not configured', () => {
+      globalThis['ngServerMode'] = true;
+
       resetFetchBackendWarningFlag();
 
       const consoleWarnSpy = spyOn(console, 'warn');
 
       TestBed.resetTestingModule();
       TestBed.configureTestingModule({
-        providers: [
-          // Setting this flag to verify that there is a
-          // `console.warn` produced in case `fetch` is not
-          // enabled while running code on the server.
-          {provide: PLATFORM_ID, useValue: 'server'},
-          provideHttpClient(),
-        ],
+        providers: [provideHttpClient()],
       });
 
       TestBed.inject(HttpHandler);
@@ -577,6 +561,8 @@ describe('provideHttpClient', () => {
       expect(consoleWarnSpy.calls.argsFor(0)[0]).toContain(
         'NG02801: Angular detected that `HttpClient` is not configured to use `fetch` APIs.',
       );
+
+      globalThis['ngServerMode'] = undefined;
     });
   });
 });


### PR DESCRIPTION
Drops `isPlatformServer(platformId)` in favor of `ngServerMode` in the `HttpInterceptorHandler`.