### PR TITLE
build: Export language service bundle

### DIFF
--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -14,6 +14,9 @@
       "types": "./index.d.ts",
       "default": "./index.js"
     },
+    "./bundles/language-service.js": {
+      "default": "./bundles/language-service.js"
+    },
     "./package.json": {
       "default": "./package.json"
     },


### PR DESCRIPTION
fixes Plugin activation failed: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './bundles/language-service.js' is not defined by 'exports'
