### PR TITLE
feat(signal-forms): allow validation logic to return null and false

### DIFF
--- a/packages/forms/experimental/src/api/logic.ts
+++ b/packages/forms/experimental/src/api/logic.ts
@@ -9,16 +9,8 @@
 import {ReactiveMetadataKey} from '../api/metadata';
 import {FieldPathNode} from '../path_node';
 import {assertPathIsCurrent} from '../schema';
-import type {
-  FieldContext,
-  FieldPath,
-  LogicFn,
-  Mutable,
-  PathKind,
-  TreeValidator,
-  Validator,
-} from './types';
-import {ValidationError, WithField} from './validation_errors';
+import type {FieldContext, FieldPath, LogicFn, PathKind, TreeValidator, Validator} from './types';
+import {addDefaultField, ValidationError, WithField} from './validation_errors';
 
 /**
  * Adds logic to a field to conditionally disable it.
@@ -116,10 +108,10 @@ export function validateTree<TValue, TPathKind extends PathKind = PathKind.Root>
     const errors = logic(ctx);
     if (Array.isArray(errors)) {
       for (const error of errors) {
-        (error as Mutable<ValidationError | WithField<ValidationError>>).field ??= ctx.field;
+        addDefaultField(error, ctx.field);
       }
     } else if (errors) {
-      (errors as Mutable<ValidationError | WithField<ValidationError>>).field ??= ctx.field;
+      addDefaultField(errors as WithField<ValidationError>, ctx.field);
     }
     return errors;
   };

--- a/packages/forms/experimental/src/api/logic.ts
+++ b/packages/forms/experimental/src/api/logic.ts
@@ -114,8 +114,12 @@ export function validateTree<TValue, TPathKind extends PathKind = PathKind.Root>
   const pathNode = FieldPathNode.unwrapFieldPath(path);
   const wrappedLogic = (ctx: FieldContext<TValue, TPathKind>) => {
     const errors = logic(ctx);
-    for (const error of errors) {
-      (error as Mutable<ValidationError | WithField<ValidationError>>).field ??= ctx.field;
+    if (Array.isArray(errors)) {
+      for (const error of errors) {
+        (error as Mutable<ValidationError | WithField<ValidationError>>).field ??= ctx.field;
+      }
+    } else if (errors) {
+      (errors as Mutable<ValidationError | WithField<ValidationError>>).field ??= ctx.field;
     }
     return errors;
   };

--- a/packages/forms/experimental/src/api/types.ts
+++ b/packages/forms/experimental/src/api/types.ts
@@ -48,13 +48,21 @@ export interface DisabledReason {
  * a single `ValidationError`, or a list of `ValidationError` which can be used to indicate multiple
  * errors.
  */
-export type ValidationResult = readonly ValidationError[] | ValidationError | undefined;
+export type ValidationResult =
+  | readonly ValidationError[]
+  | ValidationError
+  | false
+  | null
+  | undefined;
 
-export type AsyncValidationResult =
+export type TreeValidationResult =
   | readonly WithField<ValidationError>[]
   | WithField<ValidationError>
-  | 'pending'
+  | false
+  | null
   | undefined;
+
+export type AsyncValidationResult = TreeValidationResult | 'pending';
 
 /**
  * An object that represents a single field in a form. This includes both primitive value fields
@@ -252,7 +260,7 @@ export type Validator<TValue, TPathKind extends PathKind = PathKind.Root> = Logi
 
 export type TreeValidator<TValue, TPathKind extends PathKind = PathKind.Root> = LogicFn<
   TValue,
-  (ValidationError | WithField<ValidationError>)[],
+  TreeValidationResult,
   TPathKind
 >;
 

--- a/packages/forms/experimental/src/api/validation_errors.ts
+++ b/packages/forms/experimental/src/api/validation_errors.ts
@@ -44,7 +44,7 @@ export function createError<TError extends ValidationError, TArgs extends any[]>
   ...params: TArgs
 ): TError | WithField<TError> {
   const instance = new errorCtor(...(params as unknown as TArgs));
-  (instance as Mutable<ValidationError | WithField<ValidationError>>).field = target;
+  addDefaultField(instance, target!);
   return instance;
 }
 
@@ -61,6 +61,20 @@ export function stripField<E extends ValidationError>(e: WithField<E> | E): E {
   Reflect.setPrototypeOf(newE, Object.getPrototypeOf(e));
   Object.assign(newE, e, {field: undefined});
   return newE as E;
+}
+
+/**
+ * Adds the given default field on to the given error if the error does not already have a field.
+ * @param e The error to add the field to
+ * @param field The default field to add
+ * @returns The passed in error, with its field set.
+ */
+export function addDefaultField<E extends ValidationError>(
+  e: E | WithField<E>,
+  field: Field<unknown>,
+): WithField<E> {
+  (e as Mutable<ValidationError | WithField<ValidationError>>).field ??= field;
+  return e as WithField<E>;
 }
 
 /**

--- a/packages/forms/experimental/src/logic_node.ts
+++ b/packages/forms/experimental/src/logic_node.ts
@@ -88,6 +88,13 @@ export class ArrayMergeIgnoreLogic<TElement, TIgnore = never> extends AbstractLo
   readonly TElement[],
   TElement | readonly (TElement | TIgnore)[] | TIgnore | undefined
 > {
+  static ignoreFalseAndNull<TElement>(predicates: ReadonlyArray<BoundPredicate>) {
+    return new ArrayMergeIgnoreLogic<TElement, false | null>(
+      predicates,
+      (e: unknown) => e === false || e === null,
+    );
+  }
+
   constructor(
     predicates: ReadonlyArray<BoundPredicate>,
     private ignore: undefined | ((e: TElement | undefined | TIgnore) => e is TIgnore),

--- a/packages/forms/experimental/src/logic_node_2.ts
+++ b/packages/forms/experimental/src/logic_node_2.ts
@@ -19,6 +19,7 @@ import {ValidationError, WithField} from './api/validation_errors';
 import {setBoundPathDepthForResolution} from './field/context';
 import {
   AbstractLogic,
+  ArrayMergeIgnoreLogic,
   ArrayMergeLogic,
   BooleanOrLogic,
   BoundPredicate,
@@ -265,11 +266,11 @@ export class LogicContainer {
   /** Logic that determines if the field is read-only. */
   readonly readonly: BooleanOrLogic;
   /** Logic that produces synchronous validation errors for the field. */
