### PR TITLE
refactor(common): move `ngServerMode` check outside `tap()` to enable tree-shaking

### DIFF
--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -776,7 +776,6 @@
       "stringifyForError",
       "subscribeOn",
       "syncViewWithBlueprint",
-      "tap",
       "throwCyclicDependencyError",
       "throwError",
       "throwInvalidWriteToSignalErrorFn",


### PR DESCRIPTION
In this commit, the `ngServerMode` check is moved outside the RxJS `pipe()` to ensure that server-only logic is excluded from client bundles. Previously, the `tap()` operator and its closure were always included in the output, even though `ngServerMode` was false on the client and the side effect was never triggered.

By guarding the observable chain earlier, this reduces the RxJS stack frame depth, which simplifies debugging by avoiding unnecessary operator noise in client-side stack traces.

The resulting logic is also easier to reason about and avoids evaluating `HttpResponse` instances where not needed.