### PR TITLE
refactor(zone.js): remove unused jasmine globalerror monkey patch.

### DIFF
--- a/packages/zone.js/test/node_bluebird_entry_point.init.ts
+++ b/packages/zone.js/test/node_bluebird_entry_point.init.ts
@@ -43,26 +43,3 @@ patchTaskTracking(Zone);
 patchWtf(Zone);
 patchRxJs(Zone);
 patchPromiseTesting(Zone);
-
-const globalErrors = (jasmine as any).GlobalErrors;
-const symbol = Zone.__symbol__;
-if (globalErrors && !(jasmine as any)[symbol('GlobalErrors')]) {
-  (jasmine as any)[symbol('GlobalErrors')] = globalErrors;
-  (jasmine as any).GlobalErrors = function () {
-    const instance = new globalErrors();
-    const originalInstall = instance.install;
-    if (originalInstall && !instance[symbol('install')]) {
-      instance[symbol('install')] = originalInstall;
-      instance.install = function () {
-        const originalHandlers = process.listeners('unhandledRejection');
-        const r = originalInstall.apply(this, arguments);
-        process.removeAllListeners('unhandledRejection');
-        if (originalHandlers) {
-          originalHandlers.forEach((h) => process.on('unhandledRejection', h));
-        }
-        return r;
-      };
-    }
-    return instance;
-  };
-}


### PR DESCRIPTION
This is for testing purposes for now. See discussion on the related issue.

fixes #63072
