### PR TITLE
docs(docs-infra): cookie consent should be top-most

### DIFF
--- a/adev/shared-docs/styles/_z-index.scss
+++ b/adev/shared-docs/styles/_z-index.scss
@@ -2,7 +2,7 @@
   --z-index-mini-menu: 200;
   --z-index-top-level-banner: 150;
   --z-index-nav: 100;
-  --z-index-cookie-consent: 60;
+  --z-index-cookie-consent: 200;
   --z-index-content: 50;
   --z-index-icon: 10;
 }


### PR DESCRIPTION
Priori to this change, the cookie popup could be covered by the tutorial editor. 