### PR TITLE
fix(devtools): correct path to load fonts for devtools devserver

### DIFF
--- a/devtools/src/index.html
+++ b/devtools/src/index.html
@@ -8,7 +8,7 @@
     <link rel="icon" type="image/x-icon" href="assets/icon16.png" />
     <link
       rel="stylesheet"
-      href="/angular/third_party/fonts.google.com/material-symbols-outlined/outlined.css"
+      href="/_main/third_party/fonts.google.com/material-symbols-outlined/outlined.css"
     />
 
     <link rel="stylesheet" href="./styles.css" />


### PR DESCRIPTION
This broke in c35c0c7f2f. This commit changes the path to load the external stylesheet to reflect the new directory path.

Before:
<img width="1510" height="795" alt="Screenshot 2025-08-25 at 1 07 13 AM" src="https://github.com/user-attachments/assets/5dabbcd2-ab0f-4834-9a04-37a4fd04a10e" />


After:
<img width="1507" height="793" alt="Screenshot 2025-08-25 at 1 06 48 AM" src="https://github.com/user-attachments/assets/0bee75ae-e623-43c1-929e-1f3dc35aec28" />
