### PR TITLE
docs: use correct closing quote in `input` and `model` import usage notes

### DIFF
--- a/packages/core/src/authoring/input/input.ts
+++ b/packages/core/src/authoring/input/input.ts
@@ -119,7 +119,7 @@ export interface InputFunction {
  * To use signal-based inputs, import `input` from `@angular/core`.
  *
  * ```ts
- * import {input} from '@angular/core`;
+ * import {input} from '@angular/core';
  * ```
  *
  * Inside your component, introduce a new class member and initialize

--- a/packages/core/src/authoring/model/model.ts
+++ b/packages/core/src/authoring/model/model.ts
@@ -69,7 +69,7 @@ export interface ModelFunction {
  * To use `model()`, import the function from `@angular/core`.
  *
  * ```ts
- * import {model} from '@angular/core`;
+ * import {model} from '@angular/core';
  * ```
  *
  * Inside your component, introduce a new class member and initialize


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The usage notes for `input` and `model` imports have an incorrect closing quote (backtick instead of a single quote), which isn't valid.

Issue Number: N/A


## What is the new behavior?
Fixes the imports to have a closing single quote

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
