### PR TITLE
fix(devtools): stop reseting currentlyMatchedIndex when a node is selected in the component explorer

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.ts
@@ -165,7 +165,6 @@ export class DirectiveForestComponent {
     this.populateParents(node.position);
     this.selectNode.emit(node.original);
     this.selectedNode.set(node);
-    this.currentlyMatchedIndex.set(-1);
   }
 
   clearSelectedNode(): void {


### PR DESCRIPTION
This was causing some unintended behaviour when paired with our new zoneless configuration. I'm not sure why currentlyMatchedIndex was getting set to -1 here. With this removed it seems like things are working as expected. Previously a select call would reset this index *after* a search filter was applied, which would cause weird behaviour with the "next" and "prev" buttons.
