### PR TITLE
feat(docs-infra): add file explorer tree to the playground editor

### DIFF
--- a/adev/src/app/editor/code-editor/code-editor.component.html
+++ b/adev/src/app/editor/code-editor/code-editor.component.html
@@ -1,118 +1,146 @@
-<!-- Code Editor Tabs -->
-<div class="docs-code-editor-tabs">
-  <div class="adev-tabs-and-plus">
-    <mat-tab-group animationDuration="0ms" mat-stretch-tabs="false">
-      <!--
-        Hint: we would like to keep only one instance of #codeEditorWrapper,
-        that's why we're not placing this element as content of mat-tab, just to
-        not call another time init method from CodeMirrorEditor service.
-      -->
-      @for (file of files(); track file) {
-        <mat-tab #tab>
-          <ng-template mat-tab-label>
-            @if (tab.isActive && isRenamingFile()) {
-              <form
-                (submit)="renameFile($event, file.filename)"
-                (docsClickOutside)="closeRenameFile()"
+<!-- Sidebar -->
+<div class="activity-bar-container">
+  <div class="activity-bar">
+    <button
+      (click)="onToggleExplorer()"
+      [ngClass]="{'active': isExplorerExpanded()}"
+      type="button"
+      aria-label="Toggle source code pane"
+      matTooltip="Toggle source code pane"
+      matTooltipPosition="above"
+    >
+      <docs-icon class="active" [ngClass]="{'active': isExplorerExpanded()}"> folder </docs-icon>
+    </button>
+
+    <button
+      type="button"
+      aria-label="Open current code in editor in an online editor"
+      [cdkMenuTriggerFor]="launcherMenu"
+    >
+      <docs-icon>launch</docs-icon>
+    </button>
+
+    <!-- launcher dropdown window -->
+    <ng-template #launcherMenu>
+      <div class="adev-editor-splitview-button" cdkMenu>
+        <button cdkMenuItem (click)="openCurrentSolutionInFirebaseStudio()">
+          <span>Open in Firebase Studio </span>
+          <img
+            class="icon"
+            src="assets/images/tutorials/common/firebase-studio_logo.svg"
+            height="32"
+          />
+        </button>
+        <button cdkMenuItem (click)="openCurrentCodeInStackBlitz()">Open in StackBlitz</button>
+      </div>
+    </ng-template>
+    <button
+      type="button"
+      (click)="downloadCurrentCodeEditorState()"
+      aria-label="Download current source code"
+      matTooltip="Download current source code"
+      matTooltipPosition="above"
+    >
+      <docs-icon>download</docs-icon>
+    </button>
+  </div>
+
+  <as-split direction="horizontal" restrictMove="true" gutterSize="5">
+    @if (isExplorerExpanded()) {
+      <as-split-area class="adev-left-side" size="30">
+        <div class="explorer">
+          <div class="explorer-header">
+            @if (canCreateFile()) {
+              <button
+                class="adev-add-file"
+                (click)="onAddButtonClick()"
+                aria-label="Add a new file"
+                matTooltip="Add a new file"
+                matTooltipPosition="above"
               >
+                <docs-icon>add</docs-icon>
+              </button>
+            }
+          </div>
+          <div class="explorer-body">
+            @if (isCreatingFile()) {
+              <form (submit)="createFile($event)" class="explorer-item-wrapper">
+                <docs-icon class="file-icon">draft</docs-icon>
                 <input
-                  name="rename-file"
-                  class="adev-rename-file-input"
-                  #renameFileInput
+                  name="new-file"
+                  class="adev-new-file-input"
+                  #createFileInput
+                  (blur)="onDiscardFile()"
                   (keydown)="$event.stopPropagation()"
                 />
               </form>
-            } @else if (restrictedMode()) {
-              {{ file.filename.replace('src/app/', '') }}
-            } @else {
-              {{ file.filename.replace('src/', '') }}
             }
-
-            @if (tab.isActive && canRenameFile(file.filename)) {
-              <button
-                class="docs-rename-file"
-                aria-label="rename file"
-                matTooltip="Rename file"
-                matTooltipPosition="above"
-                (click)="onRenameButtonClick()"
+            <mat-tree #tree [childrenAccessor]="childrenAccessor" [dataSource]="fileTree()">
+              <mat-tree-node
+                class="explorer-item-wrapper"
+                [ngClass]="{'explorer-selected-item': activeFile() === file.name && !isCreatingFile()}"
+                #treeNode
+                (click)="onSetActiveFile(file.name)"
+                *matTreeNodeDef="let file; let index = $index"
+                matTreeNodeMinHeight="10"
               >
-                <docs-icon>edit</docs-icon>
-              </button>
-            }
-            @if (tab.isActive && canDeleteFile(file.filename)) {
-              <button
-                class="docs-delete-file"
-                aria-label="Delete file"
-                matTooltip="Delete file"
-                matTooltipPosition="above"
-                (click)="deleteFile(file.filename)"
-              >
-                <docs-icon>delete</docs-icon>
-              </button>
-            }
-          </ng-template>
-        </mat-tab>
-      }
-      @if (isCreatingFile()) {
-        <mat-tab>
-          <ng-template mat-tab-label>
-            <form (submit)="createFile($event)">
-              <input
-                name="new-file"
-                class="adev-new-file-input"
-                #createFileInput
-                (keydown)="$event.stopPropagation()"
-              />
-            </form>
-          </ng-template>
-        </mat-tab>
-      }
-    </mat-tab-group>
+                <docs-icon class="file-icon">draft</docs-icon>
 
-    @if (canCreateFile()) {
-      <button
-        class="adev-add-file"
-        (click)="onAddButtonClick()"
-        aria-label="Add a new file"
-        matTooltip="Add a new file"
-        matTooltipPosition="above"
-      >
-        <docs-icon>add</docs-icon>
-      </button>
+                <div class="explorer-item">
+                  @if (activeFile() === file.name && isRenamingFile()) {
+                    <form
+                      (submit)="renameFile($event, file.name)"
+                      (docsClickOutside)="closeRenameFile()"
+                    >
+                      <input
+                        name="rename-file"
+                        class="adev-rename-file-input"
+                        #renameFileInput
+                        (keydown)="$event.stopPropagation()"
+                      />
+                    </form>
+                  } @else if (restrictedMode()) {
+                    {{ file.name.replace('src/app/', '') }}
+                  } @else {
+                    {{ file.name.replace('src/', '') }}
+                  }
+                  <div class="explorer-item-actions">
+                    @if (activeFile() === file.name && canRenameFile(file.name)) {
+                      <button
+                        class="docs-rename-file"
+                        aria-label="rename file"
+                        matTooltip="Rename file"
+                        matTooltipPosition="above"
+                        (click)="onRenameButtonClick()"
+                      >
+                        <docs-icon>edit</docs-icon>
+                      </button>
+                    }
+                    @if (activeFile() === file.name && canDeleteFile(file.name)) {
+                      <button
+                        class="docs-delete-file"
+                        aria-label="Delete file"
+                        matTooltip="Delete file"
+                        matTooltipPosition="above"
+                        (click)="deleteFile(file.name)"
+                      >
+                        <docs-icon>delete</docs-icon>
+                      </button>
+                    }
+                  </div>
+                </div>
+              </mat-tree-node>
+            </mat-tree>
+          </div>
+        </div>
+      </as-split-area>
     }
-  </div>
-
-  <button
-    class="adev-editor-download-button"
-    type="button"
-    aria-label="Open current code in editor in an online editor"
-    [cdkMenuTriggerFor]="launcherMenu"
-  >
-    <docs-icon>launch</docs-icon>
-  </button>
-  <!-- launcher dropdown window -->
-  <ng-template #launcherMenu>
-    <div class="adev-editor-dropdown" cdkMenu>
-      <button cdkMenuItem (click)="openCurrentSolutionInFirebaseStudio()">
-        <span>Open in Firebase Studio </span>
-        <img class="icon" src="assets/images/tutorials/common/firebase-studio_logo.svg" height="32" />
-      </button>
-      <button cdkMenuItem (click)="openCurrentCodeInStackBlitz()">Open in StackBlitz</button>
-    </div>
-  </ng-template>
-  <button
-    class="adev-editor-download-button"
-    type="button"
-    (click)="downloadCurrentCodeEditorState()"
-    aria-label="Download current source code"
-    matTooltip="Download current source code"
-    matTooltipPosition="above"
-  >
-    <docs-icon>download</docs-icon>
-  </button>
+    <as-split-area class="adev-right-side" [size]="70">
+      <!-- Code Editor -->
+      <div #codeEditorWrapper class="adev-code-editor-wrapper"></div>
+    </as-split-area>
+  </as-split>
 </div>
-<!-- Code Editor -->
-<div #codeEditorWrapper class="adev-code-editor-wrapper"></div>
 
 @if (displayErrorsBox()) {
   <div class="adev-inline-errors-box">

--- a/adev/src/app/editor/code-editor/code-editor.component.html
+++ b/adev/src/app/editor/code-editor/code-editor.component.html
@@ -3,7 +3,7 @@
   <div class="activity-bar">
     <button
       (click)="onToggleExplorer()"
-      [ngClass]="{'active': isExplorerExpanded()}"
+      [class.active]="isExplorerExpanded()"
       type="button"
       aria-label="Toggle source code pane"
       matTooltip="Toggle source code pane"

--- a/adev/src/app/editor/code-editor/code-editor.component.html
+++ b/adev/src/app/editor/code-editor/code-editor.component.html
@@ -9,7 +9,7 @@
       matTooltip="Toggle source code pane"
       matTooltipPosition="above"
     >
-      <docs-icon class="active" [ngClass]="{'active': isExplorerExpanded()}"> folder </docs-icon>
+      <docs-icon [class.active]="isExplorerExpanded()"> folder </docs-icon>
     </button>
 
     <button
@@ -78,7 +78,7 @@
             <mat-tree #tree [childrenAccessor]="childrenAccessor" [dataSource]="fileTree()">
               <mat-tree-node
                 class="explorer-item-wrapper"
-                [ngClass]="{'explorer-selected-item': activeFile() === file.name && !isCreatingFile()}"
+                [class.explorer-selected-item]="activeFile() === file.name && !isCreatingFile()"
                 #treeNode
                 (click)="onSetActiveFile(file.name)"
                 *matTreeNodeDef="let file; let index = $index"

--- a/adev/src/app/editor/code-editor/code-editor.component.html
+++ b/adev/src/app/editor/code-editor/code-editor.component.html
@@ -22,7 +22,7 @@
 
     <!-- launcher dropdown window -->
     <ng-template #launcherMenu>
-      <div class="adev-editor-splitview-button" cdkMenu>
+      <div class="adev-editor-splitview-button adev-editor-dropdown" cdkMenu>
         <button cdkMenuItem (click)="openCurrentSolutionInFirebaseStudio()">
           <span>Open in Firebase Studio </span>
           <img

--- a/adev/src/app/editor/code-editor/code-editor.component.scss
+++ b/adev/src/app/editor/code-editor/code-editor.component.scss
@@ -65,17 +65,109 @@
   position: relative;
 }
 
-.docs-code-editor-tabs {
-  display: flex;
+.activity-bar-container {
+  height: 100%;
   background: var(--octonary-contrast);
-  border-block-end: 1px solid var(--senary-contrast);
-  transition: background 0.3s ease, border 0.3s ease;
+  display: flex;
+}
+.activity-bar{
+  padding-top: .5rem;
+  width: 48px;
+  height: 100%;
+  border-inline-end: 1px solid var(--senary-contrast);
+
+  button{
+    width: 3rem;
+    height: 3rem;
+    
+    docs-icon {
+      color: var(--gray-400);
+      transition: color 0.3s ease;
+      font-size: 1.5rem;
+    }
+
+    &.active {
+      border-left: 2px solid var(--gray-50);
+
+      docs-icon {
+        color: var(--gray-50)
+      }
+    }
+
+    &:hover{
+      docs-icon {
+        color: var(--gray-50)
+      }
+    }
+  }
+}
+.explorer{
+  width: 100%;
+  display: flex;
+  padding-top: .5rem;
+  display: flex;
+  flex-direction: column;
+}
+.explorer-header{
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+  border-bottom: 1px solid var(--senary-contrast);
+}
+.explorer-body{
+  padding-inline: 2px;
+  padding-top: .5rem;
+  padding-bottom: .5rem;
+
+  form {
+    display: flex;
+  }
 }
 
-.adev-tabs-and-plus {
+.explorer-item-wrapper{
+  min-height: 10px;
   display: flex;
-  width: calc(100% - 2.875rem * 2);
-  min-height: 48px;
+  align-items: center;
+  width: 100%;
+  cursor: pointer;
+  border: 1px solid transparent;
+  
+  .file-icon{
+    font-size: 1rem;
+    font-weight: 100;
+    color: var(--gray-400)
+  }
+
+  &:not(.selected-node):hover {
+    background-color: var(--gray-800);
+  }
+}
+
+.explorer-item,
+.adev-new-file-input,
+.adev-rename-file-input {
+  width: 100%;
+  height: 1.4rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-inline: .2rem;
+  font-size: .8rem;
+  color: var(--gray-300);
+  font-family: var(--code-font);
+}
+
+.explorer-selected-item,
+.adev-new-file-input,
+.adev-rename-file-input {
+  border: 1px solid var(--bright-blue);
+  background-color: var(--gray-700);
+  color: white;
+}
+
+.explorer-item-actions{
+  display: flex;
+  gap: .2rem;
 }
 
 .adev-add-file,
@@ -105,23 +197,15 @@
 
 .adev-new-file-input,
 .adev-rename-file-input {
-  color: var(--primary-contrast);
-  border: none;
-  border-radius: 0;
-  border-block-end: 1px solid var(--senary-contrast);
-  background: transparent;
   outline: none;
-  transition: color 0.3s ease;
-  &:focus {
-    background: transparent;
-    border-block-end: 1px solid var(--primary-contrast);
-  }
+  font-size: 1rem;
 }
 
 .adev-code-editor-wrapper {
   // adjust height for terminal tabs
   // so that scroll bar & content do not render under tabs
-  height: calc(100% - 49px);
+  height: 100%;
+  width: 100%;
   transition: height 0.3s ease;
 
   &-hidden {
@@ -189,7 +273,7 @@
   docs-icon {
     color: var(--gray-400);
     transition: color 0.3s ease;
-    font-size: 1.3rem;
+    font-size: 2rem;
   }
 
   &:hover {

--- a/adev/src/app/editor/code-editor/code-editor.component.ts
+++ b/adev/src/app/editor/code-editor/code-editor.component.ts
@@ -105,7 +105,7 @@ export class CodeEditor {
   readonly errors = signal<DiagnosticWithLocation[]>([]);
   readonly files = this.codeMirrorEditor.openFiles;
   readonly fileTree = computed(() => this.files().map( editorFile => ({name: editorFile.filename}))
-  )
+  );
   readonly activeFile = signal<string>('');
   readonly isCreatingFile = signal<boolean>(false);
   readonly isRenamingFile = signal<boolean>(false);
@@ -185,7 +185,7 @@ export class CodeEditor {
   }
 
   onToggleExplorer() {
-    this.isExplorerExpanded.update((oldState:boolean) => !oldState)
+    this.isExplorerExpanded.update((oldState:boolean) => !oldState);
   }
 
   onDiscardFile() {
@@ -250,7 +250,7 @@ export class CodeEditor {
       await this.codeMirrorEditor.createFile(newFile);
     }
 
-    this.activeFile.set('src/' + newFileInputValue)
+    this.activeFile.set('src/' + newFileInputValue);
     this.isCreatingFile.set(false);
   }
 

--- a/adev/src/app/editor/code-editor/code-editor.component.ts
+++ b/adev/src/app/editor/code-editor/code-editor.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CommonModule, Location} from '@angular/common';
+import {Location} from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -56,7 +56,6 @@ const ANGULAR_DEV = 'https://angular.dev';
   imports: [
     MatTreeModule,
     AngularSplitModule,
-    CommonModule,
     MatTooltip,
     IconComponent,
     ClickOutside,


### PR DESCRIPTION
replaced tabs with mat-tree to support nesting files under folders in the future.

resolves #52659 issue

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
currently Playgound uses tabs to show different files

Issue Number: #52659 


## What is the new behavior?
added a sidebar called the activity bar which includes a folder icon, when clicked, expands a the file explorer section.
the file explorer includes a header that allows creating new files, and the list of files which are created using the mat-tree component. the reason that the mat-tree component is choosen, is to create the support for future to to add folder creation capabilities.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
<img width="814" height="671" alt="image" src="https://github.com/user-attachments/assets/c2548c6c-da0c-48b1-a45c-20da2209753b" />
