### PR TITLE
fix(core): unregister `onDestroy` in `outputToObservable`

### DIFF
--- a/packages/core/rxjs-interop/src/output_to_observable.ts
+++ b/packages/core/rxjs-interop/src/output_to_observable.ts
@@ -24,9 +24,12 @@ export function outputToObservable<T>(ref: OutputRef<T>): Observable<T> {
     // Complete the observable upon directive/component destroy.
     // Note: May be `undefined` if an `EventEmitter` is declared outside
     // of an injection context.
-    destroyRef?.onDestroy(() => observer.complete());
+    const unregisterOnDestroy = destroyRef?.onDestroy(() => observer.complete());
 
     const subscription = ref.subscribe((v) => observer.next(v));
-    return () => subscription.unsubscribe();
+    return () => {
+      subscription.unsubscribe();
+      unregisterOnDestroy?.();
+    };
   });
 }


### PR DESCRIPTION
We should remove the `onDestroy` listener once subscription is unsubscribed because components might not be destroyed yet, but they still would capture subscribers.