### PR TITLE
build: remove bazel flag usage for adev

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -169,8 +169,6 @@ test:saucelabs --flaky_test_attempts=1
 
 # --ng_perf will ask the Ivy compiler to produce performance results for each build.
 build --flag_alias=ng_perf=//packages/compiler-cli:ng_perf
-# --full_build_adev will run adev build/serve in a full mode, performing prerendering and DCE.
-build --flag_alias=full_build_adev=//adev:full_build_adev
 
 ####################################################
 # User bazel configuration

--- a/.github/workflows/adev-preview-build.yml
+++ b/.github/workflows/adev-preview-build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install node modules
         run: pnpm install --frozen-lockfile
       - name: Build adev to ensure it continues to work
-        run: pnpm bazel build //adev:build --full_build_adev --config=release
+        run: pnpm bazel build //adev:build.production
       - uses: angular/dev-infra/github-actions/previews/pack-and-upload-artifact@0004737f3823ef0908fdc95a742ec3f03cb1af03
         with:
           workflow-artifact-name: 'adev-preview'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Run tests
         run: pnpm bazel test //adev/...
       - name: Build adev in fast mode to ensure it continues to work
-        run: pnpm bazel build //adev:build --config=release
+        run: pnpm bazel build //adev:build
 
   publish-snapshots:
     runs-on:
@@ -204,7 +204,7 @@ jobs:
       - name: Install node modules
         run: pnpm install --frozen-lockfile
       - name: Build adev to ensure it continues to work
-        run: pnpm bazel build //adev:build --full_build_adev --config=release
+        run: pnpm bazel build //adev:build.production
       - name: Deploy to firebase
         uses: ./.github/actions/deploy-docs-site
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Run tests
         run: pnpm bazel test //adev/...
       - name: Build adev in fast mode to ensure it continues to work
-        run: pnpm bazel build //adev:build --config=release
+        run: pnpm bazel build //adev:build
 
   zone-js:
     runs-on:

--- a/adev/BUILD.bazel
+++ b/adev/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@rules_angular//src/architect:ng_application.bzl", "ng_application")
 load("@rules_angular//src/architect:ng_config.bzl", "ng_config")
@@ -101,56 +100,49 @@ TEST_DEPS = [
 
 ng_config(name = "ng_config")
 
-bool_flag(
-    name = "full_build_adev",
-    build_setting_default = False,
-)
-
-config_setting(
-    name = "prod_build",
-    flag_values = {
-        ":full_build_adev": "true",
-    },
-)
-
-config_setting(
-    name = "dev_build",
-    flag_values = {
-        ":full_build_adev": "false",
-    },
-)
-
-config_based_architect_env = select({
-    ":dev_build": {
-        "NG_BUILD_PARTIAL_SSR": "1",
-    },
-    ":prod_build": {
-        "NG_BUILD_OPTIMIZE_CHUNKS": "1",
-    },
-})
-
-config_based_architect_flags = select({
-    ":dev_build": [
-        "--configuration",
-        "development",
-    ],
-    ":prod_build": [
-        "--configuration",
-        "production",
-    ],
-})
-
 ng_application(
     name = "build",
     srcs = APPLICATION_FILES + APPLICATION_DEPS,
-    args = config_based_architect_flags,
-    env = config_based_architect_env,
+    args = [
+        "--configuration",
+        "development",
+    ],
+    env = {
+        "NG_BUILD_PARTIAL_SSR": "1",
+    },
     ng_config = ":ng_config",
     node_modules = "//adev:node_modules",
     project_name = "angular-dev",
-    serve_args = config_based_architect_flags + [
+    serve_args = [
         "--port",
         "4201",
+    ],
+    tags = [
+        # Tagged as manual as both build and build.production use the same output directory.
+        "manual",
+    ],
+)
+
+ng_application(
+    name = "build.production",
+    srcs = APPLICATION_FILES + APPLICATION_DEPS,
+    args = [
+        "--configuration",
+        "production",
+    ],
+    env = {
+        "NG_BUILD_OPTIMIZE_CHUNKS": "1",
+    },
+    ng_config = ":ng_config",
+    node_modules = "//adev:node_modules",
+    project_name = "angular-dev",
+    serve_args = [
+        "--port",
+        "4201",
+    ],
+    tags = [
+        # Tagged as manual as both build and build.production use the same output directory.
+        "manual",
     ],
 )
 


### PR DESCRIPTION
Previously we used a configuration flag for adev, instead we now separate into two different targets since our flag didn't need to cause a full reanalysis to run since everything before the final target should be a cache hit.
