### PR TITLE
fix(docs-infra): put content in `<main>` element

### DIFF
--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
@@ -42,7 +42,7 @@ import {ExampleViewer} from '../example-viewer/example-viewer.component';
 
 const TOC_HOST_ELEMENT_NAME = 'docs-table-of-contents';
 export const ASSETS_EXAMPLES_PATH = 'assets/content/examples';
-export const DOCS_VIEWER_SELECTOR = 'docs-viewer';
+export const DOCS_VIEWER_SELECTOR = 'docs-viewer, main[docsViewer]';
 export const DOCS_CODE_SELECTOR = '.docs-code';
 export const DOCS_CODE_MUTLIFILE_SELECTOR = '.docs-code-multifile';
 // TODO: Update the branch/sha

--- a/adev/src/app/features/docs/docs.component.html
+++ b/adev/src/app/features/docs/docs.component.html
@@ -1,8 +1,7 @@
 @let docContent = this.docContent();
 @if (docContent) {
-  <docs-viewer
+  <main docsViewer
     class="docs-viewer"
     [docContent]="docContent.contents"
-    [hasToc]="true"
-  />
+    [hasToc]="true"></main>
 }

--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.html
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.html
@@ -1,9 +1,9 @@
 @if (docContent(); as docContent) {
-  <docs-viewer
+  <main docsViewer
     [docContent]="docContent.contents"
     [hasToc]="true"
     (contentLoaded)="onContentLoaded()"
-  />
+  ></main>
 }
 
 <div id="jump-msg" class="cdk-visually-hidden">Jump to details</div>

--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
@@ -10,19 +10,19 @@
   padding-bottom: var(--layout-padding);
 
 
-  //applying styles when TOC position got translated to the top right 
+  //applying styles when TOC position got translated to the top right
   @include mq.for-large-desktop-up {
     // take the available space except a reserved area for TOC
     width: calc(100% - 16rem);
   }
 
 
-  docs-viewer {
+  main {
     display: block;
     padding-inline: var(--layout-padding);
     width: 100%;
 
-    //applying styles when TOC position got translated to the top right 
+    //applying styles when TOC position got translated to the top right
     @include mq.for-large-desktop-up {
       // take the available space except a reserved area for TOC
       max-width: var(--page-width);

--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.spec.ts
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.spec.ts
@@ -64,7 +64,7 @@ describe('ApiReferenceDetailsPage', () => {
   it('should load the doc content', () => {
     expect(component.docContent()?.contents).toBeTruthy();
 
-    const docsViewer = fixture.nativeElement.querySelector('docs-viewer');
+    const docsViewer = fixture.nativeElement.querySelector('main');
     expect(docsViewer).toBeTruthy();
   });
 });

--- a/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.html
+++ b/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.html
@@ -1,5 +1,5 @@
 @if (docContent(); as docContent) {
-  <docs-viewer [docContent]="docContent.contents" [hasToc]="true" />
+  <main docsViewer [docContent]="docContent.contents" [hasToc]="true"></main>
 }
 
 <div id="jump-msg" class="cdk-visually-hidden">Jump to details</div>

--- a/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.scss
+++ b/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.scss
@@ -11,19 +11,19 @@
 
 
 
-  //applying styles when TOC position got translated to the top right 
+  //applying styles when TOC position got translated to the top right
   @include mq.for-large-desktop-up{
     // take the available space except a reserved area for TOC
     width: calc(100% - 16rem);
   }
 
 
-  docs-viewer {
+  main {
     display: block;
     padding-inline: var(--layout-padding);
     width: 100%;
 
-    //applying styles when TOC position got translated to the top right 
+    //applying styles when TOC position got translated to the top right
     @include mq.for-large-desktop-up{
       // take the available space except a reserved area for TOC
       max-width: var(--page-width);

--- a/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.spec.ts
+++ b/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.spec.ts
@@ -64,7 +64,7 @@ describe('CliReferenceDetailsPage', () => {
   it('should load the doc content', () => {
     expect(component.docContent()?.contents).toBeTruthy();
 
-    const docsViewer = fixture.nativeElement.querySelector('docs-viewer');
+    const docsViewer = fixture.nativeElement.querySelector('main');
     expect(docsViewer).toBeTruthy();
   });
 });

--- a/adev/src/app/features/tutorial/tutorial.component.html
+++ b/adev/src/app/features/tutorial/tutorial.component.html
@@ -7,10 +7,9 @@
 
       <!-- Tutorial Content -->
       @if (documentContent(); as documentContent) {
-        <docs-viewer
+        <main docsViewer
           [docContent]="documentContent"
-          class="docs-viewer docs-viewer-scroll-margin-large"
-        />
+          class="docs-viewer docs-viewer-scroll-margin-large"></main>
       }
     </div>
   }


### PR DESCRIPTION
This fix updates the adev `DocViewer` component to support rendering with the `main[docsViewer` selector so that the primary content for the page is inside of a `<main>` element (without introducing an extra DOM element).