### PR TITLE
fix(@angular/core): mark `zone.js` as an optional peer dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,9 @@
   "peerDependenciesMeta": {
     "@angular/compiler": {
       "optional": true
+    },
+    "zone.js": {
+      "optional": true
     }
   },
   "repository": {


### PR DESCRIPTION
`zone.js` is no longer mandatory.

