### PR TITLE
build: correct the query for discovering all releasable packages

### DIFF
--- a/scripts/build/package-builder.mts
+++ b/scripts/build/package-builder.mts
@@ -26,8 +26,8 @@ const releaseTargetTag = 'release-with-framework';
 
 /** Command that queries Bazel for all release package targets. */
 const queryPackagesCmd =
-  `${bazelCmd} query --output=label "attr('tags', '\\[.*${releaseTargetTag}.*\\]', //packages/...) ` +
-  `intersect kind('ng_package|pkg_npm', //packages/...)"`;
+  `${bazelCmd} query --output=label "filter(':npm_package$', ` +
+  `attr('tags', '\\[.*${releaseTargetTag}.*\\]', //packages/...))"`;
 
 /** Path for the default distribution output directory. */
 const defaultDistPath = join(projectDir, 'dist/packages-dist');


### PR DESCRIPTION
Update the bazel query for finding all releasable packages to look for all targets with the name `npm_package` that contain the expected tag.
