### PR TITLE
release: bump Angular DevTools version to 1.0.36

### DIFF
--- a/devtools/projects/shell-browser/src/manifest/manifest.chrome.json
+++ b/devtools/projects/shell-browser/src/manifest/manifest.chrome.json
@@ -3,8 +3,8 @@
   "short_name": "Angular DevTools",
   "name": "Angular DevTools",
   "description": "Angular DevTools extends Chrome DevTools adding Angular specific debugging and profiling capabilities.",
-  "version": "1.0.35",
-  "version_name": "1.0.35",
+  "version": "1.0.36",
+  "version_name": "1.0.36",
   "minimum_chrome_version": "102",
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"

--- a/devtools/projects/shell-browser/src/manifest/manifest.firefox.json
+++ b/devtools/projects/shell-browser/src/manifest/manifest.firefox.json
@@ -3,7 +3,7 @@
   "short_name": "Angular DevTools",
   "name": "Angular DevTools",
   "description": "Angular DevTools extends Firefox DevTools adding Angular specific debugging and profiling capabilities.",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
   "icons": {
     "16": "assets/icon16.png",


### PR DESCRIPTION
Fix release for broken profiler tab in 1.0.35.