### PR TITLE
refactor(core): Add injection primitives for shared services.

### DIFF
--- a/goldens/public-api/core/primitives/di/index.api.md
+++ b/goldens/public-api/core/primitives/di/index.api.md
@@ -7,6 +7,9 @@
 // @public (undocumented)
 export function getCurrentInjector(): Injector | undefined | null;
 
+// @public (undocumented)
+export function inject<T>(token: InjectionToken<T>, options?: unknown): T | NotFound;
+
 // @public
 export interface InjectionToken<T> {
     // (undocumented)
@@ -34,6 +37,9 @@ export class NotFoundError extends Error {
     // (undocumented)
     readonly name: string;
 }
+
+// @public (undocumented)
+export function registerInjectable<T>(ctor: unknown, declaration: ɵɵInjectableDeclaration<T>): InjectionToken<T>;
 
 // @public (undocumented)
 export function setCurrentInjector(injector: Injector | null | undefined): Injector | undefined | null;

--- a/packages/core/primitives/di/index.ts
+++ b/packages/core/primitives/di/index.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-export {setCurrentInjector, getCurrentInjector} from './src/injector';
+export {setCurrentInjector, getCurrentInjector, inject} from './src/injector';
 export type {Injector} from './src/injector';
 export {NOT_FOUND, NotFoundError, isNotFound} from './src/not_found';
 export type {NotFound} from './src/not_found';
 export type {InjectionToken, ɵɵInjectableDeclaration} from './src/injection_token';
+export {registerInjectable} from './src/injection_token';

--- a/packages/core/primitives/di/src/injection_token.ts
+++ b/packages/core/primitives/di/src/injection_token.ts
@@ -66,3 +66,26 @@ export interface ɵɵInjectableDeclaration<T> {
 export interface InjectionToken<T> {
   ɵprov: ɵɵInjectableDeclaration<T>;
 }
+
+export function defineInjectable<T>(opts: {
+  token: unknown;
+  providedIn?: Type<any> | 'root' | 'platform' | 'any' | 'environment' | null;
+  factory: () => T;
+}): unknown {
+  return {
+    token: opts.token,
+    providedIn: (opts.providedIn as any) || null,
+    factory: opts.factory,
+    value: undefined,
+  } as ɵɵInjectableDeclaration<T>;
+}
+
+type Constructor<T> = Function & {prototype: T};
+
+export function registerInjectable<T>(
+  ctor: unknown,
+  declaration: ɵɵInjectableDeclaration<T>,
+): InjectionToken<T> {
+  (ctor as unknown as InjectionToken<T>).ɵprov = declaration;
+  return ctor as Constructor<T> & InjectionToken<T>;
+}

--- a/packages/core/primitives/di/src/injector.ts
+++ b/packages/core/primitives/di/src/injector.ts
@@ -7,7 +7,7 @@
  */
 
 import {InjectionToken} from './injection_token';
-import {NotFound} from './not_found';
+import {NotFound, NOT_FOUND} from './not_found';
 
 export interface Injector {
   retrieve<T>(token: InjectionToken<T>, options?: unknown): T | NotFound;
@@ -31,4 +31,12 @@ export function setCurrentInjector(
   const former = _currentInjector;
   _currentInjector = injector;
   return former;
+}
+
+export function inject<T>(token: InjectionToken<T>, options?: unknown): T | NotFound {
+  const currentInjector = getCurrentInjector();
+  if (!currentInjector) {
+    return NOT_FOUND;
+  }
+  return currentInjector.retrieve(token, options);
 }

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -571,7 +571,7 @@
       "initTNodeFlags",
       "initializeDirectives",
       "initializeInputAndOutputAliases",
-      "inject",
+      "inject2",
       "injectArgs",
       "injectDestroyRef",
       "injectElementRef",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -526,7 +526,7 @@
       "initTNodeFlags",
       "initializeDirectives",
       "initializeInputAndOutputAliases",
-      "inject",
+      "inject2",
       "injectArgs",
       "injectDestroyRef",
       "injectElementRef",

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -673,7 +673,7 @@
       "initTNodeFlags",
       "initializeDirectives",
       "initializeInputAndOutputAliases",
-      "inject",
+      "inject2",
       "injectArgs",
       "injectDestroyRef",
       "injectElementRef",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -674,7 +674,7 @@
       "initTNodeFlags",
       "initializeDirectives",
       "initializeInputAndOutputAliases",
-      "inject",
+      "inject2",
       "injectArgs",
       "injectChangeDetectorRef",
       "injectDestroyRef",

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -547,7 +547,7 @@
       "initTransferState",
       "initializeDirectives",
       "initializeInputAndOutputAliases",
-      "inject",
+      "inject2",
       "injectArgs",
       "injectDestroyRef",
       "injectElementRef",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -753,7 +753,7 @@
       "initTNodeFlags",
       "initializeDirectives",
       "initializeInputAndOutputAliases",
-      "inject",
+      "inject2",
       "injectArgs",
       "injectAttributeImpl",
       "injectChangeDetectorRef",

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -437,7 +437,7 @@
       "initTNodeFlags",
       "initializeDirectives",
       "initializeInputAndOutputAliases",
-      "inject",
+      "inject2",
       "injectArgs",
       "injectDestroyRef",
       "injectElementRef",


### PR DESCRIPTION
This way, an arbitrary service can implement Angular's service requirements without a hard dependency on @angular/core

ex:

class Foo {
   bar = inject(Bar);
}

registerInjectable(Foo);

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
