### PR TITLE
fix(core): Fixed InputBinding behavior when a property set to @Input and cdr strategy OnPush

### DIFF
--- a/packages/core/src/render3/dynamic_bindings.ts
+++ b/packages/core/src/render3/dynamic_bindings.ts
@@ -16,6 +16,9 @@ import {TVIEW} from './interfaces/view';
 import {getCurrentTNode, getLView, getSelectedTNode, nextBindingIndex} from './state';
 import {stringifyForError} from './util/stringify_utils';
 import {createOutputListener} from './view/directive_outputs';
+import {markViewDirty} from './instructions/mark_view_dirty';
+import {getComponentLViewByIndex} from './util/view_utils';
+import {NotificationSource} from '../change_detection/scheduling/zoneless_scheduling';
 
 /** Symbol used to store and retrieve metadata about a binding. */
 export const BINDING: unique symbol = /* @__PURE__ */ Symbol('BINDING');
@@ -69,6 +72,9 @@ function inputBindingUpdate(targetDirectiveIdx: number, publicName: string, valu
   if (bindingUpdated(lView, bindingIndex, value)) {
     const tView = lView[TVIEW];
     const tNode = getSelectedTNode();
+
+    const componentLView = getComponentLViewByIndex(tNode.index, lView);
+    markViewDirty(componentLView, NotificationSource.SetInput);
 
     // TODO(pk): don't check on each and every binding, just assert in dev mode
     const targetDef = tView.directiveRegistry![targetDirectiveIdx];

--- a/packages/core/test/acceptance/create_component_spec.ts
+++ b/packages/core/test/acceptance/create_component_spec.ts
@@ -36,6 +36,7 @@ import {
 } from '../../src/core';
 import {stringifyForError} from '../../src/render3/util/stringify_utils';
 import {TestBed} from '../../testing';
+import {ChangeDetectionStrategy} from '@angular/compiler';
 
 describe('createComponent', () => {
   it('should create an instance of a standalone component', () => {
@@ -1110,6 +1111,34 @@ describe('createComponent', () => {
       }).toThrowError(
         /Cannot call `setInput` on a component that is using the `inputBinding` or `twoWayBinding` functions/,
       );
+    });
+
+    it('should update view of component set with the onPush strategy after input change', () => {
+      @Component({
+        standalone: true,
+        changeDetection: ChangeDetectionStrategy.OnPush,
+        template: 'Value: {{ value }}',
+      })
+      class DisplayOnPushComponent {
+        @Input() value: number = -1;
+      }
+
+      const hostElement = document.createElement('div');
+      const environmentInjector = TestBed.inject(EnvironmentInjector);
+      const valueSignal = signal(10);
+
+      const componentRef = createComponent(DisplayOnPushComponent, {
+        hostElement,
+        environmentInjector,
+        bindings: [inputBinding('value', valueSignal)],
+      });
+
+      componentRef.changeDetectorRef.detectChanges();
+      expect(hostElement.textContent).toBe('Value: 10');
+
+      valueSignal.set(20);
+      componentRef.changeDetectorRef.detectChanges();
+      expect(hostElement.textContent).toBe('Value: 20');
     });
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

inputBinding to bind to an old-style @Input() property of an OnPush component doesn't mark the component for check and therefore never updates the template of that component.

Issue Number: #62343 


## What is the new behavior?

Fixed InputBinding behavior when a property set to @Input and a component with cdr strategy set to OnPush would never update the component view

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
