### PR TITLE
docs(structural-directives): replace @Input() with input.required() i…

### DIFF
--- a/adev/src/content/guide/directives/structural-directives.md
+++ b/adev/src/content/guide/directives/structural-directives.md
@@ -90,13 +90,13 @@ export class SelectDirective {
 
 </docs-step>
 <docs-step title="Add the 'selectFrom' input">
-Add a `selectFrom` `@Input()` property.
+Add a `selectFrom` `input()` property.
 
 ```ts
 export class SelectDirective {
   // ...
 
-  @Input({required: true}) selectFrom!: DataSource;
+  selectFrom = input.required<DataSource<unknown>>();
 }
 ```
 


### PR DESCRIPTION
…n guide  The Structural Directives guide still shows the legacy `@Input()` decorator for the `selectFrom` property of `SelectDirective`.   Since Angular 16 introduced the `input.required()` API and the guide now targets Angular 17+, updating the example prevents confusion and compiles without “required input”  No runtime behavior is changed; this is documentation only.  Closes N/A (no tracking issue)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
`structural-directives.md` still recommends the `@Input()` decorator for
required inputs, which is outdated for Angular 17. New projects using
`input.required()` get compiler diagnostics when they copy the old code.

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
