### PR TITLE
docs(docs-infra): fix tutorial tooltip

### DIFF
--- a/adev/src/app/editor/code-editor/constants/theme-styles.ts
+++ b/adev/src/app/editor/code-editor/constants/theme-styles.ts
@@ -44,7 +44,6 @@ export const CODE_EDITOR_THEME_STYLES = {
     'overflow-y': 'scroll',
     'max-height': '70%',
     'max-width': '100%',
-    'margin-right': '10px',
   },
   '.cm-tooltip.cm-tooltip-autocomplete > ul': {
     background: 'var(--code-editor-autocomplete-background)',

--- a/adev/src/app/features/tutorial/tutorial.component.scss
+++ b/adev/src/app/features/tutorial/tutorial.component.scss
@@ -143,6 +143,9 @@ $column-width: calc(50% - #{$resizer-width} - var(--layout-padding));
   min-width: 300px;
   padding-block-start: var(--layout-padding);
   height: 100vh;
+
+  // should be suprior to the tutorial content or the tooltip won't integrate properly
+  z-index: var( --z-index-nav);
 }
 
 .adev-split-tutorial {


### PR DESCRIPTION
The code editor tooltip exhibits some weird bug when there is a margin applied. The root issue is unknown but at least it improves the current situation.

fixes #60923
