### PR TITLE
ci: use new pull-request-labeling action

### DIFF
--- a/.github/workflows/dev-infra.yml
+++ b/.github/workflows/dev-infra.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: angular/dev-infra/github-actions/commit-message-based-labels@f072244090ead81c3fc2446317a1d4d7a6727537
+      - uses: angular/dev-infra/github-actions/pull-request-labeling@3a765b303ce300f607b658abd4eb8a981bc7277f
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}
   post_approval_changes:


### PR DESCRIPTION
This moves to the new labeling which includes the feature request made in https://github.com/angular/dev-infra/issues/2851