### PR TITLE
ci: update pullapprove public-api rules

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -414,8 +414,8 @@ groups:
         - ~leonsenft
         - ~mattrbeck
     reviews:
-      request: 3 # Request reviews from 3 people
-      required: 2 # Require that 2 people approve
+      request: 2
+      required: 1
       reviewed_for: required
 
   # ================================================


### PR DESCRIPTION
This reduces the required reviews to 1 and requested reviewers to 2 to reduce friction.
