### PR TITLE
docs: fix pluralization error in templates guide

### DIFF
--- a/adev/src/content/introduction/essentials/templates.md
+++ b/adev/src/content/introduction/essentials/templates.md
@@ -61,7 +61,7 @@ You can also bind to HTML _attributes_ by prefixing the attribute name with `att
 <ul [attr.role]="listRole()">
 ```
 
-Angular automatically updates DOM properties and attribute when the bound value changes.
+Angular automatically updates DOM properties and attributes when the bound value changes.
 
 ## Handling user interaction
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In the "Setting dynamic properties and attributes" section, the concluding sentence has a pluralization error. "Properties" is plural, but "attribute" is singular, which is grammatically inconsistent.

Issue Number: N/A


## What is the new behavior?
The error has been corrected by changing "attribute" to its plural form, "attributes," to match "properties."

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->