### PR TITLE
fix(devtools): MessageBus.on return type

### DIFF
--- a/devtools/projects/protocol/src/lib/message-bus.ts
+++ b/devtools/projects/protocol/src/lib/message-bus.ts
@@ -9,7 +9,7 @@
 export type Parameters<F> = F extends (...args: infer T) => any ? T : never;
 
 export abstract class MessageBus<T> {
-  abstract on<E extends keyof T>(topic: E, cb: T[E]): void;
+  abstract on<E extends keyof T>(topic: E, cb: T[E]): () => void;
   abstract once<E extends keyof T>(topic: E, cb: T[E]): void;
   abstract emit<E extends keyof T>(topic: E, args?: Parameters<T[E]>): boolean;
   abstract destroy(): void;

--- a/devtools/projects/protocol/src/lib/priority-aware-message-bus.spec.ts
+++ b/devtools/projects/protocol/src/lib/priority-aware-message-bus.spec.ts
@@ -15,8 +15,11 @@ class MockMessageBus extends MessageBus<Events> {
   override emit(_: Topic, __: any): boolean {
     return true;
   }
-  override on(topic: Topic, cb: any): void {
+  override on(topic: Topic, cb: any): () => void {
     this.cbs[topic] = cb;
+    return () => {
+      delete this.cbs[topic];
+    };
   }
   override once(topic: Topic, cb: any): void {
     this.cbs[topic] = cb;

--- a/devtools/projects/protocol/src/lib/priority-aware-message-bus.ts
+++ b/devtools/projects/protocol/src/lib/priority-aware-message-bus.ts
@@ -60,7 +60,7 @@ export class PriorityAwareMessageBus extends MessageBus<Events> {
     super();
   }
 
-  override on<E extends Topic>(topic: E, cb: Events[E]): void {
+  override on<E extends Topic>(topic: E, cb: Events[E]): () => void {
     return this._bus.on(topic, (...args: any) => {
       (cb as any)(...args);
       this._afterMessage(topic);


### PR DESCRIPTION
It appears that the intent is to return an unlisten function when `on` is called. The message bus implementations indicate that. However, the `MessageBus` abstract class returns `void` instead. This prevents us to unlisten events in the BE and FE apps. 

Change to `on: () => void`.