### PR TITLE
feat(core): Add destroyed property on DestroyRef

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -593,6 +593,7 @@ export function destroyPlatform(): void;
 
 // @public
 export abstract class DestroyRef {
+    abstract get destroyed(): boolean;
     abstract onDestroy(callback: () => void): () => void;
 }
 

--- a/packages/core/rxjs-interop/src/take_until_destroyed.ts
+++ b/packages/core/rxjs-interop/src/take_until_destroyed.ts
@@ -27,11 +27,11 @@ export function takeUntilDestroyed<T>(destroyRef?: DestroyRef): MonoTypeOperator
   }
 
   const destroyed$ = new Observable<void>((subscriber) => {
-    if ((destroyRef as unknown as {destroyed: boolean}).destroyed) {
+    if (destroyRef.destroyed) {
       subscriber.next();
       return;
     }
-    const unregisterFn = destroyRef!.onDestroy(subscriber.next.bind(subscriber));
+    const unregisterFn = destroyRef.onDestroy(subscriber.next.bind(subscriber));
     return unregisterFn;
   });
 

--- a/packages/core/src/linker/destroy_ref.ts
+++ b/packages/core/src/linker/destroy_ref.ts
@@ -46,7 +46,9 @@ export abstract class DestroyRef {
    */
   abstract onDestroy(callback: () => void): () => void;
 
-  /** @internal */
+  /**
+   * Indicates whether the instance has already been destroyed and whether its `onDestroy` callbacks have executed.
+   */
   abstract get destroyed(): boolean;
 
   /**


### PR DESCRIPTION
Since `DestroyRef.onDestroy` throws if the `DestroyRef` is already
destroyed, there is a need to be able to tell if it is already destroyed
before attempting to register a callback.

(first commit is in #61847)