### PR TITLE
ci: remove git restore of pnpm lock file

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
   ],
   "postUpgradeTasks": {
     "commands": [
-      "git restore .yarn/releases/yarn-1.22.22.cjs pnpm-lock.yaml .npmrc",
+      "git restore .yarn/releases/yarn-1.22.22.cjs .npmrc",
       "pnpm install --frozen-lockfile",
       "pnpm bazel run //.github/actions/deploy-docs-site:main.update",
       "pnpm bazel run //packages/common:base_currencies_file.update",


### PR DESCRIPTION
Since now, we no longer have two lock file (yarn and pnpm) the resorting of the pnpm lock file is no longer needed and is its update is handled by Renovate.

