### PR TITLE
feat(http): Add redirected property to HttpResponse and HttpErrorResp…

### DIFF
--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -2508,6 +2508,7 @@ export class HttpErrorResponse extends HttpResponseBase implements Error {
         status?: number;
         statusText?: string;
         url?: string;
+        redirected?: boolean;
     });
     // (undocumented)
     readonly error: any | null;
@@ -2931,6 +2932,7 @@ export class HttpResponse<T> extends HttpResponseBase {
         status?: number;
         statusText?: string;
         url?: string;
+        redirected?: boolean;
     });
     readonly body: T | null;
     // (undocumented)
@@ -2941,6 +2943,7 @@ export class HttpResponse<T> extends HttpResponseBase {
         status?: number;
         statusText?: string;
         url?: string;
+        redirected?: boolean;
     }): HttpResponse<T>;
     // (undocumented)
     clone<V>(update: {
@@ -2949,6 +2952,7 @@ export class HttpResponse<T> extends HttpResponseBase {
         status?: number;
         statusText?: string;
         url?: string;
+        redirected?: boolean;
     }): HttpResponse<V>;
     // (undocumented)
     readonly type: HttpEventType.Response;
@@ -2961,9 +2965,11 @@ export abstract class HttpResponseBase {
         status?: number;
         statusText?: string;
         url?: string;
+        redirected?: boolean;
     }, defaultStatus?: number, defaultStatusText?: string);
     readonly headers: HttpHeaders;
     readonly ok: boolean;
+    readonly redirected?: boolean;
     readonly status: number;
     readonly statusText: string;
     readonly type: HttpEventType.Response | HttpEventType.ResponseHeader;

--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -271,6 +271,8 @@ export class FetchBackend implements HttpBackend {
     // asked for JSON data and the body cannot be parsed as such.
     const ok = status >= 200 && status < 300;
 
+    const redirected = response.redirected;
+
     if (ok) {
       observer.next(
         new HttpResponse({
@@ -279,6 +281,7 @@ export class FetchBackend implements HttpBackend {
           status,
           statusText,
           url,
+          redirected,
         }),
       );
 
@@ -293,6 +296,7 @@ export class FetchBackend implements HttpBackend {
           status,
           statusText,
           url,
+          redirected,
         }),
       );
     }

