### PR TITLE
docs: update to new standalone default behavior

### DIFF
--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -49,34 +49,25 @@ export interface DirectiveDecorator {
    *
    * ### Declaring directives
    *
-   * In order to make a directive available to other components in your application, you should do
-   * one of the following:
-   *  - either mark the directive as [standalone](guide/components/importing),
-   *  - or declare it in an NgModule by adding it to the `declarations` and `exports` fields.
-   *
-   * ** Marking a directive as standalone **
-   *
-   * You can add the `standalone: true` flag to the Directive decorator metadata to declare it as
-   * [standalone](guide/components/importing):
+   * By default, directives are marked as [standalone](guide/components/importing), which makes
+   * them available to other components in your application.
    *
    * ```ts
    * @Directive({
-   *   standalone: true,
    *   selector: 'my-directive',
    * })
-   * class MyDirective {}
    * ```
    *
-   * When marking a directive as standalone, please make sure that the directive is not already
-   * declared in an NgModule.
-   *
+   * Please make sure that directives marked as standalone are not already declared in an NgModule.
    *
    * ** Declaring a directive in an NgModule **
-   *
-   * Another approach is to declare a directive in an NgModule:
+   * If you want to declare a directive in an ngModule, add the `standalone: false` flag to the
+   * Directive decorator metadata and add the directive to the `declarations` and `exports`
+   * fields of your ngModule.
    *
    * ```ts
    * @Directive({
+   *   standalone: false,
    *   selector: 'my-directive',
    * })
    * class MyDirective {}


### PR DESCRIPTION
When declaring directives, the standalone flag is set to true by default in current Angular versions.

The docs for the directive decorator should correctly explain the default behavior, while still mentioning when to set it to false.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The current docs describe how to set the standalone flag of a directive to true to make the directive available to other components. The wording implies that it needs to be set explicitly, even though it is the default behavior in current versions of Angular.


## What is the new behavior?

The documentation reflects the current behavior of the standalone flag and explains what needs to be done to declare a directive in a module instead.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
-