### PR TITLE
refactor(compiler): fix import manager to be closure property renaming compatible

### DIFF
--- a/packages/compiler-cli/src/ngtsc/translator/src/import_manager/check_unique_identifier_name.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/import_manager/check_unique_identifier_name.ts
@@ -29,12 +29,17 @@ export function createGenerateUniqueIdentifierHelper(): ImportManagerConfig['gen
 
   return (sourceFile: ts.SourceFile, symbolName: string) => {
     const sf = sourceFile as SourceFileWithIdentifiers;
-    if (sf.identifiers === undefined) {
+
+    // NOTE: Typically accesses to TS fields are not renamed because the 1P externs
+    // produced from TypeScript are ensuring public fields are considered "external".
+    // See: https://developers.google.com/closure/compiler/docs/externs-and-exports.
+    // This property is internal, so not part of the externs— so we need be cautious
+    if (sf['identifiers'] === undefined) {
       throw new Error('Source file unexpectedly lacks map of parsed `identifiers`.');
     }
 
     const isUniqueIdentifier = (name: string) =>
-      !sf.identifiers!.has(name) && !isGeneratedIdentifier(sf, name);
+      !sf['identifiers']!.has(name) && !isGeneratedIdentifier(sf, name);
 
     if (isUniqueIdentifier(symbolName)) {
       markIdentifierAsGenerated(sf, symbolName);


### PR DESCRIPTION
The `generateUniqueIdentifier` helper relies on the internal `identifiers` property of a `ts.SourceFile`. As this is not a public-facing API, it is not included in the externs provided to Closure Compiler. Consequently, it is susceptible to being renamed during advanced optimizations, which would lead to runtime failures.

To prevent this, the property is now accessed via a string literal (`sf['identifiers']`). This change ensures that the property name is preserved through the compilation process. An explanatory comment has been added to clarify the necessity of this approach for future reference.