### PR TITLE
build: ensure optimization rule can use `compiler-cli` from HEAD

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
@@ -1,7 +1,8 @@
 # @generated
 # Input hashes for repository rule npm_translate_lock(name = "npm2", pnpm_lock = "@//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
-.npmrc=-151232324
+.npmrc=-1406867100
+.pnpmfile.cjs=-2033668682
 adev/shared-docs/pipeline/api-gen/package.json=939673974
 modules/package.json=1088918580
 package.json=-1576947150
@@ -18,7 +19,7 @@ packages/platform-browser/package.json=-1163479450
 packages/router/package.json=860819913
 packages/upgrade/package.json=16347051
 packages/zone.js/package.json=-1545343303
-pnpm-lock.yaml=-1557989717
+pnpm-lock.yaml=-1025578619
 pnpm-workspace.yaml=-1264776080
 tools/bazel/rules_angular_store/package.json=-239561259
 yarn.lock=-1393712141

--- a/.npmrc
+++ b/.npmrc
@@ -9,6 +9,4 @@ hoist=false
 # Avoid pnpm auto-installing peer dependencies. We want to be explicit about our versions used
 # for peer dependencies, avoiding potential mismatches. In addition, it ensures we can continue
 # to rely on peer dependency placeholders substituted via Bazel.
