### PR TITLE
fix(compiler): recover invalid parenthesized expressions

### DIFF
--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -1062,8 +1062,13 @@ class _ParseAST {
     if (this.consumeOptionalCharacter(chars.$LPAREN)) {
       this.rparensExpected++;
       const result = this.parsePipe();
+      if (!this.consumeOptionalCharacter(chars.$RPAREN)) {
+        this.error('Missing closing parentheses');
+        // Calling into `error` above will attempt to recover up until the next closing paren.
+        // If that's the case, consume it so we can partially recover the expression.
+        this.consumeOptionalCharacter(chars.$RPAREN);
+      }
       this.rparensExpected--;
-      this.expectCharacter(chars.$RPAREN);
       return new ParenthesizedExpression(this.span(start), this.sourceSpan(start), result);
     } else if (this.next.isKeywordNull()) {
       this.advance();


### PR DESCRIPTION
When the expression parser consumes tokens inside a parenthesized expression, it looks for valid tokens until it hits and invalid one or a closing paren. If it finds an invalid token, it reports an error and tries to recover until it finds a closing paren. The problem is that in such cases, it would produce the `ParenthesizedExpression` and continue parsing **from** from the closing paren which would then produce more errors that add noise to the output and result in an incorrect representation of the user's code. E.g. `foo((event.target as HTMLElement).value)` would be recovered to `foo((event.target)).value` instead of `foo((event.target).value)`.

These changes resolve the issue by skipping over the closing paren at the recovery point.

Fixes #61792.
