### PR TITLE
refactor(core): Support Error like object for resource errors.

### DIFF
--- a/packages/core/rxjs-interop/test/rx_resource_spec.ts
+++ b/packages/core/rxjs-interop/test/rx_resource_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {of, Observable, BehaviorSubject} from 'rxjs';
+import {of, Observable, BehaviorSubject, throwError} from 'rxjs';
 import {TestBed} from '../../testing';
 import {ApplicationRef, Injector, signal} from '../../src/core';
 import {rxResource} from '../src';
@@ -87,6 +87,31 @@ describe('rxResource()', () => {
       injector: appRef.injector,
     });
     await appRef.whenStable();
+  });
+
+  it('should handle Error like objects', async () => {
+    class FooError implements Error {
+      name = 'FooError';
+      message = 'This is a FooError';
+    }
+
+    const injector = TestBed.inject(Injector);
+    const appRef = TestBed.inject(ApplicationRef);
+
+    const sig = signal(1);
+    const observable = throwError(() => new FooError());
+
+    const rxRes = rxResource({
+      params: sig,
+      stream: () => observable,
+      injector: injector,
+    });
+
+    await appRef.whenStable();
+
+    expect(rxRes.error()).toBeInstanceOf(FooError);
+
+    expect(() => rxRes.value()).toThrowError(/This is a FooError/);
   });
 });
 

--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -460,11 +460,20 @@ function isResolved<T>(state: ResourceStreamItem<T>): state is {value: T} {
 }
 
 export function encapsulateResourceError(error: unknown): Error {
-  if (error instanceof Error) {
+  if (isErrorLike(error)) {
     return error;
   }
 
   return new ResourceWrappedError(error);
+}
+
+export function isErrorLike(error: unknown): error is Error {
+  return (
+    error instanceof Error ||
+    (typeof error === 'object' &&
+      typeof (error as Error).name === 'string' &&
+      typeof (error as Error).message === 'string')
+  );
 }
 
 class ResourceValueError extends Error {


### PR DESCRIPTION
Error like objects will be treated as errors.

Related to #61861
