### PR TITLE
refactor(forms): add numeric validator

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -168,6 +168,9 @@ export type FieldValidationResult<E extends ValidationError = ValidationError> =
 export type FieldValidator<TValue, TPathKind extends PathKind = PathKind.Root> = LogicFn<TValue, FieldValidationResult, TPathKind>;
 
 // @public
+export const FLOATING_POINT: AggregateProperty<boolean, boolean>;
+
+// @public
 export function form<TValue>(model: WritableSignal<TValue>): Field<TValue>;
 
 // @public
@@ -350,7 +353,36 @@ export type Mutable<T> = {
 export const NgValidationError: abstract new () => NgValidationError;
 
 // @public (undocumented)
-export type NgValidationError = RequiredValidationError | MinValidationError | MaxValidationError | MinLengthValidationError | MaxLengthValidationError | PatternValidationError | EmailValidationError | StandardSchemaValidationError;
+export type NgValidationError = RequiredValidationError | MinValidationError | MaxValidationError | MinLengthValidationError | MaxLengthValidationError | PatternValidationError | EmailValidationError | NumericValidationError | StandardSchemaValidationError;
+
+// @public
+export function numeric<TPathKind extends PathKind = PathKind.Root>(path: FieldPath<string, TPathKind>, config?: BaseValidatorConfig<string, TPathKind> & {
+    float?: boolean | LogicFn<string, boolean, TPathKind>;
+    pattern?: RegExp | LogicFn<string, RegExp, TPathKind>;
+}): void;
+
+// @public
+export function numericError(options: WithField<NumericValidationErrorOptions>): NumericValidationError;
+
+// @public
+export function numericError(options?: NumericValidationErrorOptions): WithoutField<NumericValidationError>;
+
+// @public
+export class NumericValidationError extends _NgValidationError {
+    constructor(options?: NumericValidationErrorOptions);
+    readonly float: boolean;
+    // (undocumented)
+    readonly kind = "numeric";
+    readonly pattern: RegExp;
+}
+
+// @public
+export interface NumericValidationErrorOptions extends ValidationErrorOptions {
+    // (undocumented)
+    float?: boolean;
+    // (undocumented)
+    pattern?: RegExp;
+}
 
 // @public
 export type OneOrMany<T> = T | readonly T[];
@@ -515,6 +547,11 @@ export interface ValidationError {
     readonly field: Field<unknown>;
     readonly kind: string;
     readonly message?: string;
+}
+
+// @public
+export interface ValidationErrorOptions {
+    message?: string;
 }
 
 // @public

--- a/packages/forms/signals/src/api/control_directive.ts
+++ b/packages/forms/signals/src/api/control_directive.ts
@@ -38,7 +38,16 @@ import {
   privateSetComponentInput as privateSetInputSignal,
 } from '../util/private';
 import {FormCheckboxControl, FormUiControl, FormValueControl} from './control';
-import {AggregateProperty, MAX, MAX_LENGTH, MIN, MIN_LENGTH, PATTERN, REQUIRED} from './property';
+import {
+  AggregateProperty,
+  FLOATING_POINT,
+  MAX,
+  MAX_LENGTH,
+  MIN,
+  MIN_LENGTH,
+  PATTERN,
+  REQUIRED,
+} from './property';
 import type {Field} from './types';
 
 /**
@@ -242,6 +251,10 @@ export class Control<T> {
     this.maybeSynchronize(this.propertySource(MIN_LENGTH), this.withAttribute(input, 'minLength'));
     this.maybeSynchronize(this.propertySource(MAX), this.withAttribute(input, 'max'));
     this.maybeSynchronize(this.propertySource(MAX_LENGTH), this.withAttribute(input, 'maxLength'));
+    this.maybeSynchronize(
+      () => (this.propertySource(FLOATING_POINT)() ? 'decimal' : 'numeric'),
+      this.withAttribute(input, 'inputmode'),
+    );
 
     switch (inputType) {
       case 'checkbox':

--- a/packages/forms/signals/src/api/property.ts
+++ b/packages/forms/signals/src/api/property.ts
@@ -181,3 +181,10 @@ export const MAX_LENGTH: AggregateProperty<number | undefined, number | undefine
  * @experimental 21.0.0
  */
 export const PATTERN: AggregateProperty<RegExp[], RegExp | undefined> = listProperty<RegExp>();
+
+/**
+ * An aggregate property representing whether floating point numbers are supported.
+ *
+ * @experimental 21.0.0
+ */
+export const FLOATING_POINT: AggregateProperty<boolean, boolean> = andProperty();

--- a/packages/forms/signals/src/api/validation_errors.ts
+++ b/packages/forms/signals/src/api/validation_errors.ts
@@ -8,13 +8,22 @@
 
 import type {StandardSchemaV1} from '@standard-schema/spec';
 import {Field} from './types';
+import {INTEGER_REGEXP} from './validators/util';
 
 /**
  * Options used to create a `ValidationError`.
  */
-interface ValidationErrorOptions {
+export interface ValidationErrorOptions {
   /** Human readable error message. */
   message?: string;
+}
+
+/**
+ * Options used to create a `NumericValidationError`.
+ */
+export interface NumericValidationErrorOptions extends ValidationErrorOptions {
+  float?: boolean;
+  pattern?: RegExp;
 }
 
 /**
@@ -226,6 +235,30 @@ export function emailError(
   options?: ValidationErrorOptions,
 ): WithOptionalField<EmailValidationError> {
   return new EmailValidationError(options);
+}
+
+/**
+ * Create an numeric format error associated with the target field
+ * @param options The validation error options
+ *
+ * @experimental 21.0.0
+ */
+export function numericError(
+  options: WithField<NumericValidationErrorOptions>,
+): NumericValidationError;
+/**
+ * Create an numeric format error
+ * @param options The optional validation error options
+ *
+ * @experimental 21.0.0
+ */
+export function numericError(
+  options?: NumericValidationErrorOptions,
+): WithoutField<NumericValidationError>;
+export function numericError(
+  options?: NumericValidationErrorOptions,
+): WithOptionalField<NumericValidationError> {
+  return new NumericValidationError(options);
 }
 
 /**
@@ -452,6 +485,27 @@ export class EmailValidationError extends _NgValidationError {
 }
 
 /**
+ * An error used to indicate that a value is not a valid number.
+ *
+ * @experimental 21.0.0
+ */
+export class NumericValidationError extends _NgValidationError {
+  override readonly kind = 'numeric';
+
+  /** Whether floating point numbers are allowed. */
+  readonly float: boolean;
+
+  /** The pattern the value must conform to. */
+  readonly pattern: RegExp;
+
+  constructor(options?: NumericValidationErrorOptions) {
+    super(options);
+    this.float = options?.float ?? false;
+    this.pattern = options?.pattern ?? INTEGER_REGEXP;
+  }
+}
+
+/**
  * An error used to indicate an issue validating against a standard schema.
  *
  * @experimental 21.0.0
@@ -500,4 +554,5 @@ export type NgValidationError =
   | MaxLengthValidationError
   | PatternValidationError
   | EmailValidationError
+  | NumericValidationError
   | StandardSchemaValidationError;

--- a/packages/forms/signals/src/api/validators/index.ts
+++ b/packages/forms/signals/src/api/validators/index.ts
@@ -11,6 +11,7 @@ export * from './max';
 export * from './max_length';
 export * from './min';
 export * from './min_length';
+export * from './numeric';
 export * from './pattern';
 export * from './required';
 export * from './standard_schema';

--- a/packages/forms/signals/src/api/validators/numeric.ts
+++ b/packages/forms/signals/src/api/validators/numeric.ts
@@ -22,6 +22,8 @@ import {BaseValidatorConfig, FLOAT_REGEXP, getOption, INTEGER_REGEXP, isEmpty} f
  *
  * @param path Path of the field to validate
  * @param config Optional, allows providing any of the following options:
+ *  - `float`: Whether floating point numbers are allowed
+ *  - `pattern`: The pattern the value must conform to
  *  - `error`: Custom validation error(s) to be used instead of the default `ValidationError.email()`
  *    or a function that receives the `FieldContext` and returns custom validation error(s).
  * @template TPathKind The kind of path the logic is bound to (a root path, child path, or item of an array)

--- a/packages/forms/signals/src/api/validators/numeric.ts
+++ b/packages/forms/signals/src/api/validators/numeric.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {computed} from '@angular/core';
+import {aggregateProperty, property, validate} from '../logic';
+import {FLOATING_POINT, PATTERN} from '../property';
+import {FieldPath, PathKind, type LogicFn} from '../types';
+import {numericError} from '../validation_errors';
+import {BaseValidatorConfig, FLOAT_REGEXP, getOption, INTEGER_REGEXP, isEmpty} from './util';
+
+/**
+ * Binds a validator to the given path that requires the value to match a standard numeric format.
+ * This function can only be called on string paths.
+ *
+ * In addition to binding a validator, this function adds a `FLOATING_POINT` and `PATTERN`
+ * properties to the field.
+ *
+ * @param path Path of the field to validate
+ * @param config Optional, allows providing any of the following options:
+ *  - `error`: Custom validation error(s) to be used instead of the default `ValidationError.email()`
+ *    or a function that receives the `FieldContext` and returns custom validation error(s).
+ * @template TPathKind The kind of path the logic is bound to (a root path, child path, or item of an array)
+ *
+ * @experimental 21.0.0
+ */
+export function numeric<TPathKind extends PathKind = PathKind.Root>(
+  path: FieldPath<string, TPathKind>,
+  config?: BaseValidatorConfig<string, TPathKind> & {
+    float?: boolean | LogicFn<string, boolean, TPathKind>;
+    pattern?: RegExp | LogicFn<string, RegExp, TPathKind>;
+  },
+) {
+  const FLOAT_MEMO = property(path, (ctx) =>
+    computed(() => getOption(config?.float, ctx) ?? false),
+  );
+  const PATTERN_MEMO = property(path, (ctx) =>
+    computed(
+      () =>
+        getOption(config?.pattern, ctx) ??
+        (ctx.state.property(FLOAT_MEMO)!() ? FLOAT_REGEXP : INTEGER_REGEXP),
+    ),
+  );
+  aggregateProperty(path, FLOATING_POINT, ({state}) => state.property(FLOAT_MEMO)!());
+  aggregateProperty(path, PATTERN, ({state}) => state.property(PATTERN_MEMO)!());
+  validate(path, (ctx) => {
+    if (isEmpty(ctx.value())) {
+      return undefined;
+    }
+    const float = ctx.state.property(FLOAT_MEMO)!();
+    const pattern = ctx.state.property(PATTERN_MEMO)!();
+    const value = ctx.value();
+    if (!pattern.test(value.toString()) || (typeof value === 'number' && isNaN(value))) {
+      if (config?.error) {
+        return getOption(config.error, ctx);
+      } else {
+        return numericError({float, pattern, message: getOption(config?.message, ctx)});
+      }
+    }
+
+    return undefined;
+  });
+}

--- a/packages/forms/signals/src/api/validators/util.ts
+++ b/packages/forms/signals/src/api/validators/util.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {LogicFn, OneOrMany, PathKind, type FieldContext} from '../types';
-import {ValidationError, WithoutField} from '../validation_errors';
+import type {FieldContext, LogicFn, OneOrMany, PathKind} from '../types';
+import type {ValidationError, WithoutField} from '../validation_errors';
 
 /** Represents a value that has a length or size, such as an array or string, or set. */
 export type ValueWithLengthOrSize = {length: number} | {size: number};
@@ -60,3 +60,9 @@ export function isEmpty(value: unknown): boolean {
   }
   return value === '' || value === false || value == null;
 }
+
+/** A RegExp that matches integer numbers */
+export const INTEGER_REGEXP = /^[+-]?\d+$/;
+
+/** A RegExp that matches floating point numbers */
+export const FLOAT_REGEXP = /^[+-]?\d*\.?\d+$/;

--- a/packages/forms/signals/test/node/api/validators/numeric.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/numeric.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Injector, signal} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {customError, form, numeric, numericError} from '../../../../public_api';
+import {FLOAT_REGEXP} from '../../../../src/api/validators/util';
+
+describe('numeric validator', () => {
+  it('should validate integer', () => {
+    const model = signal('123');
+    const f = form(
+      model,
+      (p) => {
+        numeric(p);
+      },
+      {
+        injector: TestBed.inject(Injector),
+      },
+    );
+
+    expect(f().errors()).toEqual([]);
+
+    model.set('123.45');
+    expect(f().errors()).toEqual([numericError({field: f})]);
+
+    model.set('abc');
+    expect(f().errors()).toEqual([numericError({field: f})]);
+  });
+
+  it('should validate floating point number', () => {
+    const model = signal('123.45');
+    const f = form(
+      model,
+      (p) => {
+        numeric(p, {float: true});
+      },
+      {
+        injector: TestBed.inject(Injector),
+      },
+    );
+
+    expect(f().errors()).toEqual([]);
+
+    model.set('123');
+    expect(f().errors()).toEqual([]);
+
+    model.set('abc');
+    expect(f().errors()).toEqual([numericError({float: true, pattern: FLOAT_REGEXP, field: f})]);
+  });
+
+  it('should validate with custom pattern', () => {
+    const model = signal('$1,234.56');
+    const f = form(
+      model,
+      (p) => {
+        numeric(p, {float: true, pattern: /^\$?\d{1,3}(,\d{3})*(\.\d{2})?$/});
+      },
+      {
+        injector: TestBed.inject(Injector),
+      },
+    );
+
+    expect(f().errors()).toEqual([]);
+
+    model.set('$1,234.5678');
+    expect(f().errors()).toEqual([
+      numericError({float: true, pattern: /^\$?\d{1,3}(,\d{3})*(\.\d{2})?$/, field: f}),
+    ]);
+  });
+
+  it('should support custom error message', () => {
+    const model = signal('abc');
+    const f = form(
+      model,
+      (p) => {
+        numeric(p, {message: 'custom message'});
+      },
+      {
+        injector: TestBed.inject(Injector),
+      },
+    );
+
+    expect(f().errors()).toEqual([
+      numericError({
+        message: 'custom message',
+        field: f,
+      }),
+    ]);
+  });
+
+  it('should support custom error', () => {
+    const model = signal('abc');
+    const f = form(
+      model,
+      (p) => {
+        numeric(p, {error: customError({kind: 'customNumericError'})});
+      },
+      {
+        injector: TestBed.inject(Injector),
+      },
+    );
+
+    expect(f().errors()).toEqual([customError({kind: 'customNumericError', field: f})]);
+  });
+
+  it('should treat empty value as valid', () => {
+    const model = signal('');
+    const f = form(
+      model,
+      (p) => {
+        numeric(p);
+      },
+      {
+        injector: TestBed.inject(Injector),
+      },
+    );
+
+    expect(f().errors()).toEqual([]);
+  });
+});

