### PR TITLE
feat(service-worker): add messageerror event handling and logging

### DIFF
--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -189,8 +189,8 @@ export class Driver implements Debuggable, UpdateSource {
       }
     });
 
-    // Handle the fetch, message, and push, notificationclick,
-    // notificationclose and pushsubscriptionchange events.
+    // Handle the fetch, message, push, notificationclick,
+    // notificationclose, pushsubscriptionchange, and messageerror events.
     this.scope.addEventListener('fetch', (event) => this.onFetch(event!));
     this.scope.addEventListener('message', (event) => this.onMessage(event!));
     this.scope.addEventListener('push', (event) => this.onPush(event!));
@@ -201,6 +201,7 @@ export class Driver implements Debuggable, UpdateSource {
       // based on the incorrect assumption that browsers don't support it.
       this.onPushSubscriptionChange(event as PushSubscriptionChangeEvent),
     );
+    this.scope.addEventListener('messageerror', (event) => this.onMessageError(event));
 
     // The debugger generates debug pages in response to debugging requests.
     this.debugger = new DebugHandler(this, this.adapter);
@@ -336,6 +337,15 @@ export class Driver implements Debuggable, UpdateSource {
   private onPushSubscriptionChange(event: PushSubscriptionChangeEvent): void {
     // Handle the pushsubscriptionchange event and keep the SW alive until it's handled.
     event.waitUntil(this.handlePushSubscriptionChange(event));
+  }
+
+  private onMessageError(event: MessageEvent): void {
+    // Handle message deserialization errors that occur when receiving messages
+    // that cannot be deserialized, typically due to corrupted data or unsupported formats.
+    this.debugger.log(
+      `Message error occurred - data could not be deserialized`,
+      `Driver.onMessageError(origin: ${event.origin})`,
+    );
   }
 
   private async ensureInitialized(event: ExtendableEvent): Promise<void> {

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -1193,6 +1193,21 @@ import {envIsSupported} from '../testing/utils';
       });
     });
 
+    describe('messageerror events', () => {
+      it('logs message deserialization errors', async () => {
+        await driver.initialized;
+
+        const debuggerLogSpy = spyOn(driver.debugger, 'log');
+
+        scope.handleMessageError('someClient');
+
+        expect(debuggerLogSpy).toHaveBeenCalledWith(
+          'Message error occurred - data could not be deserialized',
+          'Driver.onMessageError(origin: )',
+        );
+      });
+    });
+
     describe('notification close events', () => {
       it('broadcasts notification close events', async () => {
         expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -236,6 +236,24 @@ export class SwTestHarnessImpl
     return event.ready;
   }
 
+  handleMessageError(clientId: string | null) {
+    if (!this.eventHandlers.has('messageerror')) {
+      throw new Error('No messageerror handler registered');
+    }
+
+    if (clientId && !this.clients.getMock(clientId)) {
+      this.clients.add(clientId, this.scopeUrl);
+    }
+
+    const event = new MockExtendableMessageEvent(
+      null,
+      (clientId && this.clients.getMock(clientId)) || null,
+    );
+    this.eventHandlers.get('messageerror')!.call(this, event);
+
+    return event.ready;
+  }
+
   handlePush(data: Object): Promise<void> {
     if (!this.eventHandlers.has('push')) {
       throw new Error('No push handler registered');


### PR DESCRIPTION
# feat(service-worker): Add messageerror event handling and logging

Enables proper handling and logging of message deserialization errors in Angular Service Workers, improving error detection and debugging capabilities for corrupted or unsupported message formats.

## The change includes:

- Added `messageerror` event listener to the Driver class
- Implemented `onMessageError` method for handling message deserialization errors
- Added comprehensive unit tests to verify the new functionality
- Updated test harness to support messageerror event simulation
- Enhanced error logging with origin information for better debugging

## Motivation/Use Cases

The `messageerror` event handling is particularly useful for:

- **Error Detection**: Identifying when messages cannot be deserialized due to corrupted data
- **Debugging Support**: Providing detailed logging information about message errors
- **Robust Error Handling**: Gracefully handling unsupported message formats without breaking the service worker
- **Compliance with Service Worker Standards**: Implementing the full messageerror event specification
