### PR TITLE
refactor(compiler-cli): remove unused transform methods from `DtsTransform`

### DIFF
--- a/packages/compiler-cli/src/ngtsc/transform/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/api.ts
@@ -288,11 +288,6 @@ export interface ResolveResult<R> {
 }
 
 export interface DtsTransform {
-  transformClassElement?(element: ts.ClassElement, imports: ImportManager): ts.ClassElement;
-  transformFunctionDeclaration?(
-    element: ts.FunctionDeclaration,
-    imports: ImportManager,
-  ): ts.FunctionDeclaration;
   transformClass?(
     clazz: ts.ClassDeclaration,
     elements: ReadonlyArray<ts.ClassElement>,


### PR DESCRIPTION
All usages of the `DtsTransform` interface leave these two methods `undefined`, so we can remove them, as well as all code invoking them.