### PR TITLE
refactor(core): drop the usage of `PromiseSettledResult<void>`

### DIFF
--- a/integration/cli-hello-world-ivy-i18n/tsconfig.json
+++ b/integration/cli-hello-world-ivy-i18n/tsconfig.json
@@ -11,14 +11,8 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "target": "es2022",
-    "typeRoots": [
-      "node_modules/@types"
-    ],
-    "lib": [
-      "es2018",
-      "dom",
-      "ES2020.Promise"
-    ]
+    "typeRoots": ["node_modules/@types"],
+    "lib": ["es2018", "dom"]
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,

--- a/integration/cli-hello-world-lazy/tsconfig.json
+++ b/integration/cli-hello-world-lazy/tsconfig.json
@@ -11,14 +11,8 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "target": "es2022",
-    "typeRoots": [
-      "node_modules/@types"
-    ],
-    "lib": [
-      "es2018",
-      "dom",
-      "ES2020.Promise"
-    ]
+    "typeRoots": ["node_modules/@types"],
+    "lib": ["es2018", "dom"]
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,

--- a/integration/cli-hello-world/tsconfig.json
+++ b/integration/cli-hello-world/tsconfig.json
@@ -12,7 +12,7 @@
     "importHelpers": true,
     "target": "es2022",
     "typeRoots": ["node_modules/@types"],
-    "lib": ["es2018", "dom", "ES2020.Promise"]
+    "lib": ["es2018", "dom"]
   },
   "angularCompilerOptions": {
     "strictTemplates": true

--- a/integration/cli-signal-inputs/e2e/tsconfig.json
+++ b/integration/cli-signal-inputs/e2e/tsconfig.json
@@ -4,11 +4,6 @@
     "outDir": "../out-tsc/e2e",
     "module": "commonjs",
     "target": "es5",
-    "types": [
-      "jasmine",
-      "jasminewd2",
-      "node",
-      "ES2020.Promise"
-    ]
+    "types": ["jasmine", "jasminewd2", "node"]
   }
 }

--- a/integration/cli-signal-inputs/tsconfig.json
+++ b/integration/cli-signal-inputs/tsconfig.json
@@ -13,7 +13,7 @@
     "importHelpers": true,
     "target": "es2022",
     "typeRoots": ["node_modules/@types"],
-    "lib": ["es2018", "dom", "ES2020.Promise"]
+    "lib": ["es2018", "dom"]
   },
   "angularCompilerOptions": {
     "strictTemplates": true

--- a/integration/defer/tsconfig.json
+++ b/integration/defer/tsconfig.json
@@ -11,14 +11,8 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "target": "es2022",
-    "typeRoots": [
-      "node_modules/@types"
-    ],
-    "lib": [
-      "es2018",
-      "dom",
-      "ES2020.Promise"
-    ]
+    "typeRoots": ["node_modules/@types"],
+    "lib": ["es2018", "dom"]
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,

--- a/integration/legacy-animations-async/tsconfig.json
+++ b/integration/legacy-animations-async/tsconfig.json
@@ -12,14 +12,8 @@
     "importHelpers": true,
     "target": "es2022",
     "useDefineForClassFields": false,
-    "typeRoots": [
-      "node_modules/@types"
-    ],
-    "lib": [
-      "es2018",
-      "dom",
-      "ES2020.Promise"
-    ]
+    "typeRoots": ["node_modules/@types"],
+    "lib": ["es2018", "dom"]
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,

--- a/integration/legacy-animations/tsconfig.json
+++ b/integration/legacy-animations/tsconfig.json
@@ -11,14 +11,8 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "target": "es2022",
-    "typeRoots": [
-      "node_modules/@types"
-    ],
-    "lib": [
-      "es2018",
-      "dom",
-      "ES2020.Promise"
-    ]
+    "typeRoots": ["node_modules/@types"],
+    "lib": ["es2018", "dom"]
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,

--- a/integration/ng-add-localize/tsconfig.json
+++ b/integration/ng-add-localize/tsconfig.json
@@ -18,11 +18,7 @@
     "importHelpers": true,
     "target": "es2017",
     "module": "es2022",
-    "lib": [
-      "es2018",
-      "dom",
-      "ES2020.Promise"
-    ]
+    "lib": ["es2018", "dom"]
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,

--- a/integration/nodenext_resolution/tsconfig.json
+++ b/integration/nodenext_resolution/tsconfig.json
@@ -10,15 +10,8 @@
     "outDir": "./dist/out-tsc",
     "rootDir": ".",
     "target": "es2020",
-    "lib": [
-      "es2020",
-      "dom",
-      "es2020.promise"
-    ],
-    "types": [],
+    "lib": ["es2020", "dom"],
+    "types": []
   },
