### PR TITLE
feat(http): add timeout option on `httpResource`

### DIFF
--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -2143,6 +2143,7 @@ export interface HttpResourceRequest {
     params?: HttpParams | Record<string, string | number | boolean | ReadonlyArray<string | number | boolean>>;
     priority?: RequestPriority | (string & {});
     reportProgress?: boolean;
+    timeout?: number;
     transferCache?: {
         includeHeaders?: string[];
     } | boolean;

--- a/packages/common/http/src/resource.ts
+++ b/packages/common/http/src/resource.ts
@@ -284,6 +284,7 @@ function normalizeRequest(
       responseType,
       context: unwrappedRequest.context,
       transferCache: unwrappedRequest.transferCache,
+      timeout: unwrappedRequest.timeout,
     },
   );
 }

--- a/packages/common/http/src/resource_api.ts
+++ b/packages/common/http/src/resource_api.ts
@@ -92,6 +92,11 @@ export interface HttpResourceRequest {
    * See the documentation on the transfer cache for more information.
    */
   transferCache?: {includeHeaders?: string[]} | boolean;
+
+  /**
+   * The timeout for the backend HTTP request in ms.
+   */
+  timeout?: number;
 }
 
 /**

--- a/packages/common/http/test/resource_spec.ts
+++ b/packages/common/http/test/resource_spec.ts
@@ -209,6 +209,7 @@ describe('httpResource', () => {
         withCredentials: true,
         keepalive: true,
         transferCache: {includeHeaders: ['Y-Tag']},
+        timeout: 1234,
       }),
       {
         injector: TestBed.inject(Injector),
@@ -224,6 +225,7 @@ describe('httpResource', () => {
     expect(req.request.reportProgress).toEqual(true);
     expect(req.request.keepalive).toBe(true);
     expect(req.request.transferCache).toEqual({includeHeaders: ['Y-Tag']});
+    expect(req.request.timeout).toBe(1234);
   });
 
   it('should allow mapping data to an arbitrary type', async () => {


### PR DESCRIPTION
On top of #57194

This uses the option that was introduction on the HttpClient