### PR TITLE
refactor(migrations): ensure tsurge can properly emit references in g3

### DIFF
--- a/packages/core/schematics/utils/tsurge/helpers/google3/detection.ts
+++ b/packages/core/schematics/utils/tsurge/helpers/google3/detection.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+/** Whether we are executing inside Google */
+export function isGoogle3() {
+  return process.env['GOOGLE3_TSURGE'] === '1';
+}
+
+/**
+ * By default, Tsurge will always create an Angular compiler program
+ * for projects analyzed and migrated. This works perfectly fine in
+ * third-party where Tsurge migrations run in Angular CLI projects.
+ *
+ * In first party, when running against full Google3, creating an Angular
+ * program for e.g. plain `ts_library` targets is overly expensive and
+ * can result in out of memory issues for large TS targets. In 1P we can
+ * reliably distinguish between TS and Angular targets via the `angularCompilerOptions`.
+ */
+export function google3UsePlainTsProgramIfNoKnownAngularOption() {
+  return process.env['GOOGLE3_TSURGE'] === '1';
+}

--- a/packages/core/schematics/utils/tsurge/helpers/google3/target_detection.ts
+++ b/packages/core/schematics/utils/tsurge/helpers/google3/target_detection.ts
@@ -5,17 +5,3 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-
-/**
- * By default, Tsurge will always create an Angular compiler program
- * for projects analyzed and migrated. This works perfectly fine in
- * third-party where Tsurge migrations run in Angular CLI projects.
- *
- * In first party, when running against full Google3, creating an Angular
- * program for e.g. plain `ts_library` targets is overly expensive and
- * can result in out of memory issues for large TS targets. In 1P we can
- * reliably distinguish between TS and Angular targets via the `angularCompilerOptions`.
- */
-export function google3UsePlainTsProgramIfNoKnownAngularOption() {
-  return process.env['GOOGLE3_TSURGE'] === '1';
-}

--- a/packages/core/schematics/utils/tsurge/helpers/google3/unified_module_resolution.ts
+++ b/packages/core/schematics/utils/tsurge/helpers/google3/unified_module_resolution.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+// Note: Try to keep mostly in sync with
+// //depot/google3/javascript/angular2/tools/ngc_wrapped/tsc_plugin.ts
+// TODO: Consider moving this logic into the 1P launcher.
+
+import * as path from 'node:path';
+
+const EXT = /(\.ts|\.d\.ts|\.js|\.jsx|\.tsx)$/;
+
+export function fileNameToModuleNameFactory(
+  rootDirs: readonly string[],
+  workspaceName: string,
+): (importedFilePath: string) => string {
+  return (importedFilePath: string) => {
+    let relativePath = '';
+    for (const rootDir of rootDirs) {
+      const rel = path.posix.relative(rootDir, importedFilePath);
+      if (!rel.startsWith('.')) {
+        relativePath = rel;
+        break;
+      }
+    }
+
+    if (relativePath) {
+      return `${workspaceName}/${relativePath.replace(EXT, '')}`;
+    } else {
+      return importedFilePath.replace(EXT, '');
+    }
+  };
+}


### PR DESCRIPTION
Currently when Tsurge runs in g3, it creates a bare bones Angular compiler plugin. The tsconfigs from compilation units may set options like "useHostForImportGeneration", but the Ngtsc logic doesn't enable because the `fileNameToModuleName` method is not defined on the host.

This can break reference emission for Tsurge analyzers/programs and result in subtle differences to real `ng_module` compilations. This commit fixes this by making the method available in 1P Tsurge.

Notably, reference emission can occur during analysis— so even if migrations aren't "emitting TS -> JS" output.