### PR TITLE
build: enable minimumReleaseAge to mitigate dependency chain attacks

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,3 +50,41 @@ overrides:
   '@angular/language-service': 'workspace: *'
   '@angular/localize': 'workspace: *'
   '@angular/upgrade': 'workspace: *'
+
+# The minimum age of a release to be considered for dependency installation.
+# The value is in minutes (1440 minutes = 1 day).
+minimumReleaseAge: 1440
+# List of packages to exclude from the minimum release age check.
+# Wildcards are not yet supported: https://github.com/pnpm/pnpm/issues/9983
+minimumReleaseAgeExclude:
+  - '@angular-devkit/architect'
+  - '@angular-devkit/build-angular'
+  - '@angular-devkit/build-webpack'
+  - '@angular-devkit/core'
+  - '@angular-devkit/schematics-cli'
+  - '@angular-devkit/schematics'
+  - '@angular-devkit/architect-cli'
+  - '@angular-devkit/architect'
+  - '@angular/animations'
+  - '@angular/benchpress'
+  - '@angular/cdk'
+  - '@angular/ng-dev'
+  - '@angular/cli'
+  - '@angular/ssr'
+  - '@angular/common'
+  - '@angular/compiler-cli'
+  - '@angular/compiler'
+  - '@angular/core'
+  - '@angular/forms'
+  - '@angular/language-service'
+  - '@angular/localize'
+  - '@angular/material'
+  - '@angular/material-moment-adapter'
+  - '@angular/platform-browser-dynamic'
+  - '@angular/platform-browser'
+  - '@angular/platform-server'
+  - '@angular/router'
+  - '@angular/service-worker'
+  - '@ngtools/webpack'
+  - '@schematics/angular'
+  - 'ng-packagr'


### PR DESCRIPTION
This change configures pnpm's `minimumReleaseAge` setting to 1 day (1440 minutes). This is a security measure to mitigate dependency chain attacks, where malicious actors publish a new version of a dependency with malicious code and then trick users into updating to it before it can be discovered and reported.

By delaying the adoption of new releases, we reduce the window of opportunity for such attacks. The list of excluded packages contains trusted and frequently updated dependencies from the Angular team, which are considered safe to use without this delay.
