### PR TITLE
fix(compiler): handle escaped interpolation markers in templates

### DIFF
--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -1088,10 +1088,13 @@ class _Tokenizer {
     while (!endPredicate()) {
       const current = this._cursor.clone();
       if (this._interpolationConfig && this._attemptStr(this._interpolationConfig.start)) {
-        const interpolationStartIsFromEntity = this._cursor.getChars(current).match(/&[^;]+;$/);
-        if (interpolationStartIsFromEntity) {
+        const chars = this._cursor.getChars(current);
+        const firstCharIsEntity = chars.endsWith(';') && chars.includes('&');
+        const secondCharIsEntity = this._cursor.peek() === 123 &&
+                                 this._cursor.getChars(current).match(/&[^;]+;$/);
+        
+        if (firstCharIsEntity || secondCharIsEntity) {
           parts.push(this._interpolationConfig.start);
-        } else {
           this._endToken([this._processCarriageReturns(parts.join(''))], current);
           parts.length = 0;
           this._consumeInterpolation(interpolationTokenType, current, endInterpolation);

--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -1088,10 +1088,15 @@ class _Tokenizer {
     while (!endPredicate()) {
       const current = this._cursor.clone();
       if (this._interpolationConfig && this._attemptStr(this._interpolationConfig.start)) {
-        this._endToken([this._processCarriageReturns(parts.join(''))], current);
-        parts.length = 0;
-        this._consumeInterpolation(interpolationTokenType, current, endInterpolation);
-        this._beginToken(textTokenType);
+        const interpolationStartIsFromEntity = this._cursor.getChars(current).match(/&[^;]+;$/);
+        if (interpolationStartIsFromEntity) {
+          parts.push(this._interpolationConfig.start);
+        } else {
+          this._endToken([this._processCarriageReturns(parts.join(''))], current);
+          parts.length = 0;
+          this._consumeInterpolation(interpolationTokenType, current, endInterpolation);
+          this._beginToken(textTokenType);
+        }
       } else if (this._cursor.peek() === chars.$AMPERSAND) {
         this._endToken([this._processCarriageReturns(parts.join(''))]);
         parts.length = 0;


### PR DESCRIPTION
Fixes #62174

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The lexer treats all {{ sequences as interpolation starts, even when they come from HTML entities like &lbrace;&lbrace;

Issue Number: #62174


## What is the new behavior?
The lexer now detects if {{ comes from HTML entities and treats it as literal text, while still processing normal {{ as interpolation.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


