### PR TITLE
docs: fix deferrable views doc links

### DIFF
--- a/adev/src/content/guide/templates/defer.md
+++ b/adev/src/content/guide/templates/defer.md
@@ -33,9 +33,9 @@ Angular's compiler produces a [dynamic import](https://developer.mozilla.org/en-
 
 ### `@defer`
 
-This is the primary block that defines the section of content that is lazily loaded. It is not rendered initially– deferred content loads and renders once the specified [trigger](/guide/defer#triggers) occurs or the `when` condition is met.
+This is the primary block that defines the section of content that is lazily loaded. It is not rendered initially– deferred content loads and renders once the specified [trigger](/guide/templates/defer#triggers) occurs or the `when` condition is met.
 
-By default, a @defer block is triggered when the browser state becomes [idle](/guide/defer#idle).
+By default, a @defer block is triggered when the browser state becomes [idle](/guide/templates/defer#idle).
 
 ```angular-html
 @defer {
@@ -57,7 +57,7 @@ The `@placeholder` is an optional block that declares what content to show befor
 }
 ```
 
-While optional, certain triggers may require the presence of either a `@placeholder` or a [template reference variable](/guide/templates/variables#template-reference-variables) to function. See the [Triggers](/guide/defer#triggers) section for more details.
+While optional, certain triggers may require the presence of either a `@placeholder` or a [template reference variable](/guide/templates/variables#template-reference-variables) to function. See the [Triggers](/guide/templates/defer#triggers) section for more details.
 
 Angular replaces placeholder content with the main content once loading is complete. You can use any content in the placeholder section including plain HTML, components, directives, and pipes. Keep in mind the _dependencies of the placeholder block are eagerly loaded_.
 

--- a/adev/src/content/tutorials/deferrable-views/steps/2-loading-error-placeholder/README.md
+++ b/adev/src/content/tutorials/deferrable-views/steps/2-loading-error-placeholder/README.md
@@ -8,7 +8,7 @@ Deferrable views let you define content to be shown in different loading states.
       <td><code>@placeholder</code></td>
       <td>
         By default, defer blocks do not render any content before they are triggered. The <code>@placeholder</code> is an optional block that declares content to show before the deferred content loads. Angular replaces the placeholder with the deferred content after loading completes. While this block is optional, the Angular team recommends always including a placeholder.
-        <a href="https://angular.dev/guide/defer#triggers" target="_blank">
+        <a href="https://angular.dev/guide/templates/defer#triggers" target="_blank">
           Learn more in the full deferrable views documentation
         </a>
       </td>

--- a/adev/src/llms-full.txt
+++ b/adev/src/llms-full.txt
@@ -2738,9 +2738,9 @@ Angular's compiler produces a [dynamic import](https://developer.mozilla.org/en-
 
 ### `@defer`
 
-This is the primary block that defines the section of content that is lazily loaded. It is not rendered initially– deferred content loads and renders once the specified [trigger](/guide/defer#triggers) occurs or the `when` condition is met.
+This is the primary block that defines the section of content that is lazily loaded. It is not rendered initially– deferred content loads and renders once the specified [trigger](/guide/templates/defer#triggers) occurs or the `when` condition is met.
 
-By default, a @defer block is triggered when the browser state becomes [idle](/guide/defer#idle).
+By default, a @defer block is triggered when the browser state becomes [idle](/guide/templates/defer#idle).
 
 ```html
 @defer {
@@ -2762,7 +2762,7 @@ The `@placeholder` is an optional block that declares what content to show befor
 }
 ```
 
-While optional, certain triggers may require the presence of either a `@placeholder` or a [template reference variable](/guide/templates/variables#template-reference-variables) to function. See the [Triggers](/guide/defer#triggers) section for more details.
+While optional, certain triggers may require the presence of either a `@placeholder` or a [template reference variable](/guide/templates/variables#template-reference-variables) to function. See the [Triggers](/guide/templates/defer#triggers) section for more details.
 
 Angular replaces placeholder content with the main content once loading is complete. You can use any content in the placeholder section including plain HTML, components, directives, and pipes. Keep in mind the _dependencies of the placeholder block are eagerly loaded_.
 

--- a/packages/language-service/src/quick_info_built_ins.ts
+++ b/packages/language-service/src/quick_info_built_ins.ts
@@ -139,22 +139,22 @@ const BUILT_IN_NAMES_TO_DOC_MAP: {
 } = {
   '@defer': {
     docString: `A type of block that can be used to defer load the JavaScript for components, directives and pipes used inside a component template.`,
-    links: ['[Reference](https://angular.dev/guide/defer#defer)'],
+    links: ['[Reference](https://angular.dev/guide/templates/defer#defer)'],
     displayInfoKind: DisplayInfoKind.BLOCK,
   },
   '@placeholder': {
     docString: `A block for content shown prior to defer loading (Optional)`,
-    links: ['[Reference](https://angular.dev/guide/defer#placeholder)'],
+    links: ['[Reference](https://angular.dev/guide/templates/defer#placeholder)'],
     displayInfoKind: DisplayInfoKind.BLOCK,
   },
   '@error': {
     docString: `A block for content shown when defer loading errors occur (Optional)`,
-    links: ['[Reference](https://angular.dev/guide/defer#error)'],
+    links: ['[Reference](https://angular.dev/guide/templates/defer#error)'],
     displayInfoKind: DisplayInfoKind.BLOCK,
   },
   '@loading': {
     docString: `A block for content shown during defer loading (Optional)`,
-    links: ['[Reference](https://angular.dev/guide/defer#loading)'],
+    links: ['[Reference](https://angular.dev/guide/templates/defer#loading)'],
     displayInfoKind: DisplayInfoKind.BLOCK,
   },
   '@empty': {
@@ -173,38 +173,38 @@ const BUILT_IN_NAMES_TO_DOC_MAP: {
   },
   'idle': {
     docString: triggerDescriptionPreamble + `the browser reports idle state (default).`,
-    links: ['[Reference](https://angular.dev/guide/defer#on-idle)'],
+    links: ['[Reference](https://angular.dev/guide/templates/defer#on-idle)'],
     displayInfoKind: DisplayInfoKind.TRIGGER,
   },
   'immediate': {
     docString: triggerDescriptionPreamble + `the page finishes rendering.`,
-    links: ['[Reference](https://angular.dev/guide/defer#on-immediate)'],
+    links: ['[Reference](https://angular.dev/guide/templates/defer#on-immediate)'],
     displayInfoKind: DisplayInfoKind.TRIGGER,
   },
   'hover': {
     docString: triggerDescriptionPreamble + `the element has been hovered.`,
-    links: ['[Reference](https://angular.dev/guide/defer#on-hover)'],
+    links: ['[Reference](https://angular.dev/guide/templates/defer#on-hover)'],
     displayInfoKind: DisplayInfoKind.TRIGGER,
   },
   'timer': {
     docString: triggerDescriptionPreamble + `a specific timeout.`,
-    links: ['[Reference](https://angular.dev/guide/defer#on-timer)'],
+    links: ['[Reference](https://angular.dev/guide/templates/defer#on-timer)'],
     displayInfoKind: DisplayInfoKind.TRIGGER,
   },
   'interaction': {
     docString: triggerDescriptionPreamble + `the element is clicked, touched, or focused.`,
-    links: ['[Reference](https://angular.dev/guide/defer#on-interaction)'],
+    links: ['[Reference](https://angular.dev/guide/templates/defer#on-interaction)'],
     displayInfoKind: DisplayInfoKind.TRIGGER,
   },
   'viewport': {
     docString: triggerDescriptionPreamble + `the element enters the viewport.`,
-    links: ['[Reference](https://angular.dev/guide/defer#on-viewport)'],
+    links: ['[Reference](https://angular.dev/guide/templates/defer#on-viewport)'],
     displayInfoKind: DisplayInfoKind.TRIGGER,
   },
   'prefetch': {
     docString:
       'Keyword that indicates that the trigger configures when prefetching the defer block contents should start. You can use `on` and `when` conditions as prefetch triggers.',
-    links: ['[Reference](https://angular.dev/guide/defer#prefetching)'],
+    links: ['[Reference](https://angular.dev/guide/templates/defer#prefetching)'],
     displayInfoKind: DisplayInfoKind.KEYWORD,
   },
   'hydrate': {
@@ -217,13 +217,13 @@ const BUILT_IN_NAMES_TO_DOC_MAP: {
   'when': {
     docString:
       'Keyword that starts the expression-based trigger section. Should be followed by an expression that returns a boolean.',
-    links: ['[Reference](https://angular.dev/guide/defer#triggers)'],
+    links: ['[Reference](https://angular.dev/guide/templates/defer#triggers)'],
     displayInfoKind: DisplayInfoKind.KEYWORD,
   },
   'on': {
     docString:
       'Keyword that starts the event-based trigger section. Should be followed by one of the built-in triggers.',
-    links: ['[Reference](https://angular.dev/guide/defer#triggers)'],
+    links: ['[Reference](https://angular.dev/guide/templates/defer#triggers)'],
     displayInfoKind: DisplayInfoKind.KEYWORD,
   },
 };


### PR DESCRIPTION
Hello! There are incorrect links on this page https://angular.dev/guide/templates/defer