### PR TITLE
ci: update pullapprove reviewers

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -126,7 +126,7 @@ groups:
         ])
     reviewers:
       users:
-        - alxhub
+        - ~alxhub
         - AndrewKushnir
         - atscott
         - crisbeto
@@ -167,7 +167,7 @@ groups:
         ])
     reviewers:
       users:
-        - alxhub
+        - ~alxhub
         - AndrewKushnir
         - atscott
         - crisbeto
@@ -175,7 +175,7 @@ groups:
         - kirjs
         - ~jelbourn
         - thePunderWoman
-        - pkozlowski-opensource
+        - ~pkozlowski-opensource
         - mmalerba
 
   # =========================================================
@@ -198,10 +198,10 @@ groups:
           ])
     reviewers:
       users:
-        - alxhub
+        - ~alxhub
         - jelbourn
         - josephperrott
-        - pkozlowski-opensource
+        - ~pkozlowski-opensource
     reviews:
       request: -1 # request reviews from everyone
       required: 2 # require at least 2 approvals
@@ -221,14 +221,14 @@ groups:
       users:
         - ~JiaLiPassion
         - ~jelbourn
-        - alxhub
+        - ~alxhub
         - AndrewKushnir
         - atscott
         - crisbeto
         - devversion
         - kirjs
         - thePunderWoman
-        - pkozlowski-opensource
+        - ~pkozlowski-opensource
         - mmalerba
 
   # =========================================================
@@ -267,7 +267,7 @@ groups:
     reviewers:
       users:
         - alan-agius4
-        - alxhub
+        - ~alxhub
         - AndrewKushnir
         - atscott
         - bencodezen
@@ -278,7 +278,7 @@ groups:
         - thePunderWoman
         - devversion
         - josephperrott
-        - pkozlowski-opensource
+        - ~pkozlowski-opensource
         - mgechev
         - MarkTechson
         - kirjs
@@ -384,11 +384,11 @@ groups:
     reviewers:
       users:
         - AndrewKushnir
-        - alxhub
+        - ~alxhub
         - atscott
         - ~jelbourn
         - thePunderWoman
-        - pkozlowski-opensource
+        - ~pkozlowski-opensource
         - kirjs
         - mmalerba
         - crisbeto
@@ -416,13 +416,13 @@ groups:
           ])
     reviewers:
       users:
-        - alxhub
+        - ~alxhub
         - AndrewKushnir
         - atscott
         - kirjs
         - ~jelbourn
         - thePunderWoman
-        - pkozlowski-opensource
+        - ~pkozlowski-opensource
         - mmalerba
     reviews:
       request: 2 # Request reviews from 2 people
@@ -445,7 +445,7 @@ groups:
         ])
     reviewers:
       users:
-        - alxhub
+        - ~alxhub
         - AndrewKushnir
         - andrewseguin
         - dgp1130
@@ -467,8 +467,8 @@ groups:
         ])
     reviewers:
       users:
-        - pkozlowski-opensource # Pawel Kozlowski
-        - alxhub # Alex Rickabaugh
+        - ~pkozlowski-opensource # Pawel Kozlowski
+        - ~alxhub # Alex Rickabaugh
         - thePunderWoman # Jessica Janiuk
         - AndrewKushnir # Andrew Kushnir
         - atscott # Andrew Scott


### PR DESCRIPTION
This sets some people to be reviewers, but not actively requested to account for availability.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

