### PR TITLE
refactor(common): replace forEach with index loop for Domino compatibility

### DIFF
--- a/packages/core/src/image_performance_warning.ts
+++ b/packages/core/src/image_performance_warning.ts
@@ -102,7 +102,17 @@ export class ImagePerformanceWarning implements OnDestroy {
     const images = getDocument().querySelectorAll('img');
     let lcpElementFound,
       lcpElementLoadedCorrectly = false;
-    images.forEach((image) => {
+    // Important: do not refactor this to use `images.forEach` or
+    // `for (const ... of ...)`, because images might be a custom internal
+    // data structure — such as a lazily evaluated query result in Domino.
+    // (This naturally would never be a case in any browser).
+    for (let index = 0; index < images.length; index++) {
+      const image = images[index];
+
+      if (!image) {
+        continue;
+      }
+
       if (!this.options?.disableImageSizeWarning) {
         // Image elements using the NgOptimizedImage directive are excluded,
         // as that directive has its own version of this check.
@@ -122,7 +132,7 @@ export class ImagePerformanceWarning implements OnDestroy {
           }
         }
       }
-    });
+    }
     if (
       lcpElementFound &&
       !lcpElementLoadedCorrectly &&


### PR DESCRIPTION
In this commit, the use of `images.forEach` was replaced with a traditional `for (let i = 0; ...)` loop to ensure compatibility with Domino. Domino may return a custom internal data structure (e.g., a lazily evaluated query result) that does not fully support standard iteration protocols like `forEach` or `for...of`.

Naturally, this would never happen in any browser. It occurs only in unit tests when using `renderApplication()`, because Domino's `querySelectorAll` returns the following:

```js
var nodes = select(selector, context);
return nodes.item ? nodes : new NodeList(nodes);
```

In certain unit tests, it returns an object like:
`{ root: document, filter: function(e) { ... }, lastModTime: 1, done: true, cache: [] }`, which means that the object does not have a `forEach` method.

As a result, this causes an `afterAll` error: `forEach is not a function`.