### PR TITLE
feat(compiler-cli): enable type checking of host bindings by default

### DIFF
--- a/adev/src/app/features/update/update.component.ts
+++ b/adev/src/app/features/update/update.component.ts
@@ -128,8 +128,10 @@ export default class UpdateComponent {
     }
   }
 
-  @HostListener('click', ['$event.target'])
-  copyCode({tagName, textContent}: Element) {
+  @HostListener('click', ['$event'])
+  copyCode(event: Event) {
+    const {tagName, textContent} = event.target as Element;
+
     if (tagName === 'CODE') {
       this.clipboard.copy(textContent!);
       this.snackBar.open('Copied to clipboard', '', {duration: 2000});

--- a/modules/tsconfig.json
+++ b/modules/tsconfig.json
@@ -29,7 +29,6 @@
   ],
   "angularCompilerOptions": {
     "strictTemplates": true,
-    "skipTemplateCodegen": true,
-    "typeCheckHostBindings": true
+    "skipTemplateCodegen": true
   }
 }

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -1461,7 +1461,7 @@ export class NgCompiler {
     const supportJitMode = this.options['supportJitMode'] ?? true;
     const supportTestBed = this.options['supportTestBed'] ?? true;
     const externalRuntimeStyles = this.options['externalRuntimeStyles'] ?? false;
-    const typeCheckHostBindings = this.options.typeCheckHostBindings ?? false;
+    const typeCheckHostBindings = this.options.typeCheckHostBindings ?? true;
 
     // Libraries compiled in partial mode could potentially be used with TestBed within an
     // application. Since this is not known at library compilation time, support is required to

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/GOLDEN_PARTIAL.js
@@ -18,7 +18,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 export class MyCmp {
 }
 MyCmp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyCmp, deps: [], target: i0.ɵɵFactoryTarget.Component });
-MyCmp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyCmp, isStandalone: true, selector: "my-cmp", host: { attributes: { "literal1": "foo" }, listeners: { "event1": "foo()" }, properties: { "attr.attr1": "foo", "prop1": "foo", "class.class1": "false", "style.style1": "true", "class": "foo", "style": "foo" } }, ngImport: i0, template: `
+MyCmp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyCmp, isStandalone: true, selector: "my-cmp", host: { attributes: { "literal1": "foo" }, listeners: { "event1": "foo()" }, properties: { "attr.attr1": "foo", "id": "foo", "class.class1": "false", "style.style1": "true", "class": "foo", "style": "foo" } }, ngImport: i0, template: `
 		<some-elem
 			literal1="foo"
 			(event1)="foo()"
@@ -41,7 +41,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                         'literal1': 'foo',
                         '(event1)': 'foo()',
                         '[attr.attr1]': 'foo',
-                        '[prop1]': 'foo',
+                        '[id]': 'foo',
                         '[class.class1]': 'false',
                         '[style.style1]': 'true',
                         '[class]': 'foo',
@@ -60,7 +60,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 			attr.attrInterp1="interp {{foo}}"
 			propInterp1="interp {{foo}}"
 			/>
