### PR TITLE
build: add missing symbol

### DIFF
--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -519,6 +519,7 @@
       "hasParentInjector",
       "hasStyleInput",
       "hasTagAndTypeMatch",
+      "hasHydrateTriggers",
       "icuContainerIterate",
       "identity",
       "importProvidersFrom",


### PR DESCRIPTION
Fixes a broken symbol test.
