### PR TITLE
docs: display deprecation message for top most symbol

### DIFF
--- a/.ng-dev/format.mts
+++ b/.ng-dev/format.mts
@@ -7,7 +7,7 @@ export const format: FormatConfig = {
   'prettier': {
     'matchers': [
       '**/*.{yaml,yml}',
-      '**/*.{js,ts,mjs,mts,cjs,cts}',
+      '**/*.{js,ts,mjs,mts,cjs,cts,tsx}',
       'devtools/**/*.{js,ts,mjs,mts,cjs,cts,html,scss}',
 
       // Do not format d.ts files as they are generated

--- a/adev/shared-docs/pipeline/api-gen/rendering/entities/categorization.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/entities/categorization.mts
@@ -142,7 +142,10 @@ export function isDeprecatedEntry<T extends HasJsDocTags>(entry: T): boolean {
 }
 
 export function getDeprecatedEntry<T extends HasJsDocTags>(entry: T) {
-  return entry.jsdocTags.find((tag) => tag.name === 'deprecated')?.comment ?? null;
+  const comment = entry.jsdocTags.find((tag) => tag.name === 'deprecated')?.comment;
+
+  // Dropping the eventual version number in front of the comment.
+  return comment?.match(/(?:\d+(?:\.\d+)?\s*)?(.*)/s)?.[1] ?? null;
 }
 
 /** Gets whether the given entry has a given JsDoc tag. */

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/class-reference.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/class-reference.tsx
@@ -26,6 +26,7 @@ import {SectionApi} from './section-api';
 import {SectionHeading} from './section-heading';
 import {codeToHtml} from '../shiki/shiki.mjs';
 import {RawHtml} from './raw-html';
+import {DeprecationWarning} from './deprecation-warning';
 
 /** Component to render a class API reference document. */
 export function ClassReference(
@@ -44,6 +45,7 @@ export function ClassReference(
       ) : (
         ''
       )}
+      <DeprecationWarning entry={entry} />
       <SectionApi entry={entry} />
       {entry.members.length > 0 ? (
         <div class={REFERENCE_MEMBERS}>

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/constant-reference.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/constant-reference.tsx
@@ -13,12 +13,14 @@ import {SectionDescription} from './section-description';
 import {SectionUsageNotes} from './section-usage-notes';
 import {SectionApi} from './section-api';
 import {API_REFERENCE_CONTAINER} from '../styling/css-classes.mjs';
+import {DeprecationWarning} from './deprecation-warning';
 
 /** Component to render a constant API reference document. */
 export function ConstantReference(entry: ConstantEntryRenderable) {
   return (
     <div className={API_REFERENCE_CONTAINER}>
       <HeaderApi entry={entry} />
+      <DeprecationWarning entry={entry} />
       <SectionApi entry={entry} />
       <SectionDescription entry={entry} />
       <SectionUsageNotes entry={entry} />

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/deprecated-label.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/deprecated-label.tsx
@@ -13,13 +13,16 @@ export function DeprecatedLabel(props: {
   entry:
     | {deprecated: {version: string | undefined} | undefined}
     | {deprecationMessage: string | null};
+  hideLabel?: true;
 }) {
   const entry = props.entry;
 
   if ('deprecationMessage' in entry && entry.deprecationMessage !== null) {
     return (
       <div className={'docs-deprecation-message'}>
-        <span className={`${PARAM_KEYWORD_CLASS_NAME} docs-deprecated`}>@deprecated</span>
+        {!props.hideLabel && (
+          <span className={`${PARAM_KEYWORD_CLASS_NAME} docs-deprecated`}>@deprecated</span>
+        )}
         <span dangerouslySetInnerHTML={{__html: entry.deprecationMessage}}></span>
       </div>
     );

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/deprecation-warning.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/deprecation-warning.tsx
@@ -1,0 +1,27 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {h} from 'preact';
+import {DeprecatedLabel} from './deprecated-label';
+
+export function DeprecationWarning(props: {
+  entry:
+    | {deprecated: {version: string | undefined} | undefined}
+    | {deprecationMessage: string | null};
+}) {
+  const entry = props.entry;
+  return (
+    'deprecationMessage' in entry &&
+    entry.deprecationMessage && (
+      <div class="docs-alert docs-alert-important">
+        <p>Deprecation warning</p>
+        <DeprecatedLabel entry={entry} hideLabel={true} />
+      </div>
+    )
+  );
+}

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/enum-reference.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/enum-reference.tsx
@@ -13,12 +13,14 @@ import {SectionDescription} from './section-description';
 import {SectionApi} from './section-api';
 import {API_REFERENCE_CONTAINER, REFERENCE_MEMBERS} from '../styling/css-classes.mjs';
 import {ClassMember} from './class-member';
+import {DeprecationWarning} from './deprecation-warning';
 
 /** Component to render a enum API reference document. */
 export function EnumReference(entry: EnumEntryRenderable) {
   return (
     <div className={API_REFERENCE_CONTAINER}>
       <HeaderApi entry={entry} />
+      <DeprecationWarning entry={entry} />
       <SectionApi entry={entry} />
       {entry.members.length > 0 ? (
         <div class={REFERENCE_MEMBERS}>

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/function-reference.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/function-reference.tsx
@@ -27,6 +27,7 @@ import {HighlightTypeScript} from './highlight-ts';
 import {SectionApi} from './section-api';
 import {SectionDescription} from './section-description';
 import {SectionUsageNotes} from './section-usage-notes';
+import {DeprecationWarning} from './deprecation-warning';
 
 export const signatureCard = (
   name: string,
@@ -70,6 +71,7 @@ export function FunctionReference(entry: FunctionEntryRenderable) {
   return (
     <div className={API_REFERENCE_CONTAINER}>
       <HeaderApi entry={entry} />
+      <DeprecationWarning entry={entry} />
       <SectionApi entry={entry} />
       <div className={REFERENCE_MEMBERS}>
         {entry.signatures.map((s, i) =>

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/type-alias-reference.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/type-alias-reference.tsx
@@ -13,12 +13,14 @@ import {SectionDescription} from './section-description';
 import {SectionUsageNotes} from './section-usage-notes';
 import {SectionApi} from './section-api';
 import {API_REFERENCE_CONTAINER} from '../styling/css-classes.mjs';
+import {DeprecationWarning} from './deprecation-warning';
 
 /** Component to render a type alias API reference document. */
 export function TypeAliasReference(entry: TypeAliasEntryRenderable) {
   return (
     <div className={API_REFERENCE_CONTAINER}>
       <HeaderApi entry={entry} />
+      <DeprecationWarning entry={entry} />
       <SectionApi entry={entry} />
       <SectionDescription entry={entry} />
       <SectionUsageNotes entry={entry} />


### PR DESCRIPTION
For classes, types, functions, enums etc.

fixes #62365
