### PR TITLE
perf(forms): enable tree shaking of unused errors and properties

### DIFF
--- a/packages/forms/signals/src/api/logic.ts
+++ b/packages/forms/signals/src/api/logic.ts
@@ -8,7 +8,7 @@
 
 import {FieldPathNode} from '../schema/path_node';
 import {assertPathIsCurrent} from '../schema/schema';
-import {type AggregateProperty, Property} from './property';
+import {AggregateProperty, createProperty, Property} from './property';
 import type {
   FieldContext,
   FieldPath,
@@ -201,7 +201,7 @@ export function property<TValue, TData, TPathKind extends PathKind = PathKind.Ro
   } else {
     [factory] = rest;
   }
-  key ??= Property.create();
+  key ??= createProperty();
 
   const pathNode = FieldPathNode.unwrapFieldPath(path);
   pathNode.logic.addPropertyFactory(key, factory as (ctx: FieldContext<unknown>) => unknown);

--- a/packages/forms/signals/src/api/property.ts
+++ b/packages/forms/signals/src/api/property.ts
@@ -13,14 +13,13 @@
 export class Property<TValue> {
   private brand!: TValue;
 
-  protected constructor() {}
+  /** Use {@link createProperty}. */
+  private constructor() {}
+}
 
-  /**
-   * Creates a `Property`.
-   */
-  static create<TValue>() {
-    return new Property<TValue>();
-  }
+/** Creates a {@link Property}. */
+export function createProperty<TValue>(): Property<TValue> {
+  return new (Property as new () => Property<TValue>)();
 }
 
 /**
@@ -32,119 +31,121 @@ export class Property<TValue> {
 export class AggregateProperty<TAcc, TItem> {
   private brand!: [TAcc, TItem];
 
-  protected constructor(
+  /** Use {@link reducedProperty}. */
+  private constructor(
     readonly reduce: (acc: TAcc, item: TItem) => TAcc,
     readonly getInitial: () => TAcc,
   ) {}
+}
 
-  /**
-   * Creates an aggregate property that reduces its individual values into an accumulated value
-   * using the given `reduce` and `getDefault` functions.
-   * @param reduce The reducer function
-   * @param getInitial A function that gets the initial value for the reduce operation.
-   */
-  static reduce<TAcc, TItem>(reduce: (acc: TAcc, item: TItem) => TAcc, getInitial: () => TAcc) {
-    return new AggregateProperty(reduce, getInitial);
-  }
+/**
+ * Creates an aggregate property that reduces its individual values into an accumulated value using
+ * the given `reduce` and `getInitial` functions.
+ * @param reduce The reducer function.
+ * @param getInitial A function that gets the initial value for the reduce operation.
+ */
+export function reducedProperty<TAcc, TItem>(
+  reduce: (acc: TAcc, item: TItem) => TAcc,
+  getInitial: () => TAcc,
+): AggregateProperty<TAcc, TItem> {
+  return new (AggregateProperty as new (
+    reduce: (acc: TAcc, item: TItem) => TAcc,
+    getInitial: () => TAcc,
+  ) => AggregateProperty<TAcc, TItem>)(reduce, getInitial);
+}
 
-  /**
-   * Creates an aggregate property that reduces its individual values into a list.
-   */
-  static list<TItem>() {
-    return new AggregateProperty<TItem[], TItem | undefined>(
-      (acc, item) => (item === undefined ? acc : [...acc, item]),
-      () => [],
-    );
-  }
+/**
+ * Creates an aggregate property that reduces its individual values into a list.
+ */
+export function listProperty<TItem>(): AggregateProperty<TItem[], TItem | undefined> {
+  return reducedProperty<TItem[], TItem | undefined>(
+    (acc, item) => (item === undefined ? acc : [...acc, item]),
+    () => [],
+  );
+}
 
-  /**
-   * Creates an aggregate property that reduces its individual values by taking their min.
-   */
-  static min() {
-    return new AggregateProperty<number | undefined, number | undefined>(
-      (prev, next) => {
-        if (prev === undefined) {
-          return next;
-        }
-        if (next === undefined) {
-          return prev;
-        }
-        return Math.min(prev, next);
-      },
-      () => undefined,
-    );
-  }
+/**
+ * Creates an aggregate property that reduces its individual values by taking their min.
+ */
+export function minProperty(): AggregateProperty<number | undefined, number | undefined> {
+  return reducedProperty<number | undefined, number | undefined>(
+    (prev, next) => {
+      if (prev === undefined) {
+        return next;
+      }
+      if (next === undefined) {
+        return prev;
+      }
+      return Math.min(prev, next);
+    },
+    () => undefined,
+  );
+}
 
-  /**
-   * Creates an aggregate property that reduces its individual values by taking their max.
-   */
-  static max() {
-    return new AggregateProperty<number | undefined, number | undefined>(
-      (prev, next) => {
-        if (prev === undefined) {
-          return next;
-        }
-        if (next === undefined) {
-          return prev;
-        }
-        return Math.max(prev, next);
-      },
-      () => undefined,
-    );
-  }
+/**
+ * Creates an aggregate property that reduces its individual values by taking their max.
+ */
+export function maxProperty(): AggregateProperty<number | undefined, number | undefined> {
+  return reducedProperty<number | undefined, number | undefined>(
+    (prev, next) => {
+      if (prev === undefined) {
+        return next;
+      }
+      if (next === undefined) {
+        return prev;
+      }
+      return Math.max(prev, next);
+    },
+    () => undefined,
+  );
+}
 
-  /**
-   * Creates an aggregate property that reduces its individual values by logically or-ing them.
-   */
-  static or() {
-    return new AggregateProperty<boolean, boolean>(
-      (prev, next) => prev || next,
-      () => false,
-    );
-  }
+/**
+ * Creates an aggregate property that reduces its individual values by logically or-ing them.
+ */
+export function orProperty(): AggregateProperty<boolean, boolean> {
+  return reducedProperty(
+    (prev, next) => prev || next,
+    () => false,
+  );
+}
 
-  /**
-   * Creates an aggregate property that reduces its individual values by logically and-ing them.
-   */
-  static and() {
-    return new AggregateProperty<boolean, boolean>(
-      (prev, next) => prev && next,
-      () => true,
-    );
-  }
+/**
+ * Creates an aggregate property that reduces its individual values by logically and-ing them.
+ */
+export function andProperty(): AggregateProperty<boolean, boolean> {
+  return reducedProperty(
+    (prev, next) => prev && next,
+    () => true,
+  );
 }
 
 /**
  * An aggregate property representing whether the field is required.
  */
-export const REQUIRED: AggregateProperty<boolean, boolean> = AggregateProperty.or();
+export const REQUIRED: AggregateProperty<boolean, boolean> = orProperty();
 
 /**
  * An aggregate property representing the min value of the field.
  */
-export const MIN: AggregateProperty<number | undefined, number | undefined> =
-  AggregateProperty.max();
+export const MIN: AggregateProperty<number | undefined, number | undefined> = maxProperty();
 
 /**
  * An aggregate property representing the max value of the field.
  */
-export const MAX: AggregateProperty<number | undefined, number | undefined> =
-  AggregateProperty.min();
+export const MAX: AggregateProperty<number | undefined, number | undefined> = minProperty();
 
 /**
  * An aggregate property representing the min length of the field.
  */
-export const MIN_LENGTH: AggregateProperty<number | undefined, number | undefined> =
-  AggregateProperty.max();
+export const MIN_LENGTH: AggregateProperty<number | undefined, number | undefined> = maxProperty();
 
 /**
  * An aggregate property representing the max length of the field.
  */
-export const MAX_LENGTH: AggregateProperty<number | undefined, number | undefined> =
-  AggregateProperty.min();
+export const MAX_LENGTH: AggregateProperty<number | undefined, number | undefined> = minProperty();
 
 /**
  * An aggregate property representing the patterns the field must match.
  */
-export const PATTERN: AggregateProperty<RegExp[], RegExp | undefined> =
-  AggregateProperty.list<RegExp>();
+export const PATTERN: AggregateProperty<RegExp[], RegExp | undefined> = listProperty<RegExp>();

--- a/packages/forms/signals/src/api/validation_errors.ts
+++ b/packages/forms/signals/src/api/validation_errors.ts
@@ -67,7 +67,215 @@ export type WithOptionalField<T> = T & {field?: Field<unknown>};
  */
 export type WithoutField<T> = T & {field: never};
 
