### PR TITLE
refactor(devtools): make the component metadata menu more prominent

### DIFF
--- a/devtools/cypress/integration/node-search.e2e.js
+++ b/devtools/cypress/integration/node-search.e2e.js
@@ -15,7 +15,7 @@ function inputSearchText(text) {
 }
 
 function checkComponentName(name) {
-  cy.get('.component-name').should('have.text', name);
+  cy.get('.component-name > span').should('have.text', name);
 }
 
 function checkEmptyNodes() {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/BUILD.bazel
@@ -46,6 +46,7 @@ ng_project(
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/defer-view:defer-view_rjs",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view:property-view_rjs",
         "//devtools/projects/ng-devtools/src/lib/shared/button:button_rjs",
+        "//devtools/projects/ng-devtools/src/lib/shared/docs-ref-button:docs-ref-button_rjs",
         "//devtools/projects/protocol:protocol_rjs",
     ],
 )

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/component-metadata.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/component-metadata.component.html
@@ -1,10 +1,27 @@
-@if (viewEncapsulation()) {
-  <a href="https://angular.dev/api/core/ViewEncapsulation" target="_blank">
-    View Encapsulation: <span class="meta-data">{{ viewEncapsulation() }}</span>
-  </a>
-}
-@if (changeDetectionStrategy()) {
-  <a href="https://angular.dev/api/core/ChangeDetectionStrategy" target="_blank">
-    Change Detection Strategy: <span class="meta-data">{{ changeDetectionStrategy() }}</span>
-  </a>
-}
+<hr />
+<ul>
+  @if (viewEncapsulation()) {
+    <li>
+      View Encapsulation: <span class="meta-data">{{ viewEncapsulation() }}</span>
+      <a
+        href="https://angular.dev/api/core/ViewEncapsulation"
+        target="_blank"
+        matTooltip="Open docs reference"
+      >
+        <mat-icon>open_in_new</mat-icon>
+      </a>
+    </li>
+  }
+  @if (changeDetectionStrategy()) {
+    <li>
+      Change Detection Strategy: <span class="meta-data">{{ changeDetectionStrategy() }}</span>
+      <a
+        href="https://angular.dev/api/core/ChangeDetectionStrategy"
+        target="_blank"
+        matTooltip="Open docs reference"
+      >
+        <mat-icon>open_in_new</mat-icon>
+      </a>
+    </li>
+  }
+</ul>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/component-metadata.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/component-metadata.component.html
@@ -3,25 +3,13 @@
   @if (viewEncapsulation()) {
     <li>
       View Encapsulation: <span class="meta-data">{{ viewEncapsulation() }}</span>
-      <a
-        href="https://angular.dev/api/core/ViewEncapsulation"
-        target="_blank"
-        matTooltip="Open docs reference"
-      >
-        <mat-icon>open_in_new</mat-icon>
-      </a>
+      <ng-docs-ref-button docs="view-encapsulation" />
     </li>
   }
   @if (changeDetectionStrategy()) {
     <li>
       Change Detection Strategy: <span class="meta-data">{{ changeDetectionStrategy() }}</span>
-      <a
-        href="https://angular.dev/api/core/ChangeDetectionStrategy"
-        target="_blank"
-        matTooltip="Open docs reference"
-      >
-        <mat-icon>open_in_new</mat-icon>
-      </a>
+      <ng-docs-ref-button docs="change-detection" />
     </li>
   }
 </ul>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/component-metadata.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/component-metadata.component.scss
