### PR TITLE
fix for `bootstrapApplication` on 20.3.2

### DIFF
--- a/adev/src/main.server.ts
+++ b/adev/src/main.server.ts
@@ -6,11 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {bootstrapApplication, BootstrapContext} from '@angular/platform-browser';
-import {AppComponent} from './app/app.component';
-import {config} from './app/app.config.server';
+import { bootstrapApplication, BootstrapContext } from '@angular/platform-browser';
+import { AppComponent } from './app/app.component';
+import { config } from './app/app.config.server';
 
-const bootstrap = (context: BootstrapContext) =>
-  bootstrapApplication(AppComponent, config, context);
+const bootstrap = (context: BootstrapContext) => bootstrapApplication(AppComponent, config, context);
 
 export default bootstrap;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When running Angular **v20.3.2** with SSR (`main.server.ts`), the following error occurs:

```
Error: NG0401: Missing Platform: This may be due to using bootstrapApplication on the server without passing a BootstrapContext. Please make sure that bootstrapApplication is called with a context argument.
at internalCreateApplication ...
at bootstrapApplication ...
at bootstrap (/src/main.server.ts:5:25)
```

This prevents the server-side application from bootstrapping properly.


## What is the new behavior?

The fix ensures that `bootstrapApplication` in `main.server.ts` is correctly initialized with the required `BootstrapContext`.  
This resolves the **NG0401: Missing Platform** error and allows the Angular Universal server to bootstrap successfully without runtime errors.


## Does this PR introduce a breaking change?

- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This fix ensures compatibility with Angular **20.3.2 SSR setup**, preventing server bootstrap failures due to missing `BootstrapContext`.
