### PR TITLE
docs: correct grammar in next steps intro paragraph

### DIFF
--- a/adev/src/content/introduction/essentials/next-steps.md
+++ b/adev/src/content/introduction/essentials/next-steps.md
@@ -1,7 +1,7 @@
 <docs-decorative-header title="Next Steps" imgSrc="adev/src/assets/images/roadmap.svg"> <!-- markdownlint-disable-line -->
 </docs-decorative-header>
 
-Now that you have been introduced to main concepts of Angular - you're ready to put what you learned into practices with our interactive tutorials and learn more with our in-depth guides.
+Now that you have been introduced to the main concepts of Angular - you're ready to put what you learned into practice with our interactive tutorials and learn more with our in-depth guides.
 
 ## Playground
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The introductory paragraph on the `next-steps.md` page has two grammatical issues:
1. It uses the incorrect idiom "put what you learned into practices" (plural)
2. It omits the definite article before "main concepts of Angular"

Issue Number: N/A


## What is the new behavior?
Both grammatical errors have been corrected.
1. "into practices" has been changed to "into **practice**"
2. "to main concepts" has been changed to "to **the** main concepts"

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->