### PR TITLE
docs(devtools): update `pnpm` install command

### DIFF
--- a/devtools/README.md
+++ b/devtools/README.md
@@ -33,7 +33,7 @@ npm install -g pnpm
 Third, install NPM dependencies:
 
 ```shell
-pnpm --frozen-lockfile
+pnpm install --frozen-lockfile
 ```
 
 Now you should be ready to build the DevTools extension.


### PR DESCRIPTION
The `install` subcommand is necessary for `--frozen-lockfile` to work.