### PR TITLE
feat(core): support regular expressions in templates

### DIFF
--- a/adev/src/content/guide/templates/expression-syntax.md
+++ b/adev/src/content/guide/templates/expression-syntax.md
@@ -17,12 +17,7 @@ Angular supports a subset of [literal values](https://developer.mozilla.org/en-U
 | Array           | `['Onion', 'Cheese', 'Garlic']` |
 | null            | `null`                          |
 | Template string | `` `Hello ${name}` ``           |
-
-### Unsupported literals
-
-| Literal type | Example value |
-| ------------ | ------------- |
-| RegExp       | `/\d+/`       |
+| RegExp          | `/\d+/`                         |
 
 ## Globals
 

--- a/packages/compiler-cli/linker/babel/src/ast/babel_ast_factory.ts
+++ b/packages/compiler-cli/linker/babel/src/ast/babel_ast_factory.ts
@@ -215,6 +215,10 @@ export class BabelAstFactory implements AstFactory<t.Statement, t.Expression> {
     ]);
   }
 
+  createRegularExpressionLiteral(body: string, flags: string | null): t.Expression {
+    return t.regExpLiteral(body, flags ?? undefined);
+  }
+
   setSourceMapRange<T extends t.Statement | t.Expression | t.TemplateElement>(
     node: T,
     sourceMapRange: SourceMapRange | null,

--- a/packages/compiler-cli/linker/babel/test/ast/babel_ast_factory_spec.ts
+++ b/packages/compiler-cli/linker/babel/test/ast/babel_ast_factory_spec.ts
@@ -396,6 +396,18 @@ describe('BabelAstFactory', () => {
     });
   });
 
