### PR TITLE
fix(core): fix "resource returned an error that's not an Error instance" for observables that produce HttpErrorResponse inside the rxResource signal

### DIFF
--- a/packages/core/rxjs-interop/BUILD.bazel
+++ b/packages/core/rxjs-interop/BUILD.bazel
@@ -15,6 +15,7 @@ ng_project(
     ),
     interop_deps = [
         "//packages/core",
+        "//packages/common/http",
     ],
     deps = [
         "//:node_modules/rxjs",

--- a/packages/core/rxjs-interop/src/rx_resource.ts
+++ b/packages/core/rxjs-interop/src/rx_resource.ts
@@ -20,6 +20,19 @@ import {
 } from '../../src/core';
 import {Observable, Subscription} from 'rxjs';
 import {encapsulateResourceError} from '../../src/resource/resource';
+import {HttpErrorResponse} from '@angular/common/http';
+
+/**
+ * Like `encapsulateResourceError` but additionally encapsulates the `HttpErrorResponse`
+ * @param error
+ */
+export function encapsulateRxResourceError(error: unknown): Error {
+  if (error instanceof HttpErrorResponse) {
+    return error;
+  }
+
+  return encapsulateResourceError(error);
+}
 
 /**
  * Like `ResourceOptions` but uses an RxJS-based `loader`.
@@ -85,7 +98,7 @@ export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T |
       sub = streamFn(params).subscribe({
         next: (value) => send({value}),
         error: (error: unknown) => {
-          send({error: encapsulateResourceError(error)});
+          send({error: encapsulateRxResourceError(error)});
           params.abortSignal.removeEventListener('abort', onAbort);
         },
         complete: () => {

--- a/packages/core/rxjs-interop/test/BUILD.bazel
+++ b/packages/core/rxjs-interop/test/BUILD.bazel
@@ -7,6 +7,7 @@ ts_project(
     srcs = glob(["**/*.ts"]),
     interop_deps = [
         "//packages/private/testing",
+        "//packages/common/http",
     ],
     deps = [
         "//:node_modules/rxjs",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
RxResource signals were intended to work with the RxJs Observables. 
Those are often encapsulated inside the service layer or produced as a by-product by the HttpClient. 
Currently, rxResource throws an Error described in the issues below, even though HttpErrorResponse implements the Error interface.
This PR addresses the issue for the rxResource signals.

Issue Number: #62099, #61861

## What is the new behavior?
No longer throws an error "Resource returned an error that's not an Error instance".
Successfully returns the intended value by error() signal.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
