### PR TITLE
refactor(signal-forms): remove unsubmitted and submitted field states

### DIFF
--- a/goldens/public-api/forms/experimental/index.api.md
+++ b/goldens/public-api/forms/experimental/index.api.md
@@ -139,8 +139,7 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
     property<M>(prop: Property<M>): M | undefined;
     readonly readonly: Signal<boolean>;
     reset(): void;
-    resetSubmittedStatus(): void;
-    readonly submittedStatus: Signal<SubmittedStatus>;
+    readonly submitting: Signal<boolean>;
     readonly syncErrors: Signal<ValidationError[]>;
     readonly syncValid: Signal<boolean>;
     readonly touched: Signal<boolean>;
@@ -213,8 +212,6 @@ export class InteropNgControl implements Pick<NgControl, InteropSharedKeys | 'co
     get pending(): boolean | null;
     // (undocumented)
     get pristine(): boolean;
-    // (undocumented)
-    get submitted(): boolean;
     // (undocumented)
     get touched(): boolean;
     // (undocumented)

--- a/packages/forms/experimental/src/api/types.ts
+++ b/packages/forms/experimental/src/api/types.ts
@@ -236,10 +236,9 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
    */
   readonly syncValid: Signal<boolean>;
   /**
-   * A signal indicating whether the field is currently unsubmitted, submitted, or in the process of
-   * being submitted.
+   * A signal indicating whether the field is currently in the process of being submitted.
    */
-  readonly submittedStatus: Signal<SubmittedStatus>;
+  readonly submitting: Signal<boolean>;
   /**
    * The property key in the parent field under which this field is stored. If the parent field is
    * array-valued, for example, this is the index of this field in that array.
@@ -271,11 +270,6 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
    * Note this does not change the data model, which can be reset directly if desired.
    */
   reset(): void;
-
-  /**
-   * Resets the `submittedStatus` of the field and all descendant fields to unsubmitted.
-   */
-  resetSubmittedStatus(): void;
 }
 
 /**

--- a/packages/forms/experimental/src/controls/interop_ng_control.ts
+++ b/packages/forms/experimental/src/controls/interop_ng_control.ts
@@ -90,10 +90,6 @@ export class InteropNgControl
     return !this.field().touched();
   }
 
-  get submitted(): boolean {
-    return this.field().submittedStatus() === 'submitted';
-  }
-
   valueAccessor: ControlValueAccessor | null = null;
 
   hasValidator(validator: ValidatorFn): boolean {

--- a/packages/forms/experimental/src/field/node.ts
+++ b/packages/forms/experimental/src/field/node.ts
@@ -145,21 +145,14 @@ export class FieldNode implements FieldState<unknown> {
     return this.nodeState.readonly;
   }
 
-  get submittedStatus(): Signal<SubmittedStatus> {
-    return this.submitState.submittedStatus;
+  get submitting(): Signal<boolean> {
+    return this.submitState.submitting;
   }
 
   property<M>(prop: AggregateProperty<M, any>): Signal<M>;
   property<M>(prop: Property<M>): M | undefined;
   property<M>(prop: Property<M> | AggregateProperty<M, any>): Signal<M> | M | undefined {
     return this.propertyState.get(prop);
-  }
-
-  /**
-   * Resets the submitted status of this field and all of its children.
-   */
-  resetSubmittedStatus(): void {
-    this.submitState.reset();
   }
 
   /**

--- a/packages/forms/experimental/src/field/submit.ts
+++ b/packages/forms/experimental/src/field/submit.ts
@@ -16,7 +16,7 @@ import type {FieldNode} from './node';
  * State of a `FieldNode` that's associated with form submission.
  */
 export class FieldSubmitState {
-  readonly selfSubmittedStatus = signal<SubmittedStatus>('unsubmitted');
+  readonly selfSubmitting = signal<boolean>(false);
   readonly serverErrors: WritableSignal<readonly ValidationError[]>;
 
   constructor(private readonly node: FieldNode) {
@@ -27,22 +27,13 @@ export class FieldSubmitState {
   }
 
   /**
-   * The submitted status of the form.
+   * Whether this form is currently being submitted.
    */
-  readonly submittedStatus: Signal<SubmittedStatus> = computed(() =>
-    this.selfSubmittedStatus() !== 'unsubmitted'
-      ? this.selfSubmittedStatus()
-      : (this.node.structure.parent?.submitState.submittedStatus() ?? 'unsubmitted'),
-  );
+  readonly submitting: Signal<boolean> = computed(() => {
+    return this.selfSubmitting() || (this.node.structure.parent?.submitting() ?? false);
+  });
 
   setServerErrors(result: Exclude<TreeValidationResult, null | undefined>) {
     this.serverErrors.set(isArray(result) ? result.map(stripField) : [stripField(result)]);
-  }
-
-  reset(): void {
-    this.selfSubmittedStatus.set('unsubmitted');
-    for (const child of this.node.structure.children()) {
-      child.submitState.reset();
-    }
   }
 }


### PR DESCRIPTION
* `FieldState.submittedStatus` is replaced by `FieldState.submitting`, which tracks only whether the form is currently being submitted. This state is propagated downwards to all descendants of the submitted field.

* `submit()` now marks the field and all of its descendants as touched to ensure that any validation errors are displayed upon submission attempts.