### PR TITLE
feat(router): add a currentNavigation signal to the Router service.

### DIFF
--- a/adev/src/content/guide/routing/data-resolvers.md
+++ b/adev/src/content/guide/routing/data-resolvers.md
@@ -282,9 +282,7 @@ import { map } from 'rxjs';
 })
 export class App {
   private router = inject(Router);
-  isNavigating = toSignal(this.router.events.pipe(
-    map(() => !!this.router.getCurrentNavigation())
-  ));
+  isNavigating = computed(() => !!this.router.currentNavigation());
 }
 ```
 

--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -709,8 +709,10 @@ export class Router {
     // (undocumented)
     config: Routes;
     createUrlTree(commands: readonly any[], navigationExtras?: UrlCreationOptions): UrlTree;
+    readonly currentNavigation: i0.Signal<Navigation | null>;
     dispose(): void;
     get events(): Observable<Event_2>;
+    // @deprecated
     getCurrentNavigation(): Navigation | null;
     initialNavigation(): void;
     // @deprecated

--- a/integration/platform-server-hydration/size.json
+++ b/integration/platform-server-hydration/size.json
@@ -1,5 +1,5 @@
 {
-  "dist/browser/main-[hash].js": 221976,
+  "dist/browser/main-[hash].js": 227093,
   "dist/browser/polyfills-[hash].js": 34544,
   "dist/browser/event-dispatch-contract.min.js": 476
 }

--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -114,6 +114,10 @@ bundle_entrypoints = [
         "control-flow-migration",
         "packages/core/schematics/migrations/control-flow-migration/index.js",
     ],
+    [
+        "router-current-navigation",
+        "packages/core/schematics/migrations/router-current-navigation/index.js",
+    ],
 ]
 
 rollup.rollup(
@@ -128,6 +132,7 @@ rollup.rollup(
         "//packages/core/schematics/migrations/control-flow-migration",
         "//packages/core/schematics/migrations/document-core",
         "//packages/core/schematics/migrations/inject-flags",
+        "//packages/core/schematics/migrations/router-current-navigation",
         "//packages/core/schematics/migrations/test-bed-get",
         "//packages/core/schematics/ng-generate/cleanup-unused-imports",
         "//packages/core/schematics/ng-generate/inject-migration",

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -20,6 +20,12 @@
       "version": "20.0.0",
       "description": "Moves imports of `DOCUMENT` from `@angular/common` to `@angular/core`",
       "factory": "./bundles/document-core.cjs#migrate"
+    },
+    "router-current-navigation": {
+      "version": "20.2.0",
+      "description": "Replaces usages of the deprecated Router.getCurrentNavigation method with the Router.currentNavigation signal",
+      "factory": "./bundles/router-current-navigation.cjs#migrate",
+      "optional": true
     }
   }
 }

--- a/packages/core/schematics/migrations/router-current-navigation/BUILD.bazel
+++ b/packages/core/schematics/migrations/router-current-navigation/BUILD.bazel
@@ -1,0 +1,23 @@
+load("//tools:defaults2.bzl", "ts_project")
+
+package(
+    default_visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+)
+
+ts_project(
+    name = "router-current-navigation",
+    srcs = glob(["**/*.ts"]),
+    deps = [
+        "//:node_modules/@angular-devkit/schematics",
+        "//:node_modules/@types/node",
+        "//:node_modules/typescript",
+        "//packages/compiler-cli/private",
+        "//packages/compiler-cli/src/ngtsc/file_system",
+        "//packages/core/schematics/utils",
+        "//packages/core/schematics/utils/tsurge",
+        "//packages/core/schematics/utils/tsurge/helpers/angular_devkit",
+    ],
+)

--- a/packages/core/schematics/migrations/router-current-navigation/README.md
+++ b/packages/core/schematics/migrations/router-current-navigation/README.md
@@ -1,0 +1,28 @@
+## Remove `Router.getCurrentNavigation` migration
+Replaces the usages of the deprecated `Router.getCurrentNavigation` method with the new `Router.currentNavigation()` signal:
+
+### Before
+```typescript
+import { Router } from '@angular/router';
+
+export class MyService {
+  router = inject(Router);   
+
+  someMethod() {
+    const currentNavigation = this.router.getCurrentNavigation();
+  }
+}
+```
+
+### After
+```typescript
+import { Router } from '@angular/router';
+
+export class MyService {
+  router = inject(Router);   
+
+  someMethod() {
+    const currentNavigation = this.router.currentNavigation();
+  }
+}
+```

--- a/packages/core/schematics/migrations/router-current-navigation/index.ts
+++ b/packages/core/schematics/migrations/router-current-navigation/index.ts
@@ -1,0 +1,20 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Rule} from '@angular-devkit/schematics';
+import {RouterCurrentNavigationMigration} from './router_current_navigation_migration';
+import {runMigrationInDevkit} from '../../utils/tsurge/helpers/angular_devkit';
+
+export function migrate(): Rule {
+  return async (tree) => {
+    await runMigrationInDevkit({
+      tree,
+      getMigration: () => new RouterCurrentNavigationMigration(),
+    });
+  };
+}

--- a/packages/core/schematics/migrations/router-current-navigation/router_current_navigation_migration.ts
+++ b/packages/core/schematics/migrations/router-current-navigation/router_current_navigation_migration.ts
@@ -1,0 +1,139 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import ts from 'typescript';
+import {
+  confirmAsSerializable,
+  ProgramInfo,
+  ProjectFile,
+  projectFile,
+  Replacement,
+  Serializable,
+  TextUpdate,
+  TsurgeFunnelMigration,
+} from '../../utils/tsurge';
+import {getImportSpecifier} from '../../utils/typescript/imports';
+import {isReferenceToImport} from '../../utils/typescript/symbol';
+
+export interface CompilationUnitData {
+  locations: Location[];
+}
+
+/** Information about the `getCurrentNavigation` identifier in `Router.getCurrentNavigation`. */
+interface Location {
+  /** File in which the expression is defined. */
+  file: ProjectFile;
+
+  /** Start of the `getCurrentNavigation` identifier. */
+  position: number;
+}
+
+/** Name of the method being replaced. */
+const METHOD_NAME = 'getCurrentNavigation';
+
+/** Migration that replaces `Router.getCurrentNavigation` usages with `Router.currentNavigation()`. */
+export class RouterCurrentNavigationMigration extends TsurgeFunnelMigration<
+  CompilationUnitData,
+  CompilationUnitData
+> {
+  override async analyze(info: ProgramInfo): Promise<Serializable<CompilationUnitData>> {
+    const locations: Location[] = [];
+
+    for (const sourceFile of info.sourceFiles) {
+      const routerSpecifier = getImportSpecifier(sourceFile, '@angular/router', 'Router');
+
+      if (routerSpecifier === null) {
+        continue;
+      }
+
+      const typeChecker = info.program.getTypeChecker();
+      sourceFile.forEachChild(function walk(node) {
+        if (
+          ts.isPropertyAccessExpression(node) &&
+          node.name.text === METHOD_NAME &&
+          isRouterType(typeChecker, node.expression, routerSpecifier)
+        ) {
+          locations.push({file: projectFile(sourceFile, info), position: node.name.getStart()});
+        } else {
+          node.forEachChild(walk);
+        }
+      });
+    }
+
+    return confirmAsSerializable({locations});
+  }
+
+  override async migrate(globalData: CompilationUnitData) {
+    const replacements = globalData.locations.map(({file, position}) => {
+      return new Replacement(
+        file,
+        new TextUpdate({
+          position: position,
+          end: position + METHOD_NAME.length,
+          toInsert: 'currentNavigation',
+        }),
+      );
+    });
+
+    return confirmAsSerializable({replacements});
+  }
+
+  override async combine(
+    unitA: CompilationUnitData,
+    unitB: CompilationUnitData,
+  ): Promise<Serializable<CompilationUnitData>> {
+    const seen = new Set<string>();
+    const locations: Location[] = [];
+    const combined = [...unitA.locations, ...unitB.locations];
+
+    for (const location of combined) {
+      const key = `${location.file.id}#${location.position}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        locations.push(location);
+      }
+    }
+
+    return confirmAsSerializable({locations});
+  }
+
+  override async globalMeta(
+    combinedData: CompilationUnitData,
+  ): Promise<Serializable<CompilationUnitData>> {
+    return confirmAsSerializable(combinedData);
+  }
+
+  override async stats() {
+    return confirmAsSerializable({});
+  }
+}
+
+/**
+ * Checks if the given symbol represents a Router type.
+ */
+function isRouterType(
+  typeChecker: ts.TypeChecker,
+  expression: ts.Expression,
+  routerSpecifier: ts.ImportSpecifier,
+): boolean {
+  const expressionType = typeChecker.getTypeAtLocation(expression);
+  const expressionSymbol = expressionType.getSymbol();
+  if (!expressionSymbol) {
+    return false;
+  }
+
+  const declarations = expressionSymbol.getDeclarations() ?? [];
+
+  for (const declaration of declarations) {
+    if (isReferenceToImport(typeChecker, declaration, routerSpecifier)) {
+      return true;
+    }
+  }
+
+  return declarations.some((decl) => decl === routerSpecifier);
+}

