### PR TITLE
refactor(compiler): ensure compiler passes closure conformance checks

### DIFF
--- a/packages/compiler/src/expression_parser/lexer.ts
+++ b/packages/compiler/src/expression_parser/lexer.ts
@@ -133,11 +133,13 @@ export class Token {
   }
 
   isTemplateLiteralPart(): this is StringToken {
-    return this.isString() && this.kind === StringTokenKind.TemplateLiteralPart;
+    // Note: Explicit type is needed for Closure.
+    return this.isString() && (this as StringToken).kind === StringTokenKind.TemplateLiteralPart;
   }
 
   isTemplateLiteralEnd(): this is StringToken {
-    return this.isString() && this.kind === StringTokenKind.TemplateLiteralEnd;
+    // Note: Explicit type is needed for Closure.
+    return this.isString() && (this as StringToken).kind === StringTokenKind.TemplateLiteralEnd;
   }
 
   isTemplateLiteralInterpolationStart(): boolean {

--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -1709,9 +1709,15 @@ class EscapedCharacterCursor extends PlainCharacterCursor {
   }
 }
 
-export class CursorError {
+export class CursorError extends Error {
   constructor(
     public msg: string,
     public cursor: CharacterCursor,
-  ) {}
+  ) {
+    super(msg);
+
+    // Extending `Error` does not always work when code is transpiled. See:
+    // https://stackoverflow.com/questions/41102060/typescript-extending-error-class
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
 }


### PR DESCRIPTION
This commit adjusts some code of the compiler that currently results in conformance checks failures with JSCompiler/Closure.