### PR TITLE
fix(core): prevents duplicate nodes when `@if` toggles or `@for` adds and removes with leave animations

### DIFF
--- a/packages/core/src/render3/instructions/animation.ts
+++ b/packages/core/src/render3/instructions/animation.ts
@@ -26,6 +26,7 @@ import {RElement} from '../interfaces/renderer_dom';
 import {NgZone} from '../../zone';
 import {assertDefined} from '../../util/assert';
 import {determineLongestAnimation, LongestAnimation} from '../../animation/longest_animation';
+import {TNode} from '../interfaces/node';
 
 const DEFAULT_ANIMATIONS_DISABLED = false;
 const areAnimationSupported =
@@ -40,6 +41,11 @@ const noOpAnimationComplete = () => {};
 // we remove all of the classes in the case of animation composition via host bindings.
 const enterClassMap = new WeakMap<HTMLElement, {classList: string[]; cleanupFns: Function[]}>();
 const longestAnimations = new WeakMap<HTMLElement, LongestAnimation>();
+
+// Tracks nodes that are animating away for the duration of the animation. This is
+// used to prevent duplicate nodes from showing up when nodes have been toggled quickly
+// from an `@if` or `@for`.
+const leavingNodes = new WeakMap<TNode, HTMLElement[]>();
 
 /**
  * Instruction to handle the `animate.enter` behavior for class bindings.
@@ -100,6 +106,15 @@ export function ɵɵanimateEnter(value: string | Function): typeof ɵɵanimateEn
       cleanupFns.push(renderer.listen(nativeElement, 'animationstart', handleAnimationStart));
       cleanupFns.push(renderer.listen(nativeElement, 'transitionstart', handleAnimationStart));
     });
+
+    // In the case that we have an existing node that's animating away, like when
+    // an `@if` toggles quickly or `@for` adds and removes elements quickly, we
+    // need to end the animation for the former node and remove it right away to
+    // prevent duplicate nodes showing up.
+    leavingNodes
+      .get(tNode)
+      ?.pop()
+      ?.dispatchEvent(new CustomEvent('animationend', {detail: {cancel: true}}));
 
     trackEnterClasses(nativeElement, activeClasses, cleanupFns);
 
@@ -214,6 +229,7 @@ export function ɵɵanimateLeave(value: string | Function): typeof ɵɵanimateLe
     return (removalFn: VoidFunction) => {
       animateLeaveClassRunner(
         el as HTMLElement,
+        tNode,
         getClassList(value, resolvers),
         removalFn,
         renderer,
@@ -427,6 +443,7 @@ function assertAnimationTypes(value: string | Function, instruction: string) {
  */
 function animateLeaveClassRunner(
   el: HTMLElement,
+  tNode: TNode,
   classList: Set<string>,
   finalRemoveFn: VoidFunction,
   renderer: Renderer,
@@ -444,14 +461,17 @@ function animateLeaveClassRunner(
     determineLongestAnimation(event, el, longestAnimations, areAnimationSupported);
   };
 
-  const handleOutAnimationEnd = (event: AnimationEvent | TransitionEvent) => {
-    if (isLongestAnimation(event, el)) {
+  const handleOutAnimationEnd = (event: AnimationEvent | TransitionEvent | CustomEvent) => {
+    if (event instanceof CustomEvent || isLongestAnimation(event, el)) {
       // Now that we've found the longest animation, there's no need
       // to keep bubbling up this event as it's not going to apply to
       // other elements further up. We don't want it to inadvertently
       // affect any other animations on the page.
       event.stopImmediatePropagation();
       longestAnimations.delete(el);
+      if (leavingNodes.get(tNode)?.length === 0) {
+        leavingNodes.delete(tNode);
+      }
       finalRemoveFn();
     }
   };
@@ -463,6 +483,14 @@ function animateLeaveClassRunner(
       renderer.listen(el, 'animationend', handleOutAnimationEnd);
       renderer.listen(el, 'transitionend', handleOutAnimationEnd);
     });
+    // We need to track this tNode's element just to be sure we don't add
+    // a new RNode for this TNode while this one is still animating away.
+    // once the animation is complete, we remove this reference.
+    if (leavingNodes.has(tNode)) {
+      leavingNodes.get(tNode)?.push(el);
+    } else {
+      leavingNodes.set(tNode, [el]);
+    }
     for (const item of classList) {
       renderer.addClass(el, item);
     }

--- a/packages/core/test/acceptance/animation_spec.ts
+++ b/packages/core/test/acceptance/animation_spec.ts
@@ -923,5 +923,60 @@ describe('Animation', () => {
       fixture.detectChanges();
       expect(childCmp.nativeElement.className).not.toContain('slide-in fade-in');
     });
+
+    it('should reset leave animation and not duplicate node when toggled quickly', () => {
+      const animateStyles = `
+        .slide-in {
+          animation: slide-in 500ms;
+        }
+        .fade {
+          animation: fade-out 500ms;
+        }
+        @keyframes slide-in {
+          from {
+            transform: translateX(-10px);
+          }
+          to {
+            transform: translateX(0);
+          }
+        }
+        @keyframes fade-out {
+          from {
+            opacity: 1;
+          }
+          to {
+            opacity: 0;
+          }
+        }
+      `;
+
+      @Component({
+        selector: 'test-cmp',
+        styles: animateStyles,
+        template:
+          '<div>@if (show()) {<p animate.enter="slide-in" animate.leave="fade" #el>I should slide in</p>}</div>',
+        encapsulation: ViewEncapsulation.None,
+      })
+      class TestComponent {
+        show = signal(false);
+        @ViewChild('el', {read: ElementRef}) el!: ElementRef<HTMLParagraphElement>;
+      }
+      TestBed.configureTestingModule({animationsEnabled: true});
+
+      const fixture = TestBed.createComponent(TestComponent);
+      const cmp = fixture.componentInstance;
+      fixture.detectChanges();
+      cmp.show.set(true);
+      fixture.detectChanges();
+      expect(cmp.show()).toBeTruthy();
+      cmp.show.set(false);
+      fixture.detectChanges();
+      expect(cmp.show()).toBeFalsy();
+      cmp.show.set(true);
+      fixture.detectChanges();
+      expect(cmp.show()).toBeTruthy();
+      const paragraphs = fixture.debugElement.queryAll(By.css('p'));
+      expect(paragraphs.length).toBe(1);
+    });
   });
 });


### PR DESCRIPTION
In the case that a leave animation is running and someone toggles an `@if`, a new node would be inserted. For a brief moment, there may be two of the same nodes visible at once. While this is expected with native CSS, it's not ideal. Instead, we retain a reference to the leaving element and can remove that node when the new node is entering.

fixes: #63020

![openclosed](https://github.com/user-attachments/assets/d869140c-e024-47be-85ce-c2416a1daa52)

![for loop revisited](https://github.com/user-attachments/assets/3102af94-fa90-45b4-a7ba-06603737ae3d)
