### PR TITLE
refactor(core): export signal setter and updater types for wiz

### DIFF
--- a/packages/core/primitives/signals/src/signal.ts
+++ b/packages/core/primitives/signals/src/signal.ts
@@ -38,8 +38,8 @@ export interface SignalNode<T> extends ReactiveNode {
 }
 
 export type SignalBaseGetter<T> = (() => T) & {readonly [SIGNAL]: unknown};
-type SignalSetter<T> = (newValue: T) => void;
-type SignalUpdater<T> = (updateFn: (value: T) => T) => void;
+export type SignalSetter<T> = (newValue: T) => void;
+export type SignalUpdater<T> = (updateFn: (value: T) => T) => void;
 
 // Note: Closure *requires* this to be an `interface` and not a type, which is why the
 // `SignalBaseGetter` type exists to provide the correct shape.


### PR DESCRIPTION
Export signal setter and updater types for Wiz to use

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

Exports the signal getter, setter, and updater types so they can be used in Wiz.

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Types are not exported.

Issue Number: b/396516428


## What is the new behavior?
Types are exported.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No



## Other information
