### PR TITLE
feat(common): Add experimental support for the Navigation API

### DIFF
--- a/packages/common/BUILD.bazel
+++ b/packages/common/BUILD.bazel
@@ -1,7 +1,17 @@
 load("//packages/common/locales:index.bzl", "generate_base_currencies_file")
-load("//tools:defaults.bzl", "api_golden_test", "api_golden_test_npm_package", "generate_api_docs", "ng_package", "ng_project")
+load("//tools:defaults.bzl", "api_golden_test", "api_golden_test_npm_package", "generate_api_docs", "ng_package", "ng_project", "ts_config")
 
 package(default_visibility = ["//visibility:public"])
+
+ts_config(
+    name = "tsconfig_build",
+    src = "tsconfig.json",
+    visibility = ["//packages/common:__subpackages__"],
+    deps = [
+        "//:node_modules/@types/dom-navigation",
+        "//packages:tsconfig_build",
+    ],
+)
 
 # This generates the `src/i18n/currencies.ts` file through the `generate-locales` tool. Since
 # the base locale file is checked-in for Google3, it is additionally stored in a golden location.
@@ -18,7 +28,9 @@ ng_project(
             "src/**/*.ts",
         ],
     ),
+    tsconfig = ":tsconfig_build",
     deps = [
+        "//:node_modules/@types/dom-navigation",
         "//:node_modules/rxjs",
         "//packages/core",
         "//packages/core/primitives/dom-navigation",

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -17,6 +17,7 @@ export {formatDate} from './i18n/format_date';
 export {formatCurrency, formatNumber, formatPercent} from './i18n/format_number';
 export {NgLocaleLocalization, NgLocalization} from './i18n/localization';
 export {registerLocaleData} from './i18n/locale_data';
+export {PlatformNavigation} from './navigation/platform_navigation';
 export {
   Plural,
   NumberFormatStyle,

--- a/packages/common/src/navigation/platform_navigation.ts
+++ b/packages/common/src/navigation/platform_navigation.ts
@@ -6,23 +6,18 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  Injectable,
-  ɵNavigateEvent as NavigateEvent,
-  ɵNavigation as Navigation,
-  ɵNavigationCurrentEntryChangeEvent as NavigationCurrentEntryChangeEvent,
-  ɵNavigationHistoryEntry as NavigationHistoryEntry,
-  ɵNavigationNavigateOptions as NavigationNavigateOptions,
-  ɵNavigationOptions as NavigationOptions,
-  ɵNavigationReloadOptions as NavigationReloadOptions,
-  ɵNavigationResult as NavigationResult,
-  ɵNavigationTransition as NavigationTransition,
-  ɵNavigationUpdateCurrentEntryOptions as NavigationUpdateCurrentEntryOptions,
-} from '@angular/core';
+import {Injectable} from '@angular/core';
+
+/// <reference types="dom-navigation" />
 
 /**
  * This class wraps the platform Navigation API which allows server-specific and test
  * implementations.
+ *
+ * Browser support is limited, so this API may not be available in all environments,
+ * may contain bugs, and is experimental.
+ *
+ * @experimental 21.0.0
  */
 @Injectable({providedIn: 'platform', useFactory: () => (window as any).navigation})
 export abstract class PlatformNavigation implements Navigation {

--- a/packages/common/src/private_export.ts
+++ b/packages/common/src/private_export.ts
@@ -11,4 +11,3 @@ export {
   getDOM as ɵgetDOM,
   setRootDomAdapter as ɵsetRootDomAdapter,
 } from './dom_adapter';
-export {PlatformNavigation as ɵPlatformNavigation} from './navigation/platform_navigation';

--- a/packages/common/test/navigation/navigation_spec.ts
+++ b/packages/common/test/navigation/navigation_spec.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {ɵFakeNavigation as FakeNavigation} from '../../testing';
+import {PlatformNavigation} from '../../index';
+import {TestBed} from '@angular/core/testing';
+
+describe('Navigation', () => {
+  it('provides fake navigation by default', () => {
+    const nav = TestBed.inject(PlatformNavigation);
+    expect(nav).toBeInstanceOf(FakeNavigation);
+  });
+
+  it('can inject and use the navigation API by default', async () => {
+    const nav = TestBed.inject(PlatformNavigation);
+    expect(nav.entries().length).toBe(1);
+    await nav.navigate('/someUrl').finished;
+    expect(nav.entries().length).toBe(2);
+  });
+});

--- a/packages/common/testing/src/mock_platform_location.ts
+++ b/packages/common/testing/src/mock_platform_location.ts
@@ -11,7 +11,7 @@ import {
   LocationChangeEvent,
   LocationChangeListener,
   PlatformLocation,
-  ɵPlatformNavigation as PlatformNavigation,
+  PlatformNavigation,
 } from '../../index';
 import {Inject, inject, Injectable, InjectionToken, Optional} from '@angular/core';
 import {Subject} from 'rxjs';

--- a/packages/common/testing/src/navigation/provide_fake_platform_navigation.ts
+++ b/packages/common/testing/src/navigation/provide_fake_platform_navigation.ts
@@ -6,11 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  DOCUMENT,
-  PlatformLocation,
-  ɵPlatformNavigation as PlatformNavigation,
-} from '../../../index';
+import {DOCUMENT, PlatformLocation, PlatformNavigation} from '../../../index';
 import {inject, InjectionToken, Provider} from '@angular/core';
 
 import {

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "types": ["dom-navigation"],
+    "paths": {
+      "@angular/*": ["../*"],
+    }
+  }
+}

