### PR TITLE
refactor(core): remove the deprecated  `ImportedNgModuleProviders` type.

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -844,9 +844,6 @@ export interface HostListenerDecorator {
     new (eventName: string, args?: string[]): any;
 }
 
-// @public @deprecated
-export type ImportedNgModuleProviders = EnvironmentProviders;
-
 // @public
 export function importProvidersFrom(...sources: ImportProvidersSource[]): EnvironmentProviders;
 

--- a/packages/core/src/di/index.ts
+++ b/packages/core/src/di/index.ts
@@ -40,7 +40,6 @@ export {
   ClassProvider,
   ModuleWithProviders,
   ClassSansProvider,
-  ImportedNgModuleProviders,
   ConstructorProvider,
   EnvironmentProviders,
   ConstructorSansProvider,

--- a/packages/core/src/di/interface/provider.ts
+++ b/packages/core/src/di/interface/provider.ts
@@ -394,19 +394,3 @@ export interface ModuleWithProviders<T> {
   ngModule: Type<T>;
   providers?: Array<Provider | EnvironmentProviders>;
 }
-
-/**
- * Providers that were imported from NgModules via the `importProvidersFrom` function.
- *
- * These providers are meant for use in an application injector (or other environment injectors) and
- * should not be used in component injectors.
- *
- * This type cannot be directly implemented. It's returned from the `importProvidersFrom` function
- * and serves to prevent the extracted NgModule providers from being used in the wrong contexts.
- *
- * @see {@link importProvidersFrom}
- *
- * @publicApi
- * @deprecated replaced by `EnvironmentProviders`
- */
-export type ImportedNgModuleProviders = EnvironmentProviders;


### PR DESCRIPTION
Use the `EnvironmentProviders` type instead

Note: G3 already had no usages anymore. 