### PR TITLE
[20.2.x] build: enable strict deps enforcement for ts_project

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,7 +25,7 @@ git_override(
 bazel_dep(name = "devinfra")
 git_override(
     module_name = "devinfra",
-    commit = "cb03391a53dec7a1d7de8f3b2cd60935e82837fa",
+    commit = "acce054082b688da9a5a3d12c6550184eb9f7725",
     remote = "https://github.com/angular/dev-infra.git",
 )
 

--- a/adev/shared-docs/pipeline/guides/test/docs-card/BUILD.bazel
+++ b/adev/shared-docs/pipeline/guides/test/docs-card/BUILD.bazel
@@ -7,6 +7,7 @@ ts_project(
     deps = [
         "//adev:node_modules/@types/jsdom",
         "//adev:node_modules/jsdom",
+        "//adev:node_modules/marked",
         "//adev/shared-docs/pipeline/guides:guides_lib",
         "//adev/shared-docs/pipeline/guides/test:parser_context",
     ],

--- a/tools/bazel/ts_project_interop.bzl
+++ b/tools/bazel/ts_project_interop.bzl
@@ -4,11 +4,10 @@ load("@rules_angular//src/ts_project:index.bzl", _ts_project = "ts_project")
 def ts_project(
         name,
         deps = [],
+        srcs = [],
         tsconfig = None,
         testonly = False,
         visibility = None,
-        # TODO: Enable this for all `ts_project` targets at end of migration.
-        ignore_strict_deps = True,
         rule_impl = _ts_project,
         **kwargs):
     rule_impl(
@@ -17,13 +16,14 @@ def ts_project(
         declaration = True,
         tsconfig = tsconfig,
         visibility = visibility,
+        srcs = srcs,
         deps = deps,
         **kwargs
     )
 
-    if not ignore_strict_deps:
-        strict_deps_test(
-            name = "%s_strict_deps_test" % name,
-            srcs = kwargs.get("srcs", []),
-            deps = deps,
-        )
+    strict_deps_test(
+        name = "%s_strict_deps_test" % name,
+        srcs = srcs,
+        tsconfig = tsconfig,
+        deps = deps,
+    )


### PR DESCRIPTION
Enable strict_deps testings for all ts_project and ng_project targets in the repo
