### PR TITLE
fix(common): HttpResource errors should always be instance of Error

### DIFF
--- a/packages/common/http/src/resource.ts
+++ b/packages/common/http/src/resource.ts
@@ -353,7 +353,7 @@ class HttpResourceImpl<T>
                 break;
             }
           },
-          error: (error) => {
+          error: (error: Error | HttpErrorResponse) => {
             if (error instanceof HttpErrorResponse) {
               this._headers.set(error.headers);
               this._statusCode.set(error.status);


### PR DESCRIPTION
Adds explicit `Error|HttpErrorResponse` to the type of error rather than
using `any`.