### PR TITLE
fix(platform-browser): Fixes Shadowdom encapsulation to not include external styles

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -47,7 +47,7 @@
   },
   "defer": {
     "uncompressed": {
-      "main": 12709,
+      "main": 12014,
       "polyfills": 33807,
       "defer.component": 345
     }

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -30,6 +30,7 @@ describe('DefaultDomRendererV2', () => {
       declarations: [
         TestCmp,
         SomeApp,
+        ShadowComponentParentApp,
         SomeAppForCleanUp,
         CmpEncapsulationEmulated,
         CmpEncapsulationNone,
@@ -109,20 +110,63 @@ describe('DefaultDomRendererV2', () => {
     });
   });
 
-  it('should allow to style components with emulated encapsulation and no encapsulation inside of components with shadow DOM', () => {
+  it('should style non-descendant components correctly with different types of encapsulation', () => {
     const fixture = TestBed.createComponent(SomeApp);
     fixture.detectChanges();
 
     const cmp = fixture.debugElement.query(By.css('cmp-shadow')).nativeElement;
-    const shadow = cmp.shadowRoot.querySelector('.shadow');
-
+    const shadowRoot = cmp.shadowRoot;
+    const shadow = shadowRoot.querySelector('.shadow');
     expect(window.getComputedStyle(shadow).color).toEqual('rgb(255, 0, 0)');
 
-    const emulated = cmp.shadowRoot.querySelector('.emulated');
+    const emulated = fixture.debugElement.query(By.css('.emulated')).nativeElement;
     expect(window.getComputedStyle(emulated).color).toEqual('rgb(0, 0, 255)');
 
-    const none = cmp.shadowRoot.querySelector('.none');
+    const none = fixture.debugElement.query(By.css('.none')).nativeElement;
     expect(window.getComputedStyle(none).color).toEqual('rgb(0, 255, 0)');
+  });
+
+  it('should encapsulate shadow DOM components, with child components inheriting from shadow styles not global styles', () => {
+    const fixture = TestBed.createComponent(ShadowComponentParentApp);
+    fixture.detectChanges();
+
+    const cmp = fixture.debugElement.query(By.css('cmp-shadow')).nativeElement;
+    const shadowRoot = cmp.shadowRoot;
+    const shadow = shadowRoot.querySelector('.shadow');
+    expect(window.getComputedStyle(shadow).color).toEqual('rgb(255, 0, 0)');
+
+    const emulated = fixture.debugElement.query(By.css('.emulated')).nativeElement;
+    expect(window.getComputedStyle(emulated).color).toEqual('rgb(255, 0, 0)');
+
+    const none = fixture.debugElement.query(By.css('.none')).nativeElement;
+    expect(window.getComputedStyle(none).color).toEqual('rgb(255, 0, 0)');
+  });
+
+  it('child components of shadow components should inherit browser defaults rather than their component styles', () => {
+    const fixture = TestBed.createComponent(ShadowComponentParentApp);
+    fixture.detectChanges();
+
+    const cmp = fixture.debugElement.query(By.css('cmp-shadow')).nativeElement;
+    const shadowRoot = cmp.shadowRoot;
+    const shadow = shadowRoot.querySelector('.shadow');
+    expect(window.getComputedStyle(shadow).backgroundColor).toEqual('rgba(0, 0, 0, 0)');
+
+    const emulated = fixture.debugElement.query(By.css('.emulated')).nativeElement;
+    expect(window.getComputedStyle(emulated).backgroundColor).toEqual('rgba(0, 0, 0, 0)');
+
+    const none = fixture.debugElement.query(By.css('.none')).nativeElement;
+    expect(window.getComputedStyle(none).backgroundColor).toEqual('rgba(0, 0, 0, 0)');
+  });
+
+  it('shadow components should not be polluted by child components styles', () => {
+    const fixture = TestBed.createComponent(ShadowComponentParentApp);
+    fixture.detectChanges();
+
+    const cmp = fixture.debugElement.query(By.css('cmp-shadow')).nativeElement;
+    const shadowRoot = cmp.shadowRoot;
+    const shadow = shadowRoot.querySelector('.shadow');
+    expect(window.getComputedStyle(shadow).backgroundColor).not.toEqual('rgb(0, 0, 255)');
+    expect(window.getComputedStyle(shadow).backgroundColor).not.toEqual('rgb(0, 255, 0)');
   });
 
   it('should be able to append children to a <template> element', () => {
@@ -378,8 +422,14 @@ async function styleCount(
 
 @Component({
   selector: 'cmp-emulated',
-  template: `<div class="emulated"></div>`,
-  styles: [`.emulated { color: blue; }`],
+  template: `
+    <div class="emulated"></div>`,
+  styles: [
+    `.emulated {
+      background-color: blue;
+      color: blue;
+    }`,
+  ],
   encapsulation: ViewEncapsulation.Emulated,
   standalone: false,
 })
@@ -387,8 +437,14 @@ class CmpEncapsulationEmulated {}
 
 @Component({
   selector: 'cmp-none',
-  template: `<div class="none"></div>`,
-  styles: [`.none { color: lime; }`],
+  template: `
+    <div class="none"></div>`,
+  styles: [
+    `.none {
+      background-color: lime;
+      color: lime;
+    }`,
+  ],
   encapsulation: ViewEncapsulation.None,
   standalone: false,
 })
@@ -396,8 +452,16 @@ class CmpEncapsulationNone {}
 
 @Component({
   selector: 'cmp-none',
-  template: `<div class="none"></div>`,
-  styles: [`.none { color: lime; }\n/*# sourceMappingURL=cmp-none.css.map */`],
+  template: `
+    <div class="none"></div>`,
+  styles: [
+    `.none {
+      background-color: lime;
+      color: lime;
+    }
+
+    /*# sourceMappingURL=cmp-none.css.map */`,
+  ],
   encapsulation: ViewEncapsulation.None,
   standalone: false,
 })
@@ -405,8 +469,15 @@ class CmpEncapsulationNoneWithSourceMap {}
 
 @Component({
   selector: 'cmp-shadow',
-  template: `<div class="shadow"></div><cmp-emulated></cmp-emulated><cmp-none></cmp-none>`,
-  styles: [`.shadow { color: red; }`],
+  template: `
+    <div class="shadow">
+      <ng-content></ng-content>
+    </div>`,
+  styles: [
+    `.shadow {
+      color: red;
+    }`,
+  ],
   encapsulation: ViewEncapsulation.ShadowDom,
   standalone: false,
 })
@@ -422,6 +493,18 @@ class CmpEncapsulationShadow {}
   standalone: false,
 })
 export class SomeApp {}
+
+@Component({
+  selector: 'shadow-parent-app',
+  template: `
+    <cmp-shadow>
+      <cmp-emulated></cmp-emulated>
+      <cmp-none></cmp-none>
+    </cmp-shadow>
+  `,
+  standalone: false,
+})
+export class ShadowComponentParentApp {}
 
 @Component({
   selector: 'test-cmp',

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -148,8 +148,6 @@ describe('DefaultDomRendererV2', () => {
     const fixture = TestBed.createComponent(ShadowComponentParentApp);
     fixture.detectChanges();
 
-    const host = fixture.debugElement;
-    console.log(host);
     const shadowcmp = fixture.debugElement.query(By.css('cmp-shadow-children')).nativeElement;
     const shadowRoot = shadowcmp.shadowRoot;
     const shadow = shadowRoot.querySelector('.shadow');

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -35,6 +35,7 @@ describe('DefaultDomRendererV2', () => {
         CmpEncapsulationEmulated,
         CmpEncapsulationNone,
         CmpEncapsulationShadow,
+        CmpEncapsulationShadowWithChildren,
       ],
     });
     renderer = TestBed.createComponent(TestCmp).componentInstance.renderer;
@@ -130,8 +131,9 @@ describe('DefaultDomRendererV2', () => {
     const fixture = TestBed.createComponent(ShadowComponentParentApp);
     fixture.detectChanges();
 
-    const cmp = fixture.debugElement.query(By.css('cmp-shadow')).nativeElement;
-    const shadowRoot = cmp.shadowRoot;
+    const shadowcmp = fixture.debugElement.query(By.css('cmp-shadow-children')).nativeElement;
+    const shadowRoot = shadowcmp.shadowRoot;
+
     const shadow = shadowRoot.querySelector('.shadow');
     expect(window.getComputedStyle(shadow).color).toEqual('rgb(255, 0, 0)');
 
@@ -146,8 +148,10 @@ describe('DefaultDomRendererV2', () => {
     const fixture = TestBed.createComponent(ShadowComponentParentApp);
     fixture.detectChanges();
 
-    const cmp = fixture.debugElement.query(By.css('cmp-shadow')).nativeElement;
-    const shadowRoot = cmp.shadowRoot;
+    const host = fixture.debugElement;
+    console.log(host);
+    const shadowcmp = fixture.debugElement.query(By.css('cmp-shadow-children')).nativeElement;
+    const shadowRoot = shadowcmp.shadowRoot;
     const shadow = shadowRoot.querySelector('.shadow');
     expect(window.getComputedStyle(shadow).backgroundColor).toEqual('rgba(0, 0, 0, 0)');
 
@@ -162,7 +166,7 @@ describe('DefaultDomRendererV2', () => {
     const fixture = TestBed.createComponent(ShadowComponentParentApp);
     fixture.detectChanges();
 
-    const cmp = fixture.debugElement.query(By.css('cmp-shadow')).nativeElement;
+    const cmp = fixture.debugElement.query(By.css('cmp-shadow-children')).nativeElement;
     const shadowRoot = cmp.shadowRoot;
     const shadow = shadowRoot.querySelector('.shadow');
     expect(window.getComputedStyle(shadow).backgroundColor).not.toEqual('rgb(0, 0, 255)');
@@ -470,9 +474,7 @@ class CmpEncapsulationNoneWithSourceMap {}
 @Component({
   selector: 'cmp-shadow',
   template: `
-    <div class="shadow">
-      <ng-content></ng-content>
-    </div>`,
+    <div class="shadow"></div>`,
   styles: [
     `.shadow {
       color: red;
@@ -482,6 +484,23 @@ class CmpEncapsulationNoneWithSourceMap {}
   standalone: false,
 })
 class CmpEncapsulationShadow {}
+
+@Component({
+  selector: 'cmp-shadow-children',
+  template: `
+    <div class="shadow">
+      <cmp-emulated></cmp-emulated>
+      <cmp-none></cmp-none>
+    </div>`,
+  styles: [
+    `.shadow {
+      color: red;
+    }`,
+  ],
+  encapsulation: ViewEncapsulation.ShadowDom,
+  standalone: false,
+})
+class CmpEncapsulationShadowWithChildren {}
 
 @Component({
   selector: 'some-app',
@@ -495,12 +514,10 @@ class CmpEncapsulationShadow {}
 export class SomeApp {}
 
 @Component({
-  selector: 'shadow-parent-app',
+  selector: 'shadow-parent-app-with-children',
   template: `
-    <cmp-shadow>
-      <cmp-emulated></cmp-emulated>
-      <cmp-none></cmp-none>
-    </cmp-shadow>
+    <cmp-shadow-children>
+    </cmp-shadow-children>
   `,
   standalone: false,
 })


### PR DESCRIPTION
Fixes Shadowdom encapsulation to not include external styles that are not declared by the component. Prevents style bleed, so components are scoped correctly. Now adheres to the spec for Shadowdom

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: [57801](https://github.com/angular/angular/issues/57801)

The current Shadowdom implementation is incorrect, and does not adhere to the spec. Shadowdom components should be encapsulated with no style leakage, but currently, external styles are added that are completely unrelated to the shadow component. This causes significant bloat.

### Before:
<img width="385" alt="Screenshot 2025-06-27 at 15 32 02" src="https://github.com/user-attachments/assets/0b5e2f43-f9dc-4bd3-951c-a0ef8c3fe374" />

### After:
<img width="317" alt="Screenshot 2025-06-28 at 07 12 54" src="https://github.com/user-attachments/assets/380de607-1b3c-4cf6-97a2-7c3ff9735bb1" />


## What is the new behavior?
The new behaviour removes the `sharedStylesHost` from the domrenderer for ShadowDom. There should be _NO_ shared styles polluting the shadowdom.


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Now that it follows the spec, shadowdom does not now add `<style>` tags unrelated/not imported/defined by the component. If someone has built ui off of (incorrectly) expecting styles not imported by the shadow component to be there, they will need to update their components to declare the necessary styles for that component.

## Other information

I have tested this in an enterprise application (over 6000 components), with multiple shadowdom components - each use of one of these components previously added ~50kb bloat, per component. After this change, only the styles that have been declared inside the component are added to it, fixing the bug and making Angular's shadowdom implementation adhere to the spec.

Ideally this would be available as a patch version in both `v19` and `v20`

Your own documentation is currently slightly at odds with the current behaviour. This fix will make the documentation accurate/correct.

> [ViewEncapsulation.ShadowDom](https://angular.dev/guide/components/styling#viewencapsulationshadowdom)
> This mode scopes styles within a component by using [the web standard Shadow DOM API](https://developer.mozilla.org/docs/Web/Web_Components/Using_shadow_DOM). When enabling this mode, Angular attaches a shadow root to the component's host element and renders the component's template and styles into the corresponding shadow tree.
> 
> This mode strictly guarantees that only that component's styles apply to elements in the component's template. Global styles cannot affect elements in a shadow tree and styles inside the shadow tree cannot affect elements outside of that shadow tree.
