### PR TITLE
feat(core): support `as` aliases on `else if` blocks

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1859,6 +1859,33 @@ describe('type check blocks', () => {
       );
     });
 
+    it('should generate an else if block with an `as` expression', () => {
+      const TEMPLATE = `@if (expr === 1) {
+        {{expr}}
+      } @else if (expr === 2; as alias) {
+        {{alias}}
+      }`;
+
+      expect(tcb(TEMPLATE)).toContain(
+        'var _t1 = ((((this).expr)) === (2)); if ((((this).expr)) === (1)) { "" + (((this).expr)); } ' +
+          'else if (((((this).expr)) === (2)) && _t1) { "" + (_t1); }',
+      );
+    });
+
+    it('should generate block where `@if` and `@else if` have the same alias name', () => {
+      const TEMPLATE = `@if (expr === 1; as alias) {
+        {{alias}}
+      } @else if (expr === 2; as alias) {
+        {{alias}}
+      }`;
+
+      expect(tcb(TEMPLATE)).toContain(
+        'var _t1 = ((((this).expr)) === (1)); var _t2 = ((((this).expr)) === (2)); ' +
+          'if (((((this).expr)) === (1)) && _t1) { "" + (_t1); } ' +
+          'else if (((((this).expr)) === (2)) && _t2) { "" + (_t2); }',
+      );
+    });
+
     it('should not generate the body of if blocks when `checkControlFlowBodies` is disabled', () => {
       const TEMPLATE = `
           @if (expr === 0) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
@@ -2704,3 +2704,241 @@ export declare class MyApp {
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: else_if_with_alias.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+        this.one = false;
+        this.value = () => 1;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
+    <div>
+      {{message}}
+      @if (one) {
+        {{one}}
+      } @else if (value(); as alias) {
+        {{value()}} as {{alias}}
+      }
+    </div>
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <div>
+      {{message}}
+      @if (one) {
+        {{one}}
+      } @else if (value(); as alias) {
+        {{value()}} as {{alias}}
+      }
+    </div>
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: else_if_with_alias.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    message: string;
+    one: boolean;
+    value: () => number;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: else_if_with_same_alias.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+        this.one = false;
+        this.two = 2;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
+    <div>
+      {{message}}
+      @if (one; as alias) {
+        {{alias}}
+      } @else if (two; as alias) {
+        {{alias}}
+      }
+    </div>
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <div>
+      {{message}}
+      @if (one; as alias) {
+        {{alias}}
+      } @else if (two; as alias) {
+        {{alias}}
+      }
+    </div>
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: else_if_with_same_alias.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    message: string;
+    one: boolean;
+    two: number;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: else_if_multiple_with_alias.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+        this.one = 1;
+        this.two = 2;
+        this.three = 3;
+        this.four = 4;
+        this.five = 5;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
+    <div>
+      {{message}}
+      @if (one; as foo) {
+        One: {{foo}}
+      } @else if (two) {
+        Two: {{two}}
+      } @else if (three; as bar) {
+        Three: {{bar}}
+      } @else if (four; as baz) {
+        Four: {{baz}}
+      } @else if (five) {
+        Five: {{five}}
+      }
+    </div>
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <div>
+      {{message}}
+      @if (one; as foo) {
+        One: {{foo}}
+      } @else if (two) {
+        Two: {{two}}
+      } @else if (three; as bar) {
+        Three: {{bar}}
+      } @else if (four; as baz) {
+        Four: {{baz}}
+      } @else if (five) {
+        Five: {{five}}
+      }
+    </div>
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: else_if_multiple_with_alias.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    message: string;
+    one: number;
+    two: number;
+    three: number;
+    four: number;
+    five: number;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: else_if_nested_with_alias.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.foo = false;
+        this.value = () => 1;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
+    @if (foo) {
+      foo
+    } @else if (value(); as root) {
+      Root: {{value()}}/{{root}}
+
+      @if (foo) {
+        foo
+      } @else if (value(); as inner) {
+        Inner: {{value()}}/{{root}}/{{inner}}
+
+        @if (foo) {
+          foo
+        } @else if (value(); as innermost) {
+          Innermost: {{value()}}/{{root}}/{{inner}}/{{innermost}}
+        }
+      }
+    }
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    @if (foo) {
+      foo
+    } @else if (value(); as root) {
+      Root: {{value()}}/{{root}}
+
+      @if (foo) {
+        foo
+      } @else if (value(); as inner) {
+        Inner: {{value()}}/{{root}}/{{inner}}
+
+        @if (foo) {
+          foo
+        } @else if (value(); as innermost) {
+          Innermost: {{value()}}/{{root}}/{{inner}}/{{innermost}}
+        }
+      }
+    }
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: else_if_nested_with_alias.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    foo: boolean;
+    value: () => number;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
@@ -708,6 +708,66 @@
           ]
         }
       ]
+    },
+    {
+      "description": "should support `as` expression on `@else if` block",
+      "inputFiles": ["else_if_with_alias.ts"],
+      "expectations": [
+        {
+          "failureMessage": "Incorrect generated output.",
+          "files": [
+            {
+              "expected": "else_if_with_alias_template.js",
+              "generated": "else_if_with_alias.js"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "should support `@else if` with same alias as `@if`",
+      "inputFiles": ["else_if_with_same_alias.ts"],
+      "expectations": [
+        {
+          "failureMessage": "Incorrect generated output.",
+          "files": [
+            {
+              "expected": "else_if_with_same_alias_template.js",
+              "generated": "else_if_with_same_alias.js"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "should support `as` on multiple conditional branches",
+      "inputFiles": ["else_if_multiple_with_alias.ts"],
+      "expectations": [
+        {
+          "failureMessage": "Incorrect generated output.",
+          "files": [
+            {
+              "expected": "else_if_multiple_with_alias_template.js",
+              "generated": "else_if_multiple_with_alias.js"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "should support nested `@else if` with aliases",
+      "inputFiles": ["else_if_nested_with_alias.ts"],
+      "expectations": [
+        {
+          "failureMessage": "Incorrect generated output.",
+          "files": [
+            {
+              "expected": "else_if_nested_with_alias_template.js",
+              "generated": "else_if_nested_with_alias.js"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/else_if_multiple_with_alias.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/else_if_multiple_with_alias.ts
@@ -1,0 +1,28 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    <div>
+      {{message}}
+      @if (one; as foo) {
+        One: {{foo}}
+      } @else if (two) {
+        Two: {{two}}
+      } @else if (three; as bar) {
+        Three: {{bar}}
+      } @else if (four; as baz) {
+        Four: {{baz}}
+      } @else if (five) {
+        Five: {{five}}
+      }
+    </div>
+  `,
+})
+export class MyApp {
+  message = 'hello';
+  one = 1;
+  two = 2;
+  three = 3;
+  four = 4;
+  five = 5;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/else_if_multiple_with_alias_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/else_if_multiple_with_alias_template.js
@@ -1,0 +1,64 @@
+function MyApp_Conditional_2_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+  }
+  if (rf & 2) {
+    $r3$.ɵɵtextInterpolate1(" One: ", ctx, " ");
+  }
+}
+
+function MyApp_Conditional_3_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+  }
+  if (rf & 2) {
+    const ctx_r0 = $r3$.ɵɵnextContext();
+    $r3$.ɵɵtextInterpolate1(" Two: ", ctx_r0.two, " ");
+  }
+}
+
+function MyApp_Conditional_4_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+  }
+  if (rf & 2) {
+    $r3$.ɵɵtextInterpolate1(" Three: ", ctx, " ");
+  }
+}
+
+function MyApp_Conditional_5_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+  }
+  if (rf & 2) {
+    $r3$.ɵɵtextInterpolate1(" Four: ", ctx, " ");
+  }
+}
+
+function MyApp_Conditional_6_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+  }
+  if (rf & 2) {
+    const ctx_r0 = $r3$.ɵɵnextContext();
+    $r3$.ɵɵtextInterpolate1(" Five: ", ctx_r0.five, " ");
+  }
+}
+
+…
+
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵdomElementStart(0, "div");
+    $r3$.ɵɵtext(1);
+    $r3$.ɵɵconditionalCreate(2, MyApp_Conditional_2_Template, 1, 1)(3, MyApp_Conditional_3_Template, 1, 1)(4, MyApp_Conditional_4_Template, 1, 1)(5, MyApp_Conditional_5_Template, 1, 1)(6, MyApp_Conditional_6_Template, 1, 1);
+    $r3$.ɵɵdomElementEnd();
+  }
+  if (rf & 2) {
+    let $tmp_1_0$;
+    $r3$.ɵɵadvance();
+    $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
+    $r3$.ɵɵadvance();
+    $r3$.ɵɵconditional(($tmp_1_0$ = ctx.one) ? 2 : ctx.two ? 3 : ($tmp_1_0$ = ctx.three) ? 4 : ($tmp_1_0$ = ctx.four) ? 5 : ctx.five ? 6 : -1, $tmp_1_0$);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/else_if_nested_with_alias.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/else_if_nested_with_alias.ts
@@ -1,0 +1,27 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    @if (foo) {
+      foo
+    } @else if (value(); as root) {
+      Root: {{value()}}/{{root}}
+
+      @if (foo) {
+        foo
+      } @else if (value(); as inner) {
+        Inner: {{value()}}/{{root}}/{{inner}}
+
+        @if (foo) {
+          foo
+        } @else if (value(); as innermost) {
+          Innermost: {{value()}}/{{root}}/{{inner}}/{{innermost}}
+        }
+      }
+    }
+  `,
+})
+export class MyApp {
+  foo = false;
+  value = () => 1;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/else_if_nested_with_alias_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/else_if_nested_with_alias_template.js
@@ -1,0 +1,65 @@
+function MyApp_Conditional_0_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " foo ");
+  }
+}
+function MyApp_Conditional_1_Conditional_1_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " foo ");
+  }
+}
+function MyApp_Conditional_1_Conditional_2_Conditional_1_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " foo ");
+  }
+}
+function MyApp_Conditional_1_Conditional_2_Conditional_2_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+  }
+  if (rf & 2) {
+    const $inner_r1$ = $r3$.ɵɵnextContext();
+    const $root_r2$ = $r3$.ɵɵnextContext();
+    const $ctx_r2$ = $r3$.ɵɵnextContext();
+    $r3$.ɵɵtextInterpolate4(" Innermost: ", $ctx_r2$.value(), "/", $root_r2$, "/", $inner_r1$, "/", ctx, " ");
+  }
+}
+function MyApp_Conditional_1_Conditional_2_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+    $r3$.ɵɵconditionalCreate(1, MyApp_Conditional_1_Conditional_2_Conditional_1_Template, 1, 0)(2, MyApp_Conditional_1_Conditional_2_Conditional_2_Template, 1, 4);
+  }
+  if (rf & 2) {
+    let $tmp_5_0$;
+    const $root_r2$ = $r3$.ɵɵnextContext();
+    const $ctx_r2$ = $r3$.ɵɵnextContext();
+    $r3$.ɵɵtextInterpolate3(" Inner: ", $ctx_r2$.value(), "/", $root_r2$, "/", ctx, " ");
+    $r3$.ɵɵadvance();
+    $r3$.ɵɵconditional($ctx_r2$.foo ? 1 : ($tmp_5_0$ = $ctx_r2$.value()) ? 2 : -1, $tmp_5_0$);
+  }
+}
+function MyApp_Conditional_1_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+    $r3$.ɵɵconditionalCreate(1, MyApp_Conditional_1_Conditional_1_Template, 1, 0)(2, MyApp_Conditional_1_Conditional_2_Template, 3, 4);
+  }
+  if (rf & 2) {
+    let $tmp_3_0$;
+    const $ctx_r2$ = $r3$.ɵɵnextContext();
+    $r3$.ɵɵtextInterpolate2(" Root: ", $ctx_r2$.value(), "/", ctx, " ");
+    $r3$.ɵɵadvance();
+    $r3$.ɵɵconditional($ctx_r2$.foo ? 1 : ($tmp_3_0$ = $ctx_r2$.value()) ? 2 : -1, $tmp_3_0$);
+  }
+}
+
+…
+
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵconditionalCreate(0, MyApp_Conditional_0_Template, 1, 0)(1, MyApp_Conditional_1_Template, 3, 3);
+  }
+  if (rf & 2) {
+    let $tmp_0_0$;
+    $r3$.ɵɵconditional(ctx.foo ? 0 : ($tmp_0_0$ = ctx.value()) ? 1 : -1, $tmp_0_0$);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/else_if_with_alias.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/else_if_with_alias.ts
@@ -1,0 +1,19 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    <div>
+      {{message}}
+      @if (one) {
+        {{one}}
+      } @else if (value(); as alias) {
+        {{value()}} as {{alias}}
+      }
+    </div>
+  `,
+})
+export class MyApp {
+  message = 'hello';
+  one = false;
+  value = () => 1;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/else_if_with_alias_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/else_if_with_alias_template.js
@@ -1,0 +1,34 @@
+function MyApp_Conditional_2_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+  }
+  if (rf & 2) {
+    const $ctx_r0$ = $r3$.ɵɵnextContext();
+    $r3$.ɵɵtextInterpolate1(" ", $ctx_r0$.one, " ");
+  }
+}
+function MyApp_Conditional_3_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+  }
+  if (rf & 2) {
+    const $ctx_r0$ = $r3$.ɵɵnextContext();
+    $r3$.ɵɵtextInterpolate2(" ", $ctx_r0$.value(), " as ", ctx, " ");
+  }
+}
+…
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵdomElementStart(0, "div");
+    $r3$.ɵɵtext(1);
+    $r3$.ɵɵconditionalCreate(2, MyApp_Conditional_2_Template, 1, 1)(3, MyApp_Conditional_3_Template, 1, 2);
+    $r3$.ɵɵdomElementEnd();
+  }
+  if (rf & 2) {
+    let $tmp_1_0$;
+    $r3$.ɵɵadvance();
+    $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
+    $r3$.ɵɵadvance();
+    $r3$.ɵɵconditional(ctx.one ? 2 : ($tmp_1_0$ = ctx.value()) ? 3 : -1, $tmp_1_0$);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/else_if_with_same_alias.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/else_if_with_same_alias.ts
@@ -1,0 +1,19 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    <div>
+      {{message}}
+      @if (one; as alias) {
+        {{alias}}
+      } @else if (two; as alias) {
+        {{alias}}
+      }
+    </div>
+  `,
+})
+export class MyApp {
+  message = 'hello';
+  one = false;
+  two = 2;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/else_if_with_same_alias_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/else_if_with_same_alias_template.js
@@ -1,0 +1,34 @@
+function MyApp_Conditional_2_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+  }
+  if (rf & 2) {
+    $r3$.ɵɵtextInterpolate1(" ", ctx, " ");
+  }
+}
+function MyApp_Conditional_3_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+  }
+  if (rf & 2) {
+    $r3$.ɵɵtextInterpolate1(" ", ctx, " ");
+  }
+}
+
+…
+
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵdomElementStart(0, "div");
+    $r3$.ɵɵtext(1);
+    $r3$.ɵɵconditionalCreate(2, MyApp_Conditional_2_Template, 1, 1)(3, MyApp_Conditional_3_Template, 1, 1);
+    $r3$.ɵɵdomElementEnd();
+  }
+  if (rf & 2) {
+    let $tmp_1_0$;
+    $r3$.ɵɵadvance();
+    $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
+    $r3$.ɵɵadvance();
+    $r3$.ɵɵconditional(($tmp_1_0$ = ctx.one) ? 2 : ($tmp_1_0$ = ctx.two) ? 3 : -1, $tmp_1_0$);
+  }
+}

--- a/packages/compiler/src/render3/r3_control_flow.ts
+++ b/packages/compiler/src/render3/r3_control_flow.ts
@@ -620,11 +620,11 @@ function parseConditionalBlockParameters(
           `Unrecognized conditional parameter "${param.expression}"`,
         ),
       );
-    } else if (block.name !== 'if') {
+    } else if (block.name !== 'if' && !ELSE_IF_PATTERN.test(block.name)) {
       errors.push(
         new ParseError(
           param.sourceSpan,
-          '"as" expression is only allowed on the primary @if block',
+          '"as" expression is only allowed on `@if` and `@else if` blocks',
         ),
       );
     } else if (expressionAlias !== null) {

--- a/packages/compiler/src/template/pipeline/src/phases/conditionals.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/conditionals.ts
@@ -34,6 +34,7 @@ export function generateConditionalExpressions(job: ComponentCompilationJob): vo
 
       // Switch expressions assign their main test to a temporary, to avoid re-executing it.
       let tmp = op.test == null ? null : new ir.AssignTemporaryExpr(op.test, job.allocateXrefId());
+      let caseExpressionTemporaryXref: ir.XrefId | null = null;
 
       // For each remaining condition, test whether the temporary satifies the check. (If no temp is
       // present, just check each expression directly.)
@@ -50,7 +51,9 @@ export function generateConditionalExpressions(job: ComponentCompilationJob): vo
             conditionalCase.expr,
           );
         } else if (conditionalCase.alias !== null) {
-          const caseExpressionTemporaryXref = job.allocateXrefId();
+          // Since we can only pass one variable into the conditional instruction,
+          // reuse the same variable to store the result of the expressions.
+          caseExpressionTemporaryXref ??= job.allocateXrefId();
           conditionalCase.expr = new ir.AssignTemporaryExpr(
             conditionalCase.expr,
             caseExpressionTemporaryXref,

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -2386,6 +2386,24 @@ describe('R3 template transform', () => {
       ]);
     });
 
+    it('should parse an else if block with an aliased expression', () => {
+      expectFromHtml(`
+        @if (cond.expr; as foo) {
+          Main case was true!
+        } @else if (other.expr; as bar) {
+          Other case was true!
+        }
+        `).toEqual([
+        ['IfBlock'],
+        ['IfBlockBranch', 'cond.expr'],
+        ['Variable', 'foo', 'foo'],
+        ['Text', ' Main case was true! '],
+        ['IfBlockBranch', 'other.expr'],
+        ['Variable', 'bar', 'bar'],
+        ['Text', ' Other case was true! '],
+      ]);
+    });
+
     describe('validations', () => {
       it('should report an if block without a condition', () => {
         expect(() =>
@@ -2430,14 +2448,6 @@ describe('R3 template transform', () => {
           @if (foo) {hello} @else\nif (bar) {goodbye}
         `),
         ).toThrowError(/Unrecognized block @else\nif/);
