### PR TITLE
fix(migrations): avoid trailing whitespaces in unused imports migration

### DIFF
--- a/packages/core/schematics/ng-generate/cleanup-unused-imports/unused_imports_migration.ts
+++ b/packages/core/schematics/ng-generate/cleanup-unused-imports/unused_imports_migration.ts
@@ -364,15 +364,18 @@ function getArrayElementRemovalUpdate(
   // trailing comma at the end of the line is fine.
   if (parent.elements[parent.elements.length - 1] === node) {
     for (let i = position - 1; i >= 0; i--) {
-      if (sourceText[i] === ',' || sourceText[i] === ' ') {
+      const char = sourceText[i];
+      if (char === ',' || char === ' ') {
         position--;
       } else {
+        if (whitespaceOrLineFeed.test(char)) {
+          // Replace the node with its leading whitespace to preserve the formatting.
+          // This only needs to happen if we're breaking on a newline.
+          toInsert = getLeadingLineWhitespaceOfNode(node);
+        }
         break;
       }
     }
-
-    // Replace the node with its leading whitespace to preserve the formatting.
-    toInsert = getLeadingLineWhitespaceOfNode(node);
   }
 
   return new TextUpdate({position, end, toInsert});


### PR DESCRIPTION
Follow-up to #61674 where we were leaving behind some whitespace, e.g. `[One, Two, Three]` would turn into `[One ]`. These changes only preserve the whitespace if the node is preceded by a newline.

This wasn't caught by tests, because they were stripping away whitespaces before asserting. I've also reworked the tests to be sensitive to formatting changes.
