### PR TITLE
build: add `ibazel` workaround

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,3 @@
+# Workaround for: `Error finding workspace: ibazel was not invoked from within a workspace`
+# This should be removed once ibazel 0.26.x is available on NPM, but currently releases are broken.
+# See: https://github.com/bazelbuild/bazel-watcher/issues/735


### PR DESCRIPTION
`ibazel` version `0.25.0` requires a WORKSPACE file. Whlist this was fixes in later versions, the latest ibazel versions are not being released on NPM. See: https://github.com/bazelbuild/bazel-watcher/issues/735
