### PR TITLE
wip(router): rework routerLink and routerLinkActive to use signals

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { AfterContentInit } from '@angular/core';
 import { ChangeDetectorRef } from '@angular/core';
 import { ComponentRef } from '@angular/core';
 import { ElementRef } from '@angular/core';
@@ -18,12 +17,10 @@ import { LocationStrategy } from '@angular/common';
 import { ModuleWithProviders } from '@angular/core';
 import { NgModuleFactory } from '@angular/core';
 import { Observable } from 'rxjs';
-import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
 import { Provider } from '@angular/core';
 import { ProviderToken } from '@angular/core';
-import { QueryList } from '@angular/core';
 import { Renderer2 } from '@angular/core';
 import { Signal } from '@angular/core';
 import { SimpleChanges } from '@angular/core';
@@ -719,7 +716,8 @@ export class Router {
     get lastSuccessfulNavigation(): Navigation | null;
     navigate(commands: readonly any[], extras?: NavigationExtras): Promise<boolean>;
     navigateByUrl(url: string | UrlTree, extras?: NavigationBehaviorOptions): Promise<boolean>;
-    navigated: boolean;
+    get navigated(): boolean;
+    set navigated(v: boolean);
     ngOnDestroy(): void;
     // @deprecated
     onSameUrlNavigation: OnSameUrlNavigation;
@@ -796,9 +794,11 @@ export type RouterFeatures = PreloadingFeature | DebugTracingFeature | InitialNa
 export type RouterHashLocationFeature = RouterFeature<RouterFeatureKind.RouterHashLocationFeature>;
 
 // @public
-class RouterLink implements OnChanges, OnDestroy {
+class RouterLink {
     constructor(router: Router, route: ActivatedRoute, tabIndexAttribute: string | null | undefined, renderer: Renderer2, el: ElementRef, locationStrategy?: LocationStrategy | undefined);
-    fragment?: string;
+    set fragment(v: string | undefined);
+    // (undocumented)
+    get fragment(): string | undefined;
     get href(): string | null;
     set href(value: string | null);
     info?: unknown;
@@ -808,22 +808,34 @@ class RouterLink implements OnChanges, OnDestroy {
     static ngAcceptInputType_replaceUrl: unknown;
     // (undocumented)
     static ngAcceptInputType_skipLocationChange: unknown;
-    ngOnChanges(changes?: SimpleChanges): void;
-    ngOnDestroy(): any;
     onClick(button: number, ctrlKey: boolean, shiftKey: boolean, altKey: boolean, metaKey: boolean): boolean;
-    preserveFragment: boolean;
-    queryParams?: Params | null;
-    queryParamsHandling?: QueryParamsHandling | null;
+    set preserveFragment(v: boolean);
     // (undocumented)
+    get preserveFragment(): boolean;
+    set queryParams(v: Params | null | undefined);
+    // (undocumented)
+    get queryParams(): Params | null | undefined;
+    set queryParamsHandling(v: undefined | QueryParamsHandling | null);
+    // (undocumented)
+    get queryParamsHandling(): undefined | QueryParamsHandling | null;
     protected readonly reactiveHref: i0.WritableSignal<string | null>;
-    relativeTo?: ActivatedRoute | null;
-    replaceUrl: boolean;
+    set relativeTo(v: undefined | ActivatedRoute | null);
+    // (undocumented)
+    get relativeTo(): undefined | ActivatedRoute | null;
+    set replaceUrl(v: boolean);
+    // (undocumented)
+    get replaceUrl(): boolean;
     set routerLink(commandsOrUrlTree: readonly any[] | string | UrlTree | null | undefined);
-    skipLocationChange: boolean;
+    set skipLocationChange(v: boolean);
+    // (undocumented)
+    get skipLocationChange(): boolean;
     state?: {
         [k: string]: any;
     };
-    target?: string;
+    set target(v: string | undefined);
+    // (undocumented)
+    get target(): string | undefined;
+    protected _target: i0.WritableSignal<string | undefined>;
     // (undocumented)
     get urlTree(): UrlTree | null;
     // (undocumented)
@@ -835,24 +847,32 @@ export { RouterLink }
 export { RouterLink as RouterLinkWithHref }
 
 // @public
-export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit {
+export class RouterLinkActive {
     constructor(router: Router, element: ElementRef, renderer: Renderer2, cdr: ChangeDetectorRef, link?: RouterLink | undefined);
-    ariaCurrentWhenActive?: 'page' | 'step' | 'location' | 'date' | 'time' | true | false;
+    // (undocumented)
+    protected _ariaCurrent: i0.Signal<string | null>;
+    set ariaCurrentWhenActive(v: undefined | 'page' | 'step' | 'location' | 'date' | 'time' | true | false);
+    // (undocumented)
+    get ariaCurrentWhenActive(): undefined | 'page' | 'step' | 'location' | 'date' | 'time' | true | false;
+    protected _classBinding: i0.Signal<string[] | {
+        [k: string]: false;
+    }>;
+    // (undocumented)
+    protected _hasActiveLinks: i0.Signal<boolean>;
     // (undocumented)
     get isActive(): boolean;
     readonly isActiveChange: EventEmitter<boolean>;
     // (undocumented)
-    links: QueryList<RouterLink>;
-    ngAfterContentInit(): void;
-    ngOnChanges(changes: SimpleChanges): void;
-    ngOnDestroy(): void;
-    // (undocumented)
     set routerLinkActive(data: string[] | string);
-    routerLinkActiveOptions: {
+    set routerLinkActiveOptions(v: {
+        exact: boolean;
+    } | IsActiveMatchOptions);
+    // (undocumented)
+    get routerLinkActiveOptions(): {
         exact: boolean;
     } | IsActiveMatchOptions;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<RouterLinkActive, "[routerLinkActive]", ["routerLinkActive"], { "routerLinkActiveOptions": { "alias": "routerLinkActiveOptions"; "required": false; }; "ariaCurrentWhenActive": { "alias": "ariaCurrentWhenActive"; "required": false; }; "routerLinkActive": { "alias": "routerLinkActive"; "required": false; }; }, { "isActiveChange": "isActiveChange"; }, ["links"], never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<RouterLinkActive, "[routerLinkActive]", ["routerLinkActive"], { "routerLinkActive": { "alias": "routerLinkActive"; "required": false; }; "routerLinkActiveOptions": { "alias": "routerLinkActiveOptions"; "required": false; }; "ariaCurrentWhenActive": { "alias": "ariaCurrentWhenActive"; "required": false; }; }, { "isActiveChange": "isActiveChange"; }, ["_links"], never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<RouterLinkActive, [null, null, null, null, { optional: true; }]>;
 }

--- a/goldens/public-api/router/testing/index.api.md
+++ b/goldens/public-api/router/testing/index.api.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { AfterContentInit } from '@angular/core';
 import { ChangeDetectorRef } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { ComponentRef } from '@angular/core';
@@ -18,12 +17,10 @@ import { LocationStrategy } from '@angular/common';
 import { ModuleWithProviders } from '@angular/core';
 import { NgModuleFactory } from '@angular/core';
 import { Observable } from 'rxjs';
-import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
 import { Provider } from '@angular/core';
 import { ProviderToken } from '@angular/core';
-import { QueryList } from '@angular/core';
 import { Renderer2 } from '@angular/core';
 import { SimpleChanges } from '@angular/core';
 import { Type } from '@angular/core';

--- a/packages/router/src/directives/router_link_active.ts
+++ b/packages/router/src/directives/router_link_active.ts
@@ -7,29 +7,27 @@
  */
 
 import {
-  AfterContentInit,
   ChangeDetectorRef,
-  ContentChildren,
+  computed,
+  contentChildren,
   Directive,
+  effect,
   ElementRef,
   EventEmitter,
   Input,
-  OnChanges,
-  OnDestroy,
+  linkedSignal,
   Optional,
   Output,
-  QueryList,
   Renderer2,
-  SimpleChanges,
+  signal,
+  untracked,
 } from '@angular/core';
-import {from, of, Subscription} from 'rxjs';
-import {mergeAll} from 'rxjs/operators';
 
-import {Event, NavigationEnd} from '../events';
 import {Router} from '../router';
 import {IsActiveMatchOptions} from '../url_tree';
 
 import {RouterLink} from './router_link';
+import {shallowEqualArrays} from '../utils/collection';
 
 /**
  *
@@ -103,17 +101,35 @@ import {RouterLink} from './router_link';
 @Directive({
   selector: '[routerLinkActive]',
   exportAs: 'routerLinkActive',
+  host: {
+    '[attr.aria-current]': '_ariaCurrent()',
+    '[class]': '_classBinding()',
+  },
 })
-export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit {
-  @ContentChildren(RouterLink, {descendants: true}) links!: QueryList<RouterLink>;
+export class RouterLinkActive {
+  private readonly _links = contentChildren(RouterLink, {descendants: true});
 
-  private classes: string[] = [];
-  private routerEventsSubscription: Subscription;
-  private linkInputChangesSubscription?: Subscription;
-  private _isActive = false;
+  @Input()
+  set routerLinkActive(data: string[] | string) {
+    const classes = Array.isArray(data) ? data : data.split(' ');
+    this.classes.set(classes.filter((c) => !!c));
+  }
+  private classes = signal<string[]>([], {equal: shallowEqualArrays});
+  /** @docs-private */
+  protected _classBinding = computed(() =>
+    this._hasActiveLinks()
+      ? this.classes()
+      : this.classes().reduce(
+          (acc, v) => {
+            acc[v] = false;
+            return acc;
+          },
+          {} as {[k: string]: false},
+        ),
+  );
 
   get isActive(): boolean {
-    return this._isActive;
+    return untracked(this._hasActiveLinks);
   }
 
   /**
@@ -123,7 +139,22 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
    *
    * @see {@link Router#isActive}
    */
-  @Input() routerLinkActiveOptions: {exact: boolean} | IsActiveMatchOptions = {exact: false};
+  @Input() set routerLinkActiveOptions(v: {exact: boolean} | IsActiveMatchOptions) {
+    this._routerLinkActiveOptionsInput.set(v);
+  }
+  get routerLinkActiveOptions(): {exact: boolean} | IsActiveMatchOptions {
+    return untracked(this._routerLinkActiveOptionsInput);
+  }
+  private readonly _routerLinkActiveOptionsInput = signal<{exact: boolean} | IsActiveMatchOptions>({
+    exact: false,
+  });
+  private _routerLinkActiveOptions = computed(() => {
+    const options = this._routerLinkActiveOptionsInput();
+    return isActiveMatchOptions(options)
+      ? options
+      : // While the types should disallow `undefined` here, it's possible without strict inputs
+        options.exact || false;
+  });
 
   /**
    * Aria-current attribute to apply when the router link is active.
@@ -132,7 +163,33 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
    *
    * @see {@link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current}
    */
-  @Input() ariaCurrentWhenActive?: 'page' | 'step' | 'location' | 'date' | 'time' | true | false;
+  @Input() set ariaCurrentWhenActive(
+    v: undefined | 'page' | 'step' | 'location' | 'date' | 'time' | true | false,
+  ) {
+    this._ariaCurrentWhenActiveInput.set(v);
+  }
+  get ariaCurrentWhenActive():
+    | undefined
+    | 'page'
+    | 'step'
+    | 'location'
+    | 'date'
+    | 'time'
+    | true
+    | false {
+    return untracked(this._ariaCurrentWhenActiveInput);
+  }
+  private _ariaCurrentWhenActiveInput = signal<
+    undefined | 'page' | 'step' | 'location' | 'date' | 'time' | true | false
+  >(undefined);
+
+  protected _ariaCurrent = computed(() => {
+    const value = this._ariaCurrentWhenActiveInput();
+    if (!this._hasActiveLinks() || value === undefined) {
+      return null;
+    }
+    return value.toString();
+  });
 
   /**
    *
@@ -150,7 +207,9 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
    *  (isActiveChange)="this.onRouterLinkActive($event)">Bob</a>
    * ```
    */
-  @Output() readonly isActiveChange: EventEmitter<boolean> = new EventEmitter();
+  // Async emit to avoid expression changed errors since this emits during change detection
+  // Could be changed to synchronous as a breaking change in the future.
+  @Output() readonly isActiveChange: EventEmitter<boolean> = new EventEmitter(true);
 
   constructor(
     private router: Router,
@@ -159,103 +218,39 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
     private readonly cdr: ChangeDetectorRef,
     @Optional() private link?: RouterLink,
   ) {
-    this.routerEventsSubscription = router.events.subscribe((s: Event) => {
-      if (s instanceof NavigationEnd) {
-        this.update();
-      }
-    });
-  }
-
-  /** @docs-private */
-  ngAfterContentInit(): void {
-    // `of(null)` is used to force subscribe body to execute once immediately (like `startWith`).
-    of(this.links.changes, of(null))
-      .pipe(mergeAll())
-      .subscribe((_) => {
-        this.update();
-        this.subscribeToEachLinkOnChanges();
-      });
-  }
-
-  private subscribeToEachLinkOnChanges() {
-    this.linkInputChangesSubscription?.unsubscribe();
-    const allLinkChanges = [...this.links.toArray(), this.link]
-      .filter((link): link is RouterLink => !!link)
-      .map((link) => link.onChanges);
-    this.linkInputChangesSubscription = from(allLinkChanges)
-      .pipe(mergeAll())
-      .subscribe((link) => {
-        if (this._isActive !== this.isLinkActive(this.router)(link)) {
-          this.update();
-        }
-      });
-  }
-
-  @Input()
-  set routerLinkActive(data: string[] | string) {
-    const classes = Array.isArray(data) ? data : data.split(' ');
-    this.classes = classes.filter((c) => !!c);
-  }
-
-  /** @docs-private */
-  ngOnChanges(changes: SimpleChanges): void {
-    this.update();
-  }
-  /** @docs-private */
-  ngOnDestroy(): void {
-    this.routerEventsSubscription.unsubscribe();
-    this.linkInputChangesSubscription?.unsubscribe();
-  }
-
-  private update(): void {
-    if (!this.links || !this.router.navigated) return;
-
-    queueMicrotask(() => {
-      const hasActiveLinks = this.hasActiveLinks();
-      this.classes.forEach((c) => {
-        if (hasActiveLinks) {
-          this.renderer.addClass(this.element.nativeElement, c);
-        } else {
-          this.renderer.removeClass(this.element.nativeElement, c);
-        }
-      });
-      if (hasActiveLinks && this.ariaCurrentWhenActive !== undefined) {
-        this.renderer.setAttribute(
-          this.element.nativeElement,
-          'aria-current',
-          this.ariaCurrentWhenActive.toString(),
-        );
-      } else {
-        this.renderer.removeAttribute(this.element.nativeElement, 'aria-current');
-      }
-
-      // Only emit change if the active state changed.
-      if (this._isActive !== hasActiveLinks) {
-        this._isActive = hasActiveLinks;
-        this.cdr.markForCheck();
+    let lastValue = false;
+    effect(() => {
+      const hasActiveLinks = this._hasActiveLinks();
+      if (lastValue !== hasActiveLinks) {
         // Emit on isActiveChange after classes are updated
         this.isActiveChange.emit(hasActiveLinks);
       }
+      lastValue = hasActiveLinks;
     });
   }
 
-  private isLinkActive(router: Router): (link: RouterLink) => boolean {
-    const options: boolean | IsActiveMatchOptions = isActiveMatchOptions(
-      this.routerLinkActiveOptions,
-    )
-      ? this.routerLinkActiveOptions
-      : // While the types should disallow `undefined` here, it's possible without strict inputs
-        this.routerLinkActiveOptions.exact || false;
-    return (link: RouterLink) => {
-      const urlTree = link.urlTree;
-      return urlTree ? router.isActive(urlTree, options) : false;
-    };
+  private isLinkActive(link: RouterLink) {
+    return computed(() => {
+      const urlTree = link._urlTree();
+      return urlTree ? this.router._isActive(urlTree, this._routerLinkActiveOptions())() : false;
+    });
   }
 
-  private hasActiveLinks(): boolean {
-    const isActiveCheckFn = this.isLinkActive(this.router);
-    return (this.link && isActiveCheckFn(this.link)) || this.links.some(isActiveCheckFn);
-  }
+  private thisLinkActive = computed(() => (!this.link ? false : this.isLinkActive(this.link)()));
+  private contentLinkActiveSignals = computed(() =>
+    this._links().map((link) => this.isLinkActive(link)),
+  );
+  private someContentLinkActive = computed(() =>
+    this.contentLinkActiveSignals().some((active) => active()),
+  );
+  private routerHasNavigated = linkedSignal<boolean, boolean>({
+    source: () => this.router._navigated(),
+    computation: (navigated, previouslyNavigated): boolean =>
+      navigated || !!previouslyNavigated?.source,
+  });
+  protected _hasActiveLinks = computed(() => {
+    return this.routerHasNavigated() && (this.thisLinkActive() || this.someContentLinkActive());
+  });
 }
 
 /**

--- a/packages/router/test/router_link_active.spec.ts
+++ b/packages/router/test/router_link_active.spec.ts
@@ -22,6 +22,6 @@ describe('RouterLinkActive', () => {
     fixture.autoDetectChanges();
     await TestBed.inject(Router).navigateByUrl('/');
     await fixture.whenStable();
-    expect(Array.from(fixture.nativeElement.querySelector('a').classList)).toEqual([]);
+    expect(fixture.nativeElement.querySelector('a').classList.value).toEqual('');
   });
 });

--- a/packages/router/test/router_link_spec.ts
+++ b/packages/router/test/router_link_spec.ts
@@ -312,7 +312,7 @@ describe('RouterLink', () => {
     }
     TestBed.configureTestingModule({providers: [provideRouter([])]});
 
-    const fixture = TestBed.createComponent(WithUrlTree);
-    expect(() => fixture.changeDetectorRef.detectChanges()).toThrow();
+    TestBed.createComponent(WithUrlTree);
+    expect(TestBed.tick).toThrow();
   });
 });


### PR DESCRIPTION
There's currently a lot of messiness here around the getter/setter pair to avoid breaking changes. This could be addressed by (a) just breaking things (b) a settable signal input (c) keep things as they are in this PR.
