### PR TITLE
Add test coverage to ensure signal form field states are propagated to controls 

### DIFF
--- a/packages/core/src/render3/instructions/control.ts
+++ b/packages/core/src/render3/instructions/control.ts
@@ -336,7 +336,7 @@ function updateCustomControl(
   maybeWriteToDirectiveInput(componentDef, component, 'minLength', state.minLength);
   maybeWriteToDirectiveInput(componentDef, component, 'name', state.name);
   maybeWriteToDirectiveInput(componentDef, component, 'pattern', state.pattern);
-  maybeWriteToDirectiveInput(componentDef, component, 'readOnly', state.readonly);
+  maybeWriteToDirectiveInput(componentDef, component, 'readonly', state.readonly);
   maybeWriteToDirectiveInput(componentDef, component, 'required', state.required);
   maybeWriteToDirectiveInput(componentDef, component, 'touched', state.touched);
 }
@@ -376,7 +376,7 @@ function updateNativeControl(tNode: TNode, lView: LView, control: ɵControl<unkn
   // * check if bindings changed before writing.
   setNativeControlValue(input, state.value());
   renderer.setAttribute(input, 'name', state.name());
-  setBooleanAttribute(renderer, input, 'disable', state.disabled());
+  setBooleanAttribute(renderer, input, 'disabled', state.disabled());
   setBooleanAttribute(renderer, input, 'readonly', state.readonly());
   setBooleanAttribute(renderer, input, 'required', state.required());
 

--- a/packages/core/src/render3/instructions/control.ts
+++ b/packages/core/src/render3/instructions/control.ts
@@ -332,7 +332,7 @@ function updateCustomControl(
   maybeWriteToDirectiveInput(componentDef, component, 'disabledReasons', state.disabledReasons);
   maybeWriteToDirectiveInput(componentDef, component, 'max', state.max);
   maybeWriteToDirectiveInput(componentDef, component, 'maxLength', state.maxLength);
-  maybeWriteToDirectiveInput(componentDef, component, 'min', state.max);
+  maybeWriteToDirectiveInput(componentDef, component, 'min', state.min);
   maybeWriteToDirectiveInput(componentDef, component, 'minLength', state.minLength);
   maybeWriteToDirectiveInput(componentDef, component, 'name', state.name);
   maybeWriteToDirectiveInput(componentDef, component, 'pattern', state.pattern);
@@ -368,7 +368,7 @@ function maybeWriteToDirectiveInput(
  * @param control The `ɵControl` directive instance.
  */
 function updateNativeControl(tNode: TNode, lView: LView, control: ɵControl<unknown>): void {
-  const input = getNativeByTNode(tNode, lView) as HTMLInputElement;
+  const input = getNativeByTNode(tNode, lView) as NativeControlElement;
   const renderer = lView[RENDERER];
   const state = control.state();
 
@@ -381,16 +381,36 @@ function updateNativeControl(tNode: TNode, lView: LView, control: ɵControl<unkn
   setBooleanAttribute(renderer, input, 'required', state.required());
 
   // TODO: https://github.com/orgs/angular/projects/60/views/1?pane=issue&itemId=131711472
+  // * cache this in `tNode.flags`.
+  if (isNumericInput(input)) {
+    setOptionalAttribute(renderer, input, 'max', state.max());
+    setOptionalAttribute(renderer, input, 'min', state.min());
+  }
+
+  // TODO: https://github.com/orgs/angular/projects/60/views/1?pane=issue&itemId=131711472
   // * use tag and type attribute to determine which of these properties to bind.
-  setOptionalAttribute(renderer, input, 'max', state.max());
   setOptionalAttribute(renderer, input, 'maxLength', state.maxLength());
-  setOptionalAttribute(renderer, input, 'min', state.min());
   setOptionalAttribute(renderer, input, 'minLength', state.minLength());
 }
 
 /** Checks if a given value is a Date or null */
 function isDateOrNull(value: unknown): value is Date | null {
   return value === null || value instanceof Date;
+}
+
+/** Returns whether `control` has a numeric input type. */
+function isNumericInput(control: NativeControlElement) {
+  switch (control.type) {
+    case 'date':
+    case 'datetime-local':
+    case 'month':
+    case 'number':
+    case 'range':
+    case 'time':
+    case 'week':
+      return true;
+  }
+  return false;
 }
 
 /**

--- a/packages/core/src/render3/instructions/control.ts
+++ b/packages/core/src/render3/instructions/control.ts
@@ -388,9 +388,11 @@ function updateNativeControl(tNode: TNode, lView: LView, control: ɵControl<unkn
   }
 
   // TODO: https://github.com/orgs/angular/projects/60/views/1?pane=issue&itemId=131711472
-  // * use tag and type attribute to determine which of these properties to bind.
-  setOptionalAttribute(renderer, input, 'maxLength', state.maxLength());
-  setOptionalAttribute(renderer, input, 'minLength', state.minLength());
+  // * cache this in `tNode.flags`.
+  if (isTextInput(input)) {
+    setOptionalAttribute(renderer, input, 'maxLength', state.maxLength());
+    setOptionalAttribute(renderer, input, 'minLength', state.minLength());
+  }
 }
 
 /** Checks if a given value is a Date or null */
@@ -411,6 +413,18 @@ function isNumericInput(control: NativeControlElement) {
       return true;
   }
   return false;
+}
+
+/**
+ * Returns whether `control` is a text-based input.
+ *
+ * This is not the same as an input with `type="text"`, but rather any input that accepts
+ * text-based input which includes numeric types.
+ */
+function isTextInput(
+  control: NativeControlElement,
+): control is HTMLInputElement | HTMLTextAreaElementNarrowed {
+  return !(control instanceof HTMLSelectElement);
 }
 
 /**

--- a/packages/forms/signals/test/web/control_directive.spec.ts
+++ b/packages/forms/signals/test/web/control_directive.spec.ts
@@ -429,6 +429,136 @@ describe('control directive', () => {
         expect(element.min).toBe('');
       });
     });
+
+    describe('maxLength', () => {
+      it('native control', () => {
+        @Component({
+          imports: [Control],
+          template: `<textarea [control]="f"></textarea>`,
+        })
+        class TestCmp {
+          readonly maxLength = signal(20);
+          readonly f = form(signal(''), (p) => {
+            maxLength(p, this.maxLength);
+          });
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const element = fixture.nativeElement.firstChild as HTMLTextAreaElement;
+        expect(element.maxLength).toBe(20);
+
+        act(() => fixture.componentInstance.maxLength.set(15));
+        expect(element.maxLength).toBe(15);
+      });
+
+      it('custom control', () => {
+        @Component({selector: 'custom-control', template: ``})
+        class CustomControl {
+          readonly value = model('');
+          readonly maxLength = input<number | null>(null);
+        }
+
+        @Component({
+          imports: [Control, CustomControl],
+          template: `<custom-control [control]="f" />`,
+        })
+        class TestCmp {
+          readonly maxLength = signal(10);
+          readonly f = form(signal(''), (p) => {
+            maxLength(p, this.maxLength);
+          });
+          readonly customControl = viewChild.required(CustomControl);
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const component = fixture.componentInstance;
+        expect(component.customControl().maxLength()).toBe(10);
+
+        act(() => component.maxLength.set(5));
+        expect(component.customControl().maxLength()).toBe(5);
+      });
+
+      it('is not set on a native control that does not support it', () => {
+        @Component({
+          imports: [Control],
+          template: `<select [control]="f"></select>`,
+        })
+        class TestCmp {
+          readonly f = form(signal(''), (p) => {
+            maxLength(p, 10);
+          });
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const element = fixture.nativeElement.firstChild as HTMLSelectElement;
+        expect(element.getAttribute('maxLength')).toBeNull();
+      });
+    });
+
+    describe('minLength', () => {
+      it('native control', () => {
+        @Component({
+          imports: [Control],
+          template: `<textarea [control]="f"></textarea>`,
+        })
+        class TestCmp {
+          readonly minLength = signal(20);
+          readonly f = form(signal(''), (p) => {
+            minLength(p, this.minLength);
+          });
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const element = fixture.nativeElement.firstChild as HTMLTextAreaElement;
+        expect(element.minLength).toBe(20);
+
+        act(() => fixture.componentInstance.minLength.set(15));
+        expect(element.minLength).toBe(15);
+      });
+
+      it('custom control', () => {
+        @Component({selector: 'custom-control', template: ``})
+        class CustomControl {
+          readonly value = model('');
+          readonly minLength = input<number | null>(null);
+        }
+
+        @Component({
+          imports: [Control, CustomControl],
+          template: `<custom-control [control]="f" />`,
+        })
+        class TestCmp {
+          readonly minLength = signal(10);
+          readonly f = form(signal(''), (p) => {
+            minLength(p, this.minLength);
+          });
+          readonly customControl = viewChild.required(CustomControl);
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const component = fixture.componentInstance;
+        expect(component.customControl().minLength()).toBe(10);
+
+        act(() => component.minLength.set(5));
+        expect(component.customControl().minLength()).toBe(5);
+      });
+
+      it('is not set on a native control that does not support it', () => {
+        @Component({
+          imports: [Control],
+          template: `<select [control]="f"></select>`,
+        })
+        class TestCmp {
+          readonly f = form(signal(''), (p) => {
+            minLength(p, 10);
+          });
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const element = fixture.nativeElement.firstChild as HTMLSelectElement;
+        expect(element.getAttribute('minLength')).toBeNull();
+      });
+    });
   });
 
   it('synchronizes a basic form with a custom control', () => {

--- a/packages/forms/signals/test/web/control_directive.spec.ts
+++ b/packages/forms/signals/test/web/control_directive.spec.ts
@@ -33,6 +33,7 @@ import {
   type DisabledReason,
   type FieldTree,
   type FormCheckboxControl,
+  type FormUiControl,
   type FormValueControl,
   type ValidationError,
   type WithOptionalField,
@@ -79,7 +80,7 @@ describe('control directive', () => {
 
       it('custom control', () => {
         @Component({selector: 'custom-control', template: ``})
-        class CustomControl {
+        class CustomControl implements FormUiControl {
           readonly value = model(false);
           readonly disabled = input(false);
         }
@@ -153,7 +154,7 @@ describe('control directive', () => {
 
       it('custom control', () => {
         @Component({selector: 'custom-control', template: `{{value()}}`})
-        class CustomControl {
+        class CustomControl implements FormUiControl {
           readonly value = model('');
           readonly name = input('');
         }
@@ -225,7 +226,7 @@ describe('control directive', () => {
 
       it('custom control', () => {
         @Component({selector: 'custom-control', template: ``})
-        class CustomControl {
+        class CustomControl implements FormUiControl {
           readonly value = model('');
           readonly readonly = input(false);
         }
@@ -274,7 +275,7 @@ describe('control directive', () => {
 
       it('custom control', () => {
         @Component({selector: 'custom-control', template: ``})
-        class CustomControl {
+        class CustomControl implements FormUiControl {
           readonly value = model('');
           readonly required = input(false);
         }
@@ -323,9 +324,9 @@ describe('control directive', () => {
 
       it('custom control', () => {
         @Component({selector: 'custom-control', template: ``})
-        class CustomControl {
+        class CustomControl implements FormUiControl {
           readonly value = model(0);
-          readonly max = input<number | null>(null);
+          readonly max = input<number>();
         }
 
         @Component({
@@ -388,7 +389,7 @@ describe('control directive', () => {
 
       it('custom control', () => {
         @Component({selector: 'custom-control', template: ``})
-        class CustomControl {
+        class CustomControl implements FormUiControl {
           readonly value = model(0);
           readonly min = input<number>();
         }
@@ -453,9 +454,9 @@ describe('control directive', () => {
 
       it('custom control', () => {
         @Component({selector: 'custom-control', template: ``})
-        class CustomControl {
+        class CustomControl implements FormUiControl {
           readonly value = model('');
-          readonly maxLength = input<number | null>(null);
+          readonly maxLength = input<number>();
         }
 
         @Component({
@@ -518,9 +519,9 @@ describe('control directive', () => {
 
       it('custom control', () => {
         @Component({selector: 'custom-control', template: ``})
-        class CustomControl {
+        class CustomControl implements FormUiControl {
           readonly value = model('');
-          readonly minLength = input<number | null>(null);
+          readonly minLength = input<number>();
         }
 
         @Component({

--- a/packages/forms/signals/test/web/control_directive.spec.ts
+++ b/packages/forms/signals/test/web/control_directive.spec.ts
@@ -299,6 +299,136 @@ describe('control directive', () => {
         expect(component.customControl().required()).toBe(true);
       });
     });
+
+    describe('max', () => {
+      it('native control', () => {
+        @Component({
+          imports: [Control],
+          template: `<input type="number" [control]="f">`,
+        })
+        class TestCmp {
+          readonly max = signal(10);
+          readonly f = form(signal(5), (p) => {
+            max(p, this.max);
+          });
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const element = fixture.nativeElement.firstChild as HTMLInputElement;
+        expect(element.max).toBe('10');
+
+        act(() => fixture.componentInstance.max.set(5));
+        expect(element.max).toBe('5');
+      });
+
+      it('custom control', () => {
+        @Component({selector: 'custom-control', template: ``})
+        class CustomControl {
+          readonly value = model(0);
+          readonly max = input<number | null>(null);
+        }
+
+        @Component({
+          imports: [Control, CustomControl],
+          template: `<custom-control [control]="f" />`,
+        })
+        class TestCmp {
+          readonly max = signal(10);
+          readonly f = form(signal(5), (p) => {
+            max(p, this.max);
+          });
+          readonly customControl = viewChild.required(CustomControl);
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const component = fixture.componentInstance;
+        expect(component.customControl().max()).toBe(10);
+
+        act(() => component.max.set(5));
+        expect(component.customControl().max()).toBe(5);
+      });
+
+      it('is not set on native control if type does not support it', () => {
+        @Component({
+          imports: [Control],
+          template: `<input type="text" [control]="f">`,
+        })
+        class TestCmp {
+          readonly f = form(signal(5), (p) => {
+            max(p, 10);
+          });
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const element = fixture.nativeElement.firstChild as HTMLInputElement;
+        expect(element.max).toBe('');
+      });
+    });
+
+    describe('min', () => {
+      it('native control', () => {
+        @Component({
+          imports: [Control],
+          template: `<input type="number" [control]="f">`,
+        })
+        class TestCmp {
+          readonly min = signal(10);
+          readonly f = form(signal(15), (p) => {
+            min(p, this.min);
+          });
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const element = fixture.nativeElement.firstChild as HTMLInputElement;
+        expect(element.min).toBe('10');
+
+        act(() => fixture.componentInstance.min.set(5));
+        expect(element.min).toBe('5');
+      });
+
+      it('custom control', () => {
+        @Component({selector: 'custom-control', template: ``})
+        class CustomControl {
+          readonly value = model(0);
+          readonly min = input<number>();
+        }
+
+        @Component({
+          imports: [Control, CustomControl],
+          template: `<custom-control [control]="f" />`,
+        })
+        class TestCmp {
+          readonly min = signal(10);
+          readonly f = form(signal(15), (p) => {
+            min(p, this.min);
+          });
+          readonly customControl = viewChild.required(CustomControl);
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const component = fixture.componentInstance;
+        expect(component.customControl().min()).toBe(10);
+
+        act(() => component.min.set(5));
+        expect(component.customControl().min()).toBe(5);
+      });
+
+      it('is not set on native control if type does not support it', () => {
+        @Component({
+          imports: [Control],
+          template: `<input type="text" [control]="f">`,
+        })
+        class TestCmp {
+          readonly f = form(signal(15), (p) => {
+            min(p, 10);
+          });
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const element = fixture.nativeElement.firstChild as HTMLInputElement;
+        expect(element.min).toBe('');
+      });
+    });
   });
 
   it('synchronizes a basic form with a custom control', () => {


### PR DESCRIPTION
Adding test coverage has caught several typos/bugs. I've also updated the runtime to only propagate properties explicitly supported by the underlying control.