### PR TITLE
test(router): Update timeouts to reduce firefox flakiness

### DIFF
--- a/packages/router/test/integration/guards.spec.ts
+++ b/packages/router/test/integration/guards.spec.ts
@@ -1835,14 +1835,10 @@ export function guardsIntegrationSuite() {
 
       let log: string[];
       const guard1 = () => {
-        return delayObservable(5).pipe(tap({next: () => log.push('guard1')}));
+        return delayObservable(15).pipe(tap({next: () => log.push('guard1')}));
       };
       const guard2 = () => {
         return delayObservable(0).pipe(tap({next: () => log.push('guard2')}));
-      };
-      const returnFalse = () => {
-        log.push('returnFalse');
-        return false;
       };
       const returnFalseAndNavigate = () => {
         log.push('returnFalseAndNavigate');
@@ -1851,7 +1847,7 @@ export function guardsIntegrationSuite() {
       };
       const returnUrlTree = () => {
         const router = inject(Router);
-        return delayObservable(14).pipe(
+        return delayObservable(30).pipe(
           mapTo(router.parseUrl('/redirected')),
           tap({next: () => log.push('returnUrlTree')}),
         );

--- a/packages/router/test/router_preloader.spec.ts
+++ b/packages/router/test/router_preloader.spec.ts
@@ -826,7 +826,7 @@ describe('RouterPreloader', () => {
 
       lazyComponentSpy.and.returnValue(
         of(LoadedComponent).pipe(
-          switchMap((v) => new Promise((r) => setTimeout(r, 10)).then(() => v)),
+          switchMap((v) => new Promise((r) => setTimeout(r, 50)).then(() => v)),
         ),
       );
 
@@ -867,7 +867,7 @@ describe('RouterPreloader', () => {
       expect(getLoadedComponent(baseRoute)).not.toBeDefined();
       expect(getLoadedRoutes(childRoutes![0])).toBeDefined();
 
-      await timeout(10);
+      await timeout(50);
       expect(getLoadedComponent(baseRoute)).toBeDefined();
     });
 


### PR DESCRIPTION
This updates the timeouts in a couple flakey router tests. Ideally we can use the jasmine auto ticking as soon as tests are migrated to web test runner and we are on the latest version of jasmine
