### PR TITLE
fix(devtools): DOM traversal bug

### DIFF
--- a/devtools/cypress/integration/node-search.e2e.js
+++ b/devtools/cypress/integration/node-search.e2e.js
@@ -14,6 +14,10 @@ function inputSearchText(text) {
   cy.get('ng-filter .filter-input').type(text, {force: true});
 }
 
+function clearSearchInput() {
+  cy.get('ng-filter .filter-input').clear({force: true});
+}
+
 function checkComponentName(name) {
   cy.get('.component-name > span').should('have.text', name);
 }
@@ -23,12 +27,10 @@ function checkEmptyNodes() {
 }
 
 function clickSearchArrows(upwards) {
-  const buttons = cy.get('.up-down-buttons').find('button');
-
   if (upwards) {
-    buttons.first().then((btn) => btn[0].click());
+    cy.get('#up-button').click();
   } else {
-    buttons.last().then((btn) => btn[0].click());
+    cy.get('#down-button').click();
   }
 }
 
@@ -96,6 +98,22 @@ describe('Search items in component tree', () => {
 
     // should show correct component properties
     cy.get('ng-property-view').find('mat-tree-node');
+  });
+
+  it('should be able to search and select @defers in different Angular applications', () => {
+    inputSearchText('@defer');
+    checkSearchedNodesLength('.matched-text', 2);
+    cy.get('.defer-details').should('contain.text', '@placeholder(minimum 5000 ms)');
+    inputSearchText('{enter}');
+    cy.get('.defer-details').should('contain.text', '@placeholder(minimum 2000 ms)');
+  });
+
+  it('should not duplicate application roots if multiple applications are present', () => {
+    inputSearchText('app-root');
+    checkSearchedNodesLength('.matched-text', 1); // only one app-root should be found
+    clearSearchInput();
+    inputSearchText('other-app');
+    checkSearchedNodesLength('.matched-text', 1); // only one other-app should be found
   });
 
   // todo(aleksanderbodurri): revive this test if we decide to revive this functionality

