### PR TITLE
feat(devtools): clean up router tree for stable release

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.ts
@@ -70,16 +70,10 @@ export function ngDebugProfilerApiIsSupported(): boolean {
 /** Checks whether Router API is supported within window.ng */
 export function ngDebugRoutesApiIsSupported(): boolean {
   const ng = ngDebugClient();
-
-  // Temporary solution. Convert to `ɵgetLoadedRoutes` when available.
-  // If there is a Wiz application, make Routes API unavailable.
-  const roots = getAppRoots();
   return (
-    !!roots.length &&
-    !roots.some((el) => {
-      const comp = ng.getComponent!(el)!;
-      return ng.getDirectiveMetadata?.(comp)?.framework === Framework.Wiz;
-    })
+    ngDebugApiIsSupported(ng, 'ɵgetLoadedRoutes') &&
+    ngDebugApiIsSupported(ng, 'ɵgetRouterInstance') &&
+    ngDebugApiIsSupported(ng, 'ɵnavigateByUrl')
   );
 }
 

--- a/devtools/projects/ng-devtools-backend/src/lib/router-tree.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/router-tree.spec.ts
@@ -20,6 +20,7 @@ describe('parseRoutes', () => {
       isAux: false,
       isLazy: false,
       isActive: false,
+      isRedirect: false,
     });
   });
 
@@ -39,6 +40,7 @@ describe('parseRoutes', () => {
       'isAux': false,
       'isLazy': false,
       'isActive': false,
+      isRedirect: false,
     });
   });
 
