### PR TITLE
docs(docs-infra): replace deprecated RouterTestingModule with RouterM…

### DIFF
--- a/adev/shared-docs/components/breadcrumb/breadcrumb.component.spec.ts
+++ b/adev/shared-docs/components/breadcrumb/breadcrumb.component.spec.ts
@@ -23,8 +23,9 @@ describe('Breadcrumb', () => {
     navigationStateSpy = jasmine.createSpyObj('NavigationState', ['activeNavigationItem']);
 
     TestBed.configureTestingModule({
-      imports: [Breadcrumb, provideRouter([])],
+      imports: [Breadcrumb],
       providers: [
+        provideRouter([]),
         provideZonelessChangeDetection(),
         {
           provide: NavigationState,

--- a/adev/shared-docs/components/breadcrumb/breadcrumb.component.spec.ts
+++ b/adev/shared-docs/components/breadcrumb/breadcrumb.component.spec.ts
@@ -12,7 +12,7 @@ import {Breadcrumb} from './breadcrumb.component';
 import {NavigationState} from '../../services';
 import {NavigationItem} from '../../interfaces';
 import {By} from '@angular/platform-browser';
-import {RouterTestingModule} from '@angular/router/testing';
+import {provideRouter} from '@angular/router';
 import {provideZonelessChangeDetection} from '@angular/core';
 
 describe('Breadcrumb', () => {
@@ -23,7 +23,7 @@ describe('Breadcrumb', () => {
     navigationStateSpy = jasmine.createSpyObj('NavigationState', ['activeNavigationItem']);
 
     TestBed.configureTestingModule({
-      imports: [Breadcrumb, RouterTestingModule],
+      imports: [Breadcrumb, provideRouter([])],
       providers: [
         provideZonelessChangeDetection(),
         {

--- a/adev/shared-docs/components/search-dialog/search-dialog.component.spec.ts
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.spec.ts
@@ -14,8 +14,7 @@ import {ALGOLIA_CLIENT, Search} from '../../services';
 import {FakeEventTarget} from '../../testing/index';
 import {By} from '@angular/platform-browser';
 import {AlgoliaIcon} from '../algolia-icon/algolia-icon.component';
-import {RouterTestingModule} from '@angular/router/testing';
-import {Router} from '@angular/router';
+import {Router, provideRouter} from '@angular/router';
 import {ApplicationRef, provideZonelessChangeDetection, ResourceStatus} from '@angular/core';
 import {SearchResult} from '../../interfaces';
 
@@ -32,7 +31,7 @@ describe('SearchDialog', () => {
     searchResults.and.returnValue([]);
 
     TestBed.configureTestingModule({
-      imports: [SearchDialog, RouterTestingModule],
+      imports: [SearchDialog, provideRouter([])],
       providers: [
         provideZonelessChangeDetection(),
         {provide: ENVIRONMENT, useValue: {algolia: {index: 'fakeIndex'}}},

--- a/adev/shared-docs/components/search-dialog/search-dialog.component.spec.ts
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.spec.ts
@@ -31,8 +31,9 @@ describe('SearchDialog', () => {
     searchResults.and.returnValue([]);
 
     TestBed.configureTestingModule({
-      imports: [SearchDialog, provideRouter([])],
+      imports: [SearchDialog],
       providers: [
+        provideRouter([]),
         provideZonelessChangeDetection(),
         {provide: ENVIRONMENT, useValue: {algolia: {index: 'fakeIndex'}}},
         {provide: ALGOLIA_CLIENT, useValue: {search: searchResults}},

--- a/adev/shared-docs/components/table-of-contents/table-of-contents.component.spec.ts
+++ b/adev/shared-docs/components/table-of-contents/table-of-contents.component.spec.ts
@@ -41,8 +41,9 @@ describe('TableOfContents', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TableOfContents, provideRouter([])],
+      imports: [TableOfContents],
       providers: [
+        provideRouter([]),
         provideZonelessChangeDetection(),
         {
           provide: WINDOW,

--- a/adev/shared-docs/components/table-of-contents/table-of-contents.component.spec.ts
+++ b/adev/shared-docs/components/table-of-contents/table-of-contents.component.spec.ts
@@ -8,7 +8,7 @@
 
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TableOfContents} from './table-of-contents.component';
-import {RouterTestingModule} from '@angular/router/testing';
+import {provideRouter} from '@angular/router';
 import {TableOfContentsItem, TableOfContentsLevel} from '../../interfaces/index';
 import {TableOfContentsLoader} from '../../services/index';
 import {WINDOW} from '../../providers/index';
@@ -41,7 +41,7 @@ describe('TableOfContents', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TableOfContents, RouterTestingModule],
+      imports: [TableOfContents, provideRouter([])],
       providers: [
         provideZonelessChangeDetection(),
         {

--- a/adev/shared-docs/directives/click-outside/click-outside.directive.spec.ts
+++ b/adev/shared-docs/directives/click-outside/click-outside.directive.spec.ts
@@ -8,7 +8,7 @@
 
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {RouterTestingModule} from '@angular/router/testing';
+import {provideRouter} from '@angular/router';
 import {ClickOutside} from './click-outside.directive';
 import {By} from '@angular/platform-browser';
 
@@ -18,7 +18,7 @@ describe('ClickOutside', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ExampleComponent, RouterTestingModule],
+      imports: [ExampleComponent, provideRouter([])],
     });
     fixture = TestBed.createComponent(ExampleComponent);
     component = fixture.componentInstance;

--- a/adev/shared-docs/directives/click-outside/click-outside.directive.spec.ts
+++ b/adev/shared-docs/directives/click-outside/click-outside.directive.spec.ts
@@ -18,7 +18,8 @@ describe('ClickOutside', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ExampleComponent, provideRouter([])],
+      imports: [ExampleComponent],
+      providers: [provideRouter([])],
     });
     fixture = TestBed.createComponent(ExampleComponent);
     component = fixture.componentInstance;

--- a/adev/shared-docs/directives/external-link/external-link.directive.spec.ts
+++ b/adev/shared-docs/directives/external-link/external-link.directive.spec.ts
@@ -8,10 +8,9 @@
 
 import {Component} from '@angular/core';
 import {ExternalLink} from './external-link.directive';
-import {RouterLink} from '@angular/router';
+import {provideRouter, RouterLink} from '@angular/router';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {WINDOW} from '../../providers';
-import {RouterTestingModule} from '@angular/router/testing';
 import {By} from '@angular/platform-browser';
 
 describe('ExternalLink', () => {
@@ -24,7 +23,7 @@ describe('ExternalLink', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ExampleComponentWithLinks, RouterTestingModule],
+      imports: [ExampleComponentWithLinks, provideRouter([])],
       providers: [
         {
           provide: WINDOW,

--- a/adev/shared-docs/directives/external-link/external-link.directive.spec.ts
+++ b/adev/shared-docs/directives/external-link/external-link.directive.spec.ts
@@ -23,8 +23,9 @@ describe('ExternalLink', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ExampleComponentWithLinks, provideRouter([])],
+      imports: [ExampleComponentWithLinks],
       providers: [
+        provideRouter([]),
         {
           provide: WINDOW,
           useValue: fakeWindow,

--- a/adev/src/app/core/layout/footer/footer.component.spec.ts
+++ b/adev/src/app/core/layout/footer/footer.component.spec.ts
@@ -9,7 +9,7 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {WINDOW} from '@angular/docs';
-import {RouterTestingModule} from '@angular/router/testing';
+import {provideRouter} from '@angular/router';
 import {Footer} from './footer.component';
 
 describe('Footer', () => {
@@ -23,7 +23,7 @@ describe('Footer', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [Footer, RouterTestingModule],
+      imports: [Footer, provideRouter([])],
       providers: [
         {
           provide: WINDOW,

--- a/adev/src/app/core/layout/footer/footer.component.spec.ts
+++ b/adev/src/app/core/layout/footer/footer.component.spec.ts
@@ -23,8 +23,9 @@ describe('Footer', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [Footer, provideRouter([])],
+      imports: [Footer],
       providers: [
+        provideRouter([]),
         {
           provide: WINDOW,
           useValue: fakeWindow,

--- a/adev/src/app/core/layout/navigation/navigation.component.spec.ts
+++ b/adev/src/app/core/layout/navigation/navigation.component.spec.ts
@@ -9,7 +9,7 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {Navigation} from './navigation.component';
-import {RouterTestingModule} from '@angular/router/testing';
+import {provideRouter} from '@angular/router';
 import {By} from '@angular/platform-browser';
 import {PagePrefix} from '../../enums/pages';
 import {Theme, ThemeManager} from '../../services/theme-manager.service';
@@ -38,7 +38,7 @@ describe('Navigation', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Navigation, RouterTestingModule],
+      imports: [Navigation, provideRouter([])],
       providers: [
         {
           provide: WINDOW,

--- a/adev/src/app/core/layout/navigation/navigation.component.spec.ts
+++ b/adev/src/app/core/layout/navigation/navigation.component.spec.ts
@@ -38,8 +38,9 @@ describe('Navigation', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Navigation, provideRouter([])],
+      imports: [Navigation],
       providers: [
+        provideRouter([]),
         {
           provide: WINDOW,
           useValue: fakeWindow,

--- a/adev/src/app/core/layout/progress-bar/progress-bar.component.spec.ts
+++ b/adev/src/app/core/layout/progress-bar/progress-bar.component.spec.ts
@@ -10,7 +10,7 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {PROGRESS_BAR_DELAY, ProgressBarComponent} from './progress-bar.component';
 import {RouterTestingHarness} from '@angular/router/testing';
-import {provideRouter, RouterModule} from '@angular/router';
+import {provideRouter} from '@angular/router';
 
 describe('ProgressBarComponent', () => {
   let component: ProgressBarComponent;
@@ -18,7 +18,8 @@ describe('ProgressBarComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ProgressBarComponent, provideRouter([])],
+      imports: [ProgressBarComponent],
+      providers: [provideRouter([])],
     });
 
     fixture = TestBed.createComponent(ProgressBarComponent);

--- a/adev/src/app/core/layout/progress-bar/progress-bar.component.spec.ts
+++ b/adev/src/app/core/layout/progress-bar/progress-bar.component.spec.ts
@@ -9,7 +9,8 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {PROGRESS_BAR_DELAY, ProgressBarComponent} from './progress-bar.component';
-import {RouterTestingHarness, RouterTestingModule} from '@angular/router/testing';
+import {RouterTestingHarness} from '@angular/router/testing';
+import {provideRouter, RouterModule} from '@angular/router';
 
 describe('ProgressBarComponent', () => {
   let component: ProgressBarComponent;
@@ -17,7 +18,7 @@ describe('ProgressBarComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ProgressBarComponent, RouterTestingModule],
+      imports: [ProgressBarComponent, provideRouter([])],
     });
 
     fixture = TestBed.createComponent(ProgressBarComponent);

--- a/adev/src/app/features/docs/docs.component.spec.ts
+++ b/adev/src/app/features/docs/docs.component.spec.ts
@@ -25,8 +25,9 @@ describe('DocsComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [DocsComponent, provideRouter([])],
+      imports: [DocsComponent],
       providers: [
+        provideRouter([]),
         {
           provide: WINDOW,
           useValue: fakeWindow,

--- a/adev/src/app/features/docs/docs.component.spec.ts
+++ b/adev/src/app/features/docs/docs.component.spec.ts
@@ -9,7 +9,7 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import DocsComponent from './docs.component';
-import {RouterTestingModule} from '@angular/router/testing';
+import {provideRouter} from '@angular/router';
 import {DOCS_CONTENT_LOADER, WINDOW} from '@angular/docs';
 
 describe('DocsComponent', () => {
@@ -25,7 +25,7 @@ describe('DocsComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [DocsComponent, RouterTestingModule],
+      imports: [DocsComponent, provideRouter([])],
       providers: [
         {
           provide: WINDOW,


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
Replace deprecated RouterTestingModule with RouterModule.forRoot([])

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Uses deprecated RouterTestingModule

Issue Number: N/A


## What is the new behavior?
Replace deprecated RouterTestingModule with RouterModule.forRoot([])

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
