### PR TITLE
refactor(core): remove deprecated `PACKAGE_ROOT_URL` token

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1401,9 +1401,6 @@ export interface OutputRefSubscription {
     unsubscribe(): void;
 }
 
-// @public @deprecated
-export const PACKAGE_ROOT_URL: InjectionToken<string>;
-
 // @public
 export class PendingTasks {
     add(): () => void;

--- a/packages/core/src/application/application_tokens.ts
+++ b/packages/core/src/application/application_tokens.ts
@@ -69,16 +69,6 @@ export const PLATFORM_ID = new InjectionToken<Object>(ngDevMode ? 'Platform ID' 
   factory: () => 'unknown', // set a default platform name, when none set explicitly
 });
 
-/**
- * A DI token that indicates the root directory of
- * the application
- * @publicApi
- * @deprecated
- */
-export const PACKAGE_ROOT_URL = new InjectionToken<string>(
-  ngDevMode ? 'Application Packages Root URL' : '',
-);
-
 // We keep this token here, rather than the animations package, so that modules that only care
 // about which animations module is loaded (e.g. the CDK) can retrieve it without having to
 // include extra dependencies. See #44970 for more context.

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -50,7 +50,6 @@ export {provideCheckNoChangesConfig} from './change_detection/provide_check_no_c
 export {enableProdMode, isDevMode} from './util/is_dev_mode';
 export {
   APP_ID,
-  PACKAGE_ROOT_URL,
   PLATFORM_INITIALIZER,
   PLATFORM_ID,
   ANIMATION_MODULE_TYPE,


### PR DESCRIPTION
The symbol was deprecated by #51222 and already has no usages in g3.
