### PR TITLE
build: fix hermetic execution of `packages/core/test/...`

### DIFF
--- a/packages/core/test/bundling/cyclic_import/BUILD.bazel
+++ b/packages/core/test/bundling/cyclic_import/BUILD.bazel
@@ -23,13 +23,11 @@ ts_project(
     name = "test_lib",
     testonly = True,
     srcs = glob(["*_spec.ts"]),
-    interop_deps = [
-        "//packages/compiler",
-        "//packages/core/testing",
-        "//packages/private/testing",
-    ],
     deps = [
         "//:node_modules/@bazel/runfiles",
+        "//packages/compiler:compiler_rjs",
+        "//packages/core/testing:testing_rjs",
+        "//packages/private/testing:testing_rjs",
     ],
 )
 

--- a/packages/core/test/bundling/forms_reactive/BUILD.bazel
+++ b/packages/core/test/bundling/forms_reactive/BUILD.bazel
@@ -27,11 +27,11 @@ ts_project(
     name = "test_lib",
     testonly = True,
     srcs = glob(["*_spec.ts"]),
-    interop_deps = [
-        "//packages/compiler",
-        "//packages/core",
-        "//packages/core/testing",
-        "//packages/private/testing",
+    deps = [
+        "//packages/compiler:compiler_rjs",
+        "//packages/core:core_rjs",
+        "//packages/core/testing:testing_rjs",
+        "//packages/private/testing:testing_rjs",
     ],
 )
 

--- a/packages/core/test/bundling/forms_template_driven/BUILD.bazel
+++ b/packages/core/test/bundling/forms_template_driven/BUILD.bazel
@@ -27,11 +27,11 @@ ts_project(
     name = "test_lib",
     testonly = True,
     srcs = glob(["*_spec.ts"]),
-    interop_deps = [
-        "//packages/compiler",
-        "//packages/core",
-        "//packages/core/testing",
-        "//packages/private/testing",
+    deps = [
+        "//packages/compiler:compiler_rjs",
+        "//packages/core:core_rjs",
+        "//packages/core/testing:testing_rjs",
+        "//packages/private/testing:testing_rjs",
     ],
 )
 

--- a/packages/core/test/signals/BUILD.bazel
+++ b/packages/core/test/signals/BUILD.bazel
@@ -9,10 +9,10 @@ ts_project(
     srcs = glob(
         ["**/*.ts"],
     ),
-    interop_deps = [
-        "//packages/core",
-        "//packages/core/primitives/signals",
-        "//packages/core/src/util",
+    deps = [
+        "//packages/core:core_rjs",
+        "//packages/core/primitives/signals:signals_rjs",
+        "//packages/core/src/util:util_rjs",
     ],
 )
 


### PR DESCRIPTION
Due to a bug that is currently in progress of being resolved in the `rules_js` toolchain (see:
https://github.com/aspect-build/rules_js/issues/362), we were seeing subtle differences between `main` and PRs/local builds. Mostly because we recently disabled RBE for pull requests (unfortunate timing), and because RBE is a much stricter sandbox environment compared to the normal linux/darwin sandbox.

This commit fixes the issue by avoiding the interop targets that don't bring in the actual transitive node modules.