### PR TITLE
feat(signal-forms): add support for resetting forms

### DIFF
--- a/packages/forms/experimental/src/api/types.ts
+++ b/packages/forms/experimental/src/api/types.ts
@@ -193,6 +193,14 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
    * Sets the dirty status of the field to `true`.
    */
   markAsDirty(): void;
+
+  /**
+   * Resets the {@link touched} and {@link dirty} state of the field and its descendants.
+   *
+   * Note this does not change the data model, which can be reset directly if desired.
+   */
+  reset(): void;
+
   /**
    * Resets the `submittedStatus` of the field and all descendant fields to unsubmitted.
    */

--- a/packages/forms/experimental/src/field/node.ts
+++ b/packages/forms/experimental/src/field/node.ts
@@ -183,6 +183,20 @@ export class FieldNode implements FieldState<unknown> {
     this.nodeState.selfDirty.set(true);
   }
 
+  /**
+   * Resets the {@link touched} and {@link dirty} state of the field and its descendants.
+   *
+   * Note this does not change the data model, which can be reset directly if desired.
+   */
+  reset(): void {
+    this.nodeState.selfTouched.set(false);
+    this.nodeState.selfDirty.set(false);
+
+    for (const child of this.structure.children()) {
+      child.reset();
+    }
+  }
+
   static newRoot<T>(
     formRoot: FormFieldManager,
     value: WritableSignal<T>,

--- a/packages/forms/experimental/test/node/field_node.spec.ts
+++ b/packages/forms/experimental/test/node/field_node.spec.ts
@@ -38,18 +38,6 @@ interface TreeData {
 const noopSchema: SchemaOrSchemaFn<unknown> = () => {};
 
 describe('FieldNode', () => {
-  it('is untouched initially', () => {
-    const f = form(
-      signal({
-        a: 1,
-        b: 2,
-      }),
-      noopSchema,
-      {injector: TestBed.inject(Injector)},
-    );
-    expect(f().touched()).toBe(false);
-  });
-
   it('can get a child of a key that exists', () => {
     const f = form(
       signal({
@@ -153,6 +141,16 @@ describe('FieldNode', () => {
 
       f().markAsDirty();
       expect(f().dirty()).toBe(true);
+    });
+
+    it('can be reset', () => {
+      const model = signal({a: 1, b: 2});
+      const f = form(model, noopSchema, {injector: TestBed.inject(Injector)});
+      f().markAsDirty();
+      expect(f().dirty()).toBe(true);
+
+      f().reset();
+      expect(f().dirty()).toBe(false);
     });
 
     it('propagates from the children', () => {
@@ -268,6 +266,16 @@ describe('FieldNode', () => {
       value.set({a: 2});
       expect(f().touched()).toBe(false);
       expect(f.b).toBeUndefined();
+    });
+
+    it('can be reset', () => {
+      const model = signal({a: 1, b: 2});
+      const f = form(model, noopSchema, {injector: TestBed.inject(Injector)});
+      f().markAsTouched();
+      expect(f().touched()).toBe(true);
+
+      f().reset();
+      expect(f().touched()).toBe(false);
     });
   });
 
@@ -1112,6 +1120,23 @@ describe('FieldNode', () => {
 
       data.set({tag: 'table', children: [{tag: 'tr', children: [{tag: 'td', children: []}]}]});
       expect(f().valid()).toBe(true);
+    });
+  });
+
+  describe('reset', () => {
+    it('should propagate to descendants', () => {
+      const model = signal({a: {b: 2}});
+      const f = form(model, noopSchema, {injector: TestBed.inject(Injector)});
+
+      f.a.b().markAsDirty();
+      expect(f().dirty()).toBe(true);
+      expect(f.a().dirty()).toBe(true);
+      expect(f.a.b().dirty()).toBe(true);
+
+      f().reset();
+      expect(f().dirty()).toBe(false);
+      expect(f.a().dirty()).toBe(false);
+      expect(f.a.b().dirty()).toBe(false);
     });
   });
 });

--- a/packages/forms/experimental/test/node/field_node.spec.ts
+++ b/packages/forms/experimental/test/node/field_node.spec.ts
@@ -145,7 +145,7 @@ describe('FieldNode', () => {
 
     it('can be reset', () => {
       const model = signal({a: 1, b: 2});
-      const f = form(model, noopSchema, {injector: TestBed.inject(Injector)});
+      const f = form(model, {injector: TestBed.inject(Injector)});
       f().markAsDirty();
       expect(f().dirty()).toBe(true);
 
@@ -270,7 +270,7 @@ describe('FieldNode', () => {
 
     it('can be reset', () => {
       const model = signal({a: 1, b: 2});
-      const f = form(model, noopSchema, {injector: TestBed.inject(Injector)});
+      const f = form(model, {injector: TestBed.inject(Injector)});
       f().markAsTouched();
       expect(f().touched()).toBe(true);
 
@@ -1126,7 +1126,7 @@ describe('FieldNode', () => {
   describe('reset', () => {
     it('should propagate to descendants', () => {
       const model = signal({a: {b: 2}});
-      const f = form(model, noopSchema, {injector: TestBed.inject(Injector)});
+      const f = form(model, {injector: TestBed.inject(Injector)});
 
       f.a.b().markAsDirty();
       expect(f().dirty()).toBe(true);

--- a/packages/forms/experimental/test/node/field_node.spec.ts
+++ b/packages/forms/experimental/test/node/field_node.spec.ts
@@ -35,8 +35,6 @@ interface TreeData {
   next: TreeData;
 }
 
-const noopSchema: SchemaOrSchemaFn<unknown> = () => {};
-
 describe('FieldNode', () => {
   it('can get a child of a key that exists', () => {
     const f = form(
@@ -44,7 +42,6 @@ describe('FieldNode', () => {
         a: 1,
         b: 2,
       }),
-      noopSchema,
       {injector: TestBed.inject(Injector)},
     );
     expect(f.a).toBeDefined();
@@ -58,7 +55,6 @@ describe('FieldNode', () => {
           a: 1,
           b: 2,
         }),
-        noopSchema,
         {injector: TestBed.inject(Injector)},
       );
       const child = f.a;
@@ -67,7 +63,7 @@ describe('FieldNode', () => {
 
     it('should get the same instance when asking for a child multiple times', () => {
       const value = signal<{a: number; b?: number}>({a: 1, b: 2});
-      const f = form(value, noopSchema, {injector: TestBed.inject(Injector)});
+      const f = form(value, {injector: TestBed.inject(Injector)});
       const child = f.a;
       value.set({a: 3});
       expect(f.a).toBe(child);
@@ -80,7 +76,6 @@ describe('FieldNode', () => {
         a: 1,
         b: 2,
       }),
-      noopSchema,
       {
         injector: TestBed.inject(Injector),
       },
@@ -94,7 +89,6 @@ describe('FieldNode', () => {
         a: 1,
         b: 2,
       }),
-      noopSchema,
       {injector: TestBed.inject(Injector)},
     );
     const childA = computed(() => f.a);
@@ -107,7 +101,6 @@ describe('FieldNode', () => {
         a: 1,
         b: 2,
       }),
-      noopSchema,
       {injector: TestBed.inject(Injector)},
     );
     const childA = computed(() => f.a);
@@ -121,7 +114,6 @@ describe('FieldNode', () => {
           a: 1,
           b: 2,
         }),
-        noopSchema,
         {injector: TestBed.inject(Injector)},
       );
       expect(f().dirty()).toBe(false);
@@ -134,7 +126,6 @@ describe('FieldNode', () => {
           a: 1,
           b: 2,
         }),
-        noopSchema,
         {injector: TestBed.inject(Injector)},
       );
       expect(f().dirty()).toBe(false);
@@ -159,7 +150,6 @@ describe('FieldNode', () => {
           a: 1,
           b: 2,
         }),
-        noopSchema,
         {injector: TestBed.inject(Injector)},
       );
       expect(f().dirty()).toBe(false);
@@ -174,7 +164,6 @@ describe('FieldNode', () => {
           a: 1,
           b: 2,
         }),
-        noopSchema,
         {injector: TestBed.inject(Injector)},
       );
 
@@ -185,7 +174,7 @@ describe('FieldNode', () => {
 
     it('does not consider children that get removed', () => {
       const value = signal<{a: number; b?: number}>({a: 1, b: 2});
-      const f = form(value, noopSchema, {injector: TestBed.inject(Injector)});
+      const f = form(value, {injector: TestBed.inject(Injector)});
       expect(f().dirty()).toBe(false);
 
       f.b!().markAsDirty();
@@ -204,7 +193,6 @@ describe('FieldNode', () => {
           a: 1,
           b: 2,
         }),
-        noopSchema,
         {injector: TestBed.inject(Injector)},
       );
       expect(f().touched()).toBe(false);
@@ -216,7 +204,6 @@ describe('FieldNode', () => {
           a: 1,
           b: 2,
         }),
-        noopSchema,
         {injector: TestBed.inject(Injector)},
       );
       expect(f().touched()).toBe(false);
@@ -231,7 +218,6 @@ describe('FieldNode', () => {
           a: 1,
           b: 2,
         }),
-        noopSchema,
         {injector: TestBed.inject(Injector)},
       );
       expect(f().touched()).toBe(false);
@@ -246,7 +232,6 @@ describe('FieldNode', () => {
           a: 1,
           b: 2,
         }),
-        noopSchema,
         {injector: TestBed.inject(Injector)},
       );
 
@@ -257,7 +242,7 @@ describe('FieldNode', () => {
 
     it('does not consider children that get removed', () => {
       const value = signal<{a: number; b?: number}>({a: 1, b: 2});
-      const f = form(value, noopSchema, {injector: TestBed.inject(Injector)});
+      const f = form(value, {injector: TestBed.inject(Injector)});
       expect(f().touched()).toBe(false);
 
       f.b!().markAsTouched();
@@ -281,7 +266,7 @@ describe('FieldNode', () => {
 
   describe('arrays', () => {
     it('should only have child nodes for elements that exist', () => {
-      const f = form(signal([1, 2]), noopSchema, {injector: TestBed.inject(Injector)});
+      const f = form(signal([1, 2]), {injector: TestBed.inject(Injector)});
       expect(f[0]).toBeDefined();
       expect(f[1]).toBeDefined();
       expect(f[2]).not.toBeDefined();
@@ -341,7 +326,7 @@ describe('FieldNode', () => {
 
     it('should support removing elements', () => {
       const value = signal([1, 2, 3]);
-      const f = form(value, noopSchema, {injector: TestBed.inject(Injector)});
+      const f = form(value, {injector: TestBed.inject(Injector)});
       f[2]().markAsTouched();
       expect(f().touched()).toBe(true);
 
@@ -352,7 +337,7 @@ describe('FieldNode', () => {
     describe('tracking', () => {
       it('maintains identity across value moves', () => {
         const value = signal([{name: 'Alex'}, {name: 'Kirill'}]);
-        const f = form(value, noopSchema, {injector: TestBed.inject(Injector)});
+        const f = form(value, {injector: TestBed.inject(Injector)});
         const alex = f[0];
         const kirill = f[1];
 
@@ -364,7 +349,7 @@ describe('FieldNode', () => {
 
       it('maintains identity across value update', () => {
         const value = signal([{name: 'Alex'}, {name: 'Kirill'}]);
-        const f = form(value, noopSchema, {injector: TestBed.inject(Injector)});
+        const f = form(value, {injector: TestBed.inject(Injector)});
         const alex = f[0];
         const kirill = f[1];
 


### PR DESCRIPTION
Introduce a `reset()` method that restores the touched and dirty signals of a field and its descendants to their initial states. `reset()` may be called on the root `form()` field to reset the entire form.
