### PR TITLE
docs: remove the ng-class migration entry

### DIFF
--- a/adev/src/app/sub-navigation-data.ts
+++ b/adev/src/app/sub-navigation-data.ts
@@ -1418,12 +1418,6 @@ const REFERENCE_SUB_NAVIGATION_DATA: NavigationItem[] = [
         path: 'reference/migrations/self-closing-tags',
         contentPath: 'reference/migrations/self-closing-tags',
       },
-      {
-        label: 'NgClass to Class',
-        path: 'reference/migrations/ngclass-to-class',
-        contentPath: 'reference/migrations/ngclass-to-class',
-        status: 'new',
-      },
     ],
   },
 ];

--- a/adev/src/content/reference/migrations/overview.md
+++ b/adev/src/content/reference/migrations/overview.md
@@ -30,7 +30,4 @@ Learn about how you can migrate your existing angular project to the latest feat
   <docs-card title="Self-closing tags" link="Migrate now" href="reference/migrations/self-closing-tags">
     Convert component templates to use self-closing tags where possible.
   </docs-card>
-  <docs-card title="NgClass to Class Bindings" link="Migrate now" href="reference/migrations/ngclass-to-class">
-      Convert component templates to prefer class bindings over the `NgClass`directives when possible.
-  </docs-card>
 </docs-card-container>


### PR DESCRIPTION
That migration is only available in v21 / on the main branch for now.

fixes #63428
