### PR TITLE
feat(http): Add reponseType property to HttpResponse and HttpErrorRes…

### DIFF
--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -2509,6 +2509,7 @@ export class HttpErrorResponse extends HttpResponseBase implements Error {
         statusText?: string;
         url?: string;
         redirected?: boolean;
+        responseType?: ResponseType;
     });
     // (undocumented)
     readonly error: any | null;
@@ -2933,6 +2934,7 @@ export class HttpResponse<T> extends HttpResponseBase {
         statusText?: string;
         url?: string;
         redirected?: boolean;
+        responseType?: ResponseType;
     });
     readonly body: T | null;
     // (undocumented)
@@ -2944,6 +2946,7 @@ export class HttpResponse<T> extends HttpResponseBase {
         statusText?: string;
         url?: string;
         redirected?: boolean;
+        responseType?: ResponseType;
     }): HttpResponse<T>;
     // (undocumented)
     clone<V>(update: {
@@ -2953,6 +2956,7 @@ export class HttpResponse<T> extends HttpResponseBase {
         statusText?: string;
         url?: string;
         redirected?: boolean;
+        responseType?: ResponseType;
     }): HttpResponse<V>;
     // (undocumented)
     readonly type: HttpEventType.Response;
@@ -2966,10 +2970,12 @@ export abstract class HttpResponseBase {
         statusText?: string;
         url?: string;
         redirected?: boolean;
+        responseType?: ResponseType;
     }, defaultStatus?: number, defaultStatusText?: string);
     readonly headers: HttpHeaders;
     readonly ok: boolean;
     readonly redirected?: boolean;
+    readonly responseType?: ResponseType;
     readonly status: number;
     readonly statusText: string;
     readonly type: HttpEventType.Response | HttpEventType.ResponseHeader;

--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -273,6 +273,8 @@ export class FetchBackend implements HttpBackend {
 
     const redirected = response.redirected;
 
+    const responseType = response.type;
+
     if (ok) {
       observer.next(
         new HttpResponse({
@@ -282,6 +284,7 @@ export class FetchBackend implements HttpBackend {
           statusText,
           url,
           redirected,
+          responseType,
         }),
       );
 
@@ -297,6 +300,7 @@ export class FetchBackend implements HttpBackend {
           statusText,
           url,
           redirected,
+          responseType,
         }),
       );
     }

