### PR TITLE
refactor(http): rework the `HttpEvent` union to improve narrowing.

### DIFF
--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -2524,7 +2524,7 @@ export class HttpErrorResponse extends HttpResponseBase implements Error {
 }
 
 // @public
-export type HttpEvent<T> = HttpSentEvent | HttpHeaderResponse | HttpResponse<T> | HttpProgressEvent | HttpUserEvent<T>;
+export type HttpEvent<T> = HttpSentEvent | HttpHeaderResponse | HttpResponse<T> | HttpDownloadProgressEvent | HttpUploadProgressEvent | HttpUserEvent<T>;
 
 // @public
 export enum HttpEventType {

--- a/packages/common/http/src/response.ts
+++ b/packages/common/http/src/response.ts
@@ -144,7 +144,8 @@ export type HttpEvent<T> =
   | HttpSentEvent
   | HttpHeaderResponse
   | HttpResponse<T>
-  | HttpProgressEvent
+  | HttpDownloadProgressEvent
+  | HttpUploadProgressEvent
   | HttpUserEvent<T>;
 
 /**

--- a/packages/common/http/test/response_spec.ts
+++ b/packages/common/http/test/response_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {HttpHeaders} from '../src/headers';
-import {HttpResponse, HttpStatusCode} from '../src/response';
+import {HttpEvent, HttpEventType, HttpResponse, HttpStatusCode} from '../src/response';
 
 describe('HttpResponse', () => {
   describe('constructor()', () => {
@@ -92,6 +92,20 @@ describe('HttpResponse', () => {
       expect(clone.url).toBe('/bar');
       expect(clone.headers).toBe(orig.headers);
       expect(clone.redirected).toBe(false);
+    });
+  });
+
+  describe('typings', () => {
+    it('should correctly narrow based on the type', () => {
+      const httpEvent: HttpEvent<any> = {
+        type: HttpEventType.DownloadProgress,
+        loaded: 100,
+        total: 200,
+      };
+
+      if (httpEvent.type === HttpEventType.DownloadProgress) {
+        const partialText: string | undefined = httpEvent.partialText;
+      }
     });
   });
 });


### PR DESCRIPTION
Prior to this change, `HttpProgressEvent` could not be narrowed to `HttpDownloadProgressEvent` or `HttpUploadProgressEvent`
