### PR TITLE
refactor(platform-browser): Remove zone provideres from BrowserTestin…

### DIFF
--- a/packages/platform-browser/testing/src/browser.ts
+++ b/packages/platform-browser/testing/src/browser.ts
@@ -38,8 +38,6 @@ export const platformBrowserTesting: (extraProviders?: StaticProvider[]) => Plat
   exports: [BrowserModule],
   providers: [
     {provide: APP_ID, useValue: 'a'},
-    provideZonelessChangeDetectionInternal(),
-    ZONELESS_BY_DEFAULT ? [] : internalProvideZoneChangeDetection({}),
     ɵprovideFakePlatformNavigation(),
     {provide: TestComponentRenderer, useClass: DOMTestComponentRenderer},
   ],


### PR DESCRIPTION
…gModule

This removes the Zone providers from the `BrowserTestingModule`. These already exist by default in all other entrypoints to Angular environments (TestBed compiler, bootstrapModule, and createApplication).
