### PR TITLE
build: replace `docs` script with `adev`

### DIFF
--- a/adev/README.md
+++ b/adev/README.md
@@ -21,7 +21,7 @@ pnpm
 
 # Build and run local dev server
 # NOTE: Initial build will take some time
-pnpm docs
+pnpm adev
 ```
 
 If you are having issues with the docs building, see the [FAQs](#faqs) section.

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "devtools:build:firefox:release": "pnpm run -s devtools:build:firefox --jobs 4",
     "devtools:test": "bazelisk test --//devtools/projects/shell-browser/src:flag_browser=chrome -- //devtools/...",
     "devtools:test:unit": "bazelisk test -- //devtools/...",
-    "docs": "[[ -n $CI ]] && echo 'Cannot run this pnpm script on CI' && exit 1 || pnpm ibazel run //adev:build.serve",
-    "docs:build": "[[ -n $CI ]] && echo 'Cannot run this pnpm script on CI' && exit 1 || pnpm bazel build //adev:build",
+    "adev": "[[ -n $CI ]] && echo 'Cannot run this pnpm script on CI' && exit 1 || pnpm ibazel run //adev:build.serve",
+    "adev:build": "[[ -n $CI ]] && echo 'Cannot run this pnpm script on CI' && exit 1 || pnpm bazel build //adev:build",
     "benchmarks": "tsx --tsconfig=scripts/tsconfig.json scripts/benchmarks/index.mts",
     "diff-release-package": "tsx --tsconfig=scripts/tsconfig.json scripts/diff-release-package.mts"
   },


### PR DESCRIPTION
`pnpm docs` is a dedicated command to open a package docs.