-/** Common interface for all validation errors. */
+/**
+ * Create a required error associated with the target field
+ * @param options The validation error options
+ */
+export function requiredError(options: WithField<ValidationErrorOptions>): RequiredValidationError;
+/**
+ * Create a required error
+ * @param options The optional validation error options
+ */
+export function requiredError(
+  options?: ValidationErrorOptions,
+): WithoutField<RequiredValidationError>;
+export function requiredError(
+  options?: ValidationErrorOptions,
+): WithOptionalField<RequiredValidationError> {
+  return new RequiredValidationError(options);
+}
+
+/**
+ * Create a min value error associated with the target field
+ * @param min The min value constraint
+ * @param options The validation error options
+ */
+export function minError(
+  min: number,
+  options: WithField<ValidationErrorOptions>,
+): MinValidationError;
+/**
+ * Create a min value error
+ * @param min The min value constraint
+ * @param options The optional validation error options
+ */
+export function minError(
+  min: number,
+  options?: ValidationErrorOptions,
+): WithoutField<MinValidationError>;
+export function minError(
+  min: number,
+  options?: ValidationErrorOptions,
+): WithOptionalField<MinValidationError> {
+  return new MinValidationError(min, options);
+}
+
+/**
+ * Create a max value error associated with the target field
+ * @param max The max value constraint
+ * @param options The validation error options
+ */
+export function maxError(
+  max: number,
+  options: WithField<ValidationErrorOptions>,
+): MaxValidationError;
+/**
+ * Create a max value error
+ * @param max The max value constraint
+ * @param options The optional validation error options
+ */
+export function maxError(
+  max: number,
+  options?: ValidationErrorOptions,
+): WithoutField<MaxValidationError>;
+export function maxError(
+  max: number,
+  options?: ValidationErrorOptions,
+): WithOptionalField<MaxValidationError> {
+  return new MaxValidationError(max, options);
+}
+
+/**
+ * Create a minLength error associated with the target field
+ * @param minLength The minLength constraint
+ * @param options The validation error options
+ */
+export function minLengthError(
+  minLength: number,
+  options: WithField<ValidationErrorOptions>,
+): MinLengthValidationError;
+/**
+ * Create a minLength error
+ * @param minLength The minLength constraint
+ * @param options The optional validation error options
+ */
+export function minLengthError(
+  minLength: number,
+  options?: ValidationErrorOptions,
+): WithoutField<MinLengthValidationError>;
+export function minLengthError(
+  minLength: number,
+  options?: ValidationErrorOptions,
+): WithOptionalField<MinLengthValidationError> {
+  return new MinLengthValidationError(minLength, options);
+}
+
+/**
+ * Create a maxLength error associated with the target field
+ * @param maxLength The maxLength constraint
+ * @param options The validation error options
+ */
+export function maxLengthError(
+  maxLength: number,
+  options: WithField<ValidationErrorOptions>,
+): MaxLengthValidationError;
+/**
+ * Create a maxLength error
+ * @param maxLength The maxLength constraint
+ * @param options The optional validation error options
+ */
+export function maxLengthError(
+  maxLength: number,
+  options?: ValidationErrorOptions,
+): WithoutField<MaxLengthValidationError>;
+export function maxLengthError(
+  maxLength: number,
+  options?: ValidationErrorOptions,
+): WithOptionalField<MaxLengthValidationError> {
+  return new MaxLengthValidationError(maxLength, options);
+}
+
+/**
+ * Create a pattern matching error associated with the target field
+ * @param pattern The violated pattern
+ * @param options The validation error options
+ */
+export function patternError(
+  pattern: RegExp,
+  options: WithField<ValidationErrorOptions>,
+): PatternValidationError;
+/**
+ * Create a pattern matching error
+ * @param pattern The violated pattern
+ * @param options The optional validation error options
+ */
+export function patternError(
+  pattern: RegExp,
+  options?: ValidationErrorOptions,
+): WithoutField<PatternValidationError>;
+export function patternError(
+  pattern: RegExp,
+  options?: ValidationErrorOptions,
+): WithOptionalField<PatternValidationError> {
+  return new PatternValidationError(pattern, options);
+}
+
+/**
+ * Create an email format error associated with the target field
+ * @param options The validation error options
+ */
+export function emailError(options: WithField<ValidationErrorOptions>): EmailValidationError;
+/**
+ * Create an email format error
+ * @param options The optional validation error options
+ */
+export function emailError(options?: ValidationErrorOptions): WithoutField<EmailValidationError>;
+export function emailError(
+  options?: ValidationErrorOptions,
+): WithOptionalField<EmailValidationError> {
+  return new EmailValidationError(options);
+}
+
+/**
+ * Create a standard schema issue error associated with the target field
+ * @param issue The standard schema issue
+ * @param options The validation error options
+ */
+export function standardSchemaError(
+  issue: StandardSchemaV1.Issue,
+  options: WithField<ValidationErrorOptions>,
+): StandardSchemaValidationError;
+/**
+ * Create a standard schema issue error
+ * @param issue The standard schema issue
+ * @param options The optional validation error options
+ */
+export function standardSchemaError(
+  issue: StandardSchemaV1.Issue,
+  options?: ValidationErrorOptions,
+): WithoutField<StandardSchemaValidationError>;
+export function standardSchemaError(
+  issue: StandardSchemaV1.Issue,
+  options?: ValidationErrorOptions,
+): WithOptionalField<StandardSchemaValidationError> {
+  return new StandardSchemaValidationError(issue, options);
+}
+
+/**
+ * Create a custom error associated with the target field
+ * @param obj The object to create an error from
+ */
+export function customError<E extends Omit<Partial<ValidationError>, typeof BRAND>>(
+  obj: WithField<E>,
+): CustomValidationError;
+/**
+ * Create a custom error
+ * @param obj The object to create an error from
+ */
+export function customError<E extends Omit<Partial<ValidationError>, typeof BRAND>>(
+  obj?: E,
+): WithoutField<CustomValidationError>;
+export function customError<E extends Omit<Partial<ValidationError>, typeof BRAND>>(
+  obj?: E,
+): WithOptionalField<CustomValidationError> {
+  return new CustomValidationError(obj);
+}
+
+/**
+ * Common interface for all validation errors.
+ *
+ * Use the creation functions to create an instance (e.g. `requiredError`, `minError`, etc.).
+ */
 export abstract class ValidationError {
   /** Brand the class to avoid Typescript structural matching */
   [BRAND] = undefined;
@@ -85,186 +293,6 @@ export abstract class ValidationError {
     if (options) {
       Object.assign(this, options);
     }
-  }
-
-  /**
-   * Create a required error associated with the target field
-   * @param options The validation error options
-   */
-  static required(options: WithField<ValidationErrorOptions>): RequiredValidationError;
-  /**
-   * Create a required error
-   * @param options The optional validation error options
-   */
-  static required(options?: ValidationErrorOptions): WithoutField<RequiredValidationError>;
-  static required(options?: ValidationErrorOptions): WithOptionalField<RequiredValidationError> {
-    return new RequiredValidationError(options);
-  }
-
-  /**
-   * Create a min value error associated with the target field
-   * @param min The min value constraint
-   * @param options The validation error options
-   */
-  static min(min: number, options: WithField<ValidationErrorOptions>): MinValidationError;
-  /**
-   * Create a min value error
-   * @param min The min value constraint
-   * @param options The optional validation error options
-   */
-  static min(min: number, options?: ValidationErrorOptions): WithoutField<MinValidationError>;
-  static min(min: number, options?: ValidationErrorOptions): WithOptionalField<MinValidationError> {
-    return new MinValidationError(min, options);
-  }
-
-  /**
-   * Create a max value error associated with the target field
-   * @param max The max value constraint
-   * @param options The validation error options
-   */
-  static max(max: number, options: WithField<ValidationErrorOptions>): MaxValidationError;
-  /**
-   * Create a max value error
-   * @param max The max value constraint
-   * @param options The optional validation error options
-   */
-  static max(max: number, options?: ValidationErrorOptions): WithoutField<MaxValidationError>;
-  static max(max: number, options?: ValidationErrorOptions): WithOptionalField<MaxValidationError> {
-    return new MaxValidationError(max, options);
-  }
-
-  /**
-   * Create a minLength error associated with the target field
-   * @param minLength The minLength constraint
-   * @param options The validation error options
-   */
-  static minLength(
-    minLength: number,
-    options: WithField<ValidationErrorOptions>,
-  ): MinLengthValidationError;
-  /**
-   * Create a minLength error
-   * @param minLength The minLength constraint
-   * @param options The optional validation error options
-   */
-  static minLength(
-    minLength: number,
-    options?: ValidationErrorOptions,
-  ): WithoutField<MinLengthValidationError>;
-  static minLength(
-    minLength: number,
-    options?: ValidationErrorOptions,
-  ): WithOptionalField<MinLengthValidationError> {
-    return new MinLengthValidationError(minLength, options);
-  }
-
-  /**
-   * Create a maxLength error associated with the target field
-   * @param maxLength The maxLength constraint
-   * @param options The validation error options
-   */
-  static maxLength(
-    maxLength: number,
-    options: WithField<ValidationErrorOptions>,
-  ): MaxLengthValidationError;
-  /**
-   * Create a maxLength error
-   * @param maxLength The maxLength constraint
-   * @param options The optional validation error options
-   */
-  static maxLength(
-    maxLength: number,
-    options?: ValidationErrorOptions,
-  ): WithoutField<MaxLengthValidationError>;
-  static maxLength(
-    maxLength: number,
-    options?: ValidationErrorOptions,
-  ): WithOptionalField<MaxLengthValidationError> {
-    return new MaxLengthValidationError(maxLength, options);
-  }
-
-  /**
-   * Create a pattern matching error associated with the target field
-   * @param pattern The violated pattern
-   * @param options The validation error options
-   */
-  static pattern(
-    pattern: RegExp,
-    options: WithField<ValidationErrorOptions>,
-  ): PatternValidationError;
-  /**
-   * Create a pattern matching error
-   * @param pattern The violated pattern
-   * @param options The optional validation error options
-   */
-  static pattern(
-    pattern: RegExp,
-    options?: ValidationErrorOptions,
-  ): WithoutField<PatternValidationError>;
-  static pattern(
-    pattern: RegExp,
-    options?: ValidationErrorOptions,
-  ): WithOptionalField<PatternValidationError> {
-    return new PatternValidationError(pattern, options);
-  }
-
-  /**
-   * Create an email format error associated with the target field
-   * @param options The validation error options
-   */
-  static email(options: WithField<ValidationErrorOptions>): EmailValidationError;
-  /**
-   * Create an email format error
-   * @param options The optional validation error options
-   */
-  static email(options?: ValidationErrorOptions): WithoutField<EmailValidationError>;
-  static email(options?: ValidationErrorOptions): WithOptionalField<EmailValidationError> {
-    return new EmailValidationError(options);
-  }
-
-  /**
-   * Create a standard schema issue error associated with the target field
-   * @param issue The standard schema issue
-   * @param options The validation error options
-   */
-  static standardSchema(
-    issue: StandardSchemaV1.Issue,
-    options: WithField<ValidationErrorOptions>,
-  ): StandardSchemaValidationError;
-  /**
-   * Create a standard schema issue error
-   * @param issue The standard schema issue
-   * @param options The optional validation error options
-   */
-  static standardSchema(
-    issue: StandardSchemaV1.Issue,
-    options?: ValidationErrorOptions,
-  ): WithoutField<StandardSchemaValidationError>;
-  static standardSchema(
-    issue: StandardSchemaV1.Issue,
-    options?: ValidationErrorOptions,
-  ): WithOptionalField<StandardSchemaValidationError> {
-    return new StandardSchemaValidationError(issue, options);
-  }
-
-  /**
-   * Create a custom error associated with the target field
-   * @param obj The object to create an error from
-   */
-  static custom<E extends Omit<Partial<ValidationError>, typeof BRAND>>(
-    obj: WithField<E>,
-  ): CustomValidationError;
-  /**
-   * Create a custom error
-   * @param obj The object to create an error from
-   */
-  static custom<E extends Omit<Partial<ValidationError>, typeof BRAND>>(
-    obj?: E,
-  ): WithoutField<CustomValidationError>;
-  static custom<E extends Omit<Partial<ValidationError>, typeof BRAND>>(
-    obj?: E,
-  ): WithOptionalField<CustomValidationError> {
-    return new CustomValidationError(obj);
   }
 }
 

--- a/packages/forms/signals/src/api/validators/email.ts
+++ b/packages/forms/signals/src/api/validators/email.ts
@@ -8,7 +8,7 @@
 
 import {validate} from '../logic';
 import {FieldPath, PathKind} from '../types';
