### PR TITLE
docs(docs-infra): fix callouts icon collision with the content

### DIFF
--- a/adev/shared-docs/styles/docs/_callout.scss
+++ b/adev/shared-docs/styles/docs/_callout.scss
@@ -10,7 +10,6 @@
     border-style: solid;
     margin-block: 1.5rem;
     border-image: var(--callout-theme) 1;
-    position: relative;
 
     // Removes bottom line if followed by another callout
     // Prevents too many lines/visual noise
@@ -21,8 +20,7 @@
     &::before {
       font-family: var(--icons);
       // content: icon is defined in each docs-alert class below...
-      position: absolute;
-      right: 0;
+      float: right;
       margin-top: 1.35rem;
       color: var(--alert-accent);
       font-size: 1.3rem;
@@ -41,6 +39,7 @@
       max-width: fit-content;
     }
   }
+
   .docs-viewer .docs-callout h3 {
     font-size: 0.875rem;
     margin-block: 1.6rem;
@@ -48,6 +47,7 @@
 
   .docs-callout-helpful {
     --callout-theme: var(--purple-to-blue-horizontal-gradient);
+
     &::before {
       content: 'check_circle';
       color: var(--bright-blue);
@@ -56,6 +56,7 @@
 
   .docs-callout-critical {
     --callout-theme: var(--red-to-orange-horizontal-gradient);
+
     &::before {
       content: 'warning';
       color: var(--orange-red);
@@ -64,6 +65,7 @@
 
   .docs-callout-important {
     --callout-theme: var(--pink-to-purple-horizontal-gradient);
+
     &::before {
       content: 'priority_high';
       color: var(--electric-violet);


### PR DESCRIPTION
fix callouts icon collision with the content in some cases for ex: 

**Before:**
![image](https://github.com/user-attachments/assets/59034e4b-af4b-4333-8530-9432c9b3ad01)

https://angular.dev/guide/forms/template-driven-forms#add-a-conditional-error-message-to-name

**After:**
![image](https://github.com/user-attachments/assets/2ae96b3e-4a7f-4c89-8f6c-82b43f05551c)
