### PR TITLE
docs(docs-infra): run analytics only on the browser

### DIFF
--- a/adev/src/app/core/services/analytics/analytics.service.spec.ts
+++ b/adev/src/app/core/services/analytics/analytics.service.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Injector} from '@angular/core';
+import {Injector, PLATFORM_ID} from '@angular/core';
 import {ENVIRONMENT, WINDOW, LOCAL_STORAGE, MockLocalStorage} from '@angular/docs';
 import {AnalyticsService} from './analytics.service';
 
@@ -41,6 +41,7 @@ describe('AnalyticsService', () => {
         {provide: AnalyticsService, deps: [WINDOW]},
         {provide: WINDOW, useFactory: () => mockWindow, deps: []},
         {provide: LOCAL_STORAGE, useValue: mockLocalStorage},
+        {provide: PLATFORM_ID, useValue: 'browser'}, // Simulate browser platform
       ],
     });
 

--- a/adev/src/app/core/services/analytics/analytics.service.ts
+++ b/adev/src/app/core/services/analytics/analytics.service.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {inject, Injectable} from '@angular/core';
+import {inject, Injectable, PLATFORM_ID} from '@angular/core';
+import {isPlatformBrowser} from '@angular/common';
 
 import {WINDOW, ENVIRONMENT, LOCAL_STORAGE, STORAGE_KEY, setCookieConsent} from '@angular/docs';
 
@@ -29,10 +30,13 @@ export class AnalyticsService {
   private environment = inject(ENVIRONMENT);
   private window: WindowWithAnalytics = inject(WINDOW);
   private readonly localStorage = inject(LOCAL_STORAGE);
+  private isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
   constructor() {
-    this._installGlobalSiteTag();
-    this._installWindowErrorHandler();
+    if (this.isBrowser) {
+      this._installGlobalSiteTag();
+      this._installWindowErrorHandler();
+    }
   }
 
   reportError(description: string, fatal = true) {


### PR DESCRIPTION
We don't care about server, adev only uses SSG.
Also `setCookieConsent` is throwing on node.
