### PR TITLE
docs(docs-infra): correct typos in adev and wording in resource api

### DIFF
--- a/adev/src/content/guide/http/http-resource.md
+++ b/adev/src/content/guide/http/http-resource.md
@@ -19,7 +19,7 @@ userId = input.required<string>();
 user = httpResource(() => `/api/user/${userId()}`); // A reactive function as argument
 ```
 
-`httResource` is reactive, meaning that whenever one of the signal it depends on changes (like `userId`), the resource will emit a new http request. 
+`httpResource` is reactive, meaning that whenever one of the signal it depends on changes (like `userId`), the resource will emit a new http request. 
 If a request is already pending, the resource cancels the outstanding request before issuing a new one.  
 
 HELPFUL: `httpResource` differs from the `HttpClient` as it initiates the request _eagerly_. In contrast, the `HttpClient` only initiates requests upon subscription to the returned `Observable`.

--- a/adev/src/content/guide/signals/resource.md
+++ b/adev/src/content/guide/signals/resource.md
@@ -25,7 +25,7 @@ const userResource = resource({
 
 // Create a computed signal based on the result of the resource's loader function.
 const firstName = computed(() => {
-  if (useResource.hasValue()) {
+  if (userResource.hasValue()) {
     // `hasValue` serves 2 purposes:
     // - It acts as type guard to strip `undefined` from the type
     // - If protects against reading a throwing `value` when the resource is in error state

--- a/packages/core/src/resource/api.ts
+++ b/packages/core/src/resource/api.ts
@@ -161,7 +161,7 @@ export interface BaseResourceOptions<T, R> {
    * A reactive function which determines the request to be made. Whenever the request changes, the
    * loader will be triggered to fetch a new value for the resource.
    *
-   * If a request function isn't provided, the loader won't rerun unless the resource is reloaded.
+   * If a params function isn't provided, the loader won't rerun unless the resource is reloaded.
    */
   params?: () => R;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
There are typos in resource and http resource guide pages and wrong wording in the `BaseResourceOptions` API description

Issue Number: N/A


## What is the new behavior?
Corrected wording and fixed typo in the documentation.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
The first PR had a wrong commit message so I created a new one