### PR TITLE
feat(http): add credentials support for fetch requests in httpResource

### DIFF
--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -2524,6 +2524,7 @@ export interface HttpResourceRequest {
     body?: unknown;
     cache?: RequestCache | (string & {});
     context?: HttpContext;
+    credentials?: RequestCredentials | (string & {});
     headers?: HttpHeaders | Record<string, string | ReadonlyArray<string>>;
     keepalive?: boolean;
     method?: string;

--- a/packages/common/http/src/resource.ts
+++ b/packages/common/http/src/resource.ts
@@ -286,6 +286,7 @@ function normalizeRequest(
       responseType,
       context: unwrappedRequest.context,
       transferCache: unwrappedRequest.transferCache,
+      credentials: unwrappedRequest.credentials as RequestCredentials,
       timeout: unwrappedRequest.timeout,
     },
   );

--- a/packages/common/http/src/resource_api.ts
+++ b/packages/common/http/src/resource_api.ts
@@ -82,6 +82,12 @@ export interface HttpResourceRequest {
   cache?: RequestCache | (string & {});
 
   /**
+   * The credentials mode of the request, which determines how cookies and other authentication information are handled.
+   * This can affect whether credentials are sent with cross-origin requests or not.
+   */
+  credentials?: RequestCredentials | (string & {});
+
+  /**
    * Indicates the relative priority of the request. This may be used by the browser to decide the order in which requests are dispatched and resources fetched.
    */
   priority?: RequestPriority | (string & {});

--- a/packages/common/http/test/resource_spec.ts
+++ b/packages/common/http/test/resource_spec.ts
@@ -110,6 +110,7 @@ describe('httpResource', () => {
         priority: 'high',
         mode: 'cors',
         redirect: 'follow',
+        credentials: 'include',
       }),
       {injector: TestBed.inject(Injector)},
     );
@@ -124,6 +125,7 @@ describe('httpResource', () => {
     expect(req.request.priority).toBe('high');
     expect(req.request.mode).toBe('cors');
     expect(req.request.redirect).toBe('follow');
+    expect(req.request.credentials).toBe('include');
 
     req.flush([]);
 


### PR DESCRIPTION
Currently, Angular's httpResource does not expose the credentials option from the underlying Fetch API.

Exposing this option would allow developers to explicitly control how cookies, authorization headers, and TLS client certificates are handled in cross-origin requests, aligning with security requirements and enabling better integration with external APIs.

New usage

```ts
httpResource(() => ({
  url: '${ANOTHER_DOMAIN}/api/register',
  method: 'POST',
  credentials: 'include'
}));
```