--- a/packages/forms/signals/test/node/api/validators/numeric.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/numeric.spec.ts
@@ -55,11 +55,11 @@ describe('numeric validator', () => {
   });
 
   it('should validate with custom pattern', () => {
-    const model = signal('$1,234.56');
+    const model = signal('1,234.56');
     const f = form(
       model,
       (p) => {
-        numeric(p, {float: true, pattern: /^\$?\d{1,3}(,\d{3})*(\.\d{2})?$/});
+        numeric(p, {float: true, pattern: /^\d{1,3}(,\d{3})*(\.\d{2})?$/});
       },
       {
         injector: TestBed.inject(Injector),
@@ -68,9 +68,9 @@ describe('numeric validator', () => {
 
     expect(f().errors()).toEqual([]);
 
-    model.set('$1,234.5678');
+    model.set('1,234.5678');
     expect(f().errors()).toEqual([
-      numericError({float: true, pattern: /^\$?\d{1,3}(,\d{3})*(\.\d{2})?$/, field: f}),
+      numericError({float: true, pattern: /^\d{1,3}(,\d{3})*(\.\d{2})?$/, field: f}),
     ]);
   });
 

--- a/packages/forms/signals/test/web/control_directive.spec.ts
+++ b/packages/forms/signals/test/web/control_directive.spec.ts
@@ -28,6 +28,7 @@ import {
   maxLength,
   min,
   minLength,
+  numeric,
   readonly,
   required,
   type DisabledReason,
@@ -770,6 +771,38 @@ describe('control directive', () => {
         input.dispatchEvent(new Event('input'));
       });
       expect(cmp.f().value()).toBe('#0000ff');
+    });
+
+    it('should set inputmode=numeric for numeric integer field', () => {
+      @Component({
+        imports: [Control],
+        template: `<input type="color" [control]="f">`,
+      })
+      class TestCmp {
+        f = form(signal(''), (p) => {
+          numeric(p);
+        });
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const inputEl = fix.nativeElement.querySelector('input') as HTMLInputElement;
+      expect(inputEl.getAttribute('inputmode')).toEqual('numeric');
+    });
+
+    it('should set inputmode=decimal for numeric floating point field', () => {
+      @Component({
+        imports: [Control],
+        template: `<input type="color" [control]="f">`,
+      })
+      class TestCmp {
+        f = form(signal(''), (p) => {
+          numeric(p, {float: true});
+        });
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const inputEl = fix.nativeElement.querySelector('input') as HTMLInputElement;
+      expect(inputEl.getAttribute('inputmode')).toEqual('decimal');
     });
   });
 });


### PR DESCRIPTION
For accessibility reasons, it is often preferable to use a `<input type=text inputmode=numeric>` to input a number rather than a `<input type=number>`. This PR adds support for this by introducing a new `numeric` rule that sets a custom property used to determine the `inputmode`.