### PR TITLE
docs: update link to cache options

### DIFF
--- a/contributing-docs/building-and-testing-angular.md
+++ b/contributing-docs/building-and-testing-angular.md
@@ -120,7 +120,7 @@ yarn ng-dev misc build-and-link <path-to-local-project-root>
 When making changes to Angular packages and testing in a local library/project you need to
 run `ng cache disable` to disable the Angular CLI disk cache. If you are making changes that are not
 reflected in your locally served library/project, verify if you
-have [CLI Cache](https://angular.io/guide/workspace-config#cache-options) disabled.
+have [CLI Cache](https://angular.dev/reference/configs/workspace-config#cache-options) disabled.
 
 #### Invoking the Angular CLI
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently, the "CLI Cache" link points to the archived documentation on https://angular.io.

Issue Number: N/A


## What is the new behavior?
The link now points to the same cache options documentation on https://angular.dev.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->