### PR TITLE
fix(http): Add missing `timeout` and `transferCache` options to `HttpClient`

### DIFF
--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -77,6 +77,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
         body?: any | null;
     }): Observable<Blob>;
     delete(url: string, options: {
@@ -95,6 +96,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
         body?: any | null;
     }): Observable<string>;
     delete(url: string, options: {
@@ -113,6 +115,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
         body?: any | null;
     }): Observable<HttpEvent<ArrayBuffer>>;
     delete(url: string, options: {
@@ -131,6 +134,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
         body?: any | null;
     }): Observable<HttpEvent<Blob>>;
     delete(url: string, options: {
@@ -149,6 +153,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
         body?: any | null;
     }): Observable<HttpEvent<string>>;
     delete(url: string, options: {
@@ -167,6 +172,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
         body?: any | null;
     }): Observable<HttpEvent<Object>>;
     delete<T>(url: string, options: {
@@ -185,6 +191,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
         body?: any | null;
     }): Observable<HttpEvent<T>>;
     delete(url: string, options: {
@@ -203,6 +210,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
         body?: any | null;
     }): Observable<HttpResponse<ArrayBuffer>>;
     delete(url: string, options: {
@@ -221,6 +229,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
         body?: any | null;
     }): Observable<HttpResponse<Blob>>;
     delete(url: string, options: {
@@ -239,6 +248,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
         body?: any | null;
     }): Observable<HttpResponse<string>>;
     delete(url: string, options: {
@@ -257,6 +267,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
         body?: any | null;
     }): Observable<HttpResponse<Object>>;
     delete<T>(url: string, options: {
@@ -275,6 +286,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
         body?: any | null;
     }): Observable<HttpResponse<T>>;
     delete(url: string, options?: {
@@ -293,6 +305,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
         body?: any | null;
     }): Observable<Object>;
     delete<T>(url: string, options?: {
@@ -311,6 +324,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
         body?: any | null;
     }): Observable<T>;
     get(url: string, options: {
@@ -332,6 +346,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<ArrayBuffer>;
     get(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -352,6 +367,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<Blob>;
     get(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -372,6 +388,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<string>;
     get(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -392,6 +409,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpEvent<ArrayBuffer>>;
     get(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -412,6 +430,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpEvent<Blob>>;
     get(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -432,6 +451,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpEvent<string>>;
     get(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -452,6 +472,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpEvent<Object>>;
     get<T>(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -472,6 +493,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpEvent<T>>;
     get(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -492,6 +514,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpResponse<ArrayBuffer>>;
     get(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -512,6 +535,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpResponse<Blob>>;
     get(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -532,6 +556,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpResponse<string>>;
     get(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -552,6 +577,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpResponse<Object>>;
     get<T>(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -572,6 +598,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpResponse<T>>;
     get(url: string, options?: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -592,6 +619,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<Object>;
     get<T>(url: string, options?: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -612,6 +640,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<T>;
     head(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -632,6 +661,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<ArrayBuffer>;
     head(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -652,6 +682,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<Blob>;
     head(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -672,6 +703,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<string>;
     head(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -692,6 +724,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpEvent<ArrayBuffer>>;
     head(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -712,6 +745,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpEvent<Blob>>;
     head(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -732,6 +766,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpEvent<string>>;
     head(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -752,6 +787,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpEvent<Object>>;
     head<T>(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -772,6 +808,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpEvent<T>>;
     head(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -792,6 +829,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpResponse<ArrayBuffer>>;
     head(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -812,6 +850,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpResponse<Blob>>;
     head(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -832,6 +871,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpResponse<string>>;
     head(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -852,6 +892,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpResponse<Object>>;
     head<T>(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -872,6 +913,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpResponse<T>>;
     head(url: string, options?: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -892,6 +934,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<Object>;
     head<T>(url: string, options?: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -912,6 +955,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<T>;
     jsonp(url: string, callbackParam: string): Observable<Object>;
     jsonp<T>(url: string, callbackParam: string): Observable<T>;
@@ -931,6 +975,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<ArrayBuffer>;
     options(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -948,6 +993,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<Blob>;
     options(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -965,6 +1011,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<string>;
     options(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -982,6 +1029,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpEvent<ArrayBuffer>>;
     options(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -999,6 +1047,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpEvent<Blob>>;
     options(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1016,6 +1065,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpEvent<string>>;
     options(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1033,6 +1083,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpEvent<Object>>;
     options<T>(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1050,6 +1101,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpEvent<T>>;
     options(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1067,6 +1119,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpResponse<ArrayBuffer>>;
     options(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1084,6 +1137,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpResponse<Blob>>;
     options(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1101,6 +1155,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpResponse<string>>;
     options(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1118,6 +1173,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpResponse<Object>>;
     options<T>(url: string, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1135,6 +1191,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpResponse<T>>;
     options(url: string, options?: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1152,6 +1209,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<Object>;
     options<T>(url: string, options?: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1169,6 +1227,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<T>;
     patch(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1186,6 +1245,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<ArrayBuffer>;
     patch(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1203,6 +1263,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<Blob>;
     patch(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1220,6 +1281,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<string>;
     patch(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1237,6 +1299,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpEvent<ArrayBuffer>>;
     patch(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1254,6 +1317,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpEvent<Blob>>;
     patch(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1271,6 +1335,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpEvent<string>>;
     patch(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1288,6 +1353,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpEvent<Object>>;
     patch<T>(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1305,6 +1371,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpEvent<T>>;
     patch(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1322,6 +1389,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpResponse<ArrayBuffer>>;
     patch(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1339,6 +1407,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpResponse<Blob>>;
     patch(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1356,6 +1425,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpResponse<string>>;
     patch(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1373,6 +1443,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpResponse<Object>>;
     patch<T>(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1390,6 +1461,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpResponse<T>>;
     patch(url: string, body: any | null, options?: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1407,6 +1479,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<Object>;
     patch<T>(url: string, body: any | null, options?: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1424,6 +1497,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<T>;
     post(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1444,6 +1518,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<ArrayBuffer>;
     post(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1464,6 +1539,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<Blob>;
     post(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1484,6 +1560,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<string>;
     post(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1504,6 +1581,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpEvent<ArrayBuffer>>;
     post(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1524,6 +1602,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpEvent<Blob>>;
     post(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1544,6 +1623,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpEvent<string>>;
     post(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1564,6 +1644,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpEvent<Object>>;
     post<T>(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1584,6 +1665,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpEvent<T>>;
     post(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1604,6 +1686,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpResponse<ArrayBuffer>>;
     post(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1624,6 +1707,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpResponse<Blob>>;
     post(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1644,6 +1728,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpResponse<string>>;
     post(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1664,6 +1749,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpResponse<Object>>;
     post<T>(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1684,6 +1770,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpResponse<T>>;
     post(url: string, body: any | null, options?: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1704,6 +1791,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<Object>;
     post<T>(url: string, body: any | null, options?: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1724,6 +1812,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<T>;
     put(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1741,6 +1830,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<ArrayBuffer>;
     put(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1758,6 +1848,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<Blob>;
     put(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1775,6 +1866,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<string>;
     put(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1792,6 +1884,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpEvent<ArrayBuffer>>;
     put(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1809,6 +1902,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpEvent<Blob>>;
     put(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1826,6 +1920,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpEvent<string>>;
     put(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1843,6 +1938,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpEvent<Object>>;
     put<T>(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1860,6 +1956,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpEvent<T>>;
     put(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1877,6 +1974,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpResponse<ArrayBuffer>>;
     put(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1894,6 +1992,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpResponse<Blob>>;
     put(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1911,6 +2010,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpResponse<string>>;
     put(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1928,6 +2028,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpResponse<Object>>;
     put<T>(url: string, body: any | null, options: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1945,6 +2046,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<HttpResponse<T>>;
     put(url: string, body: any | null, options?: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1962,6 +2064,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<Object>;
     put<T>(url: string, body: any | null, options?: {
         headers?: HttpHeaders | Record<string, string | string[]>;
@@ -1979,6 +2082,7 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        timeout?: number;
     }): Observable<T>;
     request<R>(req: HttpRequest<any>): Observable<HttpEvent<R>>;
     request(method: string, url: string, options: {
@@ -2000,6 +2104,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<ArrayBuffer>;
     request(method: string, url: string, options: {
         body?: any;
@@ -2021,6 +2126,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<Blob>;
     request(method: string, url: string, options: {
         body?: any;
@@ -2042,6 +2148,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<string>;
     request(method: string, url: string, options: {
         body?: any;
@@ -2063,6 +2170,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpEvent<ArrayBuffer>>;
     request(method: string, url: string, options: {
         body?: any;
@@ -2084,6 +2192,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpEvent<Blob>>;
     request(method: string, url: string, options: {
         body?: any;
@@ -2105,6 +2214,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpEvent<string>>;
     request(method: string, url: string, options: {
         body?: any;
@@ -2126,6 +2236,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpEvent<any>>;
     request<R>(method: string, url: string, options: {
         body?: any;
@@ -2147,6 +2258,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpEvent<R>>;
     request(method: string, url: string, options: {
         body?: any;
@@ -2168,6 +2280,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpResponse<ArrayBuffer>>;
     request(method: string, url: string, options: {
         body?: any;
@@ -2189,6 +2302,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpResponse<Blob>>;
     request(method: string, url: string, options: {
         body?: any;
@@ -2210,6 +2324,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<HttpResponse<string>>;
     request(method: string, url: string, options: {
         body?: any;
@@ -2228,6 +2343,10 @@ export class HttpClient {
         redirect?: RequestRedirect;
         referrer?: string;
         integrity?: string;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
+        timeout?: number;
     }): Observable<HttpResponse<Object>>;
     request<R>(method: string, url: string, options: {
         body?: any;
@@ -2270,6 +2389,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<Object>;
     request<R>(method: string, url: string, options?: {
         body?: any;
@@ -2291,6 +2411,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<R>;
     request(method: string, url: string, options?: {
         body?: any;
@@ -2312,6 +2433,7 @@ export class HttpClient {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     }): Observable<any>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<HttpClient, never>;

--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -48,6 +48,7 @@ function addBody<T>(
     referrer?: string;
     integrity?: string;
     transferCache?: {includeHeaders?: string[]} | boolean;
+    timeout?: number;
   },
   body: T | null,
 ): any {
@@ -61,6 +62,7 @@ function addBody<T>(
     responseType: options.responseType,
     withCredentials: options.withCredentials,
     transferCache: options.transferCache,
+    timeout: options.timeout,
     keepalive: options.keepalive,
     priority: options.priority,
     cache: options.cache,
@@ -166,6 +168,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<ArrayBuffer>;
 
@@ -202,6 +205,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<Blob>;
 
@@ -238,6 +242,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<string>;
 
@@ -275,6 +280,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpEvent<ArrayBuffer>>;
 
@@ -312,6 +318,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpEvent<Blob>>;
 
@@ -349,6 +356,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpEvent<string>>;
 
@@ -386,6 +394,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpEvent<any>>;
 
@@ -423,6 +432,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpEvent<R>>;
 
@@ -459,6 +469,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpResponse<ArrayBuffer>>;
 
@@ -494,6 +505,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpResponse<Blob>>;
 
@@ -530,6 +542,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpResponse<string>>;
 
@@ -566,6 +579,8 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpResponse<Object>>;
 
@@ -638,6 +653,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<Object>;
 
@@ -674,6 +690,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<R>;
 
@@ -709,6 +726,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<any>;
 
@@ -761,6 +779,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     } = {},
   ): Observable<any> {
     let req: HttpRequest<any>;
@@ -809,6 +828,7 @@ export class HttpClient {
         credentials: options.credentials,
         referrer: options.referrer,
         integrity: options.integrity,
+        timeout: options.timeout,
       });
     }
     // Start with an Observable.of() the initial request, and run the handler (which
@@ -960,6 +980,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
       body?: any | null;
     },
   ): Observable<Blob>;
@@ -993,6 +1014,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
       body?: any | null;
     },
   ): Observable<string>;
@@ -1027,6 +1049,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
       body?: any | null;
     },
   ): Observable<HttpEvent<ArrayBuffer>>;
@@ -1061,6 +1084,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
       body?: any | null;
     },
   ): Observable<HttpEvent<Blob>>;
@@ -1095,6 +1119,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
       body?: any | null;
     },
   ): Observable<HttpEvent<string>>;
@@ -1129,6 +1154,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
       body?: any | null;
     },
   ): Observable<HttpEvent<Object>>;
@@ -1163,6 +1189,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
       body?: any | null;
     },
   ): Observable<HttpEvent<T>>;
@@ -1196,6 +1223,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
       body?: any | null;
     },
   ): Observable<HttpResponse<ArrayBuffer>>;
@@ -1229,6 +1257,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
       body?: any | null;
     },
   ): Observable<HttpResponse<Blob>>;
@@ -1262,6 +1291,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
       body?: any | null;
     },
   ): Observable<HttpResponse<string>>;
@@ -1296,6 +1326,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
       body?: any | null;
     },
   ): Observable<HttpResponse<Object>>;
@@ -1329,6 +1360,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
       body?: any | null;
     },
   ): Observable<HttpResponse<T>>;
@@ -1362,6 +1394,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
       body?: any | null;
     },
   ): Observable<Object>;
@@ -1395,6 +1428,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
       body?: any | null;
     },
   ): Observable<T>;
@@ -1428,6 +1462,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
       body?: any | null;
     } = {},
   ): Observable<any> {
@@ -1464,6 +1499,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<ArrayBuffer>;
 
@@ -1497,6 +1533,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<Blob>;
 
@@ -1530,6 +1567,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<string>;
 
@@ -1564,6 +1602,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpEvent<ArrayBuffer>>;
 
@@ -1597,6 +1636,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpEvent<Blob>>;
 
@@ -1630,6 +1670,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpEvent<string>>;
 
@@ -1663,6 +1704,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpEvent<Object>>;
 
@@ -1696,6 +1738,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpEvent<T>>;
 
@@ -1730,6 +1773,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpResponse<ArrayBuffer>>;
 
@@ -1764,6 +1808,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpResponse<Blob>>;
 
@@ -1798,6 +1843,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpResponse<string>>;
 
@@ -1832,6 +1878,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpResponse<Object>>;
 
@@ -1866,6 +1913,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpResponse<T>>;
 
@@ -1900,6 +1948,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<Object>;
 
@@ -1933,6 +1982,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<T>;
 
@@ -1962,6 +2012,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     } = {},
   ): Observable<any> {
     return this.request<any>('GET', url, options as any);
@@ -1997,6 +2048,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<ArrayBuffer>;
 
@@ -2031,6 +2083,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<Blob>;
 
@@ -2064,6 +2117,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<string>;
 
@@ -2098,6 +2152,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpEvent<ArrayBuffer>>;
 
@@ -2132,6 +2187,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpEvent<Blob>>;
 
@@ -2166,6 +2222,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpEvent<string>>;
 
@@ -2200,6 +2257,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpEvent<Object>>;
 
@@ -2234,6 +2292,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpEvent<T>>;
 
@@ -2268,6 +2327,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpResponse<ArrayBuffer>>;
 
@@ -2302,6 +2362,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpResponse<Blob>>;
 
@@ -2336,6 +2397,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpResponse<string>>;
 
@@ -2369,8 +2431,8 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
-
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpResponse<Object>>;
 
@@ -2405,6 +2467,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpResponse<T>>;
 
@@ -2439,6 +2502,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<Object>;
 
@@ -2473,6 +2537,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<T>;
 
@@ -2504,6 +2569,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     } = {},
   ): Observable<any> {
     return this.request<any>('HEAD', url, options as any);
@@ -2588,6 +2654,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<ArrayBuffer>;
 
@@ -2620,6 +2687,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<Blob>;
 
@@ -2652,6 +2720,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<string>;
 
@@ -2685,6 +2754,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpEvent<ArrayBuffer>>;
 
@@ -2718,6 +2788,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpEvent<Blob>>;
 
@@ -2751,6 +2822,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpEvent<string>>;
 
@@ -2784,6 +2856,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpEvent<Object>>;
 
@@ -2817,6 +2890,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpEvent<T>>;
 
@@ -2850,6 +2924,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpResponse<ArrayBuffer>>;
 
@@ -2883,6 +2958,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpResponse<Blob>>;
 
@@ -2916,6 +2992,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpResponse<string>>;
 
@@ -2949,6 +3026,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpResponse<Object>>;
 
@@ -2982,6 +3060,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpResponse<T>>;
 
@@ -3015,6 +3094,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<Object>;
 
@@ -3047,6 +3127,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<T>;
 
@@ -3077,6 +3158,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     } = {},
   ): Observable<any> {
     return this.request<any>('OPTIONS', url, options as any);
@@ -3113,6 +3195,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<ArrayBuffer>;
 
@@ -3147,6 +3230,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<Blob>;
 
@@ -3181,6 +3265,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<string>;
 
@@ -3217,6 +3302,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpEvent<ArrayBuffer>>;
 
@@ -3252,6 +3338,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpEvent<Blob>>;
 
@@ -3287,6 +3374,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpEvent<string>>;
 
@@ -3322,6 +3410,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpEvent<Object>>;
 
@@ -3357,6 +3446,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpEvent<T>>;
 
@@ -3392,6 +3482,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpResponse<ArrayBuffer>>;
 
@@ -3427,6 +3518,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpResponse<Blob>>;
 
@@ -3462,6 +3554,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpResponse<string>>;
 
@@ -3497,6 +3590,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpResponse<Object>>;
 
@@ -3532,6 +3626,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpResponse<T>>;
 
@@ -3567,6 +3662,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<Object>;
 
@@ -3602,6 +3698,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<T>;
 
@@ -3631,6 +3728,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     } = {},
   ): Observable<any> {
     return this.request<any>('PATCH', url, addBody(options, body));
@@ -3668,6 +3766,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<ArrayBuffer>;
 
@@ -3703,6 +3802,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<Blob>;
 
@@ -3738,6 +3838,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<string>;
 
@@ -3774,6 +3875,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpEvent<ArrayBuffer>>;
 
@@ -3809,6 +3911,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpEvent<Blob>>;
 
@@ -3845,6 +3948,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpEvent<string>>;
 
@@ -3881,6 +3985,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpEvent<Object>>;
 
@@ -3917,6 +4022,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpEvent<T>>;
 
@@ -3953,6 +4059,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpResponse<ArrayBuffer>>;
 
@@ -3989,6 +4096,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpResponse<Blob>>;
 
@@ -4025,6 +4133,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpResponse<string>>;
 
@@ -4061,6 +4170,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpResponse<Object>>;
 
@@ -4098,6 +4208,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<HttpResponse<T>>;
 
@@ -4133,6 +4244,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<Object>;
 
@@ -4169,6 +4281,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ): Observable<T>;
 
@@ -4200,6 +4313,7 @@ export class HttpClient {
       referrer?: string;
       integrity?: string;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     } = {},
   ): Observable<any> {
     return this.request<any>('POST', url, addBody(options, body));
@@ -4236,6 +4350,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<ArrayBuffer>;
 
@@ -4270,6 +4385,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<Blob>;
 
@@ -4304,6 +4420,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<string>;
 
@@ -4339,6 +4456,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpEvent<ArrayBuffer>>;
 
@@ -4374,6 +4492,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpEvent<Blob>>;
 
@@ -4409,6 +4528,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpEvent<string>>;
 
@@ -4444,6 +4564,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpEvent<Object>>;
 
@@ -4479,6 +4600,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpEvent<T>>;
 
@@ -4514,6 +4636,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpResponse<ArrayBuffer>>;
 
@@ -4549,6 +4672,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpResponse<Blob>>;
 
@@ -4584,6 +4708,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpResponse<string>>;
 
@@ -4619,6 +4744,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpResponse<Object>>;
 
@@ -4654,6 +4780,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<HttpResponse<T>>;
 
@@ -4688,6 +4815,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<Object>;
 
@@ -4722,6 +4850,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     },
   ): Observable<T>;
 
@@ -4752,6 +4881,7 @@ export class HttpClient {
       redirect?: RequestRedirect;
       referrer?: string;
       integrity?: string;
+      timeout?: number;
     } = {},
   ): Observable<any> {
     return this.request<any>('PUT', url, addBody(options, body));


### PR DESCRIPTION
The `timeout` option is implemented in the different HTTP backends, but the option is not actually passed to the backends. `transferCache` is also missing in one signature. This commit adds both options to `HttpClient`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

Issue Number: [N/A](https://github.com/angular/angular/issues/62581)

## Other information
I noticed while doing this that the `transferCache` option is not always passed. I am not sure why, but in DELETE and PUT requests it's absent, while for GET and POST requests, it is there. 

While I understand why it's there for GET, I question why it's absent in PUT if POST has the option. I believe it should be added everywhere for consistency. I can change this PR to do that if needed.