### PR TITLE
fix(core): Prevent an error on cleanup when an `rxResource` `stream` threw before returning an `Observable`

### DIFF
--- a/packages/core/rxjs-interop/src/rx_resource.ts
+++ b/packages/core/rxjs-interop/src/rx_resource.ts
@@ -54,11 +54,11 @@ export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T |
     ...opts,
     loader: undefined,
     stream: (params) => {
-      let sub: Subscription;
+      let sub: Subscription | undefined;
 
       // Track the abort listener so it can be removed if the Observable completes (as a memory
       // optimization).
-      const onAbort = () => sub.unsubscribe();
+      const onAbort = () => sub?.unsubscribe();
       params.abortSignal.addEventListener('abort', onAbort);
 
       // Start off stream as undefined.

--- a/packages/core/rxjs-interop/test/rx_resource_spec.ts
+++ b/packages/core/rxjs-interop/test/rx_resource_spec.ts
@@ -77,6 +77,17 @@ describe('rxResource()', () => {
     expect(res.error()).toEqual(jasmine.objectContaining({cause: 'fail'}));
     expect(res.error()!.message).toContain('Resource');
   });
+
+  it('should cleanup without error when the stream function threw an error', async () => {
+    const appRef = TestBed.inject(ApplicationRef);
+    const res = rxResource({
+      stream: () => {
+        throw 'oh no';
+      },
+      injector: appRef.injector,
+    });
+    await appRef.whenStable();
+  });
 });
 
 async function waitFor(fn: () => boolean): Promise<void> {


### PR DESCRIPTION
Before this commit, it was wrongly assumed that the stream subscription could not be `undefined`.

Fixes #63341

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #63341


## What is the new behavior?
No error

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
Please suggest a way to write this test :(