### PR TITLE
docs: add alert about `routelinkactive` being a content query

### DIFF
--- a/adev/shared-docs/pipeline/shared/marked/extensions/docs-alert.mts
+++ b/adev/shared-docs/pipeline/shared/marked/extensions/docs-alert.mts
@@ -41,7 +41,7 @@ export const docsAlertExtension = {
     let match: DocsAlert | undefined;
     for (const key of Object.keys(AlertSeverityLevel)) {
       // Capture group 1: all alert text content after the severity level
-      const rule = new RegExp('^s*' + key + ': (.*?)\n(\n|$)', 's');
+      const rule = new RegExp('^s*' + key + ': (.*?)(?:\n{2,}|\s*$)', 's');
       const possibleMatch = rule.exec(src);
 
       if (possibleMatch?.[1]) {

--- a/adev/shared-docs/pipeline/shared/marked/test/docs-alert/docs-alert.md
+++ b/adev/shared-docs/pipeline/shared/marked/test/docs-alert/docs-alert.md
@@ -16,3 +16,5 @@ CRITICAL: Use Critical to call out potential bad stuff or alert the reader they 
 IMPORTANT: Use Important for information that's crucial to comprehending the text or to completing some task.
 
 HELPFUL: Use Best practice to call out practices that are known to be successful or better than alternatives.
+
+NOTE: THIS NOTE WITHOUT A LINE RETURN

--- a/adev/shared-docs/pipeline/shared/marked/test/docs-alert/docs-alert.spec.mts
+++ b/adev/shared-docs/pipeline/shared/marked/test/docs-alert/docs-alert.spec.mts
@@ -34,4 +34,10 @@ describe('markdown to html', () => {
 
     expect(noteEl?.textContent?.trim()).toContain(`This is a multiline note`);
   });
+
+  it(`should handle alerts without a line return`, () => {
+    const noteEl = markdownDocument.querySelector(`.docs-alert-note:last-of-type`);
+
+    expect(noteEl?.textContent?.trim()).toContain(`THIS NOTE WITHOUT A LINE RETURN`);
+  });
 });

--- a/packages/router/src/directives/router_link_active.ts
+++ b/packages/router/src/directives/router_link_active.ts
@@ -96,6 +96,9 @@ import {RouterLink} from './router_link';
  * <a routerLink="/" routerLinkActive="active" ariaCurrentWhenActive="page">Home Page</a>
  * ```
  *
+ * NOTE: RouterLinkActive is a `ContentChildren` query.
+ * Content children queries do not retrieve elements or directives that are in other components' templates, since a component's template is always a black box to its ancestors.
+ *
  * @ngModule RouterModule
  *
  * @publicApi

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4801,11 +4801,6 @@ packages:
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -16696,8 +16691,8 @@ snapshots:
     optionalDependencies:
       ajv: 8.13.0
 
-  ajv-formats@2.1.1(ajv@8.17.1):
-    optionalDependencies:
+  ajv-formats@2.1.1:
+    dependencies:
       ajv: 8.17.1
 
   ajv-formats@3.0.1:
@@ -18884,7 +18879,7 @@ snapshots:
     dependencies:
       '@apidevtools/json-schema-ref-parser': 9.1.2
       ajv: 8.17.1
-      ajv-formats: 2.1.1(ajv@8.17.1)
+      ajv-formats: 2.1.1
       body-parser: 1.20.3
       content-type: 1.0.5
       deep-freeze: 0.0.1
@@ -23302,7 +23297,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
       ajv: 8.17.1
-      ajv-formats: 2.1.1(ajv@8.17.1)
+      ajv-formats: 2.1.1
       ajv-keywords: 5.1.0(ajv@8.17.1)
 
   secure-compare@3.0.1: {}


### PR DESCRIPTION
This commit also fixes an issue with alert that we're parse correctly if they were at the end of the markdown string

fixes #52877
