### PR TITLE
fix(compiler-cli): infer type of event target for void elements

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -41,6 +41,12 @@ describe('type check blocks', () => {
     expect(tcb(TEMPLATE)).toContain('(-1)');
   });
 
+  it('should assert the type for DOM events bound on void elements', () => {
+    const result = tcb(`<input (input)="handleInput($event.target.value)">`);
+    expect(result).toContain('i1.ɵassertType<typeof _t1>($event.target);');
+    expect(result).toContain('(this).handleInput((((($event).target)).value));');
+  });
+
   it('should handle keyed property access', () => {
     const TEMPLATE = `{{a[b]}}`;
     expect(tcb(TEMPLATE)).toContain('(((this).a))[((this).b)]');
@@ -371,7 +377,7 @@ describe('type check blocks', () => {
     const block = tcb(TEMPLATE);
     expect(block).not.toContain('"div"');
     expect(block).toContain(
-      'var _t2 = document.createElement("button"); ' + 'var _t1 = _t2; ' + '_t2.addEventListener',
+      'var _t1 = document.createElement("button"); ' + 'var _t2 = _t1; ' + '_t1.addEventListener',
     );
   });
 

--- a/packages/compiler/src/i18n/extractor_merger.ts
+++ b/packages/compiler/src/i18n/extractor_merger.ts
@@ -139,6 +139,7 @@ class _Visitor implements html.Visitor {
       undefined!,
       undefined!,
       undefined,
+      false,
     );
 
     const translatedNode = wrapper.visit(this, null);
@@ -380,6 +381,7 @@ class _Visitor implements html.Visitor {
           node.sourceSpan,
           node.startSourceSpan,
           node.endSourceSpan,
+          node.isVoid,
         ) as T;
       } else {
         return new html.Component(

--- a/packages/compiler/src/ml_parser/ast.ts
+++ b/packages/compiler/src/ml_parser/ast.ts
@@ -107,6 +107,7 @@ export class Element extends NodeWithI18n {
     sourceSpan: ParseSourceSpan,
     public startSourceSpan: ParseSourceSpan,
     public endSourceSpan: ParseSourceSpan | null = null,
+    readonly isVoid: boolean,
     i18n?: I18nMeta,
   ) {
     super(sourceSpan, i18n);

--- a/packages/compiler/src/ml_parser/html_whitespaces.ts
+++ b/packages/compiler/src/ml_parser/html_whitespaces.ts
@@ -79,6 +79,7 @@ export class WhitespaceVisitor implements html.Visitor {
         element.sourceSpan,
         element.startSourceSpan,
         element.endSourceSpan,
+        element.isVoid,
         element.i18n,
       );
       this.originalNodeMap?.set(newElement, element);
@@ -94,6 +95,7 @@ export class WhitespaceVisitor implements html.Visitor {
       element.sourceSpan,
       element.startSourceSpan,
       element.endSourceSpan,
+      element.isVoid,
       element.i18n,
     );
     this.originalNodeMap?.set(newElement, element);

--- a/packages/compiler/src/ml_parser/parser.ts
+++ b/packages/compiler/src/ml_parser/parser.ts
@@ -395,13 +395,13 @@ class _TreeBuilder {
     this._consumeAttributesAndDirectives(attrs, directives);
 
     const fullName = this._getElementFullName(startTagToken, this._getClosestElementLikeParent());
+    const tagDef = this._getTagDefinition(fullName);
     let selfClosing = false;
     // Note: There could have been a tokenizer error
     // so that we don't get a token for the end tag...
     if (this._peek.type === TokenType.TAG_OPEN_END_VOID) {
       this._advance();
       selfClosing = true;
-      const tagDef = this._getTagDefinition(fullName);
       if (!(tagDef?.canSelfClose || getNsPrefix(fullName) !== null || tagDef?.isVoid)) {
         this.errors.push(
           TreeError.create(
@@ -436,6 +436,7 @@ class _TreeBuilder {
       span,
       startSpan,
       undefined,
+      tagDef?.isVoid ?? false,
     );
     const parent = this._getContainer();
     const isClosedByChild =

--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -169,6 +169,7 @@ export class Element implements Node {
     public sourceSpan: ParseSourceSpan,
     public startSourceSpan: ParseSourceSpan,
     public endSourceSpan: ParseSourceSpan | null,
+    readonly isVoid: boolean,
     public i18n?: I18nMeta,
   ) {}
   visit<Result>(visitor: Visitor<Result>): Result {

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -469,4 +469,5 @@ export class Identifiers {
   static InputSignalBrandWriteType = {name: 'ɵINPUT_SIGNAL_BRAND_WRITE_TYPE', moduleName: CORE};
   static UnwrapDirectiveSignalInputs = {name: 'ɵUnwrapDirectiveSignalInputs', moduleName: CORE};
   static unwrapWritableSignal = {name: 'ɵunwrapWritableSignal', moduleName: CORE};
+  static assertType = {name: 'ɵassertType', moduleName: CORE};
 }

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -246,6 +246,7 @@ class HtmlAstToIvyAst implements html.Visitor {
         element.sourceSpan,
         element.startSourceSpan,
         element.endSourceSpan,
+        element.isVoid,
         element.i18n,
       );
     }
@@ -1151,6 +1152,7 @@ class NonBindableVisitor implements html.Visitor {
       ast.sourceSpan,
       ast.startSourceSpan,
       ast.endSourceSpan,
+      ast.isVoid,
     );
   }
 
@@ -1218,6 +1220,7 @@ class NonBindableVisitor implements html.Visitor {
       ast.sourceSpan,
       ast.startSourceSpan,
       ast.endSourceSpan,
+      false,
     );
   }
 

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -10,7 +10,6 @@ import * as html from '../../src/ml_parser/ast';
 import {HtmlParser} from '../../src/ml_parser/html_parser';
 import {ParseTreeResult, TreeError} from '../../src/ml_parser/parser';
 import {TokenizeOptions} from '../../src/ml_parser/lexer';
-import {TokenType} from '../../src/ml_parser/tokens';
 import {ParseError} from '../../src/parse_util';
 
 import {
@@ -93,6 +92,14 @@ describe('HtmlParser', () => {
           [html.Attribute, 'rel', 'author license', ['author license']],
           [html.Attribute, 'href', '/about', ['/about']],
         ]);
+      });
+
+      it('should indicate whether an element is void', () => {
+        const nodes = parser.parse('<input><div></div>', 'TestComp').rootNodes as html.Element[];
+        expect(nodes[0].name).toBe('input');
+        expect(nodes[0].isVoid).toBe(true);
+        expect(nodes[1].name).toBe('div');
+        expect(nodes[1].isVoid).toBe(false);
       });
 
       it('should not error on void elements from HTML5 spec', () => {

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -285,6 +285,14 @@ describe('R3 template transform', () => {
         ['TextAttribute', 'select', 'a'],
       ]);
     });
+
+    it('should indicate whether an element is void', () => {
+      const nodes = parse('<input><div></div>').nodes as t.Element[];
+      expect(nodes[0].name).toBe('input');
+      expect(nodes[0].isVoid).toBe(true);
+      expect(nodes[1].name).toBe('div');
+      expect(nodes[1].isVoid).toBe(false);
+    });
   });
 
   describe('Bound text nodes', () => {

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -171,3 +171,4 @@ export {getClosestComponentName as ɵgetClosestComponentName} from './internal/g
 export {getComponentDef as ɵgetComponentDef} from './render3/def_getters';
 export {DEHYDRATED_BLOCK_REGISTRY as ɵDEHYDRATED_BLOCK_REGISTRY} from './defer/registry';
 export {TimerScheduler as ɵTimerScheduler} from './defer/timer_scheduler';
+export {ɵassertType} from './type_checking';

--- a/packages/core/src/type_checking.ts
+++ b/packages/core/src/type_checking.ts
@@ -1,0 +1,13 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+/**
+ * Utility function used during template type checking to assert that a value is of a certain type.
+ * @codeGenApi
+ */
+export function ɵassertType<T>(value: unknown): asserts value is T {}

--- a/packages/core/test/render3/jit_environment_spec.ts
+++ b/packages/core/test/render3/jit_environment_spec.ts
@@ -34,6 +34,7 @@ const AOT_ONLY = new Set<string>([
   'ɵINPUT_SIGNAL_BRAND_WRITE_TYPE',
   'ɵUnwrapDirectiveSignalInputs',
   'ɵunwrapWritableSignal',
+  'ɵassertType',
 ]);
 
 /**


### PR DESCRIPTION
Currently we infer the target of DOM events to be `EventTarget | null` which is consistent with the built-in types for `addEventListener`. This is due to the fact that users can dispatch custom events, or the event might've bubbled. However, this typing is also inconvenient for some other common use cases like `<input (input)="query($event.target.value)">`, because we don't have the ability to type cast in a template.

These changes aim to make some of the cases simpler by inferring the type of `$event.target` if the event is bound on a void element which guarantees that it couldn't have bubbled.