--- a/packages/core/primitives/dom-navigation/testing/BUILD.bazel
+++ b/packages/core/primitives/dom-navigation/testing/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "ts_project", "tsec_test")
+load("//tools:defaults.bzl", "ts_config", "ts_project", "tsec_test")
 
 package(default_visibility = [
     "//packages:__pkg__",
@@ -8,6 +8,16 @@ package(default_visibility = [
     "//tools/public_api_guard:__pkg__",
 ])
 
+ts_config(
+    name = "tsconfig_build",
+    src = "tsconfig.json",
+    visibility = ["//packages/core/primitives/dom-navigation/testing:__subpackages__"],
+    deps = [
+        "//:node_modules/@types/dom-navigation",
+        "//packages:tsconfig_build",
+    ],
+)
+
 ts_project(
     name = "testing",
     srcs = glob(
@@ -16,6 +26,7 @@ ts_project(
         ],
     ),
     deps = [
+        "//:node_modules/@types/dom-navigation",
         "//packages/core/primitives/dom-navigation",
     ],
 )

--- a/packages/core/primitives/dom-navigation/testing/fake_navigation.ts
+++ b/packages/core/primitives/dom-navigation/testing/fake_navigation.ts
@@ -6,21 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  NavigationNavigateOptions,
-  NavigationTypeString,
-  NavigationOptions,
-  NavigateEvent,
-  NavigationCurrentEntryChangeEvent,
-  NavigationTransition,
-  NavigationUpdateCurrentEntryOptions,
-  NavigationReloadOptions,
-  NavigationResult,
-  NavigationHistoryEntry,
-  NavigationInterceptOptions,
-  NavigationDestination,
-  Navigation,
-} from '../src/navigation_types';
+/// <reference types="dom-navigation" />
 
 /**
  * Fake implementation of user agent history and navigation behavior. This is a

--- a/packages/core/primitives/dom-navigation/testing/test/BUILD.bazel
+++ b/packages/core/primitives/dom-navigation/testing/test/BUILD.bazel
@@ -1,4 +1,14 @@
-load("//tools:defaults.bzl", "ts_project", "zoneless_jasmine_test", "zoneless_web_test_suite")
+load("//tools:defaults.bzl", "ts_config", "ts_project", "zoneless_jasmine_test", "zoneless_web_test_suite")
+
+ts_config(
+    name = "tsconfig_test",
+    src = "tsconfig.json",
+    visibility = ["//packages/core/primitives/dom-navigation/testing/test:__subpackages__"],
+    deps = [
+        "//:node_modules/@types/dom-navigation",
+        "//packages/core/primitives/dom-navigation/testing:tsconfig_build",
+    ],
+)
 
 ts_project(
     name = "test_lib",
@@ -6,9 +16,11 @@ ts_project(
     srcs = glob(
         ["**/*.ts"],
     ),
