### PR TITLE
refactor(migration): support local string tokens for inject migration

### DIFF
--- a/packages/core/schematics/ng-generate/inject-migration/migration.ts
+++ b/packages/core/schematics/ng-generate/inject-migration/migration.ts
@@ -533,7 +533,7 @@ function migrateInjectDecorator(
 
   // `inject` no longer officially supports string injection so we need
   // to cast to any. We maintain the type by passing it as a generic.
-  if (ts.isStringLiteralLike(firstArg)) {
+  if (ts.isStringLiteralLike(firstArg) || isStringType(firstArg, localTypeChecker)) {
     typeArguments = [type || ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword)];
     injectedType += ' as any';
   } else if (
@@ -884,4 +884,11 @@ function replaceParameterReferencesInInitializer(
   }
 
   return result.join('this.');
+}
+
+function isStringType(node: ts.Expression, checker: ts.TypeChecker): boolean {
+  const type = checker.getTypeAtLocation(node);
+
+  // stringLiteral here is to cover const strings inferred as literal type.
+  return !!(type.flags & ts.TypeFlags.String || type.flags & ts.TypeFlags.StringLiteral);
 }

--- a/packages/core/schematics/test/inject_migration_spec.ts
+++ b/packages/core/schematics/test/inject_migration_spec.ts
@@ -120,7 +120,7 @@ describe('inject migration', () => {
     ]);
   });
 
-  it('should account for string tokens in @Inject()', async () => {
+  it('should account for string literal tokens in @Inject()', async () => {
     writeFile(
       '/dir.ts',
       [
@@ -141,6 +141,35 @@ describe('inject migration', () => {
       `@Directive()`,
       `class MyDir {`,
       `  private foo = inject<number>('not-officially-supported' as any);`,
+      `}`,
+    ]);
+  });
+
+  it('should account for string tokens in @Inject()', async () => {
+    writeFile(
+      '/dir.ts',
+      [
+        `import { Directive, Inject } from '@angular/core';`,
+        ``,
+        `const token = 'not-officially-supported'`,
+        ``,
+        `@Directive()`,
+        `class MyDir {`,
+        `  constructor(@Inject(token) private foo: number) {}`,
+        `}`,
+      ].join('\n'),
+    );
+
+    await runMigration();
+
+    expect(tree.readContent('/dir.ts').split('\n')).toEqual([
+      `import { Directive, inject } from '@angular/core';`,
+      ``,
+      `const token = 'not-officially-supported'`,
+      ``,
+      `@Directive()`,
+      `class MyDir {`,
+      `  private foo = inject<number>(token as any);`,
       `}`,
     ]);
   });


### PR DESCRIPTION
The `localTypeChecker` allows us to at least support locally defined strings in addition to string literals.

Improves a bit the issue repported by #61982. 
