### PR TITLE
refactor(common): remove`ngModuleFactory` input of `NgComponentOutlet`

### DIFF
--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -17,7 +17,6 @@ import { Injector } from '@angular/core';
 import { IterableDiffers } from '@angular/core';
 import { KeyValueDiffers } from '@angular/core';
 import { NgIterable } from '@angular/core';
-import { NgModuleFactory } from '@angular/core';
 import { Observable } from 'rxjs';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
@@ -503,13 +502,11 @@ export class NgComponentOutlet<T = any> implements OnChanges, DoCheck, OnDestroy
     ngComponentOutletInputs?: Record<string, unknown>;
     // (undocumented)
     ngComponentOutletNgModule?: Type<any>;
-    // @deprecated (undocumented)
-    ngComponentOutletNgModuleFactory?: NgModuleFactory<any>;
     ngDoCheck(): void;
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<NgComponentOutlet<any>, "[ngComponentOutlet]", ["ngComponentOutlet"], { "ngComponentOutlet": { "alias": "ngComponentOutlet"; "required": false; }; "ngComponentOutletInputs": { "alias": "ngComponentOutletInputs"; "required": false; }; "ngComponentOutletInjector": { "alias": "ngComponentOutletInjector"; "required": false; }; "ngComponentOutletEnvironmentInjector": { "alias": "ngComponentOutletEnvironmentInjector"; "required": false; }; "ngComponentOutletContent": { "alias": "ngComponentOutletContent"; "required": false; }; "ngComponentOutletNgModule": { "alias": "ngComponentOutletNgModule"; "required": false; }; "ngComponentOutletNgModuleFactory": { "alias": "ngComponentOutletNgModuleFactory"; "required": false; }; }, {}, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<NgComponentOutlet<any>, "[ngComponentOutlet]", ["ngComponentOutlet"], { "ngComponentOutlet": { "alias": "ngComponentOutlet"; "required": false; }; "ngComponentOutletInputs": { "alias": "ngComponentOutletInputs"; "required": false; }; "ngComponentOutletInjector": { "alias": "ngComponentOutletInjector"; "required": false; }; "ngComponentOutletEnvironmentInjector": { "alias": "ngComponentOutletEnvironmentInjector"; "required": false; }; "ngComponentOutletContent": { "alias": "ngComponentOutletContent"; "required": false; }; "ngComponentOutletNgModule": { "alias": "ngComponentOutletNgModule"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<NgComponentOutlet<any>, never>;
 }

--- a/goldens/public-api/common/upgrade/index.api.md
+++ b/goldens/public-api/common/upgrade/index.api.md
@@ -15,7 +15,6 @@ import { IterableDiffers } from '@angular/core';
 import { KeyValueDiffers } from '@angular/core';
 import { ModuleWithProviders } from '@angular/core';
 import { NgIterable } from '@angular/core';
-import { NgModuleFactory } from '@angular/core';
 import { Observable } from 'rxjs';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';

--- a/packages/common/src/directives/ng_component_outlet.ts
+++ b/packages/common/src/directives/ng_component_outlet.ts
@@ -111,10 +111,6 @@ export class NgComponentOutlet<T = any> implements OnChanges, DoCheck, OnDestroy
   @Input() ngComponentOutletContent?: any[][];
 
   @Input() ngComponentOutletNgModule?: Type<any>;
-  /**
-   * @deprecated This input is deprecated, use `ngComponentOutletNgModule` instead.
-   */
-  @Input() ngComponentOutletNgModuleFactory?: NgModuleFactory<any>;
 
   private _componentRef: ComponentRef<T> | undefined;
   private _moduleRef: NgModuleRef<any> | undefined;
@@ -175,10 +171,6 @@ export class NgComponentOutlet<T = any> implements OnChanges, DoCheck, OnDestroy
           if (this.ngComponentOutletNgModule) {
             this._moduleRef = createNgModule(
               this.ngComponentOutletNgModule,
-              getParentInjector(injector),
-            );
-          } else if (this.ngComponentOutletNgModuleFactory) {
-            this._moduleRef = this.ngComponentOutletNgModuleFactory.create(
               getParentInjector(injector),
             );
           } else {

--- a/packages/common/test/directives/ng_component_outlet_spec.ts
+++ b/packages/common/test/directives/ng_component_outlet_spec.ts
@@ -187,20 +187,6 @@ describe('insert/remove', () => {
     expect(fixture.nativeElement).toHaveText('projected foo');
   }));
 
-  it('should resolve components from other modules, if supplied as an NgModuleFactory', waitForAsync(() => {
-    const compiler = TestBed.inject(Compiler);
-    let fixture = TestBed.createComponent(TestComponent);
-
-    fixture.detectChanges();
-    expect(fixture.nativeElement).toHaveText('');
-
-    fixture.componentInstance.ngModuleFactory = compiler.compileModuleSync(TestModule2);
-    fixture.componentInstance.currentComponent = Module2InjectedComponent;
-
-    fixture.detectChanges();
-    expect(fixture.nativeElement).toHaveText('baz');
-  }));
-
   it('should resolve components from other modules, if supplied as an NgModule class reference', waitForAsync(() => {
     let fixture = TestBed.createComponent(TestComponent);
 
@@ -212,21 +198,6 @@ describe('insert/remove', () => {
 
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText('baz');
-  }));
-
-  it('should clean up moduleRef, if supplied as an NgModuleFactory', waitForAsync(() => {
-    const compiler = TestBed.inject(Compiler);
-    const fixture = TestBed.createComponent(TestComponent);
-    fixture.componentInstance.ngModuleFactory = compiler.compileModuleSync(TestModule2);
-    fixture.componentInstance.currentComponent = Module2InjectedComponent;
-    fixture.detectChanges();
-
-    const moduleRef = fixture.componentInstance.ngComponentOutlet?.['_moduleRef']!;
-    spyOn(moduleRef, 'destroy').and.callThrough();
-
-    expect(moduleRef.destroy).not.toHaveBeenCalled();
-    fixture.destroy();
-    expect(moduleRef.destroy).toHaveBeenCalled();
   }));
 
   it('should clean up moduleRef, if supplied as an NgModule class reference', waitForAsync(() => {
@@ -241,39 +212,6 @@ describe('insert/remove', () => {
     expect(moduleRef.destroy).not.toHaveBeenCalled();
     fixture.destroy();
     expect(moduleRef.destroy).toHaveBeenCalled();
-  }));
-
-  it("should not re-create moduleRef when it didn't actually change", waitForAsync(() => {
-    const compiler = TestBed.inject(Compiler);
-    const fixture = TestBed.createComponent(TestComponent);
-
-    fixture.componentInstance.ngModuleFactory = compiler.compileModuleSync(TestModule2);
-    fixture.componentInstance.currentComponent = Module2InjectedComponent;
-    fixture.detectChanges();
-    expect(fixture.nativeElement).toHaveText('baz');
-    const moduleRef = fixture.componentInstance.ngComponentOutlet?.['_moduleRef'];
-
-    fixture.componentInstance.currentComponent = Module2InjectedComponent2;
-    fixture.detectChanges();
-
-    expect(fixture.nativeElement).toHaveText('baz2');
-    expect(moduleRef).toBe(fixture.componentInstance.ngComponentOutlet?.['_moduleRef']);
-  }));
-
-  it('should re-create moduleRef when changed (NgModuleFactory)', waitForAsync(() => {
-    const compiler = TestBed.inject(Compiler);
-    const fixture = TestBed.createComponent(TestComponent);
-    fixture.componentInstance.ngModuleFactory = compiler.compileModuleSync(TestModule2);
-    fixture.componentInstance.currentComponent = Module2InjectedComponent;
-    fixture.detectChanges();
-
-    expect(fixture.nativeElement).toHaveText('baz');
-
-    fixture.componentInstance.ngModuleFactory = compiler.compileModuleSync(TestModule3);
-    fixture.componentInstance.currentComponent = Module3InjectedComponent;
-    fixture.detectChanges();
-
-    expect(fixture.nativeElement).toHaveText('bat');
   }));
 
   it('should re-create moduleRef when changed (NgModule class reference)', waitForAsync(() => {
@@ -438,7 +376,6 @@ const TEST_CMP_TEMPLATE = `<ng-template *ngComponentOutlet="
       inputs: inputs;
       content: projectables;
       ngModule: ngModule;
-      ngModuleFactory: ngModuleFactory;
     "></ng-template>`;
 @Component({
   selector: 'test-cmp',
@@ -452,7 +389,6 @@ class TestComponent {
   inputs?: Record<string, unknown>;
   projectables?: any[][];
   ngModule?: Type<unknown>;
-  ngModuleFactory?: NgModuleFactory<unknown>;
 
   get cmpRef(): ComponentRef<any> | undefined {
     return this.ngComponentOutlet?.['_componentRef'];


### PR DESCRIPTION
This was deprecated by #44815

BREAKING CHANGE: NgModuleFactory has been removed, use NgModule instead.