+    tsconfig = ":tsconfig_test",
     # Visible to //:saucelabs_unit_tests_poc target
     visibility = ["//:__pkg__"],
     deps = [
+        "//:node_modules/@types/dom-navigation",
         "//packages/core/primitives/dom-navigation/testing",
         "//packages/private/testing",
     ],

--- a/packages/core/primitives/dom-navigation/testing/test/tsconfig.json
+++ b/packages/core/primitives/dom-navigation/testing/test/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["dom-navigation", "jasmine"],
+  }
+}

--- a/packages/core/primitives/dom-navigation/testing/tsconfig.json
+++ b/packages/core/primitives/dom-navigation/testing/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../../tsconfig-build.json",
+  "compilerOptions": {
+    "types": ["dom-navigation"],
+  }
+}

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -5,21 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-export {
-  type NavigateEvent as ɵNavigateEvent,
-  type Navigation as ɵNavigation,
-  type NavigationCurrentEntryChangeEvent as ɵNavigationCurrentEntryChangeEvent,
-  type NavigationHistoryEntry as ɵNavigationHistoryEntry,
-  type NavigationNavigateOptions as ɵNavigationNavigateOptions,
-  type NavigationOptions as ɵNavigationOptions,
-  type NavigationReloadOptions as ɵNavigationReloadOptions,
-  type NavigationResult as ɵNavigationResult,
-  type NavigationTransition as ɵNavigationTransition,
-  type NavigationUpdateCurrentEntryOptions as ɵNavigationUpdateCurrentEntryOptions,
-  type NavigationTypeString as ɵNavigationTypeString,
-  type NavigationInterceptOptions as ɵNavigationInterceptOptions,
-  type NavigationDestination as ɵNavigationDestination,
-} from '../primitives/dom-navigation';
 export {setAlternateWeakRefImpl as ɵsetAlternateWeakRefImpl} from '../primitives/signals';
 export {INTERNAL_APPLICATION_ERROR_HANDLER as ɵINTERNAL_APPLICATION_ERROR_HANDLER} from './error_handler';
 export {

--- a/packages/platform-browser/testing/src/browser.ts
+++ b/packages/platform-browser/testing/src/browser.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import {PlatformLocation} from '@angular/common';
-import {MockPlatformLocation} from '@angular/common/testing';
+import {MockPlatformLocation, ɵprovideFakePlatformNavigation} from '@angular/common/testing';
 import {
   APP_ID,
   createPlatformFactory,
@@ -40,7 +40,7 @@ export const platformBrowserTesting: (extraProviders?: StaticProvider[]) => Plat
     {provide: APP_ID, useValue: 'a'},
     internalProvideZoneChangeDetection({}),
     {provide: ChangeDetectionScheduler, useExisting: ChangeDetectionSchedulerImpl},
-    {provide: PlatformLocation, useClass: MockPlatformLocation},
+    ɵprovideFakePlatformNavigation(),
     {provide: TestComponentRenderer, useClass: DOMTestComponentRenderer},
   ],
 })


### PR DESCRIPTION
The navigation API is part of interop 2025. You can find the implementation status for each major browser here:

https://wpt.fyi/results/navigation-api?label=master&label=experimental&aligned&view=interop&q=label%3Ainterop-2025-navigation

https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API

BREAKING CHANGE: (test only) - `TestBed` now provides a fake `PlatformLocation` implementation that supports the Navigation API. This may break some tests, though we have not observed any failures internally. You can revert to the old default for `TestBed` by providing the `MockPlatformLocation` from `@angular/common/testing` in your providers:
`{provide: PlatformLocation, useClass: MockPlatformLocation}`