### PR TITLE
refactor(core): Error logs links point to the archived version of th…

### DIFF
--- a/packages/compiler-cli/src/ngtsc/diagnostics/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/BUILD.bazel
@@ -9,5 +9,6 @@ ts_project(
     ]),
     deps = [
         "//:node_modules/typescript",
+        "//packages/compiler",
     ],
 )

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/error_details_base_url.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/error_details_base_url.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {VERSION} from '@angular/compiler';
+
 /**
  * Base URL for the error details page.
  *
@@ -13,4 +15,7 @@
  *  - packages/compiler-cli/src/ngtsc/diagnostics/src/error_details_base_url.ts
  *  - packages/core/src/error_details_base_url.ts
  */
-export const ERROR_DETAILS_PAGE_BASE_URL = 'https://angular.dev/errors';
+export const ERROR_DETAILS_PAGE_BASE_URL: string = (() => {
+  const versionSubDomain = VERSION.major !== '0' ? `v${VERSION.major}.` : '';
+  return `https://${versionSubDomain}angular.dev/errors`;
+})();

--- a/packages/core/src/error_details_base_url.ts
+++ b/packages/core/src/error_details_base_url.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {VERSION} from './version';
+
 /**
  * Base URL for the error details page.
  *
@@ -13,7 +15,10 @@
  *  - packages/compiler-cli/src/ngtsc/diagnostics/src/error_details_base_url.ts
  *  - packages/core/src/error_details_base_url.ts
  */
-export const ERROR_DETAILS_PAGE_BASE_URL = 'https://angular.dev/errors';
+export const ERROR_DETAILS_PAGE_BASE_URL: string = (() => {
+  const versionSubDomain = VERSION.major !== '0' ? `v${VERSION.major}.` : '';
+  return `https://${versionSubDomain}angular.dev/errors`;
+})();
 
 /**
  * URL for the XSS security documentation.


### PR DESCRIPTION
…e docs

In order to point the right context, links in error messages will target the archived version of the online doc site (v*.angular.io).

fixes #44650
