### PR TITLE
docs(core): mark after{Next,Every}Render overloads as stable

### DIFF
--- a/packages/core/src/render3/after_render/hooks.ts
+++ b/packages/core/src/render3/after_render/hooks.ts
@@ -129,7 +129,7 @@ export interface AfterRenderOptions {
  * }
  * ```
  *
- * @developerPreview
+ * @publicApi 20.0
  */
 export function afterEveryRender<E = never, W = never, M = never>(
   spec: {
@@ -191,7 +191,7 @@ export function afterEveryRender<E = never, W = never, M = never>(
  * }
  * ```
  *
- * @publicApi
+ * @publicApi 20.0
  */
 export function afterEveryRender(
   callback: VoidFunction,
@@ -308,7 +308,7 @@ export function afterEveryRender(
  * }
  * ```
  *
- * @developerPreview
+ * @publicApi 20.0
  */
 export function afterNextRender<E = never, W = never, M = never>(
   spec: {


### PR DESCRIPTION
Your blog post signaled that afterNextRender and afterEveryRender are now stable:
https://angular.love/angular-20-whats-new#Signal%20related%20APIs

However, only 1 of the overloads of those was marked as stable.

I detected this because angular-eslint errors on calls even to to the publicApi overload - and while that should probably be fixed on their end, your announcement wasn't specific about only one overload being stable, so I assume this was an oversight.

angular-eslint related issue:
https://github.com/angular-eslint/angular-eslint/issues/2534

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- N/A Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The spec overloads of afterNextRender / afterEveryRender are marked as developer preview.

Issue Number: N/A


## What is the new behavior?

They're marked as public APIs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


## Other information