-import {ValidationError} from '../validation_errors';
+import {emailError} from '../validation_errors';
 import {BaseValidatorConfig, getOption} from './util';
 
 /**
@@ -63,7 +63,7 @@ export function email<TPathKind extends PathKind = PathKind.Root>(
       if (config?.error) {
         return getOption(config.error, ctx);
       } else {
-        return ValidationError.email({message: getOption(config?.message, ctx)});
+        return emailError({message: getOption(config?.message, ctx)});
       }
     }
 

--- a/packages/forms/signals/src/api/validators/max.ts
+++ b/packages/forms/signals/src/api/validators/max.ts
@@ -10,7 +10,7 @@ import {computed} from '@angular/core';
 import {aggregateProperty, property, validate} from '../logic';
 import {MAX} from '../property';
 import {FieldPath, LogicFn, PathKind} from '../types';
-import {ValidationError} from '../validation_errors';
+import {maxError} from '../validation_errors';
 import {BaseValidatorConfig, getOption} from './util';
 
 /**
@@ -44,7 +44,7 @@ export function max<TPathKind extends PathKind = PathKind.Root>(
       if (config?.error) {
         return getOption(config.error, ctx);
       } else {
-        return ValidationError.max(max, {message: getOption(config?.message, ctx)});
+        return maxError(max, {message: getOption(config?.message, ctx)});
       }
     }
     return undefined;

--- a/packages/forms/signals/src/api/validators/max_length.ts
+++ b/packages/forms/signals/src/api/validators/max_length.ts
@@ -10,7 +10,7 @@ import {computed} from '@angular/core';
 import {aggregateProperty, property, validate} from '../logic';
 import {MAX_LENGTH} from '../property';
 import {FieldPath, LogicFn, PathKind} from '../types';
-import {ValidationError} from '../validation_errors';
+import {maxLengthError} from '../validation_errors';
 import {BaseValidatorConfig, getLengthOrSize, getOption, ValueWithLengthOrSize} from './util';
 
 /**
@@ -48,7 +48,7 @@ export function maxLength<
       if (config?.error) {
         return getOption(config.error, ctx);
       } else {
-        return ValidationError.maxLength(maxLength, {message: getOption(config?.message, ctx)});
+        return maxLengthError(maxLength, {message: getOption(config?.message, ctx)});
       }
     }
     return undefined;

--- a/packages/forms/signals/src/api/validators/min.ts
+++ b/packages/forms/signals/src/api/validators/min.ts
@@ -10,7 +10,7 @@ import {computed} from '@angular/core';
 import {aggregateProperty, property, validate} from '../logic';
 import {MIN} from '../property';
 import {FieldPath, LogicFn, PathKind} from '../types';
-import {ValidationError} from '../validation_errors';
+import {minError} from '../validation_errors';
 import {BaseValidatorConfig, getOption} from './util';
 
 /**
@@ -44,7 +44,7 @@ export function min<TPathKind extends PathKind = PathKind.Root>(
       if (config?.error) {
         return getOption(config.error, ctx);
       } else {
-        return ValidationError.min(min, {message: getOption(config?.message, ctx)});
+        return minError(min, {message: getOption(config?.message, ctx)});
       }
     }
     return undefined;

--- a/packages/forms/signals/src/api/validators/min_length.ts
+++ b/packages/forms/signals/src/api/validators/min_length.ts
@@ -10,7 +10,7 @@ import {computed} from '@angular/core';
 import {aggregateProperty, property, validate} from '../logic';
 import {MIN_LENGTH} from '../property';
 import {FieldPath, LogicFn, PathKind} from '../types';
-import {ValidationError} from '../validation_errors';
+import {minLengthError} from '../validation_errors';
 import {BaseValidatorConfig, getLengthOrSize, getOption, ValueWithLengthOrSize} from './util';
 
 /**
@@ -48,7 +48,7 @@ export function minLength<
       if (config?.error) {
         return getOption(config.error, ctx);
       } else {
-        return ValidationError.minLength(minLength, {message: getOption(config?.message, ctx)});
+        return minLengthError(minLength, {message: getOption(config?.message, ctx)});
       }
     }
     return undefined;

--- a/packages/forms/signals/src/api/validators/pattern.ts
+++ b/packages/forms/signals/src/api/validators/pattern.ts
@@ -10,7 +10,7 @@ import {computed} from '@angular/core';
 import {aggregateProperty, property, validate} from '../logic';
 import {PATTERN} from '../property';
 import {FieldPath, LogicFn, PathKind} from '../types';
-import {ValidationError} from '../validation_errors';
+import {patternError} from '../validation_errors';
 import {BaseValidatorConfig, getOption} from './util';
 
 /**
@@ -47,7 +47,7 @@ export function pattern<TPathKind extends PathKind = PathKind.Root>(
       if (config?.error) {
         return getOption(config.error, ctx);
       } else {
-        return ValidationError.pattern(pattern, {message: getOption(config?.message, ctx)});
+        return patternError(pattern, {message: getOption(config?.message, ctx)});
       }
     }
     return undefined;

--- a/packages/forms/signals/src/api/validators/required.ts
+++ b/packages/forms/signals/src/api/validators/required.ts
@@ -10,7 +10,7 @@ import {computed} from '@angular/core';
 import {aggregateProperty, property, validate} from '../logic';
 import {REQUIRED} from '../property';
 import {FieldPath, LogicFn, PathKind} from '../types';
-import {ValidationError} from '../validation_errors';
+import {requiredError} from '../validation_errors';
 import {BaseValidatorConfig, getOption} from './util';
 
 /**
@@ -47,7 +47,7 @@ export function required<TValue, TPathKind extends PathKind = PathKind.Root>(
       if (config?.error) {
         return getOption(config.error, ctx);
       } else {
-        return ValidationError.required({message: getOption(config?.message, ctx)});
+        return requiredError({message: getOption(config?.message, ctx)});
       }
     }
     return undefined;

--- a/packages/forms/signals/src/api/validators/standard_schema.ts
+++ b/packages/forms/signals/src/api/validators/standard_schema.ts
@@ -13,8 +13,8 @@ import {property, validateTree} from '../logic';
 import {Field, FieldPath} from '../types';
 import {
   addDefaultField,
+  standardSchemaError,
   StandardSchemaValidationError,
-  ValidationError,
 } from '../validation_errors';
 
 /**
@@ -105,5 +105,5 @@ function standardIssueToFormTreeError(
     const pathKey = typeof pathPart === 'object' ? pathPart.key : pathPart;
     target = target[pathKey] as Field<Record<PropertyKey, unknown>>;
   }
-  return addDefaultField(ValidationError.standardSchema(issue), target);
+  return addDefaultField(standardSchemaError(issue), target);
 }

--- a/packages/forms/signals/test/node/api/hidden.spec.ts
+++ b/packages/forms/signals/test/node/api/hidden.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {Injector, signal} from '@angular/core';
-import {form, hidden, validate, ValidationError} from '@angular/forms/signals';
+import {form, hidden, validate, customError} from '@angular/forms/signals';
 import {TestBed} from '@angular/core/testing';
 
 describe('hidden', () => {
@@ -70,7 +70,7 @@ describe('hidden', () => {
         });
 
         validate(p.name, () => {
-          return ValidationError.custom({kind: 'dog'});
+          return customError({kind: 'dog'});
         });
       },
       {injector: TestBed.inject(Injector)},

--- a/packages/forms/signals/test/node/api/validators/email.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/email.spec.ts
@@ -9,7 +9,7 @@
 import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {email, form} from '../../../../public_api';
-import {ValidationError} from '../../../../src/api/validation_errors';
+import {customError, emailError} from '../../../../src/api/validation_errors';
 
 describe('email validator', () => {
   it('returns requiredTrue error when the value is false', () => {
@@ -26,7 +26,7 @@ describe('email validator', () => {
 
     expect(f.email().errors()).toEqual([]);
     f.email().value.set('not-real-email');
-    expect(f.email().errors()).toEqual([ValidationError.email({field: f.email})]);
+    expect(f.email().errors()).toEqual([emailError({field: f.email})]);
   });
 
   it('supports custom errors', () => {
@@ -35,7 +35,7 @@ describe('email validator', () => {
       cat,
       (p) => {
         email(p.email, {
-          error: (ctx) => ValidationError.custom({kind: `special-email-${ctx.valueOf(p.name)}`}),
+          error: (ctx) => customError({kind: `special-email-${ctx.valueOf(p.name)}`}),
         });
       },
       {
@@ -44,7 +44,7 @@ describe('email validator', () => {
     );
 
     expect(f.email().errors()).toEqual([
-      ValidationError.custom({
+      customError({
         kind: 'special-email-pirojok-the-cat',
         field: f.email,
       }),
@@ -66,7 +66,7 @@ describe('email validator', () => {
     );
 
     expect(f.email().errors()).toEqual([
-      ValidationError.email({
+      emailError({
         message: 'email error',
         field: f.email,
       }),

--- a/packages/forms/signals/test/node/api/validators/max.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/max.spec.ts
@@ -9,7 +9,7 @@
 import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {MAX, form, max} from '../../../../public_api';
-import {ValidationError} from '../../../../src/api/validation_errors';
+import {customError, maxError} from '../../../../src/api/validation_errors';
 
 describe('max validator', () => {
   it('returns max error when the value is larger', () => {
@@ -22,7 +22,7 @@ describe('max validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.age().errors()).toEqual([ValidationError.max(5, {field: f.age})]);
+    expect(f.age().errors()).toEqual([maxError(5, {field: f.age})]);
   });
 
   it('is inclusive', () => {
@@ -58,7 +58,7 @@ describe('max validator', () => {
       (p) => {
         max(p.age, 5, {
           error: ({value}) => {
-            return ValidationError.custom({kind: 'special-max', message: value().toString()});
+            return customError({kind: 'special-max', message: value().toString()});
           },
         });
       },
@@ -66,7 +66,7 @@ describe('max validator', () => {
     );
 
     expect(f.age().errors()).toEqual([
-      ValidationError.custom({
+      customError({
         kind: 'special-max',
         message: '6',
         field: f.age,
@@ -87,7 +87,7 @@ describe('max validator', () => {
     );
 
     expect(f.age().errors()).toEqual([
-      ValidationError.max(5, {
+      maxError(5, {
         message: 'max error',
         field: f.age,
       }),
@@ -115,7 +115,7 @@ describe('max validator', () => {
         (p) => {
           max(p.age, 5, {
             error: ({value}) => {
-              return ValidationError.custom({kind: 'special-max', message: value().toString()});
+              return customError({kind: 'special-max', message: value().toString()});
             },
           });
         },
@@ -137,12 +137,9 @@ describe('max validator', () => {
       );
 
       f.age().value.set(12);
-      expect(f.age().errors()).toEqual([
-        ValidationError.max(10, {field: f.age}),
-        ValidationError.max(5, {field: f.age}),
-      ]);
+      expect(f.age().errors()).toEqual([maxError(10, {field: f.age}), maxError(5, {field: f.age})]);
       f.age().value.set(7);
-      expect(f.age().errors()).toEqual([ValidationError.max(5, {field: f.age})]);
+      expect(f.age().errors()).toEqual([maxError(5, {field: f.age})]);
       f.age().value.set(3);
       expect(f.age().errors()).toEqual([]);
 
@@ -162,12 +159,9 @@ describe('max validator', () => {
       );
 
       f.age().value.set(12);
-      expect(f.age().errors()).toEqual([
-        ValidationError.max(10, {field: f.age}),
-        ValidationError.max(5, {field: f.age}),
-      ]);
+      expect(f.age().errors()).toEqual([maxError(10, {field: f.age}), maxError(5, {field: f.age})]);
       f.age().value.set(7);
-      expect(f.age().errors()).toEqual([ValidationError.max(5, {field: f.age})]);
+      expect(f.age().errors()).toEqual([maxError(5, {field: f.age})]);
       f.age().value.set(3);
       expect(f.age().errors()).toEqual([]);
 
@@ -175,7 +169,7 @@ describe('max validator', () => {
 
       maxSignal.set(2);
       f.age().value.set(3);
-      expect(f.age().errors()).toEqual([ValidationError.max(2, {field: f.age})]);
+      expect(f.age().errors()).toEqual([maxError(2, {field: f.age})]);
       expect(f.age().property(MAX)()).toBe(2);
     });
 
@@ -194,14 +188,14 @@ describe('max validator', () => {
 
       // Initially, age 20 is greater than both 10 and 15
       expect(f.age().errors()).toEqual([
-        ValidationError.max(10, {field: f.age}),
-        ValidationError.max(15, {field: f.age}),
+        maxError(10, {field: f.age}),
+        maxError(15, {field: f.age}),
       ]);
 
       // Set the first max threshold to undefined
       maxSignal.set(undefined);
       // Now, age 20 is only greater than 15
-      expect(f.age().errors()).toEqual([ValidationError.max(15, {field: f.age})]);
+      expect(f.age().errors()).toEqual([maxError(15, {field: f.age})]);
 
       // Set the second max threshold to undefined
       maxSignal2.set(undefined);
@@ -222,7 +216,7 @@ describe('max validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([ValidationError.max(5, {field: f.age})]);
+      expect(f.age().errors()).toEqual([maxError(5, {field: f.age})]);
       maxValue.set(7);
       expect(f.age().errors()).toEqual([]);
     });
@@ -238,11 +232,11 @@ describe('max validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([ValidationError.max(5, {field: f.age})]);
+      expect(f.age().errors()).toEqual([maxError(5, {field: f.age})]);
       maxValue.set(undefined);
       expect(f.age().errors()).toEqual([]);
       maxValue.set(5);
-      expect(f.age().errors()).toEqual([ValidationError.max(5, {field: f.age})]);
+      expect(f.age().errors()).toEqual([maxError(5, {field: f.age})]);
     });
 
     it('handles dynamic value based on other field', () => {
@@ -258,7 +252,7 @@ describe('max validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([ValidationError.max(5, {field: f.age})]);
+      expect(f.age().errors()).toEqual([maxError(5, {field: f.age})]);
 
       f.name().value.set('other cat');
 

--- a/packages/forms/signals/test/node/api/validators/max_length.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/max_length.spec.ts
@@ -9,7 +9,7 @@
 import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {MAX_LENGTH, form, maxLength} from '../../../../public_api';
-import {ValidationError} from '../../../../src/api/validation_errors';
+import {customError, maxLengthError} from '../../../../src/api/validation_errors';
 
 describe('maxLength validator', () => {
   it('returns maxLength error when the length is larger for strings', () => {
@@ -22,7 +22,7 @@ describe('maxLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.text().errors()).toEqual([ValidationError.maxLength(3, {field: f.text})]);
+    expect(f.text().errors()).toEqual([maxLengthError(3, {field: f.text})]);
   });
 
   it('returns maxLength error when the length is larger for arrays', () => {
@@ -35,7 +35,7 @@ describe('maxLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.list().errors()).toEqual([ValidationError.maxLength(3, {field: f.list})]);
+    expect(f.list().errors()).toEqual([maxLengthError(3, {field: f.list})]);
   });
 
   it('is inclusive (no error if length equals maxLength)', () => {
@@ -71,7 +71,7 @@ describe('maxLength validator', () => {
       (p) => {
         maxLength(p.text, 5, {
           error: ({value}) => {
-            return ValidationError.custom({
+            return customError({
               kind: 'special-maxLength',
               message: `Length is ${value().length}`,
             });
@@ -82,7 +82,7 @@ describe('maxLength validator', () => {
     );
 
     expect(f.text().errors()).toEqual([
-      ValidationError.custom({
+      customError({
         kind: 'special-maxLength',
         message: 'Length is 6',
         field: f.text,
@@ -103,7 +103,7 @@ describe('maxLength validator', () => {
     );
 
     expect(f.text().errors()).toEqual([
-      ValidationError.maxLength(5, {
+      maxLengthError(5, {
         message: 'abcdef is an error!',
         field: f.text,
       }),
@@ -120,7 +120,7 @@ describe('maxLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f().errors()).toEqual([ValidationError.maxLength(3, {field: f})]);
+    expect(f().errors()).toEqual([maxLengthError(3, {field: f})]);
   });
 
   describe('custom properties', () => {
@@ -131,7 +131,7 @@ describe('maxLength validator', () => {
         (p) => {
           maxLength(p.text, 5, {
             error: ({value}) => {
-              return ValidationError.custom({
+              return customError({
                 kind: 'special-maxLength',
                 message: `Length is ${value().length}`,
               });
@@ -157,12 +157,12 @@ describe('maxLength validator', () => {
 
       f.text().value.set('abcdefghijklmno');
       expect(f.text().errors()).toEqual([
-        ValidationError.maxLength(10, {field: f.text}),
-        ValidationError.maxLength(5, {field: f.text}),
+        maxLengthError(10, {field: f.text}),
+        maxLengthError(5, {field: f.text}),
       ]);
 
       f.text().value.set('abcdefg');
-      expect(f.text().errors()).toEqual([ValidationError.maxLength(5, {field: f.text})]);
+      expect(f.text().errors()).toEqual([maxLengthError(5, {field: f.text})]);
 
       f.text().value.set('abc');
       expect(f.text().errors()).toEqual([]);
@@ -184,19 +184,19 @@ describe('maxLength validator', () => {
 
       f.text().value.set('abcdefghijklmno');
       expect(f.text().errors()).toEqual([
-        ValidationError.maxLength(10, {field: f.text}),
-        ValidationError.maxLength(5, {field: f.text}),
+        maxLengthError(10, {field: f.text}),
+        maxLengthError(5, {field: f.text}),
       ]);
 
       f.text().value.set('abcdefg');
-      expect(f.text().errors()).toEqual([ValidationError.maxLength(5, {field: f.text})]);
+      expect(f.text().errors()).toEqual([maxLengthError(5, {field: f.text})]);
 
       f.text().value.set('abc');
       expect(f.text().errors()).toEqual([]);
 
       maxLengthSignal.set(2);
 
-      expect(f.text().errors()).toEqual([ValidationError.maxLength(2, {field: f.text})]);
+      expect(f.text().errors()).toEqual([maxLengthError(2, {field: f.text})]);
       expect(f.text().property(MAX_LENGTH)()).toBe(2);
     });
   });
@@ -213,7 +213,7 @@ describe('maxLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([ValidationError.maxLength(5, {field: f.text})]);
+      expect(f.text().errors()).toEqual([maxLengthError(5, {field: f.text})]);
       dynamicMaxLength.set(7);
       expect(f.text().errors()).toEqual([]);
     });
@@ -228,7 +228,7 @@ describe('maxLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([ValidationError.maxLength(5, {field: f.text})]);
+      expect(f.text().errors()).toEqual([maxLengthError(5, {field: f.text})]);
       dynamicMaxLength.set(undefined);
       expect(f.text().errors()).toEqual([]);
     });
@@ -245,7 +245,7 @@ describe('maxLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([ValidationError.maxLength(8, {field: f.text})]);
+      expect(f.text().errors()).toEqual([maxLengthError(8, {field: f.text})]);
 
       f.category().value.set('B');
       expect(f.text().errors()).toEqual([]);

--- a/packages/forms/signals/test/node/api/validators/min.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/min.spec.ts
@@ -9,7 +9,7 @@
 import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {MIN, form, min} from '../../../../public_api';
-import {ValidationError} from '../../../../src/api/validation_errors';
+import {customError, minError} from '../../../../src/api/validation_errors';
 
 describe('min validator', () => {
   it('returns min error when the value is smaller', () => {
@@ -22,7 +22,7 @@ describe('min validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.age().errors()).toEqual([ValidationError.min(5, {field: f.age})]);
+    expect(f.age().errors()).toEqual([minError(5, {field: f.age})]);
   });
 
   it('is inclusive', () => {
@@ -58,7 +58,7 @@ describe('min validator', () => {
       (p) => {
         min(p.age, 5, {
           error: ({value}) => {
-            return ValidationError.custom({kind: 'special-min', message: value().toString()});
+            return customError({kind: 'special-min', message: value().toString()});
           },
         });
       },
@@ -66,7 +66,7 @@ describe('min validator', () => {
     );
 
     expect(f.age().errors()).toEqual([
-      ValidationError.custom({
+      customError({
         kind: 'special-min',
         message: '3',
         field: f.age,
@@ -87,7 +87,7 @@ describe('min validator', () => {
     );
 
     expect(f.age().errors()).toEqual([
-      ValidationError.min(5, {
+      minError(5, {
         message: 'min error!!',
         field: f.age,
       }),
@@ -115,7 +115,7 @@ describe('min validator', () => {
         (p) => {
           min(p.age, 5, {
             error: ({value}) => {
-              return ValidationError.custom({kind: 'special-min', message: value().toString()});
+              return customError({kind: 'special-min', message: value().toString()});
             },
           });
         },
@@ -137,12 +137,9 @@ describe('min validator', () => {
       );
 
       f.age().value.set(3);
-      expect(f.age().errors()).toEqual([
-        ValidationError.min(5, {field: f.age}),
-        ValidationError.min(10, {field: f.age}),
-      ]);
+      expect(f.age().errors()).toEqual([minError(5, {field: f.age}), minError(10, {field: f.age})]);
       f.age().value.set(7);
-      expect(f.age().errors()).toEqual([ValidationError.min(10, {field: f.age})]);
+      expect(f.age().errors()).toEqual([minError(10, {field: f.age})]);
       f.age().value.set(15);
       expect(f.age().errors()).toEqual([]);
 
@@ -162,16 +159,13 @@ describe('min validator', () => {
       );
 
       f.age().value.set(3);
-      expect(f.age().errors()).toEqual([
-        ValidationError.min(5, {field: f.age}),
-        ValidationError.min(10, {field: f.age}),
-      ]);
+      expect(f.age().errors()).toEqual([minError(5, {field: f.age}), minError(10, {field: f.age})]);
       f.age().value.set(7);
-      expect(f.age().errors()).toEqual([ValidationError.min(10, {field: f.age})]);
+      expect(f.age().errors()).toEqual([minError(10, {field: f.age})]);
       f.age().value.set(15);
       expect(f.age().errors()).toEqual([]);
       minSignal.set(30);
-      expect(f.age().errors()).toEqual([ValidationError.min(30, {field: f.age})]);
+      expect(f.age().errors()).toEqual([minError(30, {field: f.age})]);
       expect(f.age().property(MIN)()).toBe(30);
     });
 
@@ -189,11 +183,11 @@ describe('min validator', () => {
       );
 
       expect(f.age().errors()).toEqual([
-        ValidationError.min(15, {field: f.age}),
-        ValidationError.min(10, {field: f.age}),
+        minError(15, {field: f.age}),
+        minError(10, {field: f.age}),
       ]);
       minSignal.set(undefined);
-      expect(f.age().errors()).toEqual([ValidationError.min(10, {field: f.age})]);
+      expect(f.age().errors()).toEqual([minError(10, {field: f.age})]);
       minSignal2.set(undefined);
       expect(f.age().errors()).toEqual([]);
     });
@@ -211,11 +205,11 @@ describe('min validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([ValidationError.min(5, {field: f.age})]);
+      expect(f.age().errors()).toEqual([minError(5, {field: f.age})]);
       minValue.set(undefined);
       expect(f.age().errors()).toEqual([]);
       minValue.set(5);
-      expect(f.age().errors()).toEqual([ValidationError.min(5, {field: f.age})]);
+      expect(f.age().errors()).toEqual([minError(5, {field: f.age})]);
     });
 
     it('handles dynamic value', () => {
@@ -229,7 +223,7 @@ describe('min validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([ValidationError.min(5, {field: f.age})]);
+      expect(f.age().errors()).toEqual([minError(5, {field: f.age})]);
       minValue.set(2);
       expect(f.age().errors()).toEqual([]);
     });
@@ -247,7 +241,7 @@ describe('min validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([ValidationError.min(5, {field: f.age})]);
+      expect(f.age().errors()).toEqual([minError(5, {field: f.age})]);
       f.name().value.set('other cat');
       expect(f.age().errors()).toEqual([]);
     });

--- a/packages/forms/signals/test/node/api/validators/min_length.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/min_length.spec.ts
@@ -9,7 +9,7 @@
 import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {MIN_LENGTH, form, minLength} from '../../../../public_api';
-import {ValidationError} from '../../../../src/api/validation_errors';
+import {customError, minLengthError} from '../../../../src/api/validation_errors';
 
 describe('minLength validator', () => {
   it('returns minLength error when the length is smaller for strings', () => {
@@ -22,7 +22,7 @@ describe('minLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.text().errors()).toEqual([ValidationError.minLength(5, {field: f.text})]);
+    expect(f.text().errors()).toEqual([minLengthError(5, {field: f.text})]);
   });
 
   it('returns minLength error when the length is smaller for arrays', () => {
@@ -35,7 +35,7 @@ describe('minLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.list().errors()).toEqual([ValidationError.minLength(5, {field: f.list})]);
+    expect(f.list().errors()).toEqual([minLengthError(5, {field: f.list})]);
   });
 
   it('is inclusive (no error if length equals minLength)', () => {
@@ -71,7 +71,7 @@ describe('minLength validator', () => {
       (p) => {
         minLength(p.text, 5, {
           error: ({value}) => {
-            return ValidationError.custom({
+            return customError({
               kind: 'special-minLength',
               message: `Length is ${value().length}`,
             });
@@ -82,7 +82,7 @@ describe('minLength validator', () => {
     );
 
     expect(f.text().errors()).toEqual([
-      ValidationError.custom({
+      customError({
         kind: 'special-minLength',
         message: 'Length is 2',
         field: f.text,
@@ -103,7 +103,7 @@ describe('minLength validator', () => {
     );
 
     expect(f.text().errors()).toEqual([
-      ValidationError.minLength(5, {
+      minLengthError(5, {
         message: 'ab is error!',
         field: f.text,
       }),
@@ -120,7 +120,7 @@ describe('minLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f().errors()).toEqual([ValidationError.minLength(5, {field: f})]);
+    expect(f().errors()).toEqual([minLengthError(5, {field: f})]);
   });
 
   describe('custom properties', () => {
@@ -131,7 +131,7 @@ describe('minLength validator', () => {
         (p) => {
           minLength(p.text, 5, {
             error: ({value}) => {
-              return ValidationError.custom({
+              return customError({
                 kind: 'special-minLength',
                 message: `Length is ${value().length}`,
               });
@@ -157,12 +157,12 @@ describe('minLength validator', () => {
 
       f.text().value.set('ab');
       expect(f.text().errors()).toEqual([
-        ValidationError.minLength(5, {field: f.text}),
-        ValidationError.minLength(10, {field: f.text}),
+        minLengthError(5, {field: f.text}),
+        minLengthError(10, {field: f.text}),
       ]);
 
       f.text().value.set('abcdefg');
-      expect(f.text().errors()).toEqual([ValidationError.minLength(10, {field: f.text})]);
+      expect(f.text().errors()).toEqual([minLengthError(10, {field: f.text})]);
 
       f.text().value.set('abcdefghijklmno');
       expect(f.text().errors()).toEqual([]);
@@ -184,19 +184,19 @@ describe('minLength validator', () => {
 
       f.text().value.set('ab');
       expect(f.text().errors()).toEqual([
-        ValidationError.minLength(5, {field: f.text}),
-        ValidationError.minLength(10, {field: f.text}),
+        minLengthError(5, {field: f.text}),
+        minLengthError(10, {field: f.text}),
       ]);
 
       f.text().value.set('abcdefg');
-      expect(f.text().errors()).toEqual([ValidationError.minLength(10, {field: f.text})]);
+      expect(f.text().errors()).toEqual([minLengthError(10, {field: f.text})]);
 
       f.text().value.set('abcdefghijklmno');
       expect(f.text().errors()).toEqual([]);
 
       minLengthSignal.set(20);
 
-      expect(f.text().errors()).toEqual([ValidationError.minLength(20, {field: f.text})]);
+      expect(f.text().errors()).toEqual([minLengthError(20, {field: f.text})]);
       expect(f.text().property(MIN_LENGTH)()).toBe(20);
     });
   });
@@ -213,7 +213,7 @@ describe('minLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([ValidationError.minLength(5, {field: f.text})]);
+      expect(f.text().errors()).toEqual([minLengthError(5, {field: f.text})]);
       dynamicMinLength.set(3);
       expect(f.text().errors()).toEqual([]);
     });
@@ -229,7 +229,7 @@ describe('minLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([ValidationError.minLength(5, {field: f.text})]);
+      expect(f.text().errors()).toEqual([minLengthError(5, {field: f.text})]);
       dynamicMinLength.set(undefined);
       expect(f.text().errors()).toEqual([]);
     });
@@ -246,7 +246,7 @@ describe('minLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([ValidationError.minLength(8, {field: f.text})]);
+      expect(f.text().errors()).toEqual([minLengthError(8, {field: f.text})]);
 
       f.category().value.set('B');
       expect(f.text().errors()).toEqual([]);

--- a/packages/forms/signals/test/node/api/validators/pattern.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/pattern.spec.ts
@@ -9,7 +9,7 @@
 import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {PATTERN, form, pattern} from '../../../../public_api';
-import {ValidationError} from '../../../../src/api/validation_errors';
+import {customError, patternError} from '../../../../src/api/validation_errors';
 
 describe('pattern validator', () => {
   it('validates whether a value matches the pattern', () => {
@@ -22,7 +22,7 @@ describe('pattern validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.name().errors()).toEqual([ValidationError.pattern(/pir.*jok/, {field: f.name})]);
+    expect(f.name().errors()).toEqual([patternError(/pir.*jok/, {field: f.name})]);
   });
 
   it('supports custom error', () => {
@@ -30,12 +30,12 @@ describe('pattern validator', () => {
     const f = form(
       cat,
       (p) => {
-        pattern(p.name, /pir.*jok/, {error: ValidationError.custom()});
+        pattern(p.name, /pir.*jok/, {error: customError()});
       },
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.name().errors()).toEqual([ValidationError.custom({field: f.name})]);
+    expect(f.name().errors()).toEqual([customError({field: f.name})]);
   });
 
   it('supports custom error message', () => {
@@ -49,7 +49,7 @@ describe('pattern validator', () => {
     );
 
     expect(f.name().errors()).toEqual([
-      ValidationError.pattern(/pir.*jok/, {message: 'pattern error', field: f.name}),
+      patternError(/pir.*jok/, {message: 'pattern error', field: f.name}),
     ]);
   });
 
@@ -106,12 +106,12 @@ describe('pattern validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.name().errors()).toEqual([ValidationError.pattern(/pir.*jok/, {field: f.name})]);
+      expect(f.name().errors()).toEqual([patternError(/pir.*jok/, {field: f.name})]);
 
       patternSignal.set(/p.*/);
       expect(f.name().errors()).toEqual([]);
       patternSignal.set(/meow/);
