### PR TITLE
refactor(core): Update zone and zoneless error to be a warning instead

### DIFF
--- a/packages/core/src/platform/bootstrap.ts
+++ b/packages/core/src/platform/bootstrap.ts
@@ -10,7 +10,7 @@ import {Subscription} from 'rxjs';
 import {PROVIDED_NG_ZONE} from '../change_detection/scheduling/ng_zone_scheduling';
 import {R3Injector} from '../di/r3_injector';
 import {INTERNAL_APPLICATION_ERROR_HANDLER} from '../error_handler';
-import {RuntimeError, RuntimeErrorCode} from '../errors';
+import {formatRuntimeError, RuntimeError, RuntimeErrorCode} from '../errors';
 import {DEFAULT_LOCALE_ID} from '../i18n/localization';
 import {LOCALE_ID} from '../i18n/tokens';
 import {ImagePerformanceWarning} from '../image_performance_warning';
@@ -94,10 +94,12 @@ export function bootstrap<M>(
     const exceptionHandler = envInjector.get(INTERNAL_APPLICATION_ERROR_HANDLER);
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       if (envInjector.get(PROVIDED_ZONELESS) && envInjector.get(PROVIDED_NG_ZONE)) {
-        throw new RuntimeError(
-          RuntimeErrorCode.PROVIDED_BOTH_ZONE_AND_ZONELESS,
-          'Invalid change detection configuration: ' +
-            'provideZoneChangeDetection and provideZonelessChangeDetection cannot be used together.',
+        console.warn(
+          formatRuntimeError(
+            RuntimeErrorCode.PROVIDED_BOTH_ZONE_AND_ZONELESS,
+            'Both provideZoneChangeDetection and provideZonelessChangeDetection are provided. ' +
+              'This is likely a mistake. Update the application providers to use only one of the two.',
+          ),
         );
       }
     }


### PR DESCRIPTION
This updates the error thrown when both `provideZoneChangeDetection` and `provideZonelessChangeDetection` are both used in the application providers to be a warning instead. The reasons for this are twofold:

1. The migration we need for using zoneless by default isn't perfect and may add `provideZoneChangeDetection` when the zoneless provider exists. This change will prevent that from causing an error
2. There might be valid situations where a "default" is used in a common provider but that can be overridden by individal applications. In tests, we do allow this type of thing, where `initTestEnvironment` may have a default but individual tests might want to use a different one. The same logic might apply to applications in some environments.
