### PR TITLE
refactor(forms): add onError callback to validateHttp for HTTP errors

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -61,8 +61,9 @@ export type AsyncValidationResult<E extends ValidationError = ValidationError> =
 
 // @public
 export interface AsyncValidatorOptions<TValue, TParams, TResult, TPathKind extends PathKind = PathKind.Root> {
-    readonly errors: MapToErrorsFn<TValue, TResult, TPathKind>;
     readonly factory: (params: Signal<TParams | undefined>) => ResourceRef<TResult | undefined>;
+    readonly onError: (error: unknown, ctx: FieldContext<TValue, TPathKind>) => TreeValidationResult;
+    readonly onSuccess: MapToErrorsFn<TValue, TResult, TPathKind>;
     readonly params: (ctx: FieldContext<TValue, TPathKind>) => TParams;
 }
 
@@ -233,7 +234,8 @@ export function hidden<TValue, TPathKind extends PathKind = PathKind.Root>(path:
 
 // @public
 export interface HttpValidatorOptions<TValue, TResult, TPathKind extends PathKind = PathKind.Root> {
-    readonly errors: MapToErrorsFn<TValue, TResult, TPathKind>;
+    readonly onError: (error: unknown, ctx: FieldContext<TValue, TPathKind>) => TreeValidationResult;
+    readonly onSuccess: MapToErrorsFn<TValue, TResult, TPathKind>;
     readonly options?: HttpResourceOptions<TResult, unknown>;
     readonly request: ((ctx: FieldContext<TValue, TPathKind>) => string | undefined) | ((ctx: FieldContext<TValue, TPathKind>) => HttpResourceRequest | undefined);
 }

--- a/packages/forms/signals/src/api/validators/standard_schema.ts
+++ b/packages/forms/signals/src/api/validators/standard_schema.ts
@@ -87,9 +87,10 @@ export function validateStandardSchema<TSchema, TValue extends IgnoreUnknownProp
         loader: async ({params}) => (await params)?.issues ?? [],
       });
     },
-    errors: (issues, {fieldOf}) => {
+    onSuccess: (issues, {fieldOf}) => {
       return issues.map((issue) => standardIssueToFormTreeError(fieldOf(path), issue));
     },
+    onError: () => {},
   });
 }
 

--- a/packages/forms/signals/test/node/resource.spec.ts
+++ b/packages/forms/signals/test/node/resource.spec.ts
@@ -161,7 +161,7 @@ describe('resources', () => {
               return params as Cat[];
             },
           }),
-        errors: (cats, {fieldOf}) => {
+        onSuccess: (cats, {fieldOf}) => {
           return cats.map((cat, index) =>
             customError({
               kind: 'meows_too_much',
@@ -170,6 +170,7 @@ describe('resources', () => {
             }),
           );
         },
+        onError: () => null,
       });
     };
 
@@ -196,13 +197,14 @@ describe('resources', () => {
               return params as Cat[];
             },
           }),
-        errors: (cats, {fieldOf}) => {
+        onSuccess: (cats, {fieldOf}) => {
           return customError({
             kind: 'meows_too_much',
             name: cats[0].name,
             field: fieldOf(p)[0],
           });
         },
+        onError: () => null,
       });
     };
 
@@ -222,8 +224,9 @@ describe('resources', () => {
       (p) => {
         validateHttp(p, {
           request: ({value}) => `/api/check?username=${value()}`,
-          errors: (available: boolean) =>
+          onSuccess: (available: boolean) =>
             available ? undefined : customError({kind: 'username-taken'}),
+          onError: () => null,
         });
       },
       {injector},
@@ -266,8 +269,9 @@ describe('resources', () => {
       required(address.street);
       validateHttp(address, {
         request: ({value}) => ({url: '/checkaddress', params: {...value()}}),
-        errors: (message: string, {fieldOf}) =>
+        onSuccess: (message: string, {fieldOf}) =>
           customError({message, field: fieldOf(address.street)}),
+        onError: () => null,
       });
     });
     const addressForm = form(addressModel, addressSchema, {injector});
@@ -284,6 +288,38 @@ describe('resources', () => {
 
     expect(addressForm.street().errors()).toEqual([
       customError({message: 'Invalid!', field: addressForm.street}),
+    ]);
+  });
+  it('should call onError handler when http validation fails', async () => {
+    const addressModel = signal<Address>({street: '123 Main St', city: '', zip: ''});
+    const addressSchema = schema<Address>((address) => {
+      required(address.street);
+      validateHttp(address, {
+        request: ({value}) => ({url: '/checkaddress', params: {...value()}}),
+        onSuccess: () => undefined,
+        onError: () => [
+          customError({kind: 'address-api-failed', message: 'API is down', field: addressForm}),
+        ],
+      });
+    });
+
+    const addressForm = form(addressModel, addressSchema, {injector});
+
+    TestBed.tick();
+
+    const req = backend.expectOne('/checkaddress?street=123%20Main%20St&city=&zip=');
+    req.flush(null, {status: 500, statusText: 'Server Error'});
+
+    await appRef.whenStable();
+
+    expect(addressForm().pending()).toBe(false);
+    expect(addressForm().invalid()).toBe(true);
+    expect(addressForm().errors()).toEqual([
+      customError({
+        kind: 'address-api-failed',
+        message: 'API is down',
+        field: addressForm,
+      }),
     ]);
   });
 });

