### PR TITLE
fix(compiler): fixes animation event host bindings not firing

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/animations/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/animations/GOLDEN_PARTIAL.js
@@ -80,6 +80,59 @@ export declare class MyComponent {
 }
 
 /****************************************************************************************************
+ * PARTIAL FILE: animate_enter_with_event_host_bindings.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class ChildComponent {
+    fadeFn(event) {
+        event.target.classList.add('fade');
+        event.animationComplete();
+    }
+}
+ChildComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: ChildComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
+ChildComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: ChildComponent, isStandalone: true, selector: "child-component", host: { listeners: { "animate.enter": "fadeFn($event)" } }, ngImport: i0, template: `<p>Sliding Content</p>`, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: ChildComponent, decorators: [{
+            type: Component,
+            args: [{
+                    selector: 'child-component',
+                    host: { '(animate.enter)': 'fadeFn($event)' },
+                    template: `<p>Sliding Content</p>`,
+                }]
+        }] });
+export class MyComponent {
+}
+MyComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent, isStandalone: true, selector: "my-component", ngImport: i0, template: `
+    <child-component animate.enter="slide"></child-component>
+  `, isInline: true, dependencies: [{ kind: "component", type: ChildComponent, selector: "child-component" }] });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, decorators: [{
+            type: Component,
+            args: [{
+                    selector: 'my-component',
+                    imports: [ChildComponent],
+                    template: `
+    <child-component animate.enter="slide"></child-component>
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: animate_enter_with_event_host_bindings.d.ts
+ ****************************************************************************************************/
+import { AnimationCallbackEvent } from '@angular/core';
+import * as i0 from "@angular/core";
+export declare class ChildComponent {
+    fadeFn(event: AnimationCallbackEvent): void;
+    static ɵfac: i0.ɵɵFactoryDeclaration<ChildComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<ChildComponent, "child-component", never, {}, {}, never, never, true, never>;
+}
+export declare class MyComponent {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyComponent, "my-component", never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
  * PARTIAL FILE: animate_enter_with_binding.js
  ****************************************************************************************************/
 import { Component, signal } from '@angular/core';
@@ -306,6 +359,59 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
  ****************************************************************************************************/
 import * as i0 from "@angular/core";
 export declare class ChildComponent {
+    static ɵfac: i0.ɵɵFactoryDeclaration<ChildComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<ChildComponent, "child-component", never, {}, {}, never, never, true, never>;
+}
+export declare class MyComponent {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyComponent, "my-component", never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: animate_leave_with_event_host_bindings.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class ChildComponent {
+    fadeFn(event) {
+        event.target.classList.add('fade');
+        event.animationComplete();
+    }
+}
+ChildComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: ChildComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
+ChildComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: ChildComponent, isStandalone: true, selector: "child-component", host: { listeners: { "animate.leave": "fadeFn($event)" } }, ngImport: i0, template: `<p>Fading Content</p>`, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: ChildComponent, decorators: [{
+            type: Component,
+            args: [{
+                    selector: 'child-component',
+                    template: `<p>Fading Content</p>`,
+                    host: { '(animate.leave)': 'fadeFn($event)' },
+                }]
+        }] });
+export class MyComponent {
+}
+MyComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent, isStandalone: true, selector: "my-component", ngImport: i0, template: `
+      <child-component animate.leave="slide"></child-component>
+  `, isInline: true, dependencies: [{ kind: "component", type: ChildComponent, selector: "child-component" }] });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, decorators: [{
+            type: Component,
+            args: [{
+                    selector: 'my-component',
+                    imports: [ChildComponent],
+                    template: `
+      <child-component animate.leave="slide"></child-component>
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: animate_leave_with_event_host_bindings.d.ts
+ ****************************************************************************************************/
+import { AnimationCallbackEvent } from '@angular/core';
+import * as i0 from "@angular/core";
+export declare class ChildComponent {
+    fadeFn(event: AnimationCallbackEvent): void;
     static ɵfac: i0.ɵɵFactoryDeclaration<ChildComponent, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<ChildComponent, "child-component", never, {}, {}, never, never, true, never>;
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/animations/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/animations/TEST_CASES.json
@@ -36,6 +36,23 @@
       ]
     },
     {
+      "description": "should generate animate enter instructions with host binding and event",
+      "inputFiles": [
+        "animate_enter_with_event_host_bindings.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "animate_enter_with_event_host_bindings_template.js",
+              "generated": "animate_enter_with_event_host_bindings.js"
+            }
+          ],
+          "failureMessage": "Incorrect ɵɵanimateEnter() call"
+        }
+      ]
+    },
+    {
       "description": "should generate animate enter instructions on element with a binding",
       "inputFiles": [
         "animate_enter_with_binding.ts"
@@ -131,6 +148,23 @@
             {
               "expected": "animate_leave_with_string_host_bindings_template.js",
               "generated": "animate_leave_with_string_host_bindings.js"
+            }
+          ],
+          "failureMessage": "Incorrect ɵɵanimateLeave() call"
+        }
+      ]
+    },
+    {
+      "description": "should generate animate leave instructions with host binding and event",
+      "inputFiles": [
+        "animate_leave_with_event_host_bindings.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "animate_leave_with_event_host_bindings_template.js",
+              "generated": "animate_leave_with_event_host_bindings.js"
             }
           ],
           "failureMessage": "Incorrect ɵɵanimateLeave() call"

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/animations/animate_enter_with_event_host_bindings.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/animations/animate_enter_with_event_host_bindings.ts
@@ -1,0 +1,23 @@
+import {AnimationCallbackEvent, Component} from '@angular/core';
+
+@Component({
+  selector: 'child-component',
+  host: {'(animate.enter)': 'fadeFn($event)'},
+  template: `<p>Sliding Content</p>`,
+})
+export class ChildComponent {
+  fadeFn(event: AnimationCallbackEvent) {
+    event.target.classList.add('fade');
+    event.animationComplete();
+  }
+}
+
+@Component({
+  selector: 'my-component',
+  imports: [ChildComponent],
+  template: `
+    <child-component animate.enter="slide"></child-component>
+  `,
+})
+export class MyComponent {
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/animations/animate_enter_with_event_host_bindings_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/animations/animate_enter_with_event_host_bindings_template.js
@@ -1,0 +1,13 @@
+ChildComponent.ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({ type: ChildComponent, selectors: [["child-component"]], hostBindings: function ChildComponent_HostBindings(rf, ctx) { if (rf & 1) {
+        i0.ɵɵanimateEnterListener(function ChildComponent_animateenter_HostBindingHandler($event) { return ctx.fadeFn($event); });
+    } }, decls: 2, vars: 0, template: function ChildComponent_Template(rf, ctx) { if (rf & 1) {
+        i0.ɵɵdomElementStart(0, "p");
+        i0.ɵɵtext(1, "Sliding Content");
+        i0.ɵɵdomElementEnd();
+    } }, encapsulation: 2 });
+…
+MyComponent.ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({ type: MyComponent, selectors: [["my-component"]], decls: 1, vars: 0, template: function MyComponent_Template(rf, ctx) { if (rf & 1) {
+        i0.ɵɵelementStart(0, "child-component");
+        i0.ɵɵanimateEnter("slide");
+        i0.ɵɵelementEnd();
+    } }, dependencies: [ChildComponent], encapsulation: 2 });

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/animations/animate_leave_with_event_host_bindings.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/animations/animate_leave_with_event_host_bindings.ts
@@ -1,0 +1,23 @@
+import {AnimationCallbackEvent, Component} from '@angular/core';
+
+@Component({
+    selector: 'child-component',
+    template: `<p>Fading Content</p>`,
+    host: {'(animate.leave)': 'fadeFn($event)'},
+})
+export class ChildComponent {
+  fadeFn(event: AnimationCallbackEvent) {
+    event.target.classList.add('fade');
+    event.animationComplete();
+  }
+}
+
+@Component({
+    selector: 'my-component',
+    imports: [ChildComponent],
+    template: `
+      <child-component animate.leave="slide"></child-component>
+  `,
+})
+export class MyComponent {
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/animations/animate_leave_with_event_host_bindings_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/animations/animate_leave_with_event_host_bindings_template.js
@@ -1,0 +1,13 @@
+ChildComponent.ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({ type: ChildComponent, selectors: [["child-component"]], hostBindings: function ChildComponent_HostBindings(rf, ctx) { if (rf & 1) {
+        i0.ɵɵanimateLeaveListener(function ChildComponent_animateleave_HostBindingHandler($event) { return ctx.fadeFn($event); });
+    } }, features: [i0.ɵɵAnimationsFeature()], decls: 2, vars: 0, template: function ChildComponent_Template(rf, ctx) { if (rf & 1) {
+        i0.ɵɵdomElementStart(0, "p");
+        i0.ɵɵtext(1, "Fading Content");
+        i0.ɵɵdomElementEnd();
+    } }, encapsulation: 2 });
+…
+MyComponent.ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({ type: MyComponent, selectors: [["my-component"]], features: [i0.ɵɵAnimationsFeature()], decls: 1, vars: 0, template: function MyComponent_Template(rf, ctx) { if (rf & 1) {
+        i0.ɵɵelementStart(0, "child-component");
+        i0.ɵɵanimateLeave("slide");
+        i0.ɵɵelementEnd();
+    } }, dependencies: [ChildComponent], encapsulation: 2 });

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -200,21 +200,37 @@ export function ingestHostAttribute(
 }
 
 export function ingestHostEvent(job: HostBindingCompilationJob, event: e.ParsedEvent) {
-  const [phase, target] =
-    event.type !== e.ParsedEventType.LegacyAnimation
-      ? [null, event.targetOrPhase]
-      : [event.targetOrPhase, null];
-  const eventBinding = ir.createListenerOp(
-    job.root.xref,
-    new ir.SlotHandle(),
-    event.name,
-    null,
-    makeListenerHandlerOps(job.root, event.handler, event.handlerSpan),
-    phase,
-    target,
-    true,
-    event.sourceSpan,
-  );
+  let eventBinding: ir.CreateOp;
+  if (event.type === e.ParsedEventType.Animation) {
+    eventBinding = ir.createAnimationListenerOp(
+      job.root.xref,
+      new ir.SlotHandle(),
+      event.name,
+      null,
+      makeListenerHandlerOps(job.root, event.handler, event.handlerSpan),
+      event.name.endsWith('enter') ? ir.AnimationKind.ENTER : ir.AnimationKind.LEAVE,
+      event.targetOrPhase,
+      true,
+      event.sourceSpan,
+    );
+  } else {
+    const [phase, target] =
+      event.type !== e.ParsedEventType.LegacyAnimation
+        ? [null, event.targetOrPhase]
+        : [event.targetOrPhase, null];
+
+    eventBinding = ir.createListenerOp(
+      job.root.xref,
+      new ir.SlotHandle(),
+      event.name,
+      null,
+      makeListenerHandlerOps(job.root, event.handler, event.handlerSpan),
+      phase,
+      target,
+      true,
+      event.sourceSpan,
+    );
+  }
   job.root.create.push(eventBinding);
 }
 


### PR DESCRIPTION
Host bindings for `(animate.enter)` and `(animate.leave)` were not firing properly. This fixes the compiler ingest to make sure they do fire.

fixes: #63199

- [ ] Yes
- [x] No
