### PR TITLE
feat(migrations): add migration to convert ngStyle to use style

### DIFF
--- a/adev/src/app/routing/sub-navigation-data.ts
+++ b/adev/src/app/routing/sub-navigation-data.ts
@@ -1497,6 +1497,12 @@ const REFERENCE_SUB_NAVIGATION_DATA: NavigationItem[] = [
         contentPath: 'reference/migrations/ngclass-to-class',
         status: 'new',
       },
+      {
+        label: 'NgStyle to Style',
+        path: 'reference/migrations/ngstyle-to-style',
+        contentPath: 'reference/migrations/ngstyle-to-style',
+        status: 'new',
+      },
     ],
   },
 ];

--- a/adev/src/content/reference/migrations/ngstyle-to-style.md
+++ b/adev/src/content/reference/migrations/ngstyle-to-style.md
@@ -1,0 +1,45 @@
+# Migration from NgStyle to style bindings
+
+This schematic migrates NgStyle directive usages to style bindings in your application.
+It will only migrate usages that are considered safe to migrate.
+
+Run the schematic using the following command:
+
+```bash
+ng generate @angular/core:ngstyle-to-style
+```
+
+
+#### Before
+
+```html
+<div [ngStyle]="{'background-color': 'red'}">
+```
+
+
+#### After
+
+```html
+<div [style]="{'background-color': 'red'}">
+```
+
+## Configuration options
+
+The migration supports a few options for fine tuning the migration to your specific needs.
+
+### `--best-effort-mode`
+
+By default, the migration avoids migrating object references usages of `NgStyle`
+When the `--best-effort-mode` flag is enabled, `ngStyle` instances binded to object references are also migrated. 
+This can be unsafe to migrate, for example if the binded object is mutated.
+
+
+```html
+<div [ngStyle]="styleObject"></div>
+```
+
+to
+
+```html
+<div [style]="styleObject"></div>
+```

--- a/adev/src/content/reference/migrations/overview.md
+++ b/adev/src/content/reference/migrations/overview.md
@@ -33,4 +33,7 @@ Learn about how you can migrate your existing angular project to the latest feat
   <docs-card title="NgClass to Class Bindings" link="Migrate now" href="reference/migrations/ngclass-to-class">
       Convert component templates to prefer class bindings over the `NgClass` directives when possible.
   </docs-card>
+  <docs-card title="NgStyle to Style Bindings" link="Migrate now" href="reference/migrations/ngstyle-to-style">
+      Convert component templates to prefer style bindings over the `NgStyle` directives when possible.
+  </docs-card>
 </docs-card-container>

--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -44,6 +44,7 @@ npm_package(
         ":bundles",
         "//packages/core/schematics/migrations/control-flow-migration:static_files",
         "//packages/core/schematics/migrations/ngclass-to-class-migration:static_files",
+        "//packages/core/schematics/migrations/ngstyle-to-style-migration:static_files",
         "//packages/core/schematics/ng-generate/cleanup-unused-imports:static_files",
         "//packages/core/schematics/ng-generate/inject-migration:static_files",
         "//packages/core/schematics/ng-generate/output-migration:static_files",
@@ -103,6 +104,10 @@ bundle_entrypoints = [
         "packages/core/schematics/migrations/ngclass-to-class-migration/index.js",
     ],
     [
+        "ngstyle-to-style-migration",
+        "packages/core/schematics/migrations/ngstyle-to-style-migration/index.js",
+    ],
+    [
         "router-current-navigation",
         "packages/core/schematics/migrations/router-current-navigation/index.js",
     ],
@@ -133,6 +138,7 @@ rollup.rollup(
         "//packages/core/schematics/migrations/application-config-core",
         "//packages/core/schematics/migrations/control-flow-migration",
         "//packages/core/schematics/migrations/ngclass-to-class-migration",
+        "//packages/core/schematics/migrations/ngstyle-to-style-migration",
         "//packages/core/schematics/migrations/router-current-navigation",
         "//packages/core/schematics/migrations/router-last-successful-navigation",
         "//packages/core/schematics/ng-generate/cleanup-unused-imports",

--- a/packages/core/schematics/collection.json
+++ b/packages/core/schematics/collection.json
@@ -63,6 +63,12 @@
       "factory": "./bundles/ngclass-to-class-migration.cjs#migrate",
       "schema": "./migrations/ngclass-to-class-migration/schema.json",
       "aliases": ["ngclass-to-class"]
+    },
+    "ngstyle-to-style-migration": {
+      "description": "Updates usages of `ngStyle` directives to the `style` bindings where possible",
+      "factory": "./bundles/ngstyle-to-style-migration.cjs#migrate",
+      "schema": "./migrations/ngstyle-to-style-migration/schema.json",
+      "aliases": ["ngstyle-to-style"]
     }
   }
 }

--- a/packages/core/schematics/migrations/ngstyle-to-style-migration/BUILD.bazel
+++ b/packages/core/schematics/migrations/ngstyle-to-style-migration/BUILD.bazel
@@ -1,0 +1,36 @@
+load("//tools:defaults.bzl", "copy_to_bin", "ts_project")
+
+package(
+    default_visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+)
+
+copy_to_bin(
+    name = "static_files",
+    srcs = ["schema.json"],
+)
+
+ts_project(
+    name = "ngstyle-to-style-migration",
+    srcs = glob(["**/*.ts"]),
+    data = ["schema.json"],
+    deps = [
+        "//:node_modules/@angular-devkit/schematics",
+        "//:node_modules/@types/node",
+        "//:node_modules/typescript",
+        "//packages/compiler",
+        "//packages/compiler-cli",
+        "//packages/compiler-cli/private",
+        "//packages/compiler-cli/src/ngtsc/annotations",
+        "//packages/compiler-cli/src/ngtsc/annotations/directive",
+        "//packages/compiler-cli/src/ngtsc/file_system",
+        "//packages/compiler-cli/src/ngtsc/imports",
+        "//packages/compiler-cli/src/ngtsc/metadata",
+        "//packages/compiler-cli/src/ngtsc/reflection",
+        "//packages/core/schematics/utils",
+        "//packages/core/schematics/utils/tsurge",
+        "//packages/core/schematics/utils/tsurge/helpers/angular_devkit",
+    ],
+)

