### PR TITLE
refactor(core): rename all animations package symbols

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -7,7 +7,7 @@
  */
 
 import {
-  AnimationTriggerNames,
+  LegacyAnimationTriggerNames,
   BoundTarget,
   compileClassDebugInfo,
   compileHmrInitializer,
@@ -187,8 +187,8 @@ import {
 } from './resources';
 import {ComponentSymbol} from './symbol';
 import {
-  animationTriggerResolver,
-  collectAnimationNames,
+  legacyAnimationTriggerResolver,
+  collectLegacyAnimationNames,
   validateAndFlattenComponentImports,
 } from './util';
 import {getTemplateDiagnostics, createHostElement} from '../../../typecheck';
@@ -534,16 +534,16 @@ export class ComponentDecoratorHandler
     }
 
     let animations: o.Expression | null = null;
-    let animationTriggerNames: AnimationTriggerNames | null = null;
+    let legacyAnimationTriggerNames: LegacyAnimationTriggerNames | null = null;
     if (component.has('animations')) {
       const animationExpression = component.get('animations')!;
       animations = new o.WrappedNodeExpr(animationExpression);
       const animationsValue = this.evaluator.evaluate(
         animationExpression,
-        animationTriggerResolver,
+        legacyAnimationTriggerResolver,
       );
-      animationTriggerNames = {includesDynamicAnimations: false, staticTriggerNames: []};
-      collectAnimationNames(animationsValue, animationTriggerNames);
+      legacyAnimationTriggerNames = {includesDynamicAnimations: false, staticTriggerNames: []};
+      collectLegacyAnimationNames(animationsValue, legacyAnimationTriggerNames);
     }
 
     // Go through the root directories for this project, and select the one with the smallest
@@ -991,7 +991,7 @@ export class ComponentDecoratorHandler
           hostBindings: hostBindingResources,
         },
         isPoisoned,
-        animationTriggerNames,
+        legacyAnimationTriggerNames: legacyAnimationTriggerNames,
         rawImports,
         resolvedImports,
         rawDeferredImports,
@@ -1047,7 +1047,7 @@ export class ComponentDecoratorHandler
       imports: analysis.resolvedImports,
       rawImports: analysis.rawImports,
       deferredImports: analysis.resolvedDeferredImports,
