### PR TITLE
docs: fix comment breaking Highlighter

### DIFF
--- a/adev/src/content/guide/templates/two-way-binding.md
+++ b/adev/src/content/guide/templates/two-way-binding.md
@@ -99,7 +99,7 @@ Here is a simplified example:
 // './counter/counter.component.ts';
 import { Component, model } from '@angular/core';
 
-@Component({ // Omitted for brevity })
+@Component({ /* Omitted for brevity */ })
 export class CounterComponent {
   count = model<number>(0);
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
A page in the documentation has a single line comment in the middle of a code example which makes the highlighter the wrong colors

Issue Number: N/A


## What is the new behavior?

Multiline comment so the highlighter shows the right colors

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
