### PR TITLE
refactor(core): Create a base effect interface and prototype

### DIFF
--- a/goldens/public-api/core/primitives/signals/index.api.md
+++ b/goldens/public-api/core/primitives/signals/index.api.md
@@ -5,6 +5,25 @@
 ```ts
 
 // @public (undocumented)
+export const BASE_EFFECT_NODE: Omit<BaseEffectNode, 'fn' | 'destroy' | 'cleanup'>;
+
+// @public (undocumented)
+export interface BaseEffectNode extends ReactiveNode {
+    // (undocumented)
+    cleanup(): void;
+    // (undocumented)
+    cleanupFn: EffectCleanupRegisterFn;
+    // (undocumented)
+    destroy(): void;
+    // (undocumented)
+    fn: (cleanupFn: EffectCleanupRegisterFn) => void;
+    // (undocumented)
+    hasRun: boolean;
+    // (undocumented)
+    run(): void;
+}
+
+// @public (undocumented)
 export type ComputationFn<S, D> = (source: S, previous?: {
     source: S;
     value: D;
@@ -48,6 +67,12 @@ export function createWatch(fn: (onCleanup: WatchCleanupRegisterFn) => void, sch
 
 // @public
 export function defaultEquals<T>(a: T, b: T): boolean;
+
+// @public
+export type EffectCleanupFn = () => void;
+
+// @public
+export type EffectCleanupRegisterFn = (cleanupFn: EffectCleanupFn) => void;
 
 // @public (undocumented)
 export function getActiveConsumer(): ReactiveNode | null;
@@ -133,6 +158,9 @@ export interface ReactiveNode {
     recomputing: boolean;
     version: Version;
 }
+
+// @public (undocumented)
+export function runEffect(node: BaseEffectNode): void;
 
 // @public (undocumented)
 export function runPostProducerCreatedFn(node: ReactiveNode): void;

--- a/goldens/public-api/core/primitives/signals/index.api.md
+++ b/goldens/public-api/core/primitives/signals/index.api.md
@@ -5,18 +5,16 @@
 ```ts
 
 // @public (undocumented)
