### PR TITLE
fix(compiler-cli): prevent dom event assertion in TCB generation on o…

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -1057,6 +1057,9 @@ export class NgCompiler {
     const allowSignalsInTwoWayBindings =
       this.angularCoreVersion === null ||
       coreVersionSupportsFeature(this.angularCoreVersion, '>= 17.2.0-0');
+    const allowDomEventAssertion =
+      this.angularCoreVersion === null ||
+      coreVersionSupportsFeature(this.angularCoreVersion, '>= 20.2.0');
 
     // First select a type-checking configuration, based on whether full template type-checking is
     // requested.
@@ -1101,6 +1104,7 @@ export class NgCompiler {
           this.options.extendedDiagnostics?.defaultCategory || DiagnosticCategoryLabel.Warning,
         allowSignalsInTwoWayBindings,
         checkTwoWayBoundEvents,
+        allowDomEventAssertion,
       };
     } else {
       typeCheckingConfig = {
@@ -1136,6 +1140,7 @@ export class NgCompiler {
           this.options.extendedDiagnostics?.defaultCategory || DiagnosticCategoryLabel.Warning,
         allowSignalsInTwoWayBindings,
         checkTwoWayBoundEvents,
+        allowDomEventAssertion,
       };
     }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
@@ -354,6 +354,11 @@ export interface TypeCheckingConfig {
   allowSignalsInTwoWayBindings: boolean;
 
   /**
+   * Whether the type of DOM events should be asserted with '@angular/core' 'ɵassertType' (see TCB implementation).
+   */
+  allowDomEventAssertion: boolean;
+
+  /**
    * Whether to descend into the bodies of control flow blocks (`@if`, `@switch` and `@for`).
    */
   checkControlFlowBodies: boolean;

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -1680,7 +1680,8 @@ class TcbUnclaimedOutputsOp extends TcbOp {
         if (
           this.target instanceof TmplAstElement &&
           this.target.isVoid &&
-          ts.isIdentifier(target)
+          ts.isIdentifier(target) &&
+          this.tcb.env.config.allowDomEventAssertion
         ) {
           domEventAssertion = ts.factory.createCallExpression(
             this.tcb.env.referenceExternalSymbol('@angular/core', 'ɵassertType'),

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1077,6 +1077,7 @@ describe('type check blocks', () => {
       unusedStandaloneImports: 'warning',
       allowSignalsInTwoWayBindings: true,
       checkTwoWayBoundEvents: true,
+      allowDomEventAssertion: true,
     };
 
     describe('config.applyTemplateContextGuards', () => {
@@ -1453,6 +1454,14 @@ describe('type check blocks', () => {
         const block = tcb(TEMPLATE, DIRECTIVES, enableChecks);
         expect(block).toContain('var _t1 = null! as i0.Dir; ' + '_t1.fieldA = (((this).foo)); ');
       });
+    });
+
+    it('should _not_ assert the type for DOM events bound on void elements when disabled', () => {
+      const result = tcb(`<input (input)="handleInput($event.target.value)">`, undefined, {
+        ...BASE_CONFIG,
+        allowDomEventAssertion: false,
+      });
+      expect(result).not.toContain('ɵassertType');
     });
 
     describe('config.allowSignalsInTwoWayBindings', () => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -291,6 +291,7 @@ export const ALL_ENABLED_CONFIG: Readonly<TypeCheckingConfig> = {
   unusedStandaloneImports: 'warning',
   allowSignalsInTwoWayBindings: true,
   checkTwoWayBoundEvents: true,
+  allowDomEventAssertion: true,
 };
 
 // Remove 'ref' from TypeCheckableDirectiveMeta and add a 'selector' instead.
@@ -433,6 +434,7 @@ export function tcb(
     suggestionsForSuboptimalTypeInference: false,
     allowSignalsInTwoWayBindings: true,
     checkTwoWayBoundEvents: true,
+    allowDomEventAssertion: true,
     ...config,
   };
   options = options || {emitSpans: false};


### PR DESCRIPTION
…lder angular versions

This fixes an issue caused by
https://github.com/angular/angular/pull/62648 for older versions of Angular when the newest version of the language service is used. This prevents the TCB from attempting to use the assertType when it does not exist.

fixes #63046
