### PR TITLE
refactor(forms): reduce `FieldState` API to a minimal set of properties

### DIFF
--- a/goldens/public-api/forms/experimental/index.api.md
+++ b/goldens/public-api/forms/experimental/index.api.md
@@ -192,8 +192,6 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
     readonly readonly: Signal<boolean>;
     reset(): void;
     readonly submitting: Signal<boolean>;
-    readonly syncErrors: Signal<ValidationError[]>;
-    readonly syncValid: Signal<boolean>;
     readonly touched: Signal<boolean>;
     readonly valid: Signal<boolean>;
     readonly value: WritableSignal<TValue>;

--- a/packages/forms/experimental/src/api/async.ts
+++ b/packages/forms/experimental/src/api/async.ts
@@ -141,7 +141,8 @@ export function validateAsync<TValue, TParams, TResult, TPathKind extends PathKi
   const RESOURCE = property(path, (ctx) => {
     const params = computed(() => {
       const node = ctx.stateOf(path) as FieldNode;
-      if (node.validationState.shouldSkipValidation() || !node.syncValid()) {
+      const validationState = node.validationState;
+      if (validationState.shouldSkipValidation() || !validationState.syncValid()) {
         return undefined;
       }
       return opts.params(ctx);

--- a/packages/forms/experimental/src/api/types.ts
+++ b/packages/forms/experimental/src/api/types.ts
@@ -237,11 +237,6 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
    * A signal containing the current errors for the field.
    */
   readonly errors: Signal<ValidationError[]>;
-
-  /**
-   * A signal containing the current errors for the field.
-   */
-  readonly syncErrors: Signal<ValidationError[]>;
   /**
    * A signal indicating whether the field's value is currently valid.
    *
@@ -270,11 +265,6 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
    * Whether there are any validators still pending for this field.
    */
   readonly pending: Signal<boolean>;
-  /**
-   * A signal indicating whether the field's value is currently valid according to its synchronous
-   * validators. (The field's asynchronous validators may still be pending or failing).
-   */
-  readonly syncValid: Signal<boolean>;
   /**
    * A signal indicating whether the field is currently in the process of being submitted.
    */

--- a/packages/forms/experimental/src/field/node.ts
+++ b/packages/forms/experimental/src/field/node.ts
@@ -83,14 +83,6 @@ export class FieldNode implements FieldState<unknown> {
     return this.structure.keyInParent;
   }
 
-  get syncErrors(): Signal<ValidationError[]> {
-    return this.validationState.syncErrors;
-  }
-
-  get syncValid(): Signal<boolean> {
-    return this.validationState.syncValid;
-  }
-
   get errors(): Signal<ValidationError[]> {
     return this.validationState.errors;
   }

--- a/packages/forms/experimental/test/node/validation_status.spec.ts
+++ b/packages/forms/experimental/test/node/validation_status.spec.ts
@@ -50,12 +50,10 @@ describe('validation status', () => {
         {injector},
       );
 
-      expect(f().syncValid()).toBe(true);
       expect(f().valid()).toBe(true);
       expect(f().invalid()).toBe(false);
 
       f().value.set('INVALID');
-      expect(f().syncValid()).toBe(false);
       expect(f().valid()).toBe(false);
       expect(f().invalid()).toBe(true);
     });
@@ -69,12 +67,10 @@ describe('validation status', () => {
         {injector},
       );
 
-      expect(f().syncValid()).toBe(true);
       expect(f().valid()).toBe(true);
       expect(f().invalid()).toBe(false);
 
       f.child().value.set('INVALID');
-      expect(f().syncValid()).toBe(false);
       expect(f().valid()).toBe(false);
       expect(f().invalid()).toBe(true);
     });
@@ -88,12 +84,10 @@ describe('validation status', () => {
         {injector},
       );
 
-      expect(f.child().syncValid()).toBe(true);
       expect(f.child().valid()).toBe(true);
       expect(f.child().invalid()).toBe(false);
 
       f.child().value.set('INVALID');
-      expect(f.child().syncValid()).toBe(true);
       expect(f.child().valid()).toBe(true);
       expect(f.child().invalid()).toBe(false);
     });
@@ -109,12 +103,10 @@ describe('validation status', () => {
         {injector},
       );
 
-      expect(f().syncValid()).toBe(true);
       expect(f().valid()).toBe(true);
       expect(f().invalid()).toBe(false);
 
       f().value.set('INVALID');
-      expect(f().syncValid()).toBe(false);
       expect(f().valid()).toBe(false);
       expect(f().invalid()).toBe(true);
     });
@@ -130,12 +122,10 @@ describe('validation status', () => {
         {injector},
       );
 
-      expect(f.child().syncValid()).toBe(true);
       expect(f.child().valid()).toBe(true);
       expect(f.child().invalid()).toBe(false);
 
       f.child().value.set('INVALID');
-      expect(f.child().syncValid()).toBe(false);
       expect(f.child().valid()).toBe(false);
       expect(f.child().invalid()).toBe(true);
     });
