### PR TITLE
refactor(common): drop `X-Request-URL`

### DIFF
--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -19,13 +19,7 @@ import {RuntimeErrorCode} from './errors';
 
 import type {HttpBackend} from './backend';
 import {HttpHeaders} from './headers';
-import {
-  ACCEPT_HEADER,
-  ACCEPT_HEADER_VALUE,
-  CONTENT_TYPE_HEADER,
-  HttpRequest,
-  X_REQUEST_URL_HEADER,
-} from './request';
+import {ACCEPT_HEADER, ACCEPT_HEADER_VALUE, CONTENT_TYPE_HEADER, HttpRequest} from './request';
 import {
   HTTP_STATUS_CODE_OK,
   HttpDownloadProgressEvent,
@@ -40,19 +34,6 @@ import {
 import type {} from 'zone.js';
 
 const XSSI_PREFIX = /^\)\]\}',?\n/;
-
-/**
- * Determine an appropriate URL for the response, by checking either
- * response url or the X-Request-URL header.
- */
-function getResponseUrl(response: Response): string | null {
-  if (response.url) {
-    return response.url;
-  }
-  // stored as lowercase in the map
-  const xRequestUrl = X_REQUEST_URL_HEADER.toLocaleLowerCase();
-  return response.headers.get(xRequestUrl);
-}
 
 /**
  * An internal injection token to reference `FetchBackend` implementation
@@ -159,7 +140,7 @@ export class FetchBackend implements HttpBackend {
 
     const headers = new HttpHeaders(response.headers);
     const statusText = response.statusText;
-    const url = getResponseUrl(response) ?? request.urlWithParams;
+    const url = response.url || request.urlWithParams;
 
     let status = response.status;
     let body: string | ArrayBuffer | Blob | object | null = null;
@@ -253,7 +234,7 @@ export class FetchBackend implements HttpBackend {
             headers: new HttpHeaders(response.headers),
             status: response.status,
             statusText: response.statusText,
-            url: getResponseUrl(response) ?? request.urlWithParams,
+            url: response.url || request.urlWithParams,
           }),
         );
         return;

--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -101,13 +101,6 @@ export const CONTENT_TYPE_HEADER = 'Content-Type';
 export const ACCEPT_HEADER = 'Accept';
 
 /**
- * `X-Request-URL` is a custom HTTP header used in older browser versions,
- * including Firefox (< 32), Chrome (< 37), Safari (< 8), and Internet Explorer,
- * to include the full URL of the request in cross-origin requests.
- */
-export const X_REQUEST_URL_HEADER = 'X-Request-URL';
-
-/**
  * `text/plain` is a content type used to indicate that the content being
  * sent is plain text with no special formatting or structured data
  * like HTML, XML, or JSON.

--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -18,13 +18,7 @@ import {switchMap} from 'rxjs/operators';
 import type {HttpBackend} from './backend';
 import {RuntimeErrorCode} from './errors';
 import {HttpHeaders} from './headers';
-import {
-  ACCEPT_HEADER,
-  ACCEPT_HEADER_VALUE,
-  CONTENT_TYPE_HEADER,
-  HttpRequest,
-  X_REQUEST_URL_HEADER,
-} from './request';
+import {ACCEPT_HEADER, ACCEPT_HEADER_VALUE, CONTENT_TYPE_HEADER, HttpRequest} from './request';
 import {
   HTTP_STATUS_CODE_NO_CONTENT,
   HTTP_STATUS_CODE_OK,
@@ -39,22 +33,6 @@ import {
 } from './response';
 
 const XSSI_PREFIX = /^\)\]\}',?\n/;
-
-const X_REQUEST_URL_REGEXP = RegExp(`^${X_REQUEST_URL_HEADER}:`, 'm');
-
-/**
- * Determine an appropriate URL for the response, by checking either
- * XMLHttpRequest.responseURL or the X-Request-URL header.
- */
-function getResponseUrl(xhr: any): string | null {
-  if ('responseURL' in xhr && xhr.responseURL) {
-    return xhr.responseURL;
-  }
-  if (X_REQUEST_URL_REGEXP.test(xhr.getAllResponseHeaders())) {
-    return xhr.getResponseHeader(X_REQUEST_URL_HEADER);
-  }
-  return null;
-}
 
 /**
  * Validates whether the request is compatible with the XHR backend.
@@ -226,7 +204,7 @@ export class HttpXhrBackend implements HttpBackend {
 
             // Read the response URL from the XMLHttpResponse instance and fall back on the
             // request URL.
-            const url = getResponseUrl(xhr) || req.url;
+            const url = xhr.responseURL || req.url;
 
             // Construct the HttpHeaderResponse and memoize it.
             headerResponse = new HttpHeaderResponse({headers, status: xhr.status, statusText, url});

--- a/packages/common/http/test/fetch_spec.ts
+++ b/packages/common/http/test/fetch_spec.ts
@@ -510,21 +510,6 @@ describe('FetchBackend', async () => {
       fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', 'Test');
     });
 
-    it('from X-Request-URL header if the response URL is not present', (done) => {
-      backend
-        .handle(TEST_POST)
-        .pipe(toArray())
-        .subscribe((events) => {
-          expect(events.length).toBe(2);
-          expect(events[1].type).toBe(HttpEventType.Response);
-          const response = events[1] as HttpResponse<string>;
-          expect(response.url).toBe('/response/url');
-          done();
-        });
-      fetchMock.response.headers = {'X-Request-URL': '/response/url'};
-      fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', 'Test');
-    });
-
     it('falls back on Request.url if neither are available', (done) => {
       backend
         .handle(TEST_POST)

--- a/packages/common/http/test/xhr_spec.ts
+++ b/packages/common/http/test/xhr_spec.ts
@@ -387,20 +387,6 @@ describe('XhrBackend', () => {
       factory.mock.responseURL = '/response/url';
       factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', 'Test');
     });
-    it('from X-Request-URL header if XHR.responseURL is not present', (done) => {
-      backend
-        .handle(TEST_POST)
-        .pipe(toArray())
-        .subscribe((events) => {
-          expect(events.length).toBe(2);
-          expect(events[1].type).toBe(HttpEventType.Response);
-          const response = events[1] as HttpResponse<string>;
-          expect(response.url).toBe('/response/url');
-          done();
-        });
-      factory.mock.mockResponseHeaders = 'X-Request-URL: /response/url\n';
-      factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', 'Test');
-    });
     it('falls back on Request.url if neither are available', (done) => {
       backend
         .handle(TEST_POST)

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -237,8 +237,6 @@
       "VIEW_REFS",
       "ViewEncapsulation",
       "ViewRef",
-      "X_REQUEST_URL_HEADER",
-      "X_REQUEST_URL_REGEXP",
       "XhrFactory",
       "ZONELESS_ENABLED",
       "ZONELESS_SCHEDULER_DISABLED",


### PR DESCRIPTION
This commit drops the `X-Request-URL` header. It was a non-standard HTTP response header, deprecated long ago and never part of any official specification. Modern browsers now expose the final URL via the `XMLHttpRequest.responseURL` property, as defined in the WHATWG spec.