### PR TITLE
build: automatically select a random available port when running adev locally

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@ bazel_dep(name = "yq.bzl", version = "0.2.0")
 bazel_dep(name = "rules_angular")
 git_override(
     module_name = "rules_angular",
-    commit = "17eac47ea99057f7473a7d93292e76327c894ed9",
+    commit = "4010ef96de0c46db7764adc2f262258c9de3d718",
     remote = "https://github.com/devversion/rules_angular.git",
 )
 

--- a/adev/BUILD.bazel
+++ b/adev/BUILD.bazel
@@ -148,6 +148,10 @@ ng_application(
     ng_config = ":ng_config",
     node_modules = "//adev:node_modules",
     project_name = "angular-dev",
+    serve_args = config_based_architect_flags + [
+        "--port",
+        "0",
+    ],
 )
 
 ng_test(


### PR DESCRIPTION
Previously we relied on the default port of 4200, but if it was already in use then we would run into issues where the cli provided a prompt which we were unable to respond to. Instead we now request port 0 which will automatically find an available port.
