### PR TITLE
feat(core): add resource props debug name

### DIFF
--- a/packages/compiler-cli/src/ngtsc/transform/src/implicit_signal_debug_name_transform.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/implicit_signal_debug_name_transform.ts
@@ -287,6 +287,7 @@ const signalFunctions: ReadonlySet<string> = new Set([
   'contentChild',
   'contentChildren',
   'effect',
+  'linkedSignal',
 ]);
 
 function isSignalFunction(expression: ts.Identifier): boolean {

--- a/packages/core/test/signals/linked_signal_spec.ts
+++ b/packages/core/test/signals/linked_signal_spec.ts
@@ -46,6 +46,18 @@ describe('linkedSignal', () => {
     expect(firstLetterReadonly()).toBe('c');
   });
 
+  it('should support debugName in options object', () => {
+    const options = signal(['apple', 'banana', 'fig']);
+    const choice = linkedSignal({
+      source: options,
+      computation: (options) => options[0],
+      debugName: 'TestChoice',
+    });
+
+    expect(choice()).toBe('apple');
+    expect(choice.toString()).toBe('[LinkedSignal: apple]');
+  });
+
   it('should update when the source changes', () => {
     const options = signal(['apple', 'banana', 'fig']);
     const choice = linkedSignal({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

Code example:
```ts
interface User {
  id: string;
  name: string;
  email: string;
}
function fetchUser(userId: string): Promise<User> {
  return new Promise((resolve) => {
    const mockUser: User = {
      id: userId,
      name: `Mock User ${userId}`,
      email: `user${userId}@example.com`,
    };
    resolve(mockUser);
  });
}

@Component({
  selector: 'app-resource',
  imports: [JsonPipe],
  template: `
    @if (userResource.hasValue()) {
    }
    <pre>{{ userResource.value() | json }}</pre>
  `,
})
export class Resource {
  userId: Signal<string> = signal('1');
  userResource = resource({
    params: () => ({ id: this.userId() }),

    loader: ({ params }) => fetchUser(params.id),
  });

  name = computed(() => {
    if (this.userResource.hasValue()) {
      return this.userResource.value().name;
    }
    return undefined;
  });
}
```

## What is the current behavior?
In devtools signal graph resource internal signal primitives have "Unnamed" label.
<img width="408" height="493" alt="Снимок экрана 2025-08-22 в 11 32 50" src="https://github.com/user-attachments/assets/bfb330e0-da2c-4c72-9ec9-4cc9d7c539fb" />

Depends on: #63346

## What is the new behavior?
Nodes have specific names, which simplify debugging
<img width="760" height="592" alt="Снимок экрана 2025-08-23 в 11 09 22" src="https://github.com/user-attachments/assets/2aadde5c-bbde-4504-8d8f-79175ad4faf9" />



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

