### PR TITLE
docs: remove ngIf/ngFor/ngSwitch from directive overview

### DIFF
--- a/adev/src/content/guide/directives/overview.md
+++ b/adev/src/content/guide/directives/overview.md
@@ -10,9 +10,8 @@ The different types of Angular directives are as follows:
 | :------------------------------------------------------- | :-------------------------------------------------------------------------------- |
 | [Components](guide/components)                           | Used with a template. This type of directive is the most common directive type.   |
 | [Attribute directives](#built-in-attribute-directives)   | Change the appearance or behavior of an element, component, or another directive. |
-| [Structural directives](#built-in-structural-directives) | Change the DOM layout by adding and removing DOM elements.                        |
 
-This guide covers built-in [attribute directives](#built-in-attribute-directives) and [structural directives](#built-in-structural-directives).
+This guide covers built-in [attribute directives](#built-in-attribute-directives).
 
 ## Built-in attribute directives
 
@@ -128,150 +127,6 @@ For more information, see the API documentation on [DefaultValueAccessor](api/fo
 
 HELPFUL: When you write an Angular component, you don't need a value accessor or `NgModel` if you name the value and event properties according to Angular's [two-way binding syntax](guide/templates/two-way-binding#how-two-way-binding-works).
 
-## Built-in structural directives
-
-Structural directives are responsible for HTML layout.
-They shape or reshape the DOM's structure, typically by adding, removing, and manipulating the host elements to which they are attached.
-
-This section introduces the most common built-in structural directives:
-
-| Common built-in structural directives              | Details                                                          |
-| :------------------------------------------------- | :--------------------------------------------------------------- |
-| [`NgIf`](#adding-or-removing-an-element-with-ngif) | Conditionally creates or disposes of subviews from the template. |
-| [`NgFor`](#listing-items-with-ngfor)               | Repeat a node for each item in a list.                           |
-| [`NgSwitch`](#switching-cases-with-ngswitch)       | A set of directives that switch among alternative views.         |
-
-For more information, see [Structural Directives](guide/directives/structural-directives).
-
-## Adding or removing an element with `NgIf`
-
-Add or remove an element by applying an `NgIf` directive to a host element.
-
-When `NgIf` is `false`, Angular removes an element and its descendants from the DOM.
-Angular then disposes of their components, which frees up memory and resources.
-
-### Import `NgIf` in the component
-
-To use `NgIf`, add it to the component's `imports` list.
-
-<docs-code header="src/app/app.component.ts (NgIf import)" path="adev/src/content/examples/built-in-directives/src/app/app.component.ts" visibleRegion="import-ng-if"/>
-
-### Using `NgIf`
-
-To add or remove an element, bind `*ngIf` to a condition expression such as `isActive` in the following example.
-
-<docs-code header="src/app/app.component.html" path="adev/src/content/examples/built-in-directives/src/app/app.component.html" visibleRegion="NgIf-1"/>
-
-When the `isActive` expression returns a truthy value, `NgIf` adds the `ItemDetailComponent` to the DOM.
-When the expression is falsy, `NgIf` removes the `ItemDetailComponent` from the DOM and disposes of the component and all of its subcomponents.
-
-For more information on `NgIf` and `NgIfElse`, see the [NgIf API documentation](api/common/NgIf).
-
-### Guarding against `null`
-
-By default, `NgIf` prevents display of an element bound to a null value.
-
-To use `NgIf` to guard a `<div>`, add `*ngIf="yourProperty"` to the `<div>`.
-In the following example, the `currentCustomer` name appears because there is a `currentCustomer`.
-
-<docs-code header="src/app/app.component.html" path="adev/src/content/examples/built-in-directives/src/app/app.component.html" visibleRegion="NgIf-2"/>
-
-However, if the property is `null`, Angular does not display the `<div>`.
-In this example, Angular does not display the `nullCustomer` because it is `null`.
-
-<docs-code header="src/app/app.component.html" path="adev/src/content/examples/built-in-directives/src/app/app.component.html" visibleRegion="NgIf-2b"/>
-
-## Listing items with `NgFor`
-
-Use the `NgFor` directive to present a list of items.
-
-### Import `NgFor` in the component
-
-To use `NgFor`, add it to the component's `imports` list.
-
-<docs-code header="src/app/app.component.ts (NgFor import)" path="adev/src/content/examples/built-in-directives/src/app/app.component.ts" visibleRegion="import-ng-for"/>
-
-### Using `NgFor`
-
-To use `NgFor`, you have to:
-
-1. Define a block of HTML that determines how Angular renders a single item.
-1. To list your items, assign the shorthand `let item of items` to `*ngFor`.
-
-<docs-code header="src/app/app.component.html" path="adev/src/content/examples/built-in-directives/src/app/app.component.html" visibleRegion="NgFor-1"/>
-
-The string `"let item of items"` instructs Angular to do the following:
-
-- Store each item in the `items` array in the local `item` looping variable
-- Make each item available to the templated HTML for each iteration
-- Translate `"let item of items"` into an `<ng-template>` around the host element
-- Repeat the `<ng-template>` for each `item` in the list
-
-For more information see the [Structural directive shorthand](guide/directives/structural-directives#structural-directive-shorthand) section of [Structural directives](guide/directives/structural-directives).
-
-### Repeating a component view
-
-To repeat a component element, apply `*ngFor` to the selector.
-In the following example, the selector is `<app-item-detail>`.
-
-<docs-code header="src/app/app.component.html" path="adev/src/content/examples/built-in-directives/src/app/app.component.html" visibleRegion="NgFor-2"/>
-
-Reference a template input variable, such as `item`, in the following locations:
-
-- Within the `ngFor` host element
-- Within the host element descendants to access the item's properties
-
-The following example references `item` first in an interpolation and then passes in a binding to the `item` property of the `<app-item-detail>` component.
-
-<docs-code header="src/app/app.component.html" path="adev/src/content/examples/built-in-directives/src/app/app.component.html" visibleRegion="NgFor-1-2"/>
-
-For more information about template input variables, see [Structural directive shorthand](guide/directives/structural-directives#structural-directive-shorthand).
-
-### Getting the `index` of `*ngFor`
-
-Get the `index` of `*ngFor` in a template input variable and use it in the template.
-
-In the `*ngFor`, add a semicolon and `let i=index` to the shorthand.
-The following example gets the `index` in a variable named `i` and displays it with the item name.
-
-<docs-code header="src/app/app.component.html" path="adev/src/content/examples/built-in-directives/src/app/app.component.html" visibleRegion="NgFor-3"/>
-
-The index property of the `NgFor` directive context returns the zero-based index of the item in each iteration.
-
-Angular translates this instruction into an `<ng-template>` around the host element,
-then uses this template repeatedly to create a new set of elements and bindings for each `item`
-in the list.
-For more information about shorthand, see the [Structural Directives](guide/directives/structural-directives#structural-directive-shorthand) guide.
-
-## Repeating elements when a condition is true
-
-To repeat a block of HTML when a particular condition is true, put the `*ngIf` on a container element that wraps an `*ngFor` element.
-
-For more information see [one structural directive per element](guide/directives/structural-directives#one-structural-directive-per-element).
-
-### Tracking items with `*ngFor` `trackBy`
-
-Reduce the number of calls your application makes to the server by tracking changes to an item list.
-With the `*ngFor` `trackBy` property, Angular can change and re-render only those items that have changed, rather than reloading the entire list of items.
-
-1. Add a method to the component that returns the value `NgFor` should track.
-In this example, the value to track is the item's `id`.
-If the browser has already rendered `id`, Angular keeps track of it and doesn't re-query the server for the same `id`.
-
-<docs-code header="src/app/app.component.ts" path="adev/src/content/examples/built-in-directives/src/app/app.component.ts" visibleRegion="trackByItems"/>
-
-1. In the shorthand expression, set `trackBy` to the `trackByItems()` method.
-
-<docs-code header="src/app/app.component.html" path="adev/src/content/examples/built-in-directives/src/app/app.component.html" visibleRegion="trackBy"/>
-
-**Change ids** creates new items with new `item.id`s.
-In the following illustration of the `trackBy` effect, **Reset items** creates new items with the same `item.id`s.
-
-- With no `trackBy`, both buttons trigger complete DOM element replacement.
-- With `trackBy`, only changing the `id` triggers element replacement.
-
-<img alt="Animation of trackBy" src="assets/images/guide/built-in-directives/ngfor-trackby.gif">
-
 ## Hosting a directive without a DOM element
 
 The Angular `<ng-container>` is a grouping element that doesn't interfere with styles or layout because Angular doesn't put it in the DOM.
@@ -293,51 +148,6 @@ Here's a conditional paragraph using `<ng-container>`.
    <docs-code header="src/app/app.component.html (select-ngcontainer)" path="adev/src/content/examples/structural-directives/src/app/app.component.html" visibleRegion="select-ngcontainer"/>
 
    <img alt="ngcontainer options work properly" src="assets/images/guide/structural-directives/select-ngcontainer-anim.gif">
-
-## Switching cases with `NgSwitch`
-
-Like the JavaScript `switch` statement, `NgSwitch` displays one element from among several possible elements, based on a switch condition.
-Angular puts only the selected element into the DOM.
-
-<!--todo: API Flagged -->
-
-`NgSwitch` is a set of three directives:
-
-| `NgSwitch` directives | Details                                                                                                                                                                |
-| :-------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `NgSwitch`            | An attribute directive that changes the behavior of its companion directives.                                                                                          |
-| `NgSwitchCase`        | Structural directive that adds its element to the DOM when its bound value equals the switch value and removes its bound value when it doesn't equal the switch value. |
-| `NgSwitchDefault`     | Structural directive that adds its element to the DOM when there is no selected `NgSwitchCase`.                                                                        |
-
-To use the directives, add the `NgSwitch`, `NgSwitchCase` and `NgSwitchDefault` to the component's `imports` list.
-
-<docs-code header="src/app/app.component.ts (NgSwitch imports)" path="adev/src/content/examples/built-in-directives/src/app/app.component.ts" visibleRegion="import-ng-switch"/>
-
-### Using `NgSwitch`
-
-1. On an element, such as a `<div>`, add `[ngSwitch]` bound to an expression that returns the switch value, such as `feature`.
-   Though the `feature` value in this example is a string, the switch value can be of any type.
-
-1. Bind to `*ngSwitchCase` and `*ngSwitchDefault` on the elements for the cases.
-
-<docs-code header="src/app/app.component.html" path="adev/src/content/examples/built-in-directives/src/app/app.component.html" visibleRegion="NgSwitch"/>
-
-1. In the parent component, define `currentItem`, to use it in the `[ngSwitch]` expression.
-
-<docs-code header="src/app/app.component.ts" path="adev/src/content/examples/built-in-directives/src/app/app.component.ts" visibleRegion="item"/>
-
-1. In each child component, add an `item` [input property](guide/components/inputs) which is bound to the `currentItem` of the parent component.
-   The following two snippets show the parent component and one of the child components.
-   The other child components are identical to `StoutItemComponent`.
-
-   <docs-code header="In each child component, here StoutItemComponent" path="adev/src/content/examples/built-in-directives/src/app/item-switch.component.ts" visibleRegion="input"/>
-
-   <img alt="Animation of NgSwitch" src="assets/images/guide/built-in-directives/ngswitch.gif">
-
-Switch directives also work with built-in HTML elements and web components.
-For example, you could replace the `<app-best-item>` switch case with a `<div>` as follows.
-
-<docs-code header="src/app/app.component.html" path="adev/src/content/examples/built-in-directives/src/app/app.component.html" visibleRegion="NgSwitch-div"/>
 
 ## What's next
 


### PR DESCRIPTION
The section on `ngModel` still includes examples with ngIf but that's being taken care of in another PR. 