### PR TITLE
fix(compiler): incorrect spans for AST inside input value with leading space

### DIFF
--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -697,8 +697,8 @@ class HtmlAstToIvyAst implements html.Visitor {
     const value = attribute.value;
     const srcSpan = attribute.sourceSpan;
     const absoluteOffset = attribute.valueSpan
-      ? attribute.valueSpan.start.offset
-      : srcSpan.start.offset;
+      ? attribute.valueSpan.fullStart.offset
+      : srcSpan.fullStart.offset;
 
     function createKeySpan(srcSpan: ParseSourceSpan, prefix: string, identifier: string) {
       // We need to adjust the start location for the keySpan to account for the removed 'data-'

--- a/packages/compiler/test/render3/r3_ast_spans_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_spans_spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {ASTWithSource} from '../../src/expression_parser/ast';
 import {ParseSourceSpan} from '../../src/parse_util';
 import * as t from '../../src/render3/r3_ast';
 
@@ -408,6 +409,24 @@ describe('R3 AST source spans', () => {
         ['Element', '<div @animation></div>', '<div @animation>', '</div>'],
         ['BoundAttribute', '@animation', 'animation', '<empty>'],
       ]);
+    });
+
+    it('should not throw off span of value in bound attribute when leading spaces are present', () => {
+      const assertValueSpan = (template: string, start: number, end: number) => {
+        const result = parse(template);
+        const boundAttribute = (result.nodes[0] as t.Element).inputs[0];
+        const span = (boundAttribute.value as ASTWithSource).ast.sourceSpan;
+
+        expect(span.start).toBe(start);
+        expect(span.end).toBe(end);
+      };
+
+      assertValueSpan('<a [b]="helloWorld"></a>', 8, 18);
+      assertValueSpan('<a [b]=" helloWorld"></a>', 9, 19);
+      assertValueSpan('<a [b]="  helloWorld"></a>', 10, 20);
+      assertValueSpan('<a [b]="   helloWorld"></a>', 11, 21);
+      assertValueSpan('<a [b]="    helloWorld"></a>', 12, 22);
+      assertValueSpan('<a [b]="                                          helloWorld"></a>', 50, 60);
     });
   });
 


### PR DESCRIPTION
When parsing expressions inside a bound attribute, we offset all of its spans by an `absoluteOffset` in order to get the right spans in the source file. The offset was incorrect when parsing an attribute with leading spaces during the construction of the Ivy AST, because of the combination of:
1. We were setting the offset by looking at `valueSpan.start`.
2. The Ivy parser sets `leadingTriviaChars: [' ', '\n']` which means that spaces and new lines will be ignored in the `sourceSpan.start`.

These changes resolve the issue by using `valueSpan.fullStart` which includes the leading spaces.

Fixes #63069.
