### PR TITLE
fix(platform-server): pass platform injector to bootstrap in `renderApplication`

### DIFF
--- a/goldens/public-api/platform-browser/index.api.md
+++ b/goldens/public-api/platform-browser/index.api.md
@@ -14,6 +14,7 @@ import { HttpTransferCacheOptions } from '@angular/common/http';
 import * as i0 from '@angular/core';
 import * as i1 from '@angular/common';
 import { InjectionToken } from '@angular/core';
+import { Injector } from '@angular/core';
 import { ListenerOptions } from '@angular/core';
 import { NgZone } from '@angular/core';
 import { PlatformRef } from '@angular/core';
@@ -26,7 +27,7 @@ import { Type } from '@angular/core';
 import { Version } from '@angular/core';
 
 // @public
-export function bootstrapApplication(rootComponent: Type<unknown>, options?: ApplicationConfig): Promise<ApplicationRef>;
+export function bootstrapApplication(rootComponent: Type<unknown>, options?: ApplicationConfig, platformInjector?: Injector): Promise<ApplicationRef>;
 
 // @public
 export class BrowserModule {

--- a/goldens/public-api/platform-browser/index.api.md
+++ b/goldens/public-api/platform-browser/index.api.md
@@ -14,7 +14,6 @@ import { HttpTransferCacheOptions } from '@angular/common/http';
 import * as i0 from '@angular/core';
 import * as i1 from '@angular/common';
 import { InjectionToken } from '@angular/core';
-import { Injector } from '@angular/core';
 import { ListenerOptions } from '@angular/core';
 import { NgZone } from '@angular/core';
 import { PlatformRef } from '@angular/core';
@@ -27,7 +26,7 @@ import { Type } from '@angular/core';
 import { Version } from '@angular/core';
 
 // @public
-export function bootstrapApplication(rootComponent: Type<unknown>, options?: ApplicationConfig, platformInjector?: Injector): Promise<ApplicationRef>;
+export function bootstrapApplication(rootComponent: Type<unknown>, options?: ApplicationConfig): Promise<ApplicationRef>;
 
 // @public
 export class BrowserModule {

--- a/goldens/public-api/platform-server/index.api.md
+++ b/goldens/public-api/platform-server/index.api.md
@@ -4,11 +4,13 @@
 
 ```ts
 
+import { ApplicationConfig } from '@angular/core';
 import { ApplicationRef } from '@angular/core';
 import { EnvironmentProviders } from '@angular/core';
 import * as i0 from '@angular/core';
 import * as i1 from '@angular/platform-browser';
 import { InjectionToken } from '@angular/core';
+import { Injector } from '@angular/core';
 import { PlatformRef } from '@angular/core';
 import { Provider } from '@angular/core';
 import { StaticProvider } from '@angular/core';
@@ -17,6 +19,9 @@ import { Version } from '@angular/core';
 
 // @public
 export const BEFORE_APP_SERIALIZED: InjectionToken<readonly (() => void | Promise<void>)[]>;
+
+// @public
+export function bootstrapServerApplication(rootComponent: Type<unknown>, options: ApplicationConfig): (platformInjector: Injector) => Promise<ApplicationRef>;
 
 // @public
 export const INITIAL_CONFIG: InjectionToken<PlatformConfig>;
@@ -45,7 +50,7 @@ export class PlatformState {
 export function provideServerRendering(): EnvironmentProviders;
 
 // @public
-export function renderApplication<T>(bootstrap: () => Promise<ApplicationRef>, options: {
+export function renderApplication<T>(bootstrap: ReturnType<typeof bootstrapServerApplication> | (() => Promise<ApplicationRef>), options: {
     document?: string | Document;
     url?: string;
     platformProviders?: Provider[];

--- a/packages/core/src/application/create_application.ts
+++ b/packages/core/src/application/create_application.ts
@@ -21,6 +21,8 @@ import {bootstrap} from '../platform/bootstrap';
 import {profiler} from '../render3/profiler';
 import {ProfilerEvent} from '../render3/profiler_types';
 import {errorHandlerEnvironmentInitializer} from '../error_handler';
+import {RuntimeError, RuntimeErrorCode} from '../errors';
+import {Injector} from '../di';
 
 /**
  * Internal create application API that implements the core application creation logic and optional
@@ -38,16 +40,20 @@ export function internalCreateApplication(config: {
   rootComponent?: Type<unknown>;
   appProviders?: Array<Provider | EnvironmentProviders>;
   platformProviders?: Provider[];
+  platformInjector?: Injector;
 }): Promise<ApplicationRef> {
   profiler(ProfilerEvent.BootstrapApplicationStart);
   try {
-    const {rootComponent, appProviders, platformProviders} = config;
+    const {
+      rootComponent,
+      appProviders,
+      platformProviders,
+      platformInjector = createOrReusePlatformInjector(platformProviders as StaticProvider[]),
+    } = config;
 
     if ((typeof ngDevMode === 'undefined' || ngDevMode) && rootComponent !== undefined) {
       assertStandaloneComponentType(rootComponent);
     }
-
-    const platformInjector = createOrReusePlatformInjector(platformProviders as StaticProvider[]);
 
     // Create root application injector based on a set of providers configured at the platform
     // bootstrap level as well as providers passed to the bootstrap call by a user.

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -360,6 +360,7 @@
       "bloomHashBitOrFactory",
       "bootstrap",
       "bootstrapApplication",
+      "bootstrapApplicationInternal",
       "borrowReactiveLViewConsumer",
       "buildAnimationAst",
       "buildAnimationTimelines",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -41,6 +41,7 @@
       "addServerStyles",
       "baseElement",
       "bootstrapApplication",
+      "bootstrapApplicationInternal",
       "createLinkElement",
       "createProvidersConfig",
       "createStyleElement",

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -320,6 +320,7 @@
       "bloomHashBitOrFactory",
       "bootstrap",
       "bootstrapApplication",
+      "bootstrapApplicationInternal",
       "borrowReactiveLViewConsumer",
       "cacheMatchingLocalNames",
       "calcSerializedContainerSize",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -439,6 +439,7 @@
       "booleanAttribute",
       "bootstrap",
       "bootstrapApplication",
+      "bootstrapApplicationInternal",
       "borrowReactiveLViewConsumer",
       "cacheMatchingLocalNames",
       "callHook",

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -263,6 +263,7 @@
       "bloomHashBitOrFactory",
       "bootstrap",
       "bootstrapApplication",
+      "bootstrapApplicationInternal",
       "borrowReactiveLViewConsumer",
       "cacheMatchingLocalNames",
       "callHook",

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -39,6 +39,7 @@ import {
   ɵTESTABILITY_GETTER as TESTABILITY_GETTER,
   inject,
   ɵresolveComponentResources as resolveComponentResources,
+  Injector,
 } from '@angular/core';
 
 import {BrowserDomAdapter} from './browser/browser_adapter';
@@ -106,6 +107,7 @@ import {RuntimeErrorCode} from './errors';
  * @param rootComponent A reference to a standalone component that should be rendered.
  * @param options Extra configuration for the bootstrap operation, see `ApplicationConfig` for
  *     additional info.
+ * @param platformInjector The parent `Injector`.
  * @returns A promise that returns an `ApplicationRef` instance once resolved.
  *
  * @publicApi
@@ -113,8 +115,9 @@ import {RuntimeErrorCode} from './errors';
 export function bootstrapApplication(
   rootComponent: Type<unknown>,
   options?: ApplicationConfig,
+  platformInjector?: Injector,
 ): Promise<ApplicationRef> {
-  const config = {rootComponent, ...createProvidersConfig(options)};
+  const config = {rootComponent, platformInjector, ...createProvidersConfig(options)};
 
   // Attempt to resolve component resources before bootstrapping in JIT mode,
   // however don't interrupt the bootstrapping process.

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -107,12 +107,18 @@ import {RuntimeErrorCode} from './errors';
  * @param rootComponent A reference to a standalone component that should be rendered.
  * @param options Extra configuration for the bootstrap operation, see `ApplicationConfig` for
  *     additional info.
- * @param platformInjector The parent `Injector`.
  * @returns A promise that returns an `ApplicationRef` instance once resolved.
  *
  * @publicApi
  */
 export function bootstrapApplication(
+  rootComponent: Type<unknown>,
+  options?: ApplicationConfig,
+): Promise<ApplicationRef> {
+  return bootstrapApplicationInternal(rootComponent, options);
+}
+
+export function bootstrapApplicationInternal(
   rootComponent: Type<unknown>,
   options?: ApplicationConfig,
   platformInjector?: Injector,

--- a/packages/platform-browser/src/private_export.ts
+++ b/packages/platform-browser/src/private_export.ts
@@ -16,3 +16,4 @@ export {KeyEventsPlugin as ɵKeyEventsPlugin} from './dom/events/key_events';
 export {SharedStylesHost as ɵSharedStylesHost} from './dom/shared_styles_host';
 export {RuntimeErrorCode as ɵRuntimeErrorCode} from './errors';
 export {DomSanitizerImpl as ɵDomSanitizerImpl} from './security/dom_sanitization_service';
+export {bootstrapApplicationInternal as ɵbootstrapApplicationInternal} from './browser';

--- a/packages/platform-server/src/platform-server.ts
+++ b/packages/platform-server/src/platform-server.ts
@@ -8,7 +8,7 @@
 
 export {PlatformState} from './platform_state';
 export {provideServerRendering} from './provide_server';
-export {platformServer, ServerModule} from './server';
+export {platformServer, ServerModule, bootstrapServerApplication} from './server';
 export {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, PlatformConfig} from './tokens';
 export {renderApplication, renderModule} from './utils';
 

--- a/packages/platform-server/src/server.ts
+++ b/packages/platform-server/src/server.ts
@@ -15,6 +15,8 @@ import {
   ɵPLATFORM_SERVER_ID as PLATFORM_SERVER_ID,
 } from '@angular/common';
 import {
+  ApplicationConfig,
+  ApplicationRef,
   createPlatformFactory,
   Injector,
   NgModule,
@@ -27,6 +29,7 @@ import {
   StaticProvider,
   Testability,
   ɵALLOW_MULTIPLE_PLATFORMS as ALLOW_MULTIPLE_PLATFORMS,
+  Type,
   ɵsetDocument,
   ɵTESTABILITY as TESTABILITY,
 } from '@angular/core';
@@ -34,6 +37,7 @@ import {
   BrowserModule,
   EVENT_MANAGER_PLUGINS,
   ɵBrowserDomAdapter as BrowserDomAdapter,
+  bootstrapApplication,
 } from '@angular/platform-browser';
 
 import {DominoAdapter, parseDocument} from './domino_adapter';
@@ -134,4 +138,38 @@ export function platformServer(extraProviders?: StaticProvider[] | undefined): P
   }
 
   return platform;
+}
+
+/**
+ * Bootstraps an instance of an Angular application for the server platform.
+ *
+ * @usageNotes
+ * The root component passed into this function *must* be a standalone.
+ *
+ * ```ts
+ * @Component({
+ *   template: 'Hello world!'
+ * })
+ * class RootComponent {}
+ *
+ * const appRef: ApplicationRef = await bootstrapServerApplication(RootComponent, {
+ *   providers: [
+ *     {provide: BACKEND_URL, useValue: 'https://yourdomain.com/api'}
+ *   ]
+ * });
+ * ```
+ *
+ * @param rootComponent A reference to a standalone component that should be rendered.
+ * @param options Extra configuration for the bootstrap operation, see `ApplicationConfig` for
+ *     additional info.
+ * @returns A function that returns a promise that returns an `ApplicationRef` instance once resolved.
+ *
+ * @publicApi
+ */
+export function bootstrapServerApplication(
+  rootComponent: Type<unknown>,
+  options: ApplicationConfig,
+): (platformInjector: Injector) => Promise<ApplicationRef> {
+  return (platformInjector: Injector) =>
+    bootstrapApplication(rootComponent, options, platformInjector);
 }

--- a/packages/platform-server/src/server.ts
+++ b/packages/platform-server/src/server.ts
@@ -37,7 +37,7 @@ import {
   BrowserModule,
   EVENT_MANAGER_PLUGINS,
   ɵBrowserDomAdapter as BrowserDomAdapter,
-  bootstrapApplication,
+  ɵbootstrapApplicationInternal as bootstrapApplicationInternal,
 } from '@angular/platform-browser';
 
 import {DominoAdapter, parseDocument} from './domino_adapter';
@@ -152,7 +152,7 @@ export function platformServer(extraProviders?: StaticProvider[] | undefined): P
  * })
  * class RootComponent {}
  *
- * const appRef: ApplicationRef = await bootstrapServerApplication(RootComponent, {
+ * const bootstrap = bootstrapServerApplication(RootComponent, {
  *   providers: [
  *     {provide: BACKEND_URL, useValue: 'https://yourdomain.com/api'}
  *   ]
@@ -162,7 +162,7 @@ export function platformServer(extraProviders?: StaticProvider[] | undefined): P
  * @param rootComponent A reference to a standalone component that should be rendered.
  * @param options Extra configuration for the bootstrap operation, see `ApplicationConfig` for
  *     additional info.
- * @returns A function that returns a promise that returns an `ApplicationRef` instance once resolved.
+ * @returns A function that initiates the bootstrap process once called.
  *
  * @publicApi
  */
@@ -171,5 +171,5 @@ export function bootstrapServerApplication(
   options: ApplicationConfig,
 ): (platformInjector: Injector) => Promise<ApplicationRef> {
   return (platformInjector: Injector) =>
-    bootstrapApplication(rootComponent, options, platformInjector);
+    bootstrapApplicationInternal(rootComponent, options, platformInjector);
 }

--- a/packages/platform-server/src/transfer_state.ts
+++ b/packages/platform-server/src/transfer_state.ts
@@ -58,10 +58,12 @@ function warnIfStateTransferHappened(injector: Injector): void {
   if (transferStateStatus.serialized) {
     console.warn(
       `Angular detected an incompatible configuration, which causes duplicate serialization of the server-side application state.\n\n` +
-        `This can happen if the server providers have been provided more than once using different mechanisms. For example:\n\n` +
-        `  imports: [ServerModule], // Registers server providers\n` +
-        `  providers: [provideServerRendering()] // Also registers server providers\n\n` +
-        `To fix this, ensure that the \`provideServerRendering()\` function is the only provider used and remove the other(s).`,
+        `This can happen if server providers are included more than once. Common causes are:\n` +
+        `  - Using \`bootstrapApplication\` instead of \`bootstrapServerApplication\` to bootstrap the server application.\n` +
+        `  - Mixing module-based and provider-based setups, for example:\n` +
+        `    imports: [ServerModule], // Registers server providers\n` +
+        `    providers: [provideServerRendering()] // Also registers server providers\n\n` +
+        `To fix this, ensure that you use \`bootstrapServerApplication\` for your server application and that server providers are only included once.`,
     );
   }
 

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -1464,11 +1464,8 @@ class HiddenModule {}
           const output = await bootstrap;
           expect(output).toEqual(expectedOutput);
           expect(consoleSpy).toHaveBeenCalledWith(
-            jasmine.stringMatching('Angular detected an incompatible configuration'),
-          );
-          expect(consoleSpy).toHaveBeenCalledWith(
             jasmine.stringMatching(
-              `This can happen if the server providers have been provided more than once using different mechanisms.`,
+              'Angular detected an incompatible configuration, which causes duplicate serialization of the server-side application state.',
             ),
           );
         });


### PR DESCRIPTION

The `renderApplication` function creates a platform injector, but this injector was not being passed to the bootstrap function. This resulted in the bootstrap function creating a new platform injector, which is unnecessary.

This change updates `renderApplication` to pass the platform injector to the bootstrap function, ensuring the injector is reused. This is enabled by introducing a new `bootstrapServerApplication` function that facilitates passing the injector during the server-side application bootstrap process.