### PR TITLE
docs: fix link for NG8117 uninvokedFunctionInTextInterpolation

### DIFF
--- a/adev/src/content/reference/extended-diagnostics/overview.md
+++ b/adev/src/content/reference/extended-diagnostics/overview.md
@@ -8,23 +8,23 @@ The Angular compiler includes "extended diagnostics" which identify many of thes
 
 Currently, Angular supports the following extended diagnostics:
 
-| Code     | Name                                                              |
-| :------- | :---------------------------------------------------------------- |
-| `NG8101` | [`invalidBananaInBox`](extended-diagnostics/NG8101)               |
-| `NG8102` | [`nullishCoalescingNotNullable`](extended-diagnostics/NG8102)     |
-| `NG8103` | [`missingControlFlowDirective`](extended-diagnostics/NG8103)      |
-| `NG8104` | [`textAttributeNotBinding`](extended-diagnostics/NG8104)          |
-| `NG8105` | [`missingNgForOfLet`](extended-diagnostics/NG8105)                |
-| `NG8106` | [`suffixNotSupported`](extended-diagnostics/NG8106)               |
-| `NG8107` | [`optionalChainNotNullable`](extended-diagnostics/NG8107)         |
-| `NG8108` | [`skipHydrationNotStatic`](extended-diagnostics/NG8108)           |
-| `NG8109` | [`interpolatedSignalNotInvoked`](extended-diagnostics/NG8109)     |
-| `NG8111` | [`uninvokedFunctionInEventBinding`](extended-diagnostics/NG8111)  |
-| `NG8113` | [`unusedStandaloneImports`](extended-diagnostics/NG8113)          |
-| `NG8114` | [`unparenthesizedNullishCoalescing`](extended-diagnostics/NG8114) |
-| `NG8115` | [`uninvokedTrackFunction`](extended-diagnostics/NG8115)           |
-| `NG8116` | [`missingStructuralDirective`](extended-diagnostics/NG8116)       |
-| `NG8117` | [`uninvokedFunctionInTextInterpolation`](extended-diagnostics/NG8114) |
+| Code     | Name                                                                  |
+| :------- |:----------------------------------------------------------------------|
+| `NG8101` | [`invalidBananaInBox`](extended-diagnostics/NG8101)                   |
+| `NG8102` | [`nullishCoalescingNotNullable`](extended-diagnostics/NG8102)         |
+| `NG8103` | [`missingControlFlowDirective`](extended-diagnostics/NG8103)          |
+| `NG8104` | [`textAttributeNotBinding`](extended-diagnostics/NG8104)              |
+| `NG8105` | [`missingNgForOfLet`](extended-diagnostics/NG8105)                    |
+| `NG8106` | [`suffixNotSupported`](extended-diagnostics/NG8106)                   |
+| `NG8107` | [`optionalChainNotNullable`](extended-diagnostics/NG8107)             |
+| `NG8108` | [`skipHydrationNotStatic`](extended-diagnostics/NG8108)               |
+| `NG8109` | [`interpolatedSignalNotInvoked`](extended-diagnostics/NG8109)         |
+| `NG8111` | [`uninvokedFunctionInEventBinding`](extended-diagnostics/NG8111)      |
+| `NG8113` | [`unusedStandaloneImports`](extended-diagnostics/NG8113)              |
+| `NG8114` | [`unparenthesizedNullishCoalescing`](extended-diagnostics/NG8114)     |
+| `NG8115` | [`uninvokedTrackFunction`](extended-diagnostics/NG8115)               |
+| `NG8116` | [`missingStructuralDirective`](extended-diagnostics/NG8116)           |
+| `NG8117` | [`uninvokedFunctionInTextInterpolation`](extended-diagnostics/NG8117) |
 
 ## Configuration
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

The link of the new diagnostic NG8117 points to the proper one


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
