### PR TITLE
docs(docs-infra): fix minor typo on Components page

### DIFF
--- a/adev/src/content/introduction/essentials/components.md
+++ b/adev/src/content/introduction/essentials/components.md
@@ -60,7 +60,7 @@ export class UserProfile {
 
 ```angular-html
 <!-- user-profile.html -->
-<h1>Use profile</h1>
+<h1>User profile</h1>
 <p>This is the user profile page</p>
 ```
 


### PR DESCRIPTION
Fix typo on Introduction > Essentials > Components page as "Use profile" is likely meant to be written as "User profile".

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The "[Separating HTML and CSS into separate files](https://angular.dev/essentials/components#separating-html-and-css-into-separate-files)" section of the Components page of the documentation shows an example implementation of templateUrl and styleUrl for a user profile component. However, the example user-profile.html code block shows an h1 tag with the content of "Use profile" rather than "User profile".

Issue Number: N/A


## What is the new behavior?
Displays "User profile" as intended.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
