### PR TITLE
refactor(service-worker): align `getRegistration()` types

### DIFF
--- a/packages/service-worker/src/low_level.ts
+++ b/packages/service-worker/src/low_level.ts
@@ -174,8 +174,22 @@ export class NgswCommChannel {
       serviceWorker.addEventListener('controllerchange', updateController);
       updateController();
 
-      this.registration = <Observable<ServiceWorkerRegistration>>(
-        this.worker.pipe(switchMap(() => serviceWorker.getRegistration()))
+      this.registration = this.worker.pipe(
+        switchMap(() =>
+          serviceWorker.getRegistration().then((registration) => {
+            // The `getRegistration()` method may return undefined in
+            // non-secure contexts or incognito mode, where service worker
+            // registration might not be allowed.
+            if (!registration) {
+              throw new RuntimeError(
+                RuntimeErrorCode.SERVICE_WORKER_DISABLED_OR_NOT_SUPPORTED_BY_THIS_BROWSER,
+                (typeof ngDevMode === 'undefined' || ngDevMode) && ERR_SW_NOT_SUPPORTED,
+              );
+            }
+
+            return registration;
+          }),
+        ),
       );
 
       const _events = new Subject<TypedEvent>();


### PR DESCRIPTION
In this commit, we align the service worker types with those provided by TypeScript. The `ServiceWorkerContainer.getRegistration()` method returns a `Promise<ServiceWorkerRegistration | undefined>`, but we were casting it to `Observable<ServiceWorkerRegistration>`, ignoring the possibility of `undefined`.

This is unsafe, as we should account for the case where the registration is `undefined` and handle it appropriately in the push manager.

Closes #62487