### PR TITLE
refactor(core): replace EventEmitter in NgZone with Subject

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1285,10 +1285,10 @@ export class NgZone {
     readonly hasPendingMicrotasks: boolean;
     static isInAngularZone(): boolean;
     readonly isStable: boolean;
-    readonly onError: EventEmitter<any>;
-    readonly onMicrotaskEmpty: EventEmitter<any>;
-    readonly onStable: EventEmitter<any>;
-    readonly onUnstable: EventEmitter<any>;
+    readonly onError: Subject<any>;
+    readonly onMicrotaskEmpty: Subject<any>;
+    readonly onStable: Subject<any>;
+    readonly onUnstable: Subject<any>;
     run<T>(fn: (...args: any[]) => T, applyThis?: any, applyArgs?: any[]): T;
     runGuarded<T>(fn: (...args: any[]) => T, applyThis?: any, applyArgs?: any[]): T;
     runOutsideAngular<T>(fn: (...args: any[]) => T): T;

--- a/goldens/public-api/core/testing/index.api.md
+++ b/goldens/public-api/core/testing/index.api.md
@@ -6,7 +6,6 @@
 
 import { Observable } from 'rxjs';
 import { Subject } from 'rxjs';
-import { Subscription } from 'rxjs';
 
 // @public
 export class ComponentFixture<T> {

--- a/packages/upgrade/static/test/integration/change_detection_spec.ts
+++ b/packages/upgrade/static/test/integration/change_detection_spec.ts
@@ -70,13 +70,13 @@ withEachNg1Version(() => {
               const digestSpy = spyOn($rootScope, '$digest').and.callThrough();
 
               // Step 1: Ensure `$digest` is run on `onMicrotaskEmpty`.
-              ngZone.onMicrotaskEmpty.emit(null);
+              ngZone.onMicrotaskEmpty.next(null);
               expect(digestSpy).toHaveBeenCalledTimes(1);
 
               digestSpy.calls.reset();
 
               // Step 2: Cause the issue.
-              $rootScope.$apply(() => ngZone.onMicrotaskEmpty.emit(null));
+              $rootScope.$apply(() => ngZone.onMicrotaskEmpty.next(null));
 
               // With the fix, `$digest` will only be run once (for `$apply()`).
               // Without the fix, `$digest()` would have been run an extra time
@@ -86,7 +86,7 @@ withEachNg1Version(() => {
               digestSpy.calls.reset();
 
               // Step 3: Ensure that `$digest()` is still executed on `onMicrotaskEmpty`.
-              ngZone.onMicrotaskEmpty.emit(null);
+              ngZone.onMicrotaskEmpty.next(null);
               expect(digestSpy).toHaveBeenCalledTimes(1);
             }),
           0,


### PR DESCRIPTION
`EventEmitter` are a subclass of `Subject` that add extra
functionality that is not needed in `NgZone`.

Note: A migration will be provided in a follow-up PR

BREAKING CHANGE: `onUnstable`, `onMicrotaskEmpty`, `onStable` and
`onError` are now of type `Subject<any>`. Call `next()` on them instead of `emit()`.