### PR TITLE
docs: remove router testing from the testing scenarios guide

### DIFF
--- a/adev/src/app/sub-navigation-data.ts
+++ b/adev/src/app/sub-navigation-data.ts
@@ -534,6 +534,12 @@ const DOCS_SUB_NAVIGATION_DATA: NavigationItem[] = [
             contentPath: 'guide/testing/pipes',
           },
           {
+            label: 'Testing routing and navigation',
+            path: 'guide/routing/testing',
+            contentPath: 'guide/routing/testing',
+            status: 'new',
+          },
+          {
             label: 'Debugging tests',
             path: 'guide/testing/debugging',
             contentPath: 'guide/testing/debugging',

--- a/adev/src/content/guide/routing/testing.md
+++ b/adev/src/content/guide/routing/testing.md
@@ -9,7 +9,7 @@ This guide assumes you are familiar with the following tools and libraries:
 - **[Jasmine](https://jasmine.github.io/)** - JavaScript testing framework that provides the testing syntax (`describe`, `it`, `expect`)
 - **[Karma](https://karma-runner.github.io/)** - Test runner that executes tests in browsers
 - **[Angular Testing Utilities](guide/testing)** - Angular's built-in testing tools ([`TestBed`](api/core/testing/TestBed), [`ComponentFixture`](api/core/testing/ComponentFixture))
-- **[RouterTestingHarness](api/router/testing/RouterTestingHarness)** - Test harness for testing routed components with built-in navigation and component testing capabilities
+- **[`RouterTestingHarness`](api/router/testing/RouterTestingHarness)** - Test harness for testing routed components with built-in navigation and component testing capabilities
 
 ## Testing scenarios
 

--- a/adev/src/content/guide/testing/components-scenarios.md
+++ b/adev/src/content/guide/testing/components-scenarios.md
@@ -588,23 +588,6 @@ The component has to *subscribe* to the `ActivatedRoute.paramMap` observable and
 
 Tests can explore how the `HeroDetailComponent` responds to different `id` parameter values by navigating to different routes.
 
-### Testing with the `RouterTestingHarness`
-
-Here's a test demonstrating the component's behavior when the observed `id` refers to an existing hero:
-
-<docs-code header="app/hero/hero-detail.component.spec.ts (existing id)" path="adev/src/content/examples/testing/src/app/hero/hero-detail.component.spec.ts" visibleRegion="route-good-id"/>
-
-HELPFUL: In the following section, the `createComponent()` method and `page` object are discussed.
-Rely on your intuition for now.
-
-When the `id` cannot be found, the component should re-route to the `HeroListComponent`.
-
-The test suite setup provided the same router harness [described above](#routing-component).
-
-This test expects the component to try to navigate to the `HeroListComponent`.
-
-<docs-code header="app/hero/hero-detail.component.spec.ts (bad id)" path="adev/src/content/examples/testing/src/app/hero/hero-detail.component.spec.ts" visibleRegion="route-bad-id"/>
-
 ## Nested component tests
 
 Component templates often have nested components, whose templates might contain more components.


### PR DESCRIPTION
This commit also adds the router testing guide to the testing section
