### PR TITLE
docs(templates): remove unsupported operators from supported table

### DIFF
--- a/adev/src/content/guide/templates/expression-syntax.md
+++ b/adev/src/content/guide/templates/expression-syntax.md
@@ -17,7 +17,6 @@ Angular supports a subset of [literal values](https://developer.mozilla.org/en-U
 | Array                  | `['Onion', 'Cheese', 'Garlic']` |
 | null                   | `null`                          |
 | Template string        | `` `Hello ${name}` ``           |
-| Tagged template string | `` tag`Hello ${name}` ``        |
 
 ### Unsupported literals
 
@@ -64,9 +63,6 @@ Angular supports the following operators from standard JavaScript.
 | Unary Negation                  | `-x`                                     |
 | Unary Plus                      | `+y`                                     |
 | Property Accessor               | `person['name']`                         |
-| typeof                          | `typeof 42`                              |
-| void                            | `void 1`                                 |
-| in                              | `'model' in car`                         |
 | Assignment                      | `a = b`                                  |
 | Addition Assignment             | `a += b`                                 |
 | Subtraction Assignment          | `a -= b`                                 |


### PR DESCRIPTION
In the Expression Syntax guide https://angular.dev/guide/templates/expression-syntax#what-operators-are-supported the following operators are listed under "Supported operators":

- `typeof`
- `void`
- `in`

However, these same operators are also listed under "Unsupported operators" just below, and when tested in templates, they do not work and result in template parsing errors.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The "Supported operators" table in the Expression Syntax guide lists `typeof`, `void`, and `in` as usable operators in templates. However, they are not supported and result in errors if used.

Issue Number: N/A

## What is the new behavior?
The documentation has been updated to remove `typeof`, `void`, and `in` from the supported operators list. They remain listed under "Unsupported operators".

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
