### PR TITLE
build: migrate back to using the @npm// sourced benchmark test macro

### DIFF
--- a/modules/benchmarks/src/change_detection/transplanted_views/BUILD.bazel
+++ b/modules/benchmarks/src/change_detection/transplanted_views/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@devinfra//bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("@rules_angular//src/optimization:index.bzl", "optimize_angular_app")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 load("//tools:defaults.bzl", "http_server")

--- a/modules/benchmarks/src/defer/baseline/BUILD.bazel
+++ b/modules/benchmarks/src/defer/baseline/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@devinfra//bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("@rules_angular//src/optimization:index.bzl", "optimize_angular_app")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 load("//tools:defaults.bzl", "http_server")

--- a/modules/benchmarks/src/defer/main/BUILD.bazel
+++ b/modules/benchmarks/src/defer/main/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@devinfra//bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("@rules_angular//src/optimization:index.bzl", "optimize_angular_app")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 load("//tools:defaults.bzl", "http_server")

--- a/modules/benchmarks/src/expanding_rows/BUILD.bazel
+++ b/modules/benchmarks/src/expanding_rows/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@devinfra//bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("@rules_angular//src/optimization:index.bzl", "optimize_angular_app")
 load("//tools:defaults.bzl", "http_server")
 load("//tools:defaults2.bzl", "ts_project")

--- a/modules/benchmarks/src/hydration/baseline/BUILD.bazel
+++ b/modules/benchmarks/src/hydration/baseline/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@devinfra//bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("@rules_angular//src/optimization:index.bzl", "optimize_angular_app")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 load("//tools:defaults.bzl", "http_server")

--- a/modules/benchmarks/src/hydration/main/BUILD.bazel
+++ b/modules/benchmarks/src/hydration/main/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@devinfra//bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("@rules_angular//src/optimization:index.bzl", "optimize_angular_app")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 load("//tools:defaults.bzl", "http_server")

--- a/modules/benchmarks/src/js-web-frameworks/ng2/BUILD.bazel
+++ b/modules/benchmarks/src/js-web-frameworks/ng2/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@devinfra//bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("@rules_angular//src/optimization:index.bzl", "optimize_angular_app")
 load("//tools:defaults.bzl", "http_server")
 

--- a/modules/benchmarks/src/largeform/ng2/BUILD.bazel
+++ b/modules/benchmarks/src/largeform/ng2/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@devinfra//bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("@rules_angular//src/optimization:index.bzl", "optimize_angular_app")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 load("//tools:defaults.bzl", "http_server")

--- a/modules/benchmarks/src/largetable/baseline/BUILD.bazel
+++ b/modules/benchmarks/src/largetable/baseline/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@devinfra//bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("@rules_angular//src/optimization:index.bzl", "optimize_angular_app")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 load("//tools:defaults.bzl", "http_server")

--- a/modules/benchmarks/src/largetable/ng2/BUILD.bazel
+++ b/modules/benchmarks/src/largetable/ng2/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@devinfra//bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("@rules_angular//src/optimization:index.bzl", "optimize_angular_app")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 load("//tools:defaults.bzl", "http_server")

--- a/modules/benchmarks/src/largetable/ng2_switch/BUILD.bazel
+++ b/modules/benchmarks/src/largetable/ng2_switch/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@devinfra//bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("@rules_angular//src/optimization:index.bzl", "optimize_angular_app")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 load("//tools:defaults.bzl", "http_server")

--- a/modules/benchmarks/src/ng_template_outlet_context/ng2/BUILD.bazel
+++ b/modules/benchmarks/src/ng_template_outlet_context/ng2/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@devinfra//bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("@rules_angular//src/optimization:index.bzl", "optimize_angular_app")
 load("//tools:defaults.bzl", "http_server")
 

--- a/modules/benchmarks/src/styling/ng2/BUILD.bazel
+++ b/modules/benchmarks/src/styling/ng2/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@devinfra//bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("@rules_angular//src/optimization:index.bzl", "optimize_angular_app")
 load("//tools:defaults.bzl", "http_server")
 

--- a/modules/benchmarks/src/tree/baseline/BUILD.bazel
+++ b/modules/benchmarks/src/tree/baseline/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@devinfra//bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("@rules_angular//src/optimization:index.bzl", "optimize_angular_app")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 load("//tools:defaults.bzl", "http_server")

--- a/modules/benchmarks/src/tree/ng2/BUILD.bazel
+++ b/modules/benchmarks/src/tree/ng2/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@devinfra//bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("@rules_angular//src/optimization:index.bzl", "optimize_angular_app")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 load("//tools:defaults.bzl", "http_server")

--- a/modules/benchmarks/src/tree/ng2_static/BUILD.bazel
+++ b/modules/benchmarks/src/tree/ng2_static/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@devinfra//bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("@rules_angular//src/optimization:index.bzl", "optimize_angular_app")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 load("//tools:defaults.bzl", "http_server")

--- a/modules/benchmarks/src/tree/ng2_switch/BUILD.bazel
+++ b/modules/benchmarks/src/tree/ng2_switch/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@devinfra//bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("@rules_angular//src/optimization:index.bzl", "optimize_angular_app")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 load("//tools:defaults.bzl", "http_server")


### PR DESCRIPTION
Use the benchmark macro from @npm// instead of @devinfra//
