### PR TITLE
fix(core): Ensure application remains unstable during bootstrap

### DIFF
--- a/packages/platform-server/test/dom_utils.ts
+++ b/packages/platform-server/test/dom_utils.ts
@@ -110,10 +110,10 @@ export function hydrate(
   global.document = doc;
 
   const providers = [
-    ...envProviders,
     {provide: PLATFORM_ID, useValue: 'browser'},
     {provide: DOCUMENT, useFactory: () => doc},
     provideClientHydration(...hydrationFeatures()),
+    ...envProviders,
   ];
 
   return bootstrapApplication(component, {providers});


### PR DESCRIPTION
This commit ensures the application remains unstable during the entire bootstrap process. This ensures all bootstrap listeners and app initializers observe the application as being unstable until each one has gotten a chance to execute the synchronous block (potentially adding more pending tasks).

Prior to this commit, application initializers or bootstrap listeners may observe the application as being stable, even though other initializers/listeners had not yet executed. This created an ordering issue whereby the hydration bootstrap listener would observe the application as stable prior to the router performing its initial navigation.

fixes #62592
