### PR TITLE
refactor(core): remove `NgProbeToken` class

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1278,15 +1278,6 @@ export abstract class NgModuleRef<T> {
     abstract onDestroy(callback: () => void): void;
 }
 
-// @public @deprecated
-export class NgProbeToken {
-    constructor(name: string, token: any);
-    // (undocumented)
-    name: string;
-    // (undocumented)
-    token: any;
-}
-
 // @public
 export class NgZone {
     constructor(options: {

--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -92,19 +92,6 @@ export function isBoundToModule<C>(cf: ComponentFactory<C>): boolean {
 }
 
 /**
- * A token for third-party components that can register themselves with NgProbe.
- *
- * @deprecated
- * @publicApi
- */
-export class NgProbeToken {
-  constructor(
-    public name: string,
-    public token: any,
-  ) {}
-}
-
-/**
  * Provides additional options to the bootstrapping process.
  *
  * @publicApi

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -27,7 +27,6 @@ export * from './di';
 export {
   BootstrapOptions,
   ApplicationRef,
-  NgProbeToken,
   APP_BOOTSTRAP_LISTENER,
 } from './application/application_ref';
 export {PlatformRef} from './platform/platform_ref';


### PR DESCRIPTION
This class served no purpose and was deprecated in by #51396

G3 also has no usage anymore.
