### PR TITLE
fix(forms): strip optional typing from field and field path properties

### DIFF
--- a/goldens/public-api/forms/experimental/index.api.md
+++ b/goldens/public-api/forms/experimental/index.api.md
@@ -142,7 +142,7 @@ export type FieldContext<TValue, TPathKind extends PathKind = PathKind.Root> = T
 export type FieldPath<TValue, TPathKind extends PathKind = PathKind.Root> = {
     [ɵɵTYPE]: [TValue, TPathKind];
 } & (TValue extends any[] ? {} : TValue extends Record<PropertyKey, any> ? {
-    [K in keyof TValue]: FieldPath<TValue[K], PathKind.Child>;
+    [K in keyof TValue]-?: FieldPath<TValue[K], PathKind.Child>;
 } : {});
 
 // @public
@@ -438,7 +438,7 @@ export function stripField<E extends ValidationError>(e: WithField<E> | E): E;
 
 // @public
 export type Subfields<TValue> = {
-    readonly [K in keyof TValue as TValue[K] extends Function ? never : K]: MaybeField<TValue[K], string>;
+    readonly [K in keyof TValue as TValue[K] extends Function ? never : K]-?: MaybeField<TValue[K], string>;
 };
 
 // @public

--- a/packages/forms/experimental/src/api/logic.ts
+++ b/packages/forms/experimental/src/api/logic.ts
@@ -68,7 +68,7 @@ export function readonly<TValue, TPathKind extends PathKind = PathKind.Root>(
   assertPathIsCurrent(path);
 
   const pathNode = FieldPathNode.unwrapFieldPath(path);
-  pathNode.logic.addReadonlyRule(logic);
+  pathNode.logic.addReadonlyRule(logic as LogicFn<any, boolean>);
 }
 
 /**
@@ -95,7 +95,7 @@ export function hidden<TValue, TPathKind extends PathKind = PathKind.Root>(
   assertPathIsCurrent(path);
 
   const pathNode = FieldPathNode.unwrapFieldPath(path);
-  pathNode.logic.addHiddenRule(logic);
+  pathNode.logic.addHiddenRule(logic as LogicFn<any, boolean>);
 }
 
 /**
@@ -113,7 +113,7 @@ export function validate<TValue, TPathKind extends PathKind = PathKind.Root>(
   assertPathIsCurrent(path);
 
   const pathNode = FieldPathNode.unwrapFieldPath(path);
-  pathNode.logic.addSyncErrorRule(logic as Validator<TValue>);
+  pathNode.logic.addSyncErrorRule(logic as Validator<any>);
 }
 
 /**
@@ -135,9 +135,7 @@ export function validateTree<TValue, TPathKind extends PathKind = PathKind.Root>
   const wrappedLogic = (ctx: FieldContext<TValue, TPathKind>) =>
     addDefaultField(logic(ctx), ctx.field);
 
-  pathNode.logic.addSyncTreeErrorRule(
-    wrappedLogic as LogicFn<TValue, TreeValidationResultWithField>,
-  );
+  pathNode.logic.addSyncTreeErrorRule(wrappedLogic as LogicFn<any, TreeValidationResultWithField>);
 }
 
 /**
@@ -158,7 +156,7 @@ export function aggregateProperty<TValue, TPropItem, TPathKind extends PathKind 
   assertPathIsCurrent(path);
 
   const pathNode = FieldPathNode.unwrapFieldPath(path);
-  pathNode.logic.addAggregatePropertyRule(prop, logic);
+  pathNode.logic.addAggregatePropertyRule(prop, logic as LogicFn<any, TPropItem>);
 }
 
 /**

--- a/packages/forms/experimental/src/api/structure.ts
+++ b/packages/forms/experimental/src/api/structure.ts
@@ -171,7 +171,9 @@ export function form<TValue>(
 export function form<TValue>(...args: any[]): Field<TValue> {
   const [model, schema, options] = normalizeFormArgs<TValue>(args);
   const injector = options?.injector ?? inject(Injector);
-  const pathNode = runInInjectionContext(injector, () => SchemaImpl.rootCompile(schema));
+  const pathNode = runInInjectionContext(injector, () =>
+    SchemaImpl.rootCompile(schema as Schema<unknown>),
+  );
   const fieldManager = new FormFieldManager(injector);
   const fieldRoot = FieldNode.newRoot(fieldManager, model, pathNode);
   fieldManager.createFieldManagementEffect(fieldRoot.structure);
@@ -246,7 +248,7 @@ export function apply<TValue>(
   assertPathIsCurrent(path);
 
   const pathNode = FieldPathNode.unwrapFieldPath(path);
-  pathNode.mergeIn(SchemaImpl.create(schema));
+  pathNode.mergeIn(SchemaImpl.create(schema as Schema<unknown>));
 }
 
 /**
@@ -265,7 +267,10 @@ export function applyWhen<TValue>(
   assertPathIsCurrent(path);
 
   const pathNode = FieldPathNode.unwrapFieldPath(path);
-  pathNode.mergeIn(SchemaImpl.create(schema), {fn: logic, path});
+  pathNode.mergeIn(SchemaImpl.create(schema as Schema<unknown>), {
+    fn: logic as LogicFn<any, boolean>,
+    path,
+  });
 }
 
 /**
@@ -388,7 +393,7 @@ function setServerErrors(
  * @template TValue The value type of a `Field` that this schema binds to.
  */
 export function schema<TValue>(fn: SchemaFn<TValue>): Schema<TValue> {
-  return SchemaImpl.create(fn) as unknown as Schema<TValue>;
+  return SchemaImpl.create(fn as SchemaFn<unknown>) as unknown as Schema<TValue>;
 }
 
 /** Marks a {@link node} and its descendants as touched. */

