### PR TITLE
fix(language-service): Support to resolve the re-export component.

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/api/scope.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/scope.ts
@@ -145,6 +145,14 @@ export enum PotentialImportMode {
   ForceDirect,
 }
 
+export interface DirectiveModuleExportDetails {
+  moduleSpecifier: string;
+  exportName: string;
+}
+
 export interface PotentialDirectiveModuleSpecifierResolver {
-  resolve(toImport: Reference<ClassDeclaration>, importOn: ts.Node | null): string | undefined;
+  resolve(
+    toImport: Reference<ClassDeclaration>,
+    importOn: ts.Node | null,
+  ): DirectiveModuleExportDetails | null;
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ts_util.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ts_util.ts
@@ -216,3 +216,54 @@ export function isDirectiveDeclaration(node: ts.Node): node is ts.TypeNode | ts.
     hasExpressionIdentifier(sourceFile, node, ExpressionIdentifier.DIRECTIVE)
   );
 }
+
+/**
+ * Check if the lastSymbol is an alias of the firstSymbol. For example:
+ *
+ * The NewBarComponent is an alias of BarComponent.
+ *
+ * But the NotAliasBarComponent is not an alias of BarComponent, because
+ * the NotAliasBarComponent is a new variable.
+ *
+ * This should work for most cases.
+ *
+ * https://github.com/microsoft/TypeScript/blob/9e20e032effad965567d4a1e1c30d5433b0a3332/src/compiler/checker.ts#L3638-L3652
+ *
+ * ```
+ * // a.ts
+ * export class BarComponent {};
+ * // b.ts
+ * export {BarComponent as NewBarComponent} from "./a";
+ * // c.ts
+ * import {BarComponent} from "./a"
+ * const NotAliasBarComponent = BarComponent;
+ * export {NotAliasBarComponent};
+ * ```
+ */
+export function isSymbolAliasOf(
+  firstSymbol: ts.Symbol,
+  lastSymbol: ts.Symbol,
+  typeChecker: ts.TypeChecker,
+): boolean {
+  let currentSymbol: ts.Symbol | undefined = lastSymbol;
+
+  const seenSymbol: Set<ts.Symbol> = new Set();
+  while (
+    firstSymbol !== currentSymbol &&
+    currentSymbol !== undefined &&
+    currentSymbol.flags & ts.SymbolFlags.Alias
+  ) {
+    if (seenSymbol.has(currentSymbol)) {
+      break;
+    }
+    seenSymbol.add(currentSymbol);
+
+    currentSymbol = typeChecker.getImmediateAliasedSymbol(currentSymbol);
+
+    if (currentSymbol === firstSymbol) {
+      return true;
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
In the context of TypeScript (TS), a re-exported symbol is considered a distinct symbol.
This means that a developer can choose to import either the re-exported symbol or
the original symbol. However, in the context of Angular, the re-exported symbol
is treated as the same component because it uses the same selector.

This pull request will utilize the most recent re-export component file to
resolve the module specifier.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
