### PR TITLE
build: allocate 4 CPUs for production adev build

### DIFF
--- a/.github/workflows/adev-preview-build.yml
+++ b/.github/workflows/adev-preview-build.yml
@@ -15,7 +15,7 @@ permissions: read-all
 
 jobs:
   adev-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8core
     if: |
       (github.event.action == 'labeled' && github.event.label.name == 'adev: preview') ||
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'adev: preview'))
@@ -28,7 +28,7 @@ jobs:
         uses: angular/dev-infra/github-actions/bazel/configure-remote@d776aff2258f15fc3dc1e63852887518eec3ad75
       - name: Install node modules
         run: pnpm install --frozen-lockfile
-      - name: Build adev to ensure it continues to work
+      - name: Build adev
         run: pnpm bazel build //adev:build.production
       - uses: angular/dev-infra/github-actions/previews/pack-and-upload-artifact@d776aff2258f15fc3dc1e63852887518eec3ad75
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,8 +116,6 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Run tests
         run: pnpm bazel test //adev/...
-      - name: Build adev in fast mode to ensure it continues to work
-        run: pnpm bazel build //adev:build
 
   publish-snapshots:
     runs-on:
@@ -193,7 +191,7 @@ jobs:
   adev-deploy:
     needs: [adev]
     if: needs.adev.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8core
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@d776aff2258f15fc3dc1e63852887518eec3ad75
@@ -203,7 +201,7 @@ jobs:
         uses: angular/dev-infra/github-actions/bazel/configure-remote@d776aff2258f15fc3dc1e63852887518eec3ad75
       - name: Install node modules
         run: pnpm install --frozen-lockfile
-      - name: Build adev to ensure it continues to work
+      - name: Build adev
         run: pnpm bazel build //adev:build.production
       - name: Deploy to firebase
         uses: ./.github/actions/deploy-docs-site

--- a/adev/BUILD.bazel
+++ b/adev/BUILD.bazel
@@ -109,6 +109,7 @@ ng_application(
     ],
     env = {
         "NG_BUILD_PARTIAL_SSR": "1",
+        "NG_BUILD_OPTIMIZE_CHUNK2XSx": "2",
     },
     ng_config = ":ng_config",
     node_modules = "//adev:node_modules",
@@ -120,6 +121,8 @@ ng_application(
     tags = [
         # Tagged as manual as both build and build.production use the same output directory.
         "manual",
+        # RBE will significantly slow down the build because the CLI invokes multiple, CPU-intensive instances of esbuild.
+        "no-remote-exec",
     ],
 )
 
@@ -132,6 +135,7 @@ ng_application(
     ],
     env = {
         "NG_BUILD_OPTIMIZE_CHUNKS": "1",
+        "NG_BUILD_OPTIMIZE_CHUNK2XSx": "2",
     },
     ng_config = ":ng_config",
     node_modules = "//adev:node_modules",
@@ -143,6 +147,8 @@ ng_application(
     tags = [
         # Tagged as manual as both build and build.production use the same output directory.
         "manual",
+        # RBE will significantly slow down the build because the CLI invokes multiple, CPU-intensive instances of esbuild.
+        "no-remote-exec",
     ],
 )
 

--- a/adev/src/main.ts
+++ b/adev/src/main.ts
@@ -11,3 +11,5 @@ import {appConfig} from './app/app.config';
 import {AppComponent} from './app/app.component';
 
 bootstrapApplication(AppComponent, appConfig).catch((err) => console.error(err));
+
+console.log('foo12');


### PR DESCRIPTION
The production build of the `adev` application is CPU-intensive. This change allocates 4 CPUs to the Bazel target to potentially improve build times.

Additionally, the adev-preview-build workflow is updated to use 4 CPUs for the build step, aligning the CI environment with this new configuration for better performance and consis