### PR TITLE
feat(router): Adds optional route title binding to component inputs

### DIFF
--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -31,7 +31,11 @@ import {
 } from '@angular/core';
 import {of, Subject} from 'rxjs';
 
-import {INPUT_BINDER, RoutedComponentInputBinder} from './directives/router_outlet';
+import {
+  INPUT_BINDER,
+  INPUT_TITLE_BINDING_ENABLED,
+  RoutedComponentInputBinder,
+} from './directives/router_outlet';
 import {Event, NavigationError, stringifyEvent} from './events';
 import {RedirectCommand, Routes} from './models';
 import {NAVIGATION_ERROR_HANDLER, NavigationTransitions} from './navigation_transition';
@@ -690,6 +694,18 @@ export type ComponentInputBindingFeature =
   RouterFeature<RouterFeatureKind.ComponentInputBindingFeature>;
 
 /**
+ * Configuration options for component input binding feature.
+ *
+ * @publicApi
+ */
+export interface ComponentInputBindingOptions {
+  /**
+   * When `true`, enables automatic binding of the route title to component inputs.
+   */
+  enableTitleBinding?: boolean;
+}
+
+/**
  * A type alias for providers returned by `withViewTransitions` for use with `provideRouter`.
  *
  * @see {@link withViewTransitions}
@@ -717,12 +733,25 @@ export type ViewTransitionsFeature = RouterFeature<RouterFeatureKind.ViewTransit
  * );
  * ```
  *
- * The router bindings information from any of the following sources:
+ * Enable title binding for component inputs:
+ * ```ts
+ * const appRoutes: Routes = [];
+ * bootstrapApplication(AppComponent,
+ *   {
+ *     providers: [
+ *       provideRouter(appRoutes, withComponentInputBinding({enableTitleBinding: true}))
+ *     ]
+ *   }
+ * );
+ * ```
+ *
+ * The router binds information from any of the following sources in order of precedence (lowest to highest):
  *
  *  - query parameters
  *  - path and matrix parameters
  *  - static route data
  *  - data from resolvers
+ *  - title from the route (when enableTitleBinding is true)
  *
  * Duplicate keys are resolved in the same order from above, from least to greatest,
  * meaning that resolvers have the highest precedence and override any of the other information
@@ -734,12 +763,21 @@ export type ViewTransitionsFeature = RouterFeature<RouterFeatureKind.ViewTransit
  * Default values can be provided with a resolver on the route to ensure the value is always present
  * or an input and use an input transform in the component.
  *
+ * @param options Configuration options for component input binding. When not provided, defaults
+ *   to `{enableTitleBinding: false}`.
+ * @see {@link ComponentInputBindingOptions}
  * @see {@link /guide/components/inputs#input-transforms Input Transforms}
  * @returns A set of providers for use with `provideRouter`.
  */
-export function withComponentInputBinding(): ComponentInputBindingFeature {
+export function withComponentInputBinding(
+  options?: ComponentInputBindingOptions,
+): ComponentInputBindingFeature {
   const providers = [
     RoutedComponentInputBinder,
+    {
+      provide: INPUT_TITLE_BINDING_ENABLED,
+      useValue: options?.enableTitleBinding ?? false,
+    },
     {provide: INPUT_BINDER, useExisting: RoutedComponentInputBinder},
   ];
 

--- a/packages/router/test/directives/router_outlet.spec.ts
+++ b/packages/router/test/directives/router_outlet.spec.ts
@@ -383,6 +383,62 @@ describe('component input binding', () => {
     await harness.navigateByUrl('/root/child?myInput=2');
     expect(harness.routeNativeElement!.innerText).toBe('2');
   });
+
+  it('should support title binding when enabled', async () => {
+    @Component({
+      template: '{{title}}',
+    })
+    class MyComponent {
+      @Input() title?: string;
+    }
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(
+          [
+            {
+              path: '**',
+              component: MyComponent,
+              title: 'My Page Title',
+            },
+          ],
+          withComponentInputBinding({enableTitleBinding: true}),
+        ),
+      ],
+    });
+    const harness = await RouterTestingHarness.create();
+
+    const instance = await harness.navigateByUrl('/', MyComponent);
+    expect(instance.title).toEqual('My Page Title');
+  });
+
+  it('should not bind title when disabled', async () => {
+    @Component({
+      template: '{{title ?? "no title"}}',
+    })
+    class MyComponent {
+      @Input() title?: string;
+    }
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(
+          [
+            {
+              path: '**',
+              component: MyComponent,
+              title: 'My Page Title',
+            },
+          ],
+          withComponentInputBinding(),
+        ),
+      ],
+    });
+    const harness = await RouterTestingHarness.create();
+
+    const instance = await harness.navigateByUrl('/', MyComponent);
+    expect(instance.title).toEqual(undefined);
+  });
 });
 
 describe('injectors', () => {


### PR DESCRIPTION
# Route Title Binding 

adds support for optional route title binding to component inputs when using Angular Router.

The change includes:
- Added INPUT_TITLE_BINDING_ENABLED injection token for configuration
- Enhanced ComponentInputBindingOptions interface with enableTitleBinding property
- Modified RoutedComponentInputBinder to conditionally bind route titles to component inputs
- Updated withComponentInputBinding() function to accept configuration options

## Basic Setup

First, enable title binding when configuring your router:

```typescript
import { bootstrapApplication } from '@angular/platform-browser';
import { provideRouter, withComponentInputBinding } from '@angular/router';
import { AppComponent } from './app.component';

const routes: Routes = [
  { path: 'home', component: HomeComponent, title: 'Home Page' },
  { path: 'about', component: AboutComponent, title: 'About Us' },
  { path: 'contact', component: ContactComponent, title: 'Contact' }
];

bootstrapApplication(AppComponent, {
  providers: [
    provideRouter(routes, withComponentInputBinding({ enableTitleBinding: true }))
  ]
});
```

## Simple Static Title Binding

```typescript
// Route configuration
const routes: Routes = [
  { path: 'dashboard', component: DashboardComponent, title: 'Dashboard' }
];

// Component
@Component({
  selector: 'app-dashboard',
  template: `
    <h1>{{title}}</h1>
    <p>Welcome to the {{title}} page!</p>
  `
})
export class DashboardComponent {
  @Input() title?: string; // Automatically receives 'Dashboard'
}
```

## Input Precedence Order

When multiple sources provide the same input name, the precedence is:

1. **Query parameters** (highest priority)
2. **Path/Matrix parameters**
3. **Static route data**
4. **Resolver data**
5. **Title** (when enabled, lowest priority)
