### PR TITLE
docs: remove duplicate entry for tagged template literals

### DIFF
--- a/adev/src/content/guide/templates/expression-syntax.md
+++ b/adev/src/content/guide/templates/expression-syntax.md
@@ -24,7 +24,6 @@ Angular supports a subset of [literal values](https://developer.mozilla.org/en-U
 | Literal type           | Example value            |
 | ---------------------- | ------------------------ |
 | RegExp                 | `/\d+/`                  |
-| Tagged template string | `` tag`Hello ${name}` `` |
 
 ## Globals
 


### PR DESCRIPTION
The value literal table listed tagged template strings as both supported and unsupported. The row under Unsupported literals was removed.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The documentation lists tagged template string as both a supported and an unsupported value literal in the "Expression Syntax" guide.

Issue Number: N/A


## What is the new behavior?
The incorrect duplication has been removed: tagged template string is now listed only under the supported value literals.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