-      });
-
-      it('should report an else if block that has an `as` expression', () => {
-        expect(() =>
-          parse(`
-          @if (foo) {hello} @else if (bar; as alias) {goodbye}
-        `),
-        ).toThrowError(/"as" expression is only allowed on the primary @if block/);
       });
 
       it('should report an @else if block used without an @if block', () => {

--- a/packages/core/test/acceptance/control_flow_if_spec.ts
+++ b/packages/core/test/acceptance/control_flow_if_spec.ts
@@ -316,6 +316,30 @@ describe('control flow - if', () => {
     expect(fixture.nativeElement.textContent.trim()).toBe('no 42');
   });
 
+  it('should expose expression value through alias on @else if', () => {
+    @Component({
+      template: `
+        @if (value === 0; as alias) {
+          Zero evaluates to {{alias}}
+        } @else if (value | multiply: 2; as alias) {
+          {{value}} aliased to {{alias}}
+        }
+      `,
+      imports: [MultiplyPipe],
+    })
+    class TestComponent {
+      value = 0;
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent.trim()).toBe('Zero evaluates to true');
+
+    fixture.componentInstance.value = 4;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent.trim()).toBe('4 aliased to 8');
+  });
+
   describe('content projection', () => {
     it('should project an @if with a single root node into the root node slot', () => {
       @Component({

--- a/packages/language-service/test/legacy/template_target_spec.ts
+++ b/packages/language-service/test/legacy/template_target_spec.ts
@@ -1113,6 +1113,23 @@ describe('blocks', () => {
     expect(node).toBeInstanceOf(ForLoopBlock);
   });
 
+  it('should visit alias declaration of else if block', () => {
+    const {nodes, position} = parse(`@if (false) {} @else if (title; as fo¦o) { }`);
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
+    expect(node).toBeInstanceOf(Variable);
+    expect((node as Variable).name).toBe('foo');
+  });
+
+  it('should visit alias usage of else if block', () => {
+    const {nodes, position} = parse(`@if (false) {} @else if (title; as foo) { {{ fo¦o }} }`);
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
+    expect(isExpressionNode(node!)).toBe(true);
+    expect(node).toBeInstanceOf(PropertyRead);
+    expect((node as PropertyRead).name).toBe('foo');
+  });
+
   it('should visit LHS of expression in for blocks', () => {
     const {nodes, position} = parse(`@for (fo¦o of bar; track foo) {  }`);
     const {context} = getTargetAtPosition(nodes, position)!;

--- a/packages/language-service/test/quick_info_spec.ts
+++ b/packages/language-service/test/quick_info_spec.ts
@@ -867,11 +867,19 @@ describe('quick info', () => {
         });
       });
 
-      it('if block alias variable', () => {
+      it('if block alias function call variable', () => {
         expectQuickInfo({
           templateOverride: `@if (someObject.some¦Signal(); as aliasName) {}`,
           expectedSpanText: 'someSignal',
           expectedDisplayString: '(property) someSignal: WritableSignal\n() => number',
+        });
+      });
+
+      it('else if block alias variable', () => {
+        expectQuickInfo({
+          templateOverride: `@if (false) {} @else if (constNames; as al¦iasName) {}`,
+          expectedSpanText: 'aliasName',
+          expectedDisplayString: '(variable) aliasName: [{ readonly name: "name"; }]',
         });
       });
     });


### PR DESCRIPTION
Expands support for the `as` keyword to `@else if` blocks. Previously it was only allowed on `@if`.
