### PR TITLE
release: bump Angular DevTools version to 1.0.40

### DIFF
--- a/devtools/projects/shell-browser/src/manifest/manifest.chrome.json
+++ b/devtools/projects/shell-browser/src/manifest/manifest.chrome.json
@@ -3,7 +3,7 @@
   "short_name": "Angular DevTools",
   "name": "Angular DevTools",
   "description": "Angular DevTools extends Chrome DevTools adding Angular specific debugging and profiling capabilities.",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "minimum_chrome_version": "102",
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"

--- a/devtools/projects/shell-browser/src/manifest/manifest.firefox.json
+++ b/devtools/projects/shell-browser/src/manifest/manifest.firefox.json
@@ -3,7 +3,7 @@
   "short_name": "Angular DevTools",
   "name": "Angular DevTools",
   "description": "Angular DevTools extends Firefox DevTools adding Angular specific debugging and profiling capabilities.",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
   "icons": {
     "16": "assets/icon16.png",


### PR DESCRIPTION
* feat(devtools): add transfer state tab ([#62465](https://github.com/angular/angular/pull/62465/))
* fix(devtools): stop reseting currentlyMatchedIndex when a node is selected in the component explorer ([#62727](https://github.com/angular/angular/pull/62727/))
* fix(devtools): add event tagging to prevent DDOS ([#62645](https://github.com/angular/angular/pull/62645/))
* fix(devtools): make some containers scrollable ([#62703](https://github.com/angular/angular/pull/62703/))