@@ -151,12 +141,10 @@ describe('validation status', () => {
         {injector},
       );
 
-      expect(f().syncValid()).toBe(true);
       expect(f().valid()).toBe(true);
       expect(f().invalid()).toBe(false);
 
       f.child().value.set('INVALID');
-      expect(f().syncValid()).toBe(false);
       expect(f().valid()).toBe(false);
       expect(f().invalid()).toBe(true);
     });
@@ -172,12 +160,10 @@ describe('validation status', () => {
         {injector},
       );
 
-      expect(f.sibling().syncValid()).toBe(true);
       expect(f.sibling().valid()).toBe(true);
       expect(f.sibling().invalid()).toBe(false);
 
       f.child().value.set('INVALID');
-      expect(f.sibling().syncValid()).toBe(true);
       expect(f.sibling().valid()).toBe(true);
       expect(f.sibling().invalid()).toBe(false);
     });
@@ -209,14 +195,12 @@ describe('validation status', () => {
       await waitFor(() => res?.isLoading());
 
       expect(f().pending()).toBe(true);
-      expect(f().syncValid()).toBe(true);
       expect(f().valid()).toBe(false);
       expect(f().invalid()).toBe(false);
 
       await appRef.whenStable();
 
       expect(f().pending()).toBe(false);
-      expect(f().syncValid()).toBe(true);
       expect(f().valid()).toBe(true);
       expect(f().invalid()).toBe(false);
 
@@ -224,14 +208,12 @@ describe('validation status', () => {
       await waitFor(() => res?.isLoading());
 
       expect(f().pending()).toBe(true);
-      expect(f().syncValid()).toBe(true);
       expect(f().valid()).toBe(false);
       expect(f().invalid()).toBe(false);
 
       await appRef.whenStable();
 
       expect(f().pending()).toBe(false);
-      expect(f().syncValid()).toBe(true);
       expect(f().valid()).toBe(false);
       expect(f().invalid()).toBe(true);
     });
@@ -265,14 +247,12 @@ describe('validation status', () => {
       await waitFor(() => res?.isLoading());
 
       expect(f.child().pending()).toBe(true);
-      expect(f.child().syncValid()).toBe(true);
       expect(f.child().valid()).toBe(false);
       expect(f.child().invalid()).toBe(false);
 
       await appRef.whenStable();
 
       expect(f.child().pending()).toBe(false);
-      expect(f.child().syncValid()).toBe(true);
       expect(f.child().valid()).toBe(true);
       expect(f.child().invalid()).toBe(false);
 
@@ -280,14 +260,12 @@ describe('validation status', () => {
       await waitFor(() => res?.isLoading());
 
       expect(f.child().pending()).toBe(true);
-      expect(f.child().syncValid()).toBe(true);
       expect(f.child().valid()).toBe(false);
       expect(f.child().invalid()).toBe(false);
 
       await appRef.whenStable();
 
       expect(f.child().pending()).toBe(false);
-      expect(f.child().syncValid()).toBe(true);
       expect(f.child().valid()).toBe(false);
       expect(f.child().invalid()).toBe(true);
     });
@@ -321,14 +299,12 @@ describe('validation status', () => {
       await waitFor(() => res?.isLoading());
 
       expect(f().pending()).toBe(true);
-      expect(f().syncValid()).toBe(true);
       expect(f().valid()).toBe(false);
       expect(f().invalid()).toBe(false);
 
       await appRef.whenStable();
 
       expect(f().pending()).toBe(false);
-      expect(f().syncValid()).toBe(true);
       expect(f().valid()).toBe(true);
       expect(f().invalid()).toBe(false);
 
@@ -336,14 +312,12 @@ describe('validation status', () => {
       await waitFor(() => res?.isLoading());
 
       expect(f().pending()).toBe(true);
-      expect(f().syncValid()).toBe(true);
       expect(f().valid()).toBe(false);
       expect(f().invalid()).toBe(false);
 
       await appRef.whenStable();
 
       expect(f().pending()).toBe(false);
-      expect(f().syncValid()).toBe(true);
       expect(f().valid()).toBe(false);
       expect(f().invalid()).toBe(true);
     });
@@ -380,14 +354,12 @@ describe('validation status', () => {
       await waitFor(() => res?.isLoading());
 
       expect(f.sibling().pending()).toBe(true);
-      expect(f.sibling().syncValid()).toBe(true);
       expect(f.sibling().valid()).toBe(false);
       expect(f.sibling().invalid()).toBe(false);
 
       await appRef.whenStable();
 
       expect(f.sibling().pending()).toBe(false);
-      expect(f.sibling().syncValid()).toBe(true);
       expect(f.sibling().valid()).toBe(true);
       expect(f.sibling().invalid()).toBe(false);
 
@@ -395,14 +367,12 @@ describe('validation status', () => {
       await waitFor(() => res?.isLoading());
 
       expect(f.sibling().pending()).toBe(true);
-      expect(f.sibling().syncValid()).toBe(true);
       expect(f.sibling().valid()).toBe(false);
       expect(f.sibling().invalid()).toBe(false);
 
       await appRef.whenStable();
 
       expect(f.sibling().pending()).toBe(false);
-      expect(f.sibling().syncValid()).toBe(true);
       expect(f.sibling().valid()).toBe(true);
       expect(f.sibling().invalid()).toBe(false);
     });
@@ -420,7 +390,6 @@ describe('validation status', () => {
       );
 
       expect(f().pending()).toBe(false);
-      expect(f().syncValid()).toBe(false);
       expect(f().valid()).toBe(false);
       expect(f().invalid()).toBe(true);
     });
@@ -448,7 +417,6 @@ describe('validation status', () => {
 
       await waitFor(() => res?.isLoading());
       expect(f().pending()).toBe(true);
-      expect(f().syncValid()).toBe(true);
       expect(f().valid()).toBe(false);
       expect(f().invalid()).toBe(false);
     });
@@ -488,7 +456,6 @@ describe('validation status', () => {
 
       await waitFor(() => !res?.isLoading() && res2.isLoading());
       expect(f().pending()).toBe(true);
-      expect(f().syncValid()).toBe(true);
       expect(f().valid()).toBe(false);
       expect(f().invalid()).toBe(true);
     });
@@ -529,7 +496,6 @@ describe('validation status', () => {
 
       await waitFor(() => !res?.isLoading() && res2.isLoading());
       expect(f().pending()).toBe(true);
-      expect(f().syncValid()).toBe(true);
       expect(f().valid()).toBe(false);
       expect(f().invalid()).toBe(true);
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4014,6 +4014,11 @@ packages:
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -14505,8 +14510,8 @@ snapshots:
     optionalDependencies:
       ajv: 8.13.0
 
-  ajv-formats@2.1.1:
-    dependencies:
+  ajv-formats@2.1.1(ajv@8.17.1):
+    optionalDependencies:
       ajv: 8.17.1
 
   ajv-formats@3.0.1:
@@ -16673,7 +16678,7 @@ snapshots:
     dependencies:
       '@apidevtools/json-schema-ref-parser': 9.1.2
       ajv: 8.17.1
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1(ajv@8.17.1)
       body-parser: 1.20.3
       content-type: 1.0.5
       deep-freeze: 0.0.1
@@ -20794,7 +20799,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
       ajv: 8.17.1
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1(ajv@8.17.1)
       ajv-keywords: 5.1.0(ajv@8.17.1)
 
   secure-compare@3.0.1: {}


### PR DESCRIPTION
Remove the following properties from `FieldState`

* `syncErrors`
* `syncValid`

These properties are implementation details which can be accessed internally through the field node's `validationState` where necessary.