### PR TITLE
docs: fix broken link on `assertNotInReactiveContext` ref page

### DIFF
--- a/packages/core/src/render3/reactivity/asserts.ts
+++ b/packages/core/src/render3/reactivity/asserts.ts
@@ -12,7 +12,7 @@ import {RuntimeError, RuntimeErrorCode} from '../../errors';
 
 /**
  * Asserts that the current stack frame is not within a reactive context. Useful
- * to disallow certain code from running inside a reactive context (see {@link /api/core/rxjs/toSignal toSignal})
+ * to disallow certain code from running inside a reactive context (see {@link /api/core/rxjs-interop/toSignal toSignal})
  *
  * @param debugFn a reference to the function making the assertion (used for the error message).
  *


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

On the [assertNotInReactiveContext](https://angular.dev/api/core/assertNotInReactiveContext) reference page, the link to `toSignal` leads to a [404](https://angular.dev/api/core/rxjs/toSignal) page.

Broken link: https://angular.dev/api/core/rxjs/toSignal

Related to: #57591 

## What is the new behavior?

The `toSignal` link now correctly points to its actual reference page.

Updated link: https://angular.dev/api/core/rxjs-interop/toSignal

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
