### PR TITLE
fix(core): Testing should not throw when Zone does not patch test FW …

### DIFF
--- a/packages/core/testing/src/fake_async.ts
+++ b/packages/core/testing/src/fake_async.ts
@@ -59,7 +59,7 @@ export function resetFakeAsyncZoneIfExists(): void {
  * @publicApi
  */
 export function fakeAsync(fn: Function, options?: {flush?: boolean}): (...args: any[]) => any {
-  if (fakeAsyncTestModule) {
+  if (fakeAsyncTestModule && (Zone as any)['ProxyZoneSpec']?.isLoaded()) {
     return fakeAsyncTestModule.fakeAsync(fn, options);
   }
   throw new Error(fakeAsyncTestModuleNotLoadedErrorMessage);


### PR DESCRIPTION
…APIs

This prevents `core/testing` from throwing an error if ZoneJS is present but does not patch the test FW APIs such that `fakeAsync` works automatically. For example, there is currently no patching of the vitest APIs, so if you try to use Vitest with Zone on the page, it will throw.
