### PR TITLE
feat(core): add toLinkedSignal to create a WritableSignal from an Observable

### DIFF
--- a/packages/core/rxjs-interop/src/to_linked_signal.ts
+++ b/packages/core/rxjs-interop/src/to_linked_signal.ts
@@ -1,0 +1,67 @@
+import {Observable, Subscribable} from 'rxjs';
+import {toSignal, ToSignalOptions} from '@angular/core/rxjs-interop';
+import {linkedSignal, WritableSignal} from '@angular/core';
+
+// Base case: no options -> `undefined` in the result type.
+export function toLinkedSignal<T>(
+  source: Observable<T> | Subscribable<T>,
+): WritableSignal<T | undefined>;
+
+// Options with `undefined` initial value and no `requireSync` -> `undefined`.
+export function toLinkedSignal<T>(
+  source: Observable<T> | Subscribable<T>,
+  options: NoInfer<ToSignalOptions<T | undefined>> & {
+    initialValue?: undefined;
+    requireSync?: false;
+  },
+): WritableSignal<T | undefined>;
+
+// Options with `null` initial value -> `null`.
+export function toLinkedSignal<T>(
+  source: Observable<T> | Subscribable<T>,
+  options: NoInfer<ToSignalOptions<T | null>> & {
+    initialValue?: null;
+    requireSync?: false;
+  },
+): WritableSignal<T | null>;
+
+// Options with `undefined` initial value and `requireSync` -> strict result type.
+export function toLinkedSignal<T>(
+  source: Observable<T> | Subscribable<T>,
+  options: NoInfer<ToSignalOptions<T>> & {
+    initialValue?: undefined;
+    requireSync: true;
+  },
+): WritableSignal<T>;
+
+// Options with a more specific initial value type.
+export function toLinkedSignal<T, U extends T>(
+  source: Observable<T> | Subscribable<T>,
+  options: NoInfer<ToSignalOptions<T | U>> & {
+    initialValue: U;
+    requireSync?: false;
+  },
+): WritableSignal<T | U>;
+
+/**
+ * Get the current value of an `Observable` as a reactive `WritableSignal`.
+ *
+ * `toLinkedSignal` returns a `WritableSignal` which provides synchronous reactive access to values produced
+ * by the given `Observable` or `Subscribable`, by subscribing to that source. The returned signal will always
+ * have the most recent value emitted by the subscription, and will throw an error if the source errors.
+ *
+ * The options parameter allows configuring the initial value, sync requirements, and other behaviors.
+ */
+export function toLinkedSignal<T>(
+  source: Observable<T> | Subscribable<T>,
+  options?:
+    | (NoInfer<ToSignalOptions<T | undefined>> & {initialValue?: undefined; requireSync?: false})
+    | (NoInfer<ToSignalOptions<T | null>> & {initialValue?: null; requireSync?: false})
+    | (NoInfer<ToSignalOptions<T>> & {initialValue?: undefined; requireSync: true})
+    | (NoInfer<ToSignalOptions<T>> & {initialValue: T; requireSync?: false}),
+): WritableSignal<any> {
+  // Convert the Observable/Subscribable to a signal using toSignal
+  const derived = toSignal(source, options as any);
+  // Link the derived signal to a writable signal
+  return linkedSignal(derived);
+}

--- a/packages/core/rxjs-interop/test/to_linked_signal_spec.ts
+++ b/packages/core/rxjs-interop/test/to_linked_signal_spec.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  linkedSignal,
+  WritableSignal,
+  EnvironmentInjector,
+  Injector,
+  runInInjectionContext,
+} from '@angular/core';
+import {toLinkedSignal} from '../src/to_linked_signal';
+import {BehaviorSubject, Subject} from 'rxjs';
+
+describe('toLinkedSignal()', () => {
+  it(
+    'should reflect the last emitted value of an Observable',
+    test(() => {
+      const counter$ = new BehaviorSubject(0);
+      const counter = toLinkedSignal(counter$);
+
+      expect(counter()).toBe(0);
+      counter$.next(1);
+      expect(counter()).toBe(1);
+      counter$.next(3);
+      expect(counter()).toBe(3);
+    }),
+  );
+
+  it(
+    'should allow writing to the signal and update the value',
+    test(() => {
+      const counter$ = new BehaviorSubject(0);
+      const counter = toLinkedSignal(counter$);
+
+      counter.set(5);
+      expect(counter()).toBe(5);
+      // The BehaviorSubject should not be updated by set (one-way binding)
+      expect(counter$.value).toBe(0);
+    }),
+  );
+
+  it(
+    'should support initialValue option',
+    test(() => {
+      const counter$ = new Subject<number>();
+      const counter = toLinkedSignal(counter$, {initialValue: 42});
+      expect(counter()).toBe(42);
+      counter$.next(7);
+      expect(counter()).toBe(7);
+    }),
+  );
+
+  it(
+    'should support null as initialValue',
+    test(() => {
+      const counter$ = new Subject<number>();
+      const counter = toLinkedSignal(counter$, {initialValue: null});
+      expect(counter()).toBeNull();
+      counter$.next(2);
+      expect(counter()).toBe(2);
+    }),
+  );
+
+  it(
+    'should return undefined if no value has been emitted and no initialValue',
+    test(() => {
+      const counter$ = new Subject<number>();
+      const counter = toLinkedSignal(counter$);
+      expect(counter()).toBeUndefined();
+      counter$.next(10);
+      expect(counter()).toBe(10);
+    }),
+  );
+});
+
+function test(fn: () => void | Promise<void>): () => Promise<void> {
+  return async () => {
+    const injector = Injector.create({providers: []}) as EnvironmentInjector;
+    try {
+      return await runInInjectionContext(injector, fn);
+    } finally {
+      injector.destroy();
+    }
+  };
+}


### PR DESCRIPTION

This commit introduces the `toLinkedSignal` function, which converts an Observable or Subscribable into a WritableSignal.

The function wraps Angular's `toSignal` and `linkedSignal` utilities, enabling reactive and synchronous access
to the latest value emitted by the source Observable or Subscribable.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

There is no existing function that converts an Observable or Subscribable into a WritableSignal.

Issue Number: N/A

## What is the new behavior?

Introduces the `toLinkedSignal` function which returns a WritableSignal derived from an Observable or Subscribable.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
