### PR TITLE
refactor(router): Add handling for empty observables in guards

### DIFF
--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -39,6 +39,7 @@ import {
 } from './utils/config_matching';
 import {TreeNode} from './utils/tree';
 import {firstValueFrom} from './utils/first_value_from';
+import {isEmptyError} from './utils/type_guards';
 
 /**
  * Class used to indicate there were no additional route config matches but that all segments of
@@ -257,7 +258,7 @@ export class Recognizer {
           parentRoute,
         );
       } catch (e: any) {
-        if (e?.name === NO_MATCH_ERROR_NAME) {
+        if (e?.name === NO_MATCH_ERROR_NAME || isEmptyError(e)) {
           continue;
         }
         throw e;

--- a/packages/router/test/integration/guards.spec.ts
+++ b/packages/router/test/integration/guards.spec.ts
@@ -17,7 +17,7 @@ import {
   EnvironmentInjector,
 } from '@angular/core';
 import {TestBed, ComponentFixture} from '@angular/core/testing';
-import {Subject, Observable, of, concat} from 'rxjs';
+import {Subject, Observable, of, concat, EMPTY} from 'rxjs';
 import {tap, mapTo, first, takeWhile, last, switchMap} from 'rxjs/operators';
 import {
   ActivatedRouteSnapshot,
@@ -2038,6 +2038,22 @@ export function guardsIntegrationSuite() {
           {
             path: 'a',
             canMatch: [() => inject(ConfigurableGuard).canMatch()],
+            component: BlankCmp,
+          },
+          {path: 'a', component: SimpleCmp},
+        ]);
+        const fixture = await createRoot(router, RootCmp);
+
+        router.navigateByUrl('/a');
+        await advance(fixture);
+        expect(fixture.nativeElement.innerHTML).toContain('simple');
+      });
+      it('falls back to second route when canMatch returns EMPTY', async () => {
+        const router = TestBed.inject(Router);
+        router.resetConfig([
+          {
+            path: 'a',
+            canMatch: [() => EMPTY],
             component: BlankCmp,
           },
           {path: 'a', component: SimpleCmp},


### PR DESCRIPTION
This fixes a bug introduced in #63485 where `firstValueFrom` was used. This doesn't work in all situations here because some observables don't emit before completing. These errors should result in the route matching logic moving on to the next route.

Note: This is marked as a refactor rather than fix because the commit above is not in any release yet.
