### PR TITLE
refactor(localize): add tripleslash type on Application builder

### DIFF
--- a/packages/localize/schematics/ng-add/index.ts
+++ b/packages/localize/schematics/ng-add/index.ts
@@ -96,7 +96,10 @@ function addTypeScriptConfigTypes(projectName: string): Rule {
         if (typeof value === 'string') {
           addTripleSlashType(host, value);
         }
-      } else if (target.builder === AngularBuilder.Application) {
+      } else if (
+        target.builder === AngularBuilder.Application ||
+        target.builder === AngularBuilder.BuildApplication
+      ) {
         const value = target.options?.['browser'];
         if (typeof value === 'string') {
           addTripleSlashType(host, value);


### PR DESCRIPTION
Prior to this change, the triple slash directive was only added on the angular-devkit application builder.

Fixes #61968
