### PR TITLE
fix(core): fixes race condition for zoneless apps

### DIFF
--- a/packages/platform-server/test/dom_utils.ts
+++ b/packages/platform-server/test/dom_utils.ts
@@ -110,10 +110,10 @@ export function hydrate(
   global.document = doc;
 
   const providers = [
-    ...envProviders,
     {provide: PLATFORM_ID, useValue: 'browser'},
     {provide: DOCUMENT, useFactory: () => doc},
     provideClientHydration(...hydrationFeatures()),
+    ...envProviders,
   ];
 
   return bootstrapApplication(component, {providers});


### PR DESCRIPTION
Lazy loaded routes would not properly hydrate when provideRouter was provided after the provideClientHydration call. Adding a microtask resolves the race condition and ensures those routes are properly hydrated.

fixes: #62592


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

