### PR TITLE
feat(devtools): display provider count on injector tree nodes

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree-fns.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree-fns.ts
@@ -154,6 +154,12 @@ export function transformInjectorResolutionPathsIntoTree(
         injector,
         children: [],
       };
+
+      if (injector.providers !== undefined) {
+        const providerText = injector.providers === 1 ? 'Provider' : 'Providers';
+        next.subLabel = `${injector.providers} ${providerText}`;
+      }
+
       next.injector.node = injectorIdToNode.get(next.injector.id);
       currentLevel.push(next);
       currentLevel = next.children;

--- a/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer/tree-visualizer.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer/tree-visualizer.component.scss
@@ -17,6 +17,18 @@
         background: var(--primary-contrast);
       }
 
+      .sub-label {
+        background-color: #fff;
+        padding: 1px 4px;
+        bottom: -8px;
+        right: -2px;
+        font-size: 14px;
+        position: absolute;
+        border-radius: 50px;
+        color: #000;
+        outline: 1px solid #000;
+      }
+
       .arrow {
         fill: var(--full-contrast);
       }

--- a/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer/tree-visualizer.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer/tree-visualizer.ts
@@ -18,6 +18,7 @@ const RESIZE_OBSERVER_DEBOUNCE = 250;
 
 export interface TreeNode {
   label: string;
+  subLabel?: string;
   children: TreeNode[];
 }
 
@@ -270,12 +271,20 @@ export class TreeVisualizer<T extends TreeNode = TreeNode> extends GraphRenderer
       .attr('y', -halfLabelHeight)
       .append('xhtml:div')
       .attr('class', 'node')
+      .style('position', 'relative')
       .text((node: TreeD3Node<T>) => {
         const label = node.data.label;
         return label.length > MAX_NODE_LABEL_LENGTH
           ? label.slice(0, MAX_NODE_LABEL_LENGTH - '...'.length) + '...'
           : label;
       });
+
+    d3Node.each(function (node: TreeD3Node<T>) {
+      const subLabel = node.data.subLabel;
+      if (subLabel) {
+        d3.select(this).append('div').attr('class', 'sub-label').text(subLabel);
+      }
+    });
 
     this.config.d3NodeModifier(d3Node);
 


### PR DESCRIPTION
Allows the tree visualizer to display a sublabel for each node.

Used by the injector tree to display provider count for each injector.

Closes: #63501

<img width="1512" height="495" alt="Screenshot 2025-09-07 at 9 20 00 PM" src="https://github.com/user-attachments/assets/a2a090bb-b9b8-4ae6-aa7f-2871104296f5" />
