### PR TITLE
[PATCH] fix(core): Fixes template outlet hydration

### DIFF
--- a/packages/core/src/hydration/annotate.ts
+++ b/packages/core/src/hydration/annotate.ts
@@ -595,10 +595,15 @@ function serializeLView(
       continue;
     }
 
+    // Serialize information about template.
+    if (isLContainer(lView[i]) && tNode.tView) {
+      ngh[TEMPLATES] ??= {};
+      ngh[TEMPLATES][noOffsetIndex] = getSsrId(tNode.tView!);
+    }
+
     // Check if a native node that represents a given TNode is disconnected from the DOM tree.
     // Such nodes must be excluded from the hydration (since the hydration won't be able to
     // find them), so the TNode ids are collected and used at runtime to skip the hydration.
-    //
     // This situation may happen during the content projection, when some nodes don't make it
     // into one of the content projection slots (for example, when there is no default
     // <ng-content /> slot in projector component's template).
@@ -648,13 +653,6 @@ function serializeLView(
 
     conditionallyAnnotateNodePath(ngh, tNode, lView, i18nChildren);
     if (isLContainer(lView[i])) {
-      // Serialize information about a template.
-      const embeddedTView = tNode.tView;
-      if (embeddedTView !== null) {
-        ngh[TEMPLATES] ??= {};
-        ngh[TEMPLATES][noOffsetIndex] = getSsrId(embeddedTView);
-      }
-
       // Serialize views within this LContainer.
       const hostNode = lView[i][HOST]!; // host node of this container
 

--- a/packages/core/src/render3/instructions/template.ts
+++ b/packages/core/src/render3/instructions/template.ts
@@ -264,6 +264,7 @@ function locateOrCreateContainerAnchorImpl(
   index: number,
 ): RComment {
   const hydrationInfo = lView[HYDRATION];
+
   const isNodeCreationMode =
     !hydrationInfo ||
     isInSkipHydrationBlock() ||
@@ -271,12 +272,7 @@ function locateOrCreateContainerAnchorImpl(
     isDisconnectedNode(hydrationInfo, index);
   lastNodeWasCreated(isNodeCreationMode);
 
-  // Regular creation mode.
-  if (isNodeCreationMode) {
-    return createContainerAnchorImpl(tView, lView, tNode, index);
-  }
-
-  const ssrId = hydrationInfo.data[TEMPLATES]?.[index] ?? null;
+  const ssrId = hydrationInfo?.data[TEMPLATES]?.[index] ?? null;
 
   // Apply `ssrId` value to the underlying TView if it was not previously set.
   //
@@ -295,12 +291,17 @@ function locateOrCreateContainerAnchorImpl(
     }
   }
 
+  // Regular creation mode.
+  if (isNodeCreationMode) {
+    return createContainerAnchorImpl(tView, lView, tNode, index);
+  }
+
   // Hydration mode, looking up existing elements in DOM.
-  const currentRNode = locateNextRNode(hydrationInfo, tView, lView, tNode)!;
+  const currentRNode = locateNextRNode(hydrationInfo!, tView, lView, tNode)!;
   ngDevMode && validateNodeExists(currentRNode, lView, tNode);
 
-  setSegmentHead(hydrationInfo, index, currentRNode);
-  const viewContainerSize = calcSerializedContainerSize(hydrationInfo, index);
+  setSegmentHead(hydrationInfo!, index, currentRNode);
+  const viewContainerSize = calcSerializedContainerSize(hydrationInfo!, index);
   const comment = siblingAfter<RComment>(viewContainerSize, currentRNode)!;
 
   if (ngDevMode) {


### PR DESCRIPTION
[PATCH]

Projected nodes were missing ssrId information and were skipping annotating template information, which caused templates to be destroyed and recreated rather than hydrated.

fixes: #50543

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No