### PR TITLE
refactor(core): drop injection context assertion in production

### DIFF
--- a/packages/core/src/render3/after_render/hooks.ts
+++ b/packages/core/src/render3/after_render/hooks.ts
@@ -389,7 +389,10 @@ export function afterNextRender(
       },
   options?: AfterRenderOptions,
 ): AfterRenderRef {
-  !options?.injector && assertInInjectionContext(afterNextRender);
+  if (ngDevMode && !options?.injector) {
+    assertInInjectionContext(afterNextRender);
+  }
+
   const injector = options?.injector ?? inject(Injector);
 
   if (typeof ngServerMode !== 'undefined' && ngServerMode) {


### PR DESCRIPTION
Drops `assertInInjectionContext` call in production in `afterNextRender`.