### PR TITLE
fix(compiler-cli): handle initializer APIs wrapped in type casts

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/initializer_functions.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/initializer_functions.ts
@@ -82,6 +82,10 @@ export function tryParseInitializerApi<Functions extends InitializerApiFunction[
   reflector: ReflectionHost,
   importTracker: ImportedSymbolsTracker,
 ): (InitializerFunctionMetadata & {api: Functions[number]}) | null {
+  if (ts.isAsExpression(expression) || ts.isParenthesizedExpression(expression)) {
+    return tryParseInitializerApi(functions, expression.expression, reflector, importTracker);
+  }
+
   if (!ts.isCallExpression(expression)) {
     return null;
   }

--- a/packages/compiler-cli/test/ngtsc/authoring_inputs_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/authoring_inputs_spec.ts
@@ -433,5 +433,39 @@ runInEachFileSystem(() => {
         expect(diagnostics.length).toBe(0);
       });
     });
+
+    it('should resolve input inside an `as` expression', () => {
+      env.write(
+        'test.ts',
+        `
+        import {Directive, input, Signal} from '@angular/core';
+
+        @Directive()
+        export class TestDir {
+          data = input('test') as Signal<string>;
+        }
+      `,
+      );
+      env.driveMain();
+      const js = env.getContents('test.js');
+      expect(js).toContain('inputs: { data: [1, "data"] }');
+    });
+
+    it('should resolve input inside a parenthesized expression', () => {
+      env.write(
+        'test.ts',
+        `
+        import {Directive, input, Signal} from '@angular/core';
+
+        @Directive()
+        export class TestDir {
+          data = ((input('test')));
+        }
+      `,
+      );
+      env.driveMain();
+      const js = env.getContents('test.js');
+      expect(js).toContain('inputs: { data: [1, "data"] }');
+    });
   });
 });


### PR DESCRIPTION
Fixes that the logic recognizing initializer APIs didn't account for the expression being wrapped in an `as` expresion or in a parenthesized expression. This was already accounted for in the diagnostic so these changes align the behavior between them.

Fixes #62197.
