### PR TITLE
docs: fix deprecated docs navigation background color.

### DIFF
--- a/adev/shared-docs/styles/_colors.scss
+++ b/adev/shared-docs/styles/_colors.scss
@@ -18,6 +18,9 @@
   --orange-red: oklch(63.32% 0.24 31.68); // #fa2c04
   --super-green: oklch(79.12% 0.257 155.13); // #00c572 // Used for success, merge additions, etc.
 
+  --deprecated-light: oklch(95% 0.02 304.04); // Base color
+  --deprecated-docs-bg: var(--deprecated-light); // Alias specifically for deprecated docs
+
   // subtle-purple is used for inline-code bg, docs-card hover bg & docs-code header bg
   --subtle-purple: color-mix(in srgb, var(--bright-blue) 5%, white 10%);
   --light-blue: color-mix(in srgb, var(--bright-blue), white 50%);
@@ -212,6 +215,9 @@
   --hot-red: color-mix(in srgb, oklch(61.42% 0.238 15.34), var(--full-contrast) 70%);
   --orange-red: color-mix(in srgb, oklch(63.32% 0.24 31.68), var(--full-contrast) 60%);
   --super-green: color-mix(in srgb, oklch(79.12% 0.257 155.13), var(--full-contrast) 70%);
+
+  --deprecated-dark: oklch(30% 0.02 304.04); // Base color
+  --deprecated-docs-bg: var(--deprecated-dark); // Alias specifically for deprecated docs
 
   --light-pink: color-mix(in srgb, var(--vivid-pink) 5%, var(--page-background) 75%);
 

--- a/adev/src/app/core/layout/navigation/navigation.component.scss
+++ b/adev/src/app/core/layout/navigation/navigation.component.scss
@@ -112,7 +112,7 @@
 
   &.adev-nav-primary--deprecated {
     // change nav background to indicate this is an outdated version of the docs
-    background-color: color-mix(in srgb, var(--symbolic-gray), transparent 30%);
+    background-color: var(--deprecated-docs-bg);
   }
 
   // div containing mobile close button and adev-nav_top


### PR DESCRIPTION
Backport of #58848 into v19 / main.
