### PR TITLE
fix(core): call injector `onDestroy` callback even if injector is destroyed

### DIFF
--- a/packages/core/test/acceptance/destroy_ref_spec.ts
+++ b/packages/core/test/acceptance/destroy_ref_spec.ts
@@ -64,15 +64,13 @@ describe('DestroyRef', () => {
       expect(onDestroyCalls).toBe(2);
     });
 
-    it('should throw when trying to register destroy callback on destroyed injector', () => {
+    it('should not throw when trying to register destroy callback on destroyed injector and call it immediately', () => {
       const envInjector = createEnvironmentInjector([], TestBed.inject(EnvironmentInjector));
       const destroyRef = envInjector.get(DestroyRef);
-
       envInjector.destroy();
-
-      expect(() => {
-        destroyRef.onDestroy(() => {});
-      }).toThrowError('NG0205: Injector has already been destroyed.');
+      let onDestroyCalled = false;
+      destroyRef.onDestroy(() => (onDestroyCalled = true));
+      expect(onDestroyCalled).toEqual(true);
     });
   });
 


### PR DESCRIPTION
This change is similar to the one introduced in [this commit](https://github.com/angular/angular/commit/5f7f04634f57c0fb669e2b81c85a0dff972868d8), where we applied it to `NodeInjectorDestroyRef` (which is what `DestroyRef` resolves to in the view injection context).

By default, `DestroyRef` resolves to `R3Injector`. We're applying the same change here to maintain consistency and compatibility. If the injector has already been destroyed, we invoke the `onDestroy` callback immediately, without attempting to register it for later execution. This ensures that necessary cleanup is performed gracefully and improves reliability in resource management.