### PR TITLE
docs (docs-infra): add tooltip and snackbar for copied

### DIFF
--- a/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.html
+++ b/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.html
@@ -5,11 +5,7 @@
     }
 
     @if (view() === CodeExampleViewMode.MULTI_FILE) {
-      <mat-tab-group
-        #codeTabs
-        animationDuration="0ms"
-        mat-stretch-tabs="false"
-      >
+      <mat-tab-group #codeTabs animationDuration="0ms" mat-stretch-tabs="false">
         @for (tab of tabs(); track tab) {
           <mat-tab [label]="tab.name"></mat-tab>
         }
@@ -19,9 +15,10 @@
     <div class="docs-example-viewer-icons">
       <button
         type="button"
-        class="docs-example-copy-link"
         [attr.aria-label]="'Copy link to ' + exampleMetadata()?.title + ' example to the clipboard'"
         (click)="copyLink()"
+        matTooltip="Copy link to example"
+        matTooltipPosition="above"
       >
         <i aria-hidden="true">
           <svg
@@ -45,8 +42,9 @@
         <button
           type="button"
           (click)="toggleExampleVisibility()"
-          [attr.title]="(expanded() ? 'Collapse' : 'Expand') + ' example'"
           [attr.aria-label]="(expanded() ? 'Collapse' : 'Expand') + ' code example'"
+          matTooltip="{{ expanded() ? 'Collapse' : 'Expand' }} example"
+          matTooltipPosition="above"
         >
           <i aria-hidden="true">
             @if (!expanded()) {
@@ -102,9 +100,10 @@
         <a
           [href]="githubUrl"
           target="_blank"
-          title="Open example on GitHub"
           class="docs-example-github-link"
           aria-label="Open example on GitHub"
+          matTooltip="Open example on GitHub"
+          matTooltipPosition="above"
         >
           <i aria-hidden="true">
             <svg
@@ -130,8 +129,9 @@
           [href]="stackblitzUrl"
           target="_blank"
           class="docs-example-stackblitz-link"
-          title="Edit this example in StackBlitz"
-          aria-label="Edit this example in StackBlitz"
+          aria-label="Edit example in StackBlitz"
+          matTooltip="Edit example in StackBlitz"
+          matTooltipPosition="above"
         >
           <i aria-hidden="true">
             <svg

--- a/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.ts
+++ b/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.ts
@@ -31,6 +31,8 @@ import {ExampleMetadata, Snippet} from '../../../interfaces/index';
 import {EXAMPLE_VIEWER_CONTENT_LOADER} from '../../../providers/index';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {DocViewer} from '../docs-viewer/docs-viewer.component';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {MatTooltipModule} from '@angular/material/tooltip';
 
 export enum CodeExampleViewMode {
   SNIPPET = 'snippet',
@@ -44,7 +46,13 @@ export const HIDDEN_CLASS_NAME = 'hidden';
 
 @Component({
   selector: 'docs-example-viewer',
-  imports: [CommonModule, forwardRef(() => DocViewer), CopySourceCodeButton, MatTabsModule],
+  imports: [
+    CommonModule,
+    forwardRef(() => DocViewer),
+    CopySourceCodeButton,
+    MatTabsModule,
+    MatTooltipModule,
+  ],
   templateUrl: './example-viewer.component.html',
   styleUrls: ['./example-viewer.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -56,6 +64,7 @@ export class ExampleViewer {
   @Input() stackblitzUrl: string | null = null;
   readonly matTabGroup = viewChild<MatTabGroup>('codeTabs');
 
+  private readonly snackBar = inject(MatSnackBar);
   private readonly changeDetector = inject(ChangeDetectorRef);
   private readonly clipboard = inject(Clipboard);
   private readonly destroyRef = inject(DestroyRef);
@@ -139,6 +148,10 @@ export class ExampleViewer {
       '#example-' +
       this.exampleMetadata()?.id;
     this.clipboard.copy(fullUrl);
+    this.snackBar.open(`Copied to clipboard.`, 'Dismiss', {
+      duration: 3000,
+      panelClass: 'docs-snackbar',
+    });
   }
 
   private listenToMatTabIndexChange(): void {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
No tooltip on example code block

Issue Number: N/A


## What is the new behavior?
a tooltip on hover: "Copy code"
a Copied message after clicking

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No