### PR TITLE
fix(core): `takeUntilDestroyed` completes immediately if DestroyRef a…

### DIFF
--- a/packages/core/rxjs-interop/src/take_until_destroyed.ts
+++ b/packages/core/rxjs-interop/src/take_until_destroyed.ts
@@ -26,8 +26,12 @@ export function takeUntilDestroyed<T>(destroyRef?: DestroyRef): MonoTypeOperator
     destroyRef = inject(DestroyRef);
   }
 
-  const destroyed$ = new Observable<void>((observer) => {
-    const unregisterFn = destroyRef!.onDestroy(observer.next.bind(observer));
+  const destroyed$ = new Observable<void>((subscriber) => {
+    if ((destroyRef as unknown as {destroyed: boolean}).destroyed) {
+      subscriber.next();
+      return;
+    }
+    const unregisterFn = destroyRef!.onDestroy(subscriber.next.bind(subscriber));
     return unregisterFn;
   });
 

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -175,6 +175,9 @@ export abstract class EnvironmentInjector implements Injector {
 
   abstract destroy(): void;
 
+  /** @internal */
+  abstract get destroyed(): boolean;
+
   /**
    * @internal
    */
@@ -199,7 +202,7 @@ export class R3Injector extends EnvironmentInjector implements PrimitivesInjecto
   /**
    * Flag indicating that this injector was previously destroyed.
    */
-  get destroyed(): boolean {
+  override get destroyed(): boolean {
     return this._destroyed;
   }
   private _destroyed = false;

--- a/packages/core/src/linker/destroy_ref.ts
+++ b/packages/core/src/linker/destroy_ref.ts
@@ -46,6 +46,9 @@ export abstract class DestroyRef {
    */
   abstract onDestroy(callback: () => void): () => void;
 
+  /** @internal */
+  abstract get destroyed(): boolean;
+
   /**
    * @internal
    * @nocollapse
@@ -62,6 +65,10 @@ export abstract class DestroyRef {
 export class NodeInjectorDestroyRef extends DestroyRef {
   constructor(readonly _lView: LView) {
     super();
+  }
+
+  override get destroyed() {
+    return isDestroyed(this._lView);
   }
 
   override onDestroy(callback: () => void): () => void {


### PR DESCRIPTION
…lready destroyed

Adds fix directly for `takeUntilDestroyed` to unsubscribe when already destroyed instead of putting
synchronous behavior on `DestroyRef.onDestroyed` callback as in #58008

fixes #54527
