### PR TITLE
build: use ts_config rule from rules_ts only and always load from common location

### DIFF
--- a/.github/actions/deploy-docs-site/BUILD.bazel
+++ b/.github/actions/deploy-docs-site/BUILD.bazel
@@ -1,5 +1,4 @@
-load("@aspect_rules_ts//ts:defs.bzl", rules_js_tsconfig = "ts_config")
-load("//tools:defaults2.bzl", "esbuild_checked_in", "ts_project")
+load("//tools:defaults2.bzl", "esbuild_checked_in", "ts_config", "ts_project")
 
 package(default_visibility = ["//.github/actions/deploy-docs-site:__subpackages__"])
 
@@ -22,7 +21,7 @@ esbuild_checked_in(
     ],
 )
 
-rules_js_tsconfig(
+ts_config(
     name = "tsconfig",
     src = "tsconfig.json",
 )

--- a/devtools/tools/defaults.bzl
+++ b/devtools/tools/defaults.bzl
@@ -4,7 +4,6 @@ load("@aspect_bazel_lib//lib:copy_to_bin.bzl", _copy_to_bin = "copy_to_bin")
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", _copy_to_directory = "copy_to_directory")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", _esbuild = "esbuild")
 load("@aspect_rules_js//js:defs.bzl", _js_library = "js_library")
-load("@aspect_rules_ts//ts:defs.bzl", _ts_config = "ts_config")
 load("@bazel_skylib//rules:common_settings.bzl", _string_flag = "string_flag")
 load("@build_bazel_rules_nodejs//:index.bzl", _pkg_web = "pkg_web")
 load(
@@ -15,6 +14,7 @@ load(
     _npm_sass_library = "npm_sass_library",
     _sass_binary = "sass_binary",
     _sass_library = "sass_library",
+    _ts_config = "ts_config",
     _ts_project = "ts_project",
 )
 

--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
-load("@npm//@bazel/concatjs:index.bzl", rules_node_js_ts_config = "ts_config")
 load("//:packages.bzl", "DOCS_ENTRYPOINTS")
 load("//tools:defaults2.bzl", "ts_config", "ts_project")
 
@@ -34,7 +33,7 @@ ts_project(
     ],
 )
 
-rules_node_js_ts_config(
+ts_config(
     name = "tsec_config",
     src = "tsconfig-tsec-base.json",
     deps = [

--- a/packages/benchpress/BUILD.bazel
+++ b/packages/benchpress/BUILD.bazel
@@ -1,9 +1,8 @@
-load("@aspect_rules_ts//ts:defs.bzl", rules_js_tsconfig = "ts_config")
-load("//tools:defaults2.bzl", "ng_package", "npm_package", "ts_project")
+load("//tools:defaults2.bzl", "ng_package", "npm_package", "ts_config", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
 
-rules_js_tsconfig(
+ts_config(
     name = "tsconfig_build",
     src = "tsconfig.json",
     deps = [

--- a/packages/service-worker/BUILD.bazel
+++ b/packages/service-worker/BUILD.bazel
@@ -1,10 +1,9 @@
-load("@aspect_rules_ts//ts:defs.bzl", rules_js_tsconfig = "ts_config")
 load("//tools:defaults.bzl", "generate_api_docs")
-load("//tools:defaults2.bzl", "api_golden_test", "api_golden_test_npm_package", "ng_package", "ng_project")
+load("//tools:defaults2.bzl", "api_golden_test", "api_golden_test_npm_package", "ng_package", "ng_project", "ts_config")
 
 package(default_visibility = ["//visibility:public"])
 
-rules_js_tsconfig(
+ts_config(
     name = "tsconfig_build",
     src = "tsconfig.json",
     deps = [

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
+load("//tools:defaults2.bzl", "ts_config")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/tools/bazel/tsec.bzl
+++ b/tools/bazel/tsec.bzl
@@ -1,10 +1,10 @@
 """Bazel rules and macros for running tsec over a ng_module or ts_library."""
 
 load("@aspect_rules_js//js:providers.bzl", "JsInfo")
+load("@aspect_rules_ts//ts:defs.bzl", "TsConfigInfo")
 load("@bazel_skylib//lib:new_sets.bzl", "sets")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_test")
 load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "NpmPackageInfo")
-load("@npm//@bazel/concatjs/internal:ts_config.bzl", "TsConfigInfo")
 
 TsecInteropSrcs = provider("Sources used by an interop target", fields = ["srcs"])
 TsecTargetInfo = provider("Attributes required for tsec_test to generate tsconfig.json", fields = ["srcs", "deps", "module_name", "paths", "node_modules_root"])
@@ -151,7 +151,7 @@ def _tsec_config_impl(ctx):
     if base:
         if TsConfigInfo not in base:
             fail("`base` must be a ts_config target")
-        deps.extend(base[TsConfigInfo].deps)
+        deps.extend(base[TsConfigInfo].deps.to_list())
         base_tsconfig_src = ctx.attr.base.files.to_list()[0]
 
     out = ctx.outputs.out


### PR DESCRIPTION
Only use the ts_config rule from rules_ts, and always load the rule from tools/defaults2.bzl
