### PR TITLE
build: set paths for devtools & adev

### DIFF
--- a/adev/shared-docs/tsconfig.json
+++ b/adev/shared-docs/tsconfig.json
@@ -12,6 +12,5 @@
     "jsxFactory": "h",
     "jsxFragmentFactory": "Fragment",
     "types": ["node"],
-    "paths": {},
   }
 }

--- a/adev/tsconfig.json
+++ b/adev/tsconfig.json
@@ -27,7 +27,11 @@
     "jsx": "react",
     "jsxFactory": "h",
     "jsxFragmentFactory": "Fragment",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "paths": {
+      "@angular/docs": ["./shared-docs"],
+      "@angular/*": ["../packages/*/index"]
+    }
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,

--- a/devtools/tsconfig.json
+++ b/devtools/tsconfig.json
@@ -16,6 +16,7 @@
     "target": "es2020",
     "lib": ["es2020", "dom", "dom.iterable"],
     "types": ["chrome"],
+    // TODO: Have an IDE specific tsconfig file
     "paths": {
       "@angular/*": ["../packages/*/index"]
     }


### PR DESCRIPTION
This allows the IDE to find the right imports
