### PR TITLE
feat(signal-forms): Add key & index support in FieldContext

### DIFF
--- a/packages/forms/experimental/src/api/logic.ts
+++ b/packages/forms/experimental/src/api/logic.ts
@@ -9,7 +9,16 @@
 import {MetadataKey} from '../api/metadata';
 import {FieldPathNode} from '../path_node';
 import {assertPathIsCurrent} from '../schema';
-import type {FieldPath, LogicFn, TreeValidator, Validator} from './types';
+import type {
+  ChildFieldPath,
+  ChildValidator,
+  FieldPath,
+  ItemFieldPath,
+  ItemValidator,
+  LogicFn,
+  TreeValidator,
+  Validator,
+} from './types';
 
 /**
  * Adds logic to a field to conditionally disable it.
@@ -76,11 +85,17 @@ export function hidden<T>(path: FieldPath<T>, logic: NoInfer<LogicFn<T, boolean>
  * @param logic A `Validator<T>` that returns the current validation errors.
  * @template T The data type of the field the logic is being added to.
  */
-export function validate<T>(path: FieldPath<T>, logic: NoInfer<Validator<T>>): void {
-  assertPathIsCurrent(path);
+export function validate<T>(path: FieldPath<T>, logic: NoInfer<Validator<T>>): void;
+export function validate<T>(path: ChildFieldPath<T>, logic: NoInfer<ChildValidator<T>>): void;
+export function validate<T>(path: ItemFieldPath<T>, logic: NoInfer<ItemValidator<T>>): void;
+export function validate<T>(
+  path: FieldPath<T> | ChildFieldPath<T> | ItemFieldPath<T>,
+  logic: NoInfer<Validator<T> | ChildValidator<T> | ItemValidator<T>>,
+): void {
+  assertPathIsCurrent(path as FieldPath<T>);
 
-  const pathNode = FieldPathNode.unwrapFieldPath(path);
-  pathNode.logic.addSyncErrorRule(logic);
+  const pathNode = FieldPathNode.unwrapFieldPath(path as FieldPath<T>);
+  pathNode.logic.addSyncErrorRule(logic as Validator<T>);
 }
 
 export function validateTree<T>(path: FieldPath<T>, logic: NoInfer<TreeValidator<T>>): void {

--- a/packages/forms/experimental/src/api/structure.ts
+++ b/packages/forms/experimental/src/api/structure.ts
@@ -13,8 +13,11 @@ import {FieldNode} from '../field/node';
 import {FieldPathNode} from '../path_node';
 import {assertPathIsCurrent, isSchemaOrSchemaFn, SchemaImpl} from '../schema';
 import type {
+  ChildFieldPath,
   Field,
   FieldPath,
+  ItemFieldPath,
+  ItemSchemaOrSchemaFn,
   LogicFn,
   Schema,
   SchemaFn,
@@ -181,11 +184,14 @@ export function form<T>(...args: any[]): Field<T> {
  * element of the array.
  * @template T The data type of an element in the array.
  */
-export function applyEach<T>(path: FieldPath<T[]>, schema: NoInfer<SchemaOrSchemaFn<T>>): void {
-  assertPathIsCurrent(path);
+export function applyEach<T>(
+  path: FieldPath<T[]> | ChildFieldPath<T[]> | ItemFieldPath<T[]>,
+  schema: NoInfer<ItemSchemaOrSchemaFn<T>>,
+): void {
+  assertPathIsCurrent(path as FieldPath<T[]>);
 
-  const elementPath = FieldPathNode.unwrapFieldPath(path).element.fieldPathProxy;
-  apply(elementPath, schema);
+  const elementPath = FieldPathNode.unwrapFieldPath(path as FieldPath<T[]>).element.fieldPathProxy;
+  apply(elementPath, schema as unknown as SchemaOrSchemaFn<T>);
 }
 
 /**

--- a/packages/forms/experimental/src/api/types.ts
+++ b/packages/forms/experimental/src/api/types.ts
@@ -250,6 +250,8 @@ export interface FieldContext<T> {
    * A signal of the value of the field that the logic function is bound to.
    */
   readonly value: Signal<T>;
+  readonly key: Signal<string>;
+  readonly index: Signal<number>;
   readonly state: FieldState<T>;
   readonly field: Field<T>;
   readonly valueOf: <P>(p: FieldPath<P>) => P;

--- a/packages/forms/experimental/src/api/validators/required.ts
+++ b/packages/forms/experimental/src/api/validators/required.ts
@@ -8,8 +8,16 @@
 
 import {metadata, validate} from '../logic';
 import {REQUIRED} from '../metadata';
-import {FieldPath, LogicFn} from '../types';
-import {BaseValidatorConfig} from './types';
+import {
+  ChildFieldPath,
+  ChildLogicFn,
+  FieldPath,
+  ItemFieldPath,
+  ItemLogicFn,
+  LogicFn,
+  ValidationResult,
+} from '../types';
+import {BaseValidatorConfig, ChildBaseValidatorConfig, ItemBaseValidatorConfig} from './types';
 
 /**
  * Adds logic to a field to conditionally make it required. A required field has metadata to
@@ -28,15 +36,36 @@ export function required<T>(
     emptyPredicate?: (value: T) => boolean;
     when?: NoInfer<LogicFn<T, boolean>>;
   },
+): void;
+export function required<T>(
+  path: ChildFieldPath<T>,
+  config?: ChildBaseValidatorConfig<T> & {
+    emptyPredicate?: (value: T) => boolean;
+    when?: NoInfer<ChildLogicFn<T, boolean>>;
+  },
+): void;
+export function required<T>(
+  path: ItemFieldPath<T>,
+  config?: ItemBaseValidatorConfig<T> & {
+    emptyPredicate?: (value: T) => boolean;
+    when?: NoInfer<ItemLogicFn<T, boolean>>;
+  },
+): void;
+export function required<T>(
+  path: FieldPath<T> | ChildFieldPath<T> | ItemFieldPath<T>,
+  config?: (BaseValidatorConfig<T> | ChildBaseValidatorConfig<T> | ItemBaseValidatorConfig<T>) & {
+    emptyPredicate?: (value: T) => boolean;
+    when?: NoInfer<LogicFn<T, boolean> | ChildLogicFn<T, boolean> | ItemLogicFn<T, boolean>>;
+  },
 ): void {
   const emptyPredicate = config?.emptyPredicate || ((value) => value == null || value === '');
-  const condition = config?.when ?? (() => true);
+  const condition = (config?.when ?? (() => true)) as LogicFn<T, boolean>;
 
-  metadata(path, REQUIRED, condition);
-  validate(path, (ctx) => {
+  metadata(path as FieldPath<T>, REQUIRED, condition as LogicFn<T, boolean>);
+  validate(path as FieldPath<T>, (ctx) => {
     if (condition(ctx) && emptyPredicate(ctx.value())) {
       if (config?.errors) {
-        return config.errors(ctx);
+        return (config.errors as LogicFn<T, ValidationResult>)(ctx);
       } else {
         return {kind: 'required'};
       }

--- a/packages/forms/experimental/src/api/validators/types.ts
+++ b/packages/forms/experimental/src/api/validators/types.ts
@@ -6,11 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {LogicFn, ValidationResult} from '../types';
+import {ChildLogicFn, ItemLogicFn, LogicFn, ValidationResult} from '../types';
 
 // TODO(kirjs): Consider using {length: number}
 export type ValueWithLength = Array<unknown> | string;
 
 export interface BaseValidatorConfig<T> {
   errors?: LogicFn<T, ValidationResult>;
+}
+export interface ChildBaseValidatorConfig<T> {
+  errors?: ChildLogicFn<T, ValidationResult>;
+}
+export interface ItemBaseValidatorConfig<T> {
+  errors?: ItemLogicFn<T, ValidationResult>;
 }

--- a/packages/forms/experimental/src/field/context.ts
+++ b/packages/forms/experimental/src/field/context.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {computed, Signal, WritableSignal} from '@angular/core';
+import {computed, Signal, untracked, WritableSignal} from '@angular/core';
 import {Field, FieldContext, FieldPath, FieldState} from '../api/types';
 import {FieldPathNode} from '../path_node';
 import {FieldNode} from './node';
@@ -115,6 +115,18 @@ export class FieldNodeContext implements FieldContext<unknown> {
   get value(): WritableSignal<unknown> {
     return this.node.structure.value;
   }
+
+  get key(): Signal<string> {
+    return this.node.structure.keyInParent;
+  }
+
+  readonly index = computed(() => {
+    const key = this.key();
+    if (!Array.isArray(untracked(this.node.structure.parent!.value))) {
+      throw new Error(`RuntimeError: cannot access index, parent field is not an array`);
+    }
+    return Number(key);
+  });
 
   readonly fieldOf = <P>(p: FieldPath<P>) => this.resolve(p);
   readonly stateOf = <P>(p: FieldPath<P>) => this.resolve(p)();

--- a/packages/forms/experimental/src/field/structure.ts
+++ b/packages/forms/experimental/src/field/structure.ts
@@ -44,7 +44,7 @@ export abstract class FieldNodeStructure {
    */
   abstract readonly childrenMap: Signal<Map<TrackingKey, FieldNode> | undefined>;
   abstract readonly value: WritableSignal<unknown>;
-  abstract readonly keyInParent: Signal<string | number>;
+  abstract readonly keyInParent: Signal<string>;
   abstract readonly fieldManager: FormFieldManager;
   abstract readonly root: FieldNode;
   abstract readonly pathKeys: Signal<readonly PropertyKey[]>;
@@ -124,7 +124,7 @@ export class RootFieldNodeStructure extends FieldNodeStructure {
     return ROOT_PATH_KEYS;
   }
 
-  override get keyInParent(): Signal<string | number> {
+  override get keyInParent(): Signal<string> {
     return ROOT_KEY_IN_PARENT;
   }
 
@@ -153,7 +153,7 @@ export class RootFieldNodeStructure extends FieldNodeStructure {
 export class ChildFieldNodeStructure extends FieldNodeStructure {
   override readonly root: FieldNode;
   override readonly pathKeys: Signal<readonly PropertyKey[]>;
-  override readonly keyInParent: Signal<string | number>;
+  override readonly keyInParent: Signal<string>;
   override readonly value: WritableSignal<unknown>;
 
   override readonly childrenMap: Signal<Map<TrackingKey, FieldNode> | undefined>;
@@ -168,7 +168,7 @@ export class ChildFieldNodeStructure extends FieldNodeStructure {
     logic: LogicNode,
     readonly parent: FieldNode,
     identityInParent: TrackingKey | undefined,
-    initialKeyInParent: string | number,
+    initialKeyInParent: string,
     createChildNode: (options: ChildFieldNodeOptions) => FieldNode,
   ) {
     super(logicPath, logic);
@@ -186,7 +186,7 @@ export class ChildFieldNodeStructure extends FieldNodeStructure {
         return key;
       });
     } else {
-      let lastKnownKey = initialKeyInParent as number;
+      let lastKnownKey = initialKeyInParent;
       this.keyInParent = computed(() => {
         // TODO(alxhub): future perf optimization: here we depend on the parent's value, but most
         // changes to the value aren't structural - they aren't moving around objects and thus
@@ -199,7 +199,7 @@ export class ChildFieldNodeStructure extends FieldNodeStructure {
         }
 
         // Check the parent value at the last known key to avoid a scan.
-        const data = parentValue[lastKnownKey as number];
+        const data = parentValue[lastKnownKey as unknown as number];
         if (
           isObject(data) &&
           data.hasOwnProperty(parent.structure.identitySymbol) &&
@@ -216,7 +216,7 @@ export class ChildFieldNodeStructure extends FieldNodeStructure {
             data.hasOwnProperty(parent.structure.identitySymbol) &&
             data[parent.structure.identitySymbol] === identityInParent
           ) {
-            return (lastKnownKey = i);
+            return (lastKnownKey = i.toString());
           }
         }
 
@@ -257,7 +257,7 @@ export interface ChildFieldNodeOptions {
   readonly parent: FieldNode;
   readonly logicPath: FieldPathNode;
   readonly logic: LogicNode;
-  readonly initialKeyInParent: string | number;
+  readonly initialKeyInParent: string;
   readonly identityInParent: TrackingKey | undefined;
 }
 

--- a/packages/forms/experimental/test/field_context.spec.ts
+++ b/packages/forms/experimental/test/field_context.spec.ts
@@ -5,9 +5,9 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {signal, WritableSignal} from '@angular/core';
+import {Injector, signal, WritableSignal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {FieldContext, FieldPath, form, validate} from '../public_api';
+import {applyEach, FieldContext, FieldPath, form, validate} from '../public_api';
 
 function testContext<T>(
   s: WritableSignal<T>,
@@ -51,6 +51,71 @@ describe('Field Context', () => {
       expect(ctx.field.name().value()).toEqual('pirojok-the-cat');
       expect(ctx.field.age().value()).toEqual(5);
     });
+  });
+
+  it('key', () => {
+    const keys: string[] = [];
+    const recordKey = ({key}: FieldContext<unknown>) => {
+      try {
+        keys.push(key());
+      } catch (e) {
+        keys.push((e as Error).message);
+      }
+      return undefined;
+    };
+    const cat = signal({name: 'pirojok-the-cat', age: 5});
+    const f = form(
+      cat,
+      (p) => {
+        validate(p, recordKey);
+        validate(p.name, recordKey);
+        validate(p.age, recordKey);
+      },
+      {injector: TestBed.inject(Injector)},
+    );
+    f().valid();
+    expect(keys).toEqual([
+      'RuntimeError: the top-level field in the form has no parent',
+      'name',
+      'age',
+    ]);
+  });
+
+  it('index', () => {
+    const indices: (string | number)[] = [];
+    const recordIndex = ({index}: FieldContext<unknown>) => {
+      try {
+        indices.push(index());
+      } catch (e) {
+        indices.push((e as Error).message);
+      }
+      return undefined;
+    };
+    const pets = signal({
+      cats: [
+        {name: 'pirojok-the-cat', age: 5},
+        {name: 'mielo', age: 10},
+      ],
+      owner: 'joe',
+    });
+    const f = form(
+      pets,
+      (p) => {
+        validate(p, recordIndex);
+        applyEach(p.cats, (cat) => {
+          validate(cat, recordIndex);
+        });
+        validate(p.owner, recordIndex);
+      },
+      {injector: TestBed.inject(Injector)},
+    );
+    f().valid();
+    expect(indices).toEqual([
+      'RuntimeError: the top-level field in the form has no parent',
+      0,
+      1,
+      'RuntimeError: cannot access index, parent field is not an array',
+    ]);
   });
 
   it('valueOf', () => {

--- a/packages/forms/experimental/test/field_context.spec.ts
+++ b/packages/forms/experimental/test/field_context.spec.ts
@@ -7,7 +7,15 @@
  */
 import {Injector, signal, WritableSignal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {applyEach, FieldContext, FieldPath, form, validate} from '../public_api';
+import {
+  applyEach,
+  ChildFieldContext,
+  FieldContext,
+  FieldPath,
+  form,
+  ItemFieldContext,
+  validate,
+} from '../public_api';
 
 function testContext<T>(
   s: WritableSignal<T>,
@@ -55,7 +63,7 @@ describe('Field Context', () => {
 
   it('key', () => {
     const keys: string[] = [];
-    const recordKey = ({key}: FieldContext<unknown>) => {
+    const recordKey = ({key}: ChildFieldContext<unknown>) => {
       try {
         keys.push(key());
       } catch (e) {
@@ -67,7 +75,7 @@ describe('Field Context', () => {
     const f = form(
       cat,
       (p) => {
-        validate(p, recordKey);
+        //validate(p, recordKey);
         validate(p.name, recordKey);
         validate(p.age, recordKey);
       },
@@ -75,7 +83,7 @@ describe('Field Context', () => {
     );
     f().valid();
     expect(keys).toEqual([
-      'RuntimeError: the top-level field in the form has no parent',
+      //'RuntimeError: the top-level field in the form has no parent',
       'name',
       'age',
     ]);
@@ -83,7 +91,7 @@ describe('Field Context', () => {
 
   it('index', () => {
     const indices: (string | number)[] = [];
-    const recordIndex = ({index}: FieldContext<unknown>) => {
+    const recordIndex = ({index}: ItemFieldContext<unknown>) => {
       try {
         indices.push(index());
       } catch (e) {
@@ -101,20 +109,19 @@ describe('Field Context', () => {
     const f = form(
       pets,
       (p) => {
-        validate(p, recordIndex);
+        //validate(p, recordIndex);
         applyEach(p.cats, (cat) => {
           validate(cat, recordIndex);
         });
-        validate(p.owner, recordIndex);
+        //validate(p.owner, recordIndex);
       },
       {injector: TestBed.inject(Injector)},
     );
     f().valid();
     expect(indices).toEqual([
-      'RuntimeError: the top-level field in the form has no parent',
-      0,
-      1,
-      'RuntimeError: cannot access index, parent field is not an array',
+      //'RuntimeError: the top-level field in the form has no parent',
+      0, 1,
+      //'RuntimeError: cannot access index, parent field is not an array',
     ]);
   });
 

--- a/packages/forms/experimental/test/logic_node_2.spec.ts
+++ b/packages/forms/experimental/test/logic_node_2.spec.ts
@@ -14,6 +14,8 @@ const fakeFieldContext: FieldContext<unknown> = {
   field: undefined!,
   state: undefined!,
   value: undefined!,
+  key: undefined!,
+  index: undefined!,
 };
 
 describe('LogicNodeBuilder', () => {


### PR DESCRIPTION
TODO: try this and see if its worth the added type complexity:
> Can a FieldPath know if it's generated from an array or object? We could encode the type of key() that way

I explored two ways of doing the typing. I didn't like how this one was ending up so I didn't finish it. I have an alternate PR here: https://github.com/angular/angular/pull/62442 which went a little better