+  describe('createRegularExpressionLiteral()', () => {
+    it('should create a regular expressions without flags', () => {
+      const regex = factory.createRegularExpressionLiteral('^\\d+-foo$', null);
+      expect(generate(regex).code).toEqual('/^\\d+-foo$/');
+    });
+
+    it('should create a regular expressions with flags', () => {
+      const regex = factory.createRegularExpressionLiteral('^\\d+-foo$', 'gi');
+      expect(generate(regex).code).toEqual('/^\\d+-foo$/gi');
+    });
+  });
+
   describe('setSourceMapRange()', () => {
     it('should attach the `sourceMapRange` to the given `node`', () => {
       const expr = expression.ast`42`;

--- a/packages/compiler-cli/src/ngtsc/translator/src/api/ast_factory.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/api/ast_factory.ts
@@ -273,6 +273,14 @@ export interface AstFactory<TStatement, TExpression> {
   ): TStatement;
 
   /**
+   * Create a regular expression literal (e.g. `/\d+/g`).
+   *
+   * @param body Body of the regex.
+   * @param flags Flags of the regex, if any.
+   */
+  createRegularExpressionLiteral(body: string, flags: string | null): TExpression;
+
+  /**
    * Attach a source map range to the given node.
    *
    * @param node the node to which the range should be attached.

--- a/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
@@ -189,6 +189,13 @@ export class ExpressionTranslatorVisitor<TFile, TStatement, TExpression>
     return this.setSourceMapRange(this.factory.createLiteral(ast.value), ast.sourceSpan);
   }
 
+  visitRegularExpressionLiteral(ast: o.outputAst.RegularExpressionLiteral, context: any) {
+    return this.setSourceMapRange(
+      this.factory.createRegularExpressionLiteral(ast.body, ast.flags),
+      ast.sourceSpan,
+    );
+  }
+
   visitLocalizedString(ast: o.LocalizedString, context: Context): TExpression {
     // A `$localize` message consists of `messageParts` and `expressions`, which get interleaved
     // together. The interleaved pieces look like:

--- a/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
@@ -189,6 +189,10 @@ class TypeTranslatorVisitor implements o.ExpressionVisitor, o.TypeVisitor {
     throw new Error('Method not implemented.');
   }
 
+  visitRegularExpressionLiteral(ast: o.outputAst.RegularExpressionLiteral, context: any) {
+    throw new Error('Method not implemented.');
+  }
+
   visitNotExpr(ast: o.NotExpr, context: Context) {
     throw new Error('Method not implemented.');
   }

--- a/packages/compiler-cli/src/ngtsc/translator/src/typescript_ast_factory.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/typescript_ast_factory.ts
@@ -341,6 +341,10 @@ export class TypeScriptAstFactory implements AstFactory<ts.Statement, ts.Express
     );
   }
 
+  createRegularExpressionLiteral(body: string, flags: string | null): ts.Expression {
+    return ts.factory.createRegularExpressionLiteral(`/${body}/${flags ?? ''}`);
+  }
+
   setSourceMapRange<T extends ts.Node>(node: T, sourceMapRange: SourceMapRange | null): T {
     if (sourceMapRange === null) {
       return node;

--- a/packages/compiler-cli/src/ngtsc/translator/test/typescript_ast_factory_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/test/typescript_ast_factory_spec.ts
@@ -475,6 +475,20 @@ describe('TypeScriptAstFactory', () => {
     });
   });
 
+  describe('createRegularExpressionLiteral()', () => {
+    it('should create a regular expressions without flags', () => {
+      const {generate} = setupStatements();
+      const regex = factory.createRegularExpressionLiteral('^\\d+-foo$', null);
+      expect(generate(regex)).toEqual('/^\\d+-foo$/');
+    });
+
+    it('should create a regular expressions with flags', () => {
+      const {generate} = setupStatements();
+      const regex = factory.createRegularExpressionLiteral('^\\d+-foo$', 'gi');
+      expect(generate(regex)).toEqual('/^\\d+-foo$/gi');
+    });
+  });
+
   describe('setSourceMapRange()', () => {
     it('should attach the `sourceMapRange` to the given `node`', () => {
       const {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -26,6 +26,7 @@ import {
   ParenthesizedExpression,
   PrefixNot,
   PropertyRead,
+  RegularExpressionLiteral,
   SafeCall,
   SafeKeyedRead,
   SafePropertyRead,
@@ -197,6 +198,10 @@ class AstTranslator implements AstVisitor {
 
   visitThisReceiver(ast: ThisReceiver): never {
     throw new Error('Method not implemented.');
+  }
+
+  visitRegularExpressionLiteral(ast: RegularExpressionLiteral, context: any) {
+    throw new Error('TODO');
   }
 
   visitInterpolation(ast: Interpolation): ts.Expression {
@@ -602,5 +607,8 @@ class VeSafeLhsInferenceBugDetector implements AstVisitor {
   }
   visitParenthesizedExpression(ast: ParenthesizedExpression, context: any) {
     return ast.expression.visit(this);
+  }
+  visitRegularExpressionLiteral(ast: RegularExpressionLiteral, context: any) {
+    return false;
   }
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -201,7 +201,9 @@ class AstTranslator implements AstVisitor {
   }
 
   visitRegularExpressionLiteral(ast: RegularExpressionLiteral, context: any) {
-    throw new Error('TODO');
+    return wrapForTypeChecker(
+      ts.factory.createRegularExpressionLiteral(`/${ast.body}/${ast.flags ?? ''}`),
+    );
   }
 
   visitInterpolation(ast: Interpolation): ts.Expression {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -208,6 +208,11 @@ describe('type check blocks', () => {
     );
   });
 
+  it('should generate regular expressions', () => {
+    const TEMPLATE = '{{ /\\d+/g.test("123") }}';
+    expect(tcb(TEMPLATE)).toContain('(((/\\d+/g)).test("123"))');
+  });
+
   describe('type constructors', () => {
     it('should handle missing property bindings', () => {
       const TEMPLATE = `<div dir [inputA]="foo"></div>`;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/GOLDEN_PARTIAL.js
@@ -841,3 +841,61 @@ export declare class MyApp {
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "my-app", never, {}, {}, never, never, true, never>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: regular_expression_without_global_flag.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class TestComp {
+    constructor() {
+        this.value = '123';
+    }
+}
+TestComp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestComp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+TestComp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: TestComp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `{{/^hello/i.test(value)}}`, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestComp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `{{/^hello/i.test(value)}}`,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: regular_expression_without_global_flag.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class TestComp {
+    value: string;
+    static ɵfac: i0.ɵɵFactoryDeclaration<TestComp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<TestComp, "ng-component", never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: regular_expression_with_global_flag.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class TestComp {
+    constructor() {
+        this.value = '123';
+    }
+}
+TestComp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestComp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+TestComp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: TestComp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `{{/^hello/g.test(value)}}`, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestComp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `{{/^hello/g.test(value)}}`,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: regular_expression_with_global_flag.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class TestComp {
+    value: string;
+    static ɵfac: i0.ɵɵFactoryDeclaration<TestComp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<TestComp, "ng-component", never, {}, {}, never, never, true, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/TEST_CASES.json
@@ -277,6 +277,26 @@
           "files": ["tagged_template_literals.js"]
         }
       ]
+    },
+    {
+      "description": "should optimize regular expressions without flags",
+      "inputFiles": ["regular_expression_without_global_flag.ts"],
+      "expectations": [
+        {
+          "failureMessage": "Invalid template",
+          "files": ["regular_expression_without_global_flag.js"]
+        }
+      ]
+    },
+    {
+      "description": "should not optimize global regular expressions",
+      "inputFiles": ["regular_expression_with_global_flag.ts"],
+      "expectations": [
+        {
+          "failureMessage": "Invalid template",
+          "files": ["regular_expression_with_global_flag.js"]
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/regular_expression_with_global_flag.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/regular_expression_with_global_flag.js
@@ -1,0 +1,8 @@
+function TestComp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+  }
+  if (rf & 2) {
+    $r3$.ɵɵtextInterpolate(/^hello/g.test(ctx.value));
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/regular_expression_with_global_flag.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/regular_expression_with_global_flag.ts
@@ -1,0 +1,8 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `{{/^hello/g.test(value)}}`,
+})
+export class TestComp {
+  value = '123';
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/regular_expression_without_global_flag.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/regular_expression_without_global_flag.js
@@ -1,0 +1,10 @@
+const $_c0$ = /^hello/i;
+…
+function TestComp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+  }
+  if (rf & 2) {
+    $r3$.ɵɵtextInterpolate($_c0$.test(ctx.value));
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/regular_expression_without_global_flag.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/regular_expression_without_global_flag.ts
@@ -1,0 +1,8 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `{{/^hello/i.test(value)}}`,
+})
+export class TestComp {
+  value = '123';
+}

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -8606,5 +8606,51 @@ suppress
         );
       });
     });
+
+    describe('regular expressions', () => {
+      it('should infer the type of a regular expression literal', () => {
+        env.write(
+          'test.ts',
+          `
+            import {Component} from '@angular/core';
+
+            @Component({
+              template: '{{acceptsNumber(/123/)}}',
+            })
+            class TestCmp {
+              acceptsNumber(value: number) {}
+            }
+          `,
+        );
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText).toBe(
+          `Argument of type 'RegExp' is not assignable to parameter of type 'number'.`,
+        );
+      });
+
+      it('should infer the type of methods on a regular expression literal', () => {
+        env.write(
+          'test.ts',
+          `
+            import {Component} from '@angular/core';
+
+            @Component({
+              template: '{{acceptsNumber(/123/.test("hello"))}}',
+            })
+            class TestCmp {
+              acceptsNumber(value: number) {}
+            }
+          `,
+        );
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText).toBe(
+          `Argument of type 'boolean' is not assignable to parameter of type 'number'.`,
+        );
+      });
+    });
   });
 });

--- a/packages/compiler/src/constant_pool.ts
+++ b/packages/compiler/src/constant_pool.ts
@@ -311,6 +311,8 @@ export class GenericKeyFn implements ExpressionKeyFn {
       return `"${expr.value}"`;
     } else if (expr instanceof o.LiteralExpr) {
       return String(expr.value);
+    } else if (expr instanceof o.RegularExpressionLiteral) {
+      return `/${expr.body}/${expr.flags ?? ''}`;
     } else if (expr instanceof o.LiteralArrayExpr) {
       const entries: string[] = [];
       for (const entry of expr.entries) {

--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -488,6 +488,21 @@ export class ParenthesizedExpression extends AST {
   }
 }
 
+export class RegularExpressionLiteral extends AST {
+  constructor(
+    span: ParseSpan,
+    sourceSpan: AbsoluteSourceSpan,
+    readonly body: string,
+    readonly flags: string | null,
+  ) {
+    super(span, sourceSpan);
+  }
+
+  override visit(visitor: AstVisitor, context?: any) {
+    return visitor.visitRegularExpressionLiteral(this, context);
+  }
+}
+
 /**
  * Records the absolute position of a text span in a source file, where `start` and `end` are the
  * starting and ending byte offsets, respectively, of the text span in a source file.
@@ -617,6 +632,7 @@ export interface AstVisitor {
   visitTemplateLiteralElement(ast: TemplateLiteralElement, context: any): any;
   visitTaggedTemplateLiteral(ast: TaggedTemplateLiteral, context: any): any;
   visitParenthesizedExpression(ast: ParenthesizedExpression, context: any): any;
+  visitRegularExpressionLiteral(ast: RegularExpressionLiteral, context: any): any;
   visitASTWithSource?(ast: ASTWithSource, context: any): any;
   /**
    * This function is optionally defined to allow classes that implement this
@@ -719,6 +735,7 @@ export class RecursiveAstVisitor implements AstVisitor {
   visitParenthesizedExpression(ast: ParenthesizedExpression, context: any) {
     this.visit(ast.expression, context);
   }
+  visitRegularExpressionLiteral(ast: RegularExpressionLiteral, context: any) {}
   // This is not part of the AstVisitor interface, just a helper method
   visitAll(asts: AST[], context: any): any {
     for (const ast of asts) {

--- a/packages/compiler/src/expression_parser/lexer.ts
+++ b/packages/compiler/src/expression_parser/lexer.ts
@@ -16,6 +16,8 @@ export enum TokenType {
   String,
   Operator,
   Number,
+  RegExpBody,
+  RegExpFlags,
   Error,
 }
 
@@ -128,6 +130,14 @@ export class Token {
     return this.type === TokenType.Error;
   }
 
+  isRegExpBody(): boolean {
+    return this.type === TokenType.RegExpBody;
+  }
+
+  isRegExpFlags(): boolean {
+    return this.type === TokenType.RegExpFlags;
+  }
+
   toNumber(): number {
     return this.type === TokenType.Number ? this.numValue : -1;
   }
@@ -159,6 +169,8 @@ export class Token {
       case TokenType.PrivateIdentifier:
       case TokenType.String:
       case TokenType.Error:
+      case TokenType.RegExpBody:
+      case TokenType.RegExpFlags:
         return this.strValue;
       case TokenType.Number:
         return this.numValue.toString();
@@ -205,6 +217,14 @@ function newNumberToken(index: number, end: number, n: number): Token {
 
 function newErrorToken(index: number, end: number, message: string): Token {
   return new Token(index, end, TokenType.Error, 0, message);
+}
+
+function newRegExpBodyToken(index: number, end: number, text: string): Token {
+  return new Token(index, end, TokenType.RegExpBody, 0, text);
+}
+
+function newRegExpFlagsToken(index: number, end: number, text: string): Token {
+  return new Token(index, end, TokenType.RegExpFlags, 0, text);
 }
 
 export const EOF: Token = new Token(-1, -1, TokenType.Character, 0, '');
@@ -300,6 +320,9 @@ class _Scanner {
       case chars.$MINUS:
         return this.scanComplexOperator(start, '-', chars.$EQ, '=');
       case chars.$SLASH:
+        if (this.isStartOfRegex()) {
+          return this.scanRegex(index);
+        }
         return this.scanComplexOperator(start, '/', chars.$EQ, '=');
       case chars.$PERCENT:
         return this.scanComplexOperator(start, '%', chars.$EQ, '=');
@@ -605,6 +628,78 @@ class _Scanner {
     }
 
     return newOperatorToken(start, this.index, operator);
+  }
+
+  private isStartOfRegex(): boolean {
+    if (this.tokens.length === 0) {
+      return true;
+    }
+
+    const lastToken = this.tokens[this.tokens.length - 1];
+
+    return (
+      !lastToken.isIdentifier() &&
+      !lastToken.isPrivateIdentifier() &&
+      !lastToken.isNumber() &&
+      !lastToken.isString() &&
+      !lastToken.isKeyword() &&
+      !lastToken.isCharacter(chars.$RPAREN) &&
+      !lastToken.isCharacter(chars.$RBRACKET)
+    );
+  }
+
+  private scanRegex(tokenStart: number): Token {
+    this.advance();
+    const textStart = this.index;
+    let inEscape = false;
+    let inCharacterClass = false;
+
+    while (true) {
+      const peek = this.peek;
+
+      if (peek === chars.$EOF) {
+        return this.error('Unterminated regular expression', 0);
+      }
+
+      if (inEscape) {
+        inEscape = false;
+      } else if (peek === chars.$BACKSLASH) {
+        inEscape = true;
+      } else if (peek === chars.$LBRACKET) {
+        inCharacterClass = true;
+      } else if (peek === chars.$RBRACKET) {
+        inCharacterClass = false;
+      } else if (peek === chars.$SLASH && !inCharacterClass) {
+        break;
+      }
+      this.advance();
+    }
+
+    // Note that we want the text without the slashes,
+    // but we still want the slashes to be part of the span.
+    const value = this.input.substring(textStart, this.index);
+    this.advance();
+    const bodyToken = newRegExpBodyToken(tokenStart, this.index, value);
+    const flagsToken = this.scanRegexFlags(this.index);
+
+    if (flagsToken !== null) {
+      this.tokens.push(bodyToken);
+      return flagsToken;
+    }
+
+    return bodyToken;
+  }
+
+  private scanRegexFlags(start: number): Token | null {
+    if (!chars.isAsciiLetter(this.peek)) {
+      return null;
+    }
+
+    while (chars.isAsciiLetter(this.peek)) {
+      this.advance();
+    }
+
+    return newRegExpFlagsToken(start, this.index, this.input.substring(start, this.index));
   }
 }
 

--- a/packages/compiler/src/expression_parser/serializer.ts
+++ b/packages/compiler/src/expression_parser/serializer.ts
@@ -129,6 +129,10 @@ class SerializeExpressionVisitor implements expr.AstVisitor {
     return `void ${ast.expression.visit(this, context)}`;
   }
 
+  visitRegularExpressionLiteral(ast: expr.RegularExpressionLiteral, context: any) {
+    return `/${ast.body}/${ast.flags || ''}`;
+  }
+
   visitASTWithSource(ast: expr.ASTWithSource, context: any): string {
     return ast.ast.visit(this, context);
   }

--- a/packages/compiler/src/output/abstract_emitter.ts
+++ b/packages/compiler/src/output/abstract_emitter.ts
@@ -353,6 +353,11 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     return null;
   }
 
+  visitRegularExpressionLiteral(ast: o.RegularExpressionLiteral, ctx: EmitterVisitorContext): any {
+    ctx.print(ast, `/${ast.body}/${ast.flags || ''}`);
+    return null;
+  }
+
   visitLocalizedString(ast: o.LocalizedString, ctx: EmitterVisitorContext): any {
     const head = ast.serializeI18nHead();
     ctx.print(ast, '$localize `' + head.raw);

--- a/packages/compiler/src/output/output_ast.ts
+++ b/packages/compiler/src/output/output_ast.ts
@@ -538,6 +538,32 @@ export class InstantiateExpr extends Expression {
   }
 }
 
+export class RegularExpressionLiteral extends Expression {
+  constructor(
+    public body: string,
+    public flags: string | null,
+    sourceSpan?: ParseSourceSpan | null,
+  ) {
+    super(null, sourceSpan);
+  }
+
+  override isEquivalent(e: Expression): boolean {
+    return e instanceof RegularExpressionLiteral && this.body === e.body && this.flags === e.flags;
+  }
+
+  override isConstant() {
+    return true;
+  }
+
+  override visitExpression(visitor: ExpressionVisitor, context: any): any {
+    return visitor.visitRegularExpressionLiteral(this, context);
+  }
+
+  override clone(): RegularExpressionLiteral {
+    return new RegularExpressionLiteral(this.body, this.flags, this.sourceSpan);
+  }
+}
+
 export class LiteralExpr extends Expression {
   constructor(
     public value: number | string | boolean | null | undefined,
@@ -1400,6 +1426,7 @@ export interface ExpressionVisitor {
   visitVoidExpr(ast: VoidExpr, context: any): any;
   visitArrowFunctionExpr(ast: ArrowFunctionExpr, context: any): any;
   visitParenthesizedExpr(ast: ParenthesizedExpr, context: any): any;
+  visitRegularExpressionLiteral(ast: RegularExpressionLiteral, context: any): any;
 }
 
 export const NULL_EXPR = new LiteralExpr(null, null, null);
@@ -1625,6 +1652,9 @@ export class RecursiveAstVisitor implements StatementVisitor, ExpressionVisitor 
     return this.visitExpression(ast, context);
   }
   visitLiteralExpr(ast: LiteralExpr, context: any): any {
+    return this.visitExpression(ast, context);
+  }
+  visitRegularExpressionLiteral(ast: RegularExpressionLiteral, context: any): any {
     return this.visitExpression(ast, context);
   }
   visitLocalizedString(ast: LocalizedString, context: any): any {

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -1320,7 +1320,8 @@ export function transformExpressionsInExpression(
   } else if (
     expr instanceof o.ReadVarExpr ||
     expr instanceof o.ExternalExpr ||
-    expr instanceof o.LiteralExpr
+    expr instanceof o.LiteralExpr ||
+    expr instanceof o.RegularExpressionLiteral
   ) {
     // No action for these types.
   } else {

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -60,6 +60,7 @@ import {createVariadicPipes} from './phases/pipe_variadic';
 import {propagateI18nBlocks} from './phases/propagate_i18n_blocks';
 import {extractPureFunctions} from './phases/pure_function_extraction';
 import {generatePureLiteralStructures} from './phases/pure_literal_structures';
+import {optimizeRegularExpressions} from './phases/regular_expression_optimization';
 import {reify} from './phases/reify';
 import {removeEmptyBindings} from './phases/remove_empty_bindings';
 import {removeI18nContexts} from './phases/remove_i18n_contexts';
@@ -101,6 +102,7 @@ type Phase =
 
 const phases: Phase[] = [
   {kind: Kind.Tmpl, fn: removeContentSelectors},
+  {kind: Kind.Both, fn: optimizeRegularExpressions},
   {kind: Kind.Host, fn: parseHostStyleProperties},
   {kind: Kind.Tmpl, fn: emitNamespaceChanges},
   {kind: Kind.Tmpl, fn: propagateI18nBlocks},

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -1198,6 +1198,8 @@ function convertAst(
       undefined,
       convertSourceSpan(ast.span, baseSourceSpan),
     );
+  } else if (ast instanceof e.RegularExpressionLiteral) {
+    return new o.RegularExpressionLiteral(ast.body, ast.flags, baseSourceSpan);
   } else {
     throw new Error(
       `Unhandled expression type "${ast.constructor.name}" in file "${baseSourceSpan?.start.file.url}"`,

--- a/packages/compiler/src/template/pipeline/src/phases/regular_expression_optimization.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/regular_expression_optimization.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {GenericKeyFn, SharedConstantDefinition} from '../../../../constant_pool';
+import * as o from '../../../../output/output_ast';
+import * as ir from '../../ir';
+
+import type {CompilationJob} from '../compilation';
+
+/** Optimizes regular expressions used in expressions. */
+export function optimizeRegularExpressions(job: CompilationJob): void {
+  for (const view of job.units) {
+    for (const op of view.ops()) {
+      ir.transformExpressionsInOp(
+        op,
+        (expr) => {
+          if (
+            expr instanceof o.RegularExpressionLiteral &&
+            // We can't optimize global regexes, because they're stateful.
+            (expr.flags === null || !expr.flags.includes('g'))
+          ) {
+            return job.pool.getSharedConstant(new RegularExpressionConstant(), expr);
+          }
+          return expr;
+        },
+        ir.VisitorContextFlag.None,
+      );
+    }
+  }
+}
+
+class RegularExpressionConstant extends GenericKeyFn implements SharedConstantDefinition {
+  toSharedConstantDeclaration(declName: string, keyExpr: o.Expression): o.Statement {
+    return new o.DeclareVarStmt(declName, keyExpr, undefined, o.StmtModifier.Final);
+  }
+}

--- a/packages/compiler/test/expression_parser/utils/unparser.ts
+++ b/packages/compiler/test/expression_parser/utils/unparser.ts
@@ -26,6 +26,7 @@ import {
   PrefixNot,
   PropertyRead,
   RecursiveAstVisitor,
+  RegularExpressionLiteral,
   SafeCall,
   SafeKeyedRead,
   SafePropertyRead,
@@ -235,6 +236,10 @@ class Unparser implements AstVisitor {
     this._expression += '(';
     this._visit(ast.expression);
     this._expression += ')';
+  }
+
+  visitRegularExpressionLiteral(ast: RegularExpressionLiteral, context: any) {
+    this._expression += `/${ast.body}/${ast.flags || ''}`;
   }
 
   private _visit(ast: AST) {

--- a/packages/compiler/test/expression_parser/utils/validator.ts
+++ b/packages/compiler/test/expression_parser/utils/validator.ts
@@ -24,6 +24,7 @@ import {
   PrefixNot,
   PropertyRead,
   RecursiveAstVisitor,
+  RegularExpressionLiteral,
   SafeCall,
   SafeKeyedRead,
   SafePropertyRead,
@@ -154,6 +155,10 @@ class ASTValidator extends RecursiveAstVisitor {
 
   override visitParenthesizedExpression(ast: ParenthesizedExpression, context: any): void {
     this.validate(ast, () => super.visitParenthesizedExpression(ast, context));
+  }
+
+  override visitRegularExpressionLiteral(ast: RegularExpressionLiteral, context: any): void {
+    this.validate(ast, () => super.visitRegularExpressionLiteral(ast, context));
   }
 }
 

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -127,6 +127,10 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
     this.recordAst(ast);
     super.visitParenthesizedExpression(ast, null);
   }
+  override visitRegularExpressionLiteral(ast: e.RegularExpressionLiteral, context: any): void {
+    this.recordAst(ast);
+    super.visitRegularExpressionLiteral(ast, null);
+  }
 
   visitTemplate(ast: t.Template) {
     t.visitAll(this, ast.directives);

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -2702,6 +2702,23 @@ describe('acceptance integration tests', () => {
     expect(fixture.nativeElement.textContent).toContain('Message: Hello, Bilbo - 1');
   });
 
+  it('should support regular expressions in templates', () => {
+    @Component({
+      template: 'Matches: {{/\\d+/.test(value)}}',
+    })
+    class App {
+      value = '123';
+    }
+
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toBe('Matches: true');
+
+    fixture.componentInstance.value = 'hello';
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toBe('Matches: false');
+  });
+
   it('should support void expressions', () => {
     @Component({
       host: {


### PR DESCRIPTION
Updates the template syntax to support inline regular expressions. Also includes some logic to reuse regular expressions between call sites, unless they're marked as global.