### PR TITLE
docs(docs-infra): prevent empty h3 tags when title is empty

### DIFF
--- a/adev/shared-docs/pipeline/shared/marked/extensions/docs-card/docs-card.mts
+++ b/adev/shared-docs/pipeline/shared/marked/extensions/docs-card/docs-card.mts
@@ -72,7 +72,7 @@ function getStandardCard(renderer: RendererThis, token: DocsCardToken) {
     return `
     <a href="${token.href}" ${anchorTarget(token.href)} class="docs-card">
       <div>
-        <h3>${token.title}</h3>
+        ${token.title ? `<h3>${token.title}</h3>` : ''}
         ${parseWithoutCreatingLinks(renderer, token)}
       </div>
       <span>${token.link ? token.link : 'Learn more'}</span>
@@ -82,7 +82,7 @@ function getStandardCard(renderer: RendererThis, token: DocsCardToken) {
   return `
   <div class="docs-card">
     <div>
-      <h3>${token.title}</h3>
+      ${token.title ? `<h3>${token.title}</h3>` : ''}
       ${renderer.parser.parse(token.tokens)}
     </div>
     ${token.link ? `<span>${token.link}</span>` : ''}
@@ -111,7 +111,7 @@ function getCardWithSvgIllustration(renderer: RendererThis, token: DocsCardToken
         ${illustration}
         <div class="docs-card-text-content">
           <div>
-            <h3>${token.title}</h3>
+            ${token.title ? `<h3>${token.title}</h3>` : ''}
             ${renderer.parser.parse(token.tokens)}
           </div>
           <span>${token.link ? token.link : 'Learn more'}</span>
@@ -123,7 +123,7 @@ function getCardWithSvgIllustration(renderer: RendererThis, token: DocsCardToken
     <div class="docs-card docs-card-with-svg">
       ${illustration}
       <div class="docs-card-text-content">
-      <h3>${token.title}</h3>
+      ${token.title ? `<h3>${token.title}</h3>` : ''}
       ${renderer.parser.parse(token.tokens)}
       </div>
     </div>

--- a/adev/shared-docs/pipeline/shared/marked/test/docs-card/docs-card.md
+++ b/adev/shared-docs/pipeline/shared/marked/test/docs-card/docs-card.md
@@ -3,3 +3,6 @@
   Card Content with a symbol: `CommonModule`
 </docs-card>
 <docs-card title="Image Card" imgSrc="./angular.svg"></docs-card>
+<docs-card title="" link="Open on Playground" href="/playground">
+  The fastest way to play with an Angular app. No setup required.
+</docs-card>

--- a/adev/shared-docs/pipeline/shared/marked/test/docs-card/docs-card.spec.mts
+++ b/adev/shared-docs/pipeline/shared/marked/test/docs-card/docs-card.spec.mts
@@ -27,7 +27,7 @@ describe('markdown to html', () => {
     expect(cardEl.tagName).not.toBe('A');
   });
 
-  it('creates cards withs links', () => {
+  it('creates cards with links', () => {
     const cardEl = markdownDocument.querySelectorAll('.docs-card')[1];
 
     expect(cardEl.querySelector('h3')?.textContent?.trim()).toBe('Link Card');
@@ -47,5 +47,13 @@ describe('markdown to html', () => {
 
     expect(cardEl.querySelector('h3')?.textContent?.trim()).toBe('Image Card');
     expect(cardEl.querySelector('svg')).toBeTruthy();
+  });
+
+  it('does not create empty h3 tags when title is empty', () => {
+    const cardEl = markdownDocument.querySelectorAll('.docs-card')[3];
+
+    expect(cardEl.querySelector('h3')).toBeNull();
+    expect(cardEl.tagName).toBe('A');
+    expect(cardEl.getAttribute('href')).toBe('/playground');
   });
 });


### PR DESCRIPTION
Conditionally render h3 element only when title attribute has content

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

https://github.com/user-attachments/assets/daa7f3b6-2ed2-48fb-bafc-60296d39c2bb

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
