### PR TITLE
refactor(platform-browser): remove deprecated `ApplicationConfig` export

### DIFF
--- a/goldens/public-api/platform-browser/index.api.md
+++ b/goldens/public-api/platform-browser/index.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import { ApplicationConfig as ApplicationConfig_2 } from '@angular/core';
+import { ApplicationConfig } from '@angular/core';
 import { ApplicationRef } from '@angular/core';
 import { ComponentRef } from '@angular/core';
 import { DebugElement } from '@angular/core';
@@ -24,9 +24,6 @@ import { SecurityContext } from '@angular/core';
 import { StaticProvider } from '@angular/core';
 import { Type } from '@angular/core';
 import { Version } from '@angular/core';
-
-// @public @deprecated
-export type ApplicationConfig = ApplicationConfig_2;
 
 // @public
 export function bootstrapApplication(rootComponent: Type<unknown>, options?: ApplicationConfig): Promise<ApplicationRef>;

--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -110,6 +110,10 @@ bundle_entrypoints = [
         "router-last-successful-navigation",
         "packages/core/schematics/migrations/router-last-successful-navigation/index.js",
     ],
+    [
+        "application-config-core",
+        "packages/core/schematics/migrations/application-config-core/index.js",
+    ],
 ]
 
 rollup.rollup(
@@ -121,6 +125,7 @@ rollup.rollup(
         "//:node_modules/magic-string",
         "//:node_modules/semver",
         "//packages/core/schematics:tsconfig_build",
+        "//packages/core/schematics/migrations/application-config-core",
         "//packages/core/schematics/migrations/control-flow-migration",
         "//packages/core/schematics/migrations/ngclass-to-class-migration",
         "//packages/core/schematics/migrations/router-current-navigation",

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -16,6 +16,11 @@
       "version": "21.0.0",
       "description": "Ensures that the Router.lastSuccessfulNavigation signal is now invoked",
       "factory": "./bundles/router-last-successful-navigation.cjs#migrate"
+    },
+    "application-config-core": {
+      "version": "21.0.0",
+      "description": "Moves imports of `ApplicationConfig` from `@angular/platform-browser` to `@angular/core`",
+      "factory": "./bundles/application-config-core.cjs#migrate"
     }
   }
 }

--- a/packages/core/schematics/migrations/application-config-core/BUILD.bazel
+++ b/packages/core/schematics/migrations/application-config-core/BUILD.bazel
@@ -1,0 +1,22 @@
+load("//tools:defaults.bzl", "ts_project")
+
+package(
+    default_visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+)
+
+ts_project(
+    name = "application-config-core",
+    srcs = glob(["**/*.ts"]),
+    deps = [
+        "//:node_modules/@angular-devkit/schematics",
+        "//:node_modules/typescript",
+        "//packages/compiler-cli/private",
+        "//packages/compiler-cli/src/ngtsc/file_system",
+        "//packages/core/schematics/utils",
+        "//packages/core/schematics/utils/tsurge",
+        "//packages/core/schematics/utils/tsurge/helpers/angular_devkit",
+    ],
+)

