### PR TITLE
ci: add automation label to update cdk apis and cli help workflow

### DIFF
--- a/.github/workflows/update-cdk-apis-and-cli-help.yml
+++ b/.github/workflows/update-cdk-apis-and-cli-help.yml
@@ -52,6 +52,7 @@ jobs:
           labels: |
             action: merge
             area: docs
+            target: automation
           commit-message: |
             docs: update Angular CDK apis
 
@@ -81,6 +82,7 @@ jobs:
           labels: |
             action: merge
             area: docs
+            target: automation
           commit-message: |
             docs: update Angular CLI help
 


### PR DESCRIPTION
Adds the 'target: automation' label to the 'update-cdk-apis' and 'update-cli-help' jobs in the 'update-cdk-apis-and-cli-help.yml' workflow. This will help to better track and manage automation tasks.

