### PR TITLE
docs(docs-infra): auto-links to API entries

### DIFF
--- a/adev/shared-docs/pipeline/_guides.bzl
+++ b/adev/shared-docs/pipeline/_guides.bzl
@@ -16,6 +16,12 @@ def _generate_guides(ctx):
     # Pass the the output directory path (which is the bazel-bin directory).
     args.add(ctx.bin_dir.path)
 
+    # Add the api_manifest file if provided
+    if ctx.attr.api_manifest:
+        args.add(ctx.file.api_manifest.path)
+    else:
+        args.add("")
+
     # Determine the set of html output files. For each input markdown file, produce an html
     # file with the same name (replacing the markdown extension with `.html`).
     html_outputs = []
@@ -30,9 +36,13 @@ def _generate_guides(ctx):
         html_outputs += [ctx.actions.declare_file("%s.html" % relative_basepath)]
 
     # Define an action that runs the executable.
+    inputs = ctx.files.srcs + ctx.files.data
+    if ctx.attr.api_manifest:
+        inputs.append(ctx.file.api_manifest)
+
     if (ctx.attr.mermaid_blocks):
         ctx.actions.run(
-            inputs = depset(ctx.files.srcs + ctx.files.data),
+            inputs = depset(inputs),
             executable = ctx.executable._generate_guides,
             outputs = html_outputs,
             arguments = [args],
@@ -42,7 +52,7 @@ def _generate_guides(ctx):
         )
     else:
         ctx.actions.run(
-            inputs = depset(ctx.files.srcs + ctx.files.data),
+            inputs = depset(inputs),
             executable = ctx.executable._generate_guides_no_mermaid,
             outputs = html_outputs,
             arguments = [args],
@@ -70,6 +80,10 @@ generate_guides = rule(
         "data": attr.label_list(
             doc = """Source referenced from within the markdown.""",
             allow_files = True,
+        ),
+        "api_manifest": attr.label(
+            doc = """A file containing API entries to be used in the markdown.""",
+            allow_single_file = True,
         ),
         "mermaid_blocks": attr.bool(
             doc = """Whether to transform mermaid blocks.""",

--- a/adev/shared-docs/pipeline/guides/index.mts
+++ b/adev/shared-docs/pipeline/guides/index.mts
@@ -11,10 +11,16 @@ import path from 'path';
 import {parseMarkdown} from './parse.mjs';
 import {initHighlighter} from './extensions/docs-code/format/highlight.mjs';
 
+type ApiManifest = ApiManifestPackage[];
+interface ApiManifestPackage {
+  moduleName: string;
+  entries: {name: string}[];
+}
+
 async function main() {
   const [paramFilePath] = process.argv.slice(2);
   const rawParamLines = readFileSync(paramFilePath, {encoding: 'utf8'}).split('\n');
-  const [srcs, outputFilenameExecRootRelativePath] = rawParamLines;
+  const [srcs, outputFilenameExecRootRelativePath, apiManifestPath] = rawParamLines;
 
   // The highlighter needs to be setup asynchronously
   // so we're doing it at the start of the pipeline
@@ -25,8 +31,21 @@ async function main() {
       throw new Error(`Input file "${filePath}" does not end in a ".md" file extension.`);
     }
 
+    let apiManifest: ApiManifest = [];
+    if (apiManifestPath) {
+      try {
+        const apiManifestStr = readFileSync(apiManifestPath, {encoding: 'utf8'});
+        apiManifest = JSON.parse(apiManifestStr);
+      } catch (error) {
+        console.warn('Failed to load API entries:', error);
+      }
+    }
+
     const markdownContent = readFileSync(filePath, {encoding: 'utf8'});
-    const htmlOutputContent = await parseMarkdown(markdownContent, {markdownFilePath: filePath});
+    const htmlOutputContent = await parseMarkdown(markdownContent, {
+      markdownFilePath: filePath,
+      apiEntries: mapManifestToEntries(apiManifest),
+    });
 
     // The expected file name structure is the [name of the file].md.html.
     const htmlFileName = filePath + '.html';
@@ -37,3 +56,22 @@ async function main() {
 }
 
 main();
+
+function mapManifestToEntries(apiManifest: ApiManifest): Record<string, string> {
+  const duplicateEntries = new Set<string>();
+
+  const entryToModuleMap: Record<string, string> = {};
+  for (const pkg of apiManifest) {
+    for (const entry of pkg.entries) {
+      if (duplicateEntries.has(entry.name)) {
+        continue;
+      } else if (entryToModuleMap[entry.name]) {
+        delete entryToModuleMap[entry.name];
+        duplicateEntries.add(entry.name);
+      } else {
+        entryToModuleMap[entry.name] = pkg.moduleName.replace(/^@angular\//, '');
+      }
+    }
+  }
+  return entryToModuleMap;
+}

--- a/adev/shared-docs/pipeline/guides/renderer.mts
+++ b/adev/shared-docs/pipeline/guides/renderer.mts
@@ -13,16 +13,20 @@ import {listRender} from './tranformations/list.mjs';
 import {imageRender} from './tranformations/image.mjs';
 import {textRender} from './tranformations/text.mjs';
 import {headingRender} from './tranformations/heading.mjs';
+import {codespanRender} from './tranformations/code.mjs';
 
 /**
  * Custom renderer for marked that will be used to transform markdown files to HTML
  * files that can be used in the Angular docs.
  */
 export class Renderer extends _Renderer {
+  defaultRenderer = new _Renderer();
+
   override link = linkRender;
   override table = tableRender;
   override list = listRender;
   override image = imageRender;
   override text = textRender;
   override heading = headingRender;
+  override codespan = codespanRender;
 }

--- a/adev/shared-docs/pipeline/guides/tranformations/code.mts
+++ b/adev/shared-docs/pipeline/guides/tranformations/code.mts
@@ -1,0 +1,33 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Tokens} from 'marked';
+import {getApiLink} from '../utils.mjs';
+import {Renderer} from '../renderer.mjs';
+
+export function codespanRender(this: Renderer, token: Tokens.Codespan) {
+  const apiLink = getApiLink(token.text);
+  if (apiLink) {
+    const htmlToken: Tokens.HTML = {
+      type: 'html',
+      raw: `<code>${token.text}</code>`,
+      text: this.defaultRenderer.codespan(token),
+      pre: false,
+      block: false,
+    };
+    const linkToken: Tokens.Link = {
+      type: 'link',
+      raw: `[${token.text}](${apiLink})`,
+      href: apiLink,
+      text: '',
+      tokens: [htmlToken],
+    };
+    return this.link(linkToken);
+  }
+  return this.defaultRenderer.codespan(token);
+}

--- a/adev/src/content/BUILD.bazel
+++ b/adev/src/content/BUILD.bazel
@@ -6,7 +6,12 @@ generate_guides(
     srcs = [
         "error.md",
     ],
-    data = [],
+    api_manifest = "//adev/src/assets:docs_api_manifest",
+    data = [
+        "//adev/src/assets/images:components.svg",
+        "//adev/src/content/examples",
+    ],
+    mermaid_blocks = True,
     visibility = ["//adev:__subpackages__"],
 )
 

--- a/adev/src/content/ai/BUILD.bazel
+++ b/adev/src/content/ai/BUILD.bazel
@@ -5,6 +5,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
         "//adev/src/assets/images:what_is_angular.svg",
         "//adev/src/context",

--- a/adev/src/content/best-practices/BUILD.bazel
+++ b/adev/src/content/best-practices/BUILD.bazel
@@ -6,6 +6,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
         "//adev/src/assets/images:components.svg",
         "//adev/src/content/examples",

--- a/adev/src/content/best-practices/runtime-performance/BUILD.bazel
+++ b/adev/src/content/best-practices/runtime-performance/BUILD.bazel
@@ -5,6 +5,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     mermaid_blocks = True,
     visibility = ["//adev:__subpackages__"],
 )

--- a/adev/src/content/ecosystem/BUILD.bazel
+++ b/adev/src/content/ecosystem/BUILD.bazel
@@ -6,6 +6,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     visibility = ["//adev:__subpackages__"],
 )
 

--- a/adev/src/content/ecosystem/rxjs-interop/BUILD.bazel
+++ b/adev/src/content/ecosystem/rxjs-interop/BUILD.bazel
@@ -3,9 +3,8 @@ load("//adev/shared-docs:index.bzl", "generate_guides")
 
 generate_guides(
     name = "rxjs-interop",
-    srcs = glob([
-        "*.md",
-    ]),
+    srcs = glob(["*.md"]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     visibility = ["//adev:__subpackages__"],
 )
 

--- a/adev/src/content/ecosystem/service-workers/BUILD.bazel
+++ b/adev/src/content/ecosystem/service-workers/BUILD.bazel
@@ -5,6 +5,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
         "//adev/src/content/examples",
     ],

--- a/adev/src/content/guide/BUILD.bazel
+++ b/adev/src/content/guide/BUILD.bazel
@@ -6,6 +6,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
         "//adev/src/content/examples",
     ],

--- a/adev/src/content/guide/animations/BUILD.bazel
+++ b/adev/src/content/guide/animations/BUILD.bazel
@@ -6,6 +6,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
         "//adev/src/content/examples",
     ],

