### PR TITLE
refactor(core): remove public symbol for `defineInjectable`

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -592,9 +592,6 @@ export class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChan
     onDestroy(): void;
 }
 
-// @public @deprecated (undocumented)
-export const defineInjectable: typeof ɵɵdefineInjectable;
-
 // @public
 export interface DestroyableInjector extends Injector {
     // (undocumented)

--- a/packages/core/src/di/index.ts
+++ b/packages/core/src/di/index.ts
@@ -14,13 +14,7 @@
 
 export * from './metadata';
 export {assertInInjectionContext, runInInjectionContext} from './contextual';
-export {
-  ɵɵdefineInjectable,
-  defineInjectable,
-  ɵɵdefineInjector,
-  InjectableType,
-  InjectorType,
-} from './interface/defs';
+export {ɵɵdefineInjectable, ɵɵdefineInjector, InjectableType, InjectorType} from './interface/defs';
 export {forwardRef, resolveForwardRef, ForwardRefFn} from './forward_ref';
 export {Injectable, InjectableDecorator, InjectableProvider} from './injectable';
 export {Injector, DestroyableInjector} from './injector';

--- a/packages/core/src/di/interface/defs.ts
+++ b/packages/core/src/di/interface/defs.ts
@@ -178,13 +178,6 @@ export function ɵɵdefineInjectable<T>(opts: {
 }
 
 /**
- * @deprecated in v8, delete after v10. This API should be used only by generated code, and that
- * code should now use ɵɵdefineInjectable instead.
- * @publicApi
- */
-export const defineInjectable = ɵɵdefineInjectable;
-
-/**
  * Construct an `InjectorDef` which configures an injector.
  *
  * This should be assigned to a static injector def (`ɵinj`) field on a type, which will then be an


### PR DESCRIPTION
This public symbol was deprecated in v8.
The private symbol `ɵɵdefineInjectable` remains available.
