### PR TITLE
docs(mcp): fix issue in jetbrains MCP configuration

### DIFF
--- a/adev/src/content/ai/mcp-server-setup.md
+++ b/adev/src/content/ai/mcp-server-setup.md
@@ -24,7 +24,7 @@ In your project's root, create a file named `.vscode/mcp.json` and add the follo
 ```
 
 ### JetBrains IDEs
-In JetBrains IDEs (like IntelliJ IDEA or WebStorm), after installing the MCP Server plugin, go to `Settings | Tools | AI Assistant | Model Context Protocol (MCP)`. Add a new server and select `As JSON`. Paste the following configuration, which does not use a top-level property for the server list.
+In JetBrains IDEs (like IntelliJ IDEA or WebStorm), after installing the JetBrains AI Assistant plugin, go to `Settings | Tools | AI Assistant | Model Context Protocol (MCP)`. Add a new server and select `As JSON`. Paste the following configuration, which does not use a top-level property for the server list.
 
 ```json
 {


### PR DESCRIPTION
The MCP Server Plugin mentioned is to have other applications interact with JetBrains IDEs, the MCP client integration is part of AI Assistant and in the next version of Junie (our AI Agent), once that is stable and live I will file another PR to update the documentation