### PR TITLE
refactor(core): prevent input migration from introducing a breaking c…

### DIFF
--- a/packages/core/schematics/migrations/signal-migration/src/input_detection/input_decorator.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/input_detection/input_decorator.ts
@@ -158,7 +158,14 @@ function extractSourceCodeInput(
         isRequired = !!evaluatedInputOpts.get('required');
       }
       if (evaluatedInputOpts.has('transform') && evaluatedInputOpts.get('transform') != null) {
-        transformResult = parseTransformOfInput(evaluatedInputOpts, node, reflector);
+        const result = parseTransformOfInput(evaluatedInputOpts, node, reflector);
+        if (result === 'parsingError') {
+          if (!host.config.bestEffortMode) {
+            return null;
+          }
+        } else {
+          transformResult = result;
+        }
       }
     }
   }
@@ -183,7 +190,7 @@ function parseTransformOfInput(
   evaluatedInputOpts: ResolvedValueMap,
   node: InputNode,
   reflector: ReflectionHost,
-): DecoratorInputTransform | null {
+): DecoratorInputTransform | 'parsingError' | null {
   const transformValue = evaluatedInputOpts.get('transform');
   if (!(transformValue instanceof DynamicValue) && !(transformValue instanceof Reference)) {
     return null;
@@ -220,6 +227,6 @@ function parseTransformOfInput(
     // TODO: implement error handling.
     // See failing case: e.g. inherit_definition_feature_spec.ts
     console.error(`${e.node.getSourceFile().fileName}: ${e.toString()}`);
-    return null;
+    return 'parsingError';
   }
 }

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/transform_no_explicit_types.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/transform_no_explicit_types.ts
@@ -1,0 +1,7 @@
+// tslint:disable
+
+import {Input} from '@angular/core';
+
+export class TransformFunctions {
+  @Input({transform: (v) => v * 10}) untypedTransform: number = 0;
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden.txt
@@ -1418,6 +1418,15 @@ class TransformIncompatibleTypes {
   //  cast. This worked previously because Angular was unable to check transforms.
   readonly disabled = input<boolean, unknown>(undefined, { transform: ((v: unknown) => (v === null ? undefined : !!v)) as any });
 }
+@@@@@@ transform_no_explicit_types.ts @@@@@@
+
+// tslint:disable
+
+import {Input} from '@angular/core';
+
+export class TransformFunctions {
+  @Input({transform: (v) => v * 10}) untypedTransform: number = 0;
+}
 @@@@@@ with_getters.ts @@@@@@
 
 // tslint:disable

--- a/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
@@ -1357,6 +1357,15 @@ class TransformIncompatibleTypes {
   //  cast. This worked previously because Angular was unable to check transforms.
   readonly disabled = input<boolean, unknown>(undefined, { transform: ((v: unknown) => (v === null ? undefined : !!v)) as any });
 }
+@@@@@@ transform_no_explicit_types.ts @@@@@@
+
+// tslint:disable
+
+import {input} from '@angular/core';
+
+export class TransformFunctions {
+  readonly untypedTransform = input<number>(0);
+}
 @@@@@@ with_getters.ts @@@@@@
 
 // tslint:disable


### PR DESCRIPTION
…hange

Non-typed `transform` functions were stripped by the migration prior to this commit (while still logging an error). This behavior will now only happen with `--best-effort`.

#63541
