### PR TITLE
feat(http): add cache & priority support for fetch requests in httpRe…

### DIFF
--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -2127,11 +2127,13 @@ export interface HttpResourceRef<T> extends WritableResource<T>, ResourceRef<T> 
 // @public
 export interface HttpResourceRequest {
     body?: unknown;
+    cache?: RequestCache | (string & {});
     context?: HttpContext;
     headers?: HttpHeaders | Record<string, string | ReadonlyArray<string>>;
     keepalive?: boolean;
     method?: string;
     params?: HttpParams | Record<string, string | number | boolean | ReadonlyArray<string | number | boolean>>;
+    priority?: RequestPriority | (string & {});
     reportProgress?: boolean;
     transferCache?: {
         includeHeaders?: string[];

--- a/packages/common/http/src/resource.ts
+++ b/packages/common/http/src/resource.ts
@@ -279,6 +279,8 @@ function normalizeRequest(
       reportProgress: unwrappedRequest.reportProgress,
       withCredentials: unwrappedRequest.withCredentials,
       keepalive: unwrappedRequest.keepalive,
+      cache: unwrappedRequest.cache as RequestCache,
+      priority: unwrappedRequest.priority as RequestPriority,
       responseType,
       context: unwrappedRequest.context,
       transferCache: unwrappedRequest.transferCache,

--- a/packages/common/http/src/resource_api.ts
+++ b/packages/common/http/src/resource_api.ts
@@ -76,6 +76,17 @@ export interface HttpResourceRequest {
   keepalive?: boolean;
 
   /**
+   * Controls how the request will interact with the browser's HTTP cache.
+   * This affects whether a response is retrieved from the cache, how it is stored, or if it bypasses the cache altogether.
+   */
+  cache?: RequestCache | (string & {});
+
+  /**
+   * Indicates the relative priority of the request. This may be used by the browser to decide the order in which requests are dispatched and resources fetched.
+   */
+  priority?: RequestPriority | (string & {});
+
+  /**
    * Configures the server-side rendering transfer cache for this request.
    *
    * See the documentation on the transfer cache for more information.

--- a/packages/common/http/test/resource_spec.ts
+++ b/packages/common/http/test/resource_spec.ts
@@ -106,6 +106,8 @@ describe('httpResource', () => {
         },
         withCredentials: true,
         keepalive: true,
+        cache: 'force-cache',
+        priority: 'high',
       }),
       {injector: TestBed.inject(Injector)},
     );
@@ -116,6 +118,8 @@ describe('httpResource', () => {
     expect(req.request.headers.get('X-Special')).toBe('true');
     expect(req.request.withCredentials).toBe(true);
     expect(req.request.keepalive).toBe(true);
+    expect(req.request.cache).toBe('force-cache');
+    expect(req.request.priority).toBe('high');
 
     req.flush([]);
 


### PR DESCRIPTION
Currently, Angular's httpResource doesn't expose the cache & priority option from the underlying Fetch API. This feature would allow developers to control of request and improve better performance ( web vitals ).

Example new usage : 

```ts
httpResource(() => ({
  url: '/assets/hero.jpg',
  method: 'GET',
  priority: 'high',
  cache : 'force-cache'
}));
```