### PR TITLE
refactor(language-service): handle the `undefined` value of a symbol …

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -1605,12 +1605,12 @@ function getClassDeclFromSymbol(
   }
 
   if (ts.isExportAssignment(decl)) {
-    const symbol = checker.getTypeAtLocation(decl.expression).symbol;
+    const symbol = checker.getTypeAtLocation(decl.expression).getSymbol();
     return getClassDeclFromSymbol(symbol, checker);
   }
 
   if (ts.isExportSpecifier(decl)) {
-    const symbol = checker.getTypeAtLocation(decl).symbol;
+    const symbol = checker.getTypeAtLocation(decl).getSymbol();
     return getClassDeclFromSymbol(symbol, checker);
   }
 
@@ -1697,7 +1697,7 @@ function getTheElementTagDeprecatedSuggestionDiagnostics(
   for (const tsDiag of diags) {
     const diagNode = getTokenAtPosition(sourceFile, tsDiag.start);
     const nodeType = typeChecker.getTypeAtLocation(diagNode);
-    const nodeSymbolDeclarations = nodeType.symbol.declarations;
+    const nodeSymbolDeclarations = nodeType.getSymbol()?.declarations;
     const decl =
       nodeSymbolDeclarations !== undefined && nodeSymbolDeclarations.length > 0
         ? nodeSymbolDeclarations[0]
@@ -1726,7 +1726,7 @@ function getTheElementTagDeprecatedSuggestionDiagnostics(
   const templateDiagnostics: TemplateDiagnostic[] = [];
   for (const directive of directiveNodesInTcb) {
     const directiveType = typeChecker.getTypeAtLocation(directive);
-    const directiveSymbolDeclarations = directiveType.symbol.declarations;
+    const directiveSymbolDeclarations = directiveType.getSymbol()?.declarations;
 
     const decl =
       directiveSymbolDeclarations !== undefined && directiveSymbolDeclarations.length > 0

--- a/packages/language-service/test/diagnostic_spec.ts
+++ b/packages/language-service/test/diagnostic_spec.ts
@@ -599,6 +599,36 @@ describe('getSuggestedDiagnostics', () => {
     env = LanguageServiceTestEnv.setup();
   });
 
+  it('should report deprecated for primitive type variable', () => {
+    const files = {
+      'app.ts': `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: '<div>{{name}}</div>',
+        standalone: false,
+      })
+      export class AppComponent {
+        /**
+         * @deprecated
+         * 
+         * Used to test to get the symbol of the type "string", using the
+         * "type.getSymbol()" to check if the symbol is "undefined".
+         */
+        name = 'test';
+      }
+    `,
+    };
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+
+    const diags = project.getSuggestionDiagnosticsForFile('app.ts');
+    expect(diags.length).toBe(1);
+    const {category, file, messageText} = diags[0];
+    expect(category).toBe(ts.DiagnosticCategory.Suggestion);
+    expect(file?.fileName).toBe('/test/app.ts');
+    expect(messageText).toBe(`'name' is deprecated.`);
+  });
+
   it('should report deprecated for component variable', () => {
     const files = {
       'app.ts': `


### PR DESCRIPTION
…for a type

using the `getSymbol` instead of the `type.symbol`, for the primitive type, the `type.symbol` returns the `undefined` value. The return type of `getSymbol` includes `undefined`, while `type.symbol` does not.

For example:

```ts
class BarComponent {
   /**
   * @deprecated
   */
  name = ""
}
```

The type of `name` is `string`, the `type.symbol` for the `string` returns `undefined` here.

https://github.com/microsoft/TypeScript/blob/e3ef7ff50db66b6a2af8090f79d9039356ec0096/src/services/types.ts#L111 https://github.com/microsoft/TypeScript/blob/e3ef7ff50db66b6a2af8090f79d9039356ec0096/src/compiler/types.ts#L6445

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