--- a/adev/src/content/guide/components/BUILD.bazel
+++ b/adev/src/content/guide/components/BUILD.bazel
@@ -6,6 +6,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
         "//adev/src/assets/images:components.svg",
     ],

--- a/adev/src/content/guide/di/BUILD.bazel
+++ b/adev/src/content/guide/di/BUILD.bazel
@@ -6,6 +6,8 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest =
+        "//adev/src/assets:docs_api_manifest",
     data = [
         "//adev/src/assets/images:dependency_injection.svg",
         "//adev/src/content/examples",

--- a/adev/src/content/guide/directives/BUILD.bazel
+++ b/adev/src/content/guide/directives/BUILD.bazel
@@ -6,6 +6,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
         "//adev/src/assets/images:directives.svg",
         "//adev/src/content/examples",

--- a/adev/src/content/guide/forms/BUILD.bazel
+++ b/adev/src/content/guide/forms/BUILD.bazel
@@ -6,6 +6,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
         "//adev/src/assets/images:overview.svg",
         "//adev/src/content/examples",

--- a/adev/src/content/guide/http/BUILD.bazel
+++ b/adev/src/content/guide/http/BUILD.bazel
@@ -6,6 +6,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     visibility = ["//adev:__subpackages__"],
 )
 

--- a/adev/src/content/guide/i18n/BUILD.bazel
+++ b/adev/src/content/guide/i18n/BUILD.bazel
@@ -6,6 +6,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
         "//adev/src/content/examples",
     ],

