### PR TITLE
ci: use new version of pnpm-lock.yaml file during renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
   ],
   "postUpgradeTasks": {
     "commands": [
-      "git restore .yarn/releases/yarn-1.22.22.cjs pnpm-lock.yaml .npmrc",
+      "git restore .yarn/releases/yarn-1.22.22.cjs .npmrc",
       "pnpm install --frozen-lockfile",
       "pnpm bazel run //.github/actions/deploy-docs-site:main.update",
       "pnpm bazel run //packages/common:base_currencies_file.update",


### PR DESCRIPTION
Use the newly updated pnpm_lock.yaml file during renovate post upgrade runs
