### PR TITLE
refactor(router): update error checks extending error

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1,7 +1,6 @@
 {
   "chunks": {
     "main": [
-      "ABSOLUTE_REDIRECT_ERROR_NAME",
       "AFTER_RENDER_SEQUENCES_TO_ADD",
       "ANIMATIONS_DISABLED",
       "APP_BASE_HREF",
@@ -178,7 +177,6 @@
       "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR",
       "NOT_YET",
       "NO_CHANGE",
-      "NO_MATCH_ERROR_NAME",
       "NO_PARENT_INJECTOR",
       "NULL_INJECTOR",
       "Navigation",

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -18,22 +18,28 @@ import {UrlSegment, UrlSegmentGroup, UrlSerializer, UrlTree} from './url_tree';
 import {wrapIntoObservable} from './utils/collection';
 import {firstValueFrom} from './utils/first_value_from';
 
-export const NO_MATCH_ERROR_NAME = 'ɵNoMatch';
 export class NoMatch extends Error {
-  override readonly name: string = NO_MATCH_ERROR_NAME;
   public segmentGroup: UrlSegmentGroup | null;
 
   constructor(segmentGroup?: UrlSegmentGroup) {
     super();
     this.segmentGroup = segmentGroup || null;
+
+    // Extending `Error` ends up breaking some internal tests. This appears to be a known issue
+    // when extending errors in TS and the workaround is to explicitly set the prototype.
+    // https://stackoverflow.com/questions/41102060/typescript-extending-error-class
+    Object.setPrototypeOf(this, NoMatch.prototype);
   }
 }
 
-export const ABSOLUTE_REDIRECT_ERROR_NAME = 'ɵAbsoluteRedirect';
 export class AbsoluteRedirect extends Error {
-  override readonly name: string = ABSOLUTE_REDIRECT_ERROR_NAME;
   constructor(public urlTree: UrlTree) {
     super();
+
+    // Extending `Error` ends up breaking some internal tests. This appears to be a known issue
+    // when extending errors in TS and the workaround is to explicitly set the prototype.
+    // https://stackoverflow.com/questions/41102060/typescript-extending-error-class
+    Object.setPrototypeOf(this, AbsoluteRedirect.prototype);
   }
 }
 

--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -8,13 +8,7 @@
 
 import {EnvironmentInjector, Type, ɵRuntimeError as RuntimeError} from '@angular/core';
 
-import {
-  ABSOLUTE_REDIRECT_ERROR_NAME,
-  NO_MATCH_ERROR_NAME,
-  ApplyRedirects,
-  canLoadFails,
-  NoMatch,
-} from './apply_redirects';
+import {AbsoluteRedirect, ApplyRedirects, canLoadFails, NoMatch} from './apply_redirects';
 import {createUrlTreeFromSnapshot} from './create_url_tree';
 import {RuntimeErrorCode} from './errors';
 import {Data, LoadedRouterConfig, ResolveData, Route, Routes} from './models';
@@ -146,11 +140,11 @@ export class Recognizer {
       );
       return {children, rootSnapshot};
     } catch (e: any) {
-      if (e?.name === ABSOLUTE_REDIRECT_ERROR_NAME) {
+      if (e instanceof AbsoluteRedirect) {
         this.urlTree = e.urlTree;
         return this.match(e.urlTree.root);
       }
-      if (e?.name === NO_MATCH_ERROR_NAME) {
+      if (e instanceof NoMatch) {
         throw this.noMatchError(e);
       }
 
@@ -258,7 +252,7 @@ export class Recognizer {
           parentRoute,
         );
       } catch (e: any) {
-        if (e?.name === NO_MATCH_ERROR_NAME || isEmptyError(e)) {
+        if (e instanceof NoMatch || isEmptyError(e)) {
           continue;
         }
         throw e;


### PR DESCRIPTION
I forgot about the "setPrototypeOf" fix and had a recency bias for the NotFoundError in the signal primitives.
