### PR TITLE
refactor(core): Update tests for zoneless by default

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.spec.ts
@@ -13,6 +13,7 @@ import SpyObj = jasmine.SpyObj;
 import {FrameManager} from '../../application-services/frame_manager';
 import {Events, MessageBus} from '../../../../../protocol';
 import {ApplicationOperations} from '../../application-operations';
+import {provideZoneChangeDetection} from '@angular/core';
 
 describe('RouterTreeComponent', () => {
   let messageBus: MessageBus<Events>;
@@ -32,6 +33,7 @@ describe('RouterTreeComponent', () => {
     await TestBed.configureTestingModule({
       imports: [RouterTreeComponent],
       providers: [
+        provideZoneChangeDetection(),
         {provide: ApplicationOperations, useValue: applicationOperationsSpy},
         {provide: MessageBus, useValue: messageBus},
         {provide: FrameManager, useValue: frameManager},

--- a/integration/cli-signal-inputs/src/app/greet.component.spec.ts
+++ b/integration/cli-signal-inputs/src/app/greet.component.spec.ts
@@ -11,6 +11,7 @@ describe('greet component', () => {
     expect(fixture.nativeElement.textContent).toBe('Initial - initial-unset');
 
     fixture.componentInstance.firstName = 'John';
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toBe('John - initial-unset');

--- a/integration/cli-signal-inputs/src/main.ts
+++ b/integration/cli-signal-inputs/src/main.ts
@@ -1,7 +1,8 @@
+import {provideZoneChangeDetection} from '@angular/core';
 import {bootstrapApplication, provideProtractorTestingSupport} from '@angular/platform-browser';
 
 import {AppComponent} from './app/app.component';
 
 bootstrapApplication(AppComponent, {
-  providers: [provideProtractorTestingSupport()],
+  providers: [provideZoneChangeDetection(), provideProtractorTestingSupport()],
 });

--- a/integration/platform-server/projects/ngmodule/src/app/app.module.ts
+++ b/integration/platform-server/projects/ngmodule/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import {NgModule} from '@angular/core';
+import {NgModule, provideZoneChangeDetection} from '@angular/core';
 import {
   BrowserModule,
   provideClientHydration,
@@ -11,7 +11,7 @@ import {AppComponent} from './app.component';
 @NgModule({
   declarations: [AppComponent],
   imports: [BrowserModule, AppRoutingModule],
-  providers: [provideClientHydration(withIncrementalHydration())],
+  providers: [provideZoneChangeDetection(), provideClientHydration(withIncrementalHydration())],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/integration/platform-server/projects/standalone/src/app/app.config.ts
+++ b/integration/platform-server/projects/standalone/src/app/app.config.ts
@@ -4,9 +4,11 @@ import {provideClientHydration, withIncrementalHydration} from '@angular/platfor
 import {provideRouter} from '@angular/router';
 
 import {routes} from './app.routes';
+import {provideZoneChangeDetection} from '@angular/core';
 
 export const appConfig: ApplicationConfig = {
   providers: [
+    provideZoneChangeDetection(),
     provideRouter(routes),
     provideClientHydration(withIncrementalHydration()),
     provideHttpClient(),

--- a/modules/benchmarks/src/change_detection/transplanted_views/transplanted_views.ts
+++ b/modules/benchmarks/src/change_detection/transplanted_views/transplanted_views.ts
@@ -13,6 +13,7 @@ import {
   Component,
   Input,
   NgModule,
+  provideZoneChangeDetection,
   TemplateRef,
   ViewChild,
 } from '@angular/core';
@@ -67,6 +68,7 @@ export class DeclarationComponent {
 @NgModule({
   declarations: [DeclarationComponent, InsertionComponent],
   bootstrap: [DeclarationComponent],
+  providers: [provideZoneChangeDetection()],
   imports: [BrowserModule],
 })
 export class TransplantedViewsModule {}

--- a/modules/benchmarks/src/defer/baseline/main.ts
+++ b/modules/benchmarks/src/defer/baseline/main.ts
@@ -11,9 +11,10 @@ import {bootstrapApplication, provideProtractorTestingSupport} from '@angular/pl
 import {init, syncUrlParamsToForm} from '../init';
 
 import {AppComponent} from './app.component';
+import {provideZoneChangeDetection} from '@angular/core';
 
 syncUrlParamsToForm();
 
 bootstrapApplication(AppComponent, {
-  providers: [provideProtractorTestingSupport()],
+  providers: [provideZoneChangeDetection(), provideProtractorTestingSupport()],
 }).then(init);

--- a/modules/benchmarks/src/defer/main/main.ts
+++ b/modules/benchmarks/src/defer/main/main.ts
@@ -7,6 +7,7 @@
  */
 
 import {bootstrapApplication, provideProtractorTestingSupport} from '@angular/platform-browser';
+import {provideZoneChangeDetection} from '@angular/core';
 
 import {init, syncUrlParamsToForm} from '../init';
 
@@ -15,5 +16,5 @@ import {AppComponent} from './app.component';
 syncUrlParamsToForm();
 
 bootstrapApplication(AppComponent, {
-  providers: [provideProtractorTestingSupport()],
+  providers: [provideZoneChangeDetection(), provideProtractorTestingSupport()],
 }).then(init);

--- a/modules/benchmarks/src/largeform/ng2/app.ts
+++ b/modules/benchmarks/src/largeform/ng2/app.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, NgModule} from '@angular/core';
+import {Component, NgModule, provideZoneChangeDetection} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {BrowserModule} from '@angular/platform-browser';
 
@@ -87,5 +87,6 @@ export class AppComponent {
   imports: [BrowserModule, FormsModule],
   bootstrap: [AppComponent],
   declarations: [AppComponent],
+  providers: [provideZoneChangeDetection()],
 })
 export class AppModule {}

--- a/modules/benchmarks/src/largetable/ng2/main.ts
+++ b/modules/benchmarks/src/largetable/ng2/main.ts
@@ -6,11 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {enableProdMode} from '@angular/core';
+import {enableProdMode, provideZoneChangeDetection} from '@angular/core';
 import {bootstrapApplication} from '@angular/platform-browser';
 
 import {init} from './init';
 import {TableComponent} from './table';
 
 enableProdMode();
-bootstrapApplication(TableComponent).then(init);
+bootstrapApplication(TableComponent, {
+  providers: [provideZoneChangeDetection()],
+}).then(init);

--- a/modules/benchmarks/src/largetable/ng2_switch/table.ts
+++ b/modules/benchmarks/src/largetable/ng2_switch/table.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, Input, NgModule} from '@angular/core';
+import {Component, Input, NgModule, provideZoneChangeDetection} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 
 import {emptyTable, TableCell} from '../util';
@@ -35,5 +35,10 @@ export class TableComponent {
   }
 }
 
-@NgModule({imports: [BrowserModule], bootstrap: [TableComponent], declarations: [TableComponent]})
+@NgModule({
+  imports: [BrowserModule],
+  bootstrap: [TableComponent],
+  providers: [provideZoneChangeDetection()],
+  declarations: [TableComponent],
+})
 export class AppModule {}

--- a/modules/benchmarks/src/tree/ng2/tree.ts
+++ b/modules/benchmarks/src/tree/ng2/tree.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, NgModule} from '@angular/core';
+import {Component, NgModule, provideZoneChangeDetection} from '@angular/core';
 import {BrowserModule, DomSanitizer, SafeStyle} from '@angular/platform-browser';
 
 import {emptyTree, TreeNode} from '../util';
@@ -29,7 +29,12 @@ export class TreeComponent {
   }
 }
 
-@NgModule({imports: [BrowserModule], bootstrap: [TreeComponent], declarations: [TreeComponent]})
+@NgModule({
+  imports: [BrowserModule],
+  providers: [provideZoneChangeDetection()],
+  bootstrap: [TreeComponent],
+  declarations: [TreeComponent],
+})
 export class AppModule {
   constructor(sanitizer: DomSanitizer) {
     trustedEmptyColor = sanitizer.bypassSecurityTrustStyle('');

--- a/modules/benchmarks/src/tree/ng2_static/tree.ts
+++ b/modules/benchmarks/src/tree/ng2_static/tree.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, Input, NgModule} from '@angular/core';
+import {Component, Input, NgModule, provideZoneChangeDetection} from '@angular/core';
 import {BrowserModule, DomSanitizer, SafeStyle} from '@angular/platform-browser';
 
 import {emptyTree, getMaxDepth, TreeNode} from '../util';
@@ -57,6 +57,7 @@ export function createAppModule(): any {
     imports: [BrowserModule],
     bootstrap: [RootTreeComponent],
     declarations: [components],
+    providers: [provideZoneChangeDetection()],
     jit: true,
   })
   class AppModule {

--- a/modules/benchmarks/src/tree/ng2_switch/tree.ts
+++ b/modules/benchmarks/src/tree/ng2_switch/tree.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, Input, NgModule} from '@angular/core';
+import {Component, Input, NgModule, provideZoneChangeDetection} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 
 import {emptyTree, TreeNode} from '../util';
@@ -29,5 +29,6 @@ export class TreeComponent {
   imports: [BrowserModule],
   bootstrap: [TreeComponent],
   declarations: [TreeComponent],
+  providers: [provideZoneChangeDetection()],
 })
 export class AppModule {}

--- a/modules/playground/src/async/main.ts
+++ b/modules/playground/src/async/main.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, NgModule} from '@angular/core';
+import {Component, NgModule, provideZoneChangeDetection} from '@angular/core';
 import {BrowserModule, platformBrowser} from '@angular/platform-browser';
 
 @Component({
@@ -114,6 +114,7 @@ class AsyncApplication {
   declarations: [AsyncApplication],
   bootstrap: [AsyncApplication],
   imports: [BrowserModule],
+  providers: [provideZoneChangeDetection()],
 })
 class ExampleModule {}
 

--- a/modules/playground/src/http/main.ts
+++ b/modules/playground/src/http/main.ts
@@ -7,7 +7,7 @@
  */
 
 import {HttpClientModule} from '@angular/common/http';
-import {NgModule} from '@angular/core';
+import {NgModule, provideZoneChangeDetection} from '@angular/core';
 import {BrowserModule, platformBrowser} from '@angular/platform-browser';
 
 import {HttpCmp} from './app/http_comp';
@@ -16,6 +16,7 @@ import {HttpCmp} from './app/http_comp';
   declarations: [HttpCmp],
   bootstrap: [HttpCmp],
   imports: [BrowserModule, HttpClientModule],
+  providers: [provideZoneChangeDetection()],
 })
 export class ExampleModule {}
 

--- a/modules/playground/src/jsonp/main.ts
+++ b/modules/playground/src/jsonp/main.ts
@@ -7,7 +7,7 @@
  */
 
 import {HttpClientJsonpModule, HttpClientModule} from '@angular/common/http';
-import {NgModule} from '@angular/core';
+import {NgModule, provideZoneChangeDetection} from '@angular/core';
 import {BrowserModule, platformBrowser} from '@angular/platform-browser';
 
 import {JsonpCmp} from './app/jsonp_comp';
@@ -16,6 +16,7 @@ import {JsonpCmp} from './app/jsonp_comp';
   bootstrap: [JsonpCmp],
   declarations: [JsonpCmp],
   imports: [BrowserModule, HttpClientModule, HttpClientJsonpModule],
+  providers: [provideZoneChangeDetection()],
 })
 export class ExampleModule {}
 

--- a/packages/animations/test/browser_animation_builder_spec.ts
+++ b/packages/animations/test/browser_animation_builder_spec.ts
@@ -13,13 +13,26 @@ import {
 } from '../src/animations';
 import {AnimationDriver} from '../browser';
 import {MockAnimationDriver} from '../browser/testing';
-import {Component, NgZone, RendererFactory2, ViewChild, DOCUMENT} from '@angular/core';
+import {
+  Component,
+  NgZone,
+  RendererFactory2,
+  ViewChild,
+  DOCUMENT,
+  NgModule,
+  provideZonelessChangeDetection,
+} from '@angular/core';
 import {fakeAsync, flushMicrotasks, TestBed} from '@angular/core/testing';
 import {ɵDomRendererFactory2 as DomRendererFactory2} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {ɵAsyncAnimationRendererFactory as AsyncAnimationRendererFactory} from '@angular/platform-browser/animations/async';
 import {BrowserTestingModule, platformBrowserTesting} from '@angular/platform-browser/testing';
 import {isNode} from '@angular/private/testing';
+
+@NgModule({
+  providers: [provideZonelessChangeDetection()],
+})
+class TestModule {}
 
 describe('BrowserAnimationBuilder', () => {
   if (isNode) {
@@ -233,7 +246,7 @@ describe('BrowserAnimationBuilder', () => {
       // We need to reset the test environment because
       // browser_tests.init.ts inits the environment with the NoopAnimationsModule
       TestBed.resetTestEnvironment();
-      TestBed.initTestEnvironment([BrowserTestingModule], platformBrowserTesting());
+      TestBed.initTestEnvironment([BrowserTestingModule, TestModule], platformBrowserTesting());
     });
 
     it('should throw an error when injecting AnimationBuilder without animation providers set', () => {
@@ -246,7 +259,7 @@ describe('BrowserAnimationBuilder', () => {
       // We're reset the test environment to their default values, cf browser_tests.init.ts
       TestBed.resetTestEnvironment();
       TestBed.initTestEnvironment(
-        [BrowserTestingModule, NoopAnimationsModule],
+        [BrowserTestingModule, NoopAnimationsModule, TestModule],
         platformBrowserTesting(),
       );
     });

--- a/packages/common/test/directives/ng_class_spec.ts
+++ b/packages/common/test/directives/ng_class_spec.ts
@@ -18,6 +18,7 @@ describe('binding to CSS class list', () => {
   }
 
   function detectChangesAndExpectClassName(classes: string): void {
+    fixture?.changeDetectorRef.markForCheck();
     fixture!.detectChanges();
     let nonNormalizedClassName = fixture!.debugElement.children[0].nativeElement.className;
     expect(normalizeClassNames(nonNormalizedClassName)).toEqual(normalizeClassNames(classes));
@@ -395,8 +396,10 @@ describe('binding to CSS class list', () => {
       detectChangesAndExpectClassName('');
 
       fixture.componentInstance.condition = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       fixture.componentInstance.condition = true;
+      fixture.changeDetectorRef.markForCheck();
       detectChangesAndExpectClassName('color-red');
     });
 
@@ -478,6 +481,7 @@ describe('binding to CSS class list', () => {
       expect(fixture.nativeElement.firstChild.className).toBe('option-1');
 
       fixture.componentInstance.level = 5;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement.firstChild.className).toBe('option-5');
     });

--- a/packages/common/test/directives/ng_component_outlet_spec.ts
+++ b/packages/common/test/directives/ng_component_outlet_spec.ts
@@ -43,6 +43,7 @@ describe('insert/remove', () => {
     let fixture = TestBed.createComponent(TestComponent);
 
     fixture.componentInstance.currentComponent = null;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(fixture.nativeElement).toHaveText('');
@@ -56,6 +57,7 @@ describe('insert/remove', () => {
 
     fixture.componentInstance.currentComponent = InjectedComponent;
 
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText('foo');
   }));
@@ -67,6 +69,7 @@ describe('insert/remove', () => {
     expect(fixture.nativeElement).toHaveText('');
 
     fixture.componentInstance.cmpRef = undefined;
+    fixture.changeDetectorRef.markForCheck();
     fixture.componentInstance.currentComponent = InjectedComponent;
 
     fixture.detectChanges();
@@ -83,11 +86,13 @@ describe('insert/remove', () => {
 
     fixture.componentInstance.currentComponent = InjectedComponent;
 
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText('foo');
 
     fixture.componentInstance.currentComponent = null;
 
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText('');
   }));
@@ -100,11 +105,13 @@ describe('insert/remove', () => {
 
     fixture.componentInstance.currentComponent = InjectedComponent;
 
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText('foo');
 
     fixture.componentInstance.currentComponent = InjectedComponentAgain;
 
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText('bar');
   }));
@@ -119,6 +126,7 @@ describe('insert/remove', () => {
       parent: fixture.componentRef.injector,
     });
 
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     let cmpRef: ComponentRef<InjectedComponent> = fixture.componentInstance.cmpRef!;
     expect(cmpRef).toBeInstanceOf(ComponentRef);
@@ -142,6 +150,7 @@ describe('insert/remove', () => {
       environmentInjector,
     );
 
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     let cmpRef: ComponentRef<InjectedComponent> = fixture.componentInstance.cmpRef!;
     expect(cmpRef).toBeInstanceOf(ComponentRef);
@@ -155,6 +164,7 @@ describe('insert/remove', () => {
     // We are accessing a ViewChild (ngComponentOutlet) before change detection has run
     fixture.componentInstance.cmpRef = undefined;
     fixture.componentInstance.currentComponent = InjectedComponent;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     let cmpRef: ComponentRef<InjectedComponent> = fixture.componentInstance.cmpRef!;
     expect(cmpRef).toBeInstanceOf(ComponentRef);
@@ -183,6 +193,7 @@ describe('insert/remove', () => {
         .rootNodes,
     ];
 
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText('projected foo');
   }));
@@ -196,6 +207,7 @@ describe('insert/remove', () => {
     fixture.componentInstance.ngModule = TestModule2;
     fixture.componentInstance.currentComponent = Module2InjectedComponent;
 
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText('baz');
   }));
@@ -218,12 +230,14 @@ describe('insert/remove', () => {
     const fixture = TestBed.createComponent(TestComponent);
     fixture.componentInstance.ngModule = TestModule2;
     fixture.componentInstance.currentComponent = Module2InjectedComponent;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(fixture.nativeElement).toHaveText('baz');
 
     fixture.componentInstance.ngModule = TestModule3;
     fixture.componentInstance.currentComponent = Module3InjectedComponent;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(fixture.nativeElement).toHaveText('bat');
@@ -240,6 +254,7 @@ describe('insert/remove', () => {
       providers: [{provide: TEST_TOKEN, useValue: 'child'}],
       parent: fixture.componentInstance.vcRef.injector,
     });
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(fixture.nativeElement).toHaveText('Value: child');
@@ -274,6 +289,7 @@ describe('insert/remove', () => {
     expect(outlet.componentInstance).toBeNull();
 
     fixture.componentInstance.currentComponent = InjectedComponent;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(outlet.componentInstance).toBeInstanceOf(InjectedComponent);
@@ -284,31 +300,37 @@ describe('inputs', () => {
   it('should be binding the component input', () => {
     const fixture = TestBed.createComponent(TestInputsComponent);
     fixture.componentInstance.currentComponent = ComponentWithInputs;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toBe('foo: , bar: , baz: Baz');
 
     fixture.componentInstance.inputs = {};
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toBe('foo: , bar: , baz: Baz');
 
     fixture.componentInstance.inputs = {foo: 'Foo', bar: 'Bar'};
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toBe('foo: Foo, bar: Bar, baz: Baz');
 
     fixture.componentInstance.inputs = {foo: 'Foo'};
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toBe('foo: Foo, bar: , baz: Baz');
 
     fixture.componentInstance.inputs = {foo: 'Foo', baz: null};
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toBe('foo: Foo, bar: , baz: ');
 
     fixture.componentInstance.inputs = undefined;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toBe('foo: , bar: , baz: ');
@@ -317,21 +339,25 @@ describe('inputs', () => {
   it('should be binding the component input (with mutable inputs)', () => {
     const fixture = TestBed.createComponent(TestInputsComponent);
     fixture.componentInstance.currentComponent = ComponentWithInputs;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toBe('foo: , bar: , baz: Baz');
 
     fixture.componentInstance.inputs = {foo: 'Hello', bar: 'World'};
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toBe('foo: Hello, bar: World, baz: Baz');
 
     fixture.componentInstance.inputs['bar'] = 'Angular';
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toBe('foo: Hello, bar: Angular, baz: Baz');
 
     delete fixture.componentInstance.inputs['foo'];
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toBe('foo: , bar: Angular, baz: Baz');
@@ -341,11 +367,13 @@ describe('inputs', () => {
     const fixture = TestBed.createComponent(TestInputsComponent);
     fixture.componentInstance.currentComponent = ComponentWithInputs;
     fixture.componentInstance.inputs = {foo: 'Foo', bar: 'Bar'};
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toBe('foo: Foo, bar: Bar, baz: Baz');
 
     fixture.componentInstance.currentComponent = AnotherComponentWithInputs;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toBe('[ANOTHER] foo: Foo, bar: Bar, baz: Baz');

--- a/packages/common/test/directives/ng_for_spec.ts
+++ b/packages/common/test/directives/ng_for_spec.ts
@@ -22,6 +22,7 @@ describe('ngFor', () => {
   }
 
   function detectChangesAndExpectText(text: string): void {
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText(text);
   }
@@ -300,6 +301,7 @@ describe('ngFor', () => {
       '<ng-template let-item let-i="index" #tpl>{{i}}: {{item}};</ng-template>';
     fixture = createTestComponent(template);
     getComponent().items = ['a', 'b', 'c'];
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     detectChangesAndExpectText('0: a;1: b;2: c;');
   }));
@@ -310,6 +312,7 @@ describe('ngFor', () => {
       const template = `<p *ngFor="let item of items; trackBy: value"></p>`;
       fixture = createTestComponent(template);
       fixture.componentInstance.value = 0;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
     }));
 
@@ -329,6 +332,7 @@ describe('ngFor', () => {
       fixture = createTestComponent(template);
 
       thisArg = null;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(thisArg).toBe(getComponent());
     }));
@@ -339,6 +343,7 @@ describe('ngFor', () => {
 
       const buildItemList = () => {
         getComponent().items = [{'id': 'a'}];
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         return fixture.debugElement.queryAll(By.css('p'))[0];
       };
@@ -381,8 +386,10 @@ describe('ngFor', () => {
       fixture = createTestComponent(template);
 
       getComponent().items = ['a', 'b', 'c', 'd'];
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       getComponent().items = ['e', 'f', 'g', 'h'];
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       getComponent().items = ['e', 'f', 'h'];
       detectChangesAndExpectText('efh');

--- a/packages/common/test/directives/ng_if_spec.ts
+++ b/packages/common/test/directives/ng_if_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule, NgIf} from '../../index';
-import {Component} from '@angular/core';
+import {Component, provideZoneChangeDetection} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {expect} from '@angular/private/testing/matchers';
@@ -27,6 +27,7 @@ describe('ngIf directive', () => {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
       imports: [CommonModule],
+      providers: [provideZoneChangeDetection()],
     });
   });
 

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -6,7 +6,14 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, PLATFORM_ID, Provider, Type} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  PLATFORM_ID,
+  Provider,
+  provideZoneChangeDetection,
+  Type,
+} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {DomSanitizer, SafeResourceUrl} from '@angular/platform-browser';
 import {isBrowser, isNode, withHead} from '@angular/private/testing';
@@ -34,6 +41,12 @@ import {
 import {PRECONNECT_CHECK_BLOCKLIST} from '../../src/directives/ng_optimized_image/preconnect_link_checker';
 
 describe('Image directive', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
+
   const PLACEHOLDER_BLUR_AMOUNT = 15;
 
   describe('preload <link> element on a server', () => {

--- a/packages/common/test/directives/ng_plural_spec.ts
+++ b/packages/common/test/directives/ng_plural_spec.ts
@@ -19,6 +19,7 @@ describe('ngPlural', () => {
   }
 
   function detectChangesAndExpectText<T>(text: string): void {
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText(text);
   }

--- a/packages/common/test/directives/ng_style_spec.ts
+++ b/packages/common/test/directives/ng_style_spec.ts
@@ -47,11 +47,13 @@ describe('NgStyle', () => {
     fixture = createTestComponent(template);
 
     getComponent().expr = {'max-width': '40px'};
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px'});
 
     let expr = getComponent().expr;
     expr['max-width'] = '30%';
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).toHaveCssStyle({'max-width': '30%'});
   }));
@@ -61,10 +63,12 @@ describe('NgStyle', () => {
     fixture = createTestComponent(template);
 
     getComponent().expr = {'max-width': '40px'};
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px'});
 
     getComponent().expr = null;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).not.toHaveCssStyle('max-width');
   }));
@@ -74,10 +78,12 @@ describe('NgStyle', () => {
     fixture = createTestComponent(template);
 
     getComponent().expr = {'max-width': '40px'};
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px'});
 
     getComponent().expr = undefined;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).not.toHaveCssStyle('max-width');
   }));
@@ -88,10 +94,12 @@ describe('NgStyle', () => {
     fixture = createTestComponent(template);
 
     getComponent().expr = '40';
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px'});
 
     getComponent().expr = null;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).not.toHaveCssStyle('max-width');
   }));
@@ -101,10 +109,12 @@ describe('NgStyle', () => {
     fixture = createTestComponent(`<div [ngStyle]="{'color': expr}"></div>`);
 
     getComponent().expr = 'green';
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).toHaveCssStyle({'color': 'green'});
 
     getComponent().expr = null;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).not.toHaveCssStyle('color');
   }));
@@ -115,10 +125,12 @@ describe('NgStyle', () => {
     fixture = createTestComponent(template);
 
     getComponent().expr = {'max-width.px': '40'};
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px'});
 
     getComponent().expr = {'max-width.em': '40'};
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).toHaveCssStyle({'max-width': '40em'});
   }));
@@ -135,6 +147,7 @@ describe('NgStyle', () => {
       width: '10px',
     };
 
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).toHaveCssStyle({'height': '10px', 'width': '10px'});
 
@@ -144,6 +157,7 @@ describe('NgStyle', () => {
       height: '5px',
     };
 
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).toHaveCssStyle({'height': '5px', 'width': '5px'});
   }));
@@ -154,10 +168,12 @@ describe('NgStyle', () => {
     fixture = createTestComponent(template);
 
     getComponent().expr = {'max-width': '40px'};
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px'});
 
     delete getComponent().expr['max-width'];
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).not.toHaveCssStyle('max-width');
   }));
@@ -168,10 +184,12 @@ describe('NgStyle', () => {
     fixture = createTestComponent(template);
 
     getComponent().expr = {'max-width': '40px'};
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px', 'font-size': '12px'});
 
     delete getComponent().expr['max-width'];
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).not.toHaveCssStyle('max-width');
     expectNativeEl(fixture).toHaveCssStyle({'font-size': '12px'});
@@ -183,10 +201,12 @@ describe('NgStyle', () => {
     fixture = createTestComponent(template);
 
     getComponent().expr = {'max-width': '40px'};
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px', 'font-size': '12px'});
 
     delete getComponent().expr['max-width'];
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).not.toHaveCssStyle('max-width');
     expectNativeEl(fixture).toHaveCssStyle({'font-size': '12px'});
@@ -198,17 +218,20 @@ describe('NgStyle', () => {
     fixture = createTestComponent(template);
     fixture.componentInstance.expr = 'red';
 
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).toHaveCssStyle({'color': 'red'});
 
     // Overwrite native styles so that we can check if ngStyle has performed DOM manupulation to
     // update it.
     fixture.debugElement.children[0].nativeElement.style.color = 'blue';
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     // Assert that the style hasn't been updated
     expectNativeEl(fixture).toHaveCssStyle({'color': 'blue'});
 
     fixture.componentInstance.expr = 'yellow';
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     // Assert that the style has changed now that the model has changed
     expectNativeEl(fixture).toHaveCssStyle({'color': 'yellow'});
@@ -219,6 +242,7 @@ describe('NgStyle', () => {
     fixture = createTestComponent(template);
     fixture.componentInstance.expr = 400;
 
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).toHaveCssStyle({'width': '400px'});
   });
@@ -231,6 +255,7 @@ describe('NgStyle', () => {
     const template = `<div style="width: var(--width)" [ngStyle]="{'--width': expr}"></div>`;
     fixture = createTestComponent(template);
     fixture.componentInstance.expr = '100px';
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     const target: HTMLElement = fixture.nativeElement.querySelector('div');

--- a/packages/common/test/directives/ng_switch_spec.ts
+++ b/packages/common/test/directives/ng_switch_spec.ts
@@ -19,6 +19,7 @@ describe('NgSwitch', () => {
   }
 
   function detectChangesAndExpectText(text: string): void {
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText(text);
   }
@@ -160,10 +161,12 @@ describe('NgSwitch', () => {
     expect(fixture.nativeElement).toHaveText('when a');
 
     fixture.componentInstance.switchValue = 'b';
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText('when default');
 
     fixture.componentInstance.switchValue = 'c';
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText('when default');
   });

--- a/packages/common/test/directives/ng_template_outlet_spec.ts
+++ b/packages/common/test/directives/ng_template_outlet_spec.ts
@@ -32,6 +32,7 @@ describe('NgTemplateOutlet', () => {
   }
 
   function detectChangesAndExpectText(text: string): void {
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.debugElement.nativeElement).toHaveText(text);
   }
@@ -313,6 +314,7 @@ describe('NgTemplateOutlet', () => {
     const temp = componentInstance.context1;
     componentInstance.context1 = componentInstance.context2;
     componentInstance.context2 = temp;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(nativeElement.textContent.trim()).toBe('two | one');
@@ -393,6 +395,7 @@ describe('NgTemplateOutlet', () => {
     expect(fixture.nativeElement.textContent).toBe('Name:');
 
     fixture.componentInstance.ctx = {$implicit: 'Angular'};
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toBe('Name:Angular');

--- a/packages/common/test/pipes/json_pipe_spec.ts
+++ b/packages/common/test/pipes/json_pipe_spec.ts
@@ -71,10 +71,12 @@ describe('JsonPipe', () => {
       const fixture = TestBed.createComponent(TestComp);
       const mutable: number[] = [1];
       fixture.componentInstance.data = mutable;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveText('[\n  1\n]');
 
       mutable.push(2);
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveText('[\n  1,\n  2\n]');
     }));

--- a/packages/common/test/pipes/slice_pipe_spec.ts
+++ b/packages/common/test/pipes/slice_pipe_spec.ts
@@ -107,10 +107,12 @@ describe('SlicePipe', () => {
       const fixture = TestBed.createComponent(TestComp);
       const mutable: number[] = [1, 2];
       fixture.componentInstance.data = mutable;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveText('2');
 
       mutable.push(3);
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveText('2,3');
     }));

--- a/packages/core/test/acceptance/after_render_hook_spec.ts
+++ b/packages/core/test/acceptance/after_render_hook_spec.ts
@@ -29,6 +29,7 @@ import {
   effect,
   inject,
   signal,
+  provideZoneChangeDetection,
 } from '../../src/core';
 import {NoopNgZone} from '../../src/zone/ng_zone';
 import {TestBed} from '../../testing';
@@ -46,6 +47,11 @@ function createAndAttachComponent<T>(component: Type<T>) {
 }
 
 describe('after render hooks', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   let prev: boolean;
 
   describe('browser', () => {

--- a/packages/core/test/acceptance/animation_spec.ts
+++ b/packages/core/test/acceptance/animation_spec.ts
@@ -1426,6 +1426,7 @@ describe('Animation', () => {
         );
       });
       cmp.addremove();
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tickAnimationFrames(1);
 
@@ -1498,6 +1499,7 @@ describe('Animation', () => {
         );
       });
       cmp.addremove();
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tickAnimationFrames(1);
 

--- a/packages/core/test/acceptance/attributes_spec.ts
+++ b/packages/core/test/acceptance/attributes_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component} from '../../src/core';
+import {Component, provideZoneChangeDetection} from '../../src/core';
 import {TestBed} from '../../testing';
 import {By, DomSanitizer, SafeUrl} from '@angular/platform-browser';
 
@@ -55,6 +55,11 @@ describe('attribute creation', () => {
 });
 
 describe('attribute binding', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   it('should set attribute values', () => {
     @Component({
       template: `<a [attr.href]="url"></a>`,

--- a/packages/core/test/acceptance/authoring/model_inputs_spec.ts
+++ b/packages/core/test/acceptance/authoring/model_inputs_spec.ts
@@ -162,6 +162,7 @@ describe('model inputs', () => {
 
     // Changing the value from the outside.
     host.value = 3;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(host.value).toBe(3);
     expect(host.dir.value()).toBe(3);

--- a/packages/core/test/acceptance/authoring/signal_inputs_spec.ts
+++ b/packages/core/test/acceptance/authoring/signal_inputs_spec.ts
@@ -49,6 +49,7 @@ describe('signal inputs', () => {
     expect(fixture.nativeElement.textContent).toBe('input:1');
 
     fixture.componentInstance.value = 2;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toBe('input:2');
@@ -78,6 +79,7 @@ describe('signal inputs', () => {
     expect(fixture.nativeElement.textContent).toBe('changed:computed-1');
 
     fixture.componentInstance.value = 2;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toBe('changed:computed-2');
@@ -116,6 +118,7 @@ describe('signal inputs', () => {
     expect(effectLog).toEqual([1]);
 
     fixture.componentInstance.value = 2;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(effectLog).toEqual([1, 2]);
@@ -225,6 +228,7 @@ describe('signal inputs', () => {
     expect(fixture.nativeElement.textContent).toBe('input:1');
 
     fixture.componentInstance.value = 2;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toBe('input:2');
@@ -256,12 +260,14 @@ describe('signal inputs', () => {
 
     // Changing the value from within the directive.
     host.dir.valueChange.emit(2);
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(host.value).toBe(2);
     expect(host.dir.value()).toBe(2);
 
     // Changing the value from the outside.
     host.value = 3;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(host.value).toBe(3);
     expect(host.dir.value()).toBe(3);

--- a/packages/core/test/acceptance/authoring/signal_queries_spec.ts
+++ b/packages/core/test/acceptance/authoring/signal_queries_spec.ts
@@ -127,10 +127,12 @@ describe('queries as signals', () => {
       expect(fixture.componentInstance.foundEl()).toBe(1);
 
       fixture.componentInstance.show = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.componentInstance.foundEl()).toBe(2);
 
       fixture.componentInstance.show = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.componentInstance.foundEl()).toBe(1);
     });
@@ -197,6 +199,7 @@ describe('queries as signals', () => {
       // subsequent reads should return the same result instance and _not_ trigger downstream
       // computed re-evaluation
       fixture.componentInstance.show = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.componentInstance.divEl()).toBe(divEl);
       expect(fixture.componentInstance.isThere()).toBe(1);
@@ -223,6 +226,7 @@ describe('queries as signals', () => {
       expect(result1.length).toBe(1);
 
       fixture.componentInstance.show = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       // subsequent reads should return the same result instance since the query results didn't
       // change
@@ -322,10 +326,12 @@ describe('queries as signals', () => {
       expect(fixture.nativeElement.textContent).toBe('3');
 
       fixture.componentInstance.show = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement.textContent).toBe('4');
 
       fixture.componentInstance.show = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement.textContent).toBe('3');
     });
@@ -368,10 +374,12 @@ describe('queries as signals', () => {
       expect(fixture.nativeElement.textContent).toBe('3');
 
       fixture.componentInstance.show = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement.textContent).toBe('4');
 
       fixture.componentInstance.show = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement.textContent).toBe('3');
     });
@@ -509,8 +517,10 @@ describe('queries as signals', () => {
 
       // trigger view manipulation that should dirty queries but not change the results
       fixture.componentInstance.show = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       fixture.componentInstance.show = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(fixture.componentInstance.foundElCount()).toBe(1);
@@ -545,8 +555,10 @@ describe('queries as signals', () => {
 
       // trigger view manipulation that should dirty queries but not change the results
       fixture.componentInstance.show = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       fixture.componentInstance.show = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(fixture.componentInstance.foundElCount()).toBe(1);
@@ -610,11 +622,13 @@ describe('queries as signals', () => {
       expect(fixture.componentInstance.divElsDecorator.length).toBe(1);
 
       fixture.componentInstance.show = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.componentInstance.divElsSignal().length).toBe(2);
       expect(fixture.componentInstance.divElsDecorator.length).toBe(2);
 
       fixture.componentInstance.show = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.componentInstance.divElsSignal().length).toBe(1);
       expect(fixture.componentInstance.divElsDecorator.length).toBe(1);
@@ -652,11 +666,13 @@ describe('queries as signals', () => {
       expect(fixture.componentInstance.divElsDecorator.length).toBe(1);
 
       fixture.componentInstance.show = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.componentInstance.divElsSignal().length).toBe(2);
       expect(fixture.componentInstance.divElsDecorator.length).toBe(2);
 
       fixture.componentInstance.show = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.componentInstance.divElsSignal().length).toBe(1);
       expect(fixture.componentInstance.divElsDecorator.length).toBe(1);

--- a/packages/core/test/acceptance/change_detection_signals_in_zones_spec.ts
+++ b/packages/core/test/acceptance/change_detection_signals_in_zones_spec.ts
@@ -17,6 +17,7 @@ import {
   ElementRef,
   inject,
   Input,
+  provideZoneChangeDetection,
   signal,
   TemplateRef,
   ViewChild,
@@ -26,6 +27,11 @@ import {ReactiveNode, SIGNAL} from '../../primitives/signals';
 import {TestBed} from '../../testing';
 
 describe('CheckAlways components', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   it('can read a signal', () => {
     @Component({
       template: `{{value()}}`,

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -47,6 +47,11 @@ import {
 import {By} from '@angular/platform-browser';
 
 describe('change detection', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   it('can provide zone and zoneless (last one wins like any other provider) in TestBed', () => {
     expect(() => {
       TestBed.configureTestingModule({

--- a/packages/core/test/acceptance/change_detection_transplanted_view_spec.ts
+++ b/packages/core/test/acceptance/change_detection_transplanted_view_spec.ts
@@ -22,6 +22,7 @@ import {
   ErrorHandler,
   inject,
   Input,
+  provideZoneChangeDetection,
   signal,
   TemplateRef,
   Type,
@@ -34,6 +35,11 @@ import {expect} from '@angular/private/testing/matchers';
 import {of} from 'rxjs';
 
 describe('change detection for transplanted views', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   describe('when declaration appears before insertion', () => {
     @Component({
       selector: 'onpush-insert-comp',

--- a/packages/core/test/acceptance/common_integration_spec.ts
+++ b/packages/core/test/acceptance/common_integration_spec.ts
@@ -6,11 +6,16 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, Directive} from '../../src/core';
+import {Component, Directive, provideZoneChangeDetection} from '../../src/core';
 import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
 
 describe('@angular/common integration', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   describe('NgForOf', () => {
     @Directive({
       selector: '[dir]',

--- a/packages/core/test/acceptance/content_spec.ts
+++ b/packages/core/test/acceptance/content_spec.ts
@@ -17,6 +17,7 @@ import {
   inject,
   Input,
   OnDestroy,
+  provideZoneChangeDetection,
   TemplateRef,
   ViewChild,
   ViewContainerRef,
@@ -26,6 +27,11 @@ import {By} from '@angular/platform-browser';
 import {expect} from '@angular/private/testing/matchers';
 
 describe('projection', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   function getElementHtml(element: HTMLElement) {
     return element.innerHTML
       .replace(/<!--(\W|\w)*?-->/g, '')

--- a/packages/core/test/acceptance/control_flow_for_spec.ts
+++ b/packages/core/test/acceptance/control_flow_for_spec.ts
@@ -16,12 +16,18 @@ import {
   OnInit,
   Pipe,
   PipeTransform,
+  provideZoneChangeDetection,
   TemplateRef,
   ViewContainerRef,
 } from '../../src/core';
 import {TestBed} from '../../testing';
 
 describe('control flow - for', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   it('should create, remove and move views corresponding to items in a collection', () => {
     @Component({
       template: '@for ((item of items); track item; let idx = $index) {{{item}}({{idx}})|}',

--- a/packages/core/test/acceptance/control_flow_if_spec.ts
+++ b/packages/core/test/acceptance/control_flow_if_spec.ts
@@ -16,6 +16,7 @@ import {
   OnInit,
   Pipe,
   PipeTransform,
+  provideZoneChangeDetection,
   TemplateRef,
   ViewContainerRef,
 } from '../../src/core';
@@ -30,6 +31,11 @@ class MultiplyPipe implements PipeTransform {
 }
 
 describe('control flow - if', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   it('should add and remove views based on conditions change', () => {
     @Component({template: '@if (show) {Something} @else {Nothing}'})
     class TestComponent {

--- a/packages/core/test/acceptance/control_flow_switch_spec.ts
+++ b/packages/core/test/acceptance/control_flow_switch_spec.ts
@@ -6,7 +6,14 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectorRef, Component, inject, Pipe, PipeTransform} from '../../src/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  inject,
+  Pipe,
+  PipeTransform,
+  provideZoneChangeDetection,
+} from '../../src/core';
 import {TestBed} from '../../testing';
 
 // Basic shared pipe used during testing.
@@ -18,6 +25,11 @@ class MultiplyPipe implements PipeTransform {
 }
 
 describe('control flow - switch', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   it('should show a template based on a matching case', () => {
     @Component({
       template: `

--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -34,6 +34,7 @@ import {
   Injector,
   ElementRef,
   ViewChild,
+  provideZoneChangeDetection,
 } from '../../src/core';
 import {getComponentDef} from '../../src/render3/def_getters';
 import {ComponentFixture, DeferBlockBehavior, fakeAsync, flush, TestBed, tick} from '../../testing';
@@ -221,6 +222,11 @@ const COMMON_PROVIDERS = [
 ];
 
 describe('@defer', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   beforeEach(() => {
     TestBed.configureTestingModule({providers: COMMON_PROVIDERS});
   });

--- a/packages/core/test/acceptance/destroy_ref_spec.ts
+++ b/packages/core/test/acceptance/destroy_ref_spec.ts
@@ -14,6 +14,7 @@ import {
   Directive,
   EnvironmentInjector,
   inject,
+  provideZoneChangeDetection,
 } from '../../src/core';
 import {TestBed} from '../../testing';
 
@@ -77,6 +78,11 @@ describe('DestroyRef', () => {
   });
 
   describe('for node injector', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [provideZoneChangeDetection()],
+      });
+    });
     it('should inject cleanup context in components', () => {
       let destroyed = false;
 

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -60,6 +60,7 @@ import {
   ɵINJECTOR_SCOPE,
   ɵInternalEnvironmentProviders as InternalEnvironmentProviders,
   DestroyRef,
+  provideZoneChangeDetection,
 } from '../../src/core';
 import {RuntimeError, RuntimeErrorCode} from '../../src/errors';
 import {ViewRef as ViewRefInternal} from '../../src/render3/view_ref';
@@ -422,6 +423,11 @@ describe('EnvironmentProviders', () => {
 });
 
 describe('di', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   describe('no dependencies', () => {
     it('should create directive with no deps', () => {
       @Directive({
@@ -889,6 +895,7 @@ describe('di', () => {
         TestBed.configureTestingModule({declarations: [DirectiveA, DirectiveB, MyComp, MyApp]});
         const fixture = TestBed.createComponent(MyApp);
         fixture.componentInstance.showing = true;
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         const divElement = fixture.nativeElement.querySelector('div');
@@ -2615,6 +2622,7 @@ describe('di', () => {
           const fixture = TestBed.createComponent(MyApp);
           fixture.detectChanges();
           fixture.componentInstance.showing = true;
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
 
           const dirA = fixture.componentInstance.dirA;

--- a/packages/core/test/acceptance/directive_spec.ts
+++ b/packages/core/test/acceptance/directive_spec.ts
@@ -16,6 +16,7 @@ import {
   NgModule,
   OnChanges,
   Output,
+  provideZoneChangeDetection,
   SimpleChange,
   SimpleChanges,
   TemplateRef,
@@ -26,6 +27,11 @@ import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
 
 describe('directives', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   describe('matching', () => {
     @Directive({
       selector: 'ng-template[test]',

--- a/packages/core/test/acceptance/discover_utils_spec.ts
+++ b/packages/core/test/acceptance/discover_utils_spec.ts
@@ -13,6 +13,7 @@ import {
   InjectionToken,
   Input,
   Output,
+  provideZoneChangeDetection,
   ViewChild,
   ViewEncapsulation,
 } from '../../src/core';
@@ -39,6 +40,11 @@ import {
 } from '../../src/render3/util/discovery_utils';
 
 describe('discovery utils', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   let fixture: ComponentFixture<MyApp>;
   let myApp: MyApp;
   let dirA: DirectiveA[];

--- a/packages/core/test/acceptance/exports_spec.ts
+++ b/packages/core/test/acceptance/exports_spec.ts
@@ -216,6 +216,7 @@ describe('exports', () => {
       fixture.detectChanges();
       fixture.componentInstance.outer = true;
       fixture.componentInstance.inner = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // result should be <input value="one"><div>one <input value="two"><div>one - two</div></div>

--- a/packages/core/test/acceptance/hmr_spec.ts
+++ b/packages/core/test/acceptance/hmr_spec.ts
@@ -20,6 +20,7 @@ import {
   OnDestroy,
   OnInit,
   Output,
+  provideZoneChangeDetection,
   QueryList,
   SimpleChanges,
   Type,
@@ -41,6 +42,11 @@ import {ComponentType} from '../../src/render3';
 import {isNode} from '@angular/private/testing';
 
 describe('hot module replacement', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   it('should recreate a single usage of a basic component', () => {
     let instance!: ChildCmp;
     const initialMetadata: Component = {

--- a/packages/core/test/acceptance/host_binding_spec.ts
+++ b/packages/core/test/acceptance/host_binding_spec.ts
@@ -22,6 +22,7 @@ import {
   NgModule,
   OnChanges,
   OnInit,
+  provideZoneChangeDetection,
   QueryList,
   ViewChild,
   ViewChildren,
@@ -37,6 +38,11 @@ import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 describe('host bindings', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   it('should render host bindings on the root component', () => {
     @Component({
       template: '...',

--- a/packages/core/test/acceptance/host_directives_spec.ts
+++ b/packages/core/test/acceptance/host_directives_spec.ts
@@ -21,6 +21,7 @@ import {
   OnChanges,
   OnInit,
   Output,
+  provideZoneChangeDetection,
   SimpleChanges,
   Type,
   ViewChild,
@@ -34,6 +35,12 @@ import {By} from '@angular/platform-browser';
 import {getComponent, getDirectives} from '../../src/render3/util/discovery_utils';
 
 describe('host directives', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
+
   it('should apply a basic host directive', () => {
     const logs: string[] = [];
 

--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -26,6 +26,7 @@ import {
   NO_ERRORS_SCHEMA,
   Pipe,
   PipeTransform,
+  provideZoneChangeDetection,
   QueryList,
   TemplateRef,
   Type,
@@ -46,7 +47,7 @@ describe('runtime i18n', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [AppComp, DirectiveWithTplRef, UppercasePipe],
-      providers: [provideNgReflectAttributes()],
+      providers: [provideZoneChangeDetection(), provideNgReflectAttributes()],
       // In some of the tests we use made-up tag names for better readability, however
       // they'll cause validation errors. Add the `NO_ERRORS_SCHEMA` so that we don't have
       // to declare dummy components for each one of them.

--- a/packages/core/test/acceptance/inherit_definition_feature_spec.ts
+++ b/packages/core/test/acceptance/inherit_definition_feature_spec.ts
@@ -17,6 +17,7 @@ import {
   Input,
   OnChanges,
   Output,
+  provideZoneChangeDetection,
   QueryList,
   ViewChildren,
 } from '../../src/core';
@@ -26,6 +27,11 @@ import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 describe('inheritance', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   it('should throw when trying to inherit a component from a directive', () => {
     @Component({
       selector: 'my-comp',

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -22,6 +22,7 @@ import {
   OnInit,
   Output,
   Pipe,
+  provideZoneChangeDetection,
   QueryList,
   TemplateRef,
   ViewChild,
@@ -40,6 +41,12 @@ import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 describe('acceptance integration tests', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
+
   function stripHtmlComments(str: string) {
     return str.replace(/<!--[\s\S]*?-->/g, '');
   }

--- a/packages/core/test/acceptance/let_spec.ts
+++ b/packages/core/test/acceptance/let_spec.ts
@@ -17,10 +17,16 @@ import {
   inject,
   ChangeDetectorRef,
   ViewChild,
+  provideZoneChangeDetection,
 } from '../../src/core';
 import {TestBed} from '../../testing';
 
 describe('@let declarations', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   it('should update the value of a @let declaration over time', () => {
     @Component({
       template: `

--- a/packages/core/test/acceptance/lifecycle_spec.ts
+++ b/packages/core/test/acceptance/lifecycle_spec.ts
@@ -17,6 +17,7 @@ import {
   Input,
   NgModule,
   OnChanges,
+  provideZoneChangeDetection,
   QueryList,
   SimpleChange,
   SimpleChanges,
@@ -28,6 +29,11 @@ import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
 
 describe('onChanges', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   it('should correctly support updating one Input among many', () => {
     let log: string[] = [];
 
@@ -1199,6 +1205,11 @@ describe('onChanges', () => {
 });
 
 describe('meta-programming', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   it('should allow adding lifecycle hook methods any time before first instance creation', () => {
     const events: any[] = [];
 
@@ -1315,6 +1326,11 @@ describe('meta-programming', () => {
 });
 
 describe('hooks order', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   it('should call all hooks in correct order when several directives on same node', () => {
     let log: string[] = [];
 
@@ -1485,6 +1501,11 @@ describe('hooks order', () => {
 });
 
 describe('onInit', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   it('should call onInit after inputs are the first time', () => {
     const input1Values: string[] = [];
     const input2Values: string[] = [];
@@ -2138,6 +2159,11 @@ describe('onInit', () => {
 });
 
 describe('doCheck', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   it('should call doCheck on every refresh', () => {
     let doCheckCalled = 0;
 
@@ -2422,6 +2448,11 @@ describe('doCheck', () => {
 });
 
 describe('afterContentinit', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   it('should be called only in creation mode', () => {
     let afterContentInitCalls = 0;
 
@@ -2839,6 +2870,11 @@ describe('afterContentinit', () => {
 });
 
 describe('afterContentChecked', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   it('should be called every change detection run after afterContentInit', () => {
     const events: string[] = [];
 
@@ -2887,6 +2923,11 @@ describe('afterContentChecked', () => {
 });
 
 describe('afterViewInit', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   it('should be called on creation and not in update mode', () => {
     let afterViewInitCalls = 0;
 
@@ -3370,6 +3411,11 @@ describe('afterViewInit', () => {
 });
 
 describe('afterViewChecked', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   it('should call ngAfterViewChecked every update', () => {
     let afterViewCheckedCalls = 0;
 
@@ -3625,6 +3671,11 @@ describe('afterViewChecked', () => {
 });
 
 describe('onDestroy', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   it('should call destroy when view is removed', () => {
     let destroyCalled = 0;
 
@@ -4250,6 +4301,11 @@ describe('onDestroy', () => {
 });
 
 describe('hook order', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   let events: string[] = [];
 
   beforeEach(() => (events = []));
@@ -4592,6 +4648,7 @@ describe('non-regression', () => {
     expect(destroyed).toBeFalsy();
 
     fixture.componentInstance.show = false;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(destroyed).toBeTruthy();

--- a/packages/core/test/acceptance/listener_spec.ts
+++ b/packages/core/test/acceptance/listener_spec.ts
@@ -16,6 +16,7 @@ import {
   Input,
   OnInit,
   Output,
+  provideZoneChangeDetection,
   QueryList,
   TemplateRef,
   ViewChild,
@@ -26,6 +27,11 @@ import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
 
 describe('event listeners', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   describe('even handling statements', () => {
     it('should call function on event emit', () => {
       @Component({

--- a/packages/core/test/acceptance/outputs_spec.ts
+++ b/packages/core/test/acceptance/outputs_spec.ts
@@ -334,11 +334,13 @@ describe('outputs', () => {
     expect(otherDir.change).toBe(true);
 
     fixture.componentInstance.change = false;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(otherDir.change).toBe(false);
 
     buttonToggle.change.next();
+    fixture.changeDetectorRef.markForCheck();
     expect(counter).toBe(1);
   });
 });

--- a/packages/core/test/acceptance/pipe_spec.ts
+++ b/packages/core/test/acceptance/pipe_spec.ts
@@ -21,6 +21,7 @@ import {
   OnDestroy,
   Pipe,
   PipeTransform,
+  provideZoneChangeDetection,
   SimpleChanges,
   ViewChild,
   ɵɵdefineInjectable,
@@ -328,6 +329,7 @@ describe('pipe', () => {
     expect(fixture.nativeElement).toHaveText('b');
 
     fixture.componentInstance.condition = true;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText('a');
   });
@@ -398,22 +400,27 @@ describe('pipe', () => {
 
       // change from undefined -> null
       fixture.componentInstance.person.name = null;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement.textContent).toEqual('null state:0');
 
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement.textContent).toEqual('null state:0');
 
       // change from null -> some value
       fixture.componentInstance.person.name = 'bob';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement.textContent).toEqual('bob state:1');
 
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement.textContent).toEqual('bob state:1');
 
       // change from some value -> some other value
       fixture.componentInstance.person.name = 'bart';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement.textContent).toEqual('bart state:2');
 
@@ -452,7 +459,10 @@ describe('pipe', () => {
         person = {name: 'bob'};
       }
 
-      TestBed.configureTestingModule({declarations: [App, CountingImpurePipe]});
+      TestBed.configureTestingModule({
+        declarations: [App, CountingImpurePipe],
+        providers: [provideZoneChangeDetection()],
+      });
       const fixture = TestBed.createComponent(App);
       const pipe = impurePipeInstances[0];
 
@@ -742,6 +752,11 @@ describe('pipe', () => {
   });
 
   describe('pure pipe error handling', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [provideZoneChangeDetection()],
+      });
+    });
     it('should not re-invoke pure pipes if it fails initially', () => {
       @Pipe({
         name: 'throwPipe',

--- a/packages/core/test/acceptance/profiler_spec.ts
+++ b/packages/core/test/acceptance/profiler_spec.ts
@@ -25,10 +25,16 @@ import {
   OnDestroy,
   OnInit,
   Output,
+  provideZoneChangeDetection,
   ViewChild,
 } from '../../src/core';
 
 describe('profiler', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   class TestProfiler {
     profile() {}
   }

--- a/packages/core/test/acceptance/property_binding_spec.ts
+++ b/packages/core/test/acceptance/property_binding_spec.ts
@@ -7,12 +7,25 @@
  */
 import {state, style, trigger} from '@angular/animations';
 import {CommonModule} from '@angular/common';
-import {Component, Directive, EventEmitter, Input, Output, ViewContainerRef} from '../../src/core';
+import {
+  Component,
+  Directive,
+  EventEmitter,
+  Input,
+  Output,
+  provideZoneChangeDetection,
+  ViewContainerRef,
+} from '../../src/core';
 import {TestBed} from '../../testing';
 import {By, DomSanitizer, SafeUrl} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 describe('property bindings', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   it('should support bindings to properties', () => {
     @Component({
       template: `<span [id]="id"></span>`,

--- a/packages/core/test/acceptance/providers_spec.ts
+++ b/packages/core/test/acceptance/providers_spec.ts
@@ -554,6 +554,7 @@ describe('providers', () => {
       fixture.detectChanges();
 
       fixture.componentInstance.condition = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(logs).toEqual(['OnDestroy Token']);

--- a/packages/core/test/acceptance/pure_function_spec.ts
+++ b/packages/core/test/acceptance/pure_function_spec.ts
@@ -6,11 +6,24 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import {CommonModule} from '@angular/common';
-import {Component, Directive, Input, QueryList, ViewChild, ViewChildren} from '../../src/core';
+import {
+  Component,
+  Directive,
+  Input,
+  provideZoneChangeDetection,
+  QueryList,
+  ViewChild,
+  ViewChildren,
+} from '../../src/core';
 import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
 
 describe('components using pure function instructions internally', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   describe('with array literals', () => {
     @Component({
       selector: 'my-comp',

--- a/packages/core/test/acceptance/query_spec.ts
+++ b/packages/core/test/acceptance/query_spec.ts
@@ -18,6 +18,7 @@ import {
   forwardRef,
   InjectionToken,
   Input,
+  provideZoneChangeDetection,
   QueryList,
   TemplateRef,
   Type,
@@ -30,6 +31,11 @@ import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
 
 describe('query logic', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [

--- a/packages/core/test/acceptance/renderer_factory_spec.ts
+++ b/packages/core/test/acceptance/renderer_factory_spec.ts
@@ -30,6 +30,7 @@ import {
   Component,
   DoCheck,
   NgZone,
+  provideZoneChangeDetection,
   Renderer2,
   RendererFactory2,
   RendererStyleFlags2,
@@ -41,6 +42,11 @@ import {NoopNgZone} from '../../src/zone/ng_zone';
 import {TestBed} from '../../testing';
 
 describe('renderer factory lifecycle', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   let logs: string[] = [];
   let lastCapturedType: RendererType2 | null = null;
 
@@ -358,6 +364,7 @@ describe('animation renderer factory', () => {
       );
 
       fixture.componentInstance.exp = 'on';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       const [player] = getAnimationLog();
@@ -517,6 +524,7 @@ describe('Renderer2 destruction hooks', () => {
     expect(fixture.nativeElement.textContent).toBe('ABC');
 
     fixture.componentInstance.isContentVisible = false;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toBe('');
@@ -529,6 +537,7 @@ describe('Renderer2 destruction hooks', () => {
     expect(fixture.nativeElement.textContent).toBe('comp(A)comp(B)comp(C)');
 
     fixture.componentInstance.isContentVisible = false;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toBe('');

--- a/packages/core/test/acceptance/security_spec.ts
+++ b/packages/core/test/acceptance/security_spec.ts
@@ -11,6 +11,7 @@ import {
   Component,
   Directive,
   inject,
+  provideZoneChangeDetection,
   TemplateRef,
   Type,
   ViewChild,
@@ -60,6 +61,11 @@ describe('comment node text escaping', () => {
 });
 
 describe('iframe processing', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   function getErrorMessageRegexp() {
     const errorMessagePart = 'NG0' + Math.abs(RuntimeErrorCode.UNSAFE_IFRAME_ATTRS).toString();
     return new RegExp(errorMessagePart);

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -13,6 +13,7 @@ import {
   ElementRef,
   HostBinding,
   Input,
+  provideZoneChangeDetection,
   Renderer2,
   ViewChild,
   ViewContainerRef,
@@ -29,6 +30,11 @@ import {By, DomSanitizer, SafeStyle} from '@angular/platform-browser';
 import {isBrowser} from '@angular/private/testing';
 
 describe('styling', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   describe('apply in prioritization order', () => {
     it('should perform static bindings', () => {
       @Component({

--- a/packages/core/test/acceptance/template_ref_spec.ts
+++ b/packages/core/test/acceptance/template_ref_spec.ts
@@ -293,6 +293,7 @@ describe('TemplateRef', () => {
       expect(fixture.nativeElement.textContent).toBe('Frodo');
 
       context.name = 'Bilbo';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(fixture.nativeElement.textContent).toBe('Bilbo');
@@ -309,6 +310,7 @@ describe('TemplateRef', () => {
       expect(fixture.nativeElement.textContent).toBe('Frodo');
 
       viewRef.context = {name: 'Bilbo'};
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(fixture.nativeElement.textContent).toBe('Bilbo');
@@ -347,6 +349,7 @@ describe('TemplateRef', () => {
       expect(events).toEqual(['Frodo']);
 
       viewRef.context = {name: 'Bilbo'};
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       button.click();
       expect(events).toEqual(['Frodo', 'Bilbo']);
@@ -364,6 +367,7 @@ describe('TemplateRef', () => {
       spyOn(console, 'warn');
 
       viewRef.context = {name: 'Bilbo'};
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(console.warn).toHaveBeenCalledTimes(1);

--- a/packages/core/test/acceptance/tracing_spec.ts
+++ b/packages/core/test/acceptance/tracing_spec.ts
@@ -9,6 +9,7 @@
 import {
   afterEveryRender,
   Component,
+  provideZoneChangeDetection,
   ɵTracingAction as TracingAction,
   ɵTracingService as TracingService,
   ɵTracingSnapshot as TracingSnapshot,
@@ -16,6 +17,11 @@ import {
 import {fakeAsync, TestBed} from '../../testing';
 
 describe('TracingService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   let actions: TracingAction[];
   let listeners: {event: string; handler: Function}[];
   let fakeSnapshot: TracingSnapshot;

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -31,6 +31,7 @@ import {
   OnInit,
   Pipe,
   PipeTransform,
+  provideZoneChangeDetection,
   QueryList,
   Renderer2,
   RendererFactory2,
@@ -1102,6 +1103,7 @@ describe('ViewContainerRef', () => {
       const fixture = TestBed.createComponent(AppComponent);
       fixture.detectChanges();
       fixture.componentRef.instance.visible = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
     });
   });
@@ -1324,6 +1326,11 @@ describe('ViewContainerRef', () => {
   });
 
   describe('createComponent', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [provideZoneChangeDetection()],
+      });
+    });
     let templateExecutionCounter = 0;
 
     beforeEach(() => (templateExecutionCounter = 0));
@@ -1871,6 +1878,7 @@ describe('ViewContainerRef', () => {
         TestBed.resetTestingModule();
         TestBed.configureTestingModule({
           declarations: [EmbeddedViewInsertionComp, VCRefDirective, HostComponent],
+          providers: [provideZoneChangeDetection()],
         });
         const hostValue = signal('initial');
         let dirValue = 'initial';
@@ -1999,6 +2007,7 @@ describe('ViewContainerRef', () => {
       );
 
       child.tpl = null;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(getElementHtml(fixture.nativeElement)).toEqual(`<child><div>Child</div></child>`);
     });
@@ -2057,6 +2066,7 @@ describe('ViewContainerRef', () => {
         {data: ['7'], value: 'four'},
       ];
       fixture.componentInstance.name = 'New name!';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(getElementHtml(fixture.nativeElement)).toEqual(
@@ -2085,16 +2095,19 @@ describe('ViewContainerRef', () => {
       expect(fixture.nativeElement.textContent).toBe('|one||two||three|');
 
       fixture.componentInstance.items.unshift('zero');
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(fixture.nativeElement.textContent).toBe('|zero||one||two||three|');
 
+      fixture.changeDetectorRef.markForCheck();
       fixture.componentInstance.items.push('four');
       fixture.detectChanges();
 
       expect(fixture.nativeElement.textContent).toBe('|zero||one||two||three||four|');
 
       fixture.componentInstance.items.splice(3, 0, 'two point five');
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(fixture.nativeElement.textContent).toBe(
@@ -2122,16 +2135,19 @@ describe('ViewContainerRef', () => {
       expect(fixture.nativeElement.textContent).toBe('|one||two||three|');
 
       fixture.componentInstance.items.unshift('zero');
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(fixture.nativeElement.textContent).toBe('|zero||one||two||three|');
 
       fixture.componentInstance.items.push('four');
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(fixture.nativeElement.textContent).toBe('|zero||one||two||three||four|');
 
       fixture.componentInstance.items.splice(3, 0, 'two point five');
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(fixture.nativeElement.textContent).toBe(
@@ -2157,16 +2173,19 @@ describe('ViewContainerRef', () => {
       expect(fixture.nativeElement.textContent).toBe('|one||two||three|');
 
       fixture.componentInstance.items.unshift('zero');
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(fixture.nativeElement.textContent).toBe('|zero||one||two||three|');
 
       fixture.componentInstance.items.push('four');
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(fixture.nativeElement.textContent).toBe('|zero||one||two||three||four|');
 
       fixture.componentInstance.items.splice(3, 0, 'two point five');
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(fixture.nativeElement.textContent).toBe(
@@ -2187,7 +2206,11 @@ describe('ViewContainerRef', () => {
         items = ['one', 'two', 'three'];
       }
 
-      TestBed.configureTestingModule({imports: [CommonModule], declarations: [App]});
+      TestBed.configureTestingModule({
+        imports: [CommonModule],
+        providers: [provideZoneChangeDetection()],
+        declarations: [App],
+      });
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
 
@@ -2229,16 +2252,19 @@ describe('ViewContainerRef', () => {
       expect(fixture.nativeElement.textContent).toBe('|one||two||three|');
 
       fixture.componentInstance.items.unshift('zero');
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(fixture.nativeElement.textContent).toBe('|zero||one||two||three|');
 
       fixture.componentInstance.items.push('four');
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(fixture.nativeElement.textContent).toBe('|zero||one||two||three||four|');
 
       fixture.componentInstance.items.splice(3, 0, 'two point five');
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(fixture.nativeElement.textContent).toBe(
@@ -2334,6 +2360,7 @@ describe('ViewContainerRef', () => {
       ]);
 
       log.length = 0;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(log).toEqual([
         'doCheck-A',
@@ -2352,6 +2379,7 @@ describe('ViewContainerRef', () => {
       expect(log).toEqual([]);
 
       log.length = 0;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(getElementHtml(fixture.nativeElement)).toEqual(
         '<hooks vcref="">A</hooks><hooks>C</hooks><hooks>B</hooks>',
@@ -2373,6 +2401,7 @@ describe('ViewContainerRef', () => {
       ]);
 
       log.length = 0;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(log).toEqual([
         'doCheck-A',
@@ -2388,6 +2417,7 @@ describe('ViewContainerRef', () => {
 
       log.length = 0;
       const viewRef = vcRefDir.vcref.detach(0);
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(log).toEqual([
         'doCheck-A',
@@ -2400,6 +2430,7 @@ describe('ViewContainerRef', () => {
 
       log.length = 0;
       vcRefDir.vcref.insert(viewRef!);
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(log).toEqual([
         'doCheck-A',
@@ -2415,6 +2446,7 @@ describe('ViewContainerRef', () => {
 
       log.length = 0;
       vcRefDir.vcref.remove(0);
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(log).toEqual([
         'onDestroy-C',
@@ -2447,6 +2479,7 @@ describe('ViewContainerRef', () => {
         .query(By.directive(VCRefDirective))
         .injector.get(VCRefDirective);
 
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(log).toEqual([
         'onChanges-A',
@@ -2466,6 +2499,7 @@ describe('ViewContainerRef', () => {
       ]);
 
       log.length = 0;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(log).toEqual([
         'doCheck-A',
@@ -2484,6 +2518,7 @@ describe('ViewContainerRef', () => {
       expect(log).toEqual([]);
 
       componentRef.instance.name = 'D';
+      fixture.changeDetectorRef.markForCheck();
       log.length = 0;
       fixture.detectChanges();
       expect(getElementHtml(fixture.nativeElement)).toEqual(
@@ -2505,6 +2540,7 @@ describe('ViewContainerRef', () => {
       ]);
 
       log.length = 0;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(log).toEqual([
         'doCheck-A',
@@ -2520,6 +2556,7 @@ describe('ViewContainerRef', () => {
 
       log.length = 0;
       const viewRef = vcRefDir.vcref.detach(0);
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(log).toEqual([
         'doCheck-A',
@@ -2532,6 +2569,7 @@ describe('ViewContainerRef', () => {
 
       log.length = 0;
       vcRefDir.vcref.insert(viewRef!);
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(log).toEqual([
         'doCheck-A',
@@ -2547,6 +2585,7 @@ describe('ViewContainerRef', () => {
 
       log.length = 0;
       vcRefDir.vcref.remove(0);
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(log).toEqual([
         'onDestroy-D',
@@ -2597,6 +2636,7 @@ describe('ViewContainerRef', () => {
       expect(fixture.nativeElement.children[0].getAttribute('title')).toBe('initial');
 
       componentRef.instance.title = 'changed';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(fixture.nativeElement.children[0].tagName).toBe('HOST-BINDINGS');
@@ -2606,6 +2646,11 @@ describe('ViewContainerRef', () => {
   });
 
   describe('projection', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [provideZoneChangeDetection()],
+      });
+    });
     it('should project the ViewContainerRef content along its host, in an element', () => {
       @Component({
         selector: 'child',
@@ -2915,6 +2960,7 @@ describe('ViewContainerRef', () => {
       expect(containerEl!.childNodes.length).toBe(3);
       expect(containerEl!.childNodes[1].textContent).toBe('check count: 1');
 
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(containerEl!.childNodes.length).toBe(3);

--- a/packages/core/test/acceptance/view_insertion_spec.ts
+++ b/packages/core/test/acceptance/view_insertion_spec.ts
@@ -15,6 +15,7 @@ import {
   Injectable,
   Injector,
   Input,
+  provideZoneChangeDetection,
   TemplateRef,
   ViewChild,
   ViewContainerRef,
@@ -24,6 +25,11 @@ import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
 
 describe('view insertion', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
+  });
   describe('of a simple template', () => {
     it('should insert into an empty container, at the front, in the middle, and at the end', () => {
       let _counter = 0;

--- a/packages/core/test/application_ref_integration_spec.ts
+++ b/packages/core/test/application_ref_integration_spec.ts
@@ -13,7 +13,10 @@ import {
   DoCheck,
   NgModule,
   OnInit,
+  provideZoneChangeDetection,
   TestabilityRegistry,
+  NgZone,
+  ɵNoopNgZone as NoopNgZone,
 } from '../src/core';
 import {getTestBed} from '../testing';
 import {BrowserModule} from '@angular/platform-browser';
@@ -43,7 +46,11 @@ describe('ApplicationRef bootstrap', () => {
     declarations: [HelloWorldComponent],
     bootstrap: [HelloWorldComponent],
     imports: [BrowserModule],
-    providers: [{provide: DOCUMENT, useFactory: () => document}],
+    providers: [
+      {provide: DOCUMENT, useFactory: () => document},
+      provideZoneChangeDetection(),
+      {provide: NgZone, useClass: NoopNgZone},
+    ],
   })
   class MyAppModule {}
 

--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -34,6 +34,7 @@ import {
   Type,
   ViewChild,
   ViewContainerRef,
+  provideZoneChangeDetection,
 } from '../src/core';
 import {ErrorHandler} from '../src/error_handler';
 import {ComponentRef} from '../src/linker/component_factory';
@@ -172,7 +173,10 @@ describe('bootstrap', () => {
 
   describe('ApplicationRef', () => {
     beforeEach(async () => {
-      TestBed.configureTestingModule({imports: [await createModule()]});
+      TestBed.configureTestingModule({
+        imports: [await createModule()],
+        providers: [provideZoneChangeDetection()],
+      });
     });
 
     it('should throw when reentering tick', () => {
@@ -743,7 +747,10 @@ describe('bootstrap', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
         declarations: [MyComp, ContainerComp, EmbeddedViewComp],
-        providers: [{provide: ComponentFixtureNoNgZone, useValue: true}],
+        providers: [
+          {provide: ComponentFixtureNoNgZone, useValue: true},
+          provideZoneChangeDetection(),
+        ],
       });
     });
 
@@ -940,6 +947,7 @@ describe('AppRef', () => {
     beforeEach(() => {
       stableCalled = false;
       TestBed.configureTestingModule({
+        providers: [provideZoneChangeDetection()],
         declarations: [
           SyncComp,
           MicroTaskComp,

--- a/packages/core/test/bundling/image-directive/index.ts
+++ b/packages/core/test/bundling/image-directive/index.ts
@@ -7,7 +7,7 @@
  */
 
 import '@angular/compiler';
-import {Component, importProvidersFrom} from '../../../src/core';
+import {Component, importProvidersFrom, provideZoneChangeDetection} from '../../../src/core';
 import {bootstrapApplication, provideProtractorTestingSupport} from '@angular/platform-browser';
 import {RouterModule} from '@angular/router';
 
@@ -57,6 +57,7 @@ const ROUTES = [
 
 bootstrapApplication(RootComponent, {
   providers: [
+    provideZoneChangeDetection(),
     provideProtractorTestingSupport(), //
     importProvidersFrom(RouterModule.forRoot(ROUTES)),
   ],

--- a/packages/core/test/change_detection_scheduler_spec.ts
+++ b/packages/core/test/change_detection_scheduler_spec.ts
@@ -756,6 +756,7 @@ describe('Angular with scheduler and ZoneJS', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
+        provideZoneChangeDetection(),
         {provide: ComponentFixtureAutoDetect, useValue: true},
         {provide: PLATFORM_ID, useValue: PLATFORM_BROWSER_ID},
       ],

--- a/packages/core/test/component_fixture_spec.ts
+++ b/packages/core/test/component_fixture_spec.ts
@@ -15,8 +15,8 @@ import {
   Input,
   NgZone,
   createComponent,
-  provideZonelessChangeDetection,
   provideZoneChangeDetection,
+  provideZonelessChangeDetection,
   signal,
 } from '../src/core';
 import {
@@ -166,6 +166,7 @@ describe('ComponentFixture', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
       declarations: [
         AutoDetectComp,
         AsyncComp,

--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -22,6 +22,7 @@ import {
   NO_ERRORS_SCHEMA,
   OnInit,
   Output,
+  provideZoneChangeDetection,
   Renderer2,
   TemplateRef,
   ViewChild,
@@ -341,7 +342,7 @@ describe('debug element', () => {
         TestCmptWithRenderer,
         WithTitleDir,
       ],
-      providers: [Logger],
+      providers: [Logger, provideZoneChangeDetection()],
       schemas: [NO_ERRORS_SCHEMA],
     });
   }));

--- a/packages/core/test/directive_lifecycle_integration_spec.ts
+++ b/packages/core/test/directive_lifecycle_integration_spec.ts
@@ -16,6 +16,7 @@ import {
   DoCheck,
   OnChanges,
   OnInit,
+  provideZoneChangeDetection,
 } from '../src/core';
 import {inject, TestBed} from '../testing';
 import {Log} from '../testing/src/testing_internal';
@@ -26,7 +27,7 @@ describe('directive lifecycle integration spec', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [LifecycleCmp, LifecycleDir, MyComp5],
-      providers: [Log],
+      providers: [provideZoneChangeDetection(), Log],
     }).overrideComponent(MyComp5, {set: {template: '<div [field]="123" lifecycle></div>'}});
   });
 

--- a/packages/core/test/event_emitter_spec.ts
+++ b/packages/core/test/event_emitter_spec.ts
@@ -10,7 +10,7 @@ import {TestBed} from '../testing';
 import {filter} from 'rxjs/operators';
 
 import {EventEmitter} from '../src/event_emitter';
-import {ApplicationRef, NgZone} from '../public_api';
+import {ApplicationRef, NgZone, provideZoneChangeDetection} from '../public_api';
 
 describe('EventEmitter', () => {
   let emitter: EventEmitter<number>;
@@ -207,6 +207,9 @@ describe('EventEmitter', () => {
   });
 
   it('should not prevent app from becoming stable if subscriber throws an error', async () => {
+    TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
+    });
     const logs: string[] = [];
     const ngZone = TestBed.inject(NgZone);
     const appRef = TestBed.inject(ApplicationRef);

--- a/packages/core/test/legacy_animation/legacy_animation_integration_spec.ts
+++ b/packages/core/test/legacy_animation/legacy_animation_integration_spec.ts
@@ -35,6 +35,7 @@ import {
   RendererFactory2,
   ViewChild,
   ViewContainerRef,
+  provideZoneChangeDetection,
 } from '../../src/core';
 import {fakeAsync, flushMicrotasks, TestBed} from '../../testing';
 import {ɵDomRendererFactory2} from '@angular/platform-browser';
@@ -64,7 +65,10 @@ const DEFAULT_COMPONENT_ID = '1';
     beforeEach(() => {
       resetLog();
       TestBed.configureTestingModule({
-        providers: [{provide: AnimationDriver, useClass: MockAnimationDriver}],
+        providers: [
+          {provide: AnimationDriver, useClass: MockAnimationDriver},
+          provideZoneChangeDetection(),
+        ],
         imports: [BrowserAnimationsModule],
       });
     });

--- a/packages/core/test/legacy_animation/legacy_animation_query_integration_spec.ts
+++ b/packages/core/test/legacy_animation/legacy_animation_query_integration_spec.ts
@@ -30,7 +30,7 @@ import {
 } from '@angular/animations/browser';
 import {MockAnimationDriver, MockAnimationPlayer} from '@angular/animations/browser/testing';
 import {CommonModule} from '@angular/common';
-import {Component, HostBinding, ViewChild} from '../../src/core';
+import {Component, HostBinding, ViewChild, provideZoneChangeDetection} from '../../src/core';
 import {fakeAsync, flushMicrotasks, TestBed} from '../../testing';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {isNode} from '@angular/private/testing';
@@ -53,7 +53,10 @@ import {HostListener} from '../../src/metadata/directives';
     beforeEach(() => {
       resetLog();
       TestBed.configureTestingModule({
-        providers: [{provide: AnimationDriver, useClass: MockAnimationDriver}],
+        providers: [
+          {provide: AnimationDriver, useClass: MockAnimationDriver},
+          provideZoneChangeDetection(),
+        ],
         imports: [BrowserAnimationsModule, CommonModule],
       });
     });

--- a/packages/core/test/legacy_animation/legacy_animations_with_web_animations_integration_spec.ts
+++ b/packages/core/test/legacy_animation/legacy_animations_with_web_animations_integration_spec.ts
@@ -21,7 +21,7 @@ import {
   ɵWebAnimationsPlayer,
   ɵTransitionAnimationPlayer as TransitionAnimationPlayer,
 } from '@angular/animations/browser';
-import {Component, ViewChild} from '../../src/core';
+import {Component, ViewChild, provideZoneChangeDetection} from '../../src/core';
 import {TestBed} from '../../testing';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {isNode} from '@angular/private/testing';
@@ -34,7 +34,10 @@ import {isNode} from '@angular/private/testing';
   describe('legacy animation integration tests using web animations', function () {
     beforeEach(() => {
       TestBed.configureTestingModule({
-        providers: [{provide: AnimationDriver, useClass: ɵWebAnimationsDriver}],
+        providers: [
+          {provide: AnimationDriver, useClass: ɵWebAnimationsDriver},
+          provideZoneChangeDetection(),
+        ],
         imports: [BrowserAnimationsModule],
       });
     });

--- a/packages/core/test/linker/change_detection_integration_spec.ts
+++ b/packages/core/test/linker/change_detection_integration_spec.ts
@@ -30,6 +30,7 @@ import {
   Pipe,
   PipeTransform,
   Provider,
+  provideZoneChangeDetection,
   RendererFactory2,
   RendererType2,
   SimpleChange,
@@ -137,7 +138,7 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
           PipeWithOnDestroy,
           IdentityPipe,
         ],
-        providers: [RenderLog, DirectiveLog],
+        providers: [RenderLog, DirectiveLog, provideZoneChangeDetection()],
       });
     });
 

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -34,6 +34,7 @@ import {
   Pipe,
   provideNgReflectAttributes,
   reflectComponentType,
+  signal,
   SkipSelf,
   ViewChild,
   ViewRef,
@@ -62,10 +63,10 @@ describe('integration tests', function () {
   describe('react to record changes', function () {
     it('should consume text node changes', () => {
       TestBed.configureTestingModule({declarations: [MyComp]});
-      const template = '<div>{{ctxProp}}</div>';
+      const template = '<div>{{ctxProp()}}</div>';
       TestBed.overrideComponent(MyComp, {set: {template}});
       const fixture = TestBed.createComponent(MyComp);
-      fixture.componentInstance.ctxProp = 'Hello World!';
+      fixture.componentInstance.ctxProp.set('Hello World!');
 
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveText('Hello World!');
@@ -73,10 +74,10 @@ describe('integration tests', function () {
 
     it('should update text node with a blank string when interpolation evaluates to null', () => {
       TestBed.configureTestingModule({declarations: [MyComp]});
-      const template = '<div>{{null}}{{ctxProp}}</div>';
+      const template = '<div>{{null}}{{ctxProp()}}</div>';
       TestBed.overrideComponent(MyComp, {set: {template}});
       const fixture = TestBed.createComponent(MyComp);
-      fixture.componentInstance.ctxProp = null!;
+      fixture.componentInstance.ctxProp.set(null!);
 
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveText('');
@@ -111,11 +112,11 @@ describe('integration tests', function () {
 
     it('should consume element binding changes', () => {
       TestBed.configureTestingModule({declarations: [MyComp]});
-      const template = '<div [id]="ctxProp"></div>';
+      const template = '<div [id]="ctxProp()"></div>';
       TestBed.overrideComponent(MyComp, {set: {template}});
       const fixture = TestBed.createComponent(MyComp);
 
-      fixture.componentInstance.ctxProp = 'Hello World!';
+      fixture.componentInstance.ctxProp.set('Hello World!');
       fixture.detectChanges();
 
       expect(fixture.debugElement.children[0].nativeElement.id).toEqual('Hello World!');
@@ -123,17 +124,17 @@ describe('integration tests', function () {
 
     it('should consume binding to aria-* attributes', () => {
       TestBed.configureTestingModule({declarations: [MyComp]});
-      const template = '<div [attr.aria-label]="ctxProp"></div>';
+      const template = '<div [attr.aria-label]="ctxProp()"></div>';
       TestBed.overrideComponent(MyComp, {set: {template}});
       const fixture = TestBed.createComponent(MyComp);
 
-      fixture.componentInstance.ctxProp = 'Initial aria label';
+      fixture.componentInstance.ctxProp.set('Initial aria label');
       fixture.detectChanges();
       expect(fixture.debugElement.children[0].nativeElement.getAttribute('aria-label')).toEqual(
         'Initial aria label',
       );
 
-      fixture.componentInstance.ctxProp = 'Changed aria label';
+      fixture.componentInstance.ctxProp.set('Changed aria label');
       fixture.detectChanges();
       expect(fixture.debugElement.children[0].nativeElement.getAttribute('aria-label')).toEqual(
         'Changed aria label',
@@ -142,75 +143,75 @@ describe('integration tests', function () {
 
     it('should remove an attribute when attribute expression evaluates to null', () => {
       TestBed.configureTestingModule({declarations: [MyComp]});
-      const template = '<div [attr.foo]="ctxProp"></div>';
+      const template = '<div [attr.foo]="ctxProp()"></div>';
       TestBed.overrideComponent(MyComp, {set: {template}});
       const fixture = TestBed.createComponent(MyComp);
 
-      fixture.componentInstance.ctxProp = 'bar';
+      fixture.componentInstance.ctxProp.set('bar');
       fixture.detectChanges();
       expect(fixture.debugElement.children[0].nativeElement.getAttribute('foo')).toEqual('bar');
 
-      fixture.componentInstance.ctxProp = null!;
+      fixture.componentInstance.ctxProp.set(null!);
       fixture.detectChanges();
       expect(fixture.debugElement.children[0].nativeElement.hasAttribute('foo')).toBeFalsy();
     });
 
     it('should remove style when when style expression evaluates to null', () => {
       TestBed.configureTestingModule({declarations: [MyComp]});
-      const template = '<div [style.height.px]="ctxProp"></div>';
+      const template = '<div [style.height.px]="ctxProp()"></div>';
       TestBed.overrideComponent(MyComp, {set: {template}});
       const fixture = TestBed.createComponent(MyComp);
 
-      fixture.componentInstance.ctxProp = '10';
+      fixture.componentInstance.ctxProp.set('10');
       fixture.detectChanges();
       expect(fixture.debugElement.children[0].nativeElement.style['height']).toEqual('10px');
 
-      fixture.componentInstance.ctxProp = null!;
+      fixture.componentInstance.ctxProp.set(null!);
       fixture.detectChanges();
       expect(fixture.debugElement.children[0].nativeElement.style['height']).toEqual('');
     });
 
     it('should consume binding to property names where attr name and property name do not match', () => {
       TestBed.configureTestingModule({declarations: [MyComp]});
-      const template = '<div [tabindex]="ctxNumProp"></div>';
+      const template = '<div [tabindex]="ctxNumProp()"></div>';
       TestBed.overrideComponent(MyComp, {set: {template}});
       const fixture = TestBed.createComponent(MyComp);
 
       fixture.detectChanges();
       expect(fixture.debugElement.children[0].nativeElement.tabIndex).toEqual(0);
 
-      fixture.componentInstance.ctxNumProp = 5;
+      fixture.componentInstance.ctxNumProp.set(5);
       fixture.detectChanges();
       expect(fixture.debugElement.children[0].nativeElement.tabIndex).toEqual(5);
     });
 
     it('should consume binding to camel-cased properties', () => {
       TestBed.configureTestingModule({declarations: [MyComp]});
-      const template = '<input [readOnly]="ctxBoolProp">';
+      const template = '<input [readOnly]="ctxBoolProp()">';
       TestBed.overrideComponent(MyComp, {set: {template}});
       const fixture = TestBed.createComponent(MyComp);
 
       fixture.detectChanges();
       expect(fixture.debugElement.children[0].nativeElement.readOnly).toBeFalsy();
 
-      fixture.componentInstance.ctxBoolProp = true;
+      fixture.componentInstance.ctxBoolProp.set(true);
       fixture.detectChanges();
       expect(fixture.debugElement.children[0].nativeElement.readOnly).toBeTruthy();
     });
 
     it('should consume binding to innerHtml', () => {
       TestBed.configureTestingModule({declarations: [MyComp]});
-      const template = '<div innerHtml="{{ctxProp}}"></div>';
+      const template = '<div innerHtml="{{ctxProp()}}"></div>';
       TestBed.overrideComponent(MyComp, {set: {template}});
       const fixture = TestBed.createComponent(MyComp);
 
-      fixture.componentInstance.ctxProp = 'Some <span>HTML</span>';
+      fixture.componentInstance.ctxProp.set('Some <span>HTML</span>');
       fixture.detectChanges();
       expect(fixture.debugElement.children[0].nativeElement.innerHTML).toEqual(
         'Some <span>HTML</span>',
       );
 
-      fixture.componentInstance.ctxProp = 'Some other <div>HTML</div>';
+      fixture.componentInstance.ctxProp.set('Some other <div>HTML</div>');
       fixture.detectChanges();
       expect(fixture.debugElement.children[0].nativeElement.innerHTML).toEqual(
         'Some other <div>HTML</div>',
@@ -218,13 +219,13 @@ describe('integration tests', function () {
     });
 
     it('should consume binding to htmlFor using for alias', () => {
-      const template = '<label [for]="ctxProp"></label>';
+      const template = '<label [for]="ctxProp()"></label>';
       const fixture = TestBed.configureTestingModule({declarations: [MyComp]})
         .overrideComponent(MyComp, {set: {template}})
         .createComponent(MyComp);
 
       const nativeEl = fixture.debugElement.children[0].nativeElement;
-      fixture.debugElement.componentInstance.ctxProp = 'foo';
+      fixture.debugElement.componentInstance.ctxProp.set('foo');
       fixture.detectChanges();
 
       expect(nativeEl.htmlFor).toBe('foo');
@@ -234,15 +235,15 @@ describe('integration tests', function () {
       TestBed.configureTestingModule({declarations: [MyComp, MyDir]});
       const template =
         '<span>' +
-        '<div my-dir [elprop]="ctxProp"></div>' +
+        '<div my-dir [elprop]="ctxProp()"></div>' +
         '<div my-dir elprop="Hi there!"></div>' +
         '<div my-dir elprop="Hi {{\'there!\'}}"></div>' +
-        '<div my-dir elprop="One more {{ctxProp}}"></div>' +
+        '<div my-dir elprop="One more {{ctxProp()}}"></div>' +
         '</span>';
       TestBed.overrideComponent(MyComp, {set: {template}});
       const fixture = TestBed.createComponent(MyComp);
 
-      fixture.componentInstance.ctxProp = 'Hello World!';
+      fixture.componentInstance.ctxProp.set('Hello World!');
       fixture.detectChanges();
 
       const containerSpan = fixture.debugElement.children[0];
@@ -258,11 +259,11 @@ describe('integration tests', function () {
     describe('pipes', () => {
       it('should support pipes in bindings', () => {
         TestBed.configureTestingModule({declarations: [MyComp, MyDir, DoublePipe]});
-        const template = '<div my-dir #dir="mydir" [elprop]="ctxProp | double"></div>';
+        const template = '<div my-dir #dir="mydir" [elprop]="ctxProp() | double"></div>';
         TestBed.overrideComponent(MyComp, {set: {template}});
         const fixture = TestBed.createComponent(MyComp);
 
-        fixture.componentInstance.ctxProp = 'a';
+        fixture.componentInstance.ctxProp.set('a');
         fixture.detectChanges();
 
         const dir = fixture.debugElement.children[0].references!['dir'];
@@ -284,17 +285,17 @@ describe('integration tests', function () {
     // GH issue 328 - https://github.com/angular/angular/issues/328
     it('should support different directive types on a single node', () => {
       TestBed.configureTestingModule({declarations: [MyComp, ChildComp, MyDir]});
-      const template = '<child-cmp my-dir [elprop]="ctxProp"></child-cmp>';
+      const template = '<child-cmp my-dir [elprop]="ctxProp()"></child-cmp>';
       TestBed.overrideComponent(MyComp, {set: {template}});
       const fixture = TestBed.createComponent(MyComp);
 
-      fixture.componentInstance.ctxProp = 'Hello World!';
+      fixture.componentInstance.ctxProp.set('Hello World!');
       fixture.detectChanges();
 
       const tc = fixture.debugElement.children[0];
 
       expect(tc.injector.get(MyDir).dirProp).toEqual('Hello World!');
-      expect(tc.injector.get(ChildComp).dirProp).toEqual(null);
+      expect(tc.injector.get(ChildComp).dirProp()).toEqual(null);
     });
 
     it('should support directives where a binding attribute is not given', () => {
@@ -316,18 +317,18 @@ describe('integration tests', function () {
 
     it('should support directives where a selector matches property binding', () => {
       TestBed.configureTestingModule({declarations: [MyComp, IdDir]});
-      const template = '<p [id]="ctxProp"></p>';
+      const template = '<p [id]="ctxProp()"></p>';
       TestBed.overrideComponent(MyComp, {set: {template}});
       const fixture = TestBed.createComponent(MyComp);
 
       const tc = fixture.debugElement.children[0];
       const idDir = tc.injector.get(IdDir);
 
-      fixture.componentInstance.ctxProp = 'some_id';
+      fixture.componentInstance.ctxProp.set('some_id');
       fixture.detectChanges();
       expect(idDir.id).toEqual('some_id');
 
-      fixture.componentInstance.ctxProp = 'other_id';
+      fixture.componentInstance.ctxProp.set('other_id');
       fixture.detectChanges();
       expect(idDir.id).toEqual('other_id');
     });
@@ -383,11 +384,11 @@ describe('integration tests', function () {
     it('should not detach views in ViewContainers when the parent view is destroyed.', () => {
       TestBed.configureTestingModule({declarations: [MyComp, SomeViewport]});
       const template =
-        '<div *ngIf="ctxBoolProp"><ng-template some-viewport let-greeting="someTmpl"><span>{{greeting}}</span></ng-template></div>';
+        '<div *ngIf="ctxBoolProp()"><ng-template some-viewport let-greeting="someTmpl"><span>{{greeting}}</span></ng-template></div>';
       TestBed.overrideComponent(MyComp, {set: {template}});
       const fixture = TestBed.createComponent(MyComp);
 
-      fixture.componentInstance.ctxBoolProp = true;
+      fixture.componentInstance.ctxBoolProp.set(true);
       fixture.detectChanges();
 
       const ngIfEl = fixture.debugElement.children[0];
@@ -397,7 +398,7 @@ describe('integration tests', function () {
       expect(someViewport.container.length).toBe(2);
       expect(ngIfEl.children.length).toBe(2);
 
-      fixture.componentInstance.ctxBoolProp = false;
+      fixture.componentInstance.ctxBoolProp.set(false);
       fixture.detectChanges();
 
       expect(someViewport.container.length).toBe(2);
@@ -428,11 +429,11 @@ describe('integration tests', function () {
         schemas: [NO_ERRORS_SCHEMA],
       });
       const template =
-        '<some-directive><toolbar><ng-template toolbarpart let-toolbarProp="toolbarProp">{{ctxProp}},{{toolbarProp}},<cmp-with-host></cmp-with-host></ng-template></toolbar></some-directive>';
+        '<some-directive><toolbar><ng-template toolbarpart let-toolbarProp="toolbarProp">{{ctxProp()}},{{toolbarProp}},<cmp-with-host></cmp-with-host></ng-template></toolbar></some-directive>';
       TestBed.overrideComponent(MyComp, {set: {template}});
       const fixture = TestBed.createComponent(MyComp);
 
-      fixture.componentInstance.ctxProp = 'From myComp';
+      fixture.componentInstance.ctxProp.set('From myComp');
       fixture.detectChanges();
 
       expect(fixture.nativeElement).toHaveText(
@@ -483,7 +484,7 @@ describe('integration tests', function () {
       it('should make the assigned component accessible in property bindings, even if they were declared before the component', () => {
         TestBed.configureTestingModule({declarations: [MyComp, ChildComp]});
         const template =
-          '<ng-template [ngIf]="true">{{alice.ctxProp}}</ng-template>|{{alice.ctxProp}}|<child-cmp ref-alice></child-cmp>';
+          '<ng-template [ngIf]="true">{{alice.ctxProp()}}</ng-template>|{{alice.ctxProp()}}|<child-cmp ref-alice></child-cmp>';
         TestBed.overrideComponent(MyComp, {set: {template}});
         const fixture = TestBed.createComponent(MyComp);
 
@@ -574,17 +575,17 @@ describe('integration tests', function () {
           declarations: [MyComp, PushCmp, EventCmp],
           imports: [CommonModule],
         });
-        const template = '<push-cmp [prop]="ctxProp" #cmp></push-cmp>';
+        const template = '<push-cmp [prop]="ctxProp()" #cmp></push-cmp>';
         TestBed.overrideComponent(MyComp, {set: {template}});
         const fixture = TestBed.createComponent(MyComp);
 
         const cmp = fixture.debugElement.children[0].references!['cmp'];
 
-        fixture.componentInstance.ctxProp = 'one';
+        fixture.componentInstance.ctxProp.set('one');
         fixture.detectChanges();
         expect(cmp.numberOfChecks).toEqual(1);
 
-        fixture.componentInstance.ctxProp = 'two';
+        fixture.componentInstance.ctxProp.set('two');
         fixture.detectChanges();
         expect(cmp.numberOfChecks).toEqual(2);
       });
@@ -612,7 +613,7 @@ describe('integration tests', function () {
           declarations: [MyComp, PushCmp, EventCmp],
           imports: [CommonModule],
         });
-        const template = '<push-cmp [prop]="ctxProp" #cmp></push-cmp>';
+        const template = '<push-cmp [prop]="ctxProp()" #cmp></push-cmp>';
         TestBed.overrideComponent(MyComp, {set: {template}});
         const fixture = TestBed.createComponent(MyComp);
 
@@ -649,17 +650,17 @@ describe('integration tests', function () {
 
       it('should not affect updating properties on the component', () => {
         TestBed.configureTestingModule({declarations: [MyComp, [[PushCmpWithRef]]]});
-        const template = '<push-cmp-with-ref [prop]="ctxProp" #cmp></push-cmp-with-ref>';
+        const template = '<push-cmp-with-ref [prop]="ctxProp()" #cmp></push-cmp-with-ref>';
         TestBed.overrideComponent(MyComp, {set: {template}});
         const fixture = TestBed.createComponent(MyComp);
 
         const cmp = fixture.debugElement.children[0].references!['cmp'];
 
-        fixture.componentInstance.ctxProp = 'one';
+        fixture.componentInstance.ctxProp.set('one');
         fixture.detectChanges();
         expect(cmp.prop).toEqual('one');
 
-        fixture.componentInstance.ctxProp = 'two';
+        fixture.componentInstance.ctxProp.set('two');
         fixture.detectChanges();
         expect(cmp.prop).toEqual('two');
       });
@@ -769,7 +770,7 @@ describe('integration tests', function () {
       })
         .overrideComponent(MyComp, {
           set: {
-            template: '<ng-template emitter listener (event)="ctxProp=$event"></ng-template>',
+            template: '<ng-template emitter listener (event)="ctxProp.set($event)"></ng-template>',
           },
         })
         .createComponent(MyComp);
@@ -781,13 +782,13 @@ describe('integration tests', function () {
       const myComp = fixture.debugElement.injector.get(MyComp);
       const listener = tc.injector.get(DirectiveListeningEvent);
 
-      myComp.ctxProp = '';
+      myComp.ctxProp.set('');
       expect(listener.msg).toEqual('');
 
       emitter.event.subscribe({
         next: () => {
           expect(listener.msg).toEqual('fired !');
-          expect(myComp.ctxProp).toEqual('fired !');
+          expect(myComp.ctxProp()).toEqual('fired !');
         },
       });
 
@@ -802,14 +803,14 @@ describe('integration tests', function () {
       const tc = fixture.debugElement.children[0];
       const dir = tc.injector.get(DirectiveWithTwoWayBinding);
 
-      fixture.componentInstance.ctxProp = 'one';
+      fixture.componentInstance.ctxProp.set('one');
       fixture.detectChanges();
 
       expect(dir.control).toEqual('one');
 
       dir.controlChange.subscribe({
         next: () => {
-          expect(fixture.componentInstance.ctxProp).toEqual('two');
+          expect(fixture.componentInstance.ctxProp()).toEqual('two');
         },
       });
 
@@ -1020,13 +1021,13 @@ describe('integration tests', function () {
       TestBed.configureTestingModule({
         declarations: [MyComp, DirectiveListeningDomEvent, DirectiveListeningDomEventOther],
       });
-      const template = '<div *ngIf="ctxBoolProp" listener listenerother></div>';
+      const template = '<div *ngIf="ctxBoolProp()" listener listenerother></div>';
       TestBed.overrideComponent(MyComp, {set: {template}});
       const fixture = TestBed.createComponent(MyComp);
       const doc = TestBed.inject(DOCUMENT);
 
       globalCounter = 0;
-      fixture.componentInstance.ctxBoolProp = true;
+      fixture.componentInstance.ctxBoolProp.set(true);
       fixture.detectChanges();
 
       const tc = fixture.debugElement.children[0];
@@ -1038,12 +1039,12 @@ describe('integration tests', function () {
       expect(listenerother.eventType).toEqual('other_domEvent');
       expect(globalCounter).toEqual(1);
 
-      fixture.componentInstance.ctxBoolProp = false;
+      fixture.componentInstance.ctxBoolProp.set(false);
       fixture.detectChanges();
       dispatchEvent(getDOM().getGlobalEventTarget(doc, 'window'), 'domEvent');
       expect(globalCounter).toEqual(1);
 
-      fixture.componentInstance.ctxBoolProp = true;
+      fixture.componentInstance.ctxBoolProp.set(true);
       fixture.detectChanges();
       dispatchEvent(getDOM().getGlobalEventTarget(doc, 'window'), 'domEvent');
       expect(globalCounter).toEqual(2);
@@ -1283,13 +1284,13 @@ describe('integration tests', function () {
           ComponentWithDefaultInterpolation,
         ],
       });
-      const template = `<div>{{ctxProp}}</div>
+      const template = `<div>{{ctxProp()}}</div>
 <cmp-with-custom-interpolation-a></cmp-with-custom-interpolation-a>
 <cmp-with-custom-interpolation-b></cmp-with-custom-interpolation-b>`;
       TestBed.overrideComponent(MyComp, {set: {template}});
       const fixture = TestBed.createComponent(MyComp);
 
-      fixture.componentInstance.ctxProp = 'Default Interpolation';
+      fixture.componentInstance.ctxProp.set('Default Interpolation');
 
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveText(
@@ -1405,7 +1406,7 @@ describe('integration tests', function () {
       });
       const template = `
               <component-providing-logging-injectable #providing>
-                <directive-consuming-injectable *ngIf="ctxBoolProp">
+                <directive-consuming-injectable *ngIf="ctxBoolProp()">
                 </directive-consuming-injectable>
               </component-providing-logging-injectable>
           `;
@@ -1415,7 +1416,7 @@ describe('integration tests', function () {
       const providing = fixture.debugElement.children[0].references['providing'];
       expect(providing.created).toBe(false);
 
-      fixture.componentInstance.ctxBoolProp = true;
+      fixture.componentInstance.ctxBoolProp.set(true);
       fixture.detectChanges();
 
       expect(providing.created).toBe(true);
@@ -1571,7 +1572,7 @@ describe('integration tests', function () {
       declarations: [MyComp, SomeImperativeViewport],
       providers: [{provide: ANCHOR_ELEMENT, useValue: el('<div></div>')}],
     });
-    const template = '<div><div *someImpvp="ctxBoolProp">hello</div></div>';
+    const template = '<div><div *someImpvp="ctxBoolProp()">hello</div></div>';
     TestBed.overrideComponent(MyComp, {set: {template}});
     const anchorElement = getTestBed().inject(ANCHOR_ELEMENT);
     const fixture = TestBed.createComponent(MyComp);
@@ -1579,12 +1580,12 @@ describe('integration tests', function () {
     fixture.detectChanges();
     expect(anchorElement).toHaveText('');
 
-    fixture.componentInstance.ctxBoolProp = true;
+    fixture.componentInstance.ctxBoolProp.set(true);
     fixture.detectChanges();
 
     expect(anchorElement).toHaveText('hello');
 
-    fixture.componentInstance.ctxBoolProp = false;
+    fixture.componentInstance.ctxBoolProp.set(false);
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText('');
   });
@@ -1753,7 +1754,7 @@ describe('integration tests', function () {
   describe('Property bindings', () => {
     it('should throw on bindings to unknown properties', () => {
       TestBed.configureTestingModule({declarations: [MyComp]});
-      const template = '<div unknown="{{ctxProp}}"></div>';
+      const template = '<div unknown="{{ctxProp()}}"></div>';
       TestBed.overrideComponent(MyComp, {set: {template}});
 
       const spy = spyOn(console, 'error');
@@ -1778,18 +1779,18 @@ describe('integration tests', function () {
 
     it('should not throw for property binding to a non-existing property when there is a matching directive property', () => {
       TestBed.configureTestingModule({declarations: [MyComp, MyDir]});
-      const template = '<div my-dir [elprop]="ctxProp"></div>';
+      const template = '<div my-dir [elprop]="ctxProp()"></div>';
       TestBed.overrideComponent(MyComp, {set: {template}});
       expect(() => TestBed.createComponent(MyComp)).not.toThrow();
     });
 
     it('should not be created when there is a directive with the same property', () => {
       TestBed.configureTestingModule({declarations: [MyComp, DirectiveWithTitle]});
-      const template = '<span [title]="ctxProp"></span>';
+      const template = '<span [title]="ctxProp()"></span>';
       TestBed.overrideComponent(MyComp, {set: {template}});
       const fixture = TestBed.createComponent(MyComp);
 
-      fixture.componentInstance.ctxProp = 'TITLE';
+      fixture.componentInstance.ctxProp.set('TITLE');
       fixture.detectChanges();
 
       const el = fixture.nativeElement.querySelector('span');
@@ -1798,11 +1799,11 @@ describe('integration tests', function () {
 
     it('should work when a directive uses hostProperty to update the DOM element', () => {
       TestBed.configureTestingModule({declarations: [MyComp, DirectiveWithTitleAndHostProperty]});
-      const template = '<span [title]="ctxProp"></span>';
+      const template = '<span [title]="ctxProp()"></span>';
       TestBed.overrideComponent(MyComp, {set: {template}});
       const fixture = TestBed.createComponent(MyComp);
 
-      fixture.componentInstance.ctxProp = 'TITLE';
+      fixture.componentInstance.ctxProp.set('TITLE');
       fixture.detectChanges();
 
       const el = fixture.nativeElement.querySelector('span');
@@ -1817,11 +1818,11 @@ describe('integration tests', function () {
           declarations: [MyComp, MyDir],
         });
         TestBed.overrideComponent(MyComp, {
-          set: {template: `<div my-dir [elprop]="ctxProp"></div>`},
+          set: {template: `<div my-dir [elprop]="ctxProp()"></div>`},
         });
         const fixture = TestBed.createComponent(MyComp);
 
-        fixture.componentInstance.ctxProp = 'hello';
+        fixture.componentInstance.ctxProp.set('hello');
         fixture.detectChanges();
 
         const html = fixture.nativeElement.innerHTML;
@@ -1833,11 +1834,11 @@ describe('integration tests', function () {
           declarations: [MyComp],
         })
           .overrideComponent(MyComp, {
-            set: {template: `<ng-template [ngIf]="ctxBoolProp"></ng-template>`},
+            set: {template: `<ng-template [ngIf]="ctxBoolProp()"></ng-template>`},
           })
           .createComponent(MyComp);
 
-        fixture.componentInstance.ctxBoolProp = true;
+        fixture.componentInstance.ctxBoolProp.set(true);
         fixture.detectChanges();
 
         const html = fixture.nativeElement.innerHTML;
@@ -1850,10 +1851,12 @@ describe('integration tests', function () {
         declarations: [MyComp, MyDir],
         providers: [provideNgReflectAttributes()],
       });
-      TestBed.overrideComponent(MyComp, {set: {template: `<div my-dir [elprop]="ctxProp"></div>`}});
+      TestBed.overrideComponent(MyComp, {
+        set: {template: `<div my-dir [elprop]="ctxProp()"></div>`},
+      });
       const fixture = TestBed.createComponent(MyComp);
 
-      fixture.componentInstance.ctxProp = 'hello';
+      fixture.componentInstance.ctxProp.set('hello');
       fixture.detectChanges();
 
       const html = fixture.nativeElement.innerHTML;
@@ -1894,11 +1897,11 @@ describe('integration tests', function () {
         providers: [provideNgReflectAttributes()],
       })
         .overrideComponent(MyComp, {
-          set: {template: `<ng-template [ngIf]="ctxBoolProp"></ng-template>`},
+          set: {template: `<ng-template [ngIf]="ctxBoolProp()"></ng-template>`},
         })
         .createComponent(MyComp);
 
-      fixture.componentInstance.ctxBoolProp = true;
+      fixture.componentInstance.ctxBoolProp.set(true);
       fixture.detectChanges();
 
       const html = fixture.nativeElement.innerHTML;
@@ -1911,11 +1914,11 @@ describe('integration tests', function () {
         providers: [provideNgReflectAttributes()],
       })
         .overrideComponent(MyComp, {
-          set: {template: `<ng-container *ngIf="ctxBoolProp">content</ng-container>`},
+          set: {template: `<ng-container *ngIf="ctxBoolProp()">content</ng-container>`},
         })
         .createComponent(MyComp);
 
-      fixture.componentInstance.ctxBoolProp = true;
+      fixture.componentInstance.ctxBoolProp.set(true);
       fixture.detectChanges();
 
       const html = fixture.nativeElement.innerHTML;
@@ -1928,11 +1931,11 @@ describe('integration tests', function () {
         providers: [provideNgReflectAttributes()],
       });
       TestBed.overrideComponent(MyComp, {
-        set: {template: `<div my-dir my-dir2 [elprop]="ctxProp"></div>`},
+        set: {template: `<div my-dir my-dir2 [elprop]="ctxProp()"></div>`},
       });
       const fixture = TestBed.createComponent(MyComp);
 
-      fixture.componentInstance.ctxProp = 'hello';
+      fixture.componentInstance.ctxProp.set('hello');
       fixture.detectChanges();
 
       const html = fixture.nativeElement.innerHTML;
@@ -1958,15 +1961,17 @@ describe('integration tests', function () {
         declarations: [MyComp, MyDir, MyDir2],
         providers: [provideNgReflectAttributes()],
       });
-      TestBed.overrideComponent(MyComp, {set: {template: `<div my-dir [elprop]="ctxProp"></div>`}});
+      TestBed.overrideComponent(MyComp, {
+        set: {template: `<div my-dir [elprop]="ctxProp()"></div>`},
+      });
       const fixture = TestBed.createComponent(MyComp);
 
-      fixture.componentInstance.ctxProp = 'hello';
+      fixture.componentInstance.ctxProp.set('hello');
       fixture.detectChanges();
 
       expect(fixture.nativeElement.innerHTML).toContain('ng-reflect-dir-prop="hello"');
 
-      fixture.componentInstance.ctxProp = undefined!;
+      fixture.componentInstance.ctxProp.set(undefined!);
       fixture.detectChanges();
 
       expect(fixture.nativeElement.innerHTML).not.toContain('ng-reflect-');
@@ -1977,15 +1982,17 @@ describe('integration tests', function () {
         declarations: [MyComp, MyDir, MyDir2],
         providers: [provideNgReflectAttributes()],
       });
-      TestBed.overrideComponent(MyComp, {set: {template: `<div my-dir [elprop]="ctxProp"></div>`}});
+      TestBed.overrideComponent(MyComp, {
+        set: {template: `<div my-dir [elprop]="ctxProp()"></div>`},
+      });
       const fixture = TestBed.createComponent(MyComp);
 
-      fixture.componentInstance.ctxProp = 'hello';
+      fixture.componentInstance.ctxProp.set('hello');
       fixture.detectChanges();
 
       expect(fixture.nativeElement.innerHTML).toContain('ng-reflect-dir-prop="hello"');
 
-      fixture.componentInstance.ctxProp = null!;
+      fixture.componentInstance.ctxProp.set(null!);
       fixture.detectChanges();
 
       expect(fixture.nativeElement.innerHTML).not.toContain('ng-reflect-');
@@ -1996,10 +2003,12 @@ describe('integration tests', function () {
         declarations: [MyComp, MyDir, MyDir2],
         providers: [provideNgReflectAttributes()],
       });
-      TestBed.overrideComponent(MyComp, {set: {template: `<div my-dir [elprop]="ctxProp"></div>`}});
+      TestBed.overrideComponent(MyComp, {
+        set: {template: `<div my-dir [elprop]="ctxProp()"></div>`},
+      });
       const fixture = TestBed.createComponent(MyComp);
 
-      fixture.componentInstance.ctxProp = '';
+      fixture.componentInstance.ctxProp.set('');
       fixture.detectChanges();
 
       expect(fixture.nativeElement.innerHTML).toContain('ng-reflect-dir-prop=""');
@@ -2011,18 +2020,18 @@ describe('integration tests', function () {
         providers: [provideNgReflectAttributes()],
       })
         .overrideComponent(MyComp, {
-          set: {template: `<ng-template [ngIf]="ctxBoolProp"></ng-template>`},
+          set: {template: `<ng-template [ngIf]="ctxBoolProp()"></ng-template>`},
         })
         .createComponent(MyComp);
 
-      fixture.componentInstance.ctxBoolProp = true;
+      fixture.componentInstance.ctxBoolProp.set(true);
       fixture.detectChanges();
 
       let html = fixture.nativeElement.innerHTML;
       expect(html).toContain('bindings={');
       expect(html).toContain('"ng-reflect-ng-if": "true"');
 
-      fixture.componentInstance.ctxBoolProp = undefined!;
+      fixture.componentInstance.ctxBoolProp.set(undefined!);
       fixture.detectChanges();
 
       html = fixture.nativeElement.innerHTML;
@@ -2036,18 +2045,18 @@ describe('integration tests', function () {
         providers: [provideNgReflectAttributes()],
       })
         .overrideComponent(MyComp, {
-          set: {template: `<ng-template [ngIf]="ctxBoolProp"></ng-template>`},
+          set: {template: `<ng-template [ngIf]="ctxBoolProp()"></ng-template>`},
         })
         .createComponent(MyComp);
 
-      fixture.componentInstance.ctxBoolProp = true;
+      fixture.componentInstance.ctxBoolProp.set(true);
       fixture.detectChanges();
 
       let html = fixture.nativeElement.innerHTML;
       expect(html).toContain('bindings={');
       expect(html).toContain('"ng-reflect-ng-if": "true"');
 
-      fixture.componentInstance.ctxBoolProp = null!;
+      fixture.componentInstance.ctxBoolProp.set(null!);
       fixture.detectChanges();
 
       html = fixture.nativeElement.innerHTML;
@@ -2084,6 +2093,7 @@ describe('integration tests', function () {
       const dir = fixture.debugElement.children[0].injector.get(DirectiveWithPropDecorators);
       dir.myAttr = 'aaa';
 
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.debugElement.children[0].nativeElement.outerHTML).toContain('my-attr="aaa"');
     });
@@ -2094,7 +2104,7 @@ describe('integration tests', function () {
           declarations: [MyComp, DirectiveWithPropDecorators],
           schemas: [NO_ERRORS_SCHEMA],
         });
-        const template = `<with-prop-decorators (elEvent)="ctxProp='called'">`;
+        const template = `<with-prop-decorators (elEvent)="ctxProp.set('called')">`;
         TestBed.overrideComponent(MyComp, {set: {template}});
         const fixture = TestBed.createComponent(MyComp);
 
@@ -2105,7 +2115,7 @@ describe('integration tests', function () {
 
         tick();
 
-        expect(fixture.componentInstance.ctxProp).toEqual('called');
+        expect(fixture.componentInstance.ctxProp()).toEqual('called');
       }));
 
       it('should support host listener decorators', () => {
@@ -2282,11 +2292,13 @@ describe('integration tests', function () {
         const useEl = fixture.nativeElement.firstChild;
 
         cmp.value = '#id';
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         expect(useEl.getAttributeNS('http://www.w3.org/1999/xlink', 'href')).toEqual('#id');
 
         cmp.value = null;
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         expect(useEl.hasAttributeNS('http://www.w3.org/1999/xlink', 'href')).toEqual(false);
@@ -2524,21 +2536,21 @@ class PushCmpWithAsyncPipe {
   standalone: false,
 })
 class MyComp {
-  ctxProp: string;
-  ctxNumProp: number;
-  ctxBoolProp: boolean;
-  ctxArrProp: number[];
-  toStringThrow = {
+  readonly ctxProp = signal<string | undefined>(undefined);
+  readonly ctxNumProp = signal<number | undefined>(undefined);
+  readonly ctxBoolProp = signal<boolean | undefined>(undefined);
+  readonly ctxArrProp = signal<number[] | undefined>(undefined);
+  readonly toStringThrow = {
     toString: function () {
       throw 'boom';
     },
   };
 
   constructor() {
-    this.ctxProp = 'initial value';
-    this.ctxNumProp = 0;
-    this.ctxBoolProp = false;
-    this.ctxArrProp = [0, 1, 2];
+    this.ctxProp.set('initial value');
+    this.ctxNumProp.set(0);
+    this.ctxBoolProp.set(false);
+    this.ctxArrProp.set([0, 1, 2]);
   }
 
   throwError() {
@@ -2550,15 +2562,15 @@ class MyComp {
   selector: 'child-cmp',
   inputs: ['dirProp'],
   viewProviders: [MyService],
-  template: '{{ctxProp}}',
+  template: '{{ctxProp()}}',
   standalone: false,
 })
 class ChildComp {
-  ctxProp: string;
-  dirProp: string | null;
+  ctxProp = signal<string | undefined>(undefined);
+  dirProp = signal<string | null>(null);
   constructor(service: MyService) {
-    this.ctxProp = service.greeting;
-    this.dirProp = null;
+    this.ctxProp.set(service.greeting);
+    this.dirProp.set(null);
   }
 }
 
@@ -2573,13 +2585,13 @@ class ChildCompNoTemplate {
 
 @Component({
   selector: 'child-cmp-svc',
-  template: '{{ctxProp}}',
+  template: '{{ctxProp()}}',
   standalone: false,
 })
 class ChildCompUsingService {
-  ctxProp: string;
+  ctxProp = signal<string | undefined>(undefined);
   constructor(service: MyService) {
-    this.ctxProp = service.greeting;
+    this.ctxProp.set(service.greeting);
   }
 }
 

--- a/packages/core/test/linker/projection_integration_spec.ts
+++ b/packages/core/test/linker/projection_integration_spec.ts
@@ -300,10 +300,12 @@ describe('projection', () => {
     expect(fixture.nativeElement).toHaveText('BB()');
 
     fixture.componentInstance.showing = true;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText('BB(AA)');
 
     fixture.componentInstance.showing = false;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText('BB()');
   });

--- a/packages/core/test/linker/query_integration_spec.ts
+++ b/packages/core/test/linker/query_integration_spec.ts
@@ -23,6 +23,7 @@ import {
   ViewChildren,
   ViewContainerRef,
   ElementRef,
+  provideZoneChangeDetection,
 } from '../../src/core';
 import {ComponentFixture, TestBed, waitForAsync} from '../../testing';
 import {expect} from '@angular/private/testing/matchers';
@@ -33,6 +34,7 @@ import {stringify} from '../../src/util/stringify';
 describe('Query API', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
+      providers: [provideZoneChangeDetection()],
       declarations: [
         MyComp0,
         NeedsQuery,
@@ -189,6 +191,7 @@ describe('Query API', () => {
       q.shouldShow = false;
       q.shouldShow2 = true;
       q.logs = [];
+      view.changeDetectorRef.markForCheck();
       view.detectChanges();
       expect(q.logs).toEqual([
         ['setter', 'bar'],
@@ -198,6 +201,7 @@ describe('Query API', () => {
       q.shouldShow = false;
       q.shouldShow2 = false;
       q.logs = [];
+      view.changeDetectorRef.markForCheck();
       view.detectChanges();
       expect(q.logs).toEqual([
         ['setter', null],

--- a/packages/core/test/linker/regression_integration_spec.ts
+++ b/packages/core/test/linker/regression_integration_spec.ts
@@ -34,6 +34,7 @@ import {
   TemplateRef,
   ViewChildren,
   ViewContainerRef,
+  provideZoneChangeDetection,
 } from '../../src/core';
 import {fakeAsync, inject, TestBed, tick} from '../../testing';
 import {BrowserModule, By, platformBrowser} from '@angular/platform-browser';
@@ -336,12 +337,14 @@ describe('regressions', () => {
     const ctx = TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
 
     ctx.componentInstance.show = true;
+    ctx.changeDetectorRef.markForCheck();
     ctx.detectChanges();
     expect(ctx.componentInstance.viewContainers.length).toBe(2);
     const vc = ctx.componentInstance.viewContainers.first;
     expect(vc).toBeDefined();
 
     ctx.componentInstance.show = false;
+    ctx.changeDetectorRef.markForCheck();
     ctx.detectChanges();
     expect(ctx.componentInstance.viewContainers.first).toBe(vc);
   });
@@ -480,7 +483,7 @@ describe('regressions using bootstrap', () => {
         imports: [BrowserModule],
         declarations: [ErrorComp, EventDir],
         bootstrap: [ErrorComp],
-        providers: [{provide: ErrorHandler, useValue: errorHandler}],
+        providers: [{provide: ErrorHandler, useValue: errorHandler}, provideZoneChangeDetection()],
       })
       class TestModule {}
 

--- a/packages/core/test/linker/security_integration_spec.ts
+++ b/packages/core/test/linker/security_integration_spec.ts
@@ -138,10 +138,12 @@ describe('security integration tests', function () {
       const e = fixture.debugElement.children[0].nativeElement;
       const ci = fixture.componentInstance;
       ci.ctxProp = 'hello';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(e.getAttribute('href')).toMatch(/.*\/?hello$/);
 
       ci.ctxProp = 'javascript:alert(1)';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(e.getAttribute('href')).toEqual('unsafe:javascript:alert(1)');
     }
@@ -215,18 +217,22 @@ describe('security integration tests', function () {
       const ci = fixture.componentInstance;
       // Make sure binding harmless values works.
       ci.ctxProp = 'some <p>text</p>';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(e.innerHTML).toEqual('some <p>text</p>');
 
       ci.ctxProp = 'ha <script>evil()</script>';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(e.innerHTML).toEqual('ha ');
 
       ci.ctxProp = 'also <img src="x" onerror="evil()"> evil';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(e.innerHTML).toEqual('also <img src="x"> evil');
 
       ci.ctxProp = 'also <iframe srcdoc="evil"></iframe> evil';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(e.innerHTML).toEqual('also  evil');
     });

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {Component, Directive, HostBinding} from '../../src/core';
+import {Component, Directive, HostBinding, provideZoneChangeDetection} from '../../src/core';
 import {TestBed} from '../../testing';
 
 import {getLContext, readPatchedData} from '../../src/render3/context_discovery';
@@ -585,6 +585,7 @@ describe('sanitization', () => {
 
     TestBed.configureTestingModule({
       providers: [
+        provideZoneChangeDetection(),
         {
           provide: Sanitizer,
           useValue: sanitizer,
@@ -631,6 +632,7 @@ describe('sanitization', () => {
 
     TestBed.configureTestingModule({
       providers: [
+        provideZoneChangeDetection(),
         {
           provide: Sanitizer,
           useValue: sanitizer,

--- a/packages/core/test/render3/reactive_safety_spec.ts
+++ b/packages/core/test/render3/reactive_safety_spec.ts
@@ -110,7 +110,7 @@ describe('reactive safety', () => {
       fix.detectChanges();
       expectNotToThrowInReactiveContext(() => {
         fix.componentInstance.cond = true;
-        fix.detectChanges();
+        fix.changeDetectorRef.detectChanges();
       });
     });
   });

--- a/packages/core/test/render3/reactivity_spec.ts
+++ b/packages/core/test/render3/reactivity_spec.ts
@@ -848,6 +848,7 @@ describe('reactivity', () => {
 
         // Toggle the @if, which should create and run the effect.
         fixture.componentInstance.cond = true;
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         expect(log).toEqual(['init', 'effect']);
       });

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -11,6 +11,7 @@ import {
   APP_INITIALIZER,
   ChangeDetectorRef,
   Compiler,
+  provideZoneChangeDetection,
   Component,
   Directive,
   ElementRef,
@@ -726,6 +727,7 @@ describe('TestBed', () => {
   });
 
   it('should give the ability to trigger the change detection', () => {
+    TestBed.configureTestingModule({providers: [provideZoneChangeDetection()]});
     const hello = TestBed.createComponent(HelloWorld);
 
     hello.detectChanges();
@@ -2360,7 +2362,10 @@ describe('TestBed', () => {
     describe('with zone change detection', () => {
       it('should update fixtures with autoDetect', () => {
         TestBed.configureTestingModule({
-          providers: [{provide: ComponentFixtureAutoDetect, useValue: true}],
+          providers: [
+            {provide: ComponentFixtureAutoDetect, useValue: true},
+            provideZoneChangeDetection(),
+          ],
         });
         const {nativeElement, componentInstance} = TestBed.createComponent(Thing1);
         expect(nativeElement.textContent).toBe('1');

--- a/packages/elements/test/component-factory-strategy_spec.ts
+++ b/packages/elements/test/component-factory-strategy_spec.ts
@@ -21,6 +21,7 @@ import {
   SimpleChanges,
   createComponent,
   inject,
+  provideZoneChangeDetection,
 } from '@angular/core';
 
 import {TestBed} from '@angular/core/testing';
@@ -39,7 +40,7 @@ describe('ComponentFactoryNgElementStrategy', () => {
   let injector: Injector;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({providers: [provideZoneChangeDetection()]});
     injector = TestBed.inject(Injector);
     const strategyFactory = new ComponentNgElementStrategyFactory(TestComponent, injector);
     strategy = strategyFactory.create(injector);

--- a/packages/examples/core/test_module.ts
+++ b/packages/examples/core/test_module.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, NgModule} from '@angular/core';
+import {Component, NgModule, provideZoneChangeDetection} from '@angular/core';
 import {RouterModule} from '@angular/router';
 
 import * as animationDslExample from './animation/ts/dsl/module';
@@ -45,5 +45,6 @@ export class TestsAppComponent {}
   ],
   declarations: [TestsAppComponent],
   bootstrap: [TestsAppComponent],
+  providers: [provideZoneChangeDetection()],
 })
 export class TestsAppModule {}

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -14,6 +14,7 @@ import {
   forwardRef,
   Input,
   OnDestroy,
+  provideZoneChangeDetection,
   Type,
   ViewChild,
 } from '@angular/core';
@@ -143,6 +144,7 @@ describe('reactive forms integration tests', () => {
     TestBed.configureTestingModule({
       declarations: [component, ...directives],
       imports: [FormsModule, ReactiveFormsModule],
+      providers: [provideZoneChangeDetection()],
     });
     return TestBed.createComponent(component);
   }

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -7,7 +7,16 @@
  */
 
 import {CommonModule, ɵgetDOM as getDOM} from '@angular/common';
-import {Component, Directive, ElementRef, forwardRef, Input, Type, ViewChild} from '@angular/core';
+import {
+  Component,
+  Directive,
+  ElementRef,
+  forwardRef,
+  Input,
+  provideZoneChangeDetection,
+  Type,
+  ViewChild,
+} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick, waitForAsync} from '@angular/core/testing';
 import {
   AbstractControl,
@@ -36,6 +45,7 @@ describe('template-driven forms integration tests', () => {
     TestBed.configureTestingModule({
       declarations: [component, ...directives],
       imports: [FormsModule, CommonModule],
+      providers: [provideZoneChangeDetection()],
     });
     return TestBed.createComponent(component);
   }

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -20,6 +20,7 @@ import {
   NgZone,
   Output,
   PLATFORM_ID,
+  provideZoneChangeDetection,
   RendererFactory2,
   Type,
   ViewChild,
@@ -48,7 +49,7 @@ describe('value accessors', () => {
     TestBed.configureTestingModule({
       declarations: [component, ...directives],
       imports: [FormsModule, ReactiveFormsModule],
-      providers: [{provide: PLATFORM_ID, useValue: 'browser'}],
+      providers: [{provide: PLATFORM_ID, useValue: 'browser'}, provideZoneChangeDetection()],
     });
     return TestBed.createComponent(component);
   }
@@ -356,6 +357,7 @@ describe('value accessors', () => {
         expect(select.nativeElement.value).toEqual('1: Object');
 
         comp.cities.pop();
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         tick();
 
@@ -940,10 +942,12 @@ describe('value accessors', () => {
       it('should support setting value to null and undefined', fakeAsync(() => {
         const fixture = initTest(NgModelRadioForm);
         fixture.componentInstance.food = 'chicken';
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         tick();
 
         fixture.componentInstance.food = null!;
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         tick();
 
@@ -952,10 +956,12 @@ describe('value accessors', () => {
         expect(inputs[1].nativeElement.checked).toEqual(false);
 
         fixture.componentInstance.food = 'chicken';
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         tick();
 
         fixture.componentInstance.food = undefined!;
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         tick();
         expect(inputs[0].nativeElement.checked).toEqual(false);
@@ -1315,6 +1321,7 @@ describe('value accessors', () => {
           const comp = fixture.componentInstance;
           comp.cities = [{'name': 'SF'}, {'name': 'NYC'}];
           comp.selectedCity = comp.cities[1];
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
           tick();
 
@@ -1322,6 +1329,7 @@ describe('value accessors', () => {
           expect(select.nativeElement.value).toEqual('1: Object');
 
           comp.cities.pop();
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
           tick();
 

--- a/packages/platform-browser-dynamic/test/testing_public_browser_spec.ts
+++ b/packages/platform-browser-dynamic/test/testing_public_browser_spec.ts
@@ -7,13 +7,23 @@
  */
 
 import {ResourceLoader} from '@angular/compiler';
-import {Compiler, Component, getPlatform, NgModule} from '@angular/core';
+import {
+  Compiler,
+  Component,
+  getPlatform,
+  NgModule,
+  provideZonelessChangeDetection,
+} from '@angular/core';
 import {fakeAsync, inject, TestBed, tick, waitForAsync} from '@angular/core/testing';
 import {ResourceLoaderImpl} from '../src/resource_loader/resource_loader_impl';
 import {BrowserDynamicTestingModule, platformBrowserDynamicTesting} from '../testing';
 import {BrowserTestingModule, platformBrowserTesting} from '@angular/platform-browser/testing';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {isBrowser} from '@angular/private/testing';
+@NgModule({
+  providers: [provideZonelessChangeDetection()],
+})
+export class TestModule {}
 
 // Components for the tests.
 class FancyService {
@@ -61,7 +71,7 @@ if (isBrowser) {
           // browser_tests.init.ts doesn't use platformBrowserDynamicTesting
           TestBed.resetTestEnvironment();
           TestBed.initTestEnvironment(
-            [BrowserDynamicTestingModule],
+            [BrowserDynamicTestingModule, TestModule],
             platformBrowserDynamicTesting(),
           );
 
@@ -94,7 +104,7 @@ if (isBrowser) {
           // We're reset the test environment to their default values, cf browser_tests.init.ts
           TestBed.resetTestEnvironment();
           TestBed.initTestEnvironment(
-            [BrowserTestingModule, NoopAnimationsModule],
+            [BrowserTestingModule, NoopAnimationsModule, TestModule],
             platformBrowserTesting(),
           );
         });

--- a/packages/platform-browser/animations/async/test/animation_renderer_spec.ts
+++ b/packages/platform-browser/animations/async/test/animation_renderer_spec.ts
@@ -29,6 +29,7 @@ import {
   Injectable,
   Injector,
   NgZone,
+  provideZoneChangeDetection,
   RendererFactory2,
   RendererType2,
   runInInjectionContext,
@@ -315,7 +316,10 @@ type AnimationBrowserModule = typeof import('@angular/animations/browser');
           @ViewChild('elm') public element: any;
         }
 
-        TestBed.configureTestingModule({declarations: [Cmp]});
+        TestBed.configureTestingModule({
+          declarations: [Cmp],
+          providers: [provideZoneChangeDetection()],
+        });
 
         const fixture = TestBed.createComponent(Cmp);
         const cmp = fixture.componentInstance;
@@ -361,7 +365,10 @@ type AnimationBrowserModule = typeof import('@angular/animations/browser');
           @ViewChild('elm3') public elm3: any;
         }
 
-        TestBed.configureTestingModule({declarations: [Cmp]});
+        TestBed.configureTestingModule({
+          declarations: [Cmp],
+          providers: [provideZoneChangeDetection()],
+        });
 
         const engine = TestBed.inject(AnimationEngine);
         const fixture = TestBed.createComponent(Cmp);

--- a/packages/platform-browser/animations/test/animation_renderer_spec.ts
+++ b/packages/platform-browser/animations/test/animation_renderer_spec.ts
@@ -25,6 +25,7 @@ import {
   Injectable,
   NgModule,
   NgZone,
+  provideZoneChangeDetection,
   RendererFactory2,
   RendererType2,
   ViewChild,
@@ -220,7 +221,10 @@ import {withBody, isNode, el} from '@angular/private/testing';
         }
 
         TestBed.configureTestingModule({
-          providers: [{provide: AnimationEngine, useClass: InjectableAnimationEngine}],
+          providers: [
+            {provide: AnimationEngine, useClass: InjectableAnimationEngine},
+            provideZoneChangeDetection(),
+          ],
           declarations: [Cmp],
         });
 
@@ -269,7 +273,10 @@ import {withBody, isNode, el} from '@angular/private/testing';
         }
 
         TestBed.configureTestingModule({
-          providers: [{provide: AnimationEngine, useClass: InjectableAnimationEngine}],
+          providers: [
+            {provide: AnimationEngine, useClass: InjectableAnimationEngine},
+            provideZoneChangeDetection(),
+          ],
           declarations: [Cmp],
         });
 

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -171,7 +171,7 @@ function bootstrap(
     imports: [BrowserModule, ...imports],
     declarations: [cmpType],
     bootstrap: [cmpType],
-    providers: providers,
+    providers: [provideZoneChangeDetection(), ...providers],
     schemas: [CUSTOM_ELEMENTS_SCHEMA],
   })
   class TestModule {}
@@ -289,8 +289,12 @@ describe('bootstrap factory method', () => {
     });
 
     it('should keep change detection isolated for separately bootstrapped apps', async () => {
-      const appRef1 = await bootstrapApplication(SimpleComp);
-      const appRef2 = await bootstrapApplication(SimpleComp2);
+      const appRef1 = await bootstrapApplication(SimpleComp, {
+        providers: [provideZoneChangeDetection()],
+      });
+      const appRef2 = await bootstrapApplication(SimpleComp2, {
+        providers: [provideZoneChangeDetection()],
+      });
 
       expect(el.innerText).toBe('Hello from SimpleComp!');
       expect(el2.innerText).toBe('Hello from SimpleComp2!');
@@ -315,7 +319,9 @@ describe('bootstrap factory method', () => {
     });
 
     it('should allow bootstrapping multiple standalone components within the same app', async () => {
-      const appRef = await bootstrapApplication(SimpleComp);
+      const appRef = await bootstrapApplication(SimpleComp, {
+        providers: [provideZoneChangeDetection()],
+      });
       appRef.bootstrap(SimpleComp2);
 
       expect(el.innerText).toBe('Hello from SimpleComp!');
@@ -334,7 +340,9 @@ describe('bootstrap factory method', () => {
     });
 
     it('should allow bootstrapping non-standalone components within the same app', async () => {
-      const appRef = await bootstrapApplication(SimpleComp);
+      const appRef = await bootstrapApplication(SimpleComp, {
+        providers: [provideZoneChangeDetection()],
+      });
 
       // ApplicationRef should still allow bootstrapping non-standalone
       // components into the same application.
@@ -838,6 +846,7 @@ describe('bootstrap factory method', () => {
         declarations: [CompA, CompB],
         bootstrap: [CompA, CompB],
         schemas: [CUSTOM_ELEMENTS_SCHEMA],
+        providers: [provideZoneChangeDetection()],
       })
       class TestModuleA {}
       platformBrowser()

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -216,12 +216,14 @@ describe('DefaultDomRendererV2', () => {
 
       // Remove a single instance of the component.
       compInstance.componentOneInstanceHidden = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       // Verify style is still in DOM
       expect(await styleCount(fixture, '.emulated')).toBe(1);
 
       // Hide all instances of the component
       compInstance.componentTwoInstanceHidden = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Verify style is still in DOM
@@ -239,12 +241,14 @@ describe('DefaultDomRendererV2', () => {
 
       // Remove a single instance of the component.
       compInstance.componentOneInstanceHidden = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       // Verify style is still in DOM
       expect(await styleCount(fixture, '.none')).toBe(1);
 
       // Hide all instances of the component
       compInstance.componentTwoInstanceHidden = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Verify style is still in DOM
@@ -263,12 +267,14 @@ describe('DefaultDomRendererV2', () => {
 
       // Remove a single instance of the component.
       compInstance.componentOneInstanceHidden = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       // Verify style is still in DOM
       expect(await styleCount(fixture, '.emulated')).toBe(1);
 
       // Hide all instances of the component
       compInstance.componentTwoInstanceHidden = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Verify style is not in DOM
@@ -286,12 +292,14 @@ describe('DefaultDomRendererV2', () => {
 
       // Remove a single instance of the component.
       compInstance.componentOneInstanceHidden = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       // Verify style is still in DOM
       expect(await styleCount(fixture, '.none')).toBe(1);
 
       // Hide all instances of the component
       compInstance.componentTwoInstanceHidden = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Verify style is not in DOM

--- a/packages/platform-browser/test/testing_public_spec.ts
+++ b/packages/platform-browser/test/testing_public_spec.ts
@@ -1073,6 +1073,7 @@ Did you run and wait for 'resolveComponentResources()'?`);
       expect(componentFixture.nativeElement).toHaveText('MyIf()');
 
       componentFixture.componentInstance.showMore = true;
+      componentFixture.changeDetectorRef.markForCheck();
       componentFixture.detectChanges();
       expect(componentFixture.nativeElement).toHaveText('MyIf(More)');
     }));

--- a/packages/platform-server/test/full_app_hydration_spec.ts
+++ b/packages/platform-server/test/full_app_hydration_spec.ts
@@ -52,6 +52,7 @@ import {
   ViewEncapsulation,
   ɵNoopNgZone as NoopNgZone,
   ContentChild,
+  provideZoneChangeDetection,
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {clearTranslations, loadTranslations} from '@angular/localize';
@@ -3014,7 +3015,8 @@ describe('platform-server full application hydration integration', () => {
           }
         }
 
-        const html = await ssr(SimpleComponent);
+        const envProviders = [provideZoneChangeDetection() as any];
+        const html = await ssr(SimpleComponent, {envProviders});
 
         const ssrContents = getAppContents(html);
         expect(ssrContents).toContain('<app ngh');
@@ -3026,7 +3028,9 @@ describe('platform-server full application hydration integration', () => {
 
         resetTViewsFor(SimpleComponent);
 
-        const appRef = await prepareEnvironmentAndHydrate(doc, html, SimpleComponent);
+        const appRef = await prepareEnvironmentAndHydrate(doc, html, SimpleComponent, {
+          envProviders,
+        });
         const compRef = getComponentRef<SimpleComponent>(appRef);
         appRef.tick();
 
@@ -4852,8 +4856,8 @@ describe('platform-server full application hydration integration', () => {
             });
           }
         }
-
-        const html = await ssr(SimpleComponent);
+        const envProviders = [provideZoneChangeDetection() as any];
+        const html = await ssr(SimpleComponent, {envProviders});
         let ssrContents = getAppContents(html);
 
         expect(ssrContents).toContain('<app ngh');
@@ -4863,7 +4867,9 @@ describe('platform-server full application hydration integration', () => {
         // Before hydration
         expect(observedChildCountLog).toEqual([]);
 
-        const appRef = await prepareEnvironmentAndHydrate(doc, html, SimpleComponent);
+        const appRef = await prepareEnvironmentAndHydrate(doc, html, SimpleComponent, {
+          envProviders,
+        });
         await appRef.whenStable();
 
         // afterRender should be triggered by:
@@ -4901,7 +4907,8 @@ describe('platform-server full application hydration integration', () => {
           }
         }
 
-        const html = await ssr(SimpleComponent);
+        const envProviders = [provideZoneChangeDetection() as any];
+        const html = await ssr(SimpleComponent, {envProviders});
         let ssrContents = getAppContents(html);
 
         expect(ssrContents).toContain('<app ngh');
@@ -4911,7 +4918,9 @@ describe('platform-server full application hydration integration', () => {
         // Before hydration
         expect(observedChildCountLog).toEqual([]);
 
-        const appRef = await prepareEnvironmentAndHydrate(doc, html, SimpleComponent);
+        const appRef = await prepareEnvironmentAndHydrate(doc, html, SimpleComponent, {
+          envProviders,
+        });
 
         // afterRender should be triggered by:
         //   1.) Bootstrap
@@ -6389,7 +6398,11 @@ describe('platform-server full application hydration integration', () => {
         resetTViewsFor(SimpleComponent);
 
         const appRef = await prepareEnvironmentAndHydrate(doc, html, SimpleComponent, {
-          envProviders: [{provide: NgZone, useValue: new NoopNgZone()}, withDebugConsole()],
+          envProviders: [
+            provideZoneChangeDetection() as any,
+            {provide: NgZone, useValue: new NoopNgZone()},
+            withDebugConsole(),
+          ],
         });
         const compRef = getComponentRef<SimpleComponent>(appRef);
         appRef.tick();
@@ -6414,7 +6427,8 @@ describe('platform-server full application hydration integration', () => {
         })
         class SimpleComponent {}
 
-        const html = await ssr(SimpleComponent);
+        const envProviders = [provideZoneChangeDetection() as any];
+        const html = await ssr(SimpleComponent, {envProviders});
         const ssrContents = getAppContents(html);
 
         expect(ssrContents).toContain('<app ngh');
@@ -6424,7 +6438,11 @@ describe('platform-server full application hydration integration', () => {
         class CustomNgZone extends NgZone {}
 
         const appRef = await prepareEnvironmentAndHydrate(doc, html, SimpleComponent, {
-          envProviders: [{provide: NgZone, useValue: new CustomNgZone({})}, withDebugConsole()],
+          envProviders: [
+            provideZoneChangeDetection() as any,
+            {provide: NgZone, useValue: new CustomNgZone({})},
+            withDebugConsole(),
+          ],
         });
         const compRef = getComponentRef<SimpleComponent>(appRef);
         appRef.tick();
@@ -7148,8 +7166,10 @@ describe('platform-server full application hydration integration', () => {
           // and the server: we use it to test the logic to cleanup
           // dehydrated views.
           isServer = isPlatformServer(inject(PLATFORM_ID));
+          pendingTasks = inject(PendingTasks);
           ngOnInit() {
-            setTimeout(() => {}, 100);
+            const remove = this.pendingTasks.add();
+            setTimeout(() => void remove(), 100);
           }
         }
 
@@ -7315,7 +7335,8 @@ describe('platform-server full application hydration integration', () => {
           }
         }
 
-        const html = await ssr(SimpleComponent);
+        const envProviders = [provideZoneChangeDetection() as any];
+        const html = await ssr(SimpleComponent, {envProviders});
         let ssrContents = getAppContents(html);
 
         expect(ssrContents).toContain('<app ngh');
@@ -7329,7 +7350,9 @@ describe('platform-server full application hydration integration', () => {
         expect(ssrContents).toContain('<b>This is NgSwitch SERVER-ONLY content</b>');
 
         resetTViewsFor(SimpleComponent);
-        const appRef = await prepareEnvironmentAndHydrate(doc, html, SimpleComponent);
+        const appRef = await prepareEnvironmentAndHydrate(doc, html, SimpleComponent, {
+          envProviders,
+        });
         const compRef = getComponentRef<SimpleComponent>(appRef);
         appRef.tick();
 

--- a/packages/platform-server/test/incremental_hydration_spec.ts
+++ b/packages/platform-server/test/incremental_hydration_spec.ts
@@ -25,6 +25,7 @@ import {
   ɵJSACTION_EVENT_CONTRACT as JSACTION_EVENT_CONTRACT,
   ɵgetDocument as getDocument,
   ɵTimerScheduler as TimerScheduler,
+  provideZoneChangeDetection,
 } from '@angular/core';
 
 import {getAppContents, prepareEnvironmentAndHydrate, resetTViewsFor} from './dom_utils';
@@ -1299,7 +1300,10 @@ describe('platform-server partial hydration integration', () => {
           }
 
           const appId = 'custom-app-id';
-          const providers = [{provide: APP_ID, useValue: appId}];
+          const providers = [
+            {provide: APP_ID, useValue: appId},
+            provideZoneChangeDetection() as any,
+          ];
           const hydrationFeatures = () => [withIncrementalHydration()];
 
           const html = await ssr(SimpleComponent, {envProviders: providers, hydrationFeatures});
@@ -1894,7 +1898,7 @@ describe('platform-server partial hydration integration', () => {
       }
 
       const appId = 'custom-app-id';
-      const providers = [{provide: APP_ID, useValue: appId}];
+      const providers = [{provide: APP_ID, useValue: appId}, provideZoneChangeDetection() as any];
       const hydrationFeatures = () => [withIncrementalHydration()];
 
       const html = await ssr(SimpleComponent, {envProviders: providers, hydrationFeatures});

--- a/packages/upgrade/static/test/integration/change_detection_spec.ts
+++ b/packages/upgrade/static/test/integration/change_detection_spec.ts
@@ -15,6 +15,7 @@ import {
   Input,
   NgModule,
   NgZone,
+  provideZoneChangeDetection,
   SimpleChanges,
 } from '@angular/core';
 import {waitForAsync} from '@angular/core/testing';
@@ -42,7 +43,11 @@ withEachNg1Version(() => {
       })
       class AppComponent {}
 
-      @NgModule({declarations: [AppComponent], imports: [BrowserModule, UpgradeModule]})
+      @NgModule({
+        declarations: [AppComponent],
+        imports: [BrowserModule, UpgradeModule],
+        providers: [provideZoneChangeDetection()],
+      })
       class Ng2Module {
         ngDoBootstrap() {}
       }
@@ -195,6 +200,7 @@ withEachNg1Version(() => {
       @NgModule({
         declarations: [AppComponent, ChildComponent],
         imports: [BrowserModule, UpgradeModule],
+        providers: [provideZoneChangeDetection()],
       })
       class Ng2Module {
         ngDoBootstrap() {}

--- a/packages/upgrade/static/test/integration/downgrade_component_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_component_spec.ts
@@ -22,6 +22,7 @@ import {
   OnChanges,
   OnDestroy,
   Output,
+  provideZoneChangeDetection,
   SimpleChanges,
 } from '@angular/core';
 import {fakeAsync, tick, waitForAsync} from '@angular/core/testing';
@@ -462,6 +463,7 @@ withEachNg1Version(() => {
       @NgModule({
         imports: [BrowserModule, UpgradeModule],
         declarations: [Ng2Component],
+        providers: [provideZoneChangeDetection()],
       })
       class Ng2Module {
         ngDoBootstrap() {}

--- a/packages/upgrade/static/test/integration/downgrade_module_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_module_spec.ts
@@ -28,6 +28,7 @@ import {
   OnChanges,
   OnDestroy,
   OnInit,
+  provideZoneChangeDetection,
   StaticProvider,
   Type,
   ViewRef,
@@ -487,6 +488,7 @@ withEachNg1Version(() => {
             {provide: 'FOO', useValue: 'Mod-foo'},
             {provide: 'BAR', useValue: 'Mod-bar'},
             {provide: 'BAZ', useValue: 'Mod-baz'},
+            provideZoneChangeDetection(),
           ],
         })
         class Ng2Module {
@@ -684,6 +686,7 @@ withEachNg1Version(() => {
         @NgModule({
           declarations: [Ng2AComponent, Ng2BComponent],
           imports: [BrowserModule],
+          providers: [provideZoneChangeDetection()],
         })
         class Ng2Module {
           ngDoBootstrap() {}
@@ -753,6 +756,7 @@ withEachNg1Version(() => {
               useFactory: (i: angular.IInjectorService) => i.get('ng1Value'),
               deps: ['$injector'],
             },
+            provideZoneChangeDetection(),
           ],
         })
         class Ng2Module {
@@ -803,6 +807,7 @@ withEachNg1Version(() => {
         @NgModule({
           declarations: [Ng2Component],
           imports: [BrowserModule],
+          providers: [provideZoneChangeDetection()],
         })
         class Ng2Module {
           ngDoBootstrap() {}
@@ -842,6 +847,7 @@ withEachNg1Version(() => {
         @NgModule({
           declarations: [Ng2Component],
           imports: [BrowserModule],
+          providers: [provideZoneChangeDetection()],
         })
         class Ng2Module {
           ngDoBootstrap() {}
@@ -886,6 +892,7 @@ withEachNg1Version(() => {
         @NgModule({
           declarations: [Ng2Component],
           imports: [BrowserModule],
+          providers: [provideZoneChangeDetection()],
         })
         class Ng2Module {
           ngDoBootstrap() {}
@@ -960,6 +967,7 @@ withEachNg1Version(() => {
         @NgModule({
           declarations: [TestComponent, WrapperComponent],
           imports: [BrowserModule],
+          providers: [provideZoneChangeDetection()],
         })
         class Ng2Module {
           ngDoBootstrap() {}
@@ -1010,6 +1018,7 @@ withEachNg1Version(() => {
         @NgModule({
           declarations: [Ng2Component],
           imports: [BrowserModule],
+          providers: [provideZoneChangeDetection()],
         })
         class Ng2Module {
           ngDoBootstrap() {}
@@ -1064,6 +1073,7 @@ withEachNg1Version(() => {
         @NgModule({
           declarations: [TestComponent, WrapperComponent],
           imports: [BrowserModule],
+          providers: [provideZoneChangeDetection()],
         })
         class Ng2Module {
           ngDoBootstrap() {}
@@ -1157,6 +1167,7 @@ withEachNg1Version(() => {
         @NgModule({
           declarations: [Ng2Component],
           imports: [BrowserModule],
+          providers: [provideZoneChangeDetection()],
         })
         class Ng2Module {
           ngDoBootstrap() {}
@@ -1299,6 +1310,7 @@ withEachNg1Version(() => {
         @NgModule({
           declarations: [Ng2Component],
           imports: [BrowserModule],
+          providers: [provideZoneChangeDetection()],
         })
         class Ng2Module {
           ngDoBootstrap() {}
@@ -1350,6 +1362,7 @@ withEachNg1Version(() => {
         @NgModule({
           declarations: [Ng2Component],
           imports: [BrowserModule],
+          providers: [provideZoneChangeDetection()],
         })
         class Ng2Module {
           ngDoBootstrap() {}
@@ -1419,6 +1432,7 @@ withEachNg1Version(() => {
 
         @NgModule({
           declarations: [Ng2Component],
+          providers: [provideZoneChangeDetection()],
           imports: [BrowserModule],
         })
         class Ng2Module {
@@ -1479,6 +1493,7 @@ withEachNg1Version(() => {
         @NgModule({
           declarations: [Ng2Component],
           imports: [BrowserModule],
+          providers: [provideZoneChangeDetection()],
         })
         class Ng2Module {
           constructor(injector: Injector) {
@@ -1513,6 +1528,7 @@ withEachNg1Version(() => {
         @NgModule({
           declarations: [Ng2Component],
           imports: [BrowserModule],
+          providers: [provideZoneChangeDetection()],
         })
         class Ng2Module {
           ngDoBootstrap() {}

--- a/packages/upgrade/static/test/integration/testability_spec.ts
+++ b/packages/upgrade/static/test/integration/testability_spec.ts
@@ -6,7 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {destroyPlatform, NgModule, Testability, NgZone} from '@angular/core';
+import {
+  destroyPlatform,
+  NgModule,
+  Testability,
+  NgZone,
+  provideZoneChangeDetection,
+} from '@angular/core';
 import {fakeAsync, flush, tick} from '@angular/core/testing';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
@@ -22,7 +28,7 @@ withEachNg1Version(() => {
     beforeEach(() => destroyPlatform());
     afterEach(() => destroyPlatform());
 
-    @NgModule({imports: [BrowserModule, UpgradeModule]})
+    @NgModule({imports: [BrowserModule, UpgradeModule], providers: [provideZoneChangeDetection()]})
     class Ng2Module {
       ngDoBootstrap() {}
     }

--- a/tools/testing/browser_tests.init.mts
+++ b/tools/testing/browser_tests.init.mts
@@ -10,11 +10,19 @@ import 'zone.js';
 import './zone_base_setup.mjs';
 import '@angular/compiler'; // For JIT mode. Must be in front of any other @angular/* imports.
 
+import {NgModule, provideZonelessChangeDetection} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {BrowserTestingModule, platformBrowserTesting} from '@angular/platform-browser/testing';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+@NgModule({
+  providers: [provideZonelessChangeDetection()],
+})
+export class TestModule {}
 
-TestBed.initTestEnvironment([BrowserTestingModule, NoopAnimationsModule], platformBrowserTesting());
+TestBed.initTestEnvironment(
+  [BrowserTestingModule, NoopAnimationsModule, TestModule],
+  platformBrowserTesting(),
+);
 
 (window as any).isNode = false;
 (window as any).isBrowser = true;

--- a/tools/testing/node_tests.init.mts
+++ b/tools/testing/node_tests.init.mts
@@ -15,12 +15,18 @@ import './zone_base_setup.mjs';
 
 import '@angular/compiler'; // For JIT mode. Must be in front of any other @angular/* imports.
 // Init TestBed
+import {NgModule, provideZonelessChangeDetection} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {ServerTestingModule, platformServerTesting} from '@angular/platform-server/testing';
 import {ɵDominoAdapter as DominoAdapter} from '@angular/platform-server';
 import domino from '../../packages/platform-server/src/bundled-domino';
 
-TestBed.initTestEnvironment(ServerTestingModule, platformServerTesting());
+@NgModule({
+  providers: [provideZonelessChangeDetection()],
+})
+export class TestModule {}
+
+TestBed.initTestEnvironment([ServerTestingModule, TestModule], platformServerTesting());
 DominoAdapter.makeCurrent();
 (global as any).document =
   (DominoAdapter as any).defaultDoc ||


### PR DESCRIPTION
This updates tests and examples only to prepare for zoneless by default.

These changes were identified and made as part of #63382. Anything that failed gets `provideZoneChangeDetection` unless the fixes were easily and quickly determined.

It also adds the zoneless provider to the `initTestEnvironment` calls for tests in this repo to prevent regressions before #63382 is merged.
