### PR TITLE
feat(core): support bindings in TestBed

### DIFF
--- a/goldens/public-api/core/testing/index.api.md
+++ b/goldens/public-api/core/testing/index.api.md
@@ -114,7 +114,7 @@ export interface TestBed {
     // (undocumented)
     configureTestingModule(moduleDef: TestModuleMetadata): TestBed;
     // (undocumented)
-    createComponent<T>(component: Type<T>): ComponentFixture<T>;
+    createComponent<T>(component: Type<T>, options?: TestComponentOptions): ComponentFixture<T>;
     // (undocumented)
     execute(tokens: any[], fn: Function, context?: any): any;
     // @deprecated
@@ -175,6 +175,11 @@ export const TestBed: TestBedStatic;
 export interface TestBedStatic extends TestBed {
     // (undocumented)
     new (...args: any[]): TestBed;
+}
+
+// @public
+export interface TestComponentOptions {
+    bindings?: Binding[];
 }
 
 // @public

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -12,6 +12,7 @@
 
 import {
   ApplicationRef,
+  Binding,
   Component,
   ɵRender3ComponentFactory as ComponentFactory,
   ComponentRef,
@@ -61,6 +62,16 @@ import {TestBedCompiler} from './test_bed_compiler';
  */
 export interface TestBedStatic extends TestBed {
   new (...args: any[]): TestBed;
+}
+
+/**
+ * Options that can be configured for a test component.
+ *
+ * @publicApi
+ */
+export interface TestComponentOptions {
+  /** Bindings to apply to the test component. */
+  bindings?: Binding[];
 }
 
 /**
@@ -149,7 +160,7 @@ export interface TestBed {
 
   overrideTemplateUsingTestingModule(component: Type<any>, template: string): TestBed;
 
-  createComponent<T>(component: Type<T>): ComponentFixture<T>;
+  createComponent<T>(component: Type<T>, options?: TestComponentOptions): ComponentFixture<T>;
 
   /**
    * Execute any pending effects.
@@ -377,8 +388,11 @@ export class TestBedImpl implements TestBed {
     return TestBedImpl.INSTANCE.runInInjectionContext(fn);
   }
 
-  static createComponent<T>(component: Type<T>): ComponentFixture<T> {
-    return TestBedImpl.INSTANCE.createComponent(component);
+  static createComponent<T>(
+    component: Type<T>,
+    options?: TestComponentOptions,
+  ): ComponentFixture<T> {
+    return TestBedImpl.INSTANCE.createComponent(component, options);
   }
 
   static resetTestingModule(): TestBed {
@@ -630,7 +644,7 @@ export class TestBedImpl implements TestBed {
     return this.overrideComponent(component, {set: {template, templateUrl: null!}});
   }
 
-  createComponent<T>(type: Type<T>): ComponentFixture<T> {
+  createComponent<T>(type: Type<T>, options?: TestComponentOptions): ComponentFixture<T> {
     const testComponentRenderer = this.inject(TestComponentRenderer);
     const rootElId = `root${_nextRootElementId++}`;
     testComponentRenderer.insertRootElement(rootElId);
@@ -655,6 +669,8 @@ export class TestBedImpl implements TestBed {
         [],
         `#${rootElId}`,
         this.testModuleRef,
+        undefined,
+        options?.bindings,
       ) as ComponentRef<T>;
       return this.runInInjectionContext(() => new ComponentFixture(componentRef));
     };

--- a/packages/core/testing/src/testing.ts
+++ b/packages/core/testing/src/testing.ts
@@ -29,6 +29,7 @@ export {
   inject,
   InjectSetupWrapper,
   withModule,
+  TestComponentOptions,
 } from './test_bed';
 export {
   TestComponentRenderer,


### PR DESCRIPTION
Adds support for passing in `Binding` objects into `TestBed.createComponent`. This makes it easier to test components by avoiding the need to create a wrapper component. Furthermore, it keeps the behavior consistent between tests and the actual app. For example, given a custom checkbox that looks like this:

```typescript
@Component({
  selector: 'my-checkbox',
  template: '...',
  host: {'[class.checked]': 'isChecked()'}
})
export class MyCheckbox {
  isChecked = input(false);
}
```

A test for the `isChecked` input would look something like this:

```typescript
it('should toggle the checked class', () => {
  @Component({
    imports: [MyCheckbox],
    template: '<my-checkbox [isChecked]="isChecked"/>',
  })
  class Wrapper {
    isChecked = false;
  }

  const fixture = TestBed.createComponent(Wrapper);
  const checkbox = fixture.nativeElement.querySelector('my-checkbox');
  fixture.detectChanges();
  expect(checkbox.classList).not.toContain('checked');

  fixture.componentInstance.isChecked = true;
  fixture.detectChanges();
  expect(checkbox.classList).toContain('checked');
});
```

Whereas with the new API, the test would look like this:

```typescript
it('should toggle the checked class', () => {
  const isChecked = signal(false);
  const fixture = TestBed.createComponent(MyCheckbox, {
    bindings: [inputBinding('isChecked', isChecked)]
  });
  const checkbox = fixture.nativeElement.querySelector('my-checkbox');
  fixture.detectChanges();
  expect(checkbox.classList).not.toContain('checked');

  isChecked.set(true);
  fixture.detectChanges();
  expect(checkbox.classList).toContain('checked');
});
```