### PR TITLE
docs(docs-infra): fix & simplify scrolling for code blocks

### DIFF
--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.spec.ts
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.spec.ts
@@ -59,11 +59,9 @@ describe('DocViewer', () => {
 
   const exampleContentWithCodeSnippet = `
     <div class="docs-code" path="forms/src/app/actor.ts" header="src/app/actor.ts">
-      <pre class="docs-mini-scroll-track">
         <code>
           <div class="hljs-ln-line"></div>
         </code>
-      </pre>
     </div>
   `;
 

--- a/adev/shared-docs/pipeline/api-gen/rendering/marked/renderer.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/marked/renderer.mts
@@ -22,9 +22,7 @@ export const renderer: Partial<Renderer> = {
 
     return `
       <div class="docs-code" role="group">
-        <pre class="docs-mini-scroll-track">
-          ${highlightResult}
-        </pre>
+        ${highlightResult}
       </div>
     `;
   },

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/cli-reference.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/cli-reference.tsx
@@ -22,27 +22,25 @@ export function CliCommandReference(entry: CliCommandRenderable) {
         <HeaderCli command={entry} />
         {[entry.name, ...entry.aliases].map((command) => (
           <div class="docs-code docs-reference-cli-toc">
-            <pre class="docs-mini-scroll-track">
-              <code>
-                <div className={'shiki line cli'}>
-                  ng {commandName(entry, command)}
-                  {entry.argumentsLabel ? (
-                    <button member-id={'Arguments'} className="shiki-ln-line-argument">
-                      {entry.argumentsLabel}
-                    </button>
-                  ) : (
-                    <></>
-                  )}
-                  {entry.hasOptions ? (
-                    <button member-id={'Options'} className="shiki-ln-line-option">
-                      [options]
-                    </button>
-                  ) : (
-                    <></>
-                  )}
-                </div>
-              </code>
-            </pre>
+            <code>
+              <div className={'shiki line cli'}>
+                ng {commandName(entry, command)}
+                {entry.argumentsLabel ? (
+                  <button member-id={'Arguments'} className="shiki-ln-line-argument">
+                    {entry.argumentsLabel}
+                  </button>
+                ) : (
+                  <></>
+                )}
+                {entry.hasOptions ? (
+                  <button member-id={'Options'} className="shiki-ln-line-option">
+                    [options]
+                  </button>
+                ) : (
+                  <></>
+                )}
+              </div>
+            </code>
           </div>
         ))}
         <RawHtml value={entry.htmlDescription} />

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/code-table-of-contents.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/code-table-of-contents.tsx
@@ -26,9 +26,5 @@ export function CodeTableOfContents(props: {entry: HasRenderableToc}) {
     ${props.entry.afterCodeGroups}`;
   }
 
-  return (
-    <div class="docs-code">
-      <pre class="docs-mini-scroll-track" dangerouslySetInnerHTML={{__html: html}}></pre>
-    </div>
-  );
+  return <div class="docs-code" dangerouslySetInnerHTML={{__html: html}}></div>;
 }

--- a/adev/shared-docs/pipeline/guides/extensions/docs-code/format/index.mts
+++ b/adev/shared-docs/pipeline/guides/extensions/docs-code/format/index.mts
@@ -56,9 +56,7 @@ export function formatCode(token: CodeToken) {
   const containerEl = JSDOM.fragment(`
   <div class="docs-code">
     ${buildHeaderElement(token)}
-    <pre class="docs-mini-scroll-track">
-      ${token.code}
-    </pre>
+    ${token.code}
   </div>
   `).firstElementChild!;
 

--- a/adev/shared-docs/styles/_scroll-track.scss
+++ b/adev/shared-docs/styles/_scroll-track.scss
@@ -55,8 +55,10 @@
     }
   }
 
+  .docs-mini-scroll-track,
+  .shiki > code 
   // used on docs-code blocks
-  .docs-mini-scroll-track {
+  {
     &::-webkit-scrollbar-track {
       background: transparent;
     }
@@ -73,6 +75,10 @@
 
     &::-webkit-scrollbar-thumb:hover {
       background-color: var(--quinary-contrast);
+    }
+
+    &::-webkit-scrollbar-corner {
+      background: transparent;
     }
   }
 }

--- a/adev/shared-docs/styles/docs/_code.scss
+++ b/adev/shared-docs/styles/docs/_code.scss
@@ -1,7 +1,3 @@
-// TODO: Working on refactoring all code components & syntax highlighting
-
-/* stylelint-disable */
-
 $code-font-size: 0.875rem;
 
 @mixin docs-code-block {
@@ -101,11 +97,19 @@ $code-font-size: 0.875rem;
       border-color 0.3s ease;
     container: codeblock / inline-size;
 
-    pre {
-      overflow-x: auto;
+    &.compact {
+      code {
+        max-height: 300px;
+      }
     }
+  }
 
+  .shiki {
     code {
+      width: 100%;
+      overflow: auto;
+      padding-block: 1rem;
+
       display: flex;
       flex-direction: column;
       font-size: $code-font-size;
@@ -281,15 +285,9 @@ $code-font-size: 0.875rem;
     }
 
     pre {
-      overflow-x: auto;
       display: flex;
       flex-direction: column;
       align-items: start;
-    }
-
-    pre > * {
-      min-width: 100%;
-      width: auto;
     }
   }
 

--- a/adev/shared-docs/styles/global-styles.scss
+++ b/adev/shared-docs/styles/global-styles.scss
@@ -110,8 +110,6 @@ $theme: mat.m2-define-light-theme((color: (primary: $primary,
 }
 
 .shiki {
-  padding-block: 1rem;
-
   &.cli {
     padding-inline-start: 1rem;
   }


### PR DESCRIPTION
The shiki highlighter introduced it's own `pre` block which resulted in nested `pre` in each code blocks. 


This commit simplifies a bit the generated HTML and also improve the UX of scrollbars. 

UX improvement visible here: https://ng-dev-previews-fw--pr-angular-angular-62179-adev-prev-a3sl0awp.web.app/ai/develop-with-ai