-  readonly syncErrors: ArrayMergeLogic<ValidationError>;
+  readonly syncErrors: ArrayMergeIgnoreLogic<ValidationError, false | null>;
   /** Logic that produces synchronous validation errors for the field's subtree. */
-  readonly syncTreeErrors: ArrayMergeLogic<WithField<ValidationError>>;
+  readonly syncTreeErrors: ArrayMergeIgnoreLogic<WithField<ValidationError>, false | null>;
   /** Logic that produces asynchronous validation results (errors or 'pending'). */
-  readonly asyncErrors: ArrayMergeLogic<WithField<ValidationError> | 'pending'>;
+  readonly asyncErrors: ArrayMergeIgnoreLogic<WithField<ValidationError> | 'pending', false | null>;
   /** A map of metadata keys to the `AbstractLogic` instances that compute their values. */
   private readonly metadata = new Map<ReactiveMetadataKey<unknown>, AbstractLogic<unknown>>();
   /** A map of data keys to the factory functions that create their values. */
@@ -287,9 +288,18 @@ export class LogicContainer {
     this.hidden = new BooleanOrLogic(predicates);
     this.disabledReasons = new ArrayMergeLogic(predicates);
     this.readonly = new BooleanOrLogic(predicates);
-    this.syncErrors = new ArrayMergeLogic<ValidationError>(predicates);
-    this.syncTreeErrors = new ArrayMergeLogic<WithField<ValidationError>>(predicates);
-    this.asyncErrors = new ArrayMergeLogic<WithField<ValidationError> | 'pending'>(predicates);
+    this.syncErrors = new ArrayMergeIgnoreLogic<ValidationError, false | null>(
+      predicates,
+      (e) => e === false || e === null,
+    );
+    this.syncTreeErrors = new ArrayMergeIgnoreLogic<WithField<ValidationError>, false | null>(
+      predicates,
+      (e) => e === false || e === null,
+    );
+    this.asyncErrors = new ArrayMergeIgnoreLogic<
+      WithField<ValidationError> | 'pending',
+      false | null
+    >(predicates, (e) => e === false || e === null);
   }
 
   /**

--- a/packages/forms/experimental/src/logic_node_2.ts
+++ b/packages/forms/experimental/src/logic_node_2.ts
@@ -27,10 +27,6 @@ import {
   Predicate,
 } from './logic_node';
 
-function isFalseOrNull(e: unknown): e is false | null {
-  return e === false || e === null;
-}
-
 /**
  * Abstract base class for building a `LogicNode`.
  * This class defines the interface for adding various logic rules (e.g., hidden, disabled)

--- a/packages/forms/experimental/src/logic_node_2.ts
+++ b/packages/forms/experimental/src/logic_node_2.ts
@@ -27,6 +27,10 @@ import {
   Predicate,
 } from './logic_node';
 
+function isFalseOrNull(e: unknown): e is false | null {
+  return e === false || e === null;
+}
+
 /**
  * Abstract base class for building a `LogicNode`.
  * This class defines the interface for adding various logic rules (e.g., hidden, disabled)
@@ -288,18 +292,12 @@ export class LogicContainer {
     this.hidden = new BooleanOrLogic(predicates);
     this.disabledReasons = new ArrayMergeLogic(predicates);
     this.readonly = new BooleanOrLogic(predicates);
-    this.syncErrors = new ArrayMergeIgnoreLogic<ValidationError, false | null>(
-      predicates,
-      (e) => e === false || e === null,
-    );
-    this.syncTreeErrors = new ArrayMergeIgnoreLogic<WithField<ValidationError>, false | null>(
-      predicates,
-      (e) => e === false || e === null,
-    );
-    this.asyncErrors = new ArrayMergeIgnoreLogic<
-      WithField<ValidationError> | 'pending',
-      false | null
-    >(predicates, (e) => e === false || e === null);
+    this.syncErrors = ArrayMergeIgnoreLogic.ignoreFalseAndNull<ValidationError>(predicates);
+    this.syncTreeErrors =
+      ArrayMergeIgnoreLogic.ignoreFalseAndNull<WithField<ValidationError>>(predicates);
+    this.asyncErrors = ArrayMergeIgnoreLogic.ignoreFalseAndNull<
+      WithField<ValidationError> | 'pending'
+    >(predicates);
   }
 
   /**


### PR DESCRIPTION
Something that's come up a few times during development of this prototype is that it would be nice to allow returning values like `null` and `false` from validation logic functions. This helps people write more concise logic without the need for extra `if` blocks or ternaries. e.g.:

```
validate(p.someNumber, ({value}) => value() > 10 && ValidationError.custom({kind: 'too-high'}))
```

We've also seen LLMs trip up and `return null` at the end of the validation function if there are no errors, rather than `return undefined`. It makes sense that either of these should work to indicate no error.