### PR TITLE
refactor(core): improve linkedSignal type definitions, add debugName

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1144,6 +1144,7 @@ export function linkedSignal<S, D>(options: {
         value: NoInfer<D>;
     }) => D;
     equal?: ValueEqualityFn<NoInfer<D>>;
+    debugName?: string;
 }): WritableSignal<D>;
 
 // @public

--- a/packages/core/src/render3/reactivity/linked_signal.ts
+++ b/packages/core/src/render3/reactivity/linked_signal.ts
@@ -42,6 +42,7 @@ export function linkedSignal<S, D>(options: {
   source: () => S;
   computation: (source: NoInfer<S>, previous?: {source: NoInfer<S>; value: NoInfer<D>}) => D;
   equal?: ValueEqualityFn<NoInfer<D>>;
+  debugName?: string;
 }): WritableSignal<D>;
 
 export function linkedSignal<S, D>(
@@ -50,9 +51,10 @@ export function linkedSignal<S, D>(
         source: () => S;
         computation: ComputationFn<S, D>;
         equal?: ValueEqualityFn<D>;
+        debugName?: string;
       }
     | (() => D),
-  options?: {equal?: ValueEqualityFn<D>},
+  options?: {equal?: ValueEqualityFn<D>; debugName?: string},
 ): WritableSignal<D> {
   if (typeof optionsOrComputation === 'function') {
     const getter = createLinkedSignal<D, D>(
@@ -60,20 +62,24 @@ export function linkedSignal<S, D>(
       identityFn<D>,
       options?.equal,
     ) as LinkedSignalGetter<D, D> & WritableSignal<D>;
-    return upgradeLinkedSignalGetter(getter);
+    return upgradeLinkedSignalGetter(getter, options?.debugName);
   } else {
     const getter = createLinkedSignal<S, D>(
       optionsOrComputation.source,
       optionsOrComputation.computation,
       optionsOrComputation.equal,
     );
-    return upgradeLinkedSignalGetter(getter);
+    return upgradeLinkedSignalGetter(getter, optionsOrComputation.debugName);
   }
 }
 
-function upgradeLinkedSignalGetter<S, D>(getter: LinkedSignalGetter<S, D>): WritableSignal<D> {
+function upgradeLinkedSignalGetter<S, D>(
+  getter: LinkedSignalGetter<S, D>,
+  debugName?: string,
+): WritableSignal<D> {
   if (ngDevMode) {
     getter.toString = () => `[LinkedSignal: ${getter()}]`;
+    getter[SIGNAL].debugName = debugName;
   }
 
   const node = getter[SIGNAL] as LinkedSignalNode<S, D>;

--- a/packages/core/test/signals/linked_signal_spec.ts
+++ b/packages/core/test/signals/linked_signal_spec.ts
@@ -46,6 +46,18 @@ describe('linkedSignal', () => {
     expect(firstLetterReadonly()).toBe('c');
   });
 
+  it('should support debugName in options object', () => {
+    const options = signal(['apple', 'banana', 'fig']);
+    const choice = linkedSignal({
+      source: options,
+      computation: (options) => options[0],
+      debugName: 'TestChoice',
+    });
+
+    expect(choice()).toBe('apple');
+    expect(choice.toString()).toBe('[LinkedSignal: apple]');
+  });
+
   it('should update when the source changes', () => {
     const options = signal(['apple', 'banana', 'fig']);
     const choice = linkedSignal({


### PR DESCRIPTION
Add debugName for having ability to visualize linkedSignal name in devtools signal graph

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?


- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
all LinkedSignals has "Unnamed" name in devtools signal graph(red)
<img width="755" height="632" alt="Снимок экрана 2025-08-23 в 08 48 16" src="https://github.com/user-attachments/assets/a1e704b2-65a7-4bb5-856a-3d5dbc469120" />


## What is the new behavior?
It is possible to specify debugName
<img width="473" height="365" alt="Снимок экрана 2025-08-23 в 10 44 21" src="https://github.com/user-attachments/assets/8956e24f-1f8a-4d0c-a1d4-d2d6d78b7314" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
