### PR TITLE
feat(forms): add error summaries to fields

### DIFF
--- a/goldens/public-api/forms/experimental/index.api.md
+++ b/goldens/public-api/forms/experimental/index.api.md
@@ -170,6 +170,7 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
     readonly disabled: Signal<boolean>;
     readonly disabledReasons: Signal<readonly DisabledReason[]>;
     readonly errors: Signal<ValidationError[]>;
+    readonly errorSummary: Signal<ValidationError[]>;
     hasProperty(key: Property<any> | AggregateProperty<any, any>): boolean;
     readonly hidden: Signal<boolean>;
     readonly invalid: Signal<boolean>;

--- a/packages/forms/experimental/src/api/types.ts
+++ b/packages/forms/experimental/src/api/types.ts
@@ -242,6 +242,10 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
    */
   readonly errors: Signal<ValidationError[]>;
   /**
+   * A signal containing the {@link errors} of the field and its descendants.
+   */
+  readonly errorSummary: Signal<ValidationError[]>;
+  /**
    * A signal indicating whether the field's value is currently valid.
    *
    * Note: `valid()` is not the same as `!invalid()`.

--- a/packages/forms/experimental/src/field/node.ts
+++ b/packages/forms/experimental/src/field/node.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Signal, WritableSignal} from '@angular/core';
+import type {Signal, WritableSignal} from '@angular/core';
 import {AggregateProperty, Property} from '../api/property';
 import type {DisabledReason, Field, FieldContext, FieldState} from '../api/types';
 import type {ValidationError} from '../api/validation_errors';
@@ -27,9 +27,7 @@ import {
 } from './structure';
 import {FieldSubmitState} from './submit';
 import {ValidationState} from './validation';
-
 import type {FieldAdapter} from './field_adapter';
-
 /**
  * Internal node in the form tree for a given field.
  *
@@ -85,6 +83,10 @@ export class FieldNode implements FieldState<unknown> {
 
   get errors(): Signal<ValidationError[]> {
     return this.validationState.errors;
+  }
+
+  get errorSummary(): Signal<ValidationError[]> {
+    return this.validationState.errorSummary;
   }
 
   get pending(): Signal<boolean> {

--- a/packages/forms/experimental/src/field/validation.ts
+++ b/packages/forms/experimental/src/field/validation.ts
@@ -64,6 +64,11 @@ export interface ValidationState {
   errors: Signal<ValidationError[]>;
 
   /**
+   * The combined set of all errors that currently apply to this field and its descendants.
+   */
+  errorSummary: Signal<ValidationError[]>;
+
+  /**
    * Whether this field has any asynchronous validators still pending.
    */
   pending: Signal<boolean>;
@@ -235,6 +240,13 @@ export class FieldValidationState implements ValidationState {
     ...this.syncErrors(),
     ...this.asyncErrors().filter((err) => err !== 'pending'),
   ]);
+
+  readonly errorSummary = computed(() =>
+    reduceChildren(this.node, this.errors(), (child, result) => [
+      ...result,
+      ...child.errorSummary(),
+    ]),
+  );
 
   /**
    * Whether this field has any asynchronous validators still pending.


### PR DESCRIPTION
Add an `errorSummary` signal to `FieldState` which contains all of the validation errors of a field and its descendants. This can be used to conveniently collect all form validation errors by reading it from the root field.
