### PR TITLE
docs(docs-infra): add dark mode to example preview

### DIFF
--- a/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.scss
+++ b/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.scss
@@ -1,10 +1,12 @@
 :host {
   .docs-example-viewer-preview {
     .docs-dark-mode & {
-      background: var(--gray-100);
+      color: var(--primary-contrast);
+      background: var(--gray-900);
     }
     @media screen and (prefers-color-scheme: dark) {
-      background: var(--gray-100);
+      color: var(--primary-contrast);
+      background: var(--gray-900);
     }
     .docs-light-mode & {
       background: var(--page-background);

--- a/adev/src/content/examples/animations/src/app/enter-and-leave/enter-binding.css
+++ b/adev/src/content/examples/animations/src/app/enter-and-leave/enter-binding.css
@@ -7,7 +7,6 @@
   border: 1px solid #dddddd;
   margin-top: 1em;
   padding: 20px 20px 0px 20px;
-  color: #000000;
   font-weight: bold;
   font-size: 20px;
 }

--- a/adev/src/content/examples/animations/src/app/enter-and-leave/enter.css
+++ b/adev/src/content/examples/animations/src/app/enter-and-leave/enter.css
@@ -7,7 +7,6 @@
   border: 1px solid #dddddd;
   margin-top: 1em;
   padding: 20px 20px 0px 20px;
-  color: #000000;
   font-weight: bold;
   font-size: 20px;
 }

--- a/adev/src/content/examples/animations/src/app/enter-and-leave/leave-binding.css
+++ b/adev/src/content/examples/animations/src/app/enter-and-leave/leave-binding.css
@@ -7,7 +7,6 @@
   border: 1px solid #dddddd;
   margin-top: 1em;
   padding: 20px 20px 0px 20px;
-  color: #000000;
   font-weight: bold;
   font-size: 20px;
   opacity: 1;

--- a/adev/src/content/examples/animations/src/app/enter-and-leave/leave-event.css
+++ b/adev/src/content/examples/animations/src/app/enter-and-leave/leave-event.css
@@ -7,7 +7,6 @@
   border: 1px solid #dddddd;
   margin-top: 1em;
   padding: 20px 20px 0px 20px;
-  color: #000000;
   font-weight: bold;
   font-size: 20px;
   opacity: 1;

--- a/adev/src/content/examples/animations/src/app/enter-and-leave/leave.css
+++ b/adev/src/content/examples/animations/src/app/enter-and-leave/leave.css
@@ -7,7 +7,6 @@
   border: 1px solid #dddddd;
   margin-top: 1em;
   padding: 20px 20px 0px 20px;
-  color: #000000;
   font-weight: bold;
   font-size: 20px;
   opacity: 1;

--- a/adev/src/content/examples/animations/src/app/native-css/insert.component.css
+++ b/adev/src/content/examples/animations/src/app/native-css/insert.component.css
@@ -6,7 +6,6 @@
   border: 1px solid #dddddd;
   margin-top: 1em;
   padding: 20px 20px 0px 20px;
-  color: #000000;
   font-weight: bold;
   font-size: 20px;
 }

--- a/adev/src/content/examples/animations/src/app/native-css/remove.component.css
+++ b/adev/src/content/examples/animations/src/app/native-css/remove.component.css
@@ -6,7 +6,6 @@
   border: 1px solid #dddddd;
   margin-top: 1em;
   padding: 20px 20px 0px 20px;
-  color: #000000;
   font-weight: bold;
   font-size: 20px;
   opacity: 1;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Example previews in dark mode render almost the same as in light mode.
![ezgif-74234e3068cc6d](https://github.com/user-attachments/assets/f738dadf-9be6-4034-a6bf-ccc1a2f75e2c)

## What is the new behavior?
Proper dark mode for example previews.
![ezgif-69bf5692696f3c](https://github.com/user-attachments/assets/484886db-b3e7-430f-9e99-dea426b4ac33)

With a few changes in animation examples all existing example previews look good in dark mode.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
