### PR TITLE
docs(docs-infra): correct method names in tutorial 7-event-handling

### DIFF
--- a/adev/src/content/tutorials/learn-angular/steps/7-event-handling/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/7-event-handling/README.md
@@ -32,7 +32,7 @@ Alright, your turn to give this a try:
 Add the `showSecretMessage()` event handler function in the `App` class. Use the following code as the implementation:
 
 ```ts
-showSecretMessage()() {
+showSecretMessage() {
   this.message = 'Way to go 🚀';
 }
 ```
@@ -43,7 +43,7 @@ showSecretMessage()() {
 Update the template code in `app.ts` to bind to the `mouseover` event of the `section` element.
 
 ```angular-html
-<section (mouseover)="showSecretMessage()()">
+<section (mouseover)="showSecretMessage()">
 ```
 
 </docs-step>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The current example suggests a method name with a double pair of parentheses, which is obviously wrong.

Issue Number: N/A


## What is the new behavior?
Removed extra () from example, so that syntax is correct.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
