### PR TITLE
fix(docs): correct broken route-data-resolvers link (#61742)

### DIFF
--- a/adev/src/content/guide/routing/define-routes.md
+++ b/adev/src/content/guide/routing/define-routes.md
@@ -351,7 +351,7 @@ You can read this static data by injecting the `ActivatedRoute`. See [Reading ro
 
 ### Dynamic data with data resolvers
 
-When you need to provide dynamic data to a route, check out the [guide on route data resolvers](/guide/router/route-data-resolvers).
+When you need to provide dynamic data to a route, check out the [Resolve interface](https://angular.io/api/router/Resolve).
 
 ## Nested Routes
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

This PR fixes a broken documentation link that currently points to a non-existent page:
[route-data-resolvers](guide/route-data-resolvers), which leads to a 404 error.

As there is no standalone guide titled "route-data-resolvers", the broken link has been replaced with a direct reference to the official Resolve interface API documentation:

➡️ https://angular.io/api/router/Resolve

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The document link that currently points to a non-existent page:
[route-data-resolvers](guide/route-data-resolvers), which leads to a 404 error.

Issue Number: #61742


## What is the new behavior?

As there is no standalone guide titled "route-data-resolvers", the broken link has been replaced with a direct reference to the official Resolve interface API documentation:

➡️ https://angular.io/api/router/Resolve

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
