### PR TITLE
fix(compiler): incorrect source span for expression AST inside template attribute

### DIFF
--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -631,11 +631,11 @@ class HtmlAstToIvyAst implements html.Visitor {
 
         const parsedVariables: ParsedVariable[] = [];
         const absoluteValueOffset = attribute.valueSpan
-          ? attribute.valueSpan.start.offset
+          ? attribute.valueSpan.fullStart.offset
           : // If there is no value span the attribute does not have a value, like `attr` in
             //`<div attr></div>`. In this case, point to one character beyond the last character of
             // the attribute name.
-            attribute.sourceSpan.start.offset + attribute.name.length;
+            attribute.sourceSpan.fullStart.offset + attribute.name.length;
 
         this.bindingParser.parseInlineTemplateBinding(
           templateKey,

--- a/packages/compiler/test/render3/r3_ast_spans_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_spans_spec.ts
@@ -428,6 +428,24 @@ describe('R3 AST source spans', () => {
       assertValueSpan('<a [b]="    helloWorld"></a>', 12, 22);
       assertValueSpan('<a [b]="                                          helloWorld"></a>', 50, 60);
     });
+
+    it('should not throw off span of value in template attribute when leading spaces are present', () => {
+      const assertValueSpan = (template: string, start: number, end: number) => {
+        const result = parse(template);
+        const boundAttribute = (result.nodes[0] as t.Template).templateAttrs[0];
+        const span = (boundAttribute.value as ASTWithSource).ast.sourceSpan;
+
+        expect(span.start).toBe(start);
+        expect(span.end).toBe(end);
+      };
+
+      assertValueSpan('<ng-container *ngTemplateOutlet="helloWorld"/>', 33, 43);
+      assertValueSpan('<ng-container *ngTemplateOutlet=" helloWorld"/>', 34, 44);
+      assertValueSpan('<ng-container *ngTemplateOutlet="  helloWorld"/>', 35, 45);
+      assertValueSpan('<ng-container *ngTemplateOutlet="   helloWorld"/>', 36, 46);
+      assertValueSpan('<ng-container *ngTemplateOutlet="    helloWorld"/>', 37, 47);
+      assertValueSpan('<ng-container *ngTemplateOutlet="                    helloWorld"/>', 53, 63);
+    });
   });
 
   describe('templates', () => {


### PR DESCRIPTION
Similar fix as #63082, but for template attributes. The root cause is the same where we should be using `fullStart` instead of `start` in order to account for whitespaces being skipped.

Fixes #63157.
