### PR TITLE
fix(devtools): zone.js not being loaded for dev and prod builds

### DIFF
--- a/devtools/projects/shell-browser/src/index.html
+++ b/devtools/projects/shell-browser/src/index.html
@@ -15,7 +15,7 @@
   <body>
     <app-root></app-root>
 
-    <script src="./npm/node_modules/zone.js/bundles/zone.umd.min.js"></script>
+    <script src="./node_modules/zone.js/bundles/zone.umd.min.js"></script>
     <script type="module" src="./bundle/main.js"></script>
   </body>
 </html>

--- a/devtools/src/index.html
+++ b/devtools/src/index.html
@@ -18,7 +18,7 @@
       <app-root></app-root>
     </div>
 
-    <script src="./npm/node_modules/zone.js/bundles/zone.umd.min.js"></script>
+    <script src="./node_modules/zone.js/bundles/zone.umd.min.js"></script>
     <script type="module" src="./bundle/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Fixes a regression from #62083 by updating the remaining script imports.