-      expect(f.name().errors()).toEqual([ValidationError.pattern(/meow/, {field: f.name})]);
+      expect(f.name().errors()).toEqual([patternError(/meow/, {field: f.name})]);
 
       patternSignal.set(undefined);
 

--- a/packages/forms/signals/test/node/api/validators/required.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/required.spec.ts
@@ -9,7 +9,7 @@
 import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {form, required} from '../../../../public_api';
-import {ValidationError} from '../../../../src/api/validation_errors';
+import {customError, requiredError} from '../../../../src/api/validation_errors';
 
 describe('required validator', () => {
   it('returns required Error when the value is not present', () => {
@@ -24,7 +24,7 @@ describe('required validator', () => {
       },
     );
 
-    expect(f.name().errors()).toEqual([ValidationError.required({field: f.name})]);
+    expect(f.name().errors()).toEqual([requiredError({field: f.name})]);
     f.name().value.set('pirojok-the-cat');
     expect(f.name().errors()).toEqual([]);
   });
@@ -35,7 +35,7 @@ describe('required validator', () => {
       cat,
       (p) => {
         required(p.name, {
-          error: (ctx) => ValidationError.custom({kind: `required-${ctx.valueOf(p.age)}`}),
+          error: (ctx) => customError({kind: `required-${ctx.valueOf(p.age)}`}),
         });
       },
       {
@@ -43,9 +43,7 @@ describe('required validator', () => {
       },
     );
 
-    expect(f.name().errors()).toEqual([
-      ValidationError.custom({kind: 'required-5', field: f.name}),
-    ]);
+    expect(f.name().errors()).toEqual([customError({kind: 'required-5', field: f.name})]);
     f.name().value.set('pirojok-the-cat');
     expect(f.name().errors()).toEqual([]);
   });
@@ -64,9 +62,7 @@ describe('required validator', () => {
       },
     );
 
-    expect(f.name().errors()).toEqual([
-      ValidationError.required({message: 'required error', field: f.name}),
-    ]);
+    expect(f.name().errors()).toEqual([requiredError({message: 'required error', field: f.name})]);
     f.name().value.set('pirojok-the-cat');
     expect(f.name().errors()).toEqual([]);
   });
@@ -89,7 +85,7 @@ describe('required validator', () => {
 
     expect(f.name().errors()).toEqual([]);
     f.name().value.set('empty');
-    expect(f.name().errors()).toEqual([ValidationError.required({field: f.name})]);
+    expect(f.name().errors()).toEqual([requiredError({field: f.name})]);
   });
 
   it('supports custom condition', () => {
@@ -110,6 +106,6 @@ describe('required validator', () => {
 
     expect(f.name().errors()).toEqual([]);
     f.age().value.set(15);
-    expect(f.name().errors()).toEqual([ValidationError.required({field: f.name})]);
+    expect(f.name().errors()).toEqual([requiredError({field: f.name})]);
   });
 });

--- a/packages/forms/signals/test/node/logic_node.spec.ts
+++ b/packages/forms/signals/test/node/logic_node.spec.ts
@@ -8,7 +8,7 @@
 
 import {signal} from '@angular/core';
 import {FieldContext, FieldState} from '../../public_api';
-import {ValidationError} from '../../src/api/validation_errors';
+import {customError} from '../../src/api/validation_errors';
 import {DYNAMIC} from '../../src/schema/logic';
 import {LogicNodeBuilder} from '../../src/schema/logic_node';
 
@@ -32,11 +32,11 @@ describe('LogicNodeBuilder', () => {
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.addSyncErrorRule(() => [ValidationError.custom({kind: 'root-err'})]);
+    builder.addSyncErrorRule(() => [customError({kind: 'root-err'})]);
 
     const logicNode = builder.build();
     expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      ValidationError.custom({kind: 'root-err'}),
+      customError({kind: 'root-err'}),
     ]);
   });
 
