### PR TITLE
refactor(forms): mark all signal forms apis as experimental

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -227,6 +227,11 @@ export interface HttpValidatorOptions<TValue, TResult, TPathKind extends PathKin
 }
 
 // @public
+export type IgnoreUnknownProperties<T> = T extends Record<PropertyKey, unknown> ? {
+    [K in keyof T as RemoveStringIndexUnknownKey<K, T[K]>]: IgnoreUnknownProperties<T[K]>;
+} : T;
+
+// @public
 export interface ItemFieldContext<TValue> extends ChildFieldContext<TValue> {
     readonly index: Signal<number>;
 }
@@ -410,6 +415,9 @@ export type ReadonlyArrayLike<T> = Pick<ReadonlyArray<T>, number | 'length' | ty
 
 // @public
 export function reducedProperty<TAcc, TItem>(reduce: (acc: TAcc, item: TItem) => TAcc, getInitial: () => TAcc): AggregateProperty<TAcc, TItem>;
+
+// @public
+export type RemoveStringIndexUnknownKey<K, V> = string extends K ? unknown extends V ? never : K : K;
 
 // @public
 export const REQUIRED: AggregateProperty<boolean, boolean>;

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -4,11 +4,9 @@
 
 ```ts
 
-import { AbstractControl } from '@angular/forms';
 import { ControlValueAccessor } from '@angular/forms';
 import { DestroyableInjector } from '@angular/core';
 import { ElementRef } from '@angular/core';
-import { FormControlStatus } from '@angular/forms';
 import { HttpResourceOptions } from '@angular/common/http';
 import { HttpResourceRequest } from '@angular/common/http';
 import * as i0 from '@angular/core';
@@ -20,8 +18,6 @@ import { OutputRef } from '@angular/core';
 import { ResourceRef } from '@angular/core';
 import { Signal } from '@angular/core';
 import { StandardSchemaV1 } from '@standard-schema/spec';
-import { ValidationErrors } from '@angular/forms';
-import { ValidatorFn } from '@angular/forms';
 import { WritableSignal } from '@angular/core';
 
 // @public
@@ -229,48 +225,6 @@ export interface HttpValidatorOptions<TValue, TResult, TPathKind extends PathKin
     readonly options?: HttpResourceOptions<TResult, unknown>;
     readonly request: ((ctx: FieldContext<TValue, TPathKind>) => string | undefined) | ((ctx: FieldContext<TValue, TPathKind>) => HttpResourceRequest | undefined);
 }
-
-// @public
-export class InteropNgControl implements Pick<NgControl, InteropSharedKeys | 'control' | 'valueAccessor'>, Pick<AbstractControl<unknown>, InteropSharedKeys | 'hasValidator'> {
-    constructor(field: () => FieldState<unknown>);
-    // (undocumented)
-    readonly control: AbstractControl<any, any>;
-    // (undocumented)
-    get dirty(): boolean;
-    // (undocumented)
-    get disabled(): boolean;
-    // (undocumented)
-    get enabled(): boolean;
-    // (undocumented)
-    get errors(): ValidationErrors | null;
-    // (undocumented)
-    protected field: () => FieldState<unknown>;
-    // (undocumented)
-    hasValidator(validator: ValidatorFn): boolean;
-    // (undocumented)
-    get invalid(): boolean;
-    // (undocumented)
-    get pending(): boolean | null;
-    // (undocumented)
-    get pristine(): boolean;
-    // (undocumented)
-    get status(): FormControlStatus;
-    // (undocumented)
-    get touched(): boolean;
-    // (undocumented)
-    get untouched(): boolean;
-    // (undocumented)
-    updateValueAndValidity(): void;
-    // (undocumented)
-    get valid(): boolean;
-    // (undocumented)
-    get value(): any;
-    // (undocumented)
-    valueAccessor: ControlValueAccessor | null;
-}
-
-// @public
-export type InteropSharedKeys = 'value' | 'valid' | 'invalid' | 'touched' | 'untouched' | 'disabled' | 'enabled' | 'errors' | 'pristine' | 'dirty' | 'status';
 
 // @public
 export interface ItemFieldContext<TValue> extends ChildFieldContext<TValue> {

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -497,6 +497,9 @@ export function validateAsync<TValue, TParams, TResult, TPathKind extends PathKi
 export function validateHttp<TValue, TResult = unknown, TPathKind extends PathKind = PathKind.Root>(path: FieldPath<TValue, TPathKind>, opts: HttpValidatorOptions<TValue, TResult, TPathKind>): void;
 
 // @public
+export function validateStandardSchema<TSchema, TValue extends IgnoreUnknownProperties<TSchema>>(path: FieldPath<TValue>, schema: StandardSchemaV1<TSchema>): void;
+
+// @public
 export function validateTree<TValue, TPathKind extends PathKind = PathKind.Root>(path: FieldPath<TValue, TPathKind>, logic: NoInfer<TreeValidator<TValue, TPathKind>>): void;
 
 // @public

--- a/packages/forms/signals/public_api.ts
+++ b/packages/forms/signals/public_api.ts
@@ -13,11 +13,10 @@
  */
 export * from './src/api/async';
 export * from './src/api/control';
+export * from './src/api/control_directive';
 export * from './src/api/logic';
 export * from './src/api/property';
 export * from './src/api/structure';
 export * from './src/api/types';
-export * from './src/api/validators';
-export * from './src/controls/control';
-export * from './src/controls/interop_ng_control';
 export * from './src/api/validation_errors';
+export * from './src/api/validators';

--- a/packages/forms/signals/src/api/async.ts
+++ b/packages/forms/signals/src/api/async.ts
@@ -28,6 +28,8 @@ import {FieldContext, FieldPath, PathKind, TreeValidationResult} from './types';
  * @template TValue The type of value stored in the field being validated.
  * @template TResult The type of result returned by the async operation
  * @template TPathKind The kind of path being validated (a root path, child path, or item of an array)
+ *
+ * @experimental 21.0.0
  */
 export type MapToErrorsFn<TValue, TResult, TPathKind extends PathKind = PathKind.Root> = (
   result: TResult,
@@ -42,6 +44,8 @@ export type MapToErrorsFn<TValue, TResult, TPathKind extends PathKind = PathKind
  * @template TParams The type of parameters to the resource.
  * @template TResult The type of result returned by the resource
  * @template TPathKind The kind of path being validated (a root path, child path, or item of an array)
+ *
+ * @experimental 21.0.0
  */
 export interface AsyncValidatorOptions<
   TValue,
@@ -88,6 +92,8 @@ export interface AsyncValidatorOptions<
  * @template TValue The type of value stored in the field being validated.
  * @template TResult The type of result returned by the httpResource
  * @template TPathKind The kind of path being validated (a root path, child path, or item of an array)
+ *
+ * @experimental 21.0.0
  */
 export interface HttpValidatorOptions<TValue, TResult, TPathKind extends PathKind = PathKind.Root> {
   /**
@@ -130,6 +136,8 @@ export interface HttpValidatorOptions<TValue, TResult, TPathKind extends PathKin
  * @template TParams The type of parameters to the resource.
  * @template TResult The type of result returned by the resource
  * @template TPathKind The kind of path being validated (a root path, child path, or item of an array)
+ *
+ * @experimental 21.0.0
  */
 export function validateAsync<TValue, TParams, TResult, TPathKind extends PathKind = PathKind.Root>(
   path: FieldPath<TValue, TPathKind>,
@@ -181,6 +189,8 @@ export function validateAsync<TValue, TParams, TResult, TPathKind extends PathKi
  * @template TValue The type of value stored in the field being validated.
  * @template TResult The type of result returned by the httpResource
  * @template TPathKind The kind of path being validated (a root path, child path, or item of an array)
+ *
+ * @experimental 21.0.0
  */
 export function validateHttp<TValue, TResult = unknown, TPathKind extends PathKind = PathKind.Root>(
   path: FieldPath<TValue, TPathKind>,

--- a/packages/forms/signals/src/api/control.ts
+++ b/packages/forms/signals/src/api/control.ts
@@ -10,7 +10,11 @@ import {InputSignal, ModelSignal, OutputRef} from '@angular/core';
 import type {DisabledReason} from './types';
 import {ValidationError, type WithOptionalField} from './validation_errors';
 
-/** The base set of properties shared by all form control contracts. */
+/**
+ * The base set of properties shared by all form control contracts.
+ *
+ * @experimental 21.0.0
+ */
 export interface FormUiControl {
   // TODO: `ValidationError` and `DisabledReason` are inherently tied to the signal forms system.
   // They don't make sense when using a ccontrol separately from the forms system and setting the
@@ -107,6 +111,8 @@ export interface FormUiControl {
  * `Control` directive.
  *
  * @template TValue The type of `Field` that the implementing component can edit.
+ *
+ * @experimental 21.0.0
  */
 export interface FormValueControl<TValue> extends FormUiControl {
   /**
@@ -133,6 +139,8 @@ export interface FormValueControl<TValue> extends FormUiControl {
  * Many of the properties declared on this contract are optional. They do not need to be
  * implemented, but if they are will be kept in sync with the field state of the field bound to the
  * `Control` directive.
+ *
+ * @experimental 21.0.0
  */
 export interface FormCheckboxControl extends FormUiControl {
   /**

--- a/packages/forms/signals/src/api/control_directive.ts
+++ b/packages/forms/signals/src/api/control_directive.ts
@@ -28,17 +28,7 @@ import {
   untracked,
 } from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR, NgControl} from '@angular/forms';
-import {FormCheckboxControl, FormUiControl, FormValueControl} from '../api/control';
-import {
-  AggregateProperty,
-  MAX,
-  MAX_LENGTH,
-  MIN,
-  MIN_LENGTH,
-  PATTERN,
-  REQUIRED,
-} from '../api/property';
-import type {Field} from '../api/types';
+import {InteropNgControl} from '../controls/interop_ng_control';
 import type {FieldNode} from '../field/node';
 import {
   privateGetComponentInstance,
@@ -47,7 +37,9 @@ import {
   privateRunEffect,
   privateSetComponentInput as privateSetInputSignal,
 } from '../util/private';
-import {InteropNgControl} from './interop_ng_control';
+import {FormCheckboxControl, FormUiControl, FormValueControl} from './control';
+import {AggregateProperty, MAX, MAX_LENGTH, MIN, MIN_LENGTH, PATTERN, REQUIRED} from './property';
+import type {Field} from './types';
 
 /**
  * Binds a form `Field` to a UI control that edits it. A UI control can be one of several things:

--- a/packages/forms/signals/src/api/logic.ts
+++ b/packages/forms/signals/src/api/logic.ts
@@ -28,6 +28,8 @@ import type {
  *   and `false` when it is not disabled.
  * @template TValue The type of value stored in the field the logic is bound to.
  * @template TPathKind The kind of path the logic is bound to (a root path, child path, or item of an array)
+ *
+ * @experimental 21.0.0
  */
 export function disabled<TValue, TPathKind extends PathKind = PathKind.Root>(
   path: FieldPath<TValue, TPathKind>,
@@ -58,6 +60,8 @@ export function disabled<TValue, TPathKind extends PathKind = PathKind.Root>(
  * @param logic A reactive function that returns `true` when the field is readonly.
  * @template TValue The type of value stored in the field the logic is bound to.
  * @template TPathKind The kind of path the logic is bound to (a root path, child path, or item of an array)
+ *
+ * @experimental 21.0.0
  */
 export function readonly<TValue, TPathKind extends PathKind = PathKind.Root>(
   path: FieldPath<TValue, TPathKind>,
@@ -85,6 +89,8 @@ export function readonly<TValue, TPathKind extends PathKind = PathKind.Root>(
  * @param logic A reactive function that returns `true` when the field is hidden.
  * @template TValue The type of value stored in the field the logic is bound to.
  * @template TPathKind The kind of path the logic is bound to (a root path, child path, or item of an array)
+ *
+ * @experimental 21.0.0
  */
 export function hidden<TValue, TPathKind extends PathKind = PathKind.Root>(
   path: FieldPath<TValue, TPathKind>,
@@ -103,6 +109,8 @@ export function hidden<TValue, TPathKind extends PathKind = PathKind.Root>(
  * @param logic A `Validator` that returns the current validation errors.
  * @template TValue The type of value stored in the field the logic is bound to.
  * @template TPathKind The kind of path the logic is bound to (a root path, child path, or item of an array)
+ *
+ * @experimental 21.0.0
  */
 export function validate<TValue, TPathKind extends PathKind = PathKind.Root>(
   path: FieldPath<TValue, TPathKind>,
@@ -124,6 +132,8 @@ export function validate<TValue, TPathKind extends PathKind = PathKind.Root>(
  *   Errors returned by the validator may specify a target field to indicate an error on a child field.
  * @template TValue The type of value stored in the field the logic is bound to.
  * @template TPathKind The kind of path the logic is bound to (a root path, child path, or item of an array)
+ *
+ * @experimental 21.0.0
  */
 export function validateTree<TValue, TPathKind extends PathKind = PathKind.Root>(
   path: FieldPath<TValue, TPathKind>,
@@ -146,6 +156,8 @@ export function validateTree<TValue, TPathKind extends PathKind = PathKind.Root>
  * @template TValue The type of value stored in the field the logic is bound to.
  * @template TPropItem The type of value the property aggregates over.
  * @template TPathKind The kind of path the logic is bound to (a root path, child path, or item of an array)
+ *
+ * @experimental 21.0.0
  */
 export function aggregateProperty<TValue, TPropItem, TPathKind extends PathKind = PathKind.Root>(
   path: FieldPath<TValue, TPathKind>,
@@ -165,6 +177,8 @@ export function aggregateProperty<TValue, TPropItem, TPathKind extends PathKind 
  * @param factory A factory function that creates the value for the property.
  *   This function is **not** reactive. It is run once when the field is created.
  * @returns The newly created property
+ *
+ * @experimental 21.0.0
  */
 export function property<TValue, TData, TPathKind extends PathKind = PathKind.Root>(
   path: FieldPath<TValue, TPathKind>,
@@ -179,6 +193,8 @@ export function property<TValue, TData, TPathKind extends PathKind = PathKind.Ro
  * @param factory A factory function that creates the value for the property.
  *   This function is **not** reactive. It is run once when the field is created.
  * @returns The given property
+ *
+ * @experimental 21.0.0
  */
 export function property<TValue, TData, TPathKind extends PathKind = PathKind.Root>(
   path: FieldPath<TValue, TPathKind>,

--- a/packages/forms/signals/src/api/property.ts
+++ b/packages/forms/signals/src/api/property.ts
@@ -9,6 +9,8 @@
 /**
  * Represents a property that may be defined on a field when it is created using a `property` rule
  * in the schema. A particular `Property` can only be defined on a particular field **once**.
+ *
+ * @experimental 21.0.0
  */
 export class Property<TValue> {
   private brand!: TValue;
@@ -17,7 +19,11 @@ export class Property<TValue> {
   private constructor() {}
 }
 
-/** Creates a {@link Property}. */
+/**
+ * Creates a {@link Property}.
+ *
+ * @experimental 21.0.0
+ */
 export function createProperty<TValue>(): Property<TValue> {
   return new (Property as new () => Property<TValue>)();
 }
@@ -27,6 +33,8 @@ export function createProperty<TValue>(): Property<TValue> {
  * function. A value can be contributed to the aggregated value for a field using an
  * `aggregateProperty` rule in the schema. There may be multiple rules in a schema that contribute
  * values to the same `AggregateProperty` of the same field.
+ *
+ * @experimental 21.0.0
  */
 export class AggregateProperty<TAcc, TItem> {
   private brand!: [TAcc, TItem];
@@ -43,6 +51,8 @@ export class AggregateProperty<TAcc, TItem> {
  * the given `reduce` and `getInitial` functions.
  * @param reduce The reducer function.
  * @param getInitial A function that gets the initial value for the reduce operation.
+ *
+ * @experimental 21.0.0
  */
 export function reducedProperty<TAcc, TItem>(
   reduce: (acc: TAcc, item: TItem) => TAcc,
@@ -56,6 +66,8 @@ export function reducedProperty<TAcc, TItem>(
 
 /**
  * Creates an aggregate property that reduces its individual values into a list.
+ *
+ * @experimental 21.0.0
  */
 export function listProperty<TItem>(): AggregateProperty<TItem[], TItem | undefined> {
   return reducedProperty<TItem[], TItem | undefined>(
@@ -66,6 +78,8 @@ export function listProperty<TItem>(): AggregateProperty<TItem[], TItem | undefi
 
 /**
  * Creates an aggregate property that reduces its individual values by taking their min.
+ *
+ * @experimental 21.0.0
  */
 export function minProperty(): AggregateProperty<number | undefined, number | undefined> {
   return reducedProperty<number | undefined, number | undefined>(
@@ -84,6 +98,8 @@ export function minProperty(): AggregateProperty<number | undefined, number | un
 
 /**
  * Creates an aggregate property that reduces its individual values by taking their max.
+ *
+ * @experimental 21.0.0
  */
 export function maxProperty(): AggregateProperty<number | undefined, number | undefined> {
   return reducedProperty<number | undefined, number | undefined>(
@@ -102,6 +118,8 @@ export function maxProperty(): AggregateProperty<number | undefined, number | un
 
 /**
  * Creates an aggregate property that reduces its individual values by logically or-ing them.
+ *
+ * @experimental 21.0.0
  */
 export function orProperty(): AggregateProperty<boolean, boolean> {
   return reducedProperty(
@@ -112,6 +130,8 @@ export function orProperty(): AggregateProperty<boolean, boolean> {
 
 /**
  * Creates an aggregate property that reduces its individual values by logically and-ing them.
+ *
+ * @experimental 21.0.0
  */
 export function andProperty(): AggregateProperty<boolean, boolean> {
   return reducedProperty(
@@ -122,30 +142,42 @@ export function andProperty(): AggregateProperty<boolean, boolean> {
 
 /**
  * An aggregate property representing whether the field is required.
+ *
+ * @experimental 21.0.0
  */
 export const REQUIRED: AggregateProperty<boolean, boolean> = orProperty();
 
 /**
  * An aggregate property representing the min value of the field.
+ *
+ * @experimental 21.0.0
  */
 export const MIN: AggregateProperty<number | undefined, number | undefined> = maxProperty();
 
 /**
  * An aggregate property representing the max value of the field.
+ *
+ * @experimental 21.0.0
  */
 export const MAX: AggregateProperty<number | undefined, number | undefined> = minProperty();
 
 /**
  * An aggregate property representing the min length of the field.
+ *
+ * @experimental 21.0.0
  */
 export const MIN_LENGTH: AggregateProperty<number | undefined, number | undefined> = maxProperty();
 
 /**
  * An aggregate property representing the max length of the field.
+ *
+ * @experimental 21.0.0
  */
 export const MAX_LENGTH: AggregateProperty<number | undefined, number | undefined> = minProperty();
 
 /**
  * An aggregate property representing the patterns the field must match.
+ *
+ * @experimental 21.0.0
  */
 export const PATTERN: AggregateProperty<RegExp[], RegExp | undefined> = listProperty<RegExp>();

--- a/packages/forms/signals/src/api/structure.ts
+++ b/packages/forms/signals/src/api/structure.ts
@@ -28,7 +28,11 @@ import type {
 } from './types';
 import {ValidationError, WithOptionalField} from './validation_errors';
 
-/** Options that may be specified when creating a form. */
+/**
+ * Options that may be specified when creating a form.
+ *
+ * @experimental 21.0.0
+ */
 export interface FormOptions {
   /**
    * The injector to use for dependency injection. If this is not provided, the injector for the
@@ -89,6 +93,8 @@ function normalizeFormArgs<TValue>(
  * the model.
  * @return A `Field` representing a form around the data model.
  * @template TValue The type of the data model.
+ *
+ * @experimental 21.0.0
  */
 export function form<TValue>(model: WritableSignal<TValue>): Field<TValue>;
 
@@ -133,6 +139,8 @@ export function form<TValue>(model: WritableSignal<TValue>): Field<TValue>;
  *   2. The form options
  * @return A `Field` representing a form around the data model
  * @template TValue The type of the data model.
+ *
+ * @experimental 21.0.0
  */
 export function form<TValue>(
   model: WritableSignal<TValue>,
@@ -178,6 +186,8 @@ export function form<TValue>(
  * @param options The form options
  * @return A `Field` representing a form around the data model.
  * @template TValue The type of the data model.
+ *
+ * @experimental 21.0.0
  */
 export function form<TValue>(
   model: WritableSignal<TValue>,
@@ -231,6 +241,8 @@ export function form<TValue>(...args: any[]): Field<TValue> {
  * @param schema A schema for an element of the array, or function that binds logic to an
  * element of the array.
  * @template TValue The data type of the item field to apply the schema to.
+ *
+ * @experimental 21.0.0
  */
 export function applyEach<TValue>(
   path: FieldPath<TValue[]>,
@@ -259,6 +271,8 @@ export function applyEach<TValue>(
  * @param path The target path to apply the schema to.
  * @param schema The schema to apply to the property
  * @template TValue The data type of the field to apply the schema to.
+ *
+ * @experimental 21.0.0
  */
 export function apply<TValue>(
   path: FieldPath<TValue>,
@@ -277,6 +291,8 @@ export function apply<TValue>(
  * @param logic A `LogicFn<T, boolean>` that returns `true` when the schema should be applied.
  * @param schema The schema to apply to the field when the `logic` function returns `true`.
  * @template TValue The data type of the field to apply the schema to.
+ *
+ * @experimental 21.0.0
  */
 export function applyWhen<TValue>(
   path: FieldPath<TValue>,
@@ -298,6 +314,8 @@ export function applyWhen<TValue>(
  * @param schema The schema to apply to the field when `predicate` returns `true`.
  * @template TValue The data type of the field to apply the schema to.
  * @template TNarrowed The data type of the schema (a narrowed type of TValue).
+ *
+ * @experimental 21.0.0
  */
 export function applyWhenValue<TValue, TNarrowed extends TValue>(
   path: FieldPath<TValue>,
@@ -313,6 +331,8 @@ export function applyWhenValue<TValue, TNarrowed extends TValue>(
  *   should be applied.
  * @param schema The schema to apply to the field when `predicate` returns `true`.
  * @template TValue The data type of the field to apply the schema to.
+ *
+ * @experimental 21.0.0
  */
 export function applyWhenValue<TValue>(
   path: FieldPath<TValue>,
@@ -358,6 +378,8 @@ export function applyWhenValue(
  * @param action An asynchronous action used to submit the field. The action may return server
  * errors.
  * @template TValue The data type of the field being submitted.
+ *
+ * @experimental 21.0.0
  */
 export async function submit<TValue>(
   form: Field<TValue>,
@@ -414,6 +436,8 @@ function setServerErrors(
  * @param fn A **non-reactive** function that sets up reactive logic rules for the form.
  * @returns A schema object that implements the given logic.
  * @template TValue The value type of a `Field` that this schema binds to.
+ *
+ * @experimental 21.0.0
  */
 export function schema<TValue>(fn: SchemaFn<TValue>): Schema<TValue> {
   return SchemaImpl.create(fn) as unknown as Schema<TValue>;

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -19,6 +19,8 @@ declare const ɵɵTYPE: unique symbol;
 /**
  * Creates a type based on the given type T, but with all readonly properties made writable.
  * @template T The type to create a mutable version of.
+ *
+ * @experimental 21.0.0
  */
 export type Mutable<T> = {
   -readonly [P in keyof T]: T[P];
@@ -27,11 +29,15 @@ export type Mutable<T> = {
 /**
  * A type that represents either a single value of type `T` or a readonly array of `T`.
  * @template T The type of the value(s).
+ *
+ * @experimental 21.0.0
  */
 export type OneOrMany<T> = T | readonly T[];
 
 /**
  * The kind of `FieldPath` (`Root`, `Child` of another `FieldPath`, or `Item` in a `FieldPath` array)
+ *
+ * @experimental 21.0.0
  */
 export declare namespace PathKind {
   /**
@@ -63,11 +69,15 @@ export declare namespace PathKind {
 export type PathKind = PathKind.Root | PathKind.Child | PathKind.Item;
 /**
  * A status indicating whether a field is unsubmitted, submitted, or currently submitting.
+ *
+ * @experimental 21.0.0
  */
 export type SubmittedStatus = 'unsubmitted' | 'submitted' | 'submitting';
 
 /**
  * A reason for a field's disablement.
+ *
+ * @experimental 21.0.0
  */
 export interface DisabledReason {
   /** The field that is disabled. */
@@ -76,7 +86,11 @@ export interface DisabledReason {
   readonly message?: string;
 }
 
-/** The absence of an error which indicates a successful validation result. */
+/**
+ * The absence of an error which indicates a successful validation result.
+ *
+ * @experimental 21.0.0
+ */
 export type ValidationSuccess = null | undefined | void;
 
 /**
@@ -89,6 +103,8 @@ export type ValidationSuccess = null | undefined | void;
  *    being validated.
  *
  * @template E the type of error (defaults to {@link ValidationError}).
+ *
+ * @experimental 21.0.0
  */
 export type FieldValidationResult<E extends ValidationError = ValidationError> =
   | ValidationSuccess
@@ -104,6 +120,8 @@ export type FieldValidationResult<E extends ValidationError = ValidationError> =
  * 4. A list of {@link ValidationError} with or without fields to indicate multiple errors.
  *
  * @template E the type of error (defaults to {@link ValidationError}).
+ *
+ * @experimental 21.0.0
  */
 export type TreeValidationResult<E extends ValidationError = ValidationError> =
   | ValidationSuccess
@@ -118,6 +136,8 @@ export type TreeValidationResult<E extends ValidationError = ValidationError> =
  * 3. A list of {@link ValidationError} with fields to indicate multiple errors.
  *
  * @template E the type of error (defaults to {@link ValidationError}).
+ *
+ * @experimental 21.0.0
  */
 export type ValidationResult<E extends ValidationError = ValidationError> =
   | ValidationSuccess
@@ -131,6 +151,8 @@ export type ValidationResult<E extends ValidationError = ValidationError> =
  * 5. 'pending' if the validation is not yet resolved.
  *
  * @template E the type of error (defaults to {@link ValidationError}).
+ *
+ * @experimental 21.0.0
  */
 export type AsyncValidationResult<E extends ValidationError = ValidationError> =
   | ValidationResult<E>
@@ -145,6 +167,8 @@ export type AsyncValidationResult<E extends ValidationError = ValidationError> =
  *
  * @template TValue The type of the data which the field is wrapped around.
  * @template TKey The type of the property key which this field resides under in its parent.
+ *
+ * @experimental 21.0.0
  */
 export type Field<TValue, TKey extends string | number = string | number> = (() => FieldState<
   TValue,
@@ -160,6 +184,8 @@ export type Field<TValue, TKey extends string | number = string | number> = (() 
  * The sub-fields that a user can navigate to from a `Field<TValue>`.
  *
  * @template TValue The type of the data which the parent field is wrapped around.
+ *
+ * @experimental 21.0.0
  */
 export type Subfields<TValue> = {
   readonly [K in keyof TValue as TValue[K] extends Function ? never : K]: MaybeField<
@@ -172,6 +198,8 @@ export type Subfields<TValue> = {
  * An iterable object with the same shape as a readonly array.
  *
  * @template T The array item type.
+ *
+ * @experimental 21.0.0
  */
 export type ReadonlyArrayLike<T> = Pick<
   ReadonlyArray<T>,
@@ -187,6 +215,8 @@ export type ReadonlyArrayLike<T> = Pick<
  *
  * @template TValue The type of the data which the field is wrapped around.
  * @template TKey The type of the property key which this field resides under in its parent.
+ *
+ * @experimental 21.0.0
  */
 export type MaybeField<TValue, TKey extends string | number = string | number> =
   | (TValue & undefined)
@@ -195,6 +225,8 @@ export type MaybeField<TValue, TKey extends string | number = string | number> =
 /**
  * Contains all of the state (e.g. value, statuses, etc.) associated with a `Field`, exposed as
  * signals.
+ *
+ * @experimental 21.0.0
  */
 export interface FieldState<TValue, TKey extends string | number = string | number> {
   /**
@@ -334,6 +366,8 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
  *
  * @template TValue The type of the data which the form is wrapped around.
  * @template TPathKind The kind of path (root field, child field, or item of an array)
+ *
+ * @experimental 21.0.0
  */
 export type FieldPath<TValue, TPathKind extends PathKind = PathKind.Root> = {
   [ɵɵTYPE]: [TValue, TPathKind];
@@ -352,6 +386,8 @@ export type FieldPath<TValue, TPathKind extends PathKind = PathKind.Root> = {
  *
  * @template TValue The type of the data which the field is wrapped around.
  * @template TPathKind The kind of path (root field, child field, or item of an array)
+ *
+ * @experimental 21.0.0
  */
 export type MaybeFieldPath<TValue, TPathKind extends PathKind = PathKind.Root> =
   | (TValue & undefined)
@@ -361,6 +397,8 @@ export type MaybeFieldPath<TValue, TPathKind extends PathKind = PathKind.Root> =
  * Defines logic for a form.
  *
  * @template TValue The type of data stored in the form that this schema is attached to.
+ *
+ * @experimental 21.0.0
  */
 export type Schema<in TValue> = {
   [ɵɵTYPE]: SchemaFn<TValue, PathKind.Root>;
@@ -371,6 +409,8 @@ export type Schema<in TValue> = {
  *
  * @template TValue The type of data stored in the form that this schema function is attached to.
  * @template TPathKind The kind of path this schema function can be bound to.
+ *
+ * @experimental 21.0.0
  */
 export type SchemaFn<TValue, TPathKind extends PathKind = PathKind.Root> = (
   p: FieldPath<TValue, TPathKind>,
@@ -381,6 +421,8 @@ export type SchemaFn<TValue, TPathKind extends PathKind = PathKind.Root> = (
  *
  * @template TValue The type of data stored in the form that this schema function is attached to.
  * @template TPathKind The kind of path this schema function can be bound to.
+ *
+ * @experimental 21.0.0
  */
 export type SchemaOrSchemaFn<TValue, TPathKind extends PathKind = PathKind.Root> =
   | Schema<TValue>
@@ -393,6 +435,8 @@ export type SchemaOrSchemaFn<TValue, TPathKind extends PathKind = PathKind.Root>
  * @template TValue The data type for the field the logic is bound to.
  * @template TReturn The type of the result returned by the logic function.
  * @template TPathKind The kind of path the logic is applied to (root field, child field, or item of an array)
+ *
+ * @experimental 21.0.0
  */
 export type LogicFn<TValue, TReturn, TPathKind extends PathKind = PathKind.Root> = (
   ctx: FieldContext<TValue, TPathKind>,
@@ -404,6 +448,8 @@ export type LogicFn<TValue, TReturn, TPathKind extends PathKind = PathKind.Root>
  *
  * @template TValue The type of value stored in the field being validated
  * @template TPathKind The kind of path being validated (root field, child field, or item of an array)
+ *
+ * @experimental 21.0.0
  */
 export type FieldValidator<TValue, TPathKind extends PathKind = PathKind.Root> = LogicFn<
   TValue,
@@ -417,6 +463,8 @@ export type FieldValidator<TValue, TPathKind extends PathKind = PathKind.Root> =
  *
  * @template TValue The type of value stored in the field being validated
  * @template TPathKind The kind of path being validated (root field, child field, or item of an array)
+ *
+ * @experimental 21.0.0
  */
 export type TreeValidator<TValue, TPathKind extends PathKind = PathKind.Root> = LogicFn<
   TValue,
@@ -431,6 +479,8 @@ export type TreeValidator<TValue, TPathKind extends PathKind = PathKind.Root> = 
  *
  * @template TValue The type of value stored in the field being validated
  * @template TPathKind The kind of path being validated (root field, child field, or item of an array)
+ *
+ * @experimental 21.0.0
  */
 export type Validator<TValue, TPathKind extends PathKind = PathKind.Root> = LogicFn<
   TValue,
@@ -441,6 +491,8 @@ export type Validator<TValue, TPathKind extends PathKind = PathKind.Root> = Logi
 /**
  * Provides access to the state of the current field as well as functions that can be used to look
  * up state of other fields based on a `FieldPath`.
+ *
+ * @experimental 21.0.0
  */
 export type FieldContext<
   TValue,
@@ -453,6 +505,8 @@ export type FieldContext<
 
 /**
  * The base field context that is available for all fields.
+ *
+ * @experimental 21.0.0
  */
 export interface RootFieldContext<TValue> {
   /** A signal containing the value of the current field. */
@@ -471,6 +525,8 @@ export interface RootFieldContext<TValue> {
 
 /**
  * Field context that is available for all fields that are a child of another field.
+ *
+ * @experimental 21.0.0
  */
 export interface ChildFieldContext<TValue> extends RootFieldContext<TValue> {
   /** The key of the current field in its parent field. */
@@ -479,6 +535,8 @@ export interface ChildFieldContext<TValue> extends RootFieldContext<TValue> {
 
 /**
  * Field context that is available for all fields that are an item in an array field.
+ *
+ * @experimental 21.0.0
  */
 export interface ItemFieldContext<TValue> extends ChildFieldContext<TValue> {
   /** The index of the current field in its parent field. */

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -7,7 +7,7 @@
  */
 
 import {Signal, WritableSignal} from '@angular/core';
-import type {Control} from '../controls/control';
+import type {Control} from './control_directive';
 import {AggregateProperty, Property} from './property';
 import type {ValidationError, WithOptionalField, WithoutField} from './validation_errors';
 

--- a/packages/forms/signals/src/api/validation_errors.ts
+++ b/packages/forms/signals/src/api/validation_errors.ts
@@ -20,29 +20,39 @@ interface ValidationErrorOptions {
 /**
  * A type that requires the given type `T` to have a `field` property.
  * @template T The type to add a `field` to.
+ *
+ * @experimental 21.0.0
  */
 export type WithField<T> = T & {field: Field<unknown>};
 
 /**
  * A type that allows the given type `T` to optionally have a `field` property.
  * @template T The type to optionally add a `field` to.
+ *
+ * @experimental 21.0.0
  */
 export type WithOptionalField<T> = Omit<T, 'field'> & {field?: Field<unknown>};
 
 /**
  * A type that ensures the given type `T` does not have a `field` property.
  * @template T The type to remove the `field` from.
+ *
+ * @experimental 21.0.0
  */
 export type WithoutField<T> = T & {field: never};
 
 /**
  * Create a required error associated with the target field
  * @param options The validation error options
+ *
+ * @experimental 21.0.0
  */
 export function requiredError(options: WithField<ValidationErrorOptions>): RequiredValidationError;
 /**
  * Create a required error
  * @param options The optional validation error options
+ *
+ * @experimental 21.0.0
  */
 export function requiredError(
   options?: ValidationErrorOptions,
@@ -57,6 +67,8 @@ export function requiredError(
  * Create a min value error associated with the target field
  * @param min The min value constraint
  * @param options The validation error options
+ *
+ * @experimental 21.0.0
  */
 export function minError(
   min: number,
@@ -66,6 +78,8 @@ export function minError(
  * Create a min value error
  * @param min The min value constraint
  * @param options The optional validation error options
+ *
+ * @experimental 21.0.0
  */
 export function minError(
   min: number,
@@ -82,6 +96,8 @@ export function minError(
  * Create a max value error associated with the target field
  * @param max The max value constraint
  * @param options The validation error options
+ *
+ * @experimental 21.0.0
  */
 export function maxError(
   max: number,
@@ -91,6 +107,8 @@ export function maxError(
  * Create a max value error
  * @param max The max value constraint
  * @param options The optional validation error options
+ *
+ * @experimental 21.0.0
  */
 export function maxError(
   max: number,
@@ -107,6 +125,8 @@ export function maxError(
  * Create a minLength error associated with the target field
  * @param minLength The minLength constraint
  * @param options The validation error options
+ *
+ * @experimental 21.0.0
  */
 export function minLengthError(
   minLength: number,
@@ -116,6 +136,8 @@ export function minLengthError(
  * Create a minLength error
  * @param minLength The minLength constraint
  * @param options The optional validation error options
+ *
+ * @experimental 21.0.0
  */
 export function minLengthError(
   minLength: number,
@@ -132,6 +154,8 @@ export function minLengthError(
  * Create a maxLength error associated with the target field
  * @param maxLength The maxLength constraint
  * @param options The validation error options
+ *
+ * @experimental 21.0.0
  */
 export function maxLengthError(
   maxLength: number,
@@ -141,6 +165,8 @@ export function maxLengthError(
  * Create a maxLength error
  * @param maxLength The maxLength constraint
  * @param options The optional validation error options
+ *
+ * @experimental 21.0.0
  */
 export function maxLengthError(
   maxLength: number,
@@ -157,6 +183,8 @@ export function maxLengthError(
  * Create a pattern matching error associated with the target field
  * @param pattern The violated pattern
  * @param options The validation error options
+ *
+ * @experimental 21.0.0
  */
 export function patternError(
   pattern: RegExp,
@@ -166,6 +194,8 @@ export function patternError(
  * Create a pattern matching error
  * @param pattern The violated pattern
  * @param options The optional validation error options
+ *
+ * @experimental 21.0.0
  */
 export function patternError(
   pattern: RegExp,
@@ -181,11 +211,15 @@ export function patternError(
 /**
  * Create an email format error associated with the target field
  * @param options The validation error options
+ *
+ * @experimental 21.0.0
  */
 export function emailError(options: WithField<ValidationErrorOptions>): EmailValidationError;
 /**
  * Create an email format error
  * @param options The optional validation error options
+ *
+ * @experimental 21.0.0
  */
 export function emailError(options?: ValidationErrorOptions): WithoutField<EmailValidationError>;
 export function emailError(
@@ -198,6 +232,8 @@ export function emailError(
  * Create a standard schema issue error associated with the target field
  * @param issue The standard schema issue
  * @param options The validation error options
+ *
+ * @experimental 21.0.0
  */
 export function standardSchemaError(
   issue: StandardSchemaV1.Issue,
@@ -207,6 +243,8 @@ export function standardSchemaError(
  * Create a standard schema issue error
  * @param issue The standard schema issue
  * @param options The optional validation error options
+ *
+ * @experimental 21.0.0
  */
 export function standardSchemaError(
   issue: StandardSchemaV1.Issue,
@@ -222,6 +260,8 @@ export function standardSchemaError(
 /**
  * Create a custom error associated with the target field
  * @param obj The object to create an error from
+ *
+ * @experimental 21.0.0
  */
 export function customError<E extends Partial<ValidationError>>(
   obj: WithField<E>,
@@ -229,6 +269,8 @@ export function customError<E extends Partial<ValidationError>>(
 /**
  * Create a custom error
  * @param obj The object to create an error from
+ *
+ * @experimental 21.0.0
  */
 export function customError<E extends Partial<ValidationError>>(
   obj?: E,
@@ -243,6 +285,8 @@ export function customError<E extends Partial<ValidationError>>(
  * Common interface for all validation errors.
  *
  * Use the creation functions to create an instance (e.g. `requiredError`, `minError`, etc.).
+ *
+ * @experimental 21.0.0
  */
 export interface ValidationError {
   /** Identifies the kind of error. */
@@ -255,6 +299,8 @@ export interface ValidationError {
 
 /**
  * A custom error that may contain additional properties
+ *
+ * @experimental 21.0.0
  */
 export class CustomValidationError implements ValidationError {
   /** Brand the class to avoid Typescript structural matching */
@@ -284,6 +330,8 @@ export class CustomValidationError implements ValidationError {
 /**
  * Internal version of `NgValidationError`, we create this separately so we can change its type on
  * the exported version to a type union of the possible sub-classes.
+ *
+ * @experimental 21.0.0
  */
 abstract class _NgValidationError implements ValidationError {
   /** Brand the class to avoid Typescript structural matching */
@@ -307,6 +355,8 @@ abstract class _NgValidationError implements ValidationError {
 
 /**
  * An error used to indicate that a required field is empty.
+ *
+ * @experimental 21.0.0
  */
 export class RequiredValidationError extends _NgValidationError {
   override readonly kind = 'required';
@@ -314,6 +364,8 @@ export class RequiredValidationError extends _NgValidationError {
 
 /**
  * An error used to indicate that a value is lower than the minimum allowed.
+ *
+ * @experimental 21.0.0
  */
 export class MinValidationError extends _NgValidationError {
   override readonly kind = 'min';
@@ -328,6 +380,8 @@ export class MinValidationError extends _NgValidationError {
 
 /**
  * An error used to indicate that a value is higher than the maximum allowed.
+ *
+ * @experimental 21.0.0
  */
 export class MaxValidationError extends _NgValidationError {
   override readonly kind = 'max';
@@ -342,6 +396,8 @@ export class MaxValidationError extends _NgValidationError {
 
 /**
  * An error used to indicate that a value is shorter than the minimum allowed length.
+ *
+ * @experimental 21.0.0
  */
 export class MinLengthValidationError extends _NgValidationError {
   override readonly kind = 'minLength';
@@ -356,6 +412,8 @@ export class MinLengthValidationError extends _NgValidationError {
 
 /**
  * An error used to indicate that a value is longer than the maximum allowed length.
+ *
+ * @experimental 21.0.0
  */
 export class MaxLengthValidationError extends _NgValidationError {
   override readonly kind = 'maxLength';
@@ -370,6 +428,8 @@ export class MaxLengthValidationError extends _NgValidationError {
 
 /**
  * An error used to indicate that a value does not match the required pattern.
+ *
+ * @experimental 21.0.0
  */
 export class PatternValidationError extends _NgValidationError {
   override readonly kind = 'pattern';
@@ -384,6 +444,8 @@ export class PatternValidationError extends _NgValidationError {
 
 /**
  * An error used to indicate that a value is not a valid email.
+ *
+ * @experimental 21.0.0
  */
 export class EmailValidationError extends _NgValidationError {
   override readonly kind = 'email';
@@ -391,6 +453,8 @@ export class EmailValidationError extends _NgValidationError {
 
 /**
  * An error used to indicate an issue validating against a standard schema.
+ *
+ * @experimental 21.0.0
  */
 export class StandardSchemaValidationError extends _NgValidationError {
   override readonly kind = 'standardSchema';
@@ -424,6 +488,8 @@ export class StandardSchemaValidationError extends _NgValidationError {
  *   }
  * }
  * ```
