### PR TITLE
docs(routing): fix typo in define-routes.md

### DIFF
--- a/adev/src/content/guide/routing/define-routes.md
+++ b/adev/src/content/guide/routing/define-routes.md
@@ -219,7 +219,7 @@ export const routes: Routes = [
     loadComponent: () => import('./components/auth/login-page')
   },
   {
-    path: ',
+    path: '',
     loadComponent: () => import('./components/home/home-page')
   }
 ]


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The `define-routes.md` guide contains a typo in the "Lazily loaded components" section, where the path for the home-page component is incorrectly written as ',' instead of ''.

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information