### PR TITLE
refactor(service-worker): make `SwPush` and `SwUpdate` tree-shakable

### DIFF
--- a/goldens/public-api/service-worker/index.api.md
+++ b/goldens/public-api/service-worker/index.api.md
@@ -37,7 +37,7 @@ export class ServiceWorkerModule {
 
 // @public
 export class SwPush {
-    constructor(sw: NgswCommChannel);
+    constructor(sw?: NgswCommChannel);
     get isEnabled(): boolean;
     readonly messages: Observable<object>;
     readonly notificationClicks: Observable<{
@@ -62,7 +62,7 @@ export class SwPush {
     readonly subscription: Observable<PushSubscription | null>;
     unsubscribe(): Promise<void>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<SwPush, never>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<SwPush, [{ optional: true; }]>;
     // (undocumented)
     static ɵprov: i0.ɵɵInjectableDeclaration<SwPush>;
 }
@@ -77,14 +77,14 @@ export abstract class SwRegistrationOptions {
 
 // @public
 export class SwUpdate {
-    constructor(sw: NgswCommChannel);
+    constructor(sw?: NgswCommChannel);
     activateUpdate(): Promise<boolean>;
     checkForUpdate(): Promise<boolean>;
     get isEnabled(): boolean;
     readonly unrecoverable: Observable<UnrecoverableStateEvent>;
     readonly versionUpdates: Observable<VersionEvent>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<SwUpdate, never>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<SwUpdate, [{ optional: true; }]>;
     // (undocumented)
     static ɵprov: i0.ɵɵInjectableDeclaration<SwUpdate>;
 }

--- a/packages/service-worker/src/module.ts
+++ b/packages/service-worker/src/module.ts
@@ -9,13 +9,11 @@
 import {ModuleWithProviders, NgModule} from '@angular/core';
 
 import {provideServiceWorker, SwRegistrationOptions} from './provider';
-import {SwPush} from './push';
-import {SwUpdate} from './update';
 
 /**
  * @publicApi
  */
-@NgModule({providers: [SwPush, SwUpdate]})
+@NgModule()
 export class ServiceWorkerModule {
   /**
    * Register the given Angular Service Worker script.

--- a/packages/service-worker/src/provider.ts
+++ b/packages/service-worker/src/provider.ts
@@ -21,8 +21,6 @@ import {
 import type {Observable} from 'rxjs';
 
 import {NgswCommChannel} from './low_level';
-import {SwPush} from './push';
-import {SwUpdate} from './update';
 import {RuntimeErrorCode} from './errors';
 
 export const SCRIPT = new InjectionToken<string>(ngDevMode ? 'NGSW_REGISTER_SCRIPT' : '');
@@ -220,8 +218,6 @@ export function provideServiceWorker(
   options: SwRegistrationOptions = {},
 ): EnvironmentProviders {
   return makeEnvironmentProviders([
-    SwPush,
-    SwUpdate,
     {provide: SCRIPT, useValue: script},
     {provide: SwRegistrationOptions, useValue: options},
     {

--- a/packages/service-worker/src/update.ts
+++ b/packages/service-worker/src/update.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Injectable, ɵRuntimeError as RuntimeError} from '@angular/core';
+import {Inject, Injectable, Optional, ɵRuntimeError as RuntimeError} from '@angular/core';
 import {NEVER, Observable} from 'rxjs';
 
 import {RuntimeErrorCode} from './errors';
@@ -55,8 +55,17 @@ export class SwUpdate {
 
   private ongoingCheckForUpdate: Promise<boolean> | null = null;
 
-  constructor(private sw: NgswCommChannel) {
-    if (!sw.isEnabled) {
+  constructor(
+    // Since `SwUpdate` is provided in the root to be tree-shakable,
+    // it might be available for injection on the server.
+    // However, `provideServiceWorker` might not be present in the server's
+    // provider configuration. In that case, we fall back to an object with
+    // a single property: `isEnabled: false`.
+    @Optional()
+    @Inject(NgswCommChannel)
+    private sw: NgswCommChannel = <NgswCommChannel>{isEnabled: false},
+  ) {
+    if (!this.sw.isEnabled) {
       this.versionUpdates = NEVER;
       this.unrecoverable = NEVER;
       return;


### PR DESCRIPTION
In this commit, we mark the `SwPush` and `SwUpdate` classes as root providers. As a result, they are no longer statically referenced in the `provideServiceWorker` providers list, which previously forced them to be explicitly bundled into the main file. These classes might never be used—some consumers may use the service worker only for prefetching and caching assets.

Currently, some users work around this by using `patch-package` to modify the service worker code and remove these classes from the providers list.