### PR TITLE
docs: add missing drag & drop docs

### DIFF
--- a/adev/src/content/examples/drag-drop/src/copy-list/app/app.component.css
+++ b/adev/src/content/examples/drag-drop/src/copy-list/app/app.component.css
@@ -1,0 +1,53 @@
+.example-container {
+  width: 400px;
+  max-width: 100%;
+  margin: 0 25px 25px 0;
+  display: inline-block;
+  vertical-align: top;
+  font-family: sans-serif;
+}
+
+.example-list {
+  border: solid 1px #ccc;
+  min-height: 60px;
+  background: white;
+  border-radius: 4px;
+  overflow: hidden;
+  display: block;
+}
+
+.example-box {
+  padding: 20px 10px;
+  border-bottom: solid 1px #ccc;
+  color: rgba(0, 0, 0, 0.87);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  box-sizing: border-box;
+  cursor: move;
+  background: white;
+  font-size: 14px;
+  font-family: sans-serif;
+}
+
+.cdk-drag-preview {
+  box-sizing: border-box;
+  border-radius: 4px;
+  box-shadow:
+    0 5px 5px -3px rgba(0, 0, 0, 0.2),
+    0 8px 10px 1px rgba(0, 0, 0, 0.14),
+    0 3px 14px 2px rgba(0, 0, 0, 0.12);
+}
+
+.cdk-drag-animating {
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}
+
+.example-box:last-child {
+  border: none;
+}
+
+.example-list.cdk-drop-list-dragging .example-box:not(.cdk-drag-placeholder) {
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}

--- a/adev/src/content/examples/drag-drop/src/copy-list/app/app.component.html
+++ b/adev/src/content/examples/drag-drop/src/copy-list/app/app.component.html
@@ -1,0 +1,32 @@
+<div class="example-container">
+  <h2>Products</h2>
+
+  <div
+    cdkDropList
+    [cdkDropListData]="products"
+    [cdkDropListConnectedTo]="[cartList]"
+    cdkDropListSortingDisabled
+    cdkDropListHasAnchor
+    class="example-list"
+  >
+    @for (product of products; track $index) {
+      <div class="example-box" cdkDrag [cdkDragData]="product">{{product}}</div>
+    }
+  </div>
+</div>
+
+<div class="example-container">
+  <h2>Shopping cart</h2>
+
+  <div
+    cdkDropList
+    #cartList="cdkDropList"
+    [cdkDropListData]="cart"
+    class="example-list"
+    (cdkDropListDropped)="drop($event)"
+  >
+    @for (product of cart; track $index) {
+      <div class="example-box" cdkDrag>{{product}}</div>
+    }
+  </div>
+</div>

--- a/adev/src/content/examples/drag-drop/src/copy-list/app/app.component.ts
+++ b/adev/src/content/examples/drag-drop/src/copy-list/app/app.component.ts
@@ -1,0 +1,35 @@
+import {
+  CdkDrag,
+  CdkDragDrop,
+  CdkDropList,
+  copyArrayItem,
+  moveItemInArray,
+} from '@angular/cdk/drag-drop';
+import {Component} from '@angular/core';
+
+/**
+ * @title Drag&Drop copy between lists
+ */
+@Component({
+  selector: 'cdk-drag-drop-copy-list-example',
+  templateUrl: 'app.component.html',
+  styleUrl: 'app.component.css',
+  imports: [CdkDropList, CdkDrag],
+})
+export class CdkDragDropCopyListExample {
+  products = ['Bananas', 'Oranges', 'Bread', 'Butter', 'Soda', 'Eggs'];
+  cart = ['Tomatoes'];
+
+  drop(event: CdkDragDrop<string[]>) {
+    if (event.previousContainer === event.container) {
+      moveItemInArray(event.container.data, event.previousIndex, event.currentIndex);
+    } else {
+      copyArrayItem(
+        event.previousContainer.data,
+        event.container.data,
+        event.previousIndex,
+        event.currentIndex,
+      );
+    }
+  }
+}

--- a/adev/src/content/examples/drag-drop/src/copy-list/index.html
+++ b/adev/src/content/examples/drag-drop/src/copy-list/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<!-- #docregion -->
+<html lang="en">
+  <head>
+    <base href="/" />
+
+    <title>Drag and Drop Position Locking Example</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+
+  <body>
+    <cdk-drag-drop-copy-list-example></cdk-drag-drop-copy-list-example>
+  </body>
+</html>
+<!-- #enddocregion -->

