### PR TITLE
refactor(forms): update status states based on prev discussion

### DIFF
--- a/packages/forms/experimental/docs/signal-forms.md
+++ b/packages/forms/experimental/docs/signal-forms.md
@@ -663,12 +663,12 @@ const userSchema = schema<User>(userPath => {
 
 Because async validation is asynchronous, it has a third potential state besides `valid` or `invalid`, `pending`, which needs to be considered when determining the validity of the form. Each `FieldState` has the following signals which describe the validation state of the field.
 
-| Name                   | Type                  | Meaning                                                                                                                                  |
-| ---------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `hasPendingValidators` | `Signal<boolean>`     | `true` if there are any pending validators that may produce a validation error for this field or one of its children, `false` otherwise. |
-| `valid`                | `Signal<boolean>`     | `true` if neither the field nor any of its children has any errors or pending validators, `false` otherwise.                             |
-| `invalid`              | `Signal<boolean>`     | `true` if the field or any of its children has any errors, regardless of pending validators, `false` otherwise.                          |
-| `errors`               | `Signal<FormError[]>` | The list of validation errors associated with the field.                                                                                 |
+| Name      | Type                  | Meaning                                                                                                                                  |
+| --------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `pending` | `Signal<boolean>`     | `true` if there are any pending validators that may produce a validation error for this field or one of its children, `false` otherwise. |
+| `valid`   | `Signal<boolean>`     | `true` if neither the field nor any of its children has any errors or pending validators, `false` otherwise.                             |
+| `invalid` | `Signal<boolean>`     | `true` if the field or any of its children has any errors, regardless of pending validators, `false` otherwise.                          |
+| `errors`  | `Signal<FormError[]>` | The list of validation errors associated with the field.                                                                                 |
 
 Note that `!valid()` is not the same as `invalid()`, and `!invalid()` is not the same as `valid()`. Consider a field that has no current errors, but does have a pending validator. In this case `valid()` is `false` because of the pending validator, and `invalid()` is also false because there are no current errors.
 

--- a/packages/forms/experimental/src/api/types.ts
+++ b/packages/forms/experimental/src/api/types.ts
@@ -10,8 +10,6 @@ import {Signal, WritableSignal} from '@angular/core';
 import {DataKey} from './data';
 import {MetadataKey} from './metadata';
 
-export type ValidationStatus = 'valid' | 'invalid' | 'pending';
-
 /**
  * Symbol used to retain generic type information when it would otherwise be lost.
  */
@@ -114,10 +112,6 @@ export interface FieldState<T> {
    */
   readonly syncErrors: Signal<FormError[]>;
   /**
-   * A signal indicating the validation status of the field
-   */
-  readonly status: Signal<ValidationStatus>;
-  /**
    * A signal indicating whether the field's value is currently valid.
    *
    * Note: `valid()` is not the same as `!invalid()`.
@@ -144,7 +138,7 @@ export interface FieldState<T> {
   /**
    * Whether there are any validators still pending for this field.
    */
-  readonly hasPendingValidators: Signal<boolean>;
+  readonly pending: Signal<boolean>;
   /**
    * A signal indicating whether the field's value is currently valid.
    */

--- a/packages/forms/experimental/test/resource.spec.ts
+++ b/packages/forms/experimental/test/resource.spec.ts
@@ -183,14 +183,14 @@ describe('resources', () => {
 
     expect(usernameForm.$state.valid()).toBe(false);
     expect(usernameForm.$state.invalid()).toBe(false);
-    expect(usernameForm.$state.hasPendingValidators()).toBe(true);
+    expect(usernameForm.$state.pending()).toBe(true);
 
     req1.flush(true);
     await appRef.whenStable();
 
     expect(usernameForm.$state.valid()).toBe(true);
     expect(usernameForm.$state.invalid()).toBe(false);
-    expect(usernameForm.$state.hasPendingValidators()).toBe(false);
+    expect(usernameForm.$state.pending()).toBe(false);
     expect(true).toBe(true);
 
     usernameForm.$state.value.set('taken-user');
@@ -199,13 +199,13 @@ describe('resources', () => {
 
     expect(usernameForm.$state.valid()).toBe(false);
     expect(usernameForm.$state.invalid()).toBe(false);
-    expect(usernameForm.$state.hasPendingValidators()).toBe(true);
+    expect(usernameForm.$state.pending()).toBe(true);
 
     req2.flush(false);
     await appRef.whenStable();
 
     expect(usernameForm.$state.valid()).toBe(false);
     expect(usernameForm.$state.invalid()).toBe(true);
-    expect(usernameForm.$state.hasPendingValidators()).toBe(false);
+    expect(usernameForm.$state.pending()).toBe(false);
   });
 });

--- a/packages/forms/experimental/test/validation_status.spec.ts
+++ b/packages/forms/experimental/test/validation_status.spec.ts
@@ -39,13 +39,11 @@ describe('validation status', () => {
         {injector},
       );
 
-      expect(f.$state.status()).toBe('valid');
       expect(f.$state.syncValid()).toBe(true);
       expect(f.$state.valid()).toBe(true);
       expect(f.$state.invalid()).toBe(false);
 
       f.$state.value.set('INVALID');
-      expect(f.$state.status()).toBe('invalid');
       expect(f.$state.syncValid()).toBe(false);
       expect(f.$state.valid()).toBe(false);
       expect(f.$state.invalid()).toBe(true);
@@ -60,14 +58,12 @@ describe('validation status', () => {
         {injector},
       );
 
-      expect(f.$state.status()).toBe('valid');
       expect(f.$state.syncValid()).toBe(true);
       expect(f.$state.valid()).toBe(true);
       expect(f.$state.invalid()).toBe(false);
 
       f.child.$state.value.set('INVALID');
       expect(f.$state.syncValid()).toBe(false);
-      expect(f.$state.status()).toBe('invalid');
       expect(f.$state.valid()).toBe(false);
       expect(f.$state.invalid()).toBe(true);
     });
@@ -81,13 +77,11 @@ describe('validation status', () => {
         {injector},
       );
 
-      expect(f.child.$state.status()).toBe('valid');
       expect(f.child.$state.syncValid()).toBe(true);
       expect(f.child.$state.valid()).toBe(true);
       expect(f.child.$state.invalid()).toBe(false);
 
       f.child.$state.value.set('INVALID');
-      expect(f.child.$state.status()).toBe('valid');
       expect(f.child.$state.syncValid()).toBe(true);
       expect(f.child.$state.valid()).toBe(true);
       expect(f.child.$state.invalid()).toBe(false);
@@ -104,13 +98,11 @@ describe('validation status', () => {
         {injector},
       );
 
-      expect(f.$state.status()).toBe('valid');
       expect(f.$state.syncValid()).toBe(true);
       expect(f.$state.valid()).toBe(true);
       expect(f.$state.invalid()).toBe(false);
 
       f.$state.value.set('INVALID');
-      expect(f.$state.status()).toBe('invalid');
       expect(f.$state.syncValid()).toBe(false);
       expect(f.$state.valid()).toBe(false);
       expect(f.$state.invalid()).toBe(true);
@@ -127,13 +119,11 @@ describe('validation status', () => {
         {injector},
       );
 
-      expect(f.child.$state.status()).toBe('valid');
       expect(f.child.$state.syncValid()).toBe(true);
       expect(f.child.$state.valid()).toBe(true);
       expect(f.child.$state.invalid()).toBe(false);
 
       f.child.$state.value.set('INVALID');
-      expect(f.child.$state.status()).toBe('invalid');
       expect(f.child.$state.syncValid()).toBe(false);
       expect(f.child.$state.valid()).toBe(false);
       expect(f.child.$state.invalid()).toBe(true);
@@ -150,13 +140,11 @@ describe('validation status', () => {
         {injector},
       );
 
-      expect(f.$state.status()).toBe('valid');
       expect(f.$state.syncValid()).toBe(true);
       expect(f.$state.valid()).toBe(true);
       expect(f.$state.invalid()).toBe(false);
 
       f.child.$state.value.set('INVALID');
-      expect(f.$state.status()).toBe('invalid');
       expect(f.$state.syncValid()).toBe(false);
       expect(f.$state.valid()).toBe(false);
       expect(f.$state.invalid()).toBe(true);
@@ -173,13 +161,11 @@ describe('validation status', () => {
         {injector},
       );
 
-      expect(f.sibling.$state.status()).toBe('valid');
       expect(f.sibling.$state.syncValid()).toBe(true);
       expect(f.sibling.$state.valid()).toBe(true);
       expect(f.sibling.$state.invalid()).toBe(false);
 
       f.child.$state.value.set('INVALID');
-      expect(f.sibling.$state.status()).toBe('valid');
       expect(f.sibling.$state.syncValid()).toBe(true);
       expect(f.sibling.$state.valid()).toBe(true);
       expect(f.sibling.$state.invalid()).toBe(false);
@@ -211,16 +197,14 @@ describe('validation status', () => {
 
       await waitFor(() => res?.isLoading());
 
-      expect(f.$state.hasPendingValidators()).toBe(true);
-      expect(f.$state.status()).toBe('pending');
+      expect(f.$state.pending()).toBe(true);
       expect(f.$state.syncValid()).toBe(true);
       expect(f.$state.valid()).toBe(false);
       expect(f.$state.invalid()).toBe(false);
 
       await appRef.whenStable();
 
-      expect(f.$state.hasPendingValidators()).toBe(false);
-      expect(f.$state.status()).toBe('valid');
+      expect(f.$state.pending()).toBe(false);
       expect(f.$state.syncValid()).toBe(true);
       expect(f.$state.valid()).toBe(true);
       expect(f.$state.invalid()).toBe(false);
@@ -228,16 +212,14 @@ describe('validation status', () => {
       f.$state.value.set('INVALID');
       await waitFor(() => res?.isLoading());
 
-      expect(f.$state.hasPendingValidators()).toBe(true);
-      expect(f.$state.status()).toBe('pending');
+      expect(f.$state.pending()).toBe(true);
       expect(f.$state.syncValid()).toBe(true);
       expect(f.$state.valid()).toBe(false);
       expect(f.$state.invalid()).toBe(false);
 
       await appRef.whenStable();
 
-      expect(f.$state.hasPendingValidators()).toBe(false);
-      expect(f.$state.status()).toBe('invalid');
+      expect(f.$state.pending()).toBe(false);
       expect(f.$state.syncValid()).toBe(true);
       expect(f.$state.valid()).toBe(false);
       expect(f.$state.invalid()).toBe(true);
@@ -267,16 +249,14 @@ describe('validation status', () => {
 
       await waitFor(() => res?.isLoading());
 
-      expect(f.child.$state.hasPendingValidators()).toBe(true);
-      expect(f.child.$state.status()).toBe('pending');
+      expect(f.child.$state.pending()).toBe(true);
       expect(f.child.$state.syncValid()).toBe(true);
       expect(f.child.$state.valid()).toBe(false);
       expect(f.child.$state.invalid()).toBe(false);
 
       await appRef.whenStable();
 
-      expect(f.child.$state.hasPendingValidators()).toBe(false);
-      expect(f.child.$state.status()).toBe('valid');
+      expect(f.child.$state.pending()).toBe(false);
       expect(f.child.$state.syncValid()).toBe(true);
       expect(f.child.$state.valid()).toBe(true);
       expect(f.child.$state.invalid()).toBe(false);
@@ -284,16 +264,14 @@ describe('validation status', () => {
       f.child.$state.value.set('INVALID');
       await waitFor(() => res?.isLoading());
 
-      expect(f.child.$state.hasPendingValidators()).toBe(true);
-      expect(f.child.$state.status()).toBe('pending');
+      expect(f.child.$state.pending()).toBe(true);
       expect(f.child.$state.syncValid()).toBe(true);
       expect(f.child.$state.valid()).toBe(false);
       expect(f.child.$state.invalid()).toBe(false);
 
       await appRef.whenStable();
 
-      expect(f.child.$state.hasPendingValidators()).toBe(false);
-      expect(f.child.$state.status()).toBe('invalid');
+      expect(f.child.$state.pending()).toBe(false);
       expect(f.child.$state.syncValid()).toBe(true);
       expect(f.child.$state.valid()).toBe(false);
       expect(f.child.$state.invalid()).toBe(true);
@@ -323,16 +301,14 @@ describe('validation status', () => {
 
       await waitFor(() => res?.isLoading());
 
-      expect(f.$state.hasPendingValidators()).toBe(true);
-      expect(f.$state.status()).toBe('pending');
+      expect(f.$state.pending()).toBe(true);
       expect(f.$state.syncValid()).toBe(true);
       expect(f.$state.valid()).toBe(false);
       expect(f.$state.invalid()).toBe(false);
 
       await appRef.whenStable();
 
-      expect(f.$state.hasPendingValidators()).toBe(false);
-      expect(f.$state.status()).toBe('valid');
+      expect(f.$state.pending()).toBe(false);
       expect(f.$state.syncValid()).toBe(true);
       expect(f.$state.valid()).toBe(true);
       expect(f.$state.invalid()).toBe(false);
@@ -340,16 +316,14 @@ describe('validation status', () => {
       f.child.$state.value.set('INVALID');
       await waitFor(() => res?.isLoading());
 
-      expect(f.$state.hasPendingValidators()).toBe(true);
-      expect(f.$state.status()).toBe('pending');
+      expect(f.$state.pending()).toBe(true);
       expect(f.$state.syncValid()).toBe(true);
       expect(f.$state.valid()).toBe(false);
       expect(f.$state.invalid()).toBe(false);
 
       await appRef.whenStable();
 
-      expect(f.$state.hasPendingValidators()).toBe(false);
-      expect(f.$state.status()).toBe('invalid');
+      expect(f.$state.pending()).toBe(false);
       expect(f.$state.syncValid()).toBe(true);
       expect(f.$state.valid()).toBe(false);
       expect(f.$state.invalid()).toBe(true);
@@ -382,16 +356,14 @@ describe('validation status', () => {
 
       await waitFor(() => res?.isLoading());
 
-      expect(f.sibling.$state.hasPendingValidators()).toBe(true);
-      expect(f.sibling.$state.status()).toBe('pending');
+      expect(f.sibling.$state.pending()).toBe(true);
       expect(f.sibling.$state.syncValid()).toBe(true);
       expect(f.sibling.$state.valid()).toBe(false);
       expect(f.sibling.$state.invalid()).toBe(false);
 
       await appRef.whenStable();
 
-      expect(f.sibling.$state.hasPendingValidators()).toBe(false);
-      expect(f.sibling.$state.status()).toBe('valid');
+      expect(f.sibling.$state.pending()).toBe(false);
       expect(f.sibling.$state.syncValid()).toBe(true);
       expect(f.sibling.$state.valid()).toBe(true);
       expect(f.sibling.$state.invalid()).toBe(false);
@@ -399,16 +371,14 @@ describe('validation status', () => {
       f.child.$state.value.set('INVALID');
       await waitFor(() => res?.isLoading());
 
-      expect(f.sibling.$state.hasPendingValidators()).toBe(true);
-      expect(f.sibling.$state.status()).toBe('pending');
+      expect(f.sibling.$state.pending()).toBe(true);
       expect(f.sibling.$state.syncValid()).toBe(true);
       expect(f.sibling.$state.valid()).toBe(false);
       expect(f.sibling.$state.invalid()).toBe(false);
 
       await appRef.whenStable();
 
-      expect(f.sibling.$state.hasPendingValidators()).toBe(false);
-      expect(f.sibling.$state.status()).toBe('valid');
+      expect(f.sibling.$state.pending()).toBe(false);
       expect(f.sibling.$state.syncValid()).toBe(true);
       expect(f.sibling.$state.valid()).toBe(true);
       expect(f.sibling.$state.invalid()).toBe(false);
@@ -426,8 +396,7 @@ describe('validation status', () => {
         {injector},
       );
 
-      expect(f.$state.hasPendingValidators()).toBe(false);
-      expect(f.$state.status()).toBe('invalid');
+      expect(f.$state.pending()).toBe(false);
       expect(f.$state.syncValid()).toBe(false);
       expect(f.$state.valid()).toBe(false);
       expect(f.$state.invalid()).toBe(true);
@@ -454,8 +423,7 @@ describe('validation status', () => {
       );
 
       await waitFor(() => res?.isLoading());
-      expect(f.$state.hasPendingValidators()).toBe(true);
-      expect(f.$state.status()).toBe('pending');
+      expect(f.$state.pending()).toBe(true);
       expect(f.$state.syncValid()).toBe(true);
       expect(f.$state.valid()).toBe(false);
       expect(f.$state.invalid()).toBe(false);
@@ -492,8 +460,7 @@ describe('validation status', () => {
       );
 
       await waitFor(() => !res?.isLoading() && res2.isLoading());
-      expect(f.$state.hasPendingValidators()).toBe(true);
-      expect(f.$state.status()).toBe('invalid');
+      expect(f.$state.pending()).toBe(true);
       expect(f.$state.syncValid()).toBe(true);
       expect(f.$state.valid()).toBe(false);
       expect(f.$state.invalid()).toBe(true);
@@ -531,8 +498,7 @@ describe('validation status', () => {
       );
 
       await waitFor(() => !res?.isLoading() && res2.isLoading());
-      expect(f.$state.hasPendingValidators()).toBe(true);
-      expect(f.$state.status()).toBe('invalid');
+      expect(f.$state.pending()).toBe(true);
       expect(f.$state.syncValid()).toBe(true);
       expect(f.$state.valid()).toBe(false);
       expect(f.$state.invalid()).toBe(true);


### PR DESCRIPTION
As discussed:
- Rename `.hasPendingValidators()` to just `.pending()`
- Eliminate `.status()` as a public API

Note:
- `.status()` retained internally as part of the implementation
- renamed the `'pending'` status option to `'unknown'` to avoid confusion with `.pending()`
