### PR TITLE
fix(zone.js): waitForAsync should pass args to the test function

### DIFF
--- a/packages/zone.js/lib/zone-spec/async-test.ts
+++ b/packages/zone.js/lib/zone-spec/async-test.ts
@@ -248,7 +248,7 @@ export function patchAsyncTest(Zone: ZoneType): void {
               throw e;
             };
           }
-          runInTestZone(fn, this, done, (err: any) => {
+          runInTestZone(fn, this, undefined, done, (err: any) => {
             if (typeof err === 'string') {
               return done.fail(new Error(err));
             } else {
@@ -261,9 +261,9 @@ export function patchAsyncTest(Zone: ZoneType): void {
       // is finished. This will be correctly consumed by the Mocha framework with
       // it('...', async(myFn)); or can be used in a custom framework.
       // Not using an arrow function to preserve context passed from call site
-      return function (this: unknown) {
+      return function (this: unknown, ...args: unknown[]) {
         return new Promise<void>((finishCallback, failCallback) => {
-          runInTestZone(fn, this, finishCallback, failCallback);
+          runInTestZone(fn, this, args, finishCallback, failCallback);
         });
       };
     };
@@ -271,6 +271,7 @@ export function patchAsyncTest(Zone: ZoneType): void {
     function runInTestZone(
       fn: Function,
       context: any,
+      applyArgs: unknown[] | undefined,
       finishCallback: Function,
       failCallback: Function,
     ) {
@@ -329,7 +330,7 @@ export function patchAsyncTest(Zone: ZoneType): void {
         proxyZoneSpec.setDelegate(testZoneSpec);
         (testZoneSpec as any).patchPromiseForTest();
       });
-      return Zone.current.runGuarded(fn, context);
+      return Zone.current.runGuarded(fn, context, applyArgs);
     }
   });
 }

--- a/packages/zone.js/test/jest/jest.spec.js
+++ b/packages/zone.js/test/jest/jest.spec.js
@@ -1,3 +1,5 @@
+const waitForAsync = Zone[Zone.__symbol__('asyncTest')];
+
 function assertInsideProxyZone() {
   expect(Zone.current.name).toEqual('ProxyZone');
 }
@@ -43,6 +45,18 @@ describe('test', () => {
   test.each([[]])('test.each', () => {
     assertInsideProxyZone();
   });
+
+  test.each([
+    ['1', 1],
+    ['2', 2],
+  ])(
+    'Test.each ["%s", %s]',
+    waitForAsync((p1, p2) => {
+      expect(typeof p1).toEqual('string');
+      expect(typeof p2).toEqual('number');
+      expect(p1).toEqual('' + p2);
+    }),
+  );
 });
 
 it('it', () => {

--- a/packages/zone.js/test/vitest/vitest.spec.js
+++ b/packages/zone.js/test/vitest/vitest.spec.js
@@ -3,7 +3,8 @@ require('../../../../dist/bin/packages/zone.js/npm_package/bundles/zone-testing.
 
 import {expect, test, describe, beforeEach} from 'vitest';
 
-const {tick, withProxyZone, fakeAsync} = Zone[Zone.__symbol__('fakeAsyncTest')];
+const {tick, withProxyZone, fakeAsync, asyncTest} = Zone[Zone.__symbol__('fakeAsyncTest')];
+const waitForAsync = Zone[Zone.__symbol__('asyncTest')];
 
 describe('proxy zone behavior', () => {
   const spec = new Zone['ProxyZoneSpec']();
@@ -81,6 +82,16 @@ test(
       setTimeout(() => void (x = 2), 5000);
       tick(5000);
       expect(x).toBe(2);
+    }),
+  ),
+);
+
+test.each([[1, 2]])(
+  'it.each',
+  withProxyZone(
+    waitForAsync((arg1, arg2) => {
+      expect(arg1).toBe(1);
+      expect(arg2).toBe(2);
     }),
   ),
 );


### PR DESCRIPTION
This ensures that test functions with arguments (e.g. `it.each` in jest) are forwarded to the test function. This does not apply to jasmine, which assumes the only arguments needed would be the `done` function.

fixes #61717