### PR TITLE
Simplify assignment AST nodes

### DIFF
--- a/packages/compiler-cli/linker/test/file_linker/translator_spec.ts
+++ b/packages/compiler-cli/linker/test/file_linker/translator_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import * as o from '@angular/compiler';
+import {outputAst as o} from '@angular/compiler';
 import {TypeScriptAstFactory} from '../../../src/ngtsc/translator';
 import ts from 'typescript';
 
@@ -14,9 +14,8 @@ import {LinkerImportGenerator} from '../../src/linker_import_generator';
 
 import {generate} from './helpers';
 
-const ngImport = ts.factory.createIdentifier('ngImport');
-
 describe('Translator', () => {
+  const ngImport = ts.factory.createIdentifier('ngImport');
   let factory: TypeScriptAstFactory;
   let importGenerator: LinkerImportGenerator<ts.Statement, ts.Expression>;
 
@@ -28,16 +27,16 @@ describe('Translator', () => {
   describe('translateExpression()', () => {
     it('should generate expression specific output', () => {
       const translator = new Translator<ts.Statement, ts.Expression>(factory);
-      const outputAst = new o.WriteVarExpr('foo', new o.LiteralExpr(42));
+      const outputAst = o.variable('foo').set(o.literal(42));
       const translated = translator.translateExpression(outputAst, importGenerator);
-      expect(generate(translated)).toEqual('(foo = 42)');
+      expect(generate(translated)).toEqual('foo = 42');
     });
   });
 
   describe('translateStatement()', () => {
     it('should generate statement specific output', () => {
       const translator = new Translator<ts.Statement, ts.Expression>(factory);
-      const outputAst = new o.ExpressionStatement(new o.WriteVarExpr('foo', new o.LiteralExpr(42)));
+      const outputAst = new o.ExpressionStatement(o.variable('foo').set(o.literal(42)));
       const translated = translator.translateStatement(outputAst, importGenerator);
       expect(generate(translated)).toEqual('foo = 42;');
     });

--- a/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
@@ -13,7 +13,6 @@ import {
   ImplicitReceiver,
   ParseSourceSpan,
   PropertyRead,
-  PropertyWrite,
   TmplAstBoundAttribute,
   TmplAstComponent,
   TmplAstDirective,
@@ -143,11 +142,6 @@ class TemplateVisitor extends CombinedRecursiveAstVisitor {
   override visitPropertyRead(ast: PropertyRead) {
     this.visitIdentifier(ast, IdentifierKind.Property);
     super.visitPropertyRead(ast, null);
-  }
-
-  override visitPropertyWrite(ast: PropertyWrite) {
-    this.visitIdentifier(ast, IdentifierKind.Property);
-    super.visitPropertyWrite(ast, null);
   }
 
   override visitBoundAttribute(attribute: TmplAstBoundAttribute): void {
@@ -367,9 +361,9 @@ class TemplateVisitor extends CombinedRecursiveAstVisitor {
     // The source span of the requested AST starts at a location that is offset from the expression.
     let identifierStart = ast.sourceSpan.start - absoluteOffset;
 
-    if (ast instanceof PropertyRead || ast instanceof PropertyWrite) {
-      // For `PropertyRead` and `PropertyWrite`, the identifier starts at the `nameSpan`, not
-      // necessarily the `sourceSpan`.
+    if (ast instanceof PropertyRead) {
+      // For `PropertyRead` and the identifier starts at the `nameSpan`,
+      // not necessarily the `sourceSpan`.
       identifierStart = ast.nameSpan.start - absoluteOffset;
     }
 

--- a/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
@@ -342,7 +342,7 @@ runInEachFileSystem(() => {
       });
     });
 
-    describe('generates identifiers for PropertyWrites', () => {
+    describe('generates identifiers for property writes', () => {
       it('should discover property writes in bound events', () => {
         const template = '<div (click)="foo=bar"></div>';
         const refs = getTemplateIdentifiers(bind(template));

--- a/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
@@ -140,39 +140,6 @@ export class ExpressionTranslatorVisitor<TFile, TStatement, TExpression>
     return identifier;
   }
 
-  visitWriteVarExpr(expr: o.WriteVarExpr, context: Context): TExpression {
-    const assignment = this.factory.createAssignment(
-      this.setSourceMapRange(this.factory.createIdentifier(expr.name), expr.sourceSpan),
-      expr.value.visitExpression(this, context),
-    );
-    return context.isStatement
-      ? assignment
-      : this.factory.createParenthesizedExpression(assignment);
-  }
-
-  visitWriteKeyExpr(expr: o.WriteKeyExpr, context: Context): TExpression {
-    const exprContext = context.withExpressionMode;
-    const target = this.factory.createElementAccess(
-      expr.receiver.visitExpression(this, exprContext),
-      expr.index.visitExpression(this, exprContext),
-    );
-    const assignment = this.factory.createAssignment(
-      target,
-      expr.value.visitExpression(this, exprContext),
-    );
-    return context.isStatement
-      ? assignment
-      : this.factory.createParenthesizedExpression(assignment);
-  }
-
-  visitWritePropExpr(expr: o.WritePropExpr, context: Context): TExpression {
-    const target = this.factory.createPropertyAccess(
-      expr.receiver.visitExpression(this, context),
-      expr.name,
-    );
-    return this.factory.createAssignment(target, expr.value.visitExpression(this, context));
-  }
-
   visitInvokeFunctionExpr(ast: o.InvokeFunctionExpr, context: Context): TExpression {
     return this.setSourceMapRange(
       this.factory.createCallExpression(
@@ -364,6 +331,13 @@ export class ExpressionTranslatorVisitor<TFile, TStatement, TExpression>
   }
 
   visitBinaryOperatorExpr(ast: o.BinaryOperatorExpr, context: Context): TExpression {
+    if (ast.operator === o.BinaryOperator.Assign) {
+      return this.factory.createAssignment(
+        ast.lhs.visitExpression(this, context),
+        ast.rhs.visitExpression(this, context),
+      );
+    }
+
     if (!BINARY_OPERATORS.has(ast.operator)) {
       throw new Error(`Unknown binary operator: ${o.BinaryOperator[ast.operator]}`);
     }

--- a/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
@@ -123,18 +123,6 @@ class TypeTranslatorVisitor implements o.ExpressionVisitor, o.TypeVisitor {
     return ts.factory.createTypeQueryNode(ts.factory.createIdentifier(ast.name));
   }
 
-  visitWriteVarExpr(expr: o.WriteVarExpr, context: Context): never {
-    throw new Error('Method not implemented.');
-  }
-
-  visitWriteKeyExpr(expr: o.WriteKeyExpr, context: Context): never {
-    throw new Error('Method not implemented.');
-  }
-
-  visitWritePropExpr(expr: o.WritePropExpr, context: Context): never {
-    throw new Error('Method not implemented.');
-  }
-
   visitInvokeFunctionExpr(ast: o.InvokeFunctionExpr, context: Context): never {
     throw new Error('Method not implemented.');
   }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/completion.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/completion.ts
@@ -12,7 +12,6 @@ import {
   ImplicitReceiver,
   LiteralPrimitive,
   PropertyRead,
-  PropertyWrite,
   SafePropertyRead,
   TmplAstLetDeclaration,
   TmplAstNode,
@@ -141,16 +140,14 @@ export class CompletionEngine {
     };
   }
 
-  getExpressionCompletionLocation(
-    expr: PropertyRead | PropertyWrite | SafePropertyRead,
-  ): TcbLocation | null {
+  getExpressionCompletionLocation(expr: PropertyRead | SafePropertyRead): TcbLocation | null {
     if (this.expressionCompletionCache.has(expr)) {
       return this.expressionCompletionCache.get(expr)!;
     }
 
     // Completion works inside property reads and method calls.
     let tsExpr: ts.PropertyAccessExpression | null = null;
-    if (expr instanceof PropertyRead || expr instanceof PropertyWrite) {
+    if (expr instanceof PropertyRead) {
       // Non-safe navigation operations are trivial: `foo.bar` or `foo.bar()`
       tsExpr = findFirstMatchingNode(this.tcb, {
         filter: ts.isPropertyAccessExpression,

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/oob.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/oob.ts
@@ -10,7 +10,7 @@ import {
   AbsoluteSourceSpan,
   BindingPipe,
   PropertyRead,
-  PropertyWrite,
+  AST,
   TmplAstBoundAttribute,
   TmplAstBoundEvent,
   TmplAstComponent,
@@ -172,11 +172,7 @@ export interface OutOfBandDiagnosticRecorder {
   ): void;
 
   /** Reports cases where users are writing to `@let` declarations. */
-  illegalWriteToLetDeclaration(
-    id: TypeCheckId,
-    node: PropertyWrite,
-    target: TmplAstLetDeclaration,
-  ): void;
+  illegalWriteToLetDeclaration(id: TypeCheckId, node: AST, target: TmplAstLetDeclaration): void;
 
   /** Reports cases where users are accessing an `@let` before it is defined.. */
   letUsedBeforeDefinition(id: TypeCheckId, node: PropertyRead, target: TmplAstLetDeclaration): void;
@@ -651,11 +647,7 @@ export class OutOfBandDiagnosticRecorderImpl implements OutOfBandDiagnosticRecor
     );
   }
 
-  illegalWriteToLetDeclaration(
-    id: TypeCheckId,
-    node: PropertyWrite,
-    target: TmplAstLetDeclaration,
-  ): void {
+  illegalWriteToLetDeclaration(id: TypeCheckId, node: AST, target: TmplAstLetDeclaration): void {
     const sourceSpan = this.resolver.toTemplateParseSourceSpan(id, node.sourceSpan);
     if (sourceSpan === null) {
       throw new Error(`Assertion failure: no SourceLocation found for property write.`);

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/template_symbol_builder.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/template_symbol_builder.ts
@@ -10,10 +10,10 @@ import {
   AST,
   ASTWithName,
   ASTWithSource,
+  Binary,
   BindingPipe,
   ParseSourceSpan,
   PropertyRead,
-  PropertyWrite,
   R3Identifiers,
   SafePropertyRead,
   TmplAstBoundAttribute,
@@ -800,13 +800,16 @@ export class SymbolBuilder {
 
     let withSpan = expression.sourceSpan;
 
-    // The `name` part of a `PropertyWrite` and `ASTWithName` do not have their own
+    // The `name` part of a property write and `ASTWithName` do not have their own
     // AST so there is no way to retrieve a `Symbol` for just the `name` via a specific node.
     // Also skipping SafePropertyReads as it breaks nullish coalescing not nullable extended diagnostic
     if (
-      expression instanceof PropertyWrite ||
-      (expression instanceof ASTWithName && !(expression instanceof SafePropertyRead))
+      expression instanceof Binary &&
+      expression.operation === '=' &&
+      expression.left instanceof PropertyRead
     ) {
+      withSpan = expression.left.nameSpan;
+    } else if (expression instanceof ASTWithName && !(expression instanceof SafePropertyRead)) {
       withSpan = expression.nameSpan;
     }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/template_semantics/src/template_semantics_checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/template_semantics/src/template_semantics_checker.ts
@@ -12,7 +12,7 @@ import {
   ImplicitReceiver,
   ParsedEventType,
   PropertyRead,
-  PropertyWrite,
+  Binary,
   RecursiveAstVisitor,
   TmplAstBoundEvent,
   TmplAstLetDeclaration,
@@ -76,9 +76,12 @@ class ExpressionsSemanticsVisitor extends RecursiveAstVisitor {
     super();
   }
 
-  override visitPropertyWrite(ast: PropertyWrite, context: TmplAstNode): void {
-    super.visitPropertyWrite(ast, context);
-    this.checkForIllegalWriteInEventBinding(ast, context);
+  override visitBinary(ast: Binary, context: TmplAstNode): void {
+    if (ast.operation === '=' && ast.left instanceof PropertyRead) {
+      this.checkForIllegalWriteInEventBinding(ast.left, context);
+    } else {
+      super.visitBinary(ast, context);
+    }
   }
 
   override visitPropertyRead(ast: PropertyRead, context: TmplAstNode) {
@@ -86,7 +89,7 @@ class ExpressionsSemanticsVisitor extends RecursiveAstVisitor {
     this.checkForIllegalWriteInTwoWayBinding(ast, context);
   }
 
-  private checkForIllegalWriteInEventBinding(ast: PropertyWrite, context: TmplAstNode) {
+  private checkForIllegalWriteInEventBinding(ast: PropertyRead, context: TmplAstNode) {
     if (!(context instanceof TmplAstBoundEvent) || !(ast.receiver instanceof ImplicitReceiver)) {
       return;
     }

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
@@ -113,14 +113,14 @@ describe('type check blocks diagnostics', () => {
     it('should annotate property writes', () => {
       const TEMPLATE = `<div (click)='a.b.c = d'></div>`;
       expect(tcbWithSpans(TEMPLATE)).toContain(
-        '(((((((this).a /*14,15*/) /*14,15*/).b /*16,17*/) /*14,17*/).c /*18,19*/) /*14,23*/ = (((this).d /*22,23*/) /*22,23*/)) /*14,23*/',
+        '(((((((this).a /*14,15*/) /*14,15*/).b /*16,17*/) /*14,17*/).c /*18,19*/) /*14,21*/) = (((this).d /*22,23*/) /*22,23*/) /*14,23*/;',
       );
     });
 
     it('should $event property writes', () => {
       const TEMPLATE = `<div (click)='a = $event'></div>`;
       expect(tcbWithSpans(TEMPLATE)).toContain(
-        '(((this).a /*14,15*/) /*14,24*/ = ($event /*18,24*/)) /*14,24*/;',
+        '(((this).a /*14,15*/) /*14,17*/) = ($event /*18,24*/) /*14,24*/;',
       );
     });
 
@@ -134,7 +134,7 @@ describe('type check blocks diagnostics', () => {
     it('should annotate keyed property writes', () => {
       const TEMPLATE = `<div (click)="a[b] = c"></div>`;
       expect(tcbWithSpans(TEMPLATE)).toContain(
-        '((((this).a /*14,15*/) /*14,15*/)[((this).b /*16,17*/) /*16,17*/] = (((this).c /*21,22*/) /*21,22*/)) /*14,22*/',
+        '((((this).a /*14,15*/) /*14,15*/)[((this).b /*16,17*/) /*16,17*/] /*14,20*/) = (((this).c /*21,22*/) /*21,22*/) /*14,22*/;',
       );
     });
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -7,13 +7,13 @@
  */
 
 import {
+  AST,
   BindingPipe,
   CssSelector,
   ParseSourceFile,
   parseTemplate,
   ParseTemplateOptions,
   PropertyRead,
-  PropertyWrite,
   R3TargetBinder,
   SelectorlessMatcher,
   SelectorMatcher,
@@ -1027,11 +1027,7 @@ export class NoopOobRecorder implements OutOfBandDiagnosticRecorder {
   illegalForLoopTrackAccess(): void {}
   inaccessibleDeferredTriggerElement(): void {}
   controlFlowPreventingContentProjection(): void {}
-  illegalWriteToLetDeclaration(
-    id: TypeCheckId,
-    node: PropertyWrite,
-    target: TmplAstLetDeclaration,
-  ): void {}
+  illegalWriteToLetDeclaration(id: TypeCheckId, node: AST, target: TmplAstLetDeclaration): void {}
   letUsedBeforeDefinition(
     id: TypeCheckId,
     node: PropertyRead,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/implicit_receiver_keyed_write_inside_template_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/implicit_receiver_keyed_write_inside_template_template.js
@@ -5,7 +5,7 @@ function MyComponent_ng_template_0_Template(rf, $ctx$) {
     $i0$.ɵɵlistener("click", function MyComponent_ng_template_0_Template_button_click_0_listener() {
       $i0$.ɵɵrestoreView($_r3$);
       const $ctx_2$ = $i0$.ɵɵnextContext();
-      return $i0$.ɵɵresetView(($ctx_2$["mes" + "sage"] = "hello"));
+      return $i0$.ɵɵresetView($ctx_2$["mes" + "sage"] = "hello");
     });
     $i0$.ɵɵtext(1, "Click me");
     $i0$.ɵɵelementEnd();

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -116,9 +116,6 @@ export {
   UnaryOperatorExpr,
   VoidExpr,
   WrappedNodeExpr,
-  WriteKeyExpr,
-  WritePropExpr,
-  WriteVarExpr,
 } from './output/output_ast';
 export {JitEvaluator} from './output/output_jit';
 export {SourceMap} from './output/source_map';

--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -129,22 +129,6 @@ export class PropertyRead extends ASTWithName {
   }
 }
 
-export class PropertyWrite extends ASTWithName {
-  constructor(
-    span: ParseSpan,
-    sourceSpan: AbsoluteSourceSpan,
-    nameSpan: AbsoluteSourceSpan,
-    public receiver: AST,
-    public name: string,
-    public value: AST,
-  ) {
-    super(span, sourceSpan, nameSpan);
-  }
-  override visit(visitor: AstVisitor, context: any = null): any {
-    return visitor.visitPropertyWrite(this, context);
-  }
-}
-
 export class SafePropertyRead extends ASTWithName {
   constructor(
     span: ParseSpan,
@@ -185,21 +169,6 @@ export class SafeKeyedRead extends AST {
   }
   override visit(visitor: AstVisitor, context: any = null): any {
     return visitor.visitSafeKeyedRead(this, context);
-  }
-}
-
-export class KeyedWrite extends AST {
-  constructor(
-    span: ParseSpan,
-    sourceSpan: AbsoluteSourceSpan,
-    public receiver: AST,
-    public key: AST,
-    public value: AST,
-  ) {
-    super(span, sourceSpan);
-  }
-  override visit(visitor: AstVisitor, context: any = null): any {
-    return visitor.visitKeyedWrite(this, context);
   }
 }
 
@@ -628,7 +597,6 @@ export interface AstVisitor {
   visitImplicitReceiver(ast: ImplicitReceiver, context: any): any;
   visitInterpolation(ast: Interpolation, context: any): any;
   visitKeyedRead(ast: KeyedRead, context: any): any;
-  visitKeyedWrite(ast: KeyedWrite, context: any): any;
   visitLiteralArray(ast: LiteralArray, context: any): any;
   visitLiteralMap(ast: LiteralMap, context: any): any;
   visitLiteralPrimitive(ast: LiteralPrimitive, context: any): any;
@@ -638,7 +606,6 @@ export interface AstVisitor {
   visitVoidExpression(ast: TypeofExpression, context: any): any;
   visitNonNullAssert(ast: NonNullAssert, context: any): any;
   visitPropertyRead(ast: PropertyRead, context: any): any;
-  visitPropertyWrite(ast: PropertyWrite, context: any): any;
   visitSafePropertyRead(ast: SafePropertyRead, context: any): any;
   visitSafeKeyedRead(ast: SafeKeyedRead, context: any): any;
   visitCall(ast: Call, context: any): any;
@@ -692,11 +659,6 @@ export class RecursiveAstVisitor implements AstVisitor {
     this.visit(ast.receiver, context);
     this.visit(ast.key, context);
   }
-  visitKeyedWrite(ast: KeyedWrite, context: any): any {
-    this.visit(ast.receiver, context);
-    this.visit(ast.key, context);
-    this.visit(ast.value, context);
-  }
   visitLiteralArray(ast: LiteralArray, context: any): any {
     this.visitAll(ast.expressions, context);
   }
@@ -718,10 +680,6 @@ export class RecursiveAstVisitor implements AstVisitor {
   }
   visitPropertyRead(ast: PropertyRead, context: any): any {
     this.visit(ast.receiver, context);
-  }
-  visitPropertyWrite(ast: PropertyWrite, context: any): any {
-    this.visit(ast.receiver, context);
-    this.visit(ast.value, context);
   }
   visitSafePropertyRead(ast: SafePropertyRead, context: any): any {
     this.visit(ast.receiver, context);

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -29,7 +29,6 @@ import {
   ImplicitReceiver,
   Interpolation,
   KeyedRead,
-  KeyedWrite,
   LiteralArray,
   LiteralMap,
   LiteralMapKey,
@@ -40,7 +39,6 @@ import {
   ParseSpan,
   PrefixNot,
   PropertyRead,
-  PropertyWrite,
   RecursiveAstVisitor,
   SafeCall,
   SafeKeyedRead,
@@ -1209,14 +1207,13 @@ class _ParseAST {
       return id;
     });
     const nameSpan = this.sourceSpan(nameStart);
-    let receiver: AST;
 
     if (isSafe) {
       if (this.consumeOptionalOperator('=')) {
         this.error("The '?.' operator cannot be used in the assignment");
-        receiver = new EmptyExpr(this.span(start), this.sourceSpan(start));
+        return new EmptyExpr(this.span(start), this.sourceSpan(start));
       } else {
-        receiver = new SafePropertyRead(
+        return new SafePropertyRead(
           this.span(start),
           this.sourceSpan(start),
           nameSpan,
@@ -1230,18 +1227,17 @@ class _ParseAST {
           this.error('Bindings cannot contain assignments');
           return new EmptyExpr(this.span(start), this.sourceSpan(start));
         }
-
-        const value = this.parseConditional();
-        receiver = new PropertyWrite(
+        const receiver = new PropertyRead(
           this.span(start),
           this.sourceSpan(start),
           nameSpan,
           readReceiver,
           id,
-          value,
         );
+        const value = this.parseConditional();
+        return new Binary(this.span(start), this.sourceSpan(start), '=', receiver, value);
       } else {
-        receiver = new PropertyRead(
+        return new PropertyRead(
           this.span(start),
           this.sourceSpan(start),
           nameSpan,
@@ -1250,8 +1246,6 @@ class _ParseAST {
         );
       }
     }
-
-    return receiver;
   }
 
   private parseCall(receiver: AST, start: number, isSafe: boolean): AST {
@@ -1370,8 +1364,14 @@ class _ParseAST {
         if (isSafe) {
           this.error("The '?.' operator cannot be used in the assignment");
         } else {
+          const binaryReceiver = new KeyedRead(
+            this.span(start),
+            this.sourceSpan(start),
+            receiver,
+            key,
+          );
           const value = this.parseConditional();
-          return new KeyedWrite(this.span(start), this.sourceSpan(start), receiver, key, value);
+          return new Binary(this.span(start), this.sourceSpan(start), '=', binaryReceiver, value);
         }
       } else {
         return isSafe

--- a/packages/compiler/src/expression_parser/serializer.ts
+++ b/packages/compiler/src/expression_parser/serializer.ts
@@ -52,13 +52,6 @@ class SerializeExpressionVisitor implements expr.AstVisitor {
     return `${ast.receiver.visit(this, context)}[${ast.key.visit(this, context)}]`;
   }
 
-  visitKeyedWrite(ast: expr.KeyedWrite, context: any): string {
-    return `${ast.receiver.visit(this, context)}[${ast.key.visit(
-      this,
-      context,
-    )}] = ${ast.value.visit(this, context)}`;
-  }
-
   visitLiteralArray(ast: expr.LiteralArray, context: any): string {
     return `[${ast.expressions.map((e) => e.visit(this, context)).join(', ')}]`;
   }
@@ -105,14 +98,6 @@ class SerializeExpressionVisitor implements expr.AstVisitor {
       return ast.name;
     } else {
       return `${ast.receiver.visit(this, context)}.${ast.name}`;
-    }
-  }
-
-  visitPropertyWrite(ast: expr.PropertyWrite, context: any): string {
-    if (ast.receiver instanceof expr.ImplicitReceiver) {
-      return `${ast.name} = ${ast.value.visit(this, context)}`;
-    } else {
-      return `${ast.receiver.visit(this, context)}.${ast.name} = ${ast.value.visit(this, context)}`;
     }
   }
 

--- a/packages/compiler/src/output/abstract_emitter.ts
+++ b/packages/compiler/src/output/abstract_emitter.ts
@@ -247,47 +247,6 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
 
   abstract visitDeclareVarStmt(stmt: o.DeclareVarStmt, ctx: EmitterVisitorContext): any;
 
-  visitWriteVarExpr(expr: o.WriteVarExpr, ctx: EmitterVisitorContext): any {
-    const lineWasEmpty = ctx.lineIsEmpty();
-    if (!lineWasEmpty) {
-      ctx.print(expr, '(');
-    }
-    ctx.print(expr, `${expr.name} = `);
-    expr.value.visitExpression(this, ctx);
-    if (!lineWasEmpty) {
-      ctx.print(expr, ')');
-    }
-    return null;
-  }
-  visitWriteKeyExpr(expr: o.WriteKeyExpr, ctx: EmitterVisitorContext): any {
-    const lineWasEmpty = ctx.lineIsEmpty();
-    if (!lineWasEmpty) {
-      ctx.print(expr, '(');
-    }
-    expr.receiver.visitExpression(this, ctx);
-    ctx.print(expr, `[`);
-    expr.index.visitExpression(this, ctx);
-    ctx.print(expr, `] = `);
-    expr.value.visitExpression(this, ctx);
-    if (!lineWasEmpty) {
-      ctx.print(expr, ')');
-    }
-    return null;
-  }
-  visitWritePropExpr(expr: o.WritePropExpr, ctx: EmitterVisitorContext): any {
-    const lineWasEmpty = ctx.lineIsEmpty();
-    if (!lineWasEmpty) {
-      ctx.print(expr, '(');
-    }
-    expr.receiver.visitExpression(this, ctx);
-    ctx.print(expr, `.${expr.name} = `);
-    expr.value.visitExpression(this, ctx);
-    if (!lineWasEmpty) {
-      ctx.print(expr, ')');
-    }
-    return null;
-  }
-
   visitInvokeFunctionExpr(expr: o.InvokeFunctionExpr, ctx: EmitterVisitorContext): any {
     const shouldParenthesize = expr.fn instanceof o.ArrowFunctionExpr;
 
@@ -422,6 +381,9 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
   visitBinaryOperatorExpr(ast: o.BinaryOperatorExpr, ctx: EmitterVisitorContext): any {
     let opStr: string;
     switch (ast.operator) {
+      case o.BinaryOperator.Assign:
+        opStr = '=';
+        break;
       case o.BinaryOperator.Equals:
         opStr = '==';
         break;

--- a/packages/compiler/src/output/output_ast.ts
+++ b/packages/compiler/src/output/output_ast.ts
@@ -124,6 +124,7 @@ export enum UnaryOperator {
 export enum BinaryOperator {
   Equals,
   NotEquals,
+  Assign,
   Identical,
   NotIdentical,
   Minus,
@@ -329,8 +330,8 @@ export class ReadVarExpr extends Expression {
     return new ReadVarExpr(this.name, this.type, this.sourceSpan);
   }
 
-  set(value: Expression): WriteVarExpr {
-    return new WriteVarExpr(this.name, value, null, this.sourceSpan);
+  set(value: Expression): BinaryOperatorExpr {
+    return new BinaryOperatorExpr(BinaryOperator.Assign, this, value, null, this.sourceSpan);
   }
 }
 
@@ -409,125 +410,6 @@ export class WrappedNodeExpr<T> extends Expression {
 
   override clone(): WrappedNodeExpr<T> {
     return new WrappedNodeExpr(this.node, this.type, this.sourceSpan);
-  }
-}
-
-export class WriteVarExpr extends Expression {
-  public value: Expression;
-  constructor(
-    public name: string,
-    value: Expression,
-    type?: Type | null,
-    sourceSpan?: ParseSourceSpan | null,
-  ) {
-    super(type || value.type, sourceSpan);
-    this.value = value;
-  }
-
-  override isEquivalent(e: Expression): boolean {
-    return e instanceof WriteVarExpr && this.name === e.name && this.value.isEquivalent(e.value);
-  }
-
-  override isConstant() {
-    return false;
-  }
-
-  override visitExpression(visitor: ExpressionVisitor, context: any): any {
-    return visitor.visitWriteVarExpr(this, context);
-  }
-
-  override clone(): WriteVarExpr {
-    return new WriteVarExpr(this.name, this.value.clone(), this.type, this.sourceSpan);
-  }
-
-  toDeclStmt(type?: Type | null, modifiers?: StmtModifier): DeclareVarStmt {
-    return new DeclareVarStmt(this.name, this.value, type, modifiers, this.sourceSpan);
-  }
-
-  toConstDecl(): DeclareVarStmt {
-    return this.toDeclStmt(INFERRED_TYPE, StmtModifier.Final);
-  }
-}
-
-export class WriteKeyExpr extends Expression {
-  public value: Expression;
-  constructor(
-    public receiver: Expression,
-    public index: Expression,
-    value: Expression,
-    type?: Type | null,
-    sourceSpan?: ParseSourceSpan | null,
-  ) {
-    super(type || value.type, sourceSpan);
-    this.value = value;
-  }
-
-  override isEquivalent(e: Expression): boolean {
-    return (
-      e instanceof WriteKeyExpr &&
-      this.receiver.isEquivalent(e.receiver) &&
-      this.index.isEquivalent(e.index) &&
-      this.value.isEquivalent(e.value)
-    );
-  }
-
-  override isConstant() {
-    return false;
-  }
-
-  override visitExpression(visitor: ExpressionVisitor, context: any): any {
-    return visitor.visitWriteKeyExpr(this, context);
-  }
-
-  override clone(): WriteKeyExpr {
-    return new WriteKeyExpr(
-      this.receiver.clone(),
-      this.index.clone(),
-      this.value.clone(),
-      this.type,
-      this.sourceSpan,
-    );
-  }
-}
-
-export class WritePropExpr extends Expression {
-  public value: Expression;
-  constructor(
-    public receiver: Expression,
-    public name: string,
-    value: Expression,
-    type?: Type | null,
-    sourceSpan?: ParseSourceSpan | null,
-  ) {
-    super(type || value.type, sourceSpan);
-    this.value = value;
-  }
-
-  override isEquivalent(e: Expression): boolean {
-    return (
-      e instanceof WritePropExpr &&
-      this.receiver.isEquivalent(e.receiver) &&
-      this.name === e.name &&
-      this.value.isEquivalent(e.value)
-    );
-  }
-
-  override isConstant() {
-    return false;
-  }
-
-  override visitExpression(visitor: ExpressionVisitor, context: any): any {
-    return visitor.visitWritePropExpr(this, context);
-  }
-
-  override clone(): WritePropExpr {
-    return new WritePropExpr(
-      this.receiver.clone(),
-      this.name,
-      this.value.clone(),
-      this.type,
-      this.sourceSpan,
-    );
   }
 }
 
@@ -1313,8 +1195,14 @@ export class ReadPropExpr extends Expression {
     return visitor.visitReadPropExpr(this, context);
   }
 
-  set(value: Expression): WritePropExpr {
-    return new WritePropExpr(this.receiver, this.name, value, null, this.sourceSpan);
+  set(value: Expression): BinaryOperatorExpr {
+    return new BinaryOperatorExpr(
+      BinaryOperator.Assign,
+      this.receiver.prop(this.name),
+      value,
+      null,
+      this.sourceSpan,
+    );
   }
 
   override clone(): ReadPropExpr {
@@ -1348,8 +1236,14 @@ export class ReadKeyExpr extends Expression {
     return visitor.visitReadKeyExpr(this, context);
   }
 
-  set(value: Expression): WriteKeyExpr {
-    return new WriteKeyExpr(this.receiver, this.index, value, null, this.sourceSpan);
+  set(value: Expression): BinaryOperatorExpr {
+    return new BinaryOperatorExpr(
+      BinaryOperator.Assign,
+      this.receiver.key(this.index),
+      value,
+      null,
+      this.sourceSpan,
+    );
   }
 
   override clone(): ReadKeyExpr {
@@ -1457,9 +1351,6 @@ export class CommaExpr extends Expression {
 
 export interface ExpressionVisitor {
   visitReadVarExpr(ast: ReadVarExpr, context: any): any;
-  visitWriteVarExpr(expr: WriteVarExpr, context: any): any;
-  visitWriteKeyExpr(expr: WriteKeyExpr, context: any): any;
-  visitWritePropExpr(expr: WritePropExpr, context: any): any;
   visitInvokeFunctionExpr(ast: InvokeFunctionExpr, context: any): any;
   visitTaggedTemplateLiteralExpr(ast: TaggedTemplateLiteralExpr, context: any): any;
   visitTemplateLiteralExpr(ast: TemplateLiteralExpr, context: any): any;
@@ -1688,21 +1579,6 @@ export class RecursiveAstVisitor implements StatementVisitor, ExpressionVisitor 
     return ast;
   }
   visitReadVarExpr(ast: ReadVarExpr, context: any): any {
-    return this.visitExpression(ast, context);
-  }
-  visitWriteVarExpr(ast: WriteVarExpr, context: any): any {
-    ast.value.visitExpression(this, context);
-    return this.visitExpression(ast, context);
-  }
-  visitWriteKeyExpr(ast: WriteKeyExpr, context: any): any {
-    ast.receiver.visitExpression(this, context);
-    ast.index.visitExpression(this, context);
-    ast.value.visitExpression(this, context);
-    return this.visitExpression(ast, context);
-  }
-  visitWritePropExpr(ast: WritePropExpr, context: any): any {
-    ast.receiver.visitExpression(this, context);
-    ast.value.visitExpression(this, context);
     return this.visitExpression(ast, context);
   }
   visitDynamicImportExpr(ast: DynamicImportExpr, context: any) {

--- a/packages/compiler/src/render3/r3_factory.ts
+++ b/packages/compiler/src/render3/r3_factory.ts
@@ -133,7 +133,7 @@ export function compileFactoryFunction(meta: R3FactoryMetadata): R3CompiledExpre
 
   function makeConditionalFactory(nonCtorExpr: o.Expression): o.ReadVarExpr {
     const r = o.variable('__ngConditionalFactory__');
-    body.push(r.set(o.NULL_EXPR).toDeclStmt());
+    body.push(new o.DeclareVarStmt(r.name, o.NULL_EXPR, o.INFERRED_TYPE));
     const ctorStmt =
       ctorExpr !== null
         ? r.set(ctorExpr).toStmt()

--- a/packages/compiler/src/render3/view/i18n/get_msg_utils.ts
+++ b/packages/compiler/src/render3/view/i18n/get_msg_utils.ts
@@ -98,7 +98,12 @@ export function createGoogleGetMsgStatements(
   //  */
   // const MSG_... = goog.getMsg(..);
   // I18N_X = MSG_...;
-  const googGetMsgStmt = closureVar.set(o.variable(GOOG_GET_MSG).callFn(args)).toConstDecl();
+  const googGetMsgStmt = new o.DeclareVarStmt(
+    closureVar.name,
+    o.variable(GOOG_GET_MSG).callFn(args),
+    o.INFERRED_TYPE,
+    o.StmtModifier.Final,
+  );
   googGetMsgStmt.addLeadingComment(i18nMetaToJSDoc(message));
   const i18nAssignmentStmt = new o.ExpressionStatement(variable.set(closureVar));
   return [googGetMsgStmt, i18nAssignmentStmt];

--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -11,7 +11,6 @@ import {
   BindingPipe,
   ImplicitReceiver,
   PropertyRead,
-  PropertyWrite,
   SafePropertyRead,
   ThisReceiver,
 } from '../../expression_parser/ast';
@@ -985,11 +984,6 @@ class TemplateBinder extends CombinedRecursiveAstVisitor {
     return super.visitSafePropertyRead(ast, context);
   }
 
-  override visitPropertyWrite(ast: PropertyWrite, context: any): any {
-    this.maybeMap(ast, ast.name);
-    return super.visitPropertyWrite(ast, context);
-  }
-
   private ingestScopedNode(node: ScopedNode) {
     const childScope = this.scope.getChildScope(node);
     const binder = new TemplateBinder(
@@ -1006,7 +1000,7 @@ class TemplateBinder extends CombinedRecursiveAstVisitor {
     binder.ingest(node);
   }
 
-  private maybeMap(ast: PropertyRead | SafePropertyRead | PropertyWrite, name: string): void {
+  private maybeMap(ast: PropertyRead | SafePropertyRead, name: string): void {
     // If the receiver of the expression isn't the `ImplicitReceiver`, this isn't the root of an
     // `AST` expression that maps to a `Variable` or `Reference`.
     if (!(ast.receiver instanceof ImplicitReceiver) || ast.receiver instanceof ThisReceiver) {

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -1259,13 +1259,6 @@ export function transformExpressionsInExpression(
   } else if (expr instanceof o.ReadKeyExpr) {
     expr.receiver = transformExpressionsInExpression(expr.receiver, transform, flags);
     expr.index = transformExpressionsInExpression(expr.index, transform, flags);
-  } else if (expr instanceof o.WritePropExpr) {
-    expr.receiver = transformExpressionsInExpression(expr.receiver, transform, flags);
-    expr.value = transformExpressionsInExpression(expr.value, transform, flags);
-  } else if (expr instanceof o.WriteKeyExpr) {
-    expr.receiver = transformExpressionsInExpression(expr.receiver, transform, flags);
-    expr.index = transformExpressionsInExpression(expr.index, transform, flags);
-    expr.value = transformExpressionsInExpression(expr.value, transform, flags);
   } else if (expr instanceof o.InvokeFunctionExpr) {
     expr.fn = transformExpressionsInExpression(expr.fn, transform, flags);
     for (let i = 0; i < expr.args.length; i++) {
@@ -1293,8 +1286,6 @@ export function transformExpressionsInExpression(
     expr.expr = transformExpressionsInExpression(expr.expr, transform, flags);
   } else if (expr instanceof o.VoidExpr) {
     expr.expr = transformExpressionsInExpression(expr.expr, transform, flags);
-  } else if (expr instanceof o.WriteVarExpr) {
-    expr.value = transformExpressionsInExpression(expr.value, transform, flags);
   } else if (expr instanceof o.LocalizedString) {
     for (let i = 0; i < expr.expressions.length; i++) {
       expr.expressions[i] = transformExpressionsInExpression(expr.expressions[i], transform, flags);

--- a/packages/compiler/src/template/pipeline/src/conversion.ts
+++ b/packages/compiler/src/template/pipeline/src/conversion.ts
@@ -16,6 +16,7 @@ export const BINARY_OPERATORS = new Map([
   ['|', o.BinaryOperator.BitwiseOr],
   ['&', o.BinaryOperator.BitwiseAnd],
   ['/', o.BinaryOperator.Divide],
+  ['=', o.BinaryOperator.Assign],
   ['==', o.BinaryOperator.Equals],
   ['===', o.BinaryOperator.Identical],
   ['<', o.BinaryOperator.Lower],

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -1037,32 +1037,6 @@ function convertAst(
         convertSourceSpan(ast.span, baseSourceSpan),
       );
     }
-  } else if (ast instanceof e.PropertyWrite) {
-    if (ast.receiver instanceof e.ImplicitReceiver) {
-      return new o.WritePropExpr(
-        // TODO: Is it correct to always use the root context in place of the implicit receiver?
-        new ir.ContextExpr(job.root.xref),
-        ast.name,
-        convertAst(ast.value, job, baseSourceSpan),
-        null,
-        convertSourceSpan(ast.span, baseSourceSpan),
-      );
-    }
-    return new o.WritePropExpr(
-      convertAst(ast.receiver, job, baseSourceSpan),
-      ast.name,
-      convertAst(ast.value, job, baseSourceSpan),
-      undefined,
-      convertSourceSpan(ast.span, baseSourceSpan),
-    );
-  } else if (ast instanceof e.KeyedWrite) {
-    return new o.WriteKeyExpr(
-      convertAst(ast.receiver, job, baseSourceSpan),
-      convertAst(ast.key, job, baseSourceSpan),
-      convertAst(ast.value, job, baseSourceSpan),
-      undefined,
-      convertSourceSpan(ast.span, baseSourceSpan),
-    );
   } else if (ast instanceof e.Call) {
     if (ast.receiver instanceof e.ImplicitReceiver) {
       throw new Error(`Unexpected ImplicitReceiver`);

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -532,13 +532,13 @@ describe('parser', () => {
     it('should record property write span', () => {
       const ast = parseAction('a = b');
       expect(unparseWithSpan(ast)).toContain(['a = b', 'a = b']);
-      expect(unparseWithSpan(ast)).toContain(['a = b', '[nameSpan] a']);
+      expect(unparseWithSpan(ast)).toContain(['a', '[nameSpan] a']);
     });
 
     it('should record accessed property write span', () => {
       const ast = parseAction('a.b = c');
       expect(unparseWithSpan(ast)).toContain(['a.b = c', 'a.b = c']);
-      expect(unparseWithSpan(ast)).toContain(['a.b = c', '[nameSpan] b']);
+      expect(unparseWithSpan(ast)).toContain(['a.b', '[nameSpan] b']);
     });
 
     it('should record spans for untagged template literals with no interpolations', () => {

--- a/packages/compiler/test/expression_parser/utils/unparser.ts
+++ b/packages/compiler/test/expression_parser/utils/unparser.ts
@@ -18,7 +18,6 @@ import {
   ImplicitReceiver,
   Interpolation,
   KeyedRead,
-  KeyedWrite,
   LiteralArray,
   LiteralMap,
   LiteralPrimitive,
@@ -26,7 +25,6 @@ import {
   ParenthesizedExpression,
   PrefixNot,
   PropertyRead,
-  PropertyWrite,
   RecursiveAstVisitor,
   SafeCall,
   SafeKeyedRead,
@@ -57,13 +55,6 @@ class Unparser implements AstVisitor {
   visitPropertyRead(ast: PropertyRead, context: any) {
     this._visit(ast.receiver);
     this._expression += ast.receiver instanceof ImplicitReceiver ? `${ast.name}` : `.${ast.name}`;
-  }
-
-  visitPropertyWrite(ast: PropertyWrite, context: any) {
-    this._visit(ast.receiver);
-    this._expression +=
-      ast.receiver instanceof ImplicitReceiver ? `${ast.name} = ` : `.${ast.name} = `;
-    this._visit(ast.value);
   }
 
   visitUnary(ast: Unary, context: any) {
@@ -148,14 +139,6 @@ class Unparser implements AstVisitor {
     this._expression += '[';
     this._visit(ast.key);
     this._expression += ']';
-  }
-
-  visitKeyedWrite(ast: KeyedWrite, context: any) {
-    this._visit(ast.receiver);
-    this._expression += '[';
-    this._visit(ast.key);
-    this._expression += '] = ';
-    this._visit(ast.value);
   }
 
   visitLiteralArray(ast: LiteralArray, context: any) {

--- a/packages/compiler/test/expression_parser/utils/validator.ts
+++ b/packages/compiler/test/expression_parser/utils/validator.ts
@@ -16,7 +16,6 @@ import {
   ImplicitReceiver,
   Interpolation,
   KeyedRead,
-  KeyedWrite,
   LiteralArray,
   LiteralMap,
   LiteralPrimitive,
@@ -24,7 +23,6 @@ import {
   ParseSpan,
   PrefixNot,
   PropertyRead,
-  PropertyWrite,
   RecursiveAstVisitor,
   SafeCall,
   SafeKeyedRead,
@@ -94,10 +92,6 @@ class ASTValidator extends RecursiveAstVisitor {
     this.validate(ast, () => super.visitKeyedRead(ast, context));
   }
 
-  override visitKeyedWrite(ast: KeyedWrite, context: any): any {
-    this.validate(ast, () => super.visitKeyedWrite(ast, context));
-  }
-
   override visitLiteralArray(ast: LiteralArray, context: any): any {
     this.validate(ast, () => super.visitLiteralArray(ast, context));
   }
@@ -128,10 +122,6 @@ class ASTValidator extends RecursiveAstVisitor {
 
   override visitPropertyRead(ast: PropertyRead, context: any): any {
     this.validate(ast, () => super.visitPropertyRead(ast, context));
-  }
-
-  override visitPropertyWrite(ast: PropertyWrite, context: any): any {
-    this.validate(ast, () => super.visitPropertyWrite(ast, context));
   }
 
   override visitSafePropertyRead(ast: SafePropertyRead, context: any): any {

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -59,10 +59,6 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
     this.recordAst(ast);
     super.visitKeyedRead(ast, null);
   }
-  override visitKeyedWrite(ast: e.KeyedWrite) {
-    this.recordAst(ast);
-    super.visitKeyedWrite(ast, null);
-  }
   override visitLiteralPrimitive(ast: e.LiteralPrimitive) {
     this.recordAst(ast);
     super.visitLiteralPrimitive(ast, null);
@@ -98,10 +94,6 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
   override visitPropertyRead(ast: e.PropertyRead) {
     this.recordAst(ast);
     super.visitPropertyRead(ast, null);
-  }
-  override visitPropertyWrite(ast: e.PropertyWrite) {
-    this.recordAst(ast);
-    super.visitPropertyWrite(ast, null);
   }
   override visitSafePropertyRead(ast: e.SafePropertyRead) {
     this.recordAst(ast);

--- a/packages/core/schematics/migrations/signal-migration/src/passes/7_migrate_template_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/7_migrate_template_references.ts
@@ -30,8 +30,17 @@ export function pass7__migrateTemplateReferences<D extends ClassFieldDescriptor>
       continue;
     }
 
+    const parent = reference.from.readAstPath.at(-2);
+    let readEndPos: number;
+
+    if (reference.from.isWrite && parent) {
+      readEndPos = parent.sourceSpan.end;
+    } else {
+      readEndPos = reference.from.read.sourceSpan.end;
+    }
+
     // Skip duplicate references. E.g. if a template is shared.
-    const fileReferenceId = `${reference.from.templateFile.id}:${reference.from.read.sourceSpan.end}`;
+    const fileReferenceId = `${reference.from.templateFile.id}:${readEndPos}`;
     if (seenFileReferences.has(fileReferenceId)) {
       continue;
     }
@@ -46,8 +55,8 @@ export function pass7__migrateTemplateReferences<D extends ClassFieldDescriptor>
       new Replacement(
         reference.from.templateFile,
         new TextUpdate({
-          position: reference.from.read.sourceSpan.end,
-          end: reference.from.read.sourceSpan.end,
+          position: readEndPos,
+          end: readEndPos,
           toInsert: appendText,
         }),
       ),

--- a/packages/core/schematics/migrations/signal-migration/src/passes/8_migrate_host_bindings.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/8_migrate_host_bindings.ts
@@ -35,7 +35,14 @@ export function pass8__migrateHostBindings<D extends ClassFieldDescriptor>(
 
     const bindingField = reference.from.hostPropertyNode;
     const expressionOffset = bindingField.getStart() + 1; // account for quotes.
-    const readEndPos = expressionOffset + reference.from.read.sourceSpan.end;
+    const parent = reference.from.readAstPath.at(-2);
+    let readEndPos: number;
+
+    if (reference.from.isWrite && parent) {
+      readEndPos = expressionOffset + parent.sourceSpan.end;
+    } else {
+      readEndPos = expressionOffset + reference.from.read.sourceSpan.end;
+    }
 
     // Skip duplicate references. Can happen if the host object is shared.
     if (seenReferences.get(bindingField)?.has(readEndPos)) {

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -17,7 +17,6 @@ import {
   ParsedEventType,
   ParseSourceSpan,
   PropertyRead,
-  PropertyWrite,
   SafePropertyRead,
   TmplAstBoundAttribute,
   TmplAstBoundEvent,
@@ -68,7 +67,7 @@ import {
 import {filterAliasImports, isBoundEventWithSyntheticHandler, isWithin} from './utils';
 
 type PropertyExpressionCompletionBuilder = CompletionBuilder<
-  PropertyRead | PropertyWrite | EmptyExpr | SafePropertyRead | TmplAstBoundEvent
+  PropertyRead | EmptyExpr | SafePropertyRead | TmplAstBoundEvent
 >;
 
 type ElementAttributeCompletionBuilder = CompletionBuilder<
@@ -351,7 +350,6 @@ export class CompletionBuilder<N extends TmplAstNode | AST> {
     return (
       this.node instanceof PropertyRead ||
       this.node instanceof SafePropertyRead ||
-      this.node instanceof PropertyWrite ||
       this.node instanceof EmptyExpr ||
       // BoundEvent nodes only count as property completions if in an EventValue context.
       (this.node instanceof BoundEvent && this.nodeContext === CompletionNodeContext.EventValue)
@@ -1231,7 +1229,6 @@ function makeReplacementSpanFromParseSourceSpan(span: ParseSourceSpan): ts.TextS
 function makeReplacementSpanFromAst(
   node:
     | PropertyRead
-    | PropertyWrite
     | SafePropertyRead
     | BindingPipe
     | EmptyExpr

--- a/packages/language-service/src/references_and_rename_utils.ts
+++ b/packages/language-service/src/references_and_rename_utils.ts
@@ -7,10 +7,10 @@
  */
 import {
   AST,
+  Binary,
   BindingPipe,
   LiteralPrimitive,
   PropertyRead,
-  PropertyWrite,
   SafePropertyRead,
   TmplAstBoundAttribute,
   TmplAstBoundEvent,
@@ -375,11 +375,16 @@ export function getRenameTextAndSpanAtPosition(
     }
   } else if (
     node instanceof PropertyRead ||
-    node instanceof PropertyWrite ||
     node instanceof SafePropertyRead ||
     node instanceof BindingPipe
   ) {
     return {text: node.name, span: toTextSpan(node.nameSpan)};
+  } else if (
+    node instanceof Binary &&
+    node.operation === '=' &&
+    node.left instanceof PropertyRead
+  ) {
+    return getRenameTextAndSpanAtPosition(node.left, position);
   } else if (node instanceof LiteralPrimitive) {
     const span = toTextSpan(node.sourceSpan);
     const text = node.value;

--- a/packages/language-service/src/template_target.ts
+++ b/packages/language-service/src/template_target.ts
@@ -556,7 +556,7 @@ class TemplateTargetVisitor implements TmplAstVisitor {
     // We allow the path to contain both the `TmplAstBoundAttribute` and `TmplAstBoundEvent` for
     // two-way bindings but do not want the path to contain both the `TmplAstBoundAttribute` with
     // its children when the position is in the value span because we would then logically create a
-    // path that also contains the `PropertyWrite` from the `TmplAstBoundEvent`. This early return
+    // path that also contains the write from the `TmplAstBoundEvent`. This early return
     // condition ensures we target just `TmplAstBoundAttribute` for this case and exclude
     // `TmplAstBoundEvent` children.
     if (

--- a/packages/language-service/src/utils/index.ts
+++ b/packages/language-service/src/utils/index.ts
@@ -16,7 +16,6 @@ import {
   ParseSourceSpan,
   ParseSpan,
   PropertyRead,
-  PropertyWrite,
   SelectorMatcher,
   ThisReceiver,
   TmplAstBoundAttribute,
@@ -49,12 +48,8 @@ import {findTightestNode, getParentClassDeclaration} from './ts_utils';
 export function getTextSpanOfNode(node: TmplAstNode | AST): ts.TextSpan {
   if (isTemplateNodeWithKeyAndValue(node)) {
     return toTextSpan(node.keySpan);
-  } else if (
-    node instanceof PropertyWrite ||
-    node instanceof BindingPipe ||
-    node instanceof PropertyRead
-  ) {
-    // The `name` part of a `PropertyWrite` and `BindingPipe` does not have its own AST
+  } else if (node instanceof BindingPipe || node instanceof PropertyRead) {
+    // The `name` part of a `PropertyRead` and `BindingPipe` does not have its own AST
     // so there is no way to retrieve a `Symbol` for just the `name` via a specific node.
     return toTextSpan(node.nameSpan);
   } else {

--- a/packages/language-service/test/legacy/template_target_spec.ts
+++ b/packages/language-service/test/legacy/template_target_spec.ts
@@ -13,8 +13,6 @@ import {
   SafePropertyRead,
   SafeKeyedRead,
   KeyedRead,
-  PropertyWrite,
-  KeyedWrite,
   Binary,
   BindingPipe,
   SafeCall,
@@ -270,8 +268,8 @@ describe('getTargetAtPosition for template AST', () => {
     // When the template target returns a property read, we only use the LHS downstream because the
     // RHS would have its own node in the AST that would have been returned instead. The LHS of the
     // `PropertyWrite` is the same as the `PropertyRead`.
-    expect(node instanceof PropertyRead || node instanceof PropertyWrite).toBeTrue();
-    expect((node as PropertyRead | PropertyWrite).name).toBe('bar');
+    expect(node instanceof PropertyRead).toBeTrue();
+    expect((node as PropertyRead).name).toBe('bar');
   });
 
   it('should locate template bound event key', () => {
@@ -467,8 +465,8 @@ describe('getTargetAtPosition for template AST', () => {
     expect(parent instanceof BoundAttribute || parent instanceof BoundEvent).toBe(true);
     const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
-    expect(node instanceof PropertyRead || node instanceof PropertyWrite).toBeTrue();
-    expect((node as PropertyRead | PropertyWrite).name).toBe('bar');
+    expect(node instanceof PropertyRead).toBeTrue();
+    expect((node as PropertyRead).name).toBe('bar');
   });
 
   it('should locate switch value in ICUs', () => {
@@ -567,22 +565,22 @@ describe('getTargetAtPosition for expression AST', () => {
     expect(node).toBeInstanceOf(SafeKeyedRead);
   });
 
-  it('should locate property write', () => {
+  it('should locate property assignments', () => {
     const {errors, nodes, position} = parse(`<div (foo)="b¦ar=$event"></div>`);
     expect(errors).toBe(null);
     const {context} = getTargetAtPosition(nodes, position)!;
     const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
-    expect(node).toBeInstanceOf(PropertyWrite);
+    expect(node).toBeInstanceOf(PropertyRead);
   });
 
-  it('should locate keyed write', () => {
+  it('should locate keyed assignments', () => {
     const {errors, nodes, position} = parse(`<div (foo)="bar['baz']¦=$event"></div>`);
     expect(errors).toBe(null);
     const {context} = getTargetAtPosition(nodes, position)!;
     const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
-    expect(node).toBeInstanceOf(KeyedWrite);
+    expect(node).toBeInstanceOf(KeyedRead);
   });
 
   it('should locate binary', () => {


### PR DESCRIPTION
Includes a few changes aimed at aligning how we represent assignments in our expression and output AST to how TypeScript does it. This both simplifies the code and makes it easier to ship other operators like `??=` in the future. Summary:

### refactor(compiler): produce binary expressions instead of dedicated write ones
Currently our expression parser produces two different expressions for writes: `PropertyWrite` (e.g. `foo.bar = 123`) or `KeyedWrite` (e.g. `foo[0] = 123`). This is inconsistent with other ASTs, like TypeScript's, where writes are represented as binary expressions with a `=` operator and it makes it difficult to implement more write operators like `??=`, because we'd essentially have to duplicate them.

These changes switch the expression parser over to produce binary expressions instead.

### refactor(compiler): account for new assignment AST 
Reworks the places that were depending on `PropertyWrite` and `KeyedWrite` to account for the new AST structure.

### refactor(compiler): replace output AST write nodes 
Similarly to the previous change to the expression AST, these changes replace the `WriteVarExpr`, `WriteKeyExpr` and `WritePropExpr` from the output AST with a binary expression. This is closer aligned to TypeScript and makes it easier to translate code between the two.