### PR TITLE
fix(compiler): allow more characters in square-bracketed attribute names

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/class_bindings/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/class_bindings/GOLDEN_PARTIAL.js
@@ -272,3 +272,72 @@ export declare class MyComponent {
     static ɵcmp: i0.ɵɵComponentDeclaration<MyComponent, "my-component", never, {}, {}, never, never, true, never>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: class_binding_special_chars.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyComponent {
+    constructor() {
+        this.expr = true;
+    }
+}
+MyComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
+    <div [class.text-primary/80]="expr"
+      [class.data-active:text-green-300/80]="expr"
+      [class.data-[size='large']:p-8]="expr"></div>`, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <div [class.text-primary/80]="expr"
+      [class.data-active:text-green-300/80]="expr"
+      [class.data-[size='large']:p-8]="expr"></div>`,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: class_binding_special_chars.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyComponent {
+    expr: boolean;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyComponent, "ng-component", never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: host_class_binding_special_chars.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyComponent {
+    constructor() {
+        this.expr = true;
+    }
+}
+MyComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent, isStandalone: true, selector: "ng-component", host: { properties: { "class.text-primary/80": "expr", "class.data-active:text-green-300/80": "expr", "class.data-[size='large'": "expr" } }, ngImport: i0, template: ``, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, decorators: [{
+            type: Component,
+            args: [{
+                    template: ``,
+                    host: {
+                        '[class.text-primary/80]': 'expr',
+                        '[class.data-active:text-green-300/80]': 'expr',
+                        "[class.data-[size='large']:p-8]": 'expr',
+                    },
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: host_class_binding_special_chars.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyComponent {
+    expr: boolean;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyComponent, "ng-component", never, {}, {}, never, never, true, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/class_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/class_bindings/TEST_CASES.json
@@ -87,6 +87,34 @@
           "failureMessage": "Incorrect template"
         }
       ]
+    },
+    {
+      "description": "should handle bindings to classes with special characters in a template",
+      "inputFiles": [
+        "class_binding_special_chars.ts"
+      ],
+      "expectations": [
+        {
+          "failureMessage": "Incorrect template",
+          "files": [
+            "class_binding_special_chars.js"
+          ]
+        }
+      ]
+    },
+    {
+      "description": "should handle bindings to classes with special characters in a host context",
+      "inputFiles": [
+        "host_class_binding_special_chars.ts"
+      ],
+      "expectations": [
+        {
+          "failureMessage": "Incorrect template",
+          "files": [
+            "host_class_binding_special_chars.js"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/class_bindings/class_binding_special_chars.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/class_bindings/class_binding_special_chars.js
@@ -1,0 +1,14 @@
+$r3$.ɵɵdefineComponent({
+  …
+  decls: 1,
+  vars: 6,
+  template: function MyComponent_Template(rf, ctx) {
+    if (rf & 1) {
+      $r3$.ɵɵdomElement(0, "div");
+    }
+    if (rf & 2) {
+      $r3$.ɵɵclassProp("text-primary/80", ctx.expr)("data-active:text-green-300/80", ctx.expr)("data-[size='large']:p-8", ctx.expr);
+    }
+  },
+  …
+});

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/class_bindings/class_binding_special_chars.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/class_bindings/class_binding_special_chars.ts
@@ -1,0 +1,11 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    <div [class.text-primary/80]="expr"
+      [class.data-active:text-green-300/80]="expr"
+      [class.data-[size='large']:p-8]="expr"></div>`,
+})
+export class MyComponent {
+  expr = true;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/class_bindings/host_class_binding_special_chars.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/class_bindings/host_class_binding_special_chars.js
@@ -1,0 +1,10 @@
+$r3$.ɵɵdefineComponent({
+  …
+  hostVars: 6,
+  hostBindings: function MyComponent_HostBindings(rf, ctx) {
+    if (rf & 2) {
+      $r3$.ɵɵclassProp("text-primary/80", ctx.expr)("data-active:text-green-300/80", ctx.expr)("data-[size='large'", ctx.expr);
+    }
+  },
+  …
+});

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/class_bindings/host_class_binding_special_chars.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/class_bindings/host_class_binding_special_chars.ts
@@ -1,0 +1,13 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: ``,
+  host: {
+    '[class.text-primary/80]': 'expr',
+    '[class.data-active:text-green-300/80]': 'expr',
+    "[class.data-[size='large']:p-8]": 'expr',
+  },
+})
+export class MyComponent {
+  expr = true;
+}

--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -962,6 +962,22 @@ class _Tokenizer {
         }
         return isNameEnd(code);
       };
+    } else if (attrNameStart === chars.$LBRACKET) {
+      let openBrackets = 0;
+
+      // Be more permissive for which characters are allowed inside square-bracketed attributes,
+      // because they usually end up being bound as attribute values. Some third-party packages
+      // like Tailwind take advantage of this.
+      nameEndPredicate = (code: number) => {
+        if (code === chars.$LBRACKET) {
+          openBrackets++;
+        } else if (code === chars.$RBRACKET) {
+          openBrackets--;
+        }
+        // Only check for name-ending characters if the brackets are balanced or mismatched.
+        // Also interrupt the matching on new lines.
+        return openBrackets <= 0 ? isNameEnd(code) : chars.isNewLine(code);
+      };
     } else {
       nameEndPredicate = isNameEnd;
     }

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -502,6 +502,25 @@ describe('HtmlParser', () => {
           ]);
         });
       });
+
+      it('should parse square-bracketed attributes more permissively', () => {
+        expect(
+          humanizeDom(
+            parser.parse(
+              `<foo [class.text-primary/80]="expr" ` +
+                `[class.data-active:text-green-300/80]="expr2" ` +
+                `[class.data-[size='large']:p-8] = "expr3" some-attr/>`,
+              'TestComp',
+            ),
+          ),
+        ).toEqual([
+          [html.Element, 'foo', 0, '#selfClosing'],
+          [html.Attribute, '[class.text-primary/80]', 'expr', ['expr']],
+          [html.Attribute, '[class.data-active:text-green-300/80]', 'expr2', ['expr2']],
+          [html.Attribute, "[class.data-[size='large']:p-8]", 'expr3', ['expr3']],
+          [html.Attribute, 'some-attr', ''],
+        ]);
+      });
     });
 
     describe('comments', () => {

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -375,6 +375,20 @@ describe('R3 template transform', () => {
         ['BoundAttribute', BindingType.Style, 'someStyle', 'v'],
       ]);
     });
+
+    it('should parse class bindings with various characters', () => {
+      expectFromHtml(
+        `<foo [class.text-primary/80]="expr" ` +
+          `[class.data-active:text-green-300/80]="expr2" ` +
+          `[class.data-[size='large']:p-8] = "expr3" some-attr/>`,
+      ).toEqual([
+        ['Element', 'foo', '#selfClosing'],
+        ['TextAttribute', 'some-attr', ''],
+        ['BoundAttribute', BindingType.Class, 'text-primary/80', 'expr'],
+        ['BoundAttribute', BindingType.Class, 'data-active:text-green-300/80', 'expr2'],
+        ['BoundAttribute', BindingType.Class, `data-[size='large']:p-8`, 'expr3'],
+      ]);
+    });
   });
 
   describe('animation bindings', () => {

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -3971,6 +3971,56 @@ describe('styling', () => {
     expect(getComputedStyle(span).getPropertyValue('font-size')).toBe('10px');
   });
 
+  it('should class bindings to classes with special characters in a template', () => {
+    const className = `data-active:text-green-300/80`;
+
+    @Component({template: `<div [class.${className}]="value"></div>`})
+    class Cmp {
+      value = false;
+    }
+
+    const fixture = TestBed.createComponent(Cmp);
+    fixture.detectChanges();
+
+    const div = fixture.nativeElement.querySelector('div');
+    expect(div.classList).not.toContain(className);
+
+    fixture.componentInstance.value = true;
+    fixture.detectChanges();
+    expect(div.classList).toContain(className);
+
+    fixture.componentInstance.value = false;
+    fixture.detectChanges();
+    expect(div.classList).not.toContain(className);
+  });
+
+  it('should class bindings to classes with special characters in a host binding', () => {
+    const className = `data-active:text-green-300/80`;
+
+    @Component({
+      template: ``,
+      host: {
+        [`[class.${className}]`]: 'value',
+      },
+    })
+    class Cmp {
+      value = false;
+    }
+
+    const fixture = TestBed.createComponent(Cmp);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.classList).not.toContain(className);
+
+    fixture.componentInstance.value = true;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.classList).toContain(className);
+
+    fixture.componentInstance.value = false;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.classList).not.toContain(className);
+  });
+
   describe('regression', () => {
     it('should support sanitizer value in the [style] bindings', () => {
       @Component({


### PR DESCRIPTION
Currently the HTML parser will stop parsing as soon as it hits an end character in the name of an attribute (e.g. `/` or `>`). This ends up being problematic with some third-party packages like Tailwind which uses a wider range of characters for its class names. While the characters are fine when inside the `class` attribute, our current parser behavior prevents users from setting those classes conditionally through `[class.]` bindings.

These changes adjust the parser to handle such cases.

Fixes #61671.
