### PR TITLE
fix(core): destroying the effect node on `afterRenderEffect`

### DIFF
--- a/packages/core/src/render3/reactivity/after_render_effect.ts
+++ b/packages/core/src/render3/reactivity/after_render_effect.ts
@@ -9,6 +9,7 @@
 import {
   consumerAfterComputation,
   consumerBeforeComputation,
+  consumerDestroy,
   consumerPollProducersForChange,
   producerAccessed,
   SIGNAL,
@@ -152,7 +153,7 @@ const AFTER_RENDER_PHASE_EFFECT_NODE = /* @__PURE__ */ (() => ({
 /**
  * An `AfterRenderSequence` that manages an `afterRenderEffect`'s phase effects.
  */
-class AfterRenderEffectSequence extends AfterRenderSequence {
+export class AfterRenderEffectSequence extends AfterRenderSequence {
   /**
    * While this sequence is executing, this tracks the last phase which was called by the
    * `afterRender` machinery.
@@ -223,8 +224,14 @@ class AfterRenderEffectSequence extends AfterRenderSequence {
 
     // Run the cleanup functions for each node.
     for (const node of this.nodes) {
-      for (const fn of node?.cleanup ?? EMPTY_CLEANUP_SET) {
-        fn();
+      if (node) {
+        try {
+          for (const fn of node.cleanup ?? EMPTY_CLEANUP_SET) {
+            fn();
+          }
+        } finally {
+          consumerDestroy(node);
+        }
       }
     }
   }


### PR DESCRIPTION
Prior to this commit, the effect node wasn't destroyed.

fixes #62980
