### PR TITLE
fix(core): unable to retrieve defer blocks in tests when component injects ViewContainerRef

### DIFF
--- a/packages/core/src/defer/discovery.ts
+++ b/packages/core/src/defer/discovery.ts
@@ -9,7 +9,7 @@
 import {CONTAINER_HEADER_OFFSET} from '../render3/interfaces/container';
 import {TNode} from '../render3/interfaces/node';
 import {isLContainer, isLView} from '../render3/interfaces/type_checks';
-import {HEADER_OFFSET, LView, TVIEW} from '../render3/interfaces/view';
+import {HEADER_OFFSET, HOST, LView, TVIEW} from '../render3/interfaces/view';
 
 import {DehydratedDeferBlock, TDeferBlockDetails} from './interfaces';
 import {getTDeferBlockDetails, isTDeferBlockDetails} from './utils';
@@ -46,8 +46,15 @@ export function getDeferBlocks(lView: LView, deferBlocks: DeferBlockDetails[]) {
           continue;
         }
       }
-      for (let i = CONTAINER_HEADER_OFFSET; i < lContainer.length; i++) {
-        getDeferBlocks(lContainer[i] as LView, deferBlocks);
+
+      // The host can be an `LView` if this is the container
+      // for a component that injects `ViewContainerRef`.
+      if (isLView(lContainer[HOST])) {
+        getDeferBlocks(lContainer[HOST], deferBlocks);
+      }
+
+      for (let j = CONTAINER_HEADER_OFFSET; j < lContainer.length; j++) {
+        getDeferBlocks(lContainer[j] as LView, deferBlocks);
       }
     } else if (isLView(lView[i])) {
       // This is a component, enter the `getDeferBlocks` recursively.

--- a/packages/core/test/defer_fixture_spec.ts
+++ b/packages/core/test/defer_fixture_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {ɵPLATFORM_BROWSER_ID as PLATFORM_BROWSER_ID} from '@angular/common';
-import {Component, PLATFORM_ID} from '../src/core';
+import {Component, inject, PLATFORM_ID, ViewContainerRef} from '../src/core';
 import {PendingTasksInternal} from '../src/pending_tasks';
 import {DeferBlockBehavior, DeferBlockState, TestBed} from '../testing';
 import {expect} from '@angular/private/testing/matchers';
@@ -427,5 +427,20 @@ describe('DeferFixture', () => {
     await deferBlock.render(DeferBlockState.Complete);
     const fixtures = await deferBlock.getDeferBlocks();
     expect(fixtures.length).toBe(1);
+  });
+
+  it('should resolve defer blocks in components that inject ViewContainerRef', async () => {
+    @Component({template: '@defer {Hello}'})
+    class DeferTestComponent {
+      viewContainerRef = inject(ViewContainerRef);
+    }
+
+    TestBed.configureTestingModule({deferBlockBehavior: DeferBlockBehavior.Manual});
+    const fixture = TestBed.createComponent(DeferTestComponent);
+    fixture.detectChanges();
+
+    const deferBlocks = await fixture.getDeferBlocks();
+    expect(deferBlocks.length).toBe(1);
+    expect(fixture.componentInstance.viewContainerRef).toBeTruthy();
   });
 });


### PR DESCRIPTION
Fixes that `getDeferBlocks` wasn't accounting for the case where a component might be injecting `ViewContainerRef`. When that happens, an additional wrapper is introduced that needs to be accounted for when traversing the tree.

Fixes #62047.
