### PR TITLE
docs: update `NG_VALIDATORS` examples to use `forwardRef`

### DIFF
--- a/adev/src/content/examples/form-validation/src/app/shared/forbidden-name.directive.ts
+++ b/adev/src/content/examples/form-validation/src/app/shared/forbidden-name.directive.ts
@@ -1,5 +1,5 @@
 // #docregion
-import {Directive, input} from '@angular/core';
+import {Directive, forwardRef, input} from '@angular/core';
 import {
   AbstractControl,
   NG_VALIDATORS,
@@ -22,7 +22,13 @@ export function forbiddenNameValidator(nameRe: RegExp): ValidatorFn {
 @Directive({
   selector: '[appForbiddenName]',
   // #docregion directive-providers
-  providers: [{provide: NG_VALIDATORS, useExisting: ForbiddenValidatorDirective, multi: true}],
+  providers: [
+    {
+      provide: NG_VALIDATORS,
+      useExisting: forwardRef(() => ForbiddenValidatorDirective),
+      multi: true,
+    },
+  ],
 })
 export class ForbiddenValidatorDirective implements Validator {
   forbiddenName = input<string>('', {alias: 'appForbiddenName'});

--- a/adev/src/content/examples/form-validation/src/app/shared/unambiguous-role.directive.ts
+++ b/adev/src/content/examples/form-validation/src/app/shared/unambiguous-role.directive.ts
@@ -1,5 +1,5 @@
 // #docregion
-import {Directive} from '@angular/core';
+import {Directive, forwardRef} from '@angular/core';
 import {
   AbstractControl,
   NG_VALIDATORS,
@@ -24,7 +24,11 @@ export const unambiguousRoleValidator: ValidatorFn = (
 @Directive({
   selector: '[appUnambiguousRole]',
   providers: [
-    {provide: NG_VALIDATORS, useExisting: UnambiguousRoleValidatorDirective, multi: true},
+    {
+      provide: NG_VALIDATORS,
+      useExisting: forwardRef(() => UnambiguousRoleValidatorDirective),
+      multi: true,
+    },
   ],
 })
 export class UnambiguousRoleValidatorDirective implements Validator {

--- a/adev/src/content/examples/form-validation/src/app/shared/unambiguous-role.ts
+++ b/adev/src/content/examples/form-validation/src/app/shared/unambiguous-role.ts
@@ -1,5 +1,5 @@
 // #docregion
-import {Directive} from '@angular/core';
+import {Directive, forwardRef} from '@angular/core';
 import {
   AbstractControl,
   NG_VALIDATORS,
@@ -24,7 +24,11 @@ export const unambiguousRoleValidator: ValidatorFn = (
 @Directive({
   selector: '[appUnambiguousRole]',
   providers: [
-    {provide: NG_VALIDATORS, useExisting: UnambiguousRoleValidatorDirective, multi: true},
+    {
+      provide: NG_VALIDATORS,
+      useExisting: forwardRef(() => UnambiguousRoleValidatorDirective),
+      multi: true,
+    },
   ],
 })
 export class UnambiguousRoleValidatorDirective implements Validator {

--- a/packages/forms/src/directives/validators.ts
+++ b/packages/forms/src/directives/validators.ts
@@ -75,7 +75,7 @@ export type ValidationErrors = {
  * ```ts
  * @Directive({
  *   selector: '[customValidator]',
- *   providers: [{provide: NG_VALIDATORS, useExisting: CustomValidatorDirective, multi: true}]
+ *   providers: [{provide: NG_VALIDATORS, useExisting: forwardRef(() => CustomValidatorDirective), multi: true}]
  * })
  * class CustomValidatorDirective implements Validator {
  *   validate(control: AbstractControl): ValidationErrors|null {

--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -65,7 +65,7 @@ function lengthOrSize(value: unknown): number | null {
  * ```ts
  * @Directive({
  *   selector: '[customValidator]',
- *   providers: [{provide: NG_VALIDATORS, useExisting: CustomValidatorDirective, multi: true}]
+ *   providers: [{provide: NG_VALIDATORS, useExisting: forwardRef(() => CustomValidatorDirective), multi: true}]
  * })
  * class CustomValidatorDirective implements Validator {
  *   validate(control: AbstractControl): ValidationErrors | null {


### PR DESCRIPTION
Fixes #63239