### PR TITLE
feat(core): retain the previous value of a `resource` until the new request is resolved

### DIFF
--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -229,15 +229,16 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
             stream: undefined,
           };
         } else {
+          const isSameRequest = previous.value.extRequest.request === extRequest.request;
+          const isPreviousStreamResolved =
+            previous.value.stream && isResolved(previous.value.stream());
+
           return {
             extRequest,
             status,
             previousStatus: projectStatusOfState(previous.value),
-            // If the request hasn't changed, keep the previous stream.
-            stream:
-              previous.value.extRequest.request === extRequest.request
-                ? previous.value.stream
-                : undefined,
+            // If the request hasn't changed or the previous stream didn't error, keep the previous stream.
+            stream: isSameRequest || isPreviousStreamResolved ? previous.value.stream : undefined,
           };
         }
       },


### PR DESCRIPTION
I've marked this as a `feat` since it changes the default behavior of `resource()`, so feel free to close it if it's not aligned with the intent of the API. It's merely a proposal.

In essence, what the PR does is retain the previous value/stream of a `resource` until the request in progress is resolved. This improves the ergonomics of `resource()` in the cases of slower requests when the value is set to `undefined` until they are resolved. The current behavior results in the flickering of value-reliant UI. There are ways to workaround the issue by using additional/supporting code but it kind of defeats the purpose of `resource()`, IMO, in these situations.

A good example of the implications of the current behavior is the A.dev search dialog: each typed letter results in a new request that resets the value of the resource which leads to results disappearing during execution and then re-appearing when the response is received.