### PR TITLE
fix(platform-server): prevent false warning for duplicate state serialization

### DIFF
--- a/packages/platform-server/src/transfer_state.ts
+++ b/packages/platform-server/src/transfer_state.ts
@@ -24,7 +24,7 @@ import {BEFORE_APP_SERIALIZED} from './tokens';
 export const TRANSFER_STATE_SERIALIZED_FOR_APPID = new InjectionToken<Set<string>>(
   typeof ngDevMode === 'undefined' || ngDevMode ? 'TRANSFER_STATE_SERIALIZED_FOR_APPID' : '',
   {
-    providedIn: 'platform',
+    providedIn: 'root',
     factory: () => new Set(),
   },
 );
@@ -52,7 +52,7 @@ export function createScript(
   return script;
 }
 
-export function warnIfStateTransferHappened(injector: Injector): void {
+function warnIfStateTransferHappened(injector: Injector): void {
   const appId = injector.get(APP_ID);
   const appIdsWithTransferStateSerialized = injector.get(TRANSFER_STATE_SERIALIZED_FOR_APPID);
 

--- a/packages/platform-server/src/transfer_state.ts
+++ b/packages/platform-server/src/transfer_state.ts
@@ -20,12 +20,12 @@ import {
 
 import {BEFORE_APP_SERIALIZED} from './tokens';
 
-// Tracks whether the server-side application state for a given app ID has been serialized already.
-export const TRANSFER_STATE_SERIALIZED_FOR_APPID = new InjectionToken<Set<string>>(
-  typeof ngDevMode === 'undefined' || ngDevMode ? 'TRANSFER_STATE_SERIALIZED_FOR_APPID' : '',
+/** Tracks whether the server-side application transfer state has already been serialized. */
+const TRANSFER_STATE_STATUS = new InjectionToken<{serialized: boolean}>(
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'TRANSFER_STATE_STATUS' : '',
   {
     providedIn: 'root',
-    factory: () => new Set(),
+    factory: () => ({serialized: false}),
   },
 );
 
@@ -53,10 +53,9 @@ export function createScript(
 }
 
 function warnIfStateTransferHappened(injector: Injector): void {
-  const appId = injector.get(APP_ID);
-  const appIdsWithTransferStateSerialized = injector.get(TRANSFER_STATE_SERIALIZED_FOR_APPID);
+  const transferStateStatus = injector.get(TRANSFER_STATE_STATUS);
 
-  if (appIdsWithTransferStateSerialized.has(appId)) {
+  if (transferStateStatus.serialized) {
     console.warn(
       `Angular detected an incompatible configuration, which causes duplicate serialization of the server-side application state.\n\n` +
         `This can happen if the server providers have been provided more than once using different mechanisms. For example:\n\n` +
@@ -65,7 +64,8 @@ function warnIfStateTransferHappened(injector: Injector): void {
         `To fix this, ensure that the \`provideServerRendering()\` function is the only provider used and remove the other(s).`,
     );
   }
-  appIdsWithTransferStateSerialized.add(appId);
+
+  transferStateStatus.serialized = true;
 }
 
 function serializeTransferStateFactory() {


### PR DESCRIPTION

The `TRANSFER_STATE_SERIALIZED_FOR_APPID` provider was previously configured at the platform level, causing its state to be shared across all concurrent server-side rendering requests. This created a race condition where one request could see the `appId` from a different, concurrent request, leading to false warnings about duplicate state serialization.

This commit changes the provider's scope to ensure that each application instance gets its own unique state. This correctly isolates the serialization check to each individual request, resolving the issue of false warnings in concurrent environments.

Closes #63524
