### PR TITLE
refactor(language-service): resolve module specifier for a directive …

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
@@ -38,6 +38,7 @@ import {
 import {GlobalCompletion} from './completion';
 import {
   PotentialDirective,
+  PotentialDirectiveModuleSpecifierResolver,
   PotentialImport,
   PotentialImportMode,
   PotentialPipe,
@@ -243,6 +244,7 @@ export interface TemplateTypeChecker {
     toImport: Reference<ClassDeclaration>,
     inContext: ts.Node,
     importMode: PotentialImportMode,
+    potentialDirectiveModuleSpecifierResolver?: PotentialDirectiveModuleSpecifierResolver,
   ): ReadonlyArray<PotentialImport>;
 
   /**

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/scope.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/scope.ts
@@ -41,6 +41,14 @@ export interface TsCompletionEntryInfo {
    */
   tsCompletionEntrySymbolFileName: string;
   /**
+   * Sometime the component can be exported with a different name than the class name.
+   * For example, `export {BarComponent as NewBarComponent} from './bar.component';`
+   *
+   * Sometimes, the component is exported by the `NgModule`.
+   */
+  tsCompletionEntrySymbolName: string;
+
+  /**
    * This data is from the tsLs completion entry, and
    * will be used in the `ls.getCompletionEntryDetails`.
    */
@@ -83,7 +91,13 @@ export interface PotentialDirective {
    */
   isInScope: boolean;
 
-  tsCompletionEntryInfo: TsCompletionEntryInfo | null;
+  /**
+   * The directive can be exported by multiple modules,
+   * collecting all the entry information here.
+   *
+   * Filter the appropriate entry information when using it to compute the module specifier.
+   */
+  tsCompletionEntryInfos: TsCompletionEntryInfo[] | null;
 }
 
 /**
@@ -107,7 +121,13 @@ export interface PotentialPipe {
    */
   isInScope: boolean;
 
-  tsCompletionEntryInfo: TsCompletionEntryInfo | null;
+  /**
+   * The pipe can be exported by multiple modules,
+   * collecting all the entry information here.
+   *
+   * Filter the appropriate entry information when using it to compute the module specifier.
+   */
+  tsCompletionEntryInfos: TsCompletionEntryInfo[] | null;
 }
 
 /**
@@ -123,4 +143,8 @@ export enum PotentialImportMode {
    * as a part of the migration.
    */
   ForceDirect,
+}
+
+export interface PotentialDirectiveModuleSpecifierResolver {
+  resolve(toImport: Reference<ClassDeclaration>, importOn: ts.Node | null): string | undefined;
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/template_symbol_builder.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/template_symbol_builder.ts
@@ -261,7 +261,7 @@ export class SymbolBuilder {
           isStructural: meta.isStructural,
           isInScope: true,
           isHostDirective: false,
-          tsCompletionEntryInfo: null,
+          tsCompletionEntryInfos: null,
         };
 
         symbols.push(directiveSymbol);
@@ -310,7 +310,7 @@ export class SymbolBuilder {
           kind: SymbolKind.Directive,
           isStructural: meta.isStructural,
           isInScope: true,
-          tsCompletionEntryInfo: null,
+          tsCompletionEntryInfos: null,
         };
 
         symbols.push(directiveSymbol);
@@ -623,7 +623,7 @@ export class SymbolBuilder {
       ngModule,
       isHostDirective: false,
       isInScope: true, // TODO: this should always be in scope in this context, right?
-      tsCompletionEntryInfo: null,
+      tsCompletionEntryInfos: null,
     };
   }
 

--- a/packages/language-service/src/codefixes/fix_missing_import.ts
+++ b/packages/language-service/src/codefixes/fix_missing_import.ts
@@ -14,7 +14,6 @@ import ts from 'typescript';
 import {getTargetAtPosition, TargetNodeKind} from '../template_target';
 import {
   getCodeActionToImportTheDirectiveDeclaration,
-  getModuleSpecifierFromImportStatement,
   standaloneTraitOrNgModule,
 } from '../utils/ts_utils';
 import {getDirectiveMatchesForElementTag} from '../utils';
