### PR TITLE
fix(router): ensure preloaded components are properly activated

### DIFF
--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -694,7 +694,7 @@ export class NavigationTransitions {
           switchTap((t: NavigationTransition) => {
             const loadComponents = (route: ActivatedRouteSnapshot): Array<Observable<void>> => {
               const loaders: Array<Observable<void>> = [];
-              if (route.routeConfig?.loadComponent && !route.routeConfig._loadedComponent) {
+              if (route.routeConfig?.loadComponent) {
                 const injector = getClosestRouteInjector(route) ?? this.environmentInjector;
                 loaders.push(
                   this.configLoader.loadComponent(injector, route.routeConfig).pipe(

--- a/packages/router/test/integration/lazy_loading.spec.ts
+++ b/packages/router/test/integration/lazy_loading.spec.ts
@@ -57,6 +57,8 @@ import {
   createRoot,
   advance,
 } from './integration_helpers';
+import {getLoadedComponent} from '../../src/utils/config';
+import {of, delay} from 'rxjs';
 
 export function lazyLoadingIntegrationSuite() {
   describe('lazy loading', () => {
@@ -760,6 +762,12 @@ export function lazyLoadingIntegrationSuite() {
       })
       class LazyLoadedComponent {}
 
+      @Component({
+        selector: 'lazy',
+        template: 'LazyLoadedStandaloneComponent',
+      })
+      class LazyLoadedStandaloneComponent {}
+
       @NgModule({
         declarations: [LazyLoadedComponent],
         imports: [RouterModule.forChild([{path: 'LoadedModule2', component: LazyLoadedComponent}])],
@@ -806,6 +814,33 @@ export function lazyLoadingIntegrationSuite() {
         const secondRoutes = getLoadedRoutes(firstRoutes[0])!;
         expect(secondRoutes).toBeDefined();
         expect(secondRoutes[0].path).toEqual('LoadedModule2');
+      });
+
+      it('should activate preloaded component', async () => {
+        const router = TestBed.inject(Router);
+        const routerPreloader = TestBed.inject(RouterPreloader);
+        const fixture = await createRoot(router, RootCmp);
+
+        router.resetConfig([
+          {path: 'blank', component: BlankCmp},
+          {
+            path: 'lazy',
+            loadComponent: () => of(LazyLoadedStandaloneComponent).pipe(delay(10)),
+            canActivate: [() => of(true).pipe(delay(20))],
+          },
+        ]);
+
+        router.navigateByUrl('/blank');
+
+        await advance(fixture);
+
+        routerPreloader.preload();
+
+        router.navigateByUrl('/lazy');
+
+        await advance(fixture, 40);
+
+        expect(fixture.nativeElement).toHaveText('LazyLoadedStandaloneComponent');
       });
 
       it('should not preload when canLoad is present and does not execute guard', async () => {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

This PR addresses an issue where preloaded components are not being activated as expected when preloading is enabled. In certain scenarios, the preloading strategy loads the component, but the route activation does not occur, resulting in the component not being displayed to the user.

## What is the new behavior?

This change aims to ensure that preloaded components are properly activated after being loaded.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Please review this simplified example, which demonstrates the issue. In our production application, we encountered this problem in a more complex scenario: https://stackblitz.com/edit/stackblitz-starters-u44n3ca2?file=package.json
