### PR TITLE
fix(core): Remove ignoreChangesOutsideZone option

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -200,8 +200,6 @@ export function booleanAttribute(value: unknown): boolean;
 // @public @deprecated
 export interface BootstrapOptions {
     // @deprecated
-    ignoreChangesOutsideZone?: boolean;
-    // @deprecated
     ngZone?: NgZone | 'zone.js' | 'noop';
     // @deprecated
     ngZoneEventCoalescing?: boolean;
@@ -1300,8 +1298,6 @@ export class NgZone {
 // @public
 export interface NgZoneOptions {
     eventCoalescing?: boolean;
-    // @deprecated
-    ignoreChangesOutsideZone?: boolean;
     runCoalescing?: boolean;
 }
 

--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -154,25 +154,6 @@ export interface BootstrapOptions {
    * @deprecated BootstrapOptions is deprecated. Use `provideZoneChangeDetection` instead to configure coalescing.
    */
   ngZoneRunCoalescing?: boolean;
-
-  /**
-   * When false, change detection is scheduled when Angular receives
-   * a clear indication that templates need to be refreshed. This includes:
-   *
-   * - calling `ChangeDetectorRef.markForCheck`
-   * - calling `ComponentRef.setInput`
-   * - updating a signal that is read in a template
-   * - attaching a view that is marked dirty
-   * - removing a view
-   * - registering a render hook (templates are only refreshed if render hooks do one of the above)
-   *
-   * @deprecated This option was introduced out of caution as a way for developers to opt out of the
-   *    new behavior in v18 which schedule change detection for the above events when they occur
-   *    outside the Zone. After monitoring the results post-release, we have determined that this
-   *    feature is working as desired and do not believe it should ever be disabled by setting
-   *    this option to `true`.
-   */
-  ignoreChangesOutsideZone?: boolean;
 }
 
 /** Maximum number of times ApplicationRef will refresh all attached views in a single tick. */

--- a/packages/core/src/change_detection/scheduling/ng_zone_scheduling.ts
+++ b/packages/core/src/change_detection/scheduling/ng_zone_scheduling.ts
@@ -84,11 +84,9 @@ export const PROVIDED_NG_ZONE = new InjectionToken<boolean>(
 
 export function internalProvideZoneChangeDetection({
   ngZoneFactory,
-  ignoreChangesOutsideZone,
   scheduleInRootZone,
 }: {
   ngZoneFactory?: () => NgZone;
-  ignoreChangesOutsideZone?: boolean;
   scheduleInRootZone?: boolean;
 }): StaticProvider[] {
   ngZoneFactory ??= () =>
@@ -125,9 +123,6 @@ export function internalProvideZoneChangeDetection({
         };
       },
     },
-    // Always disable scheduler whenever explicitly disabled, even if another place called
-    // `provideZoneChangeDetection` without the 'ignore' option.
-    ignoreChangesOutsideZone === true ? {provide: ZONELESS_SCHEDULER_DISABLED, useValue: true} : [],
     {
       provide: SCHEDULE_IN_ROOT_ZONE,
       useValue: scheduleInRootZone ?? SCHEDULE_IN_ROOT_ZONE_DEFAULT,
@@ -176,7 +171,6 @@ export function internalProvideZoneChangeDetection({
  * @see {@link NgZoneOptions}
  */
 export function provideZoneChangeDetection(options?: NgZoneOptions): EnvironmentProviders {
-  const ignoreChangesOutsideZone = options?.ignoreChangesOutsideZone;
   const scheduleInRootZone = (options as any)?.scheduleInRootZone;
   const zoneProviders = internalProvideZoneChangeDetection({
     ngZoneFactory: () => {
@@ -187,7 +181,6 @@ export function provideZoneChangeDetection(options?: NgZoneOptions): Environment
       }
       return new NgZone(ngZoneOptions);
     },
-    ignoreChangesOutsideZone,
     scheduleInRootZone,
   });
   return makeEnvironmentProviders([
@@ -246,25 +239,6 @@ export interface NgZoneOptions {
    *
    */
   runCoalescing?: boolean;
-
-  /**
-   * When false, change detection is scheduled when Angular receives
-   * a clear indication that templates need to be refreshed. This includes:
-   *
-   * - calling `ChangeDetectorRef.markForCheck`
-   * - calling `ComponentRef.setInput`
-   * - updating a signal that is read in a template
-   * - attaching a view that is marked dirty
-   * - removing a view
-   * - registering a render hook (templates are only refreshed if render hooks do one of the above)
-   *
-   * @deprecated This option was introduced out of caution as a way for developers to opt out of the
-   *    new behavior in v18 which schedule change detection for the above events when they occur
-   *    outside the Zone. After monitoring the results post-release, we have determined that this
-   *    feature is working as desired and do not believe it should ever be disabled by setting
-   *    this option to `true`.
-   */
-  ignoreChangesOutsideZone?: boolean;
 }
 
 // Transforms a set of `BootstrapOptions` (supported by the NgModule-based bootstrap APIs) ->

--- a/packages/core/src/platform/platform_ref.ts
+++ b/packages/core/src/platform/platform_ref.ts
@@ -62,11 +62,9 @@ export class PlatformRef {
         }),
         scheduleInRootZone,
       });
-    const ignoreChangesOutsideZone = options?.ignoreChangesOutsideZone;
     const allAppProviders = [
       internalProvideZoneChangeDetection({
         ngZoneFactory,
-        ignoreChangesOutsideZone,
       }),
       {provide: ChangeDetectionScheduler, useExisting: ChangeDetectionSchedulerImpl},
       errorHandlerEnvironmentInitializer,

--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -21,6 +21,7 @@ import {
   ChangeDetectionStrategy,
   Compiler,
   Component,
+  DestroyRef,
   EnvironmentInjector,
   InjectionToken,
   Injector,
@@ -28,7 +29,6 @@ import {
   NgModule,
   NgZone,
   PlatformRef,
-  provideZoneChangeDetection,
   RendererFactory2,
   TemplateRef,
   Type,
@@ -940,7 +940,6 @@ describe('AppRef', () => {
     beforeEach(() => {
       stableCalled = false;
       TestBed.configureTestingModule({
-        providers: [provideZoneChangeDetection({ignoreChangesOutsideZone: true})],
         declarations: [
           SyncComp,
           MicroTaskComp,
@@ -964,7 +963,7 @@ describe('AppRef', () => {
       zone.run(() => appRef.tick());
 
       let i = 0;
-      appRef.isStable.subscribe({
+      const sub = appRef.isStable.subscribe({
         next: (stable: boolean) => {
           if (stable) {
             expect(i).toBeLessThan(expected.length);
@@ -973,6 +972,7 @@ describe('AppRef', () => {
           }
         },
       });
+      fixture.debugElement.injector.get(DestroyRef).onDestroy(() => sub.unsubscribe());
     }
 
     it('isStable should fire on synchronous component loading', waitForAsync(() => {

--- a/packages/core/test/change_detection_scheduler_spec.ts
+++ b/packages/core/test/change_detection_scheduler_spec.ts
@@ -762,27 +762,6 @@ describe('Angular with scheduler and ZoneJS', () => {
     });
   });
 
-  it('requires updates inside Angular zone when using ngZoneOnly', async () => {
-    TestBed.configureTestingModule({
-      providers: [provideZoneChangeDetection({ignoreChangesOutsideZone: true})],
-    });
-    @Component({template: '{{thing()}}'})
-    class App {
-      thing = signal('initial');
-    }
-
-    const fixture = TestBed.createComponent(App);
-    await fixture.whenStable();
-    expect(fixture.nativeElement.innerText).toContain('initial');
-
-    TestBed.inject(NgZone).runOutsideAngular(() => {
-      fixture.componentInstance.thing.set('new');
-    });
-    expect(fixture.isStable()).toBe(true);
-    await fixture.whenStable();
-    expect(fixture.nativeElement.innerText).toContain('initial');
-  });
-
   it('will not schedule change detection if listener callback is outside the zone', async () => {
     let renders = 0;
     TestBed.runInInjectionContext(() => {
@@ -894,7 +873,7 @@ describe('Angular with scheduler and ZoneJS', () => {
   it('should not run change detection twice if notified during AppRef.tick', async () => {
     TestBed.configureTestingModule({
       providers: [
-        provideZoneChangeDetection({ignoreChangesOutsideZone: false}),
+        provideZoneChangeDetection(),
         {provide: PLATFORM_ID, useValue: PLATFORM_BROWSER_ID},
       ],
     });
@@ -931,9 +910,7 @@ describe('Angular with scheduler and ZoneJS', () => {
     }
 
     TestBed.configureTestingModule({
-      providers: [
-        provideZoneChangeDetection({runCoalescing: true, ignoreChangesOutsideZone: false}),
-      ],
+      providers: [provideZoneChangeDetection({runCoalescing: true})],
     });
     @Component({template: '{{thing()}}'})
     class App {
@@ -959,9 +936,7 @@ describe('Angular with scheduler and ZoneJS', () => {
     }
 
     TestBed.configureTestingModule({
-      providers: [
-        provideZoneChangeDetection({runCoalescing: true, ignoreChangesOutsideZone: false}),
-      ],
+      providers: [provideZoneChangeDetection({runCoalescing: true})],
     });
     @Component({template: '{{thing()}}'})
     class App {


### PR DESCRIPTION
This option was introduced out of caution as a way for developers to opt out of the new behavior in v18 which scheduled change detection even when events happened outside the NgZone. After monitoring the results post-release, we have determined that this feature is working as desired and do not believe it should ever be disabled by setting this option to `true`.

This option was deprecated in v18.2, less than 3 months after it was introduced in v18. We do not really expect it to be used.

BREAKING CHANGE: `ignoreChangesOutsideZone` is no longer available as an option for configuring ZoneJS change detection behavior.
