### PR TITLE
build: enable strict deps enforcement for ts_project

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,7 +25,7 @@ git_override(
 bazel_dep(name = "devinfra")
 git_override(
     module_name = "devinfra",
-    commit = "80db036355181684ed07021a175e9f039190d3d6",
+    commit = "00a4cf14cdc374867673a52ecb556f356da8bec0",
     remote = "https://github.com/angular/dev-infra.git",
 )
 

--- a/adev/shared-docs/pipeline/api-gen/rendering/BUILD.bazel
+++ b/adev/shared-docs/pipeline/api-gen/rendering/BUILD.bazel
@@ -27,9 +27,12 @@ ts_project(
     ),
     deps = [
         ":entities",
+        "//adev:node_modules/marked",
         "//adev:node_modules/preact",
         "//adev:node_modules/preact-render-to-string",
         "//adev:node_modules/prettier",
+        "//adev:node_modules/shiki",
+        "//adev/shared-docs/pipeline/shared:linking",
         "//adev/shared-docs/pipeline/shared:shiki",
         "//adev/shared-docs/pipeline/shared/marked",
         "//adev/shared-docs/pipeline/shared/regions",

--- a/adev/shared-docs/pipeline/api-gen/rendering/test/BUILD.bazel
+++ b/adev/shared-docs/pipeline/api-gen/rendering/test/BUILD.bazel
@@ -21,6 +21,7 @@ ts_project(
         "//adev:node_modules/@types/jsdom",
         "//adev:node_modules/jsdom",
         "//adev/shared-docs/pipeline/api-gen/rendering:render_api_to_html_lib",
+        "//adev/shared-docs/pipeline/shared:shiki",
     ],
 )
 

--- a/adev/shared-docs/pipeline/guides/BUILD.bazel
+++ b/adev/shared-docs/pipeline/guides/BUILD.bazel
@@ -76,5 +76,7 @@ ts_project(
     deps = [
         ":guides_lib",
         "//adev:node_modules/@types/node",
+        "//adev/shared-docs/pipeline/shared:shiki",
+        "//adev/shared-docs/pipeline/shared/marked",
     ],
 )

--- a/adev/shared-docs/pipeline/shared/marked/BUILD.bazel
+++ b/adev/shared-docs/pipeline/shared/marked/BUILD.bazel
@@ -18,6 +18,7 @@ ts_project(
         "//adev:node_modules/marked",
         "//adev:node_modules/mermaid",
         "//adev:node_modules/playwright-core",
+        "//adev:node_modules/shiki",
         "//adev/shared-docs/pipeline/shared:linking",
         "//adev/shared-docs/pipeline/shared:shiki",
         "//adev/shared-docs/pipeline/shared/regions",

--- a/adev/shared-docs/pipeline/shared/marked/test/BUILD.bazel
+++ b/adev/shared-docs/pipeline/shared/marked/test/BUILD.bazel
@@ -4,5 +4,8 @@ ts_project(
     name = "renderer_context",
     srcs = ["renderer-context.mts"],
     visibility = ["//adev/shared-docs/pipeline/shared/marked/test:__subpackages__"],
-    deps = ["//adev/shared-docs/pipeline/shared/marked"],
+    deps = [
+        "//adev/shared-docs/pipeline/shared:shiki",
+        "//adev/shared-docs/pipeline/shared/marked",
+    ],
 )

--- a/tools/bazel/ts_project_interop.bzl
+++ b/tools/bazel/ts_project_interop.bzl
@@ -4,11 +4,10 @@ load("@rules_angular//src/ts_project:index.bzl", _ts_project = "ts_project")
 def ts_project(
         name,
         deps = [],
+        srcs = [],
         tsconfig = None,
         testonly = False,
         visibility = None,
-        # TODO: Enable this for all `ts_project` targets at end of migration.
-        ignore_strict_deps = True,
         rule_impl = _ts_project,
         **kwargs):
     rule_impl(
@@ -17,13 +16,14 @@ def ts_project(
         declaration = True,
         tsconfig = tsconfig,
         visibility = visibility,
+        srcs = srcs,
         deps = deps,
         **kwargs
     )
 
-    if not ignore_strict_deps:
-        strict_deps_test(
-            name = "%s_strict_deps_test" % name,
-            srcs = kwargs.get("srcs", []),
-            deps = deps,
-        )
+    strict_deps_test(
+        name = "%s_strict_deps_test" % name,
+        srcs = srcs,
+        tsconfig = tsconfig,
+        deps = deps,
+    )


### PR DESCRIPTION
Enable strict_deps testings for all ts_project and ng_project targets in the repo
