### PR TITLE
docs: streamline DevTools release docs

### DIFF
--- a/devtools/docs/release.md
+++ b/devtools/docs/release.md
@@ -7,11 +7,13 @@ Publishing Angular DevTools is achieved through the following steps:
 On the `main` branch, run:
 
 ```shell
-git log "HEAD...$(git log HEAD~1 --grep="release:.*Angular DevTools" --format=format:%H | head -n 1)~1" --oneline |
-    grep "(devtools):\|release:.*Angular DevTools" --color=never
+git log "HEAD...$(git log HEAD~1 --grep="release:.*Angular DevTools" --format=format:%H | head -n 1)~1" --format=format:%s |
+    grep "(devtools):\|release:.*Angular DevTools" --color=never |
+    grep -v "^refactor" --color=never
 ```
 
-If this displays any commits since the most recent release commit, then there's something to release.
+If this displays any commits since the most recent release commit, then there's something to publish.
+If it only shows the most recent release commit, then the DevTools release can be skipped.
 
 ## 1. Sync workspace
 
@@ -61,7 +63,10 @@ generation.
 
 ## 4. Publish to Chrome Chrome
 
-To publish Angular DevTools to the Chrome Web Store, first build and package the extension.
+First, make sure you have access to publish the extension by ensuring you are part of
+[the relevant Google Group](http://g/angular-chrome-web-store-publisher).
+
+Next, build and package the extension:
 
 ```shell
 # Build the Chrome version.
@@ -71,13 +76,9 @@ yarn devtools:build:chrome
 (cd dist/bin/devtools/projects/shell-browser/src/prodapp && zip -r ~/devtools-chrome.zip *)
 ```
 
-Then upload it to the Chrome Web Store.
-
-1. Go to the extension [page](https://chrome.google.com/webstore/category/extensions)
-1. Make sure your email is part of the Google Group we use for publishing the extension
-1. Navigate to "Developer Dashboard"
-1. Enter your account credentials
-1. You should be able to change the publisher to "Angular"
+Then, go to the
+[Angular DevTools Chrome Web Store page](https://chrome.google.com/webstore/devconsole/19161719-4eee-48dc-959e-8d18cea83699/ienfalfjdbdpebioblfackkekamfmbnh/edit/package)
+and upload `~/devtools-chrome.zip`.
 
 You can choose to either publish immediately or only get approval but hold to publish at a later time.
 Note that even publishing immediately still requires approval from Chrome Web Store before it is
@@ -86,7 +87,7 @@ limit on how long a review might take: https://developer.chrome.com/docs/webstor
 
 ## 5. Publish to Firefox
 
-To publish Angular DevTools as a Firefox Add-on, first build and package the extension.
+To publish Angular DevTools as a Firefox Add-on, first build and package the extension:
 
 ```shell
 # Build the Firefox version.
@@ -96,48 +97,44 @@ yarn devtools:build:firefox
 (cd dist/bin/devtools/projects/shell-browser/src/prodapp && zip -r ~/devtools-firefox.zip *)
 ```
 
-Then upload it:
+Then, go to the
+[Angular DevTools Firefox Addons page](https://addons.mozilla.org/en-US/developers/addon/angular-devtools/edit)
+and log in using the email and password [from Valentine](http://valentine/#/show/1651707871496288).
+This will require a two-factor code, which you can generate by installing
+[Google Authenticator](https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2)
+and scanning the QR code linked [from Valentine](http://valentine/#/show/1651792043556329).
 
-1.  Go to the Firefox Addons [page](https://addons.mozilla.org/developers/addons)
-1.  Find the email and password [on Valentine](http://valentine/#/show/1651707871496288)
-1.  Set up Google Authenticator with the 2FA QR code.
-    *   You can find the QR code [on Valentine as well](http://valentine/#/show/1651792043556329)
-
-The Firefox publishing process is slightly more involved than Chrome.
-
-### Changelog
-
-Mozilla asks for a changelog, which needs to be authored manually. You can generate a list of
-`(devtools)`-scoped commits since the last release with the following command:
-
-```shell
-git log "HEAD...$(git log HEAD~1 --grep="release:.*Angular DevTools" --format=format:%H | head -n 1)~1" --oneline |
-    grep "(devtools):\|release:.*Angular DevTools" --color=never
-```
-
-Internal refactors and non-Firefox changes don't need to be mentioned (note that
-`refactor(devtools)` is frequently used for feature work, so don't entirely ignore a commit for
-that reason).
-
-Mozilla's changelog rendering does support basic markdown, so you can write these in a list format:
-
-```md
-* Fixes stuff.
-* Breaks some other stuff.
-```
+Upload `~/devtools-firefox.zip` as a new version. The Firefox publishing process is slightly more
+involved than Chrome.
 
 ### Source Code
 
-Mozilla also requires extension source code with instructions to build and run it. Since DevTools
+Mozilla requires extension source code with instructions to build and run it. Since DevTools
 exists in a monorepo with critical build tooling existing outside the `devtools/` directory, we
 need to upload the entire monorepo. Package it without dependencies and generated files with the
 following command and upload it.
 
 ```shell
-rm -rf dist/ && zip -r ~/angular-source.zip * -x ".git/*" -x "node_modules/*" -x "**/node_modules/*"
+rm -rf dist/ **/node_modules/ && zip -r ~/angular-source.zip * -x ".git/*" -x "node_modules/*"
 ```
 
-Suggested note to reviewer:
+### Changelog
+
+Mozilla asks for a changelog, which needs to be authored manually. You can generate the changelog
+with the following command:
+
+```shell
+git log "HEAD~1...$(git log HEAD~1 --grep="release:.*Angular DevTools" --format=format:%H | head -n 1)" --format=format:%s |
+    grep "(devtools):" --color=never |
+    grep -v "^refactor" --color=never |
+    sed "s,^,* ,g" |
+    sed -E "s,\(#([0-9]+)\),([#\1](https://github.com/angular/angular/pull/\1/)),g"
+```
+
+### Reviewer Note
+
+There is a field to provide a note to the reviewer, copy this template and make sure to replace
+`${RELEASE_COMMIT}` with the SHA of the release commit to create a valid link.
 
 > This is a monorepo and includes much more code than just the DevTools extension. The relevant
 > code is under \`devtools/...\` and \`devtools/README.md\` contains instructions for compiling
@@ -149,4 +146,5 @@ Suggested note to reviewer:
 Similar to Chrome, we need to wait for approval from Mozilla before the extension is released.
 There's no hard upper-bound on this, but historically it typically takes at least a week.
 
-Once the release is in-review for both Chrome and Firefox, the process is complete.
+Once the new DevTools version is in-review for both Chrome and Firefox, the release process is
+complete.


### PR DESCRIPTION
This makes a few changes to try to smooth over the process:
1. Updates changelog commands to filter out `refactor` commits.
2. Tweaks the changelog command to generate a markdown list for easy copy-pasting.
3. Links directly to the store pages to cut down on clicks.
4. Moves the source code section a bove the reviewer note and changelog, to match the ordering of the Firefox Add Ons form.