### PR TITLE
feat(http): add mode & redirect for fetch request in httpResource

### DIFF
--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -2398,8 +2398,10 @@ export interface HttpResourceRequest {
     headers?: HttpHeaders | Record<string, string | ReadonlyArray<string>>;
     keepalive?: boolean;
     method?: string;
+    mode?: RequestMode | (string & {});
     params?: HttpParams | Record<string, string | number | boolean | ReadonlyArray<string | number | boolean>>;
     priority?: RequestPriority | (string & {});
+    redirect?: RequestRedirect | (string & {});
     reportProgress?: boolean;
     timeout?: number;
     transferCache?: {

--- a/packages/common/http/src/resource.ts
+++ b/packages/common/http/src/resource.ts
@@ -281,6 +281,8 @@ function normalizeRequest(
       keepalive: unwrappedRequest.keepalive,
       cache: unwrappedRequest.cache as RequestCache,
       priority: unwrappedRequest.priority as RequestPriority,
+      mode: unwrappedRequest.mode as RequestMode,
+      redirect: unwrappedRequest.redirect as RequestRedirect,
       responseType,
       context: unwrappedRequest.context,
       transferCache: unwrappedRequest.transferCache,

--- a/packages/common/http/src/resource_api.ts
+++ b/packages/common/http/src/resource_api.ts
@@ -87,6 +87,18 @@ export interface HttpResourceRequest {
   priority?: RequestPriority | (string & {});
 
   /**
+   * The mode of the request, which determines how the request will interact with the browser's security model.
+   * This can affect things like CORS (Cross-Origin Resource Sharing) and same-origin policies.
+   */
+  mode?: RequestMode | (string & {});
+
+  /**
+   * The redirect mode of the request, which determines how redirects are handled.
+   * This can affect whether the request follows redirects automatically, or if it fails when a redirect occurs.
+   */
+  redirect?: RequestRedirect | (string & {});
+
+  /**
    * Configures the server-side rendering transfer cache for this request.
    *
    * See the documentation on the transfer cache for more information.

--- a/packages/common/http/test/resource_spec.ts
+++ b/packages/common/http/test/resource_spec.ts
@@ -108,6 +108,8 @@ describe('httpResource', () => {
         keepalive: true,
         cache: 'force-cache',
         priority: 'high',
+        mode: 'cors',
+        redirect: 'follow',
       }),
       {injector: TestBed.inject(Injector)},
     );
@@ -120,6 +122,8 @@ describe('httpResource', () => {
     expect(req.request.keepalive).toBe(true);
     expect(req.request.cache).toBe('force-cache');
     expect(req.request.priority).toBe('high');
+    expect(req.request.mode).toBe('cors');
+    expect(req.request.redirect).toBe('follow');
 
     req.flush([]);
 


### PR DESCRIPTION
Currently, Angular's httpResource doesn't expose the redirect and mode options from the underlying Fetch API.
Exposing these options would allow developers to control cross-origin behavior and redirect handling more explicitly, enabling better compliance with security policies and improving integration with external APIs.

Example new usage : 

```ts
httpResource(() => ({
  url: '/api/register',
  method: 'POST',
  mode: 'cors',
  redirect: 'follow'
}));
```