### PR TITLE
feat(core): Add `destroyed` property to `EnvironmentInjector`

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -686,6 +686,7 @@ export const ENVIRONMENT_INITIALIZER: InjectionToken<readonly (() => void)[]>;
 export abstract class EnvironmentInjector implements Injector {
     // (undocumented)
     abstract destroy(): void;
+    abstract get destroyed(): boolean;
     abstract get<T>(token: ProviderToken<T>, notFoundValue: undefined, options: InjectOptions & {
         optional?: false;
     }): T;

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -175,7 +175,9 @@ export abstract class EnvironmentInjector implements Injector {
 
   abstract destroy(): void;
 
-  /** @internal */
+  /**
+   * Indicates whether the instance has already been destroyed.
+   */
   abstract get destroyed(): boolean;
 
   /**

--- a/packages/core/src/linker/destroy_ref.ts
+++ b/packages/core/src/linker/destroy_ref.ts
@@ -47,7 +47,7 @@ export abstract class DestroyRef {
   abstract onDestroy(callback: () => void): () => void;
 
   /**
-   * Indicates whether the instance has already been destroyed and whether its `onDestroy` callbacks have executed.
+   * Indicates whether the instance has already been destroyed.
    */
   abstract get destroyed(): boolean;
 


### PR DESCRIPTION
Similar to `DestroyRef`, this adds the `destroyed` property to `EnvironmentInjector`. It also has the ability to register callbacks with `onDestroy`, which throws if `destroyed` is already `true`.

This also omits the bit about whether those callbacks have executed since I realized the property is set to `true` before executing the callbacks.
