### PR TITLE
feat(elements): add option to expose public methods in `NgElement`

### DIFF
--- a/adev/src/content/guide/elements.md
+++ b/adev/src/content/guide/elements.md
@@ -69,6 +69,34 @@ Component properties and logic maps directly into HTML attributes and the browse
 
 For more information, see Web Component documentation for [Creating custom events](https://developer.mozilla.org/docs/Web/Guide/Events/Creating_and_triggering_events#Creating_custom_events).
 
+## Exposing component methods
+
+In addition to mapping component inputs and outputs to HTML attributes and DOM events, you can also expose specific component methods to be callable directly on the custom element instance via the `exposedMethods` option of `createCustomElement()`.
+
+When you provide an array of method names in `exposedMethods`, each method will be proxied to the underlying Angular component instance once it is initialized. This allows host applications (including non-Angular ones) to interact with your component’s imperative API.
+
+```typescript
+const MyElement = createCustomElement(MyComponent, {
+  injector,
+  exposedMethods: ['open', 'close', 'toggle']
+});
+
+customElements.define('my-element', MyElement);
+```
+
+Now, when you add `<my-element>` to the DOM, you can call these methods directly:
+
+const el = document.querySelector('my-element');
+el.open();    // Calls MyComponent.open()
+el.toggle();  // Calls MyComponent.toggle()
+
+### Important notes
+
+- Methods listed in `exposedMethods` must exist on the component class
+- Calls can only be made on elements that are already attached to the DOM
+- The methods keep their original `this` context, so they can safely access other component properties and services.
+- This feature is intended for public API methods only; avoid exposing internal/private logic.
+
 ## Example: A Popup Service
 
 Previously, when you wanted to add a component to an application at runtime, you had to define a _dynamic component_, and then you would have to load it, attach it to an element in the DOM, and wire up all of the dependencies, change detection, and event handling.

--- a/goldens/public-api/elements/index.api.md
+++ b/goldens/public-api/elements/index.api.md
@@ -11,7 +11,7 @@ import { Type } from '@angular/core';
 import { Version } from '@angular/core';
 
 // @public
-export function createCustomElement<P>(component: Type<any>, config: NgElementConfig): NgElementConstructor<P>;
+export function createCustomElement<P, T = any, ExposedMethods extends ExtractPublicMethods<T> = never>(component: Type<T>, config: NgElementConfig<ExposedMethods>): NgElementConstructor<P & Pick<T, ExposedMethods>>;
 
 // @public
 export abstract class NgElement extends HTMLElement {
@@ -23,10 +23,11 @@ export abstract class NgElement extends HTMLElement {
 }
 
 // @public
-export interface NgElementConfig {
+export type NgElementConfig<ExposedMethods extends keyof any = keyof any> = {
     injector: Injector;
     strategyFactory?: NgElementStrategyFactory;
-}
+    exposedMethods?: ExposedMethods[];
+};
 
 // @public
 export interface NgElementConstructor<P> {
@@ -36,6 +37,8 @@ export interface NgElementConstructor<P> {
 
 // @public
 export interface NgElementStrategy {
+    // (undocumented)
+    applyMethod?(methodName: keyof any, args: any[]): any;
     // (undocumented)
     connect(element: HTMLElement): void;
     // (undocumented)

--- a/packages/elements/src/component-factory-strategy.ts
+++ b/packages/elements/src/component-factory-strategy.ts
@@ -193,6 +193,14 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
     });
   }
 
+  applyMethod(methodName: keyof any, args: any[]): any {
+    if (!this.componentRef) {
+      throw new Error('Component is detached from DOM');
+    }
+
+    return this.componentRef.instance[methodName].apply(this.componentRef.instance, args);
+  }
+
   /**
    * Creates a new component through the component factory with the provided element host and
    * sets up its initial inputs, listens for outputs changes, and runs an initial change detection.

--- a/packages/elements/src/element-strategy.ts
+++ b/packages/elements/src/element-strategy.ts
@@ -31,6 +31,7 @@ export interface NgElementStrategy {
   disconnect(): void;
   getInputValue(propName: string): any;
   setInputValue(propName: string, value: string, transform?: (value: any) => any): void;
+  applyMethod?(methodName: keyof any, args: any[]): any;
 }
 
 /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
No direct way to expose component methods to NgElement instance

Issue Number: #63090, #22114


## What is the new behavior?
Added `exposedMethods` option to allow direct calls component methods outside web element.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
