### PR TITLE
fix(common): allow empty string in transfer cache origin mapping cond…

### DIFF
--- a/packages/common/http/src/transfer_cache.ts
+++ b/packages/common/http/src/transfer_cache.ts
@@ -404,7 +404,8 @@ function appendMissingHeadersDetection(
 function mapRequestOriginUrl(url: string, originMap: Record<string, string>): string {
   const origin = new URL(url, 'resolve://').origin;
   const mappedOrigin = originMap[origin];
-  if (!mappedOrigin) {
+  // we want '' (empty string) to pass here, so we check for undefined only
+  if (mappedOrigin === undefined) {
     return url;
   }
 


### PR DESCRIPTION
…ition

Adjusted the conditional check to specifically handle `undefined`, ensuring empty strings pass through as valid mapped origins.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## What is the current behavior?
```ts

{
  provide: HTTP_TRANSFER_CACHE_ORIGIN_MAP,
  useValue: {
     'https://some-api': ''
  }
}
```

This won't work as '' (empty string) gets skipped. But in my case, I need to replace the host with empty string, as in the client I don't use the host part to make the api call. And by having them different cache keys differ -> breaks transfer cache.

## What is the new behavior?
Empty string will be a valid replacement value.

## Does this PR introduce a breaking change?
- [x] No

