### PR TITLE
ci: update runs-on to ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           install: false
 
   test:
-    runs-on: ubuntu-latest-4core
+    runs-on: ubuntu-latest
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@4b4659eabe75a67cebf4692c3c88a98275c67200
@@ -85,7 +85,7 @@ jobs:
         run: pnpm test:ci
 
   integration-tests:
-    runs-on: ubuntu-latest-4core
+    runs-on: ubuntu-latest
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@4b4659eabe75a67cebf4692c3c88a98275c67200
@@ -102,7 +102,7 @@ jobs:
 
   adev:
     runs-on:
-      labels: ubuntu-latest-4core
+      labels: ubuntu-latest
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@4b4659eabe75a67cebf4692c3c88a98275c67200
@@ -139,7 +139,7 @@ jobs:
 
   zone-js:
     runs-on:
-      labels: ubuntu-latest-4core
+      labels: ubuntu-latest
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@4b4659eabe75a67cebf4692c3c88a98275c67200
@@ -180,7 +180,7 @@ jobs:
       - run: pnpm -C packages/zone.js/test/typings test
 
   # saucelabs:
-  #   runs-on: ubuntu-latest-4core
+  #   runs-on: ubuntu-latest
   #   env:
   #     SAUCE_TUNNEL_IDENTIFIER: angular-framework-${{ github.run_number }}
   #   steps:

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -8,7 +8,7 @@ jobs:
   # Bazel saucelabs job resides in `manual.yml` because it's currently unstable, but
   # kept as "runnable" for debugging/stabilization effort purposes.
   bazel-saucelabs:
-    runs-on: ubuntu-latest-4core
+    runs-on: ubuntu-latest
     env:
       JOBS: 2
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -73,7 +73,7 @@ jobs:
           install: false
 
   test:
-    runs-on: ubuntu-latest-8core
+    runs-on: ubuntu-latest
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@4b4659eabe75a67cebf4692c3c88a98275c67200
@@ -97,7 +97,7 @@ jobs:
           retention-days: 1
 
   integration-tests:
-    runs-on: ubuntu-latest-4core
+    runs-on: ubuntu-latest
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@4b4659eabe75a67cebf4692c3c88a98275c67200
@@ -112,7 +112,7 @@ jobs:
 
   adev:
     runs-on:
-      labels: ubuntu-latest-8core
+      labels: ubuntu-latest
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@4b4659eabe75a67cebf4692c3c88a98275c67200
@@ -129,7 +129,7 @@ jobs:
 
   zone-js:
     runs-on:
-      labels: ubuntu-latest-4core
+      labels: ubuntu-latest
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@4b4659eabe75a67cebf4692c3c88a98275c67200
@@ -166,7 +166,7 @@ jobs:
       - run: pnpm -C packages/zone.js/test/typings test
 
   # saucelabs:
-  #   runs-on: ubuntu-latest-4core
+  #   runs-on: ubuntu-latest
   #   env:
   #     SAUCE_TUNNEL_IDENTIFIER: angular-framework-${{ github.run_number }}
   #   steps:


### PR DESCRIPTION
This commit updates the `runs-on` configuration in the CI workflows (`ci.yml`, `manual.yml`, `pr.yml`) from specific `ubuntu-latest-Xcore` labels to the more general `ubuntu-latest`. This change reduces resource consumption. This change should not be needed for RBE and remote cache.
