### PR TITLE
feat(core): add `isCustomElement` property to modules and components

### DIFF
--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -170,6 +170,7 @@ export interface R3NgModuleMetadataFacade {
   imports: Function[];
   exports: Function[];
   schemas: {name: string}[] | null;
+  isCustomElement: ((tagName: string) => boolean) | null;
   id: string | null;
 }
 

--- a/packages/core/examples/is_custom_element_examples.ts
+++ b/packages/core/examples/is_custom_element_examples.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component, NgModule} from '@angular/core';
+
+// Example 1: NgModule with isCustomElement
+@Component({
+  selector: 'app-with-custom-elements',
+  template: `
+    <div>
+      <polymer-button>Polymer Button</polymer-button>
+      <lit-element>Lit Element</lit-element>
+      <my-widget>Custom Widget</my-widget>
+      <!-- This would generate an error since it doesn't match our custom element criteria -->
+      <!-- <unknown-element>Unknown</unknown-element> -->
+    </div>
+  `,
+})
+export class AppWithCustomElementsComponent {}
+
+@NgModule({
+  declarations: [AppWithCustomElementsComponent],
+  // Custom function to determine what counts as a custom element
+  isCustomElement: (tag: string) => {
+    // Allow elements that start with 'polymer-', 'lit-', or 'my-'
+    return tag.startsWith('polymer-') || tag.startsWith('lit-') || tag.startsWith('my-');
+  },
+})
+export class AppModule {}
+
+// Example 2: Standalone Component with isCustomElement
+@Component({
+  standalone: true,
+  selector: 'standalone-with-custom-elements',
+  template: `
+    <div>
+      <web-component-1>Web Component 1</web-component-1>
+      <web-component-2>Web Component 2</web-component-2>
+      <!-- Any element with dashes is considered a custom element -->
+      <some-other-element>Some Other Element</some-other-element>
+    </div>
+  `,
+  // Simple function: any tag with a dash is a custom element
+  isCustomElement: (tag: string) => tag.includes('-'),
+})
+export class StandaloneComponentWithCustomElements {}
+
+// Example 3: Complex custom element detection
+@Component({
+  standalone: true,
+  selector: 'complex-custom-element-detection',
+  template: `
+    <div>
+      <stencil-component>Stencil Component</stencil-component>
+      <angular-elements>Angular Elements</angular-elements>
+      <vue-custom-element>Vue Custom Element</vue-custom-element>
+      <legacy-element>Legacy Element</legacy-element>
+    </div>
+  `,
+  isCustomElement: (tag: string) => {
+    // More complex logic for different types of custom elements
+    const customElementPrefixes = ['stencil-', 'angular-', 'vue-'];
+    const allowedElements = new Set(['legacy-element']);
+    
+    return customElementPrefixes.some(prefix => tag.startsWith(prefix)) || 
+           allowedElements.has(tag);
+  },
+})
+export class ComplexCustomElementDetectionComponent {}
+
+// Example 4: Property binding with custom elements
+@Component({
+  standalone: true,
+  selector: 'custom-element-properties',
+  template: `
+    <div>
+      <!-- These property bindings will be allowed since the elements are recognized as custom -->
+      <my-slider 
+        [value]="sliderValue" 
+        [min]="0" 
+        [max]="100"
+        (valueChange)="onSliderChange($event)">
+      </my-slider>
+      
+      <my-data-grid 
+        [data]="gridData"
+        [columns]="gridColumns"
+        [sortable]="true">
+      </my-data-grid>
+    </div>
+  `,
+  isCustomElement: (tag: string) => tag.startsWith('my-'),
+})
+export class CustomElementPropertiesComponent {
+  sliderValue = 50;
+  gridData = [
+    { id: 1, name: 'John', age: 30 },
+    { id: 2, name: 'Jane', age: 25 },
+  ];
+  gridColumns = ['id', 'name', 'age'];
+
+  onSliderChange(value: number) {
+    this.sliderValue = value;
+  }
+}

