### PR TITLE
build: migrate all `modules/...` code to `ts_project`

### DIFF
--- a/modules/benchmarks/BUILD.bazel
+++ b/modules/benchmarks/BUILD.bazel
@@ -1,11 +1,6 @@
 load("//tools:defaults2.bzl", "ts_config")
 
-package(default_visibility = ["//visibility:public"])
-
-exports_files([
-    "tsconfig-build.json",
-    "tsconfig-e2e.json",
-])
+package(default_visibility = ["//modules/benchmarks:__subpackages__"])
 
 ts_config(
     name = "tsconfig_build",

--- a/modules/benchmarks/src/change_detection/BUILD.bazel
+++ b/modules/benchmarks/src/change_detection/BUILD.bazel
@@ -1,4 +1,3 @@
-load("//tools:defaults.bzl", "ts_library")
 load("//tools:defaults2.bzl", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
@@ -10,24 +9,28 @@ ts_project(
     deps = ["//modules/benchmarks/src:util_lib_rjs"],
 )
 
-ts_library(
+ts_project(
     name = "perf_tests_lib",
     testonly = 1,
     srcs = ["change_detection.perf-spec.ts"],
-    tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
-    deps = [
+    interop_deps = [
         "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
-        "@npm//protractor",
+    ],
+    tsconfig = "//modules/benchmarks:tsconfig_e2e",
+    deps = [
+        "//:node_modules/protractor",
     ],
 )
 
-ts_library(
+ts_project(
     name = "e2e_tests_lib",
     testonly = 1,
     srcs = ["change_detection.e2e-spec.ts"],
-    tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
-    deps = [
+    interop_deps = [
         "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
-        "@npm//protractor",
+    ],
+    tsconfig = "//modules/benchmarks:tsconfig_e2e",
+    deps = [
+        "//:node_modules/protractor",
     ],
 )

--- a/modules/benchmarks/src/defer/BUILD.bazel
+++ b/modules/benchmarks/src/defer/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
-load("//tools:defaults2.bzl", "ng_project")
+load("//tools:defaults2.bzl", "ng_project", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -16,24 +15,28 @@ ng_project(
     ],
 )
 
-ts_library(
+ts_project(
     name = "perf_tests_lib",
     testonly = 1,
     srcs = ["defer.perf-spec.ts"],
-    tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
-    deps = [
+    interop_deps = [
         "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
-        "@npm//protractor",
+    ],
+    tsconfig = "//modules/benchmarks:tsconfig_e2e",
+    deps = [
+        "//:node_modules/protractor",
     ],
 )
 
-ts_library(
+ts_project(
     name = "e2e_tests_lib",
     testonly = 1,
     srcs = ["defer.e2e-spec.ts"],
-    tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
-    deps = [
+    interop_deps = [
         "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
-        "@npm//protractor",
+    ],
+    tsconfig = "//modules/benchmarks:tsconfig_e2e",
+    deps = [
+        "//:node_modules/protractor",
     ],
 )

--- a/modules/benchmarks/src/expanding_rows/BUILD.bazel
+++ b/modules/benchmarks/src/expanding_rows/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("@rules_angular//src/optimization:index.bzl", "optimize_angular_app")
-load("//tools:defaults.bzl", "http_server", "ts_library")
+load("//tools:defaults.bzl", "http_server")
+load("//tools:defaults2.bzl", "ts_project")
 
 package(default_visibility = ["//modules/benchmarks:__subpackages__"])
 
@@ -31,14 +32,16 @@ genrule(
     cmd = "cp $</main.js $@",
 )
 
-ts_library(
+ts_project(
     name = "perf_lib",
     testonly = 1,
     srcs = ["expanding_rows.perf-spec.ts"],
-    tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
-    deps = [
+    interop_deps = [
         "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
-        "@npm//protractor",
+    ],
+    tsconfig = "//modules/benchmarks:tsconfig_e2e",
+    deps = [
+        "//:node_modules/protractor",
     ],
 )
 

--- a/modules/benchmarks/src/hydration/BUILD.bazel
+++ b/modules/benchmarks/src/hydration/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
-load("//tools:defaults2.bzl", "ng_project")
+load("//tools:defaults2.bzl", "ng_project", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -20,24 +19,28 @@ ng_project(
     ],
 )
 
-ts_library(
+ts_project(
     name = "perf_tests_lib",
     testonly = 1,
     srcs = ["hydration.perf-spec.ts"],
-    tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
-    deps = [
+    interop_deps = [
         "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
-        "@npm//protractor",
+    ],
+    tsconfig = "//modules/benchmarks:tsconfig_e2e",
+    deps = [
+        "//:node_modules/protractor",
     ],
 )
 
-ts_library(
+ts_project(
     name = "e2e_tests_lib",
     testonly = 1,
     srcs = ["hydration.e2e-spec.ts"],
-    tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
-    deps = [
+    interop_deps = [
         "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
-        "@npm//protractor",
+    ],
+    tsconfig = "//modules/benchmarks:tsconfig_e2e",
+    deps = [
+        "//:node_modules/protractor",
     ],
 )

--- a/modules/benchmarks/src/largeform/BUILD.bazel
+++ b/modules/benchmarks/src/largeform/BUILD.bazel
@@ -1,25 +1,29 @@
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:defaults2.bzl", "ts_project")
 
 package(default_visibility = ["//modules/benchmarks:__subpackages__"])
 
-ts_library(
+ts_project(
     name = "perf_tests_lib",
     testonly = 1,
     srcs = ["largeform.perf-spec.ts"],
-    tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
-    deps = [
+    interop_deps = [
         "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
-        "@npm//protractor",
+    ],
+    tsconfig = "//modules/benchmarks:tsconfig_e2e",
+    deps = [
+        "//:node_modules/protractor",
     ],
 )
 
-ts_library(
+ts_project(
     name = "e2e_tests_lib",
     testonly = 1,
     srcs = ["largeform.e2e-spec.ts"],
-    tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
-    deps = [
+    interop_deps = [
         "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
-        "@npm//protractor",
+    ],
+    tsconfig = "//modules/benchmarks:tsconfig_e2e",
+    deps = [
+        "//:node_modules/protractor",
     ],
 )

--- a/modules/benchmarks/src/largetable/BUILD.bazel
+++ b/modules/benchmarks/src/largetable/BUILD.bazel
@@ -1,4 +1,3 @@
-load("//tools:defaults.bzl", "ts_library")
 load("//tools:defaults2.bzl", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
@@ -10,24 +9,28 @@ ts_project(
     deps = ["//modules/benchmarks/src:util_lib_rjs"],
 )
 
-ts_library(
+ts_project(
     name = "perf_tests_lib",
     testonly = 1,
     srcs = ["largetable.perf-spec.ts"],
-    tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
-    deps = [
+    interop_deps = [
         "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
-        "@npm//protractor",
+    ],
+    tsconfig = "//modules/benchmarks:tsconfig_e2e",
+    deps = [
+        "//:node_modules/protractor",
     ],
 )
 
-ts_library(
+ts_project(
     name = "e2e_tests_lib",
     testonly = 1,
     srcs = ["largetable.e2e-spec.ts"],
-    tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
-    deps = [
+    interop_deps = [
         "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
-        "@npm//protractor",
+    ],
+    tsconfig = "//modules/benchmarks:tsconfig_e2e",
+    deps = [
+        "//:node_modules/protractor",
     ],
 )

--- a/modules/benchmarks/src/ng_template_outlet_context/BUILD.bazel
+++ b/modules/benchmarks/src/ng_template_outlet_context/BUILD.bazel
@@ -1,14 +1,16 @@
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:defaults2.bzl", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
 
-ts_library(
+ts_project(
     name = "perf_lib",
     testonly = True,
     srcs = ["ng_template_outlet_context.perf-spec.ts"],
-    tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
-    deps = [
+    interop_deps = [
         "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
-        "@npm//protractor",
+    ],
+    tsconfig = "//modules/benchmarks:tsconfig_e2e",
+    deps = [
+        "//:node_modules/protractor",
     ],
 )

--- a/modules/benchmarks/src/styling/BUILD.bazel
+++ b/modules/benchmarks/src/styling/BUILD.bazel
@@ -1,14 +1,16 @@
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:defaults2.bzl", "ts_project")
 
 package(default_visibility = ["//modules/benchmarks:__subpackages__"])
 
-ts_library(
+ts_project(
     name = "tests_lib",
     testonly = True,
     srcs = ["styling_perf.spec.ts"],
-    tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
-    deps = [
+    interop_deps = [
         "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
-        "@npm//protractor",
+    ],
+    tsconfig = "//modules/benchmarks:tsconfig_e2e",
+    deps = [
+        "//:node_modules/protractor",
     ],
 )

--- a/modules/benchmarks/src/tree/BUILD.bazel
+++ b/modules/benchmarks/src/tree/BUILD.bazel
@@ -1,4 +1,3 @@
-load("//tools:defaults.bzl", "ts_library")
 load("//tools:defaults2.bzl", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
@@ -10,57 +9,59 @@ ts_project(
     deps = ["//modules/benchmarks/src:util_lib_rjs"],
 )
 
-ts_library(
+ts_project(
     name = "test_utils_lib",
     testonly = 1,
     srcs = ["test_utils.ts"],
-    tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
-    deps = [
+    interop_deps = [
         "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
-        "@npm//protractor",
+    ],
+    tsconfig = "//modules/benchmarks:tsconfig_e2e",
+    deps = [
+        "//:node_modules/protractor",
     ],
 )
 
-ts_library(
+ts_project(
     name = "perf_tests_lib",
     testonly = 1,
     srcs = ["tree.perf-spec.ts"],
-    tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
+    tsconfig = "//modules/benchmarks:tsconfig_e2e",
     deps = [
-        ":test_utils_lib",
-        "@npm//protractor",
+        ":test_utils_lib_rjs",
+        "//:node_modules/protractor",
     ],
 )
 
-ts_library(
+ts_project(
     name = "e2e_tests_lib",
     testonly = 1,
     srcs = ["tree.e2e-spec.ts"],
-    tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
+    tsconfig = "//modules/benchmarks:tsconfig_e2e",
     deps = [
-        ":test_utils_lib",
-        "@npm//protractor",
+        ":test_utils_lib_rjs",
+        "//:node_modules/protractor",
     ],
 )
 
-ts_library(
+ts_project(
     name = "detect_changes_perf_tests_lib",
     testonly = 1,
     srcs = ["tree_detect_changes.perf-spec.ts"],
-    tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
+    tsconfig = "//modules/benchmarks:tsconfig_e2e",
     deps = [
-        ":test_utils_lib",
-        "@npm//protractor",
+        ":test_utils_lib_rjs",
+        "//:node_modules/protractor",
     ],
 )
 
-ts_library(
+ts_project(
     name = "detect_changes_e2e_tests_lib",
     testonly = 1,
     srcs = ["tree_detect_changes.e2e-spec.ts"],
-    tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
+    tsconfig = "//modules/benchmarks:tsconfig_e2e",
     deps = [
-        ":test_utils_lib",
-        "@npm//protractor",
+        ":test_utils_lib_rjs",
+        "//:node_modules/protractor",
     ],
 )

--- a/modules/playground/BUILD.bazel
+++ b/modules/playground/BUILD.bazel
@@ -1,4 +1,21 @@
-exports_files([
-    "tsconfig-build.json",
-    "tsconfig-e2e.json",
-])
+load("//tools:defaults2.bzl", "ts_config")
+
+package(default_visibility = ["//modules/playground:__subpackages__"])
+
+ts_config(
+    name = "tsconfig_e2e",
+    src = "tsconfig-e2e.json",
+    deps = [
+        "//:node_modules/@types/jasmine",
+        "//:node_modules/@types/node",
+    ],
+)
+
+ts_config(
+    name = "tsconfig_e2e_legacy_wd2",
+    src = "tsconfig-e2e-legacy-wd2.json",
+    deps = [
+        ":tsconfig_e2e",
+        "//:node_modules/@types/jasminewd2",
+    ],
+)

--- a/modules/playground/e2e_test/jsonp/jsonp_spec.ts
+++ b/modules/playground/e2e_test/jsonp/jsonp_spec.ts
@@ -15,9 +15,9 @@ describe('jsonp', function () {
   describe('fetching', function () {
     const URL = '/';
 
-    it('should fetch and display people', function () {
+    it('should fetch and display people', async function () {
       browser.get(URL);
-      expect(getComponentText('jsonp-app', '.people')).toEqual('hello, caitp');
+      expect(await getComponentText('jsonp-app', '.people')).toEqual('hello, caitp');
     });
   });
 });

--- a/modules/playground/e2e_test/sourcemap/BUILD.bazel
+++ b/modules/playground/e2e_test/sourcemap/BUILD.bazel
@@ -6,14 +6,13 @@ example_test(
     data = [
         "//modules/playground/src/sourcemap:bundles",
         "//modules/playground/src/sourcemap:main.ts",
-        "@npm//source-map",
     ],
     # Source-Map is using WASM and cannot be bundled for specs.
     external = ["source-map"],
     server = "//modules/playground/src/sourcemap:devserver",
     use_legacy_webdriver_types = False,
     deps = [
-        "@npm//@bazel/runfiles",
-        "@npm//source-map",
+        "//:node_modules/@bazel/runfiles",
+        "//:node_modules/source-map",
     ],
 )

--- a/modules/playground/tsconfig-build.json
+++ b/modules/playground/tsconfig-build.json
@@ -1,6 +1,0 @@
-{
-  "compilerOptions": {
-    "lib": ["dom", "es2015"],
-    "types": []
-  }
-}

--- a/modules/playground/tsconfig-e2e-legacy-wd2.json
+++ b/modules/playground/tsconfig-e2e-legacy-wd2.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-e2e.json",
+  "compilerOptions": {
+    "types": ["node", "jasminewd2"]
+  }
+}

--- a/modules/playground/tsconfig-e2e.json
+++ b/modules/playground/tsconfig-e2e.json
@@ -1,6 +1,15 @@
 {
   "compilerOptions": {
-    "lib": ["es2015", "dom"],
-    "types": ["node", "jasminewd2", "selenium-webdriver"]
+    "lib": ["es2015"],
+    "types": ["node", "jasmine"],
+    "module": "esnext",
+    "moduleResolution": "node10",
+    "strict": true,
+    "sourceMap": true,
+    "declaration": true,
+    "paths": {
+      // TODO(devversion): Consider dropping the dependency on this utilities, or put them somewhere else.
+      "@angular/build-tooling/*": ["../../external/npm/@angular/build-tooling/*"]
+    }
   }
 }


### PR DESCRIPTION
Migrates all `modules/...`  code to `ts_project`.