### PR TITLE
refactor(core): add configurable behavior for animations to testbed

### DIFF
--- a/goldens/public-api/core/testing/index.api.md
+++ b/goldens/public-api/core/testing/index.api.md
@@ -200,6 +200,7 @@ export interface TestEnvironmentOptions {
 
 // @public (undocumented)
 export interface TestModuleMetadata {
+    animationsEnabled?: boolean;
     // (undocumented)
     declarations?: any[];
     deferBlockBehavior?: DeferBlockBehavior;

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -175,4 +175,5 @@ export {ɵassertType} from './type_checking';
 export {
   ElementRegistry as ɵElementRegistry,
   AnimationRemovalRegistry as ɵAnimationRemovalRegistry,
+  ANIMATIONS_DISABLED as ɵANIMATIONS_DISABLED,
 } from './animation';

--- a/packages/core/test/acceptance/animation_spec.ts
+++ b/packages/core/test/acceptance/animation_spec.ts
@@ -15,10 +15,9 @@ import {
   signal,
   ViewChild,
 } from '@angular/core';
-import {fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {fakeAsync, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {isNode} from '@angular/private/testing';
-import {ANIMATIONS_DISABLED} from '../../src/animation';
 
 describe('Animation', () => {
   if (isNode) {
@@ -52,6 +51,8 @@ describe('Animation', () => {
         show = signal(true);
       }
 
+      TestBed.configureTestingModule({animationsEnabled: true});
+
       const fixture = TestBed.createComponent(TestComponent);
       const cmp = fixture.componentInstance;
       fixture.detectChanges();
@@ -83,9 +84,6 @@ describe('Animation', () => {
         @ViewChild('el', {read: ElementRef}) el!: ElementRef<HTMLParagraphElement>;
       }
 
-      TestBed.configureTestingModule({
-        providers: [{provide: ANIMATIONS_DISABLED, useValue: true}],
-      });
       const fixture = TestBed.createComponent(TestComponent);
       const cmp = fixture.componentInstance;
       fixture.detectChanges();
@@ -133,6 +131,8 @@ describe('Animation', () => {
         @ViewChild('el', {read: ElementRef}) el!: ElementRef<HTMLParagraphElement>;
       }
 
+      TestBed.configureTestingModule({animationsEnabled: true});
+
       const fixture = TestBed.createComponent(TestComponent);
       const cmp = fixture.componentInstance;
       fixture.detectChanges();
@@ -170,6 +170,7 @@ describe('Animation', () => {
         };
         @ViewChild('el', {read: ElementRef}) el!: ElementRef<HTMLParagraphElement>;
       }
+      TestBed.configureTestingModule({animationsEnabled: true});
 
       const fixture = TestBed.createComponent(TestComponent);
       const cmp = fixture.componentInstance;
@@ -199,6 +200,7 @@ describe('Animation', () => {
       class TestComponent {
         show = signal(true);
       }
+      TestBed.configureTestingModule({animationsEnabled: true});
 
       const fixture = TestBed.createComponent(TestComponent);
       const cmp = fixture.componentInstance;
@@ -266,6 +268,7 @@ describe('Animation', () => {
         fadeExp = 'fade';
         show = signal(true);
       }
+      TestBed.configureTestingModule({animationsEnabled: true});
 
       const fixture = TestBed.createComponent(TestComponent);
       const cmp = fixture.componentInstance;
@@ -346,6 +349,7 @@ describe('Animation', () => {
       class TestComponent {
         show = signal(true);
       }
+      TestBed.configureTestingModule({animationsEnabled: true});
 
       const fixture = TestBed.createComponent(TestComponent);
       const cmp = fixture.componentInstance;
@@ -413,6 +417,7 @@ describe('Animation', () => {
       class TestComponent {
         show = signal(true);
       }
+      TestBed.configureTestingModule({animationsEnabled: true});
 
       const fixture = TestBed.createComponent(TestComponent);
       const cmp = fixture.componentInstance;
@@ -477,6 +482,7 @@ describe('Animation', () => {
         show = signal(false);
         @ViewChild('el', {read: ElementRef}) el!: ElementRef<HTMLParagraphElement>;
       }
+      TestBed.configureTestingModule({animationsEnabled: true});
 
       const fixture = TestBed.createComponent(TestComponent);
       const cmp = fixture.componentInstance;
@@ -500,6 +506,7 @@ describe('Animation', () => {
         slide = signal('slide-in');
         @ViewChild('el', {read: ElementRef}) el!: ElementRef<HTMLParagraphElement>;
       }
+      TestBed.configureTestingModule({animationsEnabled: true});
 
       const fixture = TestBed.createComponent(TestComponent);
       const cmp = fixture.componentInstance;
@@ -521,6 +528,7 @@ describe('Animation', () => {
         show = signal(false);
         @ViewChild('el', {read: ElementRef}) el!: ElementRef<HTMLParagraphElement>;
       }
+      TestBed.configureTestingModule({animationsEnabled: true});
 
       const fixture = TestBed.createComponent(TestComponent);
       const cmp = fixture.componentInstance;
@@ -552,6 +560,7 @@ describe('Animation', () => {
         };
         @ViewChild('el', {read: ElementRef}) el!: ElementRef<HTMLParagraphElement>;
       }
+      TestBed.configureTestingModule({animationsEnabled: true});
 
       const fixture = TestBed.createComponent(TestComponent);
       const cmp = fixture.componentInstance;
@@ -599,6 +608,7 @@ describe('Animation', () => {
         classArray = ['slide-in', 'fade-in'];
         @ViewChild('el', {read: ElementRef}) el!: ElementRef<HTMLParagraphElement>;
       }
+      TestBed.configureTestingModule({animationsEnabled: true});
 
       const fixture = TestBed.createComponent(TestComponent);
       const cmp = fixture.componentInstance;
@@ -621,16 +631,12 @@ describe('Animation', () => {
         @ViewChild('el', {read: ElementRef}) el!: ElementRef<HTMLParagraphElement>;
       }
 
-      TestBed.configureTestingModule({
-        providers: [{provide: ANIMATIONS_DISABLED, useValue: true}],
-      });
       const fixture = TestBed.createComponent(TestComponent);
       const cmp = fixture.componentInstance;
       fixture.detectChanges();
       cmp.show.set(true);
       fixture.detectChanges();
       expect(cmp.show()).toBeTruthy();
-      tick();
       expect(cmp.el.nativeElement.outerHTML).not.toContain('class="slide-in"');
     }));
 
@@ -643,6 +649,7 @@ describe('Animation', () => {
         encapsulation: ViewEncapsulation.None,
       })
       class TestComponent {}
+      TestBed.configureTestingModule({animationsEnabled: true});
 
       const fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();
@@ -670,6 +677,7 @@ describe('Animation', () => {
       class TestComponent {
         fadeExp = 'fade-in';
       }
+      TestBed.configureTestingModule({animationsEnabled: true});
 
       const fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();
@@ -696,6 +704,7 @@ describe('Animation', () => {
         template: '<child-cmp animate.enter="fade-in" />',
       })
       class TestComponent {}
+      TestBed.configureTestingModule({animationsEnabled: true});
 
       const fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -2476,6 +2476,28 @@ describe('TestBed defer block behavior', () => {
   });
 });
 
+describe('TestBed animations behavior', () => {
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('should default animations behavior to disabled', () => {
+    expect(TestBedImpl.INSTANCE.getAnimationsEnabled()).toBe(false);
+  });
+
+  it('should be able to configure animations behavior', () => {
+    TestBed.configureTestingModule({animationsEnabled: true});
+    expect(TestBedImpl.INSTANCE.getAnimationsEnabled()).toBe(true);
+  });
+
+  it('should reset the animations behavior back to the default when TestBed is reset', () => {
+    TestBed.configureTestingModule({animationsEnabled: true});
+    expect(TestBedImpl.INSTANCE.getAnimationsEnabled()).toBe(true);
+    TestBed.resetTestingModule();
+    expect(TestBedImpl.INSTANCE.getAnimationsEnabled()).toBe(false);
+  });
+});
+
 describe('TestBed module teardown', () => {
   beforeEach(() => {
     TestBed.resetTestingModule();

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -45,6 +45,7 @@ import {
 import {ComponentFixture} from './component_fixture';
 import {MetadataOverride} from './metadata_override';
 import {
+  ANIMATIONS_ENABLED_DEFAULT,
   ComponentFixtureNoNgZone,
   DEFER_BLOCK_DEFAULT_BEHAVIOR,
   ModuleTeardownOptions,
@@ -239,6 +240,11 @@ export class TestBedImpl implements TestBed {
    * or set to play through.
    */
   private _instanceDeferBlockBehavior = DEFER_BLOCK_DEFAULT_BEHAVIOR;
+
+  /**
+   * Animations behavior option that specifies whether animations are enabled or disabled.
+   */
+  private _instanceAnimationsEnabled = ANIMATIONS_ENABLED_DEFAULT;
 
   /**
    * "Error on unknown elements" option that has been configured at the `TestBed` instance level.
@@ -535,6 +541,7 @@ export class TestBedImpl implements TestBed {
         this._instanceErrorOnUnknownPropertiesOption = undefined;
         this._instanceInferTagName = undefined;
         this._instanceDeferBlockBehavior = DEFER_BLOCK_DEFAULT_BEHAVIOR;
+        this._instanceAnimationsEnabled = ANIMATIONS_ENABLED_DEFAULT;
       }
     }
     return this;
@@ -567,6 +574,7 @@ export class TestBedImpl implements TestBed {
     this._instanceErrorOnUnknownPropertiesOption = moduleDef.errorOnUnknownProperties;
     this._instanceInferTagName = moduleDef.inferTagName;
     this._instanceDeferBlockBehavior = moduleDef.deferBlockBehavior ?? DEFER_BLOCK_DEFAULT_BEHAVIOR;
+    this._instanceAnimationsEnabled = moduleDef.animationsEnabled ?? ANIMATIONS_ENABLED_DEFAULT;
     // Store the current value of the strict mode option,
     // so we can restore it later
     this._previousErrorOnUnknownElementsOption = getUnknownElementStrictMode();
@@ -821,6 +829,10 @@ export class TestBedImpl implements TestBed {
 
   getDeferBlockBehavior(): DeferBlockBehavior {
     return this._instanceDeferBlockBehavior;
+  }
+
+  getAnimationsEnabled(): boolean {
+    return this._instanceAnimationsEnabled;
   }
 
   tearDownTestingModule() {

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -24,6 +24,9 @@ export const THROW_ON_UNKNOWN_PROPERTIES_DEFAULT = false;
 /** Whether defer blocks should use manual triggering or play through normally. */
 export const DEFER_BLOCK_DEFAULT_BEHAVIOR = DeferBlockBehavior.Playthrough;
 
+/** Whether animations are enabled or disabled. */
+export const ANIMATIONS_ENABLED_DEFAULT = false;
+
 /**
  * An abstract class for inserting the root test component element in a platform independent way.
  *
@@ -93,6 +96,12 @@ export interface TestModuleMetadata {
    * Otherwise `div` will be used as the tag name for test components.
    */
   inferTagName?: boolean;
+
+  /**
+   * Whether animate.enter / animate.leave should trigger as normal or be disabled.
+   * Defaults to `true`.
+   */
+  animationsEnabled?: boolean;
 }
 
 /**

--- a/packages/core/testing/src/test_bed_compiler.ts
+++ b/packages/core/testing/src/test_bed_compiler.ts
@@ -65,6 +65,7 @@ import {
   NgZone,
   ErrorHandler,
   ENVIRONMENT_INITIALIZER,
+  ɵANIMATIONS_DISABLED as ANIMATIONS_DISABLED,
 } from '../../src/core';
 
 import {ComponentDef, ComponentType} from '../../src/render3';
@@ -77,7 +78,11 @@ import {
   PipeResolver,
   Resolver,
 } from './resolvers';
-import {DEFER_BLOCK_DEFAULT_BEHAVIOR, TestModuleMetadata} from './test_bed_common';
+import {
+  ANIMATIONS_ENABLED_DEFAULT,
+  DEFER_BLOCK_DEFAULT_BEHAVIOR,
+  TestModuleMetadata,
+} from './test_bed_common';
 import {
   RETHROW_APPLICATION_ERRORS_DEFAULT,
   TestBedApplicationErrorHandler,
@@ -188,6 +193,7 @@ export class TestBedCompiler {
   private testModuleType: NgModuleType<any>;
   private testModuleRef: NgModuleRef<any> | null = null;
 
+  private animationsEnabled = ANIMATIONS_ENABLED_DEFAULT;
   private deferBlockBehavior = DEFER_BLOCK_DEFAULT_BEHAVIOR;
   private rethrowApplicationTickErrors = RETHROW_APPLICATION_ERRORS_DEFAULT;
 
@@ -232,6 +238,7 @@ export class TestBedCompiler {
     }
 
     this.deferBlockBehavior = moduleDef.deferBlockBehavior ?? DEFER_BLOCK_DEFAULT_BEHAVIOR;
+    this.animationsEnabled = moduleDef.animationsEnabled ?? ANIMATIONS_ENABLED_DEFAULT;
     this.rethrowApplicationTickErrors =
       moduleDef.rethrowApplicationErrors ?? RETHROW_APPLICATION_ERRORS_DEFAULT;
   }
@@ -945,6 +952,10 @@ export class TestBedCompiler {
     const providers = [
       {provide: Compiler, useFactory: () => new R3TestCompiler(this)},
       {provide: DEFER_BLOCK_CONFIG, useValue: {behavior: this.deferBlockBehavior}},
+      {
+        provide: ANIMATIONS_DISABLED,
+        useValue: !this.animationsEnabled,
+      },
       {
         provide: INTERNAL_APPLICATION_ERROR_HANDLER,
         useFactory: () => {


### PR DESCRIPTION
This adds a test module configuration to define whether animations should be enabled or disabled in test. By default, they are disabled.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
