### PR TITLE
refactor(devtools): keep TreeVisualizer snapped node on focus

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
@@ -11,6 +11,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  DestroyRef,
   ElementRef,
   inject,
   input,
@@ -55,6 +56,9 @@ import {DocsRefButtonComponent} from '../../shared/docs-ref-button/docs-ref-butt
 const ENV_HIERARCHY_VER_SIZE = 35;
 const EL_HIERARCHY_VER_SIZE = 65;
 const HIERARCHY_HOR_SIZE = 50;
+
+const INIT_SNAP_ZOOM_SCALE = 0.7;
+const SNAP_ZOOM_SCALE = 0.8;
 
 @Component({
   selector: 'ng-injector-tree',
@@ -123,6 +127,11 @@ export class InjectorTreeComponent {
         this.rawDirectiveForest = view.forest;
         untracked(() => this.updateInjectorTreeVisualization(view.forest));
       },
+    });
+
+    inject(DestroyRef).onDestroy(() => {
+      this.injectorTreeGraph.dispose();
+      this.elementInjectorTreeGraph.dispose();
     });
   }
 
@@ -223,7 +232,7 @@ export class InjectorTreeComponent {
     // wait for CD to run before snapping to root so that svg container can change size.
     setTimeout(() => {
       if (graph.root?.children) {
-        graph.snapToNode(graph.root.children[0], 0.7);
+        graph.snapToNode(graph.root.children[0], INIT_SNAP_ZOOM_SCALE);
       }
     });
   }
@@ -238,9 +247,9 @@ export class InjectorTreeComponent {
       const {type} = node.data.injector;
 
       if (type === 'element') {
-        this.elementInjectorTreeGraph.snapToNode(node);
+        this.elementInjectorTreeGraph.snapToNode(node, SNAP_ZOOM_SCALE);
       } else if (type === 'environment') {
-        this.injectorTreeGraph.snapToNode(node);
+        this.injectorTreeGraph.snapToNode(node, SNAP_ZOOM_SCALE);
       }
     });
   }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.ts
@@ -11,6 +11,7 @@ import {
   afterNextRender,
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   effect,
   inject,
   input,
@@ -86,6 +87,10 @@ export class RouterTreeComponent {
       write: () => {
         this.setUpRouterVisualizer();
       },
+    });
+
+    inject(DestroyRef).onDestroy(() => {
+      this.routerTreeVisualizer.dispose();
     });
   }
 

--- a/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer-host/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer-host/BUILD.bazel
@@ -22,5 +22,6 @@ ng_project(
         "//:node_modules/@angular/core",
         "//:node_modules/@types/d3",
         "//:node_modules/d3",
+        "//devtools/projects/ng-devtools/src/lib/shared/utils",
     ],
 )

--- a/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer-host/graph-renderer.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer-host/graph-renderer.ts
@@ -25,6 +25,10 @@ export abstract class GraphRenderer<T, U> {
     this.nodeMouseoutListeners = [];
   }
 
+  dispose(): void {
+    this.cleanup();
+  }
+
   onNodeClick(cb: (pointerEvent: PointerEvent, node: U) => void): void {
     this.nodeClickListeners.push(cb);
   }

--- a/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer-host/tree-visualizer.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer-host/tree-visualizer.ts
@@ -129,6 +129,7 @@ export class TreeVisualizer<T extends TreeNode = TreeNode> extends GraphRenderer
   override cleanup(): void {
     super.cleanup();
     d3.select(this.graphElement).selectAll('*').remove();
+    this.snappedNode = null;
   }
 
   override dispose(): void {

--- a/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer-host/tree-visualizer.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer-host/tree-visualizer.ts
@@ -8,11 +8,13 @@
 
 import * as d3 from 'd3';
 import {GraphRenderer} from './graph-renderer';
+import {Debouncer} from '../utils/debouncer';
 
 let arrowDefId = 0;
 let instanceIdx = 0;
 
 const MAX_NODE_LABEL_LENGTH = 25;
+const RESIZE_OBSERVER_DEBOUNCE = 250;
 
 export interface TreeNode {
   label: string;
@@ -57,6 +59,8 @@ function wrapEvent<E, V>(fn: (e: E, node: V) => void): (e: E, node: V) => void {
 
 export class TreeVisualizer<T extends TreeNode = TreeNode> extends GraphRenderer<T, TreeD3Node<T>> {
   private zoomController: d3.ZoomBehavior<HTMLElement, unknown> | null = null;
+  private snappedNode: {node: TreeD3Node<T>; scale: number} | null = null;
+  private snappedNodeListenersDisposeFn?: () => void;
   private readonly config: TreeVisualizerConfig<T>;
   private readonly defaultConfig: TreeVisualizerConfig<T> = {
     orientation: 'horizontal',
@@ -79,6 +83,8 @@ export class TreeVisualizer<T extends TreeNode = TreeNode> extends GraphRenderer
       ...this.defaultConfig,
       ...config,
     };
+
+    this.manageSnappedNode();
   }
 
   override root: TreeD3Node<T> | null = null;
@@ -106,6 +112,8 @@ export class TreeVisualizer<T extends TreeNode = TreeNode> extends GraphRenderer
       .scale(scale)
       .translate(-x, -y);
     svg.transition().duration(500).call(this.zoomController!.transform, t);
+
+    this.snappedNode = {node, scale};
   }
 
   override getNodeById(id: string): TreeD3Node<T> | null {
@@ -121,6 +129,11 @@ export class TreeVisualizer<T extends TreeNode = TreeNode> extends GraphRenderer
   override cleanup(): void {
     super.cleanup();
     d3.select(this.graphElement).selectAll('*').remove();
+  }
+
+  override dispose(): void {
+    super.dispose();
+    this.snappedNodeListenersDisposeFn?.();
   }
 
   override render(graph: T): void {
@@ -286,5 +299,45 @@ export class TreeVisualizer<T extends TreeNode = TreeNode> extends GraphRenderer
       };
     }
     return {x, y};
+  }
+
+  private manageSnappedNode() {
+    this.keepSnappedNodeOnFocus();
+    this.cleanSnappedNodeOnInteraction();
+  }
+
+  private keepSnappedNodeOnFocus() {
+    let initCall = true;
+    const debouncer = new Debouncer();
+    const resizeObserver = new ResizeObserver(
+      debouncer.debounce(([entry]) => {
+        if (!entry || !this.snappedNode) {
+          return;
+        }
+        // Avoid executing the code on observer init.
+        // The node is already being snapped.
+        if (initCall) {
+          initCall = false;
+          return;
+        }
+
+        const {node, scale} = this.snappedNode;
+        this.snapToNode(node, scale);
+      }, RESIZE_OBSERVER_DEBOUNCE),
+    );
+
+    resizeObserver.observe(this.containerElement);
+
+    this.snappedNodeListenersDisposeFn = () => {
+      resizeObserver.disconnect();
+      debouncer.cancel();
+    };
+  }
+
+  private cleanSnappedNodeOnInteraction() {
+    const svg = d3.select(this.containerElement);
+    svg.on('mousedown wheel', () => {
+      this.snappedNode = null;
+    });
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature


## What is the new behavior?

Keep `TreeVisualizer` snapped node on focus when the container/split is being resized.

The purpose of this change is to maintain the node in the visualization viewport when, for example, the split changes from horizontal to vertical orientation or the side pane is displayed. The respective node will be automatically focused as long as the user doesn't interact with the visualization or pick another node.

https://github.com/user-attachments/assets/eb6daa6f-1c2b-4787-943f-4a81785eb4fb


