### PR TITLE
fix(compiler-cli): account for expression with type arguments during HMR extraction

### DIFF
--- a/packages/compiler-cli/src/ngtsc/hmr/src/extract_dependencies.ts
+++ b/packages/compiler-cli/src/ngtsc/hmr/src/extract_dependencies.ts
@@ -316,7 +316,8 @@ class PotentialTopLevelReadsVisitor extends o.RecursiveAstVisitor {
       ts.isSwitchStatement(parent) ||
       ts.isCaseClause(parent) ||
       ts.isThrowStatement(parent) ||
-      ts.isNewExpression(parent)
+      ts.isNewExpression(parent) ||
+      ts.isExpressionWithTypeArguments(parent)
     ) {
       return parent.expression === node;
     }

--- a/packages/compiler-cli/test/ngtsc/hmr_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/hmr_spec.ts
@@ -912,6 +912,37 @@ runInEachFileSystem(() => {
       );
     });
 
+    it('should capture expressions with type arguments', () => {
+      enableHmr();
+
+      env.write(
+        'test.ts',
+        `
+          import {Component, viewChild, TemplateRef} from '@angular/core';
+
+          @Component({
+            template: '<ng-template #template/>'
+          })
+          export class Cmp {
+            template = viewChild('template', {
+              read: TemplateRef<unknown>,
+            });
+          }
+        `,
+      );
+
+      env.driveMain();
+
+      const jsContents = env.getContents('test.js');
+      const hmrContents = env.driveHmr('test.ts', 'Cmp');
+      expect(jsContents).toContain(
+        'ɵɵreplaceMetadata(Cmp, m.default, [i0], [TemplateRef, Component], import.meta, id));',
+      );
+      expect(hmrContents).toContain(
+        'export default function Cmp_UpdateMetadata(Cmp, ɵɵnamespaces, TemplateRef, Component) {',
+      );
+    });
+
     it('should generate HMR code for a transformed class', () => {
       env.write(
         'test.ts',


### PR DESCRIPTION
Fixes that the HMR extraction logic didn't account for expressions with type arguments (e.g. `viewChild('foo', {read: TemplateRef<unknown>})`).

Fixes #63240.
