### PR TITLE
fix(migrations): handle import aliases to the same module name

### DIFF
--- a/packages/core/schematics/ng-generate/standalone-migration/to-standalone.ts
+++ b/packages/core/schematics/ng-generate/standalone-migration/to-standalone.ts
@@ -194,9 +194,17 @@ function getComponentImportExpressions(
       typeChecker,
     );
 
-    if (importLocation && !seenImports.has(importLocation.symbolName)) {
-      seenImports.add(importLocation.symbolName);
-      resolvedDependencies.push(importLocation);
+    if (importLocation) {
+      // Create a unique key that includes both the symbol name and module specifier
+      // to handle cases where the same symbol name is imported from different modules
+      const importKey = importLocation.moduleSpecifier
+        ? `${importLocation.symbolName}::${importLocation.moduleSpecifier}`
+        : importLocation.symbolName;
+
+      if (!seenImports.has(importKey)) {
+        seenImports.add(importKey);
+        resolvedDependencies.push(importLocation);
+      }
     }
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If a module imports 2 modules with the same name but one with an alias, the aliased one is not added to the component imports array

e.g. when migrating this component:

```
import { Component, NgModule } from '@angular/core';
import { AnotherModule } from '../another/another';
import { AnotherModule as LegacyAnotherModule } from '../another/another-legacy';

@Component({
  selector: 'my-comp',
  template: '<another1 /> <another2 />',
  standalone: false
})
export class MyComponent {}

@NgModule({
  imports: [AnotherModule, LegacyAnotherModule],
  declarations: [MyComponent],
  exports: [MyComponent]
})
export class MyModule {}
```

The component imports array is set to:
```
imports: [AnotherModule]
```

Issue Number: #63913


## What is the new behavior?

When migrating the example above, the component imports array is set to:
```
imports: [AnotherModule, LegacyAnotherModule]
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
