### PR TITLE
test(devtools): bump cypress timeout to 10 seconds

### DIFF
--- a/devtools/cypress/cypress.config.js
+++ b/devtools/cypress/cypress.config.js
@@ -7,6 +7,7 @@
  */
 
 module.exports = {
+  defaultCommandTimeout: 10000, // Increase the default command timeout to 10 seconds
   e2e: {
     specPattern: 'integration/*.e2e.js',
     supportFile: 'support/index.js',


### PR DESCRIPTION
By default this is 4 seconds. In CI we have unreliable runtime performance so we this change gives us a bit of wiggle room to validate application behaviour.