--- a/packages/forms/experimental/src/api/types.ts
+++ b/packages/forms/experimental/src/api/types.ts
@@ -158,7 +158,7 @@ export type Field<TValue, TKey extends string | number = string | number> = (() 
  * @template TValue The type of the data which the parent field is wrapped around.
  */
 export type Subfields<TValue> = {
-  readonly [K in keyof TValue as TValue[K] extends Function ? never : K]: MaybeField<
+  readonly [K in keyof TValue as TValue[K] extends Function ? never : K]-?: MaybeField<
     TValue[K],
     string
   >;
@@ -327,7 +327,7 @@ export type FieldPath<TValue, TPathKind extends PathKind = PathKind.Root> = {
 } & (TValue extends any[]
   ? {}
   : TValue extends Record<PropertyKey, any>
-    ? {[K in keyof TValue]: FieldPath<TValue[K], PathKind.Child>}
+    ? {[K in keyof TValue]-?: FieldPath<TValue[K], PathKind.Child>}
     : {});
 
 /**

--- a/packages/forms/experimental/src/schema/logic.ts
+++ b/packages/forms/experimental/src/schema/logic.ts
@@ -219,7 +219,7 @@ function wrapWithPredicates<TValue, TReturn>(
   if (predicates.length === 0) {
     return logicFn;
   }
-  return (arg: FieldContext<any>): TReturn | typeof IGNORED => {
+  return (arg): TReturn | typeof IGNORED => {
     for (const predicate of predicates) {
       let predicateField = arg.stateOf(predicate.path) as FieldNode;
       // Check the depth of the current field vs the depth this predicate is supposed to be

--- a/packages/forms/experimental/test/node/field_proxy.spec.ts
+++ b/packages/forms/experimental/test/node/field_proxy.spec.ts
@@ -8,13 +8,25 @@
 
 import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {form} from '../../public_api';
+import {Field, form} from '../../public_api';
 
 describe('Field proxy', () => {
   it('should not forward methods through the proxy', () => {
     const f = form(signal(new Date()), {injector: TestBed.inject(Injector)});
     // @ts-expect-error
     expect(f.getDate).toBe(undefined as any);
+  });
+
+  it('should forward optional typing on value, not field', () => {
+    interface Model {
+      field?: string;
+    }
+
+    const data = signal<Model>({});
+    const f = form(data, {injector: TestBed.inject(Injector)});
+
+    // The `?` is forwarded to the field's value, and not the field itself.
+    f.field satisfies Field<string | undefined>;
   });
 
   it('should allow spreading field arrays', () => {

--- a/packages/forms/experimental/test/node/path.spec.ts
+++ b/packages/forms/experimental/test/node/path.spec.ts
@@ -8,7 +8,7 @@
 
 import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {apply, applyEach, applyWhen, form, validate} from '../../public_api';
+import {apply, applyEach, applyWhen, FieldPath, form, schema, validate} from '../../public_api';
 import {ValidationError} from '../../src/api/validation_errors';
 
 describe('path', () => {
@@ -90,6 +90,17 @@ describe('path', () => {
         },
         {injector: TestBed.inject(Injector)},
       );
+    });
+  });
+
+  it('should forward optional typing on value, not path', () => {
+    interface Model {
+      field?: string;
+    }
+
+    schema<Model>((p) => {
+      // The `?` is forwarded to the path's value, and not the path itself.
+      p.field satisfies FieldPath<string | undefined>;
     });
   });
 });


### PR DESCRIPTION
Field paths mimic the structure of their corresponding type:

```ts
interface Model1 {
  value: string | undefined;
}

schema<Model1>((model) => {
  // Type of model        `FieldPath<Model1>`
  // Type of model.value  `FieldPath<string | undefined>`

  required(model.value); // OK
});
```

Consider what _should_ be a functionally identical example:

```ts
interface Model2 {
  value?: string;
}

schema<Model2>((p) => {
  // Type of model:     `FieldPath<Model2>`
  // Type of p.value is `FieldPath<string | undefined> | undefined`
  //                                                   ^^^^^^^^^^^

  required(model.value); // ERROR
});
```

In both cases the type for `Model1.value` and `Model2.value` is `string | undefined`, but their corresponding field paths are different. This is because the type definition of `FieldPath` inadvertently carries the optional (`?`) part of `Model2.value` to the field path itself. Despite both models having equivalent types, the latter is more difficult to use because of the superfluous `undefined` on the field path property.

 The same type discrepancy exists for fields returned by `form()` as well. This change strips any optional typing (`-?`) from field path definitions to fix this discrepancy.