### PR TITLE
fix(core): fix hydration of disconnected projected nodes

### DIFF
--- a/packages/core/src/hydration/interfaces.ts
+++ b/packages/core/src/hydration/interfaces.ts
@@ -36,6 +36,7 @@ export const NODE_NAVIGATION_STEP_NEXT_SIBLING = 'n';
 export const ELEMENT_CONTAINERS = 'e';
 export const TEMPLATES = 't';
 export const CONTAINERS = 'c';
+export const MOVED = 'm';
 export const MULTIPLIER = 'x';
 export const NUM_ROOT_NODES = 'r';
 export const TEMPLATE_ID = 'i'; // as it's also an "id"
@@ -85,6 +86,14 @@ export interface SerializedView {
    * of serialized information about views within this container.
    */
   [CONTAINERS]?: Record<number, SerializedContainerView[]>;
+
+  /**
+   * Serialized information about transplanted view containers.
+   * Key-value pairs where a key is an index of the corresponding
+   * LContainer entry within an LView, and the value is a list
+   * of serialized information about views within this container.
+   */
+  [MOVED]?: SerializedContainerView[];
 
   /**
    * Serialized information about nodes in a template.

--- a/packages/core/src/hydration/utils.ts
+++ b/packages/core/src/hydration/utils.ts
@@ -26,6 +26,7 @@ import {
   DehydratedView,
   DISCONNECTED_NODES,
   ELEMENT_CONTAINERS,
+  MOVED,
   MULTIPLIER,
   NUM_ROOT_NODES,
   SerializedContainerView,
@@ -459,12 +460,27 @@ export function getSerializedContainerViews(
   return hydrationInfo.data[CONTAINERS]?.[index] ?? null;
 }
 
+export function getSerializedMovedContainerViews(
+  hydrationInfo: DehydratedView,
+): SerializedContainerView[] | undefined {
+  return hydrationInfo.data[MOVED];
+}
+
+export function hasMovedViews(hydrationInfo: DehydratedView | null): boolean {
+  return hydrationInfo?.data[MOVED] ? true : false;
+}
+
 /**
  * Computes the size of a serialized container (the number of root nodes)
  * by calculating the sum of root nodes in all dehydrated views in this container.
  */
 export function calcSerializedContainerSize(hydrationInfo: DehydratedView, index: number): number {
-  const views = getSerializedContainerViews(hydrationInfo, index) ?? [];
+  let views = [];
+  if (hasMovedViews(hydrationInfo)) {
+    views = getSerializedMovedContainerViews(hydrationInfo) ?? [];
+  } else {
+    views = getSerializedContainerViews(hydrationInfo, index) ?? [];
+  }
   let numNodes = 0;
   for (let view of views) {
     numNodes += view[NUM_ROOT_NODES] * (view[MULTIPLIER] ?? 1);

--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -9,10 +9,11 @@
 import {Injector} from '../di/injector';
 import {EnvironmentInjector} from '../di/r3_injector';
 import {validateMatchingNode} from '../hydration/error_handling';
-import {CONTAINERS} from '../hydration/interfaces';
+import {CONTAINERS, MOVED} from '../hydration/interfaces';
 import {isInSkipHydrationBlock} from '../hydration/skip_hydration';
 import {
   getSegmentHead,
+  hasMovedViews,
   isDisconnectedNode,
   markRNodeAsClaimedByHydration,
 } from '../hydration/utils';
@@ -839,7 +840,10 @@ function populateDehydratedViewsInLContainerImpl(
   // Hydration mode, looking up an anchor node and dehydrated views in DOM.
   const currentRNode: RNode | null = getSegmentHead(hydrationInfo, noOffsetIndex);
 
-  const serializedViews = hydrationInfo.data[CONTAINERS]?.[noOffsetIndex];
+  const hasMoved = hasMovedViews(hydrationInfo);
+  const serializedViews = hasMoved
+    ? hydrationInfo.data[MOVED]
+    : hydrationInfo.data[CONTAINERS]?.[noOffsetIndex];
   ngDevMode &&
     assertDefined(
       serializedViews,
@@ -863,7 +867,9 @@ function populateDehydratedViewsInLContainerImpl(
   }
 
   lContainer[NATIVE] = commentNode as RComment;
-  lContainer[DEHYDRATED_VIEWS] = dehydratedViews;
+  if (!hasMoved) {
+    lContainer[DEHYDRATED_VIEWS] = dehydratedViews;
+  }
 
   return true;
 }

--- a/packages/core/src/render3/instructions/element_container.ts
+++ b/packages/core/src/render3/instructions/element_container.ts
@@ -261,7 +261,7 @@ function locateOrCreateElementContainerNode(
 
   if (ngDevMode) {
     validateMatchingNode(comment, Node.COMMENT_NODE, null, lView, tNode);
-    markRNodeAsClaimedByHydration(comment);
+    markRNodeAsClaimedByHydration(comment, false);
   }
 
   return comment;

--- a/packages/core/src/render3/instructions/template.ts
+++ b/packages/core/src/render3/instructions/template.ts
@@ -11,6 +11,7 @@ import {locateNextRNode, siblingAfter} from '../../hydration/node_lookup_utils';
 import {
   calcSerializedContainerSize,
   canHydrateNode,
+  hasMovedViews,
   markRNodeAsClaimedByHydration,
   setSegmentHead,
 } from '../../hydration/utils';
@@ -386,7 +387,9 @@ function locateOrCreateContainerAnchorImpl(
 
   if (ngDevMode) {
     validateMatchingNode(comment, Node.COMMENT_NODE, null, lView, tNode);
-    markRNodeAsClaimedByHydration(comment);
+    if (!hasMovedViews(hydrationInfo)) {
+      markRNodeAsClaimedByHydration(comment);
+    }
   }
 
   return comment;

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -856,6 +856,12 @@ export interface TView {
    *                        (see `getComponentId` function for details)
    */
   ssrId: string | null;
+
+  /**
+   * Reference to serialized ngh index number used in case of transplated view
+   * identification.
+   */
+  nghId: number | null;
 }
 
 /** Single hook callback function. */

--- a/packages/core/src/render3/view/construction.ts
+++ b/packages/core/src/render3/view/construction.ts
@@ -116,6 +116,7 @@ export function createTView(
     consts: consts,
     incompleteFirstPass: false,
     ssrId,
+    nghId: null,
   });
   if (ngDevMode) {
     // For performance reasons it is important that the tView retains the same shape during runtime.

--- a/packages/core/test/render3/is_shape_of.ts
+++ b/packages/core/test/render3/is_shape_of.ts
@@ -136,6 +136,7 @@ const ShapeOfTView: ShapeOf<TView> = {
   consts: true,
   incompleteFirstPass: true,
   ssrId: true,
+  nghId: true,
 };
 
 /**

--- a/packages/platform-server/test/full_app_hydration_spec.ts
+++ b/packages/platform-server/test/full_app_hydration_spec.ts
@@ -51,6 +51,7 @@ import {
   ViewContainerRef,
   ViewEncapsulation,
   ɵNoopNgZone as NoopNgZone,
+  ContentChild,
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {clearTranslations, loadTranslations} from '@angular/localize';
@@ -5713,6 +5714,47 @@ describe('platform-server full application hydration integration', () => {
           verifyAllNodesClaimedForHydration(clientRootNode);
           verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
         });
+
+        it('should not render content twice with contentChildren', async () => {
+          @Component({
+            selector: 'app-shell',
+            imports: [NgTemplateOutlet],
+            template: `
+            <ng-container [ngTemplateOutlet]="customTemplate"></ng-container>
+          `,
+          })
+          class ShellCmp {
+            @ContentChild('customTemplate', {static: true})
+            customTemplate: TemplateRef<any> | null = null;
+          }
+
+          @Component({
+            imports: [ShellCmp],
+            selector: 'app',
+            template: `
+            <app-shell>
+              <ng-template #customTemplate>
+                <p>template</p>
+              </ng-template>
+            </app-shell>
+            `,
+          })
+          class SimpleComponent {}
+
+          const html = await ssr(SimpleComponent);
+          const ssrContents = getAppContents(html);
+          expect(ssrContents).toContain('<app ngh');
+
+          resetTViewsFor(SimpleComponent, ShellCmp);
+
+          const appRef = await prepareEnvironmentAndHydrate(doc, html, SimpleComponent);
+          const compRef = getComponentRef<SimpleComponent>(appRef);
+          appRef.tick();
+
+          const clientRootNode = compRef.location.nativeElement;
+          verifyAllNodesClaimedForHydration(clientRootNode);
+          verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+        }, 100_000);
 
         it('should support cases when component nodes are not projected in nested components', async () => {
           @Component({


### PR DESCRIPTION
This fixes the use case of content projection without a default slot. The ng-template was moved and ends up disconnected. This ensures we can locate those moved nodes and hydrate them properly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
