### PR TITLE
fix(devtools): transfer state settings menu item text size

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.html
@@ -147,9 +147,8 @@
         <mat-slide-toggle
           [checked]="transferStateTabEnabled()"
           (change)="setTransferStateTab($event.checked)"
-        >
-          Show Transfer State Tab</mat-slide-toggle
-        >
+        />
+        <span class="ng-mat-menu-label-text">Enable Transfer State Tab</span>
       </label>
     }
   </div>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

<img width="299" height="226" alt="Screenshot 2025-07-28 at 12 26 44" src="https://github.com/user-attachments/assets/e1591521-19de-4587-9a89-761795df2f59" />



## What is the new behavior?

Fix the text size of the transfer state settings menu item. Also, rename "Show" to "Enable" to match the rest of the non-default tabs text.