### PR TITLE
test(router): Add test for empty path redirect and no match

### DIFF
--- a/packages/router/test/integration/redirects.spec.ts
+++ b/packages/router/test/integration/redirects.spec.ts
@@ -9,6 +9,7 @@ import {LocationStrategy, Location, HashLocationStrategy} from '@angular/common'
 import {TestBed} from '@angular/core/testing';
 import {Router, NavigationStart, RoutesRecognized} from '../../src';
 import {createRoot, RootCmp, BlankCmp, TeamCmp, advance} from './integration_helpers';
+import {childNodesAsList} from '@angular/private/testing';
 
 export function redirectsIntegrationSuite() {
   describe('redirects', () => {
@@ -25,6 +26,24 @@ export function redirectsIntegrationSuite() {
       await router.navigateByUrl('old/team/22');
 
       expect(location.path()).toEqual('/team/22');
+    });
+
+    it('empty path child redirecting to no match', async () => {
+      const router = TestBed.inject(Router);
+      router.resetConfig([
+        {
+          path: 'test',
+          children: [
+            // Redirect will fail to match but does not cause navigation to fail.
+            // Either outcome could really be defended as correct, but this is what we have
+            // so this test ensures we don't unintentionally change it.
+            {path: '', redirectTo: 'no-match', pathMatch: 'full'},
+          ],
+        },
+      ]);
+
+      await router.navigateByUrl('/test');
+      expect(router.url).toEqual('/test');
     });
 
     it('can redirect from componentless named outlets', async () => {


### PR DESCRIPTION
this was discovered during some other work in the router that unintentionally changed this behavior