@@ -46,11 +46,11 @@ describe('LogicNodeBuilder', () => {
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.getChild('a').addSyncErrorRule(() => [ValidationError.custom({kind: 'root-err'})]);
+    builder.getChild('a').addSyncErrorRule(() => [customError({kind: 'root-err'})]);
 
     const logicNode = builder.build();
     expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      ValidationError.custom({kind: 'root-err'}),
+      customError({kind: 'root-err'}),
     ]);
   });
 
@@ -61,16 +61,16 @@ describe('LogicNodeBuilder', () => {
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.addSyncErrorRule(() => [ValidationError.custom({kind: 'err-1'})]);
+    builder.addSyncErrorRule(() => [customError({kind: 'err-1'})]);
 
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.addSyncErrorRule(() => [ValidationError.custom({kind: 'err-2'})]);
+    builder2.addSyncErrorRule(() => [customError({kind: 'err-2'})]);
     builder.mergeIn(builder2);
 
     const logicNode = builder.build();
     expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      ValidationError.custom({kind: 'err-1'}),
-      ValidationError.custom({kind: 'err-2'}),
+      customError({kind: 'err-1'}),
+      customError({kind: 'err-2'}),
     ]);
   });
 
@@ -81,16 +81,16 @@ describe('LogicNodeBuilder', () => {
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.getChild('a').addSyncErrorRule(() => [ValidationError.custom({kind: 'err-1'})]);
+    builder.getChild('a').addSyncErrorRule(() => [customError({kind: 'err-1'})]);
 
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.getChild('a').addSyncErrorRule(() => [ValidationError.custom({kind: 'err-2'})]);
+    builder2.getChild('a').addSyncErrorRule(() => [customError({kind: 'err-2'})]);
     builder.mergeIn(builder2);
 
     const logicNode = builder.build();
     expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      ValidationError.custom({kind: 'err-1'}),
-      ValidationError.custom({kind: 'err-2'}),
+      customError({kind: 'err-1'}),
+      customError({kind: 'err-2'}),
     ]);
   });
 
