### PR TITLE
build: split compiler-cli compliance test into more shards

### DIFF
--- a/packages/compiler-cli/test/compliance/declaration-only/BUILD.bazel
+++ b/packages/compiler-cli/test/compliance/declaration-only/BUILD.bazel
@@ -17,5 +17,5 @@ jasmine_test(
         "//packages/compiler-cli/test/compliance/test_cases",
         "//packages/core:npm_package",
     ],
-    shard_count = 2,
+    shard_count = 4,
 )


### PR DESCRIPTION
It seems that new jasmine_test runner times out with the larger size shards, by splitting into double the shards the test consistently passes as expected
