### PR TITLE
feat(compiler): Remove support for non-null assertions from two-way b…

### DIFF
--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -851,7 +851,7 @@ export class BindingParser {
     }
 
     if (ast instanceof NonNullAssert) {
-      return this._isAllowedAssignmentEvent(ast.expression);
+      return false;
     }
 
     if (
@@ -866,7 +866,7 @@ export class BindingParser {
     }
 
     if (ast instanceof PropertyRead || ast instanceof KeyedRead) {
-      if (!hasRecursiveSafeReceiver(ast)) {
+      if (!hasRecursiveSafeOrNonNullReceiver(ast)) {
         return true;
       }
     }
@@ -875,17 +875,21 @@ export class BindingParser {
   }
 }
 
-function hasRecursiveSafeReceiver(ast: AST): boolean {
+function hasRecursiveSafeOrNonNullReceiver(ast: AST): boolean {
   if (ast instanceof SafePropertyRead || ast instanceof SafeKeyedRead) {
     return true;
   }
 
   if (ast instanceof ParenthesizedExpression) {
-    return hasRecursiveSafeReceiver(ast.expression);
+    return hasRecursiveSafeOrNonNullReceiver(ast.expression);
   }
 
   if (ast instanceof PropertyRead || ast instanceof KeyedRead || ast instanceof Call) {
-    return hasRecursiveSafeReceiver(ast.receiver);
+    return hasRecursiveSafeOrNonNullReceiver(ast.receiver);
+  }
+
+  if (ast instanceof NonNullAssert) {
+    return true;
   }
 
   return false;

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -610,12 +610,16 @@ describe('R3 template transform', () => {
       ]);
     });
 
-    it('should parse bound events and properties via [(...)] with non-null operator', () => {
-      expectFromHtml('<div [(prop)]="v!"></div>').toEqual([
-        ['Element', 'div'],
-        ['BoundAttribute', BindingType.TwoWay, 'prop', 'v!'],
-        ['BoundEvent', ParsedEventType.TwoWay, 'propChange', null, 'v!'],
-      ]);
+    it('should report unsupported 2-way binding with non-null assertion operator', () => {
+      expect(() => parse(`<div [(prop)]="v!"></div>`)).toThrowError(
+        /Unsupported expression in a two-way binding/,
+      );
+    });
+
+    it('should report unsupported 2-way binding with non-null operator', () => {
+      expect(() => parse(`<div [(prop)]="a.b!.c"></div>`)).toThrowError(
+        /Unsupported expression in a two-way binding/,
+      );
     });
 
     it('should parse property reads bound via [(...)]', () => {


### PR DESCRIPTION
…indings

Typechecking for those expression is non-obvious and developers should be using separate input/output bindings

BREAKIND CHANGE: Use separate input/output bindings instead.

fixes #59116

WIP: Will require a cleanup first. 