--- a/packages/common/http/src/response.ts
+++ b/packages/common/http/src/response.ts
@@ -186,6 +186,13 @@ export abstract class HttpResponseBase {
   readonly type!: HttpEventType.Response | HttpEventType.ResponseHeader;
 
   /**
+   * Indicates whether the HTTP response was redirected during the request.
+   * This property is only available when using the Fetch API using `withFetch()`
+   * When using the default XHR Request this property will be `undefined`
+   */
+  readonly redirected?: boolean;
+
+  /**
    * Super-constructor for all responses.
    *
    * The single parameter accepted is an initialization hash. Any properties
@@ -197,6 +204,7 @@ export abstract class HttpResponseBase {
       status?: number;
       statusText?: string;
       url?: string;
+      redirected?: boolean;
     },
     defaultStatus: number = 200,
     defaultStatusText: string = 'OK',
@@ -207,6 +215,7 @@ export abstract class HttpResponseBase {
     this.status = init.status !== undefined ? init.status : defaultStatus;
     this.statusText = init.statusText || defaultStatusText;
     this.url = init.url || null;
+    this.redirected = init.redirected;
 
     // Cache the ok value to avoid defining a getter.
     this.ok = this.status >= 200 && this.status < 300;
@@ -244,7 +253,12 @@ export class HttpHeaderResponse extends HttpResponseBase {
    * given parameter hash.
    */
   clone(
-    update: {headers?: HttpHeaders; status?: number; statusText?: string; url?: string} = {},
+    update: {
+      headers?: HttpHeaders;
+      status?: number;
+      statusText?: string;
+      url?: string;
+    } = {},
   ): HttpHeaderResponse {
     // Perform a straightforward initialization of the new HttpHeaderResponse,
     // overriding the current parameters with new ones if given.
@@ -282,6 +296,7 @@ export class HttpResponse<T> extends HttpResponseBase {
       status?: number;
       statusText?: string;
       url?: string;
+      redirected?: boolean;
     } = {},
   ) {
     super(init);
@@ -296,6 +311,7 @@ export class HttpResponse<T> extends HttpResponseBase {
     status?: number;
     statusText?: string;
     url?: string;
+    redirected?: boolean;
   }): HttpResponse<T>;
   clone<V>(update: {
     body?: V | null;
@@ -303,6 +319,7 @@ export class HttpResponse<T> extends HttpResponseBase {
     status?: number;
     statusText?: string;
     url?: string;
+    redirected?: boolean;
   }): HttpResponse<V>;
   clone(
     update: {
@@ -311,6 +328,7 @@ export class HttpResponse<T> extends HttpResponseBase {
       status?: number;
       statusText?: string;
       url?: string;
+      redirected?: boolean;
     } = {},
   ): HttpResponse<any> {
     return new HttpResponse<any>({
@@ -319,6 +337,7 @@ export class HttpResponse<T> extends HttpResponseBase {
       status: update.status !== undefined ? update.status : this.status,
       statusText: update.statusText || this.statusText,
       url: update.url || this.url || undefined,
+      redirected: update.redirected ?? this.redirected,
     });
   }
 }
@@ -352,6 +371,7 @@ export class HttpErrorResponse extends HttpResponseBase implements Error {
     status?: number;
     statusText?: string;
     url?: string;
+    redirected?: boolean;
   }) {
     // Initialize with a default status of 0 / Unknown Error.
     super(init, 0, 'Unknown Error');

--- a/packages/common/http/test/response_spec.ts
+++ b/packages/common/http/test/response_spec.ts
@@ -20,6 +20,7 @@ describe('HttpResponse', () => {
         status: HttpStatusCode.Created,
         statusText: 'Created',
         url: '/test',
+        redirected: true,
       });
       expect(resp.body).toBe('test body');
       expect(resp.headers instanceof HttpHeaders).toBeTruthy();
@@ -27,6 +28,7 @@ describe('HttpResponse', () => {
       expect(resp.status).toBe(HttpStatusCode.Created);
       expect(resp.statusText).toBe('Created');
       expect(resp.url).toBe('/test');
+      expect(resp.redirected).toBe(true);
     });
     it('uses defaults if no args passed', () => {
       const resp = new HttpResponse({});
@@ -36,6 +38,7 @@ describe('HttpResponse', () => {
       expect(resp.body).toBeNull();
       expect(resp.ok).toBeTruthy();
       expect(resp.url).toBeNull();
+      expect(resp.redirected).toBeUndefined();
     });
     it('accepts a falsy body', () => {
       expect(new HttpResponse({body: false}).body).toEqual(false);
@@ -59,12 +62,14 @@ describe('HttpResponse', () => {
         status: HttpStatusCode.Created,
         statusText: 'created',
         url: '/test',
+        redirected: false,
       }).clone();
       expect(clone.body).toBe('test');
       expect(clone.status).toBe(HttpStatusCode.Created);
       expect(clone.statusText).toBe('created');
       expect(clone.url).toBe('/test');
       expect(clone.headers).not.toBeNull();
+      expect(clone.redirected).toBe(false);
     });
     it('overrides the original', () => {
       const orig = new HttpResponse({
@@ -72,18 +77,21 @@ describe('HttpResponse', () => {
         status: HttpStatusCode.Created,
         statusText: 'created',
         url: '/test',
+        redirected: true,
       });
       const clone = orig.clone({
         body: {data: 'test'},
         status: HttpStatusCode.Ok,
         statusText: 'Okay',
         url: '/bar',
+        redirected: false,
       });
       expect(clone.body).toEqual({data: 'test'});
       expect(clone.status).toBe(HttpStatusCode.Ok);
       expect(clone.statusText).toBe('Okay');
       expect(clone.url).toBe('/bar');
       expect(clone.headers).toBe(orig.headers);
+      expect(clone.redirected).toBe(false);
     });
   });
 });


### PR DESCRIPTION
# HttpResponse `redirected` Property Support

This commit adds support for the Fetch API's redirected property in HttpResponse and HttpErrorResponse when using HttpClient with the withFetch provider.

This change builds on the functionality introduced in [#62315](https://github.com/angular/angular/pull/62315), which added support for passing the redirect option to the Fetch API. With redirects now configurable, exposing the redirected property provides developers with a way to determine if a response was the result of a redirect, further aligning HttpClient's behavior with the native Fetch API and enhancing observability of request flow

## The Change Includes:

- Added `redirected` property to `HttpResponse` and `HttpErrorResponse` classes
- Updated `FetchBackend` to capture and forward the `redirected` flag from the native fetch response
- Maintains consistency with the Fetch API specification
- Added unit tests to ensure the property is correctly captured and exposed

---

## Motivation / Use Cases

The `redirected` property provides valuable information about whether the response was the result of a redirect:

- **Security**: Detect when requests have been redirected, which is important for security-sensitive applications
- **Analytics**: Track redirect behavior for performance monitoring and debugging
- **Conditional Logic**: Implement different handling based on whether a response was redirected
- **API Compliance**: Maintain consistency with the native Fetch API behavior
 
## Examples of New Usage

### Basic Redirect Detection

```typescript
import { HttpClient } from '@angular/common/http';

constructor(private http: HttpClient) {}

// Detect if the response was redirected
this.http.get('/api/data' ,   { observe: 'response' } ).subscribe({
  next: (response) => {
    if (response.redirected) {
      console.log('Response was redirected');
      console.log('Final URL:', response.url);
    }
  }
});
```

### Conditional Logic Based on Redirects

```typescript
// Handle different scenarios based on redirect status
this.http.get('/api/user-profile'  ,   { observe: 'response' } ).subscribe({
  next: (response) => {
    if (response.redirected) {
      // User might have been redirected to login page
      this.handlePossibleAuthRedirect(response);
    } else {
      // Direct response, process normally
      this.processUserProfile(response.body);
    }
  }
});
```
 