### PR TITLE
feat(service-worker): Adds for type in provideServiceWorker

### DIFF
--- a/goldens/public-api/service-worker/index.api.md
+++ b/goldens/public-api/service-worker/index.api.md
@@ -72,6 +72,7 @@ export abstract class SwRegistrationOptions {
     enabled?: boolean;
     registrationStrategy?: string | (() => Observable<unknown>);
     scope?: string;
+    type?: WorkerType;
     updateViaCache?: ServiceWorkerUpdateViaCache;
 }
 

--- a/packages/service-worker/src/provider.ts
+++ b/packages/service-worker/src/provider.ts
@@ -101,7 +101,11 @@ export function ngswAppInitializer(): void {
       }
 
       navigator.serviceWorker
-        .register(script, {scope: options.scope, updateViaCache: options.updateViaCache})
+        .register(script, {
+          scope: options.scope,
+          updateViaCache: options.updateViaCache,
+          type: options.type,
+        })
         .catch((err) =>
           console.error(
             formatRuntimeError(
@@ -158,6 +162,16 @@ export abstract class SwRegistrationOptions {
    * [ServiceWorkerRegistration.updateViaCache](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration/updateViaCache)
    */
   updateViaCache?: ServiceWorkerUpdateViaCache;
+
+  /**
+   * The type of the ServiceWorker script to register.
+   * [ServiceWorkerRegistration#type](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/register#type)
+   * - `classic`: Registers the script as a classic worker. ES module features such as `import` and `export` are NOT allowed in the script.
+   * - `module`: Registers the script as an ES module. Allows use of `import`/`export` syntax and module features.
+   *
+   * @default 'classic'
+   */
+  type?: WorkerType;
 
   /**
    * A URL that defines the ServiceWorker's registration scope; that is, what range of URLs it can

--- a/packages/service-worker/test/provider_spec.ts
+++ b/packages/service-worker/test/provider_spec.ts
@@ -67,14 +67,19 @@ async function waitForReadyToRegister() {
       };
 
       it('sets the registration options', async () => {
-        await configTestBed({enabled: true, scope: 'foo', updateViaCache: 'all'});
+        await configTestBed({enabled: true, scope: 'foo', updateViaCache: 'all', type: 'classic'});
 
         expect(TestBed.inject(SwRegistrationOptions)).toEqual({
           enabled: true,
           scope: 'foo',
           updateViaCache: 'all',
+          type: 'classic',
         });
-        expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: 'foo', updateViaCache: 'all'});
+        expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
+          scope: 'foo',
+          updateViaCache: 'all',
+          type: 'classic',
+        });
       });
 
       it('can disable the SW', async () => {
@@ -91,6 +96,7 @@ async function waitForReadyToRegister() {
         expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
           scope: undefined,
           updateViaCache: undefined,
+          type: undefined,
         });
       });
 
@@ -101,6 +107,18 @@ async function waitForReadyToRegister() {
         expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
           scope: undefined,
           updateViaCache: 'imports',
+          type: undefined,
+        });
+      });
+
+      it('can set type', async () => {
+        await configTestBed({enabled: true, type: 'module'});
+
+        expect(TestBed.inject(SwUpdate).isEnabled).toBe(true);
+        expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
+          scope: undefined,
+          updateViaCache: undefined,
+          type: 'module',
         });
       });
 
@@ -111,6 +129,7 @@ async function waitForReadyToRegister() {
         expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
           scope: undefined,
           updateViaCache: undefined,
+          type: undefined,
         });
       });
 
@@ -155,17 +174,24 @@ async function waitForReadyToRegister() {
       };
 
       it('sets the registration options (and overwrites those set via `provideServiceWorker()`', async () => {
-        configTestBed({enabled: true, scope: 'provider', updateViaCache: 'imports'});
+        configTestBed({
+          enabled: true,
+          scope: 'provider',
+          updateViaCache: 'imports',
+          type: 'module',
+        });
         await untilStable();
         expect(TestBed.inject(SwRegistrationOptions)).toEqual({
           enabled: true,
           scope: 'provider',
           updateViaCache: 'imports',
+          type: 'module',
         });
         await waitForReadyToRegister();
         expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
           scope: 'provider',
           updateViaCache: 'imports',
+          type: 'module',
         });
       });
 
@@ -186,6 +212,7 @@ async function waitForReadyToRegister() {
         expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
           scope: undefined,
           updateViaCache: undefined,
+          type: undefined,
         });
       });
 
@@ -198,6 +225,7 @@ async function waitForReadyToRegister() {
         expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
           scope: undefined,
           updateViaCache: undefined,
+          type: undefined,
         });
       });
 
@@ -271,6 +299,7 @@ async function waitForReadyToRegister() {
           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
             scope: undefined,
             updateViaCache: undefined,
+            type: undefined,
           });
         }));
 
@@ -281,6 +310,7 @@ async function waitForReadyToRegister() {
           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
             scope: undefined,
             updateViaCache: undefined,
+            type: undefined,
           });
         }));
 
@@ -298,6 +328,7 @@ async function waitForReadyToRegister() {
           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
             scope: undefined,
             updateViaCache: undefined,
+            type: undefined,
           });
         }));
 
@@ -308,6 +339,7 @@ async function waitForReadyToRegister() {
           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
             scope: undefined,
             updateViaCache: undefined,
+            type: undefined,
           });
         }));
 
@@ -323,6 +355,7 @@ async function waitForReadyToRegister() {
           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
             scope: undefined,
             updateViaCache: undefined,
+            type: undefined,
           });
         }));
 
@@ -340,6 +373,7 @@ async function waitForReadyToRegister() {
           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
             scope: undefined,
             updateViaCache: undefined,
+            type: undefined,
           });
         }));
 
@@ -357,6 +391,7 @@ async function waitForReadyToRegister() {
           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
             scope: undefined,
             updateViaCache: undefined,
+            type: undefined,
           });
         }));
 
@@ -366,6 +401,7 @@ async function waitForReadyToRegister() {
           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
             scope: undefined,
             updateViaCache: undefined,
+            type: undefined,
           });
         });
 
@@ -381,6 +417,7 @@ async function waitForReadyToRegister() {
           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
             scope: undefined,
             updateViaCache: undefined,
+            type: undefined,
           });
         }));
 
@@ -397,6 +434,7 @@ async function waitForReadyToRegister() {
           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
             scope: undefined,
             updateViaCache: undefined,
+            type: undefined,
           });
         }));
 
@@ -413,6 +451,7 @@ async function waitForReadyToRegister() {
           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
             scope: undefined,
             updateViaCache: undefined,
+            type: undefined,
           });
         }));
 
@@ -429,6 +468,7 @@ async function waitForReadyToRegister() {
           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {
             scope: undefined,
             updateViaCache: undefined,
+            type: undefined,
           });
         }));
 


### PR DESCRIPTION
feat(service-worker): Add type option to provideServiceWorker

Enables specifying the script type ('classic' or 'module') when registering Service Workers, improving compatibility with ES module features.

## The change includes:

- Added `type` to `SwRegistrationOptions` interface
- Modified service worker registration to pass the `type` option
- Added comprehensive unit tests to verify the new functionality
- Updated existing tests to include the new option

## Motivation/Use Cases

The `type` option is particularly useful for:

- **ES Module support**: Enabling ES module features like import/export in service worker scripts
- **Modern JavaScript**: Supporting modern JavaScript syntax and module system in service workers
- **Compliance with PWA best practices**: Aligning with modern service worker registration standards

## Proposed Solution

- Add `type` property to the `SwRegistrationOptions` abstract class
- Implement property handling in the service worker registration logic
- Pass the option through to the native `navigator.serviceWorker.register()` API
- Maintain full backward compatibility with existing configurations (defaults to 'classic')

## Examples of New Usage

### Basic configuration with provideServiceWorker

```typescript
export const appConfig: ApplicationConfig = {
  providers: [
    provideServiceWorker('ngsw-worker.js', {
      enabled: !isDevMode(),
      type: 'module', // Enable ES module features
    }),
  ],
};