### PR TITLE
docs(docs-infra): fix padding issue with tutorial editor.

### DIFF
--- a/adev/src/app/features/tutorial/tutorial.component.scss
+++ b/adev/src/app/features/tutorial/tutorial.component.scss
@@ -142,7 +142,7 @@ $column-width: calc(50% - #{$resizer-width} - var(--layout-padding));
   width: 100%;
   min-width: 300px;
   padding-block-start: var(--layout-padding);
-  height: 100vh;
+  height: calc(100vh - var(--layout-padding));
 
   // should be suprior to the tutorial content or the tooltip won't integrate properly
   z-index: var( --z-index-nav);


### PR DESCRIPTION
This allow the console to be entirly visible without scrolling to the bottom of the page.
