### PR TITLE
feat(forms): Relax types for min and max signal form validators

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -249,7 +249,7 @@ export type MapToErrorsFn<TValue, TResult, TPathKind extends PathKind = PathKind
 export const MAX: AggregateProperty<number | undefined, number | undefined>;
 
 // @public
-export function max<TPathKind extends PathKind = PathKind.Root>(path: FieldPath<number, TPathKind>, maxValue: number | LogicFn<number, number | undefined, TPathKind>, config?: BaseValidatorConfig<number, TPathKind>): void;
+export function max<TValue extends number | null, TPathKind extends PathKind = PathKind.Root>(path: FieldPath<TValue, TPathKind>, maxValue: number | LogicFn<TValue, number | undefined, TPathKind>, config?: BaseValidatorConfig<TValue, TPathKind>): void;
 
 // @public
 export const MAX_LENGTH: AggregateProperty<number | undefined, number | undefined>;
@@ -300,7 +300,7 @@ export type MaybeFieldPath<TValue, TPathKind extends PathKind = PathKind.Root> =
 export const MIN: AggregateProperty<number | undefined, number | undefined>;
 
 // @public
-export function min<TPathKind extends PathKind = PathKind.Root>(path: FieldPath<number, TPathKind>, minValue: number | LogicFn<number, number | undefined, TPathKind>, config?: BaseValidatorConfig<number, TPathKind>): void;
+export function min<TValue extends number | null, TPathKind extends PathKind = PathKind.Root>(path: FieldPath<TValue, TPathKind>, minValue: number | LogicFn<TValue, number | undefined, TPathKind>, config?: BaseValidatorConfig<TValue, TPathKind>): void;
 
 // @public
 export const MIN_LENGTH: AggregateProperty<number | undefined, number | undefined>;

--- a/packages/forms/signals/test/node/api/validators/max.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/max.spec.ts
@@ -122,6 +122,21 @@ describe('max validator', () => {
     expect(f().errors()).toEqual([]);
   });
 
+  it('should treat null value as valid', () => {
+    const model = signal(null);
+    const f = form(
+      model,
+      (p) => {
+        max(p, -1);
+      },
+      {
+        injector: TestBed.inject(Injector),
+      },
+    );
+
+    expect(f().errors()).toEqual([]);
+  });
+
   describe('custom properties', () => {
     it('stores the MAX property on max', () => {
       const cat = signal({name: 'pirojok-the-cat', age: 6});

--- a/packages/forms/signals/test/node/api/validators/min.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/min.spec.ts
@@ -122,6 +122,21 @@ describe('min validator', () => {
     expect(f().errors()).toEqual([]);
   });
 
+  it('should treat null value as valid', () => {
+    const model = signal(null);
+    const f = form(
+      model,
+      (p) => {
+        min(p, 10);
+      },
+      {
+        injector: TestBed.inject(Injector),
+      },
+    );
+
+    expect(f().errors()).toEqual([]);
+  });
+
   describe('custom properties', () => {
     it('stores the MIN property on min', () => {
       const cat = signal({name: 'pirojok-the-cat', age: 3});


### PR DESCRIPTION
Allow to use min and max signal form validators for fields of type `number | null` instead of only `number`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Signal form `min` and `max` validators can only be applied to field of pure `number` type.

Issue Number: #63789


## What is the new behavior?

Signal form `min` and `max` validators can be applied to fields of type `number` or `number | null`.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
