### PR TITLE
ci: keep tailwind at v3

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -53,6 +53,11 @@
         ],
         "executionMode": "branch"
       }
+    },
+    {
+      "enabled": false,
+      "matchDepNames": ["tailwindcss"],
+      "matchUpdateTypes": ["major"]
     }
   ]
 }


### PR DESCRIPTION
We'd like to keep tailwind at v3 for now
