### PR TITLE
build: mark `pnpapi` as external for esbuild

### DIFF
--- a/.github/actions/deploy-docs-site/BUILD.bazel
+++ b/.github/actions/deploy-docs-site/BUILD.bazel
@@ -12,6 +12,7 @@ esbuild_checked_in(
     entry_point = ":lib/main.mts",
     external = [
         "undici",
+        "pnpapi",
     ],
     metafile = False,
     platform = "node",


### PR DESCRIPTION
In the `deploy-docs-site` GitHub action, esbuild fails to resolve `pnpapi` during the bundling process. This is because `pnpapi` is a dependency that is available in the Node.js environment at runtime and should not be bundled.

This commit marks `pnpapi` as an external dependency for esbuild to prevent it from being bundled and resolve the build failure.

```
✘ [ERROR] Could not resolve "pnpapi" [plugin bazel-sandbox]
```

See: https://github.com/angular/angular/pull/63722#issuecomment-3278922553
