### PR TITLE
refactor(core): remove usages of Promise.withResolvers

### DIFF
--- a/packages/core/src/defer/triggering.ts
+++ b/packages/core/src/defer/triggering.ts
@@ -71,7 +71,7 @@ import {
   getTDeferBlockDetails,
 } from './utils';
 import {ApplicationRef} from '../application/application_ref';
-import type {PromiseConstructor} from '../util/promise_with_resolvers';
+import {promiseWithResolvers} from '../util/promise_with_resolvers';
 
 /**
  * Schedules triggering of a defer block for `on idle` and `on timer` conditions.
@@ -550,7 +550,7 @@ function cleanupRemainingHydrationQueue(
  */
 function populateHydratingStateForQueue(registry: DehydratedBlockRegistry, queue: string[]) {
   for (let blockId of queue) {
-    registry.hydrating.set(blockId, (Promise as unknown as PromiseConstructor).withResolvers());
+    registry.hydrating.set(blockId, promiseWithResolvers<void>());
   }
 }
 

--- a/packages/core/src/render3/instructions/animation.ts
+++ b/packages/core/src/render3/instructions/animation.ts
@@ -19,7 +19,7 @@ import {Renderer} from '../interfaces/renderer';
 import {NgZone} from '../../zone';
 import {determineLongestAnimation, allLeavingAnimations} from '../../animation/longest_animation';
 import {TNode} from '../interfaces/node';
-import type {PromiseConstructor} from '../../util/promise_with_resolvers';
+import {promiseWithResolvers} from '../../util/promise_with_resolvers';
 
 import {
   areAnimationsDisabled,
@@ -230,7 +230,7 @@ function runLeaveAnimations(
   value: string | Function,
   animationsDisabled: boolean,
 ): Promise<void> {
-  const {promise, resolve} = (Promise as unknown as PromiseConstructor).withResolvers<void>();
+  const {promise, resolve} = promiseWithResolvers<void>();
   const nativeElement = getNativeByTNode(tNode, lView) as Element;
 
   ngDevMode && assertElementNodes(nativeElement, 'animate.leave');
@@ -363,7 +363,7 @@ function runLeaveAnimationFunction(
   tNode: TNode,
   value: AnimationFunction,
 ): Promise<void> {
-  const {promise, resolve} = (Promise as unknown as PromiseConstructor).withResolvers<void>();
+  const {promise, resolve} = promiseWithResolvers<void>();
   const nativeElement = getNativeByTNode(tNode, lView) as Element;
 
   ngDevMode && assertElementNodes(nativeElement, 'animate.leave');

--- a/packages/core/src/util/promise_with_resolvers.ts
+++ b/packages/core/src/util/promise_with_resolvers.ts
@@ -27,3 +27,25 @@ export interface PromiseConstructor {
    */
   withResolvers<T>(): PromiseWithResolvers<T>;
 }
+
+/**
+ * Replace with `Promise.withResolvers()` once it's available.
+ * NET September 2026
+ *
+ * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers.
+ */
+export function promiseWithResolvers<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: any) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: any) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return {promise, resolve, reject};
+}

--- a/packages/core/test/resource/resource_spec.ts
+++ b/packages/core/test/resource/resource_spec.ts
@@ -18,8 +18,7 @@ import {
   signal,
 } from '../../src/core';
 import {TestBed} from '../../testing';
-
-import type {PromiseConstructor} from '../../src/util/promise_with_resolvers';
+import {promiseWithResolvers} from '../../src/util/promise_with_resolvers';
 
 abstract class MockBackend<T, R> {
   protected pending = new Map<
@@ -337,7 +336,7 @@ describe('resource', () => {
     const res = resource({
       params: request,
       loader: async ({params}) => {
-        const p = (Promise as unknown as PromiseConstructor).withResolvers<number>();
+        const p = promiseWithResolvers<number>();
         resolve.push(() => p.resolve(params));
         return p.promise;
       },


### PR DESCRIPTION
Promise.withResolvers is Baseline 2024. Our policy is to support browsers in the scope of Basline widely available.

Fixes #63855
