### PR TITLE
fix(devtools): sanitize route data.

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/BUILD.bazel
@@ -131,10 +131,30 @@ ts_project(
 
 ts_project(
     name = "utils",
-    srcs = ["utils.ts"],
+    srcs = [
+        "serialization-utils.ts",
+        "utils.ts",
+    ],
     interop_deps = [
         "//packages/core",
         "//devtools/projects/ng-devtools-backend/src/lib/ng-debug-api",
+    ],
+)
+
+ng_web_test_suite(
+    name = "utils_test",
+    deps = [
+        ":utils_test_lib_rjs",
+    ],
+)
+
+ts_test_library(
+    name = "utils_test_lib",
+    srcs = [
+        "serialization-utils.spec.ts",
+    ],
+    deps = [
+        ":utils_rjs",
     ],
 )
 

--- a/devtools/projects/ng-devtools-backend/src/lib/serialization-utils.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/serialization-utils.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {sanitizeObject} from './serialization-utils';
+
+describe('sanitizeObject', () => {
+  it('should not change valid object', () => {
+    const foo = {
+      bar: 'bar',
+      baz: 42,
+      qux: true,
+      quux: null,
+      corge: undefined,
+      grault: [1, 2, 3],
+      garply: {a: 'a', b: 'b'},
+    };
+
+    expect(sanitizeObject(foo)).toEqual({
+      bar: 'bar',
+      baz: 42,
+      qux: true,
+      quux: null,
+      corge: undefined,
+      grault: [1, 2, 3],
+      garply: {a: 'a', b: 'b'},
+    });
+  });
+
+  it('should remove function', () => {
+    const foo = {
+      bar: 'bar',
+      baz: () => 'baz',
+    };
+
+    expect(sanitizeObject(foo)).toEqual({
+      bar: 'bar',
+      baz: '[Non-serializable data]',
+    });
+  });
+
+  it('should strip cyclic references', () => {
+    const bar: any = {foo: null};
+    const foo = {
+      bar: bar,
+    };
+    bar.foo = foo;
+
+    expect(sanitizeObject(foo)).toEqual({
+      bar: '[Non-serializable data]',
+    });
+  });
+});

--- a/devtools/projects/ng-devtools-backend/src/lib/serialization-utils.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/serialization-utils.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+export function sanitizeObject(obj: any): any {
+  if (obj === null || typeof obj !== 'object') {
+    return isPortSerializable(obj) ? obj : '[Non-serializable data]';
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(sanitizeObject);
+  }
+
+  const result: Record<string, any> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    result[key] = isPortSerializable(value) ? value : '[Non-serializable data]';
+  }
+  return result;
+}
+
+// This is specific to chrome.runtime.Port which like JSON.stringify, cannot serialize cyclic objects
+function isPortSerializable(value: any): boolean {
+  if (typeof value === 'function') {
+    return false; // Functions are not serializable but JSON.stringify doesn't throw, it strips them out
+  }
+
+  try {
+    JSON.stringify(value); // This mimics the runtime's limitations closely
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
The serialization of route data does not support cyclic data objects. We sanitize nested route data object by replacing invalid values with a placeholder string.