--- a/packages/core/src/compiler/compiler_facade_interface.ts
+++ b/packages/core/src/compiler/compiler_facade_interface.ts
@@ -170,6 +170,7 @@ export interface R3NgModuleMetadataFacade {
   imports: Function[];
   exports: Function[];
   schemas: {name: string}[] | null;
+  isCustomElement: ((tagName: string) => boolean) | null;
   id: string | null;
 }
 

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -684,6 +684,24 @@ export interface Component extends Directive {
    * guide](guide/components/importing).
    */
   schemas?: SchemaMetadata[];
+
+  /**
+   * Function to determine if a tag name represents a custom element.
+   * If provided, this will be used instead of relying solely on CUSTOM_ELEMENTS_SCHEMA
+   * to determine if an element is a custom element.
+   * 
+   * This property is only available for standalone components - specifying it for components
+   * declared in an NgModule generates a compilation error.
+   * 
+   * @example
+   * ```ts
+   * @Component({
+   *   standalone: true,
+   *   isCustomElement: (tag) => tag.includes('-')
+   * })
+   * ```
+   */
+  isCustomElement?: (tagName: string) => boolean;
 }
 
 /**

--- a/packages/core/src/metadata/ng_module.ts
+++ b/packages/core/src/metadata/ng_module.ts
@@ -187,6 +187,20 @@ export interface NgModule {
   schemas?: Array<SchemaMetadata | any[]>;
 
   /**
+   * Function to determine if a tag name represents a custom element.
+   * If provided, this will be used instead of relying solely on CUSTOM_ELEMENTS_SCHEMA
+   * to determine if an element is a custom element.
+   * 
+   * @example
+   * ```ts
+   * @NgModule({
+   *   isCustomElement: (tag) => tag.includes('-')
+   * })
+   * ```
+   */
+  isCustomElement?: (tagName: string) => boolean;
+
+  /**
    * A name or path that uniquely identifies this NgModule in `getNgModuleById`.
    * If left `undefined`, the NgModule is not registered with `getNgModuleById`.
    */

--- a/packages/core/src/metadata/ng_module_def.ts
+++ b/packages/core/src/metadata/ng_module_def.ts
@@ -27,6 +27,7 @@ export interface NgModuleTransitiveScopes {
   compilation: {directives: Set<any>; pipes: Set<any>};
   exported: {directives: Set<any>; pipes: Set<any>};
   schemas: SchemaMetadata[] | null;
+  isCustomElement: ((tagName: string) => boolean) | null;
 }
 
 /**
@@ -71,6 +72,9 @@ export interface NgModuleDef<T> {
 
   /** The set of schemas that declare elements to be allowed in the NgModule. */
   schemas: SchemaMetadata[] | null;
+
+  /** Function to determine if a tag name represents a custom element. */
+  isCustomElement: ((tagName: string) => boolean) | null;
 
   /** Unique ID for the module with which it should be registered.  */
   id: string | null;

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -439,6 +439,7 @@ function createRootTView(
     null,
     null,
     null,
+    null, // isCustomElement
     [tAttributes],
     null,
   );

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -319,6 +319,11 @@ interface ComponentDefinition<T> extends Omit<DirectiveDefinition<T>, 'features'
    * The set of schemas that declare elements to be allowed in the component's template.
    */
   schemas?: SchemaMetadata[] | null;
+
+  /**
+   * Function to determine if a tag name represents a custom element.
+   */
+  isCustomElement?: ((tagName: string) => boolean) | null;
 }
 
 /**
@@ -369,6 +374,7 @@ export function ɵɵdefineComponent<T>(
       styles: componentDefinition.styles || EMPTY_ARRAY,
       _: null,
       schemas: componentDefinition.schemas || null,
+      isCustomElement: componentDefinition.isCustomElement || null,
       tView: null,
       id: '',
     };
@@ -417,6 +423,9 @@ export function ɵɵdefineNgModule<T>(def: {
   /** The set of schemas that declare elements to be allowed in the NgModule. */
   schemas?: SchemaMetadata[] | null;
 
