### PR TITLE
feat(service-worker): notify clients about version failures

### DIFF
--- a/goldens/public-api/service-worker/index.api.md
+++ b/goldens/public-api/service-worker/index.api.md
@@ -109,7 +109,7 @@ export interface VersionDetectedEvent {
 }
 
 // @public
-export type VersionEvent = VersionDetectedEvent | VersionInstallationFailedEvent | VersionReadyEvent | NoNewVersionDetectedEvent;
+export type VersionEvent = VersionDetectedEvent | VersionInstallationFailedEvent | VersionReadyEvent | VersionFailedEvent | NoNewVersionDetectedEvent;
 
 // @public
 export interface VersionInstallationFailedEvent {

--- a/packages/service-worker/src/low_level.ts
+++ b/packages/service-worker/src/low_level.ts
@@ -71,6 +71,23 @@ export interface VersionReadyEvent {
 }
 
 /**
+ * An event emitted when a specific version of the app has encountered a critical failure
+ * that prevents it from functioning correctly.
+ *
+ * When a version fails, the service worker will notify all clients currently using that version
+ * and may degrade to serving only existing clients if the failed version was the latest one.
+ *
+ * @see {@link /ecosystem/service-workers/communications Service Worker Communication Guide}
+ *
+ * @publicApi
+ */
+export interface VersionFailedEvent {
+  type: 'VERSION_FAILED';
+  version: {hash: string; appData?: object};
+  error: string;
+}
+
+/**
  * A union of all event types that can be emitted by
  * {@link SwUpdate#versionUpdates}.
  *
@@ -80,6 +97,7 @@ export type VersionEvent =
   | VersionDetectedEvent
   | VersionInstallationFailedEvent
   | VersionReadyEvent
+  | VersionFailedEvent
   | NoNewVersionDetectedEvent;
 
 /**

--- a/packages/service-worker/src/update.ts
+++ b/packages/service-worker/src/update.ts
@@ -66,6 +66,7 @@ export class SwUpdate {
       'VERSION_INSTALLATION_FAILED',
       'VERSION_READY',
       'NO_NEW_VERSION_DETECTED',
+      'VERSION_FAILED',
     ]);
     this.unrecoverable = this.sw.eventsOfType<UnrecoverableStateEvent>('UNRECOVERABLE_STATE');
   }

--- a/packages/service-worker/test/comm_spec.ts
+++ b/packages/service-worker/test/comm_spec.ts
@@ -13,6 +13,7 @@ import {
   NoNewVersionDetectedEvent,
   VersionDetectedEvent,
   VersionEvent,
+  VersionFailedEvent,
   VersionReadyEvent,
 } from '../src/low_level';
 import {ngswCommChannelFactory, SwRegistrationOptions} from '../src/provider';
@@ -507,6 +508,25 @@ describe('ServiceWorker library', () => {
         version: {
           hash: 'A',
         },
+      });
+    });
+    it('processes version failed events with cache corruption error', (done) => {
+      update.versionUpdates.subscribe((event) => {
+        expect(event.type).toEqual('VERSION_FAILED');
+        expect((event as VersionFailedEvent).version).toEqual({
+          hash: 'B',
+          appData: {name: 'test-app'},
+        });
+        expect((event as VersionFailedEvent).error).toContain('Cache corruption detected');
+        done();
+      });
+      mock.sendMessage({
+        type: 'VERSION_FAILED',
+        version: {
+          hash: 'B',
+          appData: {name: 'test-app'},
+        },
+        error: 'Cache corruption detected during resource fetch',
       });
     });
     it('activates updates when requested', async () => {

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -2564,6 +2564,7 @@ import {envIsSupported} from '../testing/utils';
           expect(await makeRequest(scope, '/foo.hash.js', 'client-2')).toBeNull();
           expect(mockClient2.messages).toEqual([
             jasmine.objectContaining({type: 'UNRECOVERABLE_STATE'}),
+            jasmine.objectContaining({type: 'VERSION_FAILED'}),
           ]);
 
           // This should also enter the `SW` into degraded mode, because the broken version was the


### PR DESCRIPTION
Add client notification when an app version fails, improving error visibility and debugging capabilities. When a version encounters a broken hash error, all clients using that version are now notified with details about the failure.

- Add notifyClientsAboutVersionFailure method call in versionFailed
- Ensure clients receive VERSION_FAILED events with error details
- Improve service worker error transparency for better debugging
 
Complete previous TODO 
*New Usage* : 

```ts
this.swUpdate.versionUpdates.subscribe((event: VersionEvent) => {
      switch (event.type) {
        case 'VERSION_DETECTED':
          console.log('New version detected:', event.version.hash);
          break;
          
        case 'VERSION_READY':
          console.log('New version ready:', event.latestVersion.hash);
          // Optionally show update available notification
          break;
          
        case 'VERSION_INSTALLATION_FAILED':
          console.error('Version installation failed:', event.error);
          break;
          
        case 'VERSION_FAILED':
          // NEW: Handle version failure
          this.handleVersionFailure(event);
          break;
          
        case 'NO_NEW_VERSION_DETECTED':
          console.log('No new version available');
          break;
      }
