### PR TITLE
fix(common): fix breaking applications with undefined in ngClass arrays

### DIFF
--- a/packages/common/src/directives/ng_class.ts
+++ b/packages/common/src/directives/ng_class.ts
@@ -178,11 +178,16 @@ export class NgClass implements DoCheck {
   }
 
   private _toggleClass(klass: string, enabled: boolean): void {
-    if (ngDevMode) {
-      if (typeof klass !== 'string') {
+    if (typeof klass !== 'string') {
+      if (ngDevMode) {
         throw new Error(
           `NgClass can only toggle CSS classes expressed as strings, got ${stringify(klass)}`,
         );
+      } else {
+        console.warn(
+          `NgClass can only toggle CSS classes expressed as strings, got ${stringify(klass)}`,
+        );
+        return;
       }
     }
     klass = klass.trim();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently ngClass breaks Components if undefined is used in an array. In Dev Mode we get a error message but in prod mode it is not checking and going to fail when it's trying to trim the "string" / undefined. The problem is that the ngClass doesn't get any type checks in our application. Maybe because of the application being to big or maybe something is broken. 

But anyway i think this behavior is easily fixable without affecting anyone in a negative way ( i think ). 



Issue Number: N/A


## What is the new behavior?

Instead of going on with trying to toggle a undefined class it's just stopping in PROD environments. Additionally it is logging a warning that undefined is used in ngClass ( Maybe this is to much )


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Forgive me if something is missing in this PR. This is my first PR. The next one is better 😊