### PR TITLE
refactor(devtools): disable view source button if source function is not available

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
@@ -9,6 +9,7 @@
 import {
   ComponentExplorerViewQuery,
   ComponentType,
+  DebugSignalGraphNode,
   DevToolsNode,
   DirectivePosition,
   DirectiveType,
@@ -702,13 +703,14 @@ const getSignalGraphCallback = (messageBus: MessageBus<Events>) => (element: Ele
 
   const graph = ng.ɵgetSignalGraph?.(injector);
   if (graph) {
-    const nodes = graph.nodes.map((node) => {
+    const nodes = graph.nodes.map<DebugSignalGraphNode>((node) => {
       return {
         id: node.id,
         kind: node.kind,
         label: node.label,
         epoch: node.epoch,
         preview: serializeValue(node.value),
+        debuggable: !!node.debuggableFn,
       };
     });
     messageBus.emit('latestSignalGraph', [{nodes, edges: graph.edges}]);

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-tab.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-tab.component.html
@@ -2,7 +2,7 @@
 @if (selectedNode(); as node) {
   <div class="overlay">
     <div class="header">
-      <button mat-flat-button (click)="gotoSource()">
+      <button mat-flat-button (click)="gotoSource()" [disabled]="!node.debuggable">
         <mat-icon> arrow_outward </mat-icon>
         View Source
       </button>

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -22,6 +22,7 @@ export interface DebugSignalGraphNode {
   epoch: number;
   label?: string;
   preview: Descriptor;
+  debuggable: boolean;
 }
 
 export interface DebugSignalGraphEdge {


### PR DESCRIPTION



## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A



## What is the new behavior?

if there is no debuggableFn, we shouldn't allow users to click the view source button


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
