### PR TITLE
docs(examples): consitent usage of self-closing tags 

### DIFF
--- a/adev/src/content/guide/routing/show-routes-with-outlets.md
+++ b/adev/src/content/guide/routing/show-routes-with-outlets.md
@@ -45,17 +45,17 @@ const routes: Routes = [
 When a user visits `/products`, Angular renders the following:
 
 ```angular-html
-<app-header></app-header>
-<app-products></app-products>
-<app-footer></app-footer>
+<app-header />
+<app-products />
+<app-footer />
 ```
 
 If the user goes back to the home page, then Angular renders:
 
 ```angular-html
-<app-header></app-header>
-<app-home></app-home>
-<app-footer></app-footer>
+<app-header />
+<app-home />
+<app-footer />
 ```
 
 When displaying a route, the `<router-outlet>` element remains present in the DOM as a reference point for future navigations. Angular inserts routed content just after the outlet element as a sibling.


### PR DESCRIPTION
consistent usage of self-closing tags for components in all examples on this page.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Some of the code examples on [this page](https://angular.dev/guide/routing/show-routes-with-outlets) are using self-closing tags for the same components while others are not.

Issue Number: N/A


## What is the new behavior?
All the examples are using self-closing tags for the components.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
