### PR TITLE
docs(docs-infra): Load of the typing files from Angular.

### DIFF
--- a/adev/src/app/editor/typings-loader.service.spec.ts
+++ b/adev/src/app/editor/typings-loader.service.spec.ts
@@ -56,21 +56,11 @@ describe('TypingsLoader', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should read files from directory when a glob pattern is found', async () => {
+  it('should read files from directory', async () => {
     await service.retrieveTypeDefinitions(fakeWebContainer);
 
     expect(
       service.typings().some(({path}) => path.endsWith(fakeTypeDefinitionFiles[0])),
-    ).toBeTrue();
-  });
-
-  it("should read type definition file when its path doesn't contain a glob pattern", async () => {
-    await service.retrieveTypeDefinitions(fakeWebContainer);
-
-    expect(
-      service
-        .typings()
-        .some(({path}) => path.endsWith(fakePackageJson.exports['./something'].types)),
     ).toBeTrue();
   });
 

--- a/adev/src/app/editor/typings-loader.service.ts
+++ b/adev/src/app/editor/typings-loader.service.ts
@@ -107,14 +107,10 @@ export class TypingsLoader {
         if (types) {
           const path = `/node_modules/${library}/${this.normalizePath(types)}`;
 
-          // If the path contains `*` we need to read the directory files
-          if (path.includes('*')) {
-            const directory = path.substring(0, path.lastIndexOf('/'));
-
-            directoriesToRead.push(directory);
-          } else {
-            filesToRead.push(path);
-          }
+          // We want to pull all the d.ts files in the directory
+          // as the file pointed `path` might also import other d.ts files
+          const directory = path.substring(0, path.lastIndexOf('/'));
+          directoriesToRead.push(directory);
         }
       }
     }


### PR DESCRIPTION
Following some infra changes, DTS files are now splitted over several files, which aren't referenced in the `package.json` but are directly imported in the root dts.

We chose to not use Typescript's ATA here because it only pulls the latest version from a CDN whereas we prefer to use the local definitions we have in the `node_modules` of the tutorial.

fixes #62374
