### PR TITLE
docs: fix detail about `linkedSignal`'s previous value.

### DIFF
--- a/adev/src/content/guide/signals/linked-signal.md
+++ b/adev/src/content/guide/signals/linked-signal.md
@@ -106,7 +106,7 @@ When you create a `linkedSignal`, you can pass an object with separate `source` 
 
 The `source` can be any signal, such as a `computed` or component `input`. When the value of `source` changes, `linkedSignal` updates its value to the result of the provided `computation`.
 
-The `computation` is a function that receives the new value of `source` and a `previous` object. The `previous` object has two properties— `previous.source` is the previous value of `source`, and `previous.value` is the previous result of the `computation`. You can use these previous values to decide the new result of the computation.
+The `computation` is a function that receives the new value of `source` and a `previous` object. The `previous` object has two properties— `previous.source` is the previous value of `source`, and `previous.value` is the previous value of the `linkedSignal`. You can use these previous values to decide the new result of the computation.
 
 HELPFUL: When using the `previous` parameter, it is necessary to provide the generic type arguments of `linkedSignal` explicitly. The first generic type corresponds with the type of `source` and the second generic type determines the output type of `computation`.  
 


### PR DESCRIPTION
fixes #63655
