### PR TITLE
docs(docs-infra): include page/URL fragments in the search results

### DIFF
--- a/adev/shared-docs/components/search-dialog/search-dialog.component.html
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.html
@@ -12,35 +12,49 @@
     @if (searchResults().length) {
       <ul class="docs-search-results docs-mini-scroll-track">
         @for (result of searchResults(); track result.id) {
-          <li docsSearchItem [item]="result">
+          <li docsSearchItem [item]="result" class="docs-search-result">
             <a
               [routerLink]="'/' + result.url | relativeLink: 'pathname'"
               [fragment]="result.url | relativeLink: 'hash'"
               (click)="history.addItem(result)"
             >
               <div>
-                <div class="docs-result-icon-and-type">
+                <p class="docs-search-result__label">
                   <!-- Icon -->
                   <span class="docs-search-result-icon" aria-hidden="true">
                     <i role="presentation" class="material-symbols-outlined docs-icon-small">
                       {{ result.type === 'code' ? 'code' : 'description'}}
                     </i>
                   </span>
-                  <!-- Results type -->
-                  <span class="docs-search-results__type" [innerHtml]="result.labelHtml"></span>
-                </div>
+
+                  <!-- Page title -->
+                  <span [innerHtml]="result.labelHtml"></span>
+                  @if (result.package) {
+                    <span
+                      [innerHTML]="result.package"
+                      class="docs-search-result__label__package"
+                    ></span>
+                  }
+                </p>
 
                 @if (result.subLabelHtml) {
-                  <span
-                    class="docs-search-results__type docs-search-results__lvl2"
-                    [innerHtml]="result.subLabelHtml"
-                  >
-                  </span>
+                  <p class="docs-search-result__sub-label">
+                    <span class="docs-search-result-icon" aria-hidden="true">
+                      <i role="presentation" class="material-symbols-outlined docs-icon-small">
+                        grid_3x3
+                      </i>
+                    </span>
+                    <span [innerHtml]="result.subLabelHtml"></span>
+                  </p>
+                }
+
+                @if (result.contentHtml) {
+                  <p class="docs-search-result__content" [innerHtml]="result.contentHtml"></p>
                 }
               </div>
-
-              <!-- Page title -->
-              <span class="docs-result-page-title">{{ result.category }}</span>
+              <p class="docs-search-result__category">
+                {{ result.category }}
+              </p>
             </a>
           </li>
         }

--- a/adev/shared-docs/components/search-dialog/search-dialog.component.scss
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.scss
@@ -38,11 +38,21 @@ dialog {
     margin: 0;
     border-block-end: 1px solid var(--senary-contrast);
 
-    li {
+    .docs-search-result {
       border-inline-start: 2px solid var(--senary-contrast);
       margin-inline-start: 1rem;
-      padding-inline-end: 1rem;
-      padding-block: 0.25rem;
+      display: block;
+      font-size: 0.875rem;
+
+      .docs-search-result-icon {
+        display: inline-block;
+
+        i {
+          display: flex;
+          align-items: center;
+          font-size: 1.2rem;
+        }
+      }
 
       /**
       * This rule needs ng-deep to be applied to elements that are created via a [innerHTML] binding
@@ -61,15 +71,48 @@ dialog {
         color: var(--secondary-contrast);
         display: flex;
         justify-content: space-between;
+        padding: 1rem;
         gap: 0.5rem;
+      }
 
-        .docs-search-result-icon {
-          i {
-            display: flex;
-            align-items: center;
-            font-size: 1.2rem;
-          }
+      &__label,
+      &__sub-label,
+      &__content {
+        transition: color 0.3s ease;
+      }
+
+      &__label,
+      &__sub-label {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        margin: 0;
+      }
+
+      &__label {
+        font-weight: 600;
+        flex-wrap: wrap;
+
+        &__package {
+          font-size: 0.75rem;
         }
+      }
+
+      &__content,
+      &__category {
+        margin: 0;
+      }
+
+      &__sub-label,
+      &__content {
+        margin-block-start: 0.375rem;
+        margin-inline-start: 2rem;
+        color: var(--quaternary-contrast);
+      }
+
+      &__category {
+        font-weight: 400;
+        color: var(--quaternary-contrast);
       }
 
       &.active {
@@ -80,44 +123,14 @@ dialog {
       &.active {
         background-color: var(--octonary-contrast); // stylelint-disable-line
         border-inline-start: 2px solid var(--primary-contrast);
-        a {
-          span:not(.docs-result-page-title),
-          .docs-search-results__type {
-            color: var(--primary-contrast);
-            i {
-              color: var(--primary-contrast);
-            }
-          }
+
+        .docs-search-result__label,
+        .docs-search-result__sub-label,
+        .docs-search-result__content {
+          color: var(--primary-contrast);
         }
       }
     }
-
-    .docs-search-result-icon,
-    .docs-search-results__type,
-    .docs-result-page-title {
-      color: var(--quaternary-contrast);
-      display: inline-block;
-      font-size: 0.875rem;
-      transition: color 0.3s ease;
-      padding: 0.75rem;
-      padding-inline-end: 0;
-    }
-
-    .docs-search-results__lvl2 {
-      display: inline-block;
-      margin-inline-start: 2rem;
-      padding-block-start: 0;
-    }
-
-    .docs-search-results__lvl3 {
-      margin-inline-start: 2rem;
-      padding-block-start: 0;
-    }
-  }
-
-  .docs-result-page-title {
-    font-size: 0.875rem;
-    font-weight: 400;
   }
 }
 
@@ -125,14 +138,6 @@ dialog {
 .docs-search-results__no-results {
   padding: 0.75rem;
   color: var(--gray-400);
-}
-
-.docs-result-icon-and-type {
-  display: flex;
-
-  .docs-search-results__type {
-    padding-inline-start: 0;
-  }
 }
 
 .docs-search-footer {

--- a/adev/shared-docs/components/search-history/BUILD.bazel
+++ b/adev/shared-docs/components/search-history/BUILD.bazel
@@ -22,6 +22,7 @@ ng_project(
     ],
     deps = [
         "//adev:node_modules/@angular/cdk",
+        "//adev:node_modules/@angular/common",
         "//adev:node_modules/@angular/core",
         "//adev:node_modules/@angular/router",
         "//adev/shared-docs/directives",

--- a/adev/shared-docs/components/search-history/search-history.component.html
+++ b/adev/shared-docs/components/search-history/search-history.component.html
@@ -1,3 +1,15 @@
+<ng-template #searchItem let-item="item" let-type="type">
+  <i role="presentation" class="material-symbols-outlined type-icon" aria-hidden="true">
+    {{ type === 'recent' ? 'history' : 'star' }}
+  </i>
+  <span [innerHTML]="item.labelHtml" class="label"></span>
+
+  @if (item.subLabelHtml) {
+    <i role="presentation" class="material-symbols-outlined" aria-hidden="true"> arrow_right </i>
+    <span [innerHTML]="item.subLabelHtml" class="sub-label"></span>
+  }
+</ng-template>
+
 @let items = history.items();
 
 @if (items.recent.length) {
@@ -10,8 +22,10 @@
           [fragment]="item.url | relativeLink: 'hash'"
           (click)="history.addItem(item)"
         >
-          <i role="presentation" class="material-symbols-outlined" aria-hidden="true"> history </i>
-          <span [innerHTML]="item.labelHtml"></span>
+          <ng-container
+            [ngTemplateOutlet]="searchItem"
+            [ngTemplateOutletContext]="{item, type: 'recent'}"
+          />
         </a>
 
         <button
@@ -20,7 +34,9 @@
           (click)="history.makeFavorite(item)"
           title="Make favorite"
         >
-          <i role="presentation" class="material-symbols-outlined" aria-hidden="true"> star </i>
+          <i role="presentation" class="material-symbols-outlined type-icon" aria-hidden="true">
+            star
+          </i>
         </button>
         <button
           type="button"
@@ -48,8 +64,10 @@
           [routerLink]="'/' + item.url | relativeLink: 'pathname'"
           [fragment]="item.url | relativeLink: 'hash'"
         >
-          <i role="presentation" class="material-symbols-outlined" aria-hidden="true"> star </i>
-          <span [innerHTML]="item.labelHtml"></span>
+          <ng-container
+            [ngTemplateOutlet]="searchItem"
+            [ngTemplateOutletContext]="{item, type: 'favorite'}"
+          />
         </a>
 
         <button

--- a/adev/shared-docs/components/search-history/search-history.component.scss
+++ b/adev/shared-docs/components/search-history/search-history.component.scss
@@ -41,9 +41,23 @@
         flex: 1;
         display: flex;
         align-items: center;
-        gap: 0.5rem;
         color: var(--secondary-contrast);
         transition: color 0.3s ease;
+        white-space: nowrap;
+        overflow: hidden;
+
+        .type-icon {
+          margin-inline-end: 0.75rem;
+        }
+
+        span {
+          text-overflow: ellipsis;
+          overflow: hidden;
+
+          &.sub-label {
+            flex: 1;
+          }
+        }
 
         &:hover {
           color: var(--primary-contrast);

--- a/adev/shared-docs/components/search-history/search-history.component.ts
+++ b/adev/shared-docs/components/search-history/search-history.component.ts
@@ -18,7 +18,7 @@ import {
 import {Router, RouterLink} from '@angular/router';
 import {toSignal} from '@angular/core/rxjs-interop';
 import {ActiveDescendantKeyManager} from '@angular/cdk/a11y';
-import {CommonModule} from '@angular/common';
+import {NgTemplateOutlet} from '@angular/common';
 
 import {SearchHistory} from '../../services';
 import {RelativeLink} from '../../pipes';
@@ -26,7 +26,7 @@ import {SearchItem} from '../../directives';
 
 @Component({
   selector: 'docs-search-history',
-  imports: [CommonModule, RelativeLink, RouterLink, SearchItem],
+  imports: [NgTemplateOutlet, RelativeLink, RouterLink, SearchItem],
   templateUrl: './search-history.component.html',
   styleUrl: './search-history.component.scss',
   host: {

--- a/adev/shared-docs/components/search-history/search-history.component.ts
+++ b/adev/shared-docs/components/search-history/search-history.component.ts
@@ -18,6 +18,7 @@ import {
 import {Router, RouterLink} from '@angular/router';
 import {toSignal} from '@angular/core/rxjs-interop';
 import {ActiveDescendantKeyManager} from '@angular/cdk/a11y';
+import {CommonModule} from '@angular/common';
 
 import {SearchHistory} from '../../services';
 import {RelativeLink} from '../../pipes';
@@ -25,7 +26,7 @@ import {SearchItem} from '../../directives';
 
 @Component({
   selector: 'docs-search-history',
-  imports: [RelativeLink, RouterLink, SearchItem],
+  imports: [CommonModule, RelativeLink, RouterLink, SearchItem],
   templateUrl: './search-history.component.html',
   styleUrl: './search-history.component.scss',
   host: {

--- a/adev/shared-docs/interfaces/search-results.ts
+++ b/adev/shared-docs/interfaces/search-results.ts
@@ -60,6 +60,8 @@ export interface SearchResultItem {
   type: 'doc' | 'code';
   labelHtml: string | null;
   subLabelHtml: string | null;
+  contentHtml: string | null;
+  package: string | null;
   url: string;
 
   id: string;

--- a/adev/shared-docs/services/search-history.service.ts
+++ b/adev/shared-docs/services/search-history.service.ts
@@ -19,9 +19,14 @@ export const MAX_RECENT_HISTORY_SIZE = 10;
 export interface HistoryItem {
   id: string;
   labelHtml: string;
+  subLabelHtml?: string;
   url: string;
   isFavorite: boolean;
   createdAt: number;
+}
+
+function cleanUpHtml(label: string | null): string {
+  return (label || '').replace(/<\/?mark>/g, '');
 }
 
 @Injectable({providedIn: 'root'})
@@ -46,11 +51,10 @@ export class SearchHistory {
 
   addItem(item: SearchResultItem | HistoryItem): void {
     this.updateHistory((map) => {
-      const labelHtml = (item.labelHtml || '').replace(/<\/?mark>/g, '');
-
       map.set(item.id, {
         id: item.id,
-        labelHtml,
+        labelHtml: cleanUpHtml(item.labelHtml),
+        subLabelHtml: item.subLabelHtml ? cleanUpHtml(item.subLabelHtml) : undefined,
         url: item.url,
         isFavorite: false,
         createdAt: Date.now(),

--- a/adev/shared-docs/services/search.service.ts
+++ b/adev/shared-docs/services/search.service.ts
@@ -144,13 +144,8 @@ export class Search {
     return this.getUniqueSearchResultItems(items).map((hitItem: SearchResult): SearchResultItem => {
       const content = hitItem._snippetResult.content;
       const hierarchy = hitItem._snippetResult.hierarchy;
-      const type = hitItem.hierarchy.lvl0 === 'Tutorials' ? 'code' : 'doc';
       const category = hitItem.hierarchy?.lvl0 ?? null;
-      const hasSubLabel = content || hierarchy?.lvl2 || hierarchy?.lvl3 || hierarchy?.lvl4;
-      const subLabelHtml =
-        category === 'Reference'
-          ? extractPackageNameFromUrl(hitItem.url)
-          : this.parseLabelToHtml(hasSubLabel ? this.getBestSnippetForMatch(hitItem) : null);
+      const hasSubLabel = hierarchy?.lvl2 || hierarchy?.lvl3 || hierarchy?.lvl4;
 
       return {
         id: hitItem.objectID,
@@ -158,18 +153,18 @@ export class Search {
         url: hitItem.url,
 
         labelHtml: this.parseLabelToHtml(hitItem._snippetResult.hierarchy?.lvl1?.value ?? ''),
-        subLabelHtml,
+        subLabelHtml: this.parseLabelToHtml(
+          hasSubLabel ? this.getBestSnippetForMatch(hitItem) : null,
+        ),
+        contentHtml: content ? this.parseLabelToHtml(content.value) : null,
+        package: category === 'Reference' ? extractPackageNameFromUrl(hitItem.url) : null,
+
         category: hitItem.hierarchy?.lvl0 ?? null,
       };
     });
   }
 
   private getBestSnippetForMatch(result: SearchResult): string {
-    // if there is content, return it
-    if (result._snippetResult.content !== undefined) {
-      return result._snippetResult.content.value;
-    }
-
     const hierarchy = result._snippetResult.hierarchy;
     if (hierarchy === undefined) {
       return '';
@@ -242,5 +237,5 @@ function extractPackageNameFromUrl(url: string): string | null {
   if (extractedSegment == null) {
     return null;
   }
-  return `From <code>@angular/${extractedSegment[1]}</code>`;
+  return `<code>@angular/${extractedSegment[1]}</code>`;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] angular.dev application / infrastructure changes

## What is the new behavior?

This a small feature proposal that, hopefully, further improves the search functionality. 

Currently, we are only including the page/URL fragment that represents a sub-title only if there isn't a content snippet that matches the search query. This change basically includes that fragment/sub-title in all cases. The motivation for this change is the search history, where two identical results can open different parts of the respective page, since we are storing only the page titles (e.g. `HttpClient > API` and `HttpClient > Usage Notes` will result in two `HttpClient` entries in the history). This is misleading for me personally, and it seems like bad UX.

**Search results:**
<img width="754" height="546" alt="Screenshot 2025-09-17 at 15 57 51" src="https://github.com/user-attachments/assets/7f260707-e817-4ea8-b487-0626a31ba32f" />

**Search history:**
<img width="757" height="412" alt="Screenshot 2025-09-17 at 16 06 08" src="https://github.com/user-attachments/assets/c86f7ea8-47fc-4e24-9af2-423517589c09" />

Let me know if you have any remarks or suggestions.

