### PR TITLE
build: enforce frozen lockfile mode

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,6 +12,9 @@ common --@aspect_rules_ts//ts:default_to_tsc_transpiler
 # Needed as otherwise `env` of TS actions would be ignored.
 common --incompatible_merge_fixed_and_default_shell_env
 
+# Frozen lockfile
+common --lockfile_mode=error
+
 ###############################
 # Filesystem interactions     #
 ###############################


### PR DESCRIPTION
This commit adds `lockfile_mode=error` to the `.bazelrc` file. This change ensures that any future builds will fail if the lock file is not up-to-date with the `BUILD.bazel` file, preventing inconsistencies and encouraging developers to commit updated lock files.
