### PR TITLE
docs(docs-infra): fix mermaid rendering

### DIFF
--- a/adev/shared-docs/pipeline/guides/testing/mermaid/mermaid.spec.mts
+++ b/adev/shared-docs/pipeline/guides/testing/mermaid/mermaid.spec.mts
@@ -32,6 +32,17 @@ describe('markdown to html', () => {
       "Cats" : 85
       "Rats" : 15
 \`\`\`
+
+\`\`\`mermaid
+  stateDiagram-v2
+    elementInjector: foo
+    rootInjector: bar
+    nullInjector: baz
+
+    direction BT
+    rootInjector --> elementInjector
+    elementInjector --> nullInjector
+\`\`\`;
     `;
 
     const markedInstance = marked.use({
@@ -44,6 +55,24 @@ describe('markdown to html', () => {
   }, 15_000);
 
   it('should create an svg for each mermaid code block', () => {
-    expect(markdownDocument.querySelectorAll('svg')).toHaveSize(2);
+    expect(markdownDocument.querySelectorAll('svg')).toHaveSize(3);
+  });
+
+  describe('stateDiagram-v2', () => {
+    // The custom styling is senstive to the generated SVG structure.
+    // If one of those test breaks, make sure the styling is stil OK on both the light and dark theme
+    it('should have a marker with id mermaid-generated-diagram_stateDiagram-barbEnd', async () => {
+      const stateDiagram = markdownDocument.querySelectorAll('svg')[2];
+      const marker = stateDiagram.querySelector('#mermaid-generated-diagram_stateDiagram-barbEnd');
+      expect(marker).not.toBeNull();
+      expect(marker?.tagName).toBe('marker');
+    });
+
+    it('should have a structure .statediagram-state > g > path', () => {
+      const stateDiagram = markdownDocument.querySelectorAll('svg')[2];
+      const path = stateDiagram.querySelector('.statediagram-state > g > path');
+      expect(path).not.toBeNull();
+      expect(path?.tagName).toBe('path');
+    });
   });
 });

--- a/adev/shared-docs/styles/docs/_mermaid.scss
+++ b/adev/shared-docs/styles/docs/_mermaid.scss
@@ -10,12 +10,7 @@
   --pie6: '#fe3700';
 
   background-color: var(--page-background) !important; // svg background color
-  g {
-    rect {
-      stroke: black !important; // border around the rectangles, same for dark/light theme
-      filter: drop-shadow(5px 5px 0px var(--primary-contrast));
-    }
-  }
+
   .messageText,
   .pieTitleText {
     fill: var(--primary-contrast) !important; // pie chart title text and line labels
@@ -47,13 +42,16 @@
   .marker,
   #statediagram-barbEnd,
   .transition,
-  #arrowhead path {
+  #arrowhead path,
+  #mermaid-generated-diagram_stateDiagram-barbEnd {
     // arrows
     stroke: var(--primary-contrast) !important;
     fill: var(--primary-contrast) !important;
   }
   .cluster rect,
-  .nodes rect {
+  .nodes rect,
+  .node path,
+  .cluster path {
     stroke: var(--primary-contrast) !important;
     fill: var(--page-background) !important;
   }


### PR DESCRIPTION
A recent update of mermaid change the html output. `rect` became `path`.

fixes #63308
