### PR TITLE
build: migrate usages of protractor_web_test_suite to use new rules_browser based rule

### DIFF
--- a/packages/core/test/bundling/image-directive/BUILD.bazel
+++ b/packages/core/test/bundling/image-directive/BUILD.bazel
@@ -1,5 +1,6 @@
-load("//tools:defaults.bzl", "esbuild", "http_server", "protractor_web_test_suite")
-load("//tools:defaults2.bzl", "ng_project", "ts_project")
+load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("//tools:defaults.bzl", "http_server")
+load("//tools:defaults2.bzl", "ng_project", "protractor_web_test_suite", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -18,26 +19,25 @@ ng_project(
         "index.ts",
         "playground.ts",
     ],
-    interop_deps = [
-        "//packages/common",
-        "//packages/core",
-        "//packages/platform-browser",
-        "//packages/router",
+    deps = [
+        "//packages/common:common_rjs",
+        "//packages/compiler:compiler_rjs",
+        "//packages/core:core_rjs",
+        "//packages/platform-browser:platform-browser_rjs",
+        "//packages/router:router_rjs",
     ],
 )
 
-# Note: Cannot use `app_bundle` as the e2e tests rely on `ngDevMode`
-# output which would otherwise be omitted.
 esbuild(
     name = "bundle",
+    config = {
+        "resolveExtensions": [".js"],
+    },
     entry_point = ":index.ts",
+    tsconfig = "//packages/core:tsconfig_build",
     deps = [
-        ":image-directive",
-        "//packages/common",
-        "//packages/core",
-        "//packages/platform-browser",
-        "//packages/router",
-        "@npm//rxjs",
+        ":image-directive_rjs",
+        "//packages/core:tsconfig_build",
     ],
 )
 
@@ -54,7 +54,7 @@ http_server(
     ],
     deps = [
         ":bundle",
-        "@npm//zone.js",
+        "//:node_modules/zone.js",
     ],
 )
 
@@ -64,24 +64,20 @@ ts_project(
     srcs = ["e2e/browser-logs-util.ts"] + glob([
         "e2e/**/*.e2e-spec.ts",
     ]),
-    interop_deps = [
-        "//packages/private/testing",
-    ],
     tsconfig = ":e2e/tsconfig-e2e.json",
     deps = [
         "//:node_modules/@types/jasminewd2",
         "//:node_modules/@types/node",
         "//:node_modules/@types/selenium-webdriver",
         "//:node_modules/protractor",
+        "//packages/private/testing:testing_rjs",
     ],
 )
 
 protractor_web_test_suite(
     name = "protractor_tests",
-    on_prepare = ":e2e/start-server.js",
     server = ":devserver",
     deps = [
-        ":img_dir_e2e_tests_lib",
-        "@npm//selenium-webdriver",
+        ":img_dir_e2e_tests_lib_rjs",
     ],
 )

--- a/packages/core/test/bundling/image-directive/index.html
+++ b/packages/core/test/bundling/image-directive/index.html
@@ -10,7 +10,7 @@
 
     <app-root></app-root>
 
-    <script src="npm/node_modules/zone.js/bundles/zone.umd.js"></script>
+    <script src="/angular/node_modules/zone.js/bundles/zone.umd.js"></script>
     <script src="bundle.js"></script>
   </body>
 </html>

--- a/packages/core/test/bundling/image-directive/index.ts
+++ b/packages/core/test/bundling/image-directive/index.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import '@angular/compiler';
 import {Component, importProvidersFrom} from '../../../src/core';
 import {bootstrapApplication, provideProtractorTestingSupport} from '@angular/platform-browser';
 import {RouterModule} from '@angular/router';

--- a/packages/examples/common/BUILD.bazel
+++ b/packages/examples/common/BUILD.bazel
@@ -1,5 +1,6 @@
-load("//tools:defaults.bzl", "esbuild", "http_server", "protractor_web_test_suite")
-load("//tools:defaults2.bzl", "ng_project", "ts_project")
+load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("//tools:defaults.bzl", "http_server")
+load("//tools:defaults2.bzl", "ng_project", "protractor_web_test_suite", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -9,14 +10,12 @@ ng_project(
         ["**/*.ts"],
         exclude = ["**/*_spec.ts"],
     ),
-    interop_deps = [
-        "//packages/platform-browser",
-    ],
     deps = [
         "//:node_modules/rxjs",
         "//:node_modules/zone.js",
         "//packages/common:common_rjs",
         "//packages/core:core_rjs",
+        "//packages/platform-browser:platform-browser_rjs",
         "//packages/router:router_rjs",
     ],
 )
