### PR TITLE
chore(elements): create application ref for each custom component

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -12,6 +12,7 @@
   },
   "peerDependencies": {
     "@angular/core": "0.0.0-PLACEHOLDER",
+    "@angular/platform-browser": "0.0.0-PLACEHOLDER",
     "rxjs": "^6.5.3 || ^7.4.0"
   },
   "repository": {

--- a/packages/elements/src/create-custom-element.ts
+++ b/packages/elements/src/create-custom-element.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Injector, Type} from '@angular/core';
+import {Injector, reflectComponentType, Type} from '@angular/core';
 import {Subscription} from 'rxjs';
 
 import {ComponentNgElementStrategyFactory} from './component-factory-strategy';
 import {NgElementStrategy, NgElementStrategyFactory} from './element-strategy';
-import {getComponentInputs, getDefaultAttributeToPropertyInputs} from './utils';
+import {getDefaultAttributeToPropertyInputs} from './utils';
 
 /**
  * Prototype for a class constructor based on an Angular component
@@ -133,10 +133,16 @@ export function createCustomElement<P>(
   component: Type<any>,
   config: NgElementConfig,
 ): NgElementConstructor<P> {
-  const inputs = getComponentInputs(component, config.injector);
+  const componentType = reflectComponentType(component);
+
+  if (!componentType) {
+    throw new Error('cannot read component type');
+  }
+
+  const {inputs} = componentType;
 
   const strategyFactory =
-    config.strategyFactory || new ComponentNgElementStrategyFactory(component, config.injector);
+    config.strategyFactory || new ComponentNgElementStrategyFactory(component);
 
   const attributeToPropertyInputs = getDefaultAttributeToPropertyInputs(inputs);
 

--- a/packages/elements/src/extract-projectable-nodes.ts
+++ b/packages/elements/src/extract-projectable-nodes.ts
@@ -12,7 +12,10 @@
 
 import {isElement, matchesSelector} from './utils';
 
-export function extractProjectableNodes(host: HTMLElement, ngContentSelectors: string[]): Node[][] {
+export function extractProjectableNodes(
+  host: HTMLElement,
+  ngContentSelectors: readonly string[],
+): Node[][] {
   const nodes = host.childNodes;
   const projectableNodes: Node[][] = ngContentSelectors.map(() => []);
   let wildcardIndex = -1;
@@ -37,7 +40,7 @@ export function extractProjectableNodes(host: HTMLElement, ngContentSelectors: s
   return projectableNodes;
 }
 
-function findMatchingIndex(node: Node, selectors: string[], defaultIndex: number): number {
+function findMatchingIndex(node: Node, selectors: readonly string[], defaultIndex: number): number {
   let matchingIndex = defaultIndex;
 
   if (isElement(node)) {

--- a/packages/elements/src/utils.ts
+++ b/packages/elements/src/utils.ts
@@ -5,7 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {ComponentFactoryResolver, Injector, Type} from '@angular/core';
+
+import {ComponentMirror} from '@angular/core';
 
 /**
  * Provide methods for scheduling the execution of a callback.
@@ -79,9 +80,7 @@ export function strictEquals(value1: any, value2: any): boolean {
 }
 
 /** Gets a map of default set of attributes to observe and the properties they affect. */
-export function getDefaultAttributeToPropertyInputs(
-  inputs: {propName: string; templateName: string; transform?: (value: any) => any}[],
-) {
+export function getDefaultAttributeToPropertyInputs(inputs: ComponentMirror<unknown>['inputs']) {
   const attributeToPropertyInputs: {
     [key: string]: [propName: string, transform: ((value: any) => any) | undefined];
   } = {};
@@ -90,22 +89,4 @@ export function getDefaultAttributeToPropertyInputs(
   });
 
   return attributeToPropertyInputs;
-}
-
-/**
- * Gets a component's set of inputs. Uses the injector to get the component factory where the inputs
- * are defined.
- */
-export function getComponentInputs(
-  component: Type<any>,
-  injector: Injector,
-): {
-  propName: string;
-  templateName: string;
-  transform?: (value: any) => any;
-  isSignal: boolean;
-}[] {
-  const componentFactoryResolver = injector.get(ComponentFactoryResolver);
-  const componentFactory = componentFactoryResolver.resolveComponentFactory(component);
-  return componentFactory.inputs;
 }

--- a/packages/elements/test/component-factory-strategy_spec.ts
+++ b/packages/elements/test/component-factory-strategy_spec.ts
@@ -11,7 +11,6 @@ import {
   Component,
   ComponentRef,
   Directive,
-  EnvironmentInjector,
   Injector,
   Input,
   NgZone,
@@ -39,7 +38,7 @@ describe('ComponentFactoryNgElementStrategy', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({});
     injector = TestBed.inject(Injector);
-    const strategyFactory = new ComponentNgElementStrategyFactory(TestComponent, injector);
+    const strategyFactory = new ComponentNgElementStrategyFactory(TestComponent);
     strategy = strategyFactory.create(injector);
   });
 
@@ -50,7 +49,7 @@ describe('ComponentFactoryNgElementStrategy', () => {
   }
 
   it('should create a new strategy from the factory', () => {
-    const strategyFactory = new ComponentNgElementStrategyFactory(TestComponent, injector);
+    const strategyFactory = new ComponentNgElementStrategyFactory(TestComponent);
     expect(strategyFactory.create(injector)).toBeTruthy();
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md

> [!NOTE]
> If approved, I will complete these tasks.
 
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
All custom elements live inside single application ref.

Issue #61752 


## What is the new behavior?
Added possibility to create new application ref for each custom element.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
