### PR TITLE
ci: update renovate label for non main branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -55,7 +55,7 @@
         "!main"
       ],
       "addLabels": [
-        "target: rc"
+        "target: patch"
       ]
     },
     {


### PR DESCRIPTION
The non default base branch is no longer in rc phase
