### PR TITLE
docs: fixes typo in `httpResource` example

### DIFF
--- a/adev/src/content/guide/http/http-resource.md
+++ b/adev/src/content/guide/http/http-resource.md
@@ -54,7 +54,7 @@ The signals of the `httpResource` can be used in the template to control which e
 
 ```angular-html
 @if(user.hasValue()) {
-  <user-details user="[user.value()]">
+  <user-details user="user.value()">
 } @else if (user.error()) {
   <div>Could not load user information</div>
 } @else if (user.isLoading()) {

--- a/adev/src/content/guide/http/http-resource.md
+++ b/adev/src/content/guide/http/http-resource.md
@@ -54,7 +54,7 @@ The signals of the `httpResource` can be used in the template to control which e
 
 ```angular-html
 @if(user.hasValue()) {
-  <user-details user="user.value()">
+  <user-details [user]="user.value()">
 } @else if (user.error()) {
   <div>Could not load user information</div>
 } @else if (user.isLoading()) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
httpResource example has a typo that shows extra square brackets in template. See https://angular.dev/guide/http/http-resource#

Issue Number: N/A


## What is the new behavior?
Removes the typo


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