+  /** Function to determine if a tag name represents a custom element. */
+  isCustomElement?: ((tagName: string) => boolean) | null;
+
   /** Unique ID for the module that is used with `getModuleFactory`. */
   id?: string | null;
 }): unknown {
@@ -429,6 +438,7 @@ export function ɵɵdefineNgModule<T>(def: {
       exports: def.exports || EMPTY_ARRAY,
       transitiveCompileScopes: null,
       schemas: def.schemas || null,
+      isCustomElement: def.isCustomElement || null,
       id: def.id || null,
     };
     return res;

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -294,7 +294,7 @@ export function setDomProperty<T>(
 
     if (ngDevMode) {
       validateAgainstEventProperties(propName);
-      if (!isPropertyValid(element, propName, tNode.value, lView[TVIEW].schemas)) {
+      if (!isPropertyValid(element, propName, tNode.value, lView[TVIEW].schemas, lView[TVIEW].isCustomElement)) {
         handleUnknownPropertyError(propName, tNode.value, tNode.type, lView);
       }
     }

--- a/packages/core/src/render3/instructions/template.ts
+++ b/packages/core/src/render3/instructions/template.ts
@@ -76,6 +76,7 @@ function templateCreate(
       declarationTView.pipeRegistry,
       null,
       declarationTView.schemas,
+      declarationTView.isCustomElement,
       declarationTView.consts,
       null /* ssrId */,
     ));

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -379,6 +379,12 @@ export interface ComponentDef<T> extends DirectiveDef<T> {
   schemas: SchemaMetadata[] | null;
 
   /**
+   * Function to determine if a tag name represents a custom element.
+   * If provided, this will be used instead of relying solely on CUSTOM_ELEMENTS_SCHEMA.
+   */
+  isCustomElement: ((tagName: string) => boolean) | null;
+
+  /**
    * Ivy runtime uses this place to store the computed tView for the component. This gets filled on
    * the first run of component.
    */

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -838,6 +838,12 @@ export interface TView {
   schemas: SchemaMetadata[] | null;
 
   /**
+   * Function to determine if a tag name represents a custom element.
+   * If provided, this will be used instead of relying solely on CUSTOM_ELEMENTS_SCHEMA.
+   */
+  isCustomElement: ((tagName: string) => boolean) | null;
+
+  /**
    * Array of constants for the view. Includes attribute arrays, local definition arrays etc.
    * Used for directive matching, attribute bindings, local definitions and more.
    */

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -214,6 +214,20 @@ export function compileComponent(type: Type<any>, metadata: Component): void {
         } else if (meta.isStandalone) {
           ngComponentDef.schemas = [];
         }
+
+        if (metadata.isCustomElement) {
+          if (meta.isStandalone) {
+            ngComponentDef.isCustomElement = metadata.isCustomElement;
+          } else {
+            throw new Error(
+              `The 'isCustomElement' was specified for the ${stringifyForError(
+                type,
+              )} but is only valid on a component that is standalone.`,
+            );
+          }
+        } else if (meta.isStandalone) {
+          ngComponentDef.isCustomElement = null;
+        }
       }
       return ngComponentDef;
     },

--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -156,6 +156,7 @@ export function compileNgModuleDefs(
             .map(resolveForwardRef)
             .map(expandModuleWithProviders),
           schemas: ngModule.schemas ? flatten(ngModule.schemas) : null,
+          isCustomElement: ngModule.isCustomElement || null,
           id: ngModule.id || null,
         });
         // Set `schemas` on ngModuleDef to an empty array in JIT mode to indicate that runtime
@@ -165,6 +166,8 @@ export function compileNgModuleDefs(
         if (!ngModuleDef.schemas) {
           ngModuleDef.schemas = [];
         }
+        // Set `isCustomElement` on ngModuleDef to the function from the NgModule metadata
+        ngModuleDef.isCustomElement = ngModule.isCustomElement || null;
       }
       return ngModuleDef;
     },
@@ -556,6 +559,7 @@ export function transitiveScopesFor<T>(type: Type<T>): NgModuleTransitiveScopes 
     const def = getNgModuleDefOrThrow(type);
     return {
       schemas: def.schemas || null,
+      isCustomElement: def.isCustomElement || null,
       ...scope,
     };
   } else if (isStandalone(type)) {
@@ -563,6 +567,7 @@ export function transitiveScopesFor<T>(type: Type<T>): NgModuleTransitiveScopes 
     if (directiveDef !== null) {
       return {
         schemas: null,
+        isCustomElement: null,
         compilation: {
           directives: new Set<any>(),
           pipes: new Set<any>(),
@@ -578,6 +583,7 @@ export function transitiveScopesFor<T>(type: Type<T>): NgModuleTransitiveScopes 
     if (pipeDef !== null) {
       return {
         schemas: null,
+        isCustomElement: null,
         compilation: {
           directives: new Set<any>(),
           pipes: new Set<any>(),
@@ -612,6 +618,7 @@ export function transitiveScopesForNgModule<T>(moduleType: Type<T>): NgModuleTra
 
   const scopes: NgModuleTransitiveScopes = {
     schemas: def.schemas || null,
+    isCustomElement: def.isCustomElement || null,
     compilation: {
       directives: new Set<any>(),
       pipes: new Set<any>(),

--- a/packages/core/src/render3/view/construction.ts
+++ b/packages/core/src/render3/view/construction.ts
@@ -74,6 +74,7 @@ export function createTView(
   pipes: PipeDefListOrFactory | null,
   viewQuery: ViewQueriesFunction<any> | null,
   schemas: SchemaMetadata[] | null,
+  isCustomElement: ((tagName: string) => boolean) | null,
   constsOrFactory: TConstantsOrFactory | null,
   ssrId: string | null,
 ): TView {
@@ -113,6 +114,7 @@ export function createTView(
     pipeRegistry: typeof pipes === 'function' ? pipes() : pipes,
     firstChild: null,
     schemas: schemas,
+    isCustomElement: isCustomElement,
     consts: consts,
     incompleteFirstPass: false,
     ssrId,
@@ -162,6 +164,7 @@ export function getOrCreateComponentTView(def: ComponentDef<any>): TView {
       def.pipeDefs,
       def.viewQuery,
       def.schemas,
+      def.isCustomElement,
       def.consts,
       def.id,
     ));

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -144,7 +144,7 @@ describe('di', () => {
     it('should handle initial undefined state', () => {
       const contentView = createLView(
         null,
-        createTView(TViewType.Component, null, null, 1, 0, null, null, null, null, null, null),
+        createTView(TViewType.Component, null, null, 1, 0, null, null, null, null, null, null, null),
         {},
         LViewFlags.CheckAlways,
         null,

--- a/packages/core/test/render3/element_validation_spec.ts
+++ b/packages/core/test/render3/element_validation_spec.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {isCustomElementByFunction, matchingSchemas} from '../../src/render3/instructions/element_validation';
+import {CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA} from '../../src/metadata/schema';
+
+describe('element validation', () => {
+  describe('isCustomElementByFunction', () => {
+    it('should return true when function returns true', () => {
+      const isCustomElement = (tag: string) => tag.includes('-');
+      expect(isCustomElementByFunction(isCustomElement, 'my-element')).toBe(true);
+    });
+
+    it('should return false when function returns false', () => {
+      const isCustomElement = (tag: string) => tag.includes('-');
+      expect(isCustomElementByFunction(isCustomElement, 'div')).toBe(false);
+    });
+
+    it('should return false when function is null', () => {
+      expect(isCustomElementByFunction(null, 'my-element')).toBe(false);
+    });
+
+    it('should return false when tagName is null', () => {
+      const isCustomElement = (tag: string) => tag.includes('-');
+      expect(isCustomElementByFunction(isCustomElement, null)).toBe(false);
+    });
+
+    it('should work with complex logic', () => {
+      const isCustomElement = (tag: string) => {
+        return tag.startsWith('polymer-') || tag.startsWith('lit-') || tag === 'special-element';
+      };
+      
+      expect(isCustomElementByFunction(isCustomElement, 'polymer-button')).toBe(true);
+      expect(isCustomElementByFunction(isCustomElement, 'lit-element')).toBe(true);
+      expect(isCustomElementByFunction(isCustomElement, 'special-element')).toBe(true);
+      expect(isCustomElementByFunction(isCustomElement, 'regular-element')).toBe(false);
+      expect(isCustomElementByFunction(isCustomElement, 'div')).toBe(false);
+    });
+  });
+
+  describe('matchingSchemas integration', () => {
+    it('should work with NO_ERRORS_SCHEMA', () => {
+      expect(matchingSchemas([NO_ERRORS_SCHEMA], 'any-element')).toBe(true);
+      expect(matchingSchemas([NO_ERRORS_SCHEMA], 'div')).toBe(true);
+    });
+
+    it('should work with CUSTOM_ELEMENTS_SCHEMA for hyphenated elements', () => {
+      expect(matchingSchemas([CUSTOM_ELEMENTS_SCHEMA], 'my-element')).toBe(true);
+      expect(matchingSchemas([CUSTOM_ELEMENTS_SCHEMA], 'div')).toBe(false);
+    });
+
+    it('should work with null schemas', () => {
+      expect(matchingSchemas(null, 'my-element')).toBe(false);
+      expect(matchingSchemas(null, 'div')).toBe(false);
+    });
+
+    it('should work with empty schemas array', () => {
+      expect(matchingSchemas([], 'my-element')).toBe(false);
+      expect(matchingSchemas([], 'div')).toBe(false);
+    });
+  });
+});

--- a/packages/core/test/render3/instructions/shared_spec.ts
+++ b/packages/core/test/render3/instructions/shared_spec.ts
@@ -52,6 +52,7 @@ export function enterViewWithOneDiv() {
     null,
     null,
     null,
+    null, // isCustomElement
     null,
     null,
   );

--- a/packages/core/test/render3/is_custom_element_spec.ts
+++ b/packages/core/test/render3/is_custom_element_spec.ts
@@ -1,0 +1,236 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component, NgModule, CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+describe('isCustomElement', () => {
+  describe('NgModule', () => {
+    it('should allow custom elements using isCustomElement function', () => {
+      @Component({
+        template: `<my-custom-element></my-custom-element>`,
+      })
+      class TestComponent {}
+
+      @NgModule({
+        declarations: [TestComponent],
+        isCustomElement: (tag) => tag.includes('-'),
+      })
+      class TestModule {}
+
+      expect(() => {
+        TestBed.configureTestingModule({
+          imports: [TestModule],
+        });
+        const fixture = TestBed.createComponent(TestComponent);
+        fixture.detectChanges();
+      }).not.toThrow();
+    });
+
+    it('should reject unknown elements when isCustomElement returns false', () => {
+      @Component({
+        template: `<unknown-element></unknown-element>`,
+      })
+      class TestComponent {}
+
+      @NgModule({
+        declarations: [TestComponent],
+        isCustomElement: (tag) => tag.startsWith('my-'),
+      })
+      class TestModule {}
+
+      // Should log an error but not throw in non-strict mode
+      const consoleErrorSpy = spyOn(console, 'error');
+      
+      TestBed.configureTestingModule({
+        imports: [TestModule],
+      });
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        jasmine.stringMatching(/is not a known element/)
+      );
+    });
+
+    it('should work with complex custom element detection logic', () => {
+      @Component({
+        template: `
+          <polymer-element></polymer-element>
+          <lit-element></lit-element>
+          <regular-element></regular-element>
+        `,
+      })
+      class TestComponent {}
+
+      @NgModule({
+        declarations: [TestComponent],
+        isCustomElement: (tag) => {
+          return tag.startsWith('polymer-') || tag.startsWith('lit-');
+        },
+      })
+      class TestModule {}
+
+      const consoleErrorSpy = spyOn(console, 'error');
+      
+      TestBed.configureTestingModule({
+        imports: [TestModule],
+      });
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+
+      // Should only error for regular-element
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        jasmine.stringMatching(/regular-element.*is not a known element/)
+      );
+    });
+  });
+
+  describe('Standalone Component', () => {
+    it('should allow custom elements using isCustomElement function', () => {
+      @Component({
+        standalone: true,
+        template: `<my-custom-element></my-custom-element>`,
+        isCustomElement: (tag) => tag.includes('-'),
+      })
+      class TestComponent {}
+
+      expect(() => {
+        TestBed.configureTestingModule({
+          imports: [TestComponent],
+        });
+        const fixture = TestBed.createComponent(TestComponent);
+        fixture.detectChanges();
+      }).not.toThrow();
+    });
+
+    it('should reject unknown elements when isCustomElement returns false', () => {
+      @Component({
+        standalone: true,
+        template: `<unknown-element></unknown-element>`,
+        isCustomElement: (tag) => tag.startsWith('my-'),
+      })
+      class TestComponent {}
+
+      const consoleErrorSpy = spyOn(console, 'error');
+      
+      TestBed.configureTestingModule({
+        imports: [TestComponent],
+      });
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        jasmine.stringMatching(/is not a known element/)
+      );
+    });
+
+    it('should throw error when isCustomElement is used on non-standalone component', () => {
+      expect(() => {
+        @Component({
+          template: `<div></div>`,
+          isCustomElement: (tag) => tag.includes('-'),
+        })
+        class TestComponent {}
+
+        @NgModule({
+          declarations: [TestComponent],
+        })
+        class TestModule {}
+      }).toThrow(/isCustomElement.*only valid on a component that is standalone/);
+    });
+  });
+
+  describe('Property validation', () => {
+    it('should allow properties on custom elements defined by isCustomElement', () => {
+      @Component({
+        standalone: true,
+        template: `<my-custom-element [customProp]="value"></my-custom-element>`,
+        isCustomElement: (tag) => tag.includes('-'),
+      })
+      class TestComponent {
+        value = 'test';
+      }
+
+      const consoleErrorSpy = spyOn(console, 'error');
+      
+      TestBed.configureTestingModule({
+        imports: [TestComponent],
+      });
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+
+      // Should not error about unknown property
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('should error for properties on non-custom elements', () => {
+      @Component({
+        standalone: true,
+        template: `<div [customProp]="value"></div>`,
+        isCustomElement: (tag) => tag.includes('-'),
+      })
+      class TestComponent {
+        value = 'test';
+      }
+
+      const consoleErrorSpy = spyOn(console, 'error');
+      
+      TestBed.configureTestingModule({
+        imports: [TestComponent],
+      });
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        jasmine.stringMatching(/Can't bind to 'customProp'/)
+      );
+    });
+  });
+
+  describe('Integration with CUSTOM_ELEMENTS_SCHEMA', () => {
+    it('should work alongside CUSTOM_ELEMENTS_SCHEMA', () => {
+      @Component({
+        standalone: true,
+        template: `
+          <my-custom-element></my-custom-element>
+          <other-element></other-element>
+        `,
+        schemas: [CUSTOM_ELEMENTS_SCHEMA],
+        isCustomElement: (tag) => tag.startsWith('my-'),
+      })
+      class TestComponent {}
+
+      expect(() => {
+        TestBed.configureTestingModule({
+          imports: [TestComponent],
+        });
+        const fixture = TestBed.createComponent(TestComponent);
+        fixture.detectChanges();
+      }).not.toThrow();
+    });
+
+    it('should prioritize isCustomElement over CUSTOM_ELEMENTS_SCHEMA logic', () => {
+      @Component({
+        standalone: true,
+        template: `<non-hyphenated-element></non-hyphenated-element>`,
+        isCustomElement: (tag) => tag === 'non-hyphenated-element',
+      })
+      class TestComponent {}
+
+      expect(() => {
+        TestBed.configureTestingModule({
+          imports: [TestComponent],
+        });
+        const fixture = TestBed.createComponent(TestComponent);
+        fixture.detectChanges();
+      }).not.toThrow();
+    });
+  });
+});

--- a/packages/core/test/render3/matchers_spec.ts
+++ b/packages/core/test/render3/matchers_spec.ts
@@ -49,7 +49,7 @@ describe('render3 matchers', () => {
   });
 
   describe('matchTView', () => {
-    const tView = createTView(TViewType.Root, null, null, 2, 3, null, null, null, null, null, null);
+    const tView = createTView(TViewType.Root, null, null, 2, 3, null, null, null, null, null, null, null);
     it('should match', () => {
       expect(tView).toEqual(matchTView());
       expect(tView).toEqual(matchTView({type: TViewType.Root}));
@@ -57,7 +57,7 @@ describe('render3 matchers', () => {
     });
   });
   describe('matchTNode', () => {
-    const tView = createTView(TViewType.Root, null, null, 2, 3, null, null, null, null, null, null);
+    const tView = createTView(TViewType.Root, null, null, 2, 3, null, null, null, null, null, null, null);
     const tNode = createTNode(tView, null, TNodeType.Element, 0, 'tagName', []);
 
     it('should match', () => {

--- a/packages/core/test/render3/view_fixture.ts
+++ b/packages/core/test/render3/view_fixture.ts
@@ -102,6 +102,7 @@ export class ViewFixture {
       null,
       null,
       null,
+      null, // isCustomElement
       null,
       null,
     );
@@ -147,6 +148,7 @@ export class ViewFixture {
       null,
       null,
       null,
+      null, // isCustomElement
       consts || null,
       null,
     );


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Right now the `CUSTOM_ELEMENTS_SCHEMA` breaks validation for custom elements and angular components.

Issue Number: N/A


## What is the new behavior?

This adds a new `isCustomElements` property to module and component decorators. This lets Angular know that certain elements should be treated as custom elements and skip component resolution, we can specify the `isCustomElement` option.

```ts
@NgModule({
  declarations: [AppWithCustomElementsComponent],
  // Custom function to determine what counts as a custom element
  isCustomElement: (tag: string) => {
    // Allow elements that start with 'polymer-', 'lit-', or 'my-'
    return tag.startsWith('polymer-') || tag.startsWith('lit-') || tag.startsWith('my-');
  },
})
export class AppModule {}


@Component({
  standalone: true,
  selector: 'complex-custom-element-detection',
  template: `
    <div>
      <stencil-component>Stencil Component</stencil-component>
      <angular-elements>Angular Elements</angular-elements>
      <vue-custom-element>Vue Custom Element</vue-custom-element>
      <legacy-element>Legacy Element</legacy-element>
    </div>
  `,
  isCustomElement: (tag: string) => {
    // More complex logic for different types of custom elements
    const customElementPrefixes = ['stencil-', 'angular-', 'vue-'];
    const allowedElements = new Set(['legacy-element']);

    return customElementPrefixes.some(prefix => tag.startsWith(prefix)) || 
           allowedElements.has(tag);
  },
})
export class ComplexCustomElementDetectionComponent {}
```

This is similar to the way Vuejs prevents errors with custom elements without breaking validation for framework components.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
