### PR TITLE
refactor(compiler-cli): remove `canVisitStructuralAttributes` from `T…

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/api/api.ts
@@ -83,17 +83,6 @@ export interface TemplateCheckFactory<
 export abstract class TemplateCheckWithVisitor<Code extends ErrorCode>
   implements TemplateCheck<Code>
 {
-  /**
-   * When extended diagnostics were first introduced, the visitor wasn't implemented correctly
-   * which meant that it wasn't visiting the `templateAttrs` of structural directives (e.g.
-   * the expression of `*ngIf`). Fixing the issue causes a lot of internal breakages and will likely
-   * need to be done in a major version to avoid external breakages. This flag is used to opt out
-   * pre-existing diagnostics from the correct behavior until the breakages have been fixed while
-   * ensuring that newly-written diagnostics are correct from the beginning.
-   * TODO(crisbeto): remove this flag and fix the internal brekages.
-   */
-  readonly canVisitStructuralAttributes: boolean = true;
-
   abstract code: Code;
 
   /**
@@ -153,11 +142,8 @@ class TemplateVisitor<Code extends ErrorCode> extends CombinedRecursiveAstVisito
 
     this.visitAllTemplateNodes(template.directives);
 
-    // TODO(crisbeto): remove this condition when deleting `canVisitStructuralAttributes`.
-    if (this.check.canVisitStructuralAttributes || isInlineTemplate) {
-      // `templateAttrs` aren't transferred over to the inner element so we always have to visit them.
-      this.visitAllTemplateNodes(template.templateAttrs);
-    }
+    // `templateAttrs` aren't transferred over to the inner element so we always have to visit them.
+    this.visitAllTemplateNodes(template.templateAttrs);
 
     this.visitAllTemplateNodes(template.variables);
     this.visitAllTemplateNodes(template.references);

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/nullish_coalescing_not_nullable/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/nullish_coalescing_not_nullable/index.ts
@@ -21,7 +21,6 @@ import {TemplateCheckFactory, TemplateCheckWithVisitor, TemplateContext} from '.
  * otherwise it would produce inaccurate results.
  */
 class NullishCoalescingNotNullableCheck extends TemplateCheckWithVisitor<ErrorCode.NULLISH_COALESCING_NOT_NULLABLE> {
-  override readonly canVisitStructuralAttributes = false;
   override code = ErrorCode.NULLISH_COALESCING_NOT_NULLABLE as const;
 
   override visitNode(

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/optional_chain_not_nullable/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/optional_chain_not_nullable/index.ts
@@ -28,7 +28,6 @@ import {TemplateCheckFactory, TemplateCheckWithVisitor, TemplateContext} from '.
  * otherwise it would produce inaccurate results.
  */
 class OptionalChainNotNullableCheck extends TemplateCheckWithVisitor<ErrorCode.OPTIONAL_CHAIN_NOT_NULLABLE> {
-  override readonly canVisitStructuralAttributes = false;
   override code = ErrorCode.OPTIONAL_CHAIN_NOT_NULLABLE as const;
 
   constructor(private readonly noUncheckedIndexedAccess: boolean) {


### PR DESCRIPTION
…emplateCheckWithVisitor`

This enables checking of expressions of structural directives in template diagnostics.

fixes #57094