--- a/packages/forms/signals/test/node/submit.spec.ts
+++ b/packages/forms/signals/test/node/submit.spec.ts
@@ -49,7 +49,8 @@ describe('submit', () => {
               params,
               loader: () => resolvers.promise,
             }),
-          errors: () => {},
+          onSuccess: () => {},
+          onError: () => {},
         });
       },
       {injector: TestBed.inject(Injector)},

--- a/packages/forms/signals/test/node/validation_status.spec.ts
+++ b/packages/forms/signals/test/node/validation_status.spec.ts
@@ -188,7 +188,8 @@ describe('validation status', () => {
                     setTimeout(() => r(validateValueForChild(params, undefined))),
                   ),
               })),
-            errors: (errs) => errs,
+            onSuccess: (results) => results,
+            onError: () => null,
           });
         },
         {injector},
@@ -233,11 +234,12 @@ describe('validation status', () => {
                     setTimeout(() => r(validateValueForChild(params, undefined))),
                   ),
               })),
-            errors: (errs, {fieldOf}) =>
-              errs.map((e) => ({
+            onSuccess: (results, {fieldOf}) =>
+              results.map((e) => ({
                 ...e,
                 field: fieldOf(p.child),
               })),
+            onError: () => null,
           });
         },
         {injector},
@@ -282,11 +284,12 @@ describe('validation status', () => {
                     setTimeout(() => r(validateValueForChild(params, undefined))),
                   ),
               })),
-            errors: (errs, {fieldOf}) =>
-              errs.map((e) => ({
+            onSuccess: (results, {fieldOf}) =>
+              results.map((e) => ({
                 ...e,
                 field: fieldOf(p.child),
               })),
+            onError: () => null,
           });
         },
         {injector},
@@ -334,11 +337,12 @@ describe('validation status', () => {
                     setTimeout(() => r(validateValueForChild(params, undefined))),
                   ),
               })),
-            errors: (errs, {fieldOf}) =>
-              errs.map((e) => ({
+            onSuccess: (results, {fieldOf}) =>
+              results.map((e) => ({
                 ...e,
                 field: fieldOf(p.child),
               })),
+            onError: () => null,
           });
         },
         {injector},
@@ -383,7 +387,8 @@ describe('validation status', () => {
                     setTimeout(() => r(validateValueForChild(params, undefined))),
                   ),
               })),
-            errors: (errs) => errs,
+            onSuccess: (results) => results,
+            onError: () => null,
           });
         },
         {injector},
@@ -443,7 +448,8 @@ describe('validation status', () => {
                 params,
                 loader: () => new Promise<ValidationError[]>((r) => setTimeout(() => r([]))),
               })),
-            errors: (errs) => errs,
+            onSuccess: (results) => results,
+            onError: () => null,
           });
         },
         {injector},
@@ -470,7 +476,8 @@ describe('validation status', () => {
                 params,
                 loader: () => promise,
               })),
-            errors: (errs) => errs,
+            onSuccess: (results) => results,
+            onError: () => null,
           });
           validateAsync(p, {
             params: () => [],
@@ -479,7 +486,8 @@ describe('validation status', () => {
                 params,
                 loader: () => promise2,
               })),
-            errors: (errs) => errs,
+            onSuccess: (results) => results,
+            onError: () => null,
           });
         },
         {injector},
@@ -514,7 +522,8 @@ describe('validation status', () => {
                 params,
                 loader: () => invalidPromise,
               })),
-            errors: (errs) => errs,
+            onSuccess: (results) => results,
+            onError: () => null,
           });
           validateAsync(p, {
             params: () => [],
@@ -523,7 +532,8 @@ describe('validation status', () => {
                 params,
                 loader: () => validPromise,
               })),
-            errors: (errs) => errs,
+            onSuccess: (results) => results,
+            onError: () => null,
           });
           validateAsync(p, {
             params: () => [],
@@ -532,7 +542,8 @@ describe('validation status', () => {
                 params,
                 loader: () => pendingPromise,
               })),
-            errors: (errs) => errs,
+            onSuccess: (results) => results,
+            onError: () => null,
           });
         },
         {injector},


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
is not possible handle server errors when validateHttp is applied on a field in a signal form based:

```typescript
f = form(signal({ name: '' }), (p) => {
    required(p.name, { message: 'name is required!' }),
      validateHttp(p.name, {
        request: ({ value }) => {
          return value() ? `https://api.github.com/users/${value()}` : undefined;
        },
        errors: (res: any) => {
          return res && res.id && !res.message
            ? [customError({ kind: 'notUnique', message: "l'utente esiste già" })]
            : [];
        }
      });
  });
  ```
  if server responde with http status different from 200 errors callback will not never called
  
## What is the new behavior?

now, throught onError configuration is possible to handle also server errors and different http status

```typescript
f = form(signal({ name: '' }), (p) => {
    required(p.name, { message: 'name is required!' }),
      validateHttp(p.name, {
        request: ({ value }) => {
          return value() ? `https://api.github.com/users/${value()}` : undefined;
        },
        errors: (res: any) => {
          return res && res.id && !res.message
            ? [customError({ kind: 'notUnique', message: "l'utente esiste già" })]
            : [];
        },
        onError(error:any, ctx) {
              return error && error.message
            ? [customError({ kind: 'serverError', message: error.message })]
            : [];
        },
      });
  });

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

