### PR TITLE
docs(docs-infra): Use port 4201 for adev

### DIFF
--- a/adev/BUILD.bazel
+++ b/adev/BUILD.bazel
@@ -150,7 +150,7 @@ ng_application(
     project_name = "angular-dev",
     serve_args = config_based_architect_flags + [
         "--port",
-        "0",
+        "4201",
     ],
 )
 


### PR DESCRIPTION
Having a changing port might be annoying. The best compromise is probably to use a less common port than the default used by the CLI.
