### PR TITLE
docs: typos in ngClass migration

### DIFF
--- a/adev/src/content/reference/migrations/ngclass-to-class.md
+++ b/adev/src/content/reference/migrations/ngclass-to-class.md
@@ -29,7 +29,7 @@ The migration supports a few options for fine tuning the migration to your speci
 
 ### `--migrate-space-separated-key`
 
-By default, the migration avoids migrating usages of `NgClass` in which object literal keys contain space-separated class names."
+By default, the migration avoids migrating usages of `NgClass` in which object literal keys contain space-separated class names.
 When the --migrate-space-separated-key flag is enabled, a binding is created for each individual key.
 
 

--- a/adev/src/content/reference/migrations/overview.md
+++ b/adev/src/content/reference/migrations/overview.md
@@ -31,6 +31,6 @@ Learn about how you can migrate your existing angular project to the latest feat
     Convert component templates to use self-closing tags where possible.
   </docs-card>
   <docs-card title="NgClass to Class Bindings" link="Migrate now" href="reference/migrations/ngclass-to-class">
-      Convert component templates to prefer class bindings over the `NgClass`directives when possible.
+      Convert component templates to prefer class bindings over the `NgClass` directives when possible.
   </docs-card>
 </docs-card-container>

--- a/packages/core/schematics/migrations/ngclass-to-class-migration/README.md
+++ b/packages/core/schematics/migrations/ngclass-to-class-migration/README.md
@@ -16,7 +16,7 @@ ng generate @angular/core:ngclass-to-class --path src/app/sub-component
 ```
 
 ### How does it work?
-The schematic will attempt to find all the places in the templates where the component selectors are used. And check if they can be converted to self-closing tags.
+The schematic will attempt to find all the places in the templates where the directive is used and check if it can be converted to `[class]`.
 
 Example:
 

--- a/packages/core/schematics/migrations/ngclass-to-class-migration/index.ts
+++ b/packages/core/schematics/migrations/ngclass-to-class-migration/index.ts
@@ -38,7 +38,7 @@ export function migrate(options: Options): Rule {
         }
       },
       beforeUnitAnalysis: (tsconfigPath: string) => {
-        context.logger.info(`Scanning for component tags: ${tsconfigPath}...`);
+        context.logger.info(`Scanning for ngClass bindings: ${tsconfigPath}...`);
       },
       afterAllAnalyzed: () => {
         context.logger.info(``);

--- a/packages/core/schematics/migrations/ngclass-to-class-migration/schema.json
+++ b/packages/core/schematics/migrations/ngclass-to-class-migration/schema.json
@@ -13,7 +13,7 @@
     "migrateSpaceSeparatedKey": {
       "type": "boolean",
       "description": "Enables the migration of object literals with space-separated keys",
-      "x-prompt": "Should the migration also migrate space-separated keys ?",
+      "x-prompt": "Should the migration also migrate space-separated keys?",
       "default": "false"
     }
   }

--- a/packages/core/schematics/migrations/ngclass-to-class-migration/types.ts
+++ b/packages/core/schematics/migrations/ngclass-to-class-migration/types.ts
@@ -10,7 +10,7 @@ import {ProjectFile} from '../../utils/tsurge';
 
 export interface MigrationConfig {
   /**
-   * Whether to migrate this component template to self-closing tags.
+   * Whether to migrate this component template to ngClass.
    */
   shouldMigrate?: (containingFile: ProjectFile) => boolean;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

Fixes a few typos in the ngClass migration (mentions of self closing tags migration, typos in prompts, logs and docs...).


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
