### PR TITLE
fix(compiler): exclude more safe reads expression from 2way-binding

### DIFF
--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -18,12 +18,15 @@ import {
   ImplicitReceiver,
   KeyedRead,
   NonNullAssert,
+  ParenthesizedExpression,
   ParsedEvent,
   ParsedEventType,
   ParsedProperty,
   ParsedPropertyType,
   ParsedVariable,
   PropertyRead,
+  SafeKeyedRead,
+  SafePropertyRead,
   TemplateBinding,
   ThisReceiver,
   VariableBinding,
@@ -863,11 +866,29 @@ export class BindingParser {
     }
 
     if (ast instanceof PropertyRead || ast instanceof KeyedRead) {
-      return true;
+      if (!hasRecursiveSafeReceiver(ast)) {
+        return true;
+      }
     }
 
     return false;
   }
+}
+
+function hasRecursiveSafeReceiver(ast: AST): boolean {
+  if (ast instanceof SafePropertyRead || ast instanceof SafeKeyedRead) {
+    return true;
+  }
+
+  if (ast instanceof ParenthesizedExpression) {
+    return hasRecursiveSafeReceiver(ast.expression);
+  }
+
+  if (ast instanceof PropertyRead || ast instanceof KeyedRead || ast instanceof Call) {
+    return hasRecursiveSafeReceiver(ast.receiver);
+  }
+
+  return false;
 }
 
 function isLegacyAnimationLabel(name: string): boolean {

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -646,6 +646,10 @@ describe('R3 template transform', () => {
         'v + 1',
         'foo.bar?.baz',
         `foo.bar?.['baz']`,
+        'foo?.bar.baz[0]',
+        'foo?.bar.baz[0].boo[0]',
+        'foo?.bar.baz()',
+        '(foo?.bar).baz', // not null-safe and would crash at runtime, but may not report an error without `strictNullChecks`
         'true',
         '123',
         'a.b()',
@@ -668,6 +672,13 @@ describe('R3 template transform', () => {
         expect(() => parse(`<div [(prop)]="${expression}"></div>`))
           .withContext(expression)
           .toThrowError(/Unsupported expression in a two-way binding/);
+      }
+
+      const supportedExpressions = ['(foo?.bar ?? bar).baz'];
+      for (const expression of supportedExpressions) {
+        expect(() => parse(`<div [(prop)]="${expression}"></div>`))
+          .withContext(expression)
+          .not.toThrowError();
       }
     });
 


### PR DESCRIPTION
Priori to this fix the parser would allow safereads in accestor receievers (but the direct one).

fixes #62837