### PR TITLE
docs: update testing scenarios and remove imports.

### DIFF
--- a/adev/src/content/examples/testing/src/app/app.component.router.spec.ts
+++ b/adev/src/content/examples/testing/src/app/app.component.router.spec.ts
@@ -28,7 +28,6 @@ describe('AppComponent & router testing', () => {
       Object.assign({}, appConfig, {
         providers: [
           {provide: HeroService, useClass: TestHeroService},
-          UserService,
           TwainService,
           provideHttpClient(),
           provideLocationMocks(),

--- a/adev/src/content/examples/testing/src/app/app.component.spec.ts
+++ b/adev/src/content/examples/testing/src/app/app.component.spec.ts
@@ -1,12 +1,13 @@
 // #docplaster
 import {Component, DebugElement, NO_ERRORS_SCHEMA} from '@angular/core';
-import {ComponentFixture, fakeAsync, TestBed, tick, waitForAsync} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {provideRouter, Router, RouterLink} from '@angular/router';
+import {provideRouter, Router, RouterLink, RouterOutlet} from '@angular/router';
 
 import {AppComponent} from './app.component';
 import {appConfig} from './app.config';
 import {UserService} from './model';
+import {WelcomeComponent} from './welcome/welcome.component';
 
 // #docregion component-stubs
 @Component({selector: 'app-banner', template: ''})
@@ -23,54 +24,67 @@ let comp: AppComponent;
 let fixture: ComponentFixture<AppComponent>;
 
 describe('AppComponent & TestModule', () => {
-  beforeEach(waitForAsync(() => {
+  beforeEach(() => {
     // #docregion testbed-stubs
     TestBed.configureTestingModule(
       Object.assign({}, appConfig, {
-        imports: [
-          AppComponent,
-          BannerStubComponent,
-          RouterLink,
-          RouterOutletStubComponent,
-          WelcomeStubComponent,
-        ],
         providers: [provideRouter([]), UserService],
       }),
-    )
-      // #enddocregion testbed-stubs
+    ).overrideComponent(AppComponent, {
+      set: {
+        imports: [BannerStubComponent, RouterLink, RouterOutletStubComponent, WelcomeStubComponent],
+      },
+    });
+    // #enddocregion testbed-stubs
 
-      .then(() => {
-        fixture = TestBed.createComponent(AppComponent);
-        comp = fixture.componentInstance;
-      });
-  }));
+    fixture = TestBed.createComponent(AppComponent);
+    comp = fixture.componentInstance;
+  });
   tests();
 });
 
 //////// Testing w/ NO_ERRORS_SCHEMA //////
 describe('AppComponent & NO_ERRORS_SCHEMA', () => {
-  beforeEach(waitForAsync(() => {
-    // #docregion no-errors-schema, mixed-setup
+  beforeEach(() => {
+    // #docregion no-errors-schema
     TestBed.configureTestingModule(
       Object.assign({}, appConfig, {
-        imports: [
-          AppComponent,
-          // #enddocregion no-errors-schema
-          BannerStubComponent,
-          // #docregion no-errors-schema
-          RouterLink,
-        ],
         providers: [provideRouter([]), UserService],
-        schemas: [NO_ERRORS_SCHEMA],
       }),
-    )
-      // #enddocregion no-errors-schema, mixed-setup
+    ).overrideComponent(AppComponent, {
+      set: {
+        imports: [], // resets all imports
+        schemas: [NO_ERRORS_SCHEMA],
+      },
+    });
+    // #enddocregion no-errors-schema
 
-      .then(() => {
-        fixture = TestBed.createComponent(AppComponent);
-        comp = fixture.componentInstance;
-      });
-  }));
+    fixture = TestBed.createComponent(AppComponent);
+    comp = fixture.componentInstance;
+  });
+  tests();
+});
+
+describe('AppComponent & NO_ERRORS_SCHEMA', () => {
+  beforeEach(() => {
+    // #docregion mixed-setup
+    TestBed.configureTestingModule(
+      Object.assign({}, appConfig, {
+        providers: [provideRouter([]), UserService],
+      }),
+    ).overrideComponent(AppComponent, {
+      remove: {
+        imports: [RouterOutlet, WelcomeComponent],
+      },
+      set: {
+        schemas: [NO_ERRORS_SCHEMA],
+      },
+    });
+    // #enddocregion mixed-setup
+
+    fixture = TestBed.createComponent(AppComponent);
+    comp = fixture.componentInstance;
+  });
   tests();
 });
 

--- a/adev/src/content/examples/testing/src/app/banner/banner-external.component.spec.ts
+++ b/adev/src/content/examples/testing/src/app/banner/banner-external.component.spec.ts
@@ -28,7 +28,7 @@ describe('BannerComponent (external files)', () => {
     beforeEach(async () => {
       await TestBed.configureTestingModule({
         imports: [BannerComponent],
-      }); // compile template and css
+      }).compileComponents(); // compile template and css
     });
     // #enddocregion async-before-each
 

--- a/adev/src/content/examples/testing/src/app/banner/banner.component.spec.ts
+++ b/adev/src/content/examples/testing/src/app/banner/banner.component.spec.ts
@@ -11,9 +11,6 @@ describe('BannerComponent (inline template)', () => {
   let h1: HTMLElement;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [BannerComponent],
-    });
     fixture = TestBed.createComponent(BannerComponent);
     component = fixture.componentInstance; // BannerComponent test instance
     h1 = fixture.nativeElement.querySelector('h1');

--- a/adev/src/content/examples/testing/src/app/dashboard/dashboard-hero.component.spec.ts
+++ b/adev/src/content/examples/testing/src/app/dashboard/dashboard-hero.component.spec.ts
@@ -109,7 +109,6 @@ describe('DashboardHeroComponent when inside a test host', () => {
     // #docregion test-host-setup
     TestBed.configureTestingModule({
       providers: appProviders,
-      imports: [DashboardHeroComponent, TestHostComponent],
     });
     // #enddocregion test-host-setup
   }));

--- a/adev/src/content/examples/testing/src/app/dashboard/dashboard.component.spec.ts
+++ b/adev/src/content/examples/testing/src/app/dashboard/dashboard.component.spec.ts
@@ -69,7 +69,6 @@ function compileAndCreate() {
     // #docregion router-harness
     TestBed.configureTestingModule(
       Object.assign({}, appConfig, {
-        imports: [DashboardComponent],
         providers: [
           provideRouter([{path: '**', component: DashboardComponent}]),
           provideHttpClient(),

--- a/adev/src/content/examples/testing/src/app/hero/hero-detail.component.ts
+++ b/adev/src/content/examples/testing/src/app/hero/hero-detail.component.ts
@@ -13,7 +13,7 @@ import {HeroDetailService} from './hero-detail.service';
   templateUrl: './hero-detail.component.html',
   styleUrls: ['./hero-detail.component.css'],
   providers: [HeroDetailService],
-  imports: [sharedImports, RouterLink],
+  imports: [...sharedImports],
 })
 export class HeroDetailComponent {
   // #docregion inject

--- a/adev/src/content/examples/testing/src/app/shared/canvas.component.spec.ts
+++ b/adev/src/content/examples/testing/src/app/shared/canvas.component.spec.ts
@@ -17,12 +17,6 @@ describe('CanvasComponent', () => {
   });
   // #enddocregion enable-toBlob-macrotask
   // #docregion without-toBlob-macrotask
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [CanvasComponent],
-    });
-  });
-
   it('should be able to generate blob data from canvas', fakeAsync(() => {
     const fixture = TestBed.createComponent(CanvasComponent);
     const canvasComp = fixture.componentInstance;

--- a/adev/src/content/examples/testing/src/app/twain/twain.component.spec.ts
+++ b/adev/src/content/examples/testing/src/app/twain/twain.component.spec.ts
@@ -26,7 +26,6 @@ describe('TwainComponent', () => {
   // #docregion setup
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [TwainComponent],
       providers: [TwainService],
     });
     testQuote = 'Test Quote';

--- a/adev/src/content/guide/testing/components-scenarios.md
+++ b/adev/src/content/guide/testing/components-scenarios.md
@@ -531,9 +531,8 @@ The setup for the `test-host` tests is similar to the setup for the stand-alone 
 
 <docs-code header="app/dashboard/dashboard-hero.component.spec.ts (test host setup)" path="adev/src/content/examples/testing/src/app/dashboard/dashboard-hero.component.spec.ts" visibleRegion="test-host-setup"/>
 
-This testing module configuration shows three important differences:
+This testing module configuration shows two important differences:
 
-* It *imports* both the `DashboardHeroComponent` and the `TestHostComponent`
 * It *creates* the `TestHostComponent` instead of the `DashboardHeroComponent`
 * The `TestHostComponent` sets the `DashboardHeroComponent.hero` with a binding
 
@@ -637,17 +636,15 @@ In the first technique, you create and declare stub versions of the components a
 The stub selectors match the selectors for the corresponding real components.
 But their templates and classes are empty.
 
-Then declare them in the `TestBed` configuration next to the components, directives, and pipes that need to be real.
+Then declare them by overriding the `imports` of your component using `TestBed.overrideComponent`. 
 
 <docs-code header="app/app.component.spec.ts (TestBed stubs)" path="adev/src/content/examples/testing/src/app/app.component.spec.ts" visibleRegion="testbed-stubs"/>
 
-The `AppComponent` is the test subject, so of course you declare the real version.
-
-The rest are stubs.
+HELPFUL: The `set` key in this example replaces all the exisiting imports on your component, make sure to imports all dependencies, not only the stubs. Alternatively you can use the `remove`/`add` keys to selectively remove and add imports.
 
 ### `NO_ERRORS_SCHEMA`
 
-In the second approach, add `NO_ERRORS_SCHEMA` to the `TestBed.schemas` metadata.
+In the second approach, add `NO_ERRORS_SCHEMA` to the metadata overrides of your component.
 
 <docs-code header="app/app.component.spec.ts (NO_ERRORS_SCHEMA)" path="adev/src/content/examples/testing/src/app/app.component.spec.ts" visibleRegion="no-errors-schema"/>
 
@@ -731,155 +728,6 @@ A `createComponent` method creates a `page` object and fills in the blanks once 
 Here are a few more `HeroDetailComponent` tests to reinforce the point.
 
 <docs-code header="app/hero/hero-detail.component.spec.ts (selected tests)" path="adev/src/content/examples/testing/src/app/hero/hero-detail.component.spec.ts" visibleRegion="selected-tests"/>
-
-## Calling `compileComponents()`
-
-HELPFUL: Ignore this section if you *only* run tests with the CLI `ng test` command because the CLI compiles the application before running the tests.
-
-If you run tests in a **non-CLI environment**, the tests might fail with a message like this one:
-
-<docs-code hideCopy language="shell">
-
-Error: This test module uses the component BannerComponent
-which is using a "templateUrl" or "styleUrls", but they were never compiled.
-Please call "TestBed.compileComponents" before your test.
-
-</docs-code>
-
-The root of the problem is at least one of the components involved in the test specifies an external template or CSS file as the following version of the `BannerComponent` does.
-
-<docs-code header="app/banner/banner-external.component.ts (external template & css)" path="adev/src/content/examples/testing/src/app/banner/banner-external.component.ts"/>
-
-The test fails when the `TestBed` tries to create the component.
-
-<docs-code avoid header="app/banner/banner-external.component.spec.ts (setup that fails)" path="adev/src/content/examples/testing/src/app/banner/banner-external.component.spec.ts" visibleRegion="setup-may-fail"/>
-
-Recall that the application hasn't been compiled.
-So when you call `createComponent()`, the `TestBed` compiles implicitly.
-
-That's not a problem when the source code is in memory.
-But the `BannerComponent` requires external files that the compiler must read from the file system, an inherently *asynchronous* operation.
-
-If the `TestBed` were allowed to continue, the tests would run and fail mysteriously before the compiler could finish.
-
-The preemptive error message tells you to compile explicitly with `compileComponents()`.
-
-### `compileComponents()` is async
-
-You must call `compileComponents()` within an asynchronous test function.
-
-CRITICAL: If you neglect to make the test function async (for example, forget to use `waitForAsync()` as described), you'll see this error message
-
-<docs-code hideCopy language="shell">
-
-Error: ViewDestroyedError: Attempt to use a destroyed view
-
-</docs-code>
-
-A typical approach is to divide the setup logic into two separate `beforeEach()` functions:
-
-| Functions                   | Details                      |
-| :-------------------------- | :--------------------------- |
-| Asynchronous `beforeEach()` | Compiles the components      |
-| Synchronous `beforeEach()`  | Performs the remaining setup |
-
-### The async `beforeEach`
-
-Write the first async `beforeEach` like this.
-
-<docs-code header="app/banner/banner-external.component.spec.ts (async beforeEach)" path="adev/src/content/examples/testing/src/app/banner/banner-external.component.spec.ts" visibleRegion="async-before-each"/>
-
-The `TestBed.configureTestingModule()` method returns the `TestBed` class so you can chain calls to other `TestBed` static methods such as `compileComponents()`.
-
-In this example, the `BannerComponent` is the only component to compile.
-Other examples configure the testing module with multiple components and might import application modules that hold yet more components.
-Any of them could require external files.
-
-The `TestBed.compileComponents` method asynchronously compiles all components configured in the testing module.
-
-IMPORTANT: Do not re-configure the `TestBed` after calling `compileComponents()`.
-
-Calling `compileComponents()` closes the current `TestBed` instance to further configuration.
-You cannot call any more `TestBed` configuration methods, not `configureTestingModule()` nor any of the `override...` methods.
-The `TestBed` throws an error if you try.
-
-Make `compileComponents()` the last step before calling `TestBed.createComponent()`.
-
-### The synchronous `beforeEach`
-
-The second, synchronous `beforeEach()` contains the remaining setup steps, which include creating the component and querying for elements to inspect.
-
-<docs-code header="app/banner/banner-external.component.spec.ts (synchronous beforeEach)" path="adev/src/content/examples/testing/src/app/banner/banner-external.component.spec.ts" visibleRegion="sync-before-each"/>
-
-Count on the test runner to wait for the first asynchronous `beforeEach` to finish before calling the second.
-
-### Consolidated setup
-
-You can consolidate the two `beforeEach()` functions into a single, async `beforeEach()`.
-
-The `compileComponents()` method returns a promise so you can perform the synchronous setup tasks *after* compilation by moving the synchronous code after the `await` keyword, where the promise has been resolved.
-
-<docs-code header="app/banner/banner-external.component.spec.ts (one beforeEach)" path="adev/src/content/examples/testing/src/app/banner/banner-external.component.spec.ts" visibleRegion="one-before-each"/>
-
-### `compileComponents()` is harmless
-
-There's no harm in calling `compileComponents()` when it's not required.
-
-The component test file generated by the CLI calls `compileComponents()` even though it is never required when running `ng test`.
-
-The tests in this guide only call `compileComponents` when necessary.
-
-## Setup with module imports
-
-Earlier component tests configured the testing module with a few `declarations` like this:
-
-<docs-code header="app/dashboard/dashboard-hero.component.spec.ts (configure TestBed)" path="adev/src/content/examples/testing/src/app/dashboard/dashboard-hero.component.spec.ts" visibleRegion="config-testbed"/>
-
-The `DashboardComponent` is simple.
-It needs no help.
-But more complex components often depend on other components, directives, pipes, and providers and these must be added to the testing module too.
-
-Fortunately, the `TestBed.configureTestingModule` parameter parallels the metadata passed to the `@NgModule` decorator which means you can also specify `providers` and `imports`.
-
-The `HeroDetailComponent` requires a lot of help despite its small size and simple construction.
-In addition to the support it receives from the default testing module `CommonModule`, it needs:
-
-* `NgModel` and friends in the `FormsModule` to enable two-way data binding
-* The `TitleCasePipe` from the `shared` folder
-* The Router services
-* The Hero data access services
-
-One approach is to configure the testing module from the individual pieces as in this example:
-
-<docs-code header="app/hero/hero-detail.component.spec.ts (FormsModule setup)" path="adev/src/content/examples/testing/src/app/hero/hero-detail.component.spec.ts" visibleRegion="setup-forms-module"/>
-
-HELPFUL: Notice that the `beforeEach()` is asynchronous and calls `TestBed.compileComponents` because the `HeroDetailComponent` has an external template and css file.
-
-As explained in [Calling `compileComponents()`](#calling-compilecomponents), these tests could be run in a non-CLI environment where Angular would have to compile them in the browser.
-
-### Import a shared module
-
-Because many application components need the `FormsModule` and the `TitleCasePipe`, the developer created a `SharedModule` to combine these and other frequently requested parts.
-
-The test configuration can use the `SharedModule` too as seen in this alternative setup:
-
-<docs-code header="app/hero/hero-detail.component.spec.ts (SharedModule setup)" path="adev/src/content/examples/testing/src/app/hero/hero-detail.component.spec.ts" visibleRegion="setup-shared-module"/>
-
-It's a bit tighter and smaller, with fewer import statements, which are not shown in this example.
-
-### Import a feature module
-
-The `HeroDetailComponent` is part of the `HeroModule` [Feature Module](guide/ngmodules/feature-modules) that aggregates more of the interdependent pieces including the `SharedModule`.
-Try a test configuration that imports the `HeroModule` like this one:
-
-<docs-code header="app/hero/hero-detail.component.spec.ts (HeroModule setup)" path="adev/src/content/examples/testing/src/app/hero/hero-detail.component.spec.ts" visibleRegion="setup-hero-module"/>
-
-Only the *test doubles* in the `providers` remain.
-Even the `HeroDetailComponent` declaration is gone.
-
-In fact, if you try to declare it, Angular will throw an error because `HeroDetailComponent` is declared in both the `HeroModule` and the `DynamicTestModule` created by the `TestBed`.
-
-HELPFUL: Importing the component's feature module can be the best way to configure tests when there are many mutual dependencies within the module and the module is small, as feature modules tend to be.
 
 ## Override component providers
 


### PR DESCRIPTION
With standalone, `TestBed` `imports` are not necessary anymore when configuring the Testing module.
