### PR TITLE
feat(devtools): check if signal graph is supported

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.spec.ts
@@ -11,6 +11,7 @@ import {
   ngDebugDependencyInjectionApiIsSupported,
   ngDebugProfilerApiIsSupported,
   ngDebugRoutesApiIsSupported,
+  ngDebugSignalGraphApiIsSupported,
 } from './ng-debug-api';
 import {Framework} from '../component-tree/core-enums';
 
@@ -111,6 +112,26 @@ describe('ng-debug-api', () => {
       (globalThis as any).ng = fakeNgGlobal(Framework.Wiz);
 
       expect(ngDebugRoutesApiIsSupported()).toBeFalse();
+    });
+  });
+
+  describe('ngDebugSignalGraphIsSupported', () => {
+    beforeEach(() => mockRoot());
+
+    it('should support Signal Graph API with getSignalGraph', () => {
+      (globalThis as any).ng = fakeNgGlobal(Framework.Angular);
+      (globalThis as any).ng.ɵgetSignalGraph = () => {};
+      expect(ngDebugSignalGraphApiIsSupported()).toBeTrue();
+    });
+
+    it('should not support Signal Graph API with no getSignalGraph', () => {
+      (globalThis as any).ng = fakeNgGlobal(Framework.ACX);
+      (globalThis as any).ng.ɵgetSignalGraph = 'not implemented';
+      expect(ngDebugSignalGraphApiIsSupported()).toBeFalse();
+
+      (globalThis as any).ng = fakeNgGlobal(Framework.ACX);
+      (globalThis as any).ng.ɵgetSignalGraph = undefined;
+      expect(ngDebugSignalGraphApiIsSupported()).toBeFalse();
     });
   });
 });

--- a/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.ts
@@ -75,3 +75,9 @@ export function ngDebugRoutesApiIsSupported(): boolean {
     })
   );
 }
+
+/** Checks whether Signal Graph API is supported within window.ng */
+export function ngDebugSignalGraphApiIsSupported(): boolean {
+  const ng = ngDebugClient();
+  return ngDebugApiIsSupported(ng, 'ɵgetSignalGraph');
+}

--- a/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/supported-apis.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/supported-apis.ts
@@ -11,6 +11,7 @@ import {
   ngDebugDependencyInjectionApiIsSupported,
   ngDebugProfilerApiIsSupported,
   ngDebugRoutesApiIsSupported,
+  ngDebugSignalGraphApiIsSupported,
 } from './ng-debug-api';
 
 /**
@@ -22,10 +23,12 @@ export function getSupportedApis(): SupportedApis {
   const profiler = ngDebugProfilerApiIsSupported();
   const dependencyInjection = ngDebugDependencyInjectionApiIsSupported();
   const routes = ngDebugRoutesApiIsSupported();
+  const signals = ngDebugSignalGraphApiIsSupported();
 
   return {
     profiler,
     dependencyInjection,
     routes,
+    signals,
   };
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools.component.ts
@@ -66,6 +66,7 @@ export class DevToolsComponent implements OnDestroy {
     profiler: false,
     dependencyInjection: false,
     routes: false,
+    signals: false,
   });
   readonly ivy = signal<boolean | undefined>(undefined);
 

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -338,6 +338,7 @@ export interface SupportedApis {
   profiler: boolean;
   dependencyInjection: boolean;
   routes: boolean;
+  signals: boolean;
 }
 
 export interface Events {


### PR DESCRIPTION
add a new devtools field in SupportedApis to check if the getSignalGraphApi exists

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

See https://github.com/angular/angular/pull/60478 for a more complete demo

By setting this API to unsupported, we can also hide the UI until it is more complete

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
