### PR TITLE
feat(router): Run `loadComponent` and `loadChildren` functions in the…

### DIFF
--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -87,6 +87,7 @@ import {UrlHandlingStrategy} from './url_handling_strategy';
 import {isUrlTree, UrlSerializer, UrlTree} from './url_tree';
 import {Checks, getAllRouteGuards} from './utils/preactivation';
 import {CREATE_VIEW_TRANSITION} from './utils/view_transition';
+import {getClosestRouteInjector} from './utils/config';
 
 /**
  * @description
@@ -694,8 +695,9 @@ export class NavigationTransitions {
             const loadComponents = (route: ActivatedRouteSnapshot): Array<Observable<void>> => {
               const loaders: Array<Observable<void>> = [];
               if (route.routeConfig?.loadComponent && !route.routeConfig._loadedComponent) {
+                const injector = getClosestRouteInjector(route) ?? this.environmentInjector;
                 loaders.push(
-                  this.configLoader.loadComponent(route.routeConfig).pipe(
+                  this.configLoader.loadComponent(injector, route.routeConfig).pipe(
                     tap((loadedComponent) => {
                       route.component = loadedComponent;
                     }),

--- a/packages/router/src/router_preloader.ts
+++ b/packages/router/src/router_preloader.ts
@@ -160,7 +160,7 @@ export class RouterPreloader implements OnDestroy {
         }),
       );
       if (route.loadComponent && !route._loadedComponent) {
-        const loadComponent$ = this.loader.loadComponent(route);
+        const loadComponent$ = this.loader.loadComponent(injector, route);
         return from([recursiveLoadChildren$, loadComponent$]).pipe(mergeAll());
       } else {
         return recursiveLoadChildren$;


### PR DESCRIPTION
… route's injection context

This updates the loader code to run the `loadComponent` and `loadChildren` functions in the appropriate injection context for the route.

A primary motiviation for this feature is to bring `loadChildren` with
standalone components and the routes array to
feature-parity with what was possible when using `loadChildren` and a
module that provided routes via the `ROUTES` token and a factory
function (which would have injection context).

fixes #51532
