### PR TITLE
docs: add initial documentation for MCP server tools

### DIFF
--- a/adev/src/content/ai/mcp-server-setup.md
+++ b/adev/src/content/ai/mcp-server-setup.md
@@ -65,3 +65,29 @@ For these IDEs, create a configuration file and add the following snippet. Note 
   }
 }
 ```
+
+## Available Tools
+
+The Angular CLI MCP server provides several tools to assist you in your development workflow. Here's an overview of the available tools:
+
+### Get Angular Coding Best Practices Guide (`get_best_practices`)
+
+This tool provides a guide on modern Angular coding best practices. Before you start writing or modifying code, you can use this tool to ensure your work aligns with current standards, such as using standalone components, typed forms, and the latest control flow syntax.
+
+*   **Outputs:** The content of the best practices guide.
+
+### Search Angular Documentation (`search_documentation`)
+
+This tool allows you to search the official Angular documentation at [angular.dev](https://angular.dev). It's the recommended way to find up-to-date information on Angular APIs, tutorials, and guides.
+
+*   **Outputs:** A list of search results, including title, breadcrumbs, and URL. May also include the content of the top-ranked page.
+
+### List Angular Projects (`list_projects`)
+
+This tool lists all the applications and libraries in your current Angular workspace. It reads the `angular.json` file to identify and provide details about each project.
+
+*   **Outputs:** A list of project objects, with details for each project like its name, type (`application` or `library`), root directory, and component selector prefix.
+
+## Feedback and New Ideas
+
+The Angular team welcomes your feedback on the existing MCP capabilities and any ideas you have for new tools or features. Please share your thoughts by opening an issue on the [angular/angular GitHub repository](https://github.com/angular/angular/issues).


### PR DESCRIPTION
Adds documentation for the tools available in the Angular CLI MCP server. This includes:
- get_best_practices
- search_documentation
- list_projects

Also includes a section for providing feedback and ideas for new capabilities.