### PR TITLE
refactor(devtools): double the Angular app detection attempts

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools.component.ts
@@ -27,7 +27,7 @@ import {BrowserStylesService} from './application-services/browser_styles_servic
 import {MatIconRegistry} from '@angular/material/icon';
 import {SUPPORTED_APIS} from './application-providers/supported_apis';
 
-const DETECT_ANGULAR_ATTEMPTS = 10;
+const DETECT_ANGULAR_ATTEMPTS = 20;
 
 enum AngularStatus {
   /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Sometimes the Angular client app is not detected and the DevTools displays "Angular application not detected".


## What is the new behavior?

This doesn't completely resolve the core issue but it should hopefully be a partial solution to some of the instances when the "app not detected" message appears. This is when the resource scripts that are in charge of the backend code are not loaded on time, i.e. within the 5s timeframe. The change increases this time to 10s which should, hopefully, handle cases where the app might take a bit longer to load given the extension content scripts are loaded on `document_idle`. Without this change, the "not detected" message might appear and then disappear after the backend responds back.
