### PR TITLE
refactor(devtools): fix renamed function.

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.ts
@@ -103,7 +103,7 @@ export function ngDebugSignalPropertiesInspectionApiIsSupported(): boolean {
   const ng = ngDebugClient();
 
   // If all apps are Angular, make the API available.
-  const roots = getRoots();
+  const roots = getAppRoots();
   return (
     !!roots.length &&
     roots.every((el) => {


### PR DESCRIPTION
`getRoots` was renamed `getAppRoots` in a prior commit.
