### PR TITLE
feat(core): add duplicate input binding validation for dynamic compon…

### DIFF
--- a/goldens/public-api/core/errors.api.md
+++ b/goldens/public-api/core/errors.api.md
@@ -40,6 +40,8 @@ export const enum RuntimeErrorCode {
     // (undocumented)
     DUPLICATE_DIRECTIVE = 309,
     // (undocumented)
+    DUPLICATE_INPUT_BINDING = 318,
+    // (undocumented)
     EXPORT_NOT_FOUND = -301,
     // (undocumented)
     EXPRESSION_CHANGED_AFTER_CHECKED = -100,

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -63,6 +63,7 @@ export const enum RuntimeErrorCode {
   NO_BINDING_TARGET = 315,
   INVALID_BINDING_TARGET = 316,
   INVALID_SET_INPUT_CALL = 317,
+  DUPLICATE_INPUT_BINDING = 318,
 
   // Bootstrap Errors
   MULTIPLE_PLATFORMS = 400,

--- a/packages/core/src/render3/dynamic_bindings.ts
+++ b/packages/core/src/render3/dynamic_bindings.ts
@@ -40,6 +40,9 @@ export interface BindingInternal extends Binding {
   /** Target index (in a view's registry) to which to apply the binding. */
   targetIdx?: number;
 
+  /** Public name of the input (for input and twoWay bindings). */
+  publicName?: string;
+
   /** Callback that will be invoked during creation. */
   create?(): void;
 
@@ -123,6 +126,7 @@ export function inputBinding(publicName: string, value: () => unknown): Binding 
   // don't get tree shaken when constructed by a function like this.
   const binding: BindingInternal = {
     [BINDING]: INPUT_BINDING_METADATA,
+    publicName,
     update: () => inputBindingUpdate((binding as BindingInternal).targetIdx!, publicName, value()),
   };
 
@@ -205,6 +209,7 @@ export function twoWayBinding(publicName: string, value: WritableSignal<unknown>
       kind: 'twoWay',
       requiredVars: input[BINDING].requiredVars + output[BINDING].requiredVars,
     },
+    publicName,
     set targetIdx(idx: number) {
       (input as Writable<BindingInternal>).targetIdx = idx;
       (output as Writable<BindingInternal>).targetIdx = idx;

--- a/packages/core/test/acceptance/create_component_spec.ts
+++ b/packages/core/test/acceptance/create_component_spec.ts
@@ -1113,6 +1113,132 @@ describe('createComponent', () => {
       );
     });
 
+    it('should throw when using multiple inputBindings targeting the same property', () => {
+      @Component({
+        standalone: true,
+        template: 'Text: {{ text }}',
+      })
+      class DummyChildComponent {
+        @Input() text = '';
+      }
+
+      const hostElement = document.createElement('div');
+      const environmentInjector = TestBed.inject(EnvironmentInjector);
+      const modelInput = signal('first');
+      const anotherSignal = signal('second');
+
+      expect(() => {
+        createComponent(DummyChildComponent, {
+          hostElement,
+          environmentInjector,
+          bindings: [
+            inputBinding('text', modelInput),
+            inputBinding('text', anotherSignal),
+            inputBinding('text', () => 'static'),
+          ],
+        });
+      }).toThrowError(
+        /Multiple input bindings found for the same property 'text'. Each input property can only have one binding per component./,
+      );
+    });
+
+    it('should throw when using inputBinding and twoWayBinding targeting the same property', () => {
+      @Component({
+        standalone: true,
+        template: 'Text: {{ text }}',
+      })
+      class DummyChildComponent {
+        @Input() text = '';
+        @Output() textChange = new EventEmitter();
+      }
+
+      const hostElement = document.createElement('div');
+      const environmentInjector = TestBed.inject(EnvironmentInjector);
+      const modelInput = signal('first');
+      const twoWaySignal = signal('second');
+
+      expect(() => {
+        createComponent(DummyChildComponent, {
+          hostElement,
+          environmentInjector,
+          bindings: [inputBinding('text', modelInput), twoWayBinding('text', twoWaySignal)],
+        });
+      }).toThrowError(
+        /Multiple input bindings found for the same property 'text'. Each input property can only have one binding per component./,
+      );
+    });
+
+    it('should throw when using multiple inputBindings targeting the same property on a directive', () => {
+      @Directive()
+      class TestDirective {
+        @Input() value = '';
+      }
+
+      @Component({
+        standalone: true,
+        template: 'Component',
+      })
+      class TestComponent {}
+
+      const hostElement = document.createElement('div');
+      const environmentInjector = TestBed.inject(EnvironmentInjector);
+      const firstSignal = signal('first');
+      const secondSignal = signal('second');
+
+      expect(() => {
+        createComponent(TestComponent, {
+          hostElement,
+          environmentInjector,
+          directives: [
+            {
+              type: TestDirective,
+              bindings: [
+                inputBinding('value', firstSignal),
+                inputBinding('value', secondSignal),
+                inputBinding('value', () => 'static'),
+              ],
+            },
+          ],
+        });
+      }).toThrowError(
+        /Multiple input bindings found for the same property 'value'. Each input property can only have one binding per directive./,
+      );
+    });
+
+    it('should throw when using inputBinding and twoWayBinding targeting the same property on a directive', () => {
+      @Directive()
+      class TestDirective {
+        @Input() value = '';
+        @Output() valueChange = new EventEmitter();
+      }
+
+      @Component({
+        standalone: true,
+        template: 'Component',
+      })
+      class TestComponent {}
+
+      const hostElement = document.createElement('div');
+      const environmentInjector = TestBed.inject(EnvironmentInjector);
+      const inputSignal = signal('input');
+      const twoWaySignal = signal('twoWay');
+
+      expect(() => {
+        createComponent(TestComponent, {
+          hostElement,
+          environmentInjector,
+          directives: [
+            {
+              type: TestDirective,
+              bindings: [inputBinding('value', inputSignal), twoWayBinding('value', twoWaySignal)],
+            },
+          ],
+        });
+      }).toThrowError(
+        /Multiple input bindings found for the same property 'value'. Each input property can only have one binding per directive./,
+      );
+    });
+
     it('should update view of component set with the onPush strategy after input change', () => {
       @Component({
         standalone: true,


### PR DESCRIPTION
# Add duplicate input binding validation for dynamic component

## Overview
This PR adds validation to detect duplicate input bindings when using `createComponent` with `inputBinding` and `twoWayBinding` functions. It prevents silent overwrites and ensures predictable behavior by throwing a clear error when multiple bindings target the same input property.

## Motivation
When creating components dynamically using `createComponent`, developers can accidentally bind multiple values to the same input property, leading to unpredictable behavior where later bindings silently overwrite earlier ones. This diagnostic helps catch such issues early during development.

 
The following code would execute without warning, with the last binding silently taking precedence:

```typescript
createComponent(DummyChildComponent, {
  bindings: [
    inputBinding('text', modelInput),      // This gets overwritten
    inputBinding('text', anotherSignal),   // This gets overwritten  
    inputBinding('text', () => 'static'), // This wins silently
  ],
});
```

## Solution
- Detects duplicate input bindings for both components and directives
- Throws a clear `RuntimeError` with error code `DUPLICATE_INPUT_BINDING` (318)
- Works with both `inputBinding` and `twoWayBinding` functions
- Only runs in development mode

 ## Examples

### Component Bindings
```typescript
// ❌ Throws error
createComponent(MyComponent, {
  bindings: [
    inputBinding('value', signal1),
    inputBinding('value', signal2), 
    inputBinding('value' , ()=> 'staticText' )// Error: duplicate binding
  ],
});

// ❌ Throws error  
createComponent(MyComponent, {
  bindings: [
    inputBinding('value', signal1),
    twoWayBinding('value', signal2), // Error: duplicate binding
  ],
});
```

### Directive Bindings
```typescript
// ❌ Throws error
createComponent(MyComponent, {
  directives: [{
    type: MyDirective,
    bindings: [
      inputBinding('prop', signal1),
      inputBinding('prop', signal2), // Error: duplicate binding
    ],
  }],
});
```

### Error Message
```text
Multiple input bindings found for the same property 'text'. Each input property can only have one binding per component.
```
 