--- a/packages/core/schematics/migrations/application-config-core/application-config-core-migration.ts
+++ b/packages/core/schematics/migrations/application-config-core/application-config-core-migration.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {ImportManager} from '@angular/compiler-cli/private/migrations';
+import {applyImportManagerChanges} from '../../utils/tsurge/helpers/apply_import_manager';
+import {
+  confirmAsSerializable,
+  ProgramInfo,
+  Replacement,
+  Serializable,
+  TsurgeFunnelMigration,
+} from '../../utils/tsurge';
+import {getImportSpecifier} from '../../utils/typescript/imports';
+
+export interface CompilationUnitData {
+  replacements: Replacement[];
+}
+
+/** Migration that moves the import of `ApplicationConfig` from `platform-browser` to `core`. */
+export class ApplicationConfigCoreMigration extends TsurgeFunnelMigration<
+  CompilationUnitData,
+  CompilationUnitData
+> {
+  override async analyze(info: ProgramInfo): Promise<Serializable<CompilationUnitData>> {
+    const replacements: Replacement[] = [];
+    let importManager: ImportManager | null = null;
+
+    for (const sourceFile of info.sourceFiles) {
+      const specifier = getImportSpecifier(
+        sourceFile,
+        '@angular/platform-browser',
+        'ApplicationConfig',
+      );
+      if (!specifier) {
+        continue;
+      }
+
+      importManager ??= new ImportManager({
+        // Prevent the manager from trying to generate a non-conflicting import.
+        generateUniqueIdentifier: () => null,
+        shouldUseSingleQuotes: () => true,
+      });
+
+      importManager.removeImport(sourceFile, 'ApplicationConfig', '@angular/platform-browser');
+      importManager.addImport({
+        exportSymbolName: 'ApplicationConfig',
+        exportModuleSpecifier: '@angular/core',
+        requestedFile: sourceFile,
+        unsafeAliasOverride: specifier.propertyName ? specifier.name.text : undefined,
+      });
+    }
+
+    if (importManager !== null) {
+      applyImportManagerChanges(importManager, replacements, info.sourceFiles, info);
+    }
+
+    return confirmAsSerializable({replacements});
+  }
+
+  override async migrate(globalData: CompilationUnitData) {
+    return confirmAsSerializable(globalData);
+  }
+
+  override async combine(
+    unitA: CompilationUnitData,
+    unitB: CompilationUnitData,
+  ): Promise<Serializable<CompilationUnitData>> {
+    const seen = new Set<string>();
+    const combined: Replacement[] = [];
+
+    [unitA.replacements, unitB.replacements].forEach((replacements) => {
+      replacements.forEach((current) => {
+        const {position, end, toInsert} = current.update.data;
+        const key = current.projectFile.id + '/' + position + '/' + end + '/' + toInsert;
+
+        if (!seen.has(key)) {
+          seen.add(key);
+          combined.push(current);
+        }
+      });
+    });
+
+    return confirmAsSerializable({replacements: combined});
+  }
+
+  override async globalMeta(
+    combinedData: CompilationUnitData,
+  ): Promise<Serializable<CompilationUnitData>> {
+    return confirmAsSerializable(combinedData);
+  }
+
+  override async stats() {
+    return confirmAsSerializable({});
+  }
+}

--- a/packages/core/schematics/migrations/application-config-core/index.ts
+++ b/packages/core/schematics/migrations/application-config-core/index.ts
@@ -1,0 +1,20 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Rule} from '@angular-devkit/schematics';
+import {ApplicationConfigCoreMigration} from './application-config-core-migration';
+import {runMigrationInDevkit} from '../../utils/tsurge/helpers/angular_devkit';
+
+export function migrate(): Rule {
+  return async (tree) => {
+    await runMigrationInDevkit({
+      tree,
+      getMigration: () => new ApplicationConfigCoreMigration(),
+    });
+  };
+}

