### PR TITLE
ci: adjust renovate teams

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -367,7 +367,8 @@ groups:
       users:
         - ~alan-agius4
       teams:
-        - framework-team
+        - angular-caretaker
+        - ~framework-team
 
   # =========================================================
   #  Public API


### PR DESCRIPTION
This switches framework team to approve but not requested, and adds the currently active caretaker group to the teams for renovate.

