### PR TITLE
refactor(signal-forms): use discriminated union for errors

### DIFF
--- a/packages/forms/experimental/src/api/async.ts
+++ b/packages/forms/experimental/src/api/async.ts
@@ -15,6 +15,15 @@ import {defineResource} from './data';
 import {FieldContext, FieldPath, PathKind} from './types';
 import {ValidationError, WithField} from './validation_errors';
 
+export type MapToErrorsFn<TValue, TData, TPathKind extends PathKind = PathKind.Root> = (
+  data: TData,
+  ctx: FieldContext<TValue, TPathKind>,
+) =>
+  | ValidationError
+  | WithField<ValidationError>
+  | (ValidationError | WithField<ValidationError>)[]
+  | undefined;
+
 export interface AsyncValidatorOptions<
   TValue,
   TRequest,
@@ -23,14 +32,7 @@ export interface AsyncValidatorOptions<
 > {
   readonly params: (ctx: FieldContext<TValue, TPathKind>) => TRequest;
   readonly factory: (req: Signal<TRequest | undefined>) => ResourceRef<TData | undefined>;
-  readonly errors: (
-    data: TData,
-    ctx: FieldContext<TValue, TPathKind>,
-  ) =>
-    | ValidationError
-    | WithField<ValidationError>
-    | (ValidationError | WithField<ValidationError>)[]
-    | undefined;
+  readonly errors: MapToErrorsFn<TValue, TData, TPathKind>;
 }
 
 export function validateAsync<TValue, TRequest, TData, TPathKind extends PathKind = PathKind.Root>(
@@ -84,15 +86,7 @@ export function validateHttp<TValue, TData = unknown, TPathKind extends PathKind
   path: FieldPath<TValue, TPathKind>,
   opts: {
     request: (ctx: FieldContext<TValue, TPathKind>) => string | undefined;
-    errors: (
-      data: TData,
-
-      ctx: FieldContext<TValue, TPathKind>,
-    ) =>
-      | ValidationError
-      | WithField<ValidationError>
-      | (ValidationError | WithField<ValidationError>)[]
-      | undefined;
+    errors: MapToErrorsFn<TValue, TData, TPathKind>;
     options?: HttpResourceOptions<TData, unknown>;
   },
 ): void;
@@ -101,15 +95,7 @@ export function validateHttp<TValue, TData = unknown, TPathKind extends PathKind
   path: FieldPath<TValue, TPathKind>,
   opts: {
     request: (ctx: FieldContext<TValue, TPathKind>) => HttpResourceRequest | undefined;
-    errors: (
-      data: TData,
-
-      ctx: FieldContext<TValue, TPathKind>,
-    ) =>
-      | ValidationError
-      | WithField<ValidationError>
-      | (ValidationError | WithField<ValidationError>)[]
-      | undefined;
+    errors: MapToErrorsFn<TValue, TData, TPathKind>;
     options?: HttpResourceOptions<TData, unknown>;
   },
 ): void;

--- a/packages/forms/experimental/src/api/async.ts
+++ b/packages/forms/experimental/src/api/async.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {httpResource, HttpResourceOptions, HttpResourceRequest} from '@angular/common/http';
@@ -12,7 +12,8 @@ import {FieldNode} from '../field/node';
 import {FieldPathNode} from '../path_node';
 import {assertPathIsCurrent} from '../schema';
 import {defineResource} from './data';
-import {FieldContext, FieldPath, FormTreeError, PathKind} from './types';
+import {FieldContext, FieldPath, PathKind} from './types';
+import {ValidationTreeError} from './validation_errors';
 
 export interface AsyncValidatorOptions<
   TValue,
@@ -25,7 +26,7 @@ export interface AsyncValidatorOptions<
   readonly errors: (
     data: TData,
     ctx: FieldContext<TValue, TPathKind>,
-  ) => FormTreeError | FormTreeError[] | undefined;
+  ) => ValidationTreeError | ValidationTreeError[] | undefined;
 }
 
 export function validateAsync<TValue, TRequest, TData, TPathKind extends PathKind = PathKind.Root>(
@@ -73,8 +74,9 @@ export function validateHttp<TValue, TData = unknown, TPathKind extends PathKind
     request: (ctx: FieldContext<TValue, TPathKind>) => string | undefined;
     errors: (
       data: TData,
+
       ctx: FieldContext<TValue, TPathKind>,
-    ) => FormTreeError | FormTreeError[] | undefined;
+    ) => ValidationTreeError | ValidationTreeError[] | undefined;
     options?: HttpResourceOptions<TData, unknown>;
   },
 ): void;
@@ -85,8 +87,9 @@ export function validateHttp<TValue, TData = unknown, TPathKind extends PathKind
     request: (ctx: FieldContext<TValue, TPathKind>) => HttpResourceRequest | undefined;
     errors: (
       data: TData,
+
       ctx: FieldContext<TValue, TPathKind>,
-    ) => FormTreeError | FormTreeError[] | undefined;
+    ) => ValidationTreeError | ValidationTreeError[] | undefined;
     options?: HttpResourceOptions<TData, unknown>;
   },
 ): void;

--- a/packages/forms/experimental/src/api/control.ts
+++ b/packages/forms/experimental/src/api/control.ts
@@ -7,11 +7,11 @@
  */
 
 import {InputSignal, ModelSignal, OutputRef} from '@angular/core';
