### PR TITLE
refactor(core): add a `getTransferState` for the devtools

### DIFF
--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -272,6 +272,7 @@ export {
   FrameworkAgnosticGlobalUtils as ɵFrameworkAgnosticGlobalUtils,
   GlobalDevModeUtils as ɵGlobalDevModeUtils,
 } from './render3/util/global_utils';
+export {getTransferState as ɵgetTransferState} from './render3/util/transfer_state_utils';
 export {
   ViewRef as ɵViewRef,
   isViewDirty as ɵisViewDirty,

--- a/packages/core/src/hydration/utils.ts
+++ b/packages/core/src/hydration/utils.ts
@@ -69,6 +69,13 @@ export const NGH_DEFER_BLOCKS_KEY: StateKey<{[key: string]: SerializedDeferBlock
 }>(TRANSFER_STATE_DEFER_BLOCKS_INFO);
 
 /**
+ * Checks whether a given key is used by the framework for transferring hydration data.
+ */
+export function isInternalHydrationTransferStateKey(key: string): boolean {
+  return key === TRANSFER_STATE_TOKEN_ID || key === TRANSFER_STATE_DEFER_BLOCKS_INFO;
+}
+
+/**
  * The name of the attribute that would be added to host component
  * nodes and contain a reference to a particular slot in transferred
  * state that contains the necessary hydration info for this component.

--- a/packages/core/src/render3/util/transfer_state_utils.ts
+++ b/packages/core/src/render3/util/transfer_state_utils.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {getDocument} from '../interfaces/document';
+import {Injector} from '../../di';
+import {isInternalHydrationTransferStateKey} from '../../hydration/utils';
+import {APP_ID} from '../../application/application_tokens';
+import {retrieveTransferredState} from '../../transfer_state';
+
+/**
+ * Retrieves transfer state data from the DOM using the provided injector to get APP_ID.
+ * This approach works by getting the APP_ID from the injector and then finding the
+ * corresponding transfer state script tag. Internal framework keys used for hydration
+ * are stripped from the result.
+ *
+ * @param injector - The injector to use for getting APP_ID
+ * @returns The transfer state data as an object, or empty object if not available
+ */
+export function getTransferState(injector: Injector): Record<string, unknown> {
+  const doc = getDocument();
+  const appId = injector.get(APP_ID);
+
+  const transferState = retrieveTransferredState(doc, appId);
+
+  // Strip internal keys
+  const filteredEntries: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(transferState)) {
+    if (!isInternalHydrationTransferStateKey(key)) {
+      filteredEntries[key] = value;
+    }
+  }
+
+  return filteredEntries;
+}

--- a/packages/core/src/transfer_state.ts
+++ b/packages/core/src/transfer_state.ts
@@ -148,7 +148,7 @@ export class TransferState {
   }
 }
 
-function retrieveTransferredState(
+export function retrieveTransferredState(
   doc: Document,
   appId: string,
 ): Record<string, unknown | undefined> {

--- a/packages/platform-server/test/hydration_utils.ts
+++ b/packages/platform-server/test/hydration_utils.ts
@@ -202,7 +202,7 @@ export function timeout(delay: number): Promise<void> {
 }
 
 export function getHydrationInfoFromTransferState(input: string): string | undefined {
-  return input.match(/<script[^>]+>(.*?)<\/script>/)?.[1];
+  return input.match(/<script.*application\/json[^>]+>(.*?)<\/script>/)?.[1];
 }
 
 export function withNoopErrorHandler() {


### PR DESCRIPTION
`getTransferState` will expose public data from the transfer state. It will for example remove internal hydration data.