--- a/packages/core/schematics/migrations/ngstyle-to-style-migration/README.md
+++ b/packages/core/schematics/migrations/ngstyle-to-style-migration/README.md
@@ -1,0 +1,29 @@
+
+# ngStyle to style migration
+This schematic helps developers to convert ngStyle directive usages to style bindings where possible.
+
+## How to run this migration?
+The migration can be run using the following command:
+
+```bash
+ng generate @angular/core:ngstyle-to-style
+```
+
+By default, the migration will go over the entire application. If you want to apply this migration to a subset of the files, you can pass the path argument as shown below:
+
+```bash
+ng generate @angular/core:ngstyle-to-style --path src/app/sub-component
+```
+
+### How does it work?
+The schematic will attempt to find all the places in the templates where the directive is used and check if it can be converted to [style].
+
+Example:
+
+```html
+<!-- Before -->
+<div [ngStyle]="{'background-color': 'red'}">
+
+<!-- After -->
+<div [style]="{'background-color': 'red'}">
+```

--- a/packages/core/schematics/migrations/ngstyle-to-style-migration/index.ts
+++ b/packages/core/schematics/migrations/ngstyle-to-style-migration/index.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Rule} from '@angular-devkit/schematics';
+import {NgStyleMigration} from './ngstyle-to-style-migration';
+import {MigrationStage, runMigrationInDevkit} from '../../utils/tsurge/helpers/angular_devkit';
+
+interface Options {
+  path: string;
+  analysisDir: string;
+  bestEffortMode?: boolean;
+}
+
+export function migrate(options: Options): Rule {
+  return async (tree, context) => {
+    await runMigrationInDevkit({
+      tree,
+      getMigration: (fs) =>
+        new NgStyleMigration({
+          bestEffortMode: options.bestEffortMode,
+          shouldMigrate: (file) => {
+            return (
+              file.rootRelativePath.startsWith(fs.normalize(options.path)) &&
+              !/(^|\/)node_modules\//.test(file.rootRelativePath)
+            );
+          },
+        }),
+      beforeProgramCreation: (tsconfigPath: string, stage: MigrationStage) => {
+        if (stage === MigrationStage.Analysis) {
+          context.logger.info(`Preparing analysis for: ${tsconfigPath}...`);
+        } else {
+          context.logger.info(`Running migration for: ${tsconfigPath}...`);
+        }
+      },
+      beforeUnitAnalysis: (tsconfigPath: string) => {
+        context.logger.info(`Scanning for component tags: ${tsconfigPath}...`);
+      },
+      afterAllAnalyzed: () => {
+        context.logger.info(``);
+        context.logger.info(`Processing analysis data between targets...`);
+        context.logger.info(``);
+      },
+      afterAnalysisFailure: () => {
+        context.logger.error('Migration failed unexpectedly with no analysis data');
+      },
+      whenDone: ({
+        touchedFilesCount,
+        replacementCount,
+      }: {
+        touchedFilesCount: number;
+        replacementCount: number;
+      }) => {
+        context.logger.info('');
+        context.logger.info(`Successfully migrated to style bindings from ngStyle 🎉`);
+        context.logger.info(
+          `  -> Migrated ${replacementCount} ngStyle to style bindings in ${touchedFilesCount} files.`,
+        );
+      },
+    });
+  };
+}

