### PR TITLE
fix(core): Prevent leave animations on a move operation

### DIFF
--- a/packages/core/src/animation/interfaces.ts
+++ b/packages/core/src/animation/interfaces.ts
@@ -85,4 +85,12 @@ export interface AnimationLViewData {
 
   // Leave animations that apply to nodes in this view
   running?: Promise<PromiseSettledResult<void>[]>;
+
+  // Skip leave animations
+  // This flag is solely used when move operations occur. DOM Node move
+  // operations occur in lists, like `@for` loops, and use the same code
+  // path during move that detaching or removing does. So to prevent
+  // unexpected disappearing of moving nodes, we use this flag to skip
+  // the animations in that case.
+  skipLeaveAnimations?: boolean;
 }

--- a/packages/core/src/render3/list_reconciliation.ts
+++ b/packages/core/src/render3/list_reconciliation.ts
@@ -20,7 +20,7 @@ export abstract class LiveCollection<T, V> {
   abstract get length(): number;
   abstract at(index: number): V;
   abstract attach(index: number, item: T): void;
-  abstract detach(index: number): T;
+  abstract detach(index: number, skipLeaveAnimations?: boolean): T;
   abstract create(index: number, value: V): T;
   destroy(item: T): void {
     // noop by default
@@ -45,7 +45,11 @@ export abstract class LiveCollection<T, V> {
     }
   }
   move(prevIndex: number, newIdx: number): void {
-    this.attach(newIdx, this.detach(prevIndex));
+    // For move operations, the detach code path is the same one used for removing
+    // DOM nodes, which would trigger `animate.leave` bindings. We need to skip
+    // those animations in the case of a move operation so the moving elements don't
+    // unexpectedly disappear.
+    this.attach(newIdx, this.detach(prevIndex, true /* skipLeaveAnimations */));
   }
 }
 

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -352,12 +352,18 @@ function cleanUpView(tView: TView, lView: LView): void {
 
 function runLeaveAnimationsWithCallback(lView: LView | undefined, callback: Function) {
   if (lView && lView[ANIMATIONS] && lView[ANIMATIONS].leave) {
-    const runningAnimations = [];
-    for (let animateFn of lView[ANIMATIONS].leave) {
-      runningAnimations.push(animateFn());
+    if (lView[ANIMATIONS].skipLeaveAnimations) {
+      lView[ANIMATIONS].skipLeaveAnimations = false;
+    } else {
+      const leaveAnimations = lView[ANIMATIONS].leave;
+      const runningAnimations = [];
+      for (let index = 0; index < leaveAnimations.length; index++) {
+        const animateFn = leaveAnimations[index];
+        runningAnimations.push(animateFn());
+      }
+      lView[ANIMATIONS].running = Promise.allSettled(runningAnimations);
+      lView[ANIMATIONS].leave = undefined;
     }
-    lView[ANIMATIONS].running = Promise.allSettled(runningAnimations);
-    lView[ANIMATIONS].leave = undefined;
   }
   runAfterLeaveAnimations(lView, callback);
 }


### PR DESCRIPTION
When a user has `animate.leave` on a list of items in a `@for`, but are only showing a subset using a computed, removing the second to last item results in a move operation on the last item. There's no native atomic move API in the browser. So this results in the element being detached and attached at its new index. The detaching of the node resulted in leave animations firing. This fix addresses this by adding a flag in the `LView[ANIMATIONS]` `AnimationLViewData` interface to allow for skipping animations. During list reconciliation, we set this flag so that the animations are skipped over. The flag is flipped back after the move operation is complete.

There is one complication that results from this. The index adjustment of elements in the list happens synchronously while the leave animation is asynchronous. This results in the leaving item getting shifted to the end of the list. This is not ideal but likely can be addressed in a future refactor.

https://github.com/user-attachments/assets/583bb5ca-23e7-40d0-84e3-9a4b89f9cc01

fixes: #63544