-# TODO(devversion): Temporarily during migration this is flipped as we can't have `workspace:*` deps
-# in the `package.json` also processed by Yarn.
-auto-install-peers=true
+auto-install-peers=false

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -1,0 +1,32 @@
+function readPackage(pkg, context) {
+  // TODO(devversion): This exists temporarily during migration as we can't have `workspace:*` deps
+  // in the `package.json` also processed by Yarn
+  if (pkg.name === 'angular-srcs') {
+    pkg.dependencies = {
+      ...pkg.dependencies,
+      // These dependencies are added to the workspace root so that peer dependencies
+      // are resolved via these locally-built versions. e.g. compiler-cli's peer deps.
+      '@angular/compiler': 'workspace:*',
+      '@angular/compiler-cli': 'workspace:*',
+    };
+  }
+
+  // TODO(devversion): This allows us to make compiler/TS a production dependency of compiler-cli
+  // because `rules_js` doesn't otherwise include the dependency in the `npm_package_store`.
+  // See: https://github.com/aspect-build/rules_js/issues/2226
+  if (pkg.name === '@angular/compiler-cli') {
+    pkg.dependencies = {
+      ...pkg.dependencies,
+      '@angular/compiler': 'workspace:*',
+      'typescript': '5.8.3',
+    };
+  }
+
+  return pkg;
+}
+
+module.exports = {
+  hooks: {
+    readPackage,
+  },
+};

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -107,6 +107,7 @@ load("@aspect_rules_js//npm:repositories.bzl", "npm_translate_lock")
 npm_translate_lock(
     name = "npm2",
     data = [
+        "//:.pnpmfile.cjs",
         "//:package.json",
         "//:pnpm-workspace.yaml",
         "//adev/shared-docs/pipeline/api-gen:package.json",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '6.0'
 
 settings:
-  autoInstallPeers: true
+  autoInstallPeers: false
   excludeLinksFromLockfile: false
 
 onlyBuiltDependencies: []
@@ -16,7 +16,7 @@ importers:
     dependencies:
       '@angular-devkit/build-angular':
         specifier: 20.0.0-rc.3
-        version: 20.0.0-rc.3(@angular/core@20.0.0-rc.2)(@angular/platform-browser@20.0.0-rc.2)(@angular/ssr@20.0.0-rc.3)(@types/node@18.19.103)(chokidar@4.0.3)(karma@6.4.4)(protractor@7.0.0)(tsx@4.19.4)(typescript@5.8.2)(vite@6.3.5)
+        version: 20.0.0-rc.3(@angular/compiler-cli@packages+compiler-cli)(@angular/compiler@packages+compiler)(@angular/ssr@20.0.0-rc.3)(@types/node@18.19.103)(chokidar@4.0.3)(karma@6.4.4)(protractor@7.0.0)(tsx@4.19.4)(typescript@5.8.2)
       '@angular-devkit/core':
         specifier: 20.0.0-rc.3
         version: 20.0.0-rc.3(chokidar@4.0.3)
@@ -25,19 +25,25 @@ importers:
         version: 20.0.0-rc.3(chokidar@4.0.3)
       '@angular/build':
         specifier: 20.0.0-rc.3
-        version: 20.0.0-rc.3(@angular/core@20.0.0-rc.2)(@angular/platform-browser@20.0.0-rc.2)(@angular/ssr@20.0.0-rc.3)(@types/node@18.19.103)(chokidar@4.0.3)(karma@6.4.4)(less@4.3.0)(postcss@8.5.3)(terser@5.39.2)(tslib@2.8.1)(tsx@4.19.4)(typescript@5.8.2)
+        version: 20.0.0-rc.3(@angular/compiler-cli@packages+compiler-cli)(@angular/compiler@packages+compiler)(@angular/ssr@20.0.0-rc.3)(@types/node@18.19.103)(chokidar@4.0.3)(karma@6.4.4)(terser@5.39.2)(tslib@2.8.1)(tsx@4.19.4)(typescript@5.8.2)
       '@angular/cdk':
         specifier: 20.0.0-rc.2
-        version: 20.0.0-rc.2(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)(rxjs@7.8.2)
+        version: 20.0.0-rc.2(rxjs@7.8.2)
       '@angular/cli':
         specifier: 20.0.0-rc.3
         version: 20.0.0-rc.3(@types/node@18.19.103)(chokidar@4.0.3)
+      '@angular/compiler':
+        specifier: workspace:*
+        version: link:packages/compiler
+      '@angular/compiler-cli':
+        specifier: workspace:*
+        version: link:packages/compiler-cli
       '@angular/material':
         specifier: 20.0.0-rc.2
-        version: 20.0.0-rc.2(@angular/cdk@20.0.0-rc.2)(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)(@angular/forms@20.0.0-rc.2)(@angular/platform-browser@20.0.0-rc.2)(rxjs@7.8.2)
+        version: 20.0.0-rc.2(@angular/cdk@20.0.0-rc.2)(rxjs@7.8.2)
       '@angular/ssr':
         specifier: 20.0.0-rc.3
-        version: 20.0.0-rc.3(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)(@angular/router@20.0.0-rc.2)
+        version: 20.0.0-rc.3
       '@babel/cli':
         specifier: 7.27.2
         version: 7.27.2(@babel/core@7.27.1)
@@ -49,7 +55,7 @@ importers:
         version: 7.27.1
       '@bazel/concatjs':
         specifier: 5.8.1
-        version: 5.8.1(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-junit-reporter@2.0.1)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(typescript@5.8.2)
+        version: 5.8.1(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(typescript@5.8.2)
       '@bazel/esbuild':
         specifier: 5.8.1
         version: 5.8.1
@@ -250,10 +256,10 @@ importers:
         version: 2.0.1
       ngx-flamegraph:
         specifier: 0.0.12
-        version: 0.0.12(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)
+        version: 0.0.12
       ngx-progressbar:
         specifier: ^14.0.0
-        version: 14.0.0(@angular/cdk@20.0.0-rc.2)(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)(rxjs@7.8.2)
+        version: 14.0.0(@angular/cdk@20.0.0-rc.2)(rxjs@7.8.2)
       open-in-idx:
         specifier: ^0.1.1
         version: 0.1.1
@@ -350,7 +356,7 @@ importers:
         version: 0.2000.0-rc.3(chokidar@4.0.3)
       '@angular/build-tooling':
         specifier: https://github.com/angular/dev-infra-private-build-tooling-builds.git#5db176c0f3211663830fd3ff4064c1dff0eaccb4
-        version: github.com/angular/dev-infra-private-build-tooling-builds/5db176c0f3211663830fd3ff4064c1dff0eaccb4(@angular/ssr@20.0.0-rc.3)(chokidar@4.0.3)(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-junit-reporter@2.0.1)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(less@4.3.0)(postcss@8.5.3)(rxjs@7.8.2)(terser@5.39.2)(tsx@4.19.4)(zone.js@0.12.0)
+        version: github.com/angular/dev-infra-private-build-tooling-builds/5db176c0f3211663830fd3ff4064c1dff0eaccb4(@angular/compiler-cli@packages+compiler-cli)(@angular/compiler@packages+compiler)(@angular/ssr@20.0.0-rc.3)(chokidar@4.0.3)(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(rxjs@7.8.2)(terser@5.39.2)(tsx@4.19.4)
       '@angular/ng-dev':
         specifier: https://github.com/angular/dev-infra-private-ng-dev-builds.git#39b8cbd214dc08e81b7a69624d9dc152ce7c42db
         version: github.com/angular/dev-infra-private-ng-dev-builds/39b8cbd214dc08e81b7a69624d9dc152ce7c42db
@@ -416,7 +422,7 @@ importers:
         version: 1.5.1
       '@nginfra/angular-linking':
         specifier: ^1.0.10
-        version: 1.0.10
+        version: 1.0.10(@angular/compiler-cli@packages+compiler-cli)
       '@octokit/graphql':
         specifier: ^9.0.0
         version: 9.0.1
@@ -452,7 +458,7 @@ importers:
         version: 0.5.16
       angular-split:
         specifier: ^19.0.0
-        version: 19.0.0(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)(rxjs@7.8.2)
+        version: 19.0.0(rxjs@7.8.2)
       check-side-effects:
         specifier: 0.0.23
         version: 0.0.23
@@ -572,7 +578,7 @@ importers:
         version: link:../packages/animations
       '@angular/build':
         specifier: 20.0.0-rc.1
-        version: 20.0.0-rc.1(@angular/compiler-cli@20.0.0-rc.2)(@angular/compiler@packages+compiler)(@angular/core@packages+core)(@angular/localize@packages+localize)(@angular/platform-browser@packages+platform-browser)(@angular/ssr@20.0.0-rc.3)(@types/node@18.19.103)(chokidar@4.0.3)(karma@6.4.4)(less@4.3.0)(postcss@8.5.3)(terser@5.39.2)(tslib@2.8.1)(tsx@4.19.4)(typescript@5.8.3)
+        version: 20.0.0-rc.1(@angular/compiler-cli@packages+compiler-cli)(@angular/compiler@packages+compiler)(@angular/core@packages+core)(@angular/localize@packages+localize)(@angular/platform-browser@packages+platform-browser)(@angular/ssr@20.0.0-rc.3)(@types/node@18.19.103)(chokidar@4.0.3)(karma@6.4.4)(terser@5.39.2)(tslib@2.8.1)(tsx@4.19.4)(typescript@5.8.2)
       '@angular/common':
         specifier: workspace:*
         version: link:../packages/common
@@ -606,24 +612,12 @@ importers:
 
   packages/animations:
     dependencies:
-      '@angular/common':
-        specifier: 0.0.0-PLACEHOLDER
-        version: link:../common
-      '@angular/core':
-        specifier: 0.0.0-PLACEHOLDER
-        version: link:../core
       tslib:
         specifier: ^2.3.0
         version: 2.8.1
 
   packages/common:
     dependencies:
-      '@angular/core':
-        specifier: 0.0.0-PLACEHOLDER
-        version: link:../core
-      rxjs:
-        specifier: ^6.5.3 || ^7.4.0
-        version: 7.8.2
       tslib:
         specifier: ^2.3.0
         version: 2.8.1
@@ -637,7 +631,7 @@ importers:
   packages/compiler-cli:
     dependencies:
       '@angular/compiler':
-        specifier: 0.0.0-PLACEHOLDER
+        specifier: workspace:*
         version: link:../compiler
       '@babel/core':
         specifier: 7.27.1
@@ -661,7 +655,7 @@ importers:
         specifier: ^2.3.0
         version: 2.8.1
       typescript:
-        specifier: '>=5.8 <5.9'
+        specifier: 5.8.3
         version: 5.8.3
       yargs:
         specifier: ^17.2.1
@@ -669,18 +663,9 @@ importers:
 
   packages/core:
     dependencies:
-      '@angular/compiler':
-        specifier: 0.0.0-PLACEHOLDER
-        version: link:../compiler
-      rxjs:
-        specifier: ^6.5.3 || ^7.4.0
-        version: 7.8.2
       tslib:
         specifier: ^2.3.0
         version: 2.8.1
-      zone.js:
-        specifier: ~0.15.0
-        version: link:../zone.js
 
   packages/core/test/bundling:
     dependencies:
@@ -689,7 +674,7 @@ importers:
         version: link:../../../animations
       '@angular/build':
         specifier: 20.0.0-rc.1
-        version: 20.0.0-rc.1(@angular/compiler-cli@20.0.0-rc.2)(@angular/compiler@20.0.0-rc.2)(@angular/core@packages+core)(@angular/platform-browser@packages+platform-browser)(@angular/ssr@20.0.0-rc.3)(@types/node@18.19.103)(chokidar@4.0.3)(karma@6.4.4)(less@4.3.0)(postcss@8.5.3)(terser@5.39.2)(tslib@2.8.1)(tsx@4.19.4)(typescript@5.8.3)
+        version: 20.0.0-rc.1(@angular/compiler-cli@packages+compiler-cli)(@angular/compiler@packages+compiler)(@angular/core@packages+core)(@angular/localize@packages+localize)(@angular/platform-browser@packages+platform-browser)(@angular/ssr@20.0.0-rc.3)(@types/node@18.19.103)(chokidar@4.0.3)(karma@6.4.4)(terser@5.39.2)(tslib@2.8.1)(tsx@4.19.4)(typescript@5.8.2)
       '@angular/common':
         specifier: workspace:*
         version: link:../../../common
@@ -708,30 +693,12 @@ importers:
 
   packages/forms:
     dependencies:
-      '@angular/common':
-        specifier: 0.0.0-PLACEHOLDER
-        version: link:../common
-      '@angular/core':
-        specifier: 0.0.0-PLACEHOLDER
-        version: link:../core
-      '@angular/platform-browser':
-        specifier: 0.0.0-PLACEHOLDER
-        version: link:../platform-browser
-      rxjs:
-        specifier: ^6.5.3 || ^7.4.0
-        version: 7.8.2
       tslib:
         specifier: ^2.3.0
         version: 2.8.1
 
   packages/localize:
     dependencies:
-      '@angular/compiler':
-        specifier: 0.0.0-PLACEHOLDER
-        version: link:../compiler
-      '@angular/compiler-cli':
-        specifier: 0.0.0-PLACEHOLDER
-        version: link:../compiler-cli
       '@babel/core':
         specifier: 7.27.1
         version: 7.27.1
@@ -747,69 +714,24 @@ importers:
 
   packages/platform-browser:
     dependencies:
-      '@angular/animations':
-        specifier: 0.0.0-PLACEHOLDER
-        version: link:../animations
-      '@angular/common':
-        specifier: 0.0.0-PLACEHOLDER
-        version: link:../common
-      '@angular/core':
-        specifier: 0.0.0-PLACEHOLDER
-        version: link:../core
       tslib:
         specifier: ^2.3.0
         version: 2.8.1
 
   packages/platform-browser-dynamic:
     dependencies:
-      '@angular/common':
-        specifier: 0.0.0-PLACEHOLDER
-        version: link:../common
-      '@angular/compiler':
-        specifier: 0.0.0-PLACEHOLDER
-        version: link:../compiler
-      '@angular/core':
-        specifier: 0.0.0-PLACEHOLDER
-        version: link:../core
-      '@angular/platform-browser':
-        specifier: 0.0.0-PLACEHOLDER
-        version: link:../platform-browser
       tslib:
         specifier: ^2.3.0
         version: 2.8.1
 
   packages/router:
     dependencies:
-      '@angular/common':
-        specifier: 0.0.0-PLACEHOLDER
-        version: link:../common
-      '@angular/core':
-        specifier: 0.0.0-PLACEHOLDER
-        version: link:../core
-      '@angular/platform-browser':
-        specifier: 0.0.0-PLACEHOLDER
-        version: link:../platform-browser
-      rxjs:
-        specifier: ^6.5.3 || ^7.4.0
-        version: 7.8.2
       tslib:
         specifier: ^2.3.0
         version: 2.8.1
 
   packages/upgrade:
     dependencies:
-      '@angular/compiler':
-        specifier: 0.0.0-PLACEHOLDER
-        version: link:../compiler
-      '@angular/core':
-        specifier: 0.0.0-PLACEHOLDER
-        version: link:../core
-      '@angular/platform-browser':
-        specifier: 0.0.0-PLACEHOLDER
-        version: link:../platform-browser
-      '@angular/platform-browser-dynamic':
-        specifier: 0.0.0-PLACEHOLDER
-        version: link:../platform-browser-dynamic
       tslib:
         specifier: ^2.3.0
         version: 2.8.1
@@ -848,7 +770,7 @@ importers:
         version: 2.8.1
       vitest:
         specifier: ^3.1.3
-        version: 3.1.4(@types/node@10.17.60)(jsdom@26.1.0)(less@4.3.0)(terser@5.39.2)(tsx@4.19.4)
+        version: 3.1.4(@types/node@10.17.60)(jsdom@26.1.0)(terser@5.39.2)(tsx@4.19.4)
 
   tools/bazel/rules_angular_store:
     dependencies:
@@ -1060,7 +982,7 @@ packages:
     transitivePeerDependencies:
       - chokidar
 
-  /@angular-devkit/build-angular@20.0.0-rc.3(@angular/core@20.0.0-rc.2)(@angular/platform-browser@20.0.0-rc.2)(@angular/ssr@20.0.0-rc.3)(@types/node@18.19.103)(chokidar@4.0.3)(karma@6.4.4)(protractor@7.0.0)(tsx@4.19.4)(typescript@5.8.2)(vite@6.3.5):
+  /@angular-devkit/build-angular@20.0.0-rc.3(@angular/compiler-cli@packages+compiler-cli)(@angular/compiler@packages+compiler)(@angular/ssr@20.0.0-rc.3)(@types/node@18.19.103)(chokidar@4.0.3)(karma@6.4.4)(protractor@7.0.0)(tsx@4.19.4)(typescript@5.8.2):
     resolution: {integrity: sha512-DMqwX0ZfWPzWLPPdGB4pFxFccyEznPkS5TFZcb/Leu6XIYMcXPOEGWpvDII69rwplEECWOGVb8LIzj5cZgil9Q==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     peerDependencies:
@@ -1114,10 +1036,9 @@ packages:
       '@angular-devkit/architect': 0.2000.0-rc.3(chokidar@4.0.3)
       '@angular-devkit/build-webpack': 0.2000.0-rc.3(chokidar@4.0.3)(webpack-dev-server@5.2.1)(webpack@5.99.8)
       '@angular-devkit/core': 20.0.0-rc.3(chokidar@4.0.3)
-      '@angular/build': 20.0.0-rc.3(@angular/core@20.0.0-rc.2)(@angular/platform-browser@20.0.0-rc.2)(@angular/ssr@20.0.0-rc.3)(@types/node@18.19.103)(chokidar@4.0.3)(karma@6.4.4)(less@4.3.0)(postcss@8.5.3)(terser@5.39.1)(tslib@2.8.1)(tsx@4.19.4)(typescript@5.8.2)
-      '@angular/core': 20.0.0-rc.2(rxjs@7.8.2)(zone.js@0.12.0)
-      '@angular/platform-browser': 20.0.0-rc.2(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)
-      '@angular/ssr': 20.0.0-rc.3(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)(@angular/router@20.0.0-rc.2)
+      '@angular/build': 20.0.0-rc.3(@angular/compiler-cli@packages+compiler-cli)(@angular/compiler@packages+compiler)(@angular/ssr@20.0.0-rc.3)(@types/node@18.19.103)(chokidar@4.0.3)(karma@6.4.4)(less@4.3.0)(postcss@8.5.3)(terser@5.39.1)(tslib@2.8.1)(tsx@4.19.4)(typescript@5.8.2)
+      '@angular/compiler-cli': link:packages/compiler-cli
+      '@angular/ssr': 20.0.0-rc.3
       '@babel/core': 7.27.1
       '@babel/generator': 7.27.1
       '@babel/helper-annotate-as-pure': 7.27.1
@@ -1128,7 +1049,7 @@ packages:
       '@babel/preset-env': 7.27.2(@babel/core@7.27.1)
       '@babel/runtime': 7.27.1
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 20.0.0-rc.3(typescript@5.8.2)(webpack@5.99.8)
+      '@ngtools/webpack': 20.0.0-rc.3(@angular/compiler-cli@packages+compiler-cli)(typescript@5.8.2)(webpack@5.99.8)
       '@vitejs/plugin-basic-ssl': 2.0.0(vite@6.3.5)
       ansi-colors: 4.1.3
       autoprefixer: 10.4.21(postcss@8.5.3)
@@ -1234,7 +1155,7 @@ packages:
         optional: true
     dependencies:
       ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
+      ajv-formats: 3.0.1
       chokidar: 4.0.3
       jsonc-parser: 3.3.1
       picomatch: 4.0.2
@@ -1252,7 +1173,7 @@ packages:
         optional: true
     dependencies:
       ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
+      ajv-formats: 3.0.1
       chokidar: 4.0.3
       jsonc-parser: 3.3.1
       picomatch: 4.0.2
@@ -1270,7 +1191,7 @@ packages:
         optional: true
     dependencies:
       ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
+      ajv-formats: 3.0.1
       chokidar: 4.0.3
       jsonc-parser: 3.3.1
       picomatch: 4.0.2
@@ -1290,17 +1211,17 @@ packages:
       - chokidar
     dev: false
 
-  /@angular/benchpress@0.3.0(rxjs@7.8.2)(zone.js@0.12.0):
+  /@angular/benchpress@0.3.0(rxjs@7.8.2):
     resolution: {integrity: sha512-ApxoY5lTj1S0QFLdq5ZdTfdkIds1m3tma9EJOZpNVHRU9eCj2D/5+VFb5tlWsv9NHQ2S0XXkJjauFOAdfzT8uw==}
     dependencies:
-      '@angular/core': 14.3.0(rxjs@7.8.2)(zone.js@0.12.0)
+      '@angular/core': 14.3.0(rxjs@7.8.2)
       reflect-metadata: 0.1.14
     transitivePeerDependencies:
       - rxjs
       - zone.js
     dev: true
 
-  /@angular/build@19.1.0-rc.0(@angular/ssr@20.0.0-rc.3)(@types/node@18.19.103)(chokidar@4.0.3)(less@4.3.0)(postcss@8.5.3)(terser@5.39.2)(tsx@4.19.4)(typescript@5.7.3):
+  /@angular/build@19.1.0-rc.0(@angular/compiler-cli@packages+compiler-cli)(@angular/compiler@packages+compiler)(@angular/ssr@20.0.0-rc.3)(@types/node@18.19.103)(chokidar@4.0.3)(terser@5.39.2)(tsx@4.19.4)(typescript@5.7.3):
     resolution: {integrity: sha512-ALl+MVMYBF+E7HyAQ+1MtE6sNIOAX0o2Sfs0wdIQfM2unRl6jPsz/Ker4BjnNQIK4wRCcstyzBv5mZBDulfFIQ==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     peerDependencies:
@@ -1335,7 +1256,9 @@ packages:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1901.0-rc.0(chokidar@4.0.3)
-      '@angular/ssr': 20.0.0-rc.3(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)(@angular/router@20.0.0-rc.2)
+      '@angular/compiler': link:packages/compiler
+      '@angular/compiler-cli': link:packages/compiler-cli
+      '@angular/ssr': 20.0.0-rc.3
       '@babel/core': 7.26.0
       '@babel/helper-annotate-as-pure': 7.25.9
       '@babel/helper-split-export-declaration': 7.24.7
@@ -1348,19 +1271,17 @@ packages:
       fast-glob: 3.3.3
       https-proxy-agent: 7.0.6(supports-color@10.0.0)
       istanbul-lib-instrument: 6.0.3
-      less: 4.3.0
       listr2: 8.2.5
       magic-string: 0.30.17
       mrmime: 2.0.0
       parse5-html-rewriting-stream: 7.0.0
       picomatch: 4.0.2
       piscina: 4.8.0
-      postcss: 8.5.3
       rollup: 4.30.1
       sass: 1.83.1
       semver: 7.6.3
       typescript: 5.7.3
-      vite: 6.0.7(@types/node@18.19.103)(less@4.3.0)(sass@1.83.1)(terser@5.39.2)(tsx@4.19.4)
+      vite: 6.0.7(@types/node@18.19.103)(sass@1.83.1)(terser@5.39.2)(tsx@4.19.4)
       watchpack: 2.4.2
     optionalDependencies:
       lmdb: 3.2.2
@@ -1378,105 +1299,7 @@ packages:
       - yaml
     dev: true
 
-  /@angular/build@20.0.0-rc.1(@angular/compiler-cli@20.0.0-rc.2)(@angular/compiler@20.0.0-rc.2)(@angular/core@packages+core)(@angular/platform-browser@packages+platform-browser)(@angular/ssr@20.0.0-rc.3)(@types/node@18.19.103)(chokidar@4.0.3)(karma@6.4.4)(less@4.3.0)(postcss@8.5.3)(terser@5.39.2)(tslib@2.8.1)(tsx@4.19.4)(typescript@5.8.3):
-    resolution: {integrity: sha512-Wyg86m0Y4yZMveqSRX8TAElKMyM/PJYAgNgU1ZAZFFqVl69i7mCGXoTGERF6zDtBa3Yo0YnFFuRzNgD6g/RJsA==}
-    engines: {node: ^20.11.1 || ^22.11.0 || >=24.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
-    peerDependencies:
-      '@angular/compiler': ^20.0.0 || ^20.0.0-next.0
-      '@angular/compiler-cli': ^20.0.0 || ^20.0.0-next.0
-      '@angular/core': ^20.0.0 || ^20.0.0-next.0
-      '@angular/localize': ^20.0.0 || ^20.0.0-next.0
-      '@angular/platform-browser': ^20.0.0 || ^20.0.0-next.0
-      '@angular/platform-server': ^20.0.0 || ^20.0.0-next.0
-      '@angular/service-worker': ^20.0.0 || ^20.0.0-next.0
-      '@angular/ssr': ^20.0.0-rc.1
-      karma: ^6.4.0
-      less: ^4.2.0
-      ng-packagr: ^20.0.0 || ^20.0.0-next.0
-      postcss: ^8.4.0
-      tailwindcss: ^2.0.0 || ^3.0.0 || ^4.0.0
-      tslib: ^2.3.0
-      typescript: '>=5.8 <5.9'
-      vitest: ^3.1.1
-    peerDependenciesMeta:
-      '@angular/core':
-        optional: true
-      '@angular/localize':
-        optional: true
-      '@angular/platform-browser':
-        optional: true
-      '@angular/platform-server':
-        optional: true
-      '@angular/service-worker':
-        optional: true
-      '@angular/ssr':
-        optional: true
-      karma:
-        optional: true
-      less:
-        optional: true
-      ng-packagr:
-        optional: true
-      postcss:
-        optional: true
-      tailwindcss:
-        optional: true
-      vitest:
-        optional: true
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.2000.0-rc.1(chokidar@4.0.3)
-      '@angular/compiler': 20.0.0-rc.2
-      '@angular/compiler-cli': 20.0.0-rc.2(@angular/compiler@20.0.0-rc.2)(typescript@5.8.3)
-      '@angular/core': link:packages/core
-      '@angular/platform-browser': link:packages/platform-browser
-      '@angular/ssr': 20.0.0-rc.3(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)(@angular/router@20.0.0-rc.2)
-      '@babel/core': 7.27.1
-      '@babel/helper-annotate-as-pure': 7.27.1
-      '@babel/helper-split-export-declaration': 7.24.7
-      '@inquirer/confirm': 5.1.10(@types/node@18.19.103)
-      '@vitejs/plugin-basic-ssl': 2.0.0(vite@6.3.5)
-      beasties: 0.3.3
-      browserslist: 4.24.5
-      esbuild: 0.25.4
-      https-proxy-agent: 7.0.6(supports-color@10.0.0)
-      istanbul-lib-instrument: 6.0.3
-      jsonc-parser: 3.3.1
-      karma: 6.4.4
-      less: 4.3.0
-      listr2: 8.3.3
-      magic-string: 0.30.17
-      mrmime: 2.0.1
-      parse5-html-rewriting-stream: 7.1.0
-      picomatch: 4.0.2
-      piscina: 5.0.0
-      postcss: 8.5.3
-      rollup: 4.40.2
-      sass: 1.88.0
-      semver: 7.7.2
-      source-map-support: 0.5.21
-      tinyglobby: 0.2.13
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vite: 6.3.5(@types/node@18.19.103)(less@4.3.0)(sass@1.88.0)(terser@5.39.2)(tsx@4.19.4)
-      watchpack: 2.4.2
-    optionalDependencies:
-      lmdb: 3.3.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - chokidar
-      - jiti
-      - lightningcss
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-    dev: false
-
-  /@angular/build@20.0.0-rc.1(@angular/compiler-cli@20.0.0-rc.2)(@angular/compiler@packages+compiler)(@angular/core@packages+core)(@angular/localize@packages+localize)(@angular/platform-browser@packages+platform-browser)(@angular/ssr@20.0.0-rc.3)(@types/node@18.19.103)(chokidar@4.0.3)(karma@6.4.4)(less@4.3.0)(postcss@8.5.3)(terser@5.39.2)(tslib@2.8.1)(tsx@4.19.4)(typescript@5.8.3):
+  /@angular/build@20.0.0-rc.1(@angular/compiler-cli@packages+compiler-cli)(@angular/compiler@packages+compiler)(@angular/core@packages+core)(@angular/localize@packages+localize)(@angular/platform-browser@packages+platform-browser)(@angular/ssr@20.0.0-rc.3)(@types/node@18.19.103)(chokidar@4.0.3)(karma@6.4.4)(terser@5.39.2)(tslib@2.8.1)(tsx@4.19.4)(typescript@5.8.2):
     resolution: {integrity: sha512-Wyg86m0Y4yZMveqSRX8TAElKMyM/PJYAgNgU1ZAZFFqVl69i7mCGXoTGERF6zDtBa3Yo0YnFFuRzNgD6g/RJsA==}
     engines: {node: ^20.11.1 || ^22.11.0 || >=24.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     peerDependencies:
@@ -1525,11 +1348,11 @@ packages:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2000.0-rc.1(chokidar@4.0.3)
       '@angular/compiler': link:packages/compiler
-      '@angular/compiler-cli': 20.0.0-rc.2(@angular/compiler@packages+compiler)(typescript@5.8.3)
+      '@angular/compiler-cli': link:packages/compiler-cli
       '@angular/core': link:packages/core
       '@angular/localize': link:packages/localize
       '@angular/platform-browser': link:packages/platform-browser
-      '@angular/ssr': 20.0.0-rc.3(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)(@angular/router@20.0.0-rc.2)
+      '@angular/ssr': 20.0.0-rc.3
       '@babel/core': 7.27.1
       '@babel/helper-annotate-as-pure': 7.27.1
       '@babel/helper-split-export-declaration': 7.24.7
@@ -1542,22 +1365,20 @@ packages:
       istanbul-lib-instrument: 6.0.3
       jsonc-parser: 3.3.1
       karma: 6.4.4
-      less: 4.3.0
       listr2: 8.3.3
       magic-string: 0.30.17
       mrmime: 2.0.1
       parse5-html-rewriting-stream: 7.1.0
       picomatch: 4.0.2
       piscina: 5.0.0
-      postcss: 8.5.3
       rollup: 4.40.2
       sass: 1.88.0
       semver: 7.7.2
       source-map-support: 0.5.21
       tinyglobby: 0.2.13
       tslib: 2.8.1
-      typescript: 5.8.3
-      vite: 6.3.5(@types/node@18.19.103)(less@4.3.0)(sass@1.88.0)(terser@5.39.2)(tsx@4.19.4)
+      typescript: 5.8.2
+      vite: 6.3.5(@types/node@18.19.103)(sass@1.88.0)(terser@5.39.2)(tsx@4.19.4)
       watchpack: 2.4.2
     optionalDependencies:
       lmdb: 3.3.0
@@ -1575,7 +1396,7 @@ packages:
       - yaml
     dev: false
 
-  /@angular/build@20.0.0-rc.3(@angular/core@20.0.0-rc.2)(@angular/platform-browser@20.0.0-rc.2)(@angular/ssr@20.0.0-rc.3)(@types/node@18.19.103)(chokidar@4.0.3)(karma@6.4.4)(less@4.3.0)(postcss@8.5.3)(terser@5.39.1)(tslib@2.8.1)(tsx@4.19.4)(typescript@5.8.2):
+  /@angular/build@20.0.0-rc.3(@angular/compiler-cli@packages+compiler-cli)(@angular/compiler@packages+compiler)(@angular/ssr@20.0.0-rc.3)(@types/node@18.19.103)(chokidar@4.0.3)(karma@6.4.4)(less@4.3.0)(postcss@8.5.3)(terser@5.39.1)(tslib@2.8.1)(tsx@4.19.4)(typescript@5.8.2):
     resolution: {integrity: sha512-O5OIcL5jT3MOHuPjKD3po71OcmVmSsr/JLru+eSNsN1bcfEPALqhtwbwoIVgnoT/awZxzMZVvxxMflB/uIradQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     peerDependencies:
@@ -1623,9 +1444,9 @@ packages:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2000.0-rc.3(chokidar@4.0.3)
-      '@angular/core': 20.0.0-rc.2(rxjs@7.8.2)(zone.js@0.12.0)
-      '@angular/platform-browser': 20.0.0-rc.2(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)
-      '@angular/ssr': 20.0.0-rc.3(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)(@angular/router@20.0.0-rc.2)
+      '@angular/compiler': link:packages/compiler
+      '@angular/compiler-cli': link:packages/compiler-cli
+      '@angular/ssr': 20.0.0-rc.3
       '@babel/core': 7.27.1
       '@babel/helper-annotate-as-pure': 7.27.1
       '@babel/helper-split-export-declaration': 7.24.7
@@ -1671,7 +1492,7 @@ packages:
       - yaml
     dev: false
 
-  /@angular/build@20.0.0-rc.3(@angular/core@20.0.0-rc.2)(@angular/platform-browser@20.0.0-rc.2)(@angular/ssr@20.0.0-rc.3)(@types/node@18.19.103)(chokidar@4.0.3)(karma@6.4.4)(less@4.3.0)(postcss@8.5.3)(terser@5.39.2)(tslib@2.8.1)(tsx@4.19.4)(typescript@5.8.2):
+  /@angular/build@20.0.0-rc.3(@angular/compiler-cli@packages+compiler-cli)(@angular/compiler@packages+compiler)(@angular/ssr@20.0.0-rc.3)(@types/node@18.19.103)(chokidar@4.0.3)(karma@6.4.4)(terser@5.39.2)(tslib@2.8.1)(tsx@4.19.4)(typescript@5.8.2):
     resolution: {integrity: sha512-O5OIcL5jT3MOHuPjKD3po71OcmVmSsr/JLru+eSNsN1bcfEPALqhtwbwoIVgnoT/awZxzMZVvxxMflB/uIradQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     peerDependencies:
@@ -1719,9 +1540,9 @@ packages:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2000.0-rc.3(chokidar@4.0.3)
-      '@angular/core': 20.0.0-rc.2(rxjs@7.8.2)(zone.js@0.12.0)
-      '@angular/platform-browser': 20.0.0-rc.2(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)
-      '@angular/ssr': 20.0.0-rc.3(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)(@angular/router@20.0.0-rc.2)
+      '@angular/compiler': link:packages/compiler
+      '@angular/compiler-cli': link:packages/compiler-cli
+      '@angular/ssr': 20.0.0-rc.3
       '@babel/core': 7.27.1
       '@babel/helper-annotate-as-pure': 7.27.1
       '@babel/helper-split-export-declaration': 7.24.7
@@ -1734,14 +1555,12 @@ packages:
       istanbul-lib-instrument: 6.0.3
       jsonc-parser: 3.3.1
       karma: 6.4.4
-      less: 4.3.0
       listr2: 8.3.3
       magic-string: 0.30.17
       mrmime: 2.0.1
       parse5-html-rewriting-stream: 7.1.0
       picomatch: 4.0.2
       piscina: 5.0.0
-      postcss: 8.5.3
       rollup: 4.40.2
       sass: 1.88.0
       semver: 7.7.2
@@ -1749,7 +1568,7 @@ packages:
       tinyglobby: 0.2.13
       tslib: 2.8.1
       typescript: 5.8.2
-      vite: 6.3.5(@types/node@18.19.103)(less@4.3.0)(sass@1.88.0)(terser@5.39.2)(tsx@4.19.4)
+      vite: 6.3.5(@types/node@18.19.103)(sass@1.88.0)(terser@5.39.2)(tsx@4.19.4)
       watchpack: 2.4.2
     optionalDependencies:
       lmdb: 3.3.0
@@ -1767,15 +1586,13 @@ packages:
       - yaml
     dev: false
 
-  /@angular/cdk@20.0.0-rc.2(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)(rxjs@7.8.2):
+  /@angular/cdk@20.0.0-rc.2(rxjs@7.8.2):
     resolution: {integrity: sha512-jqv5621my90f9mn3iZRkAp8f7Dn1b16QyuDl6csOsH4wATySIprCE9jECcyAOtWvWGibw4fr5kocYkX+Lljlag==}
     peerDependencies:
       '@angular/common': ^20.0.0-0 || ^20.1.0-0 || ^20.2.0-0 || ^20.3.0-0 || ^21.0.0-0
       '@angular/core': ^20.0.0-0 || ^20.1.0-0 || ^20.2.0-0 || ^20.3.0-0 || ^21.0.0-0
       rxjs: ^6.5.3 || ^7.4.0
     dependencies:
-      '@angular/common': 20.0.0-rc.2(@angular/core@20.0.0-rc.2)(rxjs@7.8.2)
-      '@angular/core': 20.0.0-rc.2(rxjs@7.8.2)(zone.js@0.12.0)
       parse5: 7.3.0
       rxjs: 7.8.2
       tslib: 2.8.1
@@ -1808,69 +1625,7 @@ packages:
       - supports-color
     dev: false
 
-  /@angular/common@20.0.0-rc.2(@angular/core@20.0.0-rc.2)(rxjs@7.8.2):
-    resolution: {integrity: sha512-uI6cz18nN/SqUpGB4m6rKUVPJGEyDaWwBK46sS5XVrpTLwTah1ELQGbJfjX1HNZMTdjF+v8SxBLLpikf9XFMeA==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-    peerDependencies:
-      '@angular/core': 20.0.0-rc.2
-      rxjs: ^6.5.3 || ^7.4.0
-    dependencies:
-      '@angular/core': 20.0.0-rc.2(rxjs@7.8.2)(zone.js@0.12.0)
-      rxjs: 7.8.2
-      tslib: 2.8.1
-
-  /@angular/compiler-cli@20.0.0-rc.2(@angular/compiler@20.0.0-rc.2)(typescript@5.8.3):
-    resolution: {integrity: sha512-poPedZI8qNBvdjPikAFWNpiNzIDEgkwVhhCxPyznUjsnvg4fDDLvxgMX1EWYk/sr/jdbDLYydaBqYQznpzl9Zw==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-    hasBin: true
-    peerDependencies:
-      '@angular/compiler': 20.0.0-rc.2
-      typescript: '>=5.8 <5.9'
-    dependencies:
-      '@angular/compiler': 20.0.0-rc.2
-      '@babel/core': 7.27.1
-      '@jridgewell/sourcemap-codec': 1.5.0
-      chokidar: 4.0.3
-      convert-source-map: 1.9.0
-      reflect-metadata: 0.2.2
-      semver: 7.7.2
-      tslib: 2.8.1
-      typescript: 5.8.3
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@angular/compiler-cli@20.0.0-rc.2(@angular/compiler@packages+compiler)(typescript@5.8.3):
-    resolution: {integrity: sha512-poPedZI8qNBvdjPikAFWNpiNzIDEgkwVhhCxPyznUjsnvg4fDDLvxgMX1EWYk/sr/jdbDLYydaBqYQznpzl9Zw==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-    hasBin: true
-    peerDependencies:
-      '@angular/compiler': 20.0.0-rc.2
-      typescript: '>=5.8 <5.9'
-    dependencies:
-      '@angular/compiler': link:packages/compiler
-      '@babel/core': 7.27.1
-      '@jridgewell/sourcemap-codec': 1.5.0
-      chokidar: 4.0.3
-      convert-source-map: 1.9.0
-      reflect-metadata: 0.2.2
-      semver: 7.7.2
-      tslib: 2.8.1
-      typescript: 5.8.3
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@angular/compiler@20.0.0-rc.2:
-    resolution: {integrity: sha512-dlBxczXg4QvEetXdS4IxS2wujotrqBi2IeG9kXBwyT8rYCuoQ/XkiARYtWze9gSx8vhDj2HYjY2TgdGcWvezwQ==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-    dependencies:
-      tslib: 2.8.1
-    dev: false
-
-  /@angular/core@14.3.0(rxjs@7.8.2)(zone.js@0.12.0):
+  /@angular/core@14.3.0(rxjs@7.8.2):
     resolution: {integrity: sha512-wYiwItc0Uyn4FWZ/OAx/Ubp2/WrD3EgUJ476y1XI7yATGPF8n9Ld5iCXT08HOvc4eBcYlDfh90kTXR6/MfhzdQ==}
     engines: {node: ^14.15.0 || >=16.10.0}
     peerDependencies:
@@ -1879,41 +1634,9 @@ packages:
     dependencies:
       rxjs: 7.8.2
       tslib: 2.8.1
-      zone.js: 0.12.0
     dev: true
 
-  /@angular/core@20.0.0-rc.2(rxjs@7.8.2)(zone.js@0.12.0):
-    resolution: {integrity: sha512-yblIk2fE5PUVfzeono+fEd/gQsIH45kmOrxmmmAjXBx1B5qXkoBGgFMtqtJ4VjQRVk1CsLFikCejBoygz6waeA==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-    peerDependencies:
-      '@angular/compiler': 20.0.0-rc.2
-      rxjs: ^6.5.3 || ^7.4.0
-      zone.js: ~0.15.0
-    peerDependenciesMeta:
-      '@angular/compiler':
-        optional: true
-    dependencies:
-      rxjs: 7.8.2
-      tslib: 2.8.1
-      zone.js: 0.12.0
-
-  /@angular/forms@20.0.0-rc.2(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)(@angular/platform-browser@20.0.0-rc.2)(rxjs@7.8.2):
-    resolution: {integrity: sha512-M1JP2xEo6A8nOm5/HExQpihGiZEZT3LiwO6hge+uMlsNw7Z5rs5m4t547uZhBROrxMfIoBk/n02OXGk62WE3SQ==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-    peerDependencies:
-      '@angular/common': 20.0.0-rc.2
-      '@angular/core': 20.0.0-rc.2
-      '@angular/platform-browser': 20.0.0-rc.2
-      rxjs: ^6.5.3 || ^7.4.0
-    dependencies:
-      '@angular/common': 20.0.0-rc.2(@angular/core@20.0.0-rc.2)(rxjs@7.8.2)
-      '@angular/core': 20.0.0-rc.2(rxjs@7.8.2)(zone.js@0.12.0)
-      '@angular/platform-browser': 20.0.0-rc.2(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)
-      rxjs: 7.8.2
-      tslib: 2.8.1
-    dev: false
-
-  /@angular/material@20.0.0-rc.2(@angular/cdk@20.0.0-rc.2)(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)(@angular/forms@20.0.0-rc.2)(@angular/platform-browser@20.0.0-rc.2)(rxjs@7.8.2):
+  /@angular/material@20.0.0-rc.2(@angular/cdk@20.0.0-rc.2)(rxjs@7.8.2):
     resolution: {integrity: sha512-/ktz7f9Kc3+8NaJGDAROFlgGWMWGb0SgLio4CcxxZ2JxNH4JB2XSTnoQoFrShATTuaoBQ/D8/YaE+L5BZTPvGw==}
     peerDependencies:
       '@angular/cdk': 20.0.0-rc.2
@@ -1923,46 +1646,12 @@ packages:
       '@angular/platform-browser': ^20.0.0-0 || ^20.1.0-0 || ^20.2.0-0 || ^20.3.0-0 || ^21.0.0-0
       rxjs: ^6.5.3 || ^7.4.0
     dependencies:
-      '@angular/cdk': 20.0.0-rc.2(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)(rxjs@7.8.2)
-      '@angular/common': 20.0.0-rc.2(@angular/core@20.0.0-rc.2)(rxjs@7.8.2)
-      '@angular/core': 20.0.0-rc.2(rxjs@7.8.2)(zone.js@0.12.0)
-      '@angular/forms': 20.0.0-rc.2(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)(@angular/platform-browser@20.0.0-rc.2)(rxjs@7.8.2)
-      '@angular/platform-browser': 20.0.0-rc.2(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)
+      '@angular/cdk': 20.0.0-rc.2(rxjs@7.8.2)
       rxjs: 7.8.2
       tslib: 2.8.1
     dev: false
 
-  /@angular/platform-browser@20.0.0-rc.2(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2):
-    resolution: {integrity: sha512-mqaR2ZkbpMYRtDbF9JMI+w2sDkXJyaQFVgPpGE5KwDQS53n+1uCP+OPi6b0M0PMJSSirpPdP4+iqQG+DyTZfvA==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-    peerDependencies:
-      '@angular/animations': 20.0.0-rc.2
-      '@angular/common': 20.0.0-rc.2
-      '@angular/core': 20.0.0-rc.2
-    peerDependenciesMeta:
-      '@angular/animations':
-        optional: true
-    dependencies:
-      '@angular/common': 20.0.0-rc.2(@angular/core@20.0.0-rc.2)(rxjs@7.8.2)
-      '@angular/core': 20.0.0-rc.2(rxjs@7.8.2)(zone.js@0.12.0)
-      tslib: 2.8.1
-
-  /@angular/router@20.0.0-rc.2(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)(@angular/platform-browser@20.0.0-rc.2)(rxjs@7.8.2):
-    resolution: {integrity: sha512-Cc0VFkkOS9q5+C0dXf8XnfrbkEIcgm15hYukiDafTjrB4SKoBTVA0NiHb7LyN/9Vzk1CErWz86Qk6Bc9pZ7G5w==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-    peerDependencies:
-      '@angular/common': 20.0.0-rc.2
-      '@angular/core': 20.0.0-rc.2
-      '@angular/platform-browser': 20.0.0-rc.2
-      rxjs: ^6.5.3 || ^7.4.0
-    dependencies:
-      '@angular/common': 20.0.0-rc.2(@angular/core@20.0.0-rc.2)(rxjs@7.8.2)
-      '@angular/core': 20.0.0-rc.2(rxjs@7.8.2)(zone.js@0.12.0)
-      '@angular/platform-browser': 20.0.0-rc.2(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)
-      rxjs: 7.8.2
-      tslib: 2.8.1
-
-  /@angular/ssr@20.0.0-rc.3(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)(@angular/router@20.0.0-rc.2):
+  /@angular/ssr@20.0.0-rc.3:
     resolution: {integrity: sha512-i2fS6GRMlKd1WQF0Jskdgm7PKIAt6Jt8aCd7kKsRooXamYkMIT/FhzB09Mf5enNKRV+uKJkeB3EYFvKdk2BEfg==}
     peerDependencies:
       '@angular/common': ^20.0.0 || ^20.0.0-next.0
@@ -1973,9 +1662,6 @@ packages:
       '@angular/platform-server':
         optional: true
     dependencies:
-      '@angular/common': 20.0.0-rc.2(@angular/core@20.0.0-rc.2)(rxjs@7.8.2)
-      '@angular/core': 20.0.0-rc.2(rxjs@7.8.2)(zone.js@0.12.0)
-      '@angular/router': 20.0.0-rc.2(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)(@angular/platform-browser@20.0.0-rc.2)(rxjs@7.8.2)
       tslib: 2.8.1
 
   /@antfu/install-pkg@1.1.0:
@@ -3343,7 +3029,7 @@ packages:
     hasBin: true
     dev: true
 
-  /@bazel/concatjs@5.8.1(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-junit-reporter@2.0.1)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(typescript@5.7.3):
+  /@bazel/concatjs@5.8.1(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(typescript@5.7.3):
     resolution: {integrity: sha512-TkARsNUxgi3bjFeGwIGlffmQglNhuR9qK9uE7uKhdBZvQE5caAWVCjYiMTzo3viKDhwKn5QNRcHY5huuJMVFfA==}
     hasBin: true
     peerDependencies:
@@ -3359,7 +3045,6 @@ packages:
       karma-chrome-launcher: 3.2.0
       karma-firefox-launcher: 2.1.3
       karma-jasmine: 5.1.0(karma@6.4.4)
-      karma-junit-reporter: 2.0.1(karma@6.4.4)
       karma-requirejs: 1.1.0(karma@6.4.4)(requirejs@2.3.7)
       karma-sourcemap-loader: 0.4.0
       protobufjs: 6.8.8
@@ -3369,7 +3054,7 @@ packages:
       - typescript
     dev: true
 
-  /@bazel/concatjs@5.8.1(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-junit-reporter@2.0.1)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(typescript@5.8.2):
+  /@bazel/concatjs@5.8.1(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(typescript@5.8.2):
     resolution: {integrity: sha512-TkARsNUxgi3bjFeGwIGlffmQglNhuR9qK9uE7uKhdBZvQE5caAWVCjYiMTzo3viKDhwKn5QNRcHY5huuJMVFfA==}
     hasBin: true
     peerDependencies:
@@ -3385,7 +3070,6 @@ packages:
       karma-chrome-launcher: 3.2.0
       karma-firefox-launcher: 2.1.3
       karma-jasmine: 5.1.0(karma@6.4.4)
-      karma-junit-reporter: 2.0.1(karma@6.4.4)
       karma-requirejs: 1.1.0(karma@6.4.4)(requirejs@2.3.7)
       karma-sourcemap-loader: 0.4.0
       protobufjs: 6.8.8
@@ -5301,11 +4985,12 @@ packages:
       '@napi-rs/nice-win32-x64-msvc': 1.0.1
     optional: true
 
-  /@nginfra/angular-linking@1.0.10:
+  /@nginfra/angular-linking@1.0.10(@angular/compiler-cli@packages+compiler-cli):
     resolution: {integrity: sha512-31zx+PCN8tBlC0FYUuCxS4uVPJLAlBhi4UVp6QgoQG44RsOHKTmcRORMVSJdPLRgRuCJkY45kj+PE3AxsgiUKA==}
     peerDependencies:
       '@angular/compiler-cli': '*'
     dependencies:
+      '@angular/compiler-cli': link:packages/compiler-cli
       '@babel/core': 7.26.10
       '@types/babel__core': 7.20.5
       '@types/node': 22.15.21
@@ -5315,7 +5000,7 @@ packages:
       - supports-color
     dev: true
 
-  /@ngtools/webpack@20.0.0-rc.3(typescript@5.8.2)(webpack@5.99.8):
+  /@ngtools/webpack@20.0.0-rc.3(@angular/compiler-cli@packages+compiler-cli)(typescript@5.8.2)(webpack@5.99.8):
     resolution: {integrity: sha512-WIDAxFU671xqBy1IYDGNXpzca4fHtbrHeuSy64gSbjWcw6wCMUrwfdgCI2h5T6BjobBpxl+zQ9xa1AfdjkotSg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     peerDependencies:
@@ -5323,6 +5008,7 @@ packages:
       typescript: '>=5.8 <5.9'
       webpack: ^5.54.0
     dependencies:
+      '@angular/compiler-cli': link:packages/compiler-cli
       typescript: 5.8.2
       webpack: 5.99.8(esbuild@0.25.4)
     dev: false
@@ -6384,7 +6070,7 @@ packages:
       '@types/node': 18.19.103
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
-      ajv-formats: 3.0.1(ajv@8.13.0)
+      ajv-formats: 3.0.1
       fs-extra: 7.0.1
       import-lazy: 4.0.0
       jju: 1.4.0
@@ -6403,7 +6089,7 @@ packages:
       '@types/node': 18.19.103
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
-      ajv-formats: 3.0.1(ajv@8.13.0)
+      ajv-formats: 3.0.1
       fs-extra: 11.3.0
       import-lazy: 4.0.0
       jju: 1.4.0
@@ -7381,7 +7067,7 @@ packages:
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
     dependencies:
-      vite: 6.0.7(@types/node@18.19.103)(less@4.3.0)(sass@1.83.1)(terser@5.39.2)(tsx@4.19.4)
+      vite: 6.0.7(@types/node@18.19.103)(sass@1.83.1)(terser@5.39.2)(tsx@4.19.4)
     dev: true
 
   /@vitejs/plugin-basic-ssl@2.0.0(vite@6.3.5):
@@ -7390,7 +7076,7 @@ packages:
     peerDependencies:
       vite: ^6.0.0
     dependencies:
-      vite: 6.3.5(@types/node@18.19.103)(less@4.3.0)(sass@1.88.0)(terser@5.39.2)(tsx@4.19.4)
+      vite: 6.3.5(@types/node@18.19.103)(sass@1.88.0)(terser@5.39.2)(tsx@4.19.4)
     dev: false
 
   /@vitest/expect@3.1.4:
@@ -7416,7 +7102,7 @@ packages:
       '@vitest/spy': 3.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
-      vite: 6.3.5(@types/node@10.17.60)(less@4.3.0)(terser@5.39.2)(tsx@4.19.4)
+      vite: 6.3.5(@types/node@10.17.60)(terser@5.39.2)(tsx@4.19.4)
     dev: true
 
   /@vitest/pretty-format@3.1.4:
@@ -7734,23 +7420,8 @@ packages:
     dependencies:
       ajv: 8.17.1
 
-  /ajv-formats@3.0.1(ajv@8.13.0):
+  /ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-    dependencies:
-      ajv: 8.13.0
-
-  /ajv-formats@3.0.1(ajv@8.17.1):
-    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
     dependencies:
       ajv: 8.17.1
 
@@ -7830,15 +7501,13 @@ packages:
     resolution: {integrity: sha512-vqsT6zwu80cZ8RY7qRQBZuy6Fq5X7/N5hkV9LzNT0c8b546rw4ErGK6muW1u2JnDKYa7+jJuaGM702bWir4HGw==}
     dev: false
 
-  /angular-split@19.0.0(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)(rxjs@7.8.2):
+  /angular-split@19.0.0(rxjs@7.8.2):
     resolution: {integrity: sha512-vQqXWLcCimFmInu2lpGKIfS9FtYBgKmoWenPjeYkHSRdWmb7HLGlQoNPj1oALrwdhIWFPdySgp0BIXDe2IAepQ==}
     peerDependencies:
       '@angular/common': '>=19.0.0'
       '@angular/core': '>=19.0.0'
       rxjs: '>=7.0.0'
     dependencies:
-      '@angular/common': 20.0.0-rc.2(@angular/core@20.0.0-rc.2)(rxjs@7.8.2)
-      '@angular/core': 20.0.0-rc.2(rxjs@7.8.2)(zone.js@0.12.0)
       rxjs: 7.8.2
       tslib: 2.8.1
     dev: true
@@ -9765,6 +9434,7 @@ packages:
     resolution: {integrity: sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==}
     dependencies:
       is-what: 3.14.1
+    dev: false
 
   /copy-descriptor@0.1.1:
     resolution: {integrity: sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==}
@@ -10938,6 +10608,7 @@ packages:
     hasBin: true
     dependencies:
       prr: 1.0.1
+    dev: false
     optional: true
 
   /error-ex@1.3.2:
@@ -11750,7 +11421,7 @@ packages:
       '@modelcontextprotocol/sdk': 1.12.0
       abort-controller: 3.0.0
       ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
+      ajv-formats: 3.0.1
       archiver: 7.0.1
       async-lock: 1.4.1
       body-parser: 1.20.3
@@ -13061,6 +12732,7 @@ packages:
     resolution: {integrity: sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==}
     engines: {node: '>=0.10.0'}
     hasBin: true
+    dev: false
     optional: true
 
   /immediate@3.0.6:
@@ -13631,6 +13303,7 @@ packages:
 
   /is-what@3.14.1:
     resolution: {integrity: sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==}
+    dev: false
 
   /is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
@@ -14622,16 +14295,6 @@ packages:
       jasmine-core: 4.6.1
       karma: 6.4.4
 
-  /karma-junit-reporter@2.0.1(karma@6.4.4):
-    resolution: {integrity: sha512-VtcGfE0JE4OE1wn0LK8xxDKaTP7slN8DO3I+4xg6gAi1IoAHAXOJ1V9G/y45Xg6sxdxPOR3THCFtDlAfBo9Afw==}
-    engines: {node: '>= 8'}
-    peerDependencies:
-      karma: '>=0.9'
-    dependencies:
-      karma: 6.4.4
-      path-is-absolute: 1.0.1
-      xmlbuilder: 12.0.0
-
   /karma-requirejs@1.1.0(karma@6.4.4)(requirejs@2.3.7):
     resolution: {integrity: sha512-MHTOYKdwwJBkvYid0TaYvBzOnFH3TDtzo6ie5E4o9SaUSXXsfMRLa/whUz6efVIgTxj1xnKYasNn/XwEgJeB/Q==}
     peerDependencies:
@@ -14832,6 +14495,7 @@ packages:
       mime: 1.6.0
       needle: 3.3.1
       source-map: 0.6.1
+    dev: false
 
   /leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -15241,6 +14905,7 @@ packages:
     dependencies:
       pify: 4.0.1
       semver: 5.7.2
+    dev: false
 
   /make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -15864,6 +15529,7 @@ packages:
     dependencies:
       iconv-lite: 0.6.3
       sax: 1.4.1
+    dev: false
     optional: true
 
   /negotiator@0.6.3:
@@ -15886,18 +15552,16 @@ packages:
     engines: {node: '>= 0.4.0'}
     dev: true
 
-  /ngx-flamegraph@0.0.12(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2):
+  /ngx-flamegraph@0.0.12:
     resolution: {integrity: sha512-YoxrqlL36Bg5Ca9fu10kuSUmaWHAvx7jkxINF4/4cXn9bBPRfu78FqnZ5LIULC0+iScZcSDSWDAnUdn8H7+wGw==}
     peerDependencies:
       '@angular/common': ^9.0.0
       '@angular/core': ^9.0.0
     dependencies:
-      '@angular/common': 20.0.0-rc.2(@angular/core@20.0.0-rc.2)(rxjs@7.8.2)
-      '@angular/core': 20.0.0-rc.2(rxjs@7.8.2)(zone.js@0.12.0)
       tslib: 2.8.1
     dev: false
 
-  /ngx-progressbar@14.0.0(@angular/cdk@20.0.0-rc.2)(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)(rxjs@7.8.2):
+  /ngx-progressbar@14.0.0(@angular/cdk@20.0.0-rc.2)(rxjs@7.8.2):
     resolution: {integrity: sha512-tDj7h5F2aSI4/XaJjs50FnELVe6qFqyz3vVq22acacd3oDW2EyJB4c+IYaxMf5972OdTw0WL4n6UwQ3dqC+gCA==}
     peerDependencies:
       '@angular/cdk': '>=17.3.0'
@@ -15905,9 +15569,7 @@ packages:
       '@angular/core': '>=17.3.0'
       rxjs: '>=7.0.0'
     dependencies:
-      '@angular/cdk': 20.0.0-rc.2(@angular/common@20.0.0-rc.2)(@angular/core@20.0.0-rc.2)(rxjs@7.8.2)
-      '@angular/common': 20.0.0-rc.2(@angular/core@20.0.0-rc.2)(rxjs@7.8.2)
-      '@angular/core': 20.0.0-rc.2(rxjs@7.8.2)(zone.js@0.12.0)
+      '@angular/cdk': 20.0.0-rc.2(rxjs@7.8.2)
       rxjs: 7.8.2
       tslib: 2.8.1
     dev: false
@@ -16498,6 +16160,7 @@ packages:
   /parse-node-version@1.0.1:
     resolution: {integrity: sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==}
     engines: {node: '>= 0.10'}
+    dev: false
 
   /parse-passwd@1.0.0:
     resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
@@ -16755,6 +16418,7 @@ packages:
   /pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+    dev: false
 
   /pinkie-promise@2.0.1:
     resolution: {integrity: sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==}
@@ -17149,6 +16813,7 @@ packages:
 
   /prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
+    dev: false
     optional: true
 
   /psl@1.15.0:
@@ -19516,8 +19181,8 @@ packages:
       fdir: 6.4.4(picomatch@4.0.2)
       picomatch: 4.0.2
 
-  /tinypool@1.0.2:
-    resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
+  /tinypool@1.1.0:
+    resolution: {integrity: sha512-7CotroY9a8DKsKprEy/a14aCCm8jYVmR7aFy4fpkZM8sdpNJbKkixuNjgM50yCmip2ezc8z4N7k3oe2+rfRJCQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     dev: true
 
@@ -19749,7 +19414,7 @@ packages:
       typescript: '>=3.9.2'
     dependencies:
       '@bazel/bazelisk': 1.26.0
-      '@bazel/concatjs': 5.8.1(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-junit-reporter@2.0.1)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(typescript@5.8.2)
+      '@bazel/concatjs': 5.8.1(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(typescript@5.8.2)
       glob: 7.2.3
       minimatch: 3.1.2
       typescript: 5.8.2
@@ -20498,7 +20163,7 @@ packages:
       teex: 1.0.1
     dev: true
 
-  /vite-node@3.1.4(@types/node@10.17.60)(less@4.3.0)(terser@5.39.2)(tsx@4.19.4):
+  /vite-node@3.1.4(@types/node@10.17.60)(terser@5.39.2)(tsx@4.19.4):
     resolution: {integrity: sha512-6enNwYnpyDo4hEgytbmc6mYWHXDHYEn0D1/rw4Q+tnHUGtKTJsn8T1YkX6Q18wI5LCrS8CTYlBaiCqxOy2kvUA==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -20507,7 +20172,7 @@ packages:
       debug: 4.4.1(supports-color@10.0.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@10.17.60)(less@4.3.0)(terser@5.39.2)(tsx@4.19.4)
+      vite: 6.3.5(@types/node@10.17.60)(terser@5.39.2)(tsx@4.19.4)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -20523,7 +20188,7 @@ packages:
       - yaml
     dev: true
 
-  /vite@6.0.7(@types/node@18.19.103)(less@4.3.0)(sass@1.83.1)(terser@5.39.2)(tsx@4.19.4):
+  /vite@6.0.7(@types/node@18.19.103)(sass@1.83.1)(terser@5.39.2)(tsx@4.19.4):
     resolution: {integrity: sha512-RDt8r/7qx9940f8FcOIAH9PTViRrghKaK2K1jY3RaAURrEUbm9Du1mJ72G+jlhtG3WwodnfzY8ORQZbBavZEAQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -20565,7 +20230,6 @@ packages:
     dependencies:
       '@types/node': 18.19.103
       esbuild: 0.24.2
-      less: 4.3.0
       postcss: 8.5.3
       rollup: 4.41.1
       sass: 1.83.1
@@ -20575,7 +20239,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vite@6.3.5(@types/node@10.17.60)(less@4.3.0)(terser@5.39.2)(tsx@4.19.4):
+  /vite@6.3.5(@types/node@10.17.60)(terser@5.39.2)(tsx@4.19.4):
     resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -20618,7 +20282,6 @@ packages:
       '@types/node': 10.17.60
       esbuild: 0.25.4
       fdir: 6.4.4(picomatch@4.0.2)
-      less: 4.3.0
       picomatch: 4.0.2
       postcss: 8.5.3
       rollup: 4.41.1
@@ -20684,7 +20347,7 @@ packages:
       fsevents: 2.3.3
     dev: false
 
-  /vite@6.3.5(@types/node@18.19.103)(less@4.3.0)(sass@1.88.0)(terser@5.39.2)(tsx@4.19.4):
+  /vite@6.3.5(@types/node@18.19.103)(sass@1.88.0)(terser@5.39.2)(tsx@4.19.4):
     resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -20727,7 +20390,6 @@ packages:
       '@types/node': 18.19.103
       esbuild: 0.25.4
       fdir: 6.4.4(picomatch@4.0.2)
-      less: 4.3.0
       picomatch: 4.0.2
       postcss: 8.5.3
       rollup: 4.41.1
@@ -20739,7 +20401,7 @@ packages:
       fsevents: 2.3.3
     dev: false
 
-  /vitest@3.1.4(@types/node@10.17.60)(jsdom@26.1.0)(less@4.3.0)(terser@5.39.2)(tsx@4.19.4):
+  /vitest@3.1.4(@types/node@10.17.60)(jsdom@26.1.0)(terser@5.39.2)(tsx@4.19.4):
     resolution: {integrity: sha512-Ta56rT7uWxCSJXlBtKgIlApJnT6e6IGmTYxYcmxjJ4ujuZDI59GUQgVDObXXJujOmPDBYXHK1qmaGtneu6TNIQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -20785,10 +20447,10 @@ packages:
       tinybench: 2.9.0
       tinyexec: 0.3.2
       tinyglobby: 0.2.14
-      tinypool: 1.0.2
+      tinypool: 1.1.0
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@10.17.60)(less@4.3.0)(terser@5.39.2)(tsx@4.19.4)
-      vite-node: 3.1.4(@types/node@10.17.60)(less@4.3.0)(terser@5.39.2)(tsx@4.19.4)
+      vite: 6.3.5(@types/node@10.17.60)(terser@5.39.2)(tsx@4.19.4)
+      vite-node: 3.1.4(@types/node@10.17.60)(terser@5.39.2)(tsx@4.19.4)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - jiti
@@ -21461,10 +21123,6 @@ packages:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
 
-  /xmlbuilder@12.0.0:
-    resolution: {integrity: sha512-lMo8DJ8u6JRWp0/Y4XLa/atVDr75H9litKlb2E5j3V3MesoL50EBgZDWoLT3F/LztVnG67GjPXLZpqcky/UMnQ==}
-    engines: {node: '>=6.0'}
-
   /xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
     dev: true
@@ -21626,27 +21284,22 @@ packages:
     resolution: {integrity: sha512-/nt/67WYKnr5by3YS7LroZJbtcCBurDKKPBPWWzaxvVCGuG/NOsiKkrjoOhI8mJ+SQUXEbUzeB3S+6XDUEEj7Q==}
     dev: true
 
-  /zone.js@0.12.0:
-    resolution: {integrity: sha512-XtC+I5dXU14HrzidAKBNMqneIVUykLEAA1x+v4KVrd6AUPWlwYORF8KgsVqvgdHiKZ4BkxxjvYi/ksEixTPR0Q==}
-    dependencies:
-      tslib: 2.8.1
-
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
 
-  github.com/angular/dev-infra-private-build-tooling-builds/5db176c0f3211663830fd3ff4064c1dff0eaccb4(@angular/ssr@20.0.0-rc.3)(chokidar@4.0.3)(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-junit-reporter@2.0.1)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(less@4.3.0)(postcss@8.5.3)(rxjs@7.8.2)(terser@5.39.2)(tsx@4.19.4)(zone.js@0.12.0):
+  github.com/angular/dev-infra-private-build-tooling-builds/5db176c0f3211663830fd3ff4064c1dff0eaccb4(@angular/compiler-cli@packages+compiler-cli)(@angular/compiler@packages+compiler)(@angular/ssr@20.0.0-rc.3)(chokidar@4.0.3)(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(rxjs@7.8.2)(terser@5.39.2)(tsx@4.19.4):
     resolution: {tarball: https://codeload.github.com/angular/dev-infra-private-build-tooling-builds/tar.gz/5db176c0f3211663830fd3ff4064c1dff0eaccb4}
     id: github.com/angular/dev-infra-private-build-tooling-builds/5db176c0f3211663830fd3ff4064c1dff0eaccb4
     name: '@angular/build-tooling'
     version: 0.0.0-d44be7e28087c3499d70dda9859d51c1cd3fe1bf
     dependencies:
-      '@angular/benchpress': 0.3.0(rxjs@7.8.2)(zone.js@0.12.0)
-      '@angular/build': 19.1.0-rc.0(@angular/ssr@20.0.0-rc.3)(@types/node@18.19.103)(chokidar@4.0.3)(less@4.3.0)(postcss@8.5.3)(terser@5.39.2)(tsx@4.19.4)(typescript@5.7.3)
+      '@angular/benchpress': 0.3.0(rxjs@7.8.2)
+      '@angular/build': 19.1.0-rc.0(@angular/compiler-cli@packages+compiler-cli)(@angular/compiler@packages+compiler)(@angular/ssr@20.0.0-rc.3)(@types/node@18.19.103)(chokidar@4.0.3)(terser@5.39.2)(tsx@4.19.4)(typescript@5.7.3)
       '@babel/core': 7.27.1
       '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.27.1)
       '@bazel/buildifier': 6.3.3
-      '@bazel/concatjs': 5.8.1(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-junit-reporter@2.0.1)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(typescript@5.7.3)
+      '@bazel/concatjs': 5.8.1(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(typescript@5.7.3)
       '@bazel/esbuild': 5.8.1
       '@bazel/protractor': 5.8.1(protractor@7.0.0)
       '@bazel/runfiles': 5.8.1


### PR DESCRIPTION
This ensures that the new optimization rule, and also adev (when we complete migrating it to `rules_js`) can use the latest compiler-cli version from HEAD.