--- a/packages/core/schematics/migrations/ngstyle-to-style-migration/ngstyle-to-style-migration.ts
+++ b/packages/core/schematics/migrations/ngstyle-to-style-migration/ngstyle-to-style-migration.ts
@@ -1,0 +1,231 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import ts from 'typescript';
+import {
+  confirmAsSerializable,
+  ProgramInfo,
+  projectFile,
+  ProjectFile,
+  ProjectFileID,
+  Replacement,
+  Serializable,
+  TextUpdate,
+  TsurgeFunnelMigration,
+} from '../../utils/tsurge';
+import {
+  migrateNgStyleBindings,
+  calculateImportReplacements,
+  createNgStyleImportsArrayRemoval,
+} from './util';
+import {AbsoluteFsPath} from '@angular/compiler-cli';
+import {NgComponentTemplateVisitor} from '../../utils/ng_component_template';
+import {MigrationConfig} from './types';
+
+export interface NgStyleMigrationData {
+  file: ProjectFile;
+  replacementCount: number;
+  replacements: Replacement[];
+}
+
+export interface NgStyleCompilationUnitData {
+  ngStyleReplacements: Array<NgStyleMigrationData>;
+  importReplacements: Record<ProjectFileID, {add: Replacement[]; addAndRemove: Replacement[]}>;
+}
+
+export class NgStyleMigration extends TsurgeFunnelMigration<
+  NgStyleCompilationUnitData,
+  NgStyleCompilationUnitData
+> {
+  constructor(private readonly config: MigrationConfig = {}) {
+    super();
+  }
+
+  private processTemplate(
+    template: {content: string; inline: boolean; filePath: string | null; start: number},
+    node: ts.ClassDeclaration,
+    file: ProjectFile,
+    info: ProgramInfo,
+    typeChecker: ts.TypeChecker,
+  ): {
+    replacements: Replacement[];
+    replacementCount: number;
+    canRemoveCommonModule: boolean;
+  } | null {
+    const {migrated, changed, replacementCount, canRemoveCommonModule} = migrateNgStyleBindings(
+      template.content,
+      this.config,
+      node,
+      typeChecker,
+    );
+
+    if (!changed) {
+      return null;
+    }
+
+    const fileToMigrate = template.inline
+      ? file
+      : projectFile(template.filePath as AbsoluteFsPath, info);
+    const end = template.start + template.content.length;
+
+    return {
+      replacements: [prepareTextReplacement(fileToMigrate, migrated, template.start, end)],
+      replacementCount,
+      canRemoveCommonModule,
+    };
+  }
+
+  override async analyze(info: ProgramInfo): Promise<Serializable<NgStyleCompilationUnitData>> {
+    const {sourceFiles, program} = info;
+    const typeChecker = program.getTypeChecker();
+    const ngStyleReplacements: Array<NgStyleMigrationData> = [];
+    const filesWithNgStyleDeclarations = new Set<ts.SourceFile>();
+    const filesToRemoveCommonModule = new Set<ProjectFileID>();
+
+    for (const sf of sourceFiles) {
+      ts.forEachChild(sf, (node: ts.Node) => {
+        if (!ts.isClassDeclaration(node)) {
+          return;
+        }
+
+        const file = projectFile(sf, info);
+
+        if (this.config.shouldMigrate && !this.config.shouldMigrate(file)) {
+          return;
+        }
+
+        const templateVisitor = new NgComponentTemplateVisitor(typeChecker);
+        templateVisitor.visitNode(node);
+
+        const replacementsForStyle: Replacement[] = [];
+        let replacementCountForStyle = 0;
+        let canRemoveCommonModuleForFile = true;
+
+        for (const template of templateVisitor.resolvedTemplates) {
+          const result = this.processTemplate(template, node, file, info, typeChecker);
+          if (result) {
+            replacementsForStyle.push(...result.replacements);
+            replacementCountForStyle += result.replacementCount;
+            if (!result.canRemoveCommonModule) {
+              canRemoveCommonModuleForFile = false;
+            }
+          }
+        }
+
+        if (replacementsForStyle.length > 0) {
+          if (canRemoveCommonModuleForFile) {
+            filesToRemoveCommonModule.add(file.id);
+          }
+
+          // Handle the `@Component({ imports: [...] })` array.
+          const importsRemoval = createNgStyleImportsArrayRemoval(
+            node,
+            file,
+            typeChecker,
+            canRemoveCommonModuleForFile,
+          );
+          if (importsRemoval) {
+            replacementsForStyle.push(importsRemoval);
+          }
+
+          ngStyleReplacements.push({
+            file,
+            replacementCount: replacementCountForStyle,
+            replacements: replacementsForStyle,
+          });
+          filesWithNgStyleDeclarations.add(sf);
+        }
+      });
+    }
+
+    const importReplacements = calculateImportReplacements(
+      info,
+      filesWithNgStyleDeclarations,
+      filesToRemoveCommonModule,
+    );
+
+    return confirmAsSerializable({
+      ngStyleReplacements,
+      importReplacements,
+    });
+  }
+
+  override async combine(
+    unitA: NgStyleCompilationUnitData,
+    unitB: NgStyleCompilationUnitData,
+  ): Promise<Serializable<NgStyleCompilationUnitData>> {
+    const importReplacements: Record<
+      ProjectFileID,
+      {add: Replacement[]; addAndRemove: Replacement[]}
+    > = {};
+
+    for (const unit of [unitA, unitB]) {
+      for (const fileIDStr of Object.keys(unit.importReplacements)) {
+        const fileID = fileIDStr as ProjectFileID;
+        importReplacements[fileID] = unit.importReplacements[fileID];
+      }
+    }
+
+    return confirmAsSerializable({
+      ngStyleReplacements: [...unitA.ngStyleReplacements, ...unitB.ngStyleReplacements],
+      importReplacements,
+    });
+  }
+
+  override async globalMeta(
+    combinedData: NgStyleCompilationUnitData,
+  ): Promise<Serializable<NgStyleCompilationUnitData>> {
+    return confirmAsSerializable({
+      ngStyleReplacements: combinedData.ngStyleReplacements,
+      importReplacements: combinedData.importReplacements,
+    });
+  }
+
+  override async stats(globalMetadata: NgStyleCompilationUnitData) {
+    const touchedFilesCount = globalMetadata.ngStyleReplacements.length;
+    const replacementCount = globalMetadata.ngStyleReplacements.reduce(
+      (acc, cur) => acc + cur.replacementCount,
+      0,
+    );
+
+    return confirmAsSerializable({
+      touchedFilesCount,
+      replacementCount,
+    });
+  }
+
+  override async migrate(globalData: NgStyleCompilationUnitData) {
+    const replacements: Replacement[] = [];
+
+    replacements.push(...globalData.ngStyleReplacements.flatMap(({replacements}) => replacements));
+
+    for (const fileIDStr of Object.keys(globalData.importReplacements)) {
+      const fileID = fileIDStr as ProjectFileID;
+      const importReplacements = globalData.importReplacements[fileID];
+      replacements.push(...importReplacements.addAndRemove);
+    }
+
+    return {replacements};
+  }
+}
+
+function prepareTextReplacement(
+  file: ProjectFile,
+  replacement: string,
+  start: number,
+  end: number,
+): Replacement {
+  return new Replacement(
+    file,
+    new TextUpdate({
+      position: start,
+      end: end,
+      toInsert: replacement,
+    }),
+  );
+}

--- a/packages/core/schematics/migrations/ngstyle-to-style-migration/schema.json
+++ b/packages/core/schematics/migrations/ngstyle-to-style-migration/schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "AngularNgStyleToStyleMigration",
+  "title": "Angular ngStyle to style Migration Schema",
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string",
+      "description": "Path to the directory where all templates should be migrated.",
+      "x-prompt": "Which directory do you want to migrate?",
+      "default": "./"
+    },
+    "bestEffortMode": {
+      "type": "boolean",
+      "description": "Enables the migration of object references",
+      "x-prompt": "Should the migration also migrate object references?",
+      "default": false
+    }
+  }
+}

--- a/packages/core/schematics/migrations/ngstyle-to-style-migration/types.ts
+++ b/packages/core/schematics/migrations/ngstyle-to-style-migration/types.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {ProjectFile} from '../../utils/tsurge';
+
+export interface MigrationConfig {
+  /**
+   * Whether to migrate this component template to self-closing tags.
+   */
+  shouldMigrate?: (containingFile: ProjectFile) => boolean;
+
+  /**
+   * Whether to migrate object references
+   */
+  bestEffortMode?: boolean;
+}

