### PR TITLE
docs: fix broked link Routing guide

### DIFF
--- a/adev/src/content/guide/routing/define-routes.md
+++ b/adev/src/content/guide/routing/define-routes.md
@@ -120,7 +120,7 @@ const routes: Routes = [
 
 With this new path, users can visit `/user/leeroy/youtube` and `/user/leeroy/bluesky` and see respective social media feeds based on the parameter for the user leeroy.
 
-See [Reading route state](/guide/router/reading-route-state) for details on reading route parameters.
+See [Reading route state](/guide/routing/read-route-state) for details on reading route parameters.
 
 ### Wildcards
 
@@ -347,7 +347,7 @@ const routes: Routes = [
 
 In this code sample, the home and about page are configured with specific `analyticsId` which would then be used in their respective components for page tracking analytics.
 
-You can read this static data by injecting the `ActivatedRoute`. See [Reading route state](/guide/router/reading-route-state) for details.
+You can read this static data by injecting the `ActivatedRoute`. See [Reading route state](/guide/routing/read-route-state) for details.
 
 ### Dynamic data with data resolvers
 


### PR DESCRIPTION
Fix typo for correct display of the link
Link  [`See [Reading route state]`](https://angular.dev/guide/routing/define-routes#static-data) in the end of the section 404

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
