### PR TITLE
fix(forms): memoize `deepSignal` value

### DIFF
--- a/packages/forms/experimental/src/util/deep_signal.ts
+++ b/packages/forms/experimental/src/util/deep_signal.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Signal, untracked, WritableSignal} from '@angular/core';
+import {computed, Signal, untracked, WritableSignal} from '@angular/core';
 import {SIGNAL} from '@angular/core/primitives/signals';
 import {isArray} from './type_guards';
 
@@ -22,9 +22,8 @@ export function deepSignal<S, K extends keyof S>(
   source: WritableSignal<S>,
   prop: Signal<K>,
 ): WritableSignal<S[K]> {
-  const read: WritableSignal<S[K]> = (() => {
-    return source()[prop()];
-  }) as WritableSignal<S[K]>;
+  // Memoize the property.
+  const read = computed(() => source()[prop()]) as WritableSignal<S[K]>;
 
   read[SIGNAL] = source[SIGNAL];
   read.set = (value: S[K]) => {

--- a/packages/forms/experimental/test/node/submit.spec.ts
+++ b/packages/forms/experimental/test/node/submit.spec.ts
@@ -199,6 +199,26 @@ describe('submit', () => {
     await expectAsync(submitPromise).toBeRejectedWith(error);
     expect(f().submitting()).toBe(false);
   });
+
+  it('errors are cleared on edit', async () => {
+    const data = signal({first: '', last: ''});
+    const f = form(data, {injector: TestBed.inject(Injector)});
+
+    await submit(f, async (form) => {
+      return [
+        ValidationError.custom({kind: 'submit', field: f.first}),
+        ValidationError.custom({kind: 'submit', field: f.last}),
+      ];
+    });
+
+    expect(f.first().errors()).toEqual([ValidationError.custom({kind: 'submit'})]);
+    expect(f.last().errors()).toEqual([ValidationError.custom({kind: 'submit'})]);
+
+    f.first().value.set('Hello');
+
+    expect(f.first().errors()).toEqual([]);
+    expect(f.last().errors()).toEqual([ValidationError.custom({kind: 'submit'})]);
+  });
 });
 
 /**


### PR DESCRIPTION
Test that submission errors are cleared from their corresponding field when its value is changed. Submission errors should not be cleared from fields whose values remain unchanged. This behavior relies on fields memoizing their value, which `deepSignal()` now does.