### PR TITLE
build: bump peer deps for angular-in-memory-web-api

### DIFF
--- a/packages/misc/angular-in-memory-web-api/package.json
+++ b/packages/misc/angular-in-memory-web-api/package.json
@@ -5,8 +5,8 @@
   "author": "angular",
   "license": "MIT",
   "peerDependencies": {
-    "@angular/core": "^20.0.0-rc",
-    "@angular/common": "^20.0.0-rc",
+    "@angular/core": "^20.0.0",
+    "@angular/common": "^20.0.0",
     "rxjs": "^6.5.3 || ^7.4.0"
   },
   "dependencies": {


### PR DESCRIPTION
bumps peer deps to v20 for in memory web api
