### PR TITLE
fix(devtools): property-tab-header layout for elements

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab-header.component.scss
@@ -6,60 +6,57 @@
 
   mat-panel-title {
     width: 100%;
+  }
 
-    .element-header {
+  .element-header {
+    @extend %body-bold-01;
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    align-items: center;
+    height: 32px; /* Same as mat-expansion-panel-header height */
+    gap: 0.375rem;
+    padding-inline: 0.625rem;
+    box-sizing: border-box;
+
+    .component-name {
       @extend %body-bold-01;
+      border: none;
+      background: none;
+      padding: 0;
+      cursor: pointer;
       display: flex;
-      justify-content: space-between;
-      width: 100%;
       align-items: center;
-      height: 32px; /* Same as mat-expansion-panel-header height */
-      gap: 0.375rem;
+      gap: 0.125rem;
+      flex: 1;
+      min-width: 0;
 
-      .component-name,
-      .element-name {
-        margin-left: 0.625rem;
-      }
-
-      .component-name {
-        @extend %body-bold-01;
-        border: none;
-        background: none;
-        padding: 0;
-        cursor: pointer;
-        display: flex;
-        align-items: center;
-        gap: 0.125rem;
-        flex: 1;
-        min-width: 0;
-
-        span {
-          text-overflow: ellipsis;
-          white-space: nowrap;
-          overflow: hidden;
-        }
-
-        mat-icon {
-          font-size: 16px;
-          width: 16px;
-          flex: 0 0 16px;
-          height: 14px;
-          font-weight: bold;
-          color: var(--tertiary-contrast);
-          transition: transform 200ms ease;
-          transform-origin: 50% 55%;
-        }
-
-        &.expanded {
-          mat-icon {
-            transform: rotate(180deg);
-          }
-        }
-      }
-
-      .signal-btn {
+      span {
+        text-overflow: ellipsis;
         white-space: nowrap;
+        overflow: hidden;
       }
+
+      mat-icon {
+        font-size: 16px;
+        width: 16px;
+        flex: 0 0 16px;
+        height: 14px;
+        font-weight: bold;
+        color: var(--tertiary-contrast);
+        transition: transform 200ms ease;
+        transform-origin: 50% 55%;
+      }
+
+      &.expanded {
+        mat-icon {
+          transform: rotate(180deg);
+        }
+      }
+    }
+
+    .signal-btn {
+      white-space: nowrap;
     }
   }
 }
@@ -79,6 +76,7 @@
         .mat-expansion-panel-header {
           padding: 0;
 
+          .mat-content.mat-content-hide-toggle,
           .mat-expansion-panel-header-title {
             margin-right: 0;
           }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## What is the new behavior?

Fix SCSS scoping issue that breaks the `property-tab-header` layout for elements.

<table>
<tr>
<td>Before</td><td>After</td>
</tr>
<tr>
<td>
<img width="340" height="51" alt="Screenshot 2025-09-10 at 13 24 35" src="https://github.com/user-attachments/assets/f2cb77c5-88a6-4746-8393-85cfb3279272" />

</td>
<td>
<img width="296" height="48" alt="Screenshot 2025-09-10 at 13 22 43" src="https://github.com/user-attachments/assets/34227cab-cd5d-4fb9-9f83-9de0c0aef1d5" />


</td>
</tr>
</table>


