### PR TITLE
fix(devtools): implement signal read error handling in DevTools

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/prop-type.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/prop-type.ts
@@ -8,7 +8,7 @@
 
 import {PropType} from '../../../../protocol';
 
-import {isSignal} from '../utils';
+import {isSignal, safelyReadSignalValue} from '../utils';
 
 const commonTypes = {
   boolean: PropType.Boolean,
@@ -27,7 +27,11 @@ const commonTypes = {
  */
 export const getPropType = (prop: unknown): PropType => {
   if (isSignal(prop)) {
-    prop = prop();
+    const {error, value} = safelyReadSignalValue(prop);
+    if (error) {
+      return PropType.Unknown;
+    }
+    prop = value;
   }
 
   if (prop === undefined) {

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
@@ -8,7 +8,7 @@
 
 import {ContainerType, Descriptor, NestedProp, PropType} from '../../../../protocol';
 
-import {isSignal, unwrapSignal} from '../utils';
+import {isSignal, safelyReadSignalValue, unwrapSignal} from '../utils';
 
 import {getDescriptor, getKeys} from './object-utils';
 
@@ -173,10 +173,19 @@ const isGetterOrSetter = (descriptor: any): boolean =>
 
 const getPreview = (propData: TerminalType | CompositeType, isGetterOrSetter: boolean) => {
   if (propData.containerType === 'ReadonlySignal') {
-    return `Readonly Signal(${typeToDescriptorPreview[propData.type](propData.prop())})`;
+    const {error, value} = safelyReadSignalValue(propData.prop);
+    if (error) {
+      return 'ERROR: Could not read signal value. See console for details.';
+    }
+    return `Readonly Signal(${typeToDescriptorPreview[propData.type](value)})`;
   } else if (propData.containerType === 'WritableSignal') {
-    return `Signal(${typeToDescriptorPreview[propData.type](propData.prop())})`;
+    const {error, value} = safelyReadSignalValue(propData.prop);
+    if (error) {
+      return 'ERROR: Could not read signal value. See console for details.';
+    }
+    return `Signal(${typeToDescriptorPreview[propData.type](value)})`;
   }
+
   return !isGetterOrSetter
     ? typeToDescriptorPreview[propData.type](propData.prop)
     : typeToDescriptorPreview[PropType.Function]({name: ''});

--- a/devtools/projects/ng-devtools-backend/src/lib/utils.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/utils.ts
@@ -45,6 +45,24 @@ export function isSignal(prop: unknown): prop is (() => unknown) & {set: (value:
   return (window as any).ng.isSignal(prop);
 }
 
+export function safelyReadSignalValue(signal: any): {error?: Error; value?: any} {
+  try {
+    const value = signal();
+    return {error: undefined, value};
+  } catch (error) {
+    console.error('[Angular DevTools]: Error reading signal value:', error);
+    return {error: error as Error, value: undefined};
+  }
+}
+
 export function unwrapSignal(s: any): any {
-  return isSignal(s) ? s() : s;
+  if (!isSignal(s)) {
+    return s;
+  }
+
+  const {error, value} = safelyReadSignalValue(s);
+  if (error) {
+    return;
+  }
+  return value;
 }

--- a/devtools/src/app/demo-app/todo/app-todo.component.ts
+++ b/devtools/src/app/demo-app/todo/app-todo.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, inject, Injectable} from '@angular/core';
+import {Component, inject, Injectable, viewChild} from '@angular/core';
 import {MatDialog} from '@angular/material/dialog';
 
 import {DialogComponent} from './dialog.component';
@@ -24,6 +24,8 @@ export class MyServiceA {}
 export class AppTodoComponent {
   name!: string;
   animal!: string;
+
+  viewChildWillThrowAnError = viewChild.required('thisSignalWillThrowAnError');
 
   readonly dialog = inject(MatDialog);
 


### PR DESCRIPTION
Fixes: #61900

Previously in DevTools we would read signal values to display preview values in the UI without safely catching any errors thrown in their evaluations.

Now those signal functions are run in a safe context, their errors are caught and handled in the UI as well as replayed in the console.


<img width="1512" alt="Screenshot 2025-06-05 at 3 56 21 PM" src="https://github.com/user-attachments/assets/cb490320-5e2d-445d-bfe9-7c0d4051ea17" />
