### PR TITLE
Update next branch to reflect new release-train "v20.2.0-next.0".

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
@@ -6,7 +6,7 @@
 adev/shared-docs/pipeline/api-gen/package.json=939673974
 integration/package.json=-239561259
 modules/package.json=-597456295
-package.json=-1928784858
+package.json=1592531594
 packages/animations/package.json=-678724831
 packages/benchpress/package.json=-1908328724
 packages/common/package.json=1729763064
@@ -22,7 +22,7 @@ packages/platform-browser/package.json=-1163479450
 packages/router/package.json=860819913
 packages/upgrade/package.json=16347051
 packages/zone.js/package.json=-1005735564
-pnpm-lock.yaml=1416623477
+pnpm-lock.yaml=1466539815
 pnpm-workspace.yaml=-375658197
 tools/bazel/rules_angular_store/package.json=-239561259
 yarn.lock=-774434861

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+<a name="20.1.0-rc.0"></a>
+# 20.1.0-rc.0 (2025-07-01)
+### common
+| Commit | Type | Description |
+| -- | -- | -- |
+| [58aedc37d1](https://github.com/angular/angular/commit/58aedc37d10208ca40c1b1d4468261dd9aba5356) | feat | add support for a custom EnvironmentInjector to NgComponentOutlet directive ([#54764](https://github.com/angular/angular/pull/54764)) |
+### compiler
+| Commit | Type | Description |
+| -- | -- | -- |
+| [089ad0ee15](https://github.com/angular/angular/commit/089ad0ee15d6be9b2493bb67519cb59e0454a1ef) | fix | produce more accurate errors for interpolations ([#62258](https://github.com/angular/angular/pull/62258)) |
+### http
+| Commit | Type | Description |
+| -- | -- | -- |
+| [55fa38a1e5](https://github.com/angular/angular/commit/55fa38a1e53926d114b2290c084f3540f50b7266) | feat | add cache & priority support for fetch requests in httpResource ([#62301](https://github.com/angular/angular/pull/62301)) |
+| [b6ef42843c](https://github.com/angular/angular/commit/b6ef42843c49e50239b678bb4d8f01ab30589dd3) | feat | add credentials support for fetch requests in httpResource ([#62390](https://github.com/angular/angular/pull/62390)) |
+| [27b7ec0a62](https://github.com/angular/angular/commit/27b7ec0a6219645a5af07c2d409c34311a458374) | feat | add mode & redirect for fetch request in httpResource ([#62337](https://github.com/angular/angular/pull/62337)) |
+| [f0965c7acd](https://github.com/angular/angular/commit/f0965c7acd2fc2a4a4c18e5a47f3447c4fc7c668) | feat | Add support for fetch credentials options in HttpClient ([#62354](https://github.com/angular/angular/pull/62354)) |
+| [87322449a3](https://github.com/angular/angular/commit/87322449a33fc727ad8c80b6cc6d0a87a900a6fa) | feat | add support for fetch mode and redirect options in HttpClient ([#62315](https://github.com/angular/angular/pull/62315)) |
+| [aa861c42ff](https://github.com/angular/angular/commit/aa861c42fface06563669c188327700085774e89) | feat | add timeout option on httpResource. ([#62326](https://github.com/angular/angular/pull/62326)) |
+| [c4cffe2063](https://github.com/angular/angular/commit/c4cffe2063e790d2f8e4dc8b9c9817f2c4fcc4e7) | feat | Add timeout option to HTTP requests ([#57194](https://github.com/angular/angular/pull/57194)) |
+| [cfbbb08437](https://github.com/angular/angular/commit/cfbbb0843727dd7959d73c496307153234ee20b9) | feat | add warning when withCredentials overrides explicit credentials ([#62383](https://github.com/angular/angular/pull/62383)) |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="20.0.6"></a>
 # 20.0.6 (2025-07-01)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-srcs",
-  "version": "20.1.0-next.3",
+  "version": "20.2.0-next.0",
   "private": true,
   "description": "Angular - a web framework for modern web apps",
   "homepage": "https://github.com/angular/angular",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -647,7 +647,7 @@ importers:
     dependencies:
       '@angular/core':
         specifier: ^20.1.0-next
-        version: 20.1.0-next.3(@angular/compiler@packages+compiler)(rxjs@7.8.2)(zone.js@packages+zone.js)
+        version: 20.1.0-rc.0(@angular/compiler@packages+compiler)(rxjs@7.8.2)(zone.js@packages+zone.js)
       reflect-metadata:
         specifier: ^0.2.0
         version: 0.2.2
@@ -1654,11 +1654,11 @@ packages:
       zone.js: link:packages/zone.js
     dev: true
 
-  /@angular/core@20.1.0-next.3(@angular/compiler@packages+compiler)(rxjs@7.8.2)(zone.js@packages+zone.js):
-    resolution: {integrity: sha512-QUYew+W6NyP7oiQ5XgKP1fPeT2MJiy+SlzkxxfP2tzQBh/c5tjSlHvj12hF+WeyKe94wirz3sMnCP7tfMB6jlA==, tarball: https://registry.npmjs.org/@angular/core/-/core-20.1.0-next.3.tgz}
+  /@angular/core@20.1.0-rc.0(@angular/compiler@packages+compiler)(rxjs@7.8.2)(zone.js@packages+zone.js):
+    resolution: {integrity: sha512-dsyi29ieAjKEMspq8I9/CEtg6yPVleHk6Ii31wN3iMtKuEfAu30EZNtFgCqKzv3j4ZvJH/sBV4yh0FSZJSfgCA==, tarball: https://registry.npmjs.org/@angular/core/-/core-20.1.0-rc.0.tgz}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
     peerDependencies:
-      '@angular/compiler': 20.1.0-next.3
+      '@angular/compiler': 20.1.0-rc.0
       rxjs: ^6.5.3 || ^7.4.0
       zone.js: ~0.15.0
     peerDependenciesMeta:

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>angular/dev-infra//renovate-presets/default.json5"],
-  "baseBranches": ["main", "20.0.x"],
+  "extends": [
+    "github>angular/dev-infra//renovate-presets/default.json5"
+  ],
+  "baseBranches": [
+    "main",
+    "main"
+  ],
   "postUpgradeTasks": {
     "commands": [
       "git restore .yarn/releases/yarn-1.22.22.cjs pnpm-lock.yaml .npmrc",
@@ -38,12 +43,20 @@
   ],
   "packageRules": [
     {
-      "matchBaseBranches": ["main"],
-      "addLabels": ["target: minor"]
+      "matchBaseBranches": [
+        "main"
+      ],
+      "addLabels": [
+        "target: minor"
+      ]
     },
     {
-      "matchBaseBranches": ["!main"],
-      "addLabels": ["target: patch"]
+      "matchBaseBranches": [
+        "!main"
+      ],
+      "addLabels": [
+        "target: rc"
+      ]
     },
     {
       "matchFileNames": [


### PR DESCRIPTION
The previous "next" release-train has moved into the release-candidate phase. This PR updates the next branch to the subsequent release-train.

Also this PR cherry-picks the changelog for v20.1.0-rc.0 into the main branch so that the changelog is up to date.