### PR TITLE
fix(http): propagate plain errors when parsing fails

### DIFF
--- a/packages/common/http/test/fetch_spec.ts
+++ b/packages/common/http/test/fetch_spec.ts
@@ -213,6 +213,15 @@ describe('FetchBackend', async () => {
     expect(res.error.data).toBe('some data');
   });
 
+  it('handles a text error response when a json success response was expected', async () => {
+    const promise = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
+    fetchMock.mockFlush(HttpStatusCode.InternalServerError, 'Error', 'simple text error');
+    const events = await promise;
+    expect(events.length).toBe(2);
+    const res = events[1] as any as HttpErrorResponse;
+    expect(res.error).toBe('simple text error');
+  });
+
   it('handles a json error response with XSSI prefix', async () => {
     const promise = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
     fetchMock.mockFlush(
@@ -224,6 +233,19 @@ describe('FetchBackend', async () => {
     expect(events.length).toBe(2);
     const res = events[1] as any as HttpErrorResponse;
     expect(res.error.data).toBe('some data');
+  });
+
+  it('handles a text error response with XSSI prefix when a json success response was expected', async () => {
+    const promise = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
+    fetchMock.mockFlush(
+      HttpStatusCode.InternalServerError,
+      'Error',
+      XSSI_PREFIX + 'simple text error',
+    );
+    const events = await promise;
+    expect(events.length).toBe(2);
+    const res = events[1] as any as HttpErrorResponse;
+    expect(res.error).toBe('simple text error');
   });
 
   it('handles a json string response', async () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When the `responseType` is set to `json` and the fetch backend is active, the response body will always be parsed as JSON, regardless of whether it is a success or error response. However, it's not uncommon for successful requests to return one type and errors to return another type. The current implementation will fail parsing in this case and forward only the resulting `SyntaxError` on `HttpErrorResponse.error`. This obfuscates the source error body entirely to downstream response consumers.

Issue Number: N/A


## What is the new behavior?

The fetch backend now propagates the plain body when parsing the body fails. This replicates the behavior of the XHR backend introduced in #19773.

Propagating the plain error allows downstream error consumers to reason about the error body and decide how to parse it depending on application needs.

## Does this PR introduce a breaking change?

I'm unsure if you'd consider this breaking. The previous implementation exposed relatively useless `SyntaxError`, but people may be relying on these for some reason?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

