### PR TITLE
docs(docs-infra): Show deprecation message on the API docs

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/cli-entities.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/cli-entities.mts
@@ -28,5 +28,5 @@ export interface CliOption {
   description: string;
   positional?: number;
   aliases?: string[];
-  deprecated: {version: string | undefined} | undefined;
+  deprecated: {version: string | undefined; htmlMessage: string | undefined} | undefined;
 }

--- a/adev/shared-docs/pipeline/api-gen/rendering/entities/categorization.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/entities/categorization.mts
@@ -142,7 +142,13 @@ export function isDeprecatedEntry<T extends HasJsDocTags>(entry: T): boolean {
 }
 
 export function getDeprecatedEntry<T extends HasJsDocTags>(entry: T) {
-  return entry.jsdocTags.find((tag) => tag.name === 'deprecated')?.comment ?? null;
+  const comment = entry.jsdocTags.find((tag) => tag.name === 'deprecated')?.comment ?? null;
+  if (!comment) {
+    return null;
+  }
+
+  // Remove the version number from the deprecation message.
+  return comment.replace(/^\s*\d+\.{0,1}\d*/, '').trim();
 }
 
 /** Gets whether the given entry has a given JsDoc tag. */

--- a/adev/shared-docs/pipeline/api-gen/rendering/entities/renderables.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/entities/renderables.mts
@@ -24,11 +24,16 @@ import {
 
 import {CliCommand, CliOption} from '../cli-entities.mjs';
 
-import {HasRenderableToc} from './traits.mjs';
+import {HasDeprecatedFlag, HasRenderableToc} from './traits.mjs';
 
 /** JsDoc tag info augmented with transformed content for rendering. */
 export interface JsDocTagRenderable extends JsDocTagEntry {
   htmlComment: string;
+}
+
+export interface DeprecationInfo {
+  version: string | undefined;
+  htmlMessage: string | undefined;
 }
 
 /** A documentation entry augmented with transformed content for rendering. */
@@ -42,7 +47,7 @@ export interface DocEntryRenderable extends DocEntry {
   htmlUsageNotes: string;
 
   stable: {version: string | undefined} | undefined;
-  deprecated: {version: string | undefined} | undefined;
+  deprecated: DeprecationInfo | undefined;
   developerPreview: {version: string | undefined} | undefined;
   experimental: {version: string | undefined} | undefined;
 }
@@ -88,9 +93,8 @@ export type InterfaceEntryRenderable = ClassEntryRenderable;
 
 export type FunctionEntryRenderable = FunctionEntry &
   DocEntryRenderable &
-  HasRenderableToc & {
-    deprecationMessage: string | null;
-  };
+  HasRenderableToc &
+  HasDeprecatedFlag;
 
 export type FunctionSignatureMetadataRenderable = FunctionSignatureMetadata &
   DocEntryRenderable & {
@@ -101,8 +105,8 @@ export type FunctionSignatureMetadataRenderable = FunctionSignatureMetadata &
 export interface MemberEntryRenderable extends MemberEntry {
   htmlDescription: string;
   jsdocTags: JsDocTagRenderable[];
-  deprecationMessage: string | null;
   htmlUsageNotes: string;
+  deprecated: DeprecationInfo | undefined;
 }
 
 /** Sub-entry for a class method augmented transformed content for rendering. */

--- a/adev/shared-docs/pipeline/api-gen/rendering/entities/traits.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/entities/traits.mts
@@ -98,8 +98,7 @@ export interface HasRenderableParams {
 }
 
 export interface HasDeprecatedFlag {
-  deprecated: {version: string | undefined} | undefined;
-  deprecationMessage: string | null;
+  deprecated: {version: string | undefined; htmlMessage: string | undefined} | undefined;
 }
 
 export interface HasDeveloperPreviewFlag {

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/class-member.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/class-member.tsx
@@ -41,9 +41,9 @@ export function ClassMember(props: {member: MemberEntryRenderable}) {
     <div className={REFERENCE_MEMBER_CARD_BODY}>
       {isClassMethodEntry(member) ? (
         renderMethod(member)
-      ) : member.htmlDescription || member.deprecationMessage ? (
+      ) : member.htmlDescription || member ? (
         <div className={REFERENCE_MEMBER_CARD_ITEM}>
-          <DeprecatedLabel entry={member} />
+          <DeprecatedLabel entry={member.deprecated} />
           <RawHtml value={member.htmlDescription} />
         </div>
       ) : (

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/class-method-info.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/class-method-info.tsx
@@ -33,7 +33,7 @@ export function ClassMethodInfo(props: {
       {/* In case when method is overloaded we need to indicate which overload is deprecated */}
       {entry.deprecated ? (
         <div>
-          <DeprecatedLabel entry={entry} />
+          <DeprecatedLabel entry={entry.deprecated} />
         </div>
       ) : (
         <></>

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/cli-card.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/cli-card.tsx
@@ -17,7 +17,7 @@ export function CliCard(props: {card: CliCardRenderable}) {
       <div className={REFERENCE_MEMBER_CARD_BODY}>
         {props.card.items.map((item) => (
           <div class="docs-ref-content">
-            {item.deprecated ? <DeprecatedLabel entry={item} /> : <></>}
+            {item.deprecated ? <DeprecatedLabel entry={item.deprecated} /> : <></>}
             <div class="docs-ref-option-and-description">
               <div class="docs-reference-option">
                 <code>{item.name}</code>

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/deprecated-label.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/deprecated-label.tsx
@@ -8,22 +8,19 @@
 
 import {Fragment, h} from 'preact';
 import {PARAM_KEYWORD_CLASS_NAME} from '../styling/css-classes.mjs';
+import {DeprecationInfo} from '../entities/renderables.mjs';
 
-export function DeprecatedLabel(props: {
-  entry:
-    | {deprecated: {version: string | undefined} | undefined}
-    | {deprecationMessage: string | null};
-}) {
+export function DeprecatedLabel(props: {entry: DeprecationInfo | undefined}) {
   const entry = props.entry;
 
-  if ('deprecationMessage' in entry && entry.deprecationMessage !== null) {
+  if (entry?.htmlMessage) {
     return (
       <div className={'docs-deprecation-message'}>
         <span className={`${PARAM_KEYWORD_CLASS_NAME} docs-deprecated`}>@deprecated</span>
-        <span dangerouslySetInnerHTML={{__html: entry.deprecationMessage}}></span>
+        <span dangerouslySetInnerHTML={{__html: entry.htmlMessage}}></span>
       </div>
     );
-  } else if ('isDeprecated' in entry && entry.isDeprecated) {
+  } else if (entry) {
     return <span className={`${PARAM_KEYWORD_CLASS_NAME} docs-deprecated`}>@deprecated</span>;
   }
 

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/header-api.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/header-api.tsx
@@ -60,6 +60,19 @@ export function HeaderApi(props: {
         )}
       </div>
 
+      {entry.deprecated?.htmlMessage && (
+        <div class="docs-alert docs-alert-important">
+          <p className="foo">
+            <strong>IMPORTANT:</strong>{' '}
+            <span
+              dangerouslySetInnerHTML={{
+                __html: entry.deprecated?.htmlMessage.replace(/<p>(.*)<\/p>/s, '$1'),
+              }}
+            ></span>
+          </p>
+        </div>
+      )}
+
       <section
         className={'docs-reference-description'}
         dangerouslySetInnerHTML={{
@@ -79,7 +92,7 @@ function statusTag(entry: DocEntryRenderable) {
 
   if (entry.deprecated) {
     tag = (
-      <div className={`${HEADER_ENTRY_LABEL} type-stable full`}>
+      <div className={`${HEADER_ENTRY_LABEL} type-deprecated full`}>
         {tagInVersionString('deprecated', entry.deprecated)}
       </div>
     );
@@ -121,13 +134,6 @@ function tagInVersionString(label: string, tag: {version: string | undefined} | 
   }
 
   return <>{label}</>;
-}
-
-function tagInVersionTooltip(
-  label: string,
-  tag: {version: string | undefined} | undefined,
-): string {
-  return tag?.version ? `${label} since ${tag.version}` : label;
 }
 
 function getEntryTypeDisplayName(entryType: EntryType | string): string {

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/cli-transforms.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/cli-transforms.mts
@@ -52,7 +52,7 @@ export function getCliCardsRenderable(command: CliCommand): CliCardRenderable[] 
 function getRenderableOptions(items: CliOption[]): CliOptionRenderable[] {
   return items.map((option) => ({
     ...option,
-    deprecated: option.deprecated ? {version: undefined} : undefined,
+    deprecated: option.deprecated ? {version: undefined, htmlMessage: undefined} : undefined,
     description: marked.parse(option.description) as string,
   }));
 }

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/member-transforms.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/member-transforms.mts
@@ -8,6 +8,7 @@
 
 import {MemberEntry, MemberTags, MemberType} from '../entities.mjs';
 import {isHiddenEntry} from '../entities/categorization.mjs';
+import {MemberEntryRenderable} from '../entities/renderables.mjs';
 
 import {HasMembers, HasModuleName, HasRenderableMembers, HasRepo} from '../entities/traits.mjs';
 

--- a/adev/shared-docs/styles/_api-item-label.scss
+++ b/adev/shared-docs/styles/_api-item-label.scss
@@ -26,7 +26,8 @@
 
     &.full {
       font-size: 0.75rem;
-      &:not(:has(*)), &:not(:has(a span, span)) {
+      &:not(:has(*)),
+      &:not(:has(a span, span)) {
         // if no children, just a text node, or
         // no children with span
         padding: 0.25rem 0.5rem;
@@ -71,7 +72,8 @@
     }
 
     &.type-undecorated_class,
-    &.type-class {
+    &.type-class,
+    &.type-directive {
       --label-theme: var(--symbolic-purple);
     }
 
@@ -82,10 +84,6 @@
 
     &.type-decorator {
       --label-theme: var(--symbolic-blue);
-    }
-
-    &.type-directive {
-      --label-theme: var(--symbolic-pink);
     }
 
     &.type-element {
@@ -127,6 +125,17 @@
     &.type-developer_preview,
     &.type-deprecated {
       --label-theme: var(--hot-red);
+    }
+
+    &.type-deprecated {
+      &::before {
+        content: 'warning';
+        font-family: var(--icons);
+        display: flex;
+        align-items: center;
+        margin-left: 0.3rem;
+        margin-right: -0.2rem;
+      }
     }
   }
 }

--- a/packages/common/src/directives/ng_for_of.ts
+++ b/packages/common/src/directives/ng_for_of.ts
@@ -28,7 +28,8 @@ import {RuntimeErrorCode} from '../errors';
  * @publicApi
  *
  * @deprecated 20.0
- * The `ngFor` directive is deprecated. Use the `@for` block instead.
+ * The `ngFor` directive is deprecated. Use the built-in `@for` block instead.
+ * `@for` blocks have better performance and do not require importing `CommonModule` or `NgFor` directive.
  */
 export class NgForOfContext<T, U extends NgIterable<T> = NgIterable<T>> {
   constructor(
@@ -169,7 +170,8 @@ export class NgForOfContext<T, U extends NgIterable<T> = NgIterable<T>> {
  * @publicApi
  *
  * @deprecated 20.0
- * Use the `@for` block instead. Intent to remove in v22
+ * The `ngFor` directive is deprecated. Use the built-in `@for` block instead.
+ * `@for` blocks have better performance and do not require importing `CommonModule` or `NgFor` directive.
  */
 @Directive({
   selector: '[ngFor][ngForOf]',

--- a/packages/common/src/directives/ng_if.ts
+++ b/packages/common/src/directives/ng_if.ts
@@ -158,7 +158,8 @@ import {RuntimeErrorCode} from '../errors';
  * @publicApi
  *
  * @deprecated 20.0
- * Use the @if block instead. Intent to remove in v22
+ * The `ngIf` directive is deprecated. Use the built-in `@if` block instead.
+ * `@if` blocks do not require importing `CommonModule` or `NgIf` directive.
  */
 @Directive({
   selector: '[ngIf]',
@@ -179,7 +180,10 @@ export class NgIf<T = unknown> {
 
   /**
    * The Boolean expression to evaluate as the condition for showing a template.
-   * @deprecated Use the @if block instead. Intent to remove in v22
+   *
+   * @deprecated
+   * The `ngIf` directive is deprecated. Use the built-in `@if` block instead.
+   * `@if` blocks do not require importing `CommonModule` or `NgIf` directive.
    */
   @Input()
   set ngIf(condition: T) {
@@ -189,7 +193,7 @@ export class NgIf<T = unknown> {
 
   /**
    * A template to show if the condition expression evaluates to true.
-   * @deprecated Use the @if block instead. Intent to remove in v22
+   * @deprecated Use the `@if` block instead. Intent to remove in v22
    */
   @Input()
   set ngIfThen(templateRef: TemplateRef<NgIfContext<T>> | null) {
@@ -201,7 +205,7 @@ export class NgIf<T = unknown> {
 
   /**
    * A template to show if the condition expression evaluates to false.
-   * @deprecated Use the @if block instead. Intent to remove in v22
+   * @deprecated Use the `@if` block instead. Intent to remove in v22
    */
   @Input()
   set ngIfElse(templateRef: TemplateRef<NgIfContext<T>> | null) {
@@ -268,7 +272,7 @@ export class NgIf<T = unknown> {
  * @publicApi
  *
  * @deprecated 20.0
- * The ngIf directive is deprecated in favor of the @if block instead.
+ * The ngIf directive is deprecated in favor of the `@if` block instead.
  */
 export class NgIfContext<T = unknown> {
   public $implicit: T = null!;

--- a/packages/common/src/directives/ng_switch.ts
+++ b/packages/common/src/directives/ng_switch.ts
@@ -112,7 +112,8 @@ export class SwitchView {
  * @see [Structural Directives](guide/directives/structural-directives)
  *
  * @deprecated 20.0
- * Use the @switch block instead. Intent to remove in v22
+ * The `ngSwitch` directive is deprecated. Use the built-in `@switch` block instead.
+ * `@switch` blocks do not require importing `CommonModule` or `NgSwitch` directive.
  */
 @Directive({
   selector: '[ngSwitch]',
@@ -125,7 +126,7 @@ export class NgSwitch {
   private _lastCasesMatched = false;
   private _ngSwitch: any;
 
-  /** @deprecated Use the @switch block instead. Intent to remove in v22 */
+  /** @deprecated Use the built-in `@switch` block instead. Intent to remove in v22 */
   @Input()
   set ngSwitch(newValue: any) {
     this._ngSwitch = newValue;
@@ -200,7 +201,7 @@ export class NgSwitch {
  * @see {@link NgSwitchDefault}
  *
  * @deprecated 20.0
- * Use the @case block within a @switch block instead. Intent to remove in v22
+ * The `ngSwitch` directive is deprecated. Use the built-in `@switch` block with an `@case` block instead.
  */
 @Directive({
   selector: '[ngSwitchCase]',
@@ -249,7 +250,7 @@ export class NgSwitchCase implements DoCheck {
  * @see {@link NgSwitchCase}
  *
  * @deprecated 20.0
- * Use the @default block within a @switch block instead. Intent to remove in v22
+ * The `ngSwitch` directive is deprecated. Use the built-in `@switch` block with a `@default` block instead.
  */
 @Directive({
   selector: '[ngSwitchDefault]',


### PR DESCRIPTION
Examples :

* https://ng-dev-previews-fw--pr-angular-angular-61828-adev-prev-f8qqwi71.web.app/api/common/NgFor
* https://ng-dev-previews-fw--pr-angular-angular-61828-adev-prev-f8qqwi71.web.app/api/common/NgIf
* https://ng-dev-previews-fw--pr-angular-angular-61828-adev-prev-f8qqwi71.web.app/api/common/getLocaleDayNames