### PR TITLE
refactor(core): Add internal option to require at least one cd provider

### DIFF
--- a/packages/core/src/platform/bootstrap.ts
+++ b/packages/core/src/platform/bootstrap.ts
@@ -28,6 +28,8 @@ import {stringify} from '../util/stringify';
 import {isPromise} from '../util/lang';
 import {PendingTasksInternal} from '../pending_tasks';
 
+const REQUIRE_ONE_CD_PROVIDER = false;
+
 /**
  * InjectionToken to control root component bootstrap behavior.
  *
@@ -99,6 +101,15 @@ export function bootstrap<M>(
           'Invalid change detection configuration: ' +
             'provideZoneChangeDetection and provideZonelessChangeDetection cannot be used together.',
         );
+      }
+      if (REQUIRE_ONE_CD_PROVIDER) {
+        if (!envInjector.get(PROVIDED_ZONELESS) && !envInjector.get(PROVIDED_NG_ZONE)) {
+          throw new Error(
+            'Missing change detection configuration: ' +
+              'please add either `provideZoneChangeDetection()` or `provideZonelessChangeDetection()` ' +
+              "to the list of root providers in your application's bootstrap code.",
+          );
+        }
       }
     }
 


### PR DESCRIPTION
This option would require one of either the zone or zoneless provider so applications don't accidentally enable zoneless when the default flips if we missed it in the migration. It'll be a hard failure at bootstrap, but that's a lot easier to notice than zoneless getting turned on accidentally since many things might just work.