-  "files": [
-    "include-all.ts",
-    "node_modules/@types/jasmine/index.d.ts"
-  ]
+  "files": ["include-all.ts", "node_modules/@types/jasmine/index.d.ts"]
 }

--- a/integration/platform-server-hydration/tsconfig.json
+++ b/integration/platform-server-hydration/tsconfig.json
@@ -18,11 +18,7 @@
     "target": "ES2022",
     "module": "ES2022",
     "useDefineForClassFields": false,
-    "lib": [
-      "ES2022",
-      "dom",
-      "ES2020.Promise"
-    ]
+    "lib": ["ES2022", "dom"]
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,

--- a/integration/platform-server-zoneless/tsconfig.json
+++ b/integration/platform-server-zoneless/tsconfig.json
@@ -19,11 +19,7 @@
     "target": "ES2022",
     "module": "ES2022",
     "useDefineForClassFields": false,
-    "lib": [
-      "ES2022",
-      "dom",
-      "ES2020.Promise"
-    ]
+    "lib": ["ES2022", "dom"]
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,

--- a/integration/platform-server/e2e/tsconfig.json
+++ b/integration/platform-server/e2e/tsconfig.json
@@ -5,10 +5,6 @@
     "outDir": "../out-tsc/e2e",
     "module": "commonjs",
     "target": "es2019",
-    "types": [
-      "jasmine",
-      "node",
-      "ES2020.Promise"
-    ]
+    "types": ["jasmine", "node"]
   }
 }

--- a/integration/platform-server/tsconfig.json
+++ b/integration/platform-server/tsconfig.json
@@ -19,11 +19,7 @@
     "target": "ES2022",
     "module": "ES2022",
     "useDefineForClassFields": false,
-    "lib": [
-      "ES2022",
-      "dom",
-      "ES2020.Promise"
-    ]
+    "lib": ["ES2022", "dom"]
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,

--- a/integration/standalone-bootstrap/tsconfig.json
+++ b/integration/standalone-bootstrap/tsconfig.json
@@ -11,14 +11,8 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "target": "es2022",
-    "typeRoots": [
-      "node_modules/@types"
-    ],
-    "lib": [
-      "es2018",
-      "dom",
-      "ES2020.Promise"
-    ]
+    "typeRoots": ["node_modules/@types"],
+    "lib": ["es2018", "dom"]
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,

--- a/integration/trusted-types/tsconfig.json
+++ b/integration/trusted-types/tsconfig.json
@@ -16,11 +16,7 @@
     "importHelpers": true,
     "target": "es2022",
     "module": "es2022",
-    "lib": [
-      "es2018",
-      "dom",
-      "ES2020.Promise"
-    ]
+    "lib": ["es2018", "dom"]
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,

--- a/integration/typings_test_rxjs7/tsconfig.json
+++ b/integration/typings_test_rxjs7/tsconfig.json
@@ -10,15 +10,8 @@
     "outDir": "./dist/out-tsc",
     "rootDir": ".",
     "target": "es2020",
-    "lib": [
-      "ES2020",
-      "dom",
-      "ES2020.promise"
-    ],
-    "types": [],
+    "lib": ["ES2020", "dom"],
+    "types": []
   },
-  "files": [
-    "include-all.ts",
-    "node_modules/@types/jasmine/index.d.ts"
-  ]
+  "files": ["include-all.ts", "node_modules/@types/jasmine/index.d.ts"]
 }

--- a/integration/typings_test_ts59/tsconfig.json
+++ b/integration/typings_test_ts59/tsconfig.json
@@ -10,15 +10,8 @@
     "outDir": "./dist/out-tsc",
     "rootDir": ".",
     "target": "ES2020",
-    "lib": [
-      "ES2020",
-      "dom",
-      "ES2020.promise"
-    ],
-    "types": [],
+    "lib": ["ES2020", "dom"],
+    "types": []
   },
-  "files": [
-    "include-all.ts",
-    "node_modules/@types/jasmine/index.d.ts"
-  ]
+  "files": ["include-all.ts", "node_modules/@types/jasmine/index.d.ts"]
 }

--- a/packages/core/src/animation/interfaces.ts
+++ b/packages/core/src/animation/interfaces.ts
@@ -84,7 +84,8 @@ export interface AnimationLViewData {
   leave?: (() => Promise<void>)[];
 
   // Leave animations that apply to nodes in this view
-  running?: Promise<PromiseSettledResult<void>[]>;
+  // We chose to use unknown instead of PromiseSettledResult<void> to avoid requiring the type
+  running?: Promise<unknown>;
 
   // Skip leave animations
   // This flag is solely used when move operations occur. DOM Node move


### PR DESCRIPTION
`PromiseSettledResult<void>` requires the ES2020 typings. Those might not be provided (or `skipLibCheck` is not enabled).

fixes #63931
