### PR TITLE
refactor(core): Refactor createSignal to return a tuple

### DIFF
--- a/goldens/public-api/core/primitives/signals/index.api.md
+++ b/goldens/public-api/core/primitives/signals/index.api.md
@@ -41,9 +41,9 @@ export function createComputed<T>(computation: () => T, equal?: ValueEqualityFn<
 export function createLinkedSignal<S, D>(sourceFn: () => S, computationFn: ComputationFn<S, D>, equalityFn?: ValueEqualityFn<D>): LinkedSignalGetter<S, D>;
 
 // @public
-export function createSignal<T>(initialValue: T, equal?: ValueEqualityFn<T>): SignalGetter<T>;
+export function createSignal<T>(initialValue: T, equal?: ValueEqualityFn<T>): [SignalGetter<T>, SignalSetter<T>, SignalUpdater<T>];
 
-// @public
+// @public @deprecated
 export function createSignalTuple<T>(initialValue: T, equal?: ValueEqualityFn<T>): [SignalGetter<T>, SignalSetter<T>, SignalUpdater<T>];
 
 // @public (undocumented)

--- a/packages/core/primitives/signals/src/signal.ts
+++ b/packages/core/primitives/signals/src/signal.ts
@@ -48,9 +48,12 @@ export interface SignalGetter<T> extends SignalBaseGetter<T> {
 }
 
 /**
- * Create a `Signal` that can be set or updated directly.
+ * Creates a `Signal` getter, setter, and updater function.
  */
-export function createSignal<T>(initialValue: T, equal?: ValueEqualityFn<T>): SignalGetter<T> {
+export function createSignal<T>(
+  initialValue: T,
+  equal?: ValueEqualityFn<T>,
+): [SignalGetter<T>, SignalSetter<T>, SignalUpdater<T>] {
   const node: SignalNode<T> = Object.create(SIGNAL_NODE);
   node.value = initialValue;
   if (equal !== undefined) {
@@ -64,22 +67,20 @@ export function createSignal<T>(initialValue: T, equal?: ValueEqualityFn<T>): Si
   }
 
   runPostProducerCreatedFn(node);
-
-  return getter;
+  const set = (newValue: T) => signalSetFn(node, newValue);
+  const update = (updateFn: (value: T) => T) => signalUpdateFn(node, updateFn);
+  return [getter, set, update];
 }
 
 /**
  * Creates a `Signal` getter, setter, and updater function.
+ * @deprecated use createSignal
  */
 export function createSignalTuple<T>(
   initialValue: T,
   equal?: ValueEqualityFn<T>,
 ): [SignalGetter<T>, SignalSetter<T>, SignalUpdater<T>] {
-  const getter = createSignal(initialValue, equal);
-  const node = getter[SIGNAL];
-  const set = (newValue: T) => signalSetFn(node, newValue);
-  const update = (updateFn: (value: T) => T) => signalUpdateFn(node, updateFn);
-  return [getter, set, update];
+  return createSignal(initialValue, equal);
 }
 
 export function setPostSignalSetFn(fn: ReactiveHookFn | null): ReactiveHookFn | null {

--- a/packages/core/src/render3/reactivity/signal.ts
+++ b/packages/core/src/render3/reactivity/signal.ts
@@ -76,13 +76,13 @@ export interface CreateSignalOptions<T> {
  * Create a `Signal` that can be set or updated directly.
  */
 export function signal<T>(initialValue: T, options?: CreateSignalOptions<T>): WritableSignal<T> {
-  const signalFn = createSignal(initialValue, options?.equal) as SignalGetter<T> &
-    WritableSignal<T>;
+  const [get, set, update] = createSignal(initialValue, options?.equal);
 
+  const signalFn = get as SignalGetter<T> & WritableSignal<T>;
   const node = signalFn[SIGNAL];
 
-  signalFn.set = (newValue: T) => signalSetFn(node, newValue);
-  signalFn.update = (updateFn: (value: T) => T) => signalUpdateFn(node, updateFn);
+  signalFn.set = set;
+  signalFn.update = update;
   signalFn.asReadonly = signalAsReadonlyFn.bind(signalFn as any) as () => Signal<T>;
 
   if (ngDevMode) {


### PR DESCRIPTION
Refactor createSignal to return a tuple instead of a signal getter. createSignalTuple will be removed in a follow up pr once createSignalTuple usages in google3 are migrated to createSignal.

## PR Checklist
Please check if your PR fulfills the following requirements:

-  [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
`createSignal` returns a signal getter.

Issue Number: N/A


## What is the new behavior?
`createSignal` returns a tuple containing a getter, setter, and update function.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
