### PR TITLE
build: explicitly include types for locales in @angular/common/locales

### DIFF
--- a/packages/common/locales/BUILD.bazel
+++ b/packages/common/locales/BUILD.bazel
@@ -33,5 +33,8 @@ ts_project(
 npm_package(
     # TODO(devversion): Remove glob for checked-in legacy locale files that haven't been
     # removed in the past (when CLDR has been updated). These can be removed in a major.
-    srcs = ["global/%s.js" % l for l in LOCALES] + [":locales"] + glob(["global/*.js"]),
+    srcs = ["global/%s.js" % l for l in LOCALES] + [
+        ":locales",
+        ":locales_types",
+    ] + glob(["global/*.js"]),
 )


### PR DESCRIPTION
Include the d.ts files for each local in the @angular/common/locales files