--- a/adev/src/content/guide/ngmodules/BUILD.bazel
+++ b/adev/src/content/guide/ngmodules/BUILD.bazel
@@ -6,6 +6,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
     ],
     visibility = ["//adev:__subpackages__"],

--- a/adev/src/content/guide/performance/BUILD.bazel
+++ b/adev/src/content/guide/performance/BUILD.bazel
@@ -6,6 +6,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
         "//adev/src/assets/images:overview.svg",
     ],

--- a/adev/src/content/guide/routing/BUILD.bazel
+++ b/adev/src/content/guide/routing/BUILD.bazel
@@ -6,6 +6,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
         "//adev/src/assets/images:routing.svg",
         "//adev/src/content/examples",

--- a/adev/src/content/guide/signals/BUILD.bazel
+++ b/adev/src/content/guide/signals/BUILD.bazel
@@ -6,6 +6,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
         "//adev/src/assets/images:signals.svg",
     ],

--- a/adev/src/content/guide/templates/BUILD.bazel
+++ b/adev/src/content/guide/templates/BUILD.bazel
@@ -6,6 +6,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
         "//adev/src/assets/images:templates.svg",
     ],

--- a/adev/src/content/guide/testing/BUILD.bazel
+++ b/adev/src/content/guide/testing/BUILD.bazel
@@ -6,6 +6,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
         "//adev/src/content/examples",
     ],

--- a/adev/src/content/introduction/BUILD.bazel
+++ b/adev/src/content/introduction/BUILD.bazel
@@ -6,6 +6,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
         "//adev/src/assets/images:what_is_angular.svg",
     ],

--- a/adev/src/content/introduction/essentials/BUILD.bazel
+++ b/adev/src/content/introduction/essentials/BUILD.bazel
@@ -6,6 +6,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
         "//adev/src/assets/images:components.svg",
         "//adev/src/assets/images:dependency_injection.svg",

