### PR TITLE
fix(devtools): material components background colors

### DIFF
--- a/devtools/projects/ng-devtools/src/styles/_global.scss
+++ b/devtools/projects/ng-devtools/src/styles/_global.scss
@@ -8,23 +8,7 @@
 @include mat.all-component-typographies();
 @include mat.core();
 @include clr.root-colors();
-
 @include tg.fonts();
-
-body {
-  padding: 0;
-  margin: 0;
-  background: var(--color-background);
-  color: var(--color-text);
-  @extend %body-01;
-}
-
-input,
-select {
-  color: var(--primary-contrast);
-  background: var(--color-foreground);
-  @extend %body-01;
-}
 
 $body-tg-level: mat.m2-define-typography-level(
   $font-family: tg.$font-family,
@@ -88,6 +72,53 @@ $dark-theme: map.deep-merge(
   .mat-mdc-chip.mat-mdc-standard-chip {
     --mdc-chip-container-height: 24px;
   }
+}
+
+:root {
+  @include mat.expansion-overrides(
+    (
+      container-background-color: transparent,
+    )
+  );
+
+  @include mat.toolbar-overrides(
+    (
+      container-background-color: transparent,
+    )
+  );
+
+  @include mat.tree-overrides(
+    (
+      container-background-color: transparent,
+    )
+  );
+
+  @include mat.card-overrides(
+    (
+      elevated-container-color: transparent,
+    )
+  );
+
+  @include mat.table-overrides(
+    (
+      background-color: transparent,
+    )
+  );
+}
+
+body {
+  padding: 0;
+  margin: 0;
+  background: var(--color-background);
+  color: var(--color-text);
+  @extend %body-01;
+}
+
+input,
+select {
+  color: var(--primary-contrast);
+  background: var(--color-foreground);
+  @extend %body-01;
 }
 
 ng-devtools {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Some background colors appear to be different from intended. 

**Before (regressed):**
<img width="800" alt="Screenshot 2025-06-09 at 17 32 51" src="https://github.com/user-attachments/assets/f557d798-b5ec-4364-b826-b421f52044d6" />

**After:**
<img width="801" alt="Screenshot 2025-06-09 at 17 33 16" src="https://github.com/user-attachments/assets/a9c65ccb-7004-43d3-b2c6-b47da6f4ac19" />



## What is the new behavior?

Add overrides for the default background colors of some the Material components currently in use by Devtools. Most likely a regression by a recent Material version bump.

