### PR TITLE
refactor(forms): remove checked restriction on FormValueControl

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -216,7 +216,6 @@ export interface FormUiControl {
 
 // @public
 export interface FormValueControl<TValue> extends FormUiControl {
-    readonly checked?: undefined;
     readonly value: ModelSignal<TValue>;
 }
 

--- a/packages/forms/signals/src/api/control.ts
+++ b/packages/forms/signals/src/api/control.ts
@@ -12,10 +12,6 @@ import {ValidationError, type WithOptionalField} from './validation_errors';
 
 /** The base set of properties shared by all form control contracts. */
 export interface FormUiControl {
-  // TODO: `ValidationError` and `DisabledReason` are inherently tied to the signal forms system.
-  // They don't make sense when using a ccontrol separately from the forms system and setting the
-  // inputs individually. Givn that, should they still be part of this interface?
-
   /**
    * An input to receive the errors for the field. If implemented, the `Control` directive will
    * automatically bind errors from the bound field to this input.
@@ -115,15 +111,6 @@ export interface FormValueControl<TValue> extends FormUiControl {
    * sync with the value of the bound `Field`.
    */
   readonly value: ModelSignal<TValue>;
-  // TODO: We currently require that a `checked` input not be present, as we may want to introduce a
-  // third kind of form control for radio buttons that defines both a `value` and `checked` input.
-  // We are still evaluating whether this makes sense, but if we decide not to persue this we can
-  // remove this restriction.
-  /**
-   * The implementing component *must not* define a `checked` property. This is reserved for
-   * components that want to integrate with the `Control` directive as a checkbox.
-   */
-  readonly checked?: undefined;
 }
 
 /**

--- a/packages/forms/signals/test/web/control_directive.spec.ts
+++ b/packages/forms/signals/test/web/control_directive.spec.ts
@@ -572,6 +572,36 @@ describe('control directive', () => {
       [...fix.nativeElement.querySelectorAll('.disabled-reason')].map((e) => e.textContent),
     ).toEqual(['manual disabled', 'schema disabled']);
   });
+
+  it('should work when checked is defined on FormValueControl', () => {
+    @Component({
+      selector: 'my-input',
+      template: '<input #i [value]="value()" (input)="value.set(i.value)" />',
+    })
+    class CustomInput implements FormValueControl<string> {
+      value = model('');
+      checked = input(false);
+    }
+
+    @Component({
+      imports: [Control, CustomInput],
+      template: `<my-input [control]="f" [checked]="true" />`,
+    })
+    class TestCmp {
+      f = form<string>(signal('test'));
+      myInput = viewChild.required(CustomInput);
+    }
+
+    const fix = act(() => TestBed.createComponent(TestCmp));
+    const inputEl = fix.nativeElement.querySelector('input');
+    expect(inputEl.value).toEqual('test');
+
+    act(() => {
+      inputEl.value = 'new';
+      inputEl.dispatchEvent(new Event('input'));
+    });
+    expect(fix.componentInstance.f().value()).toEqual('new');
+  });
 });
 
 function setupRadioGroup() {


### PR DESCRIPTION
We don't need to prevent the user from defining a `checked` property. If `value` is defined it will be used regardless of if `checked` is defined.

