### PR TITLE
refactor(core): Create a base effect interface and prototype to be us…

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -661,10 +661,10 @@ export const DOCUMENT: InjectionToken<Document>;
 export function effect(effectFn: (onCleanup: EffectCleanupRegisterFn) => void, options?: CreateEffectOptions): EffectRef;
 
 // @public
-export type EffectCleanupFn = () => void;
+export type EffectCleanupFn = EffectCleanupFn_2;
 
 // @public
-export type EffectCleanupRegisterFn = (cleanupFn: EffectCleanupFn) => void;
+export type EffectCleanupRegisterFn = EffectCleanupRegisterFn_2;
 
 // @public
 export interface EffectRef {

--- a/goldens/public-api/core/primitives/signals/index.api.md
+++ b/goldens/public-api/core/primitives/signals/index.api.md
@@ -5,6 +5,25 @@
 ```ts
 
 // @public (undocumented)
+export const BASE_EFFECT_NODE: Omit<BaseEffectNode, 'fn' | 'destroy' | 'cleanup'>;
+
+// @public (undocumented)
+export interface BaseEffectNode extends ReactiveNode {
+    // (undocumented)
+    cleanup(): void;
+    // (undocumented)
+    cleanupFn: EffectCleanupRegisterFn;
+    // (undocumented)
+    destroy(): void;
+    // (undocumented)
+    fn: (cleanupFn: EffectCleanupRegisterFn) => void;
+    // (undocumented)
+    hasRun: boolean;
+    // (undocumented)
+    run(): void;
+}
+
+// @public (undocumented)
 export type ComputationFn<S, D> = (source: S, previous?: {
     source: S;
     value: D;
@@ -48,6 +67,12 @@ export function createWatch(fn: (onCleanup: WatchCleanupRegisterFn) => void, sch
 
 // @public
 export function defaultEquals<T>(a: T, b: T): boolean;
+
+// @public
+export type EffectCleanupFn = () => void;
+
+// @public
+export type EffectCleanupRegisterFn = (cleanupFn: EffectCleanupFn) => void;
 
 // @public (undocumented)
 export function getActiveConsumer(): ReactiveNode | null;
@@ -124,15 +149,18 @@ export interface ReactiveNode {
     debugName?: string;
     dirty: boolean;
     kind: string;
-    lastCleanEpoch: Version;
+    _lastCleanEpoch: Version;
     producerMustRecompute(node: unknown): boolean;
     // (undocumented)
     producerRecomputeValue(node: unknown): void;
     producers: ReactiveLink | undefined;
     producersTail: ReactiveLink | undefined;
     recomputing: boolean;
-    version: Version;
+    _version: Version;
 }
+
+// @public (undocumented)
+export function runEffect(node: BaseEffectNode): void;
 
 // @public (undocumented)
 export function runPostProducerCreatedFn(node: ReactiveNode): void;

--- a/packages/core/primitives/signals/index.ts
+++ b/packages/core/primitives/signals/index.ts
@@ -55,3 +55,10 @@ export {
 export {Watch, WatchCleanupFn, WatchCleanupRegisterFn, createWatch} from './src/watch';
 export {setAlternateWeakRefImpl} from './src/weak_ref';
 export {untracked} from './src/untracked';
+export {
+  BaseEffectNode,
+  EffectCleanupFn,
+  EffectCleanupRegisterFn,
+  BASE_EFFECT_NODE,
+  runEffect,
+} from './src/effect';

--- a/packages/core/primitives/signals/src/computed.ts
+++ b/packages/core/primitives/signals/src/computed.ts
@@ -169,7 +169,7 @@ const COMPUTED_NODE = /* @__PURE__ */ (() => {
       }
 
       node.value = newValue;
-      node.version++;
+      node.__version++;
     },
   };
 })();

--- a/packages/core/primitives/signals/src/effect.ts
+++ b/packages/core/primitives/signals/src/effect.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  consumerAfterComputation,
+  consumerBeforeComputation,
+  consumerPollProducersForChange,
+  REACTIVE_NODE,
+  ReactiveNode,
+} from './graph';
+
+// Required as the signals library is in a separate package, so we need to explicitly ensure the
+// global `ngDevMode` type is defined.
+declare const ngDevMode: boolean | undefined;
+
+/**
+ * An effect can, optionally, register a cleanup function. If registered, the cleanup is executed
+ * before the next effect run. The cleanup function makes it possible to "cancel" any work that the
+ * previous effect run might have started.
+ */
+export type EffectCleanupFn = () => void;
+
+/**
+ * A callback passed to the effect function that makes it possible to register cleanup logic.
+ */
+export type EffectCleanupRegisterFn = (cleanupFn: EffectCleanupFn) => void;
+
+export interface BaseEffectNode extends ReactiveNode {
+  hasRun: boolean;
+  cleanupFn: EffectCleanupRegisterFn;
+  fn: (cleanupFn: EffectCleanupRegisterFn) => void;
+  destroy(): void;
+  cleanup(): void;
+  run(): void;
+}
+
+export const BASE_EFFECT_NODE: Omit<BaseEffectNode, 'fn' | 'destroy' | 'cleanup'> =
+  /* @__PURE__ */ (() => ({
+    ...REACTIVE_NODE,
+    consumerIsAlwaysLive: true,
+    consumerAllowSignalWrites: true,
+    __dirty: true,
+    hasRun: false,
+    cleanupFn: () => {},
+    kind: 'effect',
+    run(this: BaseEffectNode): void {
+      runEffect(this);
+    },
+  }))();
+
+export function runEffect(node: BaseEffectNode) {
+  node.__dirty = false;
+  if (node.hasRun && !consumerPollProducersForChange(node)) {
+    return;
+  }
+  node.hasRun = true;
+  const prevNode = consumerBeforeComputation(node);
+  try {
+    node.cleanup();
+    node.fn(node.cleanupFn);
+  } finally {
+    consumerAfterComputation(node, prevNode);
+  }
+}

--- a/packages/core/primitives/signals/src/linked_signal.ts
+++ b/packages/core/primitives/signals/src/linked_signal.ts
@@ -173,7 +173,7 @@ export const LINKED_SIGNAL_NODE: object = /* @__PURE__ */ (() => {
       }
 
       node.value = newValue;
-      node.version++;
+      node.__version++;
     },
   };
 })();

--- a/packages/core/primitives/signals/src/signal.ts
+++ b/packages/core/primitives/signals/src/signal.ts
@@ -119,7 +119,7 @@ export const SIGNAL_NODE: SignalNode<unknown> = /* @__PURE__ */ (() => {
 })();
 
 function signalValueChanged<T>(node: SignalNode<T>): void {
-  node.version++;
+  node.__version++;
   producerIncrementEpoch();
   producerNotifyConsumers(node);
   postSignalSetFn?.(node);

--- a/packages/core/primitives/signals/src/watch.ts
+++ b/packages/core/primitives/signals/src/watch.ts
@@ -110,7 +110,7 @@ export function createWatch(
       );
     }
 
-    node.dirty = false;
+    node.__dirty = false;
     if (node.hasRun && !consumerPollProducersForChange(node)) {
       return;
     }

--- a/packages/core/src/render3/instructions/change_detection.ts
+++ b/packages/core/src/render3/instructions/change_detection.ts
@@ -480,14 +480,14 @@ function detectChangesInView(lView: LView, mode: ChangeDetectionMode) {
   shouldRefreshView ||= !!(flags & LViewFlags.RefreshView);
 
   // Refresh views when they have a dirty reactive consumer, regardless of mode.
-  shouldRefreshView ||= !!(consumer?.dirty && consumerPollProducersForChange(consumer));
+  shouldRefreshView ||= !!(consumer?.__dirty && consumerPollProducersForChange(consumer));
 
   shouldRefreshView ||= !!(ngDevMode && isExhaustiveCheckNoChanges());
 
   // Mark the Flags and `ReactiveNode` as not dirty before refreshing the component, so that they
   // can be re-dirtied during the refresh process.
   if (consumer) {
-    consumer.dirty = false;
+    consumer.__dirty = false;
   }
   lView[FLAGS] &= ~(LViewFlags.HasChildViewsToRefresh | LViewFlags.RefreshView);
 

--- a/packages/core/src/render3/reactivity/after_render_effect.ts
+++ b/packages/core/src/render3/reactivity/after_render_effect.ts
@@ -102,11 +102,11 @@ const AFTER_RENDER_PHASE_EFFECT_NODE = /* @__PURE__ */ (() => ({
   phaseFn(this: AfterRenderPhaseEffectNode, previousValue?: unknown): unknown {
     this.sequence.lastPhase = this.phase;
 
-    if (!this.dirty) {
+    if (!this.__dirty) {
       return this.signal;
     }
 
-    this.dirty = false;
+    this.__dirty = false;
     if (this.value !== NOT_SET && !consumerPollProducersForChange(this)) {
       // None of our producers report a change since the last time they were read, so no
       // recomputation of our value is necessary.
@@ -142,7 +142,7 @@ const AFTER_RENDER_PHASE_EFFECT_NODE = /* @__PURE__ */ (() => ({
 
     if (this.value === NOT_SET || !this.equal(this.value, newValue)) {
       this.value = newValue;
-      this.version++;
+      this.__version++;
     }
 
     return this.signal;
@@ -196,7 +196,7 @@ class AfterRenderEffectSequence extends AfterRenderSequence {
       node.sequence = this;
       node.phase = phase;
       node.userFn = effectHook;
-      node.dirty = true;
+      node.__dirty = true;
       node.signal = (() => {
         producerAccessed(node);
         return node.value;

--- a/packages/core/src/render3/reactivity/root_effect_scheduler.ts
+++ b/packages/core/src/render3/reactivity/root_effect_scheduler.ts
@@ -16,7 +16,7 @@ export interface SchedulableEffect {
   zone: {
     run<T>(fn: () => T): T;
   } | null;
-  dirty: boolean;
+  __dirty: boolean;
 }
 
 /**
@@ -62,7 +62,7 @@ export class ZoneAwareEffectScheduler implements EffectScheduler {
   }
 
   schedule(handle: SchedulableEffect): void {
-    if (!handle.dirty) {
+    if (!handle.__dirty) {
       return;
     }
     this.dirtyEffectCount++;
@@ -76,7 +76,7 @@ export class ZoneAwareEffectScheduler implements EffectScheduler {
     }
 
     queue.delete(handle);
-    if (handle.dirty) {
+    if (handle.__dirty) {
       this.dirtyEffectCount--;
     }
   }
@@ -123,7 +123,7 @@ export class ZoneAwareEffectScheduler implements EffectScheduler {
   private flushQueue(queue: Set<SchedulableEffect>): boolean {
     let ranOneEffect = false;
     for (const handle of queue) {
-      if (!handle.dirty) {
+      if (!handle.__dirty) {
         continue;
       }
       this.dirtyEffectCount--;

--- a/packages/core/src/render3/reactivity/view_effect_runner.ts
+++ b/packages/core/src/render3/reactivity/view_effect_runner.ts
@@ -20,7 +20,7 @@ export function runEffectsInView(view: LView): void {
   while (tryFlushEffects) {
     let foundDirtyEffect = false;
     for (const effect of view[EFFECTS]) {
-      if (!effect.dirty) {
+      if (!effect.__dirty) {
         continue;
       }
       foundDirtyEffect = true;

--- a/packages/core/src/render3/util/signal_debug.ts
+++ b/packages/core/src/render3/util/signal_debug.ts
@@ -116,7 +116,7 @@ function getNodesAndEdgesFromSignalMap(signalMap: ReadonlyMap<ReactiveNode, Reac
         label: consumer.debugName,
         value: consumer.value,
         kind: consumer.kind,
-        epoch: consumer.version,
+        epoch: consumer.__version,
         debuggableFn: consumer.computation,
         id,
       });
@@ -125,21 +125,21 @@ function getNodesAndEdgesFromSignalMap(signalMap: ReadonlyMap<ReactiveNode, Reac
         label: consumer.debugName,
         value: consumer.value,
         kind: consumer.kind,
-        epoch: consumer.version,
+        epoch: consumer.__version,
         id,
       });
     } else if (isTemplateEffectNode(consumer)) {
       debugSignalGraphNodes.push({
         label: consumer.debugName ?? consumer.lView?.[HOST]?.tagName?.toLowerCase?.(),
         kind: consumer.kind,
-        epoch: consumer.version,
+        epoch: consumer.__version,
         id,
       });
     } else {
       debugSignalGraphNodes.push({
         label: consumer.debugName,
         kind: consumer.kind,
-        epoch: consumer.version,
+        epoch: consumer.__version,
         id,
       });
     }
@@ -179,7 +179,7 @@ function extractSignalNodesAndEdgesFromRoots(
     }
 
     const producerNodes = [];
-    for (let link = node.producers; link !== undefined; link = link.nextProducer) {
+    for (let link = node.__producers; link !== undefined; link = link.nextProducer) {
       const producer = link.producer;
       producerNodes.push(producer);
     }

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -236,7 +236,7 @@ export function walkUpViews(nestingLevel: number, currentView: LView): LView {
 export function requiresRefreshOrTraversal(lView: LView) {
   return !!(
     lView[FLAGS] & (LViewFlags.RefreshView | LViewFlags.HasChildViewsToRefresh) ||
-    lView[REACTIVE_TEMPLATE_CONSUMER]?.dirty
+    lView[REACTIVE_TEMPLATE_CONSUMER]?.__dirty
   );
 }
 

--- a/packages/core/test/signals/signal_spec.ts
+++ b/packages/core/test/signals/signal_spec.ts
@@ -155,7 +155,7 @@ describe('signals', () => {
       // Forcibly increment the version of the source signal. This will cause a mismatch during
       // polling, and will force the derived signal to recompute if polled (which we should observe
       // in this test).
-      sourceNode.version++;
+      sourceNode.__version++;
 
       // Read the derived signal again. This should not recompute (even with the forced version
       // update) as no signals have been set since the last read.


### PR DESCRIPTION
…ed by both angular and wiz.

Add a common interface and prototype to be used to create the wiz and angular effect. Also update the reactive node interface to mark properties that should only be modified by framework code with __ syntax, and make properties that shouldn't be updated readonly.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Angular and Wiz have their own effect interface and prototype that causes a code repetition.

Issue Number: N/A


## What is the new behavior?
Adds a common interface and base prototype for both Angular and Wiz to extend.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
