### PR TITLE
docs: update link to git fixup documentation

### DIFF
--- a/contributing-docs/using-fixup-commits.md
+++ b/contributing-docs/using-fixup-commits.md
@@ -68,7 +68,7 @@ You can create a fixup commit by specifying an appropriate commit message (
 i.e. `fixup! <original-commit-message-subject>`).
 
 In addition, the `git` command-line tool provides an easy way to create a fixup commit
-via [git commit --fixup](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---fixupltcommitgt):
+via [git commit --fixup](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---fixupamendrewordcommit):
 
 ```sh
 # Create a fixup commit to fix up the last commit on the branch:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The link for the `git commit --fixup` command incorrectly points to the `-C` option in the git documentation. 

Issue Number: N/A


## What is the new behavior?
Now, the link correctly points to the `--fixup` option in the git documentation.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No