@@ -111,6 +113,7 @@ describe('parseRoutes', () => {
           'isAux': true,
           'isLazy': false,
           'isActive': undefined,
+          'isRedirect': false,
         },
         {
           'component': 'component-two',
@@ -126,6 +129,7 @@ describe('parseRoutes', () => {
           'isAux': false,
           'isLazy': false,
           'isActive': undefined,
+          'isRedirect': false,
           'children': [
             {
               'component': 'component-two-two',
@@ -141,6 +145,7 @@ describe('parseRoutes', () => {
               'isAux': false,
               'isLazy': false,
               'isActive': undefined,
+              'isRedirect': false,
             },
           ],
         },
@@ -158,6 +163,7 @@ describe('parseRoutes', () => {
           'isAux': false,
           'isLazy': true,
           'isActive': undefined,
+          'isRedirect': false,
         },
         {
           'component': 'redirect -> redirecting to -> "redirectTo"',
@@ -173,10 +179,12 @@ describe('parseRoutes', () => {
           'isAux': false,
           'isLazy': false,
           'isActive': undefined,
+          'isRedirect': true,
         },
       ],
       'isAux': false,
       'isLazy': false,
+      'isRedirect': false,
       'data': [],
       'isActive': false,
     } as any);

--- a/devtools/projects/ng-devtools-backend/src/lib/router-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/router-tree.ts
@@ -27,6 +27,7 @@ export function parseRoutes(router: Router): Route {
     children: rootChildren ? assignChildrenToParent(null, rootChildren, currentUrl) : [],
     isAux: false,
     isLazy: false,
+    isRedirect: false,
     data: [],
     isActive: currentUrl === '/',
   };
@@ -62,6 +63,7 @@ function assignChildrenToParent(
 
     // only found in aux routes, otherwise property will be undefined
     const isAux = Boolean(child.outlet);
+    const isRedirect = Boolean(child.redirectTo);
     const isLazy = Boolean(child.loadChildren || child.loadComponent);
 
     const pathWithoutParams = routePath.split('/:')[0];
@@ -81,6 +83,7 @@ function assignChildrenToParent(
       isAux,
       isLazy,
       isActive,
+      isRedirect,
     };
 
     if (childDescendents) {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.html
@@ -80,6 +80,7 @@
           [hidden]="!routerTreeVisible"
           [snapToRoot]="snapToRoot()"
           [routes]="routes()"
+          [routerDebugApiSupport]="supportedApis().routes"
         />
       }
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
@@ -104,7 +104,7 @@ export class DevToolsTabsComponent {
     if (supportedApis.dependencyInjection) {
       tabs.push('Injector Tree');
     }
-    if (supportedApis.routes && this.routerGraphEnabled() && this.routes().length > 0) {
+    if (this.routerGraphEnabled() && this.routes().length > 0) {
       tabs.push('Router Tree');
     }
     if (supportedApis.transferState && this.transferStateEnabled()) {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/route-details-row.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/route-details-row.component.html
@@ -6,14 +6,14 @@
         ng-button
         size="compact"
         (click)="btnClick.emit('')"
-        [disabled]="isRouteWithoutComponent()"
+        [disabled]="rowValue()?.toString().startsWith('Lazy ')"
       >
-        {{ data() }}
+        {{ rowValue() }}
       </button>
     }
     @case ('flag') {
-      <span [class]="data() ? 'tag-active' : 'tag-inactive'">
-        {{ data() }}
+      <span [class]="rowValue() ? 'tag-active' : 'tag-inactive'">
+        {{ rowValue() }}
       </span>
     }
     @case ('list') {
@@ -26,7 +26,13 @@
       </div>
     }
     @default {
-      <span class="row-data">{{ data() }}</span>
+      <span class="row-data">
+        @if (renderValueAsJson()) {
+          {{ rowValue() | json }}
+        } @else {
+          {{ rowValue() }}
+        }
+      </span>
     }
   }
 </td>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/route-details-row.component.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/route-details-row.component.spec.ts
@@ -24,6 +24,8 @@ describe('RouteDetailsRowComponent', () => {
     component = fixture.componentInstance;
 
     fixture.componentRef.setInput('label', 'Route Title');
+    fixture.componentRef.setInput('data', {value: 'Route Data'});
+    fixture.componentRef.setInput('dataKey', 'value');
     fixture.detectChanges();
   });
 
@@ -32,8 +34,8 @@ describe('RouteDetailsRowComponent', () => {
   });
 
   it('should render a label and text data', () => {
-    fixture.componentRef.setInput('label', 'Route Title');
-    fixture.componentRef.setInput('data', 'Route Data');
+    fixture.componentRef.setInput('data', {value: 'Route Data'});
+    fixture.componentRef.setInput('dataKey', 'value');
     fixture.detectChanges();
 
     const labelElement = fixture.debugElement.query(By.css('th'));
@@ -45,9 +47,9 @@ describe('RouteDetailsRowComponent', () => {
   });
 
   it('should render a label and flag data true', () => {
-    fixture.componentRef.setInput('label', 'Route Title');
     fixture.componentRef.setInput('type', 'flag');
-    fixture.componentRef.setInput('data', 'true');
+    fixture.componentRef.setInput('data', {isActive: true});
+    fixture.componentRef.setInput('dataKey', 'isActive');
     fixture.detectChanges();
 
     const labelElement = fixture.debugElement.query(By.css('th'));
@@ -59,9 +61,9 @@ describe('RouteDetailsRowComponent', () => {
   });
 
   it('should render a label and flag data false', () => {
-    fixture.componentRef.setInput('label', 'Route Title');
     fixture.componentRef.setInput('type', 'flag');
-    fixture.componentRef.setInput('data', false);
+    fixture.componentRef.setInput('data', {isLazy: false, isRedirect: false});
+    fixture.componentRef.setInput('dataKey', 'isLazy');
     fixture.detectChanges();
 
     const labelElement = fixture.debugElement.query(By.css('th'));
@@ -73,9 +75,9 @@ describe('RouteDetailsRowComponent', () => {
   });
 
   it('should render a label and chip data', () => {
-    fixture.componentRef.setInput('label', 'Route Title');
     fixture.componentRef.setInput('type', 'chip');
-    fixture.componentRef.setInput('data', 'Component Name');
+    fixture.componentRef.setInput('data', {name: 'Component Name'});
+    fixture.componentRef.setInput('dataKey', 'name');
     fixture.detectChanges();
 
     const labelElement = fixture.debugElement.query(By.css('th'));
@@ -87,9 +89,9 @@ describe('RouteDetailsRowComponent', () => {
   });
 
   it('should render a label and chip data disabled', () => {
-    fixture.componentRef.setInput('label', 'Route Title');
     fixture.componentRef.setInput('type', 'chip');
-    fixture.componentRef.setInput('data', 'Lazy Component Name');
+    fixture.componentRef.setInput('data', {name: 'Lazy Component Name'});
+    fixture.componentRef.setInput('dataKey', 'name');
     fixture.detectChanges();
 
     const labelElement = fixture.debugElement.query(By.css('th'));
@@ -102,9 +104,9 @@ describe('RouteDetailsRowComponent', () => {
   });
 
   it('should render a label and list data', () => {
-    fixture.componentRef.setInput('label', 'Route Title');
     fixture.componentRef.setInput('type', 'list');
-    fixture.componentRef.setInput('data', ['Guard 1', 'Guard 2']);
+    fixture.componentRef.setInput('data', {providers: ['Guard 1', 'Guard 2']});
+    fixture.componentRef.setInput('dataKey', 'providers');
     fixture.detectChanges();
 
     const labelElement = fixture.debugElement.query(By.css('th'));

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/route-details-row.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/route-details-row.component.ts
@@ -8,31 +8,37 @@
 
 import {Component, computed, input, output, ChangeDetectionStrategy} from '@angular/core';
 import {ButtonComponent} from '../../shared/button/button.component';
+import {JsonPipe} from '@angular/common';
+import {RouterTreeNode} from './router-tree-fns';
 
 export type RowType = 'text' | 'chip' | 'flag' | 'list';
 
 @Component({
+  standalone: true,
   selector: '[ng-route-details-row]',
   templateUrl: './route-details-row.component.html',
   styleUrls: ['./route-details-row.component.scss'],
-  imports: [ButtonComponent],
+  imports: [ButtonComponent, JsonPipe],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RouteDetailsRowComponent {
   readonly label = input.required<string>();
-  readonly data = input<string | boolean | string[]>();
+  readonly data = input.required<RouterTreeNode>();
+  readonly dataKey = input.required<string>();
+  readonly renderValueAsJson = input<boolean>(false);
   readonly type = input<RowType>('text');
 
   readonly btnClick = output<string>();
 
-  readonly dataArray = computed(() => {
-    return this.data() as string[];
+  readonly rowValue = computed(() => {
+    return this.data()[this.dataKey() as keyof RouterTreeNode];
   });
 
-  // Lazy and redirecting routes do not have a component associated with them.
-  // We need to disable the button click event for these routes.
-  readonly isRouteWithoutComponent = computed(
-    () =>
-      this.data()?.toString().includes('Lazy') || this.data()?.toString().includes('redirecting'),
-  );
+  readonly dataArray = computed(() => {
+    if (!this.data() || !this.dataKey()) {
+      return [];
+    }
+
+    return this.rowValue();
+  });
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.html
@@ -1,117 +1,162 @@
-<div class="filter">
-  <input
-    #searchInput
-    (input)="searchRoutes($event.target.value)"
-    placeholder="Search routes"
-    class="ng-input filter-input"
-  />
-  <div class="show-full-path">
-    <input id="show-full-path" type="checkbox" (change)="togglePathSettings()" />
-    <label for="show-full-path">Show full path</label>
+@if (routerDebugApiSupport()) {
+  <div class="filter">
+    <input
+      #searchInput
+      (input)="searchRoutes($event.target.value)"
+      placeholder="Search routes"
+      class="ng-input filter-input"
+    />
+    <div class="show-full-path">
+      <input id="show-full-path" type="checkbox" (change)="togglePathSettings()" />
+      <label for="show-full-path">Show full path</label>
+    </div>
   </div>
-</div>
-<as-split unit="percent" direction="horizontal" [gutterSize]="9" class="visualization">
-  <aside class="legend" aria-hidden="true">
-    <ul>
-      <li class="eager">Eager-loaded route</li>
-      <li class="lazy">Lazy-loaded route</li>
-      <li class="active">Active route</li>
-    </ul>
-  </aside>
-  <as-split-area size="70">
-    <as-split unit="percent" direction="vertical" [gutterSize]="9">
-      <as-split-area size="100">
-        <ng-tree-visualizer-host #routerTree a11yTitle="Router tree visualization" />
-      </as-split-area>
-    </as-split>
-  </as-split-area>
 
-  @let route = selectedRoute();
-
-  @if (route && route.data) {
-    <as-split-area size="30" minSize="20">
-      <div class="side-pane">
-        <h2 class="router-title">Routes Details</h2>
-        <button ng-button btnType="icon" class="close-btn" (click)="selectedRoute.set(null)">
-          <mat-icon>close</mat-icon>
-        </button>
-
-        <!-- TODO: Convert to a description list (<dl>) -->
-        <table class="ng-table">
-          <tr
-            ng-route-details-row
-            label="Path"
-            type="chip"
-            [data]="route.data.path"
-            (btnClick)="navigateRoute(route)"
-          ></tr>
-          <tr
-            ng-route-details-row
-            label="Component"
-            type="chip"
-            [data]="route.data.component"
-            (btnClick)="viewComponentSource(route.data.component)"
-          ></tr>
-          @if (route.data.pathMatch) {
-            <tr ng-route-details-row label="Path Match" [data]="route.data.pathMatch"></tr>
-          }
-          @if (route?.data?.data?.length > 0) {
-            <tr ng-route-details-row label="Data" [data]="route.data.data | json"></tr>
-          }
-          @if (route.data.canActivateGuards && route.data.canActivateGuards.length > 0) {
-            <tr
-              ng-route-details-row
-              label="Can Activate Guards"
-              type="list"
-              [data]="route.data.canActivateGuards"
-              (btnClick)="viewSourceFromRouter($event, 'canActivate')"
-            ></tr>
-          }
-          @if (route.data.canActivateChildGuards && route.data.canActivateChildGuards.length > 0) {
-            <tr
-              ng-route-details-row
-              label="Can Activate Child Guards"
-              type="list"
-              [data]="route.data.canActivateChildGuards"
-              (btnClick)="viewSourceFromRouter($event, 'canActivateChild')"
-            ></tr>
-          }
-          @if (route.data.canDeactivateGuards && route.data.canDeactivateGuards.length > 0) {
-            <tr
-              ng-route-details-row
-              label="Can DeActivate Guards"
-              type="list"
-              [data]="route.data.canDeactivateGuards"
-              (btnClick)="viewSourceFromRouter($event, 'canDeactivate')"
-            ></tr>
-          }
-          @if (route.data.canMatchGuards && route.data.canMatchGuards.length > 0) {
-            <tr
-              ng-route-details-row
-              label="Can Match Guards"
-              type="list"
-              [data]="route.data.canMatchGuards"
-              (btnClick)="viewSourceFromRouter($event, 'canMatch')"
-            ></tr>
-          }
-
-          @if (route.data.providers && route.data.providers.length > 0) {
-            <tr
-              ng-route-details-row
-              label="Providers"
-              type="list"
-              [data]="route.data.providers"
-              (btnClick)="viewSourceFromRouter($event, 'providers')"
-            ></tr>
-          }
-          @if (route.data.title) {
-            <tr ng-route-details-row label="Title" [data]="route.data.title"></tr>
-          }
-          <tr ng-route-details-row label="Active" type="flag" [data]="route.data.isActive"></tr>
-          <tr ng-route-details-row label="Auxiliary" type="flag" [data]="route.data.isAux"></tr>
-          <tr ng-route-details-row label="Lazy" type="flag" [data]="route.data.isLazy"></tr>
-        </table>
-      </div>
+  <as-split unit="percent" direction="horizontal" [gutterSize]="9" class="visualization">
+    <aside class="legend" aria-hidden="true">
+      <ul>
+        <li class="eager">Eager-loaded route</li>
+        <li class="lazy">Lazy-loaded route</li>
+        <li class="active">Active route</li>
+      </ul>
+    </aside>
+    <as-split-area size="70">
+      <as-split unit="percent" direction="vertical" [gutterSize]="9">
+        <as-split-area size="100">
+          <ng-tree-visualizer-host #routerTree a11yTitle="Router tree visualization" />
+        </as-split-area>
+      </as-split>
     </as-split-area>
-  }
-</as-split>
+
+    @let route = selectedRoute();
+    @let data = routeData();
+
+    @if (route && data) {
+      <as-split-area size="30" minSize="20">
+        <div class="side-pane">
+          <h2 class="router-title">Routes Details</h2>
+          <button ng-button btnType="icon" class="close-btn" (click)="selectedRoute.set(null)">
+            <mat-icon>close</mat-icon>
+          </button>
+
+          <!-- TODO: Convert to a description list (<dl>) -->
+          <table class="ng-table">
+            <tr
+              ng-route-details-row
+              label="Path"
+              type="chip"
+              dataKey="path"
+              [data]="data"
+              (btnClick)="navigateRoute(route)"
+            ></tr>
+
+            <tr
+              ng-route-details-row
+              label="Component"
+              type="chip"
+              dataKey="component"
+              [data]="data"
+              (btnClick)="viewComponentSource(data.component)"
+            ></tr>
+            @if (data.pathMatch) {
+              <tr ng-route-details-row label="Path Match" dataKey="pathMatch" [data]="data"></tr>
+            }
+            @if (route?.data?.data?.length > 0) {
+              <tr
+                ng-route-details-row
+                label="Data"
+                [renderValueAsJson]="true"
+                dataKey="data"
+                [data]="data"
+              ></tr>
+            }
+            @if (data.canActivateGuards && data.canActivateGuards.length > 0) {
+              <tr
+                ng-route-details-row
+                label="Can Activate Guards"
+                type="list"
+                dataKey="canActivateGuards"
+                [data]="data"
+                (btnClick)="viewSourceFromRouter($event, 'canActivate')"
+              ></tr>
+            }
+            @if (data.canActivateChildGuards && data.canActivateChildGuards.length > 0) {
+              <tr
+                ng-route-details-row
+                label="Can Activate Child Guards"
+                type="list"
+                dataKey="canActivateChildGuards"
+                [data]="data"
+                (btnClick)="viewSourceFromRouter($event, 'canActivateChild')"
+              ></tr>
+            }
+            @if (data.canDeactivateGuards && data.canDeactivateGuards.length > 0) {
+              <tr
+                ng-route-details-row
+                label="Can DeActivate Guards"
+                type="list"
+                dataKey="canDeactivateGuards"
+                [data]="data"
+                (btnClick)="viewSourceFromRouter($event, 'canDeactivate')"
+              ></tr>
+            }
+            @if (data.canMatchGuards && data.canMatchGuards.length > 0) {
+              <tr
+                ng-route-details-row
+                label="Can Match Guards"
+                type="list"
+                dataKey="canMatchGuards"
+                [data]="data"
+                (btnClick)="viewSourceFromRouter($event, 'canMatch')"
+              ></tr>
+            }
+
+            @if (data.providers && data.providers.length > 0) {
+              <tr
+                ng-route-details-row
+                label="Providers"
+                type="list"
+                dataKey="providers"
+                [data]="data"
+                (btnClick)="viewSourceFromRouter($event, 'providers')"
+              ></tr>
+            }
+            @if (data.title) {
+              <tr ng-route-details-row label="Title" dataKey="title" [data]="data"></tr>
+            }
+            <tr
+              ng-route-details-row
+              label="Active"
+              type="flag"
+              dataKey="isActive"
+              [data]="data"
+            ></tr>
+            <tr
+              ng-route-details-row
+              label="Auxiliary"
+              type="flag"
+              dataKey="isAux"
+              [data]="data"
+            ></tr>
+            <tr ng-route-details-row label="Lazy" type="flag" dataKey="isLazy" [data]="data"></tr>
+            <tr
+              ng-route-details-row
+              label="Redirecting"
+              type="flag"
+              dataKey="isRedirect"
+              [data]="data"
+            ></tr>
+          </table>
+        </div>
+      </as-split-area>
+    }
+  </as-split>
+} @else {
+  <div class="unsupported-version">
+    <p>
+      Router tree visualization is available for Angular applications using the latest Angular
+      20.2.x release and above. Please upgrade your application to Angular 20.2.x or newer to use
+      this feature.
+    </p>
+  </div>
+}

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.scss
@@ -104,3 +104,8 @@
     }
   }
 }
+
+.unsupported-version {
+  width: 50%;
+  margin: auto;
+}

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.spec.ts
@@ -40,41 +40,64 @@ describe('RouterTreeComponent', () => {
 
     fixture = TestBed.createComponent(RouterTreeComponent);
     component = fixture.componentInstance;
-
-    fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
-
-  it('should call application operations viewSourceFromRouter', () => {
-    component.viewSourceFromRouter('routeActiveGuard', 'guard');
-    expect(applicationOperationsSpy.viewSourceFromRouter).toHaveBeenCalledTimes(1);
-    expect(applicationOperationsSpy.viewSourceFromRouter).toHaveBeenCalledWith(
-      'routeActiveGuard',
-      'guard',
-      frameManager.selectedFrame()!,
-    );
-  });
-
-  it('should call application operations viewComponentSource', () => {
-    component.viewComponentSource('HomeComponent');
-    expect(applicationOperationsSpy.viewSourceFromRouter).toHaveBeenCalledTimes(1);
-    expect(applicationOperationsSpy.viewSourceFromRouter).toHaveBeenCalledWith(
-      'HomeComponent',
-      'component',
-      frameManager.selectedFrame()!,
-    );
-  });
-
-  it('should call emit navigateRoute', () => {
-    component.navigateRoute({
-      data: {
-        path: '/home',
-      },
+  describe('router tree apis supported', () => {
+    beforeEach(async () => {
+      fixture.componentRef.setInput('routerDebugApiSupport', true);
+      fixture.detectChanges();
     });
-    expect(messageBus.emit).toHaveBeenCalledTimes(1);
-    expect(messageBus.emit).toHaveBeenCalledWith('navigateRoute', ['/home']);
+
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should call application operations viewSourceFromRouter', () => {
+      component.viewSourceFromRouter('routeActiveGuard', 'guard');
+      expect(applicationOperationsSpy.viewSourceFromRouter).toHaveBeenCalledTimes(1);
+      expect(applicationOperationsSpy.viewSourceFromRouter).toHaveBeenCalledWith(
+        'routeActiveGuard',
+        'guard',
+        frameManager.selectedFrame()!,
+      );
+    });
+
+    it('should call application operations viewComponentSource', () => {
+      component.viewComponentSource('HomeComponent');
+      expect(applicationOperationsSpy.viewSourceFromRouter).toHaveBeenCalledTimes(1);
+      expect(applicationOperationsSpy.viewSourceFromRouter).toHaveBeenCalledWith(
+        'HomeComponent',
+        'component',
+        frameManager.selectedFrame()!,
+      );
+    });
+
+    it('should call emit navigateRoute', () => {
+      component.navigateRoute({
+        data: {
+          path: '/home',
+        },
+      });
+      expect(messageBus.emit).toHaveBeenCalledTimes(1);
+      expect(messageBus.emit).toHaveBeenCalledWith('navigateRoute', ['/home']);
+    });
+  });
+
+  describe('router tree apis not supported', () => {
+    beforeEach(async () => {
+      fixture.componentRef.setInput('routerDebugApiSupport', false);
+      fixture.detectChanges();
+    });
+
+    it('should show unsupported version message when routerDebugApiSupport is false', () => {
+      fixture.componentRef.setInput('routerDebugApiSupport', false);
+      fixture.detectChanges();
+
+      const unsupportedMsg = fixture.nativeElement.querySelector('.unsupported-version');
+      expect(unsupportedMsg).toBeTruthy();
+      expect(unsupportedMsg.textContent).toContain(
+        'Router tree visualization is available for Angular applications using the latest Angular 20.2.x release and above.',
+      );
+    });
   });
 });

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -318,6 +318,7 @@ export interface Route {
   isActive: boolean;
   isAux: boolean;
   isLazy: boolean;
+  isRedirect: boolean;
 }
 
 export interface AngularDetection {

--- a/packages/core/src/render3/util/global_utils.ts
+++ b/packages/core/src/render3/util/global_utils.ts
@@ -59,8 +59,10 @@ export const GLOBAL_PUBLISH_EXPANDO_KEY = 'ng';
 // Typing for externally published global util functions
 // Ideally we should be able to use `NgGlobalPublishUtils` using declaration merging but that doesn't work with API extractor yet.
 // Have included the typings to have type safety when working with editors that support it (VSCode).
-interface NgGlobalPublishUtils {
+export interface ExternalGlobalUtils {
   ɵgetLoadedRoutes(route: any): any;
+  ɵnavigateByUrl(router: any, url: string): any;
+  ɵgetRouterInstance(injector: any): any;
 }
 
 const globalUtilsFunctions = {
@@ -93,7 +95,6 @@ const globalUtilsFunctions = {
   'enableProfiling': enableProfiling,
 };
 type CoreGlobalUtilsFunctions = keyof typeof globalUtilsFunctions;
-type ExternalGlobalUtilsFunctions = keyof NgGlobalPublishUtils;
 
 let _published = false;
 /**
@@ -148,15 +149,15 @@ export type FrameworkAgnosticGlobalUtils = Omit<
   'getDirectiveMetadata'
 > & {
   getDirectiveMetadata(directiveOrComponentInstance: any): DirectiveDebugMetadata | null;
-};
+} & ExternalGlobalUtils;
 
 /**
  * Publishes the given function to `window.ng` from package other than @angular/core
  * So that it can be used from the browser console when an application is not in production.
  */
-export function publishExternalGlobalUtil<K extends ExternalGlobalUtilsFunctions>(
+export function publishExternalGlobalUtil<K extends keyof ExternalGlobalUtils>(
   name: K,
-  fn: NgGlobalPublishUtils[K],
+  fn: ExternalGlobalUtils[K],
 ): void {
   publishUtil(name, fn);
 }

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -29,12 +29,13 @@ import {
   Type,
   ɵperformanceMarkFeature as performanceMarkFeature,
   ɵIS_ENABLED_BLOCKING_INITIAL_NAVIGATION as IS_ENABLED_BLOCKING_INITIAL_NAVIGATION,
+  ɵpublishExternalGlobalUtil,
 } from '@angular/core';
 import {of, Subject} from 'rxjs';
 
 import {INPUT_BINDER, RoutedComponentInputBinder} from './directives/router_outlet';
 import {Event, NavigationError, stringifyEvent} from './events';
-import {RedirectCommand, Routes} from './models';
+import {RedirectCommand, Route, Routes} from './models';
 import {NAVIGATION_ERROR_HANDLER, NavigationTransitions} from './navigation_transition';
 import {Router} from './router';
 import {InMemoryScrollingOptions, ROUTER_CONFIGURATION, RouterConfigOptions} from './router_config';
@@ -50,6 +51,7 @@ import {
   VIEW_TRANSITION_OPTIONS,
   ViewTransitionsFeatureOptions,
 } from './utils/view_transition';
+import {getLoadedRoutes, getRouterInstance, navigateByUrl} from './router_devtools';
 
 /**
  * Sets up providers necessary to enable `Router` functionality for the application.
@@ -88,6 +90,13 @@ import {
  * @returns A set of providers to setup a Router.
  */
 export function provideRouter(routes: Routes, ...features: RouterFeatures[]): EnvironmentProviders {
+  if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    // Publish this util when the router is provided so that the devtools can use it.
+    ɵpublishExternalGlobalUtil('ɵgetLoadedRoutes', getLoadedRoutes);
+    ɵpublishExternalGlobalUtil('ɵgetRouterInstance', getRouterInstance);
+    ɵpublishExternalGlobalUtil('ɵnavigateByUrl', navigateByUrl);
+  }
+
   return makeEnvironmentProviders([
     {provide: ROUTES, multi: true, useValue: routes},
     typeof ngDevMode === 'undefined' || ngDevMode

--- a/packages/router/src/router_devtools.ts
+++ b/packages/router/src/router_devtools.ts
@@ -6,11 +6,31 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ɵpublishExternalGlobalUtil} from '@angular/core';
+import {Injector} from '@angular/core';
+import {Router} from './router';
 import {Route} from './models';
 
+/**
+ * Returns the loaded routes for a given route.
+ */
 export function getLoadedRoutes(route: Route): Route[] | undefined {
   return route._loadedRoutes;
 }
 
-ɵpublishExternalGlobalUtil('ɵgetLoadedRoutes', getLoadedRoutes);
+/**
+ * Returns the Router instance from the given injector, or null if not available.
+ */
+export function getRouterInstance(injector: Injector): Router | null {
+  return injector.get(Router, null, {optional: true});
+}
+
+/**
+ * Navigates the given router to the specified URL.
+ * Throws if the provided router is not an Angular Router.
+ */
+export function navigateByUrl(router: Router, url: string): Promise<boolean> {
+  if (!(router instanceof Router)) {
+    throw new Error('The provided router is not an Angular Router.');
+  }
+  return router.navigateByUrl(url);
+}

--- a/packages/router/test/router_devtools.spec.ts
+++ b/packages/router/test/router_devtools.spec.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component} from '@angular/core';
+import {Component, Injector} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {Router, RouterModule} from '../index';
-import {getLoadedRoutes} from '../src/router_devtools';
+import {getLoadedRoutes, getRouterInstance, navigateByUrl} from '../src/router_devtools';
 
 @Component({template: '<div>simple standalone</div>'})
 export class SimpleStandaloneComponent {}
@@ -70,5 +70,39 @@ describe('router_devtools', () => {
     const loadedRoutes = getLoadedRoutes(router.config[0]);
     const loadedPath = loadedRoutes && loadedRoutes[0].path;
     expect(loadedPath).toEqual(undefined);
+  });
+
+  describe('getRouterInstance', () => {
+    it('should return the Router instance from the injector', () => {
+      TestBed.configureTestingModule({
+        imports: [RouterModule.forRoot([])],
+      });
+      const injector = TestBed.inject(Injector);
+      const router = TestBed.inject(Router);
+      expect(getRouterInstance(injector)).toBe(router);
+    });
+
+    it('should return null if Router is not provided', () => {
+      const injector = Injector.create({providers: []});
+      expect(getRouterInstance(injector)).toBeNull();
+    });
+  });
+
+  describe('navigateByUrl', () => {
+    it('should navigate to the given url', async () => {
+      TestBed.configureTestingModule({
+        imports: [RouterModule.forRoot([{path: 'foo', component: SimpleStandaloneComponent}])],
+      });
+      const router = TestBed.inject(Router);
+      const result = await navigateByUrl(router, '/foo');
+      expect(result).toBeTrue();
+      expect(router.url).toBe('/foo');
+    });
+
+    it('should throw if not given a Router instance', async () => {
+      expect(() => navigateByUrl({} as unknown as Router, '/foo')).toThrowError(
+        'The provided router is not an Angular Router.',
+      );
+    });
   });
 });


### PR DESCRIPTION
Addresses some cleanup items for the router tree:

- No longer loads router ng global APIs as a side effect of importing the router. Rather this is now a runtime step that occurs when provideRouter is called.
- No longer depends on router.navigateByUrl in Angular DevTools. There is now a dedicated global util for this
- Find router instance logic no longer depends on token name
- Prevents navigating to lazy or redirect routes (these don't have an associated component)
- Feature detects the new debug APIs and disables router tree functionality if they are not present

