### PR TITLE
docs(tutorial): fixed typo in tutorial - component output properties page

### DIFF
--- a/adev/src/content/tutorials/learn-angular/steps/9-output/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/9-output/README.md
@@ -10,7 +10,7 @@ In this activity, you'll learn how to use the `output()` function to communicate
 
 <hr />
 
-To create the communication path from child to parent components, use the `output` function to initiaize a class property.
+To create the communication path from child to parent components, use the `output` function to initialize a class property.
 
 <docs-code header="child.ts" language="ts">
 @Component({...})


### PR DESCRIPTION
docs(tutorial): fixed typo in tutorial

Fixed typo in tutorial: "Component output properties" page .
Change `initiaize` to `initialize`

Fixes: #63643 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #63643


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
