### PR TITLE
refactor(signal-forms): unify how users access metadata added with `define` and `metadata`

### DIFF
--- a/packages/forms/experimental/src/api/async.ts
+++ b/packages/forms/experimental/src/api/async.ts
@@ -54,7 +54,7 @@ export function validateAsync<TValue, TRequest, TData, TPathKind extends PathKin
   });
 
   pathNode.logic.addAsyncErrorRule((ctx) => {
-    const res = ctx.state.data(dataKey)!;
+    const res = ctx.state.metadata(dataKey)!;
     switch (res.status()) {
       case 'idle':
         return undefined;

--- a/packages/forms/experimental/src/api/data.ts
+++ b/packages/forms/experimental/src/api/data.ts
@@ -9,37 +9,33 @@
 import {computed, Resource, ResourceRef, Signal} from '@angular/core';
 import {FieldPathNode} from '../path_node';
 import {assertPathIsCurrent} from '../schema';
+import {StaticMetadataKey} from './metadata';
 import type {FieldContext, FieldPath, LogicFn, PathKind} from './types';
 
-export class DataKey<TValue> {
-  /** @internal */
-  protected __phantom!: TValue;
-}
-
 export interface DefineOptions<TKey> {
-  readonly asKey?: DataKey<TKey>;
+  readonly asKey?: StaticMetadataKey<TKey>;
 }
 
 export function define<TValue, TData, TPathKind extends PathKind = PathKind.Root>(
   path: FieldPath<TValue, TPathKind>,
   factory: (ctx: FieldContext<TValue, TPathKind>) => TData,
   opts?: DefineOptions<TData>,
-): DataKey<TData> {
+): StaticMetadataKey<TData> {
   assertPathIsCurrent(path);
-  const key = opts?.asKey ?? new DataKey<Resource<TData>>();
+  const key = opts?.asKey ?? new StaticMetadataKey<Resource<TData>>();
   const pathNode = FieldPathNode.unwrapFieldPath(path);
 
   pathNode.logic.addDataFactory(key, factory as (ctx: FieldContext<unknown>) => unknown);
-  return key as DataKey<TData>;
+  return key as StaticMetadataKey<TData>;
 }
 
 export function defineComputed<TValue, TData, TPathKind extends PathKind = PathKind.Root>(
   path: FieldPath<TValue, TPathKind>,
   fn: LogicFn<TValue, TData, TPathKind>,
   opts?: DefineOptions<Signal<TData>>,
-): DataKey<Signal<TData>> {
+): StaticMetadataKey<Signal<TData>> {
   assertPathIsCurrent(path);
-  const key = opts?.asKey ?? new DataKey<Signal<TData>>();
+  const key = opts?.asKey ?? new StaticMetadataKey<Signal<TData>>();
 
   const pathNode = FieldPathNode.unwrapFieldPath(path);
   pathNode.logic.addDataFactory(key, (ctx) =>
@@ -61,9 +57,9 @@ export interface DefineResourceOptions<
 export function defineResource<TValue, TData, TRequest, TPathKind extends PathKind = PathKind.Root>(
   path: FieldPath<TValue, TPathKind>,
   opts: DefineResourceOptions<TValue, TData, TRequest, TPathKind>,
-): DataKey<ResourceRef<TData | undefined>> {
+): StaticMetadataKey<ResourceRef<TData | undefined>> {
   assertPathIsCurrent(path);
-  const key = opts.asKey ?? new DataKey<ResourceRef<TData>>();
+  const key = opts.asKey ?? new StaticMetadataKey<ResourceRef<TData>>();
 
   const factory = (ctx: FieldContext<unknown>) => {
     const params = computed(() => opts.params(ctx as FieldContext<TValue, TPathKind>));
@@ -74,5 +70,5 @@ export function defineResource<TValue, TData, TRequest, TPathKind extends PathKi
   const pathNode = FieldPathNode.unwrapFieldPath(path);
   pathNode.logic.addDataFactory(key, factory);
 
-  return key as DataKey<ResourceRef<TData | undefined>>;
+  return key as StaticMetadataKey<ResourceRef<TData | undefined>>;
 }

--- a/packages/forms/experimental/src/api/data.ts
+++ b/packages/forms/experimental/src/api/data.ts
@@ -9,7 +9,7 @@
 import {computed, Resource, ResourceRef, Signal} from '@angular/core';
 import {FieldPathNode} from '../path_node';
 import {assertPathIsCurrent} from '../schema';
-import {StaticMetadataKey} from './metadata';
+import {MetadataKey, StaticMetadataKey} from './metadata';
 import type {FieldContext, FieldPath, LogicFn, PathKind} from './types';
 
 export interface DefineOptions<TKey> {
@@ -22,7 +22,7 @@ export function define<TValue, TData, TPathKind extends PathKind = PathKind.Root
   opts?: DefineOptions<TData>,
 ): StaticMetadataKey<TData> {
   assertPathIsCurrent(path);
-  const key = opts?.asKey ?? new StaticMetadataKey<Resource<TData>>();
+  const key = opts?.asKey ?? MetadataKey.static<Resource<TData>>();
   const pathNode = FieldPathNode.unwrapFieldPath(path);
 
   pathNode.logic.addDataFactory(key, factory as (ctx: FieldContext<unknown>) => unknown);
@@ -35,7 +35,7 @@ export function defineComputed<TValue, TData, TPathKind extends PathKind = PathK
   opts?: DefineOptions<Signal<TData>>,
 ): StaticMetadataKey<Signal<TData>> {
   assertPathIsCurrent(path);
-  const key = opts?.asKey ?? new StaticMetadataKey<Signal<TData>>();
+  const key = opts?.asKey ?? MetadataKey.static<Signal<TData>>();
 
   const pathNode = FieldPathNode.unwrapFieldPath(path);
   pathNode.logic.addDataFactory(key, (ctx) =>
@@ -59,7 +59,7 @@ export function defineResource<TValue, TData, TRequest, TPathKind extends PathKi
   opts: DefineResourceOptions<TValue, TData, TRequest, TPathKind>,
 ): StaticMetadataKey<ResourceRef<TData | undefined>> {
   assertPathIsCurrent(path);
-  const key = opts.asKey ?? new StaticMetadataKey<ResourceRef<TData>>();
+  const key = opts.asKey ?? MetadataKey.static<ResourceRef<TData>>();
 
   const factory = (ctx: FieldContext<unknown>) => {
     const params = computed(() => opts.params(ctx as FieldContext<TValue, TPathKind>));

--- a/packages/forms/experimental/src/api/metadata.ts
+++ b/packages/forms/experimental/src/api/metadata.ts
@@ -119,7 +119,7 @@ export class StaticMetadataKey<TValue> extends KeyCtor<TValue> {
 /**
  * Re-cast the StaticMetadataKey constructor to allow ourselves to new it.
  */
-const StaticKeyCtor = MetadataKey as unknown as new <TValue>() => MetadataKey<TValue>;
+const StaticKeyCtor = StaticMetadataKey as unknown as new <TValue>() => StaticMetadataKey<TValue>;
 
 /**
  * Represents reactive metadata that can change depending on state of the form.

--- a/packages/forms/experimental/src/api/metadata.ts
+++ b/packages/forms/experimental/src/api/metadata.ts
@@ -92,12 +92,34 @@ export class MetadataKey<TValue> {
       () => true,
     );
   }
+
+  /**
+   * Creates a static metadata key.
+   */
+  static static<TValue>() {
+    return new StaticKeyCtor<TValue>();
+  }
 }
 
 /**
  * Re-cast the MetadataKey constructor to allow ourselves to extend it.
  */
 const KeyCtor = MetadataKey as unknown as new <TValue>() => MetadataKey<TValue>;
+
+/**
+ * Represents static metadata that is set once when the field is created and cannot change.
+ * If the metadata is not defined for a given field, its valud is undefined.
+ */
+export class StaticMetadataKey<TValue> extends KeyCtor<TValue> {
+  protected constructor() {
+    super();
+  }
+}
+
+/**
+ * Re-cast the StaticMetadataKey constructor to allow ourselves to new it.
+ */
+const StaticKeyCtor = MetadataKey as unknown as new <TValue>() => MetadataKey<TValue>;
 
 /**
  * Represents reactive metadata that can change depending on state of the form.

--- a/packages/forms/experimental/src/api/metadata.ts
+++ b/packages/forms/experimental/src/api/metadata.ts
@@ -108,7 +108,7 @@ const KeyCtor = MetadataKey as unknown as new <TValue>() => MetadataKey<TValue>;
 
 /**
  * Represents static metadata that is set once when the field is created and cannot change.
- * If the metadata is not defined for a given field, its valud is undefined.
+ * If the metadata is not defined for a given field, its value is undefined.
  */
 export class StaticMetadataKey<TValue> extends KeyCtor<TValue> {
   protected constructor() {

--- a/packages/forms/experimental/src/api/standard_schema.ts
+++ b/packages/forms/experimental/src/api/standard_schema.ts
@@ -38,7 +38,7 @@ export function validateStandardSchema<TValue>(
 
   validateTree(path, ({state, fieldOf}) => {
     // Skip sync validation if the result is a Promise.
-    const result = state.data(schemaResult)!();
+    const result = state.metadata(schemaResult)!();
     if (ɵisPromise(result)) {
       return [];
     }
@@ -48,7 +48,7 @@ export function validateStandardSchema<TValue>(
   validateAsync(path, {
     params: ({state}) => {
       // Skip async validation if the result is *not* a Promise.
-      const result = state.data(schemaResult)!();
+      const result = state.metadata(schemaResult)!();
       return ɵisPromise(result) ? result : undefined;
     },
     factory: (params) => {

--- a/packages/forms/experimental/src/api/types.ts
+++ b/packages/forms/experimental/src/api/types.ts
@@ -7,8 +7,7 @@
  */
 
 import {Signal, WritableSignal} from '@angular/core';
-import {DataKey} from './data';
-import {ReactiveMetadataKey} from './metadata';
+import {ReactiveMetadataKey, StaticMetadataKey} from './metadata';
 import {ValidationError, WithField} from './validation_errors';
 
 /**
@@ -165,7 +164,7 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
    */
   readonly keyInParent: Signal<TKey>;
 
-  data<D>(key: DataKey<D>): D | undefined;
+  data<D>(key: StaticMetadataKey<D>): D | undefined;
 
   /**
    * Reactviely reads a metadata value from the field.

--- a/packages/forms/experimental/src/api/types.ts
+++ b/packages/forms/experimental/src/api/types.ts
@@ -164,13 +164,17 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
    */
   readonly keyInParent: Signal<TKey>;
 
-  data<D>(key: StaticMetadataKey<D>): D | undefined;
-
   /**
-   * Reactviely reads a metadata value from the field.
+   * Reads a reactive metadata value from the field.
    * @param key The metadata key to read.
    */
   metadata<M>(key: ReactiveMetadataKey<M>): Signal<M>;
+
+  /**
+   * Reads a static metadata value from the field.
+   * @param key The metadata key to read.
+   */
+  metadata<M>(key: StaticMetadataKey<M>): M | undefined;
 
   /**
    * Sets the touched status of the field to `true`.

--- a/packages/forms/experimental/src/field/data.ts
+++ b/packages/forms/experimental/src/field/data.ts
@@ -7,14 +7,14 @@
  */
 
 import {computed, runInInjectionContext, untracked} from '@angular/core';
-import {DataKey} from '../api/data';
+import {StaticMetadataKey} from '../api/metadata';
 import {FieldNode} from './node';
 
 /**
  * Tracks `data` associated with a `FieldNode`.
  */
 export class FieldDataState {
-  private readonly dataMap = new Map<DataKey<unknown>, unknown>();
+  private readonly dataMap = new Map<StaticMetadataKey<unknown>, unknown>();
 
   constructor(private readonly node: FieldNode) {
     // Instantiate data dependencies.
@@ -38,7 +38,7 @@ export class FieldDataState {
     return maps;
   });
 
-  get<D>(key: DataKey<D>): D | undefined {
+  get<D>(key: StaticMetadataKey<D>): D | undefined {
     return this.dataMap.get(key) as D | undefined;
   }
 }

--- a/packages/forms/experimental/src/field/node.ts
+++ b/packages/forms/experimental/src/field/node.ts
@@ -7,7 +7,7 @@
  */
 
 import type {Signal, WritableSignal} from '@angular/core';
-import type {ReactiveMetadataKey, StaticMetadataKey} from '../api/metadata';
+import {MetadataKey, ReactiveMetadataKey, StaticMetadataKey} from '../api/metadata';
 import type {DisabledReason, Field, FieldContext, FieldState, SubmittedStatus} from '../api/types';
 import type {ValidationError} from '../api/validation_errors';
 
@@ -151,12 +151,15 @@ export class FieldNode implements FieldState<unknown> {
     return this.submitState.submittedStatus;
   }
 
-  data<D>(key: StaticMetadataKey<D>): D | undefined {
-    return this.dataState.get(key);
-  }
-
-  metadata<M>(key: ReactiveMetadataKey<M>): Signal<M> {
-    return this.metadataState.get(key);
+  metadata<M>(key: ReactiveMetadataKey<M>): Signal<M>;
+  metadata<M>(key: StaticMetadataKey<M>): M | undefined;
+  metadata<M>(key: MetadataKey<M>): Signal<M> | M | undefined {
+    if (key instanceof StaticMetadataKey) {
+      return this.dataState.get(key);
+    } else if (key instanceof ReactiveMetadataKey) {
+      return this.metadataState.get(key);
+    }
+    throw Error('Unrecognized MetadataKey type');
   }
 
   /**

--- a/packages/forms/experimental/src/field/node.ts
+++ b/packages/forms/experimental/src/field/node.ts
@@ -7,8 +7,7 @@
  */
 
 import type {Signal, WritableSignal} from '@angular/core';
-import type {DataKey} from '../api/data';
-import type {ReactiveMetadataKey} from '../api/metadata';
+import type {ReactiveMetadataKey, StaticMetadataKey} from '../api/metadata';
 import type {DisabledReason, Field, FieldContext, FieldState, SubmittedStatus} from '../api/types';
 import type {ValidationError} from '../api/validation_errors';
 
@@ -152,7 +151,7 @@ export class FieldNode implements FieldState<unknown> {
     return this.submitState.submittedStatus;
   }
 
-  data<D>(key: DataKey<D>): D | undefined {
+  data<D>(key: StaticMetadataKey<D>): D | undefined {
     return this.dataState.get(key);
   }
 

--- a/packages/forms/experimental/src/logic_node_2.ts
+++ b/packages/forms/experimental/src/logic_node_2.ts
@@ -8,11 +8,11 @@
 
 import {
   AsyncValidationResult,
-  DataKey,
   DisabledReason,
   FieldContext,
   LogicFn,
   ReactiveMetadataKey,
+  StaticMetadataKey,
   ValidationResult,
 } from '../public_api';
 import {ValidationError, WithField} from './api/validation_errors';
@@ -53,7 +53,10 @@ export abstract class AbstractLogicNodeBuilder {
   /** Adds a rule to compute metadata for a field. */
   abstract addMetadataRule<M>(key: ReactiveMetadataKey<M>, logic: LogicFn<any, M>): void;
   /** Adds a factory function to produce a data value associated with a field. */
-  abstract addDataFactory<D>(key: DataKey<D>, factory: (ctx: FieldContext<any>) => D): void;
+  abstract addDataFactory<D>(
+    key: StaticMetadataKey<D>,
+    factory: (ctx: FieldContext<any>) => D,
+  ): void;
   /**
    * Gets a builder for a child node associated with the given property key.
    * @param key The property key of the child.
@@ -127,7 +130,10 @@ export class LogicNodeBuilder extends AbstractLogicNodeBuilder {
     this.getCurrent().addMetadataRule(key, logic);
   }
 
-  override addDataFactory<D>(key: DataKey<D>, factory: (ctx: FieldContext<any>) => D): void {
+  override addDataFactory<D>(
+    key: StaticMetadataKey<D>,
+    factory: (ctx: FieldContext<any>) => D,
+  ): void {
     this.getCurrent().addDataFactory(key, factory);
   }
 
@@ -237,7 +243,10 @@ class NonMergableLogicNodeBuilder extends AbstractLogicNodeBuilder {
     this.logic.getMetadata(key).push(setBoundPathDepthForResolution(logic, this.depth));
   }
 
-  override addDataFactory<D>(key: DataKey<D>, factory: (ctx: FieldContext<any>) => D): void {
+  override addDataFactory<D>(
+    key: StaticMetadataKey<D>,
+    factory: (ctx: FieldContext<any>) => D,
+  ): void {
     this.logic.addDataFactory(key, setBoundPathDepthForResolution(factory, this.depth));
   }
 
@@ -274,7 +283,7 @@ export class LogicContainer {
   private readonly metadata = new Map<ReactiveMetadataKey<unknown>, AbstractLogic<unknown>>();
   /** A map of data keys to the factory functions that create their values. */
   private readonly dataFactories = new Map<
-    DataKey<unknown>,
+    StaticMetadataKey<unknown>,
     (ctx: FieldContext<unknown>) => unknown
   >();
 
@@ -332,11 +341,14 @@ export class LogicContainer {
 
   /**
    * Adds a data factory function for a given data key.
-   * @param key The `DataKey` to associate the factory with.
+   * @param key The `StaticMetadataKey` to associate the factory with.
    * @param factory The factory function.
    * @throws If a factory is already defined for the given key.
    */
-  addDataFactory(key: DataKey<unknown>, factory: (ctx: FieldContext<unknown>) => unknown) {
+  addDataFactory(
+    key: StaticMetadataKey<unknown>,
+    factory: (ctx: FieldContext<unknown>) => unknown,
+  ) {
     if (this.dataFactories.has(key)) {
       // TODO: name of the key?
       throw new Error(`Can't define data twice for the same key`);

--- a/packages/forms/experimental/test/node/resource.spec.ts
+++ b/packages/forms/experimental/test/node/resource.spec.ts
@@ -56,7 +56,7 @@ describe('resources', () => {
       });
 
       validate(p.name, ({state}) => {
-        const remote = state.data(res)!;
+        const remote = state.metadata(res)!;
         if (remote.hasValue()) {
           return ValidationError.custom({message: remote.value()!.toString()});
         } else {
@@ -96,7 +96,7 @@ describe('resources', () => {
         });
 
         validate(p.name, ({state}) => {
-          const remote = state.data(res)!;
+          const remote = state.metadata(res)!;
           if (remote.hasValue()) {
             return ValidationError.custom({message: remote.value()!.toString()});
           } else {


### PR DESCRIPTION
Eliminates `DataKey` and `FieldState.data` as a separate user concept from metadata. `DataKey` is now `StaticMetadataKey` and is accessed via `FieldState.metadata` the same way as wth `ReactiveMetadataKey`. Note the there are still separate logic functions (`define()` and `metadata()`) for registering static and reactive metadata to a field. I'll try to unify the way they're created in a followup PR.