### PR TITLE
feat(core): add option to infer the tag names of components in tests

### DIFF
--- a/goldens/public-api/core/testing/index.api.md
+++ b/goldens/public-api/core/testing/index.api.md
@@ -180,12 +180,13 @@ export interface TestBedStatic extends TestBed {
 // @public
 export interface TestComponentOptions {
     bindings?: Binding[];
+    inferTagName?: boolean;
 }
 
 // @public
 export class TestComponentRenderer {
     // (undocumented)
-    insertRootElement(rootElementId: string): void;
+    insertRootElement(rootElementId: string, tagName?: string): void;
     // (undocumented)
     removeAllRootElements?(): void;
 }
@@ -206,6 +207,7 @@ export interface TestModuleMetadata {
     errorOnUnknownProperties?: boolean;
     // (undocumented)
     imports?: any[];
+    inferTagName?: boolean;
     // (undocumented)
     providers?: any[];
     rethrowApplicationErrors?: boolean;

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -29,6 +29,7 @@ export {
   NgModuleTransitiveScopes as ɵNgModuleTransitiveScopes,
 } from './metadata/ng_module_def';
 export {getLContext as ɵgetLContext} from './render3/context_discovery';
+export {inferTagNameFromDefinition as ɵinferTagNameFromDefinition} from './render3/component_ref';
 export {
   NG_COMP_DEF as ɵNG_COMP_DEF,
   NG_DIR_DEF as ɵNG_DIR_DEF,

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -183,14 +183,24 @@ function createRootLViewEnvironment(rootLViewInjector: Injector): LViewEnvironme
   };
 }
 
-function createHostElement(componentDef: ComponentDef<unknown>, render: Renderer): RElement {
+function createHostElement(componentDef: ComponentDef<unknown>, renderer: Renderer): RElement {
   // Determine a tag name used for creating host elements when this component is created
   // dynamically. Default to 'div' if this component did not specify any tag name in its
   // selector.
-  const tagName = ((componentDef.selectors[0][0] as string) || 'div').toLowerCase();
+  const tagName = inferTagNameFromDefinition(componentDef);
   const namespace =
     tagName === 'svg' ? SVG_NAMESPACE : tagName === 'math' ? MATH_ML_NAMESPACE : null;
-  return createElementNode(render, tagName, namespace);
+  return createElementNode(renderer, tagName, namespace);
+}
+
+/**
+ * Infers the tag name that should be used for a component based on its definition.
+ * @param componentDef Definition for which to resolve the tag name.
+ */
+export function inferTagNameFromDefinition(componentDef: ComponentDef<unknown>): string {
+  // Take the tag name from the first selector in the
+  // definition. If there is none, fall back to `div`.
+  return ((componentDef.selectors[0][0] as string) || 'div').toLowerCase();
 }
 
 /**

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -571,6 +571,7 @@
       "includeViewProviders",
       "increaseElementDepthCount",
       "incrementInitPhaseFlags",
+      "inferTagNameFromDefinition",
       "initDomAdapter",
       "initFeatures",
       "initTNodeFlags",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -525,6 +525,7 @@
       "includeViewProviders",
       "increaseElementDepthCount",
       "incrementInitPhaseFlags",
+      "inferTagNameFromDefinition",
       "initFeatures",
       "initTNodeFlags",
       "initializeDirectives",

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -666,6 +666,7 @@
       "incrementBindingIndex",
       "incrementInitPhaseFlags",
       "indexOf",
+      "inferTagNameFromDefinition",
       "inheritContentQueries",
       "inheritHostBindings",
       "inheritViewQuery",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -667,6 +667,7 @@
       "incrementBindingIndex",
       "incrementInitPhaseFlags",
       "indexOf",
+      "inferTagNameFromDefinition",
       "inheritContentQueries",
       "inheritHostBindings",
       "inheritViewQuery",

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -541,6 +541,7 @@
       "importProvidersFrom",
       "includeViewProviders",
       "incrementInitPhaseFlags",
+      "inferTagNameFromDefinition",
       "initDisconnectedNodes",
       "initDomAdapter",
       "initFeatures",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -753,6 +753,7 @@
       "includeViewProviders",
       "increaseElementDepthCount",
       "incrementInitPhaseFlags",
+      "inferTagNameFromDefinition",
       "initDomAdapter",
       "initFeatures",
       "initTNodeFlags",

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -433,6 +433,7 @@
       "importProvidersFrom",
       "includeViewProviders",
       "incrementInitPhaseFlags",
+      "inferTagNameFromDefinition",
       "initDomAdapter",
       "initFeatures",
       "initTNodeFlags",

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -2400,6 +2400,58 @@ describe('TestBed', () => {
       });
     });
   });
+
+  describe('inferTagName', () => {
+    it('should not infer the tag name of the root component by default', () => {
+      @Component({selector: 'my-test-comp[foo]', template: ''})
+      class TestComp {}
+
+      const fixture = TestBed.createComponent(TestComp);
+      expect(fixture.nativeElement.tagName).toBe('DIV');
+    });
+
+    it('should be able to opt into inferring the tag of the root component from the selector', () => {
+      @Component({selector: 'my-test-comp[foo]', template: ''})
+      class TestComp {}
+
+      const fixture = TestBed.createComponent(TestComp, {inferTagName: true});
+      expect(fixture.nativeElement.tagName).toBe('MY-TEST-COMP');
+    });
+
+    it('should fall back to `div` if the test component does not have a tag selector', () => {
+      @Component({selector: '[foo]', template: ''})
+      class TestComp {}
+
+      const fixture = TestBed.createComponent(TestComp, {inferTagName: true});
+      expect(fixture.nativeElement.tagName).toBe('DIV');
+    });
+
+    it('should fall back to `ng-component` if the test component does not have any selector', () => {
+      @Component({template: ''})
+      class TestComp {}
+
+      const fixture = TestBed.createComponent(TestComp, {inferTagName: true});
+      expect(fixture.nativeElement.tagName).toBe('NG-COMPONENT');
+    });
+
+    it('should be able to opt into inferring the tag name through configureTestingModule', () => {
+      @Component({selector: 'my-test-comp', template: ''})
+      class TestComp {}
+
+      TestBed.configureTestingModule({inferTagName: true});
+      const fixture = TestBed.createComponent(TestComp);
+      expect(fixture.nativeElement.tagName).toBe('MY-TEST-COMP');
+    });
+
+    it('should give precedence to inferTagName from createComponent over configureTestingModule', () => {
+      @Component({selector: 'my-test-comp', template: ''})
+      class TestComp {}
+
+      TestBed.configureTestingModule({inferTagName: false});
+      const fixture = TestBed.createComponent(TestComp);
+      expect(fixture.nativeElement.tagName).toBe('DIV');
+    });
+  });
 });
 
 describe('TestBed defer block behavior', () => {

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -30,7 +30,7 @@ export const DEFER_BLOCK_DEFAULT_BEHAVIOR = DeferBlockBehavior.Playthrough;
  * @publicApi
  */
 export class TestComponentRenderer {
-  insertRootElement(rootElementId: string) {}
+  insertRootElement(rootElementId: string, tagName?: string) {}
   removeAllRootElements?() {}
 }
 
@@ -87,6 +87,12 @@ export interface TestModuleMetadata {
    * Defaults to `manual`.
    */
   deferBlockBehavior?: DeferBlockBehavior;
+
+  /**
+   * Whether to infer the tag name of test components from their selectors.
+   * Otherwise `div` will be used as the tag name for test components.
+   */
+  inferTagName?: boolean;
 }
 
 /**

--- a/packages/platform-browser/testing/src/dom_test_component_renderer.ts
+++ b/packages/platform-browser/testing/src/dom_test_component_renderer.ts
@@ -19,9 +19,9 @@ export class DOMTestComponentRenderer extends TestComponentRenderer {
     super();
   }
 
-  override insertRootElement(rootElId: string) {
+  override insertRootElement(rootElId: string, tagName = 'div') {
     this.removeAllRootElementsImpl();
-    const rootElement = getDOM().getDefaultDocument().createElement('div');
+    const rootElement = getDOM().getDefaultDocument().createElement(tagName);
     rootElement.setAttribute('id', rootElId);
     this._doc.body.appendChild(rootElement);
   }


### PR DESCRIPTION
Currently when testing a component using `TestBed.createComponent`, we always create the component as a `div` which isn't aligned with the runtime. The runtime tries to parse out the tag name from the first selector in `@Component` and only falls back to `div` if there isn't one. This behavior difference can cause components to not behave like they would in production which reduces the usefulness of the tests.

These changes add the `inferTagName` option to `TestBed.createComponent` and `TestBed.configureTestingModule` that allows apps to opt into inferring the tag name from the selector in the same way as the runtime. Currently the new option is set to `false`, but we intend to change it to `true` in a future version.