### PR TITLE
ci: automatically add target labels based on base branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,6 +37,14 @@
   ],
   "packageRules": [
     {
+      "matchBaseBranches": ["main"],
+      "addLabels": ["target: minor"]
+    },
+    {
+      "matchBaseBranches": ["!main"],
+      "addLabels": ["target: patch"]
+    },
+    {
       "matchFileNames": [
         "integration/**",
         "packages/core/schematics/migrations/signal-migration/test/**",


### PR DESCRIPTION
This commit configures Renovate to automatically apply 'target' labels to pull requests based on their base branch.

- `main` branch will get `target: minor` label.
- Other branches will get `target: patch` label.
