### PR TITLE
feat(router): Add nonIndex property to Route configuration

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -15,6 +15,7 @@ import * as i0 from '@angular/core';
 import { InjectionToken } from '@angular/core';
 import { Injector } from '@angular/core';
 import { LocationStrategy } from '@angular/common';
+import { Meta } from '@angular/platform-browser';
 import { ModuleWithProviders } from '@angular/core';
 import { NgModuleFactory } from '@angular/core';
 import { Observable } from 'rxjs';
@@ -38,6 +39,7 @@ export class ActivatedRoute {
     data: Observable<Data>;
     get firstChild(): ActivatedRoute | null;
     fragment: Observable<string | null>;
+    readonly nonIndex: Observable<boolean | undefined>;
     outlet: string;
     get paramMap(): Observable<ParamMap>;
     params: Observable<Params>;
@@ -61,6 +63,7 @@ export class ActivatedRouteSnapshot {
     data: Data;
     get firstChild(): ActivatedRouteSnapshot | null;
     fragment: string | null;
+    get nonIndex(): boolean | undefined;
     outlet: string;
     // (undocumented)
     get paramMap(): ParamMap;
@@ -218,6 +221,16 @@ export type DebugTracingFeature = RouterFeature<RouterFeatureKind.DebugTracingFe
 // @public
 export interface DefaultExport<T> {
     default: T;
+}
+
+// @public
+export class DefaultNonIndexStrategy extends NonIndexStrategy {
+    constructor(meta: Meta);
+    updateNonIndex(snapshot: RouterStateSnapshot): void;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<DefaultNonIndexStrategy, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<DefaultNonIndexStrategy>;
 }
 
 // @public
@@ -523,6 +536,18 @@ export class NavigationStart extends RouterEvent {
 }
 
 // @public
+export abstract class NonIndexStrategy {
+    // (undocumented)
+    buildNonIndex(snapshot: RouterStateSnapshot): boolean | undefined;
+    getResolvedNonIndexForRoute(snapshot: ActivatedRouteSnapshot): boolean | undefined;
+    abstract updateNonIndex(snapshot: RouterStateSnapshot): void;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<NonIndexStrategy, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<NonIndexStrategy>;
+}
+
+// @public
 export class NoPreloading implements PreloadingStrategy {
     // (undocumented)
     preload(route: Route, fn: () => Observable<any>): Observable<any>;
@@ -604,7 +629,7 @@ export class RedirectCommand {
 }
 
 // @public
-export type RedirectFunction = (redirectData: Pick<ActivatedRouteSnapshot, 'routeConfig' | 'url' | 'params' | 'queryParams' | 'fragment' | 'data' | 'outlet' | 'title'>) => MaybeAsync<string | UrlTree>;
+export type RedirectFunction = (redirectData: Pick<ActivatedRouteSnapshot, 'routeConfig' | 'url' | 'params' | 'queryParams' | 'fragment' | 'data' | 'outlet' | 'title' | 'nonIndex'>) => MaybeAsync<string | UrlTree>;
 
 // @public
 export interface Resolve<T> {
@@ -668,6 +693,7 @@ export interface Route {
     loadChildren?: LoadChildren;
     loadComponent?: () => Type<unknown> | Observable<Type<unknown> | DefaultExport<Type<unknown>>> | Promise<Type<unknown> | DefaultExport<Type<unknown>>>;
     matcher?: UrlMatcher;
+    nonIndex?: boolean | Type<Resolve<boolean>> | ResolveFn<boolean>;
     outlet?: string;
     path?: string;
     pathMatch?: 'prefix' | 'full';

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -206,10 +206,21 @@ function getRedirectResult(
     return of(redirectTo);
   }
   const redirectToFn = redirectTo;
-  const {queryParams, fragment, routeConfig, url, outlet, params, data, title} = currentSnapshot;
+  const {queryParams, fragment, routeConfig, url, outlet, params, data, title, nonIndex} =
+    currentSnapshot;
   return wrapIntoObservable(
     runInInjectionContext(injector, () =>
-      redirectToFn({params, data, queryParams, fragment, routeConfig, url, outlet, title}),
+      redirectToFn({
+        params,
+        data,
+        queryParams,
+        fragment,
+        routeConfig,
+        url,
+        outlet,
+        title,
+        nonIndex,
+      }),
     ),
   );
 }

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -70,6 +70,7 @@ export {ViewTransitionInfo, ViewTransitionsFeatureOptions} from './utils/view_tr
 export * from './models_deprecated';
 export {Navigation, NavigationExtras, UrlCreationOptions} from './navigation_transition';
 export {DefaultTitleStrategy, TitleStrategy} from './page_title_strategy';
+export {DefaultNonIndexStrategy, NonIndexStrategy} from './non_index_strategy';
 export {
   ComponentInputBindingFeature,
   DebugTracingFeature,

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -314,7 +314,15 @@ export type QueryParamsHandling = 'merge' | 'preserve' | 'replace' | '';
 export type RedirectFunction = (
   redirectData: Pick<
     ActivatedRouteSnapshot,
-    'routeConfig' | 'url' | 'params' | 'queryParams' | 'fragment' | 'data' | 'outlet' | 'title'
+    | 'routeConfig'
+    | 'url'
+    | 'params'
+    | 'queryParams'
+    | 'fragment'
+    | 'data'
+    | 'outlet'
+    | 'title'
+    | 'nonIndex'
   >,
 ) => MaybeAsync<string | UrlTree>;
 
@@ -757,6 +765,28 @@ export interface Route {
    * @internal
    */
   _loadedInjector?: EnvironmentInjector;
+
+  /**
+   * Defines a strategy for setting the non-index behavior of the route.
+   *
+   * When specified, the route will be marked as non-indexable for search engines.
+   * This can be used to control which pages should be indexed by search engines.
+   *
+   * @see {@link NonIndexStrategy}
+   *
+   * @usageNotes
+   *
+   * ### Simple Example
+   *
+   * ```
+   * const route: Route = {
+   *   path: 'admin',
+   *   component: AdminComponent,
+   *   nonIndex: true  // This page will not be indexed
+   * };
+   * ```
+   */
+  nonIndex?: boolean | Type<Resolve<boolean>> | ResolveFn<boolean>;
 }
 
 export interface LoadedRouterConfig {

--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -88,6 +88,7 @@ import {isUrlTree, UrlSerializer, UrlTree} from './url_tree';
 import {Checks, getAllRouteGuards} from './utils/preactivation';
 import {CREATE_VIEW_TRANSITION} from './utils/view_transition';
 import {getClosestRouteInjector} from './utils/config';
+import {NonIndexStrategy} from './non_index_strategy';
 
 /**
  * @description
@@ -365,6 +366,7 @@ export class NavigationTransitions {
   private readonly location = inject(Location);
   private readonly inputBindingEnabled = inject(INPUT_BINDER, {optional: true}) !== null;
   private readonly titleStrategy?: TitleStrategy = inject(TitleStrategy);
+  private readonly nonIndexStrategy?: NonIndexStrategy = inject(NonIndexStrategy);
   private readonly options = inject(ROUTER_CONFIGURATION, {optional: true}) || {};
   private readonly paramsInheritanceStrategy =
     this.options.paramsInheritanceStrategy || 'emptyOnly';
@@ -791,6 +793,7 @@ export class NavigationTransitions {
                 ),
               );
               this.titleStrategy?.updateTitle(t.targetRouterState!.snapshot);
+              this.nonIndexStrategy?.updateNonIndex(t.targetRouterState!.snapshot);
               t.resolve(true);
             },
             complete: () => {

--- a/packages/router/src/non_index_strategy.ts
+++ b/packages/router/src/non_index_strategy.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {inject, Injectable} from '@angular/core';
+import {Meta} from '@angular/platform-browser';
+import {ActivatedRouteSnapshot, RouterStateSnapshot} from './router_state';
+import {PRIMARY_OUTLET, RouteNonIndexKey} from './shared';
+
+/**
+ * Provides a strategy for setting the non-index attribute of a route after a navigation.
+ *
+ * The built-in `DefaultNonIndexStrategy` writes the non-index attribute to the `robots` meta tag.
+ *
+ * @publicApi
+ */
+@Injectable({providedIn: 'root', useFactory: () => inject(DefaultNonIndexStrategy)})
+export abstract class NonIndexStrategy {
+  /**
+   * Performs the application non-index strategy.
+   * @param snapshot The snapshot of the router state.
+   */
+  abstract updateNonIndex(snapshot: RouterStateSnapshot): void;
+
+  /**
+   * @returns The `nonIndex` value from the deepest primary route.
+   */
+  buildNonIndex(snapshot: RouterStateSnapshot): boolean | undefined {
+    let nonIndex: boolean | undefined;
+    let route: ActivatedRouteSnapshot | undefined = snapshot.root;
+    while (route !== undefined) {
+      nonIndex = this.getResolvedNonIndexForRoute(route) ?? nonIndex;
+      route = route.children.find((child) => child.outlet === PRIMARY_OUTLET);
+    }
+    return nonIndex;
+  }
+
+  /**
+   * Given an `ActivatedRouteSnapshot`, returns the final value of the
+   * `Route.nonIndex` property, which can either be a static boolean or a resolved value.
+   */
+  getResolvedNonIndexForRoute(snapshot: ActivatedRouteSnapshot): boolean | undefined {
+    return snapshot.data[RouteNonIndexKey];
+  }
+}
+
+/**
+ * The default `NonIndexStrategy` used by the Angular router.
+ *
+ * @publicApi
+ */
+@Injectable({providedIn: 'root'})
+export class DefaultNonIndexStrategy extends NonIndexStrategy {
+  constructor(private meta: Meta) {
+    super();
+  }
+
+  /**
+   * Sets the non-index attribute on the `robots` meta tag.
+   * @param snapshot The snapshot of the router state.
+   */
+  override updateNonIndex(snapshot: RouterStateSnapshot): void {
+    const nonIndex = this.buildNonIndex(snapshot);
+    this.updateMetaTag(nonIndex);
+  }
+
+  private updateMetaTag(nonIndex: boolean | undefined): void {
+    if (nonIndex === undefined) {
+      return;
+    }
+
+    if (nonIndex) {
+      this.meta.updateTag({name: 'robots', content: 'noindex,nofollow'});
+    } else if (nonIndex === false) {
+      this.meta.updateTag({name: 'robots', content: 'index,follow'});
+    }
+  }
+}

--- a/packages/router/src/operators/resolve_data.ts
+++ b/packages/router/src/operators/resolve_data.ts
@@ -15,10 +15,11 @@ import type {NavigationTransition} from '../navigation_transition';
 import {
   ActivatedRouteSnapshot,
   getInherited,
+  hasStaticNonIndex,
   hasStaticTitle,
   RouterStateSnapshot,
 } from '../router_state';
-import {RouteTitleKey} from '../shared';
+import {RouteNonIndexKey, RouteTitleKey} from '../shared';
 import {getDataKeys, wrapIntoObservable} from '../utils/collection';
 import {getClosestRouteInjector} from '../utils/config';
 import {getTokenOrFunctionIdentity} from '../utils/preactivation';
@@ -89,6 +90,11 @@ function runResolve(
   if (config?.title !== undefined && !hasStaticTitle(config)) {
     resolve[RouteTitleKey] = config.title;
   }
+
+  if (config?.nonIndex !== undefined && !hasStaticNonIndex(config)) {
+    resolve[RouteNonIndexKey] = config.nonIndex;
+  }
+
   return defer(() => {
     futureARS.data = getInherited(futureARS, futureARS.parent, paramsInheritanceStrategy).resolve;
     return resolveNode(resolve, futureARS, futureRSS, injector).pipe(

--- a/packages/router/src/shared.ts
+++ b/packages/router/src/shared.ts
@@ -24,6 +24,13 @@ export const PRIMARY_OUTLET = 'primary';
 export const RouteTitleKey: unique symbol = /* @__PURE__ */ Symbol('RouteTitle');
 
 /**
+ * A private symbol used to store the value of `Route.nonIndex` inside the `Route.data` if it is a
+ * static boolean or `Route.resolve` if anything else. This allows us to reuse the existing
+ * route data/resolvers to support the non-index feature without new instrumentation in the `Router` pipeline.
+ */
+export const RouteNonIndexKey: unique symbol = /* @__PURE__ */ Symbol('RouteNonIndex');
+
+/**
  * A collection of matrix and query URL parameters.
  * @see {@link convertToParamMap}
  * @see {@link ParamMap}

--- a/packages/router/test/non_index_strategy_spec.ts
+++ b/packages/router/test/non_index_strategy_spec.ts
@@ -1,0 +1,298 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {DOCUMENT} from '@angular/common';
+import {provideLocationMocks} from '@angular/common/testing';
+import {Component, inject, Inject, Injectable, NgModule} from '@angular/core';
+import {Meta} from '@angular/platform-browser';
+import {TestBed} from '@angular/core/testing';
+import {
+  provideRouter,
+  Router,
+  RouterModule,
+  RouterStateSnapshot,
+  NonIndexStrategy,
+  withRouterConfig,
+  ActivatedRoute,
+  ResolveFn,
+} from '../index';
+import {takeUntilDestroyed} from '../../core/rxjs-interop';
+import {RouterTestingHarness} from '../testing';
+
+describe('non-index strategy', () => {
+  describe('DefaultNonIndexStrategy', () => {
+    let router: Router;
+    let meta: Meta;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [TestModule],
+        providers: [
+          provideLocationMocks(),
+          provideRouter([], withRouterConfig({paramsInheritanceStrategy: 'always'})),
+        ],
+      });
+      router = TestBed.inject(Router);
+      meta = TestBed.inject(Meta);
+    });
+
+    it('sets page nonIndex from data', async () => {
+      router.resetConfig([{path: 'home', nonIndex: true, component: BlankCmp}]);
+      await router.navigateByUrl('home');
+
+      const robotsTag = meta.getTag('name="robots"');
+      expect(robotsTag?.content).toContain('noindex,nofollow');
+    });
+
+    it('does not set noindex when nonIndex is false', async () => {
+      router.resetConfig([{path: 'home', nonIndex: false, component: BlankCmp}]);
+      await router.navigateByUrl('home');
+
+      const robotsTag = meta.getTag('name="robots"');
+      expect(robotsTag?.content).toContain('index,follow');
+    });
+
+    it('sets nonIndex from resolved data', async () => {
+      router.resetConfig([
+        {
+          path: 'home',
+          nonIndex: NonIndexResolver,
+          component: BlankCmp,
+        },
+      ]);
+      await router.navigateByUrl('home');
+
+      const robotsTag = meta.getTag('name="robots"');
+      expect(robotsTag?.content).toContain('noindex,nofollow');
+    });
+
+    it('sets nonIndex from resolved data function', async () => {
+      router.resetConfig([
+        {
+          path: 'home',
+          nonIndex: () => true,
+          component: BlankCmp,
+        },
+      ]);
+      await router.navigateByUrl('home');
+
+      const robotsTag = meta.getTag('name="robots"');
+      expect(robotsTag?.content).toContain('noindex,nofollow');
+    });
+
+    it('inherits nonIndex from parent routes', async () => {
+      router.resetConfig([
+        {
+          path: 'parent',
+          nonIndex: true,
+          children: [{path: 'child', component: BlankCmp}],
+        },
+      ]);
+      await router.navigateByUrl('parent/child');
+
+      const robotsTag = meta.getTag('name="robots"');
+      expect(robotsTag?.content).toContain('noindex');
+    });
+
+    it('child route nonIndex overrides parent', async () => {
+      router.resetConfig([
+        {
+          path: 'home',
+          nonIndex: true,
+          children: [{path: 'child', nonIndex: false, component: BlankCmp}],
+        },
+      ]);
+      await router.navigateByUrl('home/child');
+
+      const robotsTag = meta.getTag('name="robots"');
+      expect(robotsTag?.content).toContain('index,follow');
+    });
+
+    it('sets title with child routes and named outlets', async () => {
+      router.resetConfig([
+        {
+          path: 'home',
+          title: 'My Application',
+          children: [
+            {path: '', nonIndex: false, component: BlankCmp},
+            {path: '', outlet: 'childaux', nonIndex: true, component: BlankCmp},
+          ],
+        },
+        {path: 'compose', component: BlankCmp, outlet: 'aux'},
+      ]);
+      await router.navigateByUrl('home(aux:compose)');
+
+      const robotsTag = meta.getTag('name="robots"');
+      expect(robotsTag?.content).toContain('index,follow');
+    });
+
+    it('uses deepest primary route nonIndex value', async () => {
+      router.resetConfig([
+        {
+          path: 'level1',
+          nonIndex: false,
+          children: [
+            {
+              path: 'level2',
+              nonIndex: true,
+              children: [{path: 'level3', nonIndex: false, component: BlankCmp}],
+            },
+          ],
+        },
+      ]);
+      await router.navigateByUrl('level1/level2/level3');
+
+      const robotsTag = meta.getTag('name="robots"');
+      expect(robotsTag?.content).toContain('index,follow');
+    });
+
+    it('can get the nonIndex from the ActivatedRouteSnapshot', async () => {
+      router.resetConfig([
+        {
+          path: 'home',
+          nonIndex: true,
+          component: BlankCmp,
+        },
+      ]);
+      await router.navigateByUrl('home');
+      expect(router.routerState.snapshot.root.firstChild!.nonIndex).toEqual(true);
+    });
+
+    it('pushes updates through the nonIndex observable', async () => {
+      @Component({template: ''})
+      class HomeCmp {
+        private readonly nonIndex$ = inject(ActivatedRoute).nonIndex.pipe(takeUntilDestroyed());
+        nonIndex?: boolean;
+
+        constructor() {
+          this.nonIndex$.subscribe((v) => (this.nonIndex = v));
+        }
+      }
+
+      const nonIndexResolver: ResolveFn<boolean> = (route) =>
+        JSON.parse(route.queryParams['nonIndex']);
+
+      router.resetConfig([
+        {
+          path: 'home',
+          nonIndex: nonIndexResolver,
+          component: HomeCmp,
+          runGuardsAndResolvers: 'paramsOrQueryParamsChange',
+        },
+      ]);
+
+      const harness = await RouterTestingHarness.create();
+      const homeCmp = await harness.navigateByUrl('/home?nonIndex=true', HomeCmp);
+      expect(homeCmp.nonIndex).toEqual(true);
+      await harness.navigateByUrl('home?nonIndex=false');
+      expect(homeCmp.nonIndex).toEqual(false);
+    });
+  });
+
+  describe('custom strategies', () => {
+    it('allows overriding the updateNonIndex method', async () => {
+      @Injectable({providedIn: 'root'})
+      class CustomNonIndexStrategy extends NonIndexStrategy {
+        constructor(private meta: Meta) {
+          super();
+        }
+
+        override updateNonIndex(state: RouterStateSnapshot) {
+          const nonIndex = this.buildNonIndex(state);
+          if (nonIndex) {
+            // Custom implementation: only set noindex, not nofollow
+            this.meta.updateTag({name: 'robots', content: 'noindex'});
+          }
+        }
+      }
+
+      TestBed.configureTestingModule({
+        imports: [TestModule],
+        providers: [
+          provideLocationMocks(),
+          provideRouter([]),
+          {provide: NonIndexStrategy, useClass: CustomNonIndexStrategy},
+        ],
+      });
+
+      const router = TestBed.inject(Router);
+      const meta = TestBed.inject(Meta);
+
+      router.resetConfig([{path: 'custom', nonIndex: true, component: BlankCmp}]);
+      await router.navigateByUrl('custom');
+
+      const robotsTag = meta.getTag('name="robots"');
+      expect(robotsTag?.content).toBe('noindex');
+      expect(robotsTag?.content).not.toContain('nofollow');
+    });
+
+    it('allows completely custom nonIndex logic', async () => {
+      @Injectable({providedIn: 'root'})
+      class ConditionalNonIndexStrategy extends NonIndexStrategy {
+        constructor(@Inject(DOCUMENT) private document: Document) {
+          super();
+        }
+
+        override updateNonIndex(state: RouterStateSnapshot) {
+          const nonIndex = this.buildNonIndex(state);
+          // Custom logic: add a data attribute instead of meta tag
+          if (nonIndex) {
+            this.document.body.setAttribute('data-noindex', 'true');
+          } else {
+            this.document.body.removeAttribute('data-noindex');
+          }
+        }
+      }
+
+      TestBed.configureTestingModule({
+        imports: [TestModule],
+        providers: [
+          provideLocationMocks(),
+          provideRouter([]),
+          {provide: NonIndexStrategy, useClass: ConditionalNonIndexStrategy},
+        ],
+      });
+
+      const router = TestBed.inject(Router);
+      const document = TestBed.inject(DOCUMENT);
+
+      router.resetConfig([{path: 'custom', nonIndex: true, component: BlankCmp}]);
+      await router.navigateByUrl('custom');
+
+      expect(document.body.getAttribute('data-noindex')).toBe('true');
+    });
+  });
+});
+
+@Component({
+  template: '',
+  standalone: false,
+})
+export class BlankCmp {}
+
+@Component({
+  template: `
+<router-outlet></router-outlet>
+<router-outlet name="auxiliary"></router-outlet>
+`,
+  standalone: false,
+})
+export class RootCmp {}
+
+@NgModule({
+  declarations: [BlankCmp],
+  imports: [RouterModule.forRoot([])],
+})
+export class TestModule {}
+
+@Injectable({providedIn: 'root'})
+export class NonIndexResolver {
+  resolve() {
+    return true;
+  }
+}

--- a/packages/router/test/operators/resolve_data.spec.ts
+++ b/packages/router/test/operators/resolve_data.spec.ts
@@ -185,6 +185,39 @@ describe('resolveData operator', () => {
     expect(rootSnapshot.firstChild!.title).toBe('b title');
   });
 
+  it('should have static nonIndex when there is a resolver', async () => {
+    @Component({
+      template: '',
+      standalone: false,
+    })
+    class Empty {}
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([
+          {
+            path: 'a',
+            nonIndex: true,
+            component: Empty,
+            resolve: {other: () => 'other'},
+            children: [
+              {
+                path: 'b',
+                nonIndex: true,
+                component: Empty,
+                resolve: {otherb: () => 'other b'},
+              },
+            ],
+          },
+        ]),
+      ],
+    });
+    await RouterTestingHarness.create('/a/b');
+    const rootSnapshot = TestBed.inject(Router).routerState.root.firstChild!.snapshot;
+    expect(rootSnapshot.nonIndex).toBe(true);
+    expect(rootSnapshot.firstChild!.nonIndex).toBe(true);
+  });
+
   it('can used parent data in child resolver', async () => {
     @Component({
       template: '',

--- a/packages/router/test/router_state.spec.ts
+++ b/packages/router/test/router_state.spec.ts
@@ -16,7 +16,7 @@ import {
   RouterState,
   RouterStateSnapshot,
 } from '../src/router_state';
-import {Params, RouteTitleKey} from '../src/shared';
+import {Params, RouteTitleKey , RouteNonIndexKey} from '../src/shared';
 import {UrlSegment} from '../src/url_tree';
 import {TreeNode} from '../src/utils/tree';
 
@@ -277,6 +277,33 @@ describe('RouterState & Snapshot', () => {
 
       expect(resolvedTitle).toEqual('resolved title');
       expect(snapshot.title).toEqual('resolved title');
+    });
+    it('should get resolved route nonIndex', () => {
+      const data = {[RouteNonIndexKey]: true};
+      const route = createActivatedRoute('a');
+      const snapshot = new (ActivatedRouteSnapshot as any)(
+        [],
+        null,
+        null,
+        null,
+        data,
+        null,
+        'test',
+        null,
+        null,
+        -1,
+        null!,
+      );
+      let resolvedNonIndex: boolean | undefined;
+
+      route.data.next(data);
+
+      route.nonIndex.forEach((nonIndex: boolean | undefined) => {
+        resolvedNonIndex = nonIndex;
+      });
+
+      expect(resolvedNonIndex).toEqual(true);
+      expect(snapshot.nonIndex).toEqual(true);
     });
   });
 });


### PR DESCRIPTION
 # feat(router): Add `nonIndex` property to Route configuration

## Summary

This PR introduces a new `nonIndex` property to the `Route` interface, allowing developers to easily control which routes should be excluded from search engine indexing. This enhances SEO capabilities by providing a simple flag-based approach to manage route indexability.

## Motivation

In modern web applications, controlling which pages are indexed by search engines is crucial for SEO. With Angular's increased focus on Server-Side Rendering (SSR) and static site generation, applications now generate more content that search engines can discover and index. However, not all routes should be publicly indexed - admin panels, user dashboards, draft content, and sensitive pages need to be excluded from search engine crawling. The `nonIndex` property allows developers to specify whether a route should be indexed or not, providing a straightforward way to manage this aspect of routing without requiring complex meta tag manipulation or external SEO tools.


## Type Definitions

```typescript
export interface Route {
  // ...existing properties...
  
  /**
   * Defines a strategy for setting the non-index behavior of the route.
   *
   * When specified, the route will be marked as non-indexable for search engines.
   * This can be used to control which pages should be indexed by search engines.
   *
   * @see {@link NonIndexStrategy}
   *
   * @usageNotes
   *
   * ### Simple Example
   *
   * ```
   * const route: Route = {
   *   path: 'admin',
   *   component: AdminComponent,
   *   nonIndex: true  // This page will not be indexed
   * };
   * ```
   */
  nonIndex?: boolean | Type<Resolve<boolean>> | ResolveFn<boolean>;
}
```

## Usage Examples

### Basic Usage

```typescript
const routes: Routes = [
  {
    path: 'admin',
    component: AdminComponent,
    nonIndex: true  // Simple boolean flag
  },
  {
    path: 'user-profile',
    component: UserProfileComponent,
    nonIndex: false  // Explicitly allow indexing
  }
];
```


### Custom NonIndex Strategy Service

```typescript
@Injectable({
  providedIn: 'root'
})
export class CustomNonIndexStrategy extends NonIndexStrategy {
  updateNonIndex(route: ActivatedRouteSnapshot): boolean {
    // Custom logic for determining indexability
    const userRole = inject(AuthService).getCurrentUserRole();
    const routeData = route.data;
    
    // Don't index admin routes for non-admin users
    if (routeData['requiresAdmin'] && userRole !== 'admin') {
      return false;
    }
    
    // Don't index beta features
    if (routeData['betaFeature'] && !inject(FeatureFlagService).isBetaEnabled()) {
      return false;
    }
    
    return true;
  }
}
```

### Using with Resolvers

```typescript
// Using a resolver function
const routes: Routes = [
  {
    path: 'dynamic-page',
    component: DynamicPageComponent,
    nonIndex: () => inject(ConfigService).shouldExcludeFromIndex()
  }
];

// Using a resolver class
@Injectable()
class IndexingResolver implements Resolve<boolean> {
  resolve(route: ActivatedRouteSnapshot): boolean {
    return route.params['sensitive'] === 'true';
  }
}

const routes: Routes = [
  {
    path: 'content/:sensitive',
    component: ContentComponent,
    nonIndex: IndexingResolver
  }
];
```

### Conditional Indexing

```typescript
const routes: Routes = [
  {
    path: 'article/:id',
    component: ArticleComponent,
    nonIndex: (route: ActivatedRouteSnapshot) => {
      const articleService = inject(ArticleService);
      return articleService.isDraft(route.params['id']);
    }
  }
];
```

## Benefits

### **Developer Experience**
- **Simple API**: Just add `nonIndex: true` to any route
- **Flexible**: Supports static boolean, resolver classes, and resolver functions
- **Type-safe**: Full TypeScript support with proper type definitions

### **SEO Control**
- **Granular control**: Set indexing behavior per route
- **Dynamic decisions**: Use resolvers for runtime indexing decisions
- **Search engine optimization**: Prevent sensitive or admin routes from being indexed


## Use Cases

1. **Admin Routes**: Prevent administrative interfaces from being indexed
2. **User-Specific Content**: Exclude personal dashboards and private pages
3. **Draft Content**: Hide unpublished articles or preview pages
4. **Sensitive Information**: Protect routes containing confidential data
5. **Development Routes**: Exclude debug or testing routes in production


## Breaking Changes

None. This is a purely additive feature that maintains full backward compatibility.

## Testing

The implementation includes comprehensive tests covering:
- Static boolean values
- Resolver function integration
- Resolver class integration
- Type safety verification
- Integration with existing router functionality
