### PR TITLE
refactor(core): mark `VERSION` as `@__PURE__` for better tree-shaking

### DIFF
--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -27,4 +27,4 @@ export class Version {
 /**
  * @publicApi
  */
-export const VERSION = new Version('0.0.0-PLACEHOLDER');
+export const VERSION = /* @__PURE__ */ new Version('0.0.0-PLACEHOLDER');


### PR DESCRIPTION
Annotate the `new Version(...)` call with `/* @__PURE__ */` to signal to optimizers that the constructor is side-effect free.

Without this hint, bundlers such as Terser or ESBuild may conservatively retain the `VERSION` instantiation even when unused. With the annotation, the constant can be tree-shaken away in production builds if not referenced, reducing bundle size.