### PR TITLE
build(devtools): add hermetic release build environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,13 @@ jobs:
           wait-on: 'http://localhost:4200'
           wait-on-timeout: 300
 
+        # Perform a release build of Angular DevTools using the hermetic environment to ensure it remains stable for
+        # store reviews and build verification.
+      - name: Release build
+        run: |
+          sudo apt install -qq -y podman
+          ./devtools/tools/release/build.sh
+
   test:
     runs-on: ubuntu-latest-4core
     steps:

--- a/devtools/README.md
+++ b/devtools/README.md
@@ -73,7 +73,19 @@ pnpm devtools:test:e2e
 
 ### Release builds
 
-You can build the release version of Angular DevTools for either Chrome or Firefox with:
+You can build the release version of Angular DevTools in a hermetic environment by
+[installing `podman`](https://podman.io/docs/installation) and running:
+
+```shell
+devtools/tools/release/build.sh
+```
+
+The built zip files for both Chrome and Firefox will be placed in `./devtools-chrome.zip` and
+`./devtools-firefox.zip` in the repository root.
+
+### Local production builds
+
+You can build the production version of Angular DevTools locally for either Chrome or Firefox with:
 
 ```shell
 pnpm devtools:build:chrome:release

--- a/devtools/docs/release.md
+++ b/devtools/docs/release.md
@@ -62,7 +62,7 @@ or checking out the merged commit, doing so is useful for release stability (act
 releasing what the commit history says we are) and is _necessary_ for accurate changelog
 generation.
 
-## 4. Publish to Chrome Chrome
+## 4. Publish to Chrome
 
 First, make sure you have access to publish the extension by ensuring you are part of
 [the relevant Google Group](http://g/angular-chrome-web-store-publisher).

--- a/devtools/tools/release/.containerignore
+++ b/devtools/tools/release/.containerignore
@@ -1,0 +1,5 @@
+.git
+dist
+bazel-out
+node_modules
+.angular

--- a/devtools/tools/release/Containerfile
+++ b/devtools/tools/release/Containerfile
@@ -1,0 +1,44 @@
+FROM debian:trixie-slim
+
+# Install required dependencies.
+RUN apt-get update -qq
+RUN apt-get install -y -qq curl git zip
+
+# Copy just `.nvmrc` so we don't bust the image cache more than necessary.
+COPY .nvmrc "/root/.nvmrc"
+
+# Install Node.
+RUN export readonly NODE_VERSION="$(cat /root/.nvmrc)" \
+    && export readonly NODE_MAJOR="$(echo "${NODE_VERSION}" | cut -d . -f 1)" \
+    && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && export readonly NODE_PKG_VERSION="$( \
+        apt list -a nodejs 2> /dev/null | \
+        grep "${NODE_VERSION}" | \
+        awk '{print $2}' | \
+        head -n 1 \
+    )" \
+    && apt-get install -y -qq "nodejs=${NODE_PKG_VERSION}" \
+    && corepack enable pnpm
+
+# Don't need Cypress, skipping it speeds up the install.
+# See: https://docs.cypress.io/app/references/advanced-installation#Skipping-installation
+ENV CYPRESS_INSTALL_BINARY=0
+
+# Disable Husky since it's not needed and won't work anyways as the `.git` directory is
+# not copied into the container. This just cleans up the output a bit.
+ENV HUSKY=0
+
+# Copy source code into the repo.
+ENV REPO=/angular
+COPY . "${REPO}"
+WORKDIR "${REPO}"
+
+# Install the workspace.
+RUN pnpm install --frozen-lockfile
+
+# Build DevTools.
+ENV BAZEL_FLAGS="--curses yes --color yes --show_progress_rate_limit 5"
+RUN pnpm run -s devtools:build:chrome:release ${BAZEL_FLAGS}
+RUN (cd dist/bin/devtools/projects/shell-browser/src/prodapp && zip -r "${REPO}/devtools-chrome.zip" *)
+RUN pnpm run -s devtools:build:firefox:release ${BAZEL_FLAGS}
+RUN (cd dist/bin/devtools/projects/shell-browser/src/prodapp && zip -r "${REPO}/devtools-firefox.zip" *)

--- a/devtools/tools/release/build.sh
+++ b/devtools/tools/release/build.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly IMAGE="angular-devtools-build"
+readonly CONTAINER="angular-devtools"
+
+# Build Angular DevTools and delete the image when the script completes.
+sudo podman build . -t "${IMAGE}" \
+    -f devtools/tools/release/Containerfile \
+    --ignorefile devtools/tools/release/.containerignore
+function rm_image {
+    sudo podman image rm -f "${IMAGE}" > /dev/null
+}
+trap rm_image EXIT
+
+# Start the container in an infinite loop and kill it when the script completes.
+sudo podman run --name "${CONTAINER}" --replace --detach "localhost/${IMAGE}:latest" sleep infinity
+function kill_container {
+    sudo podman kill "${CONTAINER}" > /dev/null
+    rm_image
+}
+trap kill_container EXIT
+
+# Extract the files.
+sudo podman cp "${CONTAINER}:/angular/devtools-chrome.zip" .
+sudo podman cp "${CONTAINER}:/angular/devtools-firefox.zip" .
+
+echo ""
+echo "✅ Angular DevTools build complete!"
+echo "Artifacts are available at: \"$(realpath .)/devtools-{chrome,firefox}.zip\""


### PR DESCRIPTION
Build verification for Mozilla Add Ons has been incredibly inconsistent with difficulties getting the information necessary to debug. This uses `podman` as a hermetic build environment to create something a little more reliable and consistent between Angular developers and Mozilla reviewers.

I opted for `podman` over Docker because the latter requires some extra approvals we don't want to deal with (see http://go/vm-exception). It ultimately works with the containerfile format, so the DX is fairly comparable to Docker. The hardest part was getting Node installed, as `nvm install` just wouldn't work for reasons I couldn't figure out. Instead, I manually downloaded it using the same version from `.nvmrc`.

I didn't update the release docs as I suspect it would be somewhat reudundant to ask Angular caretakers to go through this process and it significantly hurts build times since remote builds aren't configured. If we find discrepancies between local builds and the `podman` builds, then we might want to re-evaluate that decision. I validated by performing a release build with and without `podman` and confirming that the extracted ZIP files are identical for both Chrome and Firefox.

I also included this build as a CI task, since we want to make sure this remains stable for Mozilla reviewers.

@jkrems, before we merge this, can you pull the PR and make sure it works for you on Mac? I tried to keep it as simple as possible, but I think there's a reasonable risk of the Bash being non-portable to Mac, so I want to make sure that gets sorted.