### PR TITLE
refactor(devtools): add support for `afterRenderEffect` on the signal graph

### DIFF
--- a/devtools/src/app/demo-app/demo-app.component.ts
+++ b/devtools/src/app/demo-app/demo-app.component.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  afterRenderEffect,
   Component,
   computed,
   CUSTOM_ELEMENTS_SCHEMA,
@@ -82,5 +83,11 @@ export class DemoAppComponent {
       return '► Click to expand';
     }
     return '▼ Click to collapse';
+  }
+
+  constructor() {
+    afterRenderEffect(() => {
+      this.zippy();
+    });
   }
 }


### PR DESCRIPTION
Prior to this change, the `afterRenderEffect` phases were not represented in the signal graph.
