### PR TITLE
refactor(core): remove unnecessary deps arrays

### DIFF
--- a/devtools/projects/shell-browser/src/app/app.config.ts
+++ b/devtools/projects/shell-browser/src/app/app.config.ts
@@ -13,7 +13,6 @@ import {ChromeApplicationEnvironment} from './chrome-application-environment';
 import {ChromeApplicationOperations} from './chrome-application-operations';
 import {Events, MessageBus, PriorityAwareMessageBus} from '../../../protocol';
 import {FrameManager} from '../../../ng-devtools/src/lib/application-services/frame_manager';
-import {Platform} from '@angular/cdk/platform';
 import {ChromeMessageBus} from './chrome-message-bus';
 
 export const appConfig: ApplicationConfig = {
@@ -23,7 +22,6 @@ export const appConfig: ApplicationConfig = {
     {
       provide: ApplicationOperations,
       useClass: ChromeApplicationOperations,
-      deps: [Platform],
     },
     {
       provide: ApplicationEnvironment,

--- a/goldens/public-api/router/upgrade/index.api.md
+++ b/goldens/public-api/router/upgrade/index.api.md
@@ -5,15 +5,14 @@
 ```ts
 
 import { ComponentRef } from '@angular/core';
-import { InjectionToken } from '@angular/core';
+import * as i0 from '@angular/core';
 import { UpgradeModule } from '@angular/upgrade/static';
 
 // @public
 export const RouterUpgradeInitializer: {
-    provide: InjectionToken<readonly ((compRef: ComponentRef<any>) => void)[]>;
+    provide: i0.InjectionToken<readonly ((compRef: ComponentRef<any>) => void)[]>;
     multi: boolean;
-    useFactory: (ngUpgrade: UpgradeModule) => () => void;
-    deps: (typeof UpgradeModule)[];
+    useFactory: () => () => void;
 };
 
 // @public

--- a/packages/common/src/i18n/localization.ts
+++ b/packages/common/src/i18n/localization.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Inject, Injectable, LOCALE_ID, ɵRuntimeError as RuntimeError} from '@angular/core';
+import {inject, Inject, Injectable, LOCALE_ID, ɵRuntimeError as RuntimeError} from '@angular/core';
 
 import {getLocalePluralCase, Plural} from './locale_data_api';
 import {RuntimeErrorCode} from '../errors';
@@ -16,8 +16,7 @@ import {RuntimeErrorCode} from '../errors';
  */
 @Injectable({
   providedIn: 'root',
-  useFactory: (locale: string) => new NgLocaleLocalization(locale),
-  deps: [LOCALE_ID],
+  useFactory: () => new NgLocaleLocalization(inject(LOCALE_ID)),
 })
 export abstract class NgLocalization {
   abstract getPluralCategory(value: any, locale?: string): string;

--- a/packages/misc/angular-in-memory-web-api/src/http-client-in-memory-web-api-module.ts
+++ b/packages/misc/angular-in-memory-web-api/src/http-client-in-memory-web-api-module.ts
@@ -8,19 +8,19 @@
 
 import {XhrFactory} from '@angular/common';
 import {HttpBackend} from '@angular/common/http';
-import {ModuleWithProviders, NgModule, Type} from '@angular/core';
+import {inject, ModuleWithProviders, NgModule, Type} from '@angular/core';
 
 import {HttpClientBackendService} from './http-client-backend-service';
 import {InMemoryBackendConfig, InMemoryBackendConfigArgs, InMemoryDbService} from './interfaces';
 
 // Internal - Creates the in-mem backend for the HttpClient module
 // AoT requires factory to be exported
-export function httpClientInMemBackendServiceFactory(
-  dbService: InMemoryDbService,
-  options: InMemoryBackendConfig,
-  xhrFactory: XhrFactory,
-): HttpBackend {
-  return new HttpClientBackendService(dbService, options, xhrFactory) as HttpBackend;
+export function httpClientInMemBackendServiceFactory(): HttpBackend {
+  return new HttpClientBackendService(
+    inject(InMemoryDbService),
+    inject(InMemoryBackendConfig),
+    inject(XhrFactory),
+  ) as HttpBackend;
 }
 
 @NgModule()
@@ -55,7 +55,6 @@ export class HttpClientInMemoryWebApiModule {
         {
           provide: HttpBackend,
           useFactory: httpClientInMemBackendServiceFactory,
-          deps: [InMemoryDbService, InMemoryBackendConfig, XhrFactory],
         },
       ],
     };

--- a/packages/misc/angular-in-memory-web-api/src/in-memory-web-api-module.ts
+++ b/packages/misc/angular-in-memory-web-api/src/in-memory-web-api-module.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {XhrFactory} from '@angular/common';
 import {HttpBackend} from '@angular/common/http';
 import {ModuleWithProviders, NgModule, Type} from '@angular/core';
 
@@ -45,7 +44,6 @@ export class InMemoryWebApiModule {
         {
           provide: HttpBackend,
           useFactory: httpClientInMemBackendServiceFactory,
-          deps: [InMemoryDbService, InMemoryBackendConfig, XhrFactory],
         },
       ],
     };

--- a/packages/platform-browser/animations/async/src/providers.ts
+++ b/packages/platform-browser/animations/async/src/providers.ts
@@ -14,6 +14,7 @@ import {
   NgZone,
   RendererFactory2,
   ɵperformanceMarkFeature as performanceMarkFeature,
+  inject,
 } from '@angular/core';
 import {ɵDomRendererFactory2 as DomRendererFactory2} from '../../../index';
 
@@ -61,10 +62,14 @@ export function provideAnimationsAsync(
   return makeEnvironmentProviders([
     {
       provide: RendererFactory2,
-      useFactory: (doc: Document, renderer: DomRendererFactory2, zone: NgZone) => {
-        return new AsyncAnimationRendererFactory(doc, renderer, zone, type);
+      useFactory: () => {
+        return new AsyncAnimationRendererFactory(
+          inject(DOCUMENT),
+          inject(DomRendererFactory2),
+          inject(NgZone),
+          type,
+        );
       },
-      deps: [DOCUMENT, DomRendererFactory2, NgZone],
     },
     {
       provide: ANIMATION_MODULE_TYPE,

--- a/packages/platform-browser/animations/src/providers.ts
+++ b/packages/platform-browser/animations/src/providers.ts
@@ -25,7 +25,6 @@ import {
   OnDestroy,
   Provider,
   RendererFactory2,
-  ɵChangeDetectionScheduler as ChangeDetectionScheduler,
 } from '@angular/core';
 import {ɵDomRendererFactory2 as DomRendererFactory2} from '../../index';
 
@@ -51,12 +50,12 @@ export function instantiateDefaultStyleNormalizer() {
   return new WebAnimationsStyleNormalizer();
 }
 
-export function instantiateRendererFactory(
-  renderer: DomRendererFactory2,
-  engine: AnimationEngine,
-  zone: NgZone,
-) {
-  return new AnimationRendererFactory(renderer, engine, zone);
+export function instantiateRendererFactory() {
+  return new AnimationRendererFactory(
+    inject(DomRendererFactory2),
+    inject(AnimationEngine),
+    inject(NgZone),
+  );
 }
 
 const SHARED_ANIMATION_PROVIDERS: Provider[] = [
@@ -65,7 +64,6 @@ const SHARED_ANIMATION_PROVIDERS: Provider[] = [
   {
     provide: RendererFactory2,
     useFactory: instantiateRendererFactory,
-    deps: [DomRendererFactory2, AnimationEngine, NgZone],
   },
 ];
 

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -20,7 +20,6 @@ import {
   ErrorHandler,
   InjectionToken,
   NgModule,
-  NgZone,
   PLATFORM_ID,
   PLATFORM_INITIALIZER,
   platformCore,
@@ -29,7 +28,6 @@ import {
   RendererFactory2,
   StaticProvider,
   Testability,
-  TestabilityRegistry,
   Type,
   ɵINJECTOR_SCOPE as INJECTOR_SCOPE,
   ɵinternalCreateApplication as internalCreateApplication,
@@ -239,12 +237,10 @@ const TESTABILITY_PROVIDERS = [
   {
     provide: TESTABILITY,
     useClass: Testability,
-    deps: [NgZone, TestabilityRegistry, TESTABILITY_GETTER],
   },
   {
     provide: Testability, // Also provide as `Testability` for backwards-compatibility.
     useClass: Testability,
-    deps: [NgZone, TestabilityRegistry, TESTABILITY_GETTER],
   },
 ];
 
@@ -255,9 +251,8 @@ const BROWSER_MODULE_PROVIDERS: Provider[] = [
     provide: EVENT_MANAGER_PLUGINS,
     useClass: DomEventsPlugin,
     multi: true,
-    deps: [DOCUMENT],
   },
-  {provide: EVENT_MANAGER_PLUGINS, useClass: KeyEventsPlugin, multi: true, deps: [DOCUMENT]},
+  {provide: EVENT_MANAGER_PLUGINS, useClass: KeyEventsPlugin, multi: true},
   DomRendererFactory2,
   SharedStylesHost,
   EventManager,

--- a/packages/platform-server/src/location.ts
+++ b/packages/platform-server/src/location.ts
@@ -13,7 +13,7 @@ import {
   PlatformLocation,
   ɵgetDOM as getDOM,
 } from '@angular/common';
-import {Inject, Injectable, Optional, ɵWritable as Writable} from '@angular/core';
+import {inject, Inject, Injectable, Optional, ɵWritable as Writable} from '@angular/core';
 import {Subject} from 'rxjs';
 
 import {INITIAL_CONFIG, PlatformConfig} from './tokens';
@@ -57,12 +57,10 @@ export class ServerPlatformLocation implements PlatformLocation {
   public readonly search: string = '';
   public readonly hash: string = '';
   private _hashUpdate = new Subject<LocationChangeEvent>();
+  private _doc = inject(DOCUMENT);
 
-  constructor(
-    @Inject(DOCUMENT) private _doc: any,
-    @Optional() @Inject(INITIAL_CONFIG) _config: any,
-  ) {
-    const config = _config as PlatformConfig | null;
+  constructor() {
+    const config = inject(INITIAL_CONFIG, {optional: true});
     if (!config) {
       return;
     }
@@ -74,7 +72,7 @@ export class ServerPlatformLocation implements PlatformLocation {
       this.pathname = url.pathname;
       this.search = url.search;
       this.hash = url.hash;
-      this.href = _doc.location.href;
+      this.href = this._doc.location.href;
     }
   }
 

--- a/packages/platform-server/src/server.ts
+++ b/packages/platform-server/src/server.ts
@@ -18,16 +18,16 @@ import {
   createPlatformFactory,
   Injector,
   NgModule,
-  Optional,
   PLATFORM_ID,
   PLATFORM_INITIALIZER,
   platformCore,
   PlatformRef,
   Provider,
-  StaticProvider,
   Testability,
   ɵsetDocument,
   ɵTESTABILITY as TESTABILITY,
+  inject,
+  StaticProvider,
 } from '@angular/core';
 import {
   BrowserModule,
@@ -44,18 +44,19 @@ import {INITIAL_CONFIG, PlatformConfig} from './tokens';
 import {TRANSFER_STATE_SERIALIZATION_PROVIDERS} from './transfer_state';
 
 export const INTERNAL_SERVER_PLATFORM_PROVIDERS: StaticProvider[] = [
-  {provide: DOCUMENT, useFactory: _document, deps: [Injector]},
+  {provide: DOCUMENT, useFactory: _document},
   {provide: PLATFORM_ID, useValue: PLATFORM_SERVER_ID},
-  {provide: PLATFORM_INITIALIZER, useFactory: initDominoAdapter, multi: true, deps: [Injector]},
+  {provide: PLATFORM_INITIALIZER, useFactory: initDominoAdapter, multi: true},
   {
     provide: PlatformLocation,
     useClass: ServerPlatformLocation,
-    deps: [DOCUMENT, [Optional, INITIAL_CONFIG]],
+    deps: [],
   },
   {provide: PlatformState, deps: [DOCUMENT]},
 ];
 
-function initDominoAdapter(injector: Injector) {
+function initDominoAdapter() {
+  const injector = inject(Injector);
   const _enableDomEmulation = enableDomEmulation(injector);
   return () => {
     if (_enableDomEmulation) {
@@ -90,7 +91,8 @@ export const PLATFORM_SERVER_PROVIDERS: Provider[] = [
 })
 export class ServerModule {}
 
-function _document(injector: Injector) {
+function _document() {
+  const injector = inject(Injector);
   const config: PlatformConfig | null = injector.get(INITIAL_CONFIG, null);
   const _enableDomEmulation = enableDomEmulation(injector);
   let document: Document;

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -102,14 +102,14 @@ export function provideRouter(routes: Routes, ...features: RouterFeatures[]): En
     typeof ngDevMode === 'undefined' || ngDevMode
       ? {provide: ROUTER_IS_PROVIDED, useValue: true}
       : [],
-    {provide: ActivatedRoute, useFactory: rootRoute, deps: [Router]},
+    {provide: ActivatedRoute, useFactory: rootRoute},
     {provide: APP_BOOTSTRAP_LISTENER, multi: true, useFactory: getBootstrapListener},
     features.map((feature) => feature.ɵproviders),
   ]);
 }
 
-export function rootRoute(router: Router): ActivatedRoute {
-  return router.routerState.root;
+export function rootRoute(): ActivatedRoute {
+  return inject(Router).routerState.root;
 }
 
 /**

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -75,7 +75,7 @@ export const ROUTER_PROVIDERS: Provider[] = [
   {provide: UrlSerializer, useClass: DefaultUrlSerializer},
   Router,
   ChildrenOutletContexts,
-  {provide: ActivatedRoute, useFactory: rootRoute, deps: [Router]},
+  {provide: ActivatedRoute, useFactory: rootRoute},
   RouterConfigLoader,
   // Only used to warn when `provideRoutes` is used without `RouterModule` or `provideRouter`. Can
   // be removed when `provideRoutes` is removed.
@@ -149,7 +149,6 @@ export class RouterModule {
           ? {
               provide: ROUTER_FORROOT_GUARD,
               useFactory: provideForRootGuard,
-              deps: [[Router, new Optional(), new SkipSelf()]],
             }
           : [],
         config?.errorHandler
@@ -227,7 +226,9 @@ function providePathLocationStrategy(): Provider {
   return {provide: LocationStrategy, useClass: PathLocationStrategy};
 }
 
-export function provideForRootGuard(router: Router): any {
+export function provideForRootGuard(): any {
+  const router = inject(Router, {optional: true, skipSelf: true});
+
   if (router) {
     throw new RuntimeError(
       RuntimeErrorCode.FOR_ROOT_CALLED_TWICE,

--- a/packages/router/upgrade/src/upgrade.ts
+++ b/packages/router/upgrade/src/upgrade.ts
@@ -7,7 +7,7 @@
  */
 
 import {Location} from '@angular/common';
-import {APP_BOOTSTRAP_LISTENER, ComponentRef, InjectionToken} from '@angular/core';
+import {APP_BOOTSTRAP_LISTENER, ComponentRef, inject} from '@angular/core';
 import {Router, ɵRestoredState as RestoredState} from '../../index';
 import {UpgradeModule} from '@angular/upgrade/static';
 
@@ -45,14 +45,15 @@ import {UpgradeModule} from '@angular/upgrade/static';
 export const RouterUpgradeInitializer = {
   provide: APP_BOOTSTRAP_LISTENER,
   multi: true,
-  useFactory: locationSyncBootstrapListener as (ngUpgrade: UpgradeModule) => () => void,
-  deps: [UpgradeModule],
+  useFactory: locationSyncBootstrapListener as () => () => void,
 };
 
 /**
  * @internal
  */
-export function locationSyncBootstrapListener(ngUpgrade: UpgradeModule) {
+export function locationSyncBootstrapListener() {
+  const ngUpgrade = inject(UpgradeModule);
+
   return () => {
     setUpLocationSync(ngUpgrade);
   };

--- a/packages/service-worker/src/provider.ts
+++ b/packages/service-worker/src/provider.ts
@@ -123,10 +123,9 @@ function delayWithTimeout(timeout: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, timeout));
 }
 
-export function ngswCommChannelFactory(
-  opts: SwRegistrationOptions,
-  injector: Injector,
-): NgswCommChannel {
+export function ngswCommChannelFactory(): NgswCommChannel {
+  const opts = inject(SwRegistrationOptions);
+  const injector = inject(Injector);
   const isBrowser = !(typeof ngServerMode !== 'undefined' && ngServerMode);
 
   return new NgswCommChannel(
@@ -241,7 +240,6 @@ export function provideServiceWorker(
     {
       provide: NgswCommChannel,
       useFactory: ngswCommChannelFactory,
-      deps: [SwRegistrationOptions, Injector],
     },
     provideAppInitializer(ngswAppInitializer),
   ]);


### PR DESCRIPTION
We don't need to use the `deps` array syntax anymore since we have the `inject` function. These changes clean up the relevant usages.
