### PR TITLE
fix(http): Reset headers, progress, and statusCode when using `set()` in `HttpResource`

### DIFF
--- a/packages/common/http/src/resource.ts
+++ b/packages/common/http/src/resource.ts
@@ -393,6 +393,14 @@ class HttpResourceImpl<T>
     this.client = injector.get(HttpClient);
   }
 
+  override set(value: T): void {
+    super.set(value);
+
+    this._headers.set(undefined);
+    this._progress.set(undefined);
+    this._statusCode.set(undefined);
+  }
+
   // This is a type only override of the method
   declare hasValue: () => this is HttpResourceRef<Exclude<T, undefined>>;
 }

--- a/packages/common/http/test/resource_spec.ts
+++ b/packages/common/http/test/resource_spec.ts
@@ -323,4 +323,19 @@ describe('httpResource', () => {
     req = backend.expectOne('/data');
     req.flush([]);
   });
+
+  it('should reset past request data when using set()', async () => {
+    const backend = TestBed.inject(HttpTestingController);
+    const res = httpResource(() => '/data', {injector: TestBed.inject(Injector)});
+    TestBed.tick();
+    const req = backend.expectOne('/data');
+    req.flush([]);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    res.set([]);
+
+    expect(res.headers()).toBe(undefined);
+    expect(res.progress()).toBe(undefined);
+    expect(res.statusCode()).toBe(undefined);
+  });
 });


### PR DESCRIPTION
Currently, those values aren't reset, which means they are out of sync with the new value

This change is slightly opinionated, but it does seem appropriate to me.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Previous headers, progress, and statusCode are kept.

Issue Number: N/A


## What is the new behavior?
They are reset when setting a custom value.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] If you relied on this undefined behaviour, yes.
- [ ] No

## Other information
Ran into this by accident when checking only for `statusCode()` without checking for the actual `status()`.