### PR TITLE
fix(devtools): issue where on initial render DevTools would not load directive forest properly

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.ts
@@ -69,7 +69,6 @@ export class DirectiveForestComponent {
   readonly toggleInspector = output<void>();
 
   readonly viewport = viewChild.required<CdkVirtualScrollViewport>(CdkVirtualScrollViewport);
-  private readonly updateForestResult = computed(() => this.updateForest(this.forest()));
 
   readonly selectedNode = signal<FlatNode | null>(null);
   readonly highlightIdInTreeFromElement = signal<number | null>(null);
@@ -112,7 +111,8 @@ export class DirectiveForestComponent {
     this.resizeObserver.observe(this.elementRef.nativeElement);
 
     effect(() => {
-      const result = this.updateForestResult();
+      const result = this.updateForest(this.forest());
+
       const changed =
         result.movedItems.length || result.newItems.length || result.removedItems.length;
 


### PR DESCRIPTION
Commit 3e70d64b20 introduced cdk version 20.0.0-rc2 which introduced [this change to how the cdk virtual scroll sets some internal state.](https://github.com/angular/components/pull/31076/files)

Previously in DevTools we were using a computed incorrectly to respond to changes in the directive forest and apply them to the underlying datasource. With the change to the CDK shown above, this incorrect usage caused us to attempt to update underlying signals in the virtual scroll directive while within a computed callback, throwing an error.

This commit corrects our usage by swapping from a computed to an effect, allowing the underlying signals in the scroll directive to be updated without error.

Without fix:
<img width="1510" alt="Screenshot 2025-06-02 at 2 26 35 AM" src="https://github.com/user-attachments/assets/8f1397e0-3eca-44d2-9d10-960fd922c6fd" />

With fix:
<img width="1512" alt="Screenshot 2025-06-02 at 2 27 43 AM" src="https://github.com/user-attachments/assets/0257eb5d-2abf-4524-99fc-03bb36877be5" />
