### PR TITLE
fix(compiler-cli): remove internal syntax-related flags

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
@@ -81,22 +81,6 @@ export interface InternalOptions {
   supportJitMode?: boolean;
 
   /**
-   * Whether block syntax is enabled in the compiler. Defaults to true.
-   * Used in the language service to disable the new syntax for projects that aren't on v17.
-   *
-   * @internal
-   */
-  _enableBlockSyntax?: boolean;
-
-  /**
-   * Whether `@let` syntax is enabled in the compiler.
-   * Defaults to false while the feature is being developed.
-   *
-   * @internal
-   */
-  _enableLetSyntax?: boolean;
-
-  /**
    * Enables the use of `<link>` elements for component styleUrls instead of inlining the file
    * content.
    * This option is intended to be used with a development server that processes and serves

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -464,9 +464,12 @@ export class NgCompiler {
     this.usePoisonedData = usePoisonedData || !!options._compilePoisonedComponents;
     this.enableTemplateTypeChecker =
       enableTemplateTypeChecker || !!options._enableTemplateTypeChecker;
-    // TODO(crisbeto): remove this flag and base `enableBlockSyntax` on the `angularCoreVersion`.
-    this.enableBlockSyntax = options['_enableBlockSyntax'] ?? true;
-    this.enableLetSyntax = options['_enableLetSyntax'] ?? true;
+    this.enableBlockSyntax =
+      this.angularCoreVersion === null ||
+      coreVersionSupportsFeature(this.angularCoreVersion, '>= 17.0.0');
+    this.enableLetSyntax =
+      this.angularCoreVersion === null ||
+      coreVersionSupportsFeature(this.angularCoreVersion, '>= 18.1.0');
     this.enableSelectorless = options['_enableSelectorless'] ?? false;
     this.emitDeclarationOnly =
       !!options.emitDeclarationOnly && !!options._experimentalAllowEmitDeclarationOnly;

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -10649,28 +10649,6 @@ runInEachFileSystem((os: string) => {
       expect(codes).toEqual([ngErrorCode(ErrorCode.NGMODULE_BOOTSTRAP_IS_STANDALONE)]);
     });
 
-    it('should be able to turn off control flow using a compiler flag', () => {
-      env.tsconfig({_enableBlockSyntax: false});
-      env.write(
-        '/test.ts',
-        `
-        import { Component } from '@angular/core';
-
-        @Component({
-          standalone: true,
-          template: 'My email is foo@bar.com',
-        })
-        export class TestCmp {}
-      `,
-      );
-
-      env.driveMain();
-
-      // If blocks are enabled, this test will fail since `@bar.com` is an incomplete block.
-      const jsContents = env.getContents('test.js');
-      expect(jsContents).toContain('text(0, "My email is foo@bar.com")');
-    });
-
     describe('InjectorDef emit optimizations for standalone', () => {
       it('should not filter components out of NgModule.imports', () => {
         env.write(

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -811,12 +811,6 @@ function parseNgCompilerOptions(
   if (config['forceStrictTemplates'] === true) {
     options.strictTemplates = true;
   }
-  if (config['enableBlockSyntax'] === false) {
-    options['_enableBlockSyntax'] = false;
-  }
-  if (config['enableLetSyntax'] === false) {
-    options['_enableLetSyntax'] = false;
-  }
   if (config['enableSelectorless'] === true) {
     options['_enableSelectorless'] = true;
   }

--- a/packages/language-service/test/legacy/language_service_spec.ts
+++ b/packages/language-service/test/legacy/language_service_spec.ts
@@ -92,32 +92,6 @@ describe('language service adapter', () => {
       );
     });
 
-    it('should always disable block syntax if enableBlockSyntax is false', () => {
-      const {project, tsLS} = setup();
-      const ngLS = new LanguageService(project, tsLS, {
-        enableBlockSyntax: false,
-      });
-
-      expect(ngLS.getCompilerOptions()).toEqual(
-        jasmine.objectContaining({
-          '_enableBlockSyntax': false,
-        }),
-      );
-    });
-
-    it('should always disable let declarations if enableLetSyntax is false', () => {
-      const {project, tsLS} = setup();
-      const ngLS = new LanguageService(project, tsLS, {
-        enableLetSyntax: false,
-      });
-
-      expect(ngLS.getCompilerOptions()).toEqual(
-        jasmine.objectContaining({
-          '_enableLetSyntax': false,
-        }),
-      );
-    });
-
     it('should pass the @angular/core version along to the compiler', () => {
       const {project, tsLS} = setup();
       const ngLS = new LanguageService(project, tsLS, {


### PR DESCRIPTION
Removes the `_enableBlockSyntax` and `_enableLetSyntax` flags in favor of detecting them based on the Angular version.
