### PR TITLE
refactor(core): Delete createSignalTuple

### DIFF
--- a/goldens/public-api/core/primitives/signals/index.api.md
+++ b/goldens/public-api/core/primitives/signals/index.api.md
@@ -43,9 +43,6 @@ export function createLinkedSignal<S, D>(sourceFn: () => S, computationFn: Compu
 // @public
 export function createSignal<T>(initialValue: T, equal?: ValueEqualityFn<T>): [SignalGetter<T>, SignalSetter<T>, SignalUpdater<T>];
 
-// @public @deprecated
-export function createSignalTuple<T>(initialValue: T, equal?: ValueEqualityFn<T>): [SignalGetter<T>, SignalSetter<T>, SignalUpdater<T>];
-
 // @public (undocumented)
 export function createWatch(fn: (onCleanup: WatchCleanupRegisterFn) => void, schedule: (watch: Watch) => void, allowSignalWrites: boolean): Watch;
 

--- a/packages/core/primitives/signals/index.ts
+++ b/packages/core/primitives/signals/index.ts
@@ -51,7 +51,6 @@ export {
   signalGetFn,
   signalSetFn,
   signalUpdateFn,
-  createSignalTuple,
 } from './src/signal';
 export {Watch, WatchCleanupFn, WatchCleanupRegisterFn, createWatch} from './src/watch';
 export {setAlternateWeakRefImpl} from './src/weak_ref';

--- a/packages/core/primitives/signals/src/signal.ts
+++ b/packages/core/primitives/signals/src/signal.ts
@@ -72,17 +72,6 @@ export function createSignal<T>(
   return [getter, set, update];
 }
 
-/**
- * Creates a `Signal` getter, setter, and updater function.
- * @deprecated use createSignal
- */
-export function createSignalTuple<T>(
-  initialValue: T,
-  equal?: ValueEqualityFn<T>,
-): [SignalGetter<T>, SignalSetter<T>, SignalUpdater<T>] {
-  return createSignal(initialValue, equal);
-}
-
 export function setPostSignalSetFn(fn: ReactiveHookFn | null): ReactiveHookFn | null {
   const prev = postSignalSetFn;
   postSignalSetFn = fn;

--- a/packages/core/test/signals/signal_spec.ts
+++ b/packages/core/test/signals/signal_spec.ts
@@ -12,7 +12,6 @@ import {
   ReactiveNode,
   setPostProducerCreatedFn,
   setPostSignalSetFn,
-  createSignalTuple,
   SIGNAL,
 } from '../../primitives/signals';
 
@@ -224,24 +223,5 @@ describe('signals', () => {
 
     expect(producerKindsCreated).toEqual(['signal']);
     setPostProducerCreatedFn(prev);
-  });
-});
-
-describe('createSignalTuple', () => {
-  it('get returns the signal value', () => {
-    const [get] = createSignalTuple(0);
-    expect(get()).toBe(0);
-  });
-
-  it('set sets the signal value', () => {
-    const [get, set] = createSignalTuple(0);
-    set(1);
-    expect(get()).toBe(1);
-  });
-
-  it('update updates the values based on the previous value', () => {
-    const [get, , update] = createSignalTuple(0);
-    update((prev) => prev + 2);
-    expect(get()).toBe(2);
   });
 });


### PR DESCRIPTION
Delete createSignalTuple because it is no longer needed. creatSignal has the same behavior.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
It removes createSignalTuple because it is no longer needed.

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
createSignalTuple was a deprecated API

Issue Number: N/A


## What is the new behavior?
createSignalTuple is removed


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
