### PR TITLE
ci: use static target: automation label in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,14 +18,6 @@
   ],
   "packageRules": [
     {
-      "matchBaseBranches": ["main"],
-      "addLabels": ["target: minor"]
-    },
-    {
-      "matchBaseBranches": ["!main"],
-      "addLabels": ["target: patch"]
-    },
-    {
       "matchFileNames": [
         "integration/**",
         "modules/ssr-benchmarks/package.json",


### PR DESCRIPTION
The logic to update the renovate config during the release to switch the target labels from target: rc to target: patch has been removed. Instead, a static target: automation label is added to the default renovate preset.
