### PR TITLE
refactor(core): protect InjectionToken usage of `ngDevMode`

### DIFF
--- a/packages/common/http/src/interceptor.ts
+++ b/packages/common/http/src/interceptor.ts
@@ -190,14 +190,14 @@ export function chainedInterceptorFn(
  * @publicApi
  */
 export const HTTP_INTERCEPTORS = new InjectionToken<readonly HttpInterceptor[]>(
-  ngDevMode ? 'HTTP_INTERCEPTORS' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'HTTP_INTERCEPTORS' : '',
 );
 
 /**
  * A multi-provided token of `HttpInterceptorFn`s.
  */
 export const HTTP_INTERCEPTOR_FNS = new InjectionToken<readonly HttpInterceptorFn[]>(
-  ngDevMode ? 'HTTP_INTERCEPTOR_FNS' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'HTTP_INTERCEPTOR_FNS' : '',
   {factory: () => []},
 );
 
@@ -205,14 +205,14 @@ export const HTTP_INTERCEPTOR_FNS = new InjectionToken<readonly HttpInterceptorF
  * A multi-provided token of `HttpInterceptorFn`s that are only set in root.
  */
 export const HTTP_ROOT_INTERCEPTOR_FNS = new InjectionToken<readonly HttpInterceptorFn[]>(
-  ngDevMode ? 'HTTP_ROOT_INTERCEPTOR_FNS' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'HTTP_ROOT_INTERCEPTOR_FNS' : '',
 );
 
 // TODO(atscott): We need a larger discussion about stability and what should contribute to stability.
 // Should the whole interceptor chain contribute to stability or just the backend request #55075?
 // Should HttpClient contribute to stability automatically at all?
 export const REQUESTS_CONTRIBUTE_TO_STABILITY = new InjectionToken<boolean>(
-  ngDevMode ? 'REQUESTS_CONTRIBUTE_TO_STABILITY' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'REQUESTS_CONTRIBUTE_TO_STABILITY' : '',
   {providedIn: 'root', factory: () => true},
 );
 

--- a/packages/common/http/src/provider.ts
+++ b/packages/common/http/src/provider.ts
@@ -156,7 +156,7 @@ export function withInterceptors(
 }
 
 const LEGACY_INTERCEPTOR_FN = new InjectionToken<HttpInterceptorFn>(
-  ngDevMode ? 'LEGACY_INTERCEPTOR_FN' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'LEGACY_INTERCEPTOR_FN' : '',
 );
 
 /**

--- a/packages/common/http/src/transfer_cache.ts
+++ b/packages/common/http/src/transfer_cache.ts
@@ -79,7 +79,7 @@ export type HttpTransferCacheOptions = {
  * @publicApi
  */
 export const HTTP_TRANSFER_CACHE_ORIGIN_MAP = new InjectionToken<Record<string, string>>(
-  ngDevMode ? 'HTTP_TRANSFER_CACHE_ORIGIN_MAP' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'HTTP_TRANSFER_CACHE_ORIGIN_MAP' : '',
 );
 
 /**
@@ -113,7 +113,7 @@ interface CacheOptions extends HttpTransferCacheOptions {
 }
 
 const CACHE_OPTIONS = new InjectionToken<CacheOptions>(
-  ngDevMode ? 'HTTP_TRANSFER_STATE_CACHE_OPTIONS' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'HTTP_TRANSFER_STATE_CACHE_OPTIONS' : '',
 );
 
 /**

--- a/packages/common/http/src/xsrf.ts
+++ b/packages/common/http/src/xsrf.ts
@@ -22,21 +22,30 @@ import {HttpHandlerFn, HttpInterceptor} from './interceptor';
 import {HttpRequest} from './request';
 import {HttpEvent} from './response';
 
-export const XSRF_ENABLED = new InjectionToken<boolean>(ngDevMode ? 'XSRF_ENABLED' : '', {
-  factory: () => true,
-});
+export const XSRF_ENABLED = new InjectionToken<boolean>(
+  typeof ngDevMode !== undefined && ngDevMode ? 'XSRF_ENABLED' : '',
+  {
+    factory: () => true,
+  },
+);
 
 export const XSRF_DEFAULT_COOKIE_NAME = 'XSRF-TOKEN';
-export const XSRF_COOKIE_NAME = new InjectionToken<string>(ngDevMode ? 'XSRF_COOKIE_NAME' : '', {
-  providedIn: 'root',
-  factory: () => XSRF_DEFAULT_COOKIE_NAME,
-});
+export const XSRF_COOKIE_NAME = new InjectionToken<string>(
+  typeof ngDevMode !== undefined && ngDevMode ? 'XSRF_COOKIE_NAME' : '',
+  {
+    providedIn: 'root',
+    factory: () => XSRF_DEFAULT_COOKIE_NAME,
+  },
+);
 
 export const XSRF_DEFAULT_HEADER_NAME = 'X-XSRF-TOKEN';
-export const XSRF_HEADER_NAME = new InjectionToken<string>(ngDevMode ? 'XSRF_HEADER_NAME' : '', {
-  providedIn: 'root',
-  factory: () => XSRF_DEFAULT_HEADER_NAME,
-});
+export const XSRF_HEADER_NAME = new InjectionToken<string>(
+  typeof ngDevMode !== undefined && ngDevMode ? 'XSRF_HEADER_NAME' : '',
+  {
+    providedIn: 'root',
+    factory: () => XSRF_DEFAULT_HEADER_NAME,
+  },
+);
 
 /**
  * `HttpXsrfTokenExtractor` which retrieves the token from a cookie.

--- a/packages/common/src/directives/ng_optimized_image/image_loaders/image_loader.ts
+++ b/packages/common/src/directives/ng_optimized_image/image_loaders/image_loader.ts
@@ -70,10 +70,13 @@ export type ImageLoaderInfo = {
  * @see {@link NgOptimizedImage}
  * @publicApi
  */
-export const IMAGE_LOADER = new InjectionToken<ImageLoader>(ngDevMode ? 'ImageLoader' : '', {
-  providedIn: 'root',
-  factory: () => noopImageLoader,
-});
+export const IMAGE_LOADER = new InjectionToken<ImageLoader>(
+  typeof ngDevMode !== undefined && ngDevMode ? 'ImageLoader' : '',
+  {
+    providedIn: 'root',
+    factory: () => noopImageLoader,
+  },
+);
 
 /**
  * Internal helper function that makes it easier to introduce custom image loaders for the

--- a/packages/common/src/directives/ng_optimized_image/preconnect_link_checker.ts
+++ b/packages/common/src/directives/ng_optimized_image/preconnect_link_checker.ts
@@ -42,7 +42,7 @@ const INTERNAL_PRECONNECT_CHECK_BLOCKLIST = new Set(['localhost', '127.0.0.1', '
  * @publicApi
  */
 export const PRECONNECT_CHECK_BLOCKLIST = new InjectionToken<Array<string | string[]>>(
-  ngDevMode ? 'PRECONNECT_CHECK_BLOCKLIST' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'PRECONNECT_CHECK_BLOCKLIST' : '',
 );
 
 /**

--- a/packages/common/src/location/location_strategy.ts
+++ b/packages/common/src/location/location_strategy.ts
@@ -75,7 +75,9 @@ export abstract class LocationStrategy {
  *
  * @publicApi
  */
-export const APP_BASE_HREF = new InjectionToken<string>(ngDevMode ? 'appBaseHref' : '');
+export const APP_BASE_HREF = new InjectionToken<string>(
+  typeof ngDevMode !== undefined && ngDevMode ? 'appBaseHref' : '',
+);
 
 /**
  * @description

--- a/packages/common/src/location/platform_location.ts
+++ b/packages/common/src/location/platform_location.ts
@@ -73,7 +73,7 @@ export abstract class PlatformLocation {
  * @publicApi
  */
 export const LOCATION_INITIALIZED = new InjectionToken<Promise<any>>(
-  ngDevMode ? 'Location Initialized' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'Location Initialized' : '',
 );
 
 /**

--- a/packages/common/src/pipes/date_pipe.ts
+++ b/packages/common/src/pipes/date_pipe.ts
@@ -20,7 +20,7 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  * @deprecated use DATE_PIPE_DEFAULT_OPTIONS token to configure DatePipe
  */
 export const DATE_PIPE_DEFAULT_TIMEZONE = new InjectionToken<string>(
-  ngDevMode ? 'DATE_PIPE_DEFAULT_TIMEZONE' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'DATE_PIPE_DEFAULT_TIMEZONE' : '',
 );
 
 /**
@@ -55,7 +55,7 @@ export const DATE_PIPE_DEFAULT_TIMEZONE = new InjectionToken<string>(
  * ```
  */
 export const DATE_PIPE_DEFAULT_OPTIONS = new InjectionToken<DatePipeConfig>(
-  ngDevMode ? 'DATE_PIPE_DEFAULT_OPTIONS' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'DATE_PIPE_DEFAULT_OPTIONS' : '',
 );
 
 /**

--- a/packages/common/upgrade/src/location_upgrade_module.ts
+++ b/packages/common/upgrade/src/location_upgrade_module.ts
@@ -56,11 +56,11 @@ export interface LocationUpgradeConfig {
  * @publicApi
  */
 export const LOCATION_UPGRADE_CONFIGURATION = new InjectionToken<LocationUpgradeConfig>(
-  ngDevMode ? 'LOCATION_UPGRADE_CONFIGURATION' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'LOCATION_UPGRADE_CONFIGURATION' : '',
 );
 
 const APP_BASE_HREF_RESOLVED = new InjectionToken<string>(
-  ngDevMode ? 'APP_BASE_HREF_RESOLVED' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'APP_BASE_HREF_RESOLVED' : '',
 );
 
 /**

--- a/packages/core/src/application/application_tokens.ts
+++ b/packages/core/src/application/application_tokens.ts
@@ -39,10 +39,13 @@ import {getDocument} from '../render3/interfaces/document';
  *
  * @publicApi
  */
-export const APP_ID = new InjectionToken<string>(ngDevMode ? 'AppId' : '', {
-  providedIn: 'root',
-  factory: () => DEFAULT_APP_ID,
-});
+export const APP_ID = new InjectionToken<string>(
+  typeof ngDevMode !== undefined && ngDevMode ? 'AppId' : '',
+  {
+    providedIn: 'root',
+    factory: () => DEFAULT_APP_ID,
+  },
+);
 
 /** Default value of the `APP_ID` token. */
 const DEFAULT_APP_ID = 'ng';
@@ -57,17 +60,20 @@ const DEFAULT_APP_ID = 'ng';
  * @publicApi
  */
 export const PLATFORM_INITIALIZER = new InjectionToken<ReadonlyArray<() => void>>(
-  ngDevMode ? 'Platform Initializer' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'Platform Initializer' : '',
 );
 
 /**
  * A token that indicates an opaque platform ID.
  * @publicApi
  */
-export const PLATFORM_ID = new InjectionToken<Object>(ngDevMode ? 'Platform ID' : '', {
-  providedIn: 'platform',
-  factory: () => 'unknown', // set a default platform name, when none set explicitly
-});
+export const PLATFORM_ID = new InjectionToken<Object>(
+  typeof ngDevMode !== undefined && ngDevMode ? 'Platform ID' : '',
+  {
+    providedIn: 'platform',
+    factory: () => 'unknown', // set a default platform name, when none set explicitly
+  },
+);
 
 // We keep this token here, rather than the animations package, so that modules that only care
 // about which animations module is loaded (e.g. the CDK) can retrieve it without having to
@@ -79,7 +85,7 @@ export const PLATFORM_ID = new InjectionToken<Object>(ngDevMode ? 'Platform ID' 
  * @publicApi
  */
 export const ANIMATION_MODULE_TYPE = new InjectionToken<'NoopAnimations' | 'BrowserAnimations'>(
-  ngDevMode ? 'AnimationModuleType' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'AnimationModuleType' : '',
 );
 
 // TODO(crisbeto): link to CSP guide here.
@@ -90,29 +96,32 @@ export const ANIMATION_MODULE_TYPE = new InjectionToken<'NoopAnimations' | 'Brow
  *
  * @publicApi
  */
-export const CSP_NONCE = new InjectionToken<string | null>(ngDevMode ? 'CSP nonce' : '', {
-  providedIn: 'root',
-  factory: () => {
-    // Ideally we wouldn't have to use `querySelector` here since we know that the nonce will be on
-    // the root node, but because the token value is used in renderers, it has to be available
-    // *very* early in the bootstrapping process. This should be a fairly shallow search, because
-    // the app won't have been added to the DOM yet. Some approaches that were considered:
-    // 1. Find the root node through `ApplicationRef.components[i].location` - normally this would
-    // be enough for our purposes, but the token is injected very early so the `components` array
-    // isn't populated yet.
-    // 2. Find the root `LView` through the current `LView` - renderers are a prerequisite to
-    // creating the `LView`. This means that no `LView` will have been entered when this factory is
-    // invoked for the root component.
-    // 3. Have the token factory return `() => string` which is invoked when a nonce is requested -
-    // the slightly later execution does allow us to get an `LView` reference, but the fact that
-    // it is a function means that it could be executed at *any* time (including immediately) which
-    // may lead to weird bugs.
-    // 4. Have the `ComponentFactory` read the attribute and provide it to the injector under the
-    // hood - has the same problem as #1 and #2 in that the renderer is used to query for the root
-    // node and the nonce value needs to be available when the renderer is created.
-    return getDocument().body?.querySelector('[ngCspNonce]')?.getAttribute('ngCspNonce') || null;
+export const CSP_NONCE = new InjectionToken<string | null>(
+  typeof ngDevMode !== undefined && ngDevMode ? 'CSP nonce' : '',
+  {
+    providedIn: 'root',
+    factory: () => {
+      // Ideally we wouldn't have to use `querySelector` here since we know that the nonce will be on
+      // the root node, but because the token value is used in renderers, it has to be available
+      // *very* early in the bootstrapping process. This should be a fairly shallow search, because
+      // the app won't have been added to the DOM yet. Some approaches that were considered:
+      // 1. Find the root node through `ApplicationRef.components[i].location` - normally this would
+      // be enough for our purposes, but the token is injected very early so the `components` array
+      // isn't populated yet.
+      // 2. Find the root `LView` through the current `LView` - renderers are a prerequisite to
+      // creating the `LView`. This means that no `LView` will have been entered when this factory is
+      // invoked for the root component.
+      // 3. Have the token factory return `() => string` which is invoked when a nonce is requested -
+      // the slightly later execution does allow us to get an `LView` reference, but the fact that
+      // it is a function means that it could be executed at *any* time (including immediately) which
+      // may lead to weird bugs.
+      // 4. Have the `ComponentFactory` read the attribute and provide it to the injector under the
+      // hood - has the same problem as #1 and #2 in that the renderer is used to query for the root
+      // node and the nonce value needs to be available when the renderer is created.
+      return getDocument().body?.querySelector('[ngCspNonce]')?.getAttribute('ngCspNonce') || null;
+    },
   },
-});
+);
 
 /**
  * A configuration object for the image-related options. Contains:
@@ -150,7 +159,10 @@ export const IMAGE_CONFIG_DEFAULTS: ImageConfig = {
  * @see {@link ImageConfig}
  * @publicApi
  */
-export const IMAGE_CONFIG = new InjectionToken<ImageConfig>(ngDevMode ? 'ImageConfig' : '', {
-  providedIn: 'root',
-  factory: () => IMAGE_CONFIG_DEFAULTS,
-});
+export const IMAGE_CONFIG = new InjectionToken<ImageConfig>(
+  typeof ngDevMode !== undefined && ngDevMode ? 'ImageConfig' : '',
+  {
+    providedIn: 'root',
+    factory: () => IMAGE_CONFIG_DEFAULTS,
+  },
+);

--- a/packages/core/src/application/tracing.ts
+++ b/packages/core/src/application/tracing.ts
@@ -26,7 +26,7 @@ export interface TracingSnapshot {
  * Injection token for a `TracingService`, optionally provided.
  */
 export const TracingService = new InjectionToken<TracingService<TracingSnapshot>>(
-  ngDevMode ? 'TracingService' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'TracingService' : '',
 );
 
 /**

--- a/packages/core/src/change_detection/use_exhaustive_check_no_changes.ts
+++ b/packages/core/src/change_detection/use_exhaustive_check_no_changes.ts
@@ -11,5 +11,5 @@ import {InjectionToken} from '../di';
 export const USE_EXHAUSTIVE_CHECK_NO_CHANGES_DEFAULT = false;
 
 export const UseExhaustiveCheckNoChanges = new InjectionToken<boolean>(
-  ngDevMode ? 'exhaustive checkNoChanges' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'exhaustive checkNoChanges' : '',
 );

--- a/packages/core/src/defer/registry.ts
+++ b/packages/core/src/defer/registry.ts
@@ -22,7 +22,7 @@ import type {PromiseWithResolvers} from '../util/promise_with_resolvers';
  * in a tree-shakable way.
  */
 export const DEHYDRATED_BLOCK_REGISTRY = new InjectionToken<DehydratedBlockRegistry>(
-  ngDevMode ? 'DEHYDRATED_BLOCK_REGISTRY' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'DEHYDRATED_BLOCK_REGISTRY' : '',
 );
 
 /**

--- a/packages/core/src/defer/rendering.ts
+++ b/packages/core/src/defer/rendering.ts
@@ -72,7 +72,7 @@ export const DEFER_BLOCK_DEPENDENCY_INTERCEPTOR =
  * **INTERNAL**, token used for configuring defer block behavior.
  */
 export const DEFER_BLOCK_CONFIG = new InjectionToken<DeferBlockConfig>(
-  ngDevMode ? 'DEFER_BLOCK_CONFIG' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'DEFER_BLOCK_CONFIG' : '',
 );
 
 /**

--- a/packages/core/src/di/host_tag_name_token.ts
+++ b/packages/core/src/di/host_tag_name_token.ts
@@ -40,7 +40,9 @@ export const HOST_TAG_NAME: InjectionToken<string> = /* @__PURE__ */ (() => {
   // the bundler can drop the whole block. If we set `__NG_ELEMENT_ID__` at
   // the top level instead, the mutation would look like a side effect,
   // forcing the bundler to keep it even when unused.
-  const HOST_TAG_NAME_TOKEN = new InjectionToken<string>(ngDevMode ? 'HOST_TAG_NAME' : '');
+  const HOST_TAG_NAME_TOKEN = new InjectionToken<string>(
+    typeof ngDevMode !== undefined && ngDevMode ? 'HOST_TAG_NAME' : '',
+  );
 
   // HOST_TAG_NAME should be resolved at the current node, similar to e.g. ElementRef,
   // so we manually specify __NG_ELEMENT_ID__ here, instead of using a factory.

--- a/packages/core/src/di/initializer_token.ts
+++ b/packages/core/src/di/initializer_token.ts
@@ -22,5 +22,5 @@ import {InjectionToken} from './injection_token';
  * @publicApi
  */
 export const ENVIRONMENT_INITIALIZER = new InjectionToken<ReadonlyArray<() => void>>(
-  ngDevMode ? 'ENVIRONMENT_INITIALIZER' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'ENVIRONMENT_INITIALIZER' : '',
 );

--- a/packages/core/src/di/injector_token.ts
+++ b/packages/core/src/di/injector_token.ts
@@ -19,7 +19,7 @@ import {InjectorMarkers} from './injector_marker';
  * @publicApi
  */
 export const INJECTOR = new InjectionToken<Injector>(
-  ngDevMode ? 'INJECTOR' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'INJECTOR' : '',
   // Disable tslint because this is const enum which gets inlined not top level prop access.
   // tslint:disable-next-line: no-toplevel-property-access
   InjectorMarkers.Injector as any, // Special value used by Ivy to identify `Injector`.

--- a/packages/core/src/di/internal_tokens.ts
+++ b/packages/core/src/di/internal_tokens.ts
@@ -11,5 +11,5 @@ import {Type} from '../interface/type';
 import {InjectionToken} from './injection_token';
 
 export const INJECTOR_DEF_TYPES = new InjectionToken<ReadonlyArray<Type<unknown>>>(
-  ngDevMode ? 'INJECTOR_DEF_TYPES' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'INJECTOR_DEF_TYPES' : '',
 );

--- a/packages/core/src/di/scope.ts
+++ b/packages/core/src/di/scope.ts
@@ -16,5 +16,5 @@ export type InjectorScope = 'root' | 'platform' | 'environment';
  * they are provided in the root scope.
  */
 export const INJECTOR_SCOPE = new InjectionToken<InjectorScope | null>(
-  ngDevMode ? 'Set Injector scope.' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'Set Injector scope.' : '',
 );

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -15,4 +15,6 @@ import {InjectionToken} from './di';
  *
  * @publicApi
  */
-export const DOCUMENT = new InjectionToken<Document>(ngDevMode ? 'DocumentToken' : '');
+export const DOCUMENT = new InjectionToken<Document>(
+  typeof ngDevMode !== undefined && ngDevMode ? 'DocumentToken' : '',
+);

--- a/packages/core/src/event_delegation_utils.ts
+++ b/packages/core/src/event_delegation_utils.ts
@@ -95,7 +95,7 @@ export interface EventContractDetails {
 }
 
 export const JSACTION_EVENT_CONTRACT = new InjectionToken<EventContractDetails>(
-  ngDevMode ? 'EVENT_CONTRACT_DETAILS' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'EVENT_CONTRACT_DETAILS' : '',
   {
     providedIn: 'root',
     factory: () => ({}),

--- a/packages/core/src/hydration/tokens.ts
+++ b/packages/core/src/hydration/tokens.ts
@@ -62,7 +62,7 @@ export const IS_INCREMENTAL_HYDRATION_ENABLED = new InjectionToken<boolean>(
  * A map of DOM elements with `jsaction` attributes grouped by action names.
  */
 export const JSACTION_BLOCK_ELEMENT_MAP = new InjectionToken<Map<string, Set<Element>>>(
-  ngDevMode ? 'JSACTION_BLOCK_ELEMENT_MAP' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'JSACTION_BLOCK_ELEMENT_MAP' : '',
   {
     providedIn: 'root',
     factory: () => new Map<string, Set<Element>>(),

--- a/packages/core/src/i18n/tokens.ts
+++ b/packages/core/src/i18n/tokens.ts
@@ -78,10 +78,13 @@ export function getGlobalLocale(): string {
  *
  * @publicApi
  */
-export const LOCALE_ID: InjectionToken<string> = new InjectionToken(ngDevMode ? 'LocaleId' : '', {
-  providedIn: 'root',
-  factory: () => inject(LOCALE_ID, {optional: true, skipSelf: true}) || getGlobalLocale(),
-});
+export const LOCALE_ID: InjectionToken<string> = new InjectionToken(
+  typeof ngDevMode !== undefined && ngDevMode ? 'LocaleId' : '',
+  {
+    providedIn: 'root',
+    factory: () => inject(LOCALE_ID, {optional: true, skipSelf: true}) || getGlobalLocale(),
+  },
+);
 
 /**
  * Provide this token to set the default currency code your application uses for
@@ -127,7 +130,7 @@ export const LOCALE_ID: InjectionToken<string> = new InjectionToken(ngDevMode ? 
  * @publicApi
  */
 export const DEFAULT_CURRENCY_CODE = new InjectionToken<string>(
-  ngDevMode ? 'DefaultCurrencyCode' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'DefaultCurrencyCode' : '',
   {
     providedIn: 'root',
     factory: () => USD_CURRENCY_CODE,
@@ -167,7 +170,9 @@ export const DEFAULT_CURRENCY_CODE = new InjectionToken<string>(
  *
  * @publicApi
  */
-export const TRANSLATIONS = new InjectionToken<string>(ngDevMode ? 'Translations' : '');
+export const TRANSLATIONS = new InjectionToken<string>(
+  typeof ngDevMode !== undefined && ngDevMode ? 'Translations' : '',
+);
 
 /**
  * Provide this token at bootstrap to set the format of your {@link TRANSLATIONS}: `xtb`,
@@ -200,7 +205,7 @@ export const TRANSLATIONS = new InjectionToken<string>(ngDevMode ? 'Translations
  * @publicApi
  */
 export const TRANSLATIONS_FORMAT = new InjectionToken<string>(
-  ngDevMode ? 'TranslationsFormat' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'TranslationsFormat' : '',
 );
 
 /**

--- a/packages/core/src/linker/compiler.ts
+++ b/packages/core/src/linker/compiler.ts
@@ -126,7 +126,7 @@ export type CompilerOptions = {
  * @publicApi
  */
 export const COMPILER_OPTIONS = new InjectionToken<CompilerOptions[]>(
-  ngDevMode ? 'compilerOptions' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'compilerOptions' : '',
 );
 
 /**

--- a/packages/core/src/platform/bootstrap.ts
+++ b/packages/core/src/platform/bootstrap.ts
@@ -52,7 +52,7 @@ const REQUIRE_ONE_CD_PROVIDER_BOOTSTRAP_MODULE = false;
  * from component rendering.
  */
 export const ENABLE_ROOT_COMPONENT_BOOTSTRAP = new InjectionToken<boolean>(
-  ngDevMode ? 'ENABLE_ROOT_COMPONENT_BOOTSTRAP' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'ENABLE_ROOT_COMPONENT_BOOTSTRAP' : '',
 );
 
 export interface BootstrapConfig {

--- a/packages/core/src/platform/platform_destroy_listeners.ts
+++ b/packages/core/src/platform/platform_destroy_listeners.ts
@@ -15,5 +15,5 @@ import {InjectionToken} from '../di';
  * entire class tree-shakeable.
  */
 export const PLATFORM_DESTROY_LISTENERS = new InjectionToken<Set<VoidFunction>>(
-  ngDevMode ? 'PlatformDestroyListeners' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'PlatformDestroyListeners' : '',
 );

--- a/packages/forms/src/directives/control_value_accessor.ts
+++ b/packages/forms/src/directives/control_value_accessor.ts
@@ -212,5 +212,5 @@ export class BuiltInControlValueAccessor extends BaseControlValueAccessor {}
  * @publicApi
  */
 export const NG_VALUE_ACCESSOR = new InjectionToken<ReadonlyArray<ControlValueAccessor>>(
-  ngDevMode ? 'NgValueAccessor' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'NgValueAccessor' : '',
 );

--- a/packages/forms/src/directives/default_value_accessor.ts
+++ b/packages/forms/src/directives/default_value_accessor.ts
@@ -46,7 +46,7 @@ function _isAndroid(): boolean {
  * @publicApi
  */
 export const COMPOSITION_BUFFER_MODE = new InjectionToken<boolean>(
-  ngDevMode ? 'CompositionEventMode' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'CompositionEventMode' : '',
 );
 
 /**

--- a/packages/forms/src/directives/reactive_directives/form_control_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_directive.ts
@@ -42,7 +42,7 @@ import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from '../valid
  * Token to provide to turn off the ngModel warning on formControl and formControlName.
  */
 export const NG_MODEL_WITH_FORM_CONTROL_WARNING = new InjectionToken(
-  ngDevMode ? 'NgModelWithFormControlWarning' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'NgModelWithFormControlWarning' : '',
 );
 
 const formControlBinding: Provider = {

--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -77,7 +77,7 @@ function lengthOrSize(value: unknown): number | null {
  * @publicApi
  */
 export const NG_VALIDATORS = new InjectionToken<ReadonlyArray<Validator | Function>>(
-  ngDevMode ? 'NgValidators' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'NgValidators' : '',
 );
 
 /**
@@ -110,7 +110,7 @@ export const NG_VALIDATORS = new InjectionToken<ReadonlyArray<Validator | Functi
  * @publicApi
  */
 export const NG_ASYNC_VALIDATORS = new InjectionToken<ReadonlyArray<Validator | Function>>(
-  ngDevMode ? 'NgAsyncValidators' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'NgAsyncValidators' : '',
 );
 
 /**

--- a/packages/platform-browser/animations/async/src/async_animation_renderer.ts
+++ b/packages/platform-browser/animations/async/src/async_animation_renderer.ts
@@ -319,5 +319,5 @@ export class DynamicDelegationRenderer implements Renderer2 {
  * Private token for investigation purposes
  */
 export const ɵASYNC_ANIMATION_LOADING_SCHEDULER_FN = new InjectionToken<<T>(loadFn: () => T) => T>(
-  ngDevMode ? 'async_animation_loading_scheduler_fn' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'async_animation_loading_scheduler_fn' : '',
 );

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -64,7 +64,7 @@ const REMOVE_STYLES_ON_COMPONENT_DESTROY_DEFAULT = true;
  * @publicApi
  */
 export const REMOVE_STYLES_ON_COMPONENT_DESTROY = new InjectionToken<boolean>(
-  ngDevMode ? 'RemoveStylesOnCompDestroy' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'RemoveStylesOnCompDestroy' : '',
   {
     providedIn: 'root',
     factory: () => REMOVE_STYLES_ON_COMPONENT_DESTROY_DEFAULT,

--- a/packages/platform-browser/src/dom/events/event_manager.ts
+++ b/packages/platform-browser/src/dom/events/event_manager.ts
@@ -23,7 +23,7 @@ import {RuntimeErrorCode} from '../../errors';
  * @publicApi
  */
 export const EVENT_MANAGER_PLUGINS = new InjectionToken<EventManagerPlugin[]>(
-  ngDevMode ? 'EventManagerPlugins' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'EventManagerPlugins' : '',
 );
 
 /**

--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -57,7 +57,7 @@ import {PRIMARY_OUTLET} from '../shared';
  * @publicApi
  */
 export const ROUTER_OUTLET_DATA = new InjectionToken<Signal<unknown | undefined>>(
-  ngDevMode ? 'RouterOutlet data' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'RouterOutlet data' : '',
 );
 
 /**

--- a/packages/router/src/router_config_loader.ts
+++ b/packages/router/src/router_config_loader.ts
@@ -36,7 +36,9 @@ import {standardizeConfig} from './components/empty_outlet';
  *
  * @publicApi
  */
-export const ROUTES = new InjectionToken<Route[][]>(ngDevMode ? 'ROUTES' : '');
+export const ROUTES = new InjectionToken<Route[][]>(
+  typeof ngDevMode !== undefined && ngDevMode ? 'ROUTES' : '',
+);
 
 type ComponentLoader = Observable<Type<unknown>>;
 

--- a/packages/router/src/utils/view_transition.ts
+++ b/packages/router/src/utils/view_transition.ts
@@ -12,11 +12,11 @@ import {afterNextRender, InjectionToken, Injector, runInInjectionContext} from '
 import {ActivatedRouteSnapshot} from '../router_state';
 
 export const CREATE_VIEW_TRANSITION = new InjectionToken<typeof createViewTransition>(
-  ngDevMode ? 'view transition helper' : '',
+  typeof ngDevMode !== undefined && ngDevMode ? 'view transition helper' : '',
 );
 export const VIEW_TRANSITION_OPTIONS = new InjectionToken<
   ViewTransitionsFeatureOptions & {skipNextTransition: boolean}
->(ngDevMode ? 'view transition options' : '');
+>(typeof ngDevMode !== undefined && ngDevMode ? 'view transition options' : '');
 
 /**
  * Options to configure the View Transitions integration in the Router.

--- a/packages/service-worker/src/provider.ts
+++ b/packages/service-worker/src/provider.ts
@@ -25,7 +25,9 @@ import {SwPush} from './push';
 import {SwUpdate} from './update';
 import {RuntimeErrorCode} from './errors';
 
-export const SCRIPT = new InjectionToken<string>(ngDevMode ? 'NGSW_REGISTER_SCRIPT' : '');
+export const SCRIPT = new InjectionToken<string>(
+  typeof ngDevMode !== undefined && ngDevMode ? 'NGSW_REGISTER_SCRIPT' : '',
+);
 
 export function ngswAppInitializer(): void {
   if (typeof ngServerMode !== 'undefined' && ngServerMode) {


### PR DESCRIPTION
Since those are top level APIs, `ngDevMode` might not be available at runtime if they're invoked before the variable is set.

fixes #62796
