### PR TITLE
refactor(core): remove temporary resource setter function.

### DIFF
--- a/packages/core/src/resource/index.ts
+++ b/packages/core/src/resource/index.ts
@@ -7,4 +7,4 @@
  */
 
 export * from './api';
-export {resource, setResourceValueThrowsErrors as ɵsetResourceValueThrowsErrors} from './resource';
+export {resource} from './resource';

--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -83,16 +83,6 @@ export function resource<T, R>(options: ResourceOptions<T, R>): ResourceRef<T | 
   );
 }
 
-/**
- * Private helper function to set the default behavior of `Resource.value()` when the resource is
- * in the error state.
- *
- * This function is intented to be temporary to help migrate G3 code to the new throwing behavior.
- */
-export function setResourceValueThrowsErrors(value: boolean): void {
-  RESOURCE_VALUE_THROWS_ERRORS_DEFAULT = value;
-}
-
 type ResourceInternalStatus = 'idle' | 'loading' | 'resolved' | 'local';
 
 /**


### PR DESCRIPTION
Now that G3 has been fully migrated to the new throwing behavior, we don't need that setter anymore.