-	`
+	`,
                 }]
         }] });
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/TEST_CASES.json
@@ -1,20 +1,15 @@
 {
-	"$schema": "../test_case_schema.json",
-	"cases": [
-	  {
-		"description": "should emit bindings in the correct order",
-		"inputFiles": [
-		  "order_bindings.ts"
-		],
-		"expectations": [
-			{
-			  "failureMessage": "Invalid binding code",
-			  "files": [
-				"order_bindings.js"
-			  ]
-			}
-		]
-	  }
-	]
-  }
-  
+  "$schema": "../test_case_schema.json",
+  "cases": [
+    {
+      "description": "should emit bindings in the correct order",
+      "inputFiles": ["order_bindings.ts"],
+      "expectations": [
+        {
+          "failureMessage": "Invalid binding code",
+          "files": ["order_bindings.js"]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/GOLDEN_PARTIAL.js
@@ -51,14 +51,18 @@ export declare class MyModule {
 import { Directive, NgModule } from '@angular/core';
 import * as i0 from "@angular/core";
 export class HostBindingDir {
+    constructor() {
+        this.getData = () => undefined;
+    }
 }
 HostBindingDir.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: HostBindingDir, deps: [], target: i0.ɵɵFactoryTarget.Directive });
 HostBindingDir.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: HostBindingDir, isStandalone: false, selector: "[hostBindingDir]", host: { properties: { "id": "getData()?.id" } }, ngImport: i0 });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: HostBindingDir, decorators: [{
             type: Directive,
             args: [{
-                    selector: '[hostBindingDir]', host: { '[id]': 'getData()?.id' },
-                    standalone: false
+                    selector: '[hostBindingDir]',
+                    host: { '[id]': 'getData()?.id' },
+                    standalone: false,
                 }]
         }] });
 export class MyModule {
@@ -76,9 +80,9 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
  ****************************************************************************************************/
 import * as i0 from "@angular/core";
 export declare class HostBindingDir {
-    getData?: () => {
+    getData: () => {
         id: number;
-    };
+    } | undefined;
     static ɵfac: i0.ɵɵFactoryDeclaration<HostBindingDir, never>;
     static ɵdir: i0.ɵɵDirectiveDeclaration<HostBindingDir, "[hostBindingDir]", never, {}, {}, never, never, false, never>;
 }
@@ -620,8 +624,8 @@ export declare class MyDirective {
 import { Component, HostListener } from '@angular/core';
 import * as i0 from "@angular/core";
 export class MyComponent {
-    start() {
-    }
+    start() { }
+    done() { }
 }
 MyComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
 MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent, isStandalone: false, selector: "my-comp", host: { listeners: { "@animation.done": "done()", "@animation.start": "start()" } }, ngImport: i0, template: '', isInline: true });
@@ -633,7 +637,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     host: {
                         '(@animation.done)': 'done()',
                     },
-                    standalone: false
+                    standalone: false,
                 }]
         }], propDecorators: { start: [{
                 type: HostListener,
@@ -646,6 +650,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 import * as i0 from "@angular/core";
 export declare class MyComponent {
     start(): void;
+    done(): void;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyComponent, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<MyComponent, "my-comp", never, {}, {}, never, never, false, never>;
 }
@@ -656,10 +661,11 @@ export declare class MyComponent {
 import { Component, HostListener } from '@angular/core';
 import * as i0 from "@angular/core";
 export class MyComponent {
-    start() {
-    }
-    click() {
-    }
+    start() { }
+    click() { }
+    mousedown() { }
+    done() { }
+    mouseup() { }
 }
 MyComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
 MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent, isStandalone: false, selector: "my-comp", host: { listeners: { "mousedown": "mousedown()", "@animation.done": "done()", "mouseup": "mouseup()", "@animation.start": "start()", "click": "click()" } }, ngImport: i0, template: '', isInline: true });
@@ -673,7 +679,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                         '(@animation.done)': 'done()',
                         '(mouseup)': 'mouseup()',
                     },
-                    standalone: false
+                    standalone: false,
                 }]
         }], propDecorators: { start: [{
                 type: HostListener,
@@ -690,6 +696,9 @@ import * as i0 from "@angular/core";
 export declare class MyComponent {
     start(): void;
     click(): void;
+    mousedown(): void;
+    done(): void;
+    mouseup(): void;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyComponent, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<MyComponent, "my-comp", never, {}, {}, never, never, false, never>;
 }
@@ -837,40 +846,55 @@ export declare class MyModule {
  ****************************************************************************************************/
 import { Directive } from '@angular/core';
 import * as i0 from "@angular/core";
-export class HostBindingDir {
+export class HostBindingLinkDir {
     constructor() {
         this.evil = 'evil';
     }
 }
-HostBindingDir.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: HostBindingDir, deps: [], target: i0.ɵɵFactoryTarget.Directive });
-HostBindingDir.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: HostBindingDir, isStandalone: true, selector: "[hostBindingDir]", host: { properties: { "innerHtml": "evil", "href": "evil", "attr.style": "evil", "src": "evil", "sandbox": "evil" } }, ngImport: i0 });
-i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: HostBindingDir, decorators: [{
+HostBindingLinkDir.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: HostBindingLinkDir, deps: [], target: i0.ɵɵFactoryTarget.Directive });
+HostBindingLinkDir.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: HostBindingLinkDir, isStandalone: true, selector: "a[hostBindingLinkDir]", host: { properties: { "innerHtml": "evil", "href": "evil", "attr.style": "evil" } }, ngImport: i0 });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: HostBindingLinkDir, decorators: [{
             type: Directive,
             args: [{
-                    selector: '[hostBindingDir]',
+                    selector: 'a[hostBindingLinkDir]',
                     host: {
                         '[innerHtml]': 'evil',
                         '[href]': 'evil',
                         '[attr.style]': 'evil',
-                        '[src]': 'evil',
-                        '[sandbox]': 'evil',
                     },
                 }]
         }] });
