### PR TITLE
fix(core): fix animation behavior on `@for` loops

### DIFF
--- a/packages/core/src/render3/interfaces/renderer_dom.ts
+++ b/packages/core/src/render3/interfaces/renderer_dom.ts
@@ -35,6 +35,11 @@ export interface RNode {
   nextSibling: RNode | null;
 
   /**
+   * Gets the Node immediately preceding this one in the parent's childNodes
+   */
+  previousSibling: RNode | null;
+
+  /**
    * Insert a child node.
    *
    * Used exclusively for adding View root nodes into ViewAnchor location.


### PR DESCRIPTION
When `@for` loops added and removed an element in the same change detection cycle, the duplicate node prevention would cause the leaving node animation to be cancelled. This fix prevents cancellation of leave animations in `@for` loops. It also fixes a memory leak where nodes weren't properly getting cleaned up from the leaving nodes map.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