@@ -25,21 +24,26 @@ ts_project(
     name = "common_tests_lib",
     testonly = True,
     srcs = glob(["**/*_spec.ts"]),
-    interop_deps = [
-        "//packages/private/testing",
-    ],
     tsconfig = "//packages/examples:tsconfig_e2e",
     deps = [
         "//:node_modules/@types/jasminewd2",
         "//:node_modules/protractor",
         "//packages/examples/test-utils:test-utils_rjs",
+        "//packages/private/testing:testing_rjs",
     ],
 )
 
 esbuild(
     name = "app_bundle",
+    config = {
+        "resolveExtensions": [".js"],
+    },
     entry_point = ":main.ts",
-    deps = [":common_examples"],
+    tsconfig = "//packages/examples:tsconfig_build",
+    deps = [
+        ":common_examples_rjs",
+        "//packages/examples:tsconfig_build",
+    ],
 )
 
 http_server(
@@ -51,11 +55,9 @@ http_server(
 
 protractor_web_test_suite(
     name = "protractor_tests",
-    on_prepare = ":start-server.js",
     server = ":devserver",
     deps = [
-        ":common_tests_lib",
-        "@npm//selenium-webdriver",
+        ":common_tests_lib_rjs",
     ],
 )
 

--- a/packages/examples/core/BUILD.bazel
+++ b/packages/examples/core/BUILD.bazel
@@ -1,5 +1,6 @@
-load("//tools:defaults.bzl", "esbuild", "http_server", "protractor_web_test_suite")
-load("//tools:defaults2.bzl", "angular_jasmine_test", "ng_project", "ts_project")
+load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("//tools:defaults.bzl", "http_server")
+load("//tools:defaults2.bzl", "angular_jasmine_test", "ng_project", "protractor_web_test_suite", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -12,16 +13,14 @@ ng_project(
             "**/*_howto.ts",
         ],
     ),
-    interop_deps = [
-        "//packages/platform-browser",
-        "//packages/platform-browser/animations",
-    ],
     deps = [
         "//:node_modules/rxjs",
         "//:node_modules/zone.js",
         "//packages/animations:animations_rjs",
         "//packages/core:core_rjs",
         "//packages/forms:forms_rjs",
+        "//packages/platform-browser:platform-browser_rjs",
+        "//packages/platform-browser/animations:animations_rjs",
         "//packages/router:router_rjs",
     ],
 )
@@ -53,8 +52,15 @@ ts_project(
 
 esbuild(
     name = "app_bundle",
+    config = {
+        "resolveExtensions": [".js"],
+    },
     entry_point = ":main.ts",
-    deps = [":core_examples"],
+    tsconfig = "//packages/examples:tsconfig_build",
+    deps = [
+        ":core_examples_rjs",
+        "//packages/examples:tsconfig_build",
+    ],
 )
 
 http_server(
@@ -66,11 +72,9 @@ http_server(
 
 protractor_web_test_suite(
     name = "protractor_tests",
-    on_prepare = ":start-server.js",
     server = ":devserver",
     deps = [
-        ":core_e2e_tests_lib",
-        "@npm//selenium-webdriver",
+        ":core_e2e_tests_lib_rjs",
     ],
 )
 

--- a/packages/examples/forms/BUILD.bazel
+++ b/packages/examples/forms/BUILD.bazel
@@ -1,5 +1,6 @@
-load("//tools:defaults.bzl", "esbuild", "http_server", "protractor_web_test_suite")
-load("//tools:defaults2.bzl", "ng_project", "ts_project")
+load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("//tools:defaults.bzl", "http_server")
+load("//tools:defaults2.bzl", "ng_project", "protractor_web_test_suite", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -38,8 +39,15 @@ ts_project(
 
 esbuild(
     name = "app_bundle",
+    config = {
+        "resolveExtensions": [".js"],
+    },
     entry_point = ":main.ts",
-    deps = [":forms_examples"],
+    tsconfig = "//packages/examples:tsconfig_build",
+    deps = [
+        ":forms_examples_rjs",
+        "//packages/examples:tsconfig_build",
+    ],
 )
 
 http_server(
@@ -51,11 +59,9 @@ http_server(
 
 protractor_web_test_suite(
     name = "protractor_tests",
-    on_prepare = ":start-server.js",
     server = ":devserver",
     deps = [
-        ":forms_e2e_tests_lib",
-        "@npm//selenium-webdriver",
+        ":forms_e2e_tests_lib_rjs",
     ],
 )
 

--- a/packages/examples/service-worker/push/BUILD.bazel
+++ b/packages/examples/service-worker/push/BUILD.bazel
@@ -1,5 +1,6 @@
-load("//tools:defaults.bzl", "esbuild", "http_server", "protractor_web_test_suite")
-load("//tools:defaults2.bzl", "ng_project", "ts_project")
+load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("//tools:defaults.bzl", "http_server")
+load("//tools:defaults2.bzl", "ng_project", "protractor_web_test_suite", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -36,8 +37,15 @@ ts_project(
 
 esbuild(
     name = "app_bundle",
+    config = {
+        "resolveExtensions": [".js"],
+    },
     entry_point = ":main.ts",
-    deps = [":sw_push_examples"],
+    tsconfig = "//packages/examples:tsconfig_build",
+    deps = [
+        ":sw_push_examples_rjs",
+        "//packages/examples:tsconfig_build",
+    ],
 )
 
 http_server(
@@ -52,11 +60,9 @@ http_server(
 
 protractor_web_test_suite(
     name = "protractor_tests",
-    on_prepare = "start-server.js",
     server = ":devserver",
     deps = [
-        ":sw_push_e2e_tests_lib",
-        "@npm//selenium-webdriver",
+        ":sw_push_e2e_tests_lib_rjs",
     ],
 )
 

--- a/packages/examples/service-worker/registration-options/BUILD.bazel
+++ b/packages/examples/service-worker/registration-options/BUILD.bazel
@@ -1,5 +1,6 @@
-load("//tools:defaults.bzl", "esbuild", "http_server", "protractor_web_test_suite")
-load("//tools:defaults2.bzl", "ng_project", "ts_project")
+load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("//tools:defaults.bzl", "http_server")
+load("//tools:defaults2.bzl", "ng_project", "protractor_web_test_suite", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -36,8 +37,15 @@ ts_project(
 
 esbuild(
     name = "app_bundle",
+    config = {
+        "resolveExtensions": [".js"],
+    },
     entry_point = ":main.ts",
-    deps = [":sw_registration_options_examples"],
+    tsconfig = "//packages/examples:tsconfig_build",
+    deps = [
+        ":sw_registration_options_examples_rjs",
+        "//packages/examples:tsconfig_build",
+    ],
 )
 
 http_server(
@@ -52,11 +60,9 @@ http_server(
 
 protractor_web_test_suite(
     name = "protractor_tests",
-    on_prepare = "start-server.js",
     server = ":devserver",
     deps = [
-        ":sw_registration_options_e2e_tests_lib",
-        "@npm//selenium-webdriver",
+        ":sw_registration_options_e2e_tests_lib_rjs",
     ],
 )
 

--- a/tools/bazel/protractor_test.bzl
+++ b/tools/bazel/protractor_test.bzl
@@ -1,0 +1,27 @@
+load("@devinfra//bazel/spec-bundling:index_rjs.bzl", _spec_bundle = "spec_bundle")
+load("@rules_browsers//src/protractor_test:index.bzl", _protractor_test = "protractor_test")
+
+def protractor_web_test_suite(name, deps, **kwargs):
+    _spec_bundle(
+        name = "%s_bundle" % name,
+        deps = deps,
+        external = ["protractor", "selenium-webdriver"],
+    )
+
+    _protractor_test(
+        name = name,
+        deps = [":%s_bundle" % name],
+        extra_config = {
+            "useAllAngular2AppRoots": True,
+            "allScriptsTimeout": 120000,
+            "getPageTimeout": 120000,
+            "jasmineNodeOpts": {
+                "defaultTimeoutInterval": 120000,
+            },
+        },
+        data = [
+            "//:node_modules/protractor",
+            "//:node_modules/selenium-webdriver",
+        ],
+        **kwargs
+    )

--- a/tools/defaults2.bzl
+++ b/tools/defaults2.bzl
@@ -5,6 +5,7 @@ load("@rules_sass//src:index.bzl", _npm_sass_library = "npm_sass_library", _sass
 load("//tools/bazel:jasmine_test.bzl", _angular_jasmine_test = "angular_jasmine_test", _jasmine_test = "jasmine_test", _zoneless_jasmine_test = "zoneless_jasmine_test")
 load("//tools/bazel:module_name.bzl", "compute_module_name")
 load("//tools/bazel:ng_package.bzl", _ng_package = "ng_package")
+load("//tools/bazel:protractor_test.bzl", _protractor_web_test_suite = "protractor_web_test_suite")
 load("//tools/bazel:ts_project_interop.bzl", _ts_project = "ts_project")
 load("//tools/bazel:web_test.bzl", _ng_web_test_suite = "ng_web_test_suite", _zoneless_web_test_suite = "zoneless_web_test_suite")
 
@@ -19,6 +20,7 @@ zoneless_web_test_suite = _zoneless_web_test_suite
 sass_binary = _sass_binary
 sass_library = _sass_library
 npm_sass_library = _npm_sass_library
+protractor_web_test_suite = _protractor_web_test_suite
 
 def _determine_tsconfig(testonly):
     if native.package_name().startswith("packages/compiler-cli"):


### PR DESCRIPTION
Use the protractor_web_test_suite from rules_browser instead of @bazel/protractor