--- a/packages/common/http/src/response.ts
+++ b/packages/common/http/src/response.ts
@@ -193,6 +193,21 @@ export abstract class HttpResponseBase {
   readonly redirected?: boolean;
 
   /**
+   * Indicates the type of the HTTP response, based on how the request was made and how the browser handles the response.
+   *
+   * This corresponds to the `type` property of the Fetch API's `Response` object, which can indicate values such as:
+   * - `'basic'`: A same-origin response, allowing full access to the body and headers.
+   * - `'cors'`: A cross-origin response with CORS enabled, exposing only safe response headers.
+   * - `'opaque'`: A cross-origin response made with `no-cors`, where the response body and headers are inaccessible.
+   * - `'opaqueredirect'`: A response resulting from a redirect followed in `no-cors` mode.
+   * - `'error'`: A response representing a network error or similar failure.
+   *
+   * This property is only available when using the Fetch-based backend (via `withFetch()`).
+   * When using Angular's (XHR) backend, this value will be `undefined`.
+   */
+  readonly responseType?: ResponseType;
+
+  /**
    * Super-constructor for all responses.
    *
    * The single parameter accepted is an initialization hash. Any properties
@@ -205,6 +220,7 @@ export abstract class HttpResponseBase {
       statusText?: string;
       url?: string;
       redirected?: boolean;
+      responseType?: ResponseType;
     },
     defaultStatus: number = 200,
     defaultStatusText: string = 'OK',
@@ -216,7 +232,7 @@ export abstract class HttpResponseBase {
     this.statusText = init.statusText || defaultStatusText;
     this.url = init.url || null;
     this.redirected = init.redirected;
-
+    this.responseType = init.responseType;
     // Cache the ok value to avoid defining a getter.
     this.ok = this.status >= 200 && this.status < 300;
   }
@@ -297,6 +313,7 @@ export class HttpResponse<T> extends HttpResponseBase {
       statusText?: string;
       url?: string;
       redirected?: boolean;
+      responseType?: ResponseType;
     } = {},
   ) {
     super(init);
@@ -312,6 +329,7 @@ export class HttpResponse<T> extends HttpResponseBase {
     statusText?: string;
     url?: string;
     redirected?: boolean;
+    responseType?: ResponseType;
   }): HttpResponse<T>;
   clone<V>(update: {
     body?: V | null;
@@ -320,6 +338,7 @@ export class HttpResponse<T> extends HttpResponseBase {
     statusText?: string;
     url?: string;
     redirected?: boolean;
+    responseType?: ResponseType;
   }): HttpResponse<V>;
   clone(
     update: {
@@ -329,6 +348,7 @@ export class HttpResponse<T> extends HttpResponseBase {
       statusText?: string;
       url?: string;
       redirected?: boolean;
+      responseType?: ResponseType;
     } = {},
   ): HttpResponse<any> {
     return new HttpResponse<any>({
@@ -338,6 +358,7 @@ export class HttpResponse<T> extends HttpResponseBase {
       statusText: update.statusText || this.statusText,
       url: update.url || this.url || undefined,
       redirected: update.redirected ?? this.redirected,
+      responseType: update.responseType ?? this.responseType,
     });
   }
 }
@@ -372,6 +393,7 @@ export class HttpErrorResponse extends HttpResponseBase implements Error {
     statusText?: string;
     url?: string;
     redirected?: boolean;
+    responseType?: ResponseType;
   }) {
     // Initialize with a default status of 0 / Unknown Error.
     super(init, 0, 'Unknown Error');

--- a/packages/common/http/test/response_spec.ts
+++ b/packages/common/http/test/response_spec.ts
@@ -21,6 +21,7 @@ describe('HttpResponse', () => {
         statusText: 'Created',
         url: '/test',
         redirected: true,
+        responseType: 'cors',
       });
       expect(resp.body).toBe('test body');
       expect(resp.headers instanceof HttpHeaders).toBeTruthy();
@@ -29,6 +30,7 @@ describe('HttpResponse', () => {
       expect(resp.statusText).toBe('Created');
       expect(resp.url).toBe('/test');
       expect(resp.redirected).toBe(true);
+      expect(resp.responseType).toBe('cors');
     });
     it('uses defaults if no args passed', () => {
       const resp = new HttpResponse({});
@@ -39,6 +41,7 @@ describe('HttpResponse', () => {
       expect(resp.ok).toBeTruthy();
       expect(resp.url).toBeNull();
       expect(resp.redirected).toBeUndefined();
+      expect(resp.responseType).toBeUndefined();
     });
     it('accepts a falsy body', () => {
       expect(new HttpResponse({body: false}).body).toEqual(false);
@@ -63,6 +66,7 @@ describe('HttpResponse', () => {
         statusText: 'created',
         url: '/test',
         redirected: false,
+        responseType: 'cors',
       }).clone();
       expect(clone.body).toBe('test');
       expect(clone.status).toBe(HttpStatusCode.Created);
@@ -70,6 +74,7 @@ describe('HttpResponse', () => {
       expect(clone.url).toBe('/test');
       expect(clone.headers).not.toBeNull();
       expect(clone.redirected).toBe(false);
+      expect(clone.responseType).toBe('cors');
     });
     it('overrides the original', () => {
       const orig = new HttpResponse({
@@ -78,6 +83,7 @@ describe('HttpResponse', () => {
         statusText: 'created',
         url: '/test',
         redirected: true,
+        responseType: 'cors',
       });
       const clone = orig.clone({
         body: {data: 'test'},
@@ -85,6 +91,7 @@ describe('HttpResponse', () => {
         statusText: 'Okay',
         url: '/bar',
         redirected: false,
+        responseType: 'opaque',
       });
       expect(clone.body).toEqual({data: 'test'});
       expect(clone.status).toBe(HttpStatusCode.Ok);
@@ -92,6 +99,7 @@ describe('HttpResponse', () => {
       expect(clone.url).toBe('/bar');
       expect(clone.headers).toBe(orig.headers);
       expect(clone.redirected).toBe(false);
+      expect(clone.responseType).toBe('opaque');
     });
   });
 });


### PR DESCRIPTION
# HttpResponse `responseType` Property Support

This commit adds support for the Fetch API's `responseType` property in HttpResponse and HttpErrorResponse when using HttpClient with the withFetch provider.

This change enhances HttpClient's alignment with the native Fetch API by exposing the response type information that indicates how the browser handled the response based on CORS policies and request mode. This provides developers with valuable insights into the nature of the response they received.

## The Change Includes:

- Added `responseType` property to `HttpResponse` and `HttpErrorResponse` classes
- Maintains consistency with the Fetch API specification
- Added comprehensive unit tests to ensure the property is correctly captured and exposed

---

## Motivation / Use Cases

The `responseType` property provides crucial information about how the browser handled the response based on CORS policies and request configuration:

- **CORS Debugging**: Understand why certain headers or response data might be inaccessible
- **Security Analysis**: Identify opaque responses that may indicate cross-origin issues
- **Request Mode Validation**: Verify that requests are being handled according to the expected CORS mode
- **API Compliance**: Maintain consistency with the native Fetch API behavior
- **Performance Monitoring**: Track different response types for analytics and optimization

## Examples of New Usage

 

```typescript
// Debug CORS issues by checking response type
this.http.get('https://external-api.com/data', { observe: 'response' }).subscribe({
  next: (response) => {
    if (response.responseType === 'opaque') {
      console.warn('Response is opaque - headers and body may not be accessible');
      console.warn('Consider enabling CORS on the server or using a proxy');
    } else if (response.responseType === 'cors') {
      console.log('CORS is properly configured');
      // Safe to access response headers and body
      this.processResponse(response);
    }
  }
});