### PR TITLE
docs: release notes for the v20.1.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<a name="20.1.6"></a>
+# 20.1.6 (2025-08-06)
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="20.2.0-next.4"></a>
 # 20.2.0-next.4 (2025-08-06)
 ## Deprecations


### PR DESCRIPTION
Cherry-picks the changelog from the "20.1.x" branch to the next branch (main).