### PR TITLE
fix(core): make ElementRef.nativeElement readonly

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -672,7 +672,7 @@ export interface EffectRef {
 // @public
 export class ElementRef<T = any> {
     constructor(nativeElement: T);
-    nativeElement: T;
+    readonly nativeElement: T;
 }
 
 // @public

--- a/packages/core/src/linker/element_ref.ts
+++ b/packages/core/src/linker/element_ref.ts
@@ -59,7 +59,7 @@ export class ElementRef<T = any> {
    *   </p>
    * </div>
    */
-  public nativeElement: T;
+  public readonly nativeElement: T;
 
   constructor(nativeElement: T) {
     this.nativeElement = nativeElement;


### PR DESCRIPTION
There really is never a situation in which userspace code should modify the nativeElement here.

I'm mostly creating this PR to see how breaking this might be.