-import {FormError} from './types';
+import {ValidationError} from './validation_errors';
 
 export interface FormUiControl<TValue> {
   readonly value: ModelSignal<TValue>;
-  readonly errors?: InputSignal<readonly FormError[] | undefined>;
+  readonly errors?: InputSignal<readonly ValidationError[] | undefined>;
   readonly disabled?: InputSignal<boolean | string | undefined>;
   readonly readonly?: InputSignal<boolean | undefined>;
   readonly valid?: InputSignal<boolean | undefined>;

--- a/packages/forms/experimental/src/api/logic.ts
+++ b/packages/forms/experimental/src/api/logic.ts
@@ -3,13 +3,14 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {MetadataKey} from '../api/metadata';
 import {FieldPathNode} from '../path_node';
 import {assertPathIsCurrent} from '../schema';
 import type {FieldContext, FieldPath, LogicFn, PathKind, TreeValidator, Validator} from './types';
+import {ValidationError} from './validation_errors';
 
 /**
  * Adds logic to a field to conditionally disable it.
@@ -129,7 +130,7 @@ export function metadata<TValue, TMetadata, TPathKind extends PathKind = PathKin
 
 /**
  * Adds logic to a field to conditionally add a validation error to it.
- * The added FormError will be of `kind: 'custom'`
+ * The added ValidationError will be of `kind: 'custom:error'`
  *
  * @param path The target path to add the error logic to.
  * @param logic A `LogicFn<T, boolean>` that returns `true` when the error should be added.
@@ -149,17 +150,17 @@ export function error<TValue, TPathKind extends PathKind = PathKind.Root>(
     validate(path, (arg) => {
       return logic(arg)
         ? {
-            kind: 'custom',
+            kind: 'custom:error',
             message: message(arg),
           }
         : undefined;
     });
   } else {
-    const err =
+    const err: ValidationError =
       message === undefined
-        ? {kind: 'custom'}
+        ? {kind: 'custom:error'}
         : {
-            kind: 'custom',
+            kind: 'custom:error',
             message,
           };
     validate(path, (arg) => {

--- a/packages/forms/experimental/src/api/logic.ts
+++ b/packages/forms/experimental/src/api/logic.ts
@@ -109,7 +109,7 @@ export function validateTree<TValue, TPathKind extends PathKind = PathKind.Root>
     for (const error of errors) {
       (error as any).field ??= ctx.field;
     }
-    return errors as WithField<ValidationError>[];
+    return errors;
   };
   pathNode.logic.addSyncTreeErrorRule(
     wrappedLogic as LogicFn<TValue, WithField<ValidationError>[]>,

--- a/packages/forms/experimental/src/api/logic.ts
+++ b/packages/forms/experimental/src/api/logic.ts
@@ -9,7 +9,15 @@
 import {MetadataKey} from '../api/metadata';
 import {FieldPathNode} from '../path_node';
 import {assertPathIsCurrent} from '../schema';
-import type {FieldContext, FieldPath, LogicFn, PathKind, TreeValidator, Validator} from './types';
+import type {
+  FieldContext,
+  FieldPath,
+  LogicFn,
+  Mutable,
+  PathKind,
+  TreeValidator,
+  Validator,
+} from './types';
 import {ValidationError, WithField} from './validation_errors';
 
 /**
@@ -107,7 +115,7 @@ export function validateTree<TValue, TPathKind extends PathKind = PathKind.Root>
   const wrappedLogic = (ctx: FieldContext<TValue, TPathKind>) => {
     const errors = logic(ctx);
     for (const error of errors) {
-      (error as any).field ??= ctx.field;
+      (error as Mutable<ValidationError | WithField<ValidationError>>).field ??= ctx.field;
     }
     return errors;
   };

--- a/packages/forms/experimental/src/api/logic.ts
+++ b/packages/forms/experimental/src/api/logic.ts
@@ -130,7 +130,7 @@ export function metadata<TValue, TMetadata, TPathKind extends PathKind = PathKin
 
 /**
  * Adds logic to a field to conditionally add a validation error to it.
- * The added ValidationError will be of `kind: 'custom:error'`
+ * The added ValidationError will be of `kind: 'error'`
  *
  * @param path The target path to add the error logic to.
  * @param logic A `LogicFn<T, boolean>` that returns `true` when the error should be added.
@@ -150,7 +150,7 @@ export function error<TValue, TPathKind extends PathKind = PathKind.Root>(
     validate(path, (arg) => {
       return logic(arg)
         ? {
-            kind: 'custom:error',
+            kind: 'error',
             message: message(arg),
           }
         : undefined;
@@ -158,9 +158,9 @@ export function error<TValue, TPathKind extends PathKind = PathKind.Root>(
   } else {
     const err: ValidationError =
       message === undefined
-        ? {kind: 'custom:error'}
+        ? {kind: 'error'}
         : {
-            kind: 'custom:error',
+            kind: 'error',
             message,
           };
     validate(path, (arg) => {

--- a/packages/forms/experimental/src/api/standard_schema.ts
+++ b/packages/forms/experimental/src/api/standard_schema.ts
@@ -12,14 +12,7 @@ import {define} from './data';
 import {validateTree} from './logic';
 import {StandardSchemaV1} from './standard_schema_types';
 import {Field, FieldPath} from './types';
-import {ValidationTreeError} from './validation_errors';
-
-/**
- * A validation error produced by running a standard schema validator.
- */
-interface StandardSchemaFormTreeError extends ValidationTreeError {
-  issue: StandardSchemaV1.Issue;
-}
+import {StandardSchemaValidationError, ValidationError, WithField} from './validation_errors';
 
 /**
  * Validates a field using a `StandardSchemaV1` compatible validator (e.g. a zod validator).
@@ -75,20 +68,16 @@ export function validateStandardSchema<TValue>(
  *
  * @param field The root field to which the issue's path is relative.
  * @param issue The `StandardSchemaV1.Issue` to convert.
- * @returns A `StandardSchemaFormTreeError` representing the issue.
+ * @returns A `ValidationError` representing the issue.
  */
 export function standardIssueToFormTreeError(
   field: Field<unknown>,
   issue: StandardSchemaV1.Issue,
-): StandardSchemaFormTreeError {
+): WithField<StandardSchemaValidationError> {
   let target = field as Field<Record<PropertyKey, unknown>>;
   for (const pathPart of issue.path ?? []) {
     const pathKey = typeof pathPart === 'object' ? pathPart.key : pathPart;
     target = target[pathKey] as Field<Record<PropertyKey, unknown>>;
   }
-  return {
-    kind: 'standardschema',
-    field: target,
-    issue,
-  };
+  return ValidationError.standardSchema(issue, '', target);
 }

--- a/packages/forms/experimental/src/api/standard_schema.ts
+++ b/packages/forms/experimental/src/api/standard_schema.ts
@@ -11,12 +11,13 @@ import {validateAsync} from './async';
 import {define} from './data';
 import {validateTree} from './logic';
 import {StandardSchemaV1} from './standard_schema_types';
-import {Field, FieldPath, FormTreeError} from './types';
+import {Field, FieldPath} from './types';
+import {ValidationTreeError} from './validation_errors';
 
 /**
  * A validation error produced by running a standard schema validator.
  */
-interface StandardSchemaFormTreeError extends FormTreeError {
+interface StandardSchemaFormTreeError extends ValidationTreeError {
   issue: StandardSchemaV1.Issue;
 }
 
@@ -86,7 +87,7 @@ export function standardIssueToFormTreeError(
     target = target[pathKey] as Field<Record<PropertyKey, unknown>>;
   }
   return {
-    kind: '~standard',
+    kind: 'ng:standard',
     field: target,
     issue,
   };

--- a/packages/forms/experimental/src/api/standard_schema.ts
+++ b/packages/forms/experimental/src/api/standard_schema.ts
@@ -87,7 +87,7 @@ export function standardIssueToFormTreeError(
     target = target[pathKey] as Field<Record<PropertyKey, unknown>>;
   }
   return {
-    kind: 'ng:standard',
+    kind: 'standardschema',
     field: target,
     issue,
   };

--- a/packages/forms/experimental/src/api/structure.ts
+++ b/packages/forms/experimental/src/api/structure.ts
@@ -21,7 +21,7 @@ import type {
   SchemaFn,
   SchemaOrSchemaFn,
 } from './types';
-import {ValidationTreeError} from './validation_errors';
+import {ValidationError, WithField} from './validation_errors';
 
 export interface FormOptions {
   injector?: Injector;
@@ -307,7 +307,7 @@ export function applyWhenValue(
  */
 export async function submit<TValue>(
   form: Field<TValue>,
-  action: (form: Field<TValue>) => Promise<ValidationTreeError[] | void>,
+  action: (form: Field<TValue>) => Promise<(ValidationError | WithField<ValidationError>)[] | void>,
 ) {
   const api = form() as FieldNode;
   api.submitState.selfSubmittedStatus.set('submitting');

--- a/packages/forms/experimental/src/api/structure.ts
+++ b/packages/forms/experimental/src/api/structure.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {inject, Injector, runInInjectionContext, WritableSignal} from '@angular/core';
@@ -20,8 +20,8 @@ import type {
   Schema,
   SchemaFn,
   SchemaOrSchemaFn,
-  ServerError,
 } from './types';
+import {ValidationTreeError} from './validation_errors';
 
 export interface FormOptions {
   injector?: Injector;
@@ -278,7 +278,8 @@ export function applyWhenValue(
 /**
  * Submits a given `Field` using the given action function and applies any server errors resulting
  * from the action to the field. Server errors retured by the `action` will be integrated into the
- * field as a `FormError` on the sub-field indicated by the `field` property of the server error.
+ * field as a `ValidationError` on the sub-field indicated by the `field` property of the server
+ * error.
  *
  * @example ```
  * async function registerNewUser(registrationForm: Field<{username: string, password: string}>) {
@@ -306,13 +307,13 @@ export function applyWhenValue(
  */
 export async function submit<TValue>(
   form: Field<TValue>,
-  action: (form: Field<TValue>) => Promise<ServerError[] | void>,
+  action: (form: Field<TValue>) => Promise<ValidationTreeError[] | void>,
 ) {
   const api = form() as FieldNode;
   api.submitState.selfSubmittedStatus.set('submitting');
   const errors = (await action(form)) || [];
   for (const error of errors) {
-    (error.field() as FieldNode).submitState.setServerErrors(error.error);
+    ((error.field ?? form)() as FieldNode).submitState.setServerErrors(error);
   }
   api.submitState.selfSubmittedStatus.set('submitted');
 }

--- a/packages/forms/experimental/src/api/types.ts
+++ b/packages/forms/experimental/src/api/types.ts
@@ -9,7 +9,7 @@
 import {Signal, WritableSignal} from '@angular/core';
 import {DataKey} from './data';
 import {MetadataKey} from './metadata';
-import {ValidationError, ValidationTreeError} from './validation_errors';
+import {ValidationError, WithField} from './validation_errors';
 
 /**
  * Symbol used to retain generic type information when it would otherwise be lost.
@@ -47,8 +47,8 @@ export interface DisabledReason {
 export type ValidationResult = readonly ValidationError[] | ValidationError | undefined;
 
 export type AsyncValidationResult =
-  | readonly ValidationTreeError[]
-  | ValidationTreeError
+  | readonly WithField<ValidationError>[]
+  | WithField<ValidationError>
   | 'pending'
   | undefined;
 
@@ -248,7 +248,7 @@ export type Validator<TValue, TPathKind extends PathKind = PathKind.Root> = Logi
 
 export type TreeValidator<TValue, TPathKind extends PathKind = PathKind.Root> = LogicFn<
   TValue,
-  ValidationTreeError[],
+  (ValidationError | WithField<ValidationError>)[],
   TPathKind
 >;
 

--- a/packages/forms/experimental/src/api/types.ts
+++ b/packages/forms/experimental/src/api/types.ts
@@ -3,12 +3,13 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {Signal, WritableSignal} from '@angular/core';
 import {DataKey} from './data';
 import {MetadataKey} from './metadata';
+import {ValidationError, ValidationTreeError} from './validation_errors';
 
 /**
  * Symbol used to retain generic type information when it would otherwise be lost.
@@ -39,39 +40,15 @@ export interface DisabledReason {
 }
 
 /**
- * A validation error on a form. All validation errors must have a `kind` that identifies what type
- * of error it is, and may optionally have a `message` string containing a human-readable error
- * message.
- */
-export interface FormError {
-  readonly kind: string;
-  readonly message?: string;
-  readonly field?: never;
-}
-
-export interface FormTreeError extends Omit<FormError, 'field'> {
-  readonly field?: Field<unknown>;
-}
-
-/**
- * An error that is returned from the server when submitting the form. It contains a reference to
- * the validation errors as well as a reference to the `Field` node those errors should be
- * associated with.
- */
-export interface ServerError {
-  field: Field<unknown>;
-  error: ValidationResult;
-}
-
-/**
  * The result of running a validation function. The result may be `undefined` to indicate no errors,
- * a single `FormError`, or a list of `FormError` which can be used to indicate multiple errors.
+ * a single `ValidationError`, or a list of `ValidationError` which can be used to indicate multiple
+ * errors.
  */
-export type ValidationResult = readonly FormError[] | FormError | undefined;
+export type ValidationResult = readonly ValidationError[] | ValidationError | undefined;
 
 export type AsyncValidationResult =
-  | readonly FormTreeError[]
-  | FormTreeError
+  | readonly ValidationTreeError[]
+  | ValidationTreeError
   | 'pending'
   | undefined;
 
@@ -132,11 +109,11 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
   /**
    * A signal containing the current errors for the field.
    */
-  readonly errors: Signal<FormError[]>;
+  readonly errors: Signal<ValidationError[]>;
   /**
    * A signal containing the current errors for the field.
    */
-  readonly syncErrors: Signal<FormError[]>;
+  readonly syncErrors: Signal<ValidationError[]>;
   /**
    * A signal indicating whether the field's value is currently valid.
    *
@@ -271,7 +248,7 @@ export type Validator<TValue, TPathKind extends PathKind = PathKind.Root> = Logi
 
 export type TreeValidator<TValue, TPathKind extends PathKind = PathKind.Root> = LogicFn<
   TValue,
-  FormTreeError[],
+  ValidationTreeError[],
   TPathKind
 >;
 

--- a/packages/forms/experimental/src/api/types.ts
+++ b/packages/forms/experimental/src/api/types.ts
@@ -16,6 +16,10 @@ import {ValidationError, WithField} from './validation_errors';
  */
 declare const ɵɵTYPE: unique symbol;
 
+export type Mutable<T> = {
+  -readonly [P in keyof T]: T[P];
+};
+
 export declare namespace PathKind {
   export interface Root {
     [ɵɵTYPE]: 'root' | 'child' | 'item';

--- a/packages/forms/experimental/src/api/validation_errors.ts
+++ b/packages/forms/experimental/src/api/validation_errors.ts
@@ -119,7 +119,6 @@ function matchesNgErrorStructure(obj: any, allowField: boolean) {
     case 'email':
       return true;
     case 'min':
-      console.log(error.min);
       return typeof error.min === 'number';
     case 'max':
       return typeof error.max === 'number';

--- a/packages/forms/experimental/src/api/validation_errors.ts
+++ b/packages/forms/experimental/src/api/validation_errors.ts
@@ -31,7 +31,7 @@ export function createError<TError extends ValidationError, TArgs extends any[]>
  * the field.
  * @param errorCtor The subclass constructor
  * @param params The constructor params, plus the field the error applies to.
- * @return An instance of `WithField<TErorr>` created with the given constructor and params.
+ * @return An instance of `WithField<TError>` created with the given constructor and params.
  * @template TError The type of error to create
  * @template TArgs The type of arguments to the constructor
  */
@@ -135,13 +135,13 @@ export abstract class ValidationError {
 
   /**
    * Create a max value error
-   * @param min The max value constraint
+   * @param max The max value constraint
    * @param message The optional human readable error message
    */
   static max(max: number, message?: string): MaxValidationError;
   /**
    * Create a max value error targeted at a specific field
-   * @param min The max value constraint
+   * @param max The max value constraint
    * @param message The optional human readable error message
    * @param field The target field
    */
@@ -160,13 +160,13 @@ export abstract class ValidationError {
 
   /**
    * Create a minlength error
-   * @param min The minlength constraint
+   * @param minlength The minlength constraint
    * @param message The optional human readable error message
    */
   static minlength(minlength: number, message?: string): MinlengthValidationError;
   /**
    * Create a minlength error targeted at a specific field
-   * @param min The minlength constraint
+   * @param minlength The minlength constraint
    * @param message The optional human readable error message
    * @param field The target field
    */
@@ -185,13 +185,13 @@ export abstract class ValidationError {
 
   /**
    * Create a maxlength error
-   * @param min The maxlength constraint
+   * @param maxlength The maxlength constraint
    * @param message The optional human readable error message
    */
   static maxlength(maxlength: number, message?: string): MaxlengthValidationError;
   /**
    * Create a maxlength error targeted at a specific field
-   * @param min The maxlength constraint
+   * @param maxlength The maxlength constraint
    * @param message The optional human readable error message
    * @param field The target field
    */
@@ -210,13 +210,13 @@ export abstract class ValidationError {
 
   /**
    * Create a pattern matching error
-   * @param min The violated pattern
+   * @param pattern The violated pattern
    * @param message The optional human readable error message
    */
   static pattern(pattern: string, message?: string): PatternValidationError;
   /**
    * Create a pattern matching error targeted at a specific field
-   * @param min The violated pattern
+   * @param pattern The violated pattern
    * @param message The optional human readable error message
    * @param field The target field
    */
@@ -371,7 +371,7 @@ export class MaxlengthValidationError extends _NgValidationError {
   override readonly kind = 'maxlength';
 
   constructor(
-    readonly maxlegnth: number,
+    readonly maxlength: number,
     message?: string,
   ) {
     super(message);
@@ -420,7 +420,7 @@ export class StandardSchemaValidationError extends _NgValidationError {
  * @example ```
  * const f = form(...);
  * for (const e of form().errors()) {
- *   if (e instanceof NgValiationError) {
+ *   if (e instanceof NgValidationError) {
  *     switch(e.kind) {
  *       case 'required':
  *         console.log('This is required!');

--- a/packages/forms/experimental/src/api/validation_errors.ts
+++ b/packages/forms/experimental/src/api/validation_errors.ts
@@ -1,0 +1,71 @@
+import {StandardSchemaV1} from './standard_schema_types';
+import {Field} from './types';
+
+export type WithOptionalField<E extends BaseValidationError> = Omit<E, 'field'> & {
+  readonly field?: Field<unknown>;
+};
+
+/** Common interface for all validation errors. */
+export interface BaseValidationError {
+  /** Identifies the kind of error. */
+  readonly kind: string;
+  /** Human readable error message. */
+  readonly message?: string;
+  /** Reserved property used by async and tree validators. */
+  readonly field?: never;
+}
+
+export interface RequiredValidationError extends BaseValidationError {
+  readonly kind: 'ng:required';
+}
+
+export interface MinValidationError extends BaseValidationError {
+  readonly kind: 'ng:min';
+  readonly min: number;
+}
+
+export interface MaxValidationError extends BaseValidationError {
+  readonly kind: 'ng:max';
+  readonly max: number;
+}
+
+export interface MinlengthValidationError extends BaseValidationError {
+  readonly kind: 'ng:minlength';
+  readonly minlength: number;
+}
+
+export interface MaxlengthValidationError extends BaseValidationError {
+  readonly kind: 'ng:maxlength';
+  readonly maxlength: number;
+}
+
+export interface PatternValidationError extends BaseValidationError {
+  readonly kind: 'ng:pattern';
+  readonly pattern: string;
+}
+
+export interface EmailValidationError extends BaseValidationError {
+  readonly kind: 'ng:email';
+}
+
+export interface StandardSchemaValidationError extends BaseValidationError {
+  readonly kind: `ng:standard`;
+  issue: StandardSchemaV1.Issue;
+}
+
+export interface CustomValidationError extends BaseValidationError {
+  readonly kind: `custom:${string}`;
+}
+
+export type ValidationError =
+  | RequiredValidationError
+  | MinValidationError
+  | MaxValidationError
+  | MinlengthValidationError
+  | MaxlengthValidationError
+  | PatternValidationError
+  | EmailValidationError
+  | StandardSchemaValidationError
+  | CustomValidationError;
+
+export type ValidationTreeError = WithOptionalField<ValidationError>;

--- a/packages/forms/experimental/src/api/validation_errors.ts
+++ b/packages/forms/experimental/src/api/validation_errors.ts
@@ -6,62 +6,435 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {FieldNode} from '../field/node';
 import {StandardSchemaV1} from './standard_schema_types';
 import {Field} from './types';
 
-export type WithOptionalField<E extends ValidationError> = Omit<E, 'field'> & {
-  readonly field?: Field<unknown>;
+/** Internal symbol used for class branding. */
+const BRAND = Symbol();
+
+/**
+ * Creates a `ValidationError` subclass instance using the given error constructor and constructor
+ * params.
+ * @param errorCtor The subclass constructor
+ * @param params The params to pass to the constructor.
+ * @return An instance of `TError` created with the given constructor and params.
+ * @template TError The type of error to create
+ * @template TArgs The type of arguments to the constructor
+ */
+export function createError<TError extends ValidationError, TArgs extends any[]>(
+  errorCtor: new (...args: TArgs) => TError,
+  ...params: [...TArgs]
+): TError;
+/**
+ * Create a `ValidationError` subclass instance with target field using the given error constructor
+ * and constructor params. Using this method rather than the constructor directly allows assigning
+ * the field.
+ * @param errorCtor The subclass constructor
+ * @param params The constructor params, plus the field the error applies to.
+ * @return An instance of `WithField<TErorr>` created with the given constructor and params.
+ * @template TError The type of error to create
+ * @template TArgs The type of arguments to the constructor
+ */
+export function createError<TError extends ValidationError, TArgs extends any[]>(
+  errorCtor: new (...args: TArgs) => TError,
+  ...params: [...TArgs, Field<unknown> | undefined]
+): WithField<TError>;
+export function createError<TError extends ValidationError, TArgs extends any[]>(
+  errorCtor: new (...args: TArgs) => TError,
+  ...params: [...TArgs, Field<unknown> | undefined]
+): TError | WithField<TError> {
+  const field = params.pop();
+  const instance = new errorCtor(...(params as unknown as TArgs));
+  (instance as any).field = field;
+  return instance;
+}
+
+/**
+ * Returns a new `E` instance based on the given `WithField<E>`, but with the field removed.
+ * @param e The error to strip the field from
+ * @returns A new instance with the field removed, or the same instance if it didn't have a field.
+ */
+export function stripField<E extends ValidationError>(e: WithField<E> | E): E {
+  if (!e.field) {
+    return e;
+  }
+  const newE = {};
+  Reflect.setPrototypeOf(newE, Object.getPrototypeOf(e));
+  Object.assign(newE, e, {field: undefined});
+  return newE as E;
+}
+
+/**
+ * Represents a `ValidationError` with an associated target field.
+ */
+export type WithField<E extends ValidationError> = Omit<E, 'field'> & {
+  readonly field: Field<unknown>;
 };
 
 /** Common interface for all validation errors. */
-export interface ValidationError {
+export abstract class ValidationError {
+  /** Brand the class to avoid Typescript structural matching */
+  [BRAND] = undefined;
+
   /** Identifies the kind of error. */
-  readonly kind: string;
-  /** Human readable error message. */
-  readonly message?: string;
+  readonly kind: string = '';
+
   /** Reserved property used by async and tree validators. */
   readonly field?: never;
+
+  constructor(
+    /** Human readable error message. */
+    readonly message?: string,
+  ) {}
+
+  /**
+   * Create a required error
+   * @param message The optional human readable error message
+   */
+  static required(message?: string): RequiredValidationError;
+  /**
+   * Create a required error targetd at a specific field
+   * @param message The optional human readable error message
+   * @param field The target field
+   */
+  static required(
+    message: string | undefined,
+    field: Field<unknown>,
+  ): WithField<RequiredValidationError>;
+  static required(
+    message?: string,
+    field?: Field<unknown>,
+  ): RequiredValidationError | WithField<RequiredValidationError> {
+    return createError(RequiredValidationError, message, field);
+  }
+
+  /**
+   * Create a min value error
+   * @param min The min value constraint
+   * @param message The optional human readable error message
+   */
+  static min(min: number, message?: string): MinValidationError;
+  /**
+   * Create a min error targeted at a specific field
+   * @param min The min value constraint
+   * @param message The optional human readable error message
+   * @param field The target field
+   */
+  static min(
+    min: number,
+    message: string | undefined,
+    field: Field<unknown>,
+  ): WithField<MinValidationError>;
+  static min(
+    min: number,
+    message?: string,
+    field?: Field<unknown>,
+  ): MinValidationError | WithField<MinValidationError> {
+    return createError(MinValidationError, min, message, field);
+  }
+
+  /**
+   * Create a max value error
+   * @param min The max value constraint
+   * @param message The optional human readable error message
+   */
+  static max(max: number, message?: string): MaxValidationError;
+  /**
+   * Create a max value error targeted at a specific field
+   * @param min The max value constraint
+   * @param message The optional human readable error message
+   * @param field The target field
+   */
+  static max(
+    max: number,
+    message: string | undefined,
+    field: Field<unknown>,
+  ): WithField<MaxValidationError>;
+  static max(
+    max: number,
+    message?: string,
+    field?: Field<unknown>,
+  ): MaxValidationError | WithField<MaxValidationError> {
+    return createError(MaxValidationError, max, message, field);
+  }
+
+  /**
+   * Create a minlength error
+   * @param min The minlength constraint
+   * @param message The optional human readable error message
+   */
+  static minlength(minlength: number, message?: string): MinlengthValidationError;
+  /**
+   * Create a minlength error targeted at a specific field
+   * @param min The minlength constraint
+   * @param message The optional human readable error message
+   * @param field The target field
+   */
+  static minlength(
+    minlength: number,
+    message: string | undefined,
+    field: Field<unknown>,
+  ): WithField<MinlengthValidationError>;
+  static minlength(
+    minlength: number,
+    message?: string,
+    field?: Field<unknown>,
+  ): MinlengthValidationError | WithField<MinlengthValidationError> {
+    return createError(MinlengthValidationError, minlength, message, field);
+  }
+
+  /**
+   * Create a maxlength error
+   * @param min The maxlength constraint
+   * @param message The optional human readable error message
+   */
+  static maxlength(maxlength: number, message?: string): MaxlengthValidationError;
+  /**
+   * Create a maxlength error targeted at a specific field
+   * @param min The maxlength constraint
+   * @param message The optional human readable error message
+   * @param field The target field
+   */
+  static maxlength(
+    maxlength: number,
+    message: string | undefined,
+    field: Field<unknown>,
+  ): WithField<MaxlengthValidationError>;
+  static maxlength(
+    maxlength: number,
+    message?: string,
+    field?: Field<unknown>,
+  ): MaxlengthValidationError | WithField<MaxlengthValidationError> {
+    return createError(MaxlengthValidationError, maxlength, message, field);
+  }
+
+  /**
+   * Create a pattern matching error
+   * @param min The violated pattern
+   * @param message The optional human readable error message
+   */
+  static pattern(pattern: string, message?: string): PatternValidationError;
+  /**
+   * Create a pattern matching error targeted at a specific field
+   * @param min The violated pattern
+   * @param message The optional human readable error message
+   * @param field The target field
+   */
+  static pattern(
+    pattern: string,
+    message: string | undefined,
+    field: Field<unknown>,
+  ): WithField<PatternValidationError>;
+  static pattern(
+    pattern: string,
+    message?: string,
+    field?: Field<unknown>,
+  ): PatternValidationError | WithField<PatternValidationError> {
+    return createError(PatternValidationError, pattern, message, field);
+  }
+
+  /**
+   * Create an email format error
+   * @param message The optional human readable error message
+   */
+  static email(message?: string): EmailValidationError;
+  /**
+   * Create an email format error targeted at a specific field
+   * @param message The optional human readable error message
+   * @param field The target field
+   */
+  static email(message: string | undefined, field: Field<unknown>): WithField<EmailValidationError>;
+  static email(
+    message?: string,
+    field?: Field<unknown>,
+  ): EmailValidationError | WithField<EmailValidationError> {
+    return createError(EmailValidationError, message, field);
+  }
+
+  /**
+   * Create a standard schema issue error
+   * @param issue The standard schema issue
+   * @param message The optional human readable error message
+   */
+  static standardSchema(
+    issue: StandardSchemaV1.Issue,
+    message?: string,
+  ): StandardSchemaValidationError;
+  /**
+   * Create a standard schema issue error targeted at a specific field
+   * @param issue The standard schema issue
+   * @param message The optional human readable error message
+   * @param field The target field
+   */
+  static standardSchema(
+    issue: StandardSchemaV1.Issue,
+    message: string | undefined,
+    field: Field<unknown>,
+  ): WithField<StandardSchemaValidationError>;
+  static standardSchema(
+    issue: StandardSchemaV1.Issue,
+    message?: string,
+    field?: Field<unknown>,
+  ): StandardSchemaValidationError | WithField<StandardSchemaValidationError> {
+    return createError(StandardSchemaValidationError, issue, message, field);
+  }
+
+  /**
+   * Create a custom error
+   * @param obj The object to create an error from
+   */
+  static custom<E extends Omit<Partial<ValidationError>, typeof BRAND>>(
+    obj?: E,
+  ): CustomValidationError;
+  /**
+   * Create a custom error targeted at a specific field
+   * @param obj The object to create an error from
+   */
+  static custom<E extends Omit<Partial<WithField<ValidationError>>, typeof BRAND>>(
+    obj: E,
+  ): WithField<CustomValidationError | ValidationError>;
+  static custom<E extends ValidationError>(
+    obj?: E,
+  ): CustomValidationError | WithField<CustomValidationError> {
+    if (obj === undefined) {
+      return new CustomValidationError();
+    }
+    const {message, field, ...props} = obj;
+    const e = createError(CustomValidationError, message, field);
+    Object.assign(e, props);
+    return e;
+  }
 }
 
-export interface RequiredValidationError extends ValidationError {
-  readonly kind: 'required';
+/**
+ * A custom error that may contain additional properties
+ */
+export class CustomValidationError extends ValidationError {
+  [key: PropertyKey]: unknown;
 }
 
-export interface MinValidationError extends ValidationError {
-  readonly kind: 'min';
-  readonly min: number;
+abstract class _NgValidationError extends ValidationError {}
+
+/**
+ * An error used to indicate that a required field is empty.
+ */
+export class RequiredValidationError extends _NgValidationError {
+  override readonly kind = 'required';
 }
 
-export interface MaxValidationError extends ValidationError {
-  readonly kind: 'max';
-  readonly max: number;
+/**
+ * An error used to indicate that a value is lower than the minimum allowed.
+ */
+export class MinValidationError extends _NgValidationError {
+  override readonly kind = 'min';
+
+  constructor(
+    readonly min: number,
+    message?: string,
+  ) {
+    super(message);
+  }
 }
 
-export interface MinlengthValidationError extends ValidationError {
-  readonly kind: 'minlength';
-  readonly minlength: number;
+/**
+ * An error used to indicate that a value is higher than the maximum allowed.
+ */
+export class MaxValidationError extends _NgValidationError {
+  override readonly kind = 'max';
+
+  constructor(
+    readonly max: number,
+    message?: string,
+  ) {
+    super(message);
+  }
 }
 
-export interface MaxlengthValidationError extends ValidationError {
-  readonly kind: 'maxlength';
-  readonly maxlength: number;
+/**
+ * An error used to indicate that a value is shorter than the minimum allowed length.
+ */
+export class MinlengthValidationError extends _NgValidationError {
+  override readonly kind = 'minlength';
+
+  constructor(
+    readonly minlength: number,
+    message?: string,
+  ) {
+    super(message);
+  }
 }
 
-export interface PatternValidationError extends ValidationError {
-  readonly kind: 'pattern';
-  readonly pattern: string;
+/**
+ * An error used to indicate that a value is longer than the maximum allowed length.
+ */
+export class MaxlengthValidationError extends _NgValidationError {
+  override readonly kind = 'maxlength';
+
+  constructor(
+    readonly maxlegnth: number,
+    message?: string,
+  ) {
+    super(message);
+  }
 }
 
-export interface EmailValidationError extends ValidationError {
-  readonly kind: 'email';
+/**
+ * An error used to indicate that a value does not match the required pattern.
+ */
+export class PatternValidationError extends _NgValidationError {
+  override readonly kind = 'pattern';
+
+  constructor(
+    readonly pattern: string,
+    message?: string,
+  ) {
+    super(message);
+  }
 }
 
-export interface StandardSchemaValidationError extends ValidationError {
-  readonly kind: 'standardschema';
-  issue: StandardSchemaV1.Issue;
+/**
+ * An error used to indicate that a value is not a valid email.
+ */
+export class EmailValidationError extends _NgValidationError {
+  override readonly kind = 'email';
 }
 
+/**
+ * An error used to indicate an issue validating against a standard schema.
+ */
+export class StandardSchemaValidationError extends _NgValidationError {
+  override readonly kind = 'standardschema';
+
+  constructor(
+    readonly issue: StandardSchemaV1.Issue,
+    message?: string,
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * The base class for all built-in, non-custom errors. This class can be used to check if an error
+ * is one of the standard kinds, allowing you to switch on the kind to further narrow the type.
+ *
+ * @example ```
+ * const f = form(...);
+ * for (const e of form().errors()) {
+ *   if (e instanceof NgValiationError) {
+ *     switch(e.kind) {
+ *       case 'required':
+ *         console.log('This is required!');
+ *         break;
+ *       case 'min':
+ *         console.log(`Must be at least ${e.min}`);
+ *         break;
+ *       ...
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export const NgValidationError: abstract new () => NgValidationError = _NgValidationError as any;
 export type NgValidationError =
   | RequiredValidationError
   | MinValidationError
@@ -71,82 +444,3 @@ export type NgValidationError =
   | PatternValidationError
   | EmailValidationError
   | StandardSchemaValidationError;
-
-const kinds = new Set<NgValidationError['kind']>([
-  'required',
-  'min',
-  'max',
-  'minlength',
-  'maxlength',
-  'pattern',
-  'email',
-  'standardschema',
-]);
-
-export const NgValidationError: abstract new () => NgValidationError = <any>{
-  [Symbol.hasInstance]: (value: any) => matchesNgErrorStructure(value, false),
-};
-
-export type ValidationTreeError = WithOptionalField<ValidationError>;
-
-export type NgValidationTreeError =
-  | WithOptionalField<RequiredValidationError>
-  | WithOptionalField<MinValidationError>
-  | WithOptionalField<MaxValidationError>
-  | WithOptionalField<MinlengthValidationError>
-  | WithOptionalField<MaxlengthValidationError>
-  | WithOptionalField<PatternValidationError>
-  | WithOptionalField<EmailValidationError>
-  | WithOptionalField<StandardSchemaValidationError>;
-
-export const NgValidationTreeError: abstract new () => NgValidationTreeError = <any>{
-  [Symbol.hasInstance]: (value: any) => matchesNgErrorStructure(value, true),
-};
-
-const propertyKeyTypes = new Set(['string', 'number', 'symbol']);
-
-function matchesNgErrorStructure(obj: any, allowField: boolean) {
-  if (!(obj instanceof Object)) return false;
-  const error = obj as NgValidationTreeError;
-  if (typeof error.kind !== 'string') return false;
-  if (!(error.message === undefined || typeof error.message === 'string')) return false;
-  if (error.field !== undefined) {
-    if (!allowField) return false;
-    if (!(error.field instanceof FieldNode)) return false;
-  }
-  switch (error.kind) {
-    case 'required':
-    case 'email':
-      return true;
-    case 'min':
-      return typeof error.min === 'number';
-    case 'max':
-      return typeof error.max === 'number';
-    case 'minlength':
-      return typeof error.minlength === 'number';
-    case 'maxlength':
-      return typeof error.maxlength === 'number';
-    case 'pattern':
-      return typeof error.pattern === 'string';
-    case 'standardschema':
-      if (!(error.issue instanceof Object)) return false;
-      if (typeof error.issue.message !== 'string') return false;
-      if (typeof error.issue.path !== undefined) {
-        if (Array.isArray(error.issue.path)) {
-          for (const p of error.issue.path) {
-            if (p instanceof Object) {
-              if (!propertyKeyTypes.has(typeof p.key)) {
-                return false;
-              }
-            } else if (!propertyKeyTypes.has(typeof p)) {
-              return false;
-            }
-          }
-        }
-        return false;
-      }
-      return true;
-    default:
-      return false;
-  }
-}

--- a/packages/forms/experimental/src/api/validation_errors.ts
+++ b/packages/forms/experimental/src/api/validation_errors.ts
@@ -1,12 +1,21 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {FieldNode} from '../field/node';
 import {StandardSchemaV1} from './standard_schema_types';
 import {Field} from './types';
 
-export type WithOptionalField<E extends BaseValidationError> = Omit<E, 'field'> & {
+export type WithOptionalField<E extends ValidationError> = Omit<E, 'field'> & {
   readonly field?: Field<unknown>;
 };
 
 /** Common interface for all validation errors. */
-export interface BaseValidationError {
+export interface ValidationError {
   /** Identifies the kind of error. */
   readonly kind: string;
   /** Human readable error message. */
@@ -15,49 +24,45 @@ export interface BaseValidationError {
   readonly field?: never;
 }
 
-export interface RequiredValidationError extends BaseValidationError {
-  readonly kind: 'ng:required';
+export interface RequiredValidationError extends ValidationError {
+  readonly kind: 'required';
 }
 
-export interface MinValidationError extends BaseValidationError {
-  readonly kind: 'ng:min';
+export interface MinValidationError extends ValidationError {
+  readonly kind: 'min';
   readonly min: number;
 }
 
-export interface MaxValidationError extends BaseValidationError {
-  readonly kind: 'ng:max';
+export interface MaxValidationError extends ValidationError {
+  readonly kind: 'max';
   readonly max: number;
 }
 
-export interface MinlengthValidationError extends BaseValidationError {
-  readonly kind: 'ng:minlength';
+export interface MinlengthValidationError extends ValidationError {
+  readonly kind: 'minlength';
   readonly minlength: number;
 }
 
-export interface MaxlengthValidationError extends BaseValidationError {
-  readonly kind: 'ng:maxlength';
+export interface MaxlengthValidationError extends ValidationError {
+  readonly kind: 'maxlength';
   readonly maxlength: number;
 }
 
-export interface PatternValidationError extends BaseValidationError {
-  readonly kind: 'ng:pattern';
+export interface PatternValidationError extends ValidationError {
+  readonly kind: 'pattern';
   readonly pattern: string;
 }
 
-export interface EmailValidationError extends BaseValidationError {
-  readonly kind: 'ng:email';
+export interface EmailValidationError extends ValidationError {
+  readonly kind: 'email';
 }
 
-export interface StandardSchemaValidationError extends BaseValidationError {
-  readonly kind: `ng:standard`;
+export interface StandardSchemaValidationError extends ValidationError {
+  readonly kind: 'standardschema';
   issue: StandardSchemaV1.Issue;
 }
 
-export interface CustomValidationError extends BaseValidationError {
-  readonly kind: `custom:${string}`;
-}
-
-export type ValidationError =
+export type NgValidationError =
   | RequiredValidationError
   | MinValidationError
   | MaxValidationError
@@ -65,7 +70,84 @@ export type ValidationError =
   | MaxlengthValidationError
   | PatternValidationError
   | EmailValidationError
-  | StandardSchemaValidationError
-  | CustomValidationError;
+  | StandardSchemaValidationError;
+
+const kinds = new Set<NgValidationError['kind']>([
+  'required',
+  'min',
+  'max',
+  'minlength',
+  'maxlength',
+  'pattern',
+  'email',
+  'standardschema',
+]);
+
+export const NgValidationError: abstract new () => NgValidationError = <any>{
+  [Symbol.hasInstance]: (value: any) => matchesNgErrorStructure(value, false),
+};
 
 export type ValidationTreeError = WithOptionalField<ValidationError>;
+
+export type NgValidationTreeError =
+  | WithOptionalField<RequiredValidationError>
+  | WithOptionalField<MinValidationError>
+  | WithOptionalField<MaxValidationError>
+  | WithOptionalField<MinlengthValidationError>
+  | WithOptionalField<MaxlengthValidationError>
+  | WithOptionalField<PatternValidationError>
+  | WithOptionalField<EmailValidationError>
+  | WithOptionalField<StandardSchemaValidationError>;
+
+export const NgValidationTreeError: abstract new () => NgValidationTreeError = <any>{
+  [Symbol.hasInstance]: (value: any) => matchesNgErrorStructure(value, true),
+};
+
+const propertyKeyTypes = new Set(['string', 'number', 'symbol']);
+
+function matchesNgErrorStructure(obj: any, allowField: boolean) {
+  if (!(obj instanceof Object)) return false;
+  const error = obj as NgValidationTreeError;
+  if (typeof error.kind !== 'string') return false;
+  if (!(error.message === undefined || typeof error.message === 'string')) return false;
+  if (error.field !== undefined) {
+    if (!allowField) return false;
+    if (!(error.field instanceof FieldNode)) return false;
+  }
+  switch (error.kind) {
+    case 'required':
+    case 'email':
+      return true;
+    case 'min':
+      console.log(error.min);
+      return typeof error.min === 'number';
+    case 'max':
+      return typeof error.max === 'number';
+    case 'minlength':
+      return typeof error.minlength === 'number';
+    case 'maxlength':
+      return typeof error.maxlength === 'number';
+    case 'pattern':
+      return typeof error.pattern === 'string';
+    case 'standardschema':
+      if (!(error.issue instanceof Object)) return false;
+      if (typeof error.issue.message !== 'string') return false;
+      if (typeof error.issue.path !== undefined) {
+        if (Array.isArray(error.issue.path)) {
+          for (const p of error.issue.path) {
+            if (p instanceof Object) {
+              if (!propertyKeyTypes.has(typeof p.key)) {
+                return false;
+              }
+            } else if (!propertyKeyTypes.has(typeof p)) {
+              return false;
+            }
+          }
+        }
+        return false;
+      }
+      return true;
+    default:
+      return false;
+  }
+}

--- a/packages/forms/experimental/src/api/validators/email.ts
+++ b/packages/forms/experimental/src/api/validators/email.ts
@@ -58,7 +58,7 @@ export function email<TPathKind extends PathKind = PathKind.Root>(
       if (config?.errors) {
         return config.errors(ctx);
       } else {
-        return {kind: 'ng:email'};
+        return {kind: 'email'};
       }
     }
 

--- a/packages/forms/experimental/src/api/validators/email.ts
+++ b/packages/forms/experimental/src/api/validators/email.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {validate} from '../logic';
@@ -58,7 +58,7 @@ export function email<TPathKind extends PathKind = PathKind.Root>(
       if (config?.errors) {
         return config.errors(ctx);
       } else {
-        return {kind: 'email'};
+        return {kind: 'ng:email'};
       }
     }
 

--- a/packages/forms/experimental/src/api/validators/email.ts
+++ b/packages/forms/experimental/src/api/validators/email.ts
@@ -8,6 +8,7 @@
 
 import {validate} from '../logic';
 import {FieldPath, PathKind} from '../types';
+import {ValidationError} from '../validation_errors';
 import {BaseValidatorConfig} from './types';
 
 /**
@@ -58,7 +59,7 @@ export function email<TPathKind extends PathKind = PathKind.Root>(
       if (config?.errors) {
         return config.errors(ctx);
       } else {
-        return {kind: 'email'};
+        return ValidationError.email();
       }
     }
 

--- a/packages/forms/experimental/src/api/validators/max.ts
+++ b/packages/forms/experimental/src/api/validators/max.ts
@@ -9,6 +9,7 @@
 import {metadata, validate} from '../logic';
 import {MAX} from '../metadata';
 import {FieldPath, LogicFn, PathKind} from '../types';
+import {ValidationError} from '../validation_errors';
 import {BaseValidatorConfig} from './types';
 
 /**
@@ -37,7 +38,7 @@ export function max<TPathKind extends PathKind = PathKind.Root>(
       if (config?.errors) {
         return config.errors(ctx);
       } else {
-        return {kind: 'max', max: value};
+        return ValidationError.max(value);
       }
     }
 

--- a/packages/forms/experimental/src/api/validators/max.ts
+++ b/packages/forms/experimental/src/api/validators/max.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {metadata, validate} from '../logic';
@@ -37,7 +37,7 @@ export function max<TPathKind extends PathKind = PathKind.Root>(
       if (config?.errors) {
         return config.errors(ctx);
       } else {
-        return {kind: 'max'};
+        return {kind: 'ng:max', max: value};
       }
     }
 

--- a/packages/forms/experimental/src/api/validators/max.ts
+++ b/packages/forms/experimental/src/api/validators/max.ts
@@ -37,7 +37,7 @@ export function max<TPathKind extends PathKind = PathKind.Root>(
       if (config?.errors) {
         return config.errors(ctx);
       } else {
-        return {kind: 'ng:max', max: value};
+        return {kind: 'max', max: value};
       }
     }
 

--- a/packages/forms/experimental/src/api/validators/max_length.ts
+++ b/packages/forms/experimental/src/api/validators/max_length.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {metadata, validate} from '../logic';
@@ -36,7 +36,7 @@ export function maxLength<TPathKind extends PathKind = PathKind.Root>(
       if (config?.errors) {
         return config.errors(ctx);
       } else {
-        return {kind: 'maxLength'};
+        return {kind: 'ng:maxlength', maxlength: value};
       }
     }
 

--- a/packages/forms/experimental/src/api/validators/max_length.ts
+++ b/packages/forms/experimental/src/api/validators/max_length.ts
@@ -9,6 +9,7 @@
 import {metadata, validate} from '../logic';
 import {MAX_LENGTH} from '../metadata';
 import {FieldPath, LogicFn, PathKind} from '../types';
+import {ValidationError} from '../validation_errors';
 import {BaseValidatorConfig, ValueWithLength} from './types';
 
 /**
@@ -36,7 +37,7 @@ export function maxLength<TPathKind extends PathKind = PathKind.Root>(
       if (config?.errors) {
         return config.errors(ctx);
       } else {
-        return {kind: 'maxlength', maxlength: value};
+        return ValidationError.maxlength(value);
       }
     }
 

--- a/packages/forms/experimental/src/api/validators/max_length.ts
+++ b/packages/forms/experimental/src/api/validators/max_length.ts
@@ -36,7 +36,7 @@ export function maxLength<TPathKind extends PathKind = PathKind.Root>(
       if (config?.errors) {
         return config.errors(ctx);
       } else {
-        return {kind: 'ng:maxlength', maxlength: value};
+        return {kind: 'maxlength', maxlength: value};
       }
     }
 

--- a/packages/forms/experimental/src/api/validators/min.ts
+++ b/packages/forms/experimental/src/api/validators/min.ts
@@ -9,6 +9,7 @@
 import {metadata, validate} from '../logic';
 import {MIN} from '../metadata';
 import {FieldPath, LogicFn, PathKind} from '../types';
+import {ValidationError} from '../validation_errors';
 import {BaseValidatorConfig} from './types';
 
 /**
@@ -36,7 +37,7 @@ export function min<TPathKind extends PathKind = PathKind.Root>(
       if (config?.errors) {
         return config.errors(ctx);
       } else {
-        return {kind: 'min', min: value};
+        return ValidationError.min(value);
       }
     }
 

--- a/packages/forms/experimental/src/api/validators/min.ts
+++ b/packages/forms/experimental/src/api/validators/min.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {metadata, validate} from '../logic';
@@ -36,7 +36,7 @@ export function min<TPathKind extends PathKind = PathKind.Root>(
       if (config?.errors) {
         return config.errors(ctx);
       } else {
-        return {kind: 'min'};
+        return {kind: 'ng:min', min: value};
       }
     }
 

--- a/packages/forms/experimental/src/api/validators/min.ts
+++ b/packages/forms/experimental/src/api/validators/min.ts
@@ -36,7 +36,7 @@ export function min<TPathKind extends PathKind = PathKind.Root>(
       if (config?.errors) {
         return config.errors(ctx);
       } else {
-        return {kind: 'ng:min', min: value};
+        return {kind: 'min', min: value};
       }
     }
 

--- a/packages/forms/experimental/src/api/validators/min_length.ts
+++ b/packages/forms/experimental/src/api/validators/min_length.ts
@@ -37,7 +37,7 @@ export function minLength<TPathKind extends PathKind = PathKind.Root>(
       if (config?.errors) {
         return config.errors(ctx);
       } else {
-        return {kind: 'minLength'};
+        return {kind: 'ng:minlength', minlength: value};
       }
     }
 

--- a/packages/forms/experimental/src/api/validators/min_length.ts
+++ b/packages/forms/experimental/src/api/validators/min_length.ts
@@ -9,6 +9,7 @@
 import {metadata, validate} from '../logic';
 import {MIN_LENGTH} from '../metadata';
 import {FieldPath, LogicFn, PathKind} from '../types';
+import {ValidationError} from '../validation_errors';
 import {BaseValidatorConfig, ValueWithLength} from './types';
 
 /**
@@ -37,7 +38,7 @@ export function minLength<TPathKind extends PathKind = PathKind.Root>(
       if (config?.errors) {
         return config.errors(ctx);
       } else {
-        return {kind: 'minlength', minlength: value};
+        return ValidationError.minlength(value);
       }
     }
 

--- a/packages/forms/experimental/src/api/validators/min_length.ts
+++ b/packages/forms/experimental/src/api/validators/min_length.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {metadata, validate} from '../logic';
@@ -37,7 +37,7 @@ export function minLength<TPathKind extends PathKind = PathKind.Root>(
       if (config?.errors) {
         return config.errors(ctx);
       } else {
-        return {kind: 'ng:minlength', minlength: value};
+        return {kind: 'minlength', minlength: value};
       }
     }
 

--- a/packages/forms/experimental/src/api/validators/pattern.ts
+++ b/packages/forms/experimental/src/api/validators/pattern.ts
@@ -8,6 +8,7 @@
 import {metadata, validate} from '../logic';
 import {PATTERN} from '../metadata';
 import {FieldPath, LogicFn, PathKind} from '../types';
+import {ValidationError} from '../validation_errors';
 import {BaseValidatorConfig} from './types';
 
 function strToRegexp(pattern: string) {
@@ -49,7 +50,7 @@ export function pattern<TPathKind extends PathKind = PathKind.Root>(
       if (config?.errors) {
         return config.errors(ctx);
       } else {
-        return {kind: 'pattern', pattern: value};
+        return ValidationError.pattern(value);
       }
     }
 

--- a/packages/forms/experimental/src/api/validators/pattern.ts
+++ b/packages/forms/experimental/src/api/validators/pattern.ts
@@ -49,7 +49,7 @@ export function pattern<TPathKind extends PathKind = PathKind.Root>(
       if (config?.errors) {
         return config.errors(ctx);
       } else {
-        return {kind: 'pattern', pattern};
+        return {kind: 'ng:pattern', pattern: value};
       }
     }
 

--- a/packages/forms/experimental/src/api/validators/pattern.ts
+++ b/packages/forms/experimental/src/api/validators/pattern.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 import {metadata, validate} from '../logic';
 import {PATTERN} from '../metadata';
@@ -49,7 +49,7 @@ export function pattern<TPathKind extends PathKind = PathKind.Root>(
       if (config?.errors) {
         return config.errors(ctx);
       } else {
-        return {kind: 'ng:pattern', pattern: value};
+        return {kind: 'pattern', pattern: value};
       }
     }
 

--- a/packages/forms/experimental/src/api/validators/required.ts
+++ b/packages/forms/experimental/src/api/validators/required.ts
@@ -39,7 +39,7 @@ export function required<TValue, TPathKind extends PathKind = PathKind.Root>(
       if (config?.errors) {
         return config.errors(ctx);
       } else {
-        return {kind: 'required'};
+        return {kind: 'ng:required'};
       }
     }
     return undefined;

--- a/packages/forms/experimental/src/api/validators/required.ts
+++ b/packages/forms/experimental/src/api/validators/required.ts
@@ -9,6 +9,7 @@
 import {metadata, validate} from '../logic';
 import {REQUIRED} from '../metadata';
 import {FieldPath, LogicFn, PathKind} from '../types';
+import {ValidationError} from '../validation_errors';
 import {BaseValidatorConfig} from './types';
 
 /**
@@ -39,7 +40,7 @@ export function required<TValue, TPathKind extends PathKind = PathKind.Root>(
       if (config?.errors) {
         return config.errors(ctx);
       } else {
-        return {kind: 'required'};
+        return ValidationError.required();
       }
     }
     return undefined;

--- a/packages/forms/experimental/src/api/validators/required.ts
+++ b/packages/forms/experimental/src/api/validators/required.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {metadata, validate} from '../logic';
@@ -39,7 +39,7 @@ export function required<TValue, TPathKind extends PathKind = PathKind.Root>(
       if (config?.errors) {
         return config.errors(ctx);
       } else {
-        return {kind: 'ng:required'};
+        return {kind: 'required'};
       }
     }
     return undefined;

--- a/packages/forms/experimental/src/field/node.ts
+++ b/packages/forms/experimental/src/field/node.ts
@@ -9,14 +9,8 @@
 import type {Signal, WritableSignal} from '@angular/core';
 import type {DataKey} from '../api/data';
 import type {MetadataKey} from '../api/metadata';
-import type {
-  DisabledReason,
-  Field,
-  FieldContext,
-  FieldState,
-  FormError,
-  SubmittedStatus,
-} from '../api/types';
+import type {DisabledReason, Field, FieldContext, FieldState, SubmittedStatus} from '../api/types';
+import type {ValidationError} from '../api/validation_errors';
 
 import {
   ChildFieldNodeOptions,
@@ -106,7 +100,7 @@ export class FieldNode implements FieldState<unknown> {
     return this.structure.keyInParent;
   }
 
-  get syncErrors(): Signal<FormError[]> {
+  get syncErrors(): Signal<ValidationError[]> {
     return this.validationState.syncErrors;
   }
 
@@ -114,7 +108,7 @@ export class FieldNode implements FieldState<unknown> {
     return this.validationState.syncValid;
   }
 
-  get errors(): Signal<FormError[]> {
+  get errors(): Signal<ValidationError[]> {
     return this.validationState.errors;
   }
 

--- a/packages/forms/experimental/src/field/submit.ts
+++ b/packages/forms/experimental/src/field/submit.ts
@@ -3,12 +3,12 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {computed, linkedSignal, Signal, signal, WritableSignal} from '@angular/core';
-import type {AsyncValidationResult, SubmittedStatus} from '../api/types';
-import type {ValidationError, ValidationTreeError} from '../api/validation_errors';
+import type {SubmittedStatus} from '../api/types';
+import {stripField, WithField, type ValidationError} from '../api/validation_errors';
 import type {FieldNode} from './node';
 
 /**
@@ -34,12 +34,17 @@ export class FieldSubmitState {
       : (this.node.structure.parent?.submitState.submittedStatus() ?? 'unsubmitted'),
   );
 
-  setServerErrors(result: Exclude<AsyncValidationResult, 'pending'>) {
+  setServerErrors(
+    result:
+      | ValidationError
+      | WithField<ValidationError>
+      | (ValidationError | WithField<ValidationError>)[],
+  ) {
     let errors: ValidationError[];
     if (result === undefined) {
       errors = [];
     } else if (!Array.isArray(result)) {
-      errors = [stripField(result as ValidationError)];
+      errors = [stripField(result)];
     } else {
       errors = result.map(stripField);
     }
@@ -52,8 +57,4 @@ export class FieldSubmitState {
       child.submitState.reset();
     }
   }
-}
-
-function stripField({field, ...rest}: ValidationTreeError): ValidationError {
-  return rest as ValidationError;
 }

--- a/packages/forms/experimental/src/field/submit.ts
+++ b/packages/forms/experimental/src/field/submit.ts
@@ -40,15 +40,7 @@ export class FieldSubmitState {
       | WithField<ValidationError>
       | (ValidationError | WithField<ValidationError>)[],
   ) {
-    let errors: ValidationError[];
-    if (result === undefined) {
-      errors = [];
-    } else if (!Array.isArray(result)) {
-      errors = [stripField(result)];
-    } else {
-      errors = result.map(stripField);
-    }
-    this.serverErrors.set(errors);
+    this.serverErrors.set(Array.isArray(result) ? result.map(stripField) : [stripField(result)]);
   }
 
   reset(): void {

--- a/packages/forms/experimental/src/field/validation.ts
+++ b/packages/forms/experimental/src/field/validation.ts
@@ -7,7 +7,8 @@
  */
 
 import {computed, Signal} from '@angular/core';
-import type {FormError, FormTreeError, ValidationResult} from '../api/types';
+import type {ValidationResult} from '../api/types';
+import type {ValidationError, ValidationTreeError} from '../api/validation_errors';
 import type {FieldNode} from './node';
 import {reduceChildren, shortCircuitFalse} from './util';
 
@@ -17,7 +18,7 @@ import {reduceChildren, shortCircuitFalse} from './util';
 export class FieldValidationState {
   constructor(private readonly node: FieldNode) {}
 
-  private readonly rawSyncTreeErrors: Signal<FormTreeError[]> = computed(() => {
+  private readonly rawSyncTreeErrors: Signal<ValidationTreeError[]> = computed(() => {
     if (this.shouldSkipValidation()) {
       return [];
     }
@@ -30,7 +31,7 @@ export class FieldValidationState {
     ];
   });
 
-  readonly syncErrors: Signal<FormError[]> = computed(() => {
+  readonly syncErrors: Signal<ValidationError[]> = computed(() => {
     // Short-circuit running validators if validation doesn't apply to this field.
     if (this.shouldSkipValidation()) {
       return [];
@@ -57,12 +58,14 @@ export class FieldValidationState {
     );
   });
 
-  readonly syncTreeErrors: Signal<FormError[]> = computed(
+  readonly syncTreeErrors: Signal<ValidationError[]> = computed(
     () =>
-      this.rawSyncTreeErrors().filter((err) => err.field === this.node.fieldProxy) as FormError[],
+      this.rawSyncTreeErrors().filter(
+        (err) => err.field === this.node.fieldProxy,
+      ) as ValidationError[],
   );
 
-  readonly rawAsyncErrors: Signal<(FormTreeError | 'pending')[]> = computed(() => {
+  readonly rawAsyncErrors: Signal<(ValidationTreeError | 'pending')[]> = computed(() => {
     // Short-circuit running validators if validation doesn't apply to this field.
     if (this.shouldSkipValidation()) {
       return [];
@@ -85,13 +88,13 @@ export class FieldValidationState {
   /**
    * All asynchronous validation errors & pending statuses for this field.
    */
-  readonly asyncErrors: Signal<(FormError | 'pending')[]> = computed(() => {
+  readonly asyncErrors: Signal<(ValidationError | 'pending')[]> = computed(() => {
     if (this.shouldSkipValidation()) {
       return [];
     }
     return this.rawAsyncErrors().filter(
       (err) => err === 'pending' || err.field! === this.node.fieldProxy,
-    ) as Array<FormError | 'pending'>;
+    ) as Array<ValidationError | 'pending'>;
   });
 
   /**
@@ -157,7 +160,7 @@ export class FieldValidationState {
   }
 }
 
-function normalizeErrors(error: ValidationResult): FormError[] {
+function normalizeErrors(error: ValidationResult): ValidationError[] {
   if (error === undefined) {
     return [];
   }
@@ -166,5 +169,5 @@ function normalizeErrors(error: ValidationResult): FormError[] {
     return error;
   }
 
-  return [error as FormError];
+  return [error as ValidationError];
 }

--- a/packages/forms/experimental/src/field/validation.ts
+++ b/packages/forms/experimental/src/field/validation.ts
@@ -56,11 +56,8 @@ export class FieldValidationState {
     );
   });
 
-  readonly syncTreeErrors: Signal<WithField<ValidationError>[]> = computed(
-    () =>
-      this.rawSyncTreeErrors().filter(
-        (err) => err.field === this.node.fieldProxy,
-      ) as WithField<ValidationError>[],
+  readonly syncTreeErrors: Signal<WithField<ValidationError>[]> = computed(() =>
+    this.rawSyncTreeErrors().filter((err) => err.field === this.node.fieldProxy),
   );
 
   readonly rawAsyncErrors: Signal<(WithField<ValidationError> | 'pending')[]> = computed(() => {

--- a/packages/forms/experimental/src/logic_node_2.ts
+++ b/packages/forms/experimental/src/logic_node_2.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
 import {
   AsyncValidationResult,
   DataKey,
@@ -7,7 +15,7 @@ import {
   MetadataKey,
   ValidationResult,
 } from '../public_api';
-import {ValidationError, ValidationTreeError} from './api/validation_errors';
+import {ValidationError, WithField} from './api/validation_errors';
 import {setBoundPathDepthForResolution} from './field/context';
 import {
   AbstractLogic,
@@ -39,7 +47,7 @@ export abstract class AbstractLogicNodeBuilder {
   /** Adds a rule for synchronous validation errors for a field. */
   abstract addSyncErrorRule(logic: LogicFn<any, ValidationResult>): void;
   /** Adds a rule for synchronous validation errors that apply to a subtree. */
-  abstract addSyncTreeErrorRule(logic: LogicFn<any, ValidationTreeError[]>): void;
+  abstract addSyncTreeErrorRule(logic: LogicFn<any, WithField<ValidationError>[]>): void;
   /** Adds a rule for asynchronous validation errors for a field. */
   abstract addAsyncErrorRule(logic: LogicFn<any, AsyncValidationResult>): void;
   /** Adds a rule to compute metadata for a field. */
@@ -107,7 +115,7 @@ export class LogicNodeBuilder extends AbstractLogicNodeBuilder {
     this.getCurrent().addSyncErrorRule(logic);
   }
 
-  override addSyncTreeErrorRule(logic: LogicFn<any, ValidationTreeError[]>): void {
+  override addSyncTreeErrorRule(logic: LogicFn<any, WithField<ValidationError>[]>): void {
     this.getCurrent().addSyncTreeErrorRule(logic);
   }
 
@@ -217,7 +225,7 @@ class NonMergableLogicNodeBuilder extends AbstractLogicNodeBuilder {
     this.logic.syncErrors.push(setBoundPathDepthForResolution(logic, this.depth));
   }
 
-  override addSyncTreeErrorRule(logic: LogicFn<any, ValidationTreeError[]>): void {
+  override addSyncTreeErrorRule(logic: LogicFn<any, WithField<ValidationError>[]>): void {
     this.logic.syncTreeErrors.push(setBoundPathDepthForResolution(logic, this.depth));
   }
 
@@ -259,9 +267,9 @@ export class LogicContainer {
   /** Logic that produces synchronous validation errors for the field. */
   readonly syncErrors: ArrayMergeLogic<ValidationError>;
   /** Logic that produces synchronous validation errors for the field's subtree. */
-  readonly syncTreeErrors: ArrayMergeLogic<ValidationTreeError>;
+  readonly syncTreeErrors: ArrayMergeLogic<WithField<ValidationError>>;
   /** Logic that produces asynchronous validation results (errors or 'pending'). */
-  readonly asyncErrors: ArrayMergeLogic<ValidationTreeError | 'pending'>;
+  readonly asyncErrors: ArrayMergeLogic<WithField<ValidationError> | 'pending'>;
   /** A map of metadata keys to the `AbstractLogic` instances that compute their values. */
   private readonly metadata = new Map<MetadataKey<unknown>, AbstractLogic<unknown>>();
   /** A map of data keys to the factory functions that create their values. */
@@ -280,8 +288,8 @@ export class LogicContainer {
     this.disabledReasons = new ArrayMergeLogic(predicates);
     this.readonly = new BooleanOrLogic(predicates);
     this.syncErrors = new ArrayMergeLogic<ValidationError>(predicates);
-    this.syncTreeErrors = new ArrayMergeLogic<ValidationTreeError>(predicates);
-    this.asyncErrors = new ArrayMergeLogic<ValidationTreeError | 'pending'>(predicates);
+    this.syncTreeErrors = new ArrayMergeLogic<WithField<ValidationError>>(predicates);
+    this.asyncErrors = new ArrayMergeLogic<WithField<ValidationError> | 'pending'>(predicates);
   }
 
   /**

--- a/packages/forms/experimental/src/logic_node_2.ts
+++ b/packages/forms/experimental/src/logic_node_2.ts
@@ -3,12 +3,11 @@ import {
   DataKey,
   DisabledReason,
   FieldContext,
-  FormError,
-  FormTreeError,
   LogicFn,
   MetadataKey,
   ValidationResult,
 } from '../public_api';
+import {ValidationError, ValidationTreeError} from './api/validation_errors';
 import {setBoundPathDepthForResolution} from './field/context';
 import {
   AbstractLogic,
@@ -40,7 +39,7 @@ export abstract class AbstractLogicNodeBuilder {
   /** Adds a rule for synchronous validation errors for a field. */
   abstract addSyncErrorRule(logic: LogicFn<any, ValidationResult>): void;
   /** Adds a rule for synchronous validation errors that apply to a subtree. */
-  abstract addSyncTreeErrorRule(logic: LogicFn<any, FormTreeError[]>): void;
+  abstract addSyncTreeErrorRule(logic: LogicFn<any, ValidationTreeError[]>): void;
   /** Adds a rule for asynchronous validation errors for a field. */
   abstract addAsyncErrorRule(logic: LogicFn<any, AsyncValidationResult>): void;
   /** Adds a rule to compute metadata for a field. */
@@ -108,7 +107,7 @@ export class LogicNodeBuilder extends AbstractLogicNodeBuilder {
     this.getCurrent().addSyncErrorRule(logic);
   }
 
-  override addSyncTreeErrorRule(logic: LogicFn<any, FormTreeError[]>): void {
+  override addSyncTreeErrorRule(logic: LogicFn<any, ValidationTreeError[]>): void {
     this.getCurrent().addSyncTreeErrorRule(logic);
   }
 
@@ -218,7 +217,7 @@ class NonMergableLogicNodeBuilder extends AbstractLogicNodeBuilder {
     this.logic.syncErrors.push(setBoundPathDepthForResolution(logic, this.depth));
   }
 
-  override addSyncTreeErrorRule(logic: LogicFn<any, FormTreeError[]>): void {
+  override addSyncTreeErrorRule(logic: LogicFn<any, ValidationTreeError[]>): void {
     this.logic.syncTreeErrors.push(setBoundPathDepthForResolution(logic, this.depth));
   }
 
@@ -258,11 +257,11 @@ export class LogicContainer {
   /** Logic that determines if the field is read-only. */
   readonly readonly: BooleanOrLogic;
   /** Logic that produces synchronous validation errors for the field. */
-  readonly syncErrors: ArrayMergeLogic<FormError>;
+  readonly syncErrors: ArrayMergeLogic<ValidationError>;
   /** Logic that produces synchronous validation errors for the field's subtree. */
-  readonly syncTreeErrors: ArrayMergeLogic<FormTreeError>;
+  readonly syncTreeErrors: ArrayMergeLogic<ValidationTreeError>;
   /** Logic that produces asynchronous validation results (errors or 'pending'). */
-  readonly asyncErrors: ArrayMergeLogic<FormTreeError | 'pending'>;
+  readonly asyncErrors: ArrayMergeLogic<ValidationTreeError | 'pending'>;
   /** A map of metadata keys to the `AbstractLogic` instances that compute their values. */
   private readonly metadata = new Map<MetadataKey<unknown>, AbstractLogic<unknown>>();
   /** A map of data keys to the factory functions that create their values. */
@@ -280,9 +279,9 @@ export class LogicContainer {
     this.hidden = new BooleanOrLogic(predicates);
     this.disabledReasons = new ArrayMergeLogic(predicates);
     this.readonly = new BooleanOrLogic(predicates);
-    this.syncErrors = new ArrayMergeLogic<FormError>(predicates);
-    this.syncTreeErrors = new ArrayMergeLogic<FormTreeError>(predicates);
-    this.asyncErrors = new ArrayMergeLogic<FormTreeError | 'pending'>(predicates);
+    this.syncErrors = new ArrayMergeLogic<ValidationError>(predicates);
+    this.syncTreeErrors = new ArrayMergeLogic<ValidationTreeError>(predicates);
+    this.asyncErrors = new ArrayMergeLogic<ValidationTreeError | 'pending'>(predicates);
   }
 
   /**

--- a/packages/forms/experimental/test/node/api/validators/email.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/email.spec.ts
@@ -8,6 +8,7 @@
 
 import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+import {ValidationError} from '@angular/forms/experimental/src/api/validation_errors';
 import {email, form} from '../../../../public_api';
 
 describe('email validator', () => {
@@ -25,7 +26,7 @@ describe('email validator', () => {
 
     expect(f.email().errors()).toEqual([]);
     f.email().value.set('not-real-email');
-    expect(f.email().errors()).toEqual([{kind: 'email'}]);
+    expect(f.email().errors()).toEqual([ValidationError.email()]);
   });
 
   it('supports custom errors', () => {
@@ -33,13 +34,17 @@ describe('email validator', () => {
     const f = form(
       cat,
       (p) => {
-        email(p.email, {errors: (ctx) => ({kind: `special-email-${ctx.valueOf(p.name)}`})});
+        email(p.email, {
+          errors: (ctx) => ValidationError.custom({kind: `special-email-${ctx.valueOf(p.name)}`}),
+        });
       },
       {
         injector: TestBed.inject(Injector),
       },
     );
 
-    expect(f.email().errors()).toEqual([{kind: 'special-email-pirojok-the-cat'}]);
+    expect(f.email().errors()).toEqual([
+      ValidationError.custom({kind: 'special-email-pirojok-the-cat'}),
+    ]);
   });
 });

--- a/packages/forms/experimental/test/node/api/validators/email.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/email.spec.ts
@@ -25,7 +25,7 @@ describe('email validator', () => {
 
     expect(f.email().errors()).toEqual([]);
     f.email().value.set('not-real-email');
-    expect(f.email().errors()).toEqual([{kind: 'email'}]);
+    expect(f.email().errors()).toEqual([{kind: 'ng:email'}]);
   });
 
   it('supports custom errors', () => {
@@ -33,13 +33,13 @@ describe('email validator', () => {
     const f = form(
       cat,
       (p) => {
-        email(p.email, {errors: (ctx) => ({kind: 'special-email-' + ctx.valueOf(p.name)})});
+        email(p.email, {errors: (ctx) => ({kind: `custom:special-email-${ctx.valueOf(p.name)}`})});
       },
       {
         injector: TestBed.inject(Injector),
       },
     );
 
-    expect(f.email().errors()).toEqual([{kind: 'special-email-pirojok-the-cat'}]);
+    expect(f.email().errors()).toEqual([{kind: 'custom:special-email-pirojok-the-cat'}]);
   });
 });

--- a/packages/forms/experimental/test/node/api/validators/email.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/email.spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {Injector, signal} from '@angular/core';
@@ -25,7 +25,7 @@ describe('email validator', () => {
 
     expect(f.email().errors()).toEqual([]);
     f.email().value.set('not-real-email');
-    expect(f.email().errors()).toEqual([{kind: 'ng:email'}]);
+    expect(f.email().errors()).toEqual([{kind: 'email'}]);
   });
 
   it('supports custom errors', () => {
@@ -33,13 +33,13 @@ describe('email validator', () => {
     const f = form(
       cat,
       (p) => {
-        email(p.email, {errors: (ctx) => ({kind: `custom:special-email-${ctx.valueOf(p.name)}`})});
+        email(p.email, {errors: (ctx) => ({kind: `special-email-${ctx.valueOf(p.name)}`})});
       },
       {
         injector: TestBed.inject(Injector),
       },
     );
 
-    expect(f.email().errors()).toEqual([{kind: 'custom:special-email-pirojok-the-cat'}]);
+    expect(f.email().errors()).toEqual([{kind: 'special-email-pirojok-the-cat'}]);
   });
 });

--- a/packages/forms/experimental/test/node/api/validators/max.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/max.spec.ts
@@ -21,7 +21,7 @@ describe('max validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.age().errors()).toEqual([{kind: 'max'}]);
+    expect(f.age().errors()).toEqual([{kind: 'ng:max', max: 5}]);
   });
 
   it('is inclusive', () => {
@@ -57,7 +57,7 @@ describe('max validator', () => {
       (p) => {
         max(p.age, 5, {
           errors: ({value}) => {
-            return {kind: 'special-max', message: value().toString()};
+            return {kind: 'custom:special-max', message: value().toString()};
           },
         });
       },
@@ -66,7 +66,7 @@ describe('max validator', () => {
 
     expect(f.age().errors()).toEqual([
       {
-        kind: 'special-max',
+        kind: 'custom:special-max',
         message: '6',
       },
     ]);
@@ -80,7 +80,7 @@ describe('max validator', () => {
         (p) => {
           max(p.age, 5, {
             errors: ({value}) => {
-              return {kind: 'special-max', message: value().toString()};
+              return {kind: 'custom:special-max', message: value().toString()};
             },
           });
         },
@@ -102,9 +102,12 @@ describe('max validator', () => {
       );
 
       f.age().value.set(12);
-      expect(f.age().errors()).toEqual([{kind: 'max'}, {kind: 'max'}]);
+      expect(f.age().errors()).toEqual([
+        {kind: 'ng:max', max: 10},
+        {kind: 'ng:max', max: 5},
+      ]);
       f.age().value.set(7);
-      expect(f.age().errors()).toEqual([{kind: 'max'}]);
+      expect(f.age().errors()).toEqual([{kind: 'ng:max', max: 5}]);
       f.age().value.set(3);
       expect(f.age().errors()).toEqual([]);
 
@@ -124,9 +127,12 @@ describe('max validator', () => {
       );
 
       f.age().value.set(12);
-      expect(f.age().errors()).toEqual([{kind: 'max'}, {kind: 'max'}]);
+      expect(f.age().errors()).toEqual([
+        {kind: 'ng:max', max: 10},
+        {kind: 'ng:max', max: 5},
+      ]);
       f.age().value.set(7);
-      expect(f.age().errors()).toEqual([{kind: 'max'}]);
+      expect(f.age().errors()).toEqual([{kind: 'ng:max', max: 5}]);
       f.age().value.set(3);
       expect(f.age().errors()).toEqual([]);
 
@@ -134,7 +140,7 @@ describe('max validator', () => {
 
       maxSignal.set(2);
       f.age().value.set(3);
-      expect(f.age().errors()).toEqual([{kind: 'max'}]);
+      expect(f.age().errors()).toEqual([{kind: 'ng:max', max: 2}]);
       expect(f.age().metadata(MAX)()).toBe(2);
     });
 
@@ -152,12 +158,15 @@ describe('max validator', () => {
       );
 
       // Initially, age 20 is greater than both 10 and 15
-      expect(f.age().errors()).toEqual([{kind: 'max'}, {kind: 'max'}]);
+      expect(f.age().errors()).toEqual([
+        {kind: 'ng:max', max: 10},
+        {kind: 'ng:max', max: 15},
+      ]);
 
       // Set the first max threshold to undefined
       maxSignal.set(undefined);
       // Now, age 20 is only greater than 15
-      expect(f.age().errors()).toEqual([{kind: 'max'}]);
+      expect(f.age().errors()).toEqual([{kind: 'ng:max', max: 15}]);
 
       // Set the second max threshold to undefined
       maxSignal2.set(undefined);
@@ -178,7 +187,7 @@ describe('max validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([{kind: 'max'}]);
+      expect(f.age().errors()).toEqual([{kind: 'ng:max', max: 5}]);
       maxValue.set(7);
       expect(f.age().errors()).toEqual([]);
     });
@@ -194,11 +203,11 @@ describe('max validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([{kind: 'max'}]);
+      expect(f.age().errors()).toEqual([{kind: 'ng:max', max: 5}]);
       maxValue.set(undefined);
       expect(f.age().errors()).toEqual([]);
       maxValue.set(5);
-      expect(f.age().errors()).toEqual([{kind: 'max'}]);
+      expect(f.age().errors()).toEqual([{kind: 'ng:max', max: 5}]);
     });
 
     it('handles dynamic value based on other field', () => {
@@ -214,7 +223,7 @@ describe('max validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([{kind: 'max'}]);
+      expect(f.age().errors()).toEqual([{kind: 'ng:max', max: 5}]);
 
       f.name().value.set('other cat');
 

--- a/packages/forms/experimental/test/node/api/validators/max.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/max.spec.ts
@@ -8,7 +8,7 @@
 
 import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {NgValidationError} from '@angular/forms/experimental/src/api/validation_errors';
+import {ValidationError} from '@angular/forms/experimental/src/api/validation_errors';
 import {MAX, form, max} from '../../../../public_api';
 
 describe('max validator', () => {
@@ -22,7 +22,7 @@ describe('max validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'max', max: 5}]);
+    expect(f.age().errors()).toEqual([ValidationError.max(5)]);
   });
 
   it('is inclusive', () => {
@@ -58,7 +58,7 @@ describe('max validator', () => {
       (p) => {
         max(p.age, 5, {
           errors: ({value}) => {
-            return {kind: 'special-max', message: value().toString()};
+            return ValidationError.custom({kind: 'special-max', message: value().toString()});
           },
         });
       },
@@ -66,10 +66,10 @@ describe('max validator', () => {
     );
 
     expect(f.age().errors()).toEqual([
-      {
+      ValidationError.custom({
         kind: 'special-max',
         message: '6',
-      },
+      }),
     ]);
   });
 
@@ -81,7 +81,7 @@ describe('max validator', () => {
         (p) => {
           max(p.age, 5, {
             errors: ({value}) => {
-              return {kind: 'special-max', message: value().toString()};
+              return ValidationError.custom({kind: 'special-max', message: value().toString()});
             },
           });
         },
@@ -103,12 +103,9 @@ describe('max validator', () => {
       );
 
       f.age().value.set(12);
-      expect(f.age().errors() as NgValidationError[]).toEqual([
-        {kind: 'max', max: 10},
-        {kind: 'max', max: 5},
-      ]);
+      expect(f.age().errors()).toEqual([ValidationError.max(10), ValidationError.max(5)]);
       f.age().value.set(7);
-      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'max', max: 5}]);
+      expect(f.age().errors()).toEqual([ValidationError.max(5)]);
       f.age().value.set(3);
       expect(f.age().errors()).toEqual([]);
 
@@ -128,12 +125,9 @@ describe('max validator', () => {
       );
 
       f.age().value.set(12);
-      expect(f.age().errors() as NgValidationError[]).toEqual([
-        {kind: 'max', max: 10},
-        {kind: 'max', max: 5},
-      ]);
+      expect(f.age().errors()).toEqual([ValidationError.max(10), ValidationError.max(5)]);
       f.age().value.set(7);
-      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'max', max: 5}]);
+      expect(f.age().errors()).toEqual([ValidationError.max(5)]);
       f.age().value.set(3);
       expect(f.age().errors()).toEqual([]);
 
@@ -141,7 +135,7 @@ describe('max validator', () => {
 
       maxSignal.set(2);
       f.age().value.set(3);
-      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'max', max: 2}]);
+      expect(f.age().errors()).toEqual([ValidationError.max(2)]);
       expect(f.age().metadata(MAX)()).toBe(2);
     });
 
@@ -159,15 +153,12 @@ describe('max validator', () => {
       );
 
       // Initially, age 20 is greater than both 10 and 15
-      expect(f.age().errors() as NgValidationError[]).toEqual([
-        {kind: 'max', max: 10},
-        {kind: 'max', max: 15},
-      ]);
+      expect(f.age().errors()).toEqual([ValidationError.max(10), ValidationError.max(15)]);
 
       // Set the first max threshold to undefined
       maxSignal.set(undefined);
       // Now, age 20 is only greater than 15
-      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'max', max: 15}]);
+      expect(f.age().errors()).toEqual([ValidationError.max(15)]);
 
       // Set the second max threshold to undefined
       maxSignal2.set(undefined);
@@ -188,7 +179,7 @@ describe('max validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'max', max: 5}]);
+      expect(f.age().errors()).toEqual([ValidationError.max(5)]);
       maxValue.set(7);
       expect(f.age().errors()).toEqual([]);
     });
@@ -204,11 +195,11 @@ describe('max validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'max', max: 5}]);
+      expect(f.age().errors()).toEqual([ValidationError.max(5)]);
       maxValue.set(undefined);
       expect(f.age().errors()).toEqual([]);
       maxValue.set(5);
-      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'max', max: 5}]);
+      expect(f.age().errors()).toEqual([ValidationError.max(5)]);
     });
 
     it('handles dynamic value based on other field', () => {
@@ -224,7 +215,7 @@ describe('max validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'max', max: 5}]);
+      expect(f.age().errors()).toEqual([ValidationError.max(5)]);
 
       f.name().value.set('other cat');
 

--- a/packages/forms/experimental/test/node/api/validators/max.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/max.spec.ts
@@ -3,11 +3,12 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+import {NgValidationError} from '@angular/forms/experimental/src/api/validation_errors';
 import {MAX, form, max} from '../../../../public_api';
 
 describe('max validator', () => {
@@ -21,7 +22,7 @@ describe('max validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.age().errors()).toEqual([{kind: 'ng:max', max: 5}]);
+    expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'max', max: 5}]);
   });
 
   it('is inclusive', () => {
@@ -57,7 +58,7 @@ describe('max validator', () => {
       (p) => {
         max(p.age, 5, {
           errors: ({value}) => {
-            return {kind: 'custom:special-max', message: value().toString()};
+            return {kind: 'special-max', message: value().toString()};
           },
         });
       },
@@ -66,7 +67,7 @@ describe('max validator', () => {
 
     expect(f.age().errors()).toEqual([
       {
-        kind: 'custom:special-max',
+        kind: 'special-max',
         message: '6',
       },
     ]);
@@ -80,7 +81,7 @@ describe('max validator', () => {
         (p) => {
           max(p.age, 5, {
             errors: ({value}) => {
-              return {kind: 'custom:special-max', message: value().toString()};
+              return {kind: 'special-max', message: value().toString()};
             },
           });
         },
@@ -102,12 +103,12 @@ describe('max validator', () => {
       );
 
       f.age().value.set(12);
-      expect(f.age().errors()).toEqual([
-        {kind: 'ng:max', max: 10},
-        {kind: 'ng:max', max: 5},
+      expect(f.age().errors() as NgValidationError[]).toEqual([
+        {kind: 'max', max: 10},
+        {kind: 'max', max: 5},
       ]);
       f.age().value.set(7);
-      expect(f.age().errors()).toEqual([{kind: 'ng:max', max: 5}]);
+      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'max', max: 5}]);
       f.age().value.set(3);
       expect(f.age().errors()).toEqual([]);
 
@@ -127,12 +128,12 @@ describe('max validator', () => {
       );
 
       f.age().value.set(12);
-      expect(f.age().errors()).toEqual([
-        {kind: 'ng:max', max: 10},
-        {kind: 'ng:max', max: 5},
+      expect(f.age().errors() as NgValidationError[]).toEqual([
+        {kind: 'max', max: 10},
+        {kind: 'max', max: 5},
       ]);
       f.age().value.set(7);
-      expect(f.age().errors()).toEqual([{kind: 'ng:max', max: 5}]);
+      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'max', max: 5}]);
       f.age().value.set(3);
       expect(f.age().errors()).toEqual([]);
 
@@ -140,7 +141,7 @@ describe('max validator', () => {
 
       maxSignal.set(2);
       f.age().value.set(3);
-      expect(f.age().errors()).toEqual([{kind: 'ng:max', max: 2}]);
+      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'max', max: 2}]);
       expect(f.age().metadata(MAX)()).toBe(2);
     });
 
@@ -158,15 +159,15 @@ describe('max validator', () => {
       );
 
       // Initially, age 20 is greater than both 10 and 15
-      expect(f.age().errors()).toEqual([
-        {kind: 'ng:max', max: 10},
-        {kind: 'ng:max', max: 15},
+      expect(f.age().errors() as NgValidationError[]).toEqual([
+        {kind: 'max', max: 10},
+        {kind: 'max', max: 15},
       ]);
 
       // Set the first max threshold to undefined
       maxSignal.set(undefined);
       // Now, age 20 is only greater than 15
-      expect(f.age().errors()).toEqual([{kind: 'ng:max', max: 15}]);
+      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'max', max: 15}]);
 
       // Set the second max threshold to undefined
       maxSignal2.set(undefined);
@@ -187,7 +188,7 @@ describe('max validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([{kind: 'ng:max', max: 5}]);
+      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'max', max: 5}]);
       maxValue.set(7);
       expect(f.age().errors()).toEqual([]);
     });
@@ -203,11 +204,11 @@ describe('max validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([{kind: 'ng:max', max: 5}]);
+      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'max', max: 5}]);
       maxValue.set(undefined);
       expect(f.age().errors()).toEqual([]);
       maxValue.set(5);
-      expect(f.age().errors()).toEqual([{kind: 'ng:max', max: 5}]);
+      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'max', max: 5}]);
     });
 
     it('handles dynamic value based on other field', () => {
@@ -223,7 +224,7 @@ describe('max validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([{kind: 'ng:max', max: 5}]);
+      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'max', max: 5}]);
 
       f.name().value.set('other cat');
 

--- a/packages/forms/experimental/test/node/api/validators/max_length.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/max_length.spec.ts
@@ -8,7 +8,7 @@
 
 import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {NgValidationError} from '@angular/forms/experimental/src/api/validation_errors';
+import {ValidationError} from '@angular/forms/experimental/src/api/validation_errors';
 import {MAX_LENGTH, form, maxLength} from '../../../../public_api';
 
 describe('maxLength validator', () => {
@@ -22,7 +22,7 @@ describe('maxLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.text().errors() as NgValidationError[]).toEqual([{kind: 'maxlength', maxlength: 3}]);
+    expect(f.text().errors()).toEqual([ValidationError.maxlength(3)]);
   });
 
   it('returns maxLength error when the length is larger for arrays', () => {
@@ -35,7 +35,7 @@ describe('maxLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.list().errors() as NgValidationError[]).toEqual([{kind: 'maxlength', maxlength: 3}]);
+    expect(f.list().errors()).toEqual([ValidationError.maxlength(3)]);
   });
 
   it('is inclusive (no error if length equals maxLength)', () => {
@@ -71,10 +71,10 @@ describe('maxLength validator', () => {
       (p) => {
         maxLength(p.text, 5, {
           errors: ({value}) => {
-            return {
+            return ValidationError.custom({
               kind: 'special-maxLength',
               message: `Length is ${value().length}`,
-            };
+            });
           },
         });
       },
@@ -82,10 +82,10 @@ describe('maxLength validator', () => {
     );
 
     expect(f.text().errors()).toEqual([
-      {
+      ValidationError.custom({
         kind: 'special-maxLength',
         message: 'Length is 6',
-      },
+      }),
     ]);
   });
 
@@ -97,10 +97,10 @@ describe('maxLength validator', () => {
         (p) => {
           maxLength(p.text, 5, {
             errors: ({value}) => {
-              return {
+              return ValidationError.custom({
                 kind: 'special-maxLength',
                 message: `Length is ${value().length}`,
-              };
+              });
             },
           });
         },
@@ -122,13 +122,13 @@ describe('maxLength validator', () => {
       );
 
       f.text().value.set('abcdefghijklmno');
-      expect(f.text().errors() as NgValidationError[]).toEqual([
-        {kind: 'maxlength', maxlength: 10},
-        {kind: 'maxlength', maxlength: 5},
+      expect(f.text().errors()).toEqual([
+        ValidationError.maxlength(10),
+        ValidationError.maxlength(5),
       ]);
 
       f.text().value.set('abcdefg');
-      expect(f.text().errors() as NgValidationError[]).toEqual([{kind: 'maxlength', maxlength: 5}]);
+      expect(f.text().errors()).toEqual([ValidationError.maxlength(5)]);
 
       f.text().value.set('abc');
       expect(f.text().errors()).toEqual([]);
@@ -149,20 +149,20 @@ describe('maxLength validator', () => {
       );
 
       f.text().value.set('abcdefghijklmno');
-      expect(f.text().errors() as NgValidationError[]).toEqual([
-        {kind: 'maxlength', maxlength: 10},
-        {kind: 'maxlength', maxlength: 5},
+      expect(f.text().errors()).toEqual([
+        ValidationError.maxlength(10),
+        ValidationError.maxlength(5),
       ]);
 
       f.text().value.set('abcdefg');
-      expect(f.text().errors() as NgValidationError[]).toEqual([{kind: 'maxlength', maxlength: 5}]);
+      expect(f.text().errors()).toEqual([ValidationError.maxlength(5)]);
 
       f.text().value.set('abc');
       expect(f.text().errors()).toEqual([]);
 
       maxLengthSignal.set(2);
 
-      expect(f.text().errors() as NgValidationError[]).toEqual([{kind: 'maxlength', maxlength: 2}]);
+      expect(f.text().errors()).toEqual([ValidationError.maxlength(2)]);
       expect(f.text().metadata(MAX_LENGTH)()).toBe(2);
     });
   });
@@ -179,7 +179,7 @@ describe('maxLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors() as NgValidationError[]).toEqual([{kind: 'maxlength', maxlength: 5}]);
+      expect(f.text().errors()).toEqual([ValidationError.maxlength(5)]);
       dynamicMaxLength.set(7);
       expect(f.text().errors()).toEqual([]);
     });
@@ -194,7 +194,7 @@ describe('maxLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors() as NgValidationError[]).toEqual([{kind: 'maxlength', maxlength: 5}]);
+      expect(f.text().errors()).toEqual([ValidationError.maxlength(5)]);
       dynamicMaxLength.set(undefined);
       expect(f.text().errors()).toEqual([]);
     });
@@ -211,7 +211,7 @@ describe('maxLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors() as NgValidationError[]).toEqual([{kind: 'maxlength', maxlength: 8}]);
+      expect(f.text().errors()).toEqual([ValidationError.maxlength(8)]);
 
       f.category().value.set('B');
       expect(f.text().errors()).toEqual([]);

--- a/packages/forms/experimental/test/node/api/validators/max_length.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/max_length.spec.ts
@@ -21,7 +21,7 @@ describe('maxLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.text().errors()).toEqual([{kind: 'maxLength'}]);
+    expect(f.text().errors()).toEqual([{kind: 'ng:maxlength', maxlength: 3}]);
   });
 
   it('returns maxLength error when the length is larger for arrays', () => {
@@ -34,7 +34,7 @@ describe('maxLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.list().errors()).toEqual([{kind: 'maxLength'}]);
+    expect(f.list().errors()).toEqual([{kind: 'ng:maxlength', maxlength: 3}]);
   });
 
   it('is inclusive (no error if length equals maxLength)', () => {
@@ -71,7 +71,7 @@ describe('maxLength validator', () => {
         maxLength(p.text, 5, {
           errors: ({value}) => {
             return {
-              kind: 'special-maxLength',
+              kind: 'custom:special-maxLength',
               message: `Length is ${value().length}`,
             };
           },
@@ -82,7 +82,7 @@ describe('maxLength validator', () => {
 
     expect(f.text().errors()).toEqual([
       {
-        kind: 'special-maxLength',
+        kind: 'custom:special-maxLength',
         message: 'Length is 6',
       },
     ]);
@@ -97,7 +97,7 @@ describe('maxLength validator', () => {
           maxLength(p.text, 5, {
             errors: ({value}) => {
               return {
-                kind: 'special-maxLength',
+                kind: 'custom:special-maxLength',
                 message: `Length is ${value().length}`,
               };
             },
@@ -121,10 +121,13 @@ describe('maxLength validator', () => {
       );
 
       f.text().value.set('abcdefghijklmno');
-      expect(f.text().errors()).toEqual([{kind: 'maxLength'}, {kind: 'maxLength'}]);
+      expect(f.text().errors()).toEqual([
+        {kind: 'ng:maxlength', maxlength: 10},
+        {kind: 'ng:maxlength', maxlength: 5},
+      ]);
 
       f.text().value.set('abcdefg');
-      expect(f.text().errors()).toEqual([{kind: 'maxLength'}]);
+      expect(f.text().errors()).toEqual([{kind: 'ng:maxlength', maxlength: 5}]);
 
       f.text().value.set('abc');
       expect(f.text().errors()).toEqual([]);
@@ -145,17 +148,20 @@ describe('maxLength validator', () => {
       );
 
       f.text().value.set('abcdefghijklmno');
-      expect(f.text().errors()).toEqual([{kind: 'maxLength'}, {kind: 'maxLength'}]);
+      expect(f.text().errors()).toEqual([
+        {kind: 'ng:maxlength', maxlength: 10},
+        {kind: 'ng:maxlength', maxlength: 5},
+      ]);
 
       f.text().value.set('abcdefg');
-      expect(f.text().errors()).toEqual([{kind: 'maxLength'}]);
+      expect(f.text().errors()).toEqual([{kind: 'ng:maxlength', maxlength: 5}]);
 
       f.text().value.set('abc');
       expect(f.text().errors()).toEqual([]);
 
       maxLengthSignal.set(2);
 
-      expect(f.text().errors()).toEqual([{kind: 'maxLength'}]);
+      expect(f.text().errors()).toEqual([{kind: 'ng:maxlength', maxlength: 2}]);
       expect(f.text().metadata(MAX_LENGTH)()).toBe(2);
     });
   });
@@ -172,7 +178,7 @@ describe('maxLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([{kind: 'maxLength'}]);
+      expect(f.text().errors()).toEqual([{kind: 'ng:maxlength', maxlength: 5}]);
       dynamicMaxLength.set(7);
       expect(f.text().errors()).toEqual([]);
     });
@@ -187,7 +193,7 @@ describe('maxLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([{kind: 'maxLength'}]);
+      expect(f.text().errors()).toEqual([{kind: 'ng:maxlength', maxlength: 5}]);
       dynamicMaxLength.set(undefined);
       expect(f.text().errors()).toEqual([]);
     });
@@ -204,7 +210,7 @@ describe('maxLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([{kind: 'maxLength'}]);
+      expect(f.text().errors()).toEqual([{kind: 'ng:maxlength', maxlength: 8}]);
 
       f.category().value.set('B');
       expect(f.text().errors()).toEqual([]);

--- a/packages/forms/experimental/test/node/api/validators/max_length.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/max_length.spec.ts
@@ -3,11 +3,12 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+import {NgValidationError} from '@angular/forms/experimental/src/api/validation_errors';
 import {MAX_LENGTH, form, maxLength} from '../../../../public_api';
 
 describe('maxLength validator', () => {
@@ -21,7 +22,7 @@ describe('maxLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.text().errors()).toEqual([{kind: 'ng:maxlength', maxlength: 3}]);
+    expect(f.text().errors() as NgValidationError[]).toEqual([{kind: 'maxlength', maxlength: 3}]);
   });
 
   it('returns maxLength error when the length is larger for arrays', () => {
@@ -34,7 +35,7 @@ describe('maxLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.list().errors()).toEqual([{kind: 'ng:maxlength', maxlength: 3}]);
+    expect(f.list().errors() as NgValidationError[]).toEqual([{kind: 'maxlength', maxlength: 3}]);
   });
 
   it('is inclusive (no error if length equals maxLength)', () => {
@@ -71,7 +72,7 @@ describe('maxLength validator', () => {
         maxLength(p.text, 5, {
           errors: ({value}) => {
             return {
-              kind: 'custom:special-maxLength',
+              kind: 'special-maxLength',
               message: `Length is ${value().length}`,
             };
           },
@@ -82,7 +83,7 @@ describe('maxLength validator', () => {
 
     expect(f.text().errors()).toEqual([
       {
-        kind: 'custom:special-maxLength',
+        kind: 'special-maxLength',
         message: 'Length is 6',
       },
     ]);
@@ -97,7 +98,7 @@ describe('maxLength validator', () => {
           maxLength(p.text, 5, {
             errors: ({value}) => {
               return {
-                kind: 'custom:special-maxLength',
+                kind: 'special-maxLength',
                 message: `Length is ${value().length}`,
               };
             },
@@ -121,13 +122,13 @@ describe('maxLength validator', () => {
       );
 
       f.text().value.set('abcdefghijklmno');
-      expect(f.text().errors()).toEqual([
-        {kind: 'ng:maxlength', maxlength: 10},
-        {kind: 'ng:maxlength', maxlength: 5},
+      expect(f.text().errors() as NgValidationError[]).toEqual([
+        {kind: 'maxlength', maxlength: 10},
+        {kind: 'maxlength', maxlength: 5},
       ]);
 
       f.text().value.set('abcdefg');
-      expect(f.text().errors()).toEqual([{kind: 'ng:maxlength', maxlength: 5}]);
+      expect(f.text().errors() as NgValidationError[]).toEqual([{kind: 'maxlength', maxlength: 5}]);
 
       f.text().value.set('abc');
       expect(f.text().errors()).toEqual([]);
@@ -148,20 +149,20 @@ describe('maxLength validator', () => {
       );
 
       f.text().value.set('abcdefghijklmno');
-      expect(f.text().errors()).toEqual([
-        {kind: 'ng:maxlength', maxlength: 10},
-        {kind: 'ng:maxlength', maxlength: 5},
+      expect(f.text().errors() as NgValidationError[]).toEqual([
+        {kind: 'maxlength', maxlength: 10},
+        {kind: 'maxlength', maxlength: 5},
       ]);
 
       f.text().value.set('abcdefg');
-      expect(f.text().errors()).toEqual([{kind: 'ng:maxlength', maxlength: 5}]);
+      expect(f.text().errors() as NgValidationError[]).toEqual([{kind: 'maxlength', maxlength: 5}]);
 
       f.text().value.set('abc');
       expect(f.text().errors()).toEqual([]);
 
       maxLengthSignal.set(2);
 
-      expect(f.text().errors()).toEqual([{kind: 'ng:maxlength', maxlength: 2}]);
+      expect(f.text().errors() as NgValidationError[]).toEqual([{kind: 'maxlength', maxlength: 2}]);
       expect(f.text().metadata(MAX_LENGTH)()).toBe(2);
     });
   });
@@ -178,7 +179,7 @@ describe('maxLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([{kind: 'ng:maxlength', maxlength: 5}]);
+      expect(f.text().errors() as NgValidationError[]).toEqual([{kind: 'maxlength', maxlength: 5}]);
       dynamicMaxLength.set(7);
       expect(f.text().errors()).toEqual([]);
     });
@@ -193,7 +194,7 @@ describe('maxLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([{kind: 'ng:maxlength', maxlength: 5}]);
+      expect(f.text().errors() as NgValidationError[]).toEqual([{kind: 'maxlength', maxlength: 5}]);
       dynamicMaxLength.set(undefined);
       expect(f.text().errors()).toEqual([]);
     });
@@ -210,7 +211,7 @@ describe('maxLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([{kind: 'ng:maxlength', maxlength: 8}]);
+      expect(f.text().errors() as NgValidationError[]).toEqual([{kind: 'maxlength', maxlength: 8}]);
 
       f.category().value.set('B');
       expect(f.text().errors()).toEqual([]);

--- a/packages/forms/experimental/test/node/api/validators/min.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/min.spec.ts
@@ -3,11 +3,12 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+import {NgValidationError} from '@angular/forms/experimental/src/api/validation_errors';
 import {MIN, form, min} from '../../../../public_api';
 
 describe('min validator', () => {
@@ -21,7 +22,7 @@ describe('min validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.age().errors()).toEqual([{kind: 'ng:min', min: 5}]);
+    expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'min', min: 5}]);
   });
 
   it('is inclusive', () => {
@@ -57,7 +58,7 @@ describe('min validator', () => {
       (p) => {
         min(p.age, 5, {
           errors: ({value}) => {
-            return {kind: 'custom:special-min', message: value().toString()};
+            return {kind: 'special-min', message: value().toString()};
           },
         });
       },
@@ -66,7 +67,7 @@ describe('min validator', () => {
 
     expect(f.age().errors()).toEqual([
       {
-        kind: 'custom:special-min',
+        kind: 'special-min',
         message: '3',
       },
     ]);
@@ -80,7 +81,7 @@ describe('min validator', () => {
         (p) => {
           min(p.age, 5, {
             errors: ({value}) => {
-              return {kind: 'custom:special-min', message: value().toString()};
+              return {kind: 'special-min', message: value().toString()};
             },
           });
         },
@@ -102,12 +103,12 @@ describe('min validator', () => {
       );
 
       f.age().value.set(3);
-      expect(f.age().errors()).toEqual([
-        {kind: 'ng:min', min: 5},
-        {kind: 'ng:min', min: 10},
+      expect(f.age().errors() as NgValidationError[]).toEqual([
+        {kind: 'min', min: 5},
+        {kind: 'min', min: 10},
       ]);
       f.age().value.set(7);
-      expect(f.age().errors()).toEqual([{kind: 'ng:min', min: 10}]);
+      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'min', min: 10}]);
       f.age().value.set(15);
       expect(f.age().errors()).toEqual([]);
 
@@ -127,16 +128,16 @@ describe('min validator', () => {
       );
 
       f.age().value.set(3);
-      expect(f.age().errors()).toEqual([
-        {kind: 'ng:min', min: 5},
-        {kind: 'ng:min', min: 10},
+      expect(f.age().errors() as NgValidationError[]).toEqual([
+        {kind: 'min', min: 5},
+        {kind: 'min', min: 10},
       ]);
       f.age().value.set(7);
-      expect(f.age().errors()).toEqual([{kind: 'ng:min', min: 10}]);
+      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'min', min: 10}]);
       f.age().value.set(15);
       expect(f.age().errors()).toEqual([]);
       minSignal.set(30);
-      expect(f.age().errors()).toEqual([{kind: 'ng:min', min: 30}]);
+      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'min', min: 30}]);
       expect(f.age().metadata(MIN)()).toBe(30);
     });
 
@@ -153,12 +154,12 @@ describe('min validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([
-        {kind: 'ng:min', min: 15},
-        {kind: 'ng:min', min: 10},
+      expect(f.age().errors() as NgValidationError[]).toEqual([
+        {kind: 'min', min: 15},
+        {kind: 'min', min: 10},
       ]);
       minSignal.set(undefined);
-      expect(f.age().errors()).toEqual([{kind: 'ng:min', min: 10}]);
+      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'min', min: 10}]);
       minSignal2.set(undefined);
       expect(f.age().errors()).toEqual([]);
     });
@@ -176,11 +177,11 @@ describe('min validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([{kind: 'ng:min', min: 5}]);
+      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'min', min: 5}]);
       minValue.set(undefined);
       expect(f.age().errors()).toEqual([]);
       minValue.set(5);
-      expect(f.age().errors()).toEqual([{kind: 'ng:min', min: 5}]);
+      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'min', min: 5}]);
     });
 
     it('handles dynamic value', () => {
@@ -194,7 +195,7 @@ describe('min validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([{kind: 'ng:min', min: 5}]);
+      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'min', min: 5}]);
       minValue.set(2);
       expect(f.age().errors()).toEqual([]);
     });
@@ -212,7 +213,7 @@ describe('min validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([{kind: 'ng:min', min: 5}]);
+      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'min', min: 5}]);
       f.name().value.set('other cat');
       expect(f.age().errors()).toEqual([]);
     });

--- a/packages/forms/experimental/test/node/api/validators/min.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/min.spec.ts
@@ -8,7 +8,7 @@
 
 import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {NgValidationError} from '@angular/forms/experimental/src/api/validation_errors';
+import {ValidationError} from '@angular/forms/experimental/src/api/validation_errors';
 import {MIN, form, min} from '../../../../public_api';
 
 describe('min validator', () => {
@@ -22,7 +22,7 @@ describe('min validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'min', min: 5}]);
+    expect(f.age().errors()).toEqual([ValidationError.min(5)]);
   });
 
   it('is inclusive', () => {
@@ -58,7 +58,7 @@ describe('min validator', () => {
       (p) => {
         min(p.age, 5, {
           errors: ({value}) => {
-            return {kind: 'special-min', message: value().toString()};
+            return ValidationError.custom({kind: 'special-min', message: value().toString()});
           },
         });
       },
@@ -66,10 +66,10 @@ describe('min validator', () => {
     );
 
     expect(f.age().errors()).toEqual([
-      {
+      ValidationError.custom({
         kind: 'special-min',
         message: '3',
-      },
+      }),
     ]);
   });
 
@@ -81,7 +81,7 @@ describe('min validator', () => {
         (p) => {
           min(p.age, 5, {
             errors: ({value}) => {
-              return {kind: 'special-min', message: value().toString()};
+              return ValidationError.custom({kind: 'special-min', message: value().toString()});
             },
           });
         },
@@ -103,12 +103,9 @@ describe('min validator', () => {
       );
 
       f.age().value.set(3);
-      expect(f.age().errors() as NgValidationError[]).toEqual([
-        {kind: 'min', min: 5},
-        {kind: 'min', min: 10},
-      ]);
+      expect(f.age().errors()).toEqual([ValidationError.min(5), ValidationError.min(10)]);
       f.age().value.set(7);
-      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'min', min: 10}]);
+      expect(f.age().errors()).toEqual([ValidationError.min(10)]);
       f.age().value.set(15);
       expect(f.age().errors()).toEqual([]);
 
@@ -128,16 +125,13 @@ describe('min validator', () => {
       );
 
       f.age().value.set(3);
-      expect(f.age().errors() as NgValidationError[]).toEqual([
-        {kind: 'min', min: 5},
-        {kind: 'min', min: 10},
-      ]);
+      expect(f.age().errors()).toEqual([ValidationError.min(5), ValidationError.min(10)]);
       f.age().value.set(7);
-      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'min', min: 10}]);
+      expect(f.age().errors()).toEqual([ValidationError.min(10)]);
       f.age().value.set(15);
       expect(f.age().errors()).toEqual([]);
       minSignal.set(30);
-      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'min', min: 30}]);
+      expect(f.age().errors()).toEqual([ValidationError.min(30)]);
       expect(f.age().metadata(MIN)()).toBe(30);
     });
 
@@ -154,12 +148,9 @@ describe('min validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors() as NgValidationError[]).toEqual([
-        {kind: 'min', min: 15},
-        {kind: 'min', min: 10},
-      ]);
+      expect(f.age().errors()).toEqual([ValidationError.min(15), ValidationError.min(10)]);
       minSignal.set(undefined);
-      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'min', min: 10}]);
+      expect(f.age().errors()).toEqual([ValidationError.min(10)]);
       minSignal2.set(undefined);
       expect(f.age().errors()).toEqual([]);
     });
@@ -177,11 +168,11 @@ describe('min validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'min', min: 5}]);
+      expect(f.age().errors()).toEqual([ValidationError.min(5)]);
       minValue.set(undefined);
       expect(f.age().errors()).toEqual([]);
       minValue.set(5);
-      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'min', min: 5}]);
+      expect(f.age().errors()).toEqual([ValidationError.min(5)]);
     });
 
     it('handles dynamic value', () => {
@@ -195,7 +186,7 @@ describe('min validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'min', min: 5}]);
+      expect(f.age().errors()).toEqual([ValidationError.min(5)]);
       minValue.set(2);
       expect(f.age().errors()).toEqual([]);
     });
@@ -213,7 +204,7 @@ describe('min validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors() as NgValidationError[]).toEqual([{kind: 'min', min: 5}]);
+      expect(f.age().errors()).toEqual([ValidationError.min(5)]);
       f.name().value.set('other cat');
       expect(f.age().errors()).toEqual([]);
     });

--- a/packages/forms/experimental/test/node/api/validators/min.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/min.spec.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { Injector, signal } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
-import { MIN, form, min } from '../../../../public_api';
+import {Injector, signal} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {MIN, form, min} from '../../../../public_api';
 
 describe('min validator', () => {
   it('returns min error when the value is smaller', () => {
@@ -21,7 +21,7 @@ describe('min validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.age().errors()).toEqual([{kind: 'min'}]);
+    expect(f.age().errors()).toEqual([{kind: 'ng:min', min: 5}]);
   });
 
   it('is inclusive', () => {
@@ -57,7 +57,7 @@ describe('min validator', () => {
       (p) => {
         min(p.age, 5, {
           errors: ({value}) => {
-            return {kind: 'special-min', message: value().toString()};
+            return {kind: 'custom:special-min', message: value().toString()};
           },
         });
       },
@@ -66,7 +66,7 @@ describe('min validator', () => {
 
     expect(f.age().errors()).toEqual([
       {
-        kind: 'special-min',
+        kind: 'custom:special-min',
         message: '3',
       },
     ]);
@@ -80,7 +80,7 @@ describe('min validator', () => {
         (p) => {
           min(p.age, 5, {
             errors: ({value}) => {
-              return {kind: 'special-min', message: value().toString()};
+              return {kind: 'custom:special-min', message: value().toString()};
             },
           });
         },
@@ -102,9 +102,12 @@ describe('min validator', () => {
       );
 
       f.age().value.set(3);
-      expect(f.age().errors()).toEqual([{kind: 'min'}, {kind: 'min'}]);
+      expect(f.age().errors()).toEqual([
+        {kind: 'ng:min', min: 5},
+        {kind: 'ng:min', min: 10},
+      ]);
       f.age().value.set(7);
-      expect(f.age().errors()).toEqual([{kind: 'min'}]);
+      expect(f.age().errors()).toEqual([{kind: 'ng:min', min: 10}]);
       f.age().value.set(15);
       expect(f.age().errors()).toEqual([]);
 
@@ -124,13 +127,16 @@ describe('min validator', () => {
       );
 
       f.age().value.set(3);
-      expect(f.age().errors()).toEqual([{kind: 'min'}, {kind: 'min'}]);
+      expect(f.age().errors()).toEqual([
+        {kind: 'ng:min', min: 5},
+        {kind: 'ng:min', min: 10},
+      ]);
       f.age().value.set(7);
-      expect(f.age().errors()).toEqual([{kind: 'min'}]);
+      expect(f.age().errors()).toEqual([{kind: 'ng:min', min: 10}]);
       f.age().value.set(15);
       expect(f.age().errors()).toEqual([]);
       minSignal.set(30);
-      expect(f.age().errors()).toEqual([{kind: 'min'}]);
+      expect(f.age().errors()).toEqual([{kind: 'ng:min', min: 30}]);
       expect(f.age().metadata(MIN)()).toBe(30);
     });
 
@@ -147,9 +153,12 @@ describe('min validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([{kind: 'min'}, {kind: 'min'}]);
+      expect(f.age().errors()).toEqual([
+        {kind: 'ng:min', min: 15},
+        {kind: 'ng:min', min: 10},
+      ]);
       minSignal.set(undefined);
-      expect(f.age().errors()).toEqual([{kind: 'min'}]);
+      expect(f.age().errors()).toEqual([{kind: 'ng:min', min: 10}]);
       minSignal2.set(undefined);
       expect(f.age().errors()).toEqual([]);
     });
@@ -167,11 +176,11 @@ describe('min validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([{kind: 'min'}]);
+      expect(f.age().errors()).toEqual([{kind: 'ng:min', min: 5}]);
       minValue.set(undefined);
       expect(f.age().errors()).toEqual([]);
       minValue.set(5);
-      expect(f.age().errors()).toEqual([{kind: 'min'}]);
+      expect(f.age().errors()).toEqual([{kind: 'ng:min', min: 5}]);
     });
 
     it('handles dynamic value', () => {
@@ -185,7 +194,7 @@ describe('min validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([{kind: 'min'}]);
+      expect(f.age().errors()).toEqual([{kind: 'ng:min', min: 5}]);
       minValue.set(2);
       expect(f.age().errors()).toEqual([]);
     });
@@ -203,7 +212,7 @@ describe('min validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([{kind: 'min'}]);
+      expect(f.age().errors()).toEqual([{kind: 'ng:min', min: 5}]);
       f.name().value.set('other cat');
       expect(f.age().errors()).toEqual([]);
     });

--- a/packages/forms/experimental/test/node/api/validators/min_length.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/min_length.spec.ts
@@ -3,11 +3,12 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+import {NgValidationError} from '@angular/forms/experimental/src/api/validation_errors';
 import {MIN_LENGTH, form, minLength} from '../../../../public_api';
 
 describe('minLength validator', () => {
@@ -21,7 +22,7 @@ describe('minLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.text().errors()).toEqual([{kind: 'ng:minlength', minlength: 5}]);
+    expect(f.text().errors() as NgValidationError[]).toEqual([{kind: 'minlength', minlength: 5}]);
   });
 
   it('returns minLength error when the length is smaller for arrays', () => {
@@ -34,7 +35,7 @@ describe('minLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.list().errors()).toEqual([{kind: 'ng:minlength', minlength: 5}]);
+    expect(f.list().errors() as NgValidationError[]).toEqual([{kind: 'minlength', minlength: 5}]);
   });
 
   it('is inclusive (no error if length equals minLength)', () => {
@@ -71,7 +72,7 @@ describe('minLength validator', () => {
         minLength(p.text, 5, {
           errors: ({value}) => {
             return {
-              kind: 'custom:special-minLength',
+              kind: 'special-minLength',
               message: `Length is ${value().length}`,
             };
           },
@@ -82,7 +83,7 @@ describe('minLength validator', () => {
 
     expect(f.text().errors()).toEqual([
       {
-        kind: 'custom:special-minLength',
+        kind: 'special-minLength',
         message: 'Length is 2',
       },
     ]);
@@ -97,7 +98,7 @@ describe('minLength validator', () => {
           minLength(p.text, 5, {
             errors: ({value}) => {
               return {
-                kind: 'custom:special-minLength',
+                kind: 'special-minLength',
                 message: `Length is ${value().length}`,
               };
             },
@@ -121,13 +122,15 @@ describe('minLength validator', () => {
       );
 
       f.text().value.set('ab');
-      expect(f.text().errors()).toEqual([
-        {kind: 'ng:minlength', minlength: 5},
-        {kind: 'ng:minlength', minlength: 10},
+      expect(f.text().errors() as NgValidationError[]).toEqual([
+        {kind: 'minlength', minlength: 5},
+        {kind: 'minlength', minlength: 10},
       ]);
 
       f.text().value.set('abcdefg');
-      expect(f.text().errors()).toEqual([{kind: 'ng:minlength', minlength: 10}]);
+      expect(f.text().errors() as NgValidationError[]).toEqual([
+        {kind: 'minlength', minlength: 10},
+      ]);
 
       f.text().value.set('abcdefghijklmno');
       expect(f.text().errors()).toEqual([]);
@@ -148,20 +151,24 @@ describe('minLength validator', () => {
       );
 
       f.text().value.set('ab');
-      expect(f.text().errors()).toEqual([
-        {kind: 'ng:minlength', minlength: 5},
-        {kind: 'ng:minlength', minlength: 10},
+      expect(f.text().errors() as NgValidationError[]).toEqual([
+        {kind: 'minlength', minlength: 5},
+        {kind: 'minlength', minlength: 10},
       ]);
 
       f.text().value.set('abcdefg');
-      expect(f.text().errors()).toEqual([{kind: 'ng:minlength', minlength: 10}]);
+      expect(f.text().errors() as NgValidationError[]).toEqual([
+        {kind: 'minlength', minlength: 10},
+      ]);
 
       f.text().value.set('abcdefghijklmno');
       expect(f.text().errors()).toEqual([]);
 
       minLengthSignal.set(20);
 
-      expect(f.text().errors()).toEqual([{kind: 'ng:minlength', minlength: 20}]);
+      expect(f.text().errors() as NgValidationError[]).toEqual([
+        {kind: 'minlength', minlength: 20},
+      ]);
       expect(f.text().metadata(MIN_LENGTH)()).toBe(20);
     });
   });
@@ -178,7 +185,7 @@ describe('minLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([{kind: 'ng:minlength', minlength: 5}]);
+      expect(f.text().errors() as NgValidationError[]).toEqual([{kind: 'minlength', minlength: 5}]);
       dynamicMinLength.set(3);
       expect(f.text().errors()).toEqual([]);
     });
@@ -194,7 +201,7 @@ describe('minLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([{kind: 'ng:minlength', minlength: 5}]);
+      expect(f.text().errors() as NgValidationError[]).toEqual([{kind: 'minlength', minlength: 5}]);
       dynamicMinLength.set(undefined);
       expect(f.text().errors()).toEqual([]);
     });
@@ -211,7 +218,7 @@ describe('minLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([{kind: 'ng:minlength', minlength: 8}]);
+      expect(f.text().errors() as NgValidationError[]).toEqual([{kind: 'minlength', minlength: 8}]);
 
       f.category().value.set('B');
       expect(f.text().errors()).toEqual([]);

--- a/packages/forms/experimental/test/node/api/validators/min_length.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/min_length.spec.ts
@@ -21,7 +21,7 @@ describe('minLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.text().errors()).toEqual([{kind: 'minLength'}]);
+    expect(f.text().errors()).toEqual([{kind: 'ng:minlength', minlength: 5}]);
   });
 
   it('returns minLength error when the length is smaller for arrays', () => {
@@ -34,7 +34,7 @@ describe('minLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.list().errors()).toEqual([{kind: 'minLength'}]);
+    expect(f.list().errors()).toEqual([{kind: 'ng:minlength', minlength: 5}]);
   });
 
   it('is inclusive (no error if length equals minLength)', () => {
@@ -71,7 +71,7 @@ describe('minLength validator', () => {
         minLength(p.text, 5, {
           errors: ({value}) => {
             return {
-              kind: 'special-minLength',
+              kind: 'custom:special-minLength',
               message: `Length is ${value().length}`,
             };
           },
@@ -82,7 +82,7 @@ describe('minLength validator', () => {
 
     expect(f.text().errors()).toEqual([
       {
-        kind: 'special-minLength',
+        kind: 'custom:special-minLength',
         message: 'Length is 2',
       },
     ]);
@@ -97,7 +97,7 @@ describe('minLength validator', () => {
           minLength(p.text, 5, {
             errors: ({value}) => {
               return {
-                kind: 'special-minLength',
+                kind: 'custom:special-minLength',
                 message: `Length is ${value().length}`,
               };
             },
@@ -121,10 +121,13 @@ describe('minLength validator', () => {
       );
 
       f.text().value.set('ab');
-      expect(f.text().errors()).toEqual([{kind: 'minLength'}, {kind: 'minLength'}]);
+      expect(f.text().errors()).toEqual([
+        {kind: 'ng:minlength', minlength: 5},
+        {kind: 'ng:minlength', minlength: 10},
+      ]);
 
       f.text().value.set('abcdefg');
-      expect(f.text().errors()).toEqual([{kind: 'minLength'}]);
+      expect(f.text().errors()).toEqual([{kind: 'ng:minlength', minlength: 10}]);
 
       f.text().value.set('abcdefghijklmno');
       expect(f.text().errors()).toEqual([]);
@@ -145,17 +148,20 @@ describe('minLength validator', () => {
       );
 
       f.text().value.set('ab');
-      expect(f.text().errors()).toEqual([{kind: 'minLength'}, {kind: 'minLength'}]);
+      expect(f.text().errors()).toEqual([
+        {kind: 'ng:minlength', minlength: 5},
+        {kind: 'ng:minlength', minlength: 10},
+      ]);
 
       f.text().value.set('abcdefg');
-      expect(f.text().errors()).toEqual([{kind: 'minLength'}]);
+      expect(f.text().errors()).toEqual([{kind: 'ng:minlength', minlength: 10}]);
 
       f.text().value.set('abcdefghijklmno');
       expect(f.text().errors()).toEqual([]);
 
       minLengthSignal.set(20);
 
-      expect(f.text().errors()).toEqual([{kind: 'minLength'}]);
+      expect(f.text().errors()).toEqual([{kind: 'ng:minlength', minlength: 20}]);
       expect(f.text().metadata(MIN_LENGTH)()).toBe(20);
     });
   });
@@ -172,7 +178,7 @@ describe('minLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([{kind: 'minLength'}]);
+      expect(f.text().errors()).toEqual([{kind: 'ng:minlength', minlength: 5}]);
       dynamicMinLength.set(3);
       expect(f.text().errors()).toEqual([]);
     });
@@ -188,7 +194,7 @@ describe('minLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([{kind: 'minLength'}]);
+      expect(f.text().errors()).toEqual([{kind: 'ng:minlength', minlength: 5}]);
       dynamicMinLength.set(undefined);
       expect(f.text().errors()).toEqual([]);
     });
@@ -205,7 +211,7 @@ describe('minLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([{kind: 'minLength'}]);
+      expect(f.text().errors()).toEqual([{kind: 'ng:minlength', minlength: 8}]);
 
       f.category().value.set('B');
       expect(f.text().errors()).toEqual([]);

--- a/packages/forms/experimental/test/node/api/validators/min_length.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/min_length.spec.ts
@@ -8,7 +8,7 @@
 
 import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {NgValidationError} from '@angular/forms/experimental/src/api/validation_errors';
+import {ValidationError} from '@angular/forms/experimental/src/api/validation_errors';
 import {MIN_LENGTH, form, minLength} from '../../../../public_api';
 
 describe('minLength validator', () => {
@@ -22,7 +22,7 @@ describe('minLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.text().errors() as NgValidationError[]).toEqual([{kind: 'minlength', minlength: 5}]);
+    expect(f.text().errors()).toEqual([ValidationError.minlength(5)]);
   });
 
   it('returns minLength error when the length is smaller for arrays', () => {
@@ -35,7 +35,7 @@ describe('minLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.list().errors() as NgValidationError[]).toEqual([{kind: 'minlength', minlength: 5}]);
+    expect(f.list().errors()).toEqual([ValidationError.minlength(5)]);
   });
 
   it('is inclusive (no error if length equals minLength)', () => {
@@ -71,10 +71,10 @@ describe('minLength validator', () => {
       (p) => {
         minLength(p.text, 5, {
           errors: ({value}) => {
-            return {
+            return ValidationError.custom({
               kind: 'special-minLength',
               message: `Length is ${value().length}`,
-            };
+            });
           },
         });
       },
@@ -82,10 +82,10 @@ describe('minLength validator', () => {
     );
 
     expect(f.text().errors()).toEqual([
-      {
+      ValidationError.custom({
         kind: 'special-minLength',
         message: 'Length is 2',
-      },
+      }),
     ]);
   });
 
@@ -97,10 +97,10 @@ describe('minLength validator', () => {
         (p) => {
           minLength(p.text, 5, {
             errors: ({value}) => {
-              return {
+              return ValidationError.custom({
                 kind: 'special-minLength',
                 message: `Length is ${value().length}`,
-              };
+              });
             },
           });
         },
@@ -122,15 +122,13 @@ describe('minLength validator', () => {
       );
 
       f.text().value.set('ab');
-      expect(f.text().errors() as NgValidationError[]).toEqual([
-        {kind: 'minlength', minlength: 5},
-        {kind: 'minlength', minlength: 10},
+      expect(f.text().errors()).toEqual([
+        ValidationError.minlength(5),
+        ValidationError.minlength(10),
       ]);
 
       f.text().value.set('abcdefg');
-      expect(f.text().errors() as NgValidationError[]).toEqual([
-        {kind: 'minlength', minlength: 10},
-      ]);
+      expect(f.text().errors()).toEqual([ValidationError.minlength(10)]);
 
       f.text().value.set('abcdefghijklmno');
       expect(f.text().errors()).toEqual([]);
@@ -151,24 +149,20 @@ describe('minLength validator', () => {
       );
 
       f.text().value.set('ab');
-      expect(f.text().errors() as NgValidationError[]).toEqual([
-        {kind: 'minlength', minlength: 5},
-        {kind: 'minlength', minlength: 10},
+      expect(f.text().errors()).toEqual([
+        ValidationError.minlength(5),
+        ValidationError.minlength(10),
       ]);
 
       f.text().value.set('abcdefg');
-      expect(f.text().errors() as NgValidationError[]).toEqual([
-        {kind: 'minlength', minlength: 10},
-      ]);
+      expect(f.text().errors()).toEqual([ValidationError.minlength(10)]);
 
       f.text().value.set('abcdefghijklmno');
       expect(f.text().errors()).toEqual([]);
 
       minLengthSignal.set(20);
 
-      expect(f.text().errors() as NgValidationError[]).toEqual([
-        {kind: 'minlength', minlength: 20},
-      ]);
+      expect(f.text().errors()).toEqual([ValidationError.minlength(20)]);
       expect(f.text().metadata(MIN_LENGTH)()).toBe(20);
     });
   });
@@ -185,7 +179,7 @@ describe('minLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors() as NgValidationError[]).toEqual([{kind: 'minlength', minlength: 5}]);
+      expect(f.text().errors()).toEqual([ValidationError.minlength(5)]);
       dynamicMinLength.set(3);
       expect(f.text().errors()).toEqual([]);
     });
@@ -201,7 +195,7 @@ describe('minLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors() as NgValidationError[]).toEqual([{kind: 'minlength', minlength: 5}]);
+      expect(f.text().errors()).toEqual([ValidationError.minlength(5)]);
       dynamicMinLength.set(undefined);
       expect(f.text().errors()).toEqual([]);
     });
@@ -218,7 +212,7 @@ describe('minLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors() as NgValidationError[]).toEqual([{kind: 'minlength', minlength: 8}]);
+      expect(f.text().errors()).toEqual([ValidationError.minlength(8)]);
 
       f.category().value.set('B');
       expect(f.text().errors()).toEqual([]);

--- a/packages/forms/experimental/test/node/api/validators/pattern.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/pattern.spec.ts
@@ -8,6 +8,7 @@
 
 import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+import {ValidationError} from '@angular/forms/experimental/src/api/validation_errors';
 import {PATTERN, form, pattern} from '../../../../public_api';
 
 describe('pattern validator', () => {
@@ -21,11 +22,7 @@ describe('pattern validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.name().errors()).toEqual([
-      jasmine.objectContaining({
-        kind: 'pattern',
-      }),
-    ]);
+    expect(f.name().errors()).toEqual([ValidationError.pattern('pir.*jok')]);
   });
 
   it('supports custom error', () => {
@@ -38,11 +35,7 @@ describe('pattern validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.name().errors()).toEqual([
-      jasmine.objectContaining({
-        kind: 'pattern',
-      }),
-    ]);
+    expect(f.name().errors()).toEqual([ValidationError.pattern('pir.*jok')]);
   });
 
   describe('metadata', () => {
@@ -86,20 +79,12 @@ describe('pattern validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.name().errors()).toEqual([
-        jasmine.objectContaining({
-          kind: 'pattern',
-        }),
-      ]);
+      expect(f.name().errors()).toEqual([ValidationError.pattern('pir.*jok')]);
 
       patternSignal.set('p.*');
       expect(f.name().errors()).toEqual([]);
       patternSignal.set('meow');
-      expect(f.name().errors()).toEqual([
-        jasmine.objectContaining({
-          kind: 'pattern',
-        }),
-      ]);
+      expect(f.name().errors()).toEqual([ValidationError.pattern('meow')]);
 
       patternSignal.set(undefined);
 

--- a/packages/forms/experimental/test/node/api/validators/pattern.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/pattern.spec.ts
@@ -30,12 +30,12 @@ describe('pattern validator', () => {
     const f = form(
       cat,
       (p) => {
-        pattern(p.name, 'pir.*jok');
+        pattern(p.name, 'pir.*jok', {errors: () => ValidationError.custom()});
       },
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.name().errors()).toEqual([ValidationError.pattern('pir.*jok')]);
+    expect(f.name().errors()).toEqual([ValidationError.custom()]);
   });
 
   describe('metadata', () => {

--- a/packages/forms/experimental/test/node/api/validators/pattern.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/pattern.spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {Injector, signal} from '@angular/core';
@@ -23,7 +23,7 @@ describe('pattern validator', () => {
 
     expect(f.name().errors()).toEqual([
       jasmine.objectContaining({
-        kind: 'ng:pattern',
+        kind: 'pattern',
       }),
     ]);
   });
@@ -40,7 +40,7 @@ describe('pattern validator', () => {
 
     expect(f.name().errors()).toEqual([
       jasmine.objectContaining({
-        kind: 'ng:pattern',
+        kind: 'pattern',
       }),
     ]);
   });
@@ -88,7 +88,7 @@ describe('pattern validator', () => {
 
       expect(f.name().errors()).toEqual([
         jasmine.objectContaining({
-          kind: 'ng:pattern',
+          kind: 'pattern',
         }),
       ]);
 
@@ -97,7 +97,7 @@ describe('pattern validator', () => {
       patternSignal.set('meow');
       expect(f.name().errors()).toEqual([
         jasmine.objectContaining({
-          kind: 'ng:pattern',
+          kind: 'pattern',
         }),
       ]);
 

--- a/packages/forms/experimental/test/node/api/validators/pattern.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/pattern.spec.ts
@@ -23,7 +23,7 @@ describe('pattern validator', () => {
 
     expect(f.name().errors()).toEqual([
       jasmine.objectContaining({
-        kind: 'pattern',
+        kind: 'ng:pattern',
       }),
     ]);
   });
@@ -40,7 +40,7 @@ describe('pattern validator', () => {
 
     expect(f.name().errors()).toEqual([
       jasmine.objectContaining({
-        kind: 'pattern',
+        kind: 'ng:pattern',
       }),
     ]);
   });
@@ -88,7 +88,7 @@ describe('pattern validator', () => {
 
       expect(f.name().errors()).toEqual([
         jasmine.objectContaining({
-          kind: 'pattern',
+          kind: 'ng:pattern',
         }),
       ]);
 
@@ -97,7 +97,7 @@ describe('pattern validator', () => {
       patternSignal.set('meow');
       expect(f.name().errors()).toEqual([
         jasmine.objectContaining({
-          kind: 'pattern',
+          kind: 'ng:pattern',
         }),
       ]);
 

--- a/packages/forms/experimental/test/node/api/validators/required.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/required.spec.ts
@@ -8,6 +8,7 @@
 
 import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+import {ValidationError} from '@angular/forms/experimental/src/api/validation_errors';
 import {form, required} from '../../../../public_api';
 
 describe('required validator', () => {
@@ -23,7 +24,7 @@ describe('required validator', () => {
       },
     );
 
-    expect(f.name().errors()).toEqual([{kind: 'required'}]);
+    expect(f.name().errors()).toEqual([ValidationError.required()]);
     f.name().value.set('pirojok-the-cat');
     expect(f.name().errors()).toEqual([]);
   });
@@ -34,7 +35,7 @@ describe('required validator', () => {
       cat,
       (p) => {
         required(p.name, {
-          errors: (ctx) => ({kind: `required-${ctx.valueOf(p.age)}`}),
+          errors: (ctx) => ValidationError.custom({kind: `required-${ctx.valueOf(p.age)}`}),
         });
       },
       {
@@ -42,7 +43,7 @@ describe('required validator', () => {
       },
     );
 
-    expect(f.name().errors()).toEqual([{kind: 'required-5'}]);
+    expect(f.name().errors()).toEqual([ValidationError.custom({kind: 'required-5'})]);
     f.name().value.set('pirojok-the-cat');
     expect(f.name().errors()).toEqual([]);
   });
@@ -65,7 +66,7 @@ describe('required validator', () => {
 
     expect(f.name().errors()).toEqual([]);
     f.name().value.set('empty');
-    expect(f.name().errors()).toEqual([{kind: 'required'}]);
+    expect(f.name().errors()).toEqual([ValidationError.required()]);
   });
 
   it('supports custom condition', () => {
@@ -86,6 +87,6 @@ describe('required validator', () => {
 
     expect(f.name().errors()).toEqual([]);
     f.age().value.set(15);
-    expect(f.name().errors()).toEqual([{kind: 'required'}]);
+    expect(f.name().errors()).toEqual([ValidationError.required()]);
   });
 });

--- a/packages/forms/experimental/test/node/api/validators/required.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/required.spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {Injector, signal} from '@angular/core';
@@ -23,7 +23,7 @@ describe('required validator', () => {
       },
     );
 
-    expect(f.name().errors()).toEqual([{kind: 'ng:required'}]);
+    expect(f.name().errors()).toEqual([{kind: 'required'}]);
     f.name().value.set('pirojok-the-cat');
     expect(f.name().errors()).toEqual([]);
   });
@@ -34,7 +34,7 @@ describe('required validator', () => {
       cat,
       (p) => {
         required(p.name, {
-          errors: (ctx) => ({kind: `custom:required-${ctx.valueOf(p.age)}`}),
+          errors: (ctx) => ({kind: `required-${ctx.valueOf(p.age)}`}),
         });
       },
       {
@@ -42,7 +42,7 @@ describe('required validator', () => {
       },
     );
 
-    expect(f.name().errors()).toEqual([{kind: 'custom:required-5'}]);
+    expect(f.name().errors()).toEqual([{kind: 'required-5'}]);
     f.name().value.set('pirojok-the-cat');
     expect(f.name().errors()).toEqual([]);
   });
@@ -65,7 +65,7 @@ describe('required validator', () => {
 
     expect(f.name().errors()).toEqual([]);
     f.name().value.set('empty');
-    expect(f.name().errors()).toEqual([{kind: 'ng:required'}]);
+    expect(f.name().errors()).toEqual([{kind: 'required'}]);
   });
 
   it('supports custom condition', () => {
@@ -86,6 +86,6 @@ describe('required validator', () => {
 
     expect(f.name().errors()).toEqual([]);
     f.age().value.set(15);
-    expect(f.name().errors()).toEqual([{kind: 'ng:required'}]);
+    expect(f.name().errors()).toEqual([{kind: 'required'}]);
   });
 });

--- a/packages/forms/experimental/test/node/api/validators/required.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/required.spec.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { Injector, signal } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
-import { form, required } from '../../../../public_api';
+import {Injector, signal} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {form, required} from '../../../../public_api';
 
 describe('required validator', () => {
   it('returns required Error when the value is not present', () => {
@@ -23,7 +23,7 @@ describe('required validator', () => {
       },
     );
 
-    expect(f.name().errors()).toEqual([{kind: 'required'}]);
+    expect(f.name().errors()).toEqual([{kind: 'ng:required'}]);
     f.name().value.set('pirojok-the-cat');
     expect(f.name().errors()).toEqual([]);
   });
@@ -34,7 +34,7 @@ describe('required validator', () => {
       cat,
       (p) => {
         required(p.name, {
-          errors: (ctx) => ({kind: 'required-' + ctx.valueOf(p.age)}),
+          errors: (ctx) => ({kind: `custom:required-${ctx.valueOf(p.age)}`}),
         });
       },
       {
@@ -42,7 +42,7 @@ describe('required validator', () => {
       },
     );
 
-    expect(f.name().errors()).toEqual([{kind: 'required-5'}]);
+    expect(f.name().errors()).toEqual([{kind: 'custom:required-5'}]);
     f.name().value.set('pirojok-the-cat');
     expect(f.name().errors()).toEqual([]);
   });
@@ -65,7 +65,7 @@ describe('required validator', () => {
 
     expect(f.name().errors()).toEqual([]);
     f.name().value.set('empty');
-    expect(f.name().errors()).toEqual([{kind: 'required'}]);
+    expect(f.name().errors()).toEqual([{kind: 'ng:required'}]);
   });
 
   it('supports custom condition', () => {
@@ -86,6 +86,6 @@ describe('required validator', () => {
 
     expect(f.name().errors()).toEqual([]);
     f.age().value.set(15);
-    expect(f.name().errors()).toEqual([{kind: 'required'}]);
+    expect(f.name().errors()).toEqual([{kind: 'ng:required'}]);
   });
 });

--- a/packages/forms/experimental/test/node/api/when.spec.ts
+++ b/packages/forms/experimental/test/node/api/when.spec.ts
@@ -8,6 +8,7 @@
 
 import {Injector, Signal, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+import {ValidationError} from '@angular/forms/experimental/src/api/validation_errors';
 import {
   SchemaOrSchemaFn,
   applyEach,
@@ -34,7 +35,7 @@ describe('when', () => {
       (path) => {
         applyWhen(path, needsLastNamePredicate, (namePath) => {
           validate(namePath.last, ({value}) =>
-            value().length > 0 ? undefined : {kind: 'required'},
+            value().length > 0 ? undefined : ValidationError.required(),
           );
         });
       },
@@ -44,7 +45,7 @@ describe('when', () => {
     f().value.set({first: 'meow', needLastName: false, last: ''});
     expect(f.last().errors()).toEqual([]);
     f().value.set({first: 'meow', needLastName: true, last: ''});
-    expect(f.last().errors()).toEqual([{kind: 'required'}]);
+    expect(f.last().errors()).toEqual([ValidationError.required()]);
   });
 
   it('Disallows using non-local paths', () => {
@@ -55,7 +56,9 @@ describe('when', () => {
       (path) => {
         applyWhen(path, needsLastNamePredicate, (/* UNUSED */) => {
           expect(() => {
-            validate(path.last, ({value}) => (value().length > 0 ? undefined : {kind: 'required'}));
+            validate(path.last, ({value}) =>
+              value().length > 0 ? undefined : ValidationError.required(),
+            );
           }).toThrowError();
         });
       },
@@ -68,13 +71,13 @@ describe('when', () => {
 
     const s: SchemaOrSchemaFn<User> = (namePath) => {
       validate(namePath.last, ({value}) => {
-        return value().length > 0 ? undefined : {kind: 'required1'};
+        return value().length > 0 ? undefined : ValidationError.custom({kind: 'required1'});
       });
     };
 
     const s2: SchemaOrSchemaFn<User> = (namePath) => {
       validate(namePath.last, ({value}) => {
-        return value.length > 0 ? undefined : {kind: 'required2'};
+        return value.length > 0 ? undefined : ValidationError.custom({kind: 'required2'});
       });
     };
 
@@ -89,16 +92,21 @@ describe('when', () => {
       {injector: TestBed.inject(Injector)},
     );
     f.needLastName().value.set(true);
-    expect(f.items[0].last().errors()).toEqual([{kind: 'required1'}, {kind: 'required2'}]);
+    expect(f.items[0].last().errors()).toEqual([
+      ValidationError.custom({kind: 'required1'}),
+      ValidationError.custom({kind: 'required2'}),
+    ]);
     f.needLastName().value.set(false);
-    expect(f.items[0].last().errors()).toEqual([{kind: 'required1'}]);
+    expect(f.items[0].last().errors()).toEqual([ValidationError.custom({kind: 'required1'})]);
   });
 
   it('accepts a schema', () => {
     const data = signal({first: '', needLastName: false, last: ''});
 
     const s: SchemaOrSchemaFn<User> = (namePath) => {
-      validate(namePath.last, ({value}) => (value().length > 0 ? undefined : {kind: 'required'}));
+      validate(namePath.last, ({value}) =>
+        value().length > 0 ? undefined : ValidationError.required(),
+      );
     };
     const f = form(
       data,
@@ -111,7 +119,7 @@ describe('when', () => {
     f().value.set({first: 'meow', needLastName: false, last: ''});
     expect(f.last().errors()).toEqual([]);
     f().value.set({first: 'meow', needLastName: true, last: ''});
-    expect(f.last().errors()).toEqual([{kind: 'required'}]);
+    expect(f.last().errors()).toEqual([ValidationError.required()]);
   });
 
   it('supports mix of conditional and non conditional validators', () => {
@@ -119,11 +127,13 @@ describe('when', () => {
     const f = form(
       data,
       (path) => {
-        validate(path.last, ({value}) => (value().length > 4 ? undefined : {kind: 'short'}));
+        validate(path.last, ({value}) =>
+          value().length > 4 ? undefined : ValidationError.custom({kind: 'short'}),
+        );
 
         applyWhen(path, needsLastNamePredicate, (namePath /* Path */) => {
           validate(namePath.last, ({value}) =>
-            value().length > 0 ? undefined : {kind: 'required'},
+            value().length > 0 ? undefined : ValidationError.required(),
           );
         });
       },
@@ -131,16 +141,19 @@ describe('when', () => {
     );
 
     f().value.set({first: 'meow', needLastName: false, last: ''});
-    expect(f.last().errors()).toEqual([{kind: 'short'}]);
+    expect(f.last().errors()).toEqual([ValidationError.custom({kind: 'short'})]);
     f().value.set({first: 'meow', needLastName: true, last: ''});
-    expect(f.last().errors()).toEqual([{kind: 'short'}, {kind: 'required'}]);
+    expect(f.last().errors()).toEqual([
+      ValidationError.custom({kind: 'short'}),
+      ValidationError.required(),
+    ]);
   });
 
   it('supports array schema', () => {
     const data = signal({needLastName: true, items: [{first: '', last: ''}]});
     const s: SchemaOrSchemaFn<User> = (i) => {
       validate(i.last, ({value}) => {
-        return value().length > 0 ? undefined : {kind: 'required'};
+        return value().length > 0 ? undefined : ValidationError.required();
       });
     };
 
@@ -154,7 +167,7 @@ describe('when', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.items[0].last().errors()).toEqual([{kind: 'required'}]);
+    expect(f.items[0].last().errors()).toEqual([ValidationError.required()]);
     f.needLastName().value.set(false);
     expect(f.items[0].last().errors()).toEqual([]);
   });
@@ -170,18 +183,20 @@ describe('applyWhenValue', () => {
           path.numOrNull,
           (value) => value === null || value > 0,
           (num) => {
-            validate(num, ({value}) => ((value() ?? 0) < 10 ? {kind: 'too-small'} : undefined));
+            validate(num, ({value}) =>
+              (value() ?? 0) < 10 ? ValidationError.custom({kind: 'too-small'}) : undefined,
+            );
           },
         );
       },
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.numOrNull().errors()).toEqual([{kind: 'too-small'}]);
+    expect(f.numOrNull().errors()).toEqual([ValidationError.custom({kind: 'too-small'})]);
     f.numOrNull().value.set(5);
-    expect(f.numOrNull().errors()).toEqual([{kind: 'too-small'}]);
+    expect(f.numOrNull().errors()).toEqual([ValidationError.custom({kind: 'too-small'})]);
     f.numOrNull().value.set(null);
-    expect(f.numOrNull().errors()).toEqual([{kind: 'too-small'}]);
+    expect(f.numOrNull().errors()).toEqual([ValidationError.custom({kind: 'too-small'})]);
     f.numOrNull().value.set(15);
     expect(f.numOrNull().errors()).toEqual([]);
   });
@@ -195,7 +210,9 @@ describe('applyWhenValue', () => {
           path.numOrNull,
           (value) => value !== null,
           (num) => {
-            validate(num, ({value}) => (value() < 10 ? {kind: 'too-small'} : undefined));
+            validate(num, ({value}) =>
+              value() < 10 ? ValidationError.custom({kind: 'too-small'}) : undefined,
+            );
           },
         );
       },
@@ -204,7 +221,7 @@ describe('applyWhenValue', () => {
 
     expect(f.numOrNull().errors()).toEqual([]);
     f.numOrNull().value.set(5);
-    expect(f.numOrNull().errors()).toEqual([{kind: 'too-small'}]);
+    expect(f.numOrNull().errors()).toEqual([ValidationError.custom({kind: 'too-small'})]);
     f.numOrNull().value.set(null);
     expect(f.numOrNull().errors()).toEqual([]);
     f.numOrNull().value.set(15);

--- a/packages/forms/experimental/test/node/api/when.spec.ts
+++ b/packages/forms/experimental/test/node/api/when.spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {Injector, Signal, signal} from '@angular/core';
@@ -34,7 +34,7 @@ describe('when', () => {
       (path) => {
         applyWhen(path, needsLastNamePredicate, (namePath) => {
           validate(namePath.last, ({value}) =>
-            value().length > 0 ? undefined : {kind: 'ng:required'},
+            value().length > 0 ? undefined : {kind: 'required'},
           );
         });
       },
@@ -44,7 +44,7 @@ describe('when', () => {
     f().value.set({first: 'meow', needLastName: false, last: ''});
     expect(f.last().errors()).toEqual([]);
     f().value.set({first: 'meow', needLastName: true, last: ''});
-    expect(f.last().errors()).toEqual([{kind: 'ng:required'}]);
+    expect(f.last().errors()).toEqual([{kind: 'required'}]);
   });
 
   it('Disallows using non-local paths', () => {
@@ -55,9 +55,7 @@ describe('when', () => {
       (path) => {
         applyWhen(path, needsLastNamePredicate, (/* UNUSED */) => {
           expect(() => {
-            validate(path.last, ({value}) =>
-              value().length > 0 ? undefined : {kind: 'ng:required'},
-            );
+            validate(path.last, ({value}) => (value().length > 0 ? undefined : {kind: 'required'}));
           }).toThrowError();
         });
       },
@@ -70,13 +68,13 @@ describe('when', () => {
 
     const s: SchemaOrSchemaFn<User> = (namePath) => {
       validate(namePath.last, ({value}) => {
-        return value().length > 0 ? undefined : {kind: 'custom:required1'};
+        return value().length > 0 ? undefined : {kind: 'required1'};
       });
     };
 
     const s2: SchemaOrSchemaFn<User> = (namePath) => {
       validate(namePath.last, ({value}) => {
-        return value.length > 0 ? undefined : {kind: 'custom:required2'};
+        return value.length > 0 ? undefined : {kind: 'required2'};
       });
     };
 
@@ -91,21 +89,16 @@ describe('when', () => {
       {injector: TestBed.inject(Injector)},
     );
     f.needLastName().value.set(true);
-    expect(f.items[0].last().errors()).toEqual([
-      {kind: 'custom:required1'},
-      {kind: 'custom:required2'},
-    ]);
+    expect(f.items[0].last().errors()).toEqual([{kind: 'required1'}, {kind: 'required2'}]);
     f.needLastName().value.set(false);
-    expect(f.items[0].last().errors()).toEqual([{kind: 'custom:required1'}]);
+    expect(f.items[0].last().errors()).toEqual([{kind: 'required1'}]);
   });
 
   it('accepts a schema', () => {
     const data = signal({first: '', needLastName: false, last: ''});
 
     const s: SchemaOrSchemaFn<User> = (namePath) => {
-      validate(namePath.last, ({value}) =>
-        value().length > 0 ? undefined : {kind: 'ng:required'},
-      );
+      validate(namePath.last, ({value}) => (value().length > 0 ? undefined : {kind: 'required'}));
     };
     const f = form(
       data,
@@ -118,7 +111,7 @@ describe('when', () => {
     f().value.set({first: 'meow', needLastName: false, last: ''});
     expect(f.last().errors()).toEqual([]);
     f().value.set({first: 'meow', needLastName: true, last: ''});
-    expect(f.last().errors()).toEqual([{kind: 'ng:required'}]);
+    expect(f.last().errors()).toEqual([{kind: 'required'}]);
   });
 
   it('supports mix of conditional and non conditional validators', () => {
@@ -126,11 +119,11 @@ describe('when', () => {
     const f = form(
       data,
       (path) => {
-        validate(path.last, ({value}) => (value().length > 4 ? undefined : {kind: 'custom:short'}));
+        validate(path.last, ({value}) => (value().length > 4 ? undefined : {kind: 'short'}));
 
         applyWhen(path, needsLastNamePredicate, (namePath /* Path */) => {
           validate(namePath.last, ({value}) =>
-            value().length > 0 ? undefined : {kind: 'ng:required'},
+            value().length > 0 ? undefined : {kind: 'required'},
           );
         });
       },
@@ -138,16 +131,16 @@ describe('when', () => {
     );
 
     f().value.set({first: 'meow', needLastName: false, last: ''});
-    expect(f.last().errors()).toEqual([{kind: 'custom:short'}]);
+    expect(f.last().errors()).toEqual([{kind: 'short'}]);
     f().value.set({first: 'meow', needLastName: true, last: ''});
-    expect(f.last().errors()).toEqual([{kind: 'custom:short'}, {kind: 'ng:required'}]);
+    expect(f.last().errors()).toEqual([{kind: 'short'}, {kind: 'required'}]);
   });
 
   it('supports array schema', () => {
     const data = signal({needLastName: true, items: [{first: '', last: ''}]});
     const s: SchemaOrSchemaFn<User> = (i) => {
       validate(i.last, ({value}) => {
-        return value().length > 0 ? undefined : {kind: 'ng:required'};
+        return value().length > 0 ? undefined : {kind: 'required'};
       });
     };
 
@@ -161,7 +154,7 @@ describe('when', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.items[0].last().errors()).toEqual([{kind: 'ng:required'}]);
+    expect(f.items[0].last().errors()).toEqual([{kind: 'required'}]);
     f.needLastName().value.set(false);
     expect(f.items[0].last().errors()).toEqual([]);
   });
@@ -177,20 +170,18 @@ describe('applyWhenValue', () => {
           path.numOrNull,
           (value) => value === null || value > 0,
           (num) => {
-            validate(num, ({value}) =>
-              (value() ?? 0) < 10 ? {kind: 'custom:too-small'} : undefined,
-            );
+            validate(num, ({value}) => ((value() ?? 0) < 10 ? {kind: 'too-small'} : undefined));
           },
         );
       },
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.numOrNull().errors()).toEqual([{kind: 'custom:too-small'}]);
+    expect(f.numOrNull().errors()).toEqual([{kind: 'too-small'}]);
     f.numOrNull().value.set(5);
-    expect(f.numOrNull().errors()).toEqual([{kind: 'custom:too-small'}]);
+    expect(f.numOrNull().errors()).toEqual([{kind: 'too-small'}]);
     f.numOrNull().value.set(null);
-    expect(f.numOrNull().errors()).toEqual([{kind: 'custom:too-small'}]);
+    expect(f.numOrNull().errors()).toEqual([{kind: 'too-small'}]);
     f.numOrNull().value.set(15);
     expect(f.numOrNull().errors()).toEqual([]);
   });
@@ -204,7 +195,7 @@ describe('applyWhenValue', () => {
           path.numOrNull,
           (value) => value !== null,
           (num) => {
-            validate(num, ({value}) => (value() < 10 ? {kind: 'custom:too-small'} : undefined));
+            validate(num, ({value}) => (value() < 10 ? {kind: 'too-small'} : undefined));
           },
         );
       },
@@ -213,7 +204,7 @@ describe('applyWhenValue', () => {
 
     expect(f.numOrNull().errors()).toEqual([]);
     f.numOrNull().value.set(5);
-    expect(f.numOrNull().errors()).toEqual([{kind: 'custom:too-small'}]);
+    expect(f.numOrNull().errors()).toEqual([{kind: 'too-small'}]);
     f.numOrNull().value.set(null);
     expect(f.numOrNull().errors()).toEqual([]);
     f.numOrNull().value.set(15);

--- a/packages/forms/experimental/test/node/field_node.spec.ts
+++ b/packages/forms/experimental/test/node/field_node.spec.ts
@@ -837,6 +837,24 @@ describe('FieldNode', () => {
       expect(submitSpy).toHaveBeenCalledWith(initialValue);
     });
 
+    it('maps untargeted errors to form root', async () => {
+      const data = signal({first: '', last: ''});
+      const f = form(
+        data,
+        (name) => {
+          // first name required if last name specified
+          required(name.first, {when: ({valueOf}) => valueOf(name.last) !== ''});
+        },
+        {injector: TestBed.inject(Injector)},
+      );
+
+      await submit(f, () => {
+        return Promise.resolve([ValidationError.custom()]);
+      });
+
+      expect(f().errors()).toEqual([ValidationError.custom()]);
+    });
+
     it('marks the form as submitting', async () => {
       const initialValue = {first: 'meow', last: 'wuf'};
       const data = signal(initialValue);
@@ -865,10 +883,6 @@ describe('FieldNode', () => {
       resolvePromise?.();
 
       await result;
-      expect(f().submittedStatus()).toBe('submitted');
-
-      f().resetSubmittedStatus();
-      expect(f().submittedStatus()).toBe('unsubmitted');
     });
 
     it('works on child fields', async () => {

--- a/packages/forms/experimental/test/node/field_node.spec.ts
+++ b/packages/forms/experimental/test/node/field_node.spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {computed, Injector, signal} from '@angular/core';
@@ -528,7 +528,7 @@ describe('FieldNode', () => {
         (p) => {
           validate(p.a, ({value}) => {
             if (value() > 10) {
-              return {kind: 'custom:too-damn-high'};
+              return {kind: 'too-damn-high'};
             }
             return undefined;
           });
@@ -542,7 +542,7 @@ describe('FieldNode', () => {
       expect(f().valid()).toBe(true);
 
       f.a().value.set(11);
-      expect(f.a().errors()).toEqual([{kind: 'custom:too-damn-high'}]);
+      expect(f.a().errors()).toEqual([{kind: 'too-damn-high'}]);
       expect(f.a().valid()).toBe(false);
       expect(f().errors()).toEqual([]);
       expect(f().valid()).toBe(false);
@@ -554,7 +554,7 @@ describe('FieldNode', () => {
         (p) => {
           validate(p.a, ({value}) => {
             if (value() > 10) {
-              return [{kind: 'custom:too-damn-high'}, {kind: 'custom:bad'}];
+              return [{kind: 'too-damn-high'}, {kind: 'bad'}];
             }
             return undefined;
           });
@@ -566,7 +566,7 @@ describe('FieldNode', () => {
       expect(f.a().valid()).toBe(true);
 
       f.a().value.set(11);
-      expect(f.a().errors()).toEqual([{kind: 'custom:too-damn-high'}, {kind: 'custom:bad'}]);
+      expect(f.a().errors()).toEqual([{kind: 'too-damn-high'}, {kind: 'bad'}]);
       expect(f.a().valid()).toBe(false);
     });
 
@@ -575,7 +575,7 @@ describe('FieldNode', () => {
         signal({a: 1, b: 2}),
         (p) => {
           error(p.a, ({value}) => value() > 1);
-          error(p.a, ({value}) => value() > 10, 'custom:too-damn-high');
+          error(p.a, ({value}) => value() > 10, 'too-damn-high');
           error(
             p.a,
             ({value}) => value() > 100,
@@ -589,21 +589,18 @@ describe('FieldNode', () => {
       expect(f.a().valid()).toBe(true);
 
       f.a().value.set(2);
-      expect(f.a().errors()).toEqual([{kind: 'custom:error'}]);
+      expect(f.a().errors()).toEqual([{kind: 'error'}]);
       expect(f.a().valid()).toBe(false);
 
       f.a().value.set(11);
-      expect(f.a().errors()).toEqual([
-        {kind: 'custom:error'},
-        {kind: 'custom:error', message: 'custom:too-damn-high'},
-      ]);
+      expect(f.a().errors()).toEqual([{kind: 'error'}, {kind: 'error', message: 'too-damn-high'}]);
       expect(f.a().valid()).toBe(false);
 
       f.a().value.set(101);
       expect(f.a().errors()).toEqual([
-        {kind: 'custom:error'},
-        {kind: 'custom:error', message: 'custom:too-damn-high'},
-        {kind: 'custom:error', message: '101 is much too high'},
+        {kind: 'error'},
+        {kind: 'error', message: 'too-damn-high'},
+        {kind: 'error', message: '101 is much too high'},
       ]);
       expect(f.a().valid()).toBe(false);
     });
@@ -618,7 +615,7 @@ describe('FieldNode', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.first().errors()).toEqual([{kind: 'ng:required'}]);
+      expect(f.first().errors()).toEqual([{kind: 'required'}]);
       expect(f.first().valid()).toBe(false);
       expect(f.first().metadata(REQUIRED)()).toBe(true);
 
@@ -646,7 +643,7 @@ describe('FieldNode', () => {
 
       f.last().value.set('Loblaw');
 
-      expect(f.first().errors()).toEqual([{kind: 'ng:required'}]);
+      expect(f.first().errors()).toEqual([{kind: 'required'}]);
       expect(f.first().valid()).toBe(false);
       expect(f.first().metadata(REQUIRED)()).toBe(true);
 
@@ -668,7 +665,7 @@ describe('FieldNode', () => {
       );
 
       expect(f.quantity().metadata(REQUIRED)()).toBe(true);
-      expect(f.quantity().errors()).toEqual([{kind: 'ng:required'}]);
+      expect(f.quantity().errors()).toEqual([{kind: 'required'}]);
 
       f.quantity().value.set(1);
       expect(f.quantity().metadata(REQUIRED)()).toBe(true);
@@ -683,14 +680,14 @@ describe('FieldNode', () => {
           required(tx.name, {
             when: ({valueOf}) => valueOf(tx.country) === 'USA',
             errors: () => ({
-              kind: 'ng:required',
+              kind: 'required',
               message: 'Name is required in your country',
             }),
           });
           required(tx.name, {
             when: ({valueOf}) => valueOf(tx.amount) >= 1000,
             errors: () => ({
-              kind: 'ng:required',
+              kind: 'required',
               message: 'Name is required for large transactions',
             }),
           });
@@ -702,18 +699,18 @@ describe('FieldNode', () => {
 
       f.country().value.set('USA');
       expect(f.name().errors()).toEqual([
-        {kind: 'ng:required', message: 'Name is required in your country'},
+        {kind: 'required', message: 'Name is required in your country'},
       ]);
 
       f.amount().value.set(1000);
       expect(f.name().errors()).toEqual([
-        {kind: 'ng:required', message: 'Name is required in your country'},
-        {kind: 'ng:required', message: 'Name is required for large transactions'},
+        {kind: 'required', message: 'Name is required in your country'},
+        {kind: 'required', message: 'Name is required for large transactions'},
       ]);
 
       f.country().value.set('Canada');
       expect(f.name().errors()).toEqual([
-        {kind: 'ng:required', message: 'Name is required for large transactions'},
+        {kind: 'required', message: 'Name is required for large transactions'},
       ]);
 
       f.amount().value.set(100);
@@ -729,10 +726,10 @@ describe('FieldNode', () => {
             validateTree(p, ({value, fieldOf}) => {
               const errors: ValidationTreeError[] = [];
               if (value().name.length > 8) {
-                errors.push({kind: 'custom:long_name', field: fieldOf(p.name)});
+                errors.push({kind: 'long_name', field: fieldOf(p.name)});
               }
               if (value().age < 0) {
-                errors.push({kind: 'custom:temporal_anomaly', field: fieldOf(p.age)});
+                errors.push({kind: 'temporal_anomaly', field: fieldOf(p.age)});
               }
               return errors;
             });
@@ -746,12 +743,10 @@ describe('FieldNode', () => {
         f.age().value.set(-10);
 
         expect(f.name().errors()).toEqual([]);
-        expect(f.age().errors()).toEqual([
-          jasmine.objectContaining({kind: 'custom:temporal_anomaly'}),
-        ]);
+        expect(f.age().errors()).toEqual([jasmine.objectContaining({kind: 'temporal_anomaly'})]);
 
         cat.set({name: 'Fluffy McFluffington', age: 10});
-        expect(f.name().errors()).toEqual([jasmine.objectContaining({kind: 'custom:long_name'})]);
+        expect(f.name().errors()).toEqual([jasmine.objectContaining({kind: 'long_name'})]);
         expect(f.age().errors()).toEqual([]);
       });
 
@@ -763,10 +758,10 @@ describe('FieldNode', () => {
             validateTree(p, ({value, fieldOf}) => {
               const errors: ValidationTreeError[] = [];
               if (value().name.length > 8) {
-                errors.push({kind: 'custom:long_name', field: fieldOf(p.name)});
+                errors.push({kind: 'long_name', field: fieldOf(p.name)});
               }
               if (value().age < 0) {
-                errors.push({kind: 'custom:temporal_anomaly', field: fieldOf(p.age)});
+                errors.push({kind: 'temporal_anomaly', field: fieldOf(p.age)});
               }
               return errors;
             });
@@ -780,12 +775,10 @@ describe('FieldNode', () => {
         f.age().value.set(-10);
 
         expect(f.name().errors()).toEqual([]);
-        expect(f.age().errors()).toEqual([
-          jasmine.objectContaining({kind: 'custom:temporal_anomaly'}),
-        ]);
+        expect(f.age().errors()).toEqual([jasmine.objectContaining({kind: 'temporal_anomaly'})]);
 
         cat.set({name: 'Fluffy McFluffington', age: 10});
-        expect(f.name().errors()).toEqual([jasmine.objectContaining({kind: 'custom:long_name'})]);
+        expect(f.name().errors()).toEqual([jasmine.objectContaining({kind: 'long_name'})]);
         expect(f.age().errors()).toEqual([]);
       });
     });
@@ -806,13 +799,13 @@ describe('FieldNode', () => {
       await submit(f, (form) => {
         return Promise.resolve([
           {
-            kind: 'custom:lastName',
+            kind: 'lastName',
             field: form.last,
           },
         ]);
       });
 
-      expect(f.last().errors()).toEqual([{kind: 'custom:lastName'}]);
+      expect(f.last().errors()).toEqual([{kind: 'lastName'}]);
     });
 
     it('maps errors to a field', async () => {
@@ -889,7 +882,7 @@ describe('FieldNode', () => {
 
       await submit(f.first, (form) => {
         submitSpy(form().value());
-        return Promise.resolve([{kind: 'custom:lastName'}]);
+        return Promise.resolve([{kind: 'lastName'}]);
       });
 
       expect(submitSpy).toHaveBeenCalledWith('meow');
@@ -1072,7 +1065,7 @@ describe('FieldNode', () => {
           (children) => {
             applyEach(children, (c) => {
               validate(c.tag, ({value}) =>
-                value() !== 'tr' ? {kind: 'custom:invalid-child'} : undefined,
+                value() !== 'tr' ? {kind: 'invalid-child'} : undefined,
               );
             });
           },
@@ -1083,7 +1076,7 @@ describe('FieldNode', () => {
           (children) => {
             applyEach(children, (c) => {
               validate(c.tag, ({value}) =>
-                value() !== 'td' ? {kind: 'custom:invalid-child'} : undefined,
+                value() !== 'td' ? {kind: 'invalid-child'} : undefined,
               );
             });
           },

--- a/packages/forms/experimental/test/node/logic_node_2.spec.ts
+++ b/packages/forms/experimental/test/node/logic_node_2.spec.ts
@@ -23,12 +23,10 @@ describe('LogicNodeBuilder', () => {
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.addSyncErrorRule(() => [{kind: 'custom:root-err'}]);
+    builder.addSyncErrorRule(() => [{kind: 'root-err'}]);
 
     const logicNode = builder.build();
-    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'custom:root-err'},
-    ]);
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'root-err'}]);
   });
 
   it('should build child logic', () => {
@@ -37,58 +35,58 @@ describe('LogicNodeBuilder', () => {
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.getChild('a').addSyncErrorRule(() => [{kind: 'custom:root-err'}]);
+    builder.getChild('a').addSyncErrorRule(() => [{kind: 'root-err'}]);
 
     const logicNode = builder.build();
     expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'custom:root-err'},
+      {kind: 'root-err'},
     ]);
   });
 
   it('should build merged logic', () => {
     // (p) => {
-    //   validate(p, () => ({kind: 'custom:err-1'}));
-    //   validate(p, () => ({kind: 'custom:err-2'}));
+    //   validate(p, () => ({kind: 'err-1'}));
+    //   validate(p, () => ({kind: 'err-2'}));
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.addSyncErrorRule(() => [{kind: 'custom:err-1'}]);
+    builder.addSyncErrorRule(() => [{kind: 'err-1'}]);
 
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.addSyncErrorRule(() => [{kind: 'custom:err-2'}]);
+    builder2.addSyncErrorRule(() => [{kind: 'err-2'}]);
     builder.mergeIn(builder2);
 
     const logicNode = builder.build();
     expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'custom:err-1'},
-      {kind: 'custom:err-2'},
+      {kind: 'err-1'},
+      {kind: 'err-2'},
     ]);
   });
 
   it('should build merged child logic', () => {
     // (p) => {
-    //   validate(p.a, () => ({kind: 'custom:err-1'}));
-    //   validate(p.a, () => ({kind: 'custom:err-2'}));
+    //   validate(p.a, () => ({kind: 'err-1'}));
+    //   validate(p.a, () => ({kind: 'err-2'}));
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.getChild('a').addSyncErrorRule(() => [{kind: 'custom:err-1'}]);
+    builder.getChild('a').addSyncErrorRule(() => [{kind: 'err-1'}]);
 
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.getChild('a').addSyncErrorRule(() => [{kind: 'custom:err-2'}]);
+    builder2.getChild('a').addSyncErrorRule(() => [{kind: 'err-2'}]);
     builder.mergeIn(builder2);
 
     const logicNode = builder.build();
     expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'custom:err-1'},
-      {kind: 'custom:err-2'},
+      {kind: 'err-1'},
+      {kind: 'err-2'},
     ]);
   });
 
   it('should build logic with predicate', () => {
     // (p) => {
     //   applyWhen(p, pred, (p) => {
-    //     validate(p, () => ({kind: 'custom:err-1'}));
+    //     validate(p, () => ({kind: 'err-1'}));
     //   });
     // }
 
@@ -96,11 +94,11 @@ describe('LogicNodeBuilder', () => {
 
     const pred = signal(true);
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.addSyncErrorRule(() => [{kind: 'custom:err-1'}]);
+    builder2.addSyncErrorRule(() => [{kind: 'err-1'}]);
     builder.mergeIn(builder2, {fn: () => pred(), path: undefined!});
 
     const logicNode = builder.build();
-    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'custom:err-1'}]);
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
 
     pred.set(false);
     expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([]);
@@ -110,7 +108,7 @@ describe('LogicNodeBuilder', () => {
     // (p) => {
     //   applyWhen(p, pred, (p) => {
     //     apply(p, (p) => {
-    //       validate(p, () => ({kind: 'custom:err-1'}));
+    //       validate(p, () => ({kind: 'err-1'}));
     //     });
     //   });
     // }
@@ -121,13 +119,13 @@ describe('LogicNodeBuilder', () => {
     const builder2 = LogicNodeBuilder.newRoot();
 
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.addSyncErrorRule(() => [{kind: 'custom:err-1'}]);
+    builder3.addSyncErrorRule(() => [{kind: 'err-1'}]);
 
     builder2.mergeIn(builder3);
     builder.mergeIn(builder2, {fn: () => pred(), path: undefined!});
 
     const logicNode = builder.build();
-    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'custom:err-1'}]);
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
 
     pred.set(false);
     expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([]);
@@ -137,7 +135,7 @@ describe('LogicNodeBuilder', () => {
     // (p) => {
     //   applyWhen(p, pred, (p) => {
     //     apply(p, (p) => {
-    //       validate(p.a, () => ({kind: 'custom:err-1'}));
+    //       validate(p.a, () => ({kind: 'err-1'}));
     //     });
     //   });
     // }
@@ -148,14 +146,14 @@ describe('LogicNodeBuilder', () => {
     const builder2 = LogicNodeBuilder.newRoot();
 
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.getChild('a').addSyncErrorRule(() => [{kind: 'custom:err-1'}]);
+    builder3.getChild('a').addSyncErrorRule(() => [{kind: 'err-1'}]);
 
     builder2.mergeIn(builder3);
     builder.mergeIn(builder2, {fn: () => pred(), path: undefined!});
 
     const logicNode = builder.build();
     expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'custom:err-1'},
+      {kind: 'err-1'},
     ]);
 
     pred.set(false);
@@ -166,7 +164,7 @@ describe('LogicNodeBuilder', () => {
     // (p) => {
     //   applyWhen(p, pred, (p) => {
     //     applyWhen(p.a, pred2, (a) => {
-    //       validate(a, () => ({kind: 'custom:err-1'}));
+    //       validate(a, () => ({kind: 'err-1'}));
     //     });
     //   });
     // }
@@ -178,14 +176,14 @@ describe('LogicNodeBuilder', () => {
 
     const pred2 = signal(true);
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.addSyncErrorRule(() => [{kind: 'custom:err-1'}]);
+    builder3.addSyncErrorRule(() => [{kind: 'err-1'}]);
 
     builder2.getChild('a').mergeIn(builder3, {fn: () => pred2(), path: undefined!});
     builder.mergeIn(builder2, {fn: () => pred(), path: undefined!});
 
     const logicNode = builder.build();
     expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'custom:err-1'},
+      {kind: 'err-1'},
     ]);
 
     pred.set(false);
@@ -200,11 +198,11 @@ describe('LogicNodeBuilder', () => {
   it('should propagate predicates through deep application', () => {
     // (p) => {
     //   applyWhen(p, pred, (p) => {
-    //     validate(p.a.b, () => ({kind: 'custom:err-1'}));
+    //     validate(p.a.b, () => ({kind: 'err-1'}));
     //     applyWhen(p.a, pred2, (a) => {
-    //       validate(a.b, () => ({kind: 'custom:err-2'}));
+    //       validate(a.b, () => ({kind: 'err-2'}));
     //       applyWhen(a.b, pred3, (b) => {
-    //         validate(b, () => ({kind: 'custom:err-3'}));
+    //         validate(b, () => ({kind: 'err-3'}));
     //       });
     //     });
     //   });
@@ -217,15 +215,15 @@ describe('LogicNodeBuilder', () => {
     builder2
       .getChild('a')
       .getChild('b')
-      .addSyncErrorRule(() => [{kind: 'custom:err-1'}]);
+      .addSyncErrorRule(() => [{kind: 'err-1'}]);
 
     const pred2 = signal(true);
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.getChild('b').addSyncErrorRule(() => [{kind: 'custom:err-2'}]);
+    builder3.getChild('b').addSyncErrorRule(() => [{kind: 'err-2'}]);
 
     const pred3 = signal(true);
     const builder4 = LogicNodeBuilder.newRoot();
-    builder4.addSyncErrorRule(() => [{kind: 'custom:err-3'}]);
+    builder4.addSyncErrorRule(() => [{kind: 'err-3'}]);
     builder3.getChild('b').mergeIn(builder4, {fn: () => pred3(), path: undefined!});
     builder2.getChild('a').mergeIn(builder3, {fn: () => pred2(), path: undefined!});
     builder.mergeIn(builder2, {fn: () => pred(), path: undefined!});
@@ -233,21 +231,21 @@ describe('LogicNodeBuilder', () => {
     const logicNode = builder.build();
     expect(
       logicNode.getChild('a').getChild('b').logic.syncErrors.compute(fakeFieldContext),
-    ).toEqual([{kind: 'custom:err-1'}, {kind: 'custom:err-2'}, {kind: 'custom:err-3'}]);
+    ).toEqual([{kind: 'err-1'}, {kind: 'err-2'}, {kind: 'err-3'}]);
 
     pred.set(true);
     pred2.set(true);
     pred3.set(false);
     expect(
       logicNode.getChild('a').getChild('b').logic.syncErrors.compute(fakeFieldContext),
-    ).toEqual([{kind: 'custom:err-1'}, {kind: 'custom:err-2'}]);
+    ).toEqual([{kind: 'err-1'}, {kind: 'err-2'}]);
 
     pred.set(true);
     pred2.set(false);
     pred3.set(true);
     expect(
       logicNode.getChild('a').getChild('b').logic.syncErrors.compute(fakeFieldContext),
-    ).toEqual([{kind: 'custom:err-1'}]);
+    ).toEqual([{kind: 'err-1'}]);
 
     pred.set(false);
     pred2.set(true);
@@ -261,7 +259,7 @@ describe('LogicNodeBuilder', () => {
     // (p) => {
     //   applyWhen(p, pred, (p) => {
     //     applyEach(p.items, (i) => {
-    //       validate(i.last, () => ({kind: 'custom:err-1'}));
+    //       validate(i.last, () => ({kind: 'err-1'}));
     //     });
     //   });
     // };
@@ -272,7 +270,7 @@ describe('LogicNodeBuilder', () => {
     const builder2 = LogicNodeBuilder.newRoot();
 
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.getChild('last').addSyncErrorRule(() => [{kind: 'custom:err-1'}]);
+    builder3.getChild('last').addSyncErrorRule(() => [{kind: 'err-1'}]);
 
     builder2.getChild('items').getChild(DYNAMIC).mergeIn(builder3);
     builder.mergeIn(builder2, {fn: () => pred(), path: undefined!});
@@ -284,7 +282,7 @@ describe('LogicNodeBuilder', () => {
         .getChild(DYNAMIC)
         .getChild('last')
         .logic.syncErrors.compute(fakeFieldContext),
-    ).toEqual([{kind: 'custom:err-1'}]);
+    ).toEqual([{kind: 'err-1'}]);
 
     pred.set(false);
     expect(
@@ -298,100 +296,100 @@ describe('LogicNodeBuilder', () => {
 
   it('should preserve ordering across merges', () => {
     // (p) => {
-    //   validate(p, () => ({kind: 'custom:err-1'}));
+    //   validate(p, () => ({kind: 'err-1'}));
     //   apply(p, (p) => {
-    //     validate(p, () => ({kind: 'custom:err-2'}));
+    //     validate(p, () => ({kind: 'err-2'}));
     //   })
-    //   validate(p, () => ({kind: 'custom:err-3'}));
+    //   validate(p, () => ({kind: 'err-3'}));
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.addSyncErrorRule(() => [{kind: 'custom:err-1'}]);
+    builder.addSyncErrorRule(() => [{kind: 'err-1'}]);
 
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.addSyncErrorRule(() => [{kind: 'custom:err-2'}]);
+    builder2.addSyncErrorRule(() => [{kind: 'err-2'}]);
     builder.mergeIn(builder2);
 
-    builder.addSyncErrorRule(() => [{kind: 'custom:err-3'}]);
+    builder.addSyncErrorRule(() => [{kind: 'err-3'}]);
 
     const logicNode = builder.build();
     expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'custom:err-1'},
-      {kind: 'custom:err-2'},
-      {kind: 'custom:err-3'},
+      {kind: 'err-1'},
+      {kind: 'err-2'},
+      {kind: 'err-3'},
     ]);
   });
 
   it('should preserve child ordering across merges', () => {
     // (p) => {
-    //   validate(p.a, () => ({kind: 'custom:err-1'}));
+    //   validate(p.a, () => ({kind: 'err-1'}));
     //   apply(p, (p) => {
-    //     validate(p.a, () => ({kind: 'custom:err-2'}));
+    //     validate(p.a, () => ({kind: 'err-2'}));
     //   })
-    //   validate(p.a, () => ({kind: 'custom:err-3'}));
+    //   validate(p.a, () => ({kind: 'err-3'}));
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.getChild('a').addSyncErrorRule(() => [{kind: 'custom:err-1'}]);
+    builder.getChild('a').addSyncErrorRule(() => [{kind: 'err-1'}]);
 
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.getChild('a').addSyncErrorRule(() => [{kind: 'custom:err-2'}]);
+    builder2.getChild('a').addSyncErrorRule(() => [{kind: 'err-2'}]);
     builder.mergeIn(builder2);
 
-    builder.getChild('a').addSyncErrorRule(() => [{kind: 'custom:err-3'}]);
+    builder.getChild('a').addSyncErrorRule(() => [{kind: 'err-3'}]);
 
     const logicNode = builder.build();
     expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'custom:err-1'},
-      {kind: 'custom:err-2'},
-      {kind: 'custom:err-3'},
+      {kind: 'err-1'},
+      {kind: 'err-2'},
+      {kind: 'err-3'},
     ]);
   });
 
   it('should support circular logic structures', () => {
     // const s = schema((p) => {
-    //   validate(p, () => ({kind: 'custom:err-1'})),
+    //   validate(p, () => ({kind: 'err-1'})),
     //   apply(p.next, s);
     // }));
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.addSyncErrorRule(() => [{kind: 'custom:err-1'}]);
+    builder.addSyncErrorRule(() => [{kind: 'err-1'}]);
     builder.getChild('next').mergeIn(builder);
 
     const logicNode = builder.build();
-    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'custom:err-1'}]);
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
     expect(logicNode.getChild('next').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'custom:err-1'},
+      {kind: 'err-1'},
     ]);
     expect(
       logicNode.getChild('next').getChild('next').logic.syncErrors.compute(fakeFieldContext),
-    ).toEqual([{kind: 'custom:err-1'}]);
+    ).toEqual([{kind: 'err-1'}]);
   });
 
   it('should support circular logic structures with predicate', () => {
     // const s = schema((p) => {
-    //   validate(p, () => ({kind: 'custom:err-1'})),
+    //   validate(p, () => ({kind: 'err-1'})),
     //   applyWhen(p.next, pred, s);
     // }));
 
     const pred = signal(true);
     const builder = LogicNodeBuilder.newRoot();
-    builder.addSyncErrorRule(() => [{kind: 'custom:err-1'}]);
+    builder.addSyncErrorRule(() => [{kind: 'err-1'}]);
     builder.getChild('next').mergeIn(builder, {fn: () => pred(), path: undefined!});
 
     const logicNode = builder.build();
-    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'custom:err-1'}]);
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
     expect(logicNode.getChild('next').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'custom:err-1'},
+      {kind: 'err-1'},
     ]);
     expect(
       logicNode.getChild('next').getChild('next').logic.syncErrors.compute(fakeFieldContext),
-    ).toEqual([{kind: 'custom:err-1'}]);
+    ).toEqual([{kind: 'err-1'}]);
 
     // TODO: test that verifies that the same predicate can resolve with a different field context
     // on `.next` vs on `.next.next`
     pred.set(false);
-    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'custom:err-1'}]);
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
     expect(logicNode.getChild('next').logic.syncErrors.compute(fakeFieldContext)).toEqual([]);
     expect(
       logicNode.getChild('next').getChild('next').logic.syncErrors.compute(fakeFieldContext),

--- a/packages/forms/experimental/test/node/logic_node_2.spec.ts
+++ b/packages/forms/experimental/test/node/logic_node_2.spec.ts
@@ -23,10 +23,12 @@ describe('LogicNodeBuilder', () => {
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.addSyncErrorRule(() => [{kind: 'root-err'}]);
+    builder.addSyncErrorRule(() => [{kind: 'custom:root-err'}]);
 
     const logicNode = builder.build();
-    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'root-err'}]);
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
+      {kind: 'custom:root-err'},
+    ]);
   });
 
   it('should build child logic', () => {
@@ -35,58 +37,58 @@ describe('LogicNodeBuilder', () => {
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.getChild('a').addSyncErrorRule(() => [{kind: 'root-err'}]);
+    builder.getChild('a').addSyncErrorRule(() => [{kind: 'custom:root-err'}]);
 
     const logicNode = builder.build();
     expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'root-err'},
+      {kind: 'custom:root-err'},
     ]);
   });
 
   it('should build merged logic', () => {
     // (p) => {
-    //   validate(p, () => ({kind: 'err-1'}));
-    //   validate(p, () => ({kind: 'err-2'}));
+    //   validate(p, () => ({kind: 'custom:err-1'}));
+    //   validate(p, () => ({kind: 'custom:err-2'}));
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.addSyncErrorRule(() => [{kind: 'err-1'}]);
+    builder.addSyncErrorRule(() => [{kind: 'custom:err-1'}]);
 
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.addSyncErrorRule(() => [{kind: 'err-2'}]);
+    builder2.addSyncErrorRule(() => [{kind: 'custom:err-2'}]);
     builder.mergeIn(builder2);
 
     const logicNode = builder.build();
     expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'err-1'},
-      {kind: 'err-2'},
+      {kind: 'custom:err-1'},
+      {kind: 'custom:err-2'},
     ]);
   });
 
   it('should build merged child logic', () => {
     // (p) => {
-    //   validate(p.a, () => ({kind: 'err-1'}));
-    //   validate(p.a, () => ({kind: 'err-2'}));
+    //   validate(p.a, () => ({kind: 'custom:err-1'}));
+    //   validate(p.a, () => ({kind: 'custom:err-2'}));
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.getChild('a').addSyncErrorRule(() => [{kind: 'err-1'}]);
+    builder.getChild('a').addSyncErrorRule(() => [{kind: 'custom:err-1'}]);
 
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.getChild('a').addSyncErrorRule(() => [{kind: 'err-2'}]);
+    builder2.getChild('a').addSyncErrorRule(() => [{kind: 'custom:err-2'}]);
     builder.mergeIn(builder2);
 
     const logicNode = builder.build();
     expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'err-1'},
-      {kind: 'err-2'},
+      {kind: 'custom:err-1'},
+      {kind: 'custom:err-2'},
     ]);
   });
 
   it('should build logic with predicate', () => {
     // (p) => {
     //   applyWhen(p, pred, (p) => {
-    //     validate(p, () => ({kind: 'err-1'}));
+    //     validate(p, () => ({kind: 'custom:err-1'}));
     //   });
     // }
 
@@ -94,11 +96,11 @@ describe('LogicNodeBuilder', () => {
 
     const pred = signal(true);
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.addSyncErrorRule(() => [{kind: 'err-1'}]);
+    builder2.addSyncErrorRule(() => [{kind: 'custom:err-1'}]);
     builder.mergeIn(builder2, {fn: () => pred(), path: undefined!});
 
     const logicNode = builder.build();
-    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'custom:err-1'}]);
 
     pred.set(false);
     expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([]);
@@ -108,7 +110,7 @@ describe('LogicNodeBuilder', () => {
     // (p) => {
     //   applyWhen(p, pred, (p) => {
     //     apply(p, (p) => {
-    //       validate(p, () => ({kind: 'err-1'}));
+    //       validate(p, () => ({kind: 'custom:err-1'}));
     //     });
     //   });
     // }
@@ -119,13 +121,13 @@ describe('LogicNodeBuilder', () => {
     const builder2 = LogicNodeBuilder.newRoot();
 
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.addSyncErrorRule(() => [{kind: 'err-1'}]);
+    builder3.addSyncErrorRule(() => [{kind: 'custom:err-1'}]);
 
     builder2.mergeIn(builder3);
     builder.mergeIn(builder2, {fn: () => pred(), path: undefined!});
 
     const logicNode = builder.build();
-    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'custom:err-1'}]);
 
     pred.set(false);
     expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([]);
@@ -135,7 +137,7 @@ describe('LogicNodeBuilder', () => {
     // (p) => {
     //   applyWhen(p, pred, (p) => {
     //     apply(p, (p) => {
-    //       validate(p.a, () => ({kind: 'err-1'}));
+    //       validate(p.a, () => ({kind: 'custom:err-1'}));
     //     });
     //   });
     // }
@@ -146,14 +148,14 @@ describe('LogicNodeBuilder', () => {
     const builder2 = LogicNodeBuilder.newRoot();
 
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.getChild('a').addSyncErrorRule(() => [{kind: 'err-1'}]);
+    builder3.getChild('a').addSyncErrorRule(() => [{kind: 'custom:err-1'}]);
 
     builder2.mergeIn(builder3);
     builder.mergeIn(builder2, {fn: () => pred(), path: undefined!});
 
     const logicNode = builder.build();
     expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'err-1'},
+      {kind: 'custom:err-1'},
     ]);
 
     pred.set(false);
@@ -164,7 +166,7 @@ describe('LogicNodeBuilder', () => {
     // (p) => {
     //   applyWhen(p, pred, (p) => {
     //     applyWhen(p.a, pred2, (a) => {
-    //       validate(a, () => ({kind: 'err-1'}));
+    //       validate(a, () => ({kind: 'custom:err-1'}));
     //     });
     //   });
     // }
@@ -176,14 +178,14 @@ describe('LogicNodeBuilder', () => {
 
     const pred2 = signal(true);
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.addSyncErrorRule(() => [{kind: 'err-1'}]);
+    builder3.addSyncErrorRule(() => [{kind: 'custom:err-1'}]);
 
     builder2.getChild('a').mergeIn(builder3, {fn: () => pred2(), path: undefined!});
     builder.mergeIn(builder2, {fn: () => pred(), path: undefined!});
 
     const logicNode = builder.build();
     expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'err-1'},
+      {kind: 'custom:err-1'},
     ]);
 
     pred.set(false);
@@ -198,11 +200,11 @@ describe('LogicNodeBuilder', () => {
   it('should propagate predicates through deep application', () => {
     // (p) => {
     //   applyWhen(p, pred, (p) => {
-    //     validate(p.a.b, () => ({kind: 'err-1'}));
+    //     validate(p.a.b, () => ({kind: 'custom:err-1'}));
     //     applyWhen(p.a, pred2, (a) => {
-    //       validate(a.b, () => ({kind: 'err-2'}));
+    //       validate(a.b, () => ({kind: 'custom:err-2'}));
     //       applyWhen(a.b, pred3, (b) => {
-    //         validate(b, () => ({kind: 'err-3'}));
+    //         validate(b, () => ({kind: 'custom:err-3'}));
     //       });
     //     });
     //   });
@@ -215,15 +217,15 @@ describe('LogicNodeBuilder', () => {
     builder2
       .getChild('a')
       .getChild('b')
-      .addSyncErrorRule(() => [{kind: 'err-1'}]);
+      .addSyncErrorRule(() => [{kind: 'custom:err-1'}]);
 
     const pred2 = signal(true);
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.getChild('b').addSyncErrorRule(() => [{kind: 'err-2'}]);
+    builder3.getChild('b').addSyncErrorRule(() => [{kind: 'custom:err-2'}]);
 
     const pred3 = signal(true);
     const builder4 = LogicNodeBuilder.newRoot();
-    builder4.addSyncErrorRule(() => [{kind: 'err-3'}]);
+    builder4.addSyncErrorRule(() => [{kind: 'custom:err-3'}]);
     builder3.getChild('b').mergeIn(builder4, {fn: () => pred3(), path: undefined!});
     builder2.getChild('a').mergeIn(builder3, {fn: () => pred2(), path: undefined!});
     builder.mergeIn(builder2, {fn: () => pred(), path: undefined!});
@@ -231,21 +233,21 @@ describe('LogicNodeBuilder', () => {
     const logicNode = builder.build();
     expect(
       logicNode.getChild('a').getChild('b').logic.syncErrors.compute(fakeFieldContext),
-    ).toEqual([{kind: 'err-1'}, {kind: 'err-2'}, {kind: 'err-3'}]);
+    ).toEqual([{kind: 'custom:err-1'}, {kind: 'custom:err-2'}, {kind: 'custom:err-3'}]);
 
     pred.set(true);
     pred2.set(true);
     pred3.set(false);
     expect(
       logicNode.getChild('a').getChild('b').logic.syncErrors.compute(fakeFieldContext),
-    ).toEqual([{kind: 'err-1'}, {kind: 'err-2'}]);
+    ).toEqual([{kind: 'custom:err-1'}, {kind: 'custom:err-2'}]);
 
     pred.set(true);
     pred2.set(false);
     pred3.set(true);
     expect(
       logicNode.getChild('a').getChild('b').logic.syncErrors.compute(fakeFieldContext),
-    ).toEqual([{kind: 'err-1'}]);
+    ).toEqual([{kind: 'custom:err-1'}]);
 
     pred.set(false);
     pred2.set(true);
@@ -259,7 +261,7 @@ describe('LogicNodeBuilder', () => {
     // (p) => {
     //   applyWhen(p, pred, (p) => {
     //     applyEach(p.items, (i) => {
-    //       validate(i.last, () => ({kind: 'err-1'}));
+    //       validate(i.last, () => ({kind: 'custom:err-1'}));
     //     });
     //   });
     // };
@@ -270,7 +272,7 @@ describe('LogicNodeBuilder', () => {
     const builder2 = LogicNodeBuilder.newRoot();
 
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.getChild('last').addSyncErrorRule(() => [{kind: 'err-1'}]);
+    builder3.getChild('last').addSyncErrorRule(() => [{kind: 'custom:err-1'}]);
 
     builder2.getChild('items').getChild(DYNAMIC).mergeIn(builder3);
     builder.mergeIn(builder2, {fn: () => pred(), path: undefined!});
@@ -282,7 +284,7 @@ describe('LogicNodeBuilder', () => {
         .getChild(DYNAMIC)
         .getChild('last')
         .logic.syncErrors.compute(fakeFieldContext),
-    ).toEqual([{kind: 'err-1'}]);
+    ).toEqual([{kind: 'custom:err-1'}]);
 
     pred.set(false);
     expect(
@@ -296,100 +298,100 @@ describe('LogicNodeBuilder', () => {
 
   it('should preserve ordering across merges', () => {
     // (p) => {
-    //   validate(p, () => ({kind: 'err-1'}));
+    //   validate(p, () => ({kind: 'custom:err-1'}));
     //   apply(p, (p) => {
-    //     validate(p, () => ({kind: 'err-2'}));
+    //     validate(p, () => ({kind: 'custom:err-2'}));
     //   })
-    //   validate(p, () => ({kind: 'err-3'}));
+    //   validate(p, () => ({kind: 'custom:err-3'}));
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.addSyncErrorRule(() => [{kind: 'err-1'}]);
+    builder.addSyncErrorRule(() => [{kind: 'custom:err-1'}]);
 
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.addSyncErrorRule(() => [{kind: 'err-2'}]);
+    builder2.addSyncErrorRule(() => [{kind: 'custom:err-2'}]);
     builder.mergeIn(builder2);
 
-    builder.addSyncErrorRule(() => [{kind: 'err-3'}]);
+    builder.addSyncErrorRule(() => [{kind: 'custom:err-3'}]);
 
     const logicNode = builder.build();
     expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'err-1'},
-      {kind: 'err-2'},
-      {kind: 'err-3'},
+      {kind: 'custom:err-1'},
+      {kind: 'custom:err-2'},
+      {kind: 'custom:err-3'},
     ]);
   });
 
   it('should preserve child ordering across merges', () => {
     // (p) => {
-    //   validate(p.a, () => ({kind: 'err-1'}));
+    //   validate(p.a, () => ({kind: 'custom:err-1'}));
     //   apply(p, (p) => {
-    //     validate(p.a, () => ({kind: 'err-2'}));
+    //     validate(p.a, () => ({kind: 'custom:err-2'}));
     //   })
-    //   validate(p.a, () => ({kind: 'err-3'}));
+    //   validate(p.a, () => ({kind: 'custom:err-3'}));
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.getChild('a').addSyncErrorRule(() => [{kind: 'err-1'}]);
+    builder.getChild('a').addSyncErrorRule(() => [{kind: 'custom:err-1'}]);
 
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.getChild('a').addSyncErrorRule(() => [{kind: 'err-2'}]);
+    builder2.getChild('a').addSyncErrorRule(() => [{kind: 'custom:err-2'}]);
     builder.mergeIn(builder2);
 
-    builder.getChild('a').addSyncErrorRule(() => [{kind: 'err-3'}]);
+    builder.getChild('a').addSyncErrorRule(() => [{kind: 'custom:err-3'}]);
 
     const logicNode = builder.build();
     expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'err-1'},
-      {kind: 'err-2'},
-      {kind: 'err-3'},
+      {kind: 'custom:err-1'},
+      {kind: 'custom:err-2'},
+      {kind: 'custom:err-3'},
     ]);
   });
 
   it('should support circular logic structures', () => {
     // const s = schema((p) => {
-    //   validate(p, () => ({kind: 'err-1'})),
+    //   validate(p, () => ({kind: 'custom:err-1'})),
     //   apply(p.next, s);
     // }));
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.addSyncErrorRule(() => [{kind: 'err-1'}]);
+    builder.addSyncErrorRule(() => [{kind: 'custom:err-1'}]);
     builder.getChild('next').mergeIn(builder);
 
     const logicNode = builder.build();
-    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'custom:err-1'}]);
     expect(logicNode.getChild('next').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'err-1'},
+      {kind: 'custom:err-1'},
     ]);
     expect(
       logicNode.getChild('next').getChild('next').logic.syncErrors.compute(fakeFieldContext),
-    ).toEqual([{kind: 'err-1'}]);
+    ).toEqual([{kind: 'custom:err-1'}]);
   });
 
   it('should support circular logic structures with predicate', () => {
     // const s = schema((p) => {
-    //   validate(p, () => ({kind: 'err-1'})),
+    //   validate(p, () => ({kind: 'custom:err-1'})),
     //   applyWhen(p.next, pred, s);
     // }));
 
     const pred = signal(true);
     const builder = LogicNodeBuilder.newRoot();
-    builder.addSyncErrorRule(() => [{kind: 'err-1'}]);
+    builder.addSyncErrorRule(() => [{kind: 'custom:err-1'}]);
     builder.getChild('next').mergeIn(builder, {fn: () => pred(), path: undefined!});
 
     const logicNode = builder.build();
-    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'custom:err-1'}]);
     expect(logicNode.getChild('next').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'err-1'},
+      {kind: 'custom:err-1'},
     ]);
     expect(
       logicNode.getChild('next').getChild('next').logic.syncErrors.compute(fakeFieldContext),
-    ).toEqual([{kind: 'err-1'}]);
+    ).toEqual([{kind: 'custom:err-1'}]);
 
     // TODO: test that verifies that the same predicate can resolve with a different field context
     // on `.next` vs on `.next.next`
     pred.set(false);
-    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'custom:err-1'}]);
     expect(logicNode.getChild('next').logic.syncErrors.compute(fakeFieldContext)).toEqual([]);
     expect(
       logicNode.getChild('next').getChild('next').logic.syncErrors.compute(fakeFieldContext),

--- a/packages/forms/experimental/test/node/logic_node_2.spec.ts
+++ b/packages/forms/experimental/test/node/logic_node_2.spec.ts
@@ -1,5 +1,14 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
 import {signal} from '@angular/core';
 import {FieldContext, FieldState} from '../../public_api';
+import {ValidationError} from '../../src/api/validation_errors';
 import {DYNAMIC} from '../../src/logic_node';
 import {LogicNodeBuilder} from '../../src/logic_node_2';
 
@@ -23,10 +32,12 @@ describe('LogicNodeBuilder', () => {
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.addSyncErrorRule(() => [{kind: 'root-err'}]);
+    builder.addSyncErrorRule(() => [ValidationError.custom({kind: 'root-err'})]);
 
     const logicNode = builder.build();
-    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'root-err'}]);
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
+      ValidationError.custom({kind: 'root-err'}),
+    ]);
   });
 
   it('should build child logic', () => {
@@ -35,11 +46,11 @@ describe('LogicNodeBuilder', () => {
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.getChild('a').addSyncErrorRule(() => [{kind: 'root-err'}]);
+    builder.getChild('a').addSyncErrorRule(() => [ValidationError.custom({kind: 'root-err'})]);
 
     const logicNode = builder.build();
     expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'root-err'},
+      ValidationError.custom({kind: 'root-err'}),
     ]);
   });
 
@@ -50,16 +61,16 @@ describe('LogicNodeBuilder', () => {
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.addSyncErrorRule(() => [{kind: 'err-1'}]);
+    builder.addSyncErrorRule(() => [ValidationError.custom({kind: 'err-1'})]);
 
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.addSyncErrorRule(() => [{kind: 'err-2'}]);
+    builder2.addSyncErrorRule(() => [ValidationError.custom({kind: 'err-2'})]);
     builder.mergeIn(builder2);
 
     const logicNode = builder.build();
     expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'err-1'},
-      {kind: 'err-2'},
+      ValidationError.custom({kind: 'err-1'}),
+      ValidationError.custom({kind: 'err-2'}),
     ]);
   });
 
@@ -70,16 +81,16 @@ describe('LogicNodeBuilder', () => {
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.getChild('a').addSyncErrorRule(() => [{kind: 'err-1'}]);
+    builder.getChild('a').addSyncErrorRule(() => [ValidationError.custom({kind: 'err-1'})]);
 
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.getChild('a').addSyncErrorRule(() => [{kind: 'err-2'}]);
+    builder2.getChild('a').addSyncErrorRule(() => [ValidationError.custom({kind: 'err-2'})]);
     builder.mergeIn(builder2);
 
     const logicNode = builder.build();
     expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'err-1'},
-      {kind: 'err-2'},
+      ValidationError.custom({kind: 'err-1'}),
+      ValidationError.custom({kind: 'err-2'}),
     ]);
   });
 
@@ -94,11 +105,13 @@ describe('LogicNodeBuilder', () => {
 
     const pred = signal(true);
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.addSyncErrorRule(() => [{kind: 'err-1'}]);
+    builder2.addSyncErrorRule(() => [ValidationError.custom({kind: 'err-1'})]);
     builder.mergeIn(builder2, {fn: () => pred(), path: undefined!});
 
     const logicNode = builder.build();
-    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
+      ValidationError.custom({kind: 'err-1'}),
+    ]);
 
     pred.set(false);
     expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([]);
@@ -119,13 +132,15 @@ describe('LogicNodeBuilder', () => {
     const builder2 = LogicNodeBuilder.newRoot();
 
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.addSyncErrorRule(() => [{kind: 'err-1'}]);
+    builder3.addSyncErrorRule(() => [ValidationError.custom({kind: 'err-1'})]);
 
     builder2.mergeIn(builder3);
     builder.mergeIn(builder2, {fn: () => pred(), path: undefined!});
 
     const logicNode = builder.build();
-    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
+      ValidationError.custom({kind: 'err-1'}),
+    ]);
 
     pred.set(false);
     expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([]);
@@ -146,14 +161,14 @@ describe('LogicNodeBuilder', () => {
     const builder2 = LogicNodeBuilder.newRoot();
 
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.getChild('a').addSyncErrorRule(() => [{kind: 'err-1'}]);
+    builder3.getChild('a').addSyncErrorRule(() => [ValidationError.custom({kind: 'err-1'})]);
 
     builder2.mergeIn(builder3);
     builder.mergeIn(builder2, {fn: () => pred(), path: undefined!});
 
     const logicNode = builder.build();
     expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'err-1'},
+      ValidationError.custom({kind: 'err-1'}),
     ]);
 
     pred.set(false);
@@ -176,14 +191,14 @@ describe('LogicNodeBuilder', () => {
 
     const pred2 = signal(true);
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.addSyncErrorRule(() => [{kind: 'err-1'}]);
+    builder3.addSyncErrorRule(() => [ValidationError.custom({kind: 'err-1'})]);
 
     builder2.getChild('a').mergeIn(builder3, {fn: () => pred2(), path: undefined!});
     builder.mergeIn(builder2, {fn: () => pred(), path: undefined!});
 
     const logicNode = builder.build();
     expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'err-1'},
+      ValidationError.custom({kind: 'err-1'}),
     ]);
 
     pred.set(false);
@@ -215,15 +230,15 @@ describe('LogicNodeBuilder', () => {
     builder2
       .getChild('a')
       .getChild('b')
-      .addSyncErrorRule(() => [{kind: 'err-1'}]);
+      .addSyncErrorRule(() => [ValidationError.custom({kind: 'err-1'})]);
 
     const pred2 = signal(true);
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.getChild('b').addSyncErrorRule(() => [{kind: 'err-2'}]);
+    builder3.getChild('b').addSyncErrorRule(() => [ValidationError.custom({kind: 'err-2'})]);
 
     const pred3 = signal(true);
     const builder4 = LogicNodeBuilder.newRoot();
-    builder4.addSyncErrorRule(() => [{kind: 'err-3'}]);
+    builder4.addSyncErrorRule(() => [ValidationError.custom({kind: 'err-3'})]);
     builder3.getChild('b').mergeIn(builder4, {fn: () => pred3(), path: undefined!});
     builder2.getChild('a').mergeIn(builder3, {fn: () => pred2(), path: undefined!});
     builder.mergeIn(builder2, {fn: () => pred(), path: undefined!});
@@ -231,21 +246,25 @@ describe('LogicNodeBuilder', () => {
     const logicNode = builder.build();
     expect(
       logicNode.getChild('a').getChild('b').logic.syncErrors.compute(fakeFieldContext),
-    ).toEqual([{kind: 'err-1'}, {kind: 'err-2'}, {kind: 'err-3'}]);
+    ).toEqual([
+      ValidationError.custom({kind: 'err-1'}),
+      ValidationError.custom({kind: 'err-2'}),
+      ValidationError.custom({kind: 'err-3'}),
+    ]);
 
     pred.set(true);
     pred2.set(true);
     pred3.set(false);
     expect(
       logicNode.getChild('a').getChild('b').logic.syncErrors.compute(fakeFieldContext),
-    ).toEqual([{kind: 'err-1'}, {kind: 'err-2'}]);
+    ).toEqual([ValidationError.custom({kind: 'err-1'}), ValidationError.custom({kind: 'err-2'})]);
 
     pred.set(true);
     pred2.set(false);
     pred3.set(true);
     expect(
       logicNode.getChild('a').getChild('b').logic.syncErrors.compute(fakeFieldContext),
-    ).toEqual([{kind: 'err-1'}]);
+    ).toEqual([ValidationError.custom({kind: 'err-1'})]);
 
     pred.set(false);
     pred2.set(true);
@@ -270,7 +289,7 @@ describe('LogicNodeBuilder', () => {
     const builder2 = LogicNodeBuilder.newRoot();
 
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.getChild('last').addSyncErrorRule(() => [{kind: 'err-1'}]);
+    builder3.getChild('last').addSyncErrorRule(() => [ValidationError.custom({kind: 'err-1'})]);
 
     builder2.getChild('items').getChild(DYNAMIC).mergeIn(builder3);
     builder.mergeIn(builder2, {fn: () => pred(), path: undefined!});
@@ -282,7 +301,7 @@ describe('LogicNodeBuilder', () => {
         .getChild(DYNAMIC)
         .getChild('last')
         .logic.syncErrors.compute(fakeFieldContext),
-    ).toEqual([{kind: 'err-1'}]);
+    ).toEqual([ValidationError.custom({kind: 'err-1'})]);
 
     pred.set(false);
     expect(
@@ -304,19 +323,19 @@ describe('LogicNodeBuilder', () => {
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.addSyncErrorRule(() => [{kind: 'err-1'}]);
+    builder.addSyncErrorRule(() => [ValidationError.custom({kind: 'err-1'})]);
 
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.addSyncErrorRule(() => [{kind: 'err-2'}]);
+    builder2.addSyncErrorRule(() => [ValidationError.custom({kind: 'err-2'})]);
     builder.mergeIn(builder2);
 
-    builder.addSyncErrorRule(() => [{kind: 'err-3'}]);
+    builder.addSyncErrorRule(() => [ValidationError.custom({kind: 'err-3'})]);
 
     const logicNode = builder.build();
     expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'err-1'},
-      {kind: 'err-2'},
-      {kind: 'err-3'},
+      ValidationError.custom({kind: 'err-1'}),
+      ValidationError.custom({kind: 'err-2'}),
+      ValidationError.custom({kind: 'err-3'}),
     ]);
   });
 
@@ -330,19 +349,19 @@ describe('LogicNodeBuilder', () => {
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.getChild('a').addSyncErrorRule(() => [{kind: 'err-1'}]);
+    builder.getChild('a').addSyncErrorRule(() => [ValidationError.custom({kind: 'err-1'})]);
 
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.getChild('a').addSyncErrorRule(() => [{kind: 'err-2'}]);
+    builder2.getChild('a').addSyncErrorRule(() => [ValidationError.custom({kind: 'err-2'})]);
     builder.mergeIn(builder2);
 
-    builder.getChild('a').addSyncErrorRule(() => [{kind: 'err-3'}]);
+    builder.getChild('a').addSyncErrorRule(() => [ValidationError.custom({kind: 'err-3'})]);
 
     const logicNode = builder.build();
     expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'err-1'},
-      {kind: 'err-2'},
-      {kind: 'err-3'},
+      ValidationError.custom({kind: 'err-1'}),
+      ValidationError.custom({kind: 'err-2'}),
+      ValidationError.custom({kind: 'err-3'}),
     ]);
   });
 
@@ -353,17 +372,19 @@ describe('LogicNodeBuilder', () => {
     // }));
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.addSyncErrorRule(() => [{kind: 'err-1'}]);
+    builder.addSyncErrorRule(() => [ValidationError.custom({kind: 'err-1'})]);
     builder.getChild('next').mergeIn(builder);
 
     const logicNode = builder.build();
-    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
+      ValidationError.custom({kind: 'err-1'}),
+    ]);
     expect(logicNode.getChild('next').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'err-1'},
+      ValidationError.custom({kind: 'err-1'}),
     ]);
     expect(
       logicNode.getChild('next').getChild('next').logic.syncErrors.compute(fakeFieldContext),
-    ).toEqual([{kind: 'err-1'}]);
+    ).toEqual([ValidationError.custom({kind: 'err-1'})]);
   });
 
   it('should support circular logic structures with predicate', () => {
@@ -374,22 +395,26 @@ describe('LogicNodeBuilder', () => {
 
     const pred = signal(true);
     const builder = LogicNodeBuilder.newRoot();
-    builder.addSyncErrorRule(() => [{kind: 'err-1'}]);
+    builder.addSyncErrorRule(() => [ValidationError.custom({kind: 'err-1'})]);
     builder.getChild('next').mergeIn(builder, {fn: () => pred(), path: undefined!});
 
     const logicNode = builder.build();
-    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
+      ValidationError.custom({kind: 'err-1'}),
+    ]);
     expect(logicNode.getChild('next').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      {kind: 'err-1'},
+      ValidationError.custom({kind: 'err-1'}),
     ]);
     expect(
       logicNode.getChild('next').getChild('next').logic.syncErrors.compute(fakeFieldContext),
-    ).toEqual([{kind: 'err-1'}]);
+    ).toEqual([ValidationError.custom({kind: 'err-1'})]);
 
     // TODO: test that verifies that the same predicate can resolve with a different field context
     // on `.next` vs on `.next.next`
     pred.set(false);
-    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([{kind: 'err-1'}]);
+    expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
+      ValidationError.custom({kind: 'err-1'}),
+    ]);
     expect(logicNode.getChild('next').logic.syncErrors.compute(fakeFieldContext)).toEqual([]);
     expect(
       logicNode.getChild('next').getChild('next').logic.syncErrors.compute(fakeFieldContext),

--- a/packages/forms/experimental/test/node/path.spec.ts
+++ b/packages/forms/experimental/test/node/path.spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {Injector, signal} from '@angular/core';
@@ -24,7 +24,7 @@ describe('path', () => {
             (/* UNUSED */) => {
               expect(() => {
                 validate(path.last, ({value}) =>
-                  value().length > 0 ? undefined : {kind: 'ng:required'},
+                  value().length > 0 ? undefined : {kind: 'required'},
                 );
               }).toThrowError();
             },
@@ -43,7 +43,7 @@ describe('path', () => {
           apply(path, (/* UNUSED */) => {
             expect(() => {
               validate(path.last, ({value}) => {
-                return {kind: 'custom:does not matter'};
+                return {kind: 'does not matter'};
               });
             }).toThrowError();
           });
@@ -61,7 +61,7 @@ describe('path', () => {
           apply(path, (/* UNUSED */) => {
             expect(() => {
               validate(path, ({value}) => {
-                return {kind: 'custom:does not matter'};
+                return {kind: 'does not matter'};
               });
             }).toThrowError();
           });
@@ -82,7 +82,7 @@ describe('path', () => {
           applyEach(path.items, (/* UNUSED */) => {
             expect(() => {
               validate(path.needLastName, ({value}) => {
-                return {kind: 'custom:does not matter'};
+                return {kind: 'does not matter'};
               });
             }).toThrowError();
           });

--- a/packages/forms/experimental/test/node/path.spec.ts
+++ b/packages/forms/experimental/test/node/path.spec.ts
@@ -24,7 +24,7 @@ describe('path', () => {
             (/* UNUSED */) => {
               expect(() => {
                 validate(path.last, ({value}) =>
-                  value().length > 0 ? undefined : {kind: 'required'},
+                  value().length > 0 ? undefined : {kind: 'ng:required'},
                 );
               }).toThrowError();
             },
@@ -43,7 +43,7 @@ describe('path', () => {
           apply(path, (/* UNUSED */) => {
             expect(() => {
               validate(path.last, ({value}) => {
-                return {kind: 'does not matter'};
+                return {kind: 'custom:does not matter'};
               });
             }).toThrowError();
           });
@@ -61,7 +61,7 @@ describe('path', () => {
           apply(path, (/* UNUSED */) => {
             expect(() => {
               validate(path, ({value}) => {
-                return {kind: 'does not matter'};
+                return {kind: 'custom:does not matter'};
               });
             }).toThrowError();
           });
@@ -82,7 +82,7 @@ describe('path', () => {
           applyEach(path.items, (/* UNUSED */) => {
             expect(() => {
               validate(path.needLastName, ({value}) => {
-                return {kind: 'does not matter'};
+                return {kind: 'custom:does not matter'};
               });
             }).toThrowError();
           });

--- a/packages/forms/experimental/test/node/path.spec.ts
+++ b/packages/forms/experimental/test/node/path.spec.ts
@@ -9,6 +9,7 @@
 import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {apply, applyEach, applyWhen, form, validate} from '../../public_api';
+import {ValidationError} from '../../src/api/validation_errors';
 
 describe('path', () => {
   describe('Active path', () => {
@@ -24,7 +25,7 @@ describe('path', () => {
             (/* UNUSED */) => {
               expect(() => {
                 validate(path.last, ({value}) =>
-                  value().length > 0 ? undefined : {kind: 'required'},
+                  value().length > 0 ? undefined : ValidationError.required(),
                 );
               }).toThrowError();
             },
@@ -40,10 +41,10 @@ describe('path', () => {
       form(
         data,
         (path) => {
-          apply(path, (/* UNUSED */) => {
+          apply(path, () => {
             expect(() => {
-              validate(path.last, ({value}) => {
-                return {kind: 'does not matter'};
+              validate(path.last, () => {
+                return ValidationError.custom();
               });
             }).toThrowError();
           });
@@ -58,10 +59,10 @@ describe('path', () => {
       form(
         data,
         (path) => {
-          apply(path, (/* UNUSED */) => {
+          apply(path, () => {
             expect(() => {
-              validate(path, ({value}) => {
-                return {kind: 'does not matter'};
+              validate(path, () => {
+                return ValidationError.custom();
               });
             }).toThrowError();
           });
@@ -79,10 +80,10 @@ describe('path', () => {
       form(
         data,
         (path) => {
-          applyEach(path.items, (/* UNUSED */) => {
+          applyEach(path.items, () => {
             expect(() => {
-              validate(path.needLastName, ({value}) => {
-                return {kind: 'does not matter'};
+              validate(path.needLastName, () => {
+                return ValidationError.custom();
               });
             }).toThrowError();
           });

--- a/packages/forms/experimental/test/node/resource.spec.ts
+++ b/packages/forms/experimental/test/node/resource.spec.ts
@@ -57,7 +57,7 @@ describe('resources', () => {
       validate(p.name, ({state}) => {
         const remote = state.data(res)!;
         if (remote.hasValue()) {
-          return {kind: 'whatever', message: remote.value()!.toString()};
+          return {kind: 'custom:whatever', message: remote.value()!.toString()};
         } else {
           return undefined;
         }
@@ -71,7 +71,7 @@ describe('resources', () => {
     await appRef.whenStable();
     expect(f.name().errors()).toEqual([
       {
-        kind: 'whatever',
+        kind: 'custom:whatever',
         message: 'got: cat',
       },
     ]);
@@ -80,7 +80,7 @@ describe('resources', () => {
     await appRef.whenStable();
     expect(f.name().errors()).toEqual([
       {
-        kind: 'whatever',
+        kind: 'custom:whatever',
         message: 'got: dog',
       },
     ]);
@@ -99,7 +99,7 @@ describe('resources', () => {
         validate(p.name, ({state}) => {
           const remote = state.data(res)!;
           if (remote.hasValue()) {
-            return {kind: 'whatever', message: remote.value()!.toString()};
+            return {kind: 'custom:whatever', message: remote.value()!.toString()};
           } else {
             return undefined;
           }
@@ -114,13 +114,13 @@ describe('resources', () => {
     await appRef.whenStable();
     expect(f[0].name().errors()).toEqual([
       {
-        kind: 'whatever',
+        kind: 'custom:whatever',
         message: 'got: cat',
       },
     ]);
     expect(f[1].name().errors()).toEqual([
       {
-        kind: 'whatever',
+        kind: 'custom:whatever',
         message: 'got: dog',
       },
     ]);
@@ -129,13 +129,13 @@ describe('resources', () => {
     await appRef.whenStable();
     expect(f[0].name().errors()).toEqual([
       {
-        kind: 'whatever',
+        kind: 'custom:whatever',
         message: 'got: bunny',
       },
     ]);
     expect(f[1].name().errors()).toEqual([
       {
-        kind: 'whatever',
+        kind: 'custom:whatever',
         message: 'got: dog',
       },
     ]);
@@ -154,7 +154,7 @@ describe('resources', () => {
           }),
         errors: (cats, {fieldOf}) => {
           return cats.map((cat, index) => ({
-            kind: 'meows_too_much',
+            kind: 'custom:meows_too_much',
             name: cat.name,
             field: fieldOf(p)[index],
           }));
@@ -167,10 +167,10 @@ describe('resources', () => {
 
     await appRef.whenStable();
     expect(f[0]().errors()).toEqual([
-      jasmine.objectContaining({kind: 'meows_too_much', name: 'Fluffy'}),
+      jasmine.objectContaining({kind: 'custom:meows_too_much', name: 'Fluffy'}),
     ]);
     expect(f[1]().errors()).toEqual([
-      jasmine.objectContaining({kind: 'meows_too_much', name: 'Ziggy'}),
+      jasmine.objectContaining({kind: 'custom:meows_too_much', name: 'Ziggy'}),
     ]);
   });
 
@@ -187,7 +187,7 @@ describe('resources', () => {
           }),
         errors: (cats, {fieldOf}) => {
           return {
-            kind: 'meows_too_much',
+            kind: 'custom:meows_too_much',
             name: cats[0].name,
             field: fieldOf(p)[0],
           };
@@ -200,7 +200,7 @@ describe('resources', () => {
 
     await appRef.whenStable();
     expect(f[0]().errors()).toEqual([
-      jasmine.objectContaining({kind: 'meows_too_much', name: 'Fluffy'}),
+      jasmine.objectContaining({kind: 'custom:meows_too_much', name: 'Fluffy'}),
     ]);
     expect(f[1]().errors()).toEqual([]);
   });
@@ -211,7 +211,7 @@ describe('resources', () => {
       (p) => {
         validateHttp(p, {
           request: ({value}) => `/api/check?username=${value()}`,
-          errors: (available: boolean) => (available ? undefined : {kind: 'username-taken'}),
+          errors: (available: boolean) => (available ? undefined : {kind: 'custom:username-taken'}),
         });
       },
       {injector},

--- a/packages/forms/experimental/test/node/resource.spec.ts
+++ b/packages/forms/experimental/test/node/resource.spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 import {provideHttpClient} from '@angular/common/http';
 import {HttpTestingController, provideHttpClientTesting} from '@angular/common/http/testing';
@@ -57,7 +57,7 @@ describe('resources', () => {
       validate(p.name, ({state}) => {
         const remote = state.data(res)!;
         if (remote.hasValue()) {
-          return {kind: 'custom:whatever', message: remote.value()!.toString()};
+          return {kind: 'whatever', message: remote.value()!.toString()};
         } else {
           return undefined;
         }
@@ -71,7 +71,7 @@ describe('resources', () => {
     await appRef.whenStable();
     expect(f.name().errors()).toEqual([
       {
-        kind: 'custom:whatever',
+        kind: 'whatever',
         message: 'got: cat',
       },
     ]);
@@ -80,7 +80,7 @@ describe('resources', () => {
     await appRef.whenStable();
     expect(f.name().errors()).toEqual([
       {
-        kind: 'custom:whatever',
+        kind: 'whatever',
         message: 'got: dog',
       },
     ]);
@@ -99,7 +99,7 @@ describe('resources', () => {
         validate(p.name, ({state}) => {
           const remote = state.data(res)!;
           if (remote.hasValue()) {
-            return {kind: 'custom:whatever', message: remote.value()!.toString()};
+            return {kind: 'whatever', message: remote.value()!.toString()};
           } else {
             return undefined;
           }
@@ -114,13 +114,13 @@ describe('resources', () => {
     await appRef.whenStable();
     expect(f[0].name().errors()).toEqual([
       {
-        kind: 'custom:whatever',
+        kind: 'whatever',
         message: 'got: cat',
       },
     ]);
     expect(f[1].name().errors()).toEqual([
       {
-        kind: 'custom:whatever',
+        kind: 'whatever',
         message: 'got: dog',
       },
     ]);
@@ -129,13 +129,13 @@ describe('resources', () => {
     await appRef.whenStable();
     expect(f[0].name().errors()).toEqual([
       {
-        kind: 'custom:whatever',
+        kind: 'whatever',
         message: 'got: bunny',
       },
     ]);
     expect(f[1].name().errors()).toEqual([
       {
-        kind: 'custom:whatever',
+        kind: 'whatever',
         message: 'got: dog',
       },
     ]);
@@ -154,7 +154,7 @@ describe('resources', () => {
           }),
         errors: (cats, {fieldOf}) => {
           return cats.map((cat, index) => ({
-            kind: 'custom:meows_too_much',
+            kind: 'meows_too_much',
             name: cat.name,
             field: fieldOf(p)[index],
           }));
@@ -167,10 +167,10 @@ describe('resources', () => {
 
     await appRef.whenStable();
     expect(f[0]().errors()).toEqual([
-      jasmine.objectContaining({kind: 'custom:meows_too_much', name: 'Fluffy'}),
+      jasmine.objectContaining({kind: 'meows_too_much', name: 'Fluffy'}),
     ]);
     expect(f[1]().errors()).toEqual([
-      jasmine.objectContaining({kind: 'custom:meows_too_much', name: 'Ziggy'}),
+      jasmine.objectContaining({kind: 'meows_too_much', name: 'Ziggy'}),
     ]);
   });
 
@@ -187,7 +187,7 @@ describe('resources', () => {
           }),
         errors: (cats, {fieldOf}) => {
           return {
-            kind: 'custom:meows_too_much',
+            kind: 'meows_too_much',
             name: cats[0].name,
             field: fieldOf(p)[0],
           };
@@ -200,7 +200,7 @@ describe('resources', () => {
 
     await appRef.whenStable();
     expect(f[0]().errors()).toEqual([
-      jasmine.objectContaining({kind: 'custom:meows_too_much', name: 'Fluffy'}),
+      jasmine.objectContaining({kind: 'meows_too_much', name: 'Fluffy'}),
     ]);
     expect(f[1]().errors()).toEqual([]);
   });
@@ -211,7 +211,7 @@ describe('resources', () => {
       (p) => {
         validateHttp(p, {
           request: ({value}) => `/api/check?username=${value()}`,
-          errors: (available: boolean) => (available ? undefined : {kind: 'custom:username-taken'}),
+          errors: (available: boolean) => (available ? undefined : {kind: 'username-taken'}),
         });
       },
       {injector},

--- a/packages/forms/experimental/test/node/validation_status.spec.ts
+++ b/packages/forms/experimental/test/node/validation_status.spec.ts
@@ -8,22 +8,18 @@
 
 import {ApplicationRef, Injector, Resource, resource, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {
-  Field,
-  form,
-  FormError,
-  FormTreeError,
-  validate,
-  validateAsync,
-  validateTree,
-} from '../../public_api';
+import {Field, form, validate, validateAsync, validateTree} from '../../public_api';
+import {ValidationError, ValidationTreeError} from '../../src/api/validation_errors';
 
-function validateValue(value: string): FormError[] {
-  return value === 'INVALID' ? [{kind: 'error'}] : [];
+function validateValue(value: string): ValidationError[] {
+  return value === 'INVALID' ? [{kind: 'custom:error'}] : [];
 }
 
-function validateValueForChild(value: string, field: Field<unknown> | undefined): FormTreeError[] {
-  return value === 'INVALID' ? [{kind: 'error', field}] : [];
+function validateValueForChild(
+  value: string,
+  field: Field<unknown> | undefined,
+): ValidationTreeError[] {
+  return value === 'INVALID' ? [{kind: 'custom:error', field}] : [];
 }
 
 async function waitFor(fn: () => boolean, count = 100): Promise<void> {
@@ -200,7 +196,7 @@ describe('validation status', () => {
               (res = resource({
                 params,
                 loader: ({params}) =>
-                  new Promise<FormTreeError[]>((r) =>
+                  new Promise<ValidationTreeError[]>((r) =>
                     setTimeout(() => r(validateValueForChild(params, undefined))),
                   ),
               })),
@@ -252,7 +248,7 @@ describe('validation status', () => {
               (res = resource({
                 params,
                 loader: ({params}) =>
-                  new Promise<FormTreeError[]>((r) =>
+                  new Promise<ValidationTreeError[]>((r) =>
                     setTimeout(() => r(validateValueForChild(params, undefined))),
                   ),
               })),
@@ -308,7 +304,7 @@ describe('validation status', () => {
               (res = resource({
                 params,
                 loader: ({params}) =>
-                  new Promise<FormTreeError[]>((r) =>
+                  new Promise<ValidationTreeError[]>((r) =>
                     setTimeout(() => r(validateValueForChild(params, undefined))),
                   ),
               })),
@@ -367,7 +363,7 @@ describe('validation status', () => {
               (res = resource({
                 params,
                 loader: ({params}) =>
-                  new Promise<FormTreeError[]>((r) =>
+                  new Promise<ValidationTreeError[]>((r) =>
                     setTimeout(() => r(validateValueForChild(params, undefined))),
                   ),
               })),
@@ -418,7 +414,7 @@ describe('validation status', () => {
         signal('MIXED'),
         (p) => {
           validate(p, () => []);
-          validate(p, () => [{kind: 'error'}]);
+          validate(p, () => [{kind: 'custom:error'}]);
         },
         {injector},
       );
@@ -441,7 +437,7 @@ describe('validation status', () => {
             factory: (params) =>
               (res = resource({
                 params,
-                loader: () => new Promise<FormTreeError[]>((r) => setTimeout(() => r([]))),
+                loader: () => new Promise<ValidationTreeError[]>((r) => setTimeout(() => r([]))),
               })),
             errors: (errs) => errs,
           });
@@ -469,7 +465,9 @@ describe('validation status', () => {
               (res = resource({
                 params,
                 loader: () =>
-                  new Promise<FormTreeError[]>((r) => setTimeout(() => r([{kind: 'error'}]))),
+                  new Promise<ValidationTreeError[]>((r) =>
+                    setTimeout(() => r([{kind: 'custom:error'}])),
+                  ),
               })),
             errors: (errs) => errs,
           });
@@ -478,7 +476,8 @@ describe('validation status', () => {
             factory: (params) =>
               (res2 = resource({
                 params,
-                loader: () => new Promise<FormTreeError[]>((r) => setTimeout(() => r([]), 10)),
+                loader: () =>
+                  new Promise<ValidationTreeError[]>((r) => setTimeout(() => r([]), 10)),
               })),
             errors: (errs) => errs,
           });
@@ -507,7 +506,9 @@ describe('validation status', () => {
               (res = resource({
                 params,
                 loader: () =>
-                  new Promise<FormTreeError[]>((r) => setTimeout(() => r([{kind: 'error'}]))),
+                  new Promise<ValidationTreeError[]>((r) =>
+                    setTimeout(() => r([{kind: 'custom:error'}])),
+                  ),
               })),
             errors: (errs) => errs,
           });
@@ -516,7 +517,8 @@ describe('validation status', () => {
             factory: (params) =>
               (res2 = resource({
                 params,
-                loader: () => new Promise<FormTreeError[]>((r) => setTimeout(() => r([]), 10)),
+                loader: () =>
+                  new Promise<ValidationTreeError[]>((r) => setTimeout(() => r([]), 10)),
               })),
             errors: (errs) => errs,
           });

--- a/packages/forms/experimental/test/node/validation_status.spec.ts
+++ b/packages/forms/experimental/test/node/validation_status.spec.ts
@@ -555,8 +555,14 @@ describe('validation status', () => {
           case 'standardschema':
             e.issue;
             break;
+          // @ts-expect-error
+          case 'fakekind':
+            break;
         }
       }
+      // Just so we have an expectation in the test,
+      // the real goal is to test the type narrowing above.
+      expect(true).toBe(true);
     });
   });
 });

--- a/packages/forms/experimental/test/node/validation_status.spec.ts
+++ b/packages/forms/experimental/test/node/validation_status.spec.ts
@@ -536,7 +536,7 @@ describe('validation status', () => {
   });
 
   describe('NgValidationError', () => {
-    it('instaceof should check if structure matches a standard error type', () => {
+    it('instanceof should check if structure matches a standard error type', () => {
       const e1 = ValidationError.required();
       expect(e1 instanceof NgValidationError).toBe(true);
       const e2 = ValidationError.custom({kind: 'min', min: 'two'});

--- a/packages/forms/experimental/test/web/BUILD.bazel
+++ b/packages/forms/experimental/test/web/BUILD.bazel
@@ -21,6 +21,7 @@ ts_library(
 
 karma_web_test_suite(
     name = "test",
+    browsers = ["@npm//@angular/build-tooling/bazel/browsers/chromium:chromium"],
     deps = [
         ":test_lib",
     ],

--- a/packages/forms/experimental/test/web/standard_schema.spec.ts
+++ b/packages/forms/experimental/test/web/standard_schema.spec.ts
@@ -26,13 +26,13 @@ describe('standard schema integration', () => {
 
     expect(nameForm.first().errors()).toEqual([
       jasmine.objectContaining({
-        kind: '~standard',
+        kind: 'ng:standard',
         issue: jasmine.objectContaining({message: 'String must contain at least 2 character(s)'}),
       }),
     ]);
     expect(nameForm.last().errors()).toEqual([
       jasmine.objectContaining({
-        kind: '~standard',
+        kind: 'ng:standard',
         issue: jasmine.objectContaining({message: 'String must contain at least 3 character(s)'}),
       }),
     ]);
@@ -63,13 +63,13 @@ describe('standard schema integration', () => {
 
     expect(nameForm.first().errors()).toEqual([
       jasmine.objectContaining({
-        kind: '~standard',
+        kind: 'ng:standard',
         issue: jasmine.objectContaining({message: 'String must contain at least 2 character(s)'}),
       }),
     ]);
     expect(nameForm.last().errors()).toEqual([
       jasmine.objectContaining({
-        kind: '~standard',
+        kind: 'ng:standard',
         issue: jasmine.objectContaining({message: 'String must contain at least 3 character(s)'}),
       }),
     ]);

--- a/packages/forms/experimental/test/web/standard_schema.spec.ts
+++ b/packages/forms/experimental/test/web/standard_schema.spec.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
 import {ApplicationRef, Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import * as z from 'zod';
@@ -8,7 +16,7 @@ import {validateStandardSchema} from '../../src/api/standard_schema';
 // `instanceof Promise` working correctly.
 
 describe('standard schema integration', () => {
-  it('should perform sync validation using a standard schema', async () => {
+  fit('should perform sync validation using a standard schema', async () => {
     const injector = TestBed.inject(Injector);
 
     const zodName = z.object({

--- a/packages/forms/experimental/test/web/standard_schema.spec.ts
+++ b/packages/forms/experimental/test/web/standard_schema.spec.ts
@@ -16,7 +16,7 @@ import {validateStandardSchema} from '../../src/api/standard_schema';
 // `instanceof Promise` working correctly.
 
 describe('standard schema integration', () => {
-  fit('should perform sync validation using a standard schema', async () => {
+  it('should perform sync validation using a standard schema', async () => {
     const injector = TestBed.inject(Injector);
 
     const zodName = z.object({

--- a/packages/forms/experimental/test/web/standard_schema.spec.ts
+++ b/packages/forms/experimental/test/web/standard_schema.spec.ts
@@ -26,13 +26,13 @@ describe('standard schema integration', () => {
 
     expect(nameForm.first().errors()).toEqual([
       jasmine.objectContaining({
-        kind: 'ng:standard',
+        kind: 'standardschema',
         issue: jasmine.objectContaining({message: 'String must contain at least 2 character(s)'}),
       }),
     ]);
     expect(nameForm.last().errors()).toEqual([
       jasmine.objectContaining({
-        kind: 'ng:standard',
+        kind: 'standardschema',
         issue: jasmine.objectContaining({message: 'String must contain at least 3 character(s)'}),
       }),
     ]);
@@ -63,13 +63,13 @@ describe('standard schema integration', () => {
 
     expect(nameForm.first().errors()).toEqual([
       jasmine.objectContaining({
-        kind: 'ng:standard',
+        kind: 'standardschema',
         issue: jasmine.objectContaining({message: 'String must contain at least 2 character(s)'}),
       }),
     ]);
     expect(nameForm.last().errors()).toEqual([
       jasmine.objectContaining({
-        kind: 'ng:standard',
+        kind: 'standardschema',
         issue: jasmine.objectContaining({message: 'String must contain at least 3 character(s)'}),
       }),
     ]);


### PR DESCRIPTION
- Rename `FormError` to `ValidationError` and switch it to a discriminated union of classes (same for tree variants)
- Remove `ServerError` and just use the standard `ValidationTreeError` for it
- Remove `requiredTrue` as its just a special case of `required`