### PR TITLE
adev, several fixes for CLI pages

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/cli-card.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/cli-card.tsx
@@ -24,14 +24,16 @@ export function CliCard(props: {card: CliCardRenderable}) {
                 {item.aliases?.map((alias) => (
                   <div class="docs-reference-option-aliases">
                     <span>Alias</span>
-                    <code>{alias} </code>
+                    <code>{alias}</code>
                   </div>
                 ))}
               </div>
               <div dangerouslySetInnerHTML={{__html: item.description}}></div>
             </div>
             <div class="docs-reference-type-and-default">
-              {/* Display the enum values if there are some, else the type expected for the option */}
+              {/* Display the type expected for the option and the enum values if there are some. */}
+              <span>Value Type</span>
+              <code>{item.type}</code>
               {item.enum ? (
                 <>
                   <span>Allowed Values</span>
@@ -45,10 +47,7 @@ export function CliCard(props: {card: CliCardRenderable}) {
                   </span>
                 </>
               ) : (
-                <>
-                  <span>Value Type</span>
-                  <code>{item.type}</code>
-                </>
+                <></>
               )}
               {/* Default Value */}
               {item.default !== undefined ? <span>Default</span> : <></>}

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/cli-card.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/cli-card.tsx
@@ -37,14 +37,12 @@ export function CliCard(props: {card: CliCardRenderable}) {
               {item.enum ? (
                 <>
                   <span>Allowed Values</span>
-                  <span>
-                    {item.enum.map((val, i, items) => (
-                      <>
-                        <code>{val}</code>
-                        {i < items.length - 1 && ', '}
-                      </>
-                    ))}
-                  </span>
+                  {item.enum.map((val, i, items) => (
+                    <>
+                      <code>{val}</code>
+                      {i < items.length - 1 && ', '}
+                    </>
+                  ))}
                 </>
               ) : (
                 <></>

--- a/adev/shared-docs/styles/_reference.scss
+++ b/adev/shared-docs/styles/_reference.scss
@@ -373,6 +373,12 @@
 
     // "CLI member card"-specific styles
     .docs-reference-member-card {
+      .docs-reference-option-aliases {
+        span {
+          padding-right: 0.4rem;
+        }
+      }
+
       .docs-ref-content {
         padding: 1rem 0;
 

--- a/adev/shared-docs/styles/_reference.scss
+++ b/adev/shared-docs/styles/_reference.scss
@@ -393,7 +393,6 @@
             display: block;
             font-size: 0.875rem;
             margin-block-end: 0.2rem;
-            white-space: nowrap;
 
             &:not(:first-child) {
               margin-block-start: 1rem;


### PR DESCRIPTION


**fix(docs-infra): allow wrapping of types-and-default CLI options**
This change fixes an issue where long lists of enum values would display on a single line, running off the screen, especially on mobile devices.


**fix(docs-infra): add spacing between `Alias` and `Value`**
Prior to this change there was noi spacing between the Alias and Value

**fix(docs-infra): display value type in CLI pages**
The value type was not being displayed when a value had an enum, which was misleading. This change ensures the value type is always shown, so users know whether to expect a single value or an array of values.
