### PR TITLE
ci: fix and improve devtools step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,18 @@ jobs:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@7e2eefa1375195fa7616f78a76f538a188852067
         with:
-          cache-node-modules: true
+          disable-package-manager-cache: true
       - name: Setup Bazel
         uses: angular/dev-infra/github-actions/bazel/setup@7e2eefa1375195fa7616f78a76f538a188852067
       - name: Setup Bazel RBE
         uses: angular/dev-infra/github-actions/bazel/configure-remote@7e2eefa1375195fa7616f78a76f538a188852067
         with:
           google_credential: ${{ secrets.RBE_TRUSTED_BUILDS_USER }}
+      - name: Cache downloaded Cypress binary
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: '~/.cache/Cypress'
+          key: cypress-cache-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - name: Install node modules
         run: pnpm install --frozen-lockfile
       - name: Run unit tests
@@ -63,6 +68,7 @@ jobs:
           start: pnpm bazel run //devtools/src:devserver
           wait-on: 'http://localhost:4200'
           wait-on-timeout: 300
+          install: false
 
   test:
     runs-on: ubuntu-latest-4core

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@7e2eefa1375195fa7616f78a76f538a188852067
-        with:
-          cache-node-modules: true
       - name: Install node modules
         run: pnpm install --frozen-lockfile
       - name: Check code lint
@@ -75,8 +73,6 @@ jobs:
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@7e2eefa1375195fa7616f78a76f538a188852067
-        with:
-          cache-node-modules: true
       - name: Setup Bazel
         uses: angular/dev-infra/github-actions/bazel/setup@7e2eefa1375195fa7616f78a76f538a188852067
       - name: Setup Bazel Remote Caching
@@ -93,8 +89,6 @@ jobs:
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@7e2eefa1375195fa7616f78a76f538a188852067
-        with:
-          cache-node-modules: true
       - name: Setup Bazel
         uses: angular/dev-infra/github-actions/bazel/setup@7e2eefa1375195fa7616f78a76f538a188852067
       - name: Setup Bazel Remote Caching
@@ -149,12 +143,6 @@ jobs:
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@7e2eefa1375195fa7616f78a76f538a188852067
-        with:
-          cache-node-modules: true
-          node-module-directories: |
-            ./node_modules
-            ./packages/zone.js/node_modules
-            ./packages/zone.js/test/typings/node_modules
       - name: Setup Bazel
         uses: angular/dev-infra/github-actions/bazel/setup@7e2eefa1375195fa7616f78a76f538a188852067
       - name: Setup Bazel RBE
@@ -198,8 +186,6 @@ jobs:
   #   steps:
   #     - name: Initialize environment
   #       uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@b5a3609f89c06eb4037dce22a93641213a5d1508
-  #       with:
-  #         cache-node-modules: true
   #     - name: Install node modules
   #       run: pnpm install --frozen-lockfile
   #     - uses: ./.github/actions/saucelabs-legacy

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@7e2eefa1375195fa7616f78a76f538a188852067
-        with:
-          cache-node-modules: true
       - name: Install node modules
         run: pnpm install --frozen-lockfile
       - name: Check code lint
@@ -79,8 +77,6 @@ jobs:
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@7e2eefa1375195fa7616f78a76f538a188852067
-        with:
-          cache-node-modules: true
       - name: Setup Bazel
         uses: angular/dev-infra/github-actions/bazel/setup@7e2eefa1375195fa7616f78a76f538a188852067
       - name: Setup Bazel Remote Caching
@@ -105,8 +101,6 @@ jobs:
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@7e2eefa1375195fa7616f78a76f538a188852067
-        with:
-          cache-node-modules: true
       - name: Setup Bazel
         uses: angular/dev-infra/github-actions/bazel/setup@7e2eefa1375195fa7616f78a76f538a188852067
       - name: Setup Bazel Remote Caching
@@ -139,12 +133,6 @@ jobs:
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@7e2eefa1375195fa7616f78a76f538a188852067
-        with:
-          cache-node-modules: true
-          node-module-directories: |
-            ./node_modules
-            ./packages/zone.js/node_modules
-            ./packages/zone.js/test/typings/node_modules
       - name: Setup Bazel
         uses: angular/dev-infra/github-actions/bazel/setup@7e2eefa1375195fa7616f78a76f538a188852067
       - name: Setup Bazel RBE
@@ -186,8 +174,6 @@ jobs:
   #   steps:
   #     - name: Initialize environment
   #       uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@b5a3609f89c06eb4037dce22a93641213a5d1508
-  #       with:
-  #         cache-node-modules: true
   #     - name: Install node modules
   #       run: pnpm install --frozen-lockfile
   #     - uses: ./.github/actions/saucelabs-legacy

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,11 +49,16 @@ jobs:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@7e2eefa1375195fa7616f78a76f538a188852067
         with:
-          cache-node-modules: true
+          disable-package-manager-cache: true
       - name: Setup Bazel
         uses: angular/dev-infra/github-actions/bazel/setup@7e2eefa1375195fa7616f78a76f538a188852067
       - name: Setup Bazel RBE
         uses: angular/dev-infra/github-actions/bazel/configure-remote@7e2eefa1375195fa7616f78a76f538a188852067
+      - name: Cache downloaded Cypress binary
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: '~/.cache/Cypress'
+          key: cypress-cache-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - name: Install node modules
         run: pnpm install --frozen-lockfile
       - name: Run unit tests
@@ -67,6 +72,7 @@ jobs:
           start: pnpm bazel run //devtools/src:devserver
           wait-on: 'http://localhost:4200'
           wait-on-timeout: 300
+          install: false
 
   test:
     runs-on: ubuntu-latest-8core


### PR DESCRIPTION

**ci: fix and improve devtools step**

This commit updates the devtools step by disabling the package manager cache. This change is necessary because Cypress downloads its binary to a cache directory during installation, which requires a post-install script. However, when the cache is hit this is skipped.

This update also disables `pnpm install` in the Cypress action to avoid a redundant installation step. And adds a seperate cache for the downloaded Cypress binary.

See: https://docs.cypress.io/app/get-started/install-cypress#pnpm-configuration

---

**ci: remove old options from workflows**

The `cache-node-modules` option has been removed as pnpm store cache is enabled by default.