@@ -1,12 +1,35 @@
+@use '../../../../styles/typography';
+
 :host {
-  padding: 0.25rem 0.75rem;
   display: block;
+  padding-inline: 0.625rem;
 
-  a {
-    display: block;
+  hr {
+    margin: 0;
+  }
 
-    &:not(:last-child) {
-      margin-bottom: 0.25rem;
+  ul {
+    @extend %body-01;
+    list-style-type: none;
+    margin: 0;
+    padding: 0.5rem 0;
+
+    li {
+      &:not(:last-child) {
+        margin-bottom: 0.25rem;
+      }
+
+      .meta-data {
+        font-weight: bold;
+      }
+
+      mat-icon {
+        width: 16px;
+        height: 16px;
+        font-size: 16px;
+        vertical-align: bottom;
+        margin-left: 0.125rem;
+      }
     }
   }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/component-metadata.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/component-metadata.component.scss
@@ -23,11 +23,7 @@
         font-weight: bold;
       }
 
-      mat-icon {
-        width: 16px;
-        height: 16px;
-        font-size: 16px;
-        vertical-align: bottom;
+      ng-docs-ref-button {
         margin-left: 0.125rem;
       }
     }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/component-metadata.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/component-metadata.component.ts
@@ -14,7 +14,6 @@ import {
   inject,
   input,
 } from '@angular/core';
-import {MatIcon} from '@angular/material/icon';
 
 import {
   AngularDirectiveMetadata,
@@ -23,13 +22,13 @@ import {
 } from '../../../../../../protocol';
 
 import {ElementPropertyResolver} from '../property-resolver/element-property-resolver';
-import {MatTooltip} from '@angular/material/tooltip';
+import {DocsRefButtonComponent} from '../../../shared/docs-ref-button/docs-ref-button.component';
 
 @Component({
   selector: 'ng-component-metadata',
   templateUrl: './component-metadata.component.html',
   styleUrls: ['./component-metadata.component.scss'],
-  imports: [MatIcon, MatTooltip],
+  imports: [DocsRefButtonComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ComponentMetadataComponent {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/component-metadata.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/component-metadata.component.ts
@@ -14,6 +14,8 @@ import {
   inject,
   input,
 } from '@angular/core';
+import {MatIcon} from '@angular/material/icon';
+
 import {
   AngularDirectiveMetadata,
   AcxDirectiveMetadata,
@@ -21,11 +23,13 @@ import {
 } from '../../../../../../protocol';
 
 import {ElementPropertyResolver} from '../property-resolver/element-property-resolver';
+import {MatTooltip} from '@angular/material/tooltip';
 
 @Component({
   selector: 'ng-component-metadata',
   templateUrl: './component-metadata.component.html',
   styleUrls: ['./component-metadata.component.scss'],
+  imports: [MatIcon, MatTooltip],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ComponentMetadataComponent {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header.component.html
@@ -1,29 +1,34 @@
 @let comp = currentSelectedElement().component;
 @if (comp) {
   <mat-accordion class="property-tab-header">
-    <div>
-      <mat-expansion-panel [hideToggle]="true">
-        <mat-expansion-panel-header collapsedHeight="32px" expandedHeight="32px">
-          <mat-panel-title>
-            <div class="element-header">
-              <div class="component-name">{{ comp.name }}</div>
-              @if (signalGraphEnabled()) {
-                <button ng-button type="button" size="compact" (click)="showGraph($event)">
-                  Show Signal Graph
-                </button>
-              }
-            </div>
-          </mat-panel-title>
-        </mat-expansion-panel-header>
-        <ng-component-metadata [currentSelectedComponent]="comp"></ng-component-metadata>
-      </mat-expansion-panel>
-    </div>
+    <mat-expansion-panel [hideToggle]="true" [expanded]="expanded()" disabled>
+      <mat-expansion-panel-header collapsedHeight="32px" expandedHeight="32px">
+        <mat-panel-title>
+          <div class="element-header">
+            <button
+              class="component-name"
+              (click)="expanded.set(!expanded())"
+              [class.expanded]="expanded()"
+            >
+              <span>{{ comp.name }}</span>
+              <mat-icon> keyboard_arrow_down </mat-icon>
+            </button>
+            @if (signalGraphEnabled()) {
+              <button ng-button type="button" size="compact" (click)="showSignalGraph.emit()">
+                Show Signal Graph
+              </button>
+            }
+          </div>
+        </mat-panel-title>
+      </mat-expansion-panel-header>
+      <ng-component-metadata [currentSelectedComponent]="comp"></ng-component-metadata>
+    </mat-expansion-panel>
   </mat-accordion>
 } @else {
   <div class="element-header">
     <div class="element-name">{{ currentSelectedElement().element }}</div>
     @if (signalGraphEnabled()) {
-      <button ng-button type="button" size="compact" (click)="showGraph($event)">
+      <button ng-button type="button" size="compact" (click)="showSignalGraph.emit()">
         Show Signal Graph
       </button>
     }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header.component.scss
@@ -17,8 +17,36 @@
   .element-name {
     margin-left: 0.625rem;
   }
+
+  .component-name {
+    @extend %body-bold-01;
+    border: none;
+    background: none;
+    padding: 0;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.125rem;
+
+    mat-icon {
+      font-size: 16px;
+      width: 16px;
+      height: 14px;
+      font-weight: bold;
+      color: var(--tertiary-contrast);
+      transition: transform 200ms ease;
+      transform-origin: 50% 55%;
+    }
+
+    &.expanded {
+      mat-icon {
+        transform: rotate(180deg);
+      }
+    }
+  }
 }
 
+/* FRAGILE */
 ::ng-deep {
   .property-tab-header {
     mat-expansion-panel {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header.component.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, input, output} from '@angular/core';
+import {ChangeDetectionStrategy, Component, input, output, signal} from '@angular/core';
 import {MatExpansionModule} from '@angular/material/expansion';
+import {MatIcon} from '@angular/material/icon';
 
 import {IndexedNode} from '../directive-forest/index-forest';
 import {ComponentMetadataComponent} from './component-metadata.component';
@@ -18,15 +19,12 @@ import {ButtonComponent} from '../../../shared/button/button.component';
   selector: 'ng-property-tab-header',
   styleUrls: ['./property-tab-header.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [MatExpansionModule, ComponentMetadataComponent, ButtonComponent],
+  imports: [MatExpansionModule, MatIcon, ComponentMetadataComponent, ButtonComponent],
 })
 export class PropertyTabHeaderComponent {
-  readonly currentSelectedElement = input.required<IndexedNode>();
-  readonly signalGraphEnabled = input.required<boolean>();
-  readonly showSignalGraph = output<void>();
+  protected readonly currentSelectedElement = input.required<IndexedNode>();
+  protected readonly signalGraphEnabled = input.required<boolean>();
+  protected readonly showSignalGraph = output<void>();
 
-  showGraph(event: Event) {
-    event.stopPropagation();
-    this.showSignalGraph.emit();
-  }
+  protected readonly expanded = signal(false);
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/BUILD.bazel
@@ -63,6 +63,7 @@ ng_project(
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/index-forest:index-forest_rjs",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver:property-resolver_rjs",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/resolution-path:resolution-path_rjs",
+        "//devtools/projects/ng-devtools/src/lib/shared/docs-ref-button:docs-ref-button_rjs",
         "//devtools/projects/protocol:protocol_rjs",
     ],
 )

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.html
@@ -7,15 +7,7 @@
           <mat-expansion-panel-header collapsedHeight="28px" expandedHeight="28px">
             <mat-panel-title>
               Injected Services
-              <a
-                href="https://angular.dev/guide/di"
-                target="_blank"
-                class="documentation"
-                matTooltip="Open docs reference"
-                (click)="$event.stopPropagation()"
-              >
-                <mat-icon class="docs-link">open_in_new</mat-icon>
-              </a>
+              <ng-docs-ref-button docs="dependency-injection" />
             </mat-panel-title>
           </mat-expansion-panel-header>
           <ng-injected-services [controller]="controller()" />

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.scss
@@ -1,6 +1,11 @@
 @use '../../../../../styles/typography';
 
 :host {
+  ng-docs-ref-button {
+    margin-left: 0.125rem;
+  }
+
+  /* FRAGILE */
   ::ng-deep {
     mat-expansion-panel {
       border-radius: unset !important;

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.ts
@@ -25,10 +25,9 @@ import {
 } from '../../property-resolver/directive-property-resolver';
 import {FlatNode} from '../../property-resolver/element-property-resolver';
 import {PropertyViewTreeComponent} from './property-view-tree.component';
-import {MatIcon} from '@angular/material/icon';
-import {MatTooltip} from '@angular/material/tooltip';
 import {MatExpansionModule} from '@angular/material/expansion';
 import {DependencyViewerComponent} from './dependency-viewer.component';
+import {DocsRefButtonComponent} from '../../../../shared/docs-ref-button/docs-ref-button.component';
 
 @Component({
   selector: 'ng-property-view-body',
@@ -37,11 +36,10 @@ import {DependencyViewerComponent} from './dependency-viewer.component';
   imports: [
     MatExpansionModule,
     CdkDropList,
-    MatTooltip,
-    MatIcon,
     forwardRef(() => InjectedServicesComponent),
     CdkDrag,
     PropertyViewTreeComponent,
+    DocsRefButtonComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/BUILD.bazel
@@ -28,6 +28,7 @@ ng_project(
         "//:node_modules/d3",
         "//:node_modules/rxjs",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-providers:injector-providers_rjs",
+        "//devtools/projects/ng-devtools/src/lib/shared/docs-ref-button:docs-ref-button_rjs",
         "//devtools/projects/ng-devtools/src/lib/shared/split:responsive-split_rjs",
         "//devtools/projects/ng-devtools/src/lib/shared/split:split_rjs",
         "//devtools/projects/ng-devtools/src/lib/shared/tree-visualizer-host:tree-visualizer-host_rjs",

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.html
@@ -30,13 +30,7 @@
             <div class="injector-hierarchy">
               <h2>
                 <span>Environment Hierarchy</span>
-                <a
-                  class="hierarchy-ref"
-                  href="https://angular.dev/guide/di/hierarchical-dependency-injection#types-of-injector-hierarchies"
-                  target="_blank"
-                >
-                  <mat-icon matTooltip="Open docs reference"> open_in_new </mat-icon>
-                </a>
+                <ng-docs-ref-button docs="injector-hierarchies" />
               </h2>
               <section class="injector-graph">
                 <ng-tree-visualizer-host
@@ -50,13 +44,7 @@
             <div class="injector-hierarchy">
               <h2>
                 <span>Element Hierarchy</span>
-                <a
-                  class="hierarchy-ref"
-                  href="https://angular.dev/guide/di/hierarchical-dependency-injection#types-of-injector-hierarchies"
-                  target="_blank"
-                >
-                  <mat-icon matTooltip="Open docs reference"> open_in_new </mat-icon>
-                </a>
+                <ng-docs-ref-button docs="injector-hierarchies" />
               </h2>
               <section class="injector-graph">
                 <ng-tree-visualizer-host #elementTree a11yTitle="Element hierarchy visualization" />

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.scss
@@ -53,18 +53,6 @@
           display: flex;
           align-items: center;
           gap: 0.375rem;
-
-          .hierarchy-ref {
-            color: currentColor;
-            text-decoration: none;
-          }
-
-          mat-icon {
-            font-size: 1rem;
-            width: 1rem;
-            height: 1rem;
-            display: block;
-          }
         }
       }
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
@@ -19,8 +19,6 @@ import {
   untracked,
   viewChild,
 } from '@angular/core';
-import {MatIcon} from '@angular/material/icon';
-import {MatTooltip} from '@angular/material/tooltip';
 import {
   ComponentExplorerView,
   DevToolsNode,
@@ -53,6 +51,7 @@ import {
 import {SplitAreaDirective} from '../../shared/split/splitArea.directive';
 import {SplitComponent} from '../../shared/split/split.component';
 import {Direction} from '../../shared/split/interface';
+import {DocsRefButtonComponent} from '../../shared/docs-ref-button/docs-ref-button.component';
 
 const ENV_HIERARCHY_VER_SIZE = 35;
 const EL_HIERARCHY_VER_SIZE = 65;
@@ -65,9 +64,8 @@ const HIERARCHY_HOR_SIZE = 50;
     SplitAreaDirective,
     InjectorProvidersComponent,
     TreeVisualizerHostComponent,
-    MatIcon,
-    MatTooltip,
     ResponsiveSplitDirective,
+    DocsRefButtonComponent,
   ],
   templateUrl: `./injector-tree.component.html`,
   styleUrls: ['./injector-tree.component.scss'],

--- a/devtools/projects/ng-devtools/src/lib/shared/docs-ref-button/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/shared/docs-ref-button/BUILD.bazel
@@ -1,0 +1,21 @@
+load("//devtools/tools:defaults.bzl", "ng_project", "sass_binary")
+
+package(default_visibility = ["//devtools:__subpackages__"])
+
+sass_binary(
+    name = "docs-ref-button_styles",
+    src = "docs-ref-button.component.scss",
+)
+
+ng_project(
+    name = "docs-ref-button",
+    srcs = ["docs-ref-button.component.ts"],
+    angular_assets = [
+        "docs-ref-button.component.html",
+        ":docs-ref-button_styles",
+    ],
+    deps = [
+        "//:node_modules/@angular/core",
+        "//:node_modules/@angular/material",
+    ],
+)

--- a/devtools/projects/ng-devtools/src/lib/shared/docs-ref-button/docs-ref-button.component.html
+++ b/devtools/projects/ng-devtools/src/lib/shared/docs-ref-button/docs-ref-button.component.html
@@ -1,0 +1,8 @@
+<a
+  [href]="url()"
+  target="_blank"
+  matTooltip="Open docs reference"
+  (click)="$event.stopPropagation()"
+>
+  <mat-icon>open_in_new</mat-icon>
+</a>

--- a/devtools/projects/ng-devtools/src/lib/shared/docs-ref-button/docs-ref-button.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/shared/docs-ref-button/docs-ref-button.component.scss
@@ -1,0 +1,11 @@
+:host {
+  display: inline-block;
+  vertical-align: bottom;
+
+  mat-icon {
+    width: 16px;
+    height: 16px;
+    font-size: 16px;
+    display: block;
+  }
+}

--- a/devtools/projects/ng-devtools/src/lib/shared/docs-ref-button/docs-ref-button.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/docs-ref-button/docs-ref-button.component.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component, computed, input} from '@angular/core';
+import {MatIcon} from '@angular/material/icon';
+import {MatTooltip} from '@angular/material/tooltip';
+
+type Docs =
+  | 'view-encapsulation'
+  | 'change-detection'
+  | 'dependency-injection'
+  | 'injector-hierarchies';
+
+const URLS: {[key in Docs]: string} = {
+  'change-detection': 'https://angular.dev/api/core/ChangeDetectionStrategy',
+  'view-encapsulation': 'https://angular.dev/api/core/ViewEncapsulation',
+  'dependency-injection': 'https://angular.dev/guide/di',
+  'injector-hierarchies':
+    'https://angular.dev/guide/di/hierarchical-dependency-injection#types-of-injector-hierarchies',
+};
+
+@Component({
+  selector: 'ng-docs-ref-button',
+  templateUrl: './docs-ref-button.component.html',
+  styleUrl: './docs-ref-button.component.scss',
+  imports: [MatIcon, MatTooltip],
+})
+export class DocsRefButtonComponent {
+  protected readonly docs = input.required<Docs>();
+  protected readonly url = computed(() => URLS[this.docs()]);
+}

--- a/devtools/projects/ng-devtools/src/styles/_global.scss
+++ b/devtools/projects/ng-devtools/src/styles/_global.scss
@@ -113,6 +113,14 @@ a {
   display: none !important;
 }
 
+hr {
+  width: 100%;
+  height: 1px;
+  background-color: var(--color-separator);
+  border: none;
+  margin-block: 0.875rem;
+}
+
 .ver-ruler {
   width: 1px;
   height: 100%;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature


## What is the new behavior?

The menu content requires additional work but this should at least make it more prominent to the end user. 

- Add an arrow icon to indicate that this is an expansion panel. 
- Reduce the active area, which toggles the menu, to the text only. This will prevent the menu from expanding if you click the header which handles the cases when you misclick the "Show Signal Graph" button.

<table>
<tr><td>Collapsed</td><td>Expanded</td></tr>
<tr><td>
<img width="346" height="107" alt="Screenshot 2025-07-17 at 15 38 50" src="https://github.com/user-attachments/assets/8aa0d984-77d3-4bd3-b899-fd1b39af8411" />

</td><td>
<img width="336" height="149" alt="Screenshot 2025-07-18 at 10 03 05" src="https://github.com/user-attachments/assets/de4d1823-d5e3-4773-b2bf-287caf524245" />


</td></tr>
</table>

