### PR TITLE
build: move to pnpm version 9.15.9

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -103,7 +103,7 @@ npm_translate_lock(
     ],
     npmrc = "//:.npmrc",
     pnpm_lock = "//:pnpm-lock.yaml",
-    pnpm_version = "10.12.1",
+    pnpm_version = "9.15.9",
     verify_node_modules_ignored = "//:.bazelignore",
 )
 

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "homepage": "https://github.com/angular/angular",
   "bugs": "https://github.com/angular/angular/issues",
   "license": "MIT",
-  "packageManager": "pnpm@10.14.0",
+  "packageManager": "pnpm@9.15.9",
   "engines": {
     "npm": "Please use pnpm instead of NPM to install dependencies",
     "yarn": "Please use pnpm instead of Yarn to install dependencies",
-    "pnpm": "10.14.0"
+    "pnpm": "9.15.9"
   },
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,13 +8,13 @@ overrides:
   https-proxy-agent: 7.0.6
   saucelabs: 9.0.2
 
-packageExtensionsChecksum: sha256-3L73Fw32UVtE6x5BJxJPBtQtH/mgsr31grNpdhHP1IY=
+packageExtensionsChecksum: d67b1f07b351844d00c57cbace376860
 
-pnpmfileChecksum: sha256-+7KlkWdGv7+7wb/qym+KoHN4eBGq9TNblo2Ln6HTxz0=
+pnpmfileChecksum: vld6thchsqj664odlna7qhh4w4
 
 patchedDependencies:
   dagre-d3-es@7.0.11:
-    hash: 08ae1f30d46402ef53e1486454faa875683cf4152a8aab71ac255078ebfaccdd
+    hash: dp4f5qlzqey4wb2gylte6hyt4q
     path: tools/pnpm-patches/dagre-d3-es+7.0.11.patch
 
 importers:
@@ -203,7 +203,7 @@ importers:
         version: 7.9.0
       dagre-d3-es:
         specifier: ^7.0.11
-        version: 7.0.11(patch_hash=08ae1f30d46402ef53e1486454faa875683cf4152a8aab71ac255078ebfaccdd)
+        version: 7.0.11(patch_hash=dp4f5qlzqey4wb2gylte6hyt4q)
       diff:
         specifier: ^8.0.0
         version: 8.0.2
@@ -16038,7 +16038,7 @@ snapshots:
       d3-transition: 3.0.1(d3-selection@3.0.0)
       d3-zoom: 3.0.0
 
-  dagre-d3-es@7.0.11(patch_hash=08ae1f30d46402ef53e1486454faa875683cf4152a8aab71ac255078ebfaccdd):
+  dagre-d3-es@7.0.11(patch_hash=dp4f5qlzqey4wb2gylte6hyt4q):
     dependencies:
       d3: 7.9.0
       lodash-es: 4.17.21
@@ -19096,7 +19096,7 @@ snapshots:
       cytoscape-fcose: 2.2.0(cytoscape@3.33.0)
       d3: 7.9.0
       d3-sankey: 0.12.3
-      dagre-d3-es: 7.0.11(patch_hash=08ae1f30d46402ef53e1486454faa875683cf4152a8aab71ac255078ebfaccdd)
+      dagre-d3-es: 7.0.11(patch_hash=dp4f5qlzqey4wb2gylte6hyt4q)
       dayjs: 1.11.13
       dompurify: 3.2.6
       katex: 0.16.22


### PR DESCRIPTION
Use pnpm version 9.15.9 to match the rest of the organization
