### PR TITLE
fix(common): avoid injecting ApplicationRef in FetchBackend

### DIFF
--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -19,6 +19,7 @@ import { WritableResource } from '@angular/core';
 
 // @public
 export class FetchBackend implements HttpBackend {
+    constructor();
     // (undocumented)
     handle(request: HttpRequest<any>): Observable<HttpEvent<any>>;
     // (undocumented)


### PR DESCRIPTION
fixes a circular dependency caused by injecting applicationRef

fixes #61644
