### PR TITLE
fix(devtools): runtime errors caused by tree node snapping and tab change

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer-host/tree-visualizer.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer-host/tree-visualizer.ts
@@ -313,7 +313,7 @@ export class TreeVisualizer<T extends TreeNode = TreeNode> extends GraphRenderer
     const debouncer = new Debouncer();
     const resizeObserver = new ResizeObserver(
       debouncer.debounce(([entry]) => {
-        if (!entry || !this.snappedNode) {
+        if (!entry || !entry.contentRect.width || !entry.contentRect.height || !this.snappedNode) {
           return;
         }
         // Avoid executing the code on observer init.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## What is the new behavior?

Fix the runtime errors caused by the tree visualizer node auto-snapping when a tab is changed. The errors are caused since we only visually hide the tabs.