@@ -105,12 +105,12 @@ describe('LogicNodeBuilder', () => {
 
     const pred = signal(true);
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.addSyncErrorRule(() => [ValidationError.custom({kind: 'err-1'})]);
+    builder2.addSyncErrorRule(() => [customError({kind: 'err-1'})]);
     builder.mergeIn(builder2, {fn: () => pred(), path: undefined!});
 
     const logicNode = builder.build();
     expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      ValidationError.custom({kind: 'err-1'}),
+      customError({kind: 'err-1'}),
     ]);
 
     pred.set(false);
@@ -132,14 +132,14 @@ describe('LogicNodeBuilder', () => {
     const builder2 = LogicNodeBuilder.newRoot();
 
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.addSyncErrorRule(() => [ValidationError.custom({kind: 'err-1'})]);
+    builder3.addSyncErrorRule(() => [customError({kind: 'err-1'})]);
 
     builder2.mergeIn(builder3);
     builder.mergeIn(builder2, {fn: () => pred(), path: undefined!});
 
     const logicNode = builder.build();
     expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      ValidationError.custom({kind: 'err-1'}),
+      customError({kind: 'err-1'}),
     ]);
 
     pred.set(false);
@@ -161,14 +161,14 @@ describe('LogicNodeBuilder', () => {
     const builder2 = LogicNodeBuilder.newRoot();
 
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.getChild('a').addSyncErrorRule(() => [ValidationError.custom({kind: 'err-1'})]);
+    builder3.getChild('a').addSyncErrorRule(() => [customError({kind: 'err-1'})]);
 
     builder2.mergeIn(builder3);
     builder.mergeIn(builder2, {fn: () => pred(), path: undefined!});
 
     const logicNode = builder.build();
     expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      ValidationError.custom({kind: 'err-1'}),
+      customError({kind: 'err-1'}),
     ]);
 
     pred.set(false);
@@ -191,14 +191,14 @@ describe('LogicNodeBuilder', () => {
 
     const pred2 = signal(true);
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.addSyncErrorRule(() => [ValidationError.custom({kind: 'err-1'})]);
+    builder3.addSyncErrorRule(() => [customError({kind: 'err-1'})]);
 
     builder2.getChild('a').mergeIn(builder3, {fn: () => pred2(), path: undefined!});
     builder.mergeIn(builder2, {fn: () => pred(), path: undefined!});
 
     const logicNode = builder.build();
     expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      ValidationError.custom({kind: 'err-1'}),
+      customError({kind: 'err-1'}),
     ]);
 
     pred.set(false);
