### PR TITLE
feat(devtools): add transfer state tab

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.spec.ts
@@ -12,6 +12,7 @@ import {
   ngDebugProfilerApiIsSupported,
   ngDebugRoutesApiIsSupported,
   ngDebugSignalGraphApiIsSupported,
+  ngDebugTransferStateApiIsSupported,
 } from './ng-debug-api';
 import {Framework} from '../component-tree/core-enums';
 
@@ -132,6 +133,26 @@ describe('ng-debug-api', () => {
       (globalThis as any).ng = fakeNgGlobal(Framework.ACX);
       (globalThis as any).ng.ɵgetSignalGraph = undefined;
       expect(ngDebugSignalGraphApiIsSupported()).toBeFalse();
+    });
+  });
+
+  describe('ngDebugTransferStateApiIsSupported', () => {
+    beforeEach(() => mockRoot());
+
+    it('should support Transfer State API with getTransferState', () => {
+      (globalThis as any).ng = fakeNgGlobal(Framework.Angular);
+      (globalThis as any).ng.ɵgetTransferState = () => {};
+      expect(ngDebugTransferStateApiIsSupported()).toBeTrue();
+    });
+
+    it('should not support Transfer State API with no getTransferState', () => {
+      (globalThis as any).ng = fakeNgGlobal(Framework.ACX);
+      (globalThis as any).ng.ɵgetTransferState = 'not implemented';
+      expect(ngDebugTransferStateApiIsSupported()).toBeFalse();
+
+      (globalThis as any).ng = fakeNgGlobal(Framework.ACX);
+      (globalThis as any).ng.ɵgetTransferState = undefined;
+      expect(ngDebugTransferStateApiIsSupported()).toBeFalse();
     });
   });
 });

--- a/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.ts
@@ -81,3 +81,12 @@ export function ngDebugSignalGraphApiIsSupported(): boolean {
   const ng = ngDebugClient();
   return ngDebugApiIsSupported(ng, 'ɵgetSignalGraph');
 }
+
+/**
+ * Checks if transfer state is available.
+ * Transfer state is only relevant when Angular app uses Server-Side Rendering.
+ */
+export function ngDebugTransferStateApiIsSupported(): boolean {
+  const ng = ngDebugClient();
+  return ngDebugApiIsSupported(ng, 'ɵgetTransferState');
+}

