### PR TITLE
feat(service-worker): Adds support for updateViaCache in provideServi…

### DIFF
--- a/goldens/public-api/service-worker/index.api.md
+++ b/goldens/public-api/service-worker/index.api.md
@@ -72,6 +72,7 @@ export abstract class SwRegistrationOptions {
     enabled?: boolean;
     registrationStrategy?: string | (() => Observable<unknown>);
     scope?: string;
+    updateViaCache?: ServiceWorkerUpdateViaCache;
 }
 
 // @public

--- a/packages/service-worker/src/provider.ts
+++ b/packages/service-worker/src/provider.ts
@@ -101,7 +101,7 @@ export function ngswAppInitializer(): void {
       }
 
       navigator.serviceWorker
-        .register(script, {scope: options.scope})
+        .register(script, {scope: options.scope, updateViaCache: options.updateViaCache})
         .catch((err) =>
           console.error(
             formatRuntimeError(
@@ -151,6 +151,13 @@ export abstract class SwRegistrationOptions {
    * Default: true
    */
   enabled?: boolean;
+
+  /**
+   * The value of the setting used to determine the circumstances in which the browser
+   * will consult the HTTP cache when it tries to update the service worker or any scripts that are imported via importScripts().
+   * [ServiceWorkerRegistration.updateViaCache](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration/updateViaCache)
+   */
+  updateViaCache?: ServiceWorkerUpdateViaCache;
 
   /**
    * A URL that defines the ServiceWorker's registration scope; that is, what range of URLs it can

--- a/packages/service-worker/test/provider_spec.ts
+++ b/packages/service-worker/test/provider_spec.ts
@@ -67,10 +67,14 @@ async function waitForReadyToRegister() {
       };
 
       it('sets the registration options', async () => {
-        await configTestBed({enabled: true, scope: 'foo'});
+        await configTestBed({enabled: true, scope: 'foo', updateViaCache: 'all'});
 
-        expect(TestBed.inject(SwRegistrationOptions)).toEqual({enabled: true, scope: 'foo'});
-        expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: 'foo'});
+        expect(TestBed.inject(SwRegistrationOptions)).toEqual({
+          enabled: true,
+          scope: 'foo',
+          updateViaCache: 'all',
+        });
+        expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: 'foo', updateViaCache: 'all'});
       });
 
       it('can disable the SW', async () => {
@@ -84,14 +88,27 @@ async function waitForReadyToRegister() {
         await configTestBed({enabled: true});
 
         expect(TestBed.inject(SwUpdate).isEnabled).toBe(true);
-        expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+        expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
+          scope: undefined,
+        });
+      });
+
+      it('can set updateViaCache', async () => {
+        await configTestBed({enabled: true, updateViaCache: 'imports'});
+
+        expect(TestBed.inject(SwUpdate).isEnabled).toBe(true);
+        expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
+          updateViaCache: 'imports',
+        });
       });
 
       it('defaults to enabling the SW', async () => {
         await configTestBed({});
 
         expect(TestBed.inject(SwUpdate).isEnabled).toBe(true);
-        expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+        expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
+          scope: undefined,
+        });
       });
 
       it('catches and logs registration errors', async () => {
@@ -113,14 +130,19 @@ async function waitForReadyToRegister() {
         if (apiFnName === provideServiceWorkerApi) {
           TestBed.configureTestingModule({
             providers: [
-              provideServiceWorker('sw.js', staticOpts || {scope: 'static'}),
+              provideServiceWorker('sw.js', staticOpts || {scope: 'static', updateViaCache: 'all'}),
               {provide: PLATFORM_ID, useValue: 'browser'},
               {provide: SwRegistrationOptions, useFactory: () => providerOpts},
             ],
           });
         } else {
           TestBed.configureTestingModule({
-            imports: [ServiceWorkerModule.register('sw.js', staticOpts || {scope: 'static'})],
+            imports: [
+              ServiceWorkerModule.register(
+                'sw.js',
+                staticOpts || {scope: 'static', updateViaCache: 'all'},
+              ),
+            ],
             providers: [
               {provide: PLATFORM_ID, useValue: 'browser'},
               {provide: SwRegistrationOptions, useFactory: () => providerOpts},
@@ -130,11 +152,18 @@ async function waitForReadyToRegister() {
       };
 
       it('sets the registration options (and overwrites those set via `provideServiceWorker()`', async () => {
-        configTestBed({enabled: true, scope: 'provider'});
+        configTestBed({enabled: true, scope: 'provider', updateViaCache: 'imports'});
         await untilStable();
-        expect(TestBed.inject(SwRegistrationOptions)).toEqual({enabled: true, scope: 'provider'});
+        expect(TestBed.inject(SwRegistrationOptions)).toEqual({
+          enabled: true,
+          scope: 'provider',
+          updateViaCache: 'imports',
+        });
         await waitForReadyToRegister();
-        expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: 'provider'});
+        expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
+          scope: 'provider',
+          updateViaCache: 'imports',
+        });
       });
 
       it('can disable the SW', async () => {

--- a/packages/service-worker/test/provider_spec.ts
+++ b/packages/service-worker/test/provider_spec.ts
@@ -90,6 +90,7 @@ async function waitForReadyToRegister() {
         expect(TestBed.inject(SwUpdate).isEnabled).toBe(true);
         expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
           scope: undefined,
+          updateViaCache: undefined,
         });
       });
 
@@ -98,6 +99,7 @@ async function waitForReadyToRegister() {
 
         expect(TestBed.inject(SwUpdate).isEnabled).toBe(true);
         expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
+          scope: undefined,
           updateViaCache: 'imports',
         });
       });
@@ -108,6 +110,7 @@ async function waitForReadyToRegister() {
         expect(TestBed.inject(SwUpdate).isEnabled).toBe(true);
         expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
           scope: undefined,
+          updateViaCache: undefined,
         });
       });
 
@@ -180,7 +183,10 @@ async function waitForReadyToRegister() {
 
         expect(TestBed.inject(SwUpdate).isEnabled).toBe(true);
         await waitForReadyToRegister();
-        expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+        expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
+          scope: undefined,
+          updateViaCache: undefined,
+        });
       });
 
       it('defaults to enabling the SW', async () => {
@@ -189,7 +195,10 @@ async function waitForReadyToRegister() {
 
         expect(TestBed.inject(SwUpdate).isEnabled).toBe(true);
         await waitForReadyToRegister();
-        expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+        expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
+          scope: undefined,
+          updateViaCache: undefined,
+        });
       });
 
       describe('registrationStrategy', () => {
@@ -259,14 +268,20 @@ async function waitForReadyToRegister() {
           isStableSub.next(true);
 
           tick();
-          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
+            scope: undefined,
+            updateViaCache: undefined,
+          });
         }));
 
         it('defaults to registering the SW after 30s if the app does not stabilize sooner', fakeAsync(() => {
           configTestBedWithMockedStability();
           expect(swRegisterSpy).not.toHaveBeenCalled();
           tick(30000);
-          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
+            scope: undefined,
+            updateViaCache: undefined,
+          });
         }));
 
         it('registers the SW when the app stabilizes with `registerWhenStable:<timeout>`', fakeAsync(() => {
@@ -280,14 +295,20 @@ async function waitForReadyToRegister() {
           isStableSub.next(true);
 
           tick();
-          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
+            scope: undefined,
+            updateViaCache: undefined,
+          });
         }));
 
         it('registers the SW after `timeout` if the app does not stabilize with `registerWhenStable:<timeout>`', fakeAsync(() => {
           configTestBedWithMockedStability('registerWhenStable:1000');
           expect(swRegisterSpy).not.toHaveBeenCalled();
           tick(1000);
-          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
+            scope: undefined,
+            updateViaCache: undefined,
+          });
         }));
 
         it('registers the SW asap (asynchronously) before the app stabilizes with `registerWhenStable:0`', fakeAsync(() => {
@@ -299,7 +320,10 @@ async function waitForReadyToRegister() {
           expect(swRegisterSpy).not.toHaveBeenCalled();
 
           tick(0);
-          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
+            scope: undefined,
+            updateViaCache: undefined,
+          });
         }));
 
         it('registers the SW only when the app stabilizes with `registerWhenStable:`', fakeAsync(() => {
@@ -313,7 +337,10 @@ async function waitForReadyToRegister() {
           isStableSub.next(true);
 
           tick();
-          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
+            scope: undefined,
+            updateViaCache: undefined,
+          });
         }));
 
         it('registers the SW only when the app stabilizes with `registerWhenStable`', fakeAsync(() => {
@@ -327,13 +354,19 @@ async function waitForReadyToRegister() {
           isStableSub.next(true);
 
           tick();
-          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
+            scope: undefined,
+            updateViaCache: undefined,
+          });
         }));
 
         it('registers the SW immediatelly (synchronously) with `registerImmediately`', async () => {
           configTestBedWithMockedStability('registerImmediately');
           await waitForReadyToRegister();
-          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
+            scope: undefined,
+            updateViaCache: undefined,
+          });
         });
 
         it('registers the SW after the specified delay with `registerWithDelay:<delay>`', fakeAsync(() => {
@@ -345,7 +378,10 @@ async function waitForReadyToRegister() {
           expect(swRegisterSpy).not.toHaveBeenCalled();
 
           tick(100000);
-          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
+            scope: undefined,
+            updateViaCache: undefined,
+          });
         }));
 
         it('registers the SW asap (asynchronously) with `registerWithDelay:`', fakeAsync(() => {
@@ -358,7 +394,10 @@ async function waitForReadyToRegister() {
           expect(swRegisterSpy).not.toHaveBeenCalled();
 
           tick(0);
-          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
+            scope: undefined,
+            updateViaCache: undefined,
+          });
         }));
 
         it('registers the SW asap (asynchronously) with `registerWithDelay`', fakeAsync(() => {
@@ -371,7 +410,10 @@ async function waitForReadyToRegister() {
           expect(swRegisterSpy).not.toHaveBeenCalled();
 
           tick(0);
-          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
+            scope: undefined,
+            updateViaCache: undefined,
+          });
         }));
 
         it('registers the SW on first emitted value with observable factory function', fakeAsync(() => {
@@ -384,7 +426,10 @@ async function waitForReadyToRegister() {
 
           registerSub.next();
           tick();
-          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
+            scope: undefined,
+            updateViaCache: undefined,
+          });
         }));
 
         it('throws an error with unknown strategy', () => {


### PR DESCRIPTION
This commit adds support for the `updateViaCache` option when configuring Angular Service Workers.

## The change includes:

- Added `updateViaCache` to `SwRegistrationOptions` interface
- Modified service worker registration to pass the `updateViaCache` option
- Added comprehensive unit tests to verify the new functionality
- Updated existing tests to include the new option

## Motivation/Use Cases

The `updateViaCache` option is particularly useful for:

- **Fine-grained cache control**: Determining when the browser consults the HTTP cache during service worker updates
- **Performance optimization**: Controlling caching behavior for service worker scripts and imported scripts
- **Development workflows**: Better control over service worker update mechanisms during development and production
- **Compliance with PWA best practices**: Aligning with modern service worker registration standards

## Proposed Solution

- Add `updateViaCache` property to the `SwRegistrationOptions` abstract class
- Implement property handling in the service worker registration logic
- Pass the option through to the native `navigator.serviceWorker.register()` API
- Maintain full backward compatibility with existing configurations

## Examples of New Usage

### Basic configuration with provideServiceWorker

```typescript
export const appConfig: ApplicationConfig = {
  providers: [
    provideServiceWorker('ngsw-worker.js', {
      enabled: !isDevMode(),
      updateViaCache: 'imports',
      registrationStrategy: 'registerWhenStable:30000',
    }),
  ],
};