### PR TITLE
refactor(common): improve typing of `ngComponentOutletContent`

### DIFF
--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -503,7 +503,7 @@ export class NgComponentOutlet<T = any> implements OnChanges, DoCheck, OnDestroy
     get componentInstance(): T | null;
     ngComponentOutlet: Type<any> | null;
     // (undocumented)
-    ngComponentOutletContent?: any[][];
+    ngComponentOutletContent?: Node[][];
     // (undocumented)
     ngComponentOutletEnvironmentInjector?: EnvironmentInjector;
     // (undocumented)

--- a/packages/common/src/directives/ng_component_outlet.ts
+++ b/packages/common/src/directives/ng_component_outlet.ts
@@ -108,7 +108,7 @@ export class NgComponentOutlet<T = any> implements OnChanges, DoCheck, OnDestroy
   @Input() ngComponentOutletInputs?: Record<string, unknown>;
   @Input() ngComponentOutletInjector?: Injector;
   @Input() ngComponentOutletEnvironmentInjector?: EnvironmentInjector;
-  @Input() ngComponentOutletContent?: any[][];
+  @Input() ngComponentOutletContent?: Node[][];
 
   @Input() ngComponentOutletNgModule?: Type<any>;
 


### PR DESCRIPTION
BREAKING CHANGE `ngComponentOutletContent` is now of type `Node[][] | undefined` instead of `any[][]`

fixes #63538