### PR TITLE
ci: redirect adev to `index.csr.html`

### DIFF
--- a/adev/firebase.json
+++ b/adev/firebase.json
@@ -67,7 +67,7 @@
     "rewrites": [
       {
         "source": "**",
-        "destination": "/index.html"
+        "destination": "/index.csr.html"
       }
     ]
   }


### PR DESCRIPTION
The build doesn't produce an `index.html`
