### PR TITLE
refactor(core): prevent timeout from applying to non-event animation bindings

### DIFF
--- a/packages/core/src/animation/element_removal_registry.ts
+++ b/packages/core/src/animation/element_removal_registry.ts
@@ -65,6 +65,7 @@ export class ElementRegistry {
     const details = this.outElements.get(el) ?? {
       classes: null,
       animateFn: () => {},
+      isEventBinding: true,
     };
     details.animateFn = animateWrapperFn(el, value);
     this.outElements.set(el, details);
@@ -75,6 +76,7 @@ export class ElementRegistry {
     const details = this.outElements.get(el) ?? {
       classes: new Set<string>(),
       animateFn: (): void => {},
+      isEventBinding: false,
     };
     if (typeof value === 'function') {
       this.trackResolver(details, value);
@@ -109,8 +111,11 @@ export class ElementRegistry {
     };
     // this timeout is used to ensure elements actually get removed in the case
     // that the user forgot to call the remove callback. The timeout is cleared
-    // in the DOM renderer during the remove child process.
-    timeoutId = setTimeout(remove, maxAnimationTimeout);
+    // in the DOM renderer during the remove child process. It only applies
+    // to the event binding use case.
+    if (details.isEventBinding) {
+      timeoutId = setTimeout(remove, maxAnimationTimeout);
+    }
     details.animateFn(remove);
   }
 }

--- a/packages/core/src/animation/interfaces.ts
+++ b/packages/core/src/animation/interfaces.ts
@@ -67,4 +67,5 @@ export interface AnimationDetails {
   classes: Set<string> | null;
   classFns?: Function[];
   animateFn: AnimationRemoveFunction;
+  isEventBinding: boolean;
 }


### PR DESCRIPTION
The 4 second removal timeout was applying in all cases, but it should only actually apply to the situation where the event binding syntax is used for animate.leave. This ensures that's the only case in which it'll apply.

This was reported in #63388.