### PR TITLE
fix(core): fix change tracking for Resource#hasValue

### DIFF
--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -130,15 +130,19 @@ abstract class BaseWritableResource<T> implements WritableResource<T> {
 
   readonly isLoading = computed(() => this.status() === 'loading' || this.status() === 'reloading');
 
-  hasValue(): this is ResourceRef<Exclude<T, undefined>> {
-    // Note: we specifically read `isError()` instead of `status()` here to avoid triggering
-    // reactive consumers which read `hasValue()`. This way, if `hasValue()` is used inside of an
-    // effect, it doesn't cause the effect to rerun on every status change.
+  // Use a computed here to avoid triggering reactive consumers if the value changes while staying
+  // either defined or undefined.
+  private readonly isValueDefined = computed(() => {
+    // Check if it's in an error state first to prevent the error from bubbling up.
     if (this.isError()) {
       return false;
     }
 
     return this.value() !== undefined;
+  });
+
+  hasValue(): this is ResourceRef<Exclude<T, undefined>> {
+    return this.isValueDefined();
   }
 
   asReadonly(): Resource<T> {


### PR DESCRIPTION
When using `hasValue()` I would expect it to behave like any other reactive value such that changes to the internal `value()` that do not cause `hasValue()` to return anything different do not trigger change detection, but this was not the case. This change wraps the value checking in a `computed` such that it behaves as expected again while still preserving the type narrowing.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Each time a resource's value changes, even if it changes from e.g. a defined to a defined value, consumers of `hasValue()` will re-run.

Issue Number: N/A


## What is the new behavior?
Consumers of `hasValue()` will re-run only if it has actually changed, preventing unnecessary change detection.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
