### PR TITLE
ci: optimize adev CI workflows

### DIFF
--- a/.github/workflows/adev-preview-build.yml
+++ b/.github/workflows/adev-preview-build.yml
@@ -15,7 +15,7 @@ permissions: read-all
 
 jobs:
   adev-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8core
     if: |
       (github.event.action == 'labeled' && github.event.label.name == 'adev: preview') ||
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'adev: preview'))
@@ -28,7 +28,7 @@ jobs:
         uses: angular/dev-infra/github-actions/bazel/configure-remote@d776aff2258f15fc3dc1e63852887518eec3ad75
       - name: Install node modules
         run: pnpm install --frozen-lockfile
-      - name: Build adev to ensure it continues to work
+      - name: Build adev
         run: pnpm bazel build //adev:build.production
       - uses: angular/dev-infra/github-actions/previews/pack-and-upload-artifact@d776aff2258f15fc3dc1e63852887518eec3ad75
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
   adev-deploy:
     needs: [adev]
     if: needs.adev.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8core
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@d776aff2258f15fc3dc1e63852887518eec3ad75
@@ -203,7 +203,7 @@ jobs:
         uses: angular/dev-infra/github-actions/bazel/configure-remote@d776aff2258f15fc3dc1e63852887518eec3ad75
       - name: Install node modules
         run: pnpm install --frozen-lockfile
-      - name: Build adev to ensure it continues to work
+      - name: Build adev
         run: pnpm bazel build //adev:build.production
       - name: Deploy to firebase
         uses: ./.github/actions/deploy-docs-site

--- a/adev/BUILD.bazel
+++ b/adev/BUILD.bazel
@@ -120,6 +120,9 @@ ng_application(
     tags = [
         # Tagged as manual as both build and build.production use the same output directory.
         "manual",
+        # RBE significantly slows down the build because the CLI executes multiple CPU-intensive instances of esbuild.
+        # Furthermore, the current RBE machine pool lacks high-spec machines.
+        "no-remote-exec",
     ],
 )
 
@@ -143,6 +146,9 @@ ng_application(
     tags = [
         # Tagged as manual as both build and build.production use the same output directory.
         "manual",
+        # RBE significantly slows down the build because the CLI executes multiple CPU-intensive instances of esbuild.
+        # Furthermore, the current RBE machine pool lacks high-spec machines.
+        "no-remote-exec",
     ],
 )
 


### PR DESCRIPTION
This commit introduces several optimizations to the adev CI workflows:

- The adev preview build now uses a more powerful runner and creates a production build.
- Remote execution is disabled for adev builds to improve performance.

Note: Bazel cache is still being used, and the built times are reduces by about 10mins when the cache is missed.