### PR TITLE
fix(devtools): add event tagging to prevent DDOS 

### DIFF
--- a/devtools/projects/shell-browser/src/app/chrome-message-bus.ts
+++ b/devtools/projects/shell-browser/src/app/chrome-message-bus.ts
@@ -74,6 +74,7 @@ export class ChromeMessageBus extends MessageBus<Events> {
       topic,
       args,
       __ignore_ng_zone__: true,
+      __NG_DEVTOOLS_EVENT__: true,
     });
     return true;
   }

--- a/devtools/projects/shell-browser/src/app/content-script.ts
+++ b/devtools/projects/shell-browser/src/app/content-script.ts
@@ -94,7 +94,7 @@ if (!backendInitialized) {
 }
 
 const proxyEventFromWindowToDevToolsExtension = (event: MessageEvent) => {
-  if (event.source === window && event.data) {
+  if (event.source === window && event.data && event.data.__NG_DEVTOOLS_EVENT__) {
     try {
       chrome.runtime.sendMessage(event.data);
     } catch (e) {

--- a/devtools/projects/shell-browser/src/app/same-page-message-bus.ts
+++ b/devtools/projects/shell-browser/src/app/same-page-message-bus.ts
@@ -74,6 +74,7 @@ export class SamePageMessageBus extends MessageBus<Events> {
         topic,
         args,
         __ignore_ng_zone__: true,
+        __NG_DEVTOOLS_EVENT__: true,
       },
       '*',
     );

--- a/devtools/src/iframe-message-bus.ts
+++ b/devtools/src/iframe-message-bus.ts
@@ -78,6 +78,7 @@ export class IFrameMessageBus extends MessageBus<Events> {
         // event listeners but also not prevent the NgZone in the devtools app
         // from updating its UI.
         __ignore_ng_zone__: this._source === 'angular-devtools',
+        __NG_DEVTOOLS_EVENT__: true,
       },
       '*',
     );


### PR DESCRIPTION
One common problem encountered by the devtools content script is that it accepted almost any message send over the message bus. Some websites like `auth.openai.com` were spamming the bus and DDOS the devtools app.

By introducing event tagging and skipping non-devtools events we prevent DDOS of the Angular devtools content script by on forward tagged events. 

fixes #62471 #62450 #55854 