### PR TITLE
fix(devtools): router tree legend overflow

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.scss
@@ -23,6 +23,8 @@
   }
 
   .visualization {
+    position: relative;
+    overflow: hidden;
     flex: 1;
 
     .side-pane {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## What is the current behavior?

<img width="247" height="124" alt="Screenshot 2025-09-15 at 17 50 54" src="https://github.com/user-attachments/assets/019b13ae-3272-4c9a-89f1-7f9f38c1bef5" />

## What is the new behavior?

Set `overflow` to `hidden` so the router tree legend doesn't overflow its parent container.