### PR TITLE
fix(devtools): remove refresh button from transfer state tab

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.html
@@ -4,11 +4,6 @@
       <mat-icon>swap_horiz</mat-icon>
       Transfer State
     </h2>
-    <div class="actions">
-      <button ng-button btnType="icon" (click)="refresh()" matTooltip="Refresh transfer state">
-        <mat-icon>refresh</mat-icon>
-      </button>
-    </div>
   </div>
 
   @if (isLoading()) {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.scss
@@ -26,18 +26,6 @@
         height: 1.25rem;
       }
     }
-
-    .actions {
-      display: flex;
-      gap: 0.5rem;
-      align-items: center;
-
-      button {
-        display: flex;
-        align-items: center;
-        gap: 0.25rem;
-      }
-    }
   }
 
   .loading {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.ts
@@ -142,10 +142,6 @@ export class TransferStateComponent {
     }
   }
 
-  refresh(): void {
-    this.loadTransferState();
-  }
-
   isValueLong(element: HTMLElement, isExpanded: boolean = false): boolean {
     if (isExpanded) return true;
 


### PR DESCRIPTION
TransferState is only written into the DOM once during SSR and is not kept in sync with the runtime state on the client. Pressing the refresh button always re-reads the initial serialized script tag, which never changes after bootstrap.

Issue Number: #63454 