### PR TITLE
docs(docs-infra): retain the results in the search dialog while typing

### DIFF
--- a/adev/shared-docs/components/search-dialog/search-dialog.component.html
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.html
@@ -45,9 +45,9 @@
           </li>
         }
       </ul>
-    } @else if (!searchResults.isLoading() && (history.hasItems())) {
+    } @else if (history.hasItems() && !this.searchControl.value.length) {
       <docs-search-history />
-    } @else if (!searchResults.isLoading()) {
+    } @else {
       <div class="docs-search-results docs-mini-scroll-track">
         @if (!resultsResource.hasValue()) {
           <div class="docs-search-results__start-typing">

--- a/adev/shared-docs/components/search-dialog/search-dialog.component.html
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.html
@@ -9,9 +9,9 @@
       placeholder="Search docs"
     />
 
-    @if (searchResults.hasValue() && searchResults.value().length > 0) {
+    @if (searchResults().length) {
       <ul class="docs-search-results docs-mini-scroll-track">
-        @for (result of searchResults.value(); track result.id) {
+        @for (result of searchResults(); track result.id) {
           <li docsSearchItem [item]="result">
             <a
               [routerLink]="'/' + result.url | relativeLink: 'pathname'"
@@ -49,11 +49,11 @@
       <docs-search-history />
     } @else if (!searchResults.isLoading()) {
       <div class="docs-search-results docs-mini-scroll-track">
-        @if (!searchResults.hasValue()) {
+        @if (!resultsResource.hasValue()) {
           <div class="docs-search-results__start-typing">
             <span>Start typing to see results</span>
           </div>
-        } @else if (searchResults.value().length === 0) {
+        } @else if (searchResults().length === 0) {
           <div class="docs-search-results__no-results">
             <span>No results found</span>
           </div>

--- a/adev/shared-docs/components/search-dialog/search-dialog.component.ts
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.ts
@@ -69,6 +69,7 @@ export class SearchDialog {
   ).withWrap();
 
   searchQuery = this.search.searchQuery;
+  resultsResource = this.search.resultsResource;
   searchResults = this.search.searchResults;
 
   // We use a FormControl instead of relying on NgModel+signal to avoid


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] angular.dev application / infrastructure changes


## What is the new behavior?

Due to `resource()` not retaining its value while there is a request in progress, the results list flickers. The new `searchResults` signal retains that previous value until the request is completed.
