### PR TITLE
feat(forms): add associated field to all validation errors

### DIFF
--- a/packages/forms/experimental/src/api/validators/standard_schema.ts
+++ b/packages/forms/experimental/src/api/validators/standard_schema.ts
@@ -11,7 +11,11 @@ import type {StandardSchemaV1} from '@standard-schema/spec';
 import {validateAsync} from '../async';
 import {property, validateTree} from '../logic';
 import {Field, FieldPath} from '../types';
-import {StandardSchemaValidationError, ValidationError, WithField} from '../validation_errors';
+import {
+  addDefaultField,
+  StandardSchemaValidationError,
+  ValidationError,
+} from '../validation_errors';
 
 /**
  * Utility type that removes a string index key when its value is `unknown`,
@@ -26,7 +30,7 @@ export type RemoveStringIndexUnknownKey<K, V> = string extends K
 
 /**
  * Utility type that recursively ignores unknown string index properties on the given object.
- * We use this on the `TSchema` type in `validateStandardSchema` in order to accomodate Zod's
+ * We use this on the `TSchema` type in `validateStandardSchema` in order to accommodate Zod's
  * `looseObject` which includes `{[key: string]: unknown}` as part of the type.
  */
 export type IgnoreUnknownProperties<T> =
@@ -95,11 +99,11 @@ export function validateStandardSchema<TSchema, TValue extends IgnoreUnknownProp
 function standardIssueToFormTreeError(
   field: Field<unknown>,
   issue: StandardSchemaV1.Issue,
-): WithField<StandardSchemaValidationError> {
+): StandardSchemaValidationError {
   let target = field as Field<Record<PropertyKey, unknown>>;
   for (const pathPart of issue.path ?? []) {
     const pathKey = typeof pathPart === 'object' ? pathPart.key : pathPart;
     target = target[pathKey] as Field<Record<PropertyKey, unknown>>;
   }
-  return ValidationError.standardSchema(issue, '', target);
+  return addDefaultField(ValidationError.standardSchema(issue), target);
 }

--- a/packages/forms/experimental/src/api/validators/util.ts
+++ b/packages/forms/experimental/src/api/validators/util.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {LogicFn, PathKind} from '../types';
-import {ValidationError} from '../validation_errors';
+import {LogicFn, OneOrMany, PathKind} from '../types';
+import {ValidationError, WithoutField} from '../validation_errors';
 
 /** Represents a value that has a length or size, such as an array or string, or set. */
 export type ValueWithLengthOrSize = {length: number} | {size: number};
@@ -19,9 +19,8 @@ export interface BaseValidatorConfig<T, TPathKind extends PathKind = PathKind.Ro
    * or a function that receives the `FieldContext` and returns custom validation error(s).
    */
   error?:
-    | ValidationError
-    | ValidationError[]
-    | LogicFn<T, ValidationError | ValidationError[], TPathKind>;
+    | OneOrMany<WithoutField<ValidationError>>
+    | LogicFn<T, OneOrMany<WithoutField<ValidationError>>, TPathKind>;
 }
 
 export function getLengthOrSize(value: ValueWithLengthOrSize) {

--- a/packages/forms/experimental/src/schema/logic.ts
+++ b/packages/forms/experimental/src/schema/logic.ts
@@ -9,7 +9,7 @@
 import {untracked} from '@angular/core';
 import {AggregateProperty, Property} from '../api/property';
 import {DisabledReason, type FieldContext, type FieldPath, type LogicFn} from '../api/types';
-import {ValidationError, WithField} from '../api/validation_errors';
+import type {ValidationError} from '../api/validation_errors';
 import type {FieldNode} from '../field/node';
 import {isArray} from '../util/type_guards';
 
@@ -133,7 +133,7 @@ export class BooleanOrLogic extends AbstractLogic<boolean> {
  */
 export class ArrayMergeIgnoreLogic<TElement, TIgnore = never> extends AbstractLogic<
   readonly TElement[],
-  TElement | readonly (TElement | TIgnore)[] | TIgnore | undefined
+  TElement | readonly (TElement | TIgnore)[] | TIgnore | undefined | void
 > {
   /** Creates an instance of this class that ignores `null` values. */
   static ignoreNull<TElement>(predicates: ReadonlyArray<BoundPredicate>) {
@@ -255,9 +255,9 @@ export class LogicContainer {
   /** Logic that produces synchronous validation errors for the field. */
   readonly syncErrors: ArrayMergeIgnoreLogic<ValidationError, null>;
   /** Logic that produces synchronous validation errors for the field's subtree. */
-  readonly syncTreeErrors: ArrayMergeIgnoreLogic<WithField<ValidationError>, null>;
+  readonly syncTreeErrors: ArrayMergeIgnoreLogic<ValidationError, null>;
   /** Logic that produces asynchronous validation results (errors or 'pending'). */
-  readonly asyncErrors: ArrayMergeIgnoreLogic<WithField<ValidationError> | 'pending', null>;
+  readonly asyncErrors: ArrayMergeIgnoreLogic<ValidationError | 'pending', null>;
   /** A map of aggregate properties to the `AbstractLogic` instances that compute their values. */
   private readonly aggregateProperties = new Map<
     AggregateProperty<unknown, unknown>,
@@ -279,10 +279,8 @@ export class LogicContainer {
     this.disabledReasons = new ArrayMergeLogic(predicates);
     this.readonly = new BooleanOrLogic(predicates);
     this.syncErrors = ArrayMergeIgnoreLogic.ignoreNull<ValidationError>(predicates);
-    this.syncTreeErrors = ArrayMergeIgnoreLogic.ignoreNull<WithField<ValidationError>>(predicates);
-    this.asyncErrors = ArrayMergeIgnoreLogic.ignoreNull<WithField<ValidationError> | 'pending'>(
-      predicates,
-    );
+    this.syncTreeErrors = ArrayMergeIgnoreLogic.ignoreNull<ValidationError>(predicates);
+    this.asyncErrors = ArrayMergeIgnoreLogic.ignoreNull<ValidationError | 'pending'>(predicates);
   }
 
   /**

--- a/packages/forms/experimental/src/schema/logic_node.ts
+++ b/packages/forms/experimental/src/schema/logic_node.ts
@@ -7,12 +7,11 @@
  */
 
 import {AggregateProperty, Property} from '../api/property';
-import {
-  AsyncValidationResultWithField,
+import type {
+  AsyncValidationResult,
   DisabledReason,
   FieldContext,
   LogicFn,
-  TreeValidationResultWithField,
   ValidationResult,
 } from '../api/types';
 import {setBoundPathDepthForResolution} from '../field/resolution';
@@ -39,9 +38,9 @@ export abstract class AbstractLogicNodeBuilder {
   /** Adds a rule for synchronous validation errors for a field. */
   abstract addSyncErrorRule(logic: LogicFn<any, ValidationResult>): void;
   /** Adds a rule for synchronous validation errors that apply to a subtree. */
-  abstract addSyncTreeErrorRule(logic: LogicFn<any, TreeValidationResultWithField>): void;
+  abstract addSyncTreeErrorRule(logic: LogicFn<any, ValidationResult>): void;
   /** Adds a rule for asynchronous validation errors for a field. */
-  abstract addAsyncErrorRule(logic: LogicFn<any, AsyncValidationResultWithField>): void;
+  abstract addAsyncErrorRule(logic: LogicFn<any, AsyncValidationResult>): void;
   /** Adds a rule to compute an aggregate property for a field. */
   abstract addAggregatePropertyRule<M>(
     key: AggregateProperty<unknown, M>,
@@ -110,11 +109,11 @@ export class LogicNodeBuilder extends AbstractLogicNodeBuilder {
     this.getCurrent().addSyncErrorRule(logic);
   }
 
-  override addSyncTreeErrorRule(logic: LogicFn<any, TreeValidationResultWithField>): void {
+  override addSyncTreeErrorRule(logic: LogicFn<any, ValidationResult>): void {
     this.getCurrent().addSyncTreeErrorRule(logic);
   }
 
-  override addAsyncErrorRule(logic: LogicFn<any, AsyncValidationResultWithField>): void {
+  override addAsyncErrorRule(logic: LogicFn<any, AsyncValidationResult>): void {
     this.getCurrent().addAsyncErrorRule(logic);
   }
 
@@ -223,11 +222,11 @@ class NonMergeableLogicNodeBuilder extends AbstractLogicNodeBuilder {
     this.logic.syncErrors.push(setBoundPathDepthForResolution(logic, this.depth));
   }
 
-  override addSyncTreeErrorRule(logic: LogicFn<any, TreeValidationResultWithField>): void {
+  override addSyncTreeErrorRule(logic: LogicFn<any, ValidationResult>): void {
     this.logic.syncTreeErrors.push(setBoundPathDepthForResolution(logic, this.depth));
   }
 
-  override addAsyncErrorRule(logic: LogicFn<any, AsyncValidationResultWithField>): void {
+  override addAsyncErrorRule(logic: LogicFn<any, AsyncValidationResult>): void {
     this.logic.asyncErrors.push(setBoundPathDepthForResolution(logic, this.depth));
   }
 

--- a/packages/forms/experimental/test/node/api/validators/email.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/email.spec.ts
@@ -26,7 +26,7 @@ describe('email validator', () => {
 
     expect(f.email().errors()).toEqual([]);
     f.email().value.set('not-real-email');
-    expect(f.email().errors()).toEqual([ValidationError.email()]);
+    expect(f.email().errors()).toEqual([ValidationError.email({field: f.email})]);
   });
 
   it('supports custom errors', () => {
@@ -44,7 +44,10 @@ describe('email validator', () => {
     );
 
     expect(f.email().errors()).toEqual([
-      ValidationError.custom({kind: 'special-email-pirojok-the-cat'}),
+      ValidationError.custom({
+        kind: 'special-email-pirojok-the-cat',
+        field: f.email,
+      }),
     ]);
   });
 });

--- a/packages/forms/experimental/test/node/api/validators/max.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/max.spec.ts
@@ -22,7 +22,7 @@ describe('max validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.age().errors()).toEqual([ValidationError.max(5)]);
+    expect(f.age().errors()).toEqual([ValidationError.max(5, {field: f.age})]);
   });
 
   it('is inclusive', () => {
@@ -69,6 +69,7 @@ describe('max validator', () => {
       ValidationError.custom({
         kind: 'special-max',
         message: '6',
+        field: f.age,
       }),
     ]);
   });
@@ -116,9 +117,12 @@ describe('max validator', () => {
       );
 
       f.age().value.set(12);
-      expect(f.age().errors()).toEqual([ValidationError.max(10), ValidationError.max(5)]);
+      expect(f.age().errors()).toEqual([
+        ValidationError.max(10, {field: f.age}),
+        ValidationError.max(5, {field: f.age}),
+      ]);
       f.age().value.set(7);
-      expect(f.age().errors()).toEqual([ValidationError.max(5)]);
+      expect(f.age().errors()).toEqual([ValidationError.max(5, {field: f.age})]);
       f.age().value.set(3);
       expect(f.age().errors()).toEqual([]);
 
@@ -138,9 +142,12 @@ describe('max validator', () => {
       );
 
       f.age().value.set(12);
-      expect(f.age().errors()).toEqual([ValidationError.max(10), ValidationError.max(5)]);
+      expect(f.age().errors()).toEqual([
+        ValidationError.max(10, {field: f.age}),
+        ValidationError.max(5, {field: f.age}),
+      ]);
       f.age().value.set(7);
-      expect(f.age().errors()).toEqual([ValidationError.max(5)]);
+      expect(f.age().errors()).toEqual([ValidationError.max(5, {field: f.age})]);
       f.age().value.set(3);
       expect(f.age().errors()).toEqual([]);
 
@@ -148,7 +155,7 @@ describe('max validator', () => {
 
       maxSignal.set(2);
       f.age().value.set(3);
-      expect(f.age().errors()).toEqual([ValidationError.max(2)]);
+      expect(f.age().errors()).toEqual([ValidationError.max(2, {field: f.age})]);
       expect(f.age().property(MAX)()).toBe(2);
     });
 
@@ -166,12 +173,15 @@ describe('max validator', () => {
       );
 
       // Initially, age 20 is greater than both 10 and 15
-      expect(f.age().errors()).toEqual([ValidationError.max(10), ValidationError.max(15)]);
+      expect(f.age().errors()).toEqual([
+        ValidationError.max(10, {field: f.age}),
+        ValidationError.max(15, {field: f.age}),
+      ]);
 
       // Set the first max threshold to undefined
       maxSignal.set(undefined);
       // Now, age 20 is only greater than 15
-      expect(f.age().errors()).toEqual([ValidationError.max(15)]);
+      expect(f.age().errors()).toEqual([ValidationError.max(15, {field: f.age})]);
 
       // Set the second max threshold to undefined
       maxSignal2.set(undefined);
@@ -192,7 +202,7 @@ describe('max validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([ValidationError.max(5)]);
+      expect(f.age().errors()).toEqual([ValidationError.max(5, {field: f.age})]);
       maxValue.set(7);
       expect(f.age().errors()).toEqual([]);
     });
@@ -208,11 +218,11 @@ describe('max validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([ValidationError.max(5)]);
+      expect(f.age().errors()).toEqual([ValidationError.max(5, {field: f.age})]);
       maxValue.set(undefined);
       expect(f.age().errors()).toEqual([]);
       maxValue.set(5);
-      expect(f.age().errors()).toEqual([ValidationError.max(5)]);
+      expect(f.age().errors()).toEqual([ValidationError.max(5, {field: f.age})]);
     });
 
     it('handles dynamic value based on other field', () => {
@@ -228,7 +238,7 @@ describe('max validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([ValidationError.max(5)]);
+      expect(f.age().errors()).toEqual([ValidationError.max(5, {field: f.age})]);
 
       f.name().value.set('other cat');
 

--- a/packages/forms/experimental/test/node/api/validators/max_length.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/max_length.spec.ts
@@ -22,7 +22,7 @@ describe('maxLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.text().errors()).toEqual([ValidationError.maxLength(3)]);
+    expect(f.text().errors()).toEqual([ValidationError.maxLength(3, {field: f.text})]);
   });
 
   it('returns maxLength error when the length is larger for arrays', () => {
@@ -35,7 +35,7 @@ describe('maxLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.list().errors()).toEqual([ValidationError.maxLength(3)]);
+    expect(f.list().errors()).toEqual([ValidationError.maxLength(3, {field: f.list})]);
   });
 
   it('is inclusive (no error if length equals maxLength)', () => {
@@ -85,6 +85,7 @@ describe('maxLength validator', () => {
       ValidationError.custom({
         kind: 'special-maxLength',
         message: 'Length is 6',
+        field: f.text,
       }),
     ]);
   });
@@ -99,7 +100,7 @@ describe('maxLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f().errors()).toEqual([ValidationError.maxLength(3)]);
+    expect(f().errors()).toEqual([ValidationError.maxLength(3, {field: f})]);
   });
 
   describe('custom properties', () => {
@@ -136,12 +137,12 @@ describe('maxLength validator', () => {
 
       f.text().value.set('abcdefghijklmno');
       expect(f.text().errors()).toEqual([
-        ValidationError.maxLength(10),
-        ValidationError.maxLength(5),
+        ValidationError.maxLength(10, {field: f.text}),
+        ValidationError.maxLength(5, {field: f.text}),
       ]);
 
       f.text().value.set('abcdefg');
-      expect(f.text().errors()).toEqual([ValidationError.maxLength(5)]);
+      expect(f.text().errors()).toEqual([ValidationError.maxLength(5, {field: f.text})]);
 
       f.text().value.set('abc');
       expect(f.text().errors()).toEqual([]);
@@ -163,19 +164,19 @@ describe('maxLength validator', () => {
 
       f.text().value.set('abcdefghijklmno');
       expect(f.text().errors()).toEqual([
-        ValidationError.maxLength(10),
-        ValidationError.maxLength(5),
+        ValidationError.maxLength(10, {field: f.text}),
+        ValidationError.maxLength(5, {field: f.text}),
       ]);
 
       f.text().value.set('abcdefg');
-      expect(f.text().errors()).toEqual([ValidationError.maxLength(5)]);
+      expect(f.text().errors()).toEqual([ValidationError.maxLength(5, {field: f.text})]);
 
       f.text().value.set('abc');
       expect(f.text().errors()).toEqual([]);
 
       maxLengthSignal.set(2);
 
-      expect(f.text().errors()).toEqual([ValidationError.maxLength(2)]);
+      expect(f.text().errors()).toEqual([ValidationError.maxLength(2, {field: f.text})]);
       expect(f.text().property(MAX_LENGTH)()).toBe(2);
     });
   });
@@ -192,7 +193,7 @@ describe('maxLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([ValidationError.maxLength(5)]);
+      expect(f.text().errors()).toEqual([ValidationError.maxLength(5, {field: f.text})]);
       dynamicMaxLength.set(7);
       expect(f.text().errors()).toEqual([]);
     });
@@ -207,7 +208,7 @@ describe('maxLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([ValidationError.maxLength(5)]);
+      expect(f.text().errors()).toEqual([ValidationError.maxLength(5, {field: f.text})]);
       dynamicMaxLength.set(undefined);
       expect(f.text().errors()).toEqual([]);
     });
@@ -224,7 +225,7 @@ describe('maxLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([ValidationError.maxLength(8)]);
+      expect(f.text().errors()).toEqual([ValidationError.maxLength(8, {field: f.text})]);
 
       f.category().value.set('B');
       expect(f.text().errors()).toEqual([]);

--- a/packages/forms/experimental/test/node/api/validators/min.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/min.spec.ts
@@ -22,7 +22,7 @@ describe('min validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.age().errors()).toEqual([ValidationError.min(5)]);
+    expect(f.age().errors()).toEqual([ValidationError.min(5, {field: f.age})]);
   });
 
   it('is inclusive', () => {
@@ -69,6 +69,7 @@ describe('min validator', () => {
       ValidationError.custom({
         kind: 'special-min',
         message: '3',
+        field: f.age,
       }),
     ]);
   });
@@ -116,9 +117,12 @@ describe('min validator', () => {
       );
 
       f.age().value.set(3);
-      expect(f.age().errors()).toEqual([ValidationError.min(5), ValidationError.min(10)]);
+      expect(f.age().errors()).toEqual([
+        ValidationError.min(5, {field: f.age}),
+        ValidationError.min(10, {field: f.age}),
+      ]);
       f.age().value.set(7);
-      expect(f.age().errors()).toEqual([ValidationError.min(10)]);
+      expect(f.age().errors()).toEqual([ValidationError.min(10, {field: f.age})]);
       f.age().value.set(15);
       expect(f.age().errors()).toEqual([]);
 
@@ -138,13 +142,16 @@ describe('min validator', () => {
       );
 
       f.age().value.set(3);
-      expect(f.age().errors()).toEqual([ValidationError.min(5), ValidationError.min(10)]);
+      expect(f.age().errors()).toEqual([
+        ValidationError.min(5, {field: f.age}),
+        ValidationError.min(10, {field: f.age}),
+      ]);
       f.age().value.set(7);
-      expect(f.age().errors()).toEqual([ValidationError.min(10)]);
+      expect(f.age().errors()).toEqual([ValidationError.min(10, {field: f.age})]);
       f.age().value.set(15);
       expect(f.age().errors()).toEqual([]);
       minSignal.set(30);
-      expect(f.age().errors()).toEqual([ValidationError.min(30)]);
+      expect(f.age().errors()).toEqual([ValidationError.min(30, {field: f.age})]);
       expect(f.age().property(MIN)()).toBe(30);
     });
 
@@ -161,9 +168,12 @@ describe('min validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([ValidationError.min(15), ValidationError.min(10)]);
+      expect(f.age().errors()).toEqual([
+        ValidationError.min(15, {field: f.age}),
+        ValidationError.min(10, {field: f.age}),
+      ]);
       minSignal.set(undefined);
-      expect(f.age().errors()).toEqual([ValidationError.min(10)]);
+      expect(f.age().errors()).toEqual([ValidationError.min(10, {field: f.age})]);
       minSignal2.set(undefined);
       expect(f.age().errors()).toEqual([]);
     });
@@ -181,11 +191,11 @@ describe('min validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([ValidationError.min(5)]);
+      expect(f.age().errors()).toEqual([ValidationError.min(5, {field: f.age})]);
       minValue.set(undefined);
       expect(f.age().errors()).toEqual([]);
       minValue.set(5);
-      expect(f.age().errors()).toEqual([ValidationError.min(5)]);
+      expect(f.age().errors()).toEqual([ValidationError.min(5, {field: f.age})]);
     });
 
     it('handles dynamic value', () => {
@@ -199,7 +209,7 @@ describe('min validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([ValidationError.min(5)]);
+      expect(f.age().errors()).toEqual([ValidationError.min(5, {field: f.age})]);
       minValue.set(2);
       expect(f.age().errors()).toEqual([]);
     });
@@ -217,7 +227,7 @@ describe('min validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([ValidationError.min(5)]);
+      expect(f.age().errors()).toEqual([ValidationError.min(5, {field: f.age})]);
       f.name().value.set('other cat');
       expect(f.age().errors()).toEqual([]);
     });

--- a/packages/forms/experimental/test/node/api/validators/min_length.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/min_length.spec.ts
@@ -22,7 +22,7 @@ describe('minLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.text().errors()).toEqual([ValidationError.minLength(5)]);
+    expect(f.text().errors()).toEqual([ValidationError.minLength(5, {field: f.text})]);
   });
 
   it('returns minLength error when the length is smaller for arrays', () => {
@@ -35,7 +35,7 @@ describe('minLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.list().errors()).toEqual([ValidationError.minLength(5)]);
+    expect(f.list().errors()).toEqual([ValidationError.minLength(5, {field: f.list})]);
   });
 
   it('is inclusive (no error if length equals minLength)', () => {
@@ -85,6 +85,7 @@ describe('minLength validator', () => {
       ValidationError.custom({
         kind: 'special-minLength',
         message: 'Length is 2',
+        field: f.text,
       }),
     ]);
   });
@@ -99,7 +100,7 @@ describe('minLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f().errors()).toEqual([ValidationError.minLength(5)]);
+    expect(f().errors()).toEqual([ValidationError.minLength(5, {field: f})]);
   });
 
   describe('custom properties', () => {
@@ -136,12 +137,12 @@ describe('minLength validator', () => {
 
       f.text().value.set('ab');
       expect(f.text().errors()).toEqual([
-        ValidationError.minLength(5),
-        ValidationError.minLength(10),
+        ValidationError.minLength(5, {field: f.text}),
+        ValidationError.minLength(10, {field: f.text}),
       ]);
 
       f.text().value.set('abcdefg');
-      expect(f.text().errors()).toEqual([ValidationError.minLength(10)]);
+      expect(f.text().errors()).toEqual([ValidationError.minLength(10, {field: f.text})]);
 
       f.text().value.set('abcdefghijklmno');
       expect(f.text().errors()).toEqual([]);
@@ -163,19 +164,19 @@ describe('minLength validator', () => {
 
       f.text().value.set('ab');
       expect(f.text().errors()).toEqual([
-        ValidationError.minLength(5),
-        ValidationError.minLength(10),
+        ValidationError.minLength(5, {field: f.text}),
+        ValidationError.minLength(10, {field: f.text}),
       ]);
 
       f.text().value.set('abcdefg');
-      expect(f.text().errors()).toEqual([ValidationError.minLength(10)]);
+      expect(f.text().errors()).toEqual([ValidationError.minLength(10, {field: f.text})]);
 
       f.text().value.set('abcdefghijklmno');
       expect(f.text().errors()).toEqual([]);
 
       minLengthSignal.set(20);
 
-      expect(f.text().errors()).toEqual([ValidationError.minLength(20)]);
+      expect(f.text().errors()).toEqual([ValidationError.minLength(20, {field: f.text})]);
       expect(f.text().property(MIN_LENGTH)()).toBe(20);
     });
   });
@@ -192,7 +193,7 @@ describe('minLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([ValidationError.minLength(5)]);
+      expect(f.text().errors()).toEqual([ValidationError.minLength(5, {field: f.text})]);
       dynamicMinLength.set(3);
       expect(f.text().errors()).toEqual([]);
     });
@@ -208,7 +209,7 @@ describe('minLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([ValidationError.minLength(5)]);
+      expect(f.text().errors()).toEqual([ValidationError.minLength(5, {field: f.text})]);
       dynamicMinLength.set(undefined);
       expect(f.text().errors()).toEqual([]);
     });
@@ -225,7 +226,7 @@ describe('minLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([ValidationError.minLength(8)]);
+      expect(f.text().errors()).toEqual([ValidationError.minLength(8, {field: f.text})]);
 
       f.category().value.set('B');
       expect(f.text().errors()).toEqual([]);

--- a/packages/forms/experimental/test/node/api/validators/pattern.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/pattern.spec.ts
@@ -22,7 +22,7 @@ describe('pattern validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.name().errors()).toEqual([ValidationError.pattern(/pir.*jok/)]);
+    expect(f.name().errors()).toEqual([ValidationError.pattern(/pir.*jok/, {field: f.name})]);
   });
 
   it('supports custom error', () => {
@@ -35,7 +35,7 @@ describe('pattern validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.name().errors()).toEqual([ValidationError.custom()]);
+    expect(f.name().errors()).toEqual([ValidationError.custom({field: f.name})]);
   });
 
   describe('custom properties', () => {
@@ -91,12 +91,12 @@ describe('pattern validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.name().errors()).toEqual([ValidationError.pattern(/pir.*jok/)]);
+      expect(f.name().errors()).toEqual([ValidationError.pattern(/pir.*jok/, {field: f.name})]);
 
       patternSignal.set(/p.*/);
       expect(f.name().errors()).toEqual([]);
       patternSignal.set(/meow/);
-      expect(f.name().errors()).toEqual([ValidationError.pattern(/meow/)]);
+      expect(f.name().errors()).toEqual([ValidationError.pattern(/meow/, {field: f.name})]);
 
       patternSignal.set(undefined);
 

--- a/packages/forms/experimental/test/node/api/validators/required.spec.ts
+++ b/packages/forms/experimental/test/node/api/validators/required.spec.ts
@@ -24,7 +24,7 @@ describe('required validator', () => {
       },
     );
 
-    expect(f.name().errors()).toEqual([ValidationError.required()]);
+    expect(f.name().errors()).toEqual([ValidationError.required({field: f.name})]);
     f.name().value.set('pirojok-the-cat');
     expect(f.name().errors()).toEqual([]);
   });
@@ -43,7 +43,9 @@ describe('required validator', () => {
       },
     );
 
-    expect(f.name().errors()).toEqual([ValidationError.custom({kind: 'required-5'})]);
+    expect(f.name().errors()).toEqual([
+      ValidationError.custom({kind: 'required-5', field: f.name}),
+    ]);
     f.name().value.set('pirojok-the-cat');
     expect(f.name().errors()).toEqual([]);
   });
@@ -66,7 +68,7 @@ describe('required validator', () => {
 
     expect(f.name().errors()).toEqual([]);
     f.name().value.set('empty');
-    expect(f.name().errors()).toEqual([ValidationError.required()]);
+    expect(f.name().errors()).toEqual([ValidationError.required({field: f.name})]);
   });
 
   it('supports custom condition', () => {
@@ -87,6 +89,6 @@ describe('required validator', () => {
 
     expect(f.name().errors()).toEqual([]);
     f.age().value.set(15);
-    expect(f.name().errors()).toEqual([ValidationError.required()]);
+    expect(f.name().errors()).toEqual([ValidationError.required({field: f.name})]);
   });
 });

--- a/packages/forms/experimental/test/node/api/when.spec.ts
+++ b/packages/forms/experimental/test/node/api/when.spec.ts
@@ -45,7 +45,7 @@ describe('when', () => {
     f().value.set({first: 'meow', needLastName: false, last: ''});
     expect(f.last().errors()).toEqual([]);
     f().value.set({first: 'meow', needLastName: true, last: ''});
-    expect(f.last().errors()).toEqual([ValidationError.required()]);
+    expect(f.last().errors()).toEqual([ValidationError.required({field: f.last})]);
   });
 
   it('Disallows using non-local paths', () => {
@@ -93,11 +93,13 @@ describe('when', () => {
     );
     f.needLastName().value.set(true);
     expect(f.items[0].last().errors()).toEqual([
-      ValidationError.custom({kind: 'required1'}),
-      ValidationError.custom({kind: 'required2'}),
+      ValidationError.custom({kind: 'required1', field: f.items[0].last}),
+      ValidationError.custom({kind: 'required2', field: f.items[0].last}),
     ]);
     f.needLastName().value.set(false);
-    expect(f.items[0].last().errors()).toEqual([ValidationError.custom({kind: 'required1'})]);
+    expect(f.items[0].last().errors()).toEqual([
+      ValidationError.custom({kind: 'required1', field: f.items[0].last}),
+    ]);
   });
 
   it('accepts a schema', () => {
@@ -119,7 +121,7 @@ describe('when', () => {
     f().value.set({first: 'meow', needLastName: false, last: ''});
     expect(f.last().errors()).toEqual([]);
     f().value.set({first: 'meow', needLastName: true, last: ''});
-    expect(f.last().errors()).toEqual([ValidationError.required()]);
+    expect(f.last().errors()).toEqual([ValidationError.required({field: f.last})]);
   });
 
   it('supports mix of conditional and non conditional validators', () => {
@@ -141,11 +143,11 @@ describe('when', () => {
     );
 
     f().value.set({first: 'meow', needLastName: false, last: ''});
-    expect(f.last().errors()).toEqual([ValidationError.custom({kind: 'short'})]);
+    expect(f.last().errors()).toEqual([ValidationError.custom({kind: 'short', field: f.last})]);
     f().value.set({first: 'meow', needLastName: true, last: ''});
     expect(f.last().errors()).toEqual([
-      ValidationError.custom({kind: 'short'}),
-      ValidationError.required(),
+      ValidationError.custom({kind: 'short', field: f.last}),
+      ValidationError.required({field: f.last}),
     ]);
   });
 
@@ -167,7 +169,9 @@ describe('when', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.items[0].last().errors()).toEqual([ValidationError.required()]);
+    expect(f.items[0].last().errors()).toEqual([
+      ValidationError.required({field: f.items[0].last}),
+    ]);
     f.needLastName().value.set(false);
     expect(f.items[0].last().errors()).toEqual([]);
   });
@@ -192,11 +196,17 @@ describe('applyWhenValue', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.numOrNull().errors()).toEqual([ValidationError.custom({kind: 'too-small'})]);
+    expect(f.numOrNull().errors()).toEqual([
+      ValidationError.custom({kind: 'too-small', field: f.numOrNull}),
+    ]);
     f.numOrNull().value.set(5);
-    expect(f.numOrNull().errors()).toEqual([ValidationError.custom({kind: 'too-small'})]);
+    expect(f.numOrNull().errors()).toEqual([
+      ValidationError.custom({kind: 'too-small', field: f.numOrNull}),
+    ]);
     f.numOrNull().value.set(null);
-    expect(f.numOrNull().errors()).toEqual([ValidationError.custom({kind: 'too-small'})]);
+    expect(f.numOrNull().errors()).toEqual([
+      ValidationError.custom({kind: 'too-small', field: f.numOrNull}),
+    ]);
     f.numOrNull().value.set(15);
     expect(f.numOrNull().errors()).toEqual([]);
   });
@@ -221,7 +231,9 @@ describe('applyWhenValue', () => {
 
     expect(f.numOrNull().errors()).toEqual([]);
     f.numOrNull().value.set(5);
-    expect(f.numOrNull().errors()).toEqual([ValidationError.custom({kind: 'too-small'})]);
+    expect(f.numOrNull().errors()).toEqual([
+      ValidationError.custom({kind: 'too-small', field: f.numOrNull}),
+    ]);
     f.numOrNull().value.set(null);
     expect(f.numOrNull().errors()).toEqual([]);
     f.numOrNull().value.set(15);

--- a/packages/forms/experimental/test/node/resource.spec.ts
+++ b/packages/forms/experimental/test/node/resource.spec.ts
@@ -82,6 +82,7 @@ describe('resources', () => {
     expect(f.name().errors()).toEqual([
       ValidationError.custom({
         message: 'got: cat',
+        field: f.name,
       }),
     ]);
 
@@ -90,6 +91,7 @@ describe('resources', () => {
     expect(f.name().errors()).toEqual([
       ValidationError.custom({
         message: 'got: dog',
+        field: f.name,
       }),
     ]);
   });
@@ -124,11 +126,13 @@ describe('resources', () => {
     expect(f[0].name().errors()).toEqual([
       ValidationError.custom({
         message: 'got: cat',
+        field: f[0].name,
       }),
     ]);
     expect(f[1].name().errors()).toEqual([
       ValidationError.custom({
         message: 'got: dog',
+        field: f[1].name,
       }),
     ]);
 
@@ -137,11 +141,13 @@ describe('resources', () => {
     expect(f[0].name().errors()).toEqual([
       ValidationError.custom({
         message: 'got: bunny',
+        field: f[0].name,
       }),
     ]);
     expect(f[1].name().errors()).toEqual([
       ValidationError.custom({
         message: 'got: dog',
+        field: f[1].name,
       }),
     ]);
   });
@@ -174,10 +180,10 @@ describe('resources', () => {
 
     await appRef.whenStable();
     expect(f[0]().errors()).toEqual([
-      ValidationError.custom({kind: 'meows_too_much', name: 'Fluffy'}),
+      ValidationError.custom({kind: 'meows_too_much', name: 'Fluffy', field: f[0]}),
     ]);
     expect(f[1]().errors()).toEqual([
-      ValidationError.custom({kind: 'meows_too_much', name: 'Ziggy'}),
+      ValidationError.custom({kind: 'meows_too_much', name: 'Ziggy', field: f[1]}),
     ]);
   });
 
@@ -207,7 +213,7 @@ describe('resources', () => {
 
     await appRef.whenStable();
     expect(f[0]().errors()).toEqual([
-      ValidationError.custom({kind: 'meows_too_much', name: 'Fluffy'}),
+      ValidationError.custom({kind: 'meows_too_much', name: 'Fluffy', field: f[0]}),
     ]);
     expect(f[1]().errors()).toEqual([]);
   });
@@ -278,6 +284,8 @@ describe('resources', () => {
     req.flush('Invalid!');
     await appRef.whenStable();
 
-    expect(addressForm.street().errors()).toEqual([ValidationError.custom({message: 'Invalid!'})]);
+    expect(addressForm.street().errors()).toEqual([
+      ValidationError.custom({message: 'Invalid!', field: addressForm.street}),
+    ]);
   });
 });

--- a/packages/forms/experimental/test/node/submit.spec.ts
+++ b/packages/forms/experimental/test/node/submit.spec.ts
@@ -26,7 +26,7 @@ describe('submit', () => {
       fail('Submit action should run not on invalid form');
     });
 
-    expect(f.first().errors()).toEqual([ValidationError.required()]);
+    expect(f.first().errors()).toEqual([ValidationError.required({field: f.first})]);
   });
 
   it('maps error to a field', async () => {
@@ -41,15 +41,15 @@ describe('submit', () => {
     );
 
     await submit(f, (form) => {
-      return Promise.resolve([
+      return Promise.resolve(
         ValidationError.custom({
           kind: 'lastName',
           field: form.last,
         }),
-      ]);
+      );
     });
 
-    expect(f.last().errors()).toEqual([ValidationError.custom({kind: 'lastName'})]);
+    expect(f.last().errors()).toEqual([ValidationError.custom({kind: 'lastName', field: f.last})]);
   });
 
   it('maps errors to multiple fields', async () => {
@@ -73,10 +73,12 @@ describe('submit', () => {
       ]);
     });
 
-    expect(f.first().errors()).toEqual([ValidationError.custom({kind: 'firstName'})]);
+    expect(f.first().errors()).toEqual([
+      ValidationError.custom({kind: 'firstName', field: f.first}),
+    ]);
     expect(f.last().errors()).toEqual([
-      ValidationError.custom({kind: 'lastName'}),
-      ValidationError.custom({kind: 'lastName2'}),
+      ValidationError.custom({kind: 'lastName', field: f.last}),
+      ValidationError.custom({kind: 'lastName2', field: f.last}),
     ]);
   });
 
@@ -114,10 +116,10 @@ describe('submit', () => {
     );
 
     await submit(f, () => {
-      return Promise.resolve([ValidationError.custom()]);
+      return Promise.resolve(ValidationError.custom());
     });
 
-    expect(f().errors()).toEqual([ValidationError.custom()]);
+    expect(f().errors()).toEqual([ValidationError.custom({field: f})]);
   });
 
   it('marks the form as submitting', async () => {
@@ -197,7 +199,7 @@ describe('submit', () => {
 
     await submit(f.first, (form) => {
       submitSpy(form().value());
-      return Promise.resolve([ValidationError.custom({kind: 'lastName'})]);
+      return Promise.resolve(ValidationError.custom({kind: 'lastName'}));
     });
 
     expect(submitSpy).toHaveBeenCalledWith('meow');
@@ -228,13 +230,13 @@ describe('submit', () => {
       ];
     });
 
-    expect(f.first().errors()).toEqual([ValidationError.custom({kind: 'submit'})]);
-    expect(f.last().errors()).toEqual([ValidationError.custom({kind: 'submit'})]);
+    expect(f.first().errors()).toEqual([ValidationError.custom({kind: 'submit', field: f.first})]);
+    expect(f.last().errors()).toEqual([ValidationError.custom({kind: 'submit', field: f.last})]);
 
     f.first().value.set('Hello');
 
     expect(f.first().errors()).toEqual([]);
-    expect(f.last().errors()).toEqual([ValidationError.custom({kind: 'submit'})]);
+    expect(f.last().errors()).toEqual([ValidationError.custom({kind: 'submit', field: f.last})]);
   });
 });
 

--- a/packages/forms/experimental/test/node/validation_status.spec.ts
+++ b/packages/forms/experimental/test/node/validation_status.spec.ts
@@ -9,16 +9,16 @@
 import {ApplicationRef, Injector, Resource, resource, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {Field, form, validate, validateAsync, validateTree} from '../../public_api';
-import {NgValidationError, ValidationError, WithField} from '../../src/api/validation_errors';
+import {NgValidationError, ValidationError, WithoutField} from '../../src/api/validation_errors';
 
-function validateValue(value: string): ValidationError[] {
+function validateValue(value: string): WithoutField<ValidationError>[] {
   return value === 'INVALID' ? [ValidationError.custom()] : [];
 }
 
 function validateValueForChild(
   value: string,
   field: Field<unknown> | undefined,
-): WithField<ValidationError>[] {
+): ValidationError[] {
   return value === 'INVALID' ? [ValidationError.custom({field})] : [];
 }
 
@@ -182,7 +182,7 @@ describe('validation status', () => {
               (res = resource({
                 params,
                 loader: ({params}) =>
-                  new Promise<WithField<ValidationError>[]>((r) =>
+                  new Promise<ValidationError[]>((r) =>
                     setTimeout(() => r(validateValueForChild(params, undefined))),
                   ),
               })),
@@ -230,7 +230,7 @@ describe('validation status', () => {
               (res = resource({
                 params,
                 loader: ({params}) =>
-                  new Promise<WithField<ValidationError>[]>((r) =>
+                  new Promise<ValidationError[]>((r) =>
                     setTimeout(() => r(validateValueForChild(params, undefined))),
                   ),
               })),
@@ -282,7 +282,7 @@ describe('validation status', () => {
               (res = resource({
                 params,
                 loader: ({params}) =>
-                  new Promise<WithField<ValidationError>[]>((r) =>
+                  new Promise<ValidationError[]>((r) =>
                     setTimeout(() => r(validateValueForChild(params, undefined))),
                   ),
               })),
@@ -337,7 +337,7 @@ describe('validation status', () => {
               (res = resource({
                 params,
                 loader: ({params}) =>
-                  new Promise<WithField<ValidationError>[]>((r) =>
+                  new Promise<ValidationError[]>((r) =>
                     setTimeout(() => r(validateValueForChild(params, undefined))),
                   ),
               })),
@@ -406,8 +406,7 @@ describe('validation status', () => {
             factory: (params) =>
               (res = resource({
                 params,
-                loader: () =>
-                  new Promise<WithField<ValidationError>[]>((r) => setTimeout(() => r([]))),
+                loader: () => new Promise<ValidationError[]>((r) => setTimeout(() => r([]))),
               })),
             errors: (errs) => errs,
           });
@@ -445,8 +444,7 @@ describe('validation status', () => {
             factory: (params) =>
               (res2 = resource({
                 params,
-                loader: () =>
-                  new Promise<WithField<ValidationError>[]>((r) => setTimeout(() => r([]), 10)),
+                loader: () => new Promise<ValidationError[]>((r) => setTimeout(() => r([]), 10)),
               })),
             errors: (errs) => errs,
           });
@@ -485,8 +483,7 @@ describe('validation status', () => {
             factory: (params) =>
               (res2 = resource({
                 params,
-                loader: () =>
-                  new Promise<WithField<ValidationError>[]>((r) => setTimeout(() => r([]), 10)),
+                loader: () => new Promise<ValidationError[]>((r) => setTimeout(() => r([]), 10)),
               })),
             errors: (errs) => errs,
           });


### PR DESCRIPTION
Previously only tree validation errors carried their associated fields. Regular validation errors didn't carry their field because it was assumed it could be trivially inferred from context.

Error summaries (which are forthcoming) break this assumption, as they combine both regular and tree validation errors from an entire form into a single list. Without explicitly carrying their associated field, there's no way of knowing to which field a regular validation error is associated when obtained through an error summary.

Note that while all validation errors now have a field, it's not explicitly required to define one when returning an error from a logic function callback in `validateTree()`, nor is it allowed in `validate()`. These functions will automatically add the current field by default to any errors missing a field definition. This ensures that all validation errors returned from fields (e.g. `field.path.errors()`) _do_ have a defined field.

This change makes testing errors by equality more tedious; however, we only do so in our own tests to be comprehensive. In reality, it's expected that developers would simply check for an expected `error.kind` or similar property of a custom error.