-      animationTriggerNames: analysis.animationTriggerNames,
+      animationTriggerNames: analysis.legacyAnimationTriggerNames,
       schemas: analysis.schemas,
       decorator: analysis.decorator,
       assumedToExportProviders: false,

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/metadata.ts
@@ -7,7 +7,7 @@
  */
 
 import {
-  AnimationTriggerNames,
+  LegacyAnimationTriggerNames,
   DeclarationListEmitMode,
   DeferBlockDepsEmitMode,
   R3ClassDebugInfo,
@@ -88,7 +88,7 @@ export interface ComponentAnalysisData {
   inlineStyles: string[] | null;
 
   isPoisoned: boolean;
-  animationTriggerNames: AnimationTriggerNames | null;
+  legacyAnimationTriggerNames: LegacyAnimationTriggerNames | null;
 
   rawImports: ts.Expression | null;
   resolvedImports: Reference<ClassDeclaration>[] | null;

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/util.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {AnimationTriggerNames} from '@angular/compiler';
+import {LegacyAnimationTriggerNames} from '@angular/compiler';
 import {isResolvedModuleWithProviders, ResolvedModuleWithProviders} from '../../ng_module';
 import {ErrorCode, FatalDiagnosticError, makeDiagnostic} from '../../../diagnostics';
 import ts from 'typescript';
@@ -25,43 +25,46 @@ import {createValueHasWrongTypeError, getOriginNodeForDiagnostics} from '../../c
 /**
  * Collect the animation names from the static evaluation result.
  * @param value the static evaluation result of the animations
- * @param animationTriggerNames the animation names collected and whether some names could not be
+ * @param legacyAnimationTriggerNames the animation names collected and whether some names could not be
  *     statically evaluated.
  */
-export function collectAnimationNames(
+export function collectLegacyAnimationNames(
   value: ResolvedValue,
-  animationTriggerNames: AnimationTriggerNames,
+  legacyAnimationTriggerNames: LegacyAnimationTriggerNames,
 ) {
   if (value instanceof Map) {
     const name = value.get('name');
     if (typeof name === 'string') {
-      animationTriggerNames.staticTriggerNames.push(name);
+      legacyAnimationTriggerNames.staticTriggerNames.push(name);
     } else {
-      animationTriggerNames.includesDynamicAnimations = true;
+      legacyAnimationTriggerNames.includesDynamicAnimations = true;
     }
   } else if (Array.isArray(value)) {
     for (const resolvedValue of value) {
-      collectAnimationNames(resolvedValue, animationTriggerNames);
+      collectLegacyAnimationNames(resolvedValue, legacyAnimationTriggerNames);
     }
   } else {
-    animationTriggerNames.includesDynamicAnimations = true;
+    legacyAnimationTriggerNames.includesDynamicAnimations = true;
   }
 }
 
-export function isAngularAnimationsReference(reference: Reference, symbolName: string): boolean {
+export function isLegacyAngularAnimationsReference(
+  reference: Reference,
+  symbolName: string,
+): boolean {
   return (
     reference.ownedByModuleGuess === '@angular/animations' && reference.debugName === symbolName
   );
 }
 
-export const animationTriggerResolver: ForeignFunctionResolver = (
+export const legacyAnimationTriggerResolver: ForeignFunctionResolver = (
   fn,
   node,
   resolve,
   unresolvable,
 ) => {
   const animationTriggerMethodName = 'trigger';
-  if (!isAngularAnimationsReference(fn, animationTriggerMethodName)) {
+  if (!isLegacyAngularAnimationsReference(fn, animationTriggerMethodName)) {
     return unresolvable;
   }
   const triggerNameExpression = node.arguments[0];

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/interpolated_signal_not_invoked/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/interpolated_signal_not_invoked/index.ts
@@ -72,7 +72,7 @@ class InterpolatedSignalCheck extends TemplateCheckWithVisitor<ErrorCode.INTERPO
           // or an attribute binding like `[attr.role]="mySignal"`
           node.type === BindingType.Attribute ||
           // or an animation binding like `[@myAnimation]="mySignal"`
-          node.type === BindingType.Animation) &&
+          node.type === BindingType.LegacyAnimation) &&
         nodeAst
       ) {
         return buildDiagnosticForSignal(ctx, nodeAst, component);

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/uninvoked_function_in_event_binding/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/uninvoked_function_in_event_binding/index.ts
@@ -42,7 +42,8 @@ class UninvokedFunctionInEventBindingSpec extends TemplateCheckWithVisitor<Error
     if (!(node instanceof TmplAstBoundEvent)) return [];
 
     // If the node is not a regular or animation event, skip it.
-    if (node.type !== ParsedEventType.Regular && node.type !== ParsedEventType.Animation) return [];
+    if (node.type !== ParsedEventType.Regular && node.type !== ParsedEventType.LegacyAnimation)
+      return [];
 
     if (!(node.handler instanceof ASTWithSource)) return [];
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/host_bindings.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/host_bindings.ts
@@ -393,8 +393,8 @@ function createNodeFromListenerDecorator(
   let target: string | null;
 
   if (eventNameNode.text.startsWith('@')) {
-    const parsedName = parser.parseAnimationEventName(eventNameNode.text);
-    type = ParsedEventType.Animation;
+    const parsedName = parser.parseLegacyAnimationEventName(eventNameNode.text);
+    type = ParsedEventType.LegacyAnimation;
     eventName = parsedName.eventName;
     phase = parsedName.phase;
     target = null;
@@ -444,7 +444,7 @@ function inferBoundAttribute(name: string): {attrName: string; type: BindingType
     type = BindingType.Style;
   } else if (name.startsWith(animationPrefix)) {
     attrName = name.slice(animationPrefix.length);
-    type = BindingType.Animation;
+    type = BindingType.LegacyAnimation;
   } else {
     attrName = name;
     type = BindingType.Property;

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -1528,7 +1528,7 @@ export class TcbDirectiveOutputsOp extends TcbOp {
 
     for (const output of this.node.outputs) {
       if (
-        output.type === ParsedEventType.Animation ||
+        output.type === ParsedEventType.LegacyAnimation ||
         !outputs.hasBindingPropertyName(output.name)
       ) {
         continue;
@@ -1622,7 +1622,7 @@ class TcbUnclaimedOutputsOp extends TcbOp {
         }
       }
 
-      if (output.type === ParsedEventType.Animation) {
+      if (output.type === ParsedEventType.LegacyAnimation) {
         // Animation output bindings always have an `$event` parameter of type `AnimationEvent`.
         const eventType = this.tcb.env.config.checkTypeOfAnimationEvents
           ? this.tcb.env.referenceExternalType('@angular/animations', 'AnimationEvent')

--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -731,7 +731,7 @@ export class RecursiveAstVisitor implements AstVisitor {
 
 export class ParsedProperty {
   public readonly isLiteral: boolean;
-  public readonly isAnimation: boolean;
+  public readonly isLegacyAnimation: boolean;
 
   constructor(
     public name: string,
@@ -742,29 +742,29 @@ export class ParsedProperty {
     public valueSpan: ParseSourceSpan | undefined,
   ) {
     this.isLiteral = this.type === ParsedPropertyType.LITERAL_ATTR;
-    this.isAnimation = this.type === ParsedPropertyType.ANIMATION;
+    this.isLegacyAnimation = this.type === ParsedPropertyType.LEGACY_ANIMATION;
   }
 }
 
 export enum ParsedPropertyType {
   DEFAULT,
   LITERAL_ATTR,
-  ANIMATION,
+  LEGACY_ANIMATION,
   TWO_WAY,
 }
 
 export enum ParsedEventType {
   // DOM or Directive event
   Regular,
-  // Animation specific event
-  Animation,
+  // Legacy animation specific event
+  LegacyAnimation,
   // Event side of a two-way binding (e.g. `[(property)]="expression"`).
   TwoWay,
 }
 
 export class ParsedEvent {
   // Regular events have a target
-  // Animation events have a phase
+  // Legacy Animation events have a phase
   constructor(
     name: string,
     targetOrPhase: string | null,
@@ -818,8 +818,8 @@ export enum BindingType {
   Class,
   // A binding to a style rule (e.g. `[style.rule]="expression"`).
   Style,
-  // A binding to an animation reference (e.g. `[animate.key]="expression"`).
-  Animation,
+  // A binding to a legacy animation reference (e.g. `[animate.key]="expression"`).
+  LegacyAnimation,
   // Property side of a two-way binding (e.g. `[(property)]="expression"`).
   TwoWay,
 }

--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -133,7 +133,7 @@ export class BoundEvent implements Node {
     const target: string | null =
       event.type === ParsedEventType.Regular ? event.targetOrPhase : null;
     const phase: string | null =
-      event.type === ParsedEventType.Animation ? event.targetOrPhase : null;
+      event.type === ParsedEventType.LegacyAnimation ? event.targetOrPhase : null;
     if (event.keySpan === undefined) {
       throw new Error(
         `Unexpected state: keySpan must be defined for bound event but was not for ${event.name}: ${event.sourceSpan}`,

--- a/packages/compiler/src/render3/util.ts
+++ b/packages/compiler/src/render3/util.ts
@@ -36,13 +36,13 @@ export interface R3CompiledExpression {
   statements: o.Statement[];
 }
 
-const ANIMATE_SYMBOL_PREFIX = '@';
+const LEGACY_ANIMATE_SYMBOL_PREFIX = '@';
 export function prepareSyntheticPropertyName(name: string) {
-  return `${ANIMATE_SYMBOL_PREFIX}${name}`;
+  return `${LEGACY_ANIMATE_SYMBOL_PREFIX}${name}`;
 }
 
 export function prepareSyntheticListenerName(name: string, phase: string) {
-  return `${ANIMATE_SYMBOL_PREFIX}${name}.${phase}`;
+  return `${LEGACY_ANIMATE_SYMBOL_PREFIX}${name}.${phase}`;
 }
 
 export function getSafePropertyAccessString(accessor: string, name: string): string {

--- a/packages/compiler/src/render3/view/t2_api.ts
+++ b/packages/compiler/src/render3/view/t2_api.ts
@@ -89,7 +89,7 @@ export interface InputOutputPropertySet {
  * A data structure which captures the animation trigger names that are statically resolvable
  * and whether some names could not be statically evaluated.
  */
-export interface AnimationTriggerNames {
+export interface LegacyAnimationTriggerNames {
   includesDynamicAnimations: boolean;
   staticTriggerNames: string[];
 }
@@ -149,10 +149,10 @@ export interface DirectiveMeta {
   preserveWhitespaces: boolean;
 
   /**
-   * The name of animations that the user defines in the component.
-   * Only includes the animation names.
+   * The name of legacy animations that the user defines in the component.
+   * Only includes the legacy animation names.
    */
-  animationTriggerNames: AnimationTriggerNames | null;
+  animationTriggerNames: LegacyAnimationTriggerNames | null;
 }
 
 /**

--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -496,9 +496,9 @@ export enum BindingKind {
   I18n,
 
   /**
-   * Animation property bindings.
+   * Legacy animation property bindings.
    */
-  Animation,
+  LegacyAnimation,
 
   /**
    * Property side of a two-way binding.

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -746,12 +746,12 @@ export interface ListenerOp extends Op<CreateOp> {
   /**
    * Whether the listener is listening for an animation event.
    */
-  isAnimationListener: boolean;
+  isLegacyAnimationListener: boolean;
 
   /**
    * The animation phase of the listener.
    */
-  animationPhase: string | null;
+  legacyAnimationPhase: string | null;
 
   /**
    * Some event listeners can have a target, e.g. in `document:dragover`.
@@ -770,7 +770,7 @@ export function createListenerOp(
   name: string,
   tag: string | null,
   handlerOps: Array<UpdateOp>,
-  animationPhase: string | null,
+  legacyAnimationPhase: string | null,
   eventTarget: string | null,
   hostListener: boolean,
   sourceSpan: ParseSourceSpan,
@@ -787,8 +787,8 @@ export function createListenerOp(
     handlerOps: handlerList,
     handlerFnName: null,
     consumesDollarEvent: false,
-    isAnimationListener: animationPhase !== null,
-    animationPhase,
+    isLegacyAnimationListener: legacyAnimationPhase !== null,
+    legacyAnimationPhase: legacyAnimationPhase,
     eventTarget,
     sourceSpan,
     ...NEW_OP,

--- a/packages/compiler/src/template/pipeline/ir/src/ops/host.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/host.ts
@@ -24,7 +24,7 @@ export interface DomPropertyOp extends Op<UpdateOp>, ConsumesVarsTrait {
   kind: OpKind.DomProperty;
   name: string;
   expression: o.Expression | Interpolation;
-  isAnimationTrigger: boolean;
+  isLegacyAnimationTrigger: boolean;
 
   i18nContext: XrefId | null;
 
@@ -38,7 +38,7 @@ export interface DomPropertyOp extends Op<UpdateOp>, ConsumesVarsTrait {
 export function createDomPropertyOp(
   name: string,
   expression: o.Expression | Interpolation,
-  isAnimationTrigger: boolean,
+  isLegacyAnimationTrigger: boolean,
   i18nContext: XrefId | null,
   securityContext: SecurityContext | SecurityContext[],
   sourceSpan: ParseSourceSpan,
@@ -47,7 +47,7 @@ export function createDomPropertyOp(
     kind: OpKind.DomProperty,
     name,
     expression,
-    isAnimationTrigger,
+    isLegacyAnimationTrigger,
     i18nContext,
     securityContext,
     sanitizer: null,

--- a/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
@@ -227,7 +227,7 @@ export interface PropertyOp extends Op<UpdateOp>, ConsumesVarsTrait, DependsOnSl
   /**
    * Whether this property is an animation trigger.
    */
-  isAnimationTrigger: boolean;
+  isLegacyAnimationTrigger: boolean;
 
   /**
    * The security context of the binding.
@@ -260,7 +260,7 @@ export function createPropertyOp(
   target: XrefId,
   name: string,
   expression: o.Expression | Interpolation,
-  isAnimationTrigger: boolean,
+  isLegacyAnimationTrigger: boolean,
   securityContext: SecurityContext | SecurityContext[],
   isStructuralTemplateAttribute: boolean,
   templateKind: TemplateKind | null,
@@ -273,7 +273,7 @@ export function createPropertyOp(
     target,
     name,
     expression,
-    isAnimationTrigger,
+    isLegacyAnimationTrigger,
     securityContext,
     sanitizer: null,
     isStructuralTemplateAttribute,

--- a/packages/compiler/src/template/pipeline/src/phases/attribute_extraction.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/attribute_extraction.ts
@@ -24,7 +24,7 @@ export function extractAttributes(job: CompilationJob): void {
           extractAttributeOp(unit, op, elements);
           break;
         case ir.OpKind.Property:
-          if (!op.isAnimationTrigger) {
+          if (!op.isLegacyAnimationTrigger) {
             let bindingKind: ir.BindingKind;
             if (op.i18nMessage !== null && op.templateKind === null) {
               // If the binding has an i18n context, it is an i18n attribute, and should have that
@@ -94,7 +94,7 @@ export function extractAttributes(job: CompilationJob): void {
           }
           break;
         case ir.OpKind.Listener:
-          if (!op.isAnimationListener) {
+          if (!op.isLegacyAnimationListener) {
             const extractedAttributeOp = ir.createExtractedAttributeOp(
               op.target,
               ir.BindingKind.Property,

--- a/packages/compiler/src/template/pipeline/src/phases/binding_specialization.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/binding_specialization.ts
@@ -67,14 +67,14 @@ export function specializeBindings(job: CompilationJob): void {
           }
           break;
         case ir.BindingKind.Property:
-        case ir.BindingKind.Animation:
+        case ir.BindingKind.LegacyAnimation:
           if (job.kind === CompilationJobKind.Host) {
             ir.OpList.replace<ir.UpdateOp>(
               op,
               ir.createDomPropertyOp(
                 op.name,
                 op.expression,
-                op.bindingKind === ir.BindingKind.Animation,
+                op.bindingKind === ir.BindingKind.LegacyAnimation,
                 op.i18nContext,
                 op.securityContext,
                 op.sourceSpan,
@@ -87,7 +87,7 @@ export function specializeBindings(job: CompilationJob): void {
                 op.target,
                 op.name,
                 op.expression,
-                op.bindingKind === ir.BindingKind.Animation,
+                op.bindingKind === ir.BindingKind.LegacyAnimation,
                 op.securityContext,
                 op.isStructuralTemplateAttribute,
                 op.templateKind,

--- a/packages/compiler/src/template/pipeline/src/phases/naming.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/naming.ts
@@ -52,7 +52,7 @@ function addNamesToView(
     switch (op.kind) {
       case ir.OpKind.Property:
       case ir.OpKind.DomProperty:
-        if (op.isAnimationTrigger) {
+        if (op.isLegacyAnimationTrigger) {
           op.name = '@' + op.name;
         }
         break;
@@ -64,8 +64,8 @@ function addNamesToView(
           throw new Error(`Expected a slot to be assigned`);
         }
         let animation = '';
-        if (op.isAnimationListener) {
-          op.name = `@${op.name}.${op.animationPhase}`;
+        if (op.isLegacyAnimationListener) {
+          op.name = `@${op.name}.${op.legacyAnimationPhase}`;
           animation = 'animation';
         }
         if (op.hostListener) {

--- a/packages/compiler/src/template/pipeline/src/phases/ordering.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/ordering.ts
@@ -24,7 +24,7 @@ function kindWithInterpolationTest(
 
 function basicListenerKindTest(op: ir.CreateOp): boolean {
   return (
-    (op.kind === ir.OpKind.Listener && !(op.hostListener && op.isAnimationListener)) ||
+    (op.kind === ir.OpKind.Listener && !(op.hostListener && op.isLegacyAnimationListener)) ||
     op.kind === ir.OpKind.TwoWayListener
   );
 }
@@ -47,7 +47,7 @@ interface Rule<T extends ir.CreateOp | ir.UpdateOp> {
  * the groups in the order defined here.
  */
 const CREATE_ORDERING: Array<Rule<ir.CreateOp>> = [
-  {test: (op) => op.kind === ir.OpKind.Listener && op.hostListener && op.isAnimationListener},
+  {test: (op) => op.kind === ir.OpKind.Listener && op.hostListener && op.isLegacyAnimationListener},
   {test: basicListenerKindTest},
 ];
 

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -264,13 +264,13 @@ function reifyCreateOperations(unit: CompilationUnit, ops: ir.OpList<ir.CreateOp
           op,
           unit.job.mode === TemplateCompilationMode.DomOnly &&
             !op.hostListener &&
-            !op.isAnimationListener
+            !op.isLegacyAnimationListener
             ? ng.domListener(op.name, listenerFn, eventTargetResolver, op.sourceSpan)
             : ng.listener(
                 op.name,
                 listenerFn,
                 eventTargetResolver,
-                op.hostListener && op.isAnimationListener,
+                op.hostListener && op.isLegacyAnimationListener,
                 op.sourceSpan,
               ),
         );
@@ -548,7 +548,7 @@ function reifyUpdateOperations(unit: CompilationUnit, ops: ir.OpList<ir.UpdateOp
       case ir.OpKind.Property:
         ir.OpList.replace(
           op,
-          unit.job.mode === TemplateCompilationMode.DomOnly && !op.isAnimationTrigger
+          unit.job.mode === TemplateCompilationMode.DomOnly && !op.isLegacyAnimationTrigger
             ? ng.domProperty(op.name, op.expression, op.sanitizer, op.sourceSpan)
             : ng.property(op.name, op.expression, op.sanitizer, op.sourceSpan),
         );
@@ -593,7 +593,7 @@ function reifyUpdateOperations(unit: CompilationUnit, ops: ir.OpList<ir.UpdateOp
         if (op.expression instanceof ir.Interpolation) {
           throw new Error('not yet handled');
         } else {
-          if (op.isAnimationTrigger) {
+          if (op.isLegacyAnimationTrigger) {
             ir.OpList.replace(op, ng.syntheticHostProperty(op.name, op.expression, op.sourceSpan));
           } else {
             ir.OpList.replace(

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -636,7 +636,7 @@ describe('R3 template transform', () => {
     it('should parse bound animation events when event name is empty', () => {
       expectFromHtml('<div (@)="onAnimationEvent($event)"></div>', true).toEqual([
         ['Element', 'div'],
-        ['BoundEvent', ParsedEventType.Animation, '', null, 'onAnimationEvent($event)'],
+        ['BoundEvent', ParsedEventType.LegacyAnimation, '', null, 'onAnimationEvent($event)'],
       ]);
       expect(() => parse('<div (@)></div>')).toThrowError(
         /Animation event name is missing in binding/,

--- a/packages/core/test/legacy_animation/legacy_animation_integration_spec.ts
+++ b/packages/core/test/legacy_animation/legacy_animation_integration_spec.ts
@@ -52,7 +52,7 @@ const DEFAULT_COMPONENT_ID = '1';
   // these tests are only meant to be run within the DOM (for now)
   if (isNode) return;
 
-  describe('animation tests', function () {
+  describe('legacy animation tests', function () {
     function getLog(): MockAnimationPlayer[] {
       return MockAnimationDriver.log as MockAnimationPlayer[];
     }

--- a/packages/core/test/legacy_animation/legacy_animation_query_integration_spec.ts
+++ b/packages/core/test/legacy_animation/legacy_animation_query_integration_spec.ts
@@ -41,7 +41,7 @@ import {HostListener} from '../../src/metadata/directives';
   // these tests are only meant to be run within the DOM (for now)
   if (isNode) return;
 
-  describe('animation query tests', function () {
+  describe('legacy animation query tests', function () {
     function getLog(): MockAnimationPlayer[] {
       return MockAnimationDriver.log as MockAnimationPlayer[];
     }

--- a/packages/core/test/legacy_animation/legacy_animation_router_integration_spec.ts
+++ b/packages/core/test/legacy_animation/legacy_animation_router_integration_spec.ts
@@ -32,7 +32,7 @@ import {isNode} from '@angular/private/testing';
   // these tests are only meant to be run within the DOM (for now)
   if (isNode) return;
 
-  describe('Animation Router Tests', function () {
+  describe('Legacy Animation Router Tests', function () {
     function getLog(): MockAnimationPlayer[] {
       return MockAnimationDriver.log as MockAnimationPlayer[];
     }

--- a/packages/core/test/legacy_animation/legacy_animations_with_web_animations_integration_spec.ts
+++ b/packages/core/test/legacy_animation/legacy_animations_with_web_animations_integration_spec.ts
@@ -31,7 +31,7 @@ import {isNode} from '@angular/private/testing';
   // Buggy in Chromium 39, see https://github.com/angular/angular/issues/15793
   if (isNode) return;
 
-  describe('animation integration tests using web animations', function () {
+  describe('legacy animation integration tests using web animations', function () {
     beforeEach(() => {
       TestBed.configureTestingModule({
         providers: [{provide: AnimationDriver, useClass: ɵWebAnimationsDriver}],

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -901,8 +901,9 @@ export class CompletionBuilder<N extends TmplAstNode | AST> {
 
   private isAnimationCompletion(): this is ElementAnimationCompletionBuilder {
     return (
-      (this.node instanceof TmplAstBoundAttribute && this.node.type === BindingType.Animation) ||
-      (this.node instanceof TmplAstBoundEvent && this.node.type === ParsedEventType.Animation)
+      (this.node instanceof TmplAstBoundAttribute &&
+        this.node.type === BindingType.LegacyAnimation) ||
+      (this.node instanceof TmplAstBoundEvent && this.node.type === ParsedEventType.LegacyAnimation)
     );
   }
 


### PR DESCRIPTION
Renames all animations package references with a "legacy" prefix for later easy cleanup.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

