### PR TITLE
fix(http): do not display warnings `Angular detected that a `HttpClient` request with the `keepalive` option was sent using XHR` when option is not true

### DIFF
--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -93,7 +93,7 @@ function validateXhrCompatibility(req: HttpRequest<any>) {
 
   // Check each unsupported option and warn if present
   for (const {property, errorCode} of unsupportedOptions) {
-    if (property in req) {
+    if (req[property]) {
       console.warn(
         formatRuntimeError(
           errorCode,


### PR DESCRIPTION

Currently, this warning is always displayed as the option defaults to false. We update the logic to only display the warning when it's true.

