### PR TITLE
docs: update doc to clear up difference between `toObservable`/ `outp…

### DIFF
--- a/packages/core/rxjs-interop/src/output_to_observable.ts
+++ b/packages/core/rxjs-interop/src/output_to_observable.ts
@@ -12,6 +12,7 @@ import {Observable} from 'rxjs';
 /**
  * Converts an Angular output declared via `output()` or `outputFromObservable()`
  * to an observable.
+ * It creates an observable that represents the stream of "events firing" in an output.
  *
  * You can subscribe to the output via `Observable.subscribe` then.
  *

--- a/packages/core/rxjs-interop/src/to_observable.ts
+++ b/packages/core/rxjs-interop/src/to_observable.ts
@@ -34,6 +34,7 @@ export interface ToObservableOptions {
 
 /**
  * Exposes the value of an Angular `Signal` as an RxJS `Observable`.
+ * As it reflects a state, the observable will always emit the latest value upon subscription.
  *
  * The signal's value will be propagated into the `Observable`'s subscribers using an `effect`.
  *


### PR DESCRIPTION
…utToObservable`

TLDR: only `toObservable` emits synchronously on subscription.

fixes #57224
