### PR TITLE
docs(docs-infra): fix inconsistent codeblock styles

### DIFF
--- a/adev/shared-docs/styles/docs/_code.scss
+++ b/adev/shared-docs/styles/docs/_code.scss
@@ -92,6 +92,7 @@ $code-font-size: 0.875rem;
     border: 1px solid var(--senary-contrast);
     border-radius: 0.25rem;
     background: var(--octonary-contrast);
+    overflow: hidden;
     transition:
       background 0.3s ease,
       border-color 0.3s ease;
@@ -124,8 +125,6 @@ $code-font-size: 0.875rem;
 
   // shell doesn't have a header, for commands only
   .shell {
-    border: 1px solid var(--quinary-contrast);
-
     pre {
       white-space: nowrap;
     }
@@ -139,31 +138,6 @@ $code-font-size: 0.875rem;
 
       &.hidden {
         display: none;
-      }
-    }
-
-    button[docs-copy-source-code] {
-      background-color: var(--quaternary-contrast);
-      border: 1px solid var(--quinary-contrast);
-
-      @container codeblock (min-width: 400px) {
-        border: 1px solid transparent;
-      }
-
-      .docs-copy {
-        path {
-          fill: var(--quinary-contrast);
-        }
-      }
-      .docs-check {
-        color: var(--page-background);
-      }
-      &:hover {
-        .docs-copy {
-          path {
-            fill: var(--octonary-contrast);
-          }
-        }
       }
     }
   }
@@ -182,10 +156,6 @@ $code-font-size: 0.875rem;
     transition:
       background-color 0.3s ease,
       border-color 0.3s ease;
-
-    @container codeblock (min-width: 400px) {
-      border: 1px solid transparent;
-    }
 
     .docs-icon {
       transition: opacity 0.3s ease-out;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<img width="770" height="1018" alt="3yxLnaDXcRqXttZ" src="https://github.com/user-attachments/assets/754c668c-0fdf-4e33-8592-d883b8980cf8" />

Issue Number: N/A


## What is the new behavior?
<img width="756" height="999" alt="A4veGZ8kfoPQX87" src="https://github.com/user-attachments/assets/c6084d81-dae1-411f-add2-9b59a7b13d5e" />

Styles are consistent in light mode as well.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
