### PR TITLE
ci: add to public-api approvers list

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -395,6 +395,7 @@ groups:
         - mmalerba
         - crisbeto
         - devversion
+        - JeanMeche
         - ~jkrems
         - ~iteriani
         - ~tbondwilkinson


### PR DESCRIPTION
This adds reviewers to the public-api approvers list.