--- a/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/supported-apis.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/supported-apis.ts
@@ -12,6 +12,7 @@ import {
   ngDebugProfilerApiIsSupported,
   ngDebugRoutesApiIsSupported,
   ngDebugSignalGraphApiIsSupported,
+  ngDebugTransferStateApiIsSupported,
 } from './ng-debug-api';
 
 /**
@@ -24,11 +25,13 @@ export function getSupportedApis(): SupportedApis {
   const dependencyInjection = ngDebugDependencyInjectionApiIsSupported();
   const routes = ngDebugRoutesApiIsSupported();
   const signals = ngDebugSignalGraphApiIsSupported();
+  const transferState = ngDebugTransferStateApiIsSupported();
 
   return {
     profiler,
     dependencyInjection,
     routes,
     signals,
+    transferState,
   };
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/BUILD.bazel
@@ -33,6 +33,7 @@ ng_project(
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler:profiler_rjs",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree:router-tree_rjs",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/tab-update:tab-update_rjs",
+        "//devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state:transfer-state_rjs",
         "//devtools/projects/protocol:protocol_rjs",
     ],
 )

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.html
@@ -92,6 +92,11 @@
           [providers]="providers()"
         />
       }
+
+      @let transferStateVisible = activeTab() === 'Transfer State';
+      @defer (when transferStateVisible; prefetch on idle) {
+        <ng-transfer-state [hidden]="!transferStateVisible" />
+      }
     </div>
   }
 </mat-tab-nav-panel>
@@ -135,6 +140,16 @@
           (change)="setSignalGraph($event.checked)"
         />
         <span class="ng-mat-menu-label-text">Enable Signal Graph (experimental)</span>
+      </label>
+    }
+    @if (supportedApis().transferState) {
+      <label mat-menu-item disableRipple>
+        <mat-slide-toggle
+          [checked]="transferStateTabEnabled()"
+          (change)="setTransferStateTab($event.checked)"
+        >
+          Show Transfer State Tab</mat-slide-toggle
+        >
       </label>
     }
   </div>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
@@ -38,9 +38,10 @@ import {DirectiveExplorerComponent} from './directive-explorer/directive-explore
 import {InjectorTreeComponent} from './injector-tree/injector-tree.component';
 import {ProfilerComponent} from './profiler/profiler.component';
 import {RouterTreeComponent} from './router-tree/router-tree.component';
+import {TransferStateComponent} from './transfer-state/transfer-state.component';
 import {TabUpdate} from './tab-update/index';
 
-type Tab = 'Components' | 'Profiler' | 'Router Tree' | 'Injector Tree';
+type Tab = 'Components' | 'Profiler' | 'Router Tree' | 'Injector Tree' | 'Transfer State';
 
 @Component({
   selector: 'ng-devtools-tabs',
@@ -59,6 +60,7 @@ type Tab = 'Components' | 'Profiler' | 'Router Tree' | 'Injector Tree';
     ProfilerComponent,
     RouterTreeComponent,
     InjectorTreeComponent,
+    TransferStateComponent,
     MatSlideToggle,
   ],
   providers: [TabUpdate],
@@ -76,6 +78,7 @@ export class DevToolsTabsComponent {
   readonly routerGraphEnabled = signal(false);
   readonly timingAPIEnabled = signal(false);
   readonly signalGraphEnabled = signal(false);
+  readonly transferStateTabEnabled = signal(false);
 
   readonly componentExplorerView = signal<ComponentExplorerView | null>(null);
   readonly providers = signal<SerializedProviderRecord[]>([]);
@@ -96,6 +99,9 @@ export class DevToolsTabsComponent {
     }
     if (supportedApis.routes && this.routerGraphEnabled() && this.routes().length > 0) {
       tabs.push('Router Tree');
+    }
+    if (supportedApis.transferState && this.transferStateTabEnabled()) {
+      tabs.push('Transfer State');
     }
 
     return tabs;
@@ -198,5 +204,12 @@ export class DevToolsTabsComponent {
 
   protected setSignalGraph(enabled: boolean): void {
     this.signalGraphEnabled.set(enabled);
+  }
+
+  protected setTransferStateTab(enabled: boolean): void {
+    this.transferStateTabEnabled.set(enabled);
+    if (!enabled && this.activeTab() === 'Transfer State') {
+      this.activeTab.set('Components');
+    }
   }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/BUILD.bazel
@@ -1,0 +1,30 @@
+load("//devtools/tools:defaults.bzl", "ng_project", "sass_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+sass_binary(
+    name = "transfer_state_component_styles",
+    src = "transfer-state.component.scss",
+    deps = [
+        "//devtools/projects/ng-devtools/src/styles:typography",
+    ],
+)
+
+ng_project(
+    name = "transfer-state",
+    srcs = [
+        "transfer-state.component.ts",
+    ],
+    angular_assets = [
+        ":transfer-state.component.html",
+        ":transfer_state_component_styles",
+    ],
+    deps = [
+        "//:node_modules/@angular/cdk",
+        "//:node_modules/@angular/core",
+        "//:node_modules/@angular/material",
+        "//devtools/projects/ng-devtools/src/lib/shared/button:button_rjs",
+        "//devtools/projects/ng-devtools/src/lib/shared/utils:utils_rjs",
+        "//devtools/projects/protocol:protocol_rjs",
+    ],
+)

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.html
@@ -1,0 +1,137 @@
+<div class="transfer-state-container">
+  <div class="header">
+    <h2>
+      <mat-icon>swap_horiz</mat-icon>
+      Transfer State
+    </h2>
+    <div class="actions">
+      <button ng-button btnType="icon" (click)="refresh()" matTooltip="Refresh transfer state">
+        <mat-icon>refresh</mat-icon>
+      </button>
+    </div>
+  </div>
+
+  @if (isLoading()) {
+    <div class="loading">
+      <mat-icon class="spinning">hourglass_empty</mat-icon>
+      Loading transfer state...
+    </div>
+  } @else if (error()) {
+    <div class="error-card">
+      <div class="card-header">
+        <mat-icon>error</mat-icon>
+        <h3>No Transfer State Found</h3>
+      </div>
+      <div class="card-content">
+        <p>{{ error() }}</p>
+        <p>
+          Transfer state is used in Server-Side Rendering (SSR) to pass data from the server to the
+          client. If you're expecting transfer state data, make sure:
+        </p>
+        <ul>
+          <li>The application is using SSR</li>
+          <li>Transfer state is being used in your components</li>
+          <li>You're inspecting the initial page load (not after client-side navigation)</li>
+        </ul>
+      </div>
+    </div>
+  } @else if (!hasData()) {
+    <div class="empty-card">
+      <div class="card-header">
+        <mat-icon>info</mat-icon>
+        <h3>Transfer State is Empty</h3>
+      </div>
+      <div class="card-content">
+        <p>No transfer state data found on this page.</p>
+        <p>This could be normal if the page doesn't use SSR or doesn't transfer any state.</p>
+      </div>
+    </div>
+  } @else {
+    <div class="transfer-state-content">
+      <div class="summary">
+        <div class="summary-card">
+          <div class="summary-stats">
+            <div class="stat">
+              <span class="stat-value">{{ transferStateItems().length }}</span>
+              <span class="stat-label">Keys</span>
+            </div>
+            <div class="stat">
+              <span class="stat-value">{{ totalSize() }}</span>
+              <span class="stat-label">Total Size</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="table-container">
+        <table mat-table [dataSource]="transferStateItems()" class="transfer-state-table">
+          <!-- Key Column -->
+          <ng-container matColumnDef="key">
+            <th mat-header-cell *matHeaderCellDef>Key</th>
+            <td mat-cell *matCellDef="let item" class="key-cell">
+              <code>{{ item.key }}</code>
+            </td>
+          </ng-container>
+
+          <!-- Type Column -->
+          <ng-container matColumnDef="type">
+            <th mat-header-cell *matHeaderCellDef>Type</th>
+            <td mat-cell *matCellDef="let item">
+              <span class="type-badge type-{{ item.type }}">{{ item.type }}</span>
+            </td>
+          </ng-container>
+
+          <!-- Size Column -->
+          <ng-container matColumnDef="size">
+            <th mat-header-cell *matHeaderCellDef>
+              Size
+              <mat-icon class="info-icon" matTooltip="Uncompressed size">help_outline</mat-icon>
+            </th>
+            <td mat-cell *matCellDef="let item">{{ item.size }}</td>
+          </ng-container>
+
+          <!-- Value Column -->
+          <ng-container matColumnDef="value">
+            <th mat-header-cell *matHeaderCellDef>Value</th>
+            <td mat-cell *matCellDef="let item" class="value-cell">
+              <div class="value-container">
+                <pre
+                  #valuePreview
+                  class="value-preview"
+                  [class.is-expanded]="item.isExpanded"
+                ><code>{{ getFormattedValue(item.value) }}</code></pre>
+                <div class="action-buttons">
+                  @if (isValueLong(valuePreview, item.isExpanded)) {
+                    <button
+                      ng-button
+                      btnType="icon"
+                      size="compact"
+                      class="expand-button"
+                      (click)="toggleExpanded(item)"
+                      [matTooltip]="item.isExpanded ? 'Collapse value' : 'Expand value'"
+                    >
+                      <mat-icon>{{ item.isExpanded ? 'expand_less' : 'expand_more' }}</mat-icon>
+                    </button>
+                  }
+                  <button
+                    ng-button
+                    btnType="icon"
+                    size="compact"
+                    class="copy-button"
+                    (click)="copyToClipboard(item)"
+                    [matTooltip]="item.isCopied ? 'Copied!' : 'Copy value to clipboard'"
+                  >
+                    <mat-icon>{{ item.isCopied ? 'check' : 'content_copy' }}</mat-icon>
+                  </button>
+                </div>
+              </div>
+            </td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+        </table>
+      </div>
+    </div>
+  }
+</div>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.scss
@@ -1,0 +1,305 @@
+@use '../../../styles/typography';
+
+.transfer-state-container {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+    flex-shrink: 0;
+
+    h2 {
+      @extend %heading-600;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin: 0;
+      padding: 0;
+
+      mat-icon {
+        font-size: 1.25rem;
+        width: 1.25rem;
+        height: 1.25rem;
+      }
+    }
+
+    .actions {
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+
+      button {
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+      }
+    }
+  }
+
+  .loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 1;
+    gap: 0.5rem;
+    @extend %body-01;
+    color: var(--secondary-contrast);
+
+    .spinning {
+      animation: spin 2s linear infinite;
+    }
+  }
+
+  .error-card,
+  .empty-card {
+    max-width: 37.5rem;
+    margin: 0 auto;
+    background: var(--color-foreground);
+    border: 1px solid var(--color-separator);
+    border-radius: 0.25rem;
+    padding: 1rem;
+
+    .card-header {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin-bottom: 1rem;
+
+      h3 {
+        @extend %heading-500;
+        margin: 0;
+        padding: 0;
+      }
+    }
+
+    .card-content {
+      @extend %body-01;
+
+      ul {
+        margin: 0.5rem 0;
+        padding-left: 1.25rem;
+
+        li {
+          margin: 0.25rem 0;
+        }
+      }
+    }
+  }
+
+  .transfer-state-content {
+    flex: 0 1 auto;
+    display: flex;
+    flex-direction: column;
+    overflow: visible;
+
+    .summary {
+      margin-bottom: 1rem;
+      flex-shrink: 0;
+
+      .summary-card {
+        background: var(--color-foreground);
+        border: 1px solid var(--color-separator);
+        border-radius: 0.25rem;
+        padding: 0.75rem 1rem;
+      }
+
+      .summary-stats {
+        display: flex;
+        gap: 2rem;
+
+        .stat {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+
+          .stat-value {
+            font-size: 1.5rem;
+            font-weight: 600;
+            color: var(--dynamic-blue-02);
+          }
+
+          .stat-label {
+            @extend %body-01;
+            color: var(--secondary-contrast);
+            text-transform: uppercase;
+            letter-spacing: 0.03rem;
+          }
+        }
+      }
+    }
+
+    .table-container {
+      flex: 0 1 auto;
+      border: 1px solid var(--color-separator);
+      border-radius: 0.25rem;
+      max-height: 70vh;
+      overflow-y: auto;
+
+      .transfer-state-table {
+        width: 100%;
+        background: var(--color-background);
+
+        th.mat-header-cell {
+          background: var(--color-foreground);
+          font-weight: 600;
+          @extend %body-01;
+          text-transform: uppercase;
+          letter-spacing: 0.03rem;
+          padding: 0.75rem 1rem;
+          border-bottom: 2px solid var(--color-separator);
+          display: flex;
+          align-items: center;
+          gap: 0.25rem;
+        }
+
+        .info-icon {
+          font-size: 1rem;
+          height: 1rem;
+          width: 1rem;
+          color: var(--secondary-contrast);
+          flex-shrink: 0;
+        }
+
+        td {
+          padding: 0.75rem 1rem;
+          border-bottom: 1px solid var(--quinary-contrast);
+        }
+
+        .key-cell {
+          code {
+            @extend %monospaced;
+            background: var(--color-foreground);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.1875rem;
+            color: var(--color-text);
+            border: 1px solid var(--color-separator);
+          }
+        }
+
+        .value-cell {
+          min-width: 12.5rem;
+          max-width: 31.25rem;
+
+          .value-container {
+            position: relative;
+            display: flex;
+            align-items: flex-start;
+            gap: 0.5rem;
+
+            .value-preview {
+              @extend %monospaced;
+              flex: 1;
+              margin: 0;
+              background: var(--color-foreground);
+              border: 0.5rem solid var(--color-foreground);
+              border-radius: 0.1875rem;
+              overflow-x: auto;
+              white-space: pre-wrap;
+              word-break: break-word;
+              color: var(--color-text);
+              display: -webkit-box;
+              -webkit-line-clamp: 5;
+              -webkit-box-orient: vertical;
+
+              &.is-expanded {
+                -webkit-line-clamp: unset;
+                overflow-x: auto;
+              }
+            }
+
+            .action-buttons {
+              display: flex;
+              flex-direction: column;
+              gap: 0.125rem;
+              flex-shrink: 0;
+              margin-top: 0.25rem;
+
+              .expand-button,
+              .copy-button {
+                min-width: 1.5rem;
+                width: 1.5rem;
+                height: 1.5rem;
+                padding: 0;
+
+                mat-icon {
+                  font-size: 0.875rem;
+                  width: 0.875rem;
+                  height: 0.875rem;
+                }
+              }
+
+              .copy-button {
+                &.mat-icon-button {
+                  transition: all 0.2s ease;
+                }
+
+                &:has(mat-icon[data-copied='true']) {
+                  color: var(--dynamic-green-01);
+                }
+              }
+            }
+          }
+        }
+
+        .type-badge {
+          display: inline-block;
+          padding: 0.125rem 0.5rem;
+          border-radius: 0.75rem;
+          @extend %body-01;
+          font-weight: 500;
+          text-transform: uppercase;
+          letter-spacing: 0.03rem;
+          color: black;
+          border: 1px solid;
+
+          &.type-string {
+            background: var(--green-03);
+            border-color: var(--green-02);
+          }
+
+          &.type-number {
+            background: var(--purple-03);
+            border-color: var(--purple-02);
+          }
+
+          &.type-boolean {
+            background: var(--red-06);
+            border-color: var(--red-05);
+          }
+
+          &.type-object {
+            background: var(--blue-03);
+            border-color: var(--blue-02);
+          }
+
+          &.type-array {
+            background: var(--green-03);
+            border-color: var(--green-02);
+          }
+
+          &.type-null {
+            background: white;
+            border-color: var(--quaternary-contrast);
+          }
+        }
+
+        tr:hover {
+          background: var(--quinary-contrast);
+        }
+      }
+    }
+  }
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.ts
@@ -1,0 +1,181 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  Component,
+  inject,
+  signal,
+  computed,
+  linkedSignal,
+  ChangeDetectionStrategy,
+} from '@angular/core';
+import {Clipboard} from '@angular/cdk/clipboard';
+import {MatIcon} from '@angular/material/icon';
+import {MatTooltip} from '@angular/material/tooltip';
+import {
+  MatTable,
+  MatHeaderCell,
+  MatCell,
+  MatHeaderRow,
+  MatRow,
+  MatColumnDef,
+  MatHeaderCellDef,
+  MatCellDef,
+  MatHeaderRowDef,
+  MatRowDef,
+} from '@angular/material/table';
+import {ButtonComponent} from '../../shared/button/button.component';
+import {Events, MessageBus, TransferStateValue} from '../../../../../protocol';
+import {formatBytes, getFormattedValue} from '../../shared/utils/formatting';
+
+interface TransferStateItem {
+  key: string;
+  value: TransferStateValue;
+  type: string;
+  size: string;
+  isExpanded?: boolean;
+  isCopied?: boolean;
+}
+
+export const LINE_CLAMP_LIMIT = 5;
+export const COPY_FEEDBACK_TIMEOUT = 2000;
+
+@Component({
+  selector: 'ng-transfer-state',
+  standalone: true,
+  imports: [
+    MatIcon,
+    MatTooltip,
+    MatTable,
+    MatHeaderCell,
+    MatCell,
+    MatHeaderRow,
+    MatRow,
+    MatColumnDef,
+    MatHeaderCellDef,
+    MatCellDef,
+    MatHeaderRowDef,
+    MatRowDef,
+    ButtonComponent,
+  ],
+  templateUrl: './transfer-state.component.html',
+  styleUrls: ['./transfer-state.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TransferStateComponent {
+  private messageBus = inject(MessageBus) as MessageBus<Events>;
+  private clipboard = inject(Clipboard);
+
+  readonly transferStateData = signal<Record<string, TransferStateValue> | null>(null);
+  readonly error = signal<string | null>(null);
+  readonly isLoading = computed(() => !this.transferStateData() && !this.error());
+
+  readonly transferStateItems = linkedSignal<TransferStateItem[]>(() => {
+    const data = this.transferStateData();
+    if (!data) return [];
+
+    return Object.entries(data).map(([key, value]) => ({
+      key,
+      value,
+      type: this.getValueType(value),
+      size: this.getValueSize(value),
+      isExpanded: false,
+      isCopied: false,
+    }));
+  });
+
+  readonly hasData = computed(() => this.transferStateItems().length > 0);
+  readonly getFormattedValue = getFormattedValue;
+
+  readonly totalSize = computed(() => {
+    const items = this.transferStateItems();
+    if (items.length === 0) return '0 B';
+
+    let totalBytes = 0;
+    for (const item of items) {
+      const str = typeof item.value === 'string' ? item.value : JSON.stringify(item.value);
+      totalBytes += new Blob([str]).size;
+    }
+
+    return formatBytes(totalBytes);
+  });
+
+  displayedColumns: string[] = ['key', 'type', 'size', 'value'];
+
+  constructor() {
+    this.loadTransferState();
+  }
+
+  private getValueType(value: TransferStateValue): string {
+    if (value === null) return 'null';
+    if (Array.isArray(value)) return 'array';
+    return typeof value;
+  }
+
+  getValueSize(value: TransferStateValue): string {
+    const str = JSON.stringify(value);
+    const bytes = new Blob([str]).size;
+    return formatBytes(bytes);
+  }
+
+  private loadTransferState(): void {
+    this.transferStateData.set(null);
+    this.error.set(null);
+
+    try {
+      this.messageBus.emit('getTransferState');
+      this.messageBus.on('transferStateData', (data: Record<string, TransferStateValue> | null) => {
+        this.transferStateData.set(data);
+        if (!data) {
+          this.error.set(
+            'No transfer state found. Make sure you are inspecting a page with Server-Side Rendering (SSR) enabled.',
+          );
+        }
+      });
+    } catch (err) {
+      this.error.set(`Error loading transfer state: ${err}`);
+    }
+  }
+
+  refresh(): void {
+    this.loadTransferState();
+  }
+
+  isValueLong(element: HTMLElement, isExpanded: boolean = false): boolean {
+    if (isExpanded) return true;
+
+    return element.scrollHeight > element.clientHeight;
+  }
+
+  toggleExpanded(item: TransferStateItem): void {
+    this.transferStateItems.update((items) =>
+      items.map((i) => (i.key === item.key ? {...i, isExpanded: !i.isExpanded} : i)),
+    );
+  }
+
+  copyToClipboard(item: TransferStateItem): void {
+    try {
+      const textToCopy =
+        typeof item.value === 'string' ? item.value : JSON.stringify(item.value, null, 2);
+
+      this.clipboard.copy(textToCopy);
+
+      this.transferStateItems.update((items) =>
+        items.map((i) => (i.key === item.key ? {...i, isCopied: true} : i)),
+      );
+
+      setTimeout(() => {
+        this.transferStateItems.update((items) =>
+          items.map((i) => (i.key === item.key ? {...i, isCopied: false} : i)),
+        );
+      }, COPY_FEEDBACK_TIMEOUT);
+    } catch (err) {
+      console.error('Failed to copy to clipboard:', err);
+    }
+  }
+}

--- a/devtools/projects/ng-devtools/src/lib/devtools.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools.component.ts
@@ -68,6 +68,7 @@ export class DevToolsComponent implements OnDestroy {
     dependencyInjection: false,
     routes: false,
     signals: false,
+    transferState: false,
   });
   readonly ivy = signal<boolean | undefined>(undefined);
 

--- a/devtools/projects/ng-devtools/src/lib/shared/utils/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/shared/utils/BUILD.bazel
@@ -4,7 +4,10 @@ package(default_visibility = ["//devtools:__subpackages__"])
 
 ts_project(
     name = "utils",
-    srcs = ["debouncer.ts"],
+    srcs = [
+        "debouncer.ts",
+        "formatting.ts",
+    ],
 )
 
 ts_test_library(

--- a/devtools/projects/ng-devtools/src/lib/shared/utils/formatting.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/utils/formatting.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {formatBytes, getFormattedValue} from './formatting';
+
+describe('Formatting utilities', () => {
+  describe('formatBytes', () => {
+    it('should format bytes less than 1024 as B', () => {
+      expect(formatBytes(0)).toBe('0 B');
+      expect(formatBytes(512)).toBe('512 B');
+    });
+
+    it('should format bytes between 1024 and 1024*1024 as KB', () => {
+      expect(formatBytes(1024)).toBe('1.0 KB');
+    });
+
+    it('should format bytes 1024*1024 and above as MB', () => {
+      expect(formatBytes(1048576)).toBe('1.0 MB');
+    });
+
+    it('should handle edge cases', () => {
+      expect(formatBytes(1)).toBe('1 B');
+      expect(formatBytes(1025)).toBe('1.0 KB');
+      expect(formatBytes(1048577)).toBe('1.0 MB');
+    });
+  });
+
+  describe('getFormattedValue', () => {
+    it('should format null values', () => {
+      expect(getFormattedValue(null)).toBe('null');
+    });
+
+    it('should format undefined values', () => {
+      expect(getFormattedValue(undefined)).toBe('undefined');
+    });
+
+    it('should format string values with quotes', () => {
+      expect(getFormattedValue('hello')).toBe('"hello"');
+      expect(getFormattedValue('')).toBe('""');
+      expect(getFormattedValue('test string')).toBe('"test string"');
+    });
+
+    it('should format object values as JSON', () => {
+      const obj = {name: 'John', age: 30};
+      const expected = JSON.stringify(obj, null, 2);
+      expect(getFormattedValue(obj)).toBe(expected);
+    });
+
+    it('should format array values as JSON', () => {
+      const arr = [1, 2, 3];
+      const expected = JSON.stringify(arr, null, 2);
+      expect(getFormattedValue(arr)).toBe(expected);
+    });
+
+    it('should format other primitive types as strings', () => {
+      expect(getFormattedValue(42)).toBe('42');
+      expect(getFormattedValue(3.14)).toBe('3.14');
+      expect(getFormattedValue(true)).toBe('true');
+      expect(getFormattedValue(false)).toBe('false');
+    });
+
+    it('should handle symbols', () => {
+      const symbol = Symbol('test');
+      expect(getFormattedValue(symbol)).toBe(symbol.toString());
+    });
+
+    it('should handle BigInt', () => {
+      const bigInt = BigInt(123456789);
+      expect(getFormattedValue(bigInt)).toBe('123456789');
+    });
+  });
+});

--- a/devtools/projects/ng-devtools/src/lib/shared/utils/formatting.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/utils/formatting.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+/**
+ * Formats a byte count into a readable string with appropriate units.
+ * @param bytes The number of bytes to format
+ * @returns A formatted string with units (B, KB, MB)
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Formatter functions for different value types
+ */
+const formatters = {
+  null: () => 'null',
+  undefined: () => 'undefined',
+  string: (val: string) => `"${val}"`,
+  object: (val: object) => JSON.stringify(val, null, 2),
+  default: (val: unknown) => String(val),
+};
+
+/**
+ * Formats a value into a readable string representation
+ * @param value The value to format
+ * @returns A formatted string representation of the value
+ */
+export function getFormattedValue(value: unknown): string {
+  if (value === null) return formatters.null();
+  if (value === undefined) return formatters.undefined();
+  if (typeof value === 'string') return formatters.string(value);
+  if (typeof value === 'object') return formatters.object(value);
+  return formatters.default(value);
+}

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -340,7 +340,17 @@ export interface SupportedApis {
   dependencyInjection: boolean;
   routes: boolean;
   signals: boolean;
+  transferState: boolean;
 }
