### PR TITLE
fix(common): handle history `pushState|replaceState` errors in restricted environments

### DIFF
--- a/goldens/public-api/common/errors.api.md
+++ b/goldens/public-api/common/errors.api.md
@@ -51,6 +51,10 @@ export const enum RuntimeErrorCode {
     // (undocumented)
     PRIORITY_IMG_MISSING_PRECONNECT_TAG = 2956,
     // (undocumented)
+    PUSH_STATE_UNSUPPORTED = 2401,
+    // (undocumented)
+    REPLACE_STATE_UNSUPPORTED = 2402,
+    // (undocumented)
     REQUIRED_INPUT_MISSING = 2954,
     // (undocumented)
     SCROLL_RESTORATION_UNSUPPORTED = 2400,

--- a/packages/common/src/errors.ts
+++ b/packages/common/src/errors.ts
@@ -40,6 +40,8 @@ export const enum RuntimeErrorCode {
 
   // Miscellaneous errors
   SCROLL_RESTORATION_UNSUPPORTED = 2400,
+  PUSH_STATE_UNSUPPORTED = 2401,
+  REPLACE_STATE_UNSUPPORTED = 2402,
 
   // Keep 2800 - 2900 for Http Errors.
 

--- a/packages/common/src/location/location_strategy.ts
+++ b/packages/common/src/location/location_strategy.ts
@@ -14,10 +14,12 @@ import {
   InjectionToken,
   OnDestroy,
   Optional,
+  ɵformatRuntimeError as formatRuntimeError,
 } from '@angular/core';
 
 import {LocationChangeListener, PlatformLocation} from './platform_location';
 import {joinWithSlash, normalizeQueryParams} from './util';
+import {RuntimeErrorCode} from '../errors';
 
 /**
  * Enables the `Location` service to read route state from the browser's URL.
@@ -157,12 +159,38 @@ export class PathLocationStrategy extends LocationStrategy implements OnDestroy 
 
   override pushState(state: any, title: string, url: string, queryParams: string) {
     const externalUrl = this.prepareExternalUrl(url + normalizeQueryParams(queryParams));
-    this._platformLocation.pushState(state, title, externalUrl);
+    try {
+      this._platformLocation.pushState(state, title, externalUrl);
+    } catch {
+      console.warn(
+        formatRuntimeError(
+          RuntimeErrorCode.PUSH_STATE_UNSUPPORTED,
+          ngDevMode &&
+            'Failed to call `history.pushState`. This can happen in restricted environments, such as:\n' +
+              '• A sandboxed iframe\n' +
+              '• A partially loaded or inactive window\n' +
+              '• An untrusted context (e.g., test runner, browser extension, or content preview)',
+        ),
+      );
+    }
   }
 
   override replaceState(state: any, title: string, url: string, queryParams: string) {
     const externalUrl = this.prepareExternalUrl(url + normalizeQueryParams(queryParams));
-    this._platformLocation.replaceState(state, title, externalUrl);
+    try {
+      this._platformLocation.replaceState(state, title, externalUrl);
+    } catch {
+      console.warn(
+        formatRuntimeError(
+          RuntimeErrorCode.REPLACE_STATE_UNSUPPORTED,
+          ngDevMode &&
+            'Failed to call `history.replaceState`. This can happen in restricted environments, such as:\n' +
+              '• A sandboxed iframe\n' +
+              '• A partially loaded or inactive window\n' +
+              '• An untrusted context (e.g., test runner, browser extension, or content preview)',
+        ),
+      );
+    }
   }
 
   override forward(): void {


### PR DESCRIPTION
This commit wraps `history.pushState` and `history.replaceState` in try-catch blocks to prevent uncaught `SecurityError` exceptions in restricted contexts such as:

- sandboxed iframes
- partially navigated or inactive windows
- test runners, browser extensions, or content previews

While `SecurityError` is not explicitly specified in the HTML spec for history state methods, browser engines (e.g., Blink) may throw one when the associated DOMWindow is unavailable. For example, in Blink:

```cpp
void History::replaceState(...) {

...

LocalDOMWindow* window = DomWindow();
if (!window) {
  exception_state.ThrowSecurityError(
      "May not use a History object associated with a Document that is not fully active");
  return;
}
```

This change ensures more robust behavior in edge-case environments and avoids runtime crashes.

Unfortunately, it's not possible to perform any end-to-end testing of this fix.