+ *
+ * @experimental 21.0.0
  */
 export const NgValidationError: abstract new () => NgValidationError = _NgValidationError as any;
 export type NgValidationError =

--- a/packages/forms/signals/src/api/validators/email.ts
+++ b/packages/forms/signals/src/api/validators/email.ts
@@ -53,6 +53,8 @@ const EMAIL_REGEXP =
  *  - `error`: Custom validation error(s) to be used instead of the default `ValidationError.email()`
  *    or a function that receives the `FieldContext` and returns custom validation error(s).
  * @template TPathKind The kind of path the logic is bound to (a root path, child path, or item of an array)
+ *
+ * @experimental 21.0.0
  */
 export function email<TPathKind extends PathKind = PathKind.Root>(
   path: FieldPath<string, TPathKind>,

--- a/packages/forms/signals/src/api/validators/index.ts
+++ b/packages/forms/signals/src/api/validators/index.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-export {email} from './email';
-export {max} from './max';
-export {maxLength} from './max_length';
-export {min} from './min';
-export {minLength} from './min_length';
-export {pattern} from './pattern';
-export {required} from './required';
-export {validateStandardSchema} from './standard_schema';
+export * from './email';
+export * from './max';
+export * from './max_length';
+export * from './min';
+export * from './min_length';
+export * from './pattern';
+export * from './required';
+export * from './standard_schema';

--- a/packages/forms/signals/src/api/validators/index.ts
+++ b/packages/forms/signals/src/api/validators/index.ts
@@ -13,3 +13,4 @@ export {min} from './min';
 export {minLength} from './min_length';
 export {pattern} from './pattern';
 export {required} from './required';
+export {validateStandardSchema} from './standard_schema';

--- a/packages/forms/signals/src/api/validators/max.ts
+++ b/packages/forms/signals/src/api/validators/max.ts
@@ -25,6 +25,8 @@ import {BaseValidatorConfig, getOption, isEmpty} from './util';
  *  - `error`: Custom validation error(s) to be used instead of the default `ValidationError.max(maxValue)`
  *    or a function that receives the `FieldContext` and returns custom validation error(s).
  * @template TPathKind The kind of path the logic is bound to (a root path, child path, or item of an array)
+ *
+ * @experimental 21.0.0
  */
 export function max<TPathKind extends PathKind = PathKind.Root>(
   path: FieldPath<number, TPathKind>,

--- a/packages/forms/signals/src/api/validators/max_length.ts
+++ b/packages/forms/signals/src/api/validators/max_length.ts
@@ -32,6 +32,8 @@ import {
  *    or a function that receives the `FieldContext` and returns custom validation error(s).
  * @template TValue The type of value stored in the field the logic is bound to.
  * @template TPathKind The kind of path the logic is bound to (a root path, child path, or item of an array)
+ *
+ * @experimental 21.0.0
  */
 export function maxLength<
   TValue extends ValueWithLengthOrSize,

--- a/packages/forms/signals/src/api/validators/min.ts
+++ b/packages/forms/signals/src/api/validators/min.ts
@@ -25,6 +25,8 @@ import {BaseValidatorConfig, getOption, isEmpty} from './util';
  *  - `error`: Custom validation error(s) to be used instead of the default `ValidationError.min(minValue)`
  *    or a function that receives the `FieldContext` and returns custom validation error(s).
  * @template TPathKind The kind of path the logic is bound to (a root path, child path, or item of an array)
+ *
+ * @experimental 21.0.0
  */
 export function min<TPathKind extends PathKind = PathKind.Root>(
   path: FieldPath<number, TPathKind>,

--- a/packages/forms/signals/src/api/validators/min_length.ts
+++ b/packages/forms/signals/src/api/validators/min_length.ts
@@ -32,6 +32,8 @@ import {
  *    or a function that receives the `FieldContext` and returns custom validation error(s).
  * @template TValue The type of value stored in the field the logic is bound to.
  * @template TPathKind The kind of path the logic is bound to (a root path, child path, or item of an array)
+ *
+ * @experimental 21.0.0
  */
 export function minLength<
   TValue extends ValueWithLengthOrSize,

--- a/packages/forms/signals/src/api/validators/pattern.ts
+++ b/packages/forms/signals/src/api/validators/pattern.ts
@@ -24,6 +24,8 @@ import {BaseValidatorConfig, getOption, isEmpty} from './util';
  *  - `error`: Custom validation error(s) to be used instead of the default `ValidationError.pattern(pattern)`
  *    or a function that receives the `FieldContext` and returns custom validation error(s).
  * @template TPathKind The kind of path the logic is bound to (a root path, child path, or item of an array)
+ *
+ * @experimental 21.0.0
  */
 export function pattern<TPathKind extends PathKind = PathKind.Root>(
   path: FieldPath<string, TPathKind>,

--- a/packages/forms/signals/src/api/validators/required.ts
+++ b/packages/forms/signals/src/api/validators/required.ts
@@ -26,6 +26,8 @@ import {BaseValidatorConfig, getOption, isEmpty} from './util';
  *  - `when`: A function that receives the `FieldContext` and returns true if the field is required
  * @template TValue The type of value stored in the field the logic is bound to.
  * @template TPathKind The kind of path the logic is bound to (a root path, child path, or item of an array)
+ *
+ * @experimental 21.0.0
  */
 export function required<TValue, TPathKind extends PathKind = PathKind.Root>(
   path: FieldPath<TValue, TPathKind>,

--- a/packages/forms/signals/src/api/validators/standard_schema.ts
+++ b/packages/forms/signals/src/api/validators/standard_schema.ts
@@ -18,6 +18,8 @@ import {standardSchemaError, StandardSchemaValidationError} from '../validation_
  * Utility type that removes a string index key when its value is `unknown`,
  * i.e. `{[key: string]: unknown}`. It allows specific string keys to pass through, even if their
  * value is `unknown`, e.g. `{key: unknown}`.
+ *
+ * @experimental 21.0.0
  */
 export type RemoveStringIndexUnknownKey<K, V> = string extends K
   ? unknown extends V
@@ -29,6 +31,8 @@ export type RemoveStringIndexUnknownKey<K, V> = string extends K
  * Utility type that recursively ignores unknown string index properties on the given object.
  * We use this on the `TSchema` type in `validateStandardSchema` in order to accommodate Zod's
  * `looseObject` which includes `{[key: string]: unknown}` as part of the type.
+ *
+ * @experimental 21.0.0
  */
 export type IgnoreUnknownProperties<T> =
   T extends Record<PropertyKey, unknown>
@@ -47,6 +51,8 @@ export type IgnoreUnknownProperties<T> =
  * @template TSchema The type validated by the schema. This may be either the full `TValue` type,
  *   or a partial of it.
  * @template TValue The type of value stored in the field being validated.
+ *
+ * @experimental 21.0.0
  */
 export function validateStandardSchema<TSchema, TValue extends IgnoreUnknownProperties<TSchema>>(
   path: FieldPath<TValue>,

--- a/packages/forms/signals/src/controls/control.ts
+++ b/packages/forms/signals/src/controls/control.ts
@@ -63,6 +63,8 @@ import {InteropNgControl} from './interop_ng_control';
  * 4. Provides a fake `NgControl` that implements a subset of the features available on the reactive
  *    forms `NgControl`. This is provided to improve interoperability with controls designed to work
  *    with reactive forms. It should not be used by controls written for signal forms.
+ *
+ * @experimental 21.0.0
  */
 @Directive({
   selector: '[control]',

--- a/packages/forms/signals/src/field/node.ts
+++ b/packages/forms/signals/src/field/node.ts
@@ -7,13 +7,14 @@
  */
 
 import type {Signal, WritableSignal} from '@angular/core';
+import type {Control} from '../api/control_directive';
 import {AggregateProperty, Property} from '../api/property';
 import type {DisabledReason, Field, FieldContext, FieldState} from '../api/types';
 import type {ValidationError} from '../api/validation_errors';
-import type {Control} from '../controls/control';
 import {LogicNode} from '../schema/logic_node';
 import {FieldPathNode} from '../schema/path_node';
 import {FieldNodeContext} from './context';
+import type {FieldAdapter} from './field_adapter';
 import type {FormFieldManager} from './manager';
 import {FieldPropertyState} from './property';
 import {FIELD_PROXY_HANDLER} from './proxy';
@@ -27,7 +28,6 @@ import {
 } from './structure';
 import {FieldSubmitState} from './submit';
 import {ValidationState} from './validation';
-import type {FieldAdapter} from './field_adapter';
 /**
  * Internal node in the form tree for a given field.
  *

--- a/packages/forms/signals/src/field/state.ts
+++ b/packages/forms/signals/src/field/state.ts
@@ -7,8 +7,8 @@
  */
 
 import {computed, signal, Signal} from '@angular/core';
+import type {Control} from '../api/control_directive';
 import type {DisabledReason} from '../api/types';
-import type {Control} from '../controls/control';
 import type {FieldNode} from './node';
 import {reduceChildren, shortCircuitTrue} from './util';
 

--- a/packages/forms/signals/test/node/api/validators/standard_schema.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/standard_schema.spec.ts
@@ -9,8 +9,7 @@
 import {ApplicationRef, Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import * as z from 'zod';
-import {form, schema} from '../../../../public_api';
-import {validateStandardSchema} from '../../../../src/api/validators/standard_schema';
+import {form, schema, validateStandardSchema} from '../../../../public_api';
 
 interface Flight {
   id: number;


### PR DESCRIPTION
Ensure that each public API symbol in @angular/forms/signals is marked
as `@experimental`, also ensure that all public APIs live under `api/`.