### PR TITLE
feat(language-service): add methods for decoding classifications to p…

### DIFF
--- a/packages/language-service/api.ts
+++ b/packages/language-service/api.ts
@@ -110,6 +110,9 @@ export interface NgLanguageService extends ts.LanguageService {
   ): Promise<ApplyRefactoringResult | undefined>;
 
   hasCodeFixesForErrorCode(errorCode: number): boolean;
+
+  getTokenTypeFromClassification(classification: number): number | undefined;
+  getTokenModifierFromClassification(classification: number): number;
 }
 
 export function isNgLanguageService(

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -49,7 +49,7 @@ import {
 } from './utils/ts_utils';
 import {getTypeCheckInfoAtPosition, isTypeScriptFile, TypeCheckInfo} from './utils';
 import {ActiveRefactoring, allRefactorings} from './refactorings/refactoring';
-import {getClassificationsForTemplate} from './semantic_tokens';
+import {getClassificationsForTemplate, TokenEncodingConsts} from './semantic_tokens';
 import {isExternalResource} from '@angular/compiler-cli/src/ngtsc/metadata';
 
 type LanguageServiceConfig = Omit<PluginConfig, 'angularOnly'>;
@@ -361,6 +361,17 @@ export class LanguageService {
 
       return getClassificationsForTemplate(compiler, typeCheckInfo, span);
     }
+  }
+
+  getTokenTypeFromClassification(classification: number): number | undefined {
+    if (classification > TokenEncodingConsts.modifierMask) {
+      return (classification >> TokenEncodingConsts.typeOffset) - 1;
+    }
+    return undefined;
+  }
+
+  getTokenModifierFromClassification(classification: number) {
+    return classification & TokenEncodingConsts.modifierMask;
   }
 
   getCompletionsAtPosition(

--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -149,6 +149,13 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     }
   }
 
+  function getTokenTypeFromClassification(classification: number): number | undefined {
+    return ngLS.getTokenTypeFromClassification(classification);
+  }
+  function getTokenModifierFromClassification(classification: number): number {
+    return ngLS.getTokenModifierFromClassification(classification);
+  }
+
   function getCompletionsAtPosition(
     fileName: string,
     position: number,
@@ -371,6 +378,8 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     findRenameLocations,
     getRenameInfo,
     getEncodedSemanticClassifications,
+    getTokenTypeFromClassification,
+    getTokenModifierFromClassification,
     getCompletionsAtPosition,
     getCompletionEntryDetails,
     getCompletionEntrySymbol,


### PR DESCRIPTION
…ublic api

Adds `getTokenTypeFromClassification` and `getTokenModifierFromClassification` to the public API of `@angular/language-service` so LSP clients can easily decode tokens retrieved from `getEncodedSemanticClassifications`. 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
