### PR TITLE
fix(core): inject `APP_ID` before injector is destroyed

### DIFF
--- a/packages/core/src/hydration/event_replay.ts
+++ b/packages/core/src/hydration/event_replay.ts
@@ -145,11 +145,11 @@ export function withEventReplay(): Provider[] {
 
             appsWithEventReplay.add(appRef);
 
+            const appId = injector.get(APP_ID);
             appRef.onDestroy(() => {
               appsWithEventReplay.delete(appRef);
               // Ensure that we're always safe calling this in the browser.
               if (typeof ngServerMode !== 'undefined' && !ngServerMode) {
-                const appId = injector.get(APP_ID);
                 // `_ejsa` should be deleted when the app is destroyed, ensuring that
                 // no elements are still captured in the global list and are not prevented
                 // from being garbage collected.

--- a/packages/platform-server/test/event_replay_spec.ts
+++ b/packages/platform-server/test/event_replay_spec.ts
@@ -207,7 +207,16 @@ describe('event replay', () => {
     appRef.tick();
     const appId = appRef.injector.get(APP_ID);
 
+    // Important: This is done intentionally because `ApplicationRef` registers
+    // `onDestroy` callbacks, and we want to ensure that they execute successfully
+    // without resulting in any errors. This is necessary because the bodies of
+    // these `onDestroy` callbacks use the `ngServerMode` variable.
+    // Prior to setting this flag, the unit test was throwing a "destroyed injector"
+    // error — but we weren't capturing it because we hadn't explicitly set the flag to false.
+    globalThis['ngServerMode'] = false;
     appRef.destroy();
+    globalThis['ngServerMode'] = undefined;
+
     // This ensure that `_ejsas` for the current application is cleaned up
     // once the application is destroyed.
     expect(window._ejsas![appId]).toBeUndefined();


### PR DESCRIPTION
In this commit, we request `APP_ID` outside the `onDestroy` callback because the injector might already be in a destroyed state when the callback runs.