### PR TITLE
docs(migrations): update the docs for the migration to control flow s…

### DIFF
--- a/adev/src/content/reference/migrations/control-flow.md
+++ b/adev/src/content/reference/migrations/control-flow.md
@@ -8,6 +8,6 @@ Run the schematic using the following command:
 
 <docs-code language="shell">
 
-ng update @angular/core --name=control-flow-migration
+ng generate @angular/core:control-flow
 
 </docs-code>


### PR DESCRIPTION
…yntax

Change the command to execute the migration, because the command stated in the previous version results in the error "Cannot find migration 'control-flow-migration' in '@angular/core'.". The new command is more in line with the docs of other migrations.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Executing the command `ng update @angular/core --name=control-flow-migration` results in error `Cannot find migration 'control-flow-migration' in '@angular/core'.`.

Issue Number: N/A


## What is the new behavior?
The documentation is updated that shows a working command that doesn't result in an error.


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No



## Other information
