### PR TITLE
docs: update browsers support versions

### DIFF
--- a/adev/src/content/reference/versions.md
+++ b/adev/src/content/reference/versions.md
@@ -81,7 +81,7 @@ targets supporting approximately 95% of web users.
 | ------- | ------------- | --------------------------- |
 | v20     | 2025-04-30    | [Browser Set][browsers-v20] |
 
-[browsers-v20]: https://browsersl.ist/#q=Chrome+%3E%3D+105%0AChromeAndroid+%3E%3D+105%0AEdge+%3E%3D+105%0AFirefox+%3E%3D+104%0AFirefoxAndroid+%3E%3D+104%0ASafari+%3E%3D+16%0AiOS+%3E%3D+16
+[browsers-v20]: https://tonypconway.github.io/web-features/supported-browsers/?widelyAvailableOnDate=2025-04-30&includeDownstream=false
 
 Angular versions prior to v20 support the following specific browser versions:
 


### PR DESCRIPTION
The current URL is not correct as it incorrectly includes browsers. We now replace the URL with the comparer provided by baseline which will be available soonish via `web-platform-dx.github.io`.

See: https://github.com/web-platform-dx/web-features/pull/3132