### PR TITLE
feat(forms): track bound controls as field state

### DIFF
--- a/goldens/public-api/forms/experimental/index.api.md
+++ b/goldens/public-api/forms/experimental/index.api.md
@@ -173,6 +173,7 @@ export type FieldPath<TValue, TPathKind extends PathKind = PathKind.Root> = {
 
 // @public
 export interface FieldState<TValue, TKey extends string | number = string | number> {
+    readonly controls: Signal<readonly Control<unknown>[]>;
     readonly dirty: Signal<boolean>;
     readonly disabled: Signal<boolean>;
     readonly disabledReasons: Signal<readonly DisabledReason[]>;

--- a/packages/forms/experimental/src/api/types.ts
+++ b/packages/forms/experimental/src/api/types.ts
@@ -7,6 +7,7 @@
  */
 
 import {Signal, WritableSignal} from '@angular/core';
+import type {Control} from '../controls/control';
 import {AggregateProperty, Property} from './property';
 import type {ValidationError, WithField} from './validation_errors';
 
@@ -288,6 +289,10 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
    * array-valued, for example, this is the index of this field in that array.
    */
   readonly keyInParent: Signal<TKey>;
+  /**
+   * A signal containing the `Control` directives this field is currently bound to.
+   */
+  readonly controls: Signal<readonly Control<unknown>[]>;
 
   /**
    * Reads an aggregate property value from the field.

--- a/packages/forms/experimental/src/field/node.ts
+++ b/packages/forms/experimental/src/field/node.ts
@@ -10,6 +10,7 @@ import type {Signal, WritableSignal} from '@angular/core';
 import {AggregateProperty, Property} from '../api/property';
 import type {DisabledReason, Field, FieldContext, FieldState} from '../api/types';
 import type {ValidationError} from '../api/validation_errors';
+import type {Control} from '../controls/control';
 import {LogicNode} from '../schema/logic_node';
 import {FieldPathNode} from '../schema/path_node';
 import {FieldNodeContext} from './context';
@@ -143,6 +144,10 @@ export class FieldNode implements FieldState<unknown> {
 
   get readonly(): Signal<boolean> {
     return this.nodeState.readonly;
+  }
+
+  get controls(): Signal<readonly Control<unknown>[]> {
+    return this.nodeState.controls;
   }
 
   get submitting(): Signal<boolean> {

--- a/packages/forms/experimental/src/field/state.ts
+++ b/packages/forms/experimental/src/field/state.ts
@@ -8,6 +8,7 @@
 
 import {computed, signal, Signal} from '@angular/core';
 import type {DisabledReason} from '../api/types';
+import type {Control} from '../controls/control';
 import type {FieldNode} from './node';
 import {reduceChildren, shortCircuitTrue} from './util';
 
@@ -31,6 +32,9 @@ export class FieldNodeState {
    * A field is considered directly dirtied if a user changed the value of the field at least once.
    */
   readonly selfDirty = signal(false);
+
+  /** The UI controls the field is currently bound to. */
+  readonly controls = signal<readonly Control<unknown>[]>([]);
 
   constructor(private readonly node: FieldNode) {}
 

--- a/packages/forms/experimental/test/node/control_directive.spec.ts
+++ b/packages/forms/experimental/test/node/control_directive.spec.ts
@@ -243,7 +243,7 @@ describe('control directive', () => {
     expect(el.textContent).toBe('test');
   });
 
-  it('should update bound controls on the field when it is bound ad unbound', async () => {
+  it('should update bound controls on the field when it is bound and unbound', async () => {
     const f = form(signal(''), {injector: TestBed.inject(Injector)});
     expect(f().controls()).toEqual([]);
 

--- a/packages/forms/experimental/test/node/control_directive.spec.ts
+++ b/packages/forms/experimental/test/node/control_directive.spec.ts
@@ -8,17 +8,31 @@
 
 import {
   Component,
+  Injector,
   Input,
   input,
   model,
   provideZonelessChangeDetection,
   signal,
+  ViewChildren,
+  type QueryList,
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {FormCheckboxControl, FormValueControl} from '../../src/api/control';
 import {form} from '../../src/api/structure';
 import {Field} from '../../src/api/types';
 import {Control} from '../../src/controls/control';
+
+@Component({
+  selector: 'string-control',
+  template: `<input [control]="control()"/>`,
+  imports: [Control],
+})
+class TestStringControl {
+  // Note: @Input, @ViewChildren required due to JIT transforms not running in our tests.
+  @Input('control') readonly control = input.required<Field<string>>();
+  @ViewChildren(Control) readonly controlDirective!: QueryList<Control<unknown>>;
+}
 
 describe('control directive', () => {
   beforeEach(() => {
@@ -227,6 +241,57 @@ describe('control directive', () => {
 
     const el = act(() => TestBed.createComponent(TestCmp)).nativeElement;
     expect(el.textContent).toBe('test');
+  });
+
+  it('should update bound controls on the field when it is bound ad unbound', async () => {
+    const f = form(signal(''), {injector: TestBed.inject(Injector)});
+    expect(f().controls()).toEqual([]);
+
+    const fixture = act(() => {
+      const fixture = TestBed.createComponent(TestStringControl);
+      fixture.componentRef.setInput('control', signal(f));
+      return fixture;
+    });
+    expect(f().controls()).toEqual([fixture.componentInstance.controlDirective.get(0)!]);
+
+    act(() => fixture.destroy());
+    expect(f().controls()).toEqual([]);
+  });
+
+  it('should track multiple bound controls per field', async () => {
+    const f = form(signal(''), {injector: TestBed.inject(Injector)});
+    const fixture1 = act(() => {
+      const fixture = TestBed.createComponent(TestStringControl);
+      fixture.componentRef.setInput('control', signal(f));
+      return fixture;
+    });
+    const fixture2 = act(() => {
+      const fixture = TestBed.createComponent(TestStringControl);
+      fixture.componentRef.setInput('control', signal(f));
+      return fixture;
+    });
+
+    expect(f().controls()).toEqual([
+      fixture1.componentInstance.controlDirective.get(0)!,
+      fixture2.componentInstance.controlDirective.get(0)!,
+    ]);
+  });
+
+  it('should update bound controls on both fields when field binding changes', async () => {
+    const f1 = form(signal(''), {injector: TestBed.inject(Injector)});
+    const f2 = form(signal(''), {injector: TestBed.inject(Injector)});
+    const field = signal<Field<string>>(f1);
+    const fixture = act(() => {
+      const fixture = TestBed.createComponent(TestStringControl);
+      fixture.componentRef.setInput('control', field);
+      return fixture;
+    });
+    expect(f1().controls()).toEqual([fixture.componentInstance.controlDirective.get(0)!]);
+    expect(f2().controls()).toEqual([]);
+
+    act(() => field.set(f2));
+    expect(f1().controls()).toEqual([]);
+    expect(f2().controls()).toEqual([fixture.componentInstance.controlDirective.get(0)!]);
   });
 });
 


### PR DESCRIPTION
Record linkage between a `Field` and the `Control`(s) its bound to. This will be useful for error summaries that want to jump to the problem input element.