### PR TITLE
refactor(core): use version>0 instead of hasRun

### DIFF
--- a/goldens/public-api/core/primitives/signals/index.api.md
+++ b/goldens/public-api/core/primitives/signals/index.api.md
@@ -16,8 +16,6 @@ export interface BaseEffectNode extends ReactiveNode {
     // (undocumented)
     fn: () => void;
     // (undocumented)
-    hasRun: boolean;
-    // (undocumented)
     run(): void;
 }
 

--- a/packages/core/primitives/signals/src/effect.ts
+++ b/packages/core/primitives/signals/src/effect.ts
@@ -27,7 +27,6 @@ export type EffectCleanupFn = () => void;
 export type EffectCleanupRegisterFn = (cleanupFn: EffectCleanupFn) => void;
 
 export interface BaseEffectNode extends ReactiveNode {
-  hasRun: boolean;
   fn: () => void;
   destroy(): void;
   cleanup(): void;
@@ -40,16 +39,15 @@ export const BASE_EFFECT_NODE: Omit<BaseEffectNode, 'fn' | 'destroy' | 'cleanup'
     consumerIsAlwaysLive: true,
     consumerAllowSignalWrites: true,
     dirty: true,
-    hasRun: false,
     kind: 'effect',
   }))();
 
 export function runEffect(node: BaseEffectNode) {
   node.dirty = false;
-  if (node.hasRun && !consumerPollProducersForChange(node)) {
+  if (node.version > 0 && !consumerPollProducersForChange(node)) {
     return;
   }
-  node.hasRun = true;
+  node.version++;
   const prevNode = consumerBeforeComputation(node);
   try {
     node.cleanup();

--- a/packages/core/primitives/signals/src/watch.ts
+++ b/packages/core/primitives/signals/src/watch.ts
@@ -56,7 +56,6 @@ export interface Watch {
   [SIGNAL]: WatchNode;
 }
 export interface WatchNode extends ReactiveNode {
-  hasRun: boolean;
   fn: ((onCleanup: WatchCleanupRegisterFn) => void) | null;
   schedule: ((watch: Watch) => void) | null;
   cleanupFn: WatchCleanupFn;
@@ -111,10 +110,10 @@ export function createWatch(
     }
 
     node.dirty = false;
-    if (node.hasRun && !consumerPollProducersForChange(node)) {
+    if (node.version > 0 && !consumerPollProducersForChange(node)) {
       return;
     }
-    node.hasRun = true;
+    node.version++;
 
     const prevConsumer = consumerBeforeComputation(node);
     try {
@@ -152,7 +151,6 @@ const WATCH_NODE: Partial<WatchNode> = /* @__PURE__ */ (() => {
         node.schedule(node.ref);
       }
     },
-    hasRun: false,
     cleanupFn: NOOP_CLEANUP_FN,
   };
 })();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #63667


## What is the new behavior?

This saves a field for effect and watch nodes. Additionally, it should make effect nodes flash in the devtools when they rerun.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