--- a/packages/core/schematics/test/application_config_core_spec.ts
+++ b/packages/core/schematics/test/application_config_core_spec.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {getSystemPath, normalize, virtualFs} from '@angular-devkit/core';
+import {TempScopedNodeJsSyncHost} from '@angular-devkit/core/node/testing';
+import {HostTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing/index.js';
+import {resolve} from 'node:path';
+import shx from 'shelljs';
+
+describe('application-config migration', () => {
+  let runner: SchematicTestRunner;
+  let host: TempScopedNodeJsSyncHost;
+  let tree: UnitTestTree;
+  let tmpDirPath: string;
+
+  function writeFile(filePath: string, contents: string) {
+    host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
+  }
+
+  function runMigration() {
+    return runner.runSchematic('application-config-core', {}, tree);
+  }
+
+  const migrationsJsonPath = resolve('../migrations.json');
+  beforeEach(() => {
+    runner = new SchematicTestRunner('test', migrationsJsonPath);
+    host = new TempScopedNodeJsSyncHost();
+    tree = new UnitTestTree(new HostTree(host));
+    tmpDirPath = getSystemPath(host.root);
+
+    writeFile('/tsconfig.json', '{}');
+    writeFile(
+      '/angular.json',
+      JSON.stringify({
+        version: 1,
+        projects: {t: {root: '', architect: {build: {options: {tsConfig: './tsconfig.json'}}}}},
+      }),
+    );
+
+    shx.cd(tmpDirPath);
+  });
+
+  it('should migrate an import of ApplicationConfig', async () => {
+    writeFile(
+      '/dir.ts',
+      `
+        import { Directive, inject } from '@angular/core';
+        import { ApplicationConfig } from '@angular/platform-browser';
+      `,
+    );
+
+    await runMigration();
+    const content = tree.readContent('/dir.ts');
+    expect(content).toContain(
+      `import { Directive, inject, ApplicationConfig } from '@angular/core';`,
+    );
+    expect(content).not.toContain(`@angular/platform-browser`);
+  });
+
+  it('should migrate an aliased import of ApplicationConfig', async () => {
+    writeFile(
+      '/dir.ts',
+      `
+        import { Directive, inject } from '@angular/core';
+        import { ApplicationConfig as ApplicationConfigAlias } from '@angular/platform-browser';
+      `,
+    );
+
+    await runMigration();
+    const content = tree.readContent('/dir.ts');
+    expect(content).toContain(
+      `import { Directive, inject, ApplicationConfig as ApplicationConfigAlias } from '@angular/core';`,
+    );
+    expect(content).not.toContain(`@angular/platform-browser`);
+  });
+
+  it('should migrate a file that does not import @angular/core', async () => {
+    writeFile(
+      '/dir.ts',
+      `
+        import { ApplicationConfig } from '@angular/platform-browser';
+      `,
+    );
+
+    await runMigration();
+    const content = tree.readContent('/dir.ts');
+    expect(content).toContain(`import { ApplicationConfig } from '@angular/core';`);
+    expect(content).not.toContain(`@angular/platform-browser`);
+  });
+});

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -13,7 +13,7 @@ import {
   ɵPLATFORM_BROWSER_ID as PLATFORM_BROWSER_ID,
 } from '@angular/common';
 import {
-  ApplicationConfig as ApplicationConfigFromCore,
+  ApplicationConfig,
   ApplicationModule,
   ApplicationRef,
   createPlatformFactory,
@@ -50,18 +50,6 @@ import {EVENT_MANAGER_PLUGINS, EventManager} from './dom/events/event_manager';
 import {KeyEventsPlugin} from './dom/events/key_events';
 import {SharedStylesHost} from './dom/shared_styles_host';
 import {RuntimeErrorCode} from './errors';
-
-/**
- * Set of config options available during the application bootstrap operation.
- *
- * @publicApi
- *
- * @deprecated
- * `ApplicationConfig` has moved, please import `ApplicationConfig` from `@angular/core` instead.
- */
-// The below is a workaround to add a deprecated message.
-type ApplicationConfig = ApplicationConfigFromCore;
-export {ApplicationConfig};
 
 /**
  * Bootstraps an instance of an Angular application and renders a standalone component as the

--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -7,7 +7,6 @@
  */
 
 export {
-  ApplicationConfig,
   bootstrapApplication,
   BrowserModule,
   createApplication,


### PR DESCRIPTION
Removes the deprecated `ApplicationConfig` export from `@angular/platform-browser`. This export was deprecated in a prior version and developers should import `ApplicationConfig` from `@angular/core` instead.

BREAKING CHANGE:

The deprecated `ApplicationConfig` export from `@angular/platform-browser` has been removed. Please import `ApplicationConfig` from `@angular/core` instead.
