### PR TITLE
fix(router): handle errors from view transition readiness

### DIFF
--- a/packages/router/src/utils/view_transition.ts
+++ b/packages/router/src/utils/view_transition.ts
@@ -94,6 +94,11 @@ export function createViewTransition(
     // complete (below), which includes the update phase of the routed components.
     return createRenderPromise(injector);
   });
+  transition.ready.catch((error) => {
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      console.error(error);
+    }
+  });
   const {onViewTransitionCreated} = transitionOptions;
   if (onViewTransitionCreated) {
     runInInjectionContext(injector, () => onViewTransitionCreated({transition, from, to}));


### PR DESCRIPTION
This commit adds a `.catch()` handler to `transition.ready` from `document.startViewTransition` to prevent `AbortError`s in Safari when `startViewTransition` is called synchronously multiple times.

Closes #62491