--- a/adev/src/content/reference/BUILD.bazel
+++ b/adev/src/content/reference/BUILD.bazel
@@ -6,6 +6,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
         "//adev/src/assets/images:roadmap.svg",
     ],

--- a/adev/src/content/reference/concepts/BUILD.bazel
+++ b/adev/src/content/reference/concepts/BUILD.bazel
@@ -5,5 +5,6 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     visibility = ["//adev:__subpackages__"],
 )

--- a/adev/src/content/reference/configs/BUILD.bazel
+++ b/adev/src/content/reference/configs/BUILD.bazel
@@ -5,6 +5,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
         "//adev/src/content/examples",
     ],

--- a/adev/src/content/reference/errors/BUILD.bazel
+++ b/adev/src/content/reference/errors/BUILD.bazel
@@ -21,6 +21,7 @@ generate_guides(
         "overview.md",
         ":files",
     ],
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
         "//adev/src/content/examples",
     ],

--- a/adev/src/content/reference/extended-diagnostics/BUILD.bazel
+++ b/adev/src/content/reference/extended-diagnostics/BUILD.bazel
@@ -21,6 +21,7 @@ generate_guides(
         "overview.md",
         ":files",
     ],
+    api_manifest = "//adev/src/assets:docs_api_manifest",
 )
 
 generate_nav_items(

--- a/adev/src/content/reference/migrations/BUILD.bazel
+++ b/adev/src/content/reference/migrations/BUILD.bazel
@@ -5,5 +5,6 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     visibility = ["//adev:__subpackages__"],
 )

--- a/adev/src/content/tools/BUILD.bazel
+++ b/adev/src/content/tools/BUILD.bazel
@@ -5,5 +5,6 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     visibility = ["//adev:__subpackages__"],
 )

--- a/adev/src/content/tools/cli/BUILD.bazel
+++ b/adev/src/content/tools/cli/BUILD.bazel
@@ -5,6 +5,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
         "//adev/src/content/examples",
     ],

--- a/adev/src/content/tools/devtools/BUILD.bazel
+++ b/adev/src/content/tools/devtools/BUILD.bazel
@@ -5,6 +5,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
         "//adev/src/content/examples",
     ],

--- a/adev/src/content/tools/libraries/BUILD.bazel
+++ b/adev/src/content/tools/libraries/BUILD.bazel
@@ -5,6 +5,7 @@ generate_guides(
     srcs = glob([
         "*.md",
     ]),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
         "//adev/src/content/examples",
     ],

--- a/adev/src/content/tutorials/BUILD.bazel
+++ b/adev/src/content/tutorials/BUILD.bazel
@@ -11,6 +11,7 @@ generate_guides(
             "**/node_modules/**/*.md",
         ],
     ),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
         "//adev/src/assets/images:ang_illustrations-04.svg",
         "//adev/src/assets/images:learn-angular-browser.svg",

--- a/adev/src/content/tutorials/deferrable-views/BUILD.bazel
+++ b/adev/src/content/tutorials/deferrable-views/BUILD.bazel
@@ -12,6 +12,7 @@ generate_guides(
             "**/node_modules/**/*.md",
         ],
     ),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
 )
 
 filegroup(

--- a/adev/src/content/tutorials/first-app/BUILD.bazel
+++ b/adev/src/content/tutorials/first-app/BUILD.bazel
@@ -12,6 +12,7 @@ generate_guides(
             "**/node_modules/**/*.md",
         ],
     ),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
     data = [
         ":files",
     ],

--- a/adev/src/content/tutorials/learn-angular/BUILD.bazel
+++ b/adev/src/content/tutorials/learn-angular/BUILD.bazel
@@ -12,6 +12,7 @@ generate_guides(
             "**/node_modules/**/*.md",
         ],
     ),
+    api_manifest = "//adev/src/assets:docs_api_manifest",
 )
 
 filegroup(


### PR DESCRIPTION
This is a first step to create links to API entries automatically. It adds support for
- code spans (`` `symbol` ``)
- code blocks (`` ```some code here``` ``)

Links are generated from on a K/V map of API entries (symbol => package name). The map is generated from the API manifest that we're already generating for the API docs.

For the moment, entries with identical names are skipped.

This is a backport of #63162
