### PR TITLE
build(devtools): fix ng-devtools source maps

### DIFF
--- a/devtools/tsconfig.json
+++ b/devtools/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "sourceMap": true,
+    "inlineSources": true,
     "declaration": true,
     "strict": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
There is a problem with the dev app bundle where esbuild is unable to properly set the `sourcesContent` of the `js.map` files for `ng-devtools`. They are `null`. That's why, the `.ts` files are registered by Chrome DevTools but their contents cannot be loaded.

I am not entirely sure why this happens given that the `sources` paths array is properly set, but inlining the `sourcesContent` in the map files solves the issue for now which allows us to perform proper debugging in the browser.