--- a/packages/core/schematics/test/router_current_navigation_spec.ts
+++ b/packages/core/schematics/test/router_current_navigation_spec.ts
@@ -1,0 +1,156 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {getSystemPath, normalize, virtualFs} from '@angular-devkit/core';
+import {TempScopedNodeJsSyncHost} from '@angular-devkit/core/node/testing';
+import {HostTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing/index.js';
+import {resolve} from 'node:path';
+import shx from 'shelljs';
+
+describe('router-current-navigation migration', () => {
+  let runner: SchematicTestRunner;
+  let host: TempScopedNodeJsSyncHost;
+  let tree: UnitTestTree;
+  let tmpDirPath: string;
+
+  function writeFile(filePath: string, contents: string) {
+    host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
+  }
+
+  function runMigration() {
+    return runner.runSchematic('router-current-navigation', {}, tree);
+  }
+
+  const migrationsJsonPath = resolve('../migrations.json');
+  beforeEach(() => {
+    runner = new SchematicTestRunner('test', migrationsJsonPath);
+    host = new TempScopedNodeJsSyncHost();
+    tree = new UnitTestTree(new HostTree(host));
+    tmpDirPath = getSystemPath(host.root);
+
+    writeFile('/tsconfig.json', '{}');
+    writeFile(
+      '/angular.json',
+      JSON.stringify({
+        version: 1,
+        projects: {t: {root: '', architect: {build: {options: {tsConfig: './tsconfig.json'}}}}},
+      }),
+    );
+
+    writeFile(
+      '/node_modules/@angular/router/index.d.ts',
+      `
+      export declare class Router {
+        getCurrentNavigation(): Navigation | null;
+      }
+    `,
+    );
+
+    shx.cd(tmpDirPath);
+  });
+
+  it('should migrate a usage of Router.getCurrentNavigation()', async () => {
+    writeFile(
+      '/test.ts',
+      `
+        import { Router } from '@angular/router';
+
+        export class MyService {
+          constructor(private router: Router) {} 
+
+          someMethod() {
+            const currentNavigation = this.router.getCurrentNavigation();
+          }
+        }
+        `,
+    );
+
+    await runMigration();
+    expect(tree.readContent('/test.ts')).toContain(
+      'const currentNavigation = this.router.currentNavigation();',
+    );
+  });
+
+  it('should migrate a usage of Router.getCurrentNavigation() that is not in a call', async () => {
+    writeFile(
+      '/test.ts',
+      `
+        import { Router } from '@angular/router';
+
+        export class MyService {
+          constructor(private router: Router) {} 
+
+          someMethod() {
+            const currentNavigation = this.router.getCurrentNavigation
+          }
+        }
+      `,
+    );
+
+    await runMigration();
+    expect(tree.readContent('/test.ts')).toContain(
+      'const currentNavigation = this.router.currentNavigation',
+    );
+  });
+
+  it('should handle a file that is present in multiple projects', async () => {
+    writeFile('/tsconfig-2.json', '{}');
+    writeFile(
+      '/angular.json',
+      JSON.stringify({
+        version: 1,
+        projects: {
+          a: {root: '', architect: {build: {options: {tsConfig: './tsconfig.json'}}}},
+          b: {root: '', architect: {build: {options: {tsConfig: './tsconfig-2.json'}}}},
+        },
+      }),
+    );
+
+    writeFile(
+      'test.ts',
+      `
+        import { Router } from '@angular/router';
+
+        export class MyService {
+          constructor(private router: Router) {} 
+
+          someMethod() {
+            const currentNavigation = this.router.getCurrentNavigation();
+          }
+        }
+      `,
+    );
+
+    await runMigration();
+    const content = tree.readContent('/test.ts');
+    expect(content).toContain('const currentNavigation = this.router.currentNavigation');
+  });
+
+  it('should not migrate a usage of from non-angular router', async () => {
+    writeFile(
+      '/test.ts',
+      `
+        import { Router } from '@not-angular/router';
+
+        export class MyService {
+          constructor(private router: Router) {} 
+
+          someMethod() {
+            const currentNavigation = this.router.getCurrentNavigation();
+          }
+        }
+        `,
+    );
+
+    await runMigration();
+    expect(tree.readContent('/test.ts')).toContain(
+      'const currentNavigation = this.router.getCurrentNavigation();',
+    );
+  });
+});

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -15,6 +15,7 @@ import {
   ɵPendingTasksInternal as PendingTasks,
   ɵRuntimeError as RuntimeError,
   Type,
+  untracked,
   ɵINTERNAL_APPLICATION_ERROR_HANDLER,
 } from '@angular/core';
 import {Observable, Subject, Subscription, SubscriptionLike} from 'rxjs';
@@ -176,6 +177,13 @@ export class Router {
    */
   readonly componentInputBindingEnabled: boolean = !!inject(INPUT_BINDER, {optional: true});
 
+  /**
+   * Signal of the current `Navigation` object when the router is navigating, and `null` when idle.
+   *
+   * Note: The current navigation becomes to null after the NavigationEnd event is emitted.
+   */
+  readonly currentNavigation = this.navigationTransitions.currentNavigation.asReadonly();
+
   constructor() {
     this.resetConfig(this.config);
 
@@ -192,7 +200,8 @@ export class Router {
     const subscription = this.navigationTransitions.events.subscribe((e) => {
       try {
         const currentTransition = this.navigationTransitions.currentTransition;
-        const currentNavigation = this.navigationTransitions.currentNavigation;
+        const currentNavigation = untracked(this.navigationTransitions.currentNavigation);
+
         if (currentTransition !== null && currentNavigation !== null) {
           this.stateManager.handleRouterEvent(e, currentNavigation);
           if (
@@ -337,9 +346,11 @@ export class Router {
   /**
    * Returns the current `Navigation` object when the router is navigating,
    * and `null` when idle.
+   *
+   * @deprecated 20.2 Use the `currentNavigation` signal instead.
    */
   getCurrentNavigation(): Navigation | null {
-    return this.navigationTransitions.currentNavigation;
+    return untracked(this.navigationTransitions.currentNavigation);
   }
 
   /**

--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -150,6 +150,7 @@ describe('bootstrap', () => {
         const router = res.injector.get(Router);
         expect(router.navigated).toEqual(false);
         expect(router.getCurrentNavigation()).toBeNull();
+        expect(router.currentNavigation()).toBeNull();
         expect(log).toContain('TestModule');
         expect(log).toContain('NavigationError');
       });

--- a/packages/router/test/integration/integration.spec.ts
+++ b/packages/router/test/integration/integration.spec.ts
@@ -735,13 +735,16 @@ for (const browserAPI of ['navigation', 'history'] as const) {
 
       router.navigateByUrl('/user/victor');
       expect(router.getCurrentNavigation()).not.toBe(null);
+      expect(router.currentNavigation()).not.toBe(null);
       router.navigateByUrl('/user/fedor');
       // Due to https://github.com/angular/angular/issues/29389, this would be `false`
       // when running a second navigation.
       expect(router.getCurrentNavigation()).not.toBe(null);
+      expect(router.currentNavigation()).not.toBe(null);
       await advance(fixture);
 
       expect(router.getCurrentNavigation()).toBe(null);
+      expect(router.currentNavigation()).toBe(null);
       expect(fixture.nativeElement).toHaveText('user fedor');
     });
 

--- a/packages/router/test/integration/navigation.spec.ts
+++ b/packages/router/test/integration/navigation.spec.ts
@@ -738,6 +738,7 @@ export function navigationIntegrationTestSuite() {
       router.getCurrentNavigation()!.abort();
 
       expect(router.getCurrentNavigation()).toBe(null);
+      expect(router.currentNavigation()).toBe(null);
       await expectAsync(navigationPromise).toBeResolvedTo(false);
       expect(replay.value).toBeInstanceOf(NavigationCancel);
     });


### PR DESCRIPTION
This #62971 re-opened

----
This new signal property is convenient to derive a `isNavigating` state.

`isNavigating = computed(() => !!this.router.currentNavigation())`

DEPRECATED: The Router.getCurrentNavigation method is deprecated. Use the Router.currentNavigation signal instead.

fixes #62958
