### PR TITLE
 fix(core/schematics): resolve component import by exact specifier in route lazy-loading migration

### DIFF
--- a/packages/core/schematics/ng-generate/route-lazy-loading/to-lazy-routes.ts
+++ b/packages/core/schematics/ng-generate/route-lazy-loading/to-lazy-routes.ts
@@ -278,9 +278,26 @@ function migrateRoute(
     return routeMigrationResults;
   }
 
-  const componentImport = route.routeFileImports.find((importDecl) =>
-    importDecl.importClause?.getText().includes(componentClassName),
-  )!;
+  // Resolve the import that provides this component by exact specifier match
+  // Handles default imports, named imports, and aliases (e.g., `import { Foo as Bar }`).
+  const componentImport = route.routeFileImports.find((importDecl) => {
+    const clause = importDecl.importClause;
+    if (!clause) return false;
+    // Default import: import FooComponent from '...'
+    if (clause.name && ts.isIdentifier(clause.name) && clause.name.text === componentClassName) {
+      return true;
+    }
+    // Named imports: import { FooComponent } from '...'
+    const named = clause.namedBindings;
+    if (named && ts.isNamedImports(named)) {
+      return named.elements.some((el: ts.ImportSpecifier) => {
+        // Support alias: import { Foo as Bar }
+        const importedName = el.propertyName ? el.propertyName.text : el.name.text;
+        return importedName === componentClassName;
+      });
+    }
+    return false;
+  })!;
 
   // remove single and double quotes from the import path
   let componentImportPath = ts.isStringLiteral(componentImport?.moduleSpecifier)

--- a/packages/core/schematics/test/standalone_routes_spec.ts
+++ b/packages/core/schematics/test/standalone_routes_spec.ts
@@ -850,6 +850,59 @@ describe('route lazy loading migration', () => {
     );
   });
 
+  it('should resolve the correct import when one component name is a suffix of another', async () => {
+    writeFile(
+      'app.module.ts',
+      `
+      import {NgModule} from '@angular/core';
+      import {RouterModule} from '@angular/router';
+      import {FooBarComponent} from './foo-bar';
+      import {BarComponent} from './bar';
+
+      @NgModule({
+        imports: [RouterModule.forRoot([
+          {path: 'foo-bar', component: FooBarComponent},
+          {path: 'bar', component: BarComponent},
+        ])],
+      })
+      export class AppModule {}
+    `,
+    );
+
+    writeFile(
+      'foo-bar.ts',
+      `
+      import {Component} from '@angular/core';
+      @Component({template: 'foo bar', standalone: true})
+      export class FooBarComponent {}
+    `,
+    );
+
+    writeFile(
+      'bar.ts',
+      `
+      import {Component} from '@angular/core';
+      @Component({template: 'bar', standalone: true})
+      export class BarComponent {}
+    `,
+    );
+
+    await runMigration('route-lazy-loading');
+
+    const result = stripWhitespace(tree.readContent('app.module.ts'));
+
+    expect(result).toContain(
+      stripWhitespace(
+        `{path: 'foo-bar', loadComponent: () => import('./foo-bar').then(m => m.FooBarComponent)}`,
+      ),
+    );
+    expect(result).toContain(
+      stripWhitespace(
+        `{path: 'bar', loadComponent: () => import('./bar').then(m => m.BarComponent)}`,
+      ),
+    );
+  });
+
   // TODO: support multiple imports of components
   // ex import * as Components from './components';
   // export const MenuRoutes: Routes = [


### PR DESCRIPTION
## Description

Avoid substring matching on `importClause.getText()` which caused suffix collisions (e.g., `BarComponent` vs `FooBarComponent`).
Use AST-based matching for default and named (including aliased) imports to reliably resolve the correct import path when generating loadComponent.

## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The route-lazy-loading schematic resolves the component’s import by checking: 

```importDecl.importClause?.getText().includes(componentClassName)```

 This can incorrectly match a different component whose name contains the target as a suffix/prefix
 (e.g., `BarComponent` vs `FooBarComponent`), leading to the wrong module path in the generated loadComponent.

## Video:

https://github.com/user-attachments/assets/601feaae-1f21-4284-80d1-1c6171ba1beb



## Steps to Repro:

```ng g @angular/core:route-lazy-loading --path=./```

on this project:

https://stackblitz.com/edit/stackblitz-starters-kfhnxzsv?file=src%2Froutes.ts


## What is the new behavior?

Resolve the import by exact specifier using the TS AST:

* Default import: `clause.name.text === componentClassName`
* Named imports: `elements.some(el => (el.propertyName?.text ?? el.name.text) === componentClassName)` This eliminates false matches and generates the correct import path for loadComponent.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

