### PR TITLE
refactor(core): deprecate animations field on component interface

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -266,6 +266,7 @@ export type CompilerOptions = {
 
 // @public
 export interface Component extends Directive {
+    // @deprecated
     animations?: any[];
     changeDetection?: ChangeDetectionStrategy;
     encapsulation?: ViewEncapsulation;

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -604,6 +604,7 @@ export interface Component extends Directive {
    * [`state()`](api/animations/state) and `transition()` definitions.
    * See the [Animations guide](guide/animations) and animations API documentation.
    *
+   * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
    */
   animations?: any[];
 


### PR DESCRIPTION
This deprecates the animations field on the component decorator in favor of animate.enter and leave.

DEPRECATED: @angular/animations
