### PR TITLE
fix(core): allow to set a resource in an error state

### DIFF
--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -269,11 +269,17 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
       return;
     }
 
-    const current = untracked(this.value);
+    const error = untracked(this.error);
     const state = untracked(this.state);
 
-    if (state.status === 'local' && (this.equal ? this.equal(current, value) : current === value)) {
-      return;
+    if (!error) {
+      const current = untracked(this.value);
+      if (
+        state.status === 'local' &&
+        (this.equal ? this.equal(current, value) : current === value)
+      ) {
+        return;
+      }
     }
 
     // Enter Local state with the user-defined value.

--- a/packages/core/test/resource/resource_spec.ts
+++ b/packages/core/test/resource/resource_spec.ts
@@ -729,6 +729,34 @@ describe('resource', () => {
     expect(res.error()).toEqual(new Error('fail'));
   });
 
+  it('should allow to set a value on when in error state', async () => {
+    const appRef = TestBed.inject(ApplicationRef);
+    let res = resource({
+      stream: async () => signal({error: new Error('fail')}),
+      injector: TestBed.inject(Injector),
+    });
+
+    await appRef.whenStable();
+    expect(res.status()).toBe('error');
+
+    res.set('new value');
+    expect(res.status()).toBe('local');
+    expect(res.value()).toBe('new value');
+
+    // also via setting the value on the signal directly
+    res = resource({
+      stream: async () => signal({error: new Error('fail')}),
+      injector: TestBed.inject(Injector),
+    });
+
+    await appRef.whenStable();
+    expect(res.status()).toBe('error');
+
+    res.value.set('new value');
+    expect(res.status()).toBe('local');
+    expect(res.value()).toBe('new value');
+  });
+
   it('should transition across streamed states', async () => {
     const appRef = TestBed.inject(ApplicationRef);
     const stream = signal<{value: number} | {error: Error}>({value: 1});


### PR DESCRIPTION
A resource is error state should still remain writable.

fixes #62241
