### PR TITLE
fix(core): notify profiler events in case of errors

### DIFF
--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -617,6 +617,7 @@ export class ApplicationRef {
   private tickImpl = (): void => {
     (typeof ngDevMode === 'undefined' || ngDevMode) && warnIfDestroyed(this._destroyed);
     if (this._runningTick) {
+      profiler(ProfilerEvent.ChangeDetectionEnd);
       throw new RuntimeError(
         RuntimeErrorCode.RECURSIVE_APPLICATION_REF_TICK,
         ngDevMode && 'ApplicationRef.tick is called recursively',
@@ -655,8 +656,11 @@ export class ApplicationRef {
     let runs = 0;
     while (this.dirtyFlags !== ApplicationRefDirtyFlags.None && runs++ < MAXIMUM_REFRESH_RERUNS) {
       profiler(ProfilerEvent.ChangeDetectionSyncStart);
-      this.synchronizeOnce();
-      profiler(ProfilerEvent.ChangeDetectionSyncEnd);
+      try {
+        this.synchronizeOnce();
+      } finally {
+        profiler(ProfilerEvent.ChangeDetectionSyncEnd);
+      }
     }
 
     if ((typeof ngDevMode === 'undefined' || ngDevMode) && runs >= MAXIMUM_REFRESH_RERUNS) {

--- a/packages/core/src/render3/debug/chrome_dev_tools_performance.ts
+++ b/packages/core/src/render3/debug/chrome_dev_tools_performance.ts
@@ -71,14 +71,14 @@ function measureEnd(
   entryName: string,
   color: DevToolsColor,
 ) {
-  const top = eventsStack.pop();
+  let top: stackEntry | undefined;
 
-  assertDefined(top, 'Profiling error: could not find start event entry ' + startEvent);
-  assertEqual(
-    top[0],
-    startEvent,
-    `Profiling error: expected to see ${startEvent} event but got ${top[0]}`,
-  );
+  // The stack may be asymmetric when an end event for a prior start event is missing (e.g. when an exception
+  // has occurred), unroll the stack until a matching item has been found in that case.
+  do {
+    top = eventsStack.pop();
+    assertDefined(top, 'Profiling error: could not find start event entry ' + startEvent);
+  } while (top[0] !== startEvent);
 
   console.timeStamp(
     entryName,

--- a/packages/core/src/render3/instructions/change_detection.ts
+++ b/packages/core/src/render3/instructions/change_detection.ts
@@ -426,9 +426,11 @@ function detectChangesInComponent(
   profiler(ProfilerEvent.ComponentStart);
 
   const componentView = getComponentLViewByIndex(componentHostIdx, hostLView);
-  detectChangesInViewIfAttached(componentView, mode);
-
-  profiler(ProfilerEvent.ComponentEnd, componentView[CONTEXT] as any as {});
+  try {
+    detectChangesInViewIfAttached(componentView, mode);
+  } finally {
+    profiler(ProfilerEvent.ComponentEnd, componentView[CONTEXT] as any as {});
+  }
 }
 
 /**
@@ -551,8 +553,11 @@ function processHostBindingOpCodes(tView: TView, lView: LView): void {
         setBindingRootForHostBindings(bindingRootIndx, directiveIdx);
         const context = lView[directiveIdx];
         profiler(ProfilerEvent.HostBindingsUpdateStart, context);
-        hostBindingFn(RenderFlags.Update, context);
-        profiler(ProfilerEvent.HostBindingsUpdateEnd, context);
+        try {
+          hostBindingFn(RenderFlags.Update, context);
+        } finally {
+          profiler(ProfilerEvent.HostBindingsUpdateEnd, context);
+        }
       }
     }
   } finally {

--- a/packages/core/src/render3/instructions/render.ts
+++ b/packages/core/src/render3/instructions/render.ts
@@ -43,9 +43,11 @@ export function renderComponent(hostLView: LView, componentHostIdx: number) {
 
   profiler(ProfilerEvent.ComponentStart);
 
-  renderView(componentTView, componentView, componentView[CONTEXT]);
-
-  profiler(ProfilerEvent.ComponentEnd, componentView[CONTEXT] as any as {});
+  try {
+    renderView(componentTView, componentView, componentView[CONTEXT]);
+  } finally {
+    profiler(ProfilerEvent.ComponentEnd, componentView[CONTEXT] as any as {});
+  }
 }
 
 /**

--- a/packages/core/test/acceptance/chrome_dev_tools_performance_spec.ts
+++ b/packages/core/test/acceptance/chrome_dev_tools_performance_spec.ts
@@ -6,8 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {enableProfiling} from '../../src/render3/debug/chrome_dev_tools_performance';
 import {Component, HostAttributeToken, inject, Inject} from '../../src/core';
+import {enableProfiling} from '../../src/render3/debug/chrome_dev_tools_performance';
+import {profiler} from '../../src/render3/profiler';
+import {ProfilerEvent} from '../../src/render3/profiler_types';
 import {TestBed} from '../../testing';
 
 describe('Chrome DevTools Performance integration', () => {
@@ -55,6 +57,27 @@ describe('Chrome DevTools Performance integration', () => {
         fixture.detectChanges();
 
         expect((console.timeStamp as any).calls.all().length).not.toBe(0);
+      } finally {
+        stopProfiling();
+      }
+    });
+
+    it('should not crash when asymmetric events are processed', () => {
+      const timeStampSpy = spyOn(console, 'timeStamp');
+      const stopProfiling = enableProfiling();
+
+      try {
+        profiler(ProfilerEvent.ChangeDetectionSyncStart);
+        profiler(ProfilerEvent.ChangeDetectionStart);
+        profiler(ProfilerEvent.ChangeDetectionSyncEnd);
+
+        const calls = timeStampSpy.calls.all();
+        expect(calls.length).toBe(3);
+
+        const [syncStart, cdStart, syncEnd] = calls;
+        expect(syncStart.args[0]).toMatch(/^Event_/);
+        expect(cdStart.args[0]).toMatch(/^Event_/);
+        expect(syncEnd.args[0]).toMatch(/^Synchronization /);
       } finally {
         stopProfiling();
       }


### PR DESCRIPTION
Profiler events are expected to be symmetric, yet in the case of errors this symmetry may break
if events aren't always kept in sync with their corresponding start event. This commit moves
various end events to be run from a finally-block, allowing them to notify the profiler even
when an error has occurred.
    
Fixes #62947

---


**refactor(core): let the profiler handle asymmetric events leniently**

Although the prior commit has made more profiler events guaranteed symmetric
through the use of finally-blocks, there continue to be some situations
that could potentially result in asymmetric events, e.g. application
bootstrap doesn't guarantee symmetric events. This commit makes the profiler
lenient to these situations by unrolling the stack past the asymmetric event
data, eventually reaching the expected start event.
