### PR TITLE
fix(devtools): restore the router tree visualization legend

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.html
@@ -6,11 +6,13 @@
   </div>
 </div>
 <as-split unit="percent" direction="horizontal" [gutterSize]="9" class="visualization">
-  <div class="legend">
-    <p class="eager">Eager-loaded route</p>
-    <p class="lazy">Lazy-loaded route</p>
-    <p class="active">Active route</p>
-  </div>
+  <aside class="legend" aria-hidden="true">
+    <ul>
+      <li class="eager">Eager-loaded route</li>
+      <li class="lazy">Lazy-loaded route</li>
+      <li class="active">Active route</li>
+    </ul>
+  </aside>
   <as-split-area size="70">
     <as-split unit="percent" direction="vertical" [gutterSize]="9">
       <as-split-area size="100">

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.html
@@ -6,6 +6,11 @@
   </div>
 </div>
 <as-split unit="percent" direction="horizontal" [gutterSize]="9" class="visualization">
+  <div class="legend">
+    <p class="eager">Eager-loaded route</p>
+    <p class="lazy">Lazy-loaded route</p>
+    <p class="active">Active route</p>
+  </div>
   <as-split-area size="70">
     <as-split unit="percent" direction="vertical" [gutterSize]="9">
       <as-split-area size="100">

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.scss
@@ -55,38 +55,44 @@
       background-color: color-mix(in srgb, var(--color-background) 80%, transparent 20%);
       backdrop-filter: blur(8px);
 
-      p {
+      ul {
+        list-style-type: none;
+        padding: 0;
         margin: 0;
-        display: flex;
-        align-items: center;
-        gap: 0.375rem;
-        color: var(--tertiary-contrast);
 
-        &:not(:last-child) {
-          margin-bottom: 0.75rem;
-        }
+        li {
+          margin: 0;
+          display: flex;
+          align-items: center;
+          gap: 0.375rem;
+          color: var(--tertiary-contrast);
 
-        &::before {
-          content: '';
-          display: block;
-          width: 12px;
-          height: 12px;
-          border: 1px solid;
-        }
+          &:not(:last-child) {
+            margin-bottom: 0.75rem;
+          }
 
-        &.eager::before {
-          border-color: var(--red-05);
-          background-color: var(--red-06);
-        }
+          &::before {
+            content: '';
+            display: block;
+            width: 12px;
+            height: 12px;
+            border: 1px solid;
+          }
 
-        &.lazy::before {
-          border-color: var(--blue-02);
-          background-color: var(--blue-03);
-        }
+          &.eager::before {
+            border-color: var(--red-05);
+            background-color: var(--red-06);
+          }
 
-        &.active::before {
-          border-color: var(--green-02);
-          background-color: var(--green-03);
+          &.lazy::before {
+            border-color: var(--blue-02);
+            background-color: var(--blue-03);
+          }
+
+          &.active::before {
+            border-color: var(--green-02);
+            background-color: var(--green-03);
+          }
         }
       }
     }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.scss
@@ -45,5 +45,50 @@
       width: 100%;
       font-size: 0.75rem;
     }
+
+    .legend {
+      position: absolute;
+      bottom: 0.75rem;
+      left: 0.75rem;
+      padding: 0.5rem;
+      border-radius: 0.5rem;
+      background-color: color-mix(in srgb, var(--color-background) 80%, transparent 20%);
+      backdrop-filter: blur(8px);
+
+      p {
+        margin: 0;
+        display: flex;
+        align-items: center;
+        gap: 0.375rem;
+        color: var(--tertiary-contrast);
+
+        &:not(:last-child) {
+          margin-bottom: 0.75rem;
+        }
+
+        &::before {
+          content: '';
+          display: block;
+          width: 12px;
+          height: 12px;
+          border: 1px solid;
+        }
+
+        &.eager::before {
+          border-color: var(--red-05);
+          background-color: var(--red-06);
+        }
+
+        &.lazy::before {
+          border-color: var(--blue-02);
+          background-color: var(--blue-03);
+        }
+
+        &.active::before {
+          border-color: var(--green-02);
+          background-color: var(--green-03);
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## What is the current behavior?

#62264 drops the legend since it was part of the SVG visualization.

## What is the new behavior?

Fixes the regression by adding the legend in the HTML template instead.