-export class HostBindingDir2 {
+export class HostBindingImageDir {
     constructor() {
         this.evil = 'evil';
     }
 }
-HostBindingDir2.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: HostBindingDir2, deps: [], target: i0.ɵɵFactoryTarget.Directive });
-HostBindingDir2.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: HostBindingDir2, isStandalone: true, selector: "a", host: { properties: { "innerHtml": "evil", "href": "evil", "attr.style": "evil", "src": "evil", "sandbox": "evil" } }, ngImport: i0 });
-i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: HostBindingDir2, decorators: [{
+HostBindingImageDir.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: HostBindingImageDir, deps: [], target: i0.ɵɵFactoryTarget.Directive });
+HostBindingImageDir.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: HostBindingImageDir, isStandalone: true, selector: "img[hostBindingImgDir]", host: { properties: { "innerHtml": "evil", "attr.style": "evil", "src": "evil" } }, ngImport: i0 });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: HostBindingImageDir, decorators: [{
             type: Directive,
             args: [{
-                    selector: 'a',
+                    selector: 'img[hostBindingImgDir]',
                     host: {
                         '[innerHtml]': 'evil',
-                        '[href]': 'evil',
+                        '[attr.style]': 'evil',
+                        '[src]': 'evil',
+                    },
+                }]
+        }] });
+export class HostBindingIframeDir {
+    constructor() {
+        this.evil = 'evil';
+    }
+}
+HostBindingIframeDir.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: HostBindingIframeDir, deps: [], target: i0.ɵɵFactoryTarget.Directive });
+HostBindingIframeDir.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: HostBindingIframeDir, isStandalone: true, selector: "iframe[hostBindingIframeDir]", host: { properties: { "innerHtml": "evil", "attr.style": "evil", "src": "evil", "sandbox": "evil" } }, ngImport: i0 });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: HostBindingIframeDir, decorators: [{
+            type: Directive,
+            args: [{
+                    selector: 'iframe[hostBindingIframeDir]',
+                    host: {
+                        '[innerHtml]': 'evil',
                         '[attr.style]': 'evil',
                         '[src]': 'evil',
                         '[sandbox]': 'evil',
@@ -882,15 +906,20 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
  * PARTIAL FILE: sanitization.d.ts
  ****************************************************************************************************/
 import * as i0 from "@angular/core";
-export declare class HostBindingDir {
+export declare class HostBindingLinkDir {
     evil: string;
-    static ɵfac: i0.ɵɵFactoryDeclaration<HostBindingDir, never>;
-    static ɵdir: i0.ɵɵDirectiveDeclaration<HostBindingDir, "[hostBindingDir]", never, {}, {}, never, never, true, never>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<HostBindingLinkDir, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<HostBindingLinkDir, "a[hostBindingLinkDir]", never, {}, {}, never, never, true, never>;
 }
-export declare class HostBindingDir2 {
+export declare class HostBindingImageDir {
     evil: string;
-    static ɵfac: i0.ɵɵFactoryDeclaration<HostBindingDir2, never>;
-    static ɵdir: i0.ɵɵDirectiveDeclaration<HostBindingDir2, "a", never, {}, {}, never, never, true, never>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<HostBindingImageDir, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<HostBindingImageDir, "img[hostBindingImgDir]", never, {}, {}, never, never, true, never>;
+}
+export declare class HostBindingIframeDir {
+    evil: string;
+    static ɵfac: i0.ɵɵFactoryDeclaration<HostBindingIframeDir, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<HostBindingIframeDir, "iframe[hostBindingIframeDir]", never, {}, {}, never, never, true, never>;
 }
 
 /****************************************************************************************************

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/chain_synthetic_listeners.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/chain_synthetic_listeners.ts
@@ -1,15 +1,16 @@
 import {Component, HostListener} from '@angular/core';
 
 @Component({
-    selector: 'my-comp',
-    template: '',
-    host: {
-        '(@animation.done)': 'done()',
-    },
-    standalone: false
+  selector: 'my-comp',
+  template: '',
+  host: {
+    '(@animation.done)': 'done()',
+  },
+  standalone: false,
 })
 export class MyComponent {
   @HostListener('@animation.start')
-  start() {
-  }
+  start() {}
+
+  done() {}
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/chain_synthetic_listeners_mixed.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/chain_synthetic_listeners_mixed.ts
@@ -1,21 +1,23 @@
 import {Component, HostListener} from '@angular/core';
 
 @Component({
-    selector: 'my-comp',
-    template: '',
-    host: {
-        '(mousedown)': 'mousedown()',
-        '(@animation.done)': 'done()',
-        '(mouseup)': 'mouseup()',
-    },
-    standalone: false
+  selector: 'my-comp',
+  template: '',
+  host: {
+    '(mousedown)': 'mousedown()',
+    '(@animation.done)': 'done()',
+    '(mouseup)': 'mouseup()',
+  },
+  standalone: false,
 })
 export class MyComponent {
   @HostListener('@animation.start')
-  start() {
-  }
+  start() {}
 
   @HostListener('click')
-  click() {
-  }
+  click() {}
+
+  mousedown() {}
+  done() {}
+  mouseup() {}
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/host_bindings_with_temporaries.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/host_bindings_with_temporaries.ts
@@ -1,15 +1,17 @@
 import {Directive, NgModule} from '@angular/core';
 
 @Directive({
-    selector: '[hostBindingDir]', host: { '[id]': 'getData()?.id' },
-    standalone: false
+  selector: '[hostBindingDir]',
+  host: {'[id]': 'getData()?.id'},
+  standalone: false,
 })
 export class HostBindingDir {
-  getData?: () => {
-    id: number
-  };
+  getData: () =>
+    | {
+        id: number;
+      }
+    | undefined = () => undefined;
 }
 
 @NgModule({declarations: [HostBindingDir]})
-export class MyModule {
-}
+export class MyModule {}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/sanitization.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/sanitization.js
@@ -1,13 +1,20 @@
-hostBindings: function HostBindingDir_HostBindings(rf, ctx) {
+hostBindings: function HostBindingLinkDir_HostBindings(rf, ctx) {
   if (rf & 2) {
-    $r3$.ɵɵdomProperty("innerHTML", ctx.evil, $r3$.ɵɵsanitizeHtml)("href", ctx.evil, $r3$.ɵɵsanitizeUrlOrResourceUrl)("src", ctx.evil, $r3$.ɵɵsanitizeUrlOrResourceUrl)("sandbox", ctx.evil, $r3$.ɵɵvalidateIframeAttribute);
+    $r3$.ɵɵdomProperty("innerHTML", ctx.evil, $r3$.ɵɵsanitizeHtml)("href", ctx.evil, $r3$.ɵɵsanitizeUrl);
     $r3$.ɵɵattribute("style", ctx.evil, $r3$.ɵɵsanitizeStyle);
-  } 
+  }
 }
 …
-hostBindings: function HostBindingDir2_HostBindings(rf, ctx) {
+hostBindings: function HostBindingImageDir_HostBindings(rf, ctx) {
   if (rf & 2) {
-    $r3$.ɵɵdomProperty("innerHTML", ctx.evil, $r3$.ɵɵsanitizeHtml)("href", ctx.evil, $r3$.ɵɵsanitizeUrl)("src", ctx.evil)("sandbox", ctx.evil, $r3$.ɵɵvalidateIframeAttribute);
+    $r3$.ɵɵdomProperty("innerHTML", ctx.evil, $r3$.ɵɵsanitizeHtml)("src", ctx.evil, $r3$.ɵɵsanitizeUrl);
     $r3$.ɵɵattribute("style", ctx.evil, $r3$.ɵɵsanitizeStyle);
-  } 
+  }
+}
+…
+hostBindings: function HostBindingIframeDir_HostBindings(rf, ctx) {
+  if (rf & 2) {
+    $r3$.ɵɵdomProperty("innerHTML", ctx.evil, $r3$.ɵɵsanitizeHtml)("src", ctx.evil, $r3$.ɵɵsanitizeResourceUrl)("sandbox", ctx.evil, $r3$.ɵɵvalidateIframeAttribute);
+    $r3$.ɵɵattribute("style", ctx.evil, $r3$.ɵɵsanitizeStyle);
+  }
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/sanitization.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/sanitization.ts
@@ -1,29 +1,38 @@
 import {Directive} from '@angular/core';
 
 @Directive({
-  selector: '[hostBindingDir]',
+  selector: 'a[hostBindingLinkDir]',
   host: {
     '[innerHtml]': 'evil',
     '[href]': 'evil',
     '[attr.style]': 'evil',
-    '[src]': 'evil',
-    '[sandbox]': 'evil',
   },
 })
-export class HostBindingDir {
+export class HostBindingLinkDir {
   evil = 'evil';
 }
 
 @Directive({
-  selector: 'a',
+  selector: 'img[hostBindingImgDir]',
   host: {
     '[innerHtml]': 'evil',
-    '[href]': 'evil',
+    '[attr.style]': 'evil',
+    '[src]': 'evil',
+  },
+})
+export class HostBindingImageDir {
+  evil = 'evil';
+}
+
+@Directive({
+  selector: 'iframe[hostBindingIframeDir]',
+  host: {
+    '[innerHtml]': 'evil',
     '[attr.style]': 'evil',
     '[src]': 'evil',
     '[sandbox]': 'evil',
   },
 })
-export class HostBindingDir2 {
+export class HostBindingIframeDir {
   evil = 'evil';
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/order_bindings.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/order_bindings.js
@@ -5,7 +5,7 @@ function MyCmp_HostBindings(rf, ctx) {
 		$r3$.ɵɵlistener("event1", function MyCmp_event1_HostBindingHandler() { return ctx.foo(); });
 	}
 	if (rf & 2) {
-		$r3$.ɵɵdomProperty("prop1", ctx.foo);
+		$r3$.ɵɵdomProperty("id", ctx.foo);
 		$r3$.ɵɵattribute("attr1", ctx.foo);
 		$r3$.ɵɵstyleMap(ctx.foo);
         $r3$.ɵɵclassMap(ctx.foo);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/order_bindings.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/order_bindings.ts
@@ -5,8 +5,7 @@ import {Component} from '@angular/core';
   template: ``,
   inputs: ['attr1', 'prop1', 'attrInterp1', 'propInterp1'],
 })
-export class SomeCmp {
-}
+export class SomeCmp {}
 
 @Component({
   selector: 'my-cmp',
@@ -15,7 +14,7 @@ export class SomeCmp {
     'literal1': 'foo',
     '(event1)': 'foo()',
     '[attr.attr1]': 'foo',
-    '[prop1]': 'foo',
+    '[id]': 'foo',
     '[class.class1]': 'false',
     '[style.style1]': 'true',
     '[class]': 'foo',
@@ -34,7 +33,7 @@ export class SomeCmp {
 			attr.attrInterp1="interp {{foo}}"
 			propInterp1="interp {{foo}}"
 			/>
-	`
+	`,
 })
 export class MyCmp {
   foo: any;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/host_bindings/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/host_bindings/GOLDEN_PARTIAL.js
@@ -153,7 +153,7 @@ export class MyComponent {
     }
 }
 MyComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
-MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent, isStandalone: false, selector: "my-component", host: { properties: { "style!important": "myStyleExp", "class!important": "myClassExp", "class.foo!important": "this.myFooClassExp", "style.width!important": "this.myWidthExp" } }, ngImport: i0, template: `
+MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent, isStandalone: false, selector: "my-component", host: { properties: { "style.width!important": "this.myWidthExp", "class.baz!important": "myClassExp", "class.foo!important": "this.myFooClassExp" } }, ngImport: i0, template: `
     <div [style.height!important]="myHeightExp"
          [class.bar!important]="myBarClassExp"></div>
   `, isInline: true });
@@ -165,8 +165,8 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
     <div [style.height!important]="myHeightExp"
          [class.bar!important]="myBarClassExp"></div>
   `,
-                    host: { '[style!important]': 'myStyleExp', '[class!important]': 'myClassExp' },
-                    standalone: false
+                    host: { '[style.width!important]': 'myStyleExp', '[class.baz!important]': 'myClassExp' },
+                    standalone: false,
                 }]
         }], propDecorators: { myFooClassExp: [{
                 type: HostBinding,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/host_bindings/important.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/host_bindings/important.ts
@@ -1,13 +1,13 @@
 import {Component, HostBinding, NgModule} from '@angular/core';
 
 @Component({
-    selector: 'my-component',
-    template: `
+  selector: 'my-component',
+  template: `
     <div [style.height!important]="myHeightExp"
          [class.bar!important]="myBarClassExp"></div>
   `,
-    host: { '[style!important]': 'myStyleExp', '[class!important]': 'myClassExp' },
-    standalone: false
+  host: {'[style.width!important]': 'myStyleExp', '[class.baz!important]': 'myClassExp'},
+  standalone: false,
 })
 export class MyComponent {
   myStyleExp = '';
@@ -22,5 +22,4 @@ export class MyComponent {
 }
 
 @NgModule({declarations: [MyComponent]})
-export class MyModule {
-}
+export class MyModule {}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/host_bindings/important_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/host_bindings/important_template.js
@@ -1,10 +1,8 @@
 
-hostVars: 8,
+hostVars: 6,
 hostBindings: function MyComponent_HostBindings(rf, ctx) {
   if (rf & 2) {
-    $r3$.ɵɵstyleMap(ctx.myStyleExp);
-    $r3$.ɵɵclassMap(ctx.myClassExp);
     $r3$.ɵɵstyleProp("width", ctx.myWidthExp);
-    $r3$.ɵɵclassProp("foo", ctx.myFooClassExp);
+    $r3$.ɵɵclassProp("baz", ctx.myClassExp)("foo", ctx.myFooClassExp);
   }
 },

--- a/packages/compiler-cli/test/ngtsc/host_bindings_type_check_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/host_bindings_type_check_spec.ts
@@ -24,9 +24,6 @@ runInEachFileSystem(() => {
     beforeEach(() => {
       env = NgtscTestEnvironment.setup(testFiles);
       env.tsconfig({
-        // Necessary for testing host bindings.
-        typeCheckHostBindings: true,
-
         // Not required for host bindings, but they allow us to
         // exercise more parts of the type checker.
         strictTemplates: true,

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -2157,9 +2157,6 @@ describe('completions', () => {
         `title!: string; hero!: number;`,
         undefined,
         `host: {'[title]': 'ti'},`,
-        {
-          typeCheckHostBindings: true,
-        },
       );
       appFile.moveCursorToText(`'ti¦'`);
       const completions = appFile.getCompletionsAtPosition();
@@ -2172,9 +2169,6 @@ describe('completions', () => {
         `title!: string; hero!: number;`,
         undefined,
         `host: {'(click)': 't'},`,
-        {
-          typeCheckHostBindings: true,
-        },
       );
       appFile.moveCursorToText(`'(click)': 't¦'`);
       const completions = appFile.getCompletionsAtPosition();
@@ -2182,11 +2176,8 @@ describe('completions', () => {
     });
 
     it('should be able to complete inside `host` of a directive', () => {
-      const {appFile} = setupInlineTemplate(
-        '',
-        '',
-        {
-          'Dir': `
+      const {appFile} = setupInlineTemplate('', '', {
+        'Dir': `
             @Directive({
               host: {'[title]': 'ti'},
             })
@@ -2195,12 +2186,7 @@ describe('completions', () => {
               hero!: number;
             }
           `,
-        },
-        undefined,
-        {
-          typeCheckHostBindings: true,
-        },
-      );
+      });
       appFile.moveCursorToText(`'ti¦'`);
       const completions = appFile.getCompletionsAtPosition();
       expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title', 'hero']);

--- a/packages/language-service/test/definitions_spec.ts
+++ b/packages/language-service/test/definitions_spec.ts
@@ -834,9 +834,7 @@ describe('definitions', () => {
     };
     const env = LanguageServiceTestEnv.setup();
 
-    const project = createModuleAndProjectWithDeclarations(env, 'test', files, {
-      typeCheckHostBindings: true,
-    });
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
     const appFile = project.openFile('app.ts');
     project.expectNoSourceDiagnostics();
 
@@ -868,9 +866,7 @@ describe('definitions', () => {
     };
     const env = LanguageServiceTestEnv.setup();
 
-    const project = createModuleAndProjectWithDeclarations(env, 'test', files, {
-      typeCheckHostBindings: true,
-    });
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
     const appFile = project.openFile('app.ts');
     project.expectNoSourceDiagnostics();
 
@@ -901,9 +897,7 @@ describe('definitions', () => {
     };
     const env = LanguageServiceTestEnv.setup();
 
-    const project = createModuleAndProjectWithDeclarations(env, 'test', files, {
-      typeCheckHostBindings: true,
-    });
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
     const dirFile = project.openFile('dir.ts');
     project.expectNoSourceDiagnostics();
 

--- a/packages/language-service/test/gettcb_spec.ts
+++ b/packages/language-service/test/gettcb_spec.ts
@@ -93,9 +93,7 @@ describe('get typecheck block', () => {
       }`,
     };
     const env = LanguageServiceTestEnv.setup();
-    const project = createModuleAndProjectWithDeclarations(env, 'test', files, {
-      typeCheckHostBindings: true,
-    });
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
     project.expectNoSourceDiagnostics();
 
     const appFile = project.openFile('app.ts');
@@ -129,9 +127,7 @@ describe('get typecheck block', () => {
       }`,
     };
     const env = LanguageServiceTestEnv.setup();
-    const project = createModuleAndProjectWithDeclarations(env, 'test', files, {
-      typeCheckHostBindings: true,
-    });
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
     project.expectNoSourceDiagnostics();
 
     const appFile = project.openFile('app.ts');
@@ -165,9 +161,7 @@ describe('get typecheck block', () => {
       }`,
     };
     const env = LanguageServiceTestEnv.setup();
-    const project = createModuleAndProjectWithDeclarations(env, 'test', files, {
-      typeCheckHostBindings: true,
-    });
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
     project.expectNoSourceDiagnostics();
 
     const appFile = project.openFile('app.ts');

--- a/packages/language-service/test/quick_info_spec.ts
+++ b/packages/language-service/test/quick_info_spec.ts
@@ -951,13 +951,7 @@ describe('quick info', () => {
         expectedDisplayString: string;
         expectedSpanText: string;
       }) {
-        const project = env.addProject(
-          'host-bindings',
-          {'host-bindings.ts': source},
-          {
-            typeCheckHostBindings: true,
-          },
-        );
+        const project = env.addProject('host-bindings', {'host-bindings.ts': source});
         const appFile = project.openFile('host-bindings.ts');
 
         appFile.moveCursorToText(moveTo);

--- a/packages/language-service/test/references_and_rename_spec.ts
+++ b/packages/language-service/test/references_and_rename_spec.ts
@@ -1540,9 +1540,7 @@ describe('find references and rename locations', () => {
         `,
       };
       env = LanguageServiceTestEnv.setup();
-      const project = createModuleAndProjectWithDeclarations(env, 'test', files, {
-        typeCheckHostBindings: true,
-      });
+      const project = createModuleAndProjectWithDeclarations(env, 'test', files);
       appFile = project.openFile('app.ts');
     });
 

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -37,8 +37,7 @@
     "suppressTsconfigOverrideWarnings": true
   },
   "angularCompilerOptions": {
-    "strictTemplates": true,
-    "typeCheckHostBindings": true
+    "strictTemplates": true
   },
   "exclude": [
     "common/locales",


### PR DESCRIPTION
Type checking of host bindings was added in v20. We're now confident enough in it to enable it by default.

BREAKING CHANGE:
* Previously hidden type issues in host bindings may show up in your builds. Either resolve the type issues or set `"typeCheckHostBindings": false` in the `angularCompilerOptions` section of your tsconfig.
