### PR TITLE
docs: fix broken reveal answer button

### DIFF
--- a/adev/shared-docs/interfaces/tutorial.ts
+++ b/adev/shared-docs/interfaces/tutorial.ts
@@ -88,6 +88,8 @@ export interface TutorialConfigBase {
 
   /** The path to the tutorial answer folder when it's external to the tutorial */
   answerSrc?: string;
+  /** Root of the answer folder, so that proper relative paths can be computed, like in {@link openFiles}. */
+  answerRootDir?: string;
 
   /** An array of files to be open in the editor */
   openFiles?: string[];

--- a/adev/src/content/tutorials/first-app/steps/01-hello-world/config.json
+++ b/adev/src/content/tutorials/first-app/steps/01-hello-world/config.json
@@ -2,5 +2,6 @@
   "title": "Hello world!",
   "type": "editor",
   "answerSrc": "../02-Home/src",
+  "answerRootDir": "../02-Home/",
   "openFiles": ["src/app/app.ts"]
 }

--- a/adev/src/content/tutorials/first-app/steps/02-Home/config.json
+++ b/adev/src/content/tutorials/first-app/steps/02-Home/config.json
@@ -2,5 +2,6 @@
   "title": "Create home component",
   "type": "editor",
   "answerSrc": "../03-HousingLocation/src",
+  "answerRootDir": "../03-HousingLocation",
   "openFiles": ["src/app/app.ts"]
 }

--- a/adev/src/content/tutorials/first-app/steps/03-HousingLocation/config.json
+++ b/adev/src/content/tutorials/first-app/steps/03-HousingLocation/config.json
@@ -2,5 +2,6 @@
   "title": "Create housing location component",
   "type": "editor",
   "answerSrc": "../04-interfaces/src",
+  "answerRootDir": "../04-interfaces/",
   "openFiles": ["src/app/home/home.ts"]
 }

--- a/adev/src/content/tutorials/first-app/steps/04-interfaces/config.json
+++ b/adev/src/content/tutorials/first-app/steps/04-interfaces/config.json
@@ -2,5 +2,6 @@
   "title": "Create an interface",
   "type": "editor",
   "answerSrc": "../05-inputs/src",
+  "answerRootDir": "../05-inputs/",
   "openFiles": ["src/app/home/home.ts"]
 }

--- a/adev/src/content/tutorials/first-app/steps/05-inputs/config.json
+++ b/adev/src/content/tutorials/first-app/steps/05-inputs/config.json
@@ -2,5 +2,6 @@
   "title": "Add inputs to components",
   "type": "editor",
   "answerSrc": "../06-property-binding/src",
+  "answerRootDir": "../06-property-binding/",
   "openFiles": ["src/app/housing-location/housing-location.ts"]
 }

--- a/adev/src/content/tutorials/first-app/steps/06-property-binding/config.json
+++ b/adev/src/content/tutorials/first-app/steps/06-property-binding/config.json
@@ -2,5 +2,6 @@
   "title": "Add property binding to components",
   "type": "editor",
   "answerSrc": "../07-dynamic-template-values/src",
+  "answerRootDir": "../07-dynamic-template-values",
   "openFiles": ["src/app/home/home.ts"]
 }

--- a/adev/src/content/tutorials/first-app/steps/07-dynamic-template-values/config.json
+++ b/adev/src/content/tutorials/first-app/steps/07-dynamic-template-values/config.json
@@ -2,5 +2,6 @@
   "title": "Add dynamic values to templates",
   "type": "editor",
   "answerSrc": "../08-ngFor/src",
+  "answerRootDir": "../08-ngFor/",
   "openFiles": ["src/app/housing-location/housing-location.ts"]
 }

--- a/adev/src/content/tutorials/first-app/steps/08-ngFor/config.json
+++ b/adev/src/content/tutorials/first-app/steps/08-ngFor/config.json
@@ -2,5 +2,6 @@
   "title": "Use *ngFor in templates",
   "type": "editor",
   "answerSrc": "../09-services/src",
+  "answerRootDir": "../09-services/",
   "openFiles": ["src/app/home/home.ts"]
 }

--- a/adev/src/content/tutorials/first-app/steps/09-services/config.json
+++ b/adev/src/content/tutorials/first-app/steps/09-services/config.json
@@ -2,5 +2,6 @@
   "title": "Angular services",
   "type": "editor",
   "answerSrc": "../10-routing/src",
+  "answerRootDir": "../10-routing/",
   "openFiles": ["src/app/home/home.ts"]
 }

--- a/adev/src/content/tutorials/first-app/steps/10-routing/config.json
+++ b/adev/src/content/tutorials/first-app/steps/10-routing/config.json
@@ -2,5 +2,6 @@
   "title": "Add routing",
   "type": "local",
   "answerSrc": "../11-details-page/src",
+  "answerRootDir": "../11-details-page/",
   "openFiles": ["src/main.ts", "src/app/app.ts"]
 }

--- a/adev/src/content/tutorials/first-app/steps/11-details-page/config.json
+++ b/adev/src/content/tutorials/first-app/steps/11-details-page/config.json
@@ -2,6 +2,7 @@
   "title": "Customize the details page",
   "type": "local",
   "answerSrc": "../12-forms/src",
+  "answerRootDir": "../12-forms/",
   "openFiles": [
     "src/app/housing-location/housing-location.ts",
     "src/app/details/details.ts",

--- a/adev/src/content/tutorials/first-app/steps/12-forms/config.json
+++ b/adev/src/content/tutorials/first-app/steps/12-forms/config.json
@@ -2,5 +2,6 @@
   "title": "Integrate Angular forms",
   "type": "local",
   "answerSrc": "../13-search/src",
+  "answerRootDir": "../13-search/",
   "openFiles": ["src/app/housing.service.ts", "src/app/details/details.ts"]
 }

--- a/adev/src/content/tutorials/first-app/steps/13-search/config.json
+++ b/adev/src/content/tutorials/first-app/steps/13-search/config.json
@@ -2,5 +2,6 @@
   "title": "Add search functionality",
   "type": "local",
   "answerSrc": "../14-http/src",
+  "answerRootDir": "../14-http/",
   "openFiles": ["src/app/home/home.ts", "src/app/details/details.ts"]
 }

--- a/adev/src/content/tutorials/first-app/steps/14-http/config.json
+++ b/adev/src/content/tutorials/first-app/steps/14-http/config.json
@@ -2,5 +2,6 @@
   "title": "Add HTTP communication",
   "type": "local",
   "answerSrc": "./src-final",
+  "answerRootDir": "./src-final",
   "openFiles": ["src/app/app.ts"]
 }


### PR DESCRIPTION
The reveal answer button accidentally loads files into the embedded editor that aren't properly relativized. This ends up switching the currently open file to a different file, unexpectedly.

In addition, due to the incorrect paths, files like `favicon.ico` end up being loaded in the embedded editor; resulting in a bad experience as the images are shown as plain text.


https://github.com/user-attachments/assets/34483661-e8b0-4d24-8fa6-b9aab71a9152

