### PR TITLE
refactor(signal-forms): remove error logic function

### DIFF
--- a/packages/forms/experimental/src/api/logic.ts
+++ b/packages/forms/experimental/src/api/logic.ts
@@ -144,33 +144,3 @@ export function metadata<TValue, TMetadata, TPathKind extends PathKind = PathKin
   const pathNode = FieldPathNode.unwrapFieldPath(path);
   pathNode.logic.addMetadataRule(key, logic);
 }
-
-/**
- * Adds logic to a field to conditionally add a validation error to it.
- * The added ValidationError will have `kind: ''`
- *
- * @param path The target path to add the error logic to.
- * @param logic A `LogicFn<T, boolean>` that returns `true` when the error should be added.
- * @param message An optional user-facing message to add to the error, or a `LogicFn<T, string>`
- *   that returns the user-facing message
- * @template TValue The type of value stored in the field the logic is bound to.
- * @template TPathKind The kind of path the logic is bound to (a root path, child path, or item of an array)
- */
-export function error<TValue, TPathKind extends PathKind = PathKind.Root>(
-  path: FieldPath<TValue, TPathKind>,
-  logic: NoInfer<LogicFn<TValue, boolean, TPathKind>>,
-  message?: string | NoInfer<LogicFn<TValue, string, TPathKind>>,
-): void {
-  assertPathIsCurrent(path);
-
-  if (typeof message === 'function') {
-    validate(path, (arg) => {
-      return logic(arg) ? ValidationError.custom({message: message(arg)}) : undefined;
-    });
-  } else {
-    const err = ValidationError.custom({message});
-    validate(path, (arg) => {
-      return logic(arg) ? err : undefined;
-    });
-  }
-}

--- a/packages/forms/experimental/test/node/field_node.spec.ts
+++ b/packages/forms/experimental/test/node/field_node.spec.ts
@@ -13,7 +13,6 @@ import {
   applyEach,
   applyWhen,
   disabled,
-  error,
   FieldPath,
   form,
   MIN,
@@ -572,44 +571,6 @@ describe('FieldNode', () => {
       expect(f.a().errors()).toEqual([
         ValidationError.custom({kind: 'too-damn-high'}),
         ValidationError.custom({kind: 'bad'}),
-      ]);
-      expect(f.a().valid()).toBe(false);
-    });
-
-    it('should validate with shorthand syntax', () => {
-      const f = form(
-        signal({a: 1, b: 2}),
-        (p) => {
-          error(p.a, ({value}) => value() > 1);
-          error(p.a, ({value}) => value() > 10, 'too-damn-high');
-          error(
-            p.a,
-            ({value}) => value() > 100,
-            ({value}) => `${value()} is much too high`,
-          );
-        },
-        {injector: TestBed.inject(Injector)},
-      );
-
-      expect(f.a().errors()).toEqual([]);
-      expect(f.a().valid()).toBe(true);
-
-      f.a().value.set(2);
-      expect(f.a().errors()).toEqual([ValidationError.custom()]);
-      expect(f.a().valid()).toBe(false);
-
-      f.a().value.set(11);
-      expect(f.a().errors()).toEqual([
-        ValidationError.custom(),
-        ValidationError.custom({message: 'too-damn-high'}),
-      ]);
-      expect(f.a().valid()).toBe(false);
-
-      f.a().value.set(101);
-      expect(f.a().errors()).toEqual([
-        ValidationError.custom(),
-        ValidationError.custom({message: 'too-damn-high'}),
-        ValidationError.custom({message: '101 is much too high'}),
       ]);
       expect(f.a().valid()).toBe(false);
     });


### PR DESCRIPTION
We have gotten feedback from multiple sources that the distinction between `error` and `validate` is confusing. Removing `error` for now and we will explore alternate method signatures for `validate` instead in future PRs
