### PR TITLE
feat(http): add referrer & integrity support for fetch requests in ht…

### DIFF
--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -2784,12 +2784,14 @@ export interface HttpResourceRequest {
     context?: HttpContext;
     credentials?: RequestCredentials | (string & {});
     headers?: HttpHeaders | Record<string, string | ReadonlyArray<string>>;
+    integrity?: string;
     keepalive?: boolean;
     method?: string;
     mode?: RequestMode | (string & {});
     params?: HttpParams | Record<string, string | number | boolean | ReadonlyArray<string | number | boolean>>;
     priority?: RequestPriority | (string & {});
     redirect?: RequestRedirect | (string & {});
+    referrer?: string;
     reportProgress?: boolean;
     timeout?: number;
     transferCache?: {

--- a/packages/common/http/src/resource.ts
+++ b/packages/common/http/src/resource.ts
@@ -287,6 +287,8 @@ function normalizeRequest(
       context: unwrappedRequest.context,
       transferCache: unwrappedRequest.transferCache,
       credentials: unwrappedRequest.credentials as RequestCredentials,
+      referrer: unwrappedRequest.referrer,
+      integrity: unwrappedRequest.integrity,
       timeout: unwrappedRequest.timeout,
     },
   );

--- a/packages/common/http/src/resource_api.ts
+++ b/packages/common/http/src/resource_api.ts
@@ -105,6 +105,19 @@ export interface HttpResourceRequest {
   redirect?: RequestRedirect | (string & {});
 
   /**
+   * The referrer of the request, which can be used to indicate the origin of the request.
+   * This is useful for security and analytics purposes.
+   * Value is a same-origin URL, "about:client", or the empty string, to set request's referrer.
+   */
+  referrer?: string;
+
+  /**
+   * The integrity metadata of the request, which can be used to ensure the request is made with the expected content.
+   * A cryptographic hash of the resource to be fetched by request
+   */
+  integrity?: string;
+
+  /**
    * Configures the server-side rendering transfer cache for this request.
    *
    * See the documentation on the transfer cache for more information.

--- a/packages/common/http/test/resource_spec.ts
+++ b/packages/common/http/test/resource_spec.ts
@@ -111,6 +111,8 @@ describe('httpResource', () => {
         mode: 'cors',
         redirect: 'follow',
         credentials: 'include',
+        integrity: 'sha256-abc123',
+        referrer: 'https://example.com',
       }),
       {injector: TestBed.inject(Injector)},
     );
@@ -126,6 +128,8 @@ describe('httpResource', () => {
     expect(req.request.mode).toBe('cors');
     expect(req.request.redirect).toBe('follow');
     expect(req.request.credentials).toBe('include');
+    expect(req.request.integrity).toBe('sha256-abc123');
+    expect(req.request.referrer).toBe('https://example.com');
 
     req.flush([]);
 


### PR DESCRIPTION
Currently, Angular's `httpResource` does not expose the `referrer` and `integrity` options from the underlying Fetch API.

Exposing these options would provide developers with finer control over the request's **referrer** and **subresource integrity validation**, which are important for ensuring **security**, **privacy**, and **trust** in critical resource fetching scenarios.

New Usage Example

```ts
httpResource(() => ({
  url: '${CDN_DOMAIN}/assets/data.json',
  method: 'GET',
  referrer: 'no-referrer',
  integrity: 'sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GhEXAMPLEKEY='
}));
