### PR TITLE
refactor(upgrade): downgradeModule uses zone-based change detection b…

### DIFF
--- a/packages/core/src/change_detection/scheduling/ng_zone_scheduling.ts
+++ b/packages/core/src/change_detection/scheduling/ng_zone_scheduling.ts
@@ -93,6 +93,7 @@ export function internalProvideZoneChangeDetection({
   ngZoneFactory ??= () =>
     new NgZone({...getNgZoneOptions(), scheduleInRootZone} as InternalNgZoneOptions);
   return [
+    {provide: ZONELESS_ENABLED, useValue: false},
     {provide: NgZone, useFactory: ngZoneFactory},
     {
       provide: ENVIRONMENT_INITIALIZER,
@@ -164,11 +165,7 @@ export function provideZoneChangeDetection(options?: NgZoneOptions): Environment
     },
     scheduleInRootZone,
   });
-  return makeEnvironmentProviders([
-    {provide: PROVIDED_NG_ZONE, useValue: true},
-    {provide: ZONELESS_ENABLED, useValue: false},
-    zoneProviders,
-  ]);
+  return makeEnvironmentProviders([{provide: PROVIDED_NG_ZONE, useValue: true}, zoneProviders]);
 }
 
 /**

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -175,3 +175,4 @@ export {TimerScheduler as ɵTimerScheduler} from './defer/timer_scheduler';
 export {ɵassertType} from './type_checking';
 export {ANIMATIONS_DISABLED as ɵANIMATIONS_DISABLED} from './animation/interfaces';
 export {allLeavingAnimations as ɵallLeavingAnimations} from './animation/longest_animation';
+export {setZoneProvidersForNextBootstrap as ɵsetZoneProvidersForNextBootstrap} from './platform/platform_ref';

--- a/packages/core/src/platform/platform_ref.ts
+++ b/packages/core/src/platform/platform_ref.ts
@@ -14,7 +14,7 @@ import {
 } from '../change_detection/scheduling/ng_zone_scheduling';
 import {ChangeDetectionScheduler} from '../change_detection/scheduling/zoneless_scheduling';
 import {ChangeDetectionSchedulerImpl} from '../change_detection/scheduling/zoneless_scheduling_impl';
-import {Injectable, Injector} from '../di';
+import {Injectable, Injector, StaticProvider} from '../di';
 import {errorHandlerEnvironmentInitializer} from '../error_handler';
 import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {Type} from '../interface/type';
@@ -39,6 +39,7 @@ export class PlatformRef {
   private _modules: NgModuleRef<any>[] = [];
   private _destroyListeners: Array<() => void> = [];
   private _destroyed: boolean = false;
+  private _additionalApplicationProviders?: StaticProvider[];
 
   /** @internal */
   constructor(private _injector: Injector) {}
@@ -67,6 +68,7 @@ export class PlatformRef {
         ngZoneFactory,
       }),
       {provide: ChangeDetectionScheduler, useExisting: ChangeDetectionSchedulerImpl},
