### PR TITLE
Deprecate `BootstrapOptions` for configuring NgZone on `bootstrapModule`

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -188,12 +188,15 @@ export interface Binding {
 // @public
 export function booleanAttribute(value: unknown): boolean;
 
-// @public
+// @public @deprecated
 export interface BootstrapOptions {
     // @deprecated
     ignoreChangesOutsideZone?: boolean;
+    // @deprecated
     ngZone?: NgZone | 'zone.js' | 'noop';
+    // @deprecated
     ngZoneEventCoalescing?: boolean;
+    // @deprecated
     ngZoneRunCoalescing?: boolean;
 }
 

--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -108,6 +108,7 @@ export class NgProbeToken {
  * Provides additional options to the bootstrapping process.
  *
  * @publicApi
+ * @deprecated 20.2 Configure `NgZone` in the `providers` array of the application module instead.
  */
 export interface BootstrapOptions {
   /**
@@ -116,6 +117,8 @@ export interface BootstrapOptions {
    * - Provide your own `NgZone` instance.
    * - `zone.js` - Use default `NgZone` which requires `Zone.js`.
    * - `noop` - Use `NoopNgZone` which does nothing.
+   *
+   * @deprecated BootstrapOptions is deprecated. Provide `NgZone` in the `providers` array of the module instead.
    */
   ngZone?: NgZone | 'zone.js' | 'noop';
 
@@ -139,6 +142,8 @@ export interface BootstrapOptions {
    * And if this option be set to true, the change detection will be
    * triggered async by scheduling a animation frame. So in the case above,
    * the change detection will only be triggered once.
+   *
+   * @deprecated BootstrapOptions is deprecated. Use `provideZoneChangeDetection` instead to configure coalescing.
    */
   ngZoneEventCoalescing?: boolean;
 
@@ -159,6 +164,7 @@ export interface BootstrapOptions {
    * With ngZoneRunCoalescing options, all change detections in an event loop trigger only once.
    * In addition, the change detection executes in requestAnimation.
    *
+   * @deprecated BootstrapOptions is deprecated. Use `provideZoneChangeDetection` instead to configure coalescing.
    */
   ngZoneRunCoalescing?: boolean;
 


### PR DESCRIPTION
This deprecates `BootstrapOptions` since `NgZone` can now be configured
in the providers. This is a necessary step because when zoneless becomes
the default, developers will have to add ZoneJS via
`provideZoneChangeDetection` and that will override anything defined in
`BootstrapOptions`.

Note on lack of migration: This will be handled by the zoneless by default migration. Since we have to add the zone provider to existing apps, it will also pull the required options from the `BootstrapOptions` if present