### PR TITLE
feat(core): Promote zoneless to stable

### DIFF
--- a/adev/src/content/guide/zoneless.md
+++ b/adev/src/content/guide/zoneless.md
@@ -11,7 +11,7 @@ The main advantages to removing ZoneJS as a dependency are:
 
 ## Enabling Zoneless in an application
 
-The API for enabling Zoneless is currently in developer preview. The shape of the API and underlying behavior can change in patch versions.
+
 
 ```typescript
 // standalone bootstrap

--- a/adev/src/content/reference/roadmap.md
+++ b/adev/src/content/reference/roadmap.md
@@ -19,12 +19,12 @@ Start developing with the latest Angular features from our roadmap. This list re
 
 ### Available to experiment with
 
-* [Zoneless change detection](/guide/zoneless)
 * [Resource API](/guide/signals/resource)
 * [httpResource](/api/common/http/httpResource)
 
 ### Production ready
 
+* [Zoneless change detection](/guide/zoneless)
 * [Linked Signal API](/guide/signals/linked-signal)
 * [Incremental hydration](/guide/incremental-hydration)
 * [Effect API](/api/core/effect)
@@ -54,7 +54,7 @@ Start developing with the latest Angular features from our roadmap. This list re
 
   In v19 we introduced zoneless support in server-side rendering, addressed some edge cases, and created a schematic to scaffold zoneless projects. We transitioned <a href="https://fonts.google.com/">Google Fonts</a> to zoneless which improved performance, developer experience, and allowed us to identify gaps that we need to address before moving this feature to developer preview.
 
-  As of Angular v20, Zoneless Angular is now in developer preview and includes improvements in error handling and server-side rendering.
+  As of Angular v20.2, Zoneless Angular is now stable and includes improvements in error handling and server-side rendering.
   </docs-card>
   <docs-card title="Signal integrations" href="">
   We're working towards improving the integration of fundamental Angular packages, such as forms, HTTP, and router, with Signals. As part of this project, we'll seek opportunities to introduce convenient signal-based APIs or wrappers to improve the holistic developer experience.

--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
@@ -365,11 +365,8 @@ export class ChangeDetectionSchedulerImpl implements ChangeDetectionScheduler {
  * ]});
  * ```
  *
- * This API is experimental. Neither the shape, nor the underlying behavior is stable and can change
- * in patch versions. There are known feature gaps and API ergonomic considerations. We will iterate
- * on the exact API based on the feedback and our understanding of the problem and solution space.
+ * @publicApi 20.2
  *
- * @developerPreview 20.0
  * @see {@link /api/platform-browser/bootstrapApplication bootstrapApplication}
  */
 export function provideZonelessChangeDetection(): EnvironmentProviders {


### PR DESCRIPTION
This commit moves zoneless from developer preview to stable and updates the roadmap to indicate it is ready for production use.
