### PR TITLE
ci: update renovate reviewers

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -281,7 +281,6 @@ groups:
         - ~pkozlowski-opensource
         - mgechev
         - MarkTechson
-        - kirjs
         - mmalerba
         - ~hawkgs
 
@@ -369,7 +368,7 @@ groups:
         - ~alan-agius4
       teams:
         - angular-caretaker
-        - ~framework-team
+        - framework-team
 
   # =========================================================
   #  Public API


### PR DESCRIPTION
This restores the framework-team availability, since the setting was not working as intended.

Also it removes Kirill's duplicate entry for angular-dev.