--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree/get-roots.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree/get-roots.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {getRoots} from './get-roots';
+import {getAppRoots} from './get-roots';
 
 function createRoot() {
   const root = document.createElement('div');
@@ -26,7 +26,7 @@ describe('getRoots', () => {
     rootElement.appendChild(childElement);
     document.body.appendChild(rootElement);
 
-    const roots = getRoots();
+    const roots = getAppRoots();
 
     expect(roots.length).toEqual(1);
     expect(roots.pop()).toEqual(rootElement);
@@ -39,7 +39,7 @@ describe('getRoots', () => {
     document.body.appendChild(firstRoot);
     document.body.appendChild(secondRoot);
 
-    const roots = getRoots();
+    const roots = getAppRoots();
 
     expect(roots.length).toEqual(2);
     expect(roots).toContain(firstRoot);

--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree/get-roots.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree/get-roots.ts
@@ -7,7 +7,7 @@
  */
 
 /** Returns all app roots. */
-export function getRoots(): Element[] {
+export function getAppRoots(): Element[] {
   const roots = Array.from(document.documentElement.querySelectorAll('[ng-version]'));
 
   const isTopLevel = (element: Element) => {

--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/ltree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/ltree.ts
@@ -147,7 +147,7 @@ export class LTreeStrategy {
     return nodes;
   }
 
-  build(element: Element, nodes: ComponentTreeNode[] = []): ComponentTreeNode[] {
+  build(element: Element, _: number): ComponentTreeNode[] {
     const ctx = (element as any).__ngContext__;
     const rootLView = ctx.lView ?? ctx;
     return this._extract(rootLView);

--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.spec.ts
@@ -92,30 +92,6 @@ describe('render tree extraction', () => {
     expect(rtree[0].children[0].children.length).toBe(0);
   });
 
-  it('should go all the way to the root element to look up for nodes', () => {
-    const rootNode = document.createElement('body');
-    const siblingNode = document.createElement('section');
-    const appNode = document.createElement('app');
-    const childNode = document.createElement('div');
-    const childComponentNode = document.createElement('child');
-    rootNode.appendChild(appNode);
-    rootNode.appendChild(siblingNode);
-    appNode.appendChild(childNode);
-    childNode.appendChild(childComponentNode);
-
-    const appComponent: any = {};
-    const childComponent: any = {};
-    const siblingComponent: any = {};
-    componentMap.set(siblingNode, siblingComponent);
-    componentMap.set(appNode, appComponent);
-    componentMap.set(childComponentNode, childComponent);
-
-    const rtree = treeStrategy.build(appNode);
-    expect(rtree[0].children.length).toBe(1);
-    expect(rtree[0].children[0].children.length).toBe(0);
-    expect(rtree[1].component?.instance).toBe(siblingComponent);
-  });
-
   it('should use component name from `ng.getDirectiveMetadata`', () => {
     const appNode = document.createElement('app');
 

--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.ts
@@ -21,6 +21,7 @@ const extractViewTree = (
   domNode: Node | Element,
   result: ComponentTreeNode[],
   deferBlocks: DeferBlocksIterator,
+  rootId: number,
   getComponent?: FrameworkAgnosticGlobalUtils['getComponent'],
   getDirectives?: FrameworkAgnosticGlobalUtils['getDirectives'],
   getDirectiveMetadata?: FrameworkAgnosticGlobalUtils['getDirectiveMetadata'],
@@ -81,6 +82,7 @@ const extractViewTree = (
       deferredNodesToSkip,
       appendTo,
       deferBlocks,
+      rootId,
       getComponent,
       getDirectives,
       getDirectiveMetadata,
@@ -91,6 +93,7 @@ const extractViewTree = (
         node,
         appendTo,
         deferBlocks,
+        rootId,
         getComponent,
         getDirectives,
         getDirectiveMetadata,
@@ -117,6 +120,7 @@ function groupDeferChildrenIfNeeded(
   deferredNodesToSkip: Set<Node>,
   appendTo: ComponentTreeNode[],
   deferBlocks: DeferBlocksIterator,
+  rootId: number,
   getComponent?: FrameworkAgnosticGlobalUtils['getComponent'],
   getDirectives?: FrameworkAgnosticGlobalUtils['getDirectives'],
   getDirectiveMetadata?: FrameworkAgnosticGlobalUtils['getDirectiveMetadata'],
@@ -134,6 +138,7 @@ function groupDeferChildrenIfNeeded(
         child,
         childrenTree,
         deferBlocks,
+        rootId,
         getComponent,
         getDirectives,
         getDirectiveMetadata,
@@ -148,7 +153,7 @@ function groupDeferChildrenIfNeeded(
       nativeElement: undefined,
       hydration: null,
       defer: {
-        id: `deferId-${deferBlocks.currentIndex}`,
+        id: `deferId-${rootId}-${deferBlocks.currentIndex}`,
         state: currentDeferBlock.state,
         currentBlock: currentBlock(currentDeferBlock),
         triggers: groupTriggers(currentDeferBlock.triggers),
@@ -221,19 +226,15 @@ export class RTreeStrategy {
     );
   }
 
-  build(element: Element): ComponentTreeNode[] {
+  build(element: Element, rootId: number = 0): ComponentTreeNode[] {
     const ng = ngDebugClient();
     const deferBlocks = ng.ɵgetDeferBlocks?.(element) ?? [];
 
-    // We want to start from the root element so that we can find components which are attached to
-    // the application ref and which host elements have been inserted with DOM APIs.
-    while (element.parentElement && element !== document.body) {
-      element = element.parentElement;
-    }
     return extractViewTree(
       element,
       [],
       new DeferBlocksIterator(deferBlocks),
+      rootId,
       ng.getComponent,
       ng.getDirectives,
       ng.getDirectiveMetadata,

--- a/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.ts
@@ -7,7 +7,7 @@
  */
 
 import type {ɵFrameworkAgnosticGlobalUtils as GlobalUtils} from '@angular/core';
-import {getRoots} from '../component-tree/get-roots';
+import {getAppRoots} from '../component-tree/get-roots';
 import {Framework} from '../component-tree/core-enums';
 
 /** Returns a handle to window.ng APIs (global angular debugging). */
@@ -57,7 +57,7 @@ export function ngDebugProfilerApiIsSupported(): boolean {
   // Temporary solution. Convert to an eligible API when available.
   // https://github.com/angular/angular/pull/60585#discussion_r2017047132
   // If there is a Wiz application, make Profiler API unavailable.
-  const roots = getRoots();
+  const roots = getAppRoots();
   return (
     !!roots.length &&
     !roots.some((el) => {
@@ -73,7 +73,7 @@ export function ngDebugRoutesApiIsSupported(): boolean {
 
   // Temporary solution. Convert to `ɵgetLoadedRoutes` when available.
   // If there is a Wiz application, make Routes API unavailable.
-  const roots = getRoots();
+  const roots = getAppRoots();
   return (
     !!roots.length &&
     !roots.some((el) => {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/filter.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/filter.component.html
@@ -17,10 +17,20 @@
     }
   </div>
   <div class="up-down-buttons">
-    <button (click)="emitPrevMatched()" matTooltip="Previous match" aria-label="Previous match">
+    <button
+      id="up-button"
+      (click)="emitPrevMatched()"
+      matTooltip="Previous match"
+      aria-label="Previous match"
+    >
       <mat-icon class="mat-icon-rtl-mirror"> expand_less </mat-icon>
     </button>
-    <button (click)="emitNextMatched()" matTooltip="Next match" aria-label="Next match">
+    <button
+      id="down-button"
+      (click)="emitNextMatched()"
+      matTooltip="Next match"
+      aria-label="Next match"
+    >
       <mat-icon class=""> expand_more </mat-icon>
     </button>
   </div>

--- a/devtools/src/app/app.component.ts
+++ b/devtools/src/app/app.component.ts
@@ -18,3 +18,29 @@ import {Router, RouterOutlet} from '@angular/router';
 export class AppComponent {
   readonly router = inject(Router);
 }
+
+@Component({
+  selector: 'empty-component',
+  template: ``,
+})
+export class EmptyComponent {
+  // This component is just for demonstration purposes.
+  // used to test Angular DevTools traversal logic when multiple applications are present.
+}
+
+@Component({
+  selector: 'other-app',
+  template: `
+    @defer  {
+        <empty-component/>
+    }
+    @placeholder (minimum 2s) {
+        <b>Stuff will be loaded here</b>
+    }
+  `,
+  imports: [EmptyComponent],
+})
+export class OtherAppComponent {
+  // This component is just for demonstration purposes.
+  // used to test Angular DevTools traversal logic when multiple applications are present.
+}

--- a/devtools/src/app/demo-app/demo-app.component.html
+++ b/devtools/src/app/demo-app/demo-app.component.html
@@ -1,6 +1,10 @@
 <router-outlet></router-outlet>
 <app-zippy [title]="getTitle()">This is my content</app-zippy>
-<app-heavy></app-heavy>
+@defer {
+  <app-heavy></app-heavy>
+} @placeholder (minimum 5s) {
+  <b>Stuff will be loaded here</b>
+}
 <div #elementReference>HTMLElement</div>
 <div *appStructural>Test Structural Directive</div>
 <app-sample-properties></app-sample-properties>

--- a/devtools/src/app/demo-app/todo/home/todos.component.html
+++ b/devtools/src/app/demo-app/todo/home/todos.component.html
@@ -1,6 +1,4 @@
 <a [routerLink]="">Home</a>
-<a [routerLink]="">Home</a>
-<a [routerLink]="">Home</a>
 <p>{{ 'Sample text processed by a pipe' | sample }}</p>
 <section class="todoapp">
   <header class="header">

--- a/devtools/src/index.html
+++ b/devtools/src/index.html
@@ -16,6 +16,7 @@
   <body>
     <div>
       <app-root></app-root>
+      <other-app></other-app>
     </div>
 
     <script type="module" src="./bundle/main.js"></script>

--- a/devtools/src/main.ts
+++ b/devtools/src/main.ts
@@ -7,7 +7,11 @@
  */
 
 import {bootstrapApplication} from '@angular/platform-browser';
-import {AppComponent} from './app/app.component';
+import {AppComponent, OtherAppComponent} from './app/app.component';
 import {appConfig} from './app/app.config';
+import {provideZonelessChangeDetection} from '@angular/core';
 
 bootstrapApplication(AppComponent, appConfig).catch((err) => console.error(err));
+bootstrapApplication(OtherAppComponent, {
+  providers: [provideZonelessChangeDetection()],
+}).catch((err) => console.error(err));


### PR DESCRIPTION
Previously, Angular devtools would mistakenly traverse the same DOM elements multiple times while doing traversal for the component tree explorer. This error case would occur when more than 1 Angular application root component was present on the same page and in distinct DOM branches.

An example of where it would enter the irregular behaviour (previous state)

```html
<app-root>
...
</app-root>
<other-app>
...
</other-app>
```
<img width="909" height="83" alt="Screenshot 2025-07-20 at 2 03 12 AM" src="https://github.com/user-attachments/assets/3ee17d9d-d393-4333-97b4-ab05b57412c0" />


Now, we properly ignore duplicate DOM paths when looking for application and non-application root component to begin the Angular DevTools component discovery logic.

<img width="904" height="44" alt="Screenshot 2025-07-20 at 2 04 45 AM" src="https://github.com/user-attachments/assets/d0508eda-28b1-4bdf-bd2b-5523e4dc5ab9" />

