### PR TITLE
refactor(core): wrap all calls that use `getAnimations` in `requestAnimationFrame`

### DIFF
--- a/packages/core/src/render3/instructions/animation.ts
+++ b/packages/core/src/render3/instructions/animation.ts
@@ -81,8 +81,10 @@ export function ɵɵanimateEnter(value: string | Function): typeof ɵɵanimateEn
   // This also allows us to setup cancellation of animations in progress if the
   // gets removed early.
   const handleAnimationStart = (event: AnimationEvent | TransitionEvent) => {
-    determineLongestAnimation(event, nativeElement, longestAnimations, areAnimationSupported);
-    setupAnimationCancel(event, renderer);
+    requestAnimationFrame(() => {
+      determineLongestAnimation(event, nativeElement, longestAnimations, areAnimationSupported);
+      setupAnimationCancel(event, renderer);
+    });
     const eventName = event instanceof AnimationEvent ? 'animationend' : 'transitionend';
     ngZone.runOutsideAngular(() => {
       cleanupFns.push(renderer.listen(nativeElement, eventName, handleInAnimationEnd));
@@ -438,10 +440,12 @@ function animateLeaveClassRunner(
     finalRemoveFn();
   }
 
-  cancelAnimationsIfRunning(el, renderer);
+  requestAnimationFrame(() => cancelAnimationsIfRunning(el, renderer));
 
   const handleAnimationStart = (event: AnimationEvent | TransitionEvent) => {
-    determineLongestAnimation(event, el, longestAnimations, areAnimationSupported);
+    requestAnimationFrame(() =>
+      determineLongestAnimation(event, el, longestAnimations, areAnimationSupported),
+    );
   };
 
   const handleOutAnimationEnd = (event: AnimationEvent | TransitionEvent) => {


### PR DESCRIPTION
This is a safety measure to reduce style recalculation impacts on calls to `element.getAnimations()`. By requesting an animation frame, we reduce influence from other style recalculations, where the animations list might be empty. This will reduce expensive fallback calls to the `getComputedStyles` API.

