### PR TITLE
fix(devtools): Display falsy signal values correctly

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-tree.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-tree.component.html
@@ -8,7 +8,7 @@
       } @else {
         <ng-property-editor
           [key]="node.prop.name"
-          [initialValue]="node.prop.descriptor.value || node.prop.descriptor.preview"
+          [initialValue]="node.prop.descriptor.value ?? node.prop.descriptor.preview"
           [containerType]="node.prop.descriptor.containerType"
           (updateValue)="handleUpdate(node, $event)"
         />


### PR DESCRIPTION
falsy value would display their preview because of the logical or.

fixes #55727
