### PR TITLE
refactor(forms): add support for more input types

### DIFF
--- a/packages/forms/signals/src/controls/control.ts
+++ b/packages/forms/signals/src/controls/control.ts
@@ -198,6 +198,7 @@ export class Control<T> {
           break;
         case 'number':
         case 'range':
+        case 'datetime-local':
           // We can read a `number` or a `string` from this input type.
           // Prefer whichever is consistent with the current type.
           if (typeof this.state().value() === 'number') {
@@ -210,10 +211,12 @@ export class Control<T> {
         case 'month':
         case 'week':
         case 'time':
-          // We can read a `Date | null` or a `string` from this input type.
+          // We can read a `Date | null` or a `number` or a `string` from this input type.
           // Prefer whichever is consistent with the current type.
           if (isDateOrNull(this.state().value())) {
             this.state().value.set((input as HTMLInputElement).valueAsDate as T);
+          } else if (typeof this.state().value() === 'number') {
+            this.state().value.set((input as HTMLInputElement).valueAsNumber as T);
           } else {
             this.state().value.set(input.value as T);
           }
@@ -274,7 +277,8 @@ export class Control<T> {
         break;
       case 'number':
       case 'range':
-        // This input typr can receive a `number` or a `string`.
+      case 'datetime-local':
+        // This input type can receive a `number` or a `string`.
         this.maybeSynchronize(
           () => this.state().value(),
           (value) => {
@@ -290,12 +294,14 @@ export class Control<T> {
       case 'month':
       case 'week':
       case 'time':
-        // This input typr can receive a `Date | null` or a `string`.
+        // This input type can receive a `Date | null` or a `number` or a `string`.
         this.maybeSynchronize(
           () => this.state().value(),
           (value) => {
             if (isDateOrNull(value)) {
               (input as HTMLInputElement).valueAsDate = value;
+            } else if (typeof value === 'number') {
+              (input as HTMLInputElement).valueAsNumber = value;
             } else {
               input.value = value as string;
             }

--- a/packages/forms/signals/test/web/control_directive.spec.ts
+++ b/packages/forms/signals/test/web/control_directive.spec.ts
@@ -686,6 +686,62 @@ describe('control directive', () => {
       expect(cmp.f().value()).toEqual(new Date('2026-03-03T00:00:00.000Z'));
     });
 
+    it('should sync number field with date type input', () => {
+      @Component({
+        imports: [Control],
+        template: `<input type="date" [control]="f">`,
+      })
+      class TestCmp {
+        f = form(signal(new Date('2024-01-01T12:00:00Z').valueOf()));
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const cmp = fix.componentInstance as TestCmp;
+
+      // Initial state
+      expect(input.value).toBe('2024-01-01');
+
+      // Model -> View
+      act(() => cmp.f().value.set(new Date('2025-02-02T12:00:00Z').valueOf()));
+      expect(input.value).toBe('2025-02-02');
+
+      // View -> Model
+      act(() => {
+        input.value = '2026-03-03';
+        input.dispatchEvent(new Event('input'));
+      });
+      expect(cmp.f().value()).toBe(new Date('2026-03-03T00:00:00.000Z').valueOf());
+    });
+
+    it('should sync number field with datetime-local type input', () => {
+      @Component({
+        imports: [Control],
+        template: `<input type="datetime-local" [control]="f">`,
+      })
+      class TestCmp {
+        f = form(signal(new Date('2024-01-01T12:30:00Z').valueOf()));
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const cmp = fix.componentInstance as TestCmp;
+
+      // Initial state
+      expect(input.value).toBe('2024-01-01T12:30');
+
+      // Model -> View
+      act(() => cmp.f().value.set(new Date('2025-02-02T18:45:00Z').valueOf()));
+      expect(input.value).toBe('2025-02-02T18:45');
+
+      // View -> Model
+      act(() => {
+        input.value = '2026-03-03T09:15';
+        input.dispatchEvent(new Event('input'));
+      });
+      expect(cmp.f().value()).toBe(new Date('2026-03-03T09:15:00.000Z').valueOf());
+    });
+
     it('should sync string field with color type input', () => {
       @Component({
         imports: [Control],

--- a/packages/forms/signals/test/web/control_directive.spec.ts
+++ b/packages/forms/signals/test/web/control_directive.spec.ts
@@ -572,6 +572,148 @@ describe('control directive', () => {
       [...fix.nativeElement.querySelectorAll('.disabled-reason')].map((e) => e.textContent),
     ).toEqual(['manual disabled', 'schema disabled']);
   });
+
+  describe('should work with different input types', () => {
+    it('should sync string field with number type input', () => {
+      @Component({
+        imports: [Control],
+        template: `<input type="number" [control]="f">`,
+      })
+      class TestCmp {
+        f = form(signal('123'));
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const cmp = fix.componentInstance as TestCmp;
+
+      // Initial state
+      expect(input.value).toBe('123');
+
+      // Model -> View
+      act(() => cmp.f().value.set('456'));
+      expect(input.value).toBe('456');
+
+      // View -> Model
+      act(() => {
+        input.value = '789';
+        input.dispatchEvent(new Event('input'));
+      });
+      expect(cmp.f().value()).toBe('789');
+    });
+
+    it('should sync number field with number type input', () => {
+      @Component({
+        imports: [Control],
+        template: `<input type="number" [control]="f">`,
+      })
+      class TestCmp {
+        f = form(signal(123));
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const cmp = fix.componentInstance as TestCmp;
+
+      // Initial state
+      expect(input.value).toBe('123');
+
+      // Model -> View
+      act(() => cmp.f().value.set(456));
+      expect(input.value).toBe('456');
+
+      // View -> Model
+      act(() => {
+        input.value = '789';
+        input.dispatchEvent(new Event('input'));
+      });
+      expect(cmp.f().value()).toBe(789);
+    });
+
+    it('should sync string field with date type input', () => {
+      @Component({
+        imports: [Control],
+        template: `<input type="date" [control]="f">`,
+      })
+      class TestCmp {
+        f = form(signal('2024-01-01'));
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const cmp = fix.componentInstance as TestCmp;
+
+      // Initial state
+      expect(input.value).toBe('2024-01-01');
+
+      // Model -> View
+      act(() => cmp.f().value.set('2025-02-02'));
+      expect(input.value).toBe('2025-02-02');
+
+      // View -> Model
+      act(() => {
+        input.value = '2026-03-03';
+        input.dispatchEvent(new Event('input'));
+      });
+      expect(cmp.f().value()).toBe('2026-03-03');
+    });
+
+    it('should sync date field with date type input', () => {
+      @Component({
+        imports: [Control],
+        template: `<input type="date" [control]="f">`,
+      })
+      class TestCmp {
+        f = form(signal(new Date('2024-01-01T12:00:00Z')));
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const cmp = fix.componentInstance as TestCmp;
+
+      // Initial state
+      expect(input.value).toBe('2024-01-01');
+
+      // Model -> View
+      act(() => cmp.f().value.set(new Date('2025-02-02T12:00:00Z')));
+      expect(input.value).toBe('2025-02-02');
+
+      // View -> Model
+      act(() => {
+        input.value = '2026-03-03';
+        input.dispatchEvent(new Event('input'));
+      });
+      expect(cmp.f().value()).toEqual(new Date('2026-03-03T00:00:00.000Z'));
+    });
+
+    it('should sync string field with color type input', () => {
+      @Component({
+        imports: [Control],
+        template: `<input type="color" [control]="f">`,
+      })
+      class TestCmp {
+        f = form(signal('#ff0000'));
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const cmp = fix.componentInstance as TestCmp;
+
+      // Initial state
+      expect(input.value).toBe('#ff0000');
+
+      // Model -> View
+      act(() => cmp.f().value.set('#00ff00'));
+      expect(input.value).toBe('#00ff00');
+
+      // View -> Model
+      act(() => {
+        input.value = '#0000ff';
+        input.dispatchEvent(new Event('input'));
+      });
+      expect(cmp.f().value()).toBe('#0000ff');
+    });
+  });
 });
 
 function setupRadioGroup() {

--- a/packages/forms/signals/test/web/control_directive.spec.ts
+++ b/packages/forms/signals/test/web/control_directive.spec.ts
@@ -728,18 +728,20 @@ describe('control directive', () => {
       const cmp = fix.componentInstance as TestCmp;
 
       // Initial state
-      expect(input.value).toBe('2024-01-01T12:30');
+      expect(input.valueAsNumber).toBe(new Date('2024-01-01T12:30:00Z').valueOf());
 
       // Model -> View
-      act(() => cmp.f().value.set(new Date('2025-02-02T18:45:00Z').valueOf()));
-      expect(input.value).toBe('2025-02-02T18:45');
+      let newDateTimestamp = new Date('2025-02-02T18:45:00Z').valueOf();
+      act(() => cmp.f().value.set(newDateTimestamp));
+      expect(input.valueAsNumber).toBe(newDateTimestamp);
 
       // View -> Model
+      newDateTimestamp = new Date('2026-03-03T09:15:00Z').valueOf();
       act(() => {
-        input.value = '2026-03-03T09:15';
+        input.valueAsNumber = newDateTimestamp;
         input.dispatchEvent(new Event('input'));
       });
-      expect(cmp.f().value()).toBe(new Date('2026-03-03T09:15:00.000Z').valueOf());
+      expect(cmp.f().value()).toBe(newDateTimestamp);
     });
 
     it('should sync string field with color type input', () => {


### PR DESCRIPTION
Adds additional handling for input types that handle numbers:
- number
- range
- datetime-local

As well as input types that handle dates:
- date
- month
- week
- time
- *not* datetime-local which does not allow setting valueAsDate

This PR allows binding either a `Field<string>` or `Field<number>` to
the number type inputs and a `Field<string>`, `Field<numebr>`, or
`Field<Date | null>` to the date type inputs. Binding uses the
corresponding `.value`, `.valueAsNumber`, or `.valueAsDate` according to
the type of the `Field`.

When reading new values out of the input, the `Control` directive will
read the property that aligns with the type of the existing value in the
`Field` and write back the same type.