### PR TITLE
build: create release branch from FETCH_HEAD

### DIFF
--- a/devtools/tools/release.mts
+++ b/devtools/tools/release.mts
@@ -293,7 +293,7 @@ async function prepareReleasePullRequest(newVersion: string): Promise<void> {
   console.log(chalk.blue('Creating release commit...'));
   const releaseBranch = `devtools-release-${newVersion}`;
   await exec(`git branch -D ${releaseBranch}`).catch(() => {});
-  await exec(`git checkout -b ${releaseBranch}`);
+  await exec(`git checkout -b ${releaseBranch} FETCH_HEAD`);
   await exec(`git commit -m "${releaseCommitPrefix}${newVersion}" "${manifestPaths.join('" "')}"`);
   await exec(`git push origin ${releaseBranch} --force-with-lease`);
   console.log(chalk.green('Release branch pushed to your fork.'));

--- a/devtools/tools/release.mts
+++ b/devtools/tools/release.mts
@@ -437,10 +437,7 @@ function generateChangelog(commits: string[]): string {
  * @returns The reviewer note.
  */
 function getFirefoxReviewerNote(commitSha: string): string {
-  return `There is a field to provide a note to the reviewer, copy this template and make sure to replace
-${commitSha} with the SHA of the release commit to create a valid link.
-
-This is a monorepo and includes much more code than just the DevTools extension. The relevant
+  return `This is a monorepo and includes much more code than just the DevTools extension. The relevant
 code is under \`devtools/...\` and \`devtools/README.md\` contains instructions for compiling
 release builds locally.
 


### PR DESCRIPTION
When creating the release branch, it should be based on the latest upstream changes to avoid stale commits.
