### PR TITLE
fix: ensure JIT transforms with queries work with closure property renaming

### DIFF
--- a/packages/compiler-cli/src/ngtsc/transform/jit/src/initializer_api_transforms/query_functions.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/jit/src/initializer_api_transforms/query_functions.ts
@@ -21,10 +21,10 @@ import {
 
 /** Maps a query function to its decorator. */
 const queryFunctionToDecorator: Record<QueryFunctionName, string> = {
-  viewChild: 'ViewChild',
-  viewChildren: 'ViewChildren',
-  contentChild: 'ContentChild',
-  contentChildren: 'ContentChildren',
+  'viewChild': 'ViewChild',
+  'viewChildren': 'ViewChildren',
+  'contentChild': 'ContentChild',
+  'contentChildren': 'ContentChildren',
 };
 
 /**


### PR DESCRIPTION
This map for the JIT transforms accidentally is property-renamed, breaking the lookups below. This commit fixes this.