+      ...(this._additionalApplicationProviders ?? []),
       errorHandlerEnvironmentInitializer,
     ];
     const moduleRef = createNgModuleRefWithProviders(

--- a/packages/core/src/platform/platform_ref.ts
+++ b/packages/core/src/platform/platform_ref.ts
@@ -19,12 +19,15 @@ import {errorHandlerEnvironmentInitializer} from '../error_handler';
 import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {Type} from '../interface/type';
 import {CompilerOptions} from '../linker';
+import {getNgZone} from '../zone/ng_zone';
 import {NgModuleFactory, NgModuleRef} from '../linker/ng_module_factory';
 import {createNgModuleRefWithProviders} from '../render3/ng_module_ref';
 import {bootstrap, setModuleBootstrapImpl} from './bootstrap';
 import {PLATFORM_DESTROY_LISTENERS} from './platform_destroy_listeners';
 
-let _additionalApplicationProviders: StaticProvider[]|undefined = undefined;
+// Holds the set of providers to be used for the *next* application to be bootstrapped.
+// Used only for providing the zone related providers by default with `downgradeModule`.
+let _additionalApplicationProviders: StaticProvider[] | undefined = undefined;
 export function setZoneProvidersForNextBootstrap(): void {
   _additionalApplicationProviders = internalProvideZoneChangeDetection({});
 }

--- a/packages/core/src/platform/platform_ref.ts
+++ b/packages/core/src/platform/platform_ref.ts
@@ -21,9 +21,13 @@ import {Type} from '../interface/type';
 import {CompilerOptions} from '../linker';
 import {NgModuleFactory, NgModuleRef} from '../linker/ng_module_factory';
 import {createNgModuleRefWithProviders} from '../render3/ng_module_ref';
-import {getNgZone} from '../zone/ng_zone';
 import {bootstrap, setModuleBootstrapImpl} from './bootstrap';
 import {PLATFORM_DESTROY_LISTENERS} from './platform_destroy_listeners';
+
+let _additionalApplicationProviders: StaticProvider[]|undefined = undefined;
+export function setZoneProvidersForNextBootstrap(): void {
+  _additionalApplicationProviders = internalProvideZoneChangeDetection({});
+}
 
 /**
  * The Angular platform is the entry point for Angular on a web page.
@@ -68,9 +72,10 @@ export class PlatformRef {
         ngZoneFactory,
       }),
       {provide: ChangeDetectionScheduler, useExisting: ChangeDetectionSchedulerImpl},
-      ...(this._additionalApplicationProviders ?? []),
+      ...(_additionalApplicationProviders ?? []),
       errorHandlerEnvironmentInitializer,
     ];
+    _additionalApplicationProviders = undefined;
     const moduleRef = createNgModuleRefWithProviders(
       moduleFactory.moduleType,
       this.injector,

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -67,6 +67,8 @@
       "shimStylesContent"
     ],
     "lazy": [
+      "DeferComponent",
+      "_DeferComponent",
       "AFTER_RENDER_SEQUENCES_TO_ADD",
       "ANIMATIONS",
       "APP_BOOTSTRAP_LISTENER",
@@ -802,9 +804,7 @@
       "wasLastNodeCreated",
       "writeDirectClass",
       "writeDirectStyle",
-      "writeToDirectiveInput",
-      "DeferComponent",
-      "_DeferComponent"
+      "writeToDirectiveInput"
     ]
   }
 }

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -400,6 +400,7 @@
       "_a5",
       "_a6",
       "_a7",
+      "_additionalApplicationProviders",
       "_applyRootElementTransformImpl",
       "_arrayIndexOfSorted",
       "_bind",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -401,6 +401,7 @@
       "_a5",
       "_a6",
       "_a7",
+      "_additionalApplicationProviders",
       "_applyRootElementTransformImpl",
       "_arrayIndexOfSorted",
       "_bind",

--- a/packages/upgrade/static/src/downgrade_module.ts
+++ b/packages/upgrade/static/src/downgrade_module.ts
@@ -383,12 +383,12 @@ export function downgradeModule<T>(
   let bootstrapFn: (extraProviders: StaticProvider[]) => Promise<NgModuleRef<T>>;
   if (ɵutil.isNgModuleType(moduleOrBootstrapFn)) {
     // NgModule class
-    bootstrapFn = (extraProviders: StaticProvider[]) => 
-       platformBrowser(extraProviders).bootstrapModule(moduleOrBootstrapFn);
+    bootstrapFn = (extraProviders: StaticProvider[]) =>
+      platformBrowser(extraProviders).bootstrapModule(moduleOrBootstrapFn);
   } else if (!ɵutil.isFunction(moduleOrBootstrapFn)) {
     // NgModule factory
-    bootstrapFn = (extraProviders: StaticProvider[]) => 
-       platformBrowser(extraProviders).bootstrapModuleFactory(moduleOrBootstrapFn);
+    bootstrapFn = (extraProviders: StaticProvider[]) =>
+      platformBrowser(extraProviders).bootstrapModuleFactory(moduleOrBootstrapFn);
   } else {
     // bootstrap function
     bootstrapFn = moduleOrBootstrapFn;
@@ -397,7 +397,7 @@ export function downgradeModule<T>(
   const wrappedBootstrapFn = (extraProviders: StaticProvider[]) => {
     ɵsetZoneProvidersForNextBootstrap();
     return bootstrapFn(extraProviders);
-  }
+  };
 
   let injector: Injector;
 

--- a/packages/upgrade/static/src/downgrade_module.ts
+++ b/packages/upgrade/static/src/downgrade_module.ts
@@ -13,6 +13,7 @@ import {
   PlatformRef,
   StaticProvider,
   Type,
+  ɵinternalProvideZoneChangeDetection as internalProvideZoneChangeDetection,
 } from '@angular/core';
 import {platformBrowser} from '@angular/platform-browser';
 
@@ -382,12 +383,18 @@ export function downgradeModule<T>(
   let bootstrapFn: (extraProviders: StaticProvider[]) => Promise<NgModuleRef<T>>;
   if (ɵutil.isNgModuleType(moduleOrBootstrapFn)) {
     // NgModule class
-    bootstrapFn = (extraProviders: StaticProvider[]) =>
-      platformBrowser(extraProviders).bootstrapModule(moduleOrBootstrapFn);
+    bootstrapFn = (extraProviders: StaticProvider[]) => {
+      const platform = platformBrowser(extraProviders);
+      (platform as any)._additionalApplicationProviders = internalProvideZoneChangeDetection({});
+      return platform.bootstrapModule(moduleOrBootstrapFn);
+    };
   } else if (!ɵutil.isFunction(moduleOrBootstrapFn)) {
     // NgModule factory
-    bootstrapFn = (extraProviders: StaticProvider[]) =>
-      platformBrowser(extraProviders).bootstrapModuleFactory(moduleOrBootstrapFn);
+    bootstrapFn = (extraProviders: StaticProvider[]) => {
+      const platform = platformBrowser(extraProviders);
+      (platform as any)._additionalApplicationProviders = internalProvideZoneChangeDetection({});
+      return platform.bootstrapModuleFactory(moduleOrBootstrapFn);
+    };
   } else {
     // bootstrap function
     bootstrapFn = moduleOrBootstrapFn;

--- a/packages/upgrade/static/src/upgrade_module.ts
+++ b/packages/upgrade/static/src/upgrade_module.ts
@@ -14,6 +14,7 @@ import {
   PlatformRef,
   Testability,
   ɵNoopNgZone,
+  ɵinternalProvideZoneChangeDetection,
 } from '@angular/core';
 
 import {ɵangular1, ɵconstants, ɵutil} from '../common';
@@ -145,7 +146,7 @@ import {NgAdapterInjector} from './util';
  *
  * @publicApi
  */
-@NgModule({providers: [angular1Providers]})
+@NgModule({providers: [angular1Providers, ɵinternalProvideZoneChangeDetection({})]})
 export class UpgradeModule {
   /**
    * The AngularJS `$injector` for the upgrade application.

--- a/packages/upgrade/static/test/integration/downgrade_component_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_component_spec.ts
@@ -463,7 +463,6 @@ withEachNg1Version(() => {
       @NgModule({
         imports: [BrowserModule, UpgradeModule],
         declarations: [Ng2Component],
-        providers: [provideZoneChangeDetection()],
       })
       class Ng2Module {
         ngDoBootstrap() {}

--- a/packages/upgrade/static/test/integration/downgrade_component_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_component_spec.ts
@@ -22,7 +22,6 @@ import {
   OnChanges,
   OnDestroy,
   Output,
-  provideZoneChangeDetection,
   SimpleChanges,
 } from '@angular/core';
 import {fakeAsync, tick, waitForAsync} from '@angular/core/testing';

--- a/packages/upgrade/static/test/integration/downgrade_module_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_module_spec.ts
@@ -28,7 +28,6 @@ import {
   OnChanges,
   OnDestroy,
   OnInit,
-  provideZoneChangeDetection,
   StaticProvider,
   Type,
   ViewRef,
@@ -488,7 +487,6 @@ withEachNg1Version(() => {
             {provide: 'FOO', useValue: 'Mod-foo'},
             {provide: 'BAR', useValue: 'Mod-bar'},
             {provide: 'BAZ', useValue: 'Mod-baz'},
-            provideZoneChangeDetection(),
           ],
         })
         class Ng2Module {
@@ -686,7 +684,6 @@ withEachNg1Version(() => {
         @NgModule({
           declarations: [Ng2AComponent, Ng2BComponent],
           imports: [BrowserModule],
-          providers: [provideZoneChangeDetection()],
         })
         class Ng2Module {
           ngDoBootstrap() {}
@@ -756,7 +753,6 @@ withEachNg1Version(() => {
               useFactory: (i: angular.IInjectorService) => i.get('ng1Value'),
               deps: ['$injector'],
             },
-            provideZoneChangeDetection(),
           ],
         })
         class Ng2Module {
@@ -807,7 +803,6 @@ withEachNg1Version(() => {
         @NgModule({
           declarations: [Ng2Component],
           imports: [BrowserModule],
-          providers: [provideZoneChangeDetection()],
         })
         class Ng2Module {
           ngDoBootstrap() {}
@@ -847,7 +842,6 @@ withEachNg1Version(() => {
         @NgModule({
           declarations: [Ng2Component],
           imports: [BrowserModule],
-          providers: [provideZoneChangeDetection()],
         })
         class Ng2Module {
           ngDoBootstrap() {}
@@ -892,7 +886,6 @@ withEachNg1Version(() => {
         @NgModule({
           declarations: [Ng2Component],
           imports: [BrowserModule],
-          providers: [provideZoneChangeDetection()],
         })
         class Ng2Module {
           ngDoBootstrap() {}
@@ -967,7 +960,6 @@ withEachNg1Version(() => {
         @NgModule({
           declarations: [TestComponent, WrapperComponent],
           imports: [BrowserModule],
-          providers: [provideZoneChangeDetection()],
         })
         class Ng2Module {
           ngDoBootstrap() {}
@@ -1018,7 +1010,6 @@ withEachNg1Version(() => {
         @NgModule({
           declarations: [Ng2Component],
           imports: [BrowserModule],
-          providers: [provideZoneChangeDetection()],
         })
         class Ng2Module {
           ngDoBootstrap() {}
@@ -1073,7 +1064,6 @@ withEachNg1Version(() => {
         @NgModule({
           declarations: [TestComponent, WrapperComponent],
           imports: [BrowserModule],
-          providers: [provideZoneChangeDetection()],
         })
         class Ng2Module {
           ngDoBootstrap() {}
@@ -1167,7 +1157,6 @@ withEachNg1Version(() => {
         @NgModule({
           declarations: [Ng2Component],
           imports: [BrowserModule],
-          providers: [provideZoneChangeDetection()],
         })
         class Ng2Module {
           ngDoBootstrap() {}
@@ -1310,7 +1299,6 @@ withEachNg1Version(() => {
         @NgModule({
           declarations: [Ng2Component],
           imports: [BrowserModule],
-          providers: [provideZoneChangeDetection()],
         })
         class Ng2Module {
           ngDoBootstrap() {}
@@ -1362,7 +1350,6 @@ withEachNg1Version(() => {
         @NgModule({
           declarations: [Ng2Component],
           imports: [BrowserModule],
-          providers: [provideZoneChangeDetection()],
         })
         class Ng2Module {
           ngDoBootstrap() {}
@@ -1432,7 +1419,6 @@ withEachNg1Version(() => {
 
         @NgModule({
           declarations: [Ng2Component],
-          providers: [provideZoneChangeDetection()],
           imports: [BrowserModule],
         })
         class Ng2Module {
@@ -1493,7 +1479,6 @@ withEachNg1Version(() => {
         @NgModule({
           declarations: [Ng2Component],
           imports: [BrowserModule],
-          providers: [provideZoneChangeDetection()],
         })
         class Ng2Module {
           constructor(injector: Injector) {
@@ -1528,7 +1513,6 @@ withEachNg1Version(() => {
         @NgModule({
           declarations: [Ng2Component],
           imports: [BrowserModule],
-          providers: [provideZoneChangeDetection()],
         })
         class Ng2Module {
           ngDoBootstrap() {}


### PR DESCRIPTION
…y default

To avoid the need for specifying `provideZoneChangeDetection` in any/all modules used with `downgradedModule`, this change adds the zone-based change detection providers by default.
