### PR TITLE
refactor(animations): remove dependency on `@angular/common`

### DIFF
--- a/integration/legacy-animations-async/size.json
+++ b/integration/legacy-animations-async/size.json
@@ -1,5 +1,5 @@
 {
-  "dist/main.js": 86540,
+  "dist/main.js": 97227,
   "dist/polyfills.js": 33782,
   "dist/browser-[hash].js": 63949,
   "dist/open-close.component-[hash].js": 1218

--- a/integration/legacy-animations/size.json
+++ b/integration/legacy-animations/size.json
@@ -1,5 +1,5 @@
 {
-  "dist/main.js": 143167,
+  "dist/main.js": 153915,
   "dist/polyfills.js": 34023,
   "dist/open-close.component-[hash].js": 1190
 }

--- a/packages/animations/BUILD.bazel
+++ b/packages/animations/BUILD.bazel
@@ -11,7 +11,6 @@ ng_project(
         ],
     ),
     deps = [
-        "//packages/common",
         "//packages/core",
     ],
 )
@@ -72,8 +71,6 @@ generate_api_docs(
     name = "animations_docs",
     srcs = [
         ":files_for_docgen",
-        "//packages:common_files_and_deps_for_docs",
-        "//packages/common:files_for_docgen",
     ],
     entry_point = ":index.ts",
     module_name = "@angular/animations",

--- a/packages/animations/browser/BUILD.bazel
+++ b/packages/animations/browser/BUILD.bazel
@@ -30,7 +30,6 @@ generate_api_docs(
     name = "animations_browser_docs",
     srcs = [
         ":files_for_docgen",
-        "//packages:common_files_and_deps_for_docs",
         "//packages/animations:files_for_docgen",
     ],
     entry_point = ":index.ts",

--- a/packages/animations/browser/testing/BUILD.bazel
+++ b/packages/animations/browser/testing/BUILD.bazel
@@ -25,7 +25,6 @@ generate_api_docs(
     name = "animations_browser_testing_docs",
     srcs = [
         ":files_for_docgen",
-        "//packages:common_files_and_deps_for_docs",
     ],
     entry_point = ":index.ts",
     module_name = "@angular/animations/browser/testing",

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -11,8 +11,7 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@angular/core": "0.0.0-PLACEHOLDER",
-    "@angular/common": "0.0.0-PLACEHOLDER"
+    "@angular/core": "0.0.0-PLACEHOLDER"
   },
   "repository": {
     "type": "git",

--- a/packages/animations/src/animation_builder.ts
+++ b/packages/animations/src/animation_builder.ts
@@ -5,9 +5,9 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {DOCUMENT} from '@angular/common';
 import {
   ANIMATION_MODULE_TYPE,
+  DOCUMENT,
   Inject,
   inject,
   Injectable,

--- a/packages/animations/test/BUILD.bazel
+++ b/packages/animations/test/BUILD.bazel
@@ -9,7 +9,6 @@ ts_project(
         "//packages/animations",
         "//packages/animations/browser",
         "//packages/animations/browser/testing",
-        "//packages/common",
         "//packages/core",
         "//packages/core/testing",
         "//packages/platform-browser",

--- a/packages/animations/test/browser_animation_builder_spec.ts
+++ b/packages/animations/test/browser_animation_builder_spec.ts
@@ -13,8 +13,7 @@ import {
 } from '../src/animations';
 import {AnimationDriver} from '../browser';
 import {MockAnimationDriver} from '../browser/testing';
-import {DOCUMENT} from '@angular/common';
-import {Component, NgZone, RendererFactory2, ViewChild} from '@angular/core';
+import {Component, NgZone, RendererFactory2, ViewChild, DOCUMENT} from '@angular/core';
 import {fakeAsync, flushMicrotasks, TestBed} from '@angular/core/testing';
 import {ɵDomRendererFactory2 as DomRendererFactory2} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -904,9 +904,6 @@ importers:
 
   packages/animations:
     dependencies:
-      '@angular/common':
-        specifier: 'workspace: *'
-        version: link:../common
       '@angular/core':
         specifier: 'workspace: *'
         version: link:../core


### PR DESCRIPTION
`DOCUMENT` was move to `@angular/core`, so we don't need to depend on common anymore.
