### PR TITLE
docs: remove leading `$` from script examples

### DIFF
--- a/contributing-docs/building-and-testing-angular.md
+++ b/contributing-docs/building-and-testing-angular.md
@@ -3,15 +3,26 @@
 This document describes how to set up your development environment to build and test Angular.
 It also explains the basic mechanics of using `git`, `node`, and `pnpm`.
 
-* [Prerequisite Software](#prerequisite-software)
-* [Getting the Sources](#getting-the-sources)
-* [Installing NPM Modules](#installing-npm-modules)
-* [Building](#building)
-* [Running Tests Locally](#running-tests-locally)
-* [Formatting your Source Code](#formatting-your-source-code)
-* [Linting/verifying your Source Code](#lintingverifying-your-source-code)
-* [Publishing Snapshot Builds](#publishing-snapshot-builds)
-* [Bazel Support](#bazel-support)
+- [Building and Testing Angular](#building-and-testing-angular)
+  - [Prerequisite Software](#prerequisite-software)
+  - [Getting the Sources](#getting-the-sources)
+  - [Installing NPM Modules](#installing-npm-modules)
+  - [Building](#building)
+  - [Running Tests Locally](#running-tests-locally)
+    - [Testing changes against a local library/project](#testing-changes-against-a-local-libraryproject)
+    - [Building and serving a project](#building-and-serving-a-project)
+      - [Cache](#cache)
+      - [Invoking the Angular CLI](#invoking-the-angular-cli)
+  - [Formatting your source code](#formatting-your-source-code)
+  - [Linting/verifying your Source Code](#lintingverifying-your-source-code)
+  - [Publishing Snapshot Builds](#publishing-snapshot-builds)
+    - [Publishing to GitHub Repos](#publishing-to-github-repos)
+  - [Bazel Support](#bazel-support)
+    - [IDEs](#ides)
+      - [VS Code](#vs-code)
+      - [WebStorm / IntelliJ](#webstorm--intellij)
+    - [Remote Build Execution and Remote Caching](#remote-build-execution-and-remote-caching)
+      - [--config=remote flag](#--configremote-flag)
 
 See the [contribution guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md)
 if you'd like to contribute to Angular.
@@ -31,7 +42,7 @@ following on your development machine:
 
 * [Node.js](https://nodejs.org), (version specified in [`.nvmrc`](../.nvmrc)) which is used to run a
   development web server,
-  run tests, and generate distributable files.  
+  run tests, and generate distributable files.
   `.nvmrc` is read by [nvm](https://github.com/nvm-sh/nvm) commands like `nvm install`
   and `nvm use`.
 
@@ -150,7 +161,7 @@ You can automatically format your code by running:
 You can check that your code is properly formatted and adheres to coding style by running:
 
 ``` shell
-$ pnpm lint
+pnpm lint
 ```
 
 ## Publishing Snapshot Builds

--- a/contributing-docs/caretaking.md
+++ b/contributing-docs/caretaking.md
@@ -18,7 +18,7 @@ tool will automatically merge it based on the applied target label.
 To merge a PR run:
 
 ```sh
-$ pnpm ng-dev pr merge <pr number>
+pnpm ng-dev pr merge <pr number>
 ```
 
 ## Primitives and blocked merges


### PR DESCRIPTION
Copy-pasting commands like `$ pnpm lint` caused errors in shells (e.g. zsh). Updated docs to use `pnpm lint` directly so they run without modification.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
