### PR TITLE
build: add missing import

### DIFF
--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -12,6 +12,7 @@ import {
   ImplicitReceiver,
   PropertyRead,
   PropertyWrite,
+  RecursiveAstVisitor,
   SafePropertyRead,
   ThisReceiver,
 } from '../../expression_parser/ast';


### PR DESCRIPTION
Fixes the `20.0.x` branch, which was broken due to a missing import.
