### PR TITLE
refactor: expand DevTools reviewer list

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -302,12 +302,13 @@ groups:
     reviewers:
       users:
         - AleksanderBodurri
-        - devversion
+        - ~devversion
         - dgp1130
-        - josephperrott
-        - mgechev
-        - MarkTechson
-        - ~JeanMeche
+        - hawkgs
+        - jkrems
+        - ~josephperrott
+        - JeanMeche
+        - milomg
 
   # =========================================================
   #  Dev-infra


### PR DESCRIPTION
Updates the current list of DevTools reviewers to make a few small changes.
1. Adds `hawkgs` and `milomg`.
2. Removes the leading `~` from `JeanMeche` to include him in automatic review requests.
3. Adds `jkrems` for additional Googler coverage in automatic review requests.
4. Removes `mgechev` and `MarkTechson` who haven't been involved in daily DevTools development for a while.
5. Adds the leading `~` to `devversion` and `josephperrott` to remove them from automatic review requests while leaving them with access for "break glass" situations.

Note that the leading `~` means that the individual may approve PRs and satisfy the group's requirement, but PullApprove will not automatically request a review from them. See https://v3-docs.pullapprove.com/config/reviewers/#reviewers-that-dont-want-review-requests.

/CC affected individuals @devversion @josephperrott @hawkgs @jkrems @JeanMeche @milomg @MarkTechson @mgechev

(I'm happy to leave Minko and/or Mark with access using `~` to avoid automatic review requests if you two really want to keep it.)