### PR TITLE
refactor(devtools): remove `version_name` from `manifest.json`

### DIFF
--- a/devtools/projects/shell-browser/src/manifest/manifest.chrome.json
+++ b/devtools/projects/shell-browser/src/manifest/manifest.chrome.json
@@ -4,7 +4,6 @@
   "name": "Angular DevTools",
   "description": "Angular DevTools extends Chrome DevTools adding Angular specific debugging and profiling capabilities.",
   "version": "1.0.37",
-  "version_name": "1.0.37",
   "minimum_chrome_version": "102",
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"


### PR DESCRIPTION
This field defaults to `version`, so there's no need to have it when it's exactly the same. This is one less number to bump during release PRs.