### PR TITLE
refactor(service-worker): make `SwPush` and `SwUpdate` tree-shakable

### DIFF
--- a/packages/service-worker/src/module.ts
+++ b/packages/service-worker/src/module.ts
@@ -9,13 +9,11 @@
 import {ModuleWithProviders, NgModule} from '@angular/core';
 
 import {provideServiceWorker, SwRegistrationOptions} from './provider';
-import {SwPush} from './push';
-import {SwUpdate} from './update';
 
 /**
  * @publicApi
  */
-@NgModule({providers: [SwPush, SwUpdate]})
+@NgModule()
 export class ServiceWorkerModule {
   /**
    * Register the given Angular Service Worker script.

--- a/packages/service-worker/src/provider.ts
+++ b/packages/service-worker/src/provider.ts
@@ -21,8 +21,6 @@ import {
 import type {Observable} from 'rxjs';
 
 import {NgswCommChannel} from './low_level';
-import {SwPush} from './push';
-import {SwUpdate} from './update';
 import {RuntimeErrorCode} from './errors';
 
 export const SCRIPT = new InjectionToken<string>(ngDevMode ? 'NGSW_REGISTER_SCRIPT' : '');
@@ -213,8 +211,6 @@ export function provideServiceWorker(
   options: SwRegistrationOptions = {},
 ): EnvironmentProviders {
   return makeEnvironmentProviders([
-    SwPush,
-    SwUpdate,
     {provide: SCRIPT, useValue: script},
     {provide: SwRegistrationOptions, useValue: options},
     {

--- a/packages/service-worker/src/push.ts
+++ b/packages/service-worker/src/push.ts
@@ -92,7 +92,7 @@ import {ERR_SW_NOT_SUPPORTED, NgswCommChannel, PushEvent} from './low_level';
  *
  * @publicApi
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class SwPush {
   /**
    * Emits the payloads of the received push notification messages.

--- a/packages/service-worker/src/update.ts
+++ b/packages/service-worker/src/update.ts
@@ -25,7 +25,7 @@ import {
  *
  * @publicApi
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class SwUpdate {
   /**
    * Emits a `VersionDetectedEvent` event whenever a new version is detected on the server.


### PR DESCRIPTION
In this commit, we mark the `SwPush` and `SwUpdate` classes as root providers. As a result, they are no longer statically referenced in the `provideServiceWorker` providers list, which previously forced them to be explicitly bundled into the main file. These classes might never be used—some consumers may use the service worker only for prefetching and caching assets.

Practically speaking, even if a user injects the `SwPush` class without calling `provideServiceWorker()`, it would result in a DI error because the communication channel dependency is not available. There is no practical reason to keep these classes as non-root providers or to reference them explicitly.

Currently, some users work around this by using `patch-package` to modify the service worker code and remove these classes from the providers list.