### PR TITLE
fix(compiler-cli): correctly type check host listeners to own outputs

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -1116,7 +1116,8 @@ export class ComponentDecoratorHandler
     if (!ts.isClassDeclaration(node) || (meta.isPoisoned && !this.usePoisonedData)) {
       return;
     }
-    const scope = this.typeCheckScopeRegistry.getTypeCheckScope(node);
+    const ref = new Reference(node);
+    const scope = this.typeCheckScopeRegistry.getTypeCheckScope(ref);
     if (scope.isPoisoned && !this.usePoisonedData) {
       // Don't type-check components that had errors in their scopes, unless requested.
       return;
@@ -1143,15 +1144,16 @@ export class ComponentDecoratorHandler
         )
       : null;
     const hostBindingsContext: HostBindingsContext | null =
-      hostElement === null
+      hostElement === null || scope.directivesOnHost === null
         ? null
         : {
             node: hostElement,
+            directives: scope.directivesOnHost,
             sourceMapping: {type: 'direct', node},
           };
 
     ctx.addDirective(
-      new Reference(node),
+      ref,
       binder,
       scope.schemas,
       templateContext,

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
@@ -331,7 +331,8 @@ export class DirectiveDecoratorHandler
     if (!ts.isClassDeclaration(node) || (meta.isPoisoned && !this.usePoisonedData)) {
       return;
     }
-    const scope = this.typeCheckScopeRegistry.getTypeCheckScope(node);
+    const ref = new Reference(node);
+    const scope = this.typeCheckScopeRegistry.getTypeCheckScope(ref);
     if (scope.isPoisoned && !this.usePoisonedData) {
       // Don't type-check components that had errors in their scopes, unless requested.
       return;
@@ -346,15 +347,16 @@ export class DirectiveDecoratorHandler
       meta.hostBindingNodes.listenerDecorators,
     );
 
-    if (hostElement !== null) {
+    if (hostElement !== null && scope.directivesOnHost !== null) {
       const binder = new R3TargetBinder<TypeCheckableDirectiveMeta>(scope.matcher);
       const hostBindingsContext: HostBindingsContext = {
         node: hostElement,
+        directives: scope.directivesOnHost,
         sourceMapping: {type: 'direct', node},
       };
 
       ctx.addDirective(
-        new Reference(node),
+        ref,
         binder,
         scope.schemas,
         null,

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/context.ts
@@ -17,7 +17,7 @@ import {
 import ts from 'typescript';
 
 import {Reference} from '../../imports';
-import {PipeMeta} from '../../metadata';
+import {DirectiveMeta, PipeMeta} from '../../metadata';
 import {ClassDeclaration} from '../../reflection';
 
 import {SourceMapping, TypeCheckableDirectiveMeta} from './api';
@@ -47,6 +47,9 @@ export interface TemplateContext {
 export interface HostBindingsContext {
   /** AST node representing the host element of the directive. */
   node: TmplAstHostElement;
+
+  /** Directives present on the host element. */
+  directives: DirectiveMeta[];
 
   /** Describes the source of the host bindings. Used for mapping errors back. */
   sourceMapping: SourceMapping;

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
@@ -259,7 +259,13 @@ export class TypeCheckContextImpl implements TypeCheckContext {
 
     const boundTarget = binder.bind({
       template: templateContext?.nodes,
-      host: hostBindingContext?.node,
+      host:
+        hostBindingContext === null
+          ? undefined
+          : {
+              node: hostBindingContext.node,
+              directives: hostBindingContext.directives,
+            },
     });
 
     if (this.inlining === InliningMode.InlineOps) {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -55,6 +55,7 @@ import {
   TmplAstComponent,
   TmplAstDirective,
   Binary,
+  DirectiveOwner,
 } from '@angular/compiler';
 import ts from 'typescript';
 
@@ -215,7 +216,7 @@ export function generateTypeCheckBlock(
 
   // Add the host bindings type checking code.
   if (tcb.boundTarget.target.host !== undefined) {
-    const hostScope = Scope.forNodes(tcb, null, tcb.boundTarget.target.host, null, null);
+    const hostScope = Scope.forNodes(tcb, null, tcb.boundTarget.target.host.node, null, null);
     statements.push(renderBlockStatements(env, hostScope, createHostBindingsBlockGuard()));
   }
 
@@ -647,7 +648,7 @@ abstract class TcbDirectiveTypeOpBase extends TcbOp {
   constructor(
     protected tcb: Context,
     protected scope: Scope,
-    protected node: TmplAstTemplate | TmplAstElement | TmplAstComponent | TmplAstDirective,
+    protected node: DirectiveOwner,
     protected dir: TypeCheckableDirectiveMeta,
   ) {
     super();
@@ -666,6 +667,7 @@ abstract class TcbDirectiveTypeOpBase extends TcbOp {
     const rawType = this.tcb.env.referenceType(this.dir.ref);
 
     let type: ts.TypeNode;
+    let span: ParseSourceSpan;
     if (this.dir.isGeneric === false || dirRef.node.typeParameters === undefined) {
       type = rawType;
     } else {
@@ -680,9 +682,15 @@ abstract class TcbDirectiveTypeOpBase extends TcbOp {
       type = ts.factory.createTypeReferenceNode(rawType.typeName, typeArguments);
     }
 
+    if (this.node instanceof TmplAstHostElement) {
+      span = this.node.sourceSpan;
+    } else {
+      span = this.node.startSourceSpan || this.node.sourceSpan;
+    }
+
     const id = this.tcb.allocateId();
     addExpressionIdentifier(id, ExpressionIdentifier.DIRECTIVE);
-    addParseSpanInfo(id, this.node.startSourceSpan || this.node.sourceSpan);
+    addParseSpanInfo(id, span);
     this.scope.addStatement(tsDeclareVariable(id, type));
     return id;
   }
@@ -1503,7 +1511,9 @@ export class TcbDirectiveOutputsOp extends TcbOp {
   constructor(
     private tcb: Context,
     private scope: Scope,
-    private node: TmplAstTemplate | TmplAstElement | TmplAstComponent | TmplAstDirective,
+    private node: DirectiveOwner,
+    private inputs: TmplAstBoundAttribute[] | null,
+    private outputs: TmplAstBoundEvent[],
     private dir: TypeCheckableDirectiveMeta,
   ) {
     super();
@@ -1517,7 +1527,7 @@ export class TcbDirectiveOutputsOp extends TcbOp {
     let dirId: ts.Expression | null = null;
     const outputs = this.dir.outputs;
 
-    for (const output of this.node.outputs) {
+    for (const output of this.outputs) {
       if (
         output.type === ParsedEventType.LegacyAnimation ||
         !outputs.hasBindingPropertyName(output.name)
@@ -1525,9 +1535,13 @@ export class TcbDirectiveOutputsOp extends TcbOp {
         continue;
       }
 
-      if (this.tcb.env.config.checkTypeOfOutputEvents && output.name.endsWith('Change')) {
+      if (
+        this.tcb.env.config.checkTypeOfOutputEvents &&
+        this.inputs !== null &&
+        output.name.endsWith('Change')
+      ) {
         const inputName = output.name.slice(0, -6);
-        checkSplitTwoWayBinding(inputName, output, this.node.inputs, this.tcb);
+        checkSplitTwoWayBinding(inputName, output, this.inputs, this.tcb);
       }
       // TODO(alxhub): consider supporting multiple fields with the same property name for outputs.
       const field = outputs.getByBindingPropertyName(output.name)![0].classPropertyName;
@@ -2183,10 +2197,7 @@ class Scope {
    * A map of maps which tracks the index of `TcbDirectiveCtorOp`s in the `opQueue` for each
    * directive on a `TmplAstElement` or `TmplAstTemplate` node.
    */
-  private directiveOpMap = new Map<
-    TmplAstElement | TmplAstTemplate | TmplAstComponent | TmplAstDirective,
-    Map<TypeCheckableDirectiveMeta, number>
-  >();
+  private directiveOpMap = new Map<DirectiveOwner, Map<TypeCheckableDirectiveMeta, number>>();
 
   /**
    * A map of `TmplAstReference`s to the index of their `TcbReferenceOp` in the `opQueue`
@@ -2489,7 +2500,8 @@ class Scope {
       (ref instanceof TmplAstElement ||
         ref instanceof TmplAstTemplate ||
         ref instanceof TmplAstComponent ||
-        ref instanceof TmplAstDirective) &&
+        ref instanceof TmplAstDirective ||
+        ref instanceof TmplAstHostElement) &&
       directive !== undefined &&
       this.directiveOpMap.has(ref)
     ) {
@@ -2554,14 +2566,14 @@ class Scope {
         this.appendContentProjectionCheckOp(node);
       }
       this.appendDirectivesAndInputsOfElementLikeNode(node);
-      this.appendOutputsOfElementLikeNode(node);
+      this.appendOutputsOfElementLikeNode(node, node.inputs, node.outputs);
       this.appendSelectorlessDirectives(node);
       this.appendChildren(node);
       this.checkAndAppendReferencesOfNode(node);
     } else if (node instanceof TmplAstTemplate) {
       // Template children are rendered in a child scope.
       this.appendDirectivesAndInputsOfElementLikeNode(node);
-      this.appendOutputsOfElementLikeNode(node);
+      this.appendOutputsOfElementLikeNode(node, node.inputs, node.outputs);
       this.appendSelectorlessDirectives(node);
       const ctxIndex = this.opQueue.push(new TcbTemplateContextOp(this.tcb, this)) - 1;
       this.templateCtxOpMap.set(node, ctxIndex);
@@ -2596,13 +2608,7 @@ class Scope {
         this.letDeclOpMap.set(node.name, {opIndex, node});
       }
     } else if (node instanceof TmplAstHostElement) {
-      const opIndex = this.opQueue.push(new TcbHostElementOp(this.tcb, this, node)) - 1;
-      this.hostElementOpMap.set(node, opIndex);
-      this.opQueue.push(
-        new TcbUnclaimedInputsOp(this.tcb, this, node.bindings, node, null),
-        new TcbUnclaimedOutputsOp(this.tcb, this, node, node.listeners, null, null),
-        new TcbDomSchemaCheckerOp(this.tcb, node, false, null),
-      );
+      this.appendHostElement(node);
     }
   }
 
@@ -2691,7 +2697,11 @@ class Scope {
     }
   }
 
-  private appendOutputsOfElementLikeNode(node: TmplAstElement | TmplAstTemplate): void {
+  private appendOutputsOfElementLikeNode(
+    node: TmplAstElement | TmplAstTemplate | TmplAstHostElement,
+    bindings: TmplAstBoundAttribute[] | null,
+    events: TmplAstBoundEvent[],
+  ): void {
     // Collect all the outputs on the element.
     const claimedOutputs = new Set<string>();
 
@@ -2705,14 +2715,7 @@ class Scope {
       // to add them if needed.
       if (node instanceof TmplAstElement) {
         this.opQueue.push(
-          new TcbUnclaimedOutputsOp(
-            this.tcb,
-            this,
-            node,
-            node.outputs,
-            node.inputs,
-            claimedOutputs,
-          ),
+          new TcbUnclaimedOutputsOp(this.tcb, this, node, events, bindings, claimedOutputs),
         );
       }
       return;
@@ -2720,12 +2723,12 @@ class Scope {
 
     // Queue operations for all directives to check the relevant outputs for a directive.
     for (const dir of directives) {
-      this.opQueue.push(new TcbDirectiveOutputsOp(this.tcb, this, node, dir));
+      this.opQueue.push(new TcbDirectiveOutputsOp(this.tcb, this, node, bindings, events, dir));
     }
 
     // After expanding the directives, we might need to queue an operation to check any unclaimed
     // outputs.
-    if (node instanceof TmplAstElement) {
+    if (node instanceof TmplAstElement || node instanceof TmplAstHostElement) {
       // Go through the directives and register any outputs that it claims in `claimedOutputs`.
       for (const dir of directives) {
         for (const outputProperty of dir.outputs.propertyNames) {
@@ -2734,7 +2737,7 @@ class Scope {
       }
 
       this.opQueue.push(
-        new TcbUnclaimedOutputsOp(this.tcb, this, node, node.outputs, node.inputs, claimedOutputs),
+        new TcbUnclaimedOutputsOp(this.tcb, this, node, events, bindings, claimedOutputs),
       );
     }
   }
@@ -2785,7 +2788,9 @@ class Scope {
 
     if (directives !== null && directives.length > 0) {
       for (const dir of directives) {
-        this.opQueue.push(new TcbDirectiveOutputsOp(this.tcb, this, node, dir));
+        this.opQueue.push(
+          new TcbDirectiveOutputsOp(this.tcb, this, node, node.inputs, node.outputs, dir),
+        );
 
         for (const outputProperty of dir.outputs.propertyNames) {
           claimedOutputs.add(outputProperty);
@@ -3006,6 +3011,29 @@ class Scope {
     if (triggers.viewport !== undefined) {
       this.validateReferenceBasedDeferredTrigger(block, triggers.viewport);
     }
+  }
+
+  private appendHostElement(node: TmplAstHostElement): void {
+    const opIndex = this.opQueue.push(new TcbHostElementOp(this.tcb, this, node)) - 1;
+    const directives = this.tcb.boundTarget.getDirectivesOfNode(node);
+
+    if (directives !== null && directives.length > 0) {
+      const directiveOpMap = new Map<TypeCheckableDirectiveMeta, number>();
+
+      for (const directive of directives) {
+        const directiveOp = new TcbNonGenericDirectiveTypeOp(this.tcb, this, node, directive);
+        directiveOpMap.set(directive, this.opQueue.push(directiveOp) - 1);
+      }
+
+      this.directiveOpMap.set(node, directiveOpMap);
+    }
+
+    this.hostElementOpMap.set(node, opIndex);
+    this.opQueue.push(
+      new TcbUnclaimedInputsOp(this.tcb, this, node.bindings, node, null),
+      new TcbDomSchemaCheckerOp(this.tcb, node, false, null),
+    );
+    this.appendOutputsOfElementLikeNode(node, null, node.listeners);
   }
 
   private validateReferenceBasedDeferredTrigger(

--- a/packages/compiler-cli/test/ngtsc/host_bindings_type_check_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/host_bindings_type_check_spec.ts
@@ -740,5 +740,178 @@ runInEachFileSystem(() => {
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(0);
     });
+
+    it('should check component listening to own output', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component, Output, EventEmitter} from '@angular/core';
+
+          @Component({
+            template: '',
+            host: {'(customEvent)': 'expectsNumber($event)'},
+          })
+          export class Comp {
+            @Output() customEvent = new EventEmitter<string>();
+
+            expectsNumber(value: number) {}
+          }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(
+        `Argument of type 'string' is not assignable to parameter of type 'number'.`,
+      );
+    });
+
+    it('should check component listening to output from host directive', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component, Directive, Output, EventEmitter} from '@angular/core';
+
+          @Directive()
+          export class HostDir {
+            @Output() customEvent = new EventEmitter<string>();
+          }
+
+          @Component({
+            template: '',
+            host: {'(alias)': 'expectsNumber($event)'},
+            hostDirectives: [{directive: HostDir, outputs: ['customEvent: alias']}]
+          })
+          export class Comp {
+            expectsNumber(value: number) {}
+          }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(
+        `Argument of type 'string' is not assignable to parameter of type 'number'.`,
+      );
+    });
+
+    it('should check component listening to own output and from host directive', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component, Directive, Output, EventEmitter} from '@angular/core';
+
+          @Directive()
+          export class HostDir {
+            @Output() customEvent = new EventEmitter<string>();
+          }
+
+          @Component({
+            template: '',
+            host: {'(customEvent)': 'expectsNumber($event)'},
+            hostDirectives: [{directive: HostDir, outputs: ['customEvent']}]
+          })
+          export class Comp {
+            @Output() customEvent = new EventEmitter<boolean>();
+
+            expectsNumber(value: number) {}
+          }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(2);
+      expect(diags[0].messageText).toBe(
+        `Argument of type 'string' is not assignable to parameter of type 'number'.`,
+      );
+      expect(diags[1].messageText).toBe(
+        `Argument of type 'boolean' is not assignable to parameter of type 'number'.`,
+      );
+    });
+
+    it('should check directive listening to own output', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Directive, Output, EventEmitter} from '@angular/core';
+
+          @Directive({
+            host: {'(customEvent)': 'expectsNumber($event)'},
+          })
+          export class Dir {
+            @Output() customEvent = new EventEmitter<string>();
+
+            expectsNumber(value: number) {}
+          }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(
+        `Argument of type 'string' is not assignable to parameter of type 'number'.`,
+      );
+    });
+
+    it('should check directive listening to output from host directive', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Directive, Output, EventEmitter} from '@angular/core';
+
+          @Directive()
+          export class HostDir {
+            @Output() customEvent = new EventEmitter<string>();
+          }
+
+          @Directive({
+            host: {'(alias)': 'expectsNumber($event)'},
+            hostDirectives: [{directive: HostDir, outputs: ['customEvent: alias']}]
+          })
+          export class Dir {
+            expectsNumber(value: number) {}
+          }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(diags[0].messageText).toBe(
+        `Argument of type 'string' is not assignable to parameter of type 'number'.`,
+      );
+    });
+
+    it('should check directive listening to own output and from host directive', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Directive, Output, EventEmitter} from '@angular/core';
+
+          @Directive()
+          export class HostDir {
+            @Output() customEvent = new EventEmitter<string>();
+          }
+
+          @Directive({
+            host: {'(customEvent)': 'expectsNumber($event)'},
+            hostDirectives: [{directive: HostDir, outputs: ['customEvent']}]
+          })
+          export class Dir {
+            @Output() customEvent = new EventEmitter<boolean>();
+
+            expectsNumber(value: number) {}
+          }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(2);
+      expect(diags[0].messageText).toBe(
+        `Argument of type 'string' is not assignable to parameter of type 'number'.`,
+      );
+      expect(diags[1].messageText).toBe(
+        `Argument of type 'boolean' is not assignable to parameter of type 'number'.`,
+      );
+    });
   });
 });

--- a/packages/compiler/src/render3/view/t2_api.ts
+++ b/packages/compiler/src/render3/view/t2_api.ts
@@ -48,7 +48,7 @@ export type ScopedNode =
 
 /** Possible values that a reference can be resolved to. */
 export type ReferenceTarget<DirectiveT> =
-  | {directive: DirectiveT; node: DirectiveOwner}
+  | {directive: DirectiveT; node: Exclude<DirectiveOwner, HostElement>}
   | Element
   | Template;
 
@@ -56,7 +56,7 @@ export type ReferenceTarget<DirectiveT> =
 export type TemplateEntity = Reference | Variable | LetDeclaration;
 
 /** Nodes that can have directives applied to them. */
-export type DirectiveOwner = Element | Template | Component | Directive;
+export type DirectiveOwner = Element | Template | Component | Directive | HostElement;
 
 /*
  * t2 is the replacement for the `TemplateDefinitionBuilder`. It handles the operations of
@@ -70,9 +70,12 @@ export type DirectiveOwner = Element | Template | Component | Directive;
 /**
  * A logical target for analysis, which could contain a template or other types of bindings.
  */
-export interface Target {
+export interface Target<DirectiveT> {
   template?: Node[];
-  host?: HostElement;
+  host?: {
+    node: HostElement;
+    directives: DirectiveT[];
+  };
 }
 
 /**
@@ -162,7 +165,7 @@ export interface DirectiveMeta {
  * The returned `BoundTarget` has an API for extracting information about the processed target.
  */
 export interface TargetBinder<D extends DirectiveMeta> {
-  bind(target: Target): BoundTarget<D>;
+  bind(target: Target<D>): BoundTarget<D>;
 }
 
 /**
@@ -177,7 +180,7 @@ export interface BoundTarget<DirectiveT extends DirectiveMeta> {
   /**
    * Get the original `Target` that was bound.
    */
-  readonly target: Target;
+  readonly target: Target<DirectiveT>;
 
   /**
    * For a given template node (either an `Element` or a `Template`), get the set of directives

--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -84,7 +84,7 @@ type BindingsMap<DirectiveT> = Map<
 /** Shorthand for a map between a reference AST node and the entity it's targeting. */
 type ReferenceMap<DirectiveT> = Map<
   Reference,
-  Template | Element | {directive: DirectiveT; node: DirectiveOwner}
+  Template | Element | {directive: DirectiveT; node: Exclude<DirectiveOwner, HostElement>}
 >;
 
 /** Mapping between AST nodes and the directives that have been matched on them. */
@@ -171,7 +171,7 @@ export class R3TargetBinder<DirectiveT extends DirectiveMeta> implements TargetB
    * Perform a binding operation on the given `Target` and return a `BoundTarget` which contains
    * metadata about the types referenced in the template.
    */
-  bind(target: Target): BoundTarget<DirectiveT> {
+  bind(target: Target<DirectiveT>): BoundTarget<DirectiveT> {
     if (!target.template && !target.host) {
       throw new Error('Empty bound targets are not supported');
     }
@@ -229,9 +229,10 @@ export class R3TargetBinder<DirectiveT extends DirectiveMeta> implements TargetB
     // Bind the host element in a separate scope. Note that it only uses the
     // `TemplateBinder` since directives don't apply inside a host context.
     if (target.host) {
+      directives.set(target.host.node, target.host.directives);
       TemplateBinder.applyWithScope(
-        target.host,
-        Scope.apply(target.host),
+        target.host.node,
+        Scope.apply(target.host.node),
         expressions,
         symbols,
         nestingLevel,
@@ -1029,7 +1030,7 @@ class R3BoundTarget<DirectiveT extends DirectiveMeta> implements BoundTarget<Dir
   private deferredScopes: Map<DeferredBlock, Scope>;
 
   constructor(
-    readonly target: Target,
+    readonly target: Target<DirectiveT>,
     private directives: MatchedDirectives<DirectiveT>,
     private eagerDirectives: DirectiveT[],
     private missingDirectives: Set<string>,
@@ -1217,7 +1218,8 @@ class R3BoundTarget<DirectiveT extends DirectiveMeta> implements BoundTarget<Dir
     if (
       target instanceof Template ||
       target.node instanceof Component ||
-      target.node instanceof Directive
+      target.node instanceof Directive ||
+      target.node instanceof HostElement
     ) {
       return null;
     }


### PR DESCRIPTION
Currently the code that type checks host bindings assumes that all listeners are bound to the DOM, however that's not the case since host bindings can also bind to own outputs.

These changes update the TCB to generate the proper code for type checking such outputs.

Fixes #62783.