### PR TITLE
fix(core): Wrap ErrorEvent with no error property

### DIFF
--- a/packages/core/src/error_handler.ts
+++ b/packages/core/src/error_handler.ts
@@ -100,7 +100,18 @@ const globalErrorListeners = new InjectionToken<void>(ngDevMode ? 'GlobalErrorLi
       e.preventDefault();
     };
     const errorListener = (e: ErrorEvent) => {
-      errorHandler(e.error);
+      if (e.error) {
+        errorHandler(e.error);
+      } else {
+        errorHandler(
+          new Error(
+            ngDevMode
+              ? `An ErrorEvent with no error occurred. See Error.cause for details: ${e.message}`
+              : e.message,
+            {cause: e},
+          ),
+        );
+      }
       e.preventDefault();
     };
 

--- a/packages/core/test/error_handler_spec.ts
+++ b/packages/core/test/error_handler_spec.ts
@@ -65,4 +65,34 @@ describe('ErrorHandler', () => {
     expect(spy.calls.count()).toBe(1);
     window.onerror = originalWindowOnError;
   });
+
+  it('handles error events without error', async () => {
+    if (isNode) {
+      return;
+    }
+    // override global.onerror to prevent jasmine report error
+    let originalWindowOnError = window.onerror;
+    window.onerror = function () {};
+    TestBed.configureTestingModule({
+      rethrowApplicationErrors: false,
+      providers: [provideBrowserGlobalErrorListeners()],
+    });
+
+    const spy = spyOn(TestBed.inject(ErrorHandler), 'handleError');
+    await new Promise((resolve) => {
+      setTimeout(() => {
+        window.dispatchEvent(new ErrorEvent('error', {message: 'error event without error'}));
+      });
+      setTimeout(resolve, 1);
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        message:
+          'An ErrorEvent with no error occurred. See Error.cause for details: error event without error',
+      }),
+    );
+    expect(spy.calls.count()).toBe(1);
+    window.onerror = originalWindowOnError;
+  });
 });


### PR DESCRIPTION
This commit updates the global error listener to wrap the global ErrorEvent in a new Error with cause if the error property is undefined.

fixes #62078