+
+export type TransferStateValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | Record<string, unknown>
+  | unknown[];
 
 export interface Events {
   handshake: () => void;
@@ -403,6 +413,9 @@ export interface Events {
   ) => void;
 
   logProvider: (injector: SerializedInjector, providers: SerializedProviderRecord) => void;
+
+  getTransferState: () => void;
+  transferStateData: (data: Record<string, TransferStateValue> | null) => void;
 
   contentScriptConnected: (frameId: number, name: string, url: string) => void;
   contentScriptDisconnected: (frameId: number, name: string, url: string) => void;

--- a/packages/core/src/render3/util/global_utils.ts
+++ b/packages/core/src/render3/util/global_utils.ts
@@ -37,6 +37,7 @@ import {
 import {getSignalGraph} from './signal_debug';
 
 import {enableProfiling} from '../debug/chrome_dev_tools_performance';
+import {getTransferState} from './transfer_state_utils';
 
 /**
  * This file introduces series of globally accessible debug tools
@@ -75,6 +76,7 @@ const globalUtilsFunctions = {
   'ɵsetProfiler': setProfiler,
   'ɵgetSignalGraph': getSignalGraph,
   'ɵgetDeferBlocks': getDeferBlocks,
+  'ɵgetTransferState': getTransferState,
 
   'getDirectiveMetadata': getDirectiveMetadata,
   'getComponent': getComponent,


### PR DESCRIPTION
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
transfer state is visible only on elements tab in ng-state script.

Issue Number: #62237 

## What is the new behavior?
Did workaround with adding of new transfer state tab. Still consider solution with transfer state list in components tab intead of proposed. Let me know which one is prefered.

Demo:
![Click here for Demo Video](https://github.com/user-attachments/assets/91b0f6f1-e395-4935-a246-78d44bf4394d)

<img width="1097" alt="Снимок экрана 2025-07-04 в 10 30 01" src="https://github.com/user-attachments/assets/fb505eb8-3c6e-456c-b512-b63917913b6f" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
