### PR TITLE
refactor(animations): deprecate the animations package

### DIFF
--- a/goldens/public-api/animations/browser/index.api.md
+++ b/goldens/public-api/animations/browser/index.api.md
@@ -6,7 +6,7 @@
 
 import * as i0 from '@angular/core';
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export abstract class AnimationDriver {
     // (undocumented)
     abstract animate(element: any, keyframes: Array<Map<string, string | number>>, duration: number, delay: number, easing?: string | null, previousPlayers?: any[], scrubberAccessRequested?: boolean): any;
@@ -25,7 +25,7 @@ export abstract class AnimationDriver {
     abstract validateStyleProperty(prop: string): boolean;
 }
 
-// @public
+// @public @deprecated (undocumented)
 export class NoopAnimationDriver implements AnimationDriver {
     // (undocumented)
     animate(element: any, keyframes: Array<Map<string, string | number>>, duration: number, delay: number, easing: string, previousPlayers?: any[], scrubberAccessRequested?: boolean): AnimationPlayer;

--- a/goldens/public-api/animations/browser/testing/index.api.md
+++ b/goldens/public-api/animations/browser/testing/index.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export class MockAnimationDriver implements AnimationDriver {
     // (undocumented)
     animate(element: any, keyframes: Array<ɵStyleDataMap>, duration: number, delay: number, easing: string, previousPlayers?: any[]): MockAnimationPlayer;
@@ -24,7 +24,7 @@ export class MockAnimationDriver implements AnimationDriver {
     validateStyleProperty(prop: string): boolean;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export class MockAnimationPlayer extends NoopAnimationPlayer {
     constructor(element: any, keyframes: Array<ɵStyleDataMap>, duration: number, delay: number, easing: string, previousPlayers: any[]);
     // (undocumented)

--- a/goldens/public-api/animations/index.api.md
+++ b/goldens/public-api/animations/index.api.md
@@ -6,46 +6,46 @@
 
 import * as i0 from '@angular/core';
 
-// @public
+// @public @deprecated
 export function animate(timings: string | number, styles?: AnimationStyleMetadata | AnimationKeyframesSequenceMetadata | null): AnimationAnimateMetadata;
 
-// @public
+// @public @deprecated
 export function animateChild(options?: AnimateChildOptions | null): AnimationAnimateChildMetadata;
 
-// @public
+// @public @deprecated
 export interface AnimateChildOptions extends AnimationOptions {
     // (undocumented)
     duration?: number | string;
 }
 
-// @public
+// @public @deprecated
 export type AnimateTimings = {
     duration: number;
     delay: number;
     easing: string | null;
 };
 
-// @public
+// @public @deprecated
 export function animation(steps: AnimationMetadata | AnimationMetadata[], options?: AnimationOptions | null): AnimationReferenceMetadata;
 
-// @public
+// @public @deprecated
 export interface AnimationAnimateChildMetadata extends AnimationMetadata {
     options: AnimationOptions | null;
 }
 
-// @public
+// @public @deprecated
 export interface AnimationAnimateMetadata extends AnimationMetadata {
     styles: AnimationStyleMetadata | AnimationKeyframesSequenceMetadata | null;
     timings: string | number | AnimateTimings;
 }
 
-// @public
+// @public @deprecated
 export interface AnimationAnimateRefMetadata extends AnimationMetadata {
     animation: AnimationReferenceMetadata;
     options: AnimationOptions | null;
 }
 
-// @public
+// @public @deprecated
 export abstract class AnimationBuilder {
     abstract build(animation: AnimationMetadata | AnimationMetadata[]): AnimationFactory;
     // (undocumented)
@@ -54,7 +54,7 @@ export abstract class AnimationBuilder {
     static ɵprov: i0.ɵɵInjectableDeclaration<AnimationBuilder>;
 }
 
-// @public
+// @public @deprecated
 interface AnimationEvent_2 {
     disabled: boolean;
     element: any;
@@ -66,29 +66,29 @@ interface AnimationEvent_2 {
 }
 export { AnimationEvent_2 as AnimationEvent }
 
-// @public
+// @public @deprecated
 export abstract class AnimationFactory {
     abstract create(element: any, options?: AnimationOptions): AnimationPlayer;
 }
 
-// @public
+// @public @deprecated
 export interface AnimationGroupMetadata extends AnimationMetadata {
     options: AnimationOptions | null;
     steps: AnimationMetadata[];
 }
 
-// @public
+// @public @deprecated
 export interface AnimationKeyframesSequenceMetadata extends AnimationMetadata {
     steps: AnimationStyleMetadata[];
 }
 
-// @public
+// @public @deprecated
 export interface AnimationMetadata {
     // (undocumented)
     type: AnimationMetadataType;
 }
 
-// @public
+// @public @deprecated
 export enum AnimationMetadataType {
     Animate = 4,
     AnimateChild = 9,
@@ -105,7 +105,7 @@ export enum AnimationMetadataType {
     Trigger = 7
 }
 
-// @public
+// @public @deprecated
 export interface AnimationOptions {
     delay?: number | string;
     params?: {
@@ -113,7 +113,7 @@ export interface AnimationOptions {
     };
 }
 
-// @public
+// @public @deprecated
 export interface AnimationPlayer {
     beforeDestroy?: () => any;
     destroy(): void;
@@ -133,38 +133,38 @@ export interface AnimationPlayer {
     readonly totalTime: number;
 }
 
-// @public
+// @public @deprecated
 export interface AnimationQueryMetadata extends AnimationMetadata {
     animation: AnimationMetadata | AnimationMetadata[];
     options: AnimationQueryOptions | null;
     selector: string;
 }
 
-// @public
+// @public @deprecated
 export interface AnimationQueryOptions extends AnimationOptions {
     limit?: number;
     optional?: boolean;
 }
 
-// @public
+// @public @deprecated
 export interface AnimationReferenceMetadata extends AnimationMetadata {
     animation: AnimationMetadata | AnimationMetadata[];
     options: AnimationOptions | null;
 }
 
-// @public
+// @public @deprecated
 export interface AnimationSequenceMetadata extends AnimationMetadata {
     options: AnimationOptions | null;
     steps: AnimationMetadata[];
 }
 
-// @public
+// @public @deprecated
 export interface AnimationStaggerMetadata extends AnimationMetadata {
     animation: AnimationMetadata | AnimationMetadata[];
     timings: string | number;
 }
 
-// @public
+// @public @deprecated
 export interface AnimationStateMetadata extends AnimationMetadata {
     name: string;
     options?: {
@@ -175,7 +175,7 @@ export interface AnimationStateMetadata extends AnimationMetadata {
     styles: AnimationStyleMetadata;
 }
 
-// @public
+// @public @deprecated
 export interface AnimationStyleMetadata extends AnimationMetadata {
     offset: number | null;
     styles: '*' | {
@@ -185,7 +185,7 @@ export interface AnimationStyleMetadata extends AnimationMetadata {
     } | '*'>;
 }
 
-// @public
+// @public @deprecated
 export interface AnimationTransitionMetadata extends AnimationMetadata {
     animation: AnimationMetadata | AnimationMetadata[];
     expr: string | ((fromState: string, toState: string, element?: any, params?: {
@@ -194,7 +194,7 @@ export interface AnimationTransitionMetadata extends AnimationMetadata {
     options: AnimationOptions | null;
 }
 
-// @public
+// @public @deprecated
 export interface AnimationTriggerMetadata extends AnimationMetadata {
     definitions: AnimationMetadata[];
     name: string;
@@ -205,16 +205,16 @@ export interface AnimationTriggerMetadata extends AnimationMetadata {
     } | null;
 }
 
-// @public
+// @public @deprecated
 export const AUTO_STYLE = "*";
 
-// @public
+// @public @deprecated
 export function group(steps: AnimationMetadata[], options?: AnimationOptions | null): AnimationGroupMetadata;
 
-// @public
+// @public @deprecated
 export function keyframes(steps: AnimationStyleMetadata[]): AnimationKeyframesSequenceMetadata;
 
-// @public
+// @public @deprecated
 export class NoopAnimationPlayer implements AnimationPlayer {
     constructor(duration?: number, delay?: number);
     // (undocumented)
@@ -249,38 +249,38 @@ export class NoopAnimationPlayer implements AnimationPlayer {
     readonly totalTime: number;
 }
 
-// @public
+// @public @deprecated
 export function query(selector: string, animation: AnimationMetadata | AnimationMetadata[], options?: AnimationQueryOptions | null): AnimationQueryMetadata;
 
-// @public
+// @public @deprecated
 export function sequence(steps: AnimationMetadata[], options?: AnimationOptions | null): AnimationSequenceMetadata;
 
-// @public
+// @public @deprecated
 export function stagger(timings: string | number, animation: AnimationMetadata | AnimationMetadata[]): AnimationStaggerMetadata;
 
-// @public
+// @public @deprecated
 export function state(name: string, styles: AnimationStyleMetadata, options?: {
     params: {
         [name: string]: any;
     };
 }): AnimationStateMetadata;
 
-// @public
+// @public @deprecated
 export function style(tokens: '*' | {
     [key: string]: string | number;
 } | Array<'*' | {
     [key: string]: string | number;
 }>): AnimationStyleMetadata;
 
-// @public
+// @public @deprecated
 export function transition(stateChangeExpr: string | ((fromState: string, toState: string, element?: any, params?: {
     [key: string]: any;
 }) => boolean), steps: AnimationMetadata | AnimationMetadata[], options?: AnimationOptions | null): AnimationTransitionMetadata;
 
-// @public
+// @public @deprecated
 export function trigger(name: string, definitions: AnimationMetadata[]): AnimationTriggerMetadata;
 
-// @public
+// @public @deprecated
 export function useAnimation(animation: AnimationReferenceMetadata, options?: AnimationOptions | null): AnimationAnimateRefMetadata;
 
 // (No @packageDocumentation comment for this package)

--- a/goldens/public-api/platform-browser/animations/async/index.api.md
+++ b/goldens/public-api/platform-browser/animations/async/index.api.md
@@ -6,7 +6,7 @@
 
 import { EnvironmentProviders } from '@angular/core';
 
-// @public
+// @public @deprecated
 export function provideAnimationsAsync(type?: 'animations' | 'noop'): EnvironmentProviders;
 
 // (No @packageDocumentation comment for this package)

--- a/goldens/public-api/platform-browser/animations/index.api.md
+++ b/goldens/public-api/platform-browser/animations/index.api.md
@@ -12,7 +12,7 @@ import { Provider } from '@angular/core';
 
 export { ANIMATION_MODULE_TYPE }
 
-// @public
+// @public @deprecated
 export class BrowserAnimationsModule {
     static withConfig(config: BrowserAnimationsModuleConfig): ModuleWithProviders<BrowserAnimationsModule>;
     // (undocumented)
@@ -23,12 +23,12 @@ export class BrowserAnimationsModule {
     static ɵmod: i0.ɵɵNgModuleDeclaration<BrowserAnimationsModule, never, never, [typeof BrowserModule]>;
 }
 
-// @public
+// @public @deprecated
 export interface BrowserAnimationsModuleConfig {
     disableAnimations?: boolean;
 }
 
-// @public
+// @public @deprecated
 export class NoopAnimationsModule {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<NoopAnimationsModule, never>;
@@ -38,10 +38,10 @@ export class NoopAnimationsModule {
     static ɵmod: i0.ɵɵNgModuleDeclaration<NoopAnimationsModule, never, never, [typeof BrowserModule]>;
 }
 
-// @public
+// @public @deprecated
 export function provideAnimations(): Provider[];
 
-// @public
+// @public @deprecated
 export function provideNoopAnimations(): Provider[];
 
 // (No @packageDocumentation comment for this package)

--- a/packages/animations/browser/src/render/animation_driver.ts
+++ b/packages/animations/browser/src/render/animation_driver.ts
@@ -13,6 +13,8 @@ import {containsElement, getParentElement, invokeQuery, validateStyleProperty} f
 /**
  * @publicApi
  *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
+ *
  * `AnimationDriver` implentation for Noop animations
  */
 @Injectable()
@@ -72,6 +74,8 @@ export class NoopAnimationDriver implements AnimationDriver {
 
 /**
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export abstract class AnimationDriver {
   /**

--- a/packages/animations/browser/testing/src/mock_animation_driver.ts
+++ b/packages/animations/browser/testing/src/mock_animation_driver.ts
@@ -25,6 +25,8 @@ import {
 
 /**
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export class MockAnimationDriver implements AnimationDriver {
   static log: AnimationPlayer[] = [];
@@ -77,6 +79,8 @@ export class MockAnimationDriver implements AnimationDriver {
 
 /**
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export class MockAnimationPlayer extends NoopAnimationPlayer {
   private __finished = false;

--- a/packages/animations/src/animation_builder.ts
+++ b/packages/animations/src/animation_builder.ts
@@ -68,6 +68,8 @@ import {AnimationPlayer} from './players/animation_player';
  * ```
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 @Injectable({providedIn: 'root', useFactory: () => inject(BrowserAnimationBuilder)})
 export abstract class AnimationBuilder {
@@ -86,6 +88,8 @@ export abstract class AnimationBuilder {
  * method.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export abstract class AnimationFactory {
   /**

--- a/packages/animations/src/animation_event.ts
+++ b/packages/animations/src/animation_event.ts
@@ -36,6 +36,8 @@
  * ```
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export interface AnimationEvent {
   /**

--- a/packages/animations/src/animation_metadata.ts
+++ b/packages/animations/src/animation_metadata.ts
@@ -23,6 +23,8 @@ export type ɵStyleDataMap = Map<string, string | number>;
  * @see {@link animate}
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export declare type AnimateTimings = {
   /**
@@ -64,6 +66,8 @@ export declare type AnimateTimings = {
  * make use of `AnimationOptions`.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export declare interface AnimationOptions {
   /**
@@ -87,6 +91,8 @@ export declare interface AnimationOptions {
  * @see {@link animateChild}
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export declare interface AnimateChildOptions extends AnimationOptions {
   duration?: number | string;
@@ -99,6 +105,8 @@ export declare interface AnimateChildOptions extends AnimationOptions {
  * collects them into a corresponding `AnimationMetadata` object.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export enum AnimationMetadataType {
   /**
@@ -172,6 +180,8 @@ export enum AnimationMetadataType {
  * Specifies automatic styling.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export const AUTO_STYLE = '*';
 
@@ -179,6 +189,8 @@ export const AUTO_STYLE = '*';
  * Base for animation data structures.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export interface AnimationMetadata {
   type: AnimationMetadataType;
@@ -189,6 +201,8 @@ export interface AnimationMetadata {
  * `trigger()` function.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export interface AnimationTriggerMetadata extends AnimationMetadata {
   /**
@@ -212,6 +226,8 @@ export interface AnimationTriggerMetadata extends AnimationMetadata {
  * Instantiated and returned by the [`state()`](api/animations/state) function.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export interface AnimationStateMetadata extends AnimationMetadata {
   /**
@@ -235,6 +251,8 @@ export interface AnimationStateMetadata extends AnimationMetadata {
  * `transition()` function.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export interface AnimationTransitionMetadata extends AnimationMetadata {
   /**
@@ -266,6 +284,8 @@ export interface AnimationTransitionMetadata extends AnimationMetadata {
  * passed to the `useAnimation()` function.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export interface AnimationReferenceMetadata extends AnimationMetadata {
   /**
@@ -285,6 +305,8 @@ export interface AnimationReferenceMetadata extends AnimationMetadata {
  * the `query()` function.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export interface AnimationQueryMetadata extends AnimationMetadata {
   /**
@@ -306,6 +328,8 @@ export interface AnimationQueryMetadata extends AnimationMetadata {
  * the `keyframes()` function.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export interface AnimationKeyframesSequenceMetadata extends AnimationMetadata {
   /**
@@ -319,6 +343,8 @@ export interface AnimationKeyframesSequenceMetadata extends AnimationMetadata {
  * the `style()` function.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export interface AnimationStyleMetadata extends AnimationMetadata {
   /**
@@ -336,6 +362,8 @@ export interface AnimationStyleMetadata extends AnimationMetadata {
  * the `animate()` function.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export interface AnimationAnimateMetadata extends AnimationMetadata {
   /**
@@ -353,6 +381,8 @@ export interface AnimationAnimateMetadata extends AnimationMetadata {
  * Instantiated and returned by the `animateChild` function.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export interface AnimationAnimateChildMetadata extends AnimationMetadata {
   /**
@@ -368,6 +398,8 @@ export interface AnimationAnimateChildMetadata extends AnimationMetadata {
  * Instantiated and returned by the `useAnimation()` function.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export interface AnimationAnimateRefMetadata extends AnimationMetadata {
   /**
@@ -387,6 +419,8 @@ export interface AnimationAnimateRefMetadata extends AnimationMetadata {
  * Instantiated and returned by the `sequence()` function.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export interface AnimationSequenceMetadata extends AnimationMetadata {
   /**
@@ -406,6 +440,8 @@ export interface AnimationSequenceMetadata extends AnimationMetadata {
  * Instantiated and returned by the `group()` function.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export interface AnimationGroupMetadata extends AnimationMetadata {
   /**
@@ -425,6 +461,8 @@ export interface AnimationGroupMetadata extends AnimationMetadata {
  * Passed to the `query()` function.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export declare interface AnimationQueryOptions extends AnimationOptions {
   /**
@@ -447,6 +485,8 @@ export declare interface AnimationQueryOptions extends AnimationOptions {
  * Instantiated and returned by the `stagger()` function.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  **/
 export interface AnimationStaggerMetadata extends AnimationMetadata {
   /**
@@ -606,6 +646,8 @@ export interface AnimationStaggerMetadata extends AnimationMetadata {
  * the `.disabled` flag on the event is true.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export function trigger(name: string, definitions: AnimationMetadata[]): AnimationTriggerMetadata {
   return {type: AnimationMetadataType.Trigger, name, definitions, options: {}};
@@ -668,6 +710,8 @@ export function trigger(name: string, definitions: AnimationMetadata[]): Animati
  * ```
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export function animate(
   timings: string | number,
@@ -708,6 +752,8 @@ export function animate(
  * instruction until all of the inner animation steps have completed.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export function group(
   steps: AnimationMetadata[],
@@ -748,6 +794,8 @@ export function group(
  * steps have completed.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  **/
 export function sequence(
   steps: AnimationMetadata[],
@@ -794,6 +842,8 @@ export function sequence(
  * ```
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  **/
 export function style(
   tokens: '*' | {[key: string]: string | number} | Array<'*' | {[key: string]: string | number}>,
@@ -829,6 +879,8 @@ export function style(
  * even when the animation ends.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  **/
 export function state(
   name: string,
@@ -882,6 +934,8 @@ export function state(
  *```
 
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export function keyframes(steps: AnimationStyleMetadata[]): AnimationKeyframesSequenceMetadata {
   return {type: AnimationMetadataType.Keyframes, steps};
@@ -1032,6 +1086,8 @@ export function keyframes(steps: AnimationStyleMetadata[]): AnimationKeyframesSe
  *    ```
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  **/
 export function transition(
   stateChangeExpr:
@@ -1092,6 +1148,8 @@ export function transition(
  * animated, `useAnimation()` throws an error.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export function animation(
   steps: AnimationMetadata | AnimationMetadata[],
@@ -1118,6 +1176,8 @@ export function animation(
  * and transitions are not handled by this API.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export function animateChild(
   options: AnimateChildOptions | null = null,
@@ -1134,6 +1194,8 @@ export function animateChild(
  * @return An object that contains the animation parameters.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export function useAnimation(
   animation: AnimationReferenceMetadata,
@@ -1261,6 +1323,8 @@ export function useAnimation(
  * ```
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export function query(
   selector: string,
@@ -1349,6 +1413,8 @@ export function query(
  * ```
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export function stagger(
   timings: string | number,

--- a/packages/animations/src/players/animation_player.ts
+++ b/packages/animations/src/players/animation_player.ts
@@ -18,6 +18,8 @@
  * @see {@link animate}
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export interface AnimationPlayer {
   /**
@@ -116,6 +118,8 @@ export interface AnimationPlayer {
  * @see {@link AnimationPlayer}
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export class NoopAnimationPlayer implements AnimationPlayer {
   private _onDoneFns: Function[] = [];

--- a/packages/platform-browser/animations/async/src/providers.ts
+++ b/packages/platform-browser/animations/async/src/providers.ts
@@ -45,6 +45,8 @@ import {AsyncAnimationRendererFactory} from './async_animation_renderer';
  * @param type pass `'noop'` as argument to disable animations.
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export function provideAnimationsAsync(
   type: 'animations' | 'noop' = 'animations',

--- a/packages/platform-browser/animations/src/module.ts
+++ b/packages/platform-browser/animations/src/module.ts
@@ -18,6 +18,8 @@ import {BROWSER_ANIMATIONS_PROVIDERS, BROWSER_NOOP_ANIMATIONS_PROVIDERS} from '.
 /**
  * Object used to configure the behavior of {@link BrowserAnimationsModule}
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export interface BrowserAnimationsModuleConfig {
   /**
@@ -31,6 +33,8 @@ export interface BrowserAnimationsModuleConfig {
  * Exports `BrowserModule` with additional dependency-injection providers
  * for use with animations. See [Animations](guide/animations).
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 @NgModule({
   exports: [BrowserModule],
@@ -86,6 +90,9 @@ export class BrowserAnimationsModule {
  * ```
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
+ *
  */
 export function provideAnimations(): Provider[] {
   performanceMarkFeature('NgEagerAnimations');
@@ -97,6 +104,8 @@ export function provideAnimations(): Provider[] {
 /**
  * A null player that must be imported to allow disabling of animations.
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 @NgModule({
   exports: [BrowserModule],
@@ -124,6 +133,8 @@ export class NoopAnimationsModule {}
  * ```
  *
  * @publicApi
+ *
+ * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
 export function provideNoopAnimations(): Provider[] {
   // Return a copy to prevent changes to the original array in case any in-place


### PR DESCRIPTION
This deprecates the animations package in favor of using `animate.enter` and `animate.leave` with intent to remove the full package in v22.2.

DEPRECATED: @angular/animations