-export const BASE_EFFECT_NODE: Omit<BaseEffectNode, 'fn' | 'destroy' | 'cleanup'>;
+export const BASE_EFFECT_NODE: Omit<BaseEffectNode, 'fn' | 'destroy' | 'cleanup' | 'run'>;
 
 // @public (undocumented)
 export interface BaseEffectNode extends ReactiveNode {
     // (undocumented)
     cleanup(): void;
     // (undocumented)
-    cleanupFn: EffectCleanupRegisterFn;
-    // (undocumented)
     destroy(): void;
     // (undocumented)
-    fn: (cleanupFn: EffectCleanupRegisterFn) => void;
+    fn: () => void;
     // (undocumented)
     hasRun: boolean;
     // (undocumented)
@@ -67,12 +65,6 @@ export function createWatch(fn: (onCleanup: WatchCleanupRegisterFn) => void, sch
 
 // @public
 export function defaultEquals<T>(a: T, b: T): boolean;
-
-// @public
-export type EffectCleanupFn = () => void;
-
-// @public
-export type EffectCleanupRegisterFn = (cleanupFn: EffectCleanupFn) => void;
 
 // @public (undocumented)
 export function getActiveConsumer(): ReactiveNode | null;

--- a/packages/core/primitives/signals/index.ts
+++ b/packages/core/primitives/signals/index.ts
@@ -55,3 +55,10 @@ export {
 export {Watch, WatchCleanupFn, WatchCleanupRegisterFn, createWatch} from './src/watch';
 export {setAlternateWeakRefImpl} from './src/weak_ref';
 export {untracked} from './src/untracked';
+export {
+  runEffect,
+  BASE_EFFECT_NODE,
+  BaseEffectNode,
+  EffectCleanupFn,
+  EffectCleanupRegisterFn,
+} from './src/effect';

--- a/packages/core/primitives/signals/index.ts
+++ b/packages/core/primitives/signals/index.ts
@@ -55,10 +55,4 @@ export {
 export {Watch, WatchCleanupFn, WatchCleanupRegisterFn, createWatch} from './src/watch';
 export {setAlternateWeakRefImpl} from './src/weak_ref';
 export {untracked} from './src/untracked';
-export {
-  runEffect,
-  BASE_EFFECT_NODE,
-  BaseEffectNode,
-  EffectCleanupFn,
-  EffectCleanupRegisterFn,
-} from './src/effect';
+export {runEffect, BASE_EFFECT_NODE, BaseEffectNode} from './src/effect';

--- a/packages/core/primitives/signals/src/effect.ts
+++ b/packages/core/primitives/signals/src/effect.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  consumerAfterComputation,
+  consumerBeforeComputation,
+  consumerPollProducersForChange,
+  REACTIVE_NODE,
+  ReactiveNode,
+} from './graph';
+
+/**
+ * An effect can, optionally, register a cleanup function. If registered, the cleanup is executed
+ * before the next effect run. The cleanup function makes it possible to "cancel" any work that the
+ * previous effect run might have started.
+ */
+export type EffectCleanupFn = () => void;
+
+/**
+ * A callback passed to the effect function that makes it possible to register cleanup logic.
+ */
+export type EffectCleanupRegisterFn = (cleanupFn: EffectCleanupFn) => void;
+
+export interface BaseEffectNode extends ReactiveNode {
+  hasRun: boolean;
+  fn: () => void;
+  destroy(): void;
+  cleanup(): void;
+  run(): void;
+}
+
+export const BASE_EFFECT_NODE: Omit<BaseEffectNode, 'fn' | 'destroy' | 'cleanup' | 'run'> =
+  /* @__PURE__ */ (() => ({
+    ...REACTIVE_NODE,
+    consumerIsAlwaysLive: true,
+    consumerAllowSignalWrites: true,
+    dirty: true,
+    hasRun: false,
+    kind: 'effect',
+  }))();
+
+export function runEffect(node: BaseEffectNode) {
+  node.dirty = false;
+  if (node.hasRun && !consumerPollProducersForChange(node)) {
+    return;
+  }
+  node.hasRun = true;
+  const prevNode = consumerBeforeComputation(node);
+  try {
+    node.cleanup();
+    node.fn();
+  } finally {
+    consumerAfterComputation(node, prevNode);
+  }
+}

--- a/packages/core/src/core_reactivity_export_internal.ts
+++ b/packages/core/src/core_reactivity_export_internal.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-export {SIGNAL as ɵSIGNAL} from '../primitives/signals';
+export {SIGNAL as ɵSIGNAL, EffectCleanupFn, EffectCleanupRegisterFn} from '../primitives/signals';
 
 export {isSignal, Signal, ValueEqualityFn} from './render3/reactivity/api';
 export {computed, CreateComputedOptions} from './render3/reactivity/computed';
@@ -18,13 +18,7 @@ export {
 } from './render3/reactivity/signal';
 export {linkedSignal} from './render3/reactivity/linked_signal';
 export {untracked} from './render3/reactivity/untracked';
-export {
-  CreateEffectOptions,
-  effect,
-  EffectRef,
-  EffectCleanupFn,
-  EffectCleanupRegisterFn,
-} from './render3/reactivity/effect';
+export {CreateEffectOptions, effect, EffectRef} from './render3/reactivity/effect';
 export {EffectScheduler as ɵEffectScheduler} from './render3/reactivity/root_effect_scheduler';
 export {afterRenderEffect, ɵFirstAvailableSignal} from './render3/reactivity/after_render_effect';
 export {assertNotInReactiveContext} from './render3/reactivity/asserts';

--- a/packages/core/src/core_reactivity_export_internal.ts
+++ b/packages/core/src/core_reactivity_export_internal.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-export {SIGNAL as ɵSIGNAL, EffectCleanupFn, EffectCleanupRegisterFn} from '../primitives/signals';
+export {SIGNAL as ɵSIGNAL} from '../primitives/signals';
 
 export {isSignal, Signal, ValueEqualityFn} from './render3/reactivity/api';
 export {computed, CreateComputedOptions} from './render3/reactivity/computed';
@@ -18,7 +18,13 @@ export {
 } from './render3/reactivity/signal';
 export {linkedSignal} from './render3/reactivity/linked_signal';
 export {untracked} from './render3/reactivity/untracked';
-export {CreateEffectOptions, effect, EffectRef} from './render3/reactivity/effect';
+export {
+  CreateEffectOptions,
+  effect,
+  EffectRef,
+  EffectCleanupFn,
+  EffectCleanupRegisterFn,
+} from './render3/reactivity/effect';
 export {EffectScheduler as ɵEffectScheduler} from './render3/reactivity/root_effect_scheduler';
 export {afterRenderEffect, ɵFirstAvailableSignal} from './render3/reactivity/after_render_effect';
 export {assertNotInReactiveContext} from './render3/reactivity/asserts';

--- a/packages/core/src/render3/reactivity/after_render_effect.ts
+++ b/packages/core/src/render3/reactivity/after_render_effect.ts
@@ -15,10 +15,11 @@ import {
   SIGNAL,
   SIGNAL_NODE,
   type SignalNode,
+  type EffectCleanupFn,
+  type EffectCleanupRegisterFn,
 } from '../../../primitives/signals';
 
 import {type Signal} from '../reactivity/api';
-import {type EffectCleanupFn, type EffectCleanupRegisterFn} from './effect';
 
 import {TracingService, TracingSnapshot} from '../../application/tracing';
 import {

--- a/packages/core/src/render3/reactivity/after_render_effect.ts
+++ b/packages/core/src/render3/reactivity/after_render_effect.ts
@@ -15,12 +15,9 @@ import {
   SIGNAL,
   SIGNAL_NODE,
   type SignalNode,
-  type EffectCleanupFn,
-  type EffectCleanupRegisterFn,
 } from '../../../primitives/signals';
-
+import {type EffectCleanupFn, type EffectCleanupRegisterFn} from './effect';
 import {type Signal} from '../reactivity/api';
-
 import {TracingService, TracingSnapshot} from '../../application/tracing';
 import {
   ChangeDetectionScheduler,

--- a/packages/core/src/render3/reactivity/effect.ts
+++ b/packages/core/src/render3/reactivity/effect.ts
@@ -7,15 +7,16 @@
  */
 
 import {
-  REACTIVE_NODE,
-  ReactiveNode,
   SIGNAL,
-  consumerAfterComputation,
-  consumerBeforeComputation,
   consumerDestroy,
-  consumerPollProducersForChange,
   isInNotificationPhase,
   setActiveConsumer,
+  getActiveConsumer,
+  BaseEffectNode,
+  EffectCleanupFn,
+  EffectCleanupRegisterFn,
+  BASE_EFFECT_NODE,
+  runEffect,
 } from '../../../primitives/signals';
 import {FLAGS, LViewFlags, LView, EFFECTS} from '../interfaces/view';
 import {markAncestorsForTraversal} from '../util/view_utils';
@@ -94,22 +95,6 @@ export interface CreateEffectOptions {
    */
   debugName?: string;
 }
-
-/**
- * An effect can, optionally, register a cleanup function. If registered, the cleanup is executed
- * before the next effect run. The cleanup function makes it possible to "cancel" any work that the
- * previous effect run might have started.
- *
- * @publicApi 20.0
- */
-export type EffectCleanupFn = () => void;
-
-/**
- * A callback passed to the effect function that makes it possible to register cleanup logic.
- *
- * @publicApi 20.0
- */
-export type EffectCleanupRegisterFn = (cleanupFn: EffectCleanupFn) => void;
 
 /**
  * Registers an "effect" that will be scheduled & executed whenever the signals that it reads
@@ -191,17 +176,12 @@ export function effect(
   return effectRef;
 }
 
-export interface EffectNode extends ReactiveNode, SchedulableEffect {
-  hasRun: boolean;
+export interface EffectNode extends BaseEffectNode, SchedulableEffect {
   cleanupFns: EffectCleanupFn[] | undefined;
   injector: Injector;
   notifier: ChangeDetectionScheduler;
 
   onDestroyFn: () => void;
-  fn: (cleanupFn: EffectCleanupRegisterFn) => void;
-  run(): void;
-  destroy(): void;
-  maybeCleanup(): void;
 }
 
 export interface ViewEffectNode extends EffectNode {
@@ -212,47 +192,27 @@ export interface RootEffectNode extends EffectNode {
   scheduler: EffectScheduler;
 }
 
-export const BASE_EFFECT_NODE: Omit<EffectNode, 'fn' | 'destroy' | 'injector' | 'notifier'> =
+export const EFFECT_NODE: Omit<EffectNode, 'fn' | 'destroy' | 'injector' | 'notifier'> =
   /* @__PURE__ */ (() => ({
-    ...REACTIVE_NODE,
-    consumerIsAlwaysLive: true,
-    consumerAllowSignalWrites: true,
-    dirty: true,
-    hasRun: false,
+    ...BASE_EFFECT_NODE,
     cleanupFns: undefined,
     zone: null,
-    kind: 'effect',
     onDestroyFn: noop,
     run(this: EffectNode): void {
-      this.dirty = false;
-
       if (ngDevMode && isInNotificationPhase()) {
         throw new Error(`Schedulers cannot synchronously execute watches while scheduling.`);
       }
-
-      if (this.hasRun && !consumerPollProducersForChange(this)) {
-        return;
-      }
-      this.hasRun = true;
-
-      const registerCleanupFn: EffectCleanupRegisterFn = (cleanupFn) =>
-        (this.cleanupFns ??= []).push(cleanupFn);
-
-      const prevNode = consumerBeforeComputation(this);
-
       // We clear `setIsRefreshingViews` so that `markForCheck()` within the body of an effect will
       // cause CD to reach the component in question.
       const prevRefreshingViews = setIsRefreshingViews(false);
       try {
-        this.maybeCleanup();
-        this.fn(registerCleanupFn);
+        runEffect(this);
       } finally {
         setIsRefreshingViews(prevRefreshingViews);
-        consumerAfterComputation(this, prevNode);
       }
     },
 
-    maybeCleanup(this: EffectNode): void {
+    cleanup(this: EffectNode): void {
       if (!this.cleanupFns?.length) {
         return;
       }
@@ -273,7 +233,7 @@ export const BASE_EFFECT_NODE: Omit<EffectNode, 'fn' | 'destroy' | 'injector' | 
 
 export const ROOT_EFFECT_NODE: Omit<RootEffectNode, 'fn' | 'scheduler' | 'notifier' | 'injector'> =
   /* @__PURE__ */ (() => ({
-    ...BASE_EFFECT_NODE,
+    ...EFFECT_NODE,
     consumerMarkedDirty(this: RootEffectNode) {
       this.scheduler.schedule(this);
       this.notifier.notify(NotificationSource.RootEffect);
@@ -281,14 +241,14 @@ export const ROOT_EFFECT_NODE: Omit<RootEffectNode, 'fn' | 'scheduler' | 'notifi
     destroy(this: RootEffectNode) {
       consumerDestroy(this);
       this.onDestroyFn();
-      this.maybeCleanup();
+      this.cleanup();
       this.scheduler.remove(this);
     },
   }))();
 
 export const VIEW_EFFECT_NODE: Omit<ViewEffectNode, 'fn' | 'view' | 'injector' | 'notifier'> =
   /* @__PURE__ */ (() => ({
-    ...BASE_EFFECT_NODE,
+    ...EFFECT_NODE,
     consumerMarkedDirty(this: ViewEffectNode): void {
       this.view[FLAGS] |= LViewFlags.HasChildViewsToRefresh;
       markAncestorsForTraversal(this.view);
@@ -297,7 +257,7 @@ export const VIEW_EFFECT_NODE: Omit<ViewEffectNode, 'fn' | 'view' | 'injector' |
     destroy(this: ViewEffectNode): void {
       consumerDestroy(this);
       this.onDestroyFn();
-      this.maybeCleanup();
+      this.cleanup();
       this.view[EFFECTS]?.delete(this);
     },
   }))();
@@ -311,7 +271,7 @@ export function createViewEffect(
   node.view = view;
   node.zone = typeof Zone !== 'undefined' ? Zone.current : null;
   node.notifier = notifier;
-  node.fn = fn;
+  node.fn = createEffectFn(node, fn);
 
   view[EFFECTS] ??= new Set();
   view[EFFECTS].add(node);
@@ -326,11 +286,17 @@ export function createRootEffect(
   notifier: ChangeDetectionScheduler,
 ): RootEffectNode {
   const node = Object.create(ROOT_EFFECT_NODE) as RootEffectNode;
-  node.fn = fn;
+  node.fn = createEffectFn(node, fn);
   node.scheduler = scheduler;
   node.notifier = notifier;
   node.zone = typeof Zone !== 'undefined' ? Zone.current : null;
   node.scheduler.add(node);
   node.notifier.notify(NotificationSource.RootEffect);
   return node;
+}
+
+function createEffectFn(node: EffectNode, fn: (onCleanup: EffectCleanupRegisterFn) => void) {
+  return () => {
+    fn((cleanupFn) => (node.cleanupFns ??= []).push(cleanupFn));
+  };
 }

--- a/packages/core/src/render3/reactivity/effect.ts
+++ b/packages/core/src/render3/reactivity/effect.ts
@@ -11,10 +11,7 @@ import {
   consumerDestroy,
   isInNotificationPhase,
   setActiveConsumer,
-  getActiveConsumer,
   BaseEffectNode,
-  EffectCleanupFn,
-  EffectCleanupRegisterFn,
   BASE_EFFECT_NODE,
   runEffect,
 } from '../../../primitives/signals';
@@ -95,6 +92,22 @@ export interface CreateEffectOptions {
    */
   debugName?: string;
 }
+
+/**
+ * An effect can, optionally, register a cleanup function. If registered, the cleanup is executed
+ * before the next effect run. The cleanup function makes it possible to "cancel" any work that the
+ * previous effect run might have started.
+ *
+ * @publicApi 20.0
+ */
+export type EffectCleanupFn = () => void;
+
+/**
+ * A callback passed to the effect function that makes it possible to register cleanup logic.
+ *
+ * @publicApi 20.0
+ */
+export type EffectCleanupRegisterFn = (cleanupFn: EffectCleanupFn) => void;
 
 /**
  * Registers an "effect" that will be scheduled & executed whenever the signals that it reads


### PR DESCRIPTION
Add a common effect interface and prototype to be used to create the wiz and angular effects.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
Adds a base effect interface and prototype to be extended by Angular and Wiz.

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Angular and Wiz both write their own effect prototype and interface. This results in code duplication.

Issue Number: N/A


## What is the new behavior?
There is a base effect prototype and interface that both Angular and Wiz will extend.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
