### PR TITLE
docs: add page NG8115 (uninvokedTrackFunction)

### DIFF
--- a/adev/src/content/reference/extended-diagnostics/NG8115.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8115.md
@@ -1,0 +1,61 @@
+# Uninvoked Track Function
+
+This diagnostic detects when a track function is not invoked in `@for` blocks.
+
+<docs-code language="typescript">
+
+import {Component} from '@angular/core';
+
+@Component({
+  template: `@for (item of items; track trackByName) {}`,
+})
+class Items {
+  protected trackByName(item) { return item.name; }
+}
+
+</docs-code>
+
+## What's wrong with that?
+
+`@for` blocks need to uniquely identify items in the iterable to correctly perform DOM updates when items in the iterable are reordered, new items are added, or existing items are removed.
+When you don't invoke the function, the reconcialiation algorithm will use the function reference instead of returned value to compare items. 
+
+## What should I do instead?
+
+Ensure to invoke the track function when you use it in a `@for` block to execute the function so the loop can uniquely identify items.
+
+<docs-code language="typescript">
+
+import {Component} from '@angular/core';
+
+@Component({
+  template: `@for (item of items; track trackByName(item)) {}`,
+})
+class Items {
+  protected trackByName(item) { return item.name; }
+}
+
+</docs-code>
+
+## Configuration requirements
+
+[`strictTemplates`](tools/cli/template-typecheck#strict-mode) must be enabled for any extended diagnostic to emit.
+`uninvokedTrackFunction` has no additional requirements beyond `strictTemplates`.
+
+## What if I can't avoid this?
+
+This diagnostic can be disabled by editing the project's `tsconfig.json` file:
+
+<docs-code language="json">
+{
+  "angularCompilerOptions": {
+    "extendedDiagnostics": {
+      "checks": {
+        "uninvokedTrackFunction": "suppress"
+      }
+    }
+  }
+}
+</docs-code>
+
+See [extended diagnostic configuration](extended-diagnostics#configuration) for more info.

--- a/adev/src/content/reference/extended-diagnostics/overview.md
+++ b/adev/src/content/reference/extended-diagnostics/overview.md
@@ -22,6 +22,7 @@ Currently, Angular supports the following extended diagnostics:
 | `NG8111` | [`uninvokedFunctionInEventBinding`](extended-diagnostics/NG8111)  |
 | `NG8113` | [`unusedStandaloneImports`](extended-diagnostics/NG8113)          |
 | `NG8114` | [`unparenthesizedNullishCoalescing`](extended-diagnostics/NG8114) |
+| `NG8115` | [`uninvokedTrackFunction`](extended-diagnostics/NG8115)           |
 | `NG8116` | [`missingStructuralDirective`](extended-diagnostics/NG8116)       |
 
 ## Configuration
@@ -50,8 +51,7 @@ Check severity can be configured as an [Angular compiler option](reference/confi
       // The category to use for any diagnostics not listed in `checks` above.
       "defaultCategory": "error"
     }
-
-}
+  }
 }
 </docs-code>
 


### PR DESCRIPTION
Adds documentation for `NG8115 (uninvokedTrackFunction)`

Pull request that added the diagnostic:

https://github.com/angular/angular/pull/60495

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

This adds documentation for the extended diagnostic `NG8115 (uninvokedTrackFunction)`

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

No diagnostic for `NG8115 (uninvokedTrackFunction)`

Issue Number: N/A


## What is the new behavior?

Adds a diagnostic for `NG8115 (uninvokedTrackFunction)`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

@eneajaho offered to check this out :0 ty

Fun fact: I noticed this while I was just going to make a change for the incorrect indentation that I did in the second commit lol.