### PR TITLE
docs: update breaking change for nullish coalesching + parenthesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,11 @@ Blog post: https://blog.angular.dev/announcing-angular-v20-b5c9c06cf301
   `void` operator, which would make the above example invalid. If you have
   existing expressions that need to refer to a property named `void`,
   change the expression to use `this.void` instead: `{{this.void}}`.
+- Parenthesis are always respected. 
+
+  This can lead to runtime breakages when a nullish coalescing operator is nested within parentheses. 
+  eg. `{{ (foo?.bar).baz }}` will throw if `foo` is nullish. This is the same behavior as native JavaScript. 
+
 ### core
 - TypeScript versions less than 5.8 are no longer supported.
 - the `TestBed.flushEffects()` was removed - use

--- a/adev/src/app/features/update/recommendations.ts
+++ b/adev/src/app/features/update/recommendations.ts
@@ -2734,4 +2734,12 @@ export const RECOMMENDATIONS: Step[] = [
     action:
       'Review `DatePipe` usages. Using the `Y` (week-numbering year) formatter without also including `w` (week number) is now detected as suspicious. Use `y` (year) if that was the intent, or include `w` alongside `Y`.',
   },
+  {
+    possibleIn: 2000,
+    necessaryAsOf: 2000,
+    level: ApplicationComplexity.Medium,
+    step: '20.0.0_handle_uncaught_listener_errors_in_tests',
+    action:
+      'In templates parentheses are now always respected. This can lead to runtime breakages when nullish coalescing were nested in parathesis. eg `(foo?.bar).baz` will throw if `foo` is nullish as it would in native JavaScript.',
+  },
 ];


### PR DESCRIPTION
This breakage was introduced by #60169

fixes #62375
