### PR TITLE
fix(core/schematics): skip migration for non-type-safe tokens in inject-migration and log warnings

### DIFF
--- a/packages/core/schematics/ng-generate/inject-migration/migration.ts
+++ b/packages/core/schematics/ng-generate/inject-migration/migration.ts
@@ -533,9 +533,13 @@ function migrateInjectDecorator(
 
   // `inject` no longer officially supports string injection so we need
   // to cast to any. We maintain the type by passing it as a generic.
+  // skip migration for string and variable tokens; add warning comment to inform the user
   if (ts.isStringLiteralLike(firstArg)) {
-    typeArguments = [type || ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword)];
-    injectedType += ' as any';
+    injectedType = `// WARNING: String token '${firstArg.text}' found. Skipping migration. Please replace with InjectionToken.\n` + injectedType;
+    typeArguments = null;
+  } else if (ts.isIdentifier(firstArg)) {
+    injectedType = `// WARNING: Variable token '${firstArg.text}' found. Skipping migration. Please replace with InjectionToken.\n` + injectedType;
+    typeArguments = null;
   } else if (
     ts.isCallExpression(firstArg) &&
     ts.isIdentifier(firstArg.expression) &&


### PR DESCRIPTION
### Summary

This PR updates the inject migration logic to skip non-type-safe tokens (like string literals and variable/import references) and instead insert inline warning comments to guide developers to replace them with InjectionToken instances. This avoids invalid automatic transformations that could lead to compile-time errors.

### Issue

Fixes https://github.com/angular/angular/issues/61982

### Details

- When the migration encounters a string literal token (e.g., 'myToken'), it now adds a comment like:
`// WARNING: String token 'myToken' found. Skipping migration. Please replace with InjectionToken.`
- When the token is an identifier (e.g., a variable or imported symbol), it adds:
`// WARNING: Variable token 'myToken' found. Skipping migration. Please replace with InjectionToken.`
### Tests

No new tests were added, but manual testing confirms the comment is correctly inserted in migrated code.

---

Please review and let me know if any changes are needed.
