### PR TITLE
ci: fix incorrect base branch in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   ],
   "baseBranches": [
     "main",
-    "main"
+    "20.1.x"
   ],
   "postUpgradeTasks": {
     "commands": [


### PR DESCRIPTION
There is a bug in ng-dev which set the inco
