### PR TITLE
fix(core): prevent animations renderer from impacting `animate.leave`

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1553,7 +1553,7 @@ export abstract class Renderer2 {
     abstract nextSibling(node: any): any;
     abstract parentNode(node: any): any;
     abstract removeAttribute(el: any, name: string, namespace?: string | null): void;
-    abstract removeChild(parent: any, oldChild: any, isHostElement?: boolean): void;
+    abstract removeChild(parent: any, oldChild: any, isHostElement?: boolean, requireSynchronousElementRemoval?: boolean): void;
     abstract removeClass(el: any, name: string): void;
     abstract removeStyle(el: any, style: string, flags?: RendererStyleFlags2): void;
     abstract selectRootElement(selectorOrNode: string | any, preserveContent?: boolean): any;

--- a/packages/animations/browser/src/render/renderer.ts
+++ b/packages/animations/browser/src/render/renderer.ts
@@ -78,7 +78,20 @@ export class BaseAnimationRenderer implements Renderer2 {
     this.engine.onInsert(this.namespaceId, newChild, parent, isMove);
   }
 
-  removeChild(parent: any, oldChild: any, isHostElement?: boolean): void {
+  // TODO(thePunderWoman): remove the requireSynchronousElementRemoval flag after the
+  // animations package has been fully deleted post v23.
+  removeChild(
+    parent: any,
+    oldChild: any,
+    isHostElement?: boolean,
+    requireSynchronousElementRemoval?: boolean,
+  ): void {
+    // Elements using the new `animate.leave` API require synchronous removal and should
+    // skip the rest of the legacy animation behaviors.
+    if (requireSynchronousElementRemoval) {
+      this.delegate.removeChild(parent, oldChild, isHostElement);
+      return;
+    }
     // Prior to the changes in #57203, this method wasn't being called at all by `core` if the child
     // doesn't have a parent. There appears to be some animation-specific downstream logic that
     // depends on the null check happening before the animation engine. This check keeps the old

--- a/packages/core/src/render/api.ts
+++ b/packages/core/src/render/api.ts
@@ -125,9 +125,15 @@ export abstract class Renderer2 {
    * @param parent The parent node.
    * @param oldChild The child node to remove.
    * @param isHostElement Optionally signal to the renderer whether this element is a host element
-   * or not
+   * @param requireSynchronousElementRemoval Optionally signal to the renderer whether this element
+   * needs synchronous removal
    */
-  abstract removeChild(parent: any, oldChild: any, isHostElement?: boolean): void;
+  abstract removeChild(
+    parent: any,
+    oldChild: any,
+    isHostElement?: boolean,
+    requireSynchronousElementRemoval?: boolean,
+  ): void;
   /**
    * Implement this callback to prepare an element to be bootstrapped
    * as a root element, and return the element instance.

--- a/packages/core/src/render3/dom_node_manipulation.ts
+++ b/packages/core/src/render3/dom_node_manipulation.ts
@@ -81,9 +81,16 @@ export function nativeAppendOrInsertBefore(
  * @param renderer A renderer to be used
  * @param rNode The native node that should be removed
  * @param isHostElement A flag indicating if a node to be removed is a host of a component.
+ * @param requireSynchronousElementRemoval A flag indicating if a node requires synchronous
+ * removal from the DOM.
  */
-export function nativeRemoveNode(renderer: Renderer, rNode: RNode, isHostElement?: boolean): void {
-  renderer.removeChild(null, rNode, isHostElement);
+export function nativeRemoveNode(
+  renderer: Renderer,
+  rNode: RNode,
+  isHostElement?: boolean,
+  requireSynchronousElementRemoval?: boolean,
+): void {
+  renderer.removeChild(null, rNode, isHostElement, requireSynchronousElementRemoval);
 }
 
 /**

--- a/packages/core/src/render3/interfaces/renderer.ts
+++ b/packages/core/src/render3/interfaces/renderer.ts
@@ -44,7 +44,13 @@ export interface Renderer {
   destroyNode?: ((node: RNode) => void) | null;
   appendChild(parent: RElement, newChild: RNode): void;
   insertBefore(parent: RNode, newChild: RNode, refChild: RNode | null, isMove?: boolean): void;
-  removeChild(parent: RElement | null, oldChild: RNode, isHostElement?: boolean): void;
+  // TODO(thePunderWoman): remove the requireSynchronousElementRemoval flag once the animations package has been deleted after v23.
+  removeChild(
+    parent: RElement | null,
+    oldChild: RNode,
+    isHostElement?: boolean,
+    requireSynchronousElementRemoval?: boolean,
+  ): void;
   selectRootElement(selectorOrNode: string | any, preserveContent?: boolean): RElement;
 
   parentNode(node: RNode): RElement | null;


### PR DESCRIPTION
This bypasses the animation renderer when removing nodes that have `animate.leave` animations. This is accomplished by exposing the root renderer via a new `Renderer2` function called `getBaseRenderer()`. For most renderers, this will just be the current renderer, but for the animations renderer, it will always get the root renderer.

fixes: #63893
