### PR TITLE
test(docs-infra): Use the zoneless testing rules

### DIFF
--- a/adev/shared-docs/components/breadcrumb/BUILD.bazel
+++ b/adev/shared-docs/components/breadcrumb/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//adev/shared-docs:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_project")
+load("//adev/shared-docs:defaults.bzl", "ng_project", "ts_project", "zoneless_web_test_suite")
 load("//tools:defaults2.bzl", "sass_binary")
 
 package(default_visibility = ["//visibility:private"])
@@ -46,7 +46,7 @@ ts_project(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [":test_lib_rjs"],
 )

--- a/adev/shared-docs/components/cookie-popup/BUILD.bazel
+++ b/adev/shared-docs/components/cookie-popup/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//adev/shared-docs:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_project")
+load("//adev/shared-docs:defaults.bzl", "ng_project", "ts_project", "zoneless_web_test_suite")
 load("//tools:defaults2.bzl", "sass_binary")
 
 package(default_visibility = ["//visibility:private"])
@@ -42,7 +42,7 @@ ts_project(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [":test_lib_rjs"],
 )

--- a/adev/shared-docs/components/copy-source-code-button/BUILD.bazel
+++ b/adev/shared-docs/components/copy-source-code-button/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//adev/shared-docs:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_project")
+load("//adev/shared-docs:defaults.bzl", "ng_project", "ts_project", "zoneless_web_test_suite")
 
 ng_project(
     name = "copy-source-code-button",
@@ -34,7 +34,7 @@ ts_project(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [":test_lib_rjs"],
 )

--- a/adev/shared-docs/components/copy-source-code-button/copy-source-code-button.component.spec.ts
+++ b/adev/shared-docs/components/copy-source-code-button/copy-source-code-button.component.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ComponentFixture, TestBed, fakeAsync, tick} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {
   CONFIRMATION_DISPLAY_TIME_MS,
@@ -74,7 +74,8 @@ describe('CopySourceCodeButton', () => {
     expect(copySpy.calls.argsFor(0)[0].trim()).toBe(expectedCodeToBeCopied);
   });
 
-  it(`should set ${SUCCESSFULLY_COPY_CLASS_NAME} for ${CONFIRMATION_DISPLAY_TIME_MS} ms when copy was executed properly`, fakeAsync(() => {
+  it(`should set ${SUCCESSFULLY_COPY_CLASS_NAME} for ${CONFIRMATION_DISPLAY_TIME_MS} ms when copy was executed properly`, () => {
+    const clock = jasmine.clock().install();
     component.code.set('example');
 
     fixture.detectChanges();
@@ -85,13 +86,15 @@ describe('CopySourceCodeButton', () => {
 
     expect(button).toHaveClass(SUCCESSFULLY_COPY_CLASS_NAME);
 
-    tick(CONFIRMATION_DISPLAY_TIME_MS);
+    clock.tick(CONFIRMATION_DISPLAY_TIME_MS);
     fixture.detectChanges();
 
     expect(button).not.toHaveClass(SUCCESSFULLY_COPY_CLASS_NAME);
-  }));
+    clock.uninstall();
+  });
 
-  it(`should set ${FAILED_COPY_CLASS_NAME} for ${CONFIRMATION_DISPLAY_TIME_MS} ms when copy failed`, fakeAsync(() => {
+  it(`should set ${FAILED_COPY_CLASS_NAME} for ${CONFIRMATION_DISPLAY_TIME_MS} ms when copy failed`, async () => {
+    const clock = jasmine.clock().install();
     component.code.set('example');
     copySpy.and.throwError('Fake copy error');
 
@@ -104,11 +107,12 @@ describe('CopySourceCodeButton', () => {
 
     expect(button).toHaveClass(FAILED_COPY_CLASS_NAME);
 
-    tick(CONFIRMATION_DISPLAY_TIME_MS);
+    clock.tick(CONFIRMATION_DISPLAY_TIME_MS);
     fixture.detectChanges();
 
     expect(button).not.toHaveClass(FAILED_COPY_CLASS_NAME);
-  }));
+    clock.uninstall();
+  });
 });
 
 @Component({

--- a/adev/shared-docs/components/navigation-list/BUILD.bazel
+++ b/adev/shared-docs/components/navigation-list/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//adev/shared-docs:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_project")
+load("//adev/shared-docs:defaults.bzl", "ng_project", "ts_project", "zoneless_web_test_suite")
 load("//tools:defaults2.bzl", "sass_binary")
 
 package(default_visibility = ["//visibility:private"])
@@ -51,7 +51,7 @@ ts_project(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [":test_lib_rjs"],
 )

--- a/adev/shared-docs/components/search-dialog/BUILD.bazel
+++ b/adev/shared-docs/components/search-dialog/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//adev/shared-docs:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_project")
+load("//adev/shared-docs:defaults.bzl", "ng_project", "ts_project", "zoneless_web_test_suite")
 load("//tools:defaults2.bzl", "sass_binary")
 
 package(default_visibility = ["//visibility:private"])
@@ -56,7 +56,7 @@ ts_project(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [":test_lib_rjs"],
 )

--- a/adev/shared-docs/components/search-history/BUILD.bazel
+++ b/adev/shared-docs/components/search-history/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//adev/shared-docs:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_project")
+load("//adev/shared-docs:defaults.bzl", "ng_project", "ts_project", "zoneless_web_test_suite")
 load("//tools:defaults2.bzl", "sass_binary")
 
 package(default_visibility = ["//visibility:private"])
@@ -44,7 +44,7 @@ ts_project(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [":test_lib_rjs"],
 )

--- a/adev/shared-docs/components/select/BUILD.bazel
+++ b/adev/shared-docs/components/select/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//adev/shared-docs:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_project")
+load("//adev/shared-docs:defaults.bzl", "ng_project", "ts_project", "zoneless_web_test_suite")
 load("//tools:defaults2.bzl", "sass_binary")
 
 package(default_visibility = ["//visibility:private"])
@@ -39,7 +39,7 @@ ts_project(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [":test_lib_rjs"],
 )

--- a/adev/shared-docs/components/slide-toggle/BUILD.bazel
+++ b/adev/shared-docs/components/slide-toggle/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//adev/shared-docs:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_project")
+load("//adev/shared-docs:defaults.bzl", "ng_project", "ts_project", "zoneless_web_test_suite")
 load("//tools:defaults2.bzl", "sass_binary")
 
 package(default_visibility = ["//visibility:private"])
@@ -39,7 +39,7 @@ ts_project(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [":test_lib_rjs"],
 )

--- a/adev/shared-docs/components/table-of-contents/BUILD.bazel
+++ b/adev/shared-docs/components/table-of-contents/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//adev/shared-docs:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_project")
+load("//adev/shared-docs:defaults.bzl", "ng_project", "ts_project", "zoneless_web_test_suite")
 load("//tools:defaults2.bzl", "sass_binary")
 
 package(default_visibility = ["//visibility:private"])
@@ -50,7 +50,7 @@ ts_project(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [":test_lib_rjs"],
 )

--- a/adev/shared-docs/components/text-field/BUILD.bazel
+++ b/adev/shared-docs/components/text-field/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//adev/shared-docs:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_project")
+load("//adev/shared-docs:defaults.bzl", "ng_project", "ts_project", "zoneless_web_test_suite")
 load("//tools:defaults2.bzl", "sass_binary")
 
 package(default_visibility = ["//visibility:private"])
@@ -41,7 +41,7 @@ ts_project(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [":test_lib_rjs"],
 )

--- a/adev/shared-docs/components/top-level-banner/BUILD.bazel
+++ b/adev/shared-docs/components/top-level-banner/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//adev/shared-docs:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_project")
+load("//adev/shared-docs:defaults.bzl", "ng_project", "ts_project", "zoneless_web_test_suite")
 load("//tools:defaults2.bzl", "sass_binary")
 
 package(default_visibility = ["//visibility:private"])
@@ -42,7 +42,7 @@ ts_project(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [":test_lib_rjs"],
 )

--- a/adev/shared-docs/components/viewers/BUILD.bazel
+++ b/adev/shared-docs/components/viewers/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//adev/shared-docs:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_project")
+load("//adev/shared-docs:defaults.bzl", "ng_project", "ts_project", "zoneless_web_test_suite")
 load("//tools:defaults2.bzl", "sass_binary")
 
 package(default_visibility = ["//visibility:private"])
@@ -68,7 +68,7 @@ ts_project(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [":test_lib_rjs"],
 )

--- a/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.spec.ts
+++ b/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {ExampleViewer} from './example-viewer.component';
 import {ExampleMetadata, ExampleViewerContentLoader} from '../../../interfaces';
 import {EXAMPLE_VIEWER_CONTENT_LOADER} from '../../../providers';
@@ -48,7 +48,7 @@ describe('ExampleViewer', () => {
     fixture.detectChanges();
   });
 
-  it('should set file extensions as tab names when all files have different extension', waitForAsync(async () => {
+  it('should set file extensions as tab names when all files have different extension', async () => {
     componentRef.setInput(
       'metadata',
       getMetadata({
@@ -66,9 +66,9 @@ describe('ExampleViewer', () => {
     expect(component.tabs()![0].name).toBe('TS');
     expect(component.tabs()![1].name).toBe('HTML');
     expect(component.tabs()![2].name).toBe('CSS');
-  }));
+  });
 
-  it('should generate correct code content for multi file mode when it is expanded', waitForAsync(async () => {
+  it('should generate correct code content for multi file mode when it is expanded', async () => {
     componentRef.setInput(
       'metadata',
       getMetadata({
@@ -86,7 +86,7 @@ describe('ExampleViewer', () => {
     expect(component.tabs()![0].code).toBe('typescript file');
     expect(component.tabs()![1].code).toBe('html file');
     expect(component.tabs()![2].code).toBe('css file');
-  }));
+  });
 
   it('should set file names as tab names when there is at least one duplication', async () => {
     componentRef.setInput(
@@ -107,14 +107,14 @@ describe('ExampleViewer', () => {
     expect(component.tabs()![2].name).toBe('another-example.ts');
   });
 
-  it('should expand button not appear when there is no hidden line', waitForAsync(async () => {
+  it('should expand button not appear when there is no hidden line', async () => {
     componentRef.setInput('metadata', getMetadata());
     await component.renderExample();
     const button = fixture.debugElement.query(By.css('button[aria-label="Expand code example"]'));
     expect(button).toBeNull();
-  }));
+  });
 
-  it('should have line with hidden line class when expand button is present', waitForAsync(async () => {
+  it('should have line with hidden line class when expand button is present', async () => {
     const expectedCodeSnippetContent =
       'typescript code<br/>' + '<div class="line">hidden line</div>';
 
@@ -136,9 +136,9 @@ describe('ExampleViewer', () => {
 
     const hiddenLine = fixture.debugElement.query(By.css('div[class="line hidden"]'));
     expect(hiddenLine).toBeTruthy();
-  }));
+  });
 
-  it('should have no more line with hidden line class when expand button is clicked', waitForAsync(async () => {
+  it('should have no more line with hidden line class when expand button is clicked', async () => {
     const expectedCodeSnippetContent =
       'typescript code<br/>' + '<div class="line">hidden line</div>';
 
@@ -166,9 +166,9 @@ describe('ExampleViewer', () => {
 
     const hiddenLine = fixture.debugElement.query(By.css('div[class="line hidden"]'));
     expect(hiddenLine).toBeNull();
-  }));
+  });
 
-  it('should set exampleComponent when metadata contains path and preview is true', waitForAsync(async () => {
+  it('should set exampleComponent when metadata contains path and preview is true', async () => {
     exampleContentSpy.loadPreview.and.resolveTo(ExampleComponent);
     componentRef.setInput(
       'metadata',
@@ -179,9 +179,9 @@ describe('ExampleViewer', () => {
     );
     await component.renderExample();
     expect(component.exampleComponent).toBe(ExampleComponent);
-  }));
+  });
 
-  it('should display GitHub button when githubUrl is provided and there is preview', waitForAsync(async () => {
+  it('should display GitHub button when githubUrl is provided and there is preview', async () => {
     exampleContentSpy.loadPreview.and.resolveTo(ExampleComponent);
     componentRef.setInput(
       'metadata',
@@ -199,9 +199,9 @@ describe('ExampleViewer', () => {
     );
     expect(githubButton).toBeTruthy();
     expect(githubButton.nativeElement.href).toBe(component.githubUrl);
-  }));
+  });
 
-  it('should display StackBlitz button when stackblitzUrl is provided and there is preview', waitForAsync(async () => {
+  it('should display StackBlitz button when stackblitzUrl is provided and there is preview', async () => {
     exampleContentSpy.loadPreview.and.resolveTo(ExampleComponent);
     componentRef.setInput(
       'metadata',
@@ -219,9 +219,9 @@ describe('ExampleViewer', () => {
     );
     expect(stackblitzButton).toBeTruthy();
     expect(stackblitzButton.nativeElement.href).toBe(component.stackblitzUrl);
-  }));
+  });
 
-  it('should set expanded flag in metadata after toggleExampleVisibility', waitForAsync(async () => {
+  it('should set expanded flag in metadata after toggleExampleVisibility', async () => {
     componentRef.setInput('metadata', getMetadata());
     await component.renderExample();
     component.toggleExampleVisibility();
@@ -231,10 +231,10 @@ describe('ExampleViewer', () => {
     expect(await tab.getLabel()).toBe('TS');
     component.toggleExampleVisibility();
     expect(component.expanded()).toBeFalse();
-  }));
+  });
 
   // TODO(josephperrott): enable once the docs-viewer/example-viewer circle is sorted out.
-  xit('should call clipboard service when clicked on copy source code', waitForAsync(async () => {
+  xit('should call clipboard service when clicked on copy source code', async () => {
     const expectedCodeSnippetContent = 'typescript code';
     componentRef.setInput(
       'metadata',
@@ -256,9 +256,9 @@ describe('ExampleViewer', () => {
     button.click();
 
     expect(spy.calls.argsFor(0)[0]?.trim()).toBe(expectedCodeSnippetContent);
-  }));
+  });
 
-  it('should call clipboard service when clicked on copy example link', waitForAsync(async () => {
+  it('should call clipboard service when clicked on copy example link', async () => {
     componentRef.setInput('metadata', getMetadata());
     component.expanded.set(true);
     fixture.detectChanges();
@@ -271,7 +271,7 @@ describe('ExampleViewer', () => {
     ).nativeElement;
     button.click();
     expect(spy.calls.argsFor(0)[0].trim()).toBe(`${window.location.href}#example-1`);
-  }));
+  });
 });
 
 const getMetadata = (value: Partial<ExampleMetadata> = {}): ExampleMetadata => {

--- a/adev/shared-docs/defaults.bzl
+++ b/adev/shared-docs/defaults.bzl
@@ -1,8 +1,8 @@
 load(
     "//tools:defaults2.bzl",
     _ng_project = "ng_project",
-    _ng_web_test_suite = "ng_web_test_suite",
     _ts_project = "ts_project",
+    _zoneless_web_test_suite = "zoneless_web_test_suite",
 )
 
 def ts_project(name, tsconfig = None, testonly = False, enable_runtime_rnjs_interop = False, **kwargs):
@@ -31,14 +31,14 @@ def ng_project(name, tsconfig = None, testonly = False, enable_runtime_rnjs_inte
         **kwargs
     )
 
-def ng_web_test_suite(deps = [], **kwargs):
+def zoneless_web_test_suite(deps = [], **kwargs):
     # Provide required modules for the imports in //tools/testing/browser_tests.init.mts
     deps = deps + [
         "//:node_modules/@angular/compiler",
         "//:node_modules/@angular/core",
         "//:node_modules/@angular/platform-browser",
     ]
-    _ng_web_test_suite(
+    _zoneless_web_test_suite(
         deps = deps,
         tsconfig = "//adev/shared-docs:tsconfig_test",
         **kwargs

--- a/adev/shared-docs/directives/click-outside/BUILD.bazel
+++ b/adev/shared-docs/directives/click-outside/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//adev/shared-docs:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_project")
+load("//adev/shared-docs:defaults.bzl", "ng_project", "ts_project", "zoneless_web_test_suite")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -30,7 +30,7 @@ ts_project(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [":test_lib_rjs"],
 )

--- a/adev/shared-docs/directives/external-link/BUILD.bazel
+++ b/adev/shared-docs/directives/external-link/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//adev/shared-docs:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_project")
+load("//adev/shared-docs:defaults.bzl", "ng_project", "ts_project", "zoneless_web_test_suite")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -34,7 +34,7 @@ ts_project(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [":test_lib_rjs"],
 )

--- a/adev/shared-docs/pipeline/api-gen/extraction/test/BUILD.bazel
+++ b/adev/shared-docs/pipeline/api-gen/extraction/test/BUILD.bazel
@@ -1,6 +1,6 @@
 load("//adev/shared-docs:defaults.bzl", "ts_project")
 load("//adev/shared-docs/pipeline/api-gen/extraction:extract_api_to_json.bzl", "extract_api_to_json")
-load("//tools:defaults2.bzl", "jasmine_test")
+load("//tools:defaults2.bzl", "zoneless_jasmine_test")
 
 package(default_visibility = ["//adev/shared-docs/pipeline/api-gen:__subpackages__"])
 
@@ -60,7 +60,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "unit_tests",
     data = [":unit_test_lib_rjs"],
 )

--- a/adev/shared-docs/pipeline/api-gen/manifest/test/BUILD.bazel
+++ b/adev/shared-docs/pipeline/api-gen/manifest/test/BUILD.bazel
@@ -1,7 +1,7 @@
 load("//adev/shared-docs:defaults.bzl", "ts_project")
 load("//adev/shared-docs/pipeline/api-gen/extraction:extract_api_to_json.bzl", "extract_api_to_json")
 load("//adev/shared-docs/pipeline/api-gen/manifest:generate_api_manifest.bzl", "generate_api_manifest")
-load("//tools:defaults2.bzl", "jasmine_test")
+load("//tools:defaults2.bzl", "zoneless_jasmine_test")
 
 generate_api_manifest(
     name = "test",
@@ -33,7 +33,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "unit_tests",
     data = [
         ":unit_test_lib_rjs",

--- a/adev/shared-docs/pipeline/api-gen/rendering/test/BUILD.bazel
+++ b/adev/shared-docs/pipeline/api-gen/rendering/test/BUILD.bazel
@@ -1,6 +1,6 @@
 load("//adev/shared-docs:defaults.bzl", "ts_project")
 load("//adev/shared-docs/pipeline/api-gen/rendering:render_api_to_html.bzl", "render_api_to_html")
-load("//tools:defaults2.bzl", "jasmine_test")
+load("//tools:defaults2.bzl", "zoneless_jasmine_test")
 
 render_api_to_html(
     name = "test",
@@ -26,7 +26,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "unit_tests",
     data = [
         ":unit_test_lib_rjs",

--- a/adev/shared-docs/pipeline/guides/testing/docs-alert/BUILD.bazel
+++ b/adev/shared-docs/pipeline/guides/testing/docs-alert/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//adev/shared-docs:defaults.bzl", "ts_project")
-load("//tools:defaults2.bzl", "jasmine_test")
+load("//tools:defaults2.bzl", "zoneless_jasmine_test")
 
 ts_project(
     name = "docs-alert",
@@ -15,7 +15,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         "docs-alert.md",

--- a/adev/shared-docs/pipeline/guides/testing/docs-callout/BUILD.bazel
+++ b/adev/shared-docs/pipeline/guides/testing/docs-callout/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//adev/shared-docs:defaults.bzl", "ts_project")
-load("//tools:defaults2.bzl", "jasmine_test")
+load("//tools:defaults2.bzl", "zoneless_jasmine_test")
 
 ts_project(
     name = "docs-callout",
@@ -15,7 +15,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         "docs-callout.md",

--- a/adev/shared-docs/pipeline/guides/testing/docs-card-container/BUILD.bazel
+++ b/adev/shared-docs/pipeline/guides/testing/docs-card-container/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//adev/shared-docs:defaults.bzl", "ts_project")
-load("//tools:defaults2.bzl", "jasmine_test")
+load("//tools:defaults2.bzl", "zoneless_jasmine_test")
 
 ts_project(
     name = "docs-card-container",
@@ -15,7 +15,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         "docs-card-container.md",

--- a/adev/shared-docs/pipeline/guides/testing/docs-card/BUILD.bazel
+++ b/adev/shared-docs/pipeline/guides/testing/docs-card/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//adev/shared-docs:defaults.bzl", "ts_project")
-load("//tools:defaults2.bzl", "jasmine_test")
+load("//tools:defaults2.bzl", "zoneless_jasmine_test")
 
 ts_project(
     name = "docs-card",
@@ -13,7 +13,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         "angular.svg",

--- a/adev/shared-docs/pipeline/guides/testing/docs-code-block/BUILD.bazel
+++ b/adev/shared-docs/pipeline/guides/testing/docs-code-block/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//adev/shared-docs:defaults.bzl", "ts_project")
-load("//tools:defaults2.bzl", "jasmine_test")
+load("//tools:defaults2.bzl", "zoneless_jasmine_test")
 
 ts_project(
     name = "docs-code-block",
@@ -15,7 +15,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         "docs-code-block.md",

--- a/adev/shared-docs/pipeline/guides/testing/docs-code-multifile/BUILD.bazel
+++ b/adev/shared-docs/pipeline/guides/testing/docs-code-multifile/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//adev/shared-docs:defaults.bzl", "ts_project")
-load("//tools:defaults2.bzl", "jasmine_test")
+load("//tools:defaults2.bzl", "zoneless_jasmine_test")
 
 ts_project(
     name = "docs-code-multifile",
@@ -15,7 +15,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         "docs-code-multifile.md",

--- a/adev/shared-docs/pipeline/guides/testing/docs-code/BUILD.bazel
+++ b/adev/shared-docs/pipeline/guides/testing/docs-code/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//adev/shared-docs:defaults.bzl", "ts_project")
-load("//tools:defaults2.bzl", "jasmine_test")
+load("//tools:defaults2.bzl", "zoneless_jasmine_test")
 
 ts_project(
     name = "docs-code",
@@ -15,7 +15,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         "docs-code.md",

--- a/adev/shared-docs/pipeline/guides/testing/docs-decorative-header/BUILD.bazel
+++ b/adev/shared-docs/pipeline/guides/testing/docs-decorative-header/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//adev/shared-docs:defaults.bzl", "ts_project")
-load("//tools:defaults2.bzl", "jasmine_test")
+load("//tools:defaults2.bzl", "zoneless_jasmine_test")
 
 ts_project(
     name = "docs-decorative-header",
@@ -15,7 +15,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         "decoration.svg",

--- a/adev/shared-docs/pipeline/guides/testing/docs-pill-row/BUILD.bazel
+++ b/adev/shared-docs/pipeline/guides/testing/docs-pill-row/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//adev/shared-docs:defaults.bzl", "ts_project")
-load("//tools:defaults2.bzl", "jasmine_test")
+load("//tools:defaults2.bzl", "zoneless_jasmine_test")
 
 ts_project(
     name = "docs-pill-row",
@@ -15,7 +15,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         "docs-pill-row.md",

--- a/adev/shared-docs/pipeline/guides/testing/docs-pill/BUILD.bazel
+++ b/adev/shared-docs/pipeline/guides/testing/docs-pill/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//adev/shared-docs:defaults.bzl", "ts_project")
-load("//tools:defaults2.bzl", "jasmine_test")
+load("//tools:defaults2.bzl", "zoneless_jasmine_test")
 
 ts_project(
     name = "docs-pill",
@@ -15,7 +15,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         "docs-pill.md",

--- a/adev/shared-docs/pipeline/guides/testing/docs-step/BUILD.bazel
+++ b/adev/shared-docs/pipeline/guides/testing/docs-step/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//adev/shared-docs:defaults.bzl", "ts_project")
-load("//tools:defaults2.bzl", "jasmine_test")
+load("//tools:defaults2.bzl", "zoneless_jasmine_test")
 
 ts_project(
     name = "docs-step",
@@ -15,7 +15,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         "docs-step.md",

--- a/adev/shared-docs/pipeline/guides/testing/docs-video/BUILD.bazel
+++ b/adev/shared-docs/pipeline/guides/testing/docs-video/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//adev/shared-docs:defaults.bzl", "ts_project")
-load("//tools:defaults2.bzl", "jasmine_test")
+load("//tools:defaults2.bzl", "zoneless_jasmine_test")
 
 ts_project(
     name = "docs-video",
@@ -15,7 +15,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         "docs-video.md",

--- a/adev/shared-docs/pipeline/guides/testing/docs-workflow/BUILD.bazel
+++ b/adev/shared-docs/pipeline/guides/testing/docs-workflow/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//adev/shared-docs:defaults.bzl", "ts_project")
-load("//tools:defaults2.bzl", "jasmine_test")
+load("//tools:defaults2.bzl", "zoneless_jasmine_test")
 
 ts_project(
     name = "docs-workflow",
@@ -15,7 +15,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         "docs-workflow.md",

--- a/adev/shared-docs/pipeline/guides/testing/heading/BUILD.bazel
+++ b/adev/shared-docs/pipeline/guides/testing/heading/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//adev/shared-docs:defaults.bzl", "ts_project")
-load("//tools:defaults2.bzl", "jasmine_test")
+load("//tools:defaults2.bzl", "zoneless_jasmine_test")
 
 ts_project(
     name = "heading",
@@ -15,7 +15,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         "heading.md",

--- a/adev/shared-docs/pipeline/guides/testing/image/BUILD.bazel
+++ b/adev/shared-docs/pipeline/guides/testing/image/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//adev/shared-docs:defaults.bzl", "ts_project")
-load("//tools:defaults2.bzl", "jasmine_test")
+load("//tools:defaults2.bzl", "zoneless_jasmine_test")
 
 ts_project(
     name = "image",
@@ -15,7 +15,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         "image.md",

--- a/adev/shared-docs/pipeline/guides/testing/link/BUILD.bazel
+++ b/adev/shared-docs/pipeline/guides/testing/link/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//adev/shared-docs:defaults.bzl", "ts_project")
-load("//tools:defaults2.bzl", "jasmine_test")
+load("//tools:defaults2.bzl", "zoneless_jasmine_test")
 
 ts_project(
     name = "link",
@@ -15,7 +15,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         "link.md",

--- a/adev/shared-docs/pipeline/guides/testing/list/BUILD.bazel
+++ b/adev/shared-docs/pipeline/guides/testing/list/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//adev/shared-docs:defaults.bzl", "ts_project")
-load("//tools:defaults2.bzl", "jasmine_test")
+load("//tools:defaults2.bzl", "zoneless_jasmine_test")
 
 ts_project(
     name = "list",
@@ -15,7 +15,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         "list.md",

--- a/adev/shared-docs/pipeline/guides/testing/mermaid/BUILD.bazel
+++ b/adev/shared-docs/pipeline/guides/testing/mermaid/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//adev/shared-docs:defaults.bzl", "ts_project")
-load("//tools:defaults2.bzl", "jasmine_test")
+load("//tools:defaults2.bzl", "zoneless_jasmine_test")
 
 ts_project(
     name = "unit_test_lib",
@@ -15,7 +15,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "unit_tests",
     data = [
         ":unit_test_lib_rjs",

--- a/adev/shared-docs/pipeline/guides/testing/table/BUILD.bazel
+++ b/adev/shared-docs/pipeline/guides/testing/table/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//adev/shared-docs:defaults.bzl", "ts_project")
-load("//tools:defaults2.bzl", "jasmine_test")
+load("//tools:defaults2.bzl", "zoneless_jasmine_test")
 
 ts_project(
     name = "table",
@@ -15,7 +15,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         "table.md",

--- a/adev/shared-docs/pipeline/guides/testing/text/BUILD.bazel
+++ b/adev/shared-docs/pipeline/guides/testing/text/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//adev/shared-docs:defaults.bzl", "ts_project")
-load("//tools:defaults2.bzl", "jasmine_test")
+load("//tools:defaults2.bzl", "zoneless_jasmine_test")
 
 ts_project(
     name = "text",
@@ -15,7 +15,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         "text.md",

--- a/adev/shared-docs/pipeline/navigation/test/BUILD.bazel
+++ b/adev/shared-docs/pipeline/navigation/test/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//adev/shared-docs:defaults.bzl", "ts_project")
-load("//tools:defaults2.bzl", "jasmine_test")
+load("//tools:defaults2.bzl", "zoneless_jasmine_test")
 
 package(default_visibility = ["//adev/shared-docs/pipeline/navigation:__subpackages__"])
 
@@ -13,7 +13,7 @@ ts_project(
     ],
 )
 
-jasmine_test(
+zoneless_jasmine_test(
     name = "unit_tests",
     data = [":unit_test_lib_rjs"],
 )

--- a/adev/shared-docs/services/BUILD.bazel
+++ b/adev/shared-docs/services/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//adev/shared-docs:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_project")
+load("//adev/shared-docs:defaults.bzl", "ng_project", "ts_project", "zoneless_web_test_suite")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -52,7 +52,7 @@ ts_project(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [":test_lib_rjs"],
 )


### PR DESCRIPTION
This will spare use the warning logs when the tests run.

```
      NG0914: The application is using zoneless change detection, but is still loading Zone.js. Consider removing Zone.js to get the full benefits of zoneless. In applications using the Angular CLI, Zone.js is typically included in the "polyfills" section of the angular.json file.
```

This commit also drops the remaning tests that relied on `waitForAsync`/`fakeAsync`/`flushMicrotasks`