### PR TITLE
refactor(forms): Explicitly specify FormRecord in AbstractControl

### DIFF
--- a/goldens/public-api/forms/index.api.md
+++ b/goldens/public-api/forms/index.api.md
@@ -44,6 +44,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
     readonly events: Observable<ControlEvent<TValue>>;
     get<P extends string | readonly (string | number)[]>(path: P): AbstractControl<ɵGetProperty<TRawValue, P>> | null;
     get<P extends string | Array<string | number>>(path: P): AbstractControl<ɵGetProperty<TRawValue, P>> | null;
+    get<P extends string | Array<string | number>>(path: P): AbstractControl | null;
     getError(errorCode: string, path?: Array<string | number> | string): any;
     getRawValue(): any;
     hasAsyncValidator(validator: AsyncValidatorFn): boolean;
@@ -76,7 +77,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
-    get parent(): FormGroup | FormArray | null;
+    get parent(): FormGroup | FormArray | FormRecord | null;
     abstract patchValue(value: TValue, options?: Object): void;
     get pending(): boolean;
     get pristine(): boolean;

--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -1501,6 +1501,12 @@ export abstract class AbstractControl<
   ): AbstractControl<ɵGetProperty<TRawValue, P>> | null;
 
   /**
+   * This is basically a fallback signature, used when you can't get the other two to work.
+   * Usually happens when you have invoke the method on a union type like FormGroup | FormRecord
+   */
+  get<P extends string | Array<string | number>>(path: P): AbstractControl | null;
+
+  /**
    * Retrieves a child control given the control's name or path.
    *
    * @param path A dot-delimited string or array of string/number values that define the path to the

--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -33,7 +33,7 @@ import {
   toObservable,
 } from '../validators';
 import type {FormArray} from './form_array';
-import type {FormGroup} from './form_group';
+import type {FormGroup, FormRecord} from './form_group';
 
 /**
  * Reports that a control is valid, meaning that no errors exist in the input value.
@@ -449,7 +449,7 @@ export type ɵGetProperty<T, K> =
         any;
 
 /**
- * This is the base class for `FormControl`, `FormGroup`, and `FormArray`.
+ * This is the base class for `FormControl`, `FormGroup`, `FormArray`, and `FormRecord`.
  *
  * It provides some of the shared behavior that all controls and groups of controls have, like
  * running validators, calculating status, and resetting state. It also defines the properties
@@ -490,7 +490,7 @@ export abstract class AbstractControl<
   /** @internal */
   _updateOn?: FormHooks;
 
-  private _parent: FormGroup | FormArray | null = null;
+  private _parent: FormGroup | FormArray | FormRecord | null = null;
   private _asyncValidationSubscription: any;
 
   /**
@@ -586,7 +586,7 @@ export abstract class AbstractControl<
   /**
    * The parent control.
    */
-  get parent(): FormGroup | FormArray | null {
+  get parent(): FormGroup | FormArray | FormRecord | null {
     return this._parent;
   }
 

--- a/packages/forms/test/typed_integration_spec.ts
+++ b/packages/forms/test/typed_integration_spec.ts
@@ -663,6 +663,13 @@ describe('Typed Class', () => {
         let t1 = c.get('foobar')?.value;
         t1 = null as unknown as ValueType;
       }
+      {
+        // In this case we're not able to infer the type because parent is AbstractControl<any,any,any>
+        type ValueType = any;
+        let t: ValueType = c.parent?.get('foobar')?.value;
+        let t1 = c.get('foobar')?.value;
+        t1 = null as unknown as ValueType;
+      }
     });
 
     it('is assignable to AbstractControl', () => {


### PR DESCRIPTION
Even though FormRecord is already fully supported due to it being a kind of FormGroup, explicitly including it in comments and types helps to increase its visibility. This commit should be a no-op.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ X ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ X ] Tests for the changes have been added (for bug fixes / features)
  - Ran existing tests, no failures
- [ X ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ X ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ X ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ X ] No