@@ -83,28 +82,14 @@ function getCodeActions({typeCheckInfo, start, compiler, tsLs, preferences}: Cod
     return [];
   }
   for (const currMatch of matches.values()) {
-    let moduleSpecifier: string | undefined;
-    if (!currMatch.isInScope) {
-      moduleSpecifier = getModuleSpecifierFromImportStatement(
-        currMatch,
-        checker,
-        typeCheckInfo.declaration,
-        tsLs,
-        currMatch.tsCompletionEntryInfo?.tsCompletionEntryData,
-        preferences.includeCompletionsForModuleExports,
-      );
-    }
     const currentMatchCodeAction =
       getCodeActionToImportTheDirectiveDeclaration(
         compiler,
+        typeCheckInfo.declaration,
         importOn,
         currMatch,
-        moduleSpecifier !== undefined && currMatch.tsCompletionEntryInfo !== null
-          ? {
-              moduleSpecifier,
-              symbolFileName: currMatch.tsCompletionEntryInfo.tsCompletionEntrySymbolFileName,
-            }
-          : null,
+        tsLs,
+        preferences.includeCompletionsForModuleExports,
       ) ?? [];
 
     codeActions.push(

--- a/packages/language-service/src/utils/ts_utils.ts
+++ b/packages/language-service/src/utils/ts_utils.ts
@@ -8,12 +8,17 @@
 import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
 import {
   PotentialDirective,
+  PotentialDirectiveModuleSpecifierResolver,
   PotentialImportMode,
   PotentialPipe,
   TemplateTypeChecker,
+  TsCompletionEntryInfo,
 } from '@angular/compiler-cli/src/ngtsc/typecheck/api';
 import ts from 'typescript';
 import {guessIndentationInSingleLine} from './format';
+import * as path from 'path';
+import {ClassDeclaration} from '@angular/compiler-cli/src/ngtsc/reflection';
+import {Reference} from '@angular/compiler-cli/src/ngtsc/imports';
 
 /**
  * Return the node that most tightly encompasses the specified `position`.
@@ -213,44 +218,20 @@ export function ensureArrayWithIdentifier(
   return ts.factory.updateArrayLiteralExpression(arr, [...arr.elements, expression]);
 }
 
-export function moduleSpecifierPointsToFile(
-  tsChecker: ts.TypeChecker,
-  moduleSpecifier: ts.Expression,
-  file: ts.SourceFile,
-): boolean {
-  const specifierSymbol = tsChecker.getSymbolAtLocation(moduleSpecifier);
-  if (specifierSymbol === undefined) {
-    console.error(`Undefined symbol for module specifier ${moduleSpecifier.getText()}`);
-    return false;
-  }
-  const symbolDeclarations = specifierSymbol.declarations;
-  if (symbolDeclarations === undefined || symbolDeclarations.length === 0) {
-    console.error(`Unknown symbol declarations for module specifier ${moduleSpecifier.getText()}`);
-    return false;
-  }
-  for (const symbolDeclaration of symbolDeclarations) {
-    if (symbolDeclaration.getSourceFile().fileName === file.fileName) {
-      return true;
-    }
-  }
-  return false;
-}
-
 /**
  * Determine whether this an import of the given `propertyName` from a particular module
  * specifier already exists. If so, return the local name for that import, which might be an
  * alias.
  */
 export function hasImport(
-  tsChecker: ts.TypeChecker,
   importDeclarations: ts.ImportDeclaration[],
   propName: string,
-  origin: ts.SourceFile,
+  moduleSpecifier: string,
 ): string | null {
   return (
     importDeclarations
-      .filter((declaration) =>
-        moduleSpecifierPointsToFile(tsChecker, declaration.moduleSpecifier, origin),
+      .filter(
+        (declaration) => getStringLiteralText(declaration.moduleSpecifier) === moduleSpecifier,
       )
       .map((declaration) => importHas(declaration, propName))
       .find((prop) => prop !== null) ?? null
@@ -359,29 +340,22 @@ export function standaloneTraitOrNgModule(
  * should be used as the import name.
  */
 export function updateImportsForTypescriptFile(
-  tsChecker: ts.TypeChecker,
   file: ts.SourceFile,
   symbolName: string,
   declarationName: string,
   moduleSpecifier: string,
-  tsFileToImport: ts.SourceFile,
 ): [ts.TextChange[], string] {
   // The trait might already be imported, possibly under a different name. If so, determine the
   // local name of the imported trait.
   const allImports = findAllMatchingNodes(file, {filter: ts.isImportDeclaration});
-  const existingImportName: string | null = hasImport(
-    tsChecker,
-    allImports,
-    symbolName,
-    tsFileToImport,
-  );
+  const existingImportName: string | null = hasImport(allImports, symbolName, moduleSpecifier);
   if (existingImportName !== null) {
     return [[], existingImportName];
   }
 
   // If the trait has not already been imported, we need to insert the new import.
-  const existingImportDeclaration = allImports.find((decl) =>
-    moduleSpecifierPointsToFile(tsChecker, decl.moduleSpecifier, tsFileToImport),
+  const existingImportDeclaration = allImports.find(
+    (decl) => getStringLiteralText(decl.moduleSpecifier) === moduleSpecifier,
   );
   const importName = nonCollidingImportName(
     allImports,
@@ -677,33 +651,36 @@ export function printNode(node: ts.Node, sourceFile: ts.SourceFile): string {
   return getOrCreatePrinter().printNode(ts.EmitHint.Unspecified, node, sourceFile);
 }
 
-interface DirectiveModuleSpecifier {
-  moduleSpecifier: string;
-  symbolFileName: string;
-}
-
 /**
  * Get the code actions to tell the vscode how to import the directive into the standalone component or ng module.
  */
 export function getCodeActionToImportTheDirectiveDeclaration(
   compiler: NgCompiler,
+  component: ts.ClassDeclaration,
   importOn: ts.ClassDeclaration,
   directive: PotentialDirective | PotentialPipe,
-  directiveModuleSpecifier: DirectiveModuleSpecifier | null,
+  tsLs: ts.LanguageService,
+  includeCompletionsForModuleExports?: boolean,
 ): ts.CodeAction[] | undefined {
   const codeActions: ts.CodeAction[] = [];
-  const currMatchSymbol = directive.tsSymbol.valueDeclaration!;
-  const moduleSpecifierSourceFile = directiveModuleSpecifier
-    ? compiler.getCurrentProgram().getSourceFile(directiveModuleSpecifier.symbolFileName)
-    : currMatchSymbol.getSourceFile();
 
-  if (moduleSpecifierSourceFile === undefined) {
-    return;
-  }
-
+  const potentialDirectiveModuleSpecifierResolver =
+    new PotentialDirectiveModuleSpecifierResolverImpl(
+      compiler,
+      directive,
+      compiler.getTemplateTypeChecker(),
+      component,
+      tsLs,
+      includeCompletionsForModuleExports,
+    );
   const potentialImports = compiler
     .getTemplateTypeChecker()
-    .getPotentialImportsFor(directive.ref, importOn, PotentialImportMode.Normal);
+    .getPotentialImportsFor(
+      directive.ref,
+      importOn,
+      PotentialImportMode.Normal,
+      potentialDirectiveModuleSpecifierResolver,
+    );
   const declarationName = directive.ref.node.name.getText();
 
   for (const potentialImport of potentialImports) {
@@ -713,12 +690,10 @@ export function getCodeActionToImportTheDirectiveDeclaration(
 
     if (potentialImport.moduleSpecifier) {
       const [importChanges, generatedImportName] = updateImportsForTypescriptFile(
-        compiler.getCurrentProgram().getTypeChecker(),
         importOn.getSourceFile(),
         potentialImport.symbolName,
         declarationName,
-        directiveModuleSpecifier?.moduleSpecifier ?? potentialImport.moduleSpecifier,
-        moduleSpecifierSourceFile,
+        potentialImport.moduleSpecifier,
       );
       importName = generatedImportName;
       fileImportChanges.push(...importChanges);
@@ -727,12 +702,10 @@ export function getCodeActionToImportTheDirectiveDeclaration(
         // Note that we pass the `importOn` file twice since we know that the potential import
         // is within the same file, because it doesn't have a `moduleSpecifier`.
         const [forwardRefImports, generatedForwardRefName] = updateImportsForTypescriptFile(
-          compiler.getCurrentProgram().getTypeChecker(),
           importOn.getSourceFile(),
           'forwardRef',
           declarationName,
           '@angular/core',
-          importOn.getSourceFile(),
         );
         fileImportChanges.push(...forwardRefImports);
         forwardRefName = generatedForwardRefName;
@@ -750,11 +723,8 @@ export function getCodeActionToImportTheDirectiveDeclaration(
     if (traitImportChanges.length === 0) continue;
 
     let description = `Import ${importName}`;
-    if (
-      potentialImport.moduleSpecifier !== undefined ||
-      directiveModuleSpecifier?.moduleSpecifier !== undefined
-    ) {
-      description += ` from '${directiveModuleSpecifier?.moduleSpecifier ?? potentialImport.moduleSpecifier}' on ${importOn.name!.text}`;
+    if (potentialImport.moduleSpecifier !== undefined) {
+      description += ` from '${potentialImport.moduleSpecifier}' on ${importOn.name!.text}`;
     }
     codeActions.push({
       description,
@@ -770,6 +740,109 @@ export function getCodeActionToImportTheDirectiveDeclaration(
   return codeActions;
 }
 
+function getStringLiteralText(moduleSpecifier: ts.Expression): string | undefined {
+  if (ts.isStringLiteral(moduleSpecifier)) {
+    return moduleSpecifier.text;
+  }
+  return undefined;
+}
+
+/**
+ * Try to compute the module specifier after applying the paths from tsconfig or package.json export rules.
+ *
+ * Try to reuse the module specifier if the import in the `importOn` can export the `toImport` node.
+ *
+ * If a module specifier cannot be resolved, return undefined, and the Angular compiler will apply its own rules.
+ *
+ * There is one exception here. For example
+ *
+ * ```ts
+ * // app.ts
+ * @Component({
+ *     selector: 'app-foo',
+ *     template: '',
+ * })
+ * export class FooComponent {}
+ *
+ * @Component({
+ *     selector: 'app-bar',
+ *     template: '',
+ * })
+ *
+ * export class BarComponent {}
+ *
+ * ```
+ *
+ * ```ts
+ * // app.module.ts
+ * import {BarComponent} from "./app";
+ * @NgModule({
+ *     declarations: [BarComponent],
+ *     exports: [BarComponent],
+ *     imports: []
+ * })
+ * export class AppModule {}
+ * ```
+ *
+ * ```ts
+ * // test.ts
+ * // The `@/app.module` resolves to `./app.module.ts`.
+ * // The `@/app` resolves to `./app`.
+ * // It's configured in the `paths` in the tsconfig.
+ * import {AppModule} from "@/app.module";
+ *
+ * @Component({
+ *     selector: 'app-baz',
+ *     template: '<app-bar/><app-foo/>',
+ *     imports: [AppModule],
+ * })
+ * export class BazComponent {}
+ * ```
+ *
+ * When providing the code action for the `app-foo` in the `test.ts` file,
+ * the module specifier is `./app.ts`, not `@/app`. Because the TCB has imported
+ * the `./app.ts` for the `app-bar`, the tsLs will reuse the import statement
+ * in the TCB, no module specifier can be extracted, and the `@/app.module` doesn't
+ * export the `FooComponent`. So the module specifier will be generated by
+ * the Angular compiler.
+ *
+ * The developer should export the `FooComponent` in the `AppModule`.
+ *
+ */
+class PotentialDirectiveModuleSpecifierResolverImpl
+  implements PotentialDirectiveModuleSpecifierResolver
+{
+  constructor(
+    private readonly compiler: NgCompiler,
+    private readonly directive: PotentialDirective | PotentialPipe,
+    private readonly templateTypeChecker: TemplateTypeChecker,
+    private readonly component: ts.ClassDeclaration,
+    private readonly tsLS: ts.LanguageService,
+    private readonly includeCompletionsForModuleExports: boolean | undefined,
+  ) {}
+
+  resolve(toImport: Reference<ClassDeclaration>, importOn: ts.Node | null): string | undefined {
+    if (toImport.node.getSourceFile().fileName === importOn?.getSourceFile().fileName) {
+      return undefined;
+    }
+    const moduleSpecifier = getModuleSpecifierIfExists(this.compiler, importOn, toImport.node);
+
+    if (moduleSpecifier !== null) {
+      return moduleSpecifier;
+    }
+
+    return getModuleSpecifierFromImportStatement(
+      this.directive.tsCompletionEntryInfos,
+      toImport,
+      importOn,
+      this.templateTypeChecker,
+      this.component,
+      this.tsLS,
+      this.includeCompletionsForModuleExports,
+    );
+  }
+}
+
 const importRegex = /\bimport\b[\s\S]*?\bfrom\b\s*(['"`])(.*?)\1/;
 /**
  * Get the module specifier from the code actions returned by the `ls.getCompletionEntryDetails`.
@@ -780,21 +853,25 @@ const importRegex = /\bimport\b[\s\S]*?\bfrom\b\s*(['"`])(.*?)\1/;
  * If the directive needs to import a new external module, the code action will include the text
  * like `import { FooComponent } from '@foo'`. The `@foo` will be returned by the function.
  */
-export function getModuleSpecifierFromImportStatement(
-  directive: PotentialDirective | PotentialPipe,
+function getModuleSpecifierFromImportStatement(
+  tsCompletionEntryInfos: TsCompletionEntryInfo[] | null,
+  toImport: Reference<ClassDeclaration>,
+  importOn: ts.Node | null,
   templateTypeChecker: TemplateTypeChecker,
   component: ts.ClassDeclaration,
   tsLS: ts.LanguageService,
-  data: ts.CompletionEntryData | undefined,
   includeCompletionsForModuleExports: boolean | undefined,
 ): string | undefined {
-  if (
-    directive.tsSymbol.declarations?.[0]?.getSourceFile().fileName ===
-    component.getSourceFile().fileName
-  ) {
+  const tsCompletionEntryInfo = findTsCompletionEntryInfoForImport(
+    tsCompletionEntryInfos,
+    toImport,
+  );
+
+  if (tsCompletionEntryInfo === undefined) {
     return undefined;
   }
-  const tsEntryName = directive.tsSymbol.name;
+
+  const tsEntryName = tsCompletionEntryInfo.tsCompletionEntrySymbolName;
 
   const globalContext = templateTypeChecker.getGlobalTsContext(component);
   if (globalContext === null) {
@@ -810,22 +887,121 @@ export function getModuleSpecifierFromImportStatement(
     {
       includeCompletionsForModuleExports,
     },
-    data,
+    tsCompletionEntryInfo.tsCompletionEntryData,
   );
 
   const actions = completionListDetail?.codeActions;
   if (actions === undefined) {
     return undefined;
   }
+
+  const tcbDir = path.posix.dirname(globalContext.tcbPath);
+  const importOnDir = importOn ? path.posix.dirname(importOn.getSourceFile().fileName) : undefined;
+
   for (const action of actions) {
     for (const changes of action.changes) {
       for (const textChange of changes.textChanges) {
         const match = importRegex.exec(textChange.newText);
         if (match !== null) {
-          return match[2];
+          let moduleSpecifier = match[2];
+          /**
+           * The TCB path may differ from the ng module path. If the module specifier is a relative path,
+           * it must be relative to the NG module path.
+           */
+          if (
+            moduleSpecifier.startsWith('.') &&
+            tcbDir !== importOnDir &&
+            importOnDir !== undefined
+          ) {
+            const moduleSpecifierFullPath = path.posix.resolve(tcbDir, moduleSpecifier);
+            moduleSpecifier = path.posix.relative(importOnDir, moduleSpecifierFullPath);
+            if (!moduleSpecifier.startsWith('.')) {
+              moduleSpecifier = `./${moduleSpecifier}`;
+            }
+          }
+          return moduleSpecifier;
         }
       }
     }
   }
   return undefined;
+}
+
+function findTsCompletionEntryInfoForImport(
+  tsCompletionEntryInfos: TsCompletionEntryInfo[] | null,
+  toImport: Reference<ClassDeclaration>,
+): TsCompletionEntryInfo | undefined {
+  const toImportSymbolName = toImport.node.name?.text;
+  const toImportSymbolFileName = toImport.node.getSourceFile().fileName;
+
+  return tsCompletionEntryInfos?.find(
+    (entry) =>
+      entry.tsCompletionEntrySymbolName === toImportSymbolName &&
+      entry.tsCompletionEntrySymbolFileName === toImportSymbolFileName,
+  );
+}
+
+function moduleSpecifierPointsToSymbol(
+  tsChecker: ts.TypeChecker,
+  moduleSpecifier: ts.Expression,
+): ts.Symbol | null {
+  const specifierSymbol = tsChecker.getSymbolAtLocation(moduleSpecifier);
+  if (specifierSymbol === undefined) {
+    console.error(`Undefined symbol for module specifier ${moduleSpecifier.getText()}`);
+    return null;
+  }
+  const symbolDeclarations = specifierSymbol.declarations;
+  if (symbolDeclarations === undefined || symbolDeclarations.length === 0) {
+    console.error(`Unknown symbol declarations for module specifier ${moduleSpecifier.getText()}`);
+    return null;
+  }
+
+  if (symbolDeclarations.length > 0) {
+    const sf = symbolDeclarations[0].getSourceFile();
+    return tsChecker.getSymbolAtLocation(sf) ?? null;
+  }
+
+  return null;
+}
+
+/**
+ * Retrieve all imports from the `importOn` and check if any import can export the node specified by `toImport`.
+ * If a matching import is found, attempt to reuse it.
+ */
+function getModuleSpecifierIfExists(
+  compiler: NgCompiler,
+  importOn: ts.Node | null,
+  toImport: ClassDeclaration,
+): string | null {
+  if (importOn === null) {
+    return null;
+  }
+
+  const allImports = findAllMatchingNodes(importOn.getSourceFile(), {
+    filter: ts.isImportDeclaration,
+  });
+
+  const typeChecker = compiler.getCurrentProgram().getTypeChecker();
+
+  for (const importDecl of allImports) {
+    const importSymbol = moduleSpecifierPointsToSymbol(typeChecker, importDecl.moduleSpecifier);
+
+    if (importSymbol === null) {
+      continue;
+    }
+
+    const toImportSymbolFromModule = typeChecker.tryGetMemberInModuleExports(
+      toImport.name.getText(),
+      importSymbol,
+    );
+
+    /**
+     * Make sure these are the same node.
+     */
+    if (toImportSymbolFromModule?.declarations?.[0] === toImport) {
+      return getStringLiteralText(importDecl.moduleSpecifier) ?? null;
+    }
+  }
+
+  return null;
 }


### PR DESCRIPTION
…exported by multiple different files

When providing the code action for the directive that is exported by multiple modules in different files, the directive must save all the TS completion entry data for every module to compute the module specifier.

When providing a completion item, because the LS only supports displaying one directive at a time, the first one will be picked.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
