### PR TITLE
docs: correctly look for examples in the bin_dir instead of execPath

### DIFF
--- a/adev/shared-docs/pipeline/_previews.bzl
+++ b/adev/shared-docs/pipeline/_previews.bzl
@@ -7,8 +7,10 @@ def _generate_previews_impl(ctx):
     # Set the arguments for the actions inputs and out put location.
     args = ctx.actions.args()
 
-    # Path to the examples for which previews are being generated.
-    args.add(ctx.attr.example_srcs.label.package)
+    # Path to the examples for which previews are being generated. Because examples are
+    # generated files, we need to look in the bin_dir subpath for them instead of the
+    # execPath
+    args.add("{}/{}".format(ctx.bin_dir.path, ctx.attr.example_srcs.label.package))
 
     # Path to the preview map template.
     args.add(ctx.file._template_src)

--- a/adev/shared-docs/pipeline/examples/previews/index.mts
+++ b/adev/shared-docs/pipeline/examples/previews/index.mts
@@ -69,6 +69,9 @@ async function main() {
     }))
     .filter((result) => result.componentNames.length > 0);
 
+  if (filesWithComponent.length === 0) {
+    throw Error('No previews found for the previews component map.');
+  }
   const previewsComponentMap = generatePreviewsComponentMap(filesWithComponent);
 
   await writeFile(outputFilePath, previewsComponentMap);


### PR DESCRIPTION
Properly look for the example files for live previews in the bin_dir
