### PR TITLE
fix(forms): improve select performance

### DIFF
--- a/packages/forms/test/BUILD.bazel
+++ b/packages/forms/test/BUILD.bazel
@@ -6,7 +6,9 @@ ts_project(
     testonly = True,
     srcs = glob(["**/*.ts"]),
     interop_deps = [
+        "//packages/animations/browser",
         "//packages/platform-browser",
+        "//packages/platform-browser/animations",
         "//packages/platform-browser/testing",
         "//packages/private/testing",
     ],

--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {SimpleChange, ɵWritable as Writable} from '@angular/core';
-import {fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
+import {ChangeDetectorRef, SimpleChange, ɵWritable as Writable} from '@angular/core';
+import {fakeAsync, flushMicrotasks, TestBed, tick} from '@angular/core/testing';
 import {
   AbstractControl,
   CheckboxControlValueAccessor,
@@ -96,8 +96,15 @@ describe('Form Directives', () => {
       });
 
       it('should return select accessor when provided', () => {
-        const selectAccessor = new SelectControlValueAccessor(null!, null!);
-        expect(selectValueAccessor(dir, [defaultAccessor, selectAccessor])).toEqual(selectAccessor);
+        TestBed.configureTestingModule({
+          providers: [{provide: ChangeDetectorRef, useValue: null!}],
+        });
+        TestBed.runInInjectionContext(() => {
+          const selectAccessor = new SelectControlValueAccessor(null!, null!);
+          expect(selectValueAccessor(dir, [defaultAccessor, selectAccessor])).toEqual(
+            selectAccessor,
+          );
+        });
       });
 
       it('should return select multiple accessor when provided', () => {
@@ -108,9 +115,14 @@ describe('Form Directives', () => {
       });
 
       it('should throw when more than one build-in accessor is provided', () => {
-        const checkboxAccessor = new CheckboxControlValueAccessor(null!, null!);
-        const selectAccessor = new SelectControlValueAccessor(null!, null!);
-        expect(() => selectValueAccessor(dir, [checkboxAccessor, selectAccessor])).toThrowError();
+        TestBed.configureTestingModule({
+          providers: [{provide: ChangeDetectorRef, useValue: null!}],
+        });
+        TestBed.runInInjectionContext(() => {
+          const checkboxAccessor = new CheckboxControlValueAccessor(null!, null!);
+          const selectAccessor = new SelectControlValueAccessor(null!, null!);
+          expect(() => selectValueAccessor(dir, [checkboxAccessor, selectAccessor])).toThrowError();
+        });
       });
 
       it('should return custom accessor when provided', () => {
@@ -133,636 +145,679 @@ describe('Form Directives', () => {
         const customAccessor: ControlValueAccessor = {} as any;
         expect(() => selectValueAccessor(dir, [customAccessor, customAccessor])).toThrowError();
       });
-    });
 
-    describe('composeValidators', () => {
-      it('should compose functions', () => {
-        const dummy1 = () => ({'dummy1': true});
-        const dummy2 = () => ({'dummy2': true});
-        const v = composeValidators([dummy1, dummy2])!;
-        expect(v(new FormControl(''))).toEqual({'dummy1': true, 'dummy2': true});
+      describe('composeValidators', () => {
+        it('should compose functions', () => {
+          const dummy1 = () => ({'dummy1': true});
+          const dummy2 = () => ({'dummy2': true});
+          const v = composeValidators([dummy1, dummy2])!;
+          expect(v(new FormControl(''))).toEqual({'dummy1': true, 'dummy2': true});
+        });
+
+        it('should compose validator directives', () => {
+          const dummy1 = () => ({'dummy1': true});
+          const v = composeValidators([dummy1, new CustomValidatorDirective()])!;
+          expect(v(new FormControl(''))).toEqual({'dummy1': true, 'custom': true});
+        });
       });
 
-      it('should compose validator directives', () => {
-        const dummy1 = () => ({'dummy1': true});
-        const v = composeValidators([dummy1, new CustomValidatorDirective()])!;
-        expect(v(new FormControl(''))).toEqual({'dummy1': true, 'custom': true});
+      describe('formGroup', () => {
+        beforeEach(() => {
+          dir = {path: []} as any;
+        });
+
+        it('should throw when given an empty array', () => {
+          expect(() => selectValueAccessor(dir, [])).toThrowError();
+        });
+
+        it('should throw when accessor is not provided as array', () => {
+          expect(() => selectValueAccessor(dir, {} as any[])).toThrowError(
+            'NG01200: Value accessor was not provided as an array for form control with unspecified name attribute. Check that the `NG_VALUE_ACCESSOR` token is configured as a `multi: true` provider.',
+          );
+        });
+
+        it('should return the default value accessor when no other provided', () => {
+          expect(selectValueAccessor(dir, [defaultAccessor])).toEqual(defaultAccessor);
+        });
+
+        it('should return checkbox accessor when provided', () => {
+          const checkboxAccessor = new CheckboxControlValueAccessor(null!, null!);
+          expect(selectValueAccessor(dir, [defaultAccessor, checkboxAccessor])).toEqual(
+            checkboxAccessor,
+          );
+        });
+
+        it('should return select multiple accessor when provided', () => {
+          const selectMultipleAccessor = new SelectMultipleControlValueAccessor(null!, null!);
+          expect(selectValueAccessor(dir, [defaultAccessor, selectMultipleAccessor])).toEqual(
+            selectMultipleAccessor,
+          );
+        });
+
+        it('should return custom accessor when provided', () => {
+          const customAccessor: ControlValueAccessor = {} as any;
+          const checkboxAccessor = new CheckboxControlValueAccessor(null!, null!);
+          expect(
+            selectValueAccessor(dir, <any>[defaultAccessor, customAccessor, checkboxAccessor]),
+          ).toEqual(customAccessor);
+        });
+
+        it('should return custom accessor when provided with select multiple', () => {
+          const customAccessor: ControlValueAccessor = {} as any;
+          const selectMultipleAccessor = new SelectMultipleControlValueAccessor(null!, null!);
+          expect(
+            selectValueAccessor(dir, <any>[
+              defaultAccessor,
+              customAccessor,
+              selectMultipleAccessor,
+            ]),
+          ).toEqual(customAccessor);
+        });
+
+        it('should throw when more than one custom accessor is provided', () => {
+          const customAccessor: ControlValueAccessor = {} as any;
+          expect(() => selectValueAccessor(dir, [customAccessor, customAccessor])).toThrowError();
+        });
+      });
+
+      describe('composeValidators', () => {
+        it('should compose functions', () => {
+          const dummy1 = () => ({'dummy1': true});
+          const dummy2 = () => ({'dummy2': true});
+          const v = composeValidators([dummy1, dummy2])!;
+          expect(v(new FormControl(''))).toEqual({'dummy1': true, 'dummy2': true});
+        });
+
+        it('should compose validator directives', () => {
+          const dummy1 = () => ({'dummy1': true});
+          const v = composeValidators([dummy1, new CustomValidatorDirective()])!;
+          expect(v(new FormControl(''))).toEqual({'dummy1': true, 'custom': true});
+        });
       });
     });
-  });
 
-  describe('formGroup', () => {
-    let form: FormGroupDirective;
-    let formModel: FormGroup;
-    let loginControlDir: FormControlName;
+    describe('formGroup', () => {
+      let form: FormGroupDirective;
+      let formModel: FormGroup;
+      let loginControlDir: FormControlName;
 
-    beforeEach(() => {
-      form = new FormGroupDirective([], []);
-      formModel = new FormGroup({
-        'login': new FormControl(),
-        'passwords': new FormGroup({
-          'password': new FormControl(),
-          'passwordConfirm': new FormControl(),
-        }),
-      });
-      form.form = formModel;
+      beforeEach(() => {
+        form = new FormGroupDirective([], []);
+        formModel = new FormGroup({
+          'login': new FormControl(),
+          'passwords': new FormGroup({
+            'password': new FormControl(),
+            'passwordConfirm': new FormControl(),
+          }),
+        });
+        form.form = formModel;
 
-      loginControlDir = new FormControlName(
-        form,
-        [Validators.required],
-        [asyncValidator('expected')],
-        [defaultAccessor],
-        null,
-      );
-      loginControlDir.name = 'login';
-      loginControlDir.valueAccessor = new DummyControlValueAccessor();
-    });
-
-    it('should reexport control properties', () => {
-      expect(form.control).toBe(formModel);
-      expect(form.value).toBe(formModel.value);
-      expect(form.valid).toBe(formModel.valid);
-      expect(form.invalid).toBe(formModel.invalid);
-      expect(form.pending).toBe(formModel.pending);
-      expect(form.errors).toBe(formModel.errors);
-      expect(form.pristine).toBe(formModel.pristine);
-      expect(form.dirty).toBe(formModel.dirty);
-      expect(form.touched).toBe(formModel.touched);
-      expect(form.untouched).toBe(formModel.untouched);
-      expect(form.statusChanges).toBe(formModel.statusChanges);
-      expect(form.valueChanges).toBe(formModel.valueChanges);
-    });
-
-    it('should reexport control methods', () => {
-      expect(form.hasError('required')).toBe(formModel.hasError('required'));
-      expect(form.getError('required')).toBe(formModel.getError('required'));
-
-      formModel.setErrors({required: true});
-      expect(form.hasError('required')).toBe(formModel.hasError('required'));
-      expect(form.getError('required')).toBe(formModel.getError('required'));
-    });
-
-    describe('addControl', () => {
-      it('should throw when no control found', () => {
-        const dir = new FormControlName(form, null!, null!, [defaultAccessor], null);
-        dir.name = 'invalidName';
-
-        expect(() => form.addControl(dir)).toThrowError(
-          new RegExp(`Cannot find control with name: 'invalidName'`),
+        loginControlDir = new FormControlName(
+          form,
+          [Validators.required],
+          [asyncValidator('expected')],
+          [defaultAccessor],
+          null,
         );
+        loginControlDir.name = 'login';
+        loginControlDir.valueAccessor = new DummyControlValueAccessor();
       });
 
-      it('should throw for a named control when no value accessor', () => {
-        const dir = new FormControlName(form, null!, null!, null!, null);
-        dir.name = 'login';
-
-        expect(() => form.addControl(dir)).toThrowError(
-          new RegExp(
-            `NG01203: No value accessor for form control name: 'login'. Find more at https://angular.dev/errors/NG01203`,
-          ),
-        );
+      it('should reexport control properties', () => {
+        expect(form.control).toBe(formModel);
+        expect(form.value).toBe(formModel.value);
+        expect(form.valid).toBe(formModel.valid);
+        expect(form.invalid).toBe(formModel.invalid);
+        expect(form.pending).toBe(formModel.pending);
+        expect(form.errors).toBe(formModel.errors);
+        expect(form.pristine).toBe(formModel.pristine);
+        expect(form.dirty).toBe(formModel.dirty);
+        expect(form.touched).toBe(formModel.touched);
+        expect(form.untouched).toBe(formModel.untouched);
+        expect(form.statusChanges).toBe(formModel.statusChanges);
+        expect(form.valueChanges).toBe(formModel.valueChanges);
       });
 
-      it('should throw when no value accessor with path', () => {
-        const group = new FormGroupName(form, null!, null!);
-        const dir = new FormControlName(group, null!, null!, null!, null);
-        group.name = 'passwords';
-        dir.name = 'password';
+      it('should reexport control methods', () => {
+        expect(form.hasError('required')).toBe(formModel.hasError('required'));
+        expect(form.getError('required')).toBe(formModel.getError('required'));
 
-        expect(() => form.addControl(dir)).toThrowError(
-          new RegExp(
-            `NG01203: No value accessor for form control path: 'passwords -> password'. Find more at https://angular.dev/errors/NG01203`,
-          ),
-        );
+        formModel.setErrors({required: true});
+        expect(form.hasError('required')).toBe(formModel.hasError('required'));
+        expect(form.getError('required')).toBe(formModel.getError('required'));
       });
 
-      it('should set up validators', fakeAsync(() => {
-        form.addControl(loginControlDir);
+      describe('addControl', () => {
+        it('should throw when no control found', () => {
+          const dir = new FormControlName(form, null!, null!, [defaultAccessor], null);
+          dir.name = 'invalidName';
 
-        // sync validators are set
-        expect(formModel.hasError('required', ['login'])).toBe(true);
-        expect(formModel.hasError('async', ['login'])).toBe(false);
+          expect(() => form.addControl(dir)).toThrowError(
+            new RegExp(`Cannot find control with name: 'invalidName'`),
+          );
+        });
 
-        (<FormControl>formModel.get('login')).setValue('invalid value');
+        it('should throw for a named control when no value accessor', () => {
+          const dir = new FormControlName(form, null!, null!, null!, null);
+          dir.name = 'login';
 
-        // sync validator passes, running async validators
-        expect(formModel.pending).toBe(true);
+          expect(() => form.addControl(dir)).toThrowError(
+            new RegExp(
+              `NG01203: No value accessor for form control name: 'login'. Find more at https://angular.dev/errors/NG01203`,
+            ),
+          );
+        });
+
+        it('should throw when no value accessor with path', () => {
+          const group = new FormGroupName(form, null!, null!);
+          const dir = new FormControlName(group, null!, null!, null!, null);
+          group.name = 'passwords';
+          dir.name = 'password';
+
+          expect(() => form.addControl(dir)).toThrowError(
+            new RegExp(
+              `NG01203: No value accessor for form control path: 'passwords -> password'. Find more at https://angular.dev/errors/NG01203`,
+            ),
+          );
+        });
+
+        it('should set up validators', fakeAsync(() => {
+          form.addControl(loginControlDir);
+
+          // sync validators are set
+          expect(formModel.hasError('required', ['login'])).toBe(true);
+          expect(formModel.hasError('async', ['login'])).toBe(false);
+
+          (<FormControl>formModel.get('login')).setValue('invalid value');
+
+          // sync validator passes, running async validators
+          expect(formModel.pending).toBe(true);
+
+          tick();
+
+          expect(formModel.hasError('required', ['login'])).toBe(false);
+          expect(formModel.hasError('async', ['login'])).toBe(true);
+        }));
+
+        it('should write value to the DOM', () => {
+          (<FormControl>formModel.get(['login'])).setValue('initValue');
+
+          form.addControl(loginControlDir);
+
+          expect((<any>loginControlDir.valueAccessor).writtenValue).toEqual('initValue');
+        });
+
+        it('should add the directive to the list of directives included in the form', () => {
+          form.addControl(loginControlDir);
+          expect(form.directives).toEqual([loginControlDir]);
+        });
+      });
+
+      describe('addFormGroup', () => {
+        const matchingPasswordsValidator = (g: AbstractControl) => {
+          const controls = (g as FormGroup).controls;
+          if (controls['password'].value != controls['passwordConfirm'].value) {
+            return {'differentPasswords': true};
+          } else {
+            return null;
+          }
+        };
+
+        it('should set up validator', fakeAsync(() => {
+          const group = new FormGroupName(
+            form,
+            [matchingPasswordsValidator],
+            [asyncValidator('expected')],
+          );
+          group.name = 'passwords';
+          form.addFormGroup(group);
+
+          (<FormControl>formModel.get(['passwords', 'password'])).setValue('somePassword');
+          (<FormControl>formModel.get(['passwords', 'passwordConfirm'])).setValue(
+            'someOtherPassword',
+          );
+
+          // sync validators are set
+          expect(formModel.hasError('differentPasswords', ['passwords'])).toEqual(true);
+
+          (<FormControl>formModel.get(['passwords', 'passwordConfirm'])).setValue('somePassword');
+
+          // sync validators pass, running async validators
+          expect(formModel.pending).toBe(true);
+
+          tick();
+
+          expect(formModel.hasError('async', ['passwords'])).toBe(true);
+        }));
+      });
+
+      describe('removeControl', () => {
+        it('should remove the directive to the list of directives included in the form', () => {
+          form.addControl(loginControlDir);
+          form.removeControl(loginControlDir);
+          expect(form.directives).toEqual([]);
+        });
+      });
+
+      describe('ngOnChanges', () => {
+        it('should update dom values of all the directives', () => {
+          form.addControl(loginControlDir);
+
+          (<FormControl>formModel.get(['login'])).setValue('new value');
+
+          form.ngOnChanges({});
+
+          expect((<any>loginControlDir.valueAccessor).writtenValue).toEqual('new value');
+        });
+
+        it('should set up a sync validator', () => {
+          const formValidator = (c: AbstractControl) => ({'custom': true});
+          const f = new FormGroupDirective([formValidator], []);
+          f.form = formModel;
+          f.ngOnChanges({'form': new SimpleChange(null, null, false)});
+
+          expect(formModel.errors).toEqual({'custom': true});
+        });
+
+        it('should set up an async validator', fakeAsync(() => {
+          const f = new FormGroupDirective([], [asyncValidator('expected')]);
+          f.form = formModel;
+          f.ngOnChanges({'form': new SimpleChange(null, null, false)});
+
+          tick();
+
+          expect(formModel.errors).toEqual({'async': true});
+        }));
+      });
+    });
+
+    describe('NgForm', () => {
+      let form: NgForm;
+      let formModel: FormGroup;
+      let loginControlDir: NgModel;
+      let personControlGroupDir: NgModelGroup;
+
+      beforeEach(() => {
+        form = new NgForm([], []);
+        formModel = form.form;
+
+        personControlGroupDir = new NgModelGroup(form, [], []);
+        personControlGroupDir.name = 'person';
+
+        loginControlDir = new NgModel(personControlGroupDir, null!, null!, [defaultAccessor]);
+        loginControlDir.name = 'login';
+        loginControlDir.valueAccessor = new DummyControlValueAccessor();
+      });
+
+      it('should reexport control properties', () => {
+        expect(form.control).toBe(formModel);
+        expect(form.value).toBe(formModel.value);
+        expect(form.valid).toBe(formModel.valid);
+        expect(form.invalid).toBe(formModel.invalid);
+        expect(form.pending).toBe(formModel.pending);
+        expect(form.errors).toBe(formModel.errors);
+        expect(form.pristine).toBe(formModel.pristine);
+        expect(form.dirty).toBe(formModel.dirty);
+        expect(form.touched).toBe(formModel.touched);
+        expect(form.untouched).toBe(formModel.untouched);
+        expect(form.statusChanges).toBe(formModel.statusChanges);
+        expect(form.status).toBe(formModel.status);
+        expect(form.valueChanges).toBe(formModel.valueChanges);
+        expect(form.disabled).toBe(formModel.disabled);
+        expect(form.enabled).toBe(formModel.enabled);
+      });
+
+      it('should reexport control methods', () => {
+        expect(form.hasError('required')).toBe(formModel.hasError('required'));
+        expect(form.getError('required')).toBe(formModel.getError('required'));
+
+        formModel.setErrors({required: true});
+        expect(form.hasError('required')).toBe(formModel.hasError('required'));
+        expect(form.getError('required')).toBe(formModel.getError('required'));
+      });
+
+      describe('addControl & addFormGroup', () => {
+        it('should create a control with the given name', fakeAsync(() => {
+          form.addFormGroup(personControlGroupDir);
+          form.addControl(loginControlDir);
+
+          flushMicrotasks();
+
+          expect(formModel.get(['person', 'login'])).not.toBeNull();
+        }));
+
+        // should update the form's value and validity
+      });
+
+      describe('removeControl & removeFormGroup', () => {
+        it('should remove control', fakeAsync(() => {
+          form.addFormGroup(personControlGroupDir);
+          form.addControl(loginControlDir);
+
+          form.removeFormGroup(personControlGroupDir);
+          form.removeControl(loginControlDir);
+
+          flushMicrotasks();
+
+          expect(formModel.get(['person'])).toBeNull();
+          expect(formModel.get(['person', 'login'])).toBeNull();
+        }));
+
+        // should update the form's value and validity
+      });
+
+      it('should set up sync validator', fakeAsync(() => {
+        const formValidator = () => ({'custom': true});
+        const f = new NgForm([formValidator], []);
 
         tick();
 
-        expect(formModel.hasError('required', ['login'])).toBe(false);
-        expect(formModel.hasError('async', ['login'])).toBe(true);
+        expect(f.form.errors).toEqual({'custom': true});
       }));
 
-      it('should write value to the DOM', () => {
-        (<FormControl>formModel.get(['login'])).setValue('initValue');
+      it('should set up async validator', fakeAsync(() => {
+        const f = new NgForm([], [asyncValidator('expected')]);
 
-        form.addControl(loginControlDir);
+        tick();
 
-        expect((<any>loginControlDir.valueAccessor).writtenValue).toEqual('initValue');
+        expect(f.form.errors).toEqual({'async': true});
+      }));
+    });
+
+    describe('FormGroupName', () => {
+      let formModel: FormGroup;
+      let controlGroupDir: FormGroupName;
+
+      beforeEach(() => {
+        formModel = new FormGroup({'login': new FormControl(null)});
+
+        const parent = new FormGroupDirective([], []);
+        parent.form = new FormGroup({'group': formModel});
+        controlGroupDir = new FormGroupName(parent, [], []);
+        controlGroupDir.name = 'group';
       });
 
-      it('should add the directive to the list of directives included in the form', () => {
-        form.addControl(loginControlDir);
-        expect(form.directives).toEqual([loginControlDir]);
+      it('should reexport control properties', () => {
+        expect(controlGroupDir.control).toBe(formModel);
+        expect(controlGroupDir.value).toBe(formModel.value);
+        expect(controlGroupDir.valid).toBe(formModel.valid);
+        expect(controlGroupDir.invalid).toBe(formModel.invalid);
+        expect(controlGroupDir.pending).toBe(formModel.pending);
+        expect(controlGroupDir.errors).toBe(formModel.errors);
+        expect(controlGroupDir.pristine).toBe(formModel.pristine);
+        expect(controlGroupDir.dirty).toBe(formModel.dirty);
+        expect(controlGroupDir.touched).toBe(formModel.touched);
+        expect(controlGroupDir.untouched).toBe(formModel.untouched);
+        expect(controlGroupDir.statusChanges).toBe(formModel.statusChanges);
+        expect(controlGroupDir.status).toBe(formModel.status);
+        expect(controlGroupDir.valueChanges).toBe(formModel.valueChanges);
+        expect(controlGroupDir.disabled).toBe(formModel.disabled);
+        expect(controlGroupDir.enabled).toBe(formModel.enabled);
+      });
+
+      it('should reexport control methods', () => {
+        expect(controlGroupDir.hasError('required')).toBe(formModel.hasError('required'));
+        expect(controlGroupDir.getError('required')).toBe(formModel.getError('required'));
+
+        formModel.setErrors({required: true});
+        expect(controlGroupDir.hasError('required')).toBe(formModel.hasError('required'));
+        expect(controlGroupDir.getError('required')).toBe(formModel.getError('required'));
       });
     });
 
-    describe('addFormGroup', () => {
-      const matchingPasswordsValidator = (g: AbstractControl) => {
-        const controls = (g as FormGroup).controls;
-        if (controls['password'].value != controls['passwordConfirm'].value) {
-          return {'differentPasswords': true};
-        } else {
-          return null;
-        }
+    describe('FormArrayName', () => {
+      let formModel: FormArray;
+      let formArrayDir: FormArrayName;
+
+      beforeEach(() => {
+        const parent = new FormGroupDirective([], []);
+        formModel = new FormArray([new FormControl('')]);
+        parent.form = new FormGroup({'array': formModel});
+        formArrayDir = new FormArrayName(parent, [], []);
+        formArrayDir.name = 'array';
+      });
+
+      it('should reexport control properties', () => {
+        expect(formArrayDir.control).toBe(formModel);
+        expect(formArrayDir.value).toBe(formModel.value);
+        expect(formArrayDir.valid).toBe(formModel.valid);
+        expect(formArrayDir.invalid).toBe(formModel.invalid);
+        expect(formArrayDir.pending).toBe(formModel.pending);
+        expect(formArrayDir.errors).toBe(formModel.errors);
+        expect(formArrayDir.pristine).toBe(formModel.pristine);
+        expect(formArrayDir.dirty).toBe(formModel.dirty);
+        expect(formArrayDir.touched).toBe(formModel.touched);
+        expect(formArrayDir.status).toBe(formModel.status);
+        expect(formArrayDir.untouched).toBe(formModel.untouched);
+        expect(formArrayDir.disabled).toBe(formModel.disabled);
+        expect(formArrayDir.enabled).toBe(formModel.enabled);
+      });
+
+      it('should reexport control methods', () => {
+        expect(formArrayDir.hasError('required')).toBe(formModel.hasError('required'));
+        expect(formArrayDir.getError('required')).toBe(formModel.getError('required'));
+
+        formModel.setErrors({required: true});
+        expect(formArrayDir.hasError('required')).toBe(formModel.hasError('required'));
+        expect(formArrayDir.getError('required')).toBe(formModel.getError('required'));
+      });
+    });
+
+    describe('FormControlDirective', () => {
+      let controlDir: FormControlDirective;
+      let control: FormControl;
+      const checkProperties = function (control: FormControl) {
+        expect(controlDir.control).toBe(control);
+        expect(controlDir.value).toBe(control.value);
+        expect(controlDir.valid).toBe(control.valid);
+        expect(controlDir.invalid).toBe(control.invalid);
+        expect(controlDir.pending).toBe(control.pending);
+        expect(controlDir.errors).toBe(control.errors);
+        expect(controlDir.pristine).toBe(control.pristine);
+        expect(controlDir.dirty).toBe(control.dirty);
+        expect(controlDir.touched).toBe(control.touched);
+        expect(controlDir.untouched).toBe(control.untouched);
+        expect(controlDir.statusChanges).toBe(control.statusChanges);
+        expect(controlDir.status).toBe(control.status);
+        expect(controlDir.valueChanges).toBe(control.valueChanges);
+        expect(controlDir.disabled).toBe(control.disabled);
+        expect(controlDir.enabled).toBe(control.enabled);
       };
 
-      it('should set up validator', fakeAsync(() => {
-        const group = new FormGroupName(
-          form,
-          [matchingPasswordsValidator],
+      beforeEach(() => {
+        controlDir = new FormControlDirective([Validators.required], [], [defaultAccessor], null);
+        controlDir.valueAccessor = new DummyControlValueAccessor();
+
+        control = new FormControl(null);
+        controlDir.form = control;
+      });
+
+      it('should reexport control properties', () => {
+        checkProperties(control);
+      });
+
+      it('should reexport control methods', () => {
+        expect(controlDir.hasError('required')).toBe(control.hasError('required'));
+        expect(controlDir.getError('required')).toBe(control.getError('required'));
+
+        control.setErrors({required: true});
+        expect(controlDir.hasError('required')).toBe(control.hasError('required'));
+        expect(controlDir.getError('required')).toBe(control.getError('required'));
+      });
+
+      it('should reexport new control properties', () => {
+        const newControl = new FormControl(null);
+        controlDir.form = newControl;
+        controlDir.ngOnChanges({'form': new SimpleChange(control, newControl, false)});
+
+        checkProperties(newControl);
+      });
+
+      it('should set up validator', () => {
+        expect(control.valid).toBe(true);
+
+        // this will add the required validator and recalculate the validity
+        controlDir.ngOnChanges({'form': new SimpleChange(null, control, false)});
+
+        expect(control.valid).toBe(false);
+      });
+    });
+
+    describe('NgModel', () => {
+      let ngModel: NgModel;
+      let control: FormControl;
+
+      beforeEach(() => {
+        ngModel = new NgModel(
+          null!,
+          [Validators.required],
           [asyncValidator('expected')],
+          [defaultAccessor],
         );
-        group.name = 'passwords';
-        form.addFormGroup(group);
+        ngModel.valueAccessor = new DummyControlValueAccessor();
+        control = ngModel.control;
+      });
 
-        (<FormControl>formModel.get(['passwords', 'password'])).setValue('somePassword');
-        (<FormControl>formModel.get(['passwords', 'passwordConfirm'])).setValue(
-          'someOtherPassword',
+      it('should reexport control properties', () => {
+        expect(ngModel.control).toBe(control);
+        expect(ngModel.value).toBe(control.value);
+        expect(ngModel.valid).toBe(control.valid);
+        expect(ngModel.invalid).toBe(control.invalid);
+        expect(ngModel.pending).toBe(control.pending);
+        expect(ngModel.errors).toBe(control.errors);
+        expect(ngModel.pristine).toBe(control.pristine);
+        expect(ngModel.dirty).toBe(control.dirty);
+        expect(ngModel.touched).toBe(control.touched);
+        expect(ngModel.untouched).toBe(control.untouched);
+        expect(ngModel.statusChanges).toBe(control.statusChanges);
+        expect(ngModel.status).toBe(control.status);
+        expect(ngModel.valueChanges).toBe(control.valueChanges);
+        expect(ngModel.disabled).toBe(control.disabled);
+        expect(ngModel.enabled).toBe(control.enabled);
+      });
+
+      it('should reexport control methods', () => {
+        expect(ngModel.hasError('required')).toBe(control.hasError('required'));
+        expect(ngModel.getError('required')).toBe(control.getError('required'));
+
+        control.setErrors({required: true});
+        expect(ngModel.hasError('required')).toBe(control.hasError('required'));
+        expect(ngModel.getError('required')).toBe(control.getError('required'));
+      });
+
+      it('should throw when no value accessor with named control', () => {
+        const namedDir = new NgModel(null!, null!, null!, null!);
+        namedDir.name = 'one';
+
+        expect(() => namedDir.ngOnChanges({})).toThrowError(
+          new RegExp(
+            `NG01203: No value accessor for form control name: 'one'. Find more at https://angular.dev/errors/NG01203`,
+          ),
         );
+      });
 
-        // sync validators are set
-        expect(formModel.hasError('differentPasswords', ['passwords'])).toEqual(true);
+      it('should throw when no value accessor with unnamed control', () => {
+        const unnamedDir = new NgModel(null!, null!, null!, null!);
 
-        (<FormControl>formModel.get(['passwords', 'passwordConfirm'])).setValue('somePassword');
+        expect(() => unnamedDir.ngOnChanges({})).toThrowError(
+          new RegExp(
+            `NG01203: No value accessor for form control unspecified name attribute. Find more at https://angular.dev/errors/NG01203`,
+          ),
+        );
+      });
 
-        // sync validators pass, running async validators
-        expect(formModel.pending).toBe(true);
-
+      it('should set up validator', fakeAsync(() => {
+        // this will add the required validator and recalculate the validity
+        ngModel.ngOnChanges({});
         tick();
 
-        expect(formModel.hasError('async', ['passwords'])).toBe(true);
-      }));
-    });
+        expect(ngModel.control.errors).toEqual({'required': true});
 
-    describe('removeControl', () => {
-      it('should remove the directive to the list of directives included in the form', () => {
-        form.addControl(loginControlDir);
-        form.removeControl(loginControlDir);
-        expect(form.directives).toEqual([]);
-      });
-    });
-
-    describe('ngOnChanges', () => {
-      it('should update dom values of all the directives', () => {
-        form.addControl(loginControlDir);
-
-        (<FormControl>formModel.get(['login'])).setValue('new value');
-
-        form.ngOnChanges({});
-
-        expect((<any>loginControlDir.valueAccessor).writtenValue).toEqual('new value');
-      });
-
-      it('should set up a sync validator', () => {
-        const formValidator = (c: AbstractControl) => ({'custom': true});
-        const f = new FormGroupDirective([formValidator], []);
-        f.form = formModel;
-        f.ngOnChanges({'form': new SimpleChange(null, null, false)});
-
-        expect(formModel.errors).toEqual({'custom': true});
-      });
-
-      it('should set up an async validator', fakeAsync(() => {
-        const f = new FormGroupDirective([], [asyncValidator('expected')]);
-        f.form = formModel;
-        f.ngOnChanges({'form': new SimpleChange(null, null, false)});
-
+        ngModel.control.setValue('someValue');
         tick();
 
-        expect(formModel.errors).toEqual({'async': true});
-      }));
-    });
-  });
-
-  describe('NgForm', () => {
-    let form: NgForm;
-    let formModel: FormGroup;
-    let loginControlDir: NgModel;
-    let personControlGroupDir: NgModelGroup;
-
-    beforeEach(() => {
-      form = new NgForm([], []);
-      formModel = form.form;
-
-      personControlGroupDir = new NgModelGroup(form, [], []);
-      personControlGroupDir.name = 'person';
-
-      loginControlDir = new NgModel(personControlGroupDir, null!, null!, [defaultAccessor]);
-      loginControlDir.name = 'login';
-      loginControlDir.valueAccessor = new DummyControlValueAccessor();
-    });
-
-    it('should reexport control properties', () => {
-      expect(form.control).toBe(formModel);
-      expect(form.value).toBe(formModel.value);
-      expect(form.valid).toBe(formModel.valid);
-      expect(form.invalid).toBe(formModel.invalid);
-      expect(form.pending).toBe(formModel.pending);
-      expect(form.errors).toBe(formModel.errors);
-      expect(form.pristine).toBe(formModel.pristine);
-      expect(form.dirty).toBe(formModel.dirty);
-      expect(form.touched).toBe(formModel.touched);
-      expect(form.untouched).toBe(formModel.untouched);
-      expect(form.statusChanges).toBe(formModel.statusChanges);
-      expect(form.status).toBe(formModel.status);
-      expect(form.valueChanges).toBe(formModel.valueChanges);
-      expect(form.disabled).toBe(formModel.disabled);
-      expect(form.enabled).toBe(formModel.enabled);
-    });
-
-    it('should reexport control methods', () => {
-      expect(form.hasError('required')).toBe(formModel.hasError('required'));
-      expect(form.getError('required')).toBe(formModel.getError('required'));
-
-      formModel.setErrors({required: true});
-      expect(form.hasError('required')).toBe(formModel.hasError('required'));
-      expect(form.getError('required')).toBe(formModel.getError('required'));
-    });
-
-    describe('addControl & addFormGroup', () => {
-      it('should create a control with the given name', fakeAsync(() => {
-        form.addFormGroup(personControlGroupDir);
-        form.addControl(loginControlDir);
-
-        flushMicrotasks();
-
-        expect(formModel.get(['person', 'login'])).not.toBeNull();
+        expect(ngModel.control.errors).toEqual({'async': true});
       }));
 
-      // should update the form's value and validity
-    });
+      it('should mark as disabled properly', fakeAsync(() => {
+        ngModel.ngOnChanges({isDisabled: new SimpleChange('', undefined, false)});
+        tick();
+        expect(ngModel.control.disabled).toEqual(false);
 
-    describe('removeControl & removeFormGroup', () => {
-      it('should remove control', fakeAsync(() => {
-        form.addFormGroup(personControlGroupDir);
-        form.addControl(loginControlDir);
+        ngModel.ngOnChanges({isDisabled: new SimpleChange('', null, false)});
+        tick();
+        expect(ngModel.control.disabled).toEqual(false);
 
-        form.removeFormGroup(personControlGroupDir);
-        form.removeControl(loginControlDir);
+        ngModel.ngOnChanges({isDisabled: new SimpleChange('', false, false)});
+        tick();
+        expect(ngModel.control.disabled).toEqual(false);
 
-        flushMicrotasks();
+        ngModel.ngOnChanges({isDisabled: new SimpleChange('', 'false', false)});
+        tick();
+        expect(ngModel.control.disabled).toEqual(false);
 
-        expect(formModel.get(['person'])).toBeNull();
-        expect(formModel.get(['person', 'login'])).toBeNull();
+        ngModel.ngOnChanges({isDisabled: new SimpleChange('', 0, false)});
+        tick();
+        expect(ngModel.control.disabled).toEqual(false);
+
+        ngModel.ngOnChanges({isDisabled: new SimpleChange(null, '', false)});
+        tick();
+        expect(ngModel.control.disabled).toEqual(true);
+
+        ngModel.ngOnChanges({isDisabled: new SimpleChange(null, 'true', false)});
+        tick();
+        expect(ngModel.control.disabled).toEqual(true);
+
+        ngModel.ngOnChanges({isDisabled: new SimpleChange(null, true, false)});
+        tick();
+        expect(ngModel.control.disabled).toEqual(true);
+
+        ngModel.ngOnChanges({isDisabled: new SimpleChange(null, 'anything else', false)});
+        tick();
+        expect(ngModel.control.disabled).toEqual(true);
       }));
-
-      // should update the form's value and validity
     });
 
-    it('should set up sync validator', fakeAsync(() => {
-      const formValidator = () => ({'custom': true});
-      const f = new NgForm([formValidator], []);
+    describe('FormControlName', () => {
+      let formModel: FormControl;
+      let controlNameDir: FormControlName;
 
-      tick();
+      beforeEach(() => {
+        formModel = new FormControl('name');
 
-      expect(f.form.errors).toEqual({'custom': true});
-    }));
-
-    it('should set up async validator', fakeAsync(() => {
-      const f = new NgForm([], [asyncValidator('expected')]);
-
-      tick();
-
-      expect(f.form.errors).toEqual({'async': true});
-    }));
-
-    describe('events emissions', () => {
-      it('formControl should emit an event when resetting a form', () => {
-        const f = new NgForm([], []);
-        const events: ControlEvent[] = [];
-
-        f.form.events.subscribe((event) => events.push(event));
-        f.resetForm();
-
-        expect(events.length).toBe(4);
-        expect(events[0]).toBeInstanceOf(TouchedChangeEvent);
-        expect(events[1]).toBeInstanceOf(ValueChangeEvent);
-        expect(events[2]).toBeInstanceOf(StatusChangeEvent);
-
-        // The event that matters
-        expect(events[3]).toBeInstanceOf(FormResetEvent);
-        expect(events[3].source).toBe(f.form);
+        const parent = new FormGroupDirective([], []);
+        parent.form = new FormGroup({'name': formModel});
+        controlNameDir = new FormControlName(parent, [], [], [defaultAccessor], null);
+        controlNameDir.name = 'name';
+        (controlNameDir as Writable<FormControlName>).control = formModel;
       });
 
-      it('formControl should emit an event when submitting a form', () => {
-        const f = new NgForm([], []);
-        const events: ControlEvent[] = [];
-
-        f.form.events.subscribe((event) => events.push(event));
-        f.onSubmit({} as any);
-
-        expect(events.length).toBe(1);
-        expect(events[0]).toBeInstanceOf(FormSubmittedEvent);
-        expect(events[0].source).toBe(f.form);
+      it('should reexport control properties', () => {
+        expect(controlNameDir.control).toBe(formModel);
+        expect(controlNameDir.value).toBe(formModel.value);
+        expect(controlNameDir.valid).toBe(formModel.valid);
+        expect(controlNameDir.invalid).toBe(formModel.invalid);
+        expect(controlNameDir.pending).toBe(formModel.pending);
+        expect(controlNameDir.errors).toBe(formModel.errors);
+        expect(controlNameDir.pristine).toBe(formModel.pristine);
+        expect(controlNameDir.dirty).toBe(formModel.dirty);
+        expect(controlNameDir.touched).toBe(formModel.touched);
+        expect(controlNameDir.untouched).toBe(formModel.untouched);
+        expect(controlNameDir.statusChanges).toBe(formModel.statusChanges);
+        expect(controlNameDir.status).toBe(formModel.status);
+        expect(controlNameDir.valueChanges).toBe(formModel.valueChanges);
+        expect(controlNameDir.disabled).toBe(formModel.disabled);
+        expect(controlNameDir.enabled).toBe(formModel.enabled);
       });
-    });
-  });
 
-  describe('FormGroupName', () => {
-    let formModel: FormGroup;
-    let controlGroupDir: FormGroupName;
+      it('should reexport control methods', () => {
+        expect(controlNameDir.hasError('required')).toBe(formModel.hasError('required'));
+        expect(controlNameDir.getError('required')).toBe(formModel.getError('required'));
 
-    beforeEach(() => {
-      formModel = new FormGroup({'login': new FormControl(null)});
-
-      const parent = new FormGroupDirective([], []);
-      parent.form = new FormGroup({'group': formModel});
-      controlGroupDir = new FormGroupName(parent, [], []);
-      controlGroupDir.name = 'group';
-    });
-
-    it('should reexport control properties', () => {
-      expect(controlGroupDir.control).toBe(formModel);
-      expect(controlGroupDir.value).toBe(formModel.value);
-      expect(controlGroupDir.valid).toBe(formModel.valid);
-      expect(controlGroupDir.invalid).toBe(formModel.invalid);
-      expect(controlGroupDir.pending).toBe(formModel.pending);
-      expect(controlGroupDir.errors).toBe(formModel.errors);
-      expect(controlGroupDir.pristine).toBe(formModel.pristine);
-      expect(controlGroupDir.dirty).toBe(formModel.dirty);
-      expect(controlGroupDir.touched).toBe(formModel.touched);
-      expect(controlGroupDir.untouched).toBe(formModel.untouched);
-      expect(controlGroupDir.statusChanges).toBe(formModel.statusChanges);
-      expect(controlGroupDir.status).toBe(formModel.status);
-      expect(controlGroupDir.valueChanges).toBe(formModel.valueChanges);
-      expect(controlGroupDir.disabled).toBe(formModel.disabled);
-      expect(controlGroupDir.enabled).toBe(formModel.enabled);
-    });
-
-    it('should reexport control methods', () => {
-      expect(controlGroupDir.hasError('required')).toBe(formModel.hasError('required'));
-      expect(controlGroupDir.getError('required')).toBe(formModel.getError('required'));
-
-      formModel.setErrors({required: true});
-      expect(controlGroupDir.hasError('required')).toBe(formModel.hasError('required'));
-      expect(controlGroupDir.getError('required')).toBe(formModel.getError('required'));
-    });
-  });
-
-  describe('FormArrayName', () => {
-    let formModel: FormArray;
-    let formArrayDir: FormArrayName;
-
-    beforeEach(() => {
-      const parent = new FormGroupDirective([], []);
-      formModel = new FormArray([new FormControl('')]);
-      parent.form = new FormGroup({'array': formModel});
-      formArrayDir = new FormArrayName(parent, [], []);
-      formArrayDir.name = 'array';
-    });
-
-    it('should reexport control properties', () => {
-      expect(formArrayDir.control).toBe(formModel);
-      expect(formArrayDir.value).toBe(formModel.value);
-      expect(formArrayDir.valid).toBe(formModel.valid);
-      expect(formArrayDir.invalid).toBe(formModel.invalid);
-      expect(formArrayDir.pending).toBe(formModel.pending);
-      expect(formArrayDir.errors).toBe(formModel.errors);
-      expect(formArrayDir.pristine).toBe(formModel.pristine);
-      expect(formArrayDir.dirty).toBe(formModel.dirty);
-      expect(formArrayDir.touched).toBe(formModel.touched);
-      expect(formArrayDir.status).toBe(formModel.status);
-      expect(formArrayDir.untouched).toBe(formModel.untouched);
-      expect(formArrayDir.disabled).toBe(formModel.disabled);
-      expect(formArrayDir.enabled).toBe(formModel.enabled);
-    });
-
-    it('should reexport control methods', () => {
-      expect(formArrayDir.hasError('required')).toBe(formModel.hasError('required'));
-      expect(formArrayDir.getError('required')).toBe(formModel.getError('required'));
-
-      formModel.setErrors({required: true});
-      expect(formArrayDir.hasError('required')).toBe(formModel.hasError('required'));
-      expect(formArrayDir.getError('required')).toBe(formModel.getError('required'));
-    });
-  });
-
-  describe('FormControlDirective', () => {
-    let controlDir: FormControlDirective;
-    let control: FormControl;
-    const checkProperties = function (control: FormControl) {
-      expect(controlDir.control).toBe(control);
-      expect(controlDir.value).toBe(control.value);
-      expect(controlDir.valid).toBe(control.valid);
-      expect(controlDir.invalid).toBe(control.invalid);
-      expect(controlDir.pending).toBe(control.pending);
-      expect(controlDir.errors).toBe(control.errors);
-      expect(controlDir.pristine).toBe(control.pristine);
-      expect(controlDir.dirty).toBe(control.dirty);
-      expect(controlDir.touched).toBe(control.touched);
-      expect(controlDir.untouched).toBe(control.untouched);
-      expect(controlDir.statusChanges).toBe(control.statusChanges);
-      expect(controlDir.status).toBe(control.status);
-      expect(controlDir.valueChanges).toBe(control.valueChanges);
-      expect(controlDir.disabled).toBe(control.disabled);
-      expect(controlDir.enabled).toBe(control.enabled);
-    };
-
-    beforeEach(() => {
-      controlDir = new FormControlDirective([Validators.required], [], [defaultAccessor], null);
-      controlDir.valueAccessor = new DummyControlValueAccessor();
-
-      control = new FormControl(null);
-      controlDir.form = control;
-    });
-
-    it('should reexport control properties', () => {
-      checkProperties(control);
-    });
-
-    it('should reexport control methods', () => {
-      expect(controlDir.hasError('required')).toBe(control.hasError('required'));
-      expect(controlDir.getError('required')).toBe(control.getError('required'));
-
-      control.setErrors({required: true});
-      expect(controlDir.hasError('required')).toBe(control.hasError('required'));
-      expect(controlDir.getError('required')).toBe(control.getError('required'));
-    });
-
-    it('should reexport new control properties', () => {
-      const newControl = new FormControl(null);
-      controlDir.form = newControl;
-      controlDir.ngOnChanges({'form': new SimpleChange(control, newControl, false)});
-
-      checkProperties(newControl);
-    });
-
-    it('should set up validator', () => {
-      expect(control.valid).toBe(true);
-
-      // this will add the required validator and recalculate the validity
-      controlDir.ngOnChanges({'form': new SimpleChange(null, control, false)});
-
-      expect(control.valid).toBe(false);
-    });
-  });
-
-  describe('NgModel', () => {
-    let ngModel: NgModel;
-    let control: FormControl;
-
-    beforeEach(() => {
-      ngModel = new NgModel(
-        null!,
-        [Validators.required],
-        [asyncValidator('expected')],
-        [defaultAccessor],
-      );
-      ngModel.valueAccessor = new DummyControlValueAccessor();
-      control = ngModel.control;
-    });
-
-    it('should reexport control properties', () => {
-      expect(ngModel.control).toBe(control);
-      expect(ngModel.value).toBe(control.value);
-      expect(ngModel.valid).toBe(control.valid);
-      expect(ngModel.invalid).toBe(control.invalid);
-      expect(ngModel.pending).toBe(control.pending);
-      expect(ngModel.errors).toBe(control.errors);
-      expect(ngModel.pristine).toBe(control.pristine);
-      expect(ngModel.dirty).toBe(control.dirty);
-      expect(ngModel.touched).toBe(control.touched);
-      expect(ngModel.untouched).toBe(control.untouched);
-      expect(ngModel.statusChanges).toBe(control.statusChanges);
-      expect(ngModel.status).toBe(control.status);
-      expect(ngModel.valueChanges).toBe(control.valueChanges);
-      expect(ngModel.disabled).toBe(control.disabled);
-      expect(ngModel.enabled).toBe(control.enabled);
-    });
-
-    it('should reexport control methods', () => {
-      expect(ngModel.hasError('required')).toBe(control.hasError('required'));
-      expect(ngModel.getError('required')).toBe(control.getError('required'));
-
-      control.setErrors({required: true});
-      expect(ngModel.hasError('required')).toBe(control.hasError('required'));
-      expect(ngModel.getError('required')).toBe(control.getError('required'));
-    });
-
-    it('should throw when no value accessor with named control', () => {
-      const namedDir = new NgModel(null!, null!, null!, null!);
-      namedDir.name = 'one';
-
-      expect(() => namedDir.ngOnChanges({})).toThrowError(
-        new RegExp(
-          `NG01203: No value accessor for form control name: 'one'. Find more at https://angular.dev/errors/NG01203`,
-        ),
-      );
-    });
-
-    it('should throw when no value accessor with unnamed control', () => {
-      const unnamedDir = new NgModel(null!, null!, null!, null!);
-
-      expect(() => unnamedDir.ngOnChanges({})).toThrowError(
-        new RegExp(
-          `NG01203: No value accessor for form control unspecified name attribute. Find more at https://angular.dev/errors/NG01203`,
-        ),
-      );
-    });
-
-    it('should set up validator', fakeAsync(() => {
-      // this will add the required validator and recalculate the validity
-      ngModel.ngOnChanges({});
-      tick();
-
-      expect(ngModel.control.errors).toEqual({'required': true});
-
-      ngModel.control.setValue('someValue');
-      tick();
-
-      expect(ngModel.control.errors).toEqual({'async': true});
-    }));
-
-    it('should mark as disabled properly', fakeAsync(() => {
-      ngModel.ngOnChanges({isDisabled: new SimpleChange('', undefined, false)});
-      tick();
-      expect(ngModel.control.disabled).toEqual(false);
-
-      ngModel.ngOnChanges({isDisabled: new SimpleChange('', null, false)});
-      tick();
-      expect(ngModel.control.disabled).toEqual(false);
-
-      ngModel.ngOnChanges({isDisabled: new SimpleChange('', false, false)});
-      tick();
-      expect(ngModel.control.disabled).toEqual(false);
-
-      ngModel.ngOnChanges({isDisabled: new SimpleChange('', 'false', false)});
-      tick();
-      expect(ngModel.control.disabled).toEqual(false);
-
-      ngModel.ngOnChanges({isDisabled: new SimpleChange('', 0, false)});
-      tick();
-      expect(ngModel.control.disabled).toEqual(false);
-
-      ngModel.ngOnChanges({isDisabled: new SimpleChange(null, '', false)});
-      tick();
-      expect(ngModel.control.disabled).toEqual(true);
-
-      ngModel.ngOnChanges({isDisabled: new SimpleChange(null, 'true', false)});
-      tick();
-      expect(ngModel.control.disabled).toEqual(true);
-
-      ngModel.ngOnChanges({isDisabled: new SimpleChange(null, true, false)});
-      tick();
-      expect(ngModel.control.disabled).toEqual(true);
-
-      ngModel.ngOnChanges({isDisabled: new SimpleChange(null, 'anything else', false)});
-      tick();
-      expect(ngModel.control.disabled).toEqual(true);
-    }));
-  });
-
-  describe('FormControlName', () => {
-    let formModel: FormControl;
-    let controlNameDir: FormControlName;
-
-    beforeEach(() => {
-      formModel = new FormControl('name');
-
-      const parent = new FormGroupDirective([], []);
-      parent.form = new FormGroup({'name': formModel});
-      controlNameDir = new FormControlName(parent, [], [], [defaultAccessor], null);
-      controlNameDir.name = 'name';
-      (controlNameDir as Writable<FormControlName>).control = formModel;
-    });
-
-    it('should reexport control properties', () => {
-      expect(controlNameDir.control).toBe(formModel);
-      expect(controlNameDir.value).toBe(formModel.value);
-      expect(controlNameDir.valid).toBe(formModel.valid);
-      expect(controlNameDir.invalid).toBe(formModel.invalid);
-      expect(controlNameDir.pending).toBe(formModel.pending);
-      expect(controlNameDir.errors).toBe(formModel.errors);
-      expect(controlNameDir.pristine).toBe(formModel.pristine);
-      expect(controlNameDir.dirty).toBe(formModel.dirty);
-      expect(controlNameDir.touched).toBe(formModel.touched);
-      expect(controlNameDir.untouched).toBe(formModel.untouched);
-      expect(controlNameDir.statusChanges).toBe(formModel.statusChanges);
-      expect(controlNameDir.status).toBe(formModel.status);
-      expect(controlNameDir.valueChanges).toBe(formModel.valueChanges);
-      expect(controlNameDir.disabled).toBe(formModel.disabled);
-      expect(controlNameDir.enabled).toBe(formModel.enabled);
-    });
-
-    it('should reexport control methods', () => {
-      expect(controlNameDir.hasError('required')).toBe(formModel.hasError('required'));
-      expect(controlNameDir.getError('required')).toBe(formModel.getError('required'));
-
-      formModel.setErrors({required: true});
-      expect(controlNameDir.hasError('required')).toBe(formModel.hasError('required'));
-      expect(controlNameDir.getError('required')).toBe(formModel.getError('required'));
+        formModel.setErrors({required: true});
+        expect(controlNameDir.hasError('required')).toBe(formModel.hasError('required'));
+        expect(controlNameDir.getError('required')).toBe(formModel.getError('required'));
+      });
     });
   });
 });

--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -145,679 +145,636 @@ describe('Form Directives', () => {
         const customAccessor: ControlValueAccessor = {} as any;
         expect(() => selectValueAccessor(dir, [customAccessor, customAccessor])).toThrowError();
       });
-
-      describe('composeValidators', () => {
-        it('should compose functions', () => {
-          const dummy1 = () => ({'dummy1': true});
-          const dummy2 = () => ({'dummy2': true});
-          const v = composeValidators([dummy1, dummy2])!;
-          expect(v(new FormControl(''))).toEqual({'dummy1': true, 'dummy2': true});
-        });
-
-        it('should compose validator directives', () => {
-          const dummy1 = () => ({'dummy1': true});
-          const v = composeValidators([dummy1, new CustomValidatorDirective()])!;
-          expect(v(new FormControl(''))).toEqual({'dummy1': true, 'custom': true});
-        });
-      });
-
-      describe('formGroup', () => {
-        beforeEach(() => {
-          dir = {path: []} as any;
-        });
-
-        it('should throw when given an empty array', () => {
-          expect(() => selectValueAccessor(dir, [])).toThrowError();
-        });
-
-        it('should throw when accessor is not provided as array', () => {
-          expect(() => selectValueAccessor(dir, {} as any[])).toThrowError(
-            'NG01200: Value accessor was not provided as an array for form control with unspecified name attribute. Check that the `NG_VALUE_ACCESSOR` token is configured as a `multi: true` provider.',
-          );
-        });
-
-        it('should return the default value accessor when no other provided', () => {
-          expect(selectValueAccessor(dir, [defaultAccessor])).toEqual(defaultAccessor);
-        });
-
-        it('should return checkbox accessor when provided', () => {
-          const checkboxAccessor = new CheckboxControlValueAccessor(null!, null!);
-          expect(selectValueAccessor(dir, [defaultAccessor, checkboxAccessor])).toEqual(
-            checkboxAccessor,
-          );
-        });
-
-        it('should return select multiple accessor when provided', () => {
-          const selectMultipleAccessor = new SelectMultipleControlValueAccessor(null!, null!);
-          expect(selectValueAccessor(dir, [defaultAccessor, selectMultipleAccessor])).toEqual(
-            selectMultipleAccessor,
-          );
-        });
-
-        it('should return custom accessor when provided', () => {
-          const customAccessor: ControlValueAccessor = {} as any;
-          const checkboxAccessor = new CheckboxControlValueAccessor(null!, null!);
-          expect(
-            selectValueAccessor(dir, <any>[defaultAccessor, customAccessor, checkboxAccessor]),
-          ).toEqual(customAccessor);
-        });
-
-        it('should return custom accessor when provided with select multiple', () => {
-          const customAccessor: ControlValueAccessor = {} as any;
-          const selectMultipleAccessor = new SelectMultipleControlValueAccessor(null!, null!);
-          expect(
-            selectValueAccessor(dir, <any>[
-              defaultAccessor,
-              customAccessor,
-              selectMultipleAccessor,
-            ]),
-          ).toEqual(customAccessor);
-        });
-
-        it('should throw when more than one custom accessor is provided', () => {
-          const customAccessor: ControlValueAccessor = {} as any;
-          expect(() => selectValueAccessor(dir, [customAccessor, customAccessor])).toThrowError();
-        });
-      });
-
-      describe('composeValidators', () => {
-        it('should compose functions', () => {
-          const dummy1 = () => ({'dummy1': true});
-          const dummy2 = () => ({'dummy2': true});
-          const v = composeValidators([dummy1, dummy2])!;
-          expect(v(new FormControl(''))).toEqual({'dummy1': true, 'dummy2': true});
-        });
-
-        it('should compose validator directives', () => {
-          const dummy1 = () => ({'dummy1': true});
-          const v = composeValidators([dummy1, new CustomValidatorDirective()])!;
-          expect(v(new FormControl(''))).toEqual({'dummy1': true, 'custom': true});
-        });
-      });
     });
 
-    describe('formGroup', () => {
-      let form: FormGroupDirective;
-      let formModel: FormGroup;
-      let loginControlDir: FormControlName;
+    describe('composeValidators', () => {
+      it('should compose functions', () => {
+        const dummy1 = () => ({'dummy1': true});
+        const dummy2 = () => ({'dummy2': true});
+        const v = composeValidators([dummy1, dummy2])!;
+        expect(v(new FormControl(''))).toEqual({'dummy1': true, 'dummy2': true});
+      });
 
-      beforeEach(() => {
-        form = new FormGroupDirective([], []);
-        formModel = new FormGroup({
-          'login': new FormControl(),
-          'passwords': new FormGroup({
-            'password': new FormControl(),
-            'passwordConfirm': new FormControl(),
-          }),
-        });
-        form.form = formModel;
+      it('should compose validator directives', () => {
+        const dummy1 = () => ({'dummy1': true});
+        const v = composeValidators([dummy1, new CustomValidatorDirective()])!;
+        expect(v(new FormControl(''))).toEqual({'dummy1': true, 'custom': true});
+      });
+    });
+  });
 
-        loginControlDir = new FormControlName(
-          form,
-          [Validators.required],
-          [asyncValidator('expected')],
-          [defaultAccessor],
-          null,
+  describe('formGroup', () => {
+    let form: FormGroupDirective;
+    let formModel: FormGroup;
+    let loginControlDir: FormControlName;
+
+    beforeEach(() => {
+      form = new FormGroupDirective([], []);
+      formModel = new FormGroup({
+        'login': new FormControl(),
+        'passwords': new FormGroup({
+          'password': new FormControl(),
+          'passwordConfirm': new FormControl(),
+        }),
+      });
+      form.form = formModel;
+
+      loginControlDir = new FormControlName(
+        form,
+        [Validators.required],
+        [asyncValidator('expected')],
+        [defaultAccessor],
+        null,
+      );
+      loginControlDir.name = 'login';
+      loginControlDir.valueAccessor = new DummyControlValueAccessor();
+    });
+
+    it('should reexport control properties', () => {
+      expect(form.control).toBe(formModel);
+      expect(form.value).toBe(formModel.value);
+      expect(form.valid).toBe(formModel.valid);
+      expect(form.invalid).toBe(formModel.invalid);
+      expect(form.pending).toBe(formModel.pending);
+      expect(form.errors).toBe(formModel.errors);
+      expect(form.pristine).toBe(formModel.pristine);
+      expect(form.dirty).toBe(formModel.dirty);
+      expect(form.touched).toBe(formModel.touched);
+      expect(form.untouched).toBe(formModel.untouched);
+      expect(form.statusChanges).toBe(formModel.statusChanges);
+      expect(form.valueChanges).toBe(formModel.valueChanges);
+    });
+
+    it('should reexport control methods', () => {
+      expect(form.hasError('required')).toBe(formModel.hasError('required'));
+      expect(form.getError('required')).toBe(formModel.getError('required'));
+
+      formModel.setErrors({required: true});
+      expect(form.hasError('required')).toBe(formModel.hasError('required'));
+      expect(form.getError('required')).toBe(formModel.getError('required'));
+    });
+
+    describe('addControl', () => {
+      it('should throw when no control found', () => {
+        const dir = new FormControlName(form, null!, null!, [defaultAccessor], null);
+        dir.name = 'invalidName';
+
+        expect(() => form.addControl(dir)).toThrowError(
+          new RegExp(`Cannot find control with name: 'invalidName'`),
         );
-        loginControlDir.name = 'login';
-        loginControlDir.valueAccessor = new DummyControlValueAccessor();
       });
 
-      it('should reexport control properties', () => {
-        expect(form.control).toBe(formModel);
-        expect(form.value).toBe(formModel.value);
-        expect(form.valid).toBe(formModel.valid);
-        expect(form.invalid).toBe(formModel.invalid);
-        expect(form.pending).toBe(formModel.pending);
-        expect(form.errors).toBe(formModel.errors);
-        expect(form.pristine).toBe(formModel.pristine);
-        expect(form.dirty).toBe(formModel.dirty);
-        expect(form.touched).toBe(formModel.touched);
-        expect(form.untouched).toBe(formModel.untouched);
-        expect(form.statusChanges).toBe(formModel.statusChanges);
-        expect(form.valueChanges).toBe(formModel.valueChanges);
+      it('should throw for a named control when no value accessor', () => {
+        const dir = new FormControlName(form, null!, null!, null!, null);
+        dir.name = 'login';
+
+        expect(() => form.addControl(dir)).toThrowError(
+          new RegExp(
+            `NG01203: No value accessor for form control name: 'login'. Find more at https://angular.dev/errors/NG01203`,
+          ),
+        );
       });
 
-      it('should reexport control methods', () => {
-        expect(form.hasError('required')).toBe(formModel.hasError('required'));
-        expect(form.getError('required')).toBe(formModel.getError('required'));
+      it('should throw when no value accessor with path', () => {
+        const group = new FormGroupName(form, null!, null!);
+        const dir = new FormControlName(group, null!, null!, null!, null);
+        group.name = 'passwords';
+        dir.name = 'password';
 
-        formModel.setErrors({required: true});
-        expect(form.hasError('required')).toBe(formModel.hasError('required'));
-        expect(form.getError('required')).toBe(formModel.getError('required'));
+        expect(() => form.addControl(dir)).toThrowError(
+          new RegExp(
+            `NG01203: No value accessor for form control path: 'passwords -> password'. Find more at https://angular.dev/errors/NG01203`,
+          ),
+        );
       });
 
-      describe('addControl', () => {
-        it('should throw when no control found', () => {
-          const dir = new FormControlName(form, null!, null!, [defaultAccessor], null);
-          dir.name = 'invalidName';
+      it('should set up validators', fakeAsync(() => {
+        form.addControl(loginControlDir);
 
-          expect(() => form.addControl(dir)).toThrowError(
-            new RegExp(`Cannot find control with name: 'invalidName'`),
-          );
-        });
+        // sync validators are set
+        expect(formModel.hasError('required', ['login'])).toBe(true);
+        expect(formModel.hasError('async', ['login'])).toBe(false);
 
-        it('should throw for a named control when no value accessor', () => {
-          const dir = new FormControlName(form, null!, null!, null!, null);
-          dir.name = 'login';
+        (<FormControl>formModel.get('login')).setValue('invalid value');
 
-          expect(() => form.addControl(dir)).toThrowError(
-            new RegExp(
-              `NG01203: No value accessor for form control name: 'login'. Find more at https://angular.dev/errors/NG01203`,
-            ),
-          );
-        });
-
-        it('should throw when no value accessor with path', () => {
-          const group = new FormGroupName(form, null!, null!);
-          const dir = new FormControlName(group, null!, null!, null!, null);
-          group.name = 'passwords';
-          dir.name = 'password';
-
-          expect(() => form.addControl(dir)).toThrowError(
-            new RegExp(
-              `NG01203: No value accessor for form control path: 'passwords -> password'. Find more at https://angular.dev/errors/NG01203`,
-            ),
-          );
-        });
-
-        it('should set up validators', fakeAsync(() => {
-          form.addControl(loginControlDir);
-
-          // sync validators are set
-          expect(formModel.hasError('required', ['login'])).toBe(true);
-          expect(formModel.hasError('async', ['login'])).toBe(false);
-
-          (<FormControl>formModel.get('login')).setValue('invalid value');
-
-          // sync validator passes, running async validators
-          expect(formModel.pending).toBe(true);
-
-          tick();
-
-          expect(formModel.hasError('required', ['login'])).toBe(false);
-          expect(formModel.hasError('async', ['login'])).toBe(true);
-        }));
-
-        it('should write value to the DOM', () => {
-          (<FormControl>formModel.get(['login'])).setValue('initValue');
-
-          form.addControl(loginControlDir);
-
-          expect((<any>loginControlDir.valueAccessor).writtenValue).toEqual('initValue');
-        });
-
-        it('should add the directive to the list of directives included in the form', () => {
-          form.addControl(loginControlDir);
-          expect(form.directives).toEqual([loginControlDir]);
-        });
-      });
-
-      describe('addFormGroup', () => {
-        const matchingPasswordsValidator = (g: AbstractControl) => {
-          const controls = (g as FormGroup).controls;
-          if (controls['password'].value != controls['passwordConfirm'].value) {
-            return {'differentPasswords': true};
-          } else {
-            return null;
-          }
-        };
-
-        it('should set up validator', fakeAsync(() => {
-          const group = new FormGroupName(
-            form,
-            [matchingPasswordsValidator],
-            [asyncValidator('expected')],
-          );
-          group.name = 'passwords';
-          form.addFormGroup(group);
-
-          (<FormControl>formModel.get(['passwords', 'password'])).setValue('somePassword');
-          (<FormControl>formModel.get(['passwords', 'passwordConfirm'])).setValue(
-            'someOtherPassword',
-          );
-
-          // sync validators are set
-          expect(formModel.hasError('differentPasswords', ['passwords'])).toEqual(true);
-
-          (<FormControl>formModel.get(['passwords', 'passwordConfirm'])).setValue('somePassword');
-
-          // sync validators pass, running async validators
-          expect(formModel.pending).toBe(true);
-
-          tick();
-
-          expect(formModel.hasError('async', ['passwords'])).toBe(true);
-        }));
-      });
-
-      describe('removeControl', () => {
-        it('should remove the directive to the list of directives included in the form', () => {
-          form.addControl(loginControlDir);
-          form.removeControl(loginControlDir);
-          expect(form.directives).toEqual([]);
-        });
-      });
-
-      describe('ngOnChanges', () => {
-        it('should update dom values of all the directives', () => {
-          form.addControl(loginControlDir);
-
-          (<FormControl>formModel.get(['login'])).setValue('new value');
-
-          form.ngOnChanges({});
-
-          expect((<any>loginControlDir.valueAccessor).writtenValue).toEqual('new value');
-        });
-
-        it('should set up a sync validator', () => {
-          const formValidator = (c: AbstractControl) => ({'custom': true});
-          const f = new FormGroupDirective([formValidator], []);
-          f.form = formModel;
-          f.ngOnChanges({'form': new SimpleChange(null, null, false)});
-
-          expect(formModel.errors).toEqual({'custom': true});
-        });
-
-        it('should set up an async validator', fakeAsync(() => {
-          const f = new FormGroupDirective([], [asyncValidator('expected')]);
-          f.form = formModel;
-          f.ngOnChanges({'form': new SimpleChange(null, null, false)});
-
-          tick();
-
-          expect(formModel.errors).toEqual({'async': true});
-        }));
-      });
-    });
-
-    describe('NgForm', () => {
-      let form: NgForm;
-      let formModel: FormGroup;
-      let loginControlDir: NgModel;
-      let personControlGroupDir: NgModelGroup;
-
-      beforeEach(() => {
-        form = new NgForm([], []);
-        formModel = form.form;
-
-        personControlGroupDir = new NgModelGroup(form, [], []);
-        personControlGroupDir.name = 'person';
-
-        loginControlDir = new NgModel(personControlGroupDir, null!, null!, [defaultAccessor]);
-        loginControlDir.name = 'login';
-        loginControlDir.valueAccessor = new DummyControlValueAccessor();
-      });
-
-      it('should reexport control properties', () => {
-        expect(form.control).toBe(formModel);
-        expect(form.value).toBe(formModel.value);
-        expect(form.valid).toBe(formModel.valid);
-        expect(form.invalid).toBe(formModel.invalid);
-        expect(form.pending).toBe(formModel.pending);
-        expect(form.errors).toBe(formModel.errors);
-        expect(form.pristine).toBe(formModel.pristine);
-        expect(form.dirty).toBe(formModel.dirty);
-        expect(form.touched).toBe(formModel.touched);
-        expect(form.untouched).toBe(formModel.untouched);
-        expect(form.statusChanges).toBe(formModel.statusChanges);
-        expect(form.status).toBe(formModel.status);
-        expect(form.valueChanges).toBe(formModel.valueChanges);
-        expect(form.disabled).toBe(formModel.disabled);
-        expect(form.enabled).toBe(formModel.enabled);
-      });
-
-      it('should reexport control methods', () => {
-        expect(form.hasError('required')).toBe(formModel.hasError('required'));
-        expect(form.getError('required')).toBe(formModel.getError('required'));
-
-        formModel.setErrors({required: true});
-        expect(form.hasError('required')).toBe(formModel.hasError('required'));
-        expect(form.getError('required')).toBe(formModel.getError('required'));
-      });
-
-      describe('addControl & addFormGroup', () => {
-        it('should create a control with the given name', fakeAsync(() => {
-          form.addFormGroup(personControlGroupDir);
-          form.addControl(loginControlDir);
-
-          flushMicrotasks();
-
-          expect(formModel.get(['person', 'login'])).not.toBeNull();
-        }));
-
-        // should update the form's value and validity
-      });
-
-      describe('removeControl & removeFormGroup', () => {
-        it('should remove control', fakeAsync(() => {
-          form.addFormGroup(personControlGroupDir);
-          form.addControl(loginControlDir);
-
-          form.removeFormGroup(personControlGroupDir);
-          form.removeControl(loginControlDir);
-
-          flushMicrotasks();
-
-          expect(formModel.get(['person'])).toBeNull();
-          expect(formModel.get(['person', 'login'])).toBeNull();
-        }));
-
-        // should update the form's value and validity
-      });
-
-      it('should set up sync validator', fakeAsync(() => {
-        const formValidator = () => ({'custom': true});
-        const f = new NgForm([formValidator], []);
+        // sync validator passes, running async validators
+        expect(formModel.pending).toBe(true);
 
         tick();
 
-        expect(f.form.errors).toEqual({'custom': true});
+        expect(formModel.hasError('required', ['login'])).toBe(false);
+        expect(formModel.hasError('async', ['login'])).toBe(true);
       }));
 
-      it('should set up async validator', fakeAsync(() => {
-        const f = new NgForm([], [asyncValidator('expected')]);
+      it('should write value to the DOM', () => {
+        (<FormControl>formModel.get(['login'])).setValue('initValue');
 
-        tick();
+        form.addControl(loginControlDir);
 
-        expect(f.form.errors).toEqual({'async': true});
-      }));
-    });
-
-    describe('FormGroupName', () => {
-      let formModel: FormGroup;
-      let controlGroupDir: FormGroupName;
-
-      beforeEach(() => {
-        formModel = new FormGroup({'login': new FormControl(null)});
-
-        const parent = new FormGroupDirective([], []);
-        parent.form = new FormGroup({'group': formModel});
-        controlGroupDir = new FormGroupName(parent, [], []);
-        controlGroupDir.name = 'group';
+        expect((<any>loginControlDir.valueAccessor).writtenValue).toEqual('initValue');
       });
 
-      it('should reexport control properties', () => {
-        expect(controlGroupDir.control).toBe(formModel);
-        expect(controlGroupDir.value).toBe(formModel.value);
-        expect(controlGroupDir.valid).toBe(formModel.valid);
-        expect(controlGroupDir.invalid).toBe(formModel.invalid);
-        expect(controlGroupDir.pending).toBe(formModel.pending);
-        expect(controlGroupDir.errors).toBe(formModel.errors);
-        expect(controlGroupDir.pristine).toBe(formModel.pristine);
-        expect(controlGroupDir.dirty).toBe(formModel.dirty);
-        expect(controlGroupDir.touched).toBe(formModel.touched);
-        expect(controlGroupDir.untouched).toBe(formModel.untouched);
-        expect(controlGroupDir.statusChanges).toBe(formModel.statusChanges);
-        expect(controlGroupDir.status).toBe(formModel.status);
-        expect(controlGroupDir.valueChanges).toBe(formModel.valueChanges);
-        expect(controlGroupDir.disabled).toBe(formModel.disabled);
-        expect(controlGroupDir.enabled).toBe(formModel.enabled);
-      });
-
-      it('should reexport control methods', () => {
-        expect(controlGroupDir.hasError('required')).toBe(formModel.hasError('required'));
-        expect(controlGroupDir.getError('required')).toBe(formModel.getError('required'));
-
-        formModel.setErrors({required: true});
-        expect(controlGroupDir.hasError('required')).toBe(formModel.hasError('required'));
-        expect(controlGroupDir.getError('required')).toBe(formModel.getError('required'));
+      it('should add the directive to the list of directives included in the form', () => {
+        form.addControl(loginControlDir);
+        expect(form.directives).toEqual([loginControlDir]);
       });
     });
 
-    describe('FormArrayName', () => {
-      let formModel: FormArray;
-      let formArrayDir: FormArrayName;
-
-      beforeEach(() => {
-        const parent = new FormGroupDirective([], []);
-        formModel = new FormArray([new FormControl('')]);
-        parent.form = new FormGroup({'array': formModel});
-        formArrayDir = new FormArrayName(parent, [], []);
-        formArrayDir.name = 'array';
-      });
-
-      it('should reexport control properties', () => {
-        expect(formArrayDir.control).toBe(formModel);
-        expect(formArrayDir.value).toBe(formModel.value);
-        expect(formArrayDir.valid).toBe(formModel.valid);
-        expect(formArrayDir.invalid).toBe(formModel.invalid);
-        expect(formArrayDir.pending).toBe(formModel.pending);
-        expect(formArrayDir.errors).toBe(formModel.errors);
-        expect(formArrayDir.pristine).toBe(formModel.pristine);
-        expect(formArrayDir.dirty).toBe(formModel.dirty);
-        expect(formArrayDir.touched).toBe(formModel.touched);
-        expect(formArrayDir.status).toBe(formModel.status);
-        expect(formArrayDir.untouched).toBe(formModel.untouched);
-        expect(formArrayDir.disabled).toBe(formModel.disabled);
-        expect(formArrayDir.enabled).toBe(formModel.enabled);
-      });
-
-      it('should reexport control methods', () => {
-        expect(formArrayDir.hasError('required')).toBe(formModel.hasError('required'));
-        expect(formArrayDir.getError('required')).toBe(formModel.getError('required'));
-
-        formModel.setErrors({required: true});
-        expect(formArrayDir.hasError('required')).toBe(formModel.hasError('required'));
-        expect(formArrayDir.getError('required')).toBe(formModel.getError('required'));
-      });
-    });
-
-    describe('FormControlDirective', () => {
-      let controlDir: FormControlDirective;
-      let control: FormControl;
-      const checkProperties = function (control: FormControl) {
-        expect(controlDir.control).toBe(control);
-        expect(controlDir.value).toBe(control.value);
-        expect(controlDir.valid).toBe(control.valid);
-        expect(controlDir.invalid).toBe(control.invalid);
-        expect(controlDir.pending).toBe(control.pending);
-        expect(controlDir.errors).toBe(control.errors);
-        expect(controlDir.pristine).toBe(control.pristine);
-        expect(controlDir.dirty).toBe(control.dirty);
-        expect(controlDir.touched).toBe(control.touched);
-        expect(controlDir.untouched).toBe(control.untouched);
-        expect(controlDir.statusChanges).toBe(control.statusChanges);
-        expect(controlDir.status).toBe(control.status);
-        expect(controlDir.valueChanges).toBe(control.valueChanges);
-        expect(controlDir.disabled).toBe(control.disabled);
-        expect(controlDir.enabled).toBe(control.enabled);
+    describe('addFormGroup', () => {
+      const matchingPasswordsValidator = (g: AbstractControl) => {
+        const controls = (g as FormGroup).controls;
+        if (controls['password'].value != controls['passwordConfirm'].value) {
+          return {'differentPasswords': true};
+        } else {
+          return null;
+        }
       };
 
-      beforeEach(() => {
-        controlDir = new FormControlDirective([Validators.required], [], [defaultAccessor], null);
-        controlDir.valueAccessor = new DummyControlValueAccessor();
-
-        control = new FormControl(null);
-        controlDir.form = control;
-      });
-
-      it('should reexport control properties', () => {
-        checkProperties(control);
-      });
-
-      it('should reexport control methods', () => {
-        expect(controlDir.hasError('required')).toBe(control.hasError('required'));
-        expect(controlDir.getError('required')).toBe(control.getError('required'));
-
-        control.setErrors({required: true});
-        expect(controlDir.hasError('required')).toBe(control.hasError('required'));
-        expect(controlDir.getError('required')).toBe(control.getError('required'));
-      });
-
-      it('should reexport new control properties', () => {
-        const newControl = new FormControl(null);
-        controlDir.form = newControl;
-        controlDir.ngOnChanges({'form': new SimpleChange(control, newControl, false)});
-
-        checkProperties(newControl);
-      });
-
-      it('should set up validator', () => {
-        expect(control.valid).toBe(true);
-
-        // this will add the required validator and recalculate the validity
-        controlDir.ngOnChanges({'form': new SimpleChange(null, control, false)});
-
-        expect(control.valid).toBe(false);
-      });
-    });
-
-    describe('NgModel', () => {
-      let ngModel: NgModel;
-      let control: FormControl;
-
-      beforeEach(() => {
-        ngModel = new NgModel(
-          null!,
-          [Validators.required],
-          [asyncValidator('expected')],
-          [defaultAccessor],
-        );
-        ngModel.valueAccessor = new DummyControlValueAccessor();
-        control = ngModel.control;
-      });
-
-      it('should reexport control properties', () => {
-        expect(ngModel.control).toBe(control);
-        expect(ngModel.value).toBe(control.value);
-        expect(ngModel.valid).toBe(control.valid);
-        expect(ngModel.invalid).toBe(control.invalid);
-        expect(ngModel.pending).toBe(control.pending);
-        expect(ngModel.errors).toBe(control.errors);
-        expect(ngModel.pristine).toBe(control.pristine);
-        expect(ngModel.dirty).toBe(control.dirty);
-        expect(ngModel.touched).toBe(control.touched);
-        expect(ngModel.untouched).toBe(control.untouched);
-        expect(ngModel.statusChanges).toBe(control.statusChanges);
-        expect(ngModel.status).toBe(control.status);
-        expect(ngModel.valueChanges).toBe(control.valueChanges);
-        expect(ngModel.disabled).toBe(control.disabled);
-        expect(ngModel.enabled).toBe(control.enabled);
-      });
-
-      it('should reexport control methods', () => {
-        expect(ngModel.hasError('required')).toBe(control.hasError('required'));
-        expect(ngModel.getError('required')).toBe(control.getError('required'));
-
-        control.setErrors({required: true});
-        expect(ngModel.hasError('required')).toBe(control.hasError('required'));
-        expect(ngModel.getError('required')).toBe(control.getError('required'));
-      });
-
-      it('should throw when no value accessor with named control', () => {
-        const namedDir = new NgModel(null!, null!, null!, null!);
-        namedDir.name = 'one';
-
-        expect(() => namedDir.ngOnChanges({})).toThrowError(
-          new RegExp(
-            `NG01203: No value accessor for form control name: 'one'. Find more at https://angular.dev/errors/NG01203`,
-          ),
-        );
-      });
-
-      it('should throw when no value accessor with unnamed control', () => {
-        const unnamedDir = new NgModel(null!, null!, null!, null!);
-
-        expect(() => unnamedDir.ngOnChanges({})).toThrowError(
-          new RegExp(
-            `NG01203: No value accessor for form control unspecified name attribute. Find more at https://angular.dev/errors/NG01203`,
-          ),
-        );
-      });
-
       it('should set up validator', fakeAsync(() => {
-        // this will add the required validator and recalculate the validity
-        ngModel.ngOnChanges({});
+        const group = new FormGroupName(
+          form,
+          [matchingPasswordsValidator],
+          [asyncValidator('expected')],
+        );
+        group.name = 'passwords';
+        form.addFormGroup(group);
+
+        (<FormControl>formModel.get(['passwords', 'password'])).setValue('somePassword');
+        (<FormControl>formModel.get(['passwords', 'passwordConfirm'])).setValue(
+          'someOtherPassword',
+        );
+
+        // sync validators are set
+        expect(formModel.hasError('differentPasswords', ['passwords'])).toEqual(true);
+
+        (<FormControl>formModel.get(['passwords', 'passwordConfirm'])).setValue('somePassword');
+
+        // sync validators pass, running async validators
+        expect(formModel.pending).toBe(true);
+
         tick();
 
-        expect(ngModel.control.errors).toEqual({'required': true});
-
-        ngModel.control.setValue('someValue');
-        tick();
-
-        expect(ngModel.control.errors).toEqual({'async': true});
-      }));
-
-      it('should mark as disabled properly', fakeAsync(() => {
-        ngModel.ngOnChanges({isDisabled: new SimpleChange('', undefined, false)});
-        tick();
-        expect(ngModel.control.disabled).toEqual(false);
-
-        ngModel.ngOnChanges({isDisabled: new SimpleChange('', null, false)});
-        tick();
-        expect(ngModel.control.disabled).toEqual(false);
-
-        ngModel.ngOnChanges({isDisabled: new SimpleChange('', false, false)});
-        tick();
-        expect(ngModel.control.disabled).toEqual(false);
-
-        ngModel.ngOnChanges({isDisabled: new SimpleChange('', 'false', false)});
-        tick();
-        expect(ngModel.control.disabled).toEqual(false);
-
-        ngModel.ngOnChanges({isDisabled: new SimpleChange('', 0, false)});
-        tick();
-        expect(ngModel.control.disabled).toEqual(false);
-
-        ngModel.ngOnChanges({isDisabled: new SimpleChange(null, '', false)});
-        tick();
-        expect(ngModel.control.disabled).toEqual(true);
-
-        ngModel.ngOnChanges({isDisabled: new SimpleChange(null, 'true', false)});
-        tick();
-        expect(ngModel.control.disabled).toEqual(true);
-
-        ngModel.ngOnChanges({isDisabled: new SimpleChange(null, true, false)});
-        tick();
-        expect(ngModel.control.disabled).toEqual(true);
-
-        ngModel.ngOnChanges({isDisabled: new SimpleChange(null, 'anything else', false)});
-        tick();
-        expect(ngModel.control.disabled).toEqual(true);
+        expect(formModel.hasError('async', ['passwords'])).toBe(true);
       }));
     });
 
-    describe('FormControlName', () => {
-      let formModel: FormControl;
-      let controlNameDir: FormControlName;
+    describe('removeControl', () => {
+      it('should remove the directive to the list of directives included in the form', () => {
+        form.addControl(loginControlDir);
+        form.removeControl(loginControlDir);
+        expect(form.directives).toEqual([]);
+      });
+    });
 
-      beforeEach(() => {
-        formModel = new FormControl('name');
+    describe('ngOnChanges', () => {
+      it('should update dom values of all the directives', () => {
+        form.addControl(loginControlDir);
 
-        const parent = new FormGroupDirective([], []);
-        parent.form = new FormGroup({'name': formModel});
-        controlNameDir = new FormControlName(parent, [], [], [defaultAccessor], null);
-        controlNameDir.name = 'name';
-        (controlNameDir as Writable<FormControlName>).control = formModel;
+        (<FormControl>formModel.get(['login'])).setValue('new value');
+
+        form.ngOnChanges({});
+
+        expect((<any>loginControlDir.valueAccessor).writtenValue).toEqual('new value');
       });
 
-      it('should reexport control properties', () => {
-        expect(controlNameDir.control).toBe(formModel);
-        expect(controlNameDir.value).toBe(formModel.value);
-        expect(controlNameDir.valid).toBe(formModel.valid);
-        expect(controlNameDir.invalid).toBe(formModel.invalid);
-        expect(controlNameDir.pending).toBe(formModel.pending);
-        expect(controlNameDir.errors).toBe(formModel.errors);
-        expect(controlNameDir.pristine).toBe(formModel.pristine);
-        expect(controlNameDir.dirty).toBe(formModel.dirty);
-        expect(controlNameDir.touched).toBe(formModel.touched);
-        expect(controlNameDir.untouched).toBe(formModel.untouched);
-        expect(controlNameDir.statusChanges).toBe(formModel.statusChanges);
-        expect(controlNameDir.status).toBe(formModel.status);
-        expect(controlNameDir.valueChanges).toBe(formModel.valueChanges);
-        expect(controlNameDir.disabled).toBe(formModel.disabled);
-        expect(controlNameDir.enabled).toBe(formModel.enabled);
+      it('should set up a sync validator', () => {
+        const formValidator = (c: AbstractControl) => ({'custom': true});
+        const f = new FormGroupDirective([formValidator], []);
+        f.form = formModel;
+        f.ngOnChanges({'form': new SimpleChange(null, null, false)});
+
+        expect(formModel.errors).toEqual({'custom': true});
       });
 
-      it('should reexport control methods', () => {
-        expect(controlNameDir.hasError('required')).toBe(formModel.hasError('required'));
-        expect(controlNameDir.getError('required')).toBe(formModel.getError('required'));
+      it('should set up an async validator', fakeAsync(() => {
+        const f = new FormGroupDirective([], [asyncValidator('expected')]);
+        f.form = formModel;
+        f.ngOnChanges({'form': new SimpleChange(null, null, false)});
 
-        formModel.setErrors({required: true});
-        expect(controlNameDir.hasError('required')).toBe(formModel.hasError('required'));
-        expect(controlNameDir.getError('required')).toBe(formModel.getError('required'));
+        tick();
+
+        expect(formModel.errors).toEqual({'async': true});
+      }));
+    });
+  });
+
+  describe('NgForm', () => {
+    let form: NgForm;
+    let formModel: FormGroup;
+    let loginControlDir: NgModel;
+    let personControlGroupDir: NgModelGroup;
+
+    beforeEach(() => {
+      form = new NgForm([], []);
+      formModel = form.form;
+
+      personControlGroupDir = new NgModelGroup(form, [], []);
+      personControlGroupDir.name = 'person';
+
+      loginControlDir = new NgModel(personControlGroupDir, null!, null!, [defaultAccessor]);
+      loginControlDir.name = 'login';
+      loginControlDir.valueAccessor = new DummyControlValueAccessor();
+    });
+
+    it('should reexport control properties', () => {
+      expect(form.control).toBe(formModel);
+      expect(form.value).toBe(formModel.value);
+      expect(form.valid).toBe(formModel.valid);
+      expect(form.invalid).toBe(formModel.invalid);
+      expect(form.pending).toBe(formModel.pending);
+      expect(form.errors).toBe(formModel.errors);
+      expect(form.pristine).toBe(formModel.pristine);
+      expect(form.dirty).toBe(formModel.dirty);
+      expect(form.touched).toBe(formModel.touched);
+      expect(form.untouched).toBe(formModel.untouched);
+      expect(form.statusChanges).toBe(formModel.statusChanges);
+      expect(form.status).toBe(formModel.status);
+      expect(form.valueChanges).toBe(formModel.valueChanges);
+      expect(form.disabled).toBe(formModel.disabled);
+      expect(form.enabled).toBe(formModel.enabled);
+    });
+
+    it('should reexport control methods', () => {
+      expect(form.hasError('required')).toBe(formModel.hasError('required'));
+      expect(form.getError('required')).toBe(formModel.getError('required'));
+
+      formModel.setErrors({required: true});
+      expect(form.hasError('required')).toBe(formModel.hasError('required'));
+      expect(form.getError('required')).toBe(formModel.getError('required'));
+    });
+
+    describe('addControl & addFormGroup', () => {
+      it('should create a control with the given name', fakeAsync(() => {
+        form.addFormGroup(personControlGroupDir);
+        form.addControl(loginControlDir);
+
+        flushMicrotasks();
+
+        expect(formModel.get(['person', 'login'])).not.toBeNull();
+      }));
+
+      // should update the form's value and validity
+    });
+
+    describe('removeControl & removeFormGroup', () => {
+      it('should remove control', fakeAsync(() => {
+        form.addFormGroup(personControlGroupDir);
+        form.addControl(loginControlDir);
+
+        form.removeFormGroup(personControlGroupDir);
+        form.removeControl(loginControlDir);
+
+        flushMicrotasks();
+
+        expect(formModel.get(['person'])).toBeNull();
+        expect(formModel.get(['person', 'login'])).toBeNull();
+      }));
+
+      // should update the form's value and validity
+    });
+
+    it('should set up sync validator', fakeAsync(() => {
+      const formValidator = () => ({'custom': true});
+      const f = new NgForm([formValidator], []);
+
+      tick();
+
+      expect(f.form.errors).toEqual({'custom': true});
+    }));
+
+    it('should set up async validator', fakeAsync(() => {
+      const f = new NgForm([], [asyncValidator('expected')]);
+
+      tick();
+
+      expect(f.form.errors).toEqual({'async': true});
+    }));
+
+    describe('events emissions', () => {
+      it('formControl should emit an event when resetting a form', () => {
+        const f = new NgForm([], []);
+        const events: ControlEvent[] = [];
+
+        f.form.events.subscribe((event) => events.push(event));
+        f.resetForm();
+
+        expect(events.length).toBe(4);
+        expect(events[0]).toBeInstanceOf(TouchedChangeEvent);
+        expect(events[1]).toBeInstanceOf(ValueChangeEvent);
+        expect(events[2]).toBeInstanceOf(StatusChangeEvent);
+
+        // The event that matters
+        expect(events[3]).toBeInstanceOf(FormResetEvent);
+        expect(events[3].source).toBe(f.form);
       });
+
+      it('formControl should emit an event when submitting a form', () => {
+        const f = new NgForm([], []);
+        const events: ControlEvent[] = [];
+
+        f.form.events.subscribe((event) => events.push(event));
+        f.onSubmit({} as any);
+
+        expect(events.length).toBe(1);
+        expect(events[0]).toBeInstanceOf(FormSubmittedEvent);
+        expect(events[0].source).toBe(f.form);
+      });
+    });
+  });
+
+  describe('FormGroupName', () => {
+    let formModel: FormGroup;
+    let controlGroupDir: FormGroupName;
+
+    beforeEach(() => {
+      formModel = new FormGroup({'login': new FormControl(null)});
+
+      const parent = new FormGroupDirective([], []);
+      parent.form = new FormGroup({'group': formModel});
+      controlGroupDir = new FormGroupName(parent, [], []);
+      controlGroupDir.name = 'group';
+    });
+
+    it('should reexport control properties', () => {
+      expect(controlGroupDir.control).toBe(formModel);
+      expect(controlGroupDir.value).toBe(formModel.value);
+      expect(controlGroupDir.valid).toBe(formModel.valid);
+      expect(controlGroupDir.invalid).toBe(formModel.invalid);
+      expect(controlGroupDir.pending).toBe(formModel.pending);
+      expect(controlGroupDir.errors).toBe(formModel.errors);
+      expect(controlGroupDir.pristine).toBe(formModel.pristine);
+      expect(controlGroupDir.dirty).toBe(formModel.dirty);
+      expect(controlGroupDir.touched).toBe(formModel.touched);
+      expect(controlGroupDir.untouched).toBe(formModel.untouched);
+      expect(controlGroupDir.statusChanges).toBe(formModel.statusChanges);
+      expect(controlGroupDir.status).toBe(formModel.status);
+      expect(controlGroupDir.valueChanges).toBe(formModel.valueChanges);
+      expect(controlGroupDir.disabled).toBe(formModel.disabled);
+      expect(controlGroupDir.enabled).toBe(formModel.enabled);
+    });
+
+    it('should reexport control methods', () => {
+      expect(controlGroupDir.hasError('required')).toBe(formModel.hasError('required'));
+      expect(controlGroupDir.getError('required')).toBe(formModel.getError('required'));
+
+      formModel.setErrors({required: true});
+      expect(controlGroupDir.hasError('required')).toBe(formModel.hasError('required'));
+      expect(controlGroupDir.getError('required')).toBe(formModel.getError('required'));
+    });
+  });
+
+  describe('FormArrayName', () => {
+    let formModel: FormArray;
+    let formArrayDir: FormArrayName;
+
+    beforeEach(() => {
+      const parent = new FormGroupDirective([], []);
+      formModel = new FormArray([new FormControl('')]);
+      parent.form = new FormGroup({'array': formModel});
+      formArrayDir = new FormArrayName(parent, [], []);
+      formArrayDir.name = 'array';
+    });
+
+    it('should reexport control properties', () => {
+      expect(formArrayDir.control).toBe(formModel);
+      expect(formArrayDir.value).toBe(formModel.value);
+      expect(formArrayDir.valid).toBe(formModel.valid);
+      expect(formArrayDir.invalid).toBe(formModel.invalid);
+      expect(formArrayDir.pending).toBe(formModel.pending);
+      expect(formArrayDir.errors).toBe(formModel.errors);
+      expect(formArrayDir.pristine).toBe(formModel.pristine);
+      expect(formArrayDir.dirty).toBe(formModel.dirty);
+      expect(formArrayDir.touched).toBe(formModel.touched);
+      expect(formArrayDir.status).toBe(formModel.status);
+      expect(formArrayDir.untouched).toBe(formModel.untouched);
+      expect(formArrayDir.disabled).toBe(formModel.disabled);
+      expect(formArrayDir.enabled).toBe(formModel.enabled);
+    });
+
+    it('should reexport control methods', () => {
+      expect(formArrayDir.hasError('required')).toBe(formModel.hasError('required'));
+      expect(formArrayDir.getError('required')).toBe(formModel.getError('required'));
+
+      formModel.setErrors({required: true});
+      expect(formArrayDir.hasError('required')).toBe(formModel.hasError('required'));
+      expect(formArrayDir.getError('required')).toBe(formModel.getError('required'));
+    });
+  });
+
+  describe('FormControlDirective', () => {
+    let controlDir: FormControlDirective;
+    let control: FormControl;
+    const checkProperties = function (control: FormControl) {
+      expect(controlDir.control).toBe(control);
+      expect(controlDir.value).toBe(control.value);
+      expect(controlDir.valid).toBe(control.valid);
+      expect(controlDir.invalid).toBe(control.invalid);
+      expect(controlDir.pending).toBe(control.pending);
+      expect(controlDir.errors).toBe(control.errors);
+      expect(controlDir.pristine).toBe(control.pristine);
+      expect(controlDir.dirty).toBe(control.dirty);
+      expect(controlDir.touched).toBe(control.touched);
+      expect(controlDir.untouched).toBe(control.untouched);
+      expect(controlDir.statusChanges).toBe(control.statusChanges);
+      expect(controlDir.status).toBe(control.status);
+      expect(controlDir.valueChanges).toBe(control.valueChanges);
+      expect(controlDir.disabled).toBe(control.disabled);
+      expect(controlDir.enabled).toBe(control.enabled);
+    };
+
+    beforeEach(() => {
+      controlDir = new FormControlDirective([Validators.required], [], [defaultAccessor], null);
+      controlDir.valueAccessor = new DummyControlValueAccessor();
+
+      control = new FormControl(null);
+      controlDir.form = control;
+    });
+
+    it('should reexport control properties', () => {
+      checkProperties(control);
+    });
+
+    it('should reexport control methods', () => {
+      expect(controlDir.hasError('required')).toBe(control.hasError('required'));
+      expect(controlDir.getError('required')).toBe(control.getError('required'));
+
+      control.setErrors({required: true});
+      expect(controlDir.hasError('required')).toBe(control.hasError('required'));
+      expect(controlDir.getError('required')).toBe(control.getError('required'));
+    });
+
+    it('should reexport new control properties', () => {
+      const newControl = new FormControl(null);
+      controlDir.form = newControl;
+      controlDir.ngOnChanges({'form': new SimpleChange(control, newControl, false)});
+
+      checkProperties(newControl);
+    });
+
+    it('should set up validator', () => {
+      expect(control.valid).toBe(true);
+
+      // this will add the required validator and recalculate the validity
+      controlDir.ngOnChanges({'form': new SimpleChange(null, control, false)});
+
+      expect(control.valid).toBe(false);
+    });
+  });
+
+  describe('NgModel', () => {
+    let ngModel: NgModel;
+    let control: FormControl;
+
+    beforeEach(() => {
+      ngModel = new NgModel(
+        null!,
+        [Validators.required],
+        [asyncValidator('expected')],
+        [defaultAccessor],
+      );
+      ngModel.valueAccessor = new DummyControlValueAccessor();
+      control = ngModel.control;
+    });
+
+    it('should reexport control properties', () => {
+      expect(ngModel.control).toBe(control);
+      expect(ngModel.value).toBe(control.value);
+      expect(ngModel.valid).toBe(control.valid);
+      expect(ngModel.invalid).toBe(control.invalid);
+      expect(ngModel.pending).toBe(control.pending);
+      expect(ngModel.errors).toBe(control.errors);
+      expect(ngModel.pristine).toBe(control.pristine);
+      expect(ngModel.dirty).toBe(control.dirty);
+      expect(ngModel.touched).toBe(control.touched);
+      expect(ngModel.untouched).toBe(control.untouched);
+      expect(ngModel.statusChanges).toBe(control.statusChanges);
+      expect(ngModel.status).toBe(control.status);
+      expect(ngModel.valueChanges).toBe(control.valueChanges);
+      expect(ngModel.disabled).toBe(control.disabled);
+      expect(ngModel.enabled).toBe(control.enabled);
+    });
+
+    it('should reexport control methods', () => {
+      expect(ngModel.hasError('required')).toBe(control.hasError('required'));
+      expect(ngModel.getError('required')).toBe(control.getError('required'));
+
+      control.setErrors({required: true});
+      expect(ngModel.hasError('required')).toBe(control.hasError('required'));
+      expect(ngModel.getError('required')).toBe(control.getError('required'));
+    });
+
+    it('should throw when no value accessor with named control', () => {
+      const namedDir = new NgModel(null!, null!, null!, null!);
+      namedDir.name = 'one';
+
+      expect(() => namedDir.ngOnChanges({})).toThrowError(
+        new RegExp(
+          `NG01203: No value accessor for form control name: 'one'. Find more at https://angular.dev/errors/NG01203`,
+        ),
+      );
+    });
+
+    it('should throw when no value accessor with unnamed control', () => {
+      const unnamedDir = new NgModel(null!, null!, null!, null!);
+
+      expect(() => unnamedDir.ngOnChanges({})).toThrowError(
+        new RegExp(
+          `NG01203: No value accessor for form control unspecified name attribute. Find more at https://angular.dev/errors/NG01203`,
+        ),
+      );
+    });
+
+    it('should set up validator', fakeAsync(() => {
+      // this will add the required validator and recalculate the validity
+      ngModel.ngOnChanges({});
+      tick();
+
+      expect(ngModel.control.errors).toEqual({'required': true});
+
+      ngModel.control.setValue('someValue');
+      tick();
+
+      expect(ngModel.control.errors).toEqual({'async': true});
+    }));
+
+    it('should mark as disabled properly', fakeAsync(() => {
+      ngModel.ngOnChanges({isDisabled: new SimpleChange('', undefined, false)});
+      tick();
+      expect(ngModel.control.disabled).toEqual(false);
+
+      ngModel.ngOnChanges({isDisabled: new SimpleChange('', null, false)});
+      tick();
+      expect(ngModel.control.disabled).toEqual(false);
+
+      ngModel.ngOnChanges({isDisabled: new SimpleChange('', false, false)});
+      tick();
+      expect(ngModel.control.disabled).toEqual(false);
+
+      ngModel.ngOnChanges({isDisabled: new SimpleChange('', 'false', false)});
+      tick();
+      expect(ngModel.control.disabled).toEqual(false);
+
+      ngModel.ngOnChanges({isDisabled: new SimpleChange('', 0, false)});
+      tick();
+      expect(ngModel.control.disabled).toEqual(false);
+
+      ngModel.ngOnChanges({isDisabled: new SimpleChange(null, '', false)});
+      tick();
+      expect(ngModel.control.disabled).toEqual(true);
+
+      ngModel.ngOnChanges({isDisabled: new SimpleChange(null, 'true', false)});
+      tick();
+      expect(ngModel.control.disabled).toEqual(true);
+
+      ngModel.ngOnChanges({isDisabled: new SimpleChange(null, true, false)});
+      tick();
+      expect(ngModel.control.disabled).toEqual(true);
+
+      ngModel.ngOnChanges({isDisabled: new SimpleChange(null, 'anything else', false)});
+      tick();
+      expect(ngModel.control.disabled).toEqual(true);
+    }));
+  });
+
+  describe('FormControlName', () => {
+    let formModel: FormControl;
+    let controlNameDir: FormControlName;
+
+    beforeEach(() => {
+      formModel = new FormControl('name');
+
+      const parent = new FormGroupDirective([], []);
+      parent.form = new FormGroup({'name': formModel});
+      controlNameDir = new FormControlName(parent, [], [], [defaultAccessor], null);
+      controlNameDir.name = 'name';
+      (controlNameDir as Writable<FormControlName>).control = formModel;
+    });
+
+    it('should reexport control properties', () => {
+      expect(controlNameDir.control).toBe(formModel);
+      expect(controlNameDir.value).toBe(formModel.value);
+      expect(controlNameDir.valid).toBe(formModel.valid);
+      expect(controlNameDir.invalid).toBe(formModel.invalid);
+      expect(controlNameDir.pending).toBe(formModel.pending);
+      expect(controlNameDir.errors).toBe(formModel.errors);
+      expect(controlNameDir.pristine).toBe(formModel.pristine);
+      expect(controlNameDir.dirty).toBe(formModel.dirty);
+      expect(controlNameDir.touched).toBe(formModel.touched);
+      expect(controlNameDir.untouched).toBe(formModel.untouched);
+      expect(controlNameDir.statusChanges).toBe(formModel.statusChanges);
+      expect(controlNameDir.status).toBe(formModel.status);
+      expect(controlNameDir.valueChanges).toBe(formModel.valueChanges);
+      expect(controlNameDir.disabled).toBe(formModel.disabled);
+      expect(controlNameDir.enabled).toBe(formModel.enabled);
+    });
+
+    it('should reexport control methods', () => {
+      expect(controlNameDir.hasError('required')).toBe(formModel.hasError('required'));
+      expect(controlNameDir.getError('required')).toBe(formModel.getError('required'));
+
+      formModel.setErrors({required: true});
+      expect(controlNameDir.hasError('required')).toBe(formModel.hasError('required'));
+      expect(controlNameDir.getError('required')).toBe(formModel.getError('required'));
     });
   });
 });

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -7,13 +7,20 @@
  */
 
 import {
+  ɵAnimationEngine as AnimationEngine,
+  ɵAnimationRendererFactory as AnimationRendererFactory,
+} from '@angular/animations/browser';
+import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   Directive,
   EventEmitter,
   Input,
+  NgZone,
   Output,
+  PLATFORM_ID,
+  RendererFactory2,
   Type,
   ViewChild,
 } from '@angular/core';
@@ -32,14 +39,16 @@ import {
   ReactiveFormsModule,
   Validators,
 } from '../index';
-import {By} from '@angular/platform-browser';
+import {By, ɵDomRendererFactory2 as DomRendererFactory2} from '@angular/platform-browser';
 import {dispatchEvent, isNode} from '@angular/private/testing';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 
 describe('value accessors', () => {
   function initTest<T>(component: Type<T>, ...directives: Type<any>[]): ComponentFixture<T> {
     TestBed.configureTestingModule({
       declarations: [component, ...directives],
       imports: [FormsModule, ReactiveFormsModule],
+      providers: [{provide: PLATFORM_ID, useValue: 'browser'}],
     });
     return TestBed.createComponent(component);
   }
@@ -1040,24 +1049,426 @@ describe('value accessors', () => {
       });
     });
 
-    describe('in template-driven forms', () => {
-      it('with basic use case', fakeAsync(() => {
-        const fixture = initTest(NgModelRangeForm);
-        // model -> view
-        fixture.componentInstance.val = 4;
-        fixture.detectChanges();
-        tick();
-        const input = fixture.debugElement.query(By.css('input'));
-        expect(input.nativeElement.value).toBe('4');
-        fixture.detectChanges();
-        tick();
-        const newVal = '4';
-        input.triggerEventHandler('input', {target: {value: newVal}});
-        tick();
-        // view -> model
-        fixture.detectChanges();
-        expect(typeof fixture.componentInstance.val).toBe('number');
-      }));
+    describe('select controls', () => {
+      describe('in reactive forms', () => {
+        it(`should support primitive values`, () => {
+          if (isNode) return;
+          const fixture = initTest(FormControlNameSelect);
+          fixture.detectChanges();
+
+          // model -> view
+          const select = fixture.debugElement.query(By.css('select'));
+          const sfOption = fixture.debugElement.query(By.css('option'));
+          expect(select.nativeElement.value).toEqual('SF');
+          expect(sfOption.nativeElement.selected).toBe(true);
+
+          select.nativeElement.value = 'NY';
+          dispatchEvent(select.nativeElement, 'change');
+          fixture.detectChanges();
+
+          // view -> model
+          expect(sfOption.nativeElement.selected).toBe(false);
+          expect(fixture.componentInstance.form.value).toEqual({'city': 'NY'});
+        });
+
+        it(`should support objects`, () => {
+          if (isNode) return;
+          const fixture = initTest(FormControlSelectNgValue);
+          fixture.detectChanges();
+
+          // model -> view
+          const select = fixture.debugElement.query(By.css('select'));
+          const sfOption = fixture.debugElement.query(By.css('option'));
+          expect(select.nativeElement.value).toEqual('0: Object');
+          expect(sfOption.nativeElement.selected).toBe(true);
+        });
+
+        it('should throw an error if compareWith is not a function', () => {
+          const fixture = initTest(FormControlSelectWithCompareFn);
+          fixture.componentInstance.compareFn = null!;
+          expect(() => fixture.detectChanges()).toThrowError(
+            /compareWith must be a function, but received null/,
+          );
+        });
+
+        it('should compare options using provided compareWith function', () => {
+          if (isNode) return;
+          const fixture = initTest(FormControlSelectWithCompareFn);
+          fixture.detectChanges();
+
+          const select = fixture.debugElement.query(By.css('select'));
+          const sfOption = fixture.debugElement.query(By.css('option'));
+          expect(select.nativeElement.value).toEqual('0: Object');
+          expect(sfOption.nativeElement.selected).toBe(true);
+        });
+
+        it('should support re-assigning the options array with compareWith', () => {
+          if (isNode) return;
+          const fixture = initTest(FormControlSelectWithCompareFn);
+          fixture.detectChanges();
+
+          // Option IDs start out as 0 and 1, so setting the select value to "1: Object"
+          // will select the second option (NY).
+          const select = fixture.debugElement.query(By.css('select'));
+          expect(select.nativeElement.value).toEqual('0: Object');
+
+          select.nativeElement.value = '1: Object';
+          dispatchEvent(select.nativeElement, 'change');
+          fixture.detectChanges();
+
+          expect(fixture.componentInstance.form.value).toEqual({city: {id: 2, name: 'NY'}});
+
+          fixture.componentInstance.cities = [
+            {id: 1, name: 'SF'},
+            {id: 2, name: 'NY'},
+          ];
+          fixture.detectChanges();
+
+          // Now that the options array has been re-assigned, new option instances will
+          // be created by ngFor. These instances will have different option IDs, subsequent
+          // to the first: 2 and 3. For the second option to stay selected, the select
+          // value will need to have the ID of the current second option: 3.
+          const nyOption = fixture.debugElement.queryAll(By.css('option'))[1];
+          expect(select.nativeElement.value).toEqual('3: Object');
+          expect(nyOption.nativeElement.selected).toBe(true);
+        });
+
+        it('should support re-assigning the options array with compareWith and trackBy', () => {
+          if (isNode) return;
+          const fixture = initTest(FormControlSelectWithCompareTrackByFn);
+          fixture.detectChanges();
+
+          // Option IDs start out as 0 and 1, so setting the select value to "1: Object"
+          // will select the second option (NY).
+          const select = fixture.debugElement.query(By.css('select'));
+          expect(select.nativeElement.value).toEqual('0: Object');
+
+          select.nativeElement.value = '1: Object';
+          dispatchEvent(select.nativeElement, 'change');
+          fixture.detectChanges();
+
+          expect(fixture.componentInstance.form.value).toEqual({city: {id: 2, name: 'NY'}});
+
+          fixture.componentInstance.cities = [
+            {id: 3, name: 'LA'},
+            {id: 4, name: 'BXL'},
+          ];
+          fixture.detectChanges();
+
+          // using trackBy, instances can be re-used, the option IDs stays the same but their
+          // (ng)value can change
+          const bxlOption = fixture.debugElement.queryAll(By.css('option'))[1];
+          expect(select.nativeElement.value).not.toEqual(
+            '1: Object',
+            'expected option related value to have been unset',
+          );
+          expect(bxlOption.nativeElement.selected).toBe(
+            false,
+            'expected option to have been unset',
+          );
+          expect(fixture.componentInstance.form.value).toEqual({city: {id: 2, name: 'NY'}});
+        });
+
+        it('should keep current value when selected option is removed/replaced', () => {
+          if (isNode) return;
+          const fixture = initTest(FormControlSelectWithCompareFn);
+          fixture.detectChanges();
+
+          // Option IDs start out as 0 and 1, so setting the select value to "1: Object"
+          // will select the second option (NY).
+          const select = fixture.debugElement.query(By.css('select'));
+          expect(select.nativeElement.value).toEqual('0: Object');
+
+          select.nativeElement.value = '1: Object';
+          dispatchEvent(select.nativeElement, 'change');
+          fixture.detectChanges();
+
+          expect(fixture.componentInstance.form.value).toEqual({city: {id: 2, name: 'NY'}});
+
+          fixture.componentInstance.cities = [
+            {id: 1, name: 'SF'},
+            {id: 3, name: 'LA'},
+          ];
+          fixture.detectChanges();
+
+          // Now that the options array has been re-assigned, new option instances will
+          // be created by ngFor. These instances will have different option IDs, subsequent
+          // to the first: 2 and 3.
+          // removing the currently selected option should not unset the formValue
+          const laOption = fixture.debugElement.queryAll(By.css('option'))[1];
+          expect(select.nativeElement.value).not.toEqual(
+            '3: Object',
+            'expected removal of currently selected option to unset replacement option',
+          );
+          expect(laOption.nativeElement.selected).toBe(
+            false,
+            'expected removal of currently selected option to unset replacement option (by index)',
+          );
+          expect(fixture.componentInstance.form.value).toEqual(
+            {city: {id: 2, name: 'NY'}},
+            'expected removal of currently selected option not to unset the form value',
+          );
+        });
+
+        it('should call compareWith once for each added option until a match is found', () => {
+          // see issue #41330
+          if (isNode) return;
+          const fixture = initTest(FormControlSelectWithComparePerfFn);
+          fixture.detectChanges();
+          // compareWith should only be called once since first city is selected
+          expect(fixture.componentInstance.compareFnCalls).toEqual(1);
+        });
+
+        it('should not call compareWith for removed options', () => {
+          if (isNode) return;
+          const fixture = initTest(FormControlSelectWithComparePerfFn);
+          fixture.detectChanges();
+
+          fixture.componentInstance.compareFnCalls = 0;
+          fixture.componentInstance.cities.splice(2, 2);
+          fixture.detectChanges();
+
+          // compareWith should only be called once since first city is still selected
+          expect(fixture.componentInstance.compareFnCalls).toBe(1);
+        });
+      });
+
+      describe('in template-driven forms', () => {
+        it('with option values that are objects', fakeAsync(() => {
+          if (isNode) return;
+          const fixture = initTest(NgModelSelectForm);
+          const comp = fixture.componentInstance;
+          comp.cities = [{'name': 'SF'}, {'name': 'NYC'}, {'name': 'Buffalo'}];
+          comp.selectedCity = comp.cities[1];
+          fixture.detectChanges();
+          tick();
+
+          const select = fixture.debugElement.query(By.css('select'));
+          const nycOption = fixture.debugElement.queryAll(By.css('option'))[1];
+
+          // model -> view
+          expect(select.nativeElement.value).toEqual('1: Object');
+          expect(nycOption.nativeElement.selected).toBe(true);
+
+          select.nativeElement.value = '2: Object';
+          dispatchEvent(select.nativeElement, 'change');
+          fixture.detectChanges();
+          tick();
+
+          // view -> model
+          expect(comp.selectedCity['name']).toEqual('Buffalo');
+        }));
+
+        it('when new options are added', fakeAsync(() => {
+          if (isNode) return;
+          const fixture = initTest(NgModelSelectForm);
+          const comp = fixture.componentInstance;
+          comp.cities = [{'name': 'SF'}, {'name': 'NYC'}];
+          comp.selectedCity = comp.cities[1];
+          fixture.detectChanges();
+          tick();
+
+          comp.cities.push({'name': 'Buffalo'});
+          comp.selectedCity = comp.cities[2];
+          fixture.detectChanges();
+          tick();
+
+          const select = fixture.debugElement.query(By.css('select'));
+          const buffalo = fixture.debugElement.queryAll(By.css('option'))[2];
+          expect(select.nativeElement.value).toEqual('2: Object');
+          expect(buffalo.nativeElement.selected).toBe(true);
+        }));
+
+        it('should not select options added after the select renders', fakeAsync(() => {
+          // see issue #14505
+          if (isNode) return;
+          const fixture = initTest(NgModelSelectForm);
+          const comp = fixture.componentInstance;
+          fixture.detectChanges();
+          tick();
+
+          comp.cities.push({name: 'Minneapolis'});
+          fixture.detectChanges();
+          tick();
+
+          const select = fixture.debugElement.query(By.css('select'));
+          expect(select.nativeElement.selectedIndex).toEqual(-1);
+          const minneapolis = fixture.debugElement.queryAll(By.css('option'))[0];
+          expect(minneapolis.nativeElement.selected).toBe(false);
+        }));
+
+        it('when there is a placeholder option', fakeAsync(() => {
+          if (isNode) return;
+          const fixture = initTest(NgModelSelectWithPlaceholderForm);
+          const comp = fixture.componentInstance;
+          comp.cities = [{'name': 'SF'}, {'name': 'NYC'}];
+          fixture.detectChanges();
+          tick();
+
+          const placeholder = fixture.debugElement.queryAll(By.css('option'))[0];
+          expect(placeholder.nativeElement.selected).toBe(true);
+        }));
+
+        it('when options are removed', fakeAsync(() => {
+          if (isNode) return;
+          const fixture = initTest(NgModelSelectForm);
+          const comp = fixture.componentInstance;
+          comp.cities = [{'name': 'SF'}, {'name': 'NYC'}];
+          comp.selectedCity = comp.cities[1];
+          fixture.detectChanges();
+          tick();
+
+          const select = fixture.debugElement.query(By.css('select'));
+          expect(select.nativeElement.value).toEqual('1: Object');
+
+          comp.cities.pop();
+          fixture.detectChanges();
+          tick();
+
+          // no option should be selected, since ngModel doesn't match anything in cities array
+          expect(select.nativeElement.value).not.toEqual('1: Object');
+          expect(select.nativeElement.value).not.toEqual('0: Object');
+        }));
+
+        it('should not select first option when options are removed and animations module is used', async () => {
+          // this test is the same as the one above, but tested with BrowserAnimationsModule
+          // to ensure that issue #18430 isn't regressed.
+          if (isNode) return;
+          TestBed.configureTestingModule({
+            providers: [
+              {
+                provide: RendererFactory2,
+                useClass: AnimationRendererFactory,
+                deps: [DomRendererFactory2, AnimationEngine, NgZone],
+              },
+            ],
+            imports: [BrowserAnimationsModule, FormsModule],
+            declarations: [NgModelSelectForm],
+          });
+
+          const fixture = TestBed.createComponent(NgModelSelectForm);
+          const comp = fixture.componentInstance;
+          comp.cities = [{'name': 'SF'}, {'name': 'NYC'}];
+          comp.selectedCity = comp.cities[1];
+          fixture.autoDetectChanges();
+          await fixture.whenStable();
+
+          const select = fixture.debugElement.query(By.css('select'));
+          expect(select.nativeElement.value).toEqual('1: Object');
+
+          comp.cities.pop();
+          fixture.changeDetectorRef.markForCheck();
+          await fixture.whenStable();
+
+          // no option should be selected, since ngModel doesn't match anything in cities array
+          expect(select.nativeElement.value).not.toEqual('1: Object');
+          expect(select.nativeElement.value).not.toEqual('0: Object');
+        });
+
+        it('when option values have same content, but different identities', fakeAsync(() => {
+          if (isNode) return;
+          const fixture = initTest(NgModelSelectForm);
+          const comp = fixture.componentInstance;
+          comp.cities = [{'name': 'SF'}, {'name': 'NYC'}, {'name': 'NYC'}];
+          comp.selectedCity = comp.cities[0];
+          fixture.detectChanges();
+
+          comp.selectedCity = comp.cities[2];
+          fixture.detectChanges();
+          tick();
+
+          const select = fixture.debugElement.query(By.css('select'));
+          const secondNYC = fixture.debugElement.queryAll(By.css('option'))[2];
+          expect(select.nativeElement.value).toEqual('2: Object');
+          expect(secondNYC.nativeElement.selected).toBe(true);
+        }));
+
+        it('should work with null option', fakeAsync(() => {
+          const fixture = initTest(NgModelSelectWithNullForm);
+          const comp = fixture.componentInstance;
+          comp.cities = [{'name': 'SF'}, {'name': 'NYC'}];
+          comp.selectedCity = null;
+          fixture.detectChanges();
+
+          const select = fixture.debugElement.query(By.css('select'));
+
+          select.nativeElement.value = '2: Object';
+          dispatchEvent(select.nativeElement, 'change');
+          fixture.detectChanges();
+          tick();
+          expect(comp.selectedCity!['name']).toEqual('NYC');
+
+          select.nativeElement.value = '0: null';
+          dispatchEvent(select.nativeElement, 'change');
+          fixture.detectChanges();
+          tick();
+          expect(comp.selectedCity).toEqual(null);
+        }));
+
+        it('should throw an error when compareWith is not a function', () => {
+          const fixture = initTest(NgModelSelectWithCustomCompareFnForm);
+          const comp = fixture.componentInstance;
+          comp.compareFn = null!;
+          expect(() => fixture.detectChanges()).toThrowError(
+            /compareWith must be a function, but received null/,
+          );
+        });
+
+        it('should compare options using provided compareWith function', fakeAsync(() => {
+          if (isNode) return;
+          const fixture = initTest(NgModelSelectWithCustomCompareFnForm);
+          const comp = fixture.componentInstance;
+          comp.selectedCity = {id: 1, name: 'SF'};
+          comp.cities = [
+            {id: 1, name: 'SF'},
+            {id: 2, name: 'LA'},
+          ];
+          fixture.detectChanges();
+          tick();
+
+          const select = fixture.debugElement.query(By.css('select'));
+          const sfOption = fixture.debugElement.query(By.css('option'));
+          expect(select.nativeElement.value).toEqual('0: Object');
+          expect(sfOption.nativeElement.selected).toBe(true);
+        }));
+
+        it('should support re-assigning the options array with compareWith', fakeAsync(() => {
+          if (isNode) return;
+          const fixture = initTest(NgModelSelectWithCustomCompareFnForm);
+          fixture.componentInstance.selectedCity = {id: 1, name: 'SF'};
+          fixture.componentInstance.cities = [
+            {id: 1, name: 'SF'},
+            {id: 2, name: 'NY'},
+          ];
+          fixture.detectChanges();
+          tick();
+
+          // Option IDs start out as 0 and 1, so setting the select value to "1: Object"
+          // will select the second option (NY).
+          const select = fixture.debugElement.query(By.css('select'));
+          select.nativeElement.value = '1: Object';
+          dispatchEvent(select.nativeElement, 'change');
+          fixture.detectChanges();
+
+          const model = fixture.debugElement.children[0].injector.get(NgModel);
+          expect(model.value).toEqual({id: 2, name: 'NY'});
+
+          fixture.componentInstance.cities = [
+            {id: 1, name: 'SF'},
+            {id: 2, name: 'NY'},
+          ];
+          fixture.detectChanges();
+          tick();
+
+          // Now that the options array has been re-assigned, new option instances will
+          // be created by ngFor. These instances will have different option IDs, subsequent
+          // to the first: 2 and 3. For the second option to stay selected, the select
+          // value will need to have the ID of the current second option: 3.
+          const nyOption = fixture.debugElement.queryAll(By.css('option'))[1];
+          expect(select.nativeElement.value).toEqual('3: Object');
+          expect(nyOption.nativeElement.selected).toBe(true);
+        }));
+      });
     });
   });
 
@@ -1375,6 +1786,55 @@ class FormControlSelectWithCompareFn {
 }
 
 @Component({
+  selector: 'form-control-select-compare-with-perf',
+  template: `
+    <div [formGroup]="form">
+      <select formControlName="city" [compareWith]="compareFn">
+        <option *ngFor="let c of cities" [ngValue]="c">{{c.name}}</option>
+      </select>
+    </div>`,
+  standalone: false,
+})
+class FormControlSelectWithComparePerfFn {
+  compareFnCalls = 0;
+
+  compareFn: (o1: any, o2: any) => boolean = (o1: any, o2: any) => {
+    ++this.compareFnCalls;
+    return Object.is(o1, o2);
+  };
+
+  cities = [
+    {id: 1, name: 'SF'},
+    {id: 2, name: 'NY'},
+    {id: 3, name: 'LA'},
+    {id: 4, name: 'BXL'},
+  ];
+
+  form = new FormGroup({city: new FormControl(this.cities[0])});
+}
+
+@Component({
+  selector: 'form-control-select-compare-with-track-by',
+  template: `
+    <div [formGroup]="form">
+      <select formControlName="city" [compareWith]="compareFn">
+        <option *ngFor="let c of cities; trackBy: trackByFn" [ngValue]="c">{{c.name}}</option>
+      </select>
+    </div>`,
+  standalone: false,
+})
+class FormControlSelectWithCompareTrackByFn {
+  compareFn: (o1: any, o2: any) => boolean = (o1: any, o2: any) =>
+    o1 && o2 ? o1.id === o2.id : o1 === o2;
+  trackByFn: (index: number, item: any) => any = (index: number, item: any): any => index;
+  cities = [
+    {id: 1, name: 'SF'},
+    {id: 2, name: 'NY'},
+  ];
+  form = new FormGroup({city: new FormControl({id: 1, name: 'SF'})});
+}
+
+@Component({
   selector: 'form-control-select-multiple',
   template: `
     <div [formGroup]="form">
@@ -1438,6 +1898,22 @@ class FormControlSelectMultipleWithCompareFn {
 })
 class NgModelSelectForm {
   selectedCity: {[k: string]: string} = {};
+  cities: any[] = [];
+}
+
+@Component({
+  selector: 'ng-model-select-placeholder-form',
+  template: `
+    <form #f="ngForm">
+      <select name="city" ngModel>
+        <option value="" disabled>Choose a city</option>
+        <option *ngFor="let c of cities" [ngValue]="c"> {{c.name}} </option>
+      </select>
+    </form>
+  `,
+  standalone: false,
+})
+class NgModelSelectWithPlaceholderForm {
   cities: any[] = [];
 }
 


### PR DESCRIPTION
We defer the update until after rendering
is complete for two reasons: first, to avoid repeatedly calling `writeValue` on every option element until we find the selected one (could be the very last element). Second, to ensure that we perform the write after the DOM elements have been created (this doesn't happen until the end of change detection when animations are enabled).

This is needed to efficiently set the select value when adding/removing options. The previous approach resulted in exponentially more `_compareValue` calls than the number of option elements (issue angular#41330).

Finally, this PR fixes an issue with delayed element removal when using the animations module (in all browsers). Previously when a selected option was removed (so no option matched the ngModel anymore), Angular changed the select element value before actually removing the option from the DOM. Then when the option was finally removed from the DOM, the browser would change the select value to that of the first option, even though it didn't match the ngModel (issue angular#18430). Note that this is still somewhat of an application problem when using `ngModel`. The model value still needs to be updated to a valid value when the selected value is deleted or it will be out of sync with the DOM.

Fixes #41330, fixes #18430.


[TGP](https://fusion2.corp.google.com/presubmit/767187673/OCL:767187673:BASE:768170964:1749237427897:f6a68b3b/targets)
requires an update to the screenshots in one test, with minor shifting in the placement of the text in the select control (see cl/767187673)

Though there is a green TGP, this changes the timing of values being written to the DOM, which still caries some risk. We should merge to `main` only to give more time for things to be discovered internally prior to external release.