### PR TITLE
fix(migrations): fix bug in ngclass-to-class migration

### DIFF
--- a/packages/core/schematics/migrations/ngclass-to-class-migration/schema.json
+++ b/packages/core/schematics/migrations/ngclass-to-class-migration/schema.json
@@ -14,7 +14,7 @@
       "type": "boolean",
       "description": "Enables the migration of object literals with space-separated keys",
       "x-prompt": "Should the migration also migrate space-separated keys?",
-      "default": "false"
+      "default": false
     }
   }
 }

--- a/packages/core/schematics/test/ngclass_to_class_migration_spec.ts
+++ b/packages/core/schematics/test/ngclass_to_class_migration_spec.ts
@@ -229,6 +229,28 @@ describe('NgClass migration', () => {
       const content = tree.readContent('/app.component.ts');
       expect(content).toContain('<div [class]=""></div>');
     });
+
+    it('should not split and migrate multiple classes in one key without option', async () => {
+      writeFile(
+        '/app.component.ts',
+        `
+        import {Component} from '@angular/core';
+        import {NgClass} from '@angular/common';
+        @Component({
+        imports: [NgClass],
+        template: \`
+          <div [ngClass]="{'class1 class2': condition}"></div>
+        \` })
+        export class Cmp {}
+      `,
+      );
+
+      await runMigration();
+
+      const content = tree.readContent('/app.component.ts');
+
+      expect(content).toContain(`<div [ngClass]="{'class1 class2': condition}"></div>`);
+    });
   });
 
   describe('Simple ngClass object migrations', () => {


### PR DESCRIPTION
Fix bug in ngclass-to-class migration. The migrateSpaceSeparatedKey option was configured incorrectly and I added a test case

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The migrateSpaceSeparatedKey option was configured incorrectly


## What is the new behavior?
The migrateSpaceSeparatedKey option is now set correctly and handles migrations well


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