@@ -230,15 +230,15 @@ describe('LogicNodeBuilder', () => {
     builder2
       .getChild('a')
       .getChild('b')
-      .addSyncErrorRule(() => [ValidationError.custom({kind: 'err-1'})]);
+      .addSyncErrorRule(() => [customError({kind: 'err-1'})]);
 
     const pred2 = signal(true);
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.getChild('b').addSyncErrorRule(() => [ValidationError.custom({kind: 'err-2'})]);
+    builder3.getChild('b').addSyncErrorRule(() => [customError({kind: 'err-2'})]);
 
     const pred3 = signal(true);
     const builder4 = LogicNodeBuilder.newRoot();
-    builder4.addSyncErrorRule(() => [ValidationError.custom({kind: 'err-3'})]);
+    builder4.addSyncErrorRule(() => [customError({kind: 'err-3'})]);
     builder3.getChild('b').mergeIn(builder4, {fn: () => pred3(), path: undefined!});
     builder2.getChild('a').mergeIn(builder3, {fn: () => pred2(), path: undefined!});
     builder.mergeIn(builder2, {fn: () => pred(), path: undefined!});
@@ -247,9 +247,9 @@ describe('LogicNodeBuilder', () => {
     expect(
       logicNode.getChild('a').getChild('b').logic.syncErrors.compute(fakeFieldContext),
     ).toEqual([
-      ValidationError.custom({kind: 'err-1'}),
-      ValidationError.custom({kind: 'err-2'}),
-      ValidationError.custom({kind: 'err-3'}),
+      customError({kind: 'err-1'}),
+      customError({kind: 'err-2'}),
+      customError({kind: 'err-3'}),
     ]);
 
     pred.set(true);
@@ -257,14 +257,14 @@ describe('LogicNodeBuilder', () => {
     pred3.set(false);
     expect(
       logicNode.getChild('a').getChild('b').logic.syncErrors.compute(fakeFieldContext),
-    ).toEqual([ValidationError.custom({kind: 'err-1'}), ValidationError.custom({kind: 'err-2'})]);
+    ).toEqual([customError({kind: 'err-1'}), customError({kind: 'err-2'})]);
 
     pred.set(true);
     pred2.set(false);
     pred3.set(true);
     expect(
       logicNode.getChild('a').getChild('b').logic.syncErrors.compute(fakeFieldContext),
-    ).toEqual([ValidationError.custom({kind: 'err-1'})]);
+    ).toEqual([customError({kind: 'err-1'})]);
 
     pred.set(false);
     pred2.set(true);
@@ -289,7 +289,7 @@ describe('LogicNodeBuilder', () => {
     const builder2 = LogicNodeBuilder.newRoot();
 
     const builder3 = LogicNodeBuilder.newRoot();
-    builder3.getChild('last').addSyncErrorRule(() => [ValidationError.custom({kind: 'err-1'})]);
+    builder3.getChild('last').addSyncErrorRule(() => [customError({kind: 'err-1'})]);
 
     builder2.getChild('items').getChild(DYNAMIC).mergeIn(builder3);
     builder.mergeIn(builder2, {fn: () => pred(), path: undefined!});
@@ -301,7 +301,7 @@ describe('LogicNodeBuilder', () => {
         .getChild(DYNAMIC)
         .getChild('last')
         .logic.syncErrors.compute(fakeFieldContext),
-    ).toEqual([ValidationError.custom({kind: 'err-1'})]);
+    ).toEqual([customError({kind: 'err-1'})]);
 
     pred.set(false);
     expect(
@@ -323,19 +323,19 @@ describe('LogicNodeBuilder', () => {
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.addSyncErrorRule(() => [ValidationError.custom({kind: 'err-1'})]);
+    builder.addSyncErrorRule(() => [customError({kind: 'err-1'})]);
 
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.addSyncErrorRule(() => [ValidationError.custom({kind: 'err-2'})]);
+    builder2.addSyncErrorRule(() => [customError({kind: 'err-2'})]);
     builder.mergeIn(builder2);
 
-    builder.addSyncErrorRule(() => [ValidationError.custom({kind: 'err-3'})]);
+    builder.addSyncErrorRule(() => [customError({kind: 'err-3'})]);
 
     const logicNode = builder.build();
     expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      ValidationError.custom({kind: 'err-1'}),
-      ValidationError.custom({kind: 'err-2'}),
-      ValidationError.custom({kind: 'err-3'}),
+      customError({kind: 'err-1'}),
+      customError({kind: 'err-2'}),
+      customError({kind: 'err-3'}),
     ]);
   });
 
@@ -349,19 +349,19 @@ describe('LogicNodeBuilder', () => {
     // };
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.getChild('a').addSyncErrorRule(() => [ValidationError.custom({kind: 'err-1'})]);
+    builder.getChild('a').addSyncErrorRule(() => [customError({kind: 'err-1'})]);
 
     const builder2 = LogicNodeBuilder.newRoot();
-    builder2.getChild('a').addSyncErrorRule(() => [ValidationError.custom({kind: 'err-2'})]);
+    builder2.getChild('a').addSyncErrorRule(() => [customError({kind: 'err-2'})]);
     builder.mergeIn(builder2);
 
-    builder.getChild('a').addSyncErrorRule(() => [ValidationError.custom({kind: 'err-3'})]);
+    builder.getChild('a').addSyncErrorRule(() => [customError({kind: 'err-3'})]);
 
     const logicNode = builder.build();
     expect(logicNode.getChild('a').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      ValidationError.custom({kind: 'err-1'}),
-      ValidationError.custom({kind: 'err-2'}),
-      ValidationError.custom({kind: 'err-3'}),
+      customError({kind: 'err-1'}),
+      customError({kind: 'err-2'}),
+      customError({kind: 'err-3'}),
     ]);
   });
 
@@ -372,19 +372,19 @@ describe('LogicNodeBuilder', () => {
     // }));
 
     const builder = LogicNodeBuilder.newRoot();
-    builder.addSyncErrorRule(() => [ValidationError.custom({kind: 'err-1'})]);
+    builder.addSyncErrorRule(() => [customError({kind: 'err-1'})]);
     builder.getChild('next').mergeIn(builder);
 
     const logicNode = builder.build();
     expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      ValidationError.custom({kind: 'err-1'}),
+      customError({kind: 'err-1'}),
     ]);
     expect(logicNode.getChild('next').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      ValidationError.custom({kind: 'err-1'}),
+      customError({kind: 'err-1'}),
     ]);
     expect(
       logicNode.getChild('next').getChild('next').logic.syncErrors.compute(fakeFieldContext),
-    ).toEqual([ValidationError.custom({kind: 'err-1'})]);
+    ).toEqual([customError({kind: 'err-1'})]);
   });
 
   it('should support circular logic structures with predicate', () => {
@@ -395,25 +395,25 @@ describe('LogicNodeBuilder', () => {
 
     const pred = signal(true);
     const builder = LogicNodeBuilder.newRoot();
-    builder.addSyncErrorRule(() => [ValidationError.custom({kind: 'err-1'})]);
+    builder.addSyncErrorRule(() => [customError({kind: 'err-1'})]);
     builder.getChild('next').mergeIn(builder, {fn: () => pred(), path: undefined!});
 
     const logicNode = builder.build();
     expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      ValidationError.custom({kind: 'err-1'}),
+      customError({kind: 'err-1'}),
     ]);
     expect(logicNode.getChild('next').logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      ValidationError.custom({kind: 'err-1'}),
+      customError({kind: 'err-1'}),
     ]);
     expect(
       logicNode.getChild('next').getChild('next').logic.syncErrors.compute(fakeFieldContext),
-    ).toEqual([ValidationError.custom({kind: 'err-1'})]);
+    ).toEqual([customError({kind: 'err-1'})]);
 
     // TODO: test that verifies that the same predicate can resolve with a different field context
     // on `.next` vs on `.next.next`
     pred.set(false);
     expect(logicNode.logic.syncErrors.compute(fakeFieldContext)).toEqual([
-      ValidationError.custom({kind: 'err-1'}),
+      customError({kind: 'err-1'}),
     ]);
     expect(logicNode.getChild('next').logic.syncErrors.compute(fakeFieldContext)).toEqual([]);
     expect(

--- a/packages/forms/signals/test/node/path.spec.ts
+++ b/packages/forms/signals/test/node/path.spec.ts
@@ -9,7 +9,7 @@
 import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {apply, applyEach, applyWhen, form, validate} from '../../public_api';
-import {ValidationError} from '../../src/api/validation_errors';
+import {customError, requiredError} from '../../src/api/validation_errors';
 
 describe('path', () => {
   describe('Active path', () => {
@@ -25,7 +25,7 @@ describe('path', () => {
             (/* UNUSED */) => {
               expect(() => {
                 validate(path.last, ({value}) =>
-                  value().length > 0 ? undefined : ValidationError.required(),
+                  value().length > 0 ? undefined : requiredError(),
                 );
               }).toThrowError();
             },
@@ -44,7 +44,7 @@ describe('path', () => {
           apply(path, () => {
             expect(() => {
               validate(path.last, () => {
-                return ValidationError.custom();
+                return customError();
               });
             }).toThrowError();
           });
@@ -62,7 +62,7 @@ describe('path', () => {
           apply(path, () => {
             expect(() => {
               validate(path, () => {
-                return ValidationError.custom();
+                return customError();
               });
             }).toThrowError();
           });
@@ -83,7 +83,7 @@ describe('path', () => {
           applyEach(path.items, () => {
             expect(() => {
               validate(path.needLastName, () => {
-                return ValidationError.custom();
+                return customError();
               });
             }).toThrowError();
           });

--- a/packages/forms/signals/test/node/recursive_logic.spec.ts
+++ b/packages/forms/signals/test/node/recursive_logic.spec.ts
@@ -11,7 +11,7 @@ import {TestBed} from '@angular/core/testing';
 import {disabled, validate} from '../../src/api/logic';
 import {applyEach, applyWhen, applyWhenValue, form, schema} from '../../src/api/structure';
 import type {Field, Schema} from '../../src/api/types';
-import {ValidationError} from '../../src/api/validation_errors';
+import {customError} from '../../src/api/validation_errors';
 
 interface TreeData {
   level: number;
@@ -99,7 +99,7 @@ describe('recursive schema logic', () => {
         (children) => {
           applyEach(children, (c) => {
             validate(c.tag, ({value}) =>
-              value() !== 'tr' ? ValidationError.custom({kind: 'invalid-child'}) : undefined,
+              value() !== 'tr' ? customError({kind: 'invalid-child'}) : undefined,
             );
           });
         },
@@ -110,7 +110,7 @@ describe('recursive schema logic', () => {
         (children) => {
           applyEach(children, (c) => {
             validate(c.tag, ({value}) =>
-              value() !== 'td' ? ValidationError.custom({kind: 'invalid-child'}) : undefined,
+              value() !== 'td' ? customError({kind: 'invalid-child'}) : undefined,
             );
           });
         },

--- a/packages/forms/signals/test/node/resource.spec.ts
+++ b/packages/forms/signals/test/node/resource.spec.ts
@@ -14,7 +14,6 @@ import {isNode} from '@angular/private/testing';
 import {
   applyEach,
   form,
-  Property,
   property,
   required,
   schema,
@@ -23,7 +22,7 @@ import {
   validateAsync,
   validateHttp,
 } from '../../public_api';
-import {ValidationError} from '../../src/api/validation_errors';
+import {customError, ValidationError} from '../../src/api/validation_errors';
 
 interface Cat {
   name: string;
@@ -67,7 +66,7 @@ describe('resources', () => {
       validate(p.name, ({state}) => {
         const remote = state.property(RES)!;
         if (remote.hasValue()) {
-          return ValidationError.custom({message: remote.value()});
+          return customError({message: remote.value()});
         } else {
           return undefined;
         }
@@ -80,7 +79,7 @@ describe('resources', () => {
 
     await appRef.whenStable();
     expect(f.name().errors()).toEqual([
-      ValidationError.custom({
+      customError({
         message: 'got: cat',
         field: f.name,
       }),
@@ -89,7 +88,7 @@ describe('resources', () => {
     f.name().value.set('dog');
     await appRef.whenStable();
     expect(f.name().errors()).toEqual([
-      ValidationError.custom({
+      customError({
         message: 'got: dog',
         field: f.name,
       }),
@@ -99,8 +98,7 @@ describe('resources', () => {
   it('should create a resource per entry in an array', async () => {
     const s: SchemaOrSchemaFn<Cat[]> = function (p) {
       applyEach(p, (p) => {
-        const RES = Property.create<Resource<string | undefined>>();
-        property(p.name, RES, ({value}) => {
+        const RES = property(p.name, ({value}) => {
           return resource({
             params: () => ({x: value()}),
             loader: async ({params}) => `got: ${params.x}`,
@@ -110,7 +108,7 @@ describe('resources', () => {
         validate(p.name, ({state}) => {
           const remote = state.property(RES)!;
           if (remote.hasValue()) {
-            return ValidationError.custom({message: remote.value()});
+            return customError({message: remote.value()});
           } else {
             return undefined;
           }
@@ -124,13 +122,13 @@ describe('resources', () => {
 
     await appRef.whenStable();
     expect(f[0].name().errors()).toEqual([
-      ValidationError.custom({
+      customError({
         message: 'got: cat',
         field: f[0].name,
       }),
     ]);
     expect(f[1].name().errors()).toEqual([
-      ValidationError.custom({
+      customError({
         message: 'got: dog',
         field: f[1].name,
       }),
@@ -139,13 +137,13 @@ describe('resources', () => {
     f[0].name().value.set('bunny');
     await appRef.whenStable();
     expect(f[0].name().errors()).toEqual([
-      ValidationError.custom({
+      customError({
         message: 'got: bunny',
         field: f[0].name,
       }),
     ]);
     expect(f[1].name().errors()).toEqual([
-      ValidationError.custom({
+      customError({
         message: 'got: dog',
         field: f[1].name,
       }),
@@ -165,7 +163,7 @@ describe('resources', () => {
           }),
         errors: (cats, {fieldOf}) => {
           return cats.map((cat, index) =>
-            ValidationError.custom({
+            customError({
               kind: 'meows_too_much',
               name: cat.name,
               field: fieldOf(p)[index],
@@ -180,10 +178,10 @@ describe('resources', () => {
 
     await appRef.whenStable();
     expect(f[0]().errors()).toEqual([
-      ValidationError.custom({kind: 'meows_too_much', name: 'Fluffy', field: f[0]}),
+      customError({kind: 'meows_too_much', name: 'Fluffy', field: f[0]}),
     ]);
     expect(f[1]().errors()).toEqual([
-      ValidationError.custom({kind: 'meows_too_much', name: 'Ziggy', field: f[1]}),
+      customError({kind: 'meows_too_much', name: 'Ziggy', field: f[1]}),
     ]);
   });
 
@@ -199,7 +197,7 @@ describe('resources', () => {
             },
           }),
         errors: (cats, {fieldOf}) => {
-          return ValidationError.custom({
+          return customError({
             kind: 'meows_too_much',
             name: cats[0].name,
             field: fieldOf(p)[0],
@@ -213,7 +211,7 @@ describe('resources', () => {
 
     await appRef.whenStable();
     expect(f[0]().errors()).toEqual([
-      ValidationError.custom({kind: 'meows_too_much', name: 'Fluffy', field: f[0]}),
+      customError({kind: 'meows_too_much', name: 'Fluffy', field: f[0]}),
     ]);
     expect(f[1]().errors()).toEqual([]);
   });
@@ -225,7 +223,7 @@ describe('resources', () => {
         validateHttp(p, {
           request: ({value}) => `/api/check?username=${value()}`,
           errors: (available: boolean) =>
-            available ? undefined : ValidationError.custom({kind: 'username-taken'}),
+            available ? undefined : customError({kind: 'username-taken'}),
         });
       },
       {injector},
@@ -269,7 +267,7 @@ describe('resources', () => {
       validateHttp(address, {
         request: ({value}) => ({url: '/checkaddress', params: {...value()}}),
         errors: (message: string, {fieldOf}) =>
-          ValidationError.custom({message, field: fieldOf(address.street)}),
+          customError({message, field: fieldOf(address.street)}),
       });
     });
     const addressForm = form(addressModel, addressSchema, {injector});
@@ -285,7 +283,7 @@ describe('resources', () => {
     await appRef.whenStable();
 
     expect(addressForm.street().errors()).toEqual([
-      ValidationError.custom({message: 'Invalid!', field: addressForm.street}),
+      customError({message: 'Invalid!', field: addressForm.street}),
     ]);
   });
 });

--- a/packages/forms/signals/test/node/submit.spec.ts
+++ b/packages/forms/signals/test/node/submit.spec.ts
@@ -9,7 +9,7 @@
 import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {form, required, submit} from '../../public_api';
-import {ValidationError} from '../../src/api/validation_errors';
+import {customError, requiredError, ValidationError} from '../../src/api/validation_errors';
 
 describe('submit', () => {
   it('fails fast on invalid form', async () => {
@@ -26,7 +26,7 @@ describe('submit', () => {
       fail('Submit action should run not on invalid form');
     });
 
-    expect(f.first().errors()).toEqual([ValidationError.required({field: f.first})]);
+    expect(f.first().errors()).toEqual([requiredError({field: f.first})]);
   });
 
   it('maps error to a field', async () => {
@@ -42,14 +42,14 @@ describe('submit', () => {
 
     await submit(f, (form) => {
       return Promise.resolve(
-        ValidationError.custom({
+        customError({
           kind: 'lastName',
           field: form.last,
         }),
       );
     });
 
-    expect(f.last().errors()).toEqual([ValidationError.custom({kind: 'lastName', field: f.last})]);
+    expect(f.last().errors()).toEqual([customError({kind: 'lastName', field: f.last})]);
   });
 
   it('maps errors to multiple fields', async () => {
@@ -58,27 +58,25 @@ describe('submit', () => {
 
     await submit(f, (form) => {
       return Promise.resolve([
-        ValidationError.custom({
+        customError({
           kind: 'firstName',
           field: form.first,
         }),
-        ValidationError.custom({
+        customError({
           kind: 'lastName',
           field: form.last,
         }),
-        ValidationError.custom({
+        customError({
           kind: 'lastName2',
           field: form.last,
         }),
       ]);
     });
 
-    expect(f.first().errors()).toEqual([
-      ValidationError.custom({kind: 'firstName', field: f.first}),
-    ]);
+    expect(f.first().errors()).toEqual([customError({kind: 'firstName', field: f.first})]);
     expect(f.last().errors()).toEqual([
-      ValidationError.custom({kind: 'lastName', field: f.last}),
-      ValidationError.custom({kind: 'lastName2', field: f.last}),
+      customError({kind: 'lastName', field: f.last}),
+      customError({kind: 'lastName2', field: f.last}),
     ]);
   });
 
@@ -116,10 +114,10 @@ describe('submit', () => {
     );
 
     await submit(f, () => {
-      return Promise.resolve(ValidationError.custom());
+      return Promise.resolve(customError());
     });
 
-    expect(f().errors()).toEqual([ValidationError.custom({field: f})]);
+    expect(f().errors()).toEqual([customError({field: f})]);
   });
 
   it('marks the form as submitting', async () => {
@@ -199,7 +197,7 @@ describe('submit', () => {
 
     await submit(f.first, (form) => {
       submitSpy(form().value());
-      return Promise.resolve(ValidationError.custom({kind: 'lastName'}));
+      return Promise.resolve(customError({kind: 'lastName'}));
     });
 
     expect(submitSpy).toHaveBeenCalledWith('meow');
@@ -225,18 +223,18 @@ describe('submit', () => {
 
     await submit(f, async (form) => {
       return [
-        ValidationError.custom({kind: 'submit', field: f.first}),
-        ValidationError.custom({kind: 'submit', field: f.last}),
+        customError({kind: 'submit', field: f.first}),
+        customError({kind: 'submit', field: f.last}),
       ];
     });
 
-    expect(f.first().errors()).toEqual([ValidationError.custom({kind: 'submit', field: f.first})]);
-    expect(f.last().errors()).toEqual([ValidationError.custom({kind: 'submit', field: f.last})]);
+    expect(f.first().errors()).toEqual([customError({kind: 'submit', field: f.first})]);
+    expect(f.last().errors()).toEqual([customError({kind: 'submit', field: f.last})]);
 
     f.first().value.set('Hello');
 
     expect(f.first().errors()).toEqual([]);
-    expect(f.last().errors()).toEqual([ValidationError.custom({kind: 'submit', field: f.last})]);
+    expect(f.last().errors()).toEqual([customError({kind: 'submit', field: f.last})]);
   });
 });
 

--- a/packages/forms/signals/test/node/validation_status.spec.ts
+++ b/packages/forms/signals/test/node/validation_status.spec.ts
@@ -9,17 +9,24 @@
 import {ApplicationRef, Injector, Resource, resource, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {Field, form, validate, validateAsync, validateTree} from '../../public_api';
-import {NgValidationError, ValidationError, WithoutField} from '../../src/api/validation_errors';
+import {
+  customError,
+  NgValidationError,
+  patternError,
+  requiredError,
+  ValidationError,
+  WithoutField,
+} from '../../src/api/validation_errors';
 
 function validateValue(value: string): WithoutField<ValidationError>[] {
-  return value === 'INVALID' ? [ValidationError.custom()] : [];
+  return value === 'INVALID' ? [customError()] : [];
 }
 
 function validateValueForChild(
   value: string,
   field: Field<unknown> | undefined,
 ): ValidationError[] {
-  return value === 'INVALID' ? [ValidationError.custom({field})] : [];
+  return value === 'INVALID' ? [customError({field})] : [];
 }
 
 async function waitFor(fn: () => boolean, count = 100): Promise<void> {
@@ -384,7 +391,7 @@ describe('validation status', () => {
         signal('MIXED'),
         (p) => {
           validate(p, () => []);
-          validate(p, () => [ValidationError.custom()]);
+          validate(p, () => [customError()]);
         },
         {injector},
       );
@@ -433,9 +440,7 @@ describe('validation status', () => {
               (res = resource({
                 params,
                 loader: () =>
-                  new Promise<ValidationError[]>((r) =>
-                    setTimeout(() => r([ValidationError.custom()])),
-                  ),
+                  new Promise<ValidationError[]>((r) => setTimeout(() => r([customError()]))),
               })),
             errors: (errs) => errs,
           });
@@ -472,9 +477,7 @@ describe('validation status', () => {
               (res = resource({
                 params,
                 loader: () =>
-                  new Promise<ValidationError[]>((r) =>
-                    setTimeout(() => r([ValidationError.custom()])),
-                  ),
+                  new Promise<ValidationError[]>((r) => setTimeout(() => r([customError()]))),
               })),
             errors: (errs) => errs,
           });
@@ -500,11 +503,11 @@ describe('validation status', () => {
 
   describe('NgValidationError', () => {
     it('instanceof should check if structure matches a standard error type', () => {
-      const e1 = ValidationError.required();
+      const e1 = requiredError();
       expect(e1 instanceof NgValidationError).toBe(true);
-      const e2 = ValidationError.custom({kind: 'min', min: 'two'});
+      const e2 = customError({kind: 'min', min: 'two'});
       expect(e2 instanceof NgValidationError).toBe(false);
-      const e3 = ValidationError.pattern(/.*@.*\\.com/);
+      const e3 = patternError(/.*@.*\.com/);
       expect(e3 instanceof NgValidationError).toBe(true);
     });
 


### PR DESCRIPTION
The `ValidationError` and `AggregateProperty` classes used static factory methods to create instances. This pattern created a hard dependency from the base classes to all of their subclasses and variations.

As a result, any application importing even a single validator (e.g., required) or property would inadvertently pull in the code for all other validators and properties, preventing effective tree-shaking and increasing bundle size.

This refactoring removes the static factory methods and replaces them with standalone, exported functions or properties. This decouples the individual validators and properties, allowing bundlers to properly perform dead code elimination.