### PR TITLE
fix(router): normalize multiple leading slashes in URL parser

### DIFF
--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -615,7 +615,11 @@ class UrlParser {
   }
 
   parseRootSegment(): UrlSegmentGroup {
-    this.consumeOptional('/');
+    // Consume all leading slashes. Multiple consecutive leading slashes (e.g. `///path`)
+    // are not meaningful and would otherwise produce a `//path`-style serialized URL,
+    // which browsers interpret as protocol-relative (resolving to a different origin)
+    // and reject with a SecurityError when passed to `history.pushState`/`replaceState`.
+    while (this.consumeOptional('/')) {}
 
     if (this.remaining === '' || this.peekStartsWith('?') || this.peekStartsWith('#')) {
       return new UrlSegmentGroup([], {});

--- a/packages/router/test/url_serializer.spec.ts
+++ b/packages/router/test/url_serializer.spec.ts
@@ -417,6 +417,25 @@ describe('url serializer', () => {
     });
   });
 
+  describe('multiple leading slashes', () => {
+    // Regression test: https://github.com/angular/angular/issues/66233
+    // `///path` was parsed into an empty UrlSegment followed by `path`, which the serializer
+    // rendered as `//path` — a protocol-relative URL that browsers reject with a SecurityError
+    // when passed to history.pushState/replaceState.
+    it('should normalize multiple leading slashes when parsing', () => {
+      expect(url.serialize(url.parse('///test'))).toEqual('/test');
+    });
+
+    it('should normalize any number of leading slashes when parsing', () => {
+      expect(url.serialize(url.parse('////test'))).toEqual('/test');
+      expect(url.serialize(url.parse('/////test'))).toEqual('/test');
+    });
+
+    it('should preserve query params and fragments after normalizing leading slashes', () => {
+      expect(url.serialize(url.parse('///test?foo=bar#frag'))).toEqual('/test?foo=bar#frag');
+    });
+  });
+
   describe('error handling', () => {
     it('should throw when invalid characters inside children', () => {
       expect(() => url.parse('/one/(left#one)')).toThrowError();


### PR DESCRIPTION
URLs with three or more consecutive leading slashes (e.g. `///test`) were
parsed incorrectly by `DefaultUrlSerializer`. The parser consumed only two
leading slashes, leaving a third that caused `parseSegment()` to produce an
empty `UrlSegment`. When serialized back, that empty segment rendered as
`//test` — a protocol-relative URL that browsers resolve as a different
origin and reject with a `SecurityError` when passed to
`history.pushState`/`replaceState`.

The fix changes `parseRootSegment()` to consume all consecutive leading
slashes instead of just one, normalizing any number of leading slashes to
a single `/` before the path is parsed.

Closes #49610