### PR TITLE
docs: add MCP server setup instructions

### DIFF
--- a/adev/src/app/sub-navigation-data.ts
+++ b/adev/src/app/sub-navigation-data.ts
@@ -643,6 +643,11 @@ const DOCS_SUB_NAVIGATION_DATA: NavigationItem[] = [
         path: 'ai/develop-with-ai',
         contentPath: 'ai/develop-with-ai',
       },
+      {
+        label: 'Angular CLI MCP Server setup',
+        path: 'ai/mcp',
+        contentPath: 'ai/mcp-server-setup',
+      },
     ],
   },
   {

--- a/adev/src/content/ai/develop-with-ai.md
+++ b/adev/src/content/ai/develop-with-ai.md
@@ -26,6 +26,11 @@ Several editors, such as <a href="https://studio.firebase.google.com?utm_source=
 | VS Code | <a download=".instructions.md" href="/assets/context/guidelines.md" target="_blank">.instructions.md</a>  | <a href="https://code.visualstudio.com/docs/copilot/copilot-customization#_custom-instructions" target="_blank">Configure `.instructions.md`</a> |
 | Windsurf | <a download href="/assets/context/guidelines.md" target="_blank">guidelines.md</a>  | <a href="https://docs.windsurf.com/windsurf/cascade/memories#rules" target="_blank">Configure `guidelines.md`</a> |
 
+## Angular CLI MCP Server setup
+The Angular CLI includes an experimental [Model Context Protocol (MCP) server](https://modelcontextprotocol.io/) that allows AI assistants in your development environment to interact with the Angular CLI.
+
+[**Learn how to set up the Angular CLI MCP Server**](/ai/mcp)
+
 ## Providing Context with `llms.txt`
 `llms.txt` is a proposed standard for websites designed to help LLMs better understand and process their content. The Angular team has developed two versions of this file to help LLMs and tools that use LLMs for code generation to create better modern Angular code.
 

--- a/adev/src/content/ai/mcp-server-setup.md
+++ b/adev/src/content/ai/mcp-server-setup.md
@@ -1,0 +1,67 @@
+# Angular CLI MCP Server setup
+The Angular CLI includes an experimental [Model Context Protocol (MCP) server](https://modelcontextprotocol.io/) enabling AI assistants in your development environment to interact with the Angular CLI. We've included support for CLI powered code generation, adding packages, and more.
+
+To get started, run the following command in your terminal:
+
+```bash
+ng mcp
+```
+
+Use this command to create the base JSON configuration for your environment. Note that the file structure differs depending on your IDE. The following sections provide the configurations for several popular editors.
+
+### VS Code
+In your project's root, create a file named `.vscode/mcp.json` and add the following configuration. Note the use of the `servers` property.
+
+```json
+{
+  "servers": {
+    "angular-cli": {
+      "command": "npx",
+      "args": ["@angular/cli", "mcp"]
+    }
+  }
+}
+```
+
+### JetBrains IDEs
+In JetBrains IDEs (like IntelliJ IDEA or WebStorm), after installing the MCP Server plugin, go to `Settings | Tools | AI Assistant | Model Context Protocol (MCP)`. Add a new server and select `As JSON`. Paste the following configuration, which does not use a top-level property for the server list.
+
+```json
+{
+  "name": "Angular CLI",
+  "command": "npx",
+  "args": [
+    "@angular/cli",
+    "mcp"
+  ]
+}
+```
+
+### Firebase Studio
+Create a file named `.idx/mcp.json` in your project's root and add the following configuration:
+```json
+{
+  "mcpServers": {
+    "angular-cli": {
+      "command": "npx",
+      "args": ["@angular/cli", "mcp"]
+    }
+  }
+}
+```
+
+### Other IDEs
+For these IDEs, create a configuration file and add the following snippet. Note the use of the `mcpServers` property.
+*   **Cursor:** Create a file named `.cursor/mcp.json` in your project's root. You can also configure it globally in `~/.cursor/mcp.json`.
+*   **Other IDEs:** Check your IDE's documentation for the proper location of the MCP configuration file (often `mcp.json`).
+
+```json
+{
+  "mcpServers": {
+    "angular-cli": {
+      "command": "npx",
+      "args": ["@angular/cli", "mcp"]
+    }
+  }
+}
+```


### PR DESCRIPTION
Adds a new section to the "Develop with AI" documentation page that details how to configure the Angular CLI's Model Context Protocol (MCP) server.

This section includes:
- Instructions on how to use the command.
- IDE-specific JSON configurations for VS Code, JetBrains, Firebase Studio, and Cursor.
- Clarification on the different JSON structures required by each IDE.