--- a/adev/src/content/examples/drag-drop/src/copy-list/main.ts
+++ b/adev/src/content/examples/drag-drop/src/copy-list/main.ts
@@ -1,0 +1,5 @@
+import {bootstrapApplication} from '@angular/platform-browser';
+
+import {CdkDragDropCopyListExample} from './app/app.component';
+
+bootstrapApplication(CdkDragDropCopyListExample);

--- a/adev/src/content/guide/drag-drop.md
+++ b/adev/src/content/guide/drag-drop.md
@@ -312,6 +312,14 @@ There are cases where draggable elements can be dragged out of one `cdkDropList`
 
 Alternatively, you can modify the `CDK_DRAG_CONFIG` injection token to update sortingDisabled within the config. For more information see the [dependency injection guide](https://angular.dev/guide/di), [drag config injection token API](api/cdk/drag-drop/CDK_DRAG_CONFIG), and the [drag drop config API](api/cdk/drag-drop/DragDropConfig).
 
+### Copying items between lists
+
+By default, when an item is dragged from one list to another, it is moved out of its original list. However, you can configure the directives to copy the item, leaving the original item in the source list.
+
+To enable copying, you can set the `cdkDropListHasAnchor` input. This tells the `cdkDropList` to create an "anchor" element that stays in the original container and doesn't move with the item. If the user moves the item back into the original container, the anchor is removed automatically. The anchor element can be styled by targeting the `.cdk-drag-anchor` CSS class.
+
+Combining `cdkDropListHasAnchor` with `cdkDropListSortingDisabled` makes it possible to construct a list from which a user can copy items without being able to reorder the source list (e.g. a product list and a shopping cart).
+
 ## Customize animations
 
 Drag and drop supports animations for both:
@@ -341,3 +349,12 @@ Both `cdkDrag` and `cdkDropList` directives only apply essential styles needed f
 | .cdk-drop-list-dragging   | Selector for `cdkDropList` container element that has a draggable element currently being dragged.                                                                                                                                                                                                      |
 | .cdk-drop-list-disabled   | Selector for `cdkDropList` container elements that are disabled.                                                                                                                                                                                                                                        |
 | .cdk-drop-list-receiving  | Selector for `cdkDropList` container element that has a draggable element it can receive from a connected drop list that is currently being dragged.                                                                                                                                                    |
+| .cdk-drag-anchor          | Selector for the anchor element that is created when `cdkDropListHasAnchor` is enabled. This element indicates the position from which the dragged item started.                                                                                                                                         |
+
+## Dragging in a scrollable container
+
+If your draggable items are inside a scrollable container (e.g., a `div` with `overflow: auto`), automatic scrolling will not work unless the scrollable container has the `cdkScrollable` directive. Without it, the CDK cannot detect or control the scroll behavior of the container during drag operations.
+
+## Integrations with other components
+
+The CDK's drag-and-drop functionality can be integrated with different components. Common use cases include sortable `MatTable` components and sortable `MatTabGroup` components.

--- a/adev/src/content/guide/drag-drop.md
+++ b/adev/src/content/guide/drag-drop.md
@@ -320,6 +320,12 @@ To enable copying, you can set the `cdkDropListHasAnchor` input. This tells the 
 
 Combining `cdkDropListHasAnchor` with `cdkDropListSortingDisabled` makes it possible to construct a list from which a user can copy items without being able to reorder the source list (e.g. a product list and a shopping cart).
 
+<docs-code-multifile preview path="adev/src/content/examples/drag-drop/src/copy-list/app/app.component.ts">
+  <docs-code header="app/app.component.html" path="adev/src/content/examples/drag-drop/src/copy-list/app/app.component.html"/>
+  <docs-code header="app/app.component.ts" path="adev/src/content/examples/drag-drop/src/copy-list/app/app.component.ts"/>
+  <docs-code header="app/app.component.css" path="adev/src/content/examples/drag-drop/src/copy-list/app/app.component.css"/>
+</docs-code-multifile>
+
 ## Customize animations
 
 Drag and drop supports animations for both:


### PR DESCRIPTION
Add some documentation that's mentioned in the material.angular.dev version of the drag & drop docs, but was missing from the adev version.