--- a/packages/core/schematics/migrations/ngstyle-to-style-migration/util.ts
+++ b/packages/core/schematics/migrations/ngstyle-to-style-migration/util.ts
@@ -1,0 +1,442 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {visitAll, RecursiveVisitor, Element} from '@angular/compiler';
+import {
+  ProgramInfo,
+  projectFile,
+  ProjectFileID,
+  Replacement,
+  TextUpdate,
+  ProjectFile,
+} from '../../utils/tsurge';
+import ts from 'typescript';
+import {applyImportManagerChanges} from '../../utils/tsurge/helpers/apply_import_manager';
+import {MigrationConfig} from './types';
+import {getImportSpecifiers} from '../../utils/typescript/imports';
+import {TypeScriptReflectionHost} from '@angular/compiler-cli/src/ngtsc/reflection';
+import {ImportManager} from '@angular/compiler-cli/private/migrations';
+import {canRemoveCommonModule, parseTemplate} from '../../utils/parse_html';
+
+const ngStyleStr = 'NgStyle';
+const commonModuleStr = '@angular/common';
+const commonModuleImportsStr = 'CommonModule';
+
+export function migrateNgStyleBindings(
+  template: string,
+  config: MigrationConfig,
+  componentNode: ts.ClassDeclaration,
+  typeChecker: ts.TypeChecker,
+): {
+  replacementCount: number;
+  migrated: string;
+  changed: boolean;
+  canRemoveCommonModule: boolean;
+} {
+  const parsed = parseTemplate(template);
+  if (!parsed.tree || !parsed.tree.rootNodes.length) {
+    return {migrated: template, changed: false, replacementCount: 0, canRemoveCommonModule: false};
+  }
+
+  const visitor = new NgStyleCollector(template, componentNode, typeChecker);
+  visitAll(visitor, parsed.tree.rootNodes, config);
+
+  let newTemplate = template;
+  let changedOffset = 0;
+  let replacementCount = 0;
+
+  for (const {start, end, replacement} of visitor.replacements) {
+    const currentLength = newTemplate.length;
+
+    newTemplate = replaceTemplate(newTemplate, replacement, start, end, changedOffset);
+    changedOffset += newTemplate.length - currentLength;
+    replacementCount++;
+  }
+
+  const changed = newTemplate !== template;
+  return {
+    migrated: newTemplate,
+    changed,
+    replacementCount,
+    canRemoveCommonModule: changed ? canRemoveCommonModule(newTemplate) : false,
+  };
+}
+
+/**
+ * Creates a Replacement to remove `NgStyle` from a component's `imports` array.
+ * Uses ReflectionHost + PartialEvaluator for robust AST analysis.
+ */
+export function createNgStyleImportsArrayRemoval(
+  classNode: ts.ClassDeclaration,
+  file: ProjectFile,
+  typeChecker: ts.TypeChecker,
+  removeCommonModule: boolean,
+): Replacement | null {
+  const reflector = new TypeScriptReflectionHost(typeChecker);
+  const decorators = reflector.getDecoratorsOfDeclaration(classNode);
+  if (!decorators) {
+    return null;
+  }
+
+  const componentDecorator = decorators.find((decorator) => decorator.name === 'Component');
+  if (!componentDecorator?.node) {
+    return null;
+  }
+
+  const decoratorNode = componentDecorator.node;
+  if (
+    !ts.isDecorator(decoratorNode) ||
+    !ts.isCallExpression(decoratorNode.expression) ||
+    decoratorNode.expression.arguments.length === 0 ||
+    !ts.isObjectLiteralExpression(decoratorNode.expression.arguments[0])
+  ) {
+    return null;
+  }
+
+  const metadata = decoratorNode.expression.arguments[0];
+  const importsProperty = metadata.properties.find(
+    (p): p is ts.PropertyAssignment =>
+      ts.isPropertyAssignment(p) && p.name?.getText() === 'imports',
+  );
+
+  if (!importsProperty || !ts.isArrayLiteralExpression(importsProperty.initializer)) {
+    return null;
+  }
+
+  const importsArray = importsProperty.initializer;
+  const elementsToRemove = new Set<string>([ngStyleStr]);
+  if (removeCommonModule) {
+    elementsToRemove.add(commonModuleImportsStr);
+  }
+
+  const originalElements = importsArray.elements;
+  const filteredElements = originalElements.filter(
+    (el) => !ts.isIdentifier(el) || !elementsToRemove.has(el.text),
+  );
+
+  if (filteredElements.length === originalElements.length) {
+    return null; // No changes needed.
+  }
+
+  // If the array becomes empty, remove the entire `imports` property.
+  if (filteredElements.length === 0) {
+    const removalRange = getPropertyRemovalRange(importsProperty);
+    return new Replacement(
+      file,
+      new TextUpdate({
+        position: removalRange.start,
+        end: removalRange.end,
+        toInsert: '',
+      }),
+    );
+  }
+
+  const printer = ts.createPrinter();
+  const newArray = ts.factory.updateArrayLiteralExpression(importsArray, filteredElements);
+  const newText = printer.printNode(ts.EmitHint.Unspecified, newArray, classNode.getSourceFile());
+
+  return new Replacement(
+    file,
+    new TextUpdate({
+      position: importsArray.getStart(),
+      end: importsArray.getEnd(),
+      toInsert: newText,
+    }),
+  );
+}
+
+/**
+ * Calculates the removal range for a property in an object literal,
+ * including the trailing comma if it's not the last property.
+ */
+function getPropertyRemovalRange(property: ts.ObjectLiteralElementLike): {
+  start: number;
+  end: number;
+} {
+  const parent = property.parent;
+  if (!ts.isObjectLiteralExpression(parent)) {
+    return {start: property.getStart(), end: property.getEnd()};
+  }
+
+  const properties = parent.properties;
+  const propertyIndex = properties.indexOf(property);
+  const end = property.getEnd();
+
+  if (propertyIndex < properties.length - 1) {
+    const nextProperty = properties[propertyIndex + 1];
+    return {start: property.getStart(), end: nextProperty.getStart()};
+  }
+
+  return {start: property.getStart(), end};
+}
+
+export function calculateImportReplacements(
+  info: ProgramInfo,
+  sourceFiles: Set<ts.SourceFile>,
+  filesToRemoveCommonModule: Set<ProjectFileID>,
+) {
+  const importReplacements: Record<
+    ProjectFileID,
+    {add: Replacement[]; addAndRemove: Replacement[]}
+  > = {};
+
+  const importManager = new ImportManager();
+  for (const sf of sourceFiles) {
+    const file = projectFile(sf, info);
+
+    // Always remove NgStyle if it's imported directly.
+    importManager.removeImport(sf, ngStyleStr, commonModuleStr);
+
+    // Conditionally remove CommonModule if it's no longer needed.
+    if (filesToRemoveCommonModule.has(file.id)) {
+      importManager.removeImport(sf, commonModuleImportsStr, commonModuleStr);
+    }
+
+    const addRemove: Replacement[] = [];
+    applyImportManagerChanges(importManager, addRemove, [sf], info);
+
+    if (addRemove.length > 0) {
+      importReplacements[file.id] = {
+        add: [],
+        addAndRemove: addRemove,
+      };
+    }
+  }
+
+  return importReplacements;
+}
+
+function replaceTemplate(
+  template: string,
+  replaceValue: string,
+  start: number,
+  end: number,
+  offset: number,
+) {
+  return template.slice(0, start + offset) + replaceValue + template.slice(end + offset);
+}
+
+/**
+ * Visitor class that scans Angular templates and collects replacements
+ * for [ngStyle] bindings that use static object literals.
+ */
+class NgStyleCollector extends RecursiveVisitor {
+  readonly replacements: {start: number; end: number; replacement: string}[] = [];
+  private isNgStyleImported: boolean = true; // Default to true (permissive)
+
+  constructor(
+    private originalTemplate: string,
+    componentNode: ts.ClassDeclaration,
+    typeChecker: ts.TypeChecker,
+  ) {
+    super();
+
+    // If we have enough information, check if NgStyle is actually imported.
+    // If not, we can confidently disable the migration for this component.
+    if (componentNode && typeChecker) {
+      const imports = getImportSpecifiers(componentNode.getSourceFile(), commonModuleStr, [
+        ngStyleStr,
+        commonModuleImportsStr,
+      ]);
+
+      if (imports.length === 0) {
+        this.isNgStyleImported = false;
+      }
+    }
+  }
+
+  override visitElement(element: Element, config: MigrationConfig) {
+    // If NgStyle is not imported, do not attempt to migrate.
+    if (!this.isNgStyleImported) {
+      return;
+    }
+
+    for (const attr of element.attrs) {
+      if (attr.name !== '[ngStyle]' && attr.name !== 'ngStyle') {
+        continue;
+      }
+      if (attr.name === '[ngStyle]' && attr.valueSpan) {
+        const expr = this.originalTemplate.slice(
+          attr.valueSpan.start.offset,
+          attr.valueSpan.end.offset,
+        );
+
+        const staticMatch = parseStaticObjectLiteral(expr);
+
+        if (staticMatch === null) {
+          if (config.bestEffortMode && !isObjectLiteralSyntax(expr.trim())) {
+            const keyReplacement = this.originalTemplate
+              .slice(attr.sourceSpan.start.offset, attr.valueSpan.start.offset)
+              .replace('[ngStyle]', '[style]');
+
+            this.replacements.push({
+              start: attr.sourceSpan.start.offset,
+              end: attr.valueSpan.start.offset,
+              replacement: keyReplacement,
+            });
+          }
+          continue;
+        }
+
+        let replacement: string;
+
+        if (staticMatch.length === 0) {
+          replacement = '';
+        } else if (staticMatch.length === 1) {
+          const {key, value} = staticMatch[0];
+          // Special case: If the key is an empty string, use [style]=""
+          if (key === '') {
+            replacement = '';
+          } else {
+            // Normal single condition: use [style.styleName]="condition"
+            replacement = `[style.${key}]="${value}"`;
+          }
+        } else {
+          replacement = `[style]="${expr}"`;
+        }
+
+        this.replacements.push({
+          start: attr.sourceSpan.start.offset,
+          end: attr.sourceSpan.end.offset,
+          replacement,
+        });
+        continue;
+      }
+
+      if (attr.name === 'ngStyle' && attr.value) {
+        this.replacements.push({
+          start: attr.sourceSpan.start.offset,
+          end: attr.sourceSpan.end.offset,
+          replacement: `style="${attr.value}"`,
+        });
+      }
+    }
+
+    return super.visitElement(element, config);
+  }
+}
+
+function parseStaticObjectLiteral(expr: string): {key: string; value: string}[] | null {
+  const trimmedExpr = expr.trim();
+
+  if (trimmedExpr === '{}' || trimmedExpr === '[]') {
+    return [];
+  }
+
+  if (!isObjectLiteralSyntax(trimmedExpr)) {
+    return null;
+  }
+
+  const objectLiteral = parseAsObjectLiteral(trimmedExpr);
+  if (!objectLiteral) {
+    return null;
+  }
+
+  return extractStyleBindings(objectLiteral);
+}
+
+/**
+ * Validates basic object literal syntax
+ */
+function isObjectLiteralSyntax(expr: string): boolean {
+  return expr.startsWith('{') && expr.endsWith('}');
+}
+
+/**
+ * Parses expression as TypeScript object literal
+ */
+function parseAsObjectLiteral(expr: string): ts.ObjectLiteralExpression | null {
+  const sourceFile = ts.createSourceFile(
+    'temp.ts',
+    `const obj = ${expr}`,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+
+  const variableStatement = sourceFile.statements[0];
+  if (!ts.isVariableStatement(variableStatement)) {
+    return null;
+  }
+
+  const declaration = variableStatement.declarationList.declarations[0];
+  if (!declaration.initializer || !ts.isObjectLiteralExpression(declaration.initializer)) {
+    return null;
+  }
+
+  return declaration.initializer;
+}
+
+function extractStyleBindings(
+  objectLiteral: ts.ObjectLiteralExpression,
+): {key: string; value: string}[] | null {
+  const result: {key: string; value: string}[] = [];
+
+  for (const property of objectLiteral.properties) {
+    if (ts.isShorthandPropertyAssignment(property)) {
+      return null;
+    } else if (ts.isPropertyAssignment(property)) {
+      const keyText = extractPropertyKey(property.name);
+      const valueText = extractPropertyValue(property.initializer);
+
+      if (keyText === '' && valueText) {
+        result.push({key: '', value: valueText});
+        continue;
+      }
+
+      if (!keyText || !valueText) {
+        return null;
+      }
+
+      result.push({key: keyText, value: valueText});
+    } else {
+      return null;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Extracts text from property key (name)
+ */
+function extractPropertyKey(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+    return name.text;
+  }
+  return null;
+}
+
+/**
+ * Extracts text from property value
+ */
+function extractPropertyValue(initializer: ts.Expression): string | null {
+  // String literals: 'value' or "value"
+  if (ts.isStringLiteral(initializer)) {
+    return `'${initializer.text}'`;
+  }
+
+  // Numeric literals: 42, 3.14
+  if (ts.isNumericLiteral(initializer) || ts.isIdentifier(initializer)) {
+    return initializer.text;
+  }
+
+  // Boolean and null keywords
+  if (initializer.kind === ts.SyntaxKind.TrueKeyword) {
+    return 'true';
+  }
+
+  if (initializer.kind === ts.SyntaxKind.FalseKeyword) {
+    return 'false';
+  }
+
+  if (initializer.kind === ts.SyntaxKind.NullKeyword) {
+    return 'null';
+  }
+
+  return initializer.getText();
+}

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -24,6 +24,7 @@ jasmine_test(
         "//packages/core/schematics:schematics_jsons",
         "//packages/core/schematics/migrations/control-flow-migration:static_files",
         "//packages/core/schematics/migrations/ngclass-to-class-migration:static_files",
+        "//packages/core/schematics/migrations/ngstyle-to-style-migration:static_files",
         "//packages/core/schematics/ng-generate/cleanup-unused-imports:static_files",
         "//packages/core/schematics/ng-generate/inject-migration:static_files",
         "//packages/core/schematics/ng-generate/output-migration:static_files",

--- a/packages/core/schematics/test/ngstyle_to_style_migration_spec.ts
+++ b/packages/core/schematics/test/ngstyle_to_style_migration_spec.ts
@@ -1,0 +1,516 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {normalize, virtualFs} from '@angular-devkit/core';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing/index.js';
+import {TempScopedNodeJsSyncHost} from '@angular-devkit/core/node/testing';
+import {HostTree} from '@angular-devkit/schematics';
+import {resolve} from 'path';
+
+describe('NgStyle migration', () => {
+  let runner: SchematicTestRunner;
+  let host: TempScopedNodeJsSyncHost;
+  let tree: UnitTestTree;
+
+  function writeFile(filePath: string, contents: string) {
+    host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
+  }
+
+  function runMigration(options?: {path?: string; bestEffortMode?: boolean}) {
+    return runner.runSchematic('ngstyle-to-style', options, tree);
+  }
+
+  const collectionJsonPath = resolve('../collection.json');
+  beforeEach(() => {
+    runner = new SchematicTestRunner('test', collectionJsonPath);
+    host = new TempScopedNodeJsSyncHost();
+    tree = new UnitTestTree(new HostTree(host));
+    writeFile('/tsconfig.json', '{}');
+    writeFile(
+      '/angular.json',
+      JSON.stringify({
+        version: 1,
+        projects: {t: {root: '', architect: {build: {options: {tsConfig: './tsconfig.json'}}}}},
+      }),
+    );
+  });
+
+  it('should handle a file that is present in multiple projects', async () => {
+    writeFile('/tsconfig-2.json', '{}');
+    writeFile(
+      '/angular.json',
+      JSON.stringify({
+        version: 1,
+        projects: {
+          a: {root: '', architect: {build: {options: {tsConfig: './tsconfig.json'}}}},
+          b: {root: '', architect: {build: {options: {tsConfig: './tsconfig-2.json'}}}},
+        },
+      }),
+    );
+
+    writeFile(
+      '/app.component.ts',
+      `
+        import {Component} from '@angular/core';
+        import {NgStyle} from '@angular/common';
+        @Component({
+        imports: [NgStyle],
+        template: \`
+          <div [ngStyle]="{'background': 'red'}">
+            <p>it works</p>
+          </div>
+        \` })
+        export class Cmp {}
+      `,
+    );
+
+    await runMigration();
+
+    const content = tree.readContent('/app.component.ts');
+
+    expect(content).toContain(`<div [style.background]="'red'">`);
+  });
+
+  describe('No change cases', () => {
+    it('should not change static HTML elements', async () => {
+      writeFile(
+        '/app.component.ts',
+        `
+        import {Component} from '@angular/core';
+        import {NgStyle} from '@angular/common';
+        @Component({
+        imports: [NgStyle],
+        template: \`
+          <button id="123"></button>
+        \` })
+        export class Cmp {}
+      `,
+      );
+
+      await runMigration();
+
+      const content = tree.readContent('/app.component.ts');
+      expect(content).toContain('<button id="123"></button>');
+    });
+
+    it('should not change existing [style] bindings', async () => {
+      writeFile(
+        '/app.component.ts',
+        `
+        import {Component} from '@angular/core';
+
+        @Component({
+        template: \`
+          <div [style.color]="isError ? 'red' : 'green'"></div>
+        \` })
+        export class Cmp {}
+      `,
+      );
+
+      await runMigration();
+
+      const content = tree.readContent('/app.component.ts');
+      expect(content).toContain(`<div [style.color]="isError ? 'red' : 'green'"></div>`);
+    });
+
+    it('should remove ngStyle with empty object', async () => {
+      writeFile(
+        '/app.component.ts',
+        `
+        import {Component} from '@angular/core';
+        import {NgStyle} from '@angular/common';
+        @Component({
+        imports: [NgStyle],
+        template: \`
+          <div [ngStyle]="{}"></div>
+        \` })
+        export class Cmp {}
+      `,
+      );
+
+      await runMigration();
+
+      const content = tree.readContent('/app.component.ts');
+      expect(content).toContain('<div ></div>');
+    });
+
+    it('should remove ngStyle with empty string', async () => {
+      writeFile(
+        '/app.component.ts',
+        `
+        import {Component} from '@angular/core';
+        import {NgStyle} from '@angular/common';
+        @Component({
+        imports: [NgStyle],
+        template: \`
+          <div [ngStyle]="{'': condition}"></div>
+        \` })
+        export class Cmp {}
+      `,
+      );
+
+      await runMigration();
+
+      const content = tree.readContent('/app.component.ts');
+      expect(content).toContain('<div ></div>');
+    });
+
+    it('should not migrate a simple object reference without option', async () => {
+      writeFile(
+        '/app.component.ts',
+        `
+        import {Component} from '@angular/core';
+        import {NgStyle} from '@angular/common';
+        @Component({
+        imports: [NgStyle],
+        template: \`
+          <div [ngStyle]="customObject"></div>
+        \` })
+        export class Cmp {}
+      `,
+      );
+
+      await runMigration();
+
+      const content = tree.readContent('/app.component.ts');
+
+      expect(content).toContain(`<div [ngStyle]="customObject"></div>`);
+    });
+
+    it('should not migrate a shorthand assignment', async () => {
+      writeFile(
+        '/app.component.ts',
+        `
+        import {Component} from '@angular/core';
+        import {NgStyle} from '@angular/common';
+        @Component({
+        imports: [NgStyle],
+        template: \`
+          <div [ngStyle]="{background}"></div>
+        \` })
+        export class Cmp {}
+      `,
+      );
+
+      await runMigration();
+
+      const content = tree.readContent('/app.component.ts');
+
+      expect(content).toContain(`<div [ngStyle]="{background}"></div>`);
+    });
+  });
+
+  describe('Simple ngStyle object migrations', () => {
+    it('should migrate single key object literals', async () => {
+      writeFile(
+        '/app.component.ts',
+        `
+        import {Component} from '@angular/core';
+        import {NgStyle} from '@angular/common';
+        @Component({
+        imports: [NgStyle],
+        template: \`
+          <div [ngStyle]="{ color: isError ? 'red' : 'green' }"></div>
+        \` })
+        export class Cmp {}
+      `,
+      );
+
+      await runMigration();
+
+      const content = tree.readContent('/app.component.ts');
+      expect(content).toContain(`<div [style.color]="isError ? 'red' : 'green'"></div>`);
+    });
+  });
+
+  describe('Complex and multi-element migrations', () => {
+    it('should migrate multi-keys literals', async () => {
+      writeFile(
+        '/app.component.ts',
+        `
+        import {Component} from '@angular/core';
+        import {NgStyle} from '@angular/common';
+        @Component({
+        imports: [NgStyle],
+        template: \`
+          <div [ngStyle]="{ 'color': 'blue', 'font-weight': 'bold' }"></div>
+        \` })
+        export class Cmp {}
+      `,
+      );
+
+      await runMigration();
+
+      const content = tree.readContent('/app.component.ts');
+
+      expect(content).toContain(`<div [style]="{ 'color': 'blue', 'font-weight': 'bold' }">`);
+    });
+  });
+
+  describe('Import array management', () => {
+    it('should keep imports array when NgStyle is removed but other imports remain', async () => {
+      writeFile(
+        '/app.component.ts',
+        `
+        import {Component} from '@angular/core';
+        import {NgStyle, NgFor, NgIf} from '@angular/common';
+        @Component({
+        imports: [NgStyle, NgFor, NgIf],
+        template: \`
+          <div [ngStyle]="{'background': 'red'}">
+            <p *ngFor="let item of items">{{item}}</p>
+          </div>
+        \` })
+        export class Cmp {}
+      `,
+      );
+
+      await runMigration();
+
+      const content = tree.readContent('/app.component.ts');
+
+      expect(content).toContain(`<div [style.background]="'red'">`);
+      expect(content).toContain('imports: [NgFor, NgIf]');
+      expect(content).not.toContain('NgStyle');
+      expect(content).toContain("import {NgFor, NgIf} from '@angular/common';");
+    });
+
+    it('should remove NgStyle from middle of imports array', async () => {
+      writeFile(
+        '/app.component.ts',
+        `
+        import {Component} from '@angular/core';
+        import {NgStyle, NgFor, NgIf} from '@angular/common';
+        @Component({
+        imports: [NgFor, NgStyle, NgIf],
+        template: \`
+          <div [ngStyle]="{'background': 'red'}">
+            <p *ngFor="let item of items">{{item}}</p>
+          </div>
+        \` })
+        export class Cmp {}
+      `,
+      );
+
+      await runMigration();
+
+      const content = tree.readContent('/app.component.ts');
+
+      expect(content).toContain('imports: [NgFor, NgIf]');
+    });
+
+    it('should remove NgStyle from end of imports array', async () => {
+      writeFile(
+        '/app.component.ts',
+        `
+        import {Component} from '@angular/core';
+        import {NgStyle, NgFor, NgIf} from '@angular/common';
+        @Component({
+        imports: [NgFor, NgIf, NgStyle],
+        template: \`
+          <div [ngStyle]="{'background': 'red'}">
+            <p *ngFor="let item of items">{{item}}</p>
+          </div>
+        \` })
+        export class Cmp {}
+      `,
+      );
+
+      await runMigration();
+
+      const content = tree.readContent('/app.component.ts');
+
+      expect(content).toContain('imports: [NgFor, NgIf]');
+    });
+
+    it('should handle multiline imports array formatting', async () => {
+      writeFile(
+        '/app.component.ts',
+        `
+        import {Component} from '@angular/core';
+        import {NgStyle, NgFor, NgIf} from '@angular/common';
+        @Component({
+        imports: [
+          NgFor,
+          NgStyle,
+          NgIf
+        ],
+        template: \`
+          <div [ngStyle]="{'background': 'red'}">
+            <p *ngFor="let item of items">{{item}}</p>
+          </div>
+        \` })
+        export class Cmp {}
+      `,
+      );
+
+      await runMigration();
+
+      const content = tree.readContent('/app.component.ts');
+
+      expect(content).toContain('imports: [');
+      expect(content).toContain('NgFor,');
+      expect(content).toContain('NgIf');
+      expect(content).not.toContain('NgStyle');
+    });
+
+    it('should remove imports and trailing comma with only ngStyle imported', async () => {
+      writeFile(
+        '/app.component.ts',
+        `
+        import {Component} from '@angular/core';
+        import {NgStyle} from '@angular/common';
+
+        @Component({
+        imports: [NgStyle],
+        template: \`<div [ngStyle]="{'background': 'red'}"></div>\`
+        })
+        export class Cmp {}
+      `,
+      );
+
+      await runMigration();
+
+      const content = tree.readContent('/app.component.ts');
+
+      expect(content).toContain(`@Component({
+        template: \`<div [style.background]="'red'"></div>\`
+        })
+        export class Cmp {}`);
+    });
+
+    it('should migrate when NgStyle is provided by CommonModule', async () => {
+      writeFile(
+        '/app.component.ts',
+        `
+        import {Component} from '@angular/core';
+        import {CommonModule} from '@angular/common';
+        @Component({
+          imports: [CommonModule],
+          template: \`
+            <div [ngStyle]="{'background': 'red'}">
+              <p>{{item}}</p>
+            </div>
+          \`
+        })
+        export class Cmp {}
+      `,
+      );
+
+      await runMigration();
+
+      const content = tree.readContent('/app.component.ts');
+
+      expect(content).toContain(`<div [style.background]="'red'">`);
+      expect(content).not.toContain('imports: [CommonModule]');
+      expect(content).not.toContain("import {CommonModule} from '@angular/common';");
+    });
+
+    it('should migrate when NgStyle is provided by CommonModule but not remove CommonModule', async () => {
+      writeFile(
+        '/app.component.ts',
+        `
+        import {Component} from '@angular/core';
+        import {CommonModule} from '@angular/common';
+        @Component({
+          imports: [CommonModule],
+          template: \`
+            <div *ngIf='condition' [ngStyle]="{'background': 'red'}">
+              <p>{{item}}</p>
+            </div>
+          \`
+        })
+        export class Cmp {
+          condition = true;
+        }
+      `,
+      );
+
+      await runMigration();
+
+      const content = tree.readContent('/app.component.ts');
+
+      expect(content).toContain(` <div *ngIf='condition' [style.background]="'red'">`);
+      expect(content).toContain('imports: [CommonModule]');
+      expect(content).toContain("import {CommonModule} from '@angular/common';");
+    });
+  });
+});
+
+describe('NgStyle migration bestEffortMode option', () => {
+  let runner: SchematicTestRunner;
+  let host: TempScopedNodeJsSyncHost;
+  let tree: UnitTestTree;
+
+  function writeFile(filePath: string, contents: string) {
+    host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
+  }
+
+  function runMigration(options?: {path?: string; bestEffortMode?: boolean}) {
+    return runner.runSchematic('ngstyle-to-style', options, tree);
+  }
+
+  const collectionJsonPath = resolve('../collection.json');
+  beforeEach(() => {
+    runner = new SchematicTestRunner('test', collectionJsonPath);
+    host = new TempScopedNodeJsSyncHost();
+    tree = new UnitTestTree(new HostTree(host));
+    writeFile('/tsconfig.json', '{}');
+    writeFile(
+      '/angular.json',
+      JSON.stringify({
+        version: 1,
+        projects: {t: {root: '', architect: {build: {options: {tsConfig: './tsconfig.json'}}}}},
+      }),
+    );
+  });
+
+  it('should migrate a simple object reference', async () => {
+    writeFile(
+      '/app.component.ts',
+      `
+        import {Component} from '@angular/core';
+        import {NgStyle} from '@angular/common';
+        @Component({
+        imports: [NgStyle],
+        template: \`
+          <div [ngStyle]="styleObject"></div>
+        \` })
+        export class Cmp {}
+      `,
+    );
+
+    await runMigration({bestEffortMode: true});
+
+    const content = tree.readContent('/app.component.ts');
+
+    expect(content).toContain(`<div [style]="styleObject"></div>`);
+  });
+
+  it('should migrate a more complex object reference', async () => {
+    writeFile(
+      '/app.component.ts',
+      `
+        import {Component} from '@angular/core';
+        import {NgStyle} from '@angular/common';
+        @Component({
+        imports: [NgStyle],
+        template: \`
+          <div [ngStyle]="isActive ? stylesA : stylesB"></div>
+        \` })
+        export class Cmp {}
+      `,
+    );
+
+    await runMigration({bestEffortMode: true});
+
+    const content = tree.readContent('/app.component.ts');
+
+    expect(content).toContain(`<div [style]="isActive ? stylesA : stylesB"></div>`);
+  });
+});


### PR DESCRIPTION
Add migration to convert ngStyle to use style

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Added Migration Feature to migrate ngStyle to style

Issue Number: N/A


## What is the new behavior?
It'll migrate ngStyle to style bindings to follow the style guide [Prefer style over ngStyle](https://next.angular.dev/style-guide#prefer-class-and-style-over-ngclass-and-ngstyle)

Now
```
<some-element [style]="{'max-width.px': widthExp}" />
```

Before
```
<some-element [ngStyle]="{'max-width.px': widthExp}" />
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
