### PR TITLE
feat(core): Adds selector support to dynamic component creation

### DIFF
--- a/goldens/public-api/core/errors.api.md
+++ b/goldens/public-api/core/errors.api.md
@@ -164,6 +164,8 @@ export const enum RuntimeErrorCode {
     // (undocumented)
     RUNTIME_DEPS_INVALID_IMPORTED_TYPE = 980,
     // (undocumented)
+    RUNTIME_DEPS_INVALID_SELECTOR = 982,
+    // (undocumented)
     RUNTIME_DEPS_ORPHAN_COMPONENT = 981,
     // (undocumented)
     SIGNAL_WRITE_FROM_ILLEGAL_CONTEXT = 600,

--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -299,7 +299,7 @@ export interface ComponentDecorator {
 // @public @deprecated
 export abstract class ComponentFactory<C> {
     abstract get componentType(): Type<any>;
-    abstract create(injector: Injector, projectableNodes?: any[][], rootSelectorOrNode?: string | any, environmentInjector?: EnvironmentInjector | NgModuleRef<any>, directives?: (Type<unknown> | DirectiveWithBindings<unknown>)[], bindings?: Binding[]): ComponentRef<C>;
+    abstract create(injector: Injector, projectableNodes?: any[][], rootSelectorOrNode?: string | any, environmentInjector?: EnvironmentInjector | NgModuleRef<any>, directives?: (Type<unknown> | DirectiveWithBindings<unknown>)[], bindings?: Binding[], selector?: HostSelector): ComponentRef<C>;
     abstract get inputs(): {
         propName: string;
         templateName: string;
@@ -460,6 +460,7 @@ export function createComponent<C>(component: Type<C>, options: {
     projectableNodes?: Node[][];
     directives?: (Type<unknown> | DirectiveWithBindings<unknown>)[];
     bindings?: Binding[];
+    selector?: HostSelector;
 }): ComponentRef<C>;
 
 // @public
@@ -838,6 +839,9 @@ export interface HostListenerDecorator {
     // (undocumented)
     new (eventName: string, args?: string[]): any;
 }
+
+// @public
+export function hostSelector(selector: string): HostSelector;
 
 // @public
 export function importProvidersFrom(...sources: ImportProvidersSource[]): EnvironmentProviders;
@@ -1976,9 +1980,10 @@ export abstract class ViewContainerRef {
         projectableNodes?: Node[][];
         directives?: (Type<unknown> | DirectiveWithBindings<unknown>)[];
         bindings?: Binding[];
+        selector?: HostSelector;
     }): ComponentRef<C>;
     // @deprecated
-    abstract createComponent<C>(componentFactory: ComponentFactory<C>, index?: number, injector?: Injector, projectableNodes?: any[][], environmentInjector?: EnvironmentInjector | NgModuleRef<any>, directives?: (Type<unknown> | DirectiveWithBindings<unknown>)[], bindings?: Binding[]): ComponentRef<C>;
+    abstract createComponent<C>(componentFactory: ComponentFactory<C>, index?: number, injector?: Injector, projectableNodes?: any[][], environmentInjector?: EnvironmentInjector | NgModuleRef<any>, directives?: (Type<unknown> | DirectiveWithBindings<unknown>)[], bindings?: Binding[], selector?: HostSelector): ComponentRef<C>;
     abstract createEmbeddedView<C>(templateRef: TemplateRef<C>, context?: C, options?: {
         index?: number;
         injector?: Injector;

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -113,6 +113,7 @@ export {
   ɵFirstAvailable,
 } from './render3/after_render/hooks';
 export {Binding, inputBinding, outputBinding, twoWayBinding} from './render3/dynamic_bindings';
+export {hostSelector} from './render3/host_selector';
 export {ApplicationConfig, mergeApplicationConfig} from './application/application_config';
 export {makeStateKey, StateKey, TransferState} from './transfer_state';
 export {booleanAttribute, numberAttribute} from './util/coercion';

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -143,6 +143,7 @@ export const enum RuntimeErrorCode {
   // Runtime dependency tracker errors
   RUNTIME_DEPS_INVALID_IMPORTED_TYPE = 980,
   RUNTIME_DEPS_ORPHAN_COMPONENT = 981,
+  RUNTIME_DEPS_INVALID_SELECTOR = 982,
 
   // resource() API errors
   MUST_PROVIDE_STREAM_OPTION = 990,

--- a/packages/core/src/linker/component_factory.ts
+++ b/packages/core/src/linker/component_factory.ts
@@ -11,6 +11,7 @@ import type {Injector} from '../di/injector';
 import type {EnvironmentInjector} from '../di/r3_injector';
 import type {Type} from '../interface/type';
 import type {Binding, DirectiveWithBindings} from '../render3/dynamic_bindings';
+import type {HostSelector} from '../render3/host_selector';
 
 import type {ElementRef} from './element_ref';
 import type {NgModuleRef} from './ng_module_factory';
@@ -125,5 +126,6 @@ export abstract class ComponentFactory<C> {
     environmentInjector?: EnvironmentInjector | NgModuleRef<any>,
     directives?: (Type<unknown> | DirectiveWithBindings<unknown>)[],
     bindings?: Binding[],
+    selector?: HostSelector,
   ): ComponentRef<C>;
 }

--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -78,6 +78,7 @@ import {EmbeddedViewRef, ViewRef} from './view_ref';
 import {addLViewToLContainer, createLContainer, detachView} from '../render3/view/container';
 import {addToEndOfViewTree} from '../render3/view/construction';
 import {Binding, DirectiveWithBindings} from '../render3/dynamic_bindings';
+import {HostSelector} from '../render3/host_selector';
 
 /**
  * Represents a container where one or more views can be attached to a component.
@@ -241,6 +242,7 @@ export abstract class ViewContainerRef {
       projectableNodes?: Node[][];
       directives?: (Type<unknown> | DirectiveWithBindings<unknown>)[];
       bindings?: Binding[];
+      selector?: HostSelector;
     },
   ): ComponentRef<C>;
 
@@ -257,6 +259,7 @@ export abstract class ViewContainerRef {
    * This information is used to retrieve corresponding NgModule injector.
    * @param directives Directives that should be applied to the component.
    * @param bindings Bindings that should be applied to the component.
+   * @param selector The host selector for the component previously assigned in decorator `@Component`.
    *
    * @returns The new `ComponentRef` which contains the component instance and the host view.
    *
@@ -272,6 +275,7 @@ export abstract class ViewContainerRef {
     environmentInjector?: EnvironmentInjector | NgModuleRef<any>,
     directives?: (Type<unknown> | DirectiveWithBindings<unknown>)[],
     bindings?: Binding[],
+    selector?: HostSelector,
   ): ComponentRef<C>;
 
   /**
@@ -437,6 +441,7 @@ const R3ViewContainerRef = class ViewContainerRef extends VE_ViewContainerRef {
       ngModuleRef?: NgModuleRef<unknown>;
       directives?: (Type<unknown> | DirectiveWithBindings<unknown>)[];
       bindings?: Binding[];
+      selector?: HostSelector;
     },
   ): ComponentRef<C>;
   /**
@@ -452,6 +457,7 @@ const R3ViewContainerRef = class ViewContainerRef extends VE_ViewContainerRef {
     environmentInjector?: EnvironmentInjector | NgModuleRef<any> | undefined,
     directives?: (Type<unknown> | DirectiveWithBindings<unknown>)[],
     bindings?: Binding[],
+    selector?: HostSelector,
   ): ComponentRef<C>;
   override createComponent<C>(
     componentFactoryOrType: ComponentFactory<C> | Type<C>,
@@ -466,12 +472,14 @@ const R3ViewContainerRef = class ViewContainerRef extends VE_ViewContainerRef {
           projectableNodes?: Node[][];
           directives?: (Type<unknown> | DirectiveWithBindings<unknown>)[];
           bindings?: Binding[];
+          selector?: HostSelector;
         },
     injector?: Injector | undefined,
     projectableNodes?: any[][] | undefined,
     environmentInjector?: EnvironmentInjector | NgModuleRef<any> | undefined,
     directives?: (Type<unknown> | DirectiveWithBindings<unknown>)[],
     bindings?: Binding[],
+    selector?: HostSelector,
   ): ComponentRef<C> {
     const isComponentFactory = componentFactoryOrType && !isType(componentFactoryOrType);
     let index: number | undefined;
@@ -518,6 +526,7 @@ const R3ViewContainerRef = class ViewContainerRef extends VE_ViewContainerRef {
         projectableNodes?: Node[][];
         directives?: (Type<unknown> | DirectiveWithBindings<unknown>)[];
         bindings?: Binding[];
+        selector?: HostSelector;
       };
       if (ngDevMode && options.environmentInjector && options.ngModuleRef) {
         throwError(
@@ -530,6 +539,7 @@ const R3ViewContainerRef = class ViewContainerRef extends VE_ViewContainerRef {
       environmentInjector = options.environmentInjector || options.ngModuleRef;
       directives = options.directives;
       bindings = options.bindings;
+      selector = options.selector;
     }
 
     const componentFactory: ComponentFactory<C> = isComponentFactory
@@ -576,6 +586,7 @@ const R3ViewContainerRef = class ViewContainerRef extends VE_ViewContainerRef {
       environmentInjector,
       directives,
       bindings,
+      selector,
     );
     this.insertImpl(
       componentRef.hostView,

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -15,6 +15,7 @@ import {ComponentFactory} from './component_ref';
 import {getComponentDef} from './def_getters';
 import {Binding, DirectiveWithBindings} from './dynamic_bindings';
 import {assertComponentDef} from './errors';
+import {HostSelector} from './host_selector';
 
 /**
  * Creates a `ComponentRef` instance based on provided component type and a set of options.
@@ -60,7 +61,7 @@ import {assertComponentDef} from './errors';
  * applicationRef.attachView(componentRef.hostView);
  * componentRef.changeDetectorRef.detectChanges();
  * ```
- * 
+ *
  * @param component Component class reference.
  * @param options Set of options to use:
  *  * `environmentInjector`: An `EnvironmentInjector` instance to be used for the component.
@@ -76,6 +77,7 @@ import {assertComponentDef} from './errors';
  * and `element3` into a separate `<ng-content>`.
  *  * `directives` (optional): Directives that should be applied to the component.
  *  * `binding` (optional): Bindings to apply to the root component.
+ *  * `selector` (optional): Selector from the component that will be used to locate the host element.
  * @returns ComponentRef instance that represents a given Component.
  *
  * @publicApi
@@ -89,6 +91,7 @@ export function createComponent<C>(
     projectableNodes?: Node[][];
     directives?: (Type<unknown> | DirectiveWithBindings<unknown>)[];
     bindings?: Binding[];
+    selector?: HostSelector;
   },
 ): ComponentRef<C> {
   ngDevMode && assertComponentDef(component);
@@ -102,6 +105,7 @@ export function createComponent<C>(
     options.environmentInjector,
     options.directives,
     options.bindings,
+    options.selector,
   );
 }
 

--- a/packages/core/src/render3/component_parse_selector.ts
+++ b/packages/core/src/render3/component_parse_selector.ts
@@ -1,0 +1,229 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  SelectorFlags,
+  CssSelector as R3CssSelector,
+  CssSelectorList as R3CssSelectorList,
+} from '../render3/interfaces/projection';
+
+// These functions are adapted from Angular's core selector parser (packages/compiler/src/core.ts).
+// They are duplicated here for functional use in render3, as direct references to compiler are not possible.
+
+const _SELECTOR_REGEXP = new RegExp(
+  '(\\:not\\()|' + // 1: ":not("
+    '(([\\.\\#]?)[-\\w]+)|' + // 2: "tag"; 3: "."/"#";
+    // "-" should appear first in the regexp below as FF31 parses "[.-\w]" as a range
+    // 4: attribute; 5: attribute_string; 6: attribute_value
+    '(?:\\[([-.\\w*\\\\$]+)(?:=(["\']?)([^\\]"\']*)\\5)?\\])|' + // "[name]", "[name=value]",
+    // "[name="value"]",
+    // "[name='value']"
+    '(\\))|' + // 7: ")"
+    '(\\s*,\\s*)', // 8: ","
+  'g',
+);
+
+/**
+ * These offsets should match the match-groups in `_SELECTOR_REGEXP` offsets.
+ */
+const SelectorRegexp = {
+  ALL: 0, // The whole match
+  NOT: 1,
+  TAG: 2,
+  PREFIX: 3,
+  ATTRIBUTE: 4,
+  ATTRIBUTE_STRING: 5,
+  ATTRIBUTE_VALUE: 6,
+  NOT_END: 7,
+  SEPARATOR: 8,
+};
+
+/**
+ * A css selector contains an element name,
+ * css classes and attribute/value pairs with the purpose
+ * of selecting subsets out of them.
+ */
+export interface CssSelector {
+  element: string | null;
+  classNames: string[];
+  /**
+   * The selectors are encoded in pairs where:
+   * - even locations are attribute names
+   * - odd locations are attribute values.
+   *
+   * Example:
+   * Selector: `[key1=value1][key2]` would parse to:
+   * ```
+   * ['key1', 'value1', 'key2', '']
+   * ```
+   */
+  attrs: string[];
+  notSelectors: CssSelector[];
+}
+
+function createCssSelector(): CssSelector {
+  return {
+    element: null,
+    classNames: [],
+    attrs: [],
+    notSelectors: [],
+  };
+}
+
+function parseCssSelector(selector: string): CssSelector[] {
+  const results: CssSelector[] = [];
+  const _addResult = (res: CssSelector[], cssSel: CssSelector) => {
+    if (
+      cssSel.notSelectors.length > 0 &&
+      !cssSel.element &&
+      cssSel.classNames.length == 0 &&
+      cssSel.attrs.length == 0
+    ) {
+      cssSel.element = '*';
+    }
+    res.push(cssSel);
+  };
+  let cssSelector = createCssSelector();
+  let match: string[] | null;
+  let current = cssSelector;
+  let inNot = false;
+  _SELECTOR_REGEXP.lastIndex = 0;
+  while ((match = _SELECTOR_REGEXP.exec(selector))) {
+    if (match[SelectorRegexp.NOT]) {
+      if (inNot) {
+        throw new Error('Nesting :not in a selector is not allowed');
+      }
+      inNot = true;
+      current = createCssSelector();
+      cssSelector.notSelectors.push(current);
+    }
+    const tag = match[SelectorRegexp.TAG];
+    if (tag) {
+      const prefix = match[SelectorRegexp.PREFIX];
+      if (prefix === '#') {
+        // #hash
+        addAttribute(current, 'id', tag.slice(1));
+      } else if (prefix === '.') {
+        // Class
+        addClassName(current, tag.slice(1));
+      } else {
+        // Element
+        setElement(current, tag);
+      }
+    }
+    const attribute = match[SelectorRegexp.ATTRIBUTE];
+
+    if (attribute) {
+      addAttribute(current, unescapeAttribute(attribute), match[SelectorRegexp.ATTRIBUTE_VALUE]);
+    }
+    if (match[SelectorRegexp.NOT_END]) {
+      inNot = false;
+      current = cssSelector;
+    }
+    if (match[SelectorRegexp.SEPARATOR]) {
+      if (inNot) {
+        throw new Error('Multiple selectors in :not are not supported');
+      }
+      _addResult(results, cssSelector);
+      cssSelector = current = createCssSelector();
+    }
+  }
+  _addResult(results, cssSelector);
+  return results;
+}
+
+/**
+ * Unescape `\$` sequences from the CSS attribute selector.
+ *
+ * This is needed because `$` can have a special meaning in CSS selectors,
+ * but we might want to match an attribute that contains `$`.
+ * [MDN web link for more
+ * info](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors).
+ * @param attr the attribute to unescape.
+ * @returns the unescaped string.
+ */
+function unescapeAttribute(attr: string): string {
+  let result = '';
+  let escaping = false;
+  for (let i = 0; i < attr.length; i++) {
+    const char = attr.charAt(i);
+    if (char === '\\') {
+      escaping = true;
+      continue;
+    }
+    if (char === '$' && !escaping) {
+      throw new Error(
+        `Error in attribute selector "${attr}". ` +
+          `Unescaped "$" is not supported. Please escape with "\\$".`,
+      );
+    }
+    escaping = false;
+    result += char;
+  }
+  return result;
+}
+
+function setElement(selector: CssSelector, element: string | null = null): void {
+  selector.element = element;
+}
+
+function addAttribute(selector: CssSelector, name: string, value: string = ''): void {
+  selector.attrs.push(name, (value && value.toLowerCase()) || '');
+}
+
+function addClassName(selector: CssSelector, name: string): void {
+  selector.classNames.push(name.toLowerCase());
+}
+
+function parserSelectorToSimpleSelector(selector: CssSelector): R3CssSelector {
+  const classes =
+    selector.classNames && selector.classNames.length
+      ? [SelectorFlags.CLASS, ...selector.classNames]
+      : [];
+  const elementName = selector.element && selector.element !== '*' ? selector.element : '';
+  return [elementName, ...selector.attrs, ...classes];
+}
+
+function parserSelectorToNegativeSelector(selector: CssSelector): R3CssSelector {
+  const classes =
+    selector.classNames && selector.classNames.length
+      ? [SelectorFlags.CLASS, ...selector.classNames]
+      : [];
+
+  if (selector.element) {
+    return [
+      SelectorFlags.NOT | SelectorFlags.ELEMENT,
+      selector.element,
+      ...selector.attrs,
+      ...classes,
+    ];
+  } else if (selector.attrs.length) {
+    return [SelectorFlags.NOT | SelectorFlags.ATTRIBUTE, ...selector.attrs, ...classes];
+  } else {
+    return selector.classNames && selector.classNames.length
+      ? [SelectorFlags.NOT | SelectorFlags.CLASS, ...selector.classNames]
+      : [];
+  }
+}
+
+function parserSelectorToR3Selector(selector: CssSelector): R3CssSelector {
+  const positive = parserSelectorToSimpleSelector(selector);
+
+  const negative: R3CssSelectorList =
+    selector.notSelectors && selector.notSelectors.length
+      ? selector.notSelectors.map((notSelector) => parserSelectorToNegativeSelector(notSelector))
+      : [];
+
+  return positive.concat(...negative);
+}
+
+export function parseSelectorStringToCssSelector(
+  selector: string | null | undefined,
+): R3CssSelectorList {
+  return selector ? parseCssSelector(selector).map(parserSelectorToR3Selector) : [];
+}

--- a/packages/core/src/render3/host_selector.ts
+++ b/packages/core/src/render3/host_selector.ts
@@ -1,0 +1,50 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {parseSelectorStringToCssSelector} from './component_parse_selector';
+import {CssSelectorList} from './interfaces/projection';
+
+export interface HostSelector {
+  /**
+   * Callback that will be invoked during selector matching.
+   */
+  parse(): CssSelectorList;
+}
+
+/**
+ * Match a host selector for dynamic component instantiation.
+ * @param selector Selector string allowed in the `@Component` decorator
+ *
+ * ### Usage Example
+ * By default `createComponent` uses the first selector element.
+ * In this example we create an instance of the `MatButton` and target
+ * elements with the 'a[mat-stroked-button]' selector.
+ *
+ * ```
+ * @Component({
+ *   selector: `
+ *     button[matButton], a[matButton], button[mat-button], button[mat-raised-button],
+ *     button[mat-flat-button], button[mat-stroked-button], a[mat-button], a[mat-raised-button],
+ *     a[mat-flat-button], a[mat-stroked-button]
+ *   `,
+ * })
+ * export class MatButton {}
+ *
+ * const buttonComponent = createComponent(MatButton, {
+ *   environmentInjector: this.injector,
+ *   selector: hostSelector('a[mat-stroked-button]')
+ * });
+ * ```
+ */
+export function hostSelector(selector: string): HostSelector {
+  const hostSelector: HostSelector = {
+    parse: () => parseSelectorStringToCssSelector(selector),
+  };
+
+  return hostSelector;
+}

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -648,6 +648,7 @@
       "increaseElementDepthCount",
       "incrementInitPhaseFlags",
       "inferTagNameFromDefinition",
+      "inferTagNameFromSelector",
       "initDomAdapter",
       "initFeatures",
       "initTNodeFlags",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -574,6 +574,7 @@
       "increaseElementDepthCount",
       "incrementInitPhaseFlags",
       "inferTagNameFromDefinition",
+      "inferTagNameFromSelector",
       "initFeatures",
       "initTNodeFlags",
       "initializeDirectives",

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -743,6 +743,7 @@
       "incrementInitPhaseFlags",
       "indexOf",
       "inferTagNameFromDefinition",
+      "inferTagNameFromSelector",
       "inheritContentQueries",
       "inheritHostBindings",
       "inheritViewQuery",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -740,6 +740,7 @@
       "incrementInitPhaseFlags",
       "indexOf",
       "inferTagNameFromDefinition",
+      "inferTagNameFromSelector",
       "inheritContentQueries",
       "inheritHostBindings",
       "inheritViewQuery",

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -591,6 +591,7 @@
       "includeViewProviders",
       "incrementInitPhaseFlags",
       "inferTagNameFromDefinition",
+      "inferTagNameFromSelector",
       "initDisconnectedNodes",
       "initDomAdapter",
       "initFeatures",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -869,6 +869,7 @@
       "increaseElementDepthCount",
       "incrementInitPhaseFlags",
       "inferTagNameFromDefinition",
+      "inferTagNameFromSelector",
       "initDomAdapter",
       "initFeatures",
       "initTNodeFlags",

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -482,6 +482,7 @@
       "includeViewProviders",
       "incrementInitPhaseFlags",
       "inferTagNameFromDefinition",
+      "inferTagNameFromSelector",
       "initDomAdapter",
       "initFeatures",
       "initTNodeFlags",


### PR DESCRIPTION
 #  Feature: Add Selector Support to Dynamic Component Creation

This PR implements the ability to specify a custom selector when dynamically creating components using `createComponent()`, addressing the limitation where developers couldn't control which selector from a multi-selector component definition gets used for the host element.

##  Motivation

Many UI libraries (like Angular Material) define components with multiple selectors to support different use cases:

```typescript
@Component({
  selector: `
    button[matButton], a[matButton], button[mat-button], button[mat-raised-button],
    button[mat-flat-button], button[mat-stroked-button], a[mat-button], a[mat-raised-button],
    a[mat-flat-button], a[mat-stroked-button]
  `,
  // ...
})
export class MatButton {}
```

Previously, `createComponent(MatButton)` would always use the first selector (`button[matButton]`), with no way to specify a different one like `a[mat-button]` for creating anchor-based buttons dynamically.

## Solution

Added an optional `selector` field to the `createComponent` options using a new function called `hostSelector`:

```typescript
createComponent(MatButton, { 
  environmentInjector, 
  selector: hostSelector('a[mat-button]')
});
```
 
## Features

- **Selector Validation**: Only selectors defined in the component are allowed.
- **Host Element Creation**: The host element matches the provided selector.
- **Error Handling**: Invalid selectors produce clear error messages.


##  Examples

### Basic Tag Selector
```typescript
createComponent(MyComponent, {
  environmentInjector,
  selector: hostSelector('custom-element')
});
```

### Complex Selector
```typescript
createComponent(MyComponent, {
  environmentInjector,
  selector: hostSelector('button.primary[type="submit"]')
});
```

### Angular Material Use Case
```typescript
const buttonRef = createComponent(MatButton, {
  environmentInjector,
  selector: hostSelector('a[mat-button]')
});
// Host element: <a mat-button></a>
```
## Error Handling

```typescript
createComponent(MyComponent, {
  environmentInjector,
  selector: hostSelector('invalid-selector')
});
// Throws: Invalid selector for component MyComponent. The selector 'invalid-selector' is not allowed.
```
 
 
 EDIT : 
 The implementation form was changed to a more functional one to make use of  Tree Shake, the code is only added when said function is used.
