### PR TITLE
docs: fix incorrect destructuring in resource loader example

### DIFF
--- a/adev/src/content/guide/signals/resource.md
+++ b/adev/src/content/guide/signals/resource.md
@@ -60,10 +60,10 @@ const userId: Signal<string> = getUserId();
 
 const userResource = resource({
   params: () => ({id: userId()}),
-  loader: ({request, abortSignal}): Promise<User> => {
+  loader: ({params, abortSignal}): Promise<User> => {
     // fetch cancels any outstanding HTTP requests when the given `AbortSignal`
     // indicates that the request has been aborted.
-    return fetch(`users/${request.id}`, {signal: abortSignal});
+    return fetch(`users/${params.id}`, {signal: abortSignal});
   },
 });
 ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In the `resource` usage example within the **"Aborting requests"** section of the `signals/resource.md` guide, the destructured parameter is incorrectly named `request`.

```ts
loader: ({request, abortSignal}) => fetch(`users/${request.id}`, { signal: abortSignal });
```
This is inconsistent with the expected ResourceLoaderParams type, which defines the field as params.

Issue Number: N/A


## What is the new behavior?
The code example now correctly uses:

```ts
loader: ({params, abortSignal}) => fetch(`users/${params.id}`, { signal: abortSignal });
```
This change aligns the example with the actual resource API and avoids potential confusion or incorrect usage.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
