### PR TITLE
fix(core): produce an error when incremental hydration is expected, but not configured

### DIFF
--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -65,6 +65,7 @@ import {
   triggerPrefetching,
   triggerResourceLoading,
   shouldAttachTrigger,
+  hasHydrateTriggers,
 } from './triggering';
 import {formatRuntimeError, RuntimeErrorCode} from '../errors';
 import {Console} from '../console';
@@ -138,8 +139,13 @@ export function ɵɵdefer(
   if (tView.firstCreatePass) {
     performanceMarkFeature('NgDefer');
 
-    if (ngDevMode && typeof ngHmrMode !== 'undefined' && ngHmrMode) {
-      logHmrWarning(injector);
+    if (ngDevMode) {
+      if (typeof ngHmrMode !== 'undefined' && ngHmrMode) {
+        logHmrWarning(injector);
+      }
+      if (hasHydrateTriggers(flags)) {
+        assertIncrementalHydrationIsConfigured(injector);
+      }
     }
 
     const tDetails: TDeferBlockDetails = {
@@ -193,8 +199,6 @@ export function ɵɵdefer(
 
   let registry: DehydratedBlockRegistry | null = null;
   if (ssrUniqueId !== null) {
-    ngDevMode && assertIncrementalHydrationIsConfigured(injector);
-
     // Store this defer block in the registry, to have an access to
     // internal data structures from hydration runtime code.
     registry = injector.get(DEHYDRATED_BLOCK_REGISTRY);


### PR DESCRIPTION
This commit updates runtime logic to produce an error when there are some `@defer` blocks with `hydrate` triggers, but the incremental hydration is not enabled via `withIncrementalHydration()`. Previously the check was only detecting the case when `withIncrementalHydration()` is present on the server, but missing on the client. With the change in this commit, the check would be performed on the server as well.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No