### PR TITLE
refactor: clean up explicit standalone flags from tests

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
@@ -1014,7 +1014,6 @@ runInEachFileSystem(() => {
             import {SomeModule} from './some_where';
 
             @Component({
-              standalone: true,
               selector: 'main',
               template: '<span>Hi!</span>',
               imports: [SomeModule],
@@ -1105,7 +1104,6 @@ runInEachFileSystem(() => {
             import {SomeModule} from './some_where';
 
             @Component({
-              standalone: true,
               selector: 'main',
               template: '<span>Hi!</span>',
               schemas: [CUSTOM_ELEMENTS_SCHEMA],

--- a/packages/compiler-cli/test/compliance/test_cases/output_function/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/output_function/GOLDEN_PARTIAL.js
@@ -93,10 +93,7 @@ export class TestDir {
 TestDir.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestDir, deps: [], target: i0.ɵɵFactoryTarget.Directive });
 TestDir.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: TestDir, isStandalone: true, outputs: { click1: "click1", click2: "click2", click3: "click3", _bla: "decoratorPublicName", _bla2: "decoratorPublicName2", clickDecorator1: "clickDecorator1", clickDecorator2: "clickDecorator2", _blaDecorator: "decoratorPublicName" }, ngImport: i0 });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestDir, decorators: [{
-            type: Directive,
-            args: [{
-                    standalone: true,
-                }]
+            type: Directive
         }], propDecorators: { clickDecorator1: [{
                 type: Output
             }], clickDecorator2: [{

--- a/packages/compiler-cli/test/compliance/test_cases/output_function/mixed_variants.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/output_function/mixed_variants.ts
@@ -1,9 +1,7 @@
 import {Directive, EventEmitter, Output, output} from '@angular/core';
 import {outputFromObservable} from '@angular/core/rxjs-interop';
 
-@Directive({
-  standalone: true,
-})
+@Directive()
 export class TestDir {
   click1 = output();
   click2 = output<boolean>();

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/animations/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/animations/GOLDEN_PARTIAL.js
@@ -45,7 +45,6 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
             type: Directive,
             args: [{
                     selector: '[any-structural-directive]',
-                    standalone: true,
                 }]
         }] });
 export class MyComponent {
@@ -61,7 +60,6 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
             args: [{
                     selector: 'my-component',
                     imports: [AnyStructuralDirective],
-                    standalone: true,
                     template: `
     <div>
       <p *any-structural-directive animate.enter="slide">Sliding Content</p>

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/animations/animate_enter_with_structural_directive.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/animations/animate_enter_with_structural_directive.ts
@@ -2,20 +2,16 @@ import {Component, Directive} from '@angular/core';
 
 @Directive({
   selector: '[any-structural-directive]',
-  standalone: true,
 })
 export class AnyStructuralDirective {}
 
-
 @Component({
-    selector: 'my-component',
-    imports: [AnyStructuralDirective],
-    standalone: true,
-    template: `
+  selector: 'my-component',
+  imports: [AnyStructuralDirective],
+  template: `
     <div>
       <p *any-structural-directive animate.enter="slide">Sliding Content</p>
     </div>
   `,
 })
-export class MyComponent {
-}
+export class MyComponent {}

--- a/packages/compiler-cli/test/ngtsc/authoring_inputs_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/authoring_inputs_spec.ts
@@ -238,14 +238,13 @@ runInEachFileSystem(() => {
         `
         import {Component, Directive, input, Output, EventEmitter} from '@angular/core';
 
-        @Directive({standalone: true, selector: '[dir]'})
+        @Directive({selector: '[dir]'})
         export class TestDir {
           value = input('hello');
           @Output() valueChange = new EventEmitter<string>();
         }
 
         @Component({
-          standalone: true,
           template: \`<div dir [(value)]="value"></div>\`,
           imports: [TestDir],
         })
@@ -270,14 +269,12 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[directiveName]',
-            standalone: true,
           })
           export class TestDir {
             data = input(1);
           }
 
           @Component({
-            standalone: true,
             template: \`<div directiveName [data]="false"></div>\`,
             imports: [TestDir],
           })
@@ -301,7 +298,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[directiveName]',
-            standalone: true,
           })
           export class TestDir {
             data = input.required({
@@ -310,7 +306,6 @@ runInEachFileSystem(() => {
           }
 
           @Component({
-            standalone: true,
             template: \`<div directiveName [data]="false"></div>\`,
             imports: [TestDir],
           })
@@ -334,14 +329,12 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[directiveName]',
-            standalone: true,
           })
           export class TestDir {
             data = input.required<boolean>();
           }
 
           @Component({
-            standalone: true,
             template: \`<div directiveName></div>\`,
             imports: [TestDir],
           })
@@ -367,7 +360,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[directiveName]',
-            standalone: true,
           })
           export class TestDir {
             #data = input.required<boolean>();
@@ -394,7 +386,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[directiveName]',
-            standalone: true,
           })
           export class TestDir {
             private data = input.required<boolean>();
@@ -421,7 +412,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[directiveName]',
-            standalone: true,
           })
           export class TestDir {
             protected data = input.required<boolean>();

--- a/packages/compiler-cli/test/ngtsc/authoring_models_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/authoring_models_spec.ts
@@ -249,14 +249,12 @@ runInEachFileSystem(() => {
 
         @Directive({
           selector: '[dir]',
-          standalone: true,
         })
         export class TestDir {
           value = model(1);
         }
 
         @Component({
-          standalone: true,
           template: \`<div dir [(value)]="value()"></div>\`,
           imports: [TestDir],
         })
@@ -280,14 +278,12 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
           })
           export class TestDir {
             value = model(1);
           }
 
           @Component({
-            standalone: true,
             template: \`<div dir [(value)]="value"></div>\`,
             imports: [TestDir],
           })
@@ -311,14 +307,12 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
           })
           export class TestDir {
             value = model(1);
           }
 
           @Component({
-            standalone: true,
             template: \`<div dir [(value)]="value"></div>\`,
             imports: [TestDir],
           })
@@ -342,7 +336,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
           })
           export class TestDir {
             @Input() value = 0;
@@ -350,7 +343,6 @@ runInEachFileSystem(() => {
           }
 
           @Component({
-            standalone: true,
             template: \`<div dir [(value)]="value"></div>\`,
             imports: [TestDir],
           })
@@ -374,14 +366,12 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
           })
           export class TestDir {
             value = model(1);
           }
 
           @Component({
-            standalone: true,
             template: \`<div dir [(value)]="value"></div>\`,
             imports: [TestDir],
           })
@@ -409,14 +399,12 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
           })
           export class TestDir {
             value = model(1);
           }
 
           @Component({
-            standalone: true,
             template: \`<div dir [(value)]="value"></div>\`,
             imports: [TestDir],
           })
@@ -438,14 +426,12 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
           })
           export class TestDir {
             value = model(1);
           }
 
           @Component({
-            standalone: true,
             template: \`<div dir (valueChange)="acceptsString($event)"></div>\`,
             imports: [TestDir],
           })
@@ -470,14 +456,12 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
           })
           export class TestDir {
             value = model.required<number>();
           }
 
           @Component({
-            standalone: true,
             template: \`<div dir></div>\`,
             imports: [TestDir],
           })
@@ -501,14 +485,12 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
           })
           export class TestDir<T extends {id: string}> {
             value = model.required<T>();
           }
 
           @Component({
-            standalone: true,
             template: \`<div dir [(value)]="value"></div>\`,
             imports: [TestDir],
           })
@@ -540,14 +522,12 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
           })
           export class TestDir<T extends {id: string}> {
             value = model.required<T>();
           }
 
           @Component({
-            standalone: true,
             template: \`<div dir [(value)]="value"></div>\`,
             imports: [TestDir],
           })
@@ -579,14 +559,12 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
           })
           export class TestDir {
             value = model(0);
           }
 
           @Component({
-            standalone: true,
             template: \`<div dir [value]="value"></div>\`,
             imports: [TestDir],
           })
@@ -612,14 +590,12 @@ runInEachFileSystem(() => {
 
         @Directive({
           selector: '[dir]',
-          standalone: true,
         })
         export class TestDir<T> {
           value = model.required<T>();
         }
 
         @Component({
-          standalone: true,
           template: \`<div dir [(value)]="value"></div>\`,
           imports: [TestDir],
         })
@@ -643,7 +619,6 @@ runInEachFileSystem(() => {
 
         @Directive({
           selector: '[dir]',
-          standalone: true,
         })
         export class TestDir {
           @Input() value = 0;
@@ -651,7 +626,6 @@ runInEachFileSystem(() => {
         }
 
         @Component({
-          standalone: true,
           template: \`<div dir [(value)]="value"></div>\`,
           imports: [TestDir],
         })
@@ -710,7 +684,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[directiveName]',
-            standalone: true,
           })
           export class TestDir {
             #data = model.required<boolean>();
@@ -737,7 +710,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[directiveName]',
-            standalone: true,
           })
           export class TestDir {
             private data = model.required<boolean>();
@@ -764,7 +736,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[directiveName]',
-            standalone: true,
           })
           export class TestDir {
             protected data = model.required<boolean>();

--- a/packages/compiler-cli/test/ngtsc/debug_transform_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/debug_transform_spec.ts
@@ -466,7 +466,7 @@ runInEachFileSystem(() => {
             `
               import {signal, computed} from '@angular/core';
               declare function equal(): boolean;
-          
+
               const testSignal = signal(123);
               const testComputed = computed(() => testSignal(), { equal });
             `,
@@ -1166,18 +1166,18 @@ runInEachFileSystem(() => {
             import {viewChild, Component} from '@angular/core';
 
             @Component({
-                selector: 'child-component',
-                standalone: true,
-                template: ''
-            }) class ChildComponent {}
+              selector: 'child-component',
+              template: ''
+            })
+            class ChildComponent {}
 
             @Component({
-                template: '<child-component/>',
-                standalone: true,
-                imports: [ChildComponent]
-            }) class MyComponent {
-                testViewChild = viewChild('foo');
-                testViewChildComponent = viewChild(ChildComponent);
+              template: '<child-component/>',
+              imports: [ChildComponent]
+            })
+            class MyComponent {
+              testViewChild = viewChild('foo');
+              testViewChildComponent = viewChild(ChildComponent);
             }
           `,
         );
@@ -1200,17 +1200,16 @@ runInEachFileSystem(() => {
 
             @Component({
                 selector: 'child-component',
-                standalone: true,
                 template: ''
             }) class ChildComponent {}
 
             @Component({
-                template: '<child-component/>',
-                standalone: true,
-                imports: [ChildComponent]
-            }) class MyComponent {
-                testViewChild = viewChild('foo');
-                testViewChildComponent = viewChild(ChildComponent);
+              template: '<child-component/>',
+              imports: [ChildComponent]
+            })
+            class MyComponent {
+              testViewChild = viewChild('foo');
+              testViewChildComponent = viewChild(ChildComponent);
             }
           `,
         );
@@ -1231,17 +1230,16 @@ runInEachFileSystem(() => {
 
             @Component({
                 selector: 'child-component',
-                standalone: true,
-                template: ''
+                                template: ''
             }) class ChildComponent {}
 
             @Component({
-                template: '<child-component/>',
-                standalone: true,
-                imports: [ChildComponent]
-            }) class MyComponent {
-                testViewChild = viewChild('foo');
-                testViewChildComponent = viewChild(ChildComponent);
+              template: '<child-component/>',
+              imports: [ChildComponent]
+            })
+            class MyComponent {
+              testViewChild = viewChild('foo');
+              testViewChildComponent = viewChild(ChildComponent);
             }
           `,
         );

--- a/packages/compiler-cli/test/ngtsc/defer_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/defer_spec.ts
@@ -31,7 +31,6 @@ runInEachFileSystem(() => {
         import { Component } from '@angular/core';
 
         @Component({
-          standalone: true,
           selector: 'cmp-a',
           template: 'CmpA!'
         })
@@ -47,14 +46,12 @@ runInEachFileSystem(() => {
 
         @Component({
           selector: 'local-dep',
-          standalone: true,
           template: 'Local dependency',
         })
         export class LocalDep {}
 
         @Component({
           selector: 'test-cmp',
-          standalone: true,
           imports: [CmpA, LocalDep],
           template: \`
             @defer {
@@ -86,7 +83,6 @@ runInEachFileSystem(() => {
           import { Component } from '@angular/core';
 
           @Component({
-            standalone: true,
             selector: 'cmp-a',
             template: 'CmpA!'
           })
@@ -102,7 +98,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'test-cmp',
-            standalone: true,
             imports: [CmpA],
             template: \`
               @defer {
@@ -132,7 +127,6 @@ runInEachFileSystem(() => {
           import { Component } from '@angular/core';
 
           @Component({
-            standalone: true,
             selector: 'cmp-a',
             template: 'CmpA!'
           })
@@ -148,7 +142,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'test-cmp',
-            standalone: true,
             imports: [CmpA],
             template: \`
               @defer {
@@ -185,14 +178,12 @@ runInEachFileSystem(() => {
           import { Component } from '@angular/core';
 
           @Component({
-            standalone: true,
             selector: 'cmp-a',
             template: 'CmpA!'
           })
           export class CmpA {}
 
           @Component({
-            standalone: true,
             selector: 'cmp-b',
             template: 'CmpB!'
           })
@@ -208,7 +199,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'test-cmp',
-            standalone: true,
             imports: [CmpA, CmpB],
             template: \`
               @defer {
@@ -247,14 +237,12 @@ runInEachFileSystem(() => {
           import { Component } from '@angular/core';
 
           @Component({
-            standalone: true,
             selector: 'cmp-a',
             template: 'CmpA!'
           })
           export class CmpA {}
 
           @Component({
-            standalone: true,
             selector: 'cmp-b',
             template: 'CmpB!'
           })
@@ -270,7 +258,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'test-cmp',
-            standalone: true,
             imports: [CmpA, CmpB],
             template: \`
               @defer {
@@ -306,7 +293,6 @@ runInEachFileSystem(() => {
           import { Component } from '@angular/core';
 
           @Component({
-            standalone: true,
             selector: 'cmp-a',
             template: 'CmpA!'
           })
@@ -322,7 +308,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'test-cmp',
-            standalone: true,
             imports: [forwardRef(() => CmpA)],
             template: \`
               @defer {
@@ -355,7 +340,6 @@ runInEachFileSystem(() => {
           export class Foo {}
 
           @Component({
-            standalone: true,
             selector: 'cmp-a',
             template: 'CmpA!'
           })
@@ -373,7 +357,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'test-cmp',
-            standalone: true,
             imports: [CmpA],
             template: \`
               @defer {
@@ -403,7 +386,6 @@ runInEachFileSystem(() => {
             export class Foo {}
 
             @Component({
-              standalone: true,
               selector: 'cmp-a',
               template: 'CmpA!'
             })
@@ -422,7 +404,6 @@ runInEachFileSystem(() => {
 
             @Component({
               selector: 'test-cmp',
-              standalone: true,
               imports: [CmpA],
               template: \`
                 @defer {
@@ -452,7 +433,6 @@ runInEachFileSystem(() => {
             export class Foo {}
 
             @Component({
-              standalone: true,
               selector: 'cmp-a',
               template: 'CmpA!'
             })
@@ -471,7 +451,6 @@ runInEachFileSystem(() => {
 
             @Component({
               selector: 'test-cmp',
-              standalone: true,
               imports: [CmpA],
               template: \`
                 @defer {
@@ -501,7 +480,6 @@ runInEachFileSystem(() => {
             export class Foo {}
 
             @Component({
-              standalone: true,
               selector: 'cmp-a',
               template: 'CmpA!'
             })
@@ -520,7 +498,6 @@ runInEachFileSystem(() => {
 
             @Component({
               selector: 'test-cmp',
-              standalone: true,
               imports: [CmpA],
               template: \`
                 @defer {
@@ -548,14 +525,12 @@ runInEachFileSystem(() => {
           import { Component } from '@angular/core';
 
           @Component({
-            standalone: true,
             selector: 'cmp-a',
             template: 'CmpA!'
           })
           export class CmpA {}
 
           @Component({
-            standalone: true,
             selector: 'cmp-b',
             template: 'CmpB!'
           })
@@ -572,7 +547,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'test-cmp',
-            standalone: true,
             imports: [CmpA, CmpB],
             template: \`
               @defer {
@@ -603,7 +577,6 @@ runInEachFileSystem(() => {
           `
           import { Component } from '@angular/core';
           @Component({
-            standalone: true,
             selector: 'cmp-a',
             template: 'CmpA!'
           })
@@ -617,13 +590,11 @@ runInEachFileSystem(() => {
           import CmpA from './cmp-a';
           @Component({
             selector: 'local-dep',
-            standalone: true,
             template: 'Local dependency',
           })
           export class LocalDep {}
           @Component({
             selector: 'test-cmp',
-            standalone: true,
             imports: [CmpA, LocalDep],
             template: \`
               @defer {
@@ -657,7 +628,6 @@ runInEachFileSystem(() => {
           import { Component } from '@angular/core';
 
           @Component({
-            standalone: true,
             selector: 'cmp',
             template: 'Cmp!'
           })
@@ -674,7 +644,6 @@ runInEachFileSystem(() => {
           const topLevelConst: Cmp = null!;
 
           @Component({
-            standalone: true,
             imports: [Cmp],
             template: \`
               @defer {
@@ -715,7 +684,6 @@ runInEachFileSystem(() => {
           import { Component } from '@angular/core';
 
           @Component({
-            standalone: true,
             selector: 'cmp',
             template: 'Cmp!'
           })
@@ -730,7 +698,6 @@ runInEachFileSystem(() => {
           import { Cmp } from './cmp';
 
           @Component({
-            standalone: true,
             imports: [Cmp],
             template: \`
               @defer {
@@ -763,7 +730,7 @@ runInEachFileSystem(() => {
         `
         import { Pipe } from '@angular/core';
 
-        @Pipe({name: 'test', standalone: true})
+        @Pipe({name: 'test'})
         export class TestPipe {
           transform() {
             return 1;
@@ -780,7 +747,6 @@ runInEachFileSystem(() => {
 
         @Component({
           selector: 'test-cmp',
-          standalone: true,
           imports: [TestPipe],
           template: '@defer (when 1 | test) { hello }',
         })
@@ -802,7 +768,7 @@ runInEachFileSystem(() => {
         `
         import { Pipe } from '@angular/core';
 
-        @Pipe({name: 'test', standalone: true})
+        @Pipe({name: 'test'})
         export class TestPipe {
           transform() {
             return 1;
@@ -819,7 +785,6 @@ runInEachFileSystem(() => {
 
         @Component({
           selector: 'test-cmp',
-          standalone: true,
           imports: [TestPipe],
           template: '@defer (when 1 | test) { hello }',
         })
@@ -841,7 +806,7 @@ runInEachFileSystem(() => {
         `
         import { Pipe } from '@angular/core';
 
-        @Pipe({name: 'test', standalone: true})
+        @Pipe({name: 'test'})
         export class TestPipe {
           transform() {
             return 1;
@@ -858,7 +823,6 @@ runInEachFileSystem(() => {
 
         @Component({
           selector: 'test-cmp',
-          standalone: true,
           imports: [TestPipe],
           template: '@defer (when 1 | test) { {{1 | test}} }',
         })
@@ -885,7 +849,6 @@ runInEachFileSystem(() => {
           `
           import {Component} from '@angular/core';
           @Component({
-            standalone: true,
             selector: 'deferred-cmp-a',
             template: 'DeferredCmpA contents',
           })
@@ -899,7 +862,6 @@ runInEachFileSystem(() => {
           `
           import {Component} from '@angular/core';
           @Component({
-            standalone: true,
             selector: 'deferred-cmp-b',
             template: 'DeferredCmpB contents',
           })
@@ -928,7 +890,6 @@ runInEachFileSystem(() => {
           import {DeferredCmpB} from './deferred-b';
           import {PipeA} from './pipe-a';
           @Component({
-            standalone: true,
             // @ts-ignore
             deferredImports: [DeferredCmpA, DeferredCmpB, PipeA],
             template: \`
@@ -993,7 +954,6 @@ runInEachFileSystem(() => {
             import {Component} from '@angular/core';
 
             @Component({
-              standalone: true,
               selector: 'eager-cmp-a',
               template: 'EagerCmpA contents',
             })
@@ -1008,7 +968,6 @@ runInEachFileSystem(() => {
             import {Component} from '@angular/core';
 
             @Component({
-              standalone: true,
               selector: 'deferred-cmp-a',
               template: 'DeferredCmpA contents',
             })
@@ -1023,7 +982,6 @@ runInEachFileSystem(() => {
             import {Component} from '@angular/core';
 
             @Component({
-              standalone: true,
               selector: 'deferred-cmp-b',
               template: 'DeferredCmpB contents',
             })
@@ -1041,7 +999,6 @@ runInEachFileSystem(() => {
             import {EagerCmpA} from './eager-a';
 
             @Component({
-              standalone: true,
               imports: [EagerCmpA],
               // @ts-ignore
               deferredImports: [DeferredCmpA, DeferredCmpB],
@@ -1106,7 +1063,6 @@ runInEachFileSystem(() => {
               @Injectable()
               class MyInjectable {}
               @Component({
-                standalone: true,
                 // @ts-ignore
                 deferredImports: [MyInjectable],
                 template: '',
@@ -1129,7 +1085,6 @@ runInEachFileSystem(() => {
               @NgModule()
               class MyModule {}
               @Component({
-                standalone: true,
                 // @ts-ignore
                 deferredImports: [MyModule],
                 template: '',
@@ -1149,8 +1104,8 @@ runInEachFileSystem(() => {
             'deferred-a.ts',
             `
               import {Component} from '@angular/core';
+
               @Component({
-                standalone: true,
                 selector: 'deferred-cmp-a',
                 template: 'DeferredCmpA contents',
               })
@@ -1163,8 +1118,8 @@ runInEachFileSystem(() => {
             'deferred-b.ts',
             `
               import {Component} from '@angular/core';
+
               @Component({
-                standalone: true,
                 selector: 'deferred-cmp-b',
                 template: 'DeferredCmpB contents',
               })
@@ -1180,7 +1135,6 @@ runInEachFileSystem(() => {
               import {DeferredCmpA} from './deferred-a';
               import {DeferredCmpB} from './deferred-b';
               @Component({
-                standalone: true,
                 // @ts-ignore
                 deferredImports: [DeferredCmpA, DeferredCmpB],
                 template: \`
@@ -1206,8 +1160,8 @@ runInEachFileSystem(() => {
             'deferred-a.ts',
             `
               import {Component} from '@angular/core';
+
               @Component({
-                standalone: true,
                 selector: 'deferred-cmp-a',
                 template: 'DeferredCmpA contents',
               })
@@ -1221,8 +1175,8 @@ runInEachFileSystem(() => {
             `
               import {Component} from '@angular/core';
               import {DeferredCmpA} from './deferred-a';
+
               @Component({
-                standalone: true,
                 // @ts-ignore
                 deferredImports: [DeferredCmpA],
                 imports: [DeferredCmpA],
@@ -1246,10 +1200,7 @@ runInEachFileSystem(() => {
             'deferred-pipe-a.ts',
             `
               import {Pipe} from '@angular/core';
-              @Pipe({
-                standalone: true,
-                name: 'deferredPipeA'
-              })
+              @Pipe({name: 'deferredPipeA'})
               export class DeferredPipeA {
                 transform() {}
               }
@@ -1260,10 +1211,7 @@ runInEachFileSystem(() => {
             'deferred-pipe-b.ts',
             `
               import {Pipe} from '@angular/core';
-              @Pipe({
-                standalone: true,
-                name: 'deferredPipeB'
-              })
+              @Pipe({name: 'deferredPipeB'})
               export class DeferredPipeB {
                 transform() {}
               }
@@ -1277,7 +1225,6 @@ runInEachFileSystem(() => {
               import {DeferredPipeA} from './deferred-pipe-a';
               import {DeferredPipeB} from './deferred-pipe-b';
               @Component({
-                standalone: true,
                 // @ts-ignore
                 deferredImports: [DeferredPipeA, DeferredPipeB],
                 template: \`
@@ -1302,7 +1249,6 @@ runInEachFileSystem(() => {
             `
             import {Component} from '@angular/core';
             @Component({
-              standalone: true,
               selector: 'deferred-cmp-a',
               template: 'DeferredCmpA contents',
             })
@@ -1317,7 +1263,6 @@ runInEachFileSystem(() => {
             import {Component} from '@angular/core';
             import {DeferredCmpA} from './deferred-a';
             @Component({
-              standalone: true,
               // @ts-ignore
               deferredImports: [DeferredCmpA],
               template: \`
@@ -1348,7 +1293,6 @@ runInEachFileSystem(() => {
             `
               import {Component} from '@angular/core';
               @Component({
-                standalone: true,
                 selector: 'deferred-cmp-a',
                 template: 'DeferredCmpA contents',
               })
@@ -1363,7 +1307,6 @@ runInEachFileSystem(() => {
               import {Component} from '@angular/core';
               import {DeferredCmpA} from './deferred-a';
               @Component({
-                standalone: true,
                 // @ts-ignore
                 deferredImports: [DeferredCmpA],
                 template: \`
@@ -1398,7 +1341,6 @@ runInEachFileSystem(() => {
           import {Component} from '@angular/core';
 
           @Component({
-            standalone: true,
             selector: 'cmp-a',
             template: 'CmpA!'
           })
@@ -1414,14 +1356,12 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'local-dep',
-            standalone: true,
             template: 'Local dependency',
           })
           export class LocalDep {}
 
           @Component({
             selector: 'test-cmp',
-            standalone: true,
             imports: [CmpA, LocalDep],
             template: \`
               @defer {
@@ -1461,7 +1401,6 @@ runInEachFileSystem(() => {
             import {Component} from '@angular/core';
 
             @Component({
-              standalone: true,
               selector: 'cmp-a',
               template: 'CmpA!'
             })
@@ -1477,7 +1416,6 @@ runInEachFileSystem(() => {
 
             @Component({
               selector: 'test-cmp',
-              standalone: true,
               imports: [CmpA],
               template: \`
                 @defer {
@@ -1518,7 +1456,6 @@ runInEachFileSystem(() => {
         import {Component} from '@angular/core';
 
         @Component({
-          standalone: true,
           selector: 'cmp-a',
           template: 'CmpA!'
         })
@@ -1534,15 +1471,13 @@ runInEachFileSystem(() => {
 
         @Component({
           selector: 'local-dep',
-          standalone: true,
           template: 'Local dependency',
         })
         export class LocalDep {}
 
         @Component({
           selector: 'test-cmp',
-          standalone: true,
-          imports: [CmpA, LocalDep],
+                    imports: [CmpA, LocalDep],
           template: \`
             @defer {
               <cmp-a />

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/directive_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/directive_doc_extraction_spec.ts
@@ -36,7 +36,6 @@ runInEachFileSystem(() => {
         `
         import {Directive} from '@angular/core';
         @Directive({
-          standalone: true,
           selector: 'user-profile',
           exportAs: 'userProfile',
         })
@@ -61,7 +60,6 @@ runInEachFileSystem(() => {
         `
         import {Component} from '@angular/core';
         @Component({
-          standalone: true,
           selector: 'user-profile',
           exportAs: 'userProfile',
           template: '',
@@ -146,7 +144,6 @@ runInEachFileSystem(() => {
         `
         import {Directive, EventEmitter, Input, Output} from '@angular/core';
         @Directive({
-          standalone: true,
           selector: 'user-profile',
           exportAs: 'userProfile',
         })
@@ -203,7 +200,6 @@ runInEachFileSystem(() => {
         `
         import {Component, EventEmitter, Input, Output} from '@angular/core';
         @Component({
-          standalone: true,
           selector: 'user-profile',
           exportAs: 'userProfile',
           template: '',
@@ -251,7 +247,6 @@ runInEachFileSystem(() => {
         `
         import {Component, EventEmitter, Input, Output} from '@angular/core';
         @Component({
-          standalone: true,
           selector: 'user-profile',
           exportAs: 'userProfile',
           template: '',

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/pipe_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/pipe_doc_extraction_spec.ts
@@ -30,7 +30,6 @@ runInEachFileSystem(() => {
         `
         import {Pipe} from '@angular/core';
         @Pipe({
-          standalone: true,
           name: 'shorten',
         })
         export class ShortenPipe {
@@ -57,7 +56,7 @@ runInEachFileSystem(() => {
         import {Pipe, NgModule} from '@angular/core';
         @Pipe({
           name: 'shorten',
-          standalone: false, 
+          standalone: false,
         })
         export class ShortenPipe {
           transform(value: string): string { return ''; }

--- a/packages/compiler-cli/test/ngtsc/hmr_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/hmr_spec.ts
@@ -50,7 +50,6 @@ runInEachFileSystem(() => {
           @Component({
             selector: 'cmp',
             template: 'hello',
-            standalone: true,
           })
           export class Cmp {}
         `,
@@ -80,7 +79,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dep]',
-            standalone: true,
           })
           export class Dep {}
         `,
@@ -94,7 +92,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'cmp',
-            standalone: true,
             template: '<div dep><div>',
             imports: [Dep],
           })
@@ -146,7 +143,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dep]',
-            standalone: true,
           })
           export class Dep {}
 
@@ -166,8 +162,7 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'cmp',
-            standalone: true,
-            template: '<div dep><div>',
+                        template: '<div dep><div>',
             imports: [DepModule],
           })
           export class Cmp {}
@@ -216,7 +211,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'cmp',
-            standalone: true,
             template: '@if (true) {hello}',
           })
           export class Cmp {}
@@ -243,7 +237,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'cmp',
-            standalone: true,
             template: '<ng-content select="header"/><ng-content/>',
           })
           export class Cmp {}
@@ -270,7 +263,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dep]',
-            standalone: true,
           })
           export class Dep {}
         `,
@@ -284,7 +276,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'cmp',
-            standalone: true,
             template: '@defer (on timer(1000)) {<div dep></div>}',
             imports: [Dep],
           })
@@ -321,7 +312,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dep]',
-            standalone: true,
           })
           export class Dep {}
         `,
@@ -335,7 +325,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'cmp',
-            standalone: true,
             template: '@defer (on timer(1000)) {<div dep></div>}',
             imports: [Dep],
           })
@@ -376,7 +365,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'cmp',
-            standalone: true,
             template: '{{#invalid}}',
           })
           export class Cmp {}
@@ -394,10 +382,7 @@ runInEachFileSystem(() => {
         `
           import {Directive} from '@angular/core';
 
-          @Component({
-            selector: '[dir]',
-            standalone: true
-          })
+          @Component({selector: '[dir]'})
           export class Dir {}
         `,
       );

--- a/packages/compiler-cli/test/ngtsc/host_directives_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/host_directives_spec.ts
@@ -34,16 +34,10 @@ runInEachFileSystem(() => {
         `
         import {Directive, Component} from '@angular/core';
 
-        @Directive({
-          selector: '[dir-a]',
-          standalone: true
-        })
+        @Directive({selector: '[dir-a]'})
         export class DirectiveA {}
 
-        @Directive({
-          selector: '[dir-b]',
-          standalone: true
-        })
+        @Directive({selector: '[dir-b]'})
         export class DirectiveB {}
 
         @Component({
@@ -79,10 +73,7 @@ runInEachFileSystem(() => {
         `
         import {Directive, Component, Input, Output, EventEmitter} from '@angular/core';
 
-        @Directive({
-          selector: '[dir-a]',
-          standalone: true
-        })
+        @Directive({selector: '[dir-a]'})
         export class HostDir {
           @Input() value: number;
           @Input() color: string;
@@ -129,10 +120,7 @@ runInEachFileSystem(() => {
         `
         import {Directive, Component, Input, Output, EventEmitter} from '@angular/core';
 
-        @Directive({
-          selector: '[dir-a]',
-          standalone: true
-        })
+        @Directive({selector: '[dir-a]'})
         export class HostDir {
           @Input('valueAlias') value: number;
           @Input('colorAlias') color: string;
@@ -183,17 +171,11 @@ runInEachFileSystem(() => {
         export class DirectiveA {
         }
 
-        @Directive({
-          standalone: true,
-          hostDirectives: [DirectiveA],
-        })
+        @Directive({hostDirectives: [DirectiveA]})
         export class DirectiveB {
         }
 
-        @Directive({
-          standalone: true,
-          hostDirectives: [DirectiveB],
-        })
+        @Directive({hostDirectives: [DirectiveB]})
         export class DirectiveC {
         }
 
@@ -263,7 +245,6 @@ runInEachFileSystem(() => {
         }
 
         @Directive({
-          standalone: true,
           hostDirectives: [{directive: forwardRef(() => DirectiveA), inputs: ['value']}],
         })
         export class DirectiveB {
@@ -315,10 +296,7 @@ runInEachFileSystem(() => {
         `
         import {Directive} from '@angular/core';
 
-        @Directive({
-          selector: '[dir-a]',
-          standalone: true
-        })
+        @Directive({selector: '[dir-a]'})
         export class DirectiveA {}
       `,
       );
@@ -328,10 +306,7 @@ runInEachFileSystem(() => {
         `
         import {Directive, Input, Output, EventEmitter} from '@angular/core';
 
-        @Directive({
-          selector: '[dir-b]',
-          standalone: true
-        })
+        @Directive({selector: '[dir-b]'})
         export class DirectiveB {
           @Input() input: any;
           @Output() output = new EventEmitter<any>();
@@ -493,14 +468,12 @@ runInEachFileSystem(() => {
 
             @Directive({
               selector: '[dir]',
-              hostDirectives: [{directive: HostDir, inputs: ['inputAlias: customAlias']}],
-              standalone: true
+              hostDirectives: [{directive: HostDir, inputs: ['inputAlias: customAlias']}]
             })
             export class Dir {}
 
             @Component({
               template: '<div dir></div>',
-              standalone: true,
               imports: [Dir]
             })
             class App {}
@@ -528,14 +501,12 @@ runInEachFileSystem(() => {
 
             @Directive({
               selector: '[dir]',
-              hostDirectives: [{directive: HostDir, inputs: ['inputAlias: customAlias']}],
-              standalone: true
+              hostDirectives: [{directive: HostDir, inputs: ['inputAlias: customAlias']}]
             })
             export class Dir {}
 
             @Component({
               template: '<div dir [customAlias]="value"></div>',
-              standalone: true,
               imports: [Dir]
             })
             class App {
@@ -600,10 +571,7 @@ runInEachFileSystem(() => {
           `
           import {Directive, Component, NgModule} from '@angular/core';
 
-          @Component({
-            template: '',
-            standalone: true,
-          })
+          @Component({template: ''})
           export class HostComp {}
 
           @Directive({
@@ -691,7 +659,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir-a]',
-            standalone: true,
             hostDirectives: [HostDirB]
           })
           export class HostDirA {}
@@ -832,7 +799,7 @@ runInEachFileSystem(() => {
           `
           import {Directive, Input} from '@angular/core';
 
-          @Directive({selector: '[host-dir]', standalone: true})
+          @Directive({selector: '[host-dir]'})
           class HostDir {
             @Input('colorAlias') color?: string;
             @Input() buttonColor?: string;
@@ -860,7 +827,7 @@ runInEachFileSystem(() => {
           `
             import {Directive, Input} from '@angular/core';
 
-            @Directive({selector: '[host-dir]', standalone: true})
+            @Directive({selector: '[host-dir]'})
             class HostDir {
               @Input('colorAlias') color?: string;
               @Input('buttonColorAlias') buttonColor?: string;
@@ -887,7 +854,7 @@ runInEachFileSystem(() => {
           `
           import {Directive, Input} from '@angular/core';
 
-          @Directive({selector: '[host-dir]', standalone: true})
+          @Directive({selector: '[host-dir]'})
           class HostDir {
             @Input('color') color?: string;
           }
@@ -910,7 +877,7 @@ runInEachFileSystem(() => {
           `
           import {Directive, Output, EventEmitter} from '@angular/core';
 
-          @Directive({selector: '[host-dir]', standalone: true})
+          @Directive({selector: '[host-dir]'})
           class HostDir {
             @Output('clickedAlias') clicked = new EventEmitter();
             @Output('tappedAlias') tapped = new EventEmitter();
@@ -937,7 +904,7 @@ runInEachFileSystem(() => {
           `
           import {Directive, Output, EventEmitter} from '@angular/core';
 
-          @Directive({selector: '[host-dir]', standalone: true})
+          @Directive({selector: '[host-dir]'})
           class HostDir {
             @Output('clicked') clicked = new EventEmitter();
           }
@@ -960,10 +927,7 @@ runInEachFileSystem(() => {
           `
           import {Directive, Component, Input} from '@angular/core';
 
-          @Directive({
-            selector: '[dir-a]',
-            standalone: true
-          })
+          @Directive({selector: '[dir-a]'})
           export class HostDir {
             @Input({required: true}) input: any;
           }
@@ -990,10 +954,7 @@ runInEachFileSystem(() => {
           `
               import {Directive, Component, Input} from '@angular/core';
 
-              @Directive({
-                selector: '[dir-a]',
-                standalone: true
-              })
+              @Directive({selector: '[dir-a]'})
               export class HostDir {
                 @Input({required: true, alias: 'inputAlias'}) input: any;
               }
@@ -1020,10 +981,7 @@ runInEachFileSystem(() => {
           `
           import {Directive, Component, Input} from '@angular/core';
 
-          @Directive({
-            selector: '[dir-a]',
-            standalone: true
-          })
+          @Directive({selector: '[dir-a]'})
           export class HostDir {
             @Input({required: true, alias: 'inputAlias'}) input: any;
           }
@@ -1048,10 +1006,7 @@ runInEachFileSystem(() => {
           `
               import {Directive, Component, Input} from '@angular/core';
 
-              @Directive({
-                selector: '[dir-a]',
-                standalone: true
-              })
+              @Directive({selector: '[dir-a]'})
               export class HostDir {
                 @Input({required: true, alias: 'inputAlias'}) input: any;
               }
@@ -1079,14 +1034,12 @@ runInEachFileSystem(() => {
           @Directive({
             outputs: ['opened: triggerOpened'],
             selector: '[trigger]',
-            standalone: true,
           })
           export class Trigger {
             opened = new EventEmitter();
           }
 
           @Directive({
-            standalone: true,
             selector: '[host]',
             hostDirectives: [{directive: Trigger, outputs: ['triggerOpened']}]
           })
@@ -1112,12 +1065,10 @@ runInEachFileSystem(() => {
           @Directive({
             outputs: ['opened: triggerOpened'],
             selector: '[trigger]',
-            standalone: true,
           })
           export class Trigger extends Base {}
 
           @Directive({
-            standalone: true,
             selector: '[host]',
             hostDirectives: [{directive: Trigger, outputs: ['triggerOpened: hostOpened']}]
           })

--- a/packages/compiler-cli/test/ngtsc/incremental_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/incremental_spec.ts
@@ -218,7 +218,7 @@ runInEachFileSystem(() => {
         import {SELECTOR} from './dep';
 
         @Component({
-          selector: SELECTOR, 
+          selector: SELECTOR,
           template: 'cmp',
           standalone: false,
         })
@@ -231,9 +231,9 @@ runInEachFileSystem(() => {
         import {Component} from '@angular/core';
 
         @Component({
-          selector: 'cmp2', 
+          selector: 'cmp2',
           template: '<cmp></cmp>',
-          standalone: false,  
+          standalone: false,
         })
         export class Cmp2 {}
       `,
@@ -592,7 +592,6 @@ runInEachFileSystem(() => {
         import {DepModule} from './provider-dep';
 
         @Component({
-          standalone: true,
           template: '',
           imports: [DepModule],
         })
@@ -899,7 +898,7 @@ runInEachFileSystem(() => {
           `
           import {Directive} from '@angular/core';
 
-          @Directive({ 
+          @Directive({
             selector: '[dir]',
             standalone: false,
           })
@@ -928,8 +927,8 @@ runInEachFileSystem(() => {
           `
           import {Directive} from '@angular/core';
 
-          @Directive({ 
-            selector: '[dir]', 
+          @Directive({
+            selector: '[dir]',
             inputs: ['added'],
             standalone: false,
           })
@@ -1316,9 +1315,9 @@ runInEachFileSystem(() => {
     import {Component} from '@angular/core';
 
     @Component({
-      selector: 'bar', 
+      selector: 'bar',
       templateUrl: './bar_component.html',
-      standalone: false,  
+      standalone: false,
     })
     export class BarCmp {}
   `,

--- a/packages/compiler-cli/test/ngtsc/local_compilation_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/local_compilation_spec.ts
@@ -140,7 +140,7 @@ runInEachFileSystem(() => {
           `
         import {NgModule, Component} from '@angular/core';
 
-        @Component({template:'', standalone: true})
+        @Component({template: ''})
         export class Comp3 {
         }
 
@@ -154,7 +154,7 @@ runInEachFileSystem(() => {
           `
         import {Component} from '@angular/core';
 
-        @Component({template:'', standalone: true})
+        @Component({template: ''})
         export class Comp2 {
         }
         `,
@@ -418,7 +418,7 @@ runInEachFileSystem(() => {
         import {Component} from '@angular/core';
 
         @Component({
-          template: '...', 
+          template: '...',
           selector: 'internal-comp',
           standalone: false,
         })
@@ -432,7 +432,7 @@ runInEachFileSystem(() => {
         import {Directive} from '@angular/core';
 
         @Directive({
-          selector: '[internal-dir]', 
+          selector: '[internal-dir]',
           standalone: false,
         })
         export class InternalDir {
@@ -787,7 +787,6 @@ runInEachFileSystem(() => {
           import {SomeThing2} from 'some-where2';
 
           @Component({
-            standalone: true,
             imports: [SomeThing, forwardRef(()=>SomeThing2)],
             selector: 'test-main',
             template: '<span>Hello world!</span>',
@@ -816,7 +815,6 @@ runInEachFileSystem(() => {
           const NG_IMPORTS = [SomeThing, forwardRef(()=>SomeThing2)];
 
           @Component({
-            standalone: true,
             imports: NG_IMPORTS,
             selector: 'test-main',
             template: '<span>Hello world!</span>',
@@ -841,7 +839,6 @@ runInEachFileSystem(() => {
       import {Component} from '@angular/core';
 
       @Component({
-        standalone: true,
         imports: [],
         selector: 'test-main',
         template: '<span>Hello world!</span>',
@@ -866,7 +863,6 @@ runInEachFileSystem(() => {
           import {Component} from '@angular/core';
 
           @Component({
-            standalone: true,
             selector: 'test-main',
             template: '<span>Hello world!</span>',
           })
@@ -1072,7 +1068,6 @@ runInEachFileSystem(() => {
           import * as SomeWhere4 from './some-where4'
 
           @Component({
-            standalone: true,
             selector: 'test-main',
             template: '<span>Hello world</span>',
           })
@@ -1148,9 +1143,7 @@ runInEachFileSystem(() => {
           import * as SomeWhere3 from './some-where3'
           import * as SomeWhere4 from './some-where4'
 
-          @Directive({
-            standalone: true,
-          })
+          @Directive()
           export class MainDirective {
             constructor(
               private someService1: SomeService1,
@@ -1222,10 +1215,7 @@ runInEachFileSystem(() => {
           import * as SomeWhere3 from './some-where3'
           import * as SomeWhere4 from './some-where4'
 
-          @Pipe({
-            name: 'pipe',
-            standalone: true,
-          })
+          @Pipe({name: 'pipe'})
           export class MainPipe {
             constructor(
               private someService1: SomeService1,
@@ -1570,7 +1560,8 @@ runInEachFileSystem(() => {
         const {code, messageText, relatedInformation, length} = errors[0];
 
         expect(code).toBe(ngErrorCode(ErrorCode.LOCAL_COMPILATION_UNRESOLVED_CONST));
-        expect(length).toBe(14), expect(relatedInformation).toBeUndefined();
+        expect(length).toBe(14);
+        expect(relatedInformation).toBeUndefined();
 
         const text = ts.flattenDiagnosticMessageText(messageText, '\n');
 
@@ -1603,7 +1594,8 @@ runInEachFileSystem(() => {
         const {code, messageText, relatedInformation, length} = errors[0];
 
         expect(code).toBe(ngErrorCode(ErrorCode.LOCAL_COMPILATION_UNRESOLVED_CONST));
-        expect(length).toBe(14), expect(relatedInformation).toBeUndefined();
+        expect(length).toBe(14);
+        expect(relatedInformation).toBeUndefined();
 
         const text = ts.flattenDiagnosticMessageText(messageText, '\n');
 
@@ -1636,7 +1628,8 @@ runInEachFileSystem(() => {
         const {code, messageText, relatedInformation, length} = errors[0];
 
         expect(code).toBe(ngErrorCode(ErrorCode.LOCAL_COMPILATION_UNRESOLVED_CONST));
-        expect(length).toBe(14), expect(relatedInformation).toBeUndefined();
+        expect(length).toBe(14);
+        expect(relatedInformation).toBeUndefined();
 
         const text = ts.flattenDiagnosticMessageText(messageText, '\n');
 
@@ -1669,7 +1662,8 @@ runInEachFileSystem(() => {
         const {code, messageText, relatedInformation, length} = errors[0];
 
         expect(code).toBe(ngErrorCode(ErrorCode.LOCAL_COMPILATION_UNRESOLVED_CONST));
-        expect(length).toBe(14), expect(relatedInformation).toBeUndefined();
+        expect(length).toBe(14);
+        expect(relatedInformation).toBeUndefined();
 
         const text = ts.flattenDiagnosticMessageText(messageText, '\n');
 
@@ -1700,7 +1694,8 @@ runInEachFileSystem(() => {
         const {code, messageText, relatedInformation, length} = errors[0];
 
         expect(code).toBe(ngErrorCode(ErrorCode.LOCAL_COMPILATION_UNRESOLVED_CONST));
-        expect(length).toBe(14), expect(relatedInformation).toBeUndefined();
+        expect(length).toBe(14);
+        expect(relatedInformation).toBeUndefined();
 
         const text = ts.flattenDiagnosticMessageText(messageText, '\n');
 
@@ -1730,7 +1725,8 @@ runInEachFileSystem(() => {
         const {code, messageText, relatedInformation, length} = errors[0];
 
         expect(code).toBe(ngErrorCode(ErrorCode.LOCAL_COMPILATION_UNRESOLVED_CONST));
-        expect(length).toBe(14), expect(relatedInformation).toBeUndefined();
+        expect(length).toBe(14);
+        expect(relatedInformation).toBeUndefined();
 
         const text = ts.flattenDiagnosticMessageText(messageText, '\n');
 
@@ -1760,7 +1756,8 @@ runInEachFileSystem(() => {
         const {code, messageText, relatedInformation, length} = errors[0];
 
         expect(code).toBe(ngErrorCode(ErrorCode.LOCAL_COMPILATION_UNRESOLVED_CONST));
-        expect(length).toBe(14), expect(relatedInformation).toBeUndefined();
+        expect(length).toBe(14);
+        expect(relatedInformation).toBeUndefined();
 
         const text = ts.flattenDiagnosticMessageText(messageText, '\n');
 
@@ -1777,8 +1774,7 @@ runInEachFileSystem(() => {
           import {ExternalString} from './some-where';
 
           @Directive({selector: '[test]', exportAs: ExternalString})
-          export class Main {
-          }
+          export class Main {}
           `,
         );
 
@@ -1789,7 +1785,8 @@ runInEachFileSystem(() => {
         const {code, messageText, relatedInformation, length} = errors[0];
 
         expect(code).toBe(ngErrorCode(ErrorCode.LOCAL_COMPILATION_UNRESOLVED_CONST));
-        expect(length).toBe(14), expect(relatedInformation).toBeUndefined();
+        expect(length).toBe(14);
+        expect(relatedInformation).toBeUndefined();
 
         const text = ts.flattenDiagnosticMessageText(messageText, '\n');
 
@@ -1922,9 +1919,7 @@ runInEachFileSystem(() => {
           `
           import {Directive, Component} from '@angular/core';
 
-          @Directive({
-            standalone: true
-          })
+          @Directive()
           export class LocalDirective {
           }
 
@@ -1959,19 +1954,11 @@ runInEachFileSystem(() => {
           import {Directive, Component} from '@angular/core';
           import {ExternalDirective} from 'some_where';
 
-          @Directive({
-            standalone: true,
-            hostDirectives: [ExternalDirective],
-          })
-          export class LocalDirective {
-          }
+          @Directive({hostDirectives: [ExternalDirective]})
+          export class LocalDirective {}
 
-          @Directive({
-            standalone: true,
-            hostDirectives: [LocalDirective],
-          })
-          export class LocalDirective2 {
-          }
+          @Directive({hostDirectives: [LocalDirective]})
+          export class LocalDirective2 {}
         `,
         );
 
@@ -2004,7 +1991,6 @@ runInEachFileSystem(() => {
           }
 
           @Directive({
-            standalone: true,
             hostDirectives: [{directive: forwardRef(() => DirectiveA), inputs: ['value']}],
           })
           export class DirectiveB {
@@ -2186,7 +2172,6 @@ runInEachFileSystem(() => {
           `
           import {Component} from '@angular/core';
           @Component({
-            standalone: true,
             selector: 'deferred-cmp-a',
             template: 'DeferredCmpA contents',
           })
@@ -2200,8 +2185,7 @@ runInEachFileSystem(() => {
           `
           import {Component} from '@angular/core';
           @Component({
-            standalone: true,
-            selector: 'deferred-cmp-b',
+                        selector: 'deferred-cmp-b',
             template: 'DeferredCmpB contents',
           })
           export class DeferredCmpB {
@@ -2216,7 +2200,6 @@ runInEachFileSystem(() => {
           import {DeferredCmpA} from './deferred-a';
           import {DeferredCmpB} from './deferred-b';
           @Component({
-            standalone: true,
             deferredImports: [DeferredCmpA, DeferredCmpB],
             template: \`
               @defer {
@@ -2267,7 +2250,6 @@ runInEachFileSystem(() => {
           `
           import {Component} from '@angular/core';
           @Component({
-            standalone: true,
             selector: 'deferred-cmp-a',
             template: 'DeferredCmpA contents',
           })
@@ -2282,7 +2264,6 @@ runInEachFileSystem(() => {
           import {Component} from '@angular/core';
           import {DeferredCmpA} from './deferred-a';
           @Component({
-            standalone: true,
             imports: [DeferredCmpA],
             template: \`
               @defer {
@@ -2320,7 +2301,6 @@ runInEachFileSystem(() => {
           `
               import {Component} from '@angular/core';
               @Component({
-                standalone: true,
                 selector: 'eager-cmp-a',
                 template: 'EagerCmpA contents',
               })
@@ -2334,7 +2314,6 @@ runInEachFileSystem(() => {
           `
               import {Component} from '@angular/core';
               @Component({
-                standalone: true,
                 selector: 'deferred-cmp-a',
                 template: 'DeferredCmpA contents',
               })
@@ -2348,8 +2327,7 @@ runInEachFileSystem(() => {
           `
               import {Component} from '@angular/core';
               @Component({
-                standalone: true,
-                selector: 'deferred-cmp-b',
+                                selector: 'deferred-cmp-b',
                 template: 'DeferredCmpB contents',
               })
               export class DeferredCmpB {
@@ -2365,7 +2343,6 @@ runInEachFileSystem(() => {
               import {DeferredCmpB} from './deferred-b';
               import {EagerCmpA} from './eager-a';
               @Component({
-                standalone: true,
                 imports: [EagerCmpA],
                 deferredImports: [DeferredCmpA, DeferredCmpB],
                 template: \`
@@ -2427,7 +2404,6 @@ runInEachFileSystem(() => {
               import {Component} from '@angular/core';
 
               @Component({
-                standalone: true,
                 selector: 'deferred-cmp-a',
                 template: 'DeferredCmpA contents',
               })
@@ -2435,7 +2411,6 @@ runInEachFileSystem(() => {
               }
 
               @Component({
-                standalone: true,
                 selector: 'deferred-cmp-b',
                 template: 'DeferredCmpB contents',
               })
@@ -2455,7 +2430,6 @@ runInEachFileSystem(() => {
               import {DeferredCmpA, DeferredCmpB} from './deferred-deps';
 
               @Component({
-                standalone: true,
                 deferredImports: [DeferredCmpA],
                 template: \`
                   @defer {
@@ -2466,7 +2440,6 @@ runInEachFileSystem(() => {
               export class AppCmpA {}
 
               @Component({
-                standalone: true,
                 deferredImports: [DeferredCmpB],
                 template: \`
                   @defer {
@@ -2521,7 +2494,6 @@ runInEachFileSystem(() => {
               import {Component} from '@angular/core';
 
               @Component({
-                standalone: true,
                 selector: 'deferred-cmp-a',
                 template: 'DeferredCmpA contents',
               })
@@ -2529,7 +2501,6 @@ runInEachFileSystem(() => {
               }
 
               @Component({
-                standalone: true,
                 selector: 'deferred-cmp-b',
                 template: 'DeferredCmpB contents',
               })
@@ -2553,7 +2524,6 @@ runInEachFileSystem(() => {
               import {DeferredCmpA, DeferredCmpB, utilityFn} from './deferred-deps';
 
               @Component({
-                standalone: true,
                 deferredImports: [DeferredCmpA],
                 template: \`
                   @defer {
@@ -2568,7 +2538,6 @@ runInEachFileSystem(() => {
               }
 
               @Component({
-                standalone: true,
                 deferredImports: [DeferredCmpB],
                 template: \`
                   @defer {
@@ -2579,7 +2548,6 @@ runInEachFileSystem(() => {
               export class AppCmpB {}
 
               @Component({
-                standalone: true,
                 template: 'Component without any dependencies'
               })
               export class ComponentWithoutDeps {}

--- a/packages/compiler-cli/test/ngtsc/ls_typecheck_helpers_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ls_typecheck_helpers_spec.ts
@@ -41,8 +41,7 @@ runInEachFileSystem(() => {
 		 import {Component} from '@angular/core';
 
 		 @Component({
-			 standalone: true,
-			 selector: 'test-cmp',
+       selector: 'test-cmp',
 			 template: '<div></div>',
 		 })
 		 export class TestCmp {}
@@ -148,8 +147,7 @@ runInEachFileSystem(() => {
 			  @Component({
 				  selector: 'app-cmp',
 				  template: '<div></div>',
-				  standalone: true,
-			  })
+				})
 			  export class AppCmp {}
 			`,
         );
@@ -200,10 +198,7 @@ runInEachFileSystem(() => {
           `
 			 import {Pipe} from '@angular/core';
 
-			 @Pipe({
-				name: 'foo-pipe',
-				standalone: true,
-			  })
+			 @Pipe({name: 'foo-pipe'})
 			  export class OnePipe {
 			  }
 			 `,
@@ -215,8 +210,7 @@ runInEachFileSystem(() => {
 			 import {Component} from '@angular/core';
 
 			 @Component({
-				 standalone: true,
-				 selector: 'two-cmp',
+        selector: 'two-cmp',
 				 template: '<div></div>',
 			 })
 			 export class TwoCmp {}

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -3229,7 +3229,7 @@ runInEachFileSystem((os: string) => {
 
           const NOT_A_FUNCTION: any = null!;
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class Dir {
             @Input({transform: NOT_A_FUNCTION}) value!: number;
           }
@@ -3249,7 +3249,6 @@ runInEachFileSystem((os: string) => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
             inputs: [{
               name: 'value',
               transform: NOT_A_FUNCTION
@@ -3274,7 +3273,7 @@ runInEachFileSystem((os: string) => {
           `
               import {Directive, Input} from '@angular/core';
 
-              @Directive({selector: '[dir]', standalone: true})
+              @Directive({selector: '[dir]'})
               export class Dir {
                 @Input({transform: (val) => 1}) value!: number;
               }
@@ -3293,7 +3292,7 @@ runInEachFileSystem((os: string) => {
           `
           import {Directive, Input} from '@angular/core';
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class Dir {
             @Input({transform: <T>(val: T) => 1}) value!: number;
           }
@@ -3312,7 +3311,7 @@ runInEachFileSystem((os: string) => {
           `
           import {Directive, Input} from '@angular/core';
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class Dir {
             @Input({transform: (val: string) => 1}) value!: number;
 
@@ -3345,7 +3344,7 @@ runInEachFileSystem((os: string) => {
             import {Directive, Input} from '@angular/core';
             import {toNumber} from './util';
 
-            @Directive({selector: '[dir]', standalone: true})
+            @Directive({selector: '[dir]'})
             export class Dir {
               @Input({transform: toNumber}) value!: number;
             }
@@ -3376,7 +3375,7 @@ runInEachFileSystem((os: string) => {
               import {Directive, Input} from '@angular/core';
               import {toNumber} from './util';
 
-              @Directive({selector: '[dir]', standalone: true})
+              @Directive({selector: '[dir]'})
               export class Dir {
                 @Input({transform: toNumber}) value!: number;
               }
@@ -3411,7 +3410,7 @@ runInEachFileSystem((os: string) => {
               import {Directive, Input} from '@angular/core';
               import {toNumber} from './util';
 
-              @Directive({selector: '[dir]', standalone: true})
+              @Directive({selector: '[dir]'})
               export class Dir {
                 @Input({transform: toNumber}) value!: number;
               }
@@ -3434,7 +3433,7 @@ runInEachFileSystem((os: string) => {
             foo: boolean;
           }
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class Dir {
             @Input({transform: (val: InternalType) => 1}) val!: number;
           }
@@ -3457,7 +3456,7 @@ runInEachFileSystem((os: string) => {
             return (innerValue: string) => outerValue;
           }
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class Dir {
             @Input({transform: createTransform(1)}) value!: number;
           }
@@ -7839,9 +7838,7 @@ runInEachFileSystem((os: string) => {
           `
         import {Directive, NgModule} from '@angular/core';
 
-        @Directive({
-          standalone: true,
-        })
+        @Directive()
         class HostDir {}
 
         // The directive is not exported.
@@ -9185,17 +9182,13 @@ runInEachFileSystem((os: string) => {
             @Input({required: true}) input: any;
           }
 
-          @Directive({
-            selector: '[dir]',
-            standalone: true
-          })
+          @Directive({selector: '[dir]'})
           export class Dir extends BaseDir {}
 
           @Component({
             selector: 'test-cmp',
             template: '<div dir></div>',
-            standalone: true,
-            imports: [Dir]
+                        imports: [Dir]
           })
           export class Cmp {}
         `,
@@ -9219,16 +9212,12 @@ runInEachFileSystem((os: string) => {
             @Input({required: true}) input: any;
           }
 
-          @Directive({
-            selector: '[dir]',
-            standalone: true
-          })
+          @Directive({selector: '[dir]'})
           export class Dir extends BaseDir {}
 
           @Component({
             selector: 'test-cmp',
             template: '<div dir [input]="value"></div>',
-            standalone: true,
             imports: [Dir]
           })
           export class Cmp {
@@ -9707,14 +9696,12 @@ runInEachFileSystem((os: string) => {
                 import {Component, Directive} from '@angular/core';
 
                 @Directive({
-                  standalone: true,
                   selector: '[sandbox]',
                   inputs: ['sandbox']
                 })
                 class Dir {}
 
                 @Component({
-                  standalone: true,
                   imports: [Dir],
                   template: \`
                     <div [sandbox]="''" [title]="'Hi!'"></div>
@@ -10583,8 +10570,7 @@ runInEachFileSystem((os: string) => {
         import {Component, NgModule} from '@angular/core';
 
         @Component({
-          standalone: true,
-          selector: 'standalone-component',
+                    selector: 'standalone-component',
           template: '...',
         })
         class StandaloneComponent {}
@@ -10610,8 +10596,7 @@ runInEachFileSystem((os: string) => {
         import {Component, NgModule, forwardRef} from '@angular/core';
 
         @Component({
-          standalone: true,
-          selector: 'standalone-component',
+                    selector: 'standalone-component',
           template: '...',
         })
         class StandaloneComponent {}
@@ -10644,7 +10629,6 @@ runInEachFileSystem((os: string) => {
           export class DepModule {}
 
           @Component({
-            standalone: true,
             selector: 'standalone-cmp',
             imports: [DepModule],
             template: '',
@@ -11078,7 +11062,6 @@ runInEachFileSystem((os: string) => {
             import {Component} from '@angular/core';
 
             @Component({
-              standalone: true,
               template: '...',
             })
             export class Comp {}

--- a/packages/compiler-cli/test/ngtsc/standalone_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/standalone_spec.ts
@@ -38,14 +38,12 @@ runInEachFileSystem(() => {
 
               @Directive({
                 selector: '[dir]',
-                standalone: true,
               })
               export class TestDir {}
 
               @Component({
                 selector: 'test-cmp',
                 template: '<div dir></div>',
-                standalone: true,
                 imports: [TestDir],
               })
               export class TestCmp {}
@@ -54,7 +52,6 @@ runInEachFileSystem(() => {
         env.driveMain();
         const jsCode = env.getContents('test.js');
         expect(jsCode).toContain('dependencies: [TestDir]');
-        expect(jsCode).toContain('standalone: true');
 
         const dtsCode = env.getContents('test.d.ts');
         expect(dtsCode).toContain(
@@ -74,7 +71,6 @@ runInEachFileSystem(() => {
               @Component({
                 selector: 'test-cmp',
                 template: '<test-cmp></test-cmp>',
-                standalone: true,
               })
               export class TestCmp {}
             `,
@@ -82,7 +78,6 @@ runInEachFileSystem(() => {
         env.driveMain();
         const jsCode = env.getContents('test.js');
         expect(jsCode).toContain('dependencies: [TestCmp]');
-        expect(jsCode).toContain('standalone: true');
       });
 
       it('should compile a basic standalone pipe', () => {
@@ -91,10 +86,7 @@ runInEachFileSystem(() => {
           `
           import {Pipe} from '@angular/core';
 
-          @Pipe({
-            standalone: true,
-            name: 'test',
-          })
+          @Pipe({name: 'test'})
           export class TestPipe {
             transform(value: any): any {}
           }
@@ -102,7 +94,6 @@ runInEachFileSystem(() => {
         );
         env.driveMain();
         const jsCode = env.getContents('test.js');
-        expect(jsCode).toContain('standalone: true');
 
         const dtsCode = env.getContents('test.d.ts');
         expect(dtsCode).toContain('i0.ɵɵPipeDeclaration<TestPipe, "test", true>');
@@ -114,10 +105,7 @@ runInEachFileSystem(() => {
           `
           import {Directive} from '@angular/core';
 
-          @Directive({
-            standalone: true,
-            selector: '[dir]',
-          })
+          @Directive({selector: '[dir]'})
           export class TestDir {}
         `,
         );
@@ -128,7 +116,6 @@ runInEachFileSystem(() => {
           import {TestDir} from './dep';
 
           @Component({
-            standalone: true,
             imports: [TestDir],
             selector: 'test-cmp',
             template: '<div dir></div>',
@@ -152,10 +139,7 @@ runInEachFileSystem(() => {
           // This import creates a cycle, since 'test.ts' imports 'dir.ts'.
           import {TestType} from './test';
 
-          @Directive({
-            standalone: true,
-            selector: '[dir]',
-          })
+          @Directive({selector: '[dir]'})
           export class TestDir {
             @Input() value?: TestType;
           }
@@ -172,7 +156,6 @@ runInEachFileSystem(() => {
           }
 
           @Component({
-            standalone: true,
             imports: [TestDir],
             selector: 'test-cmp',
             template: '<div dir></div>',
@@ -219,7 +202,6 @@ runInEachFileSystem(() => {
           import {Module} from './module';
 
           @Component({
-            standalone: true,
             imports: [forwardRef(() => Module)],
             selector: 'standalone-cmp',
             template: '<module-cmp></module-cmp>',
@@ -244,10 +226,7 @@ runInEachFileSystem(() => {
           `
               import {Component, Directive} from '@angular/core';
 
-              @Directive({
-                selector: '[dir]',
-                standalone: true,
-              })
+              @Directive({selector: '[dir]'})
               export class TestDir {}
 
               @Component({
@@ -273,7 +252,6 @@ runInEachFileSystem(() => {
 
               @Component({
                 selector: 'test-cmp',
-                standalone: true,
                 template: '<is-unknown></is-unknown>',
                 schemas: [NO_ERRORS_SCHEMA],
               })
@@ -343,7 +321,6 @@ runInEachFileSystem(() => {
               @Component({
                 selector: 'test-cmp',
                 template: '<div dir></div>',
-                standalone: true,
                 imports: [TestModule],
               })
               export class TestCmp {}
@@ -361,8 +338,7 @@ runInEachFileSystem(() => {
 
               @Directive({
                 selector: '[dir]',
-                standalone: true,
-              })
+                              })
               export class TestDir {}
 
               export const DIRECTIVES = [TestDir];
@@ -370,7 +346,6 @@ runInEachFileSystem(() => {
               @Component({
                 selector: 'test-cmp',
                 template: '<div dir></div>',
-                standalone: true,
                 imports: [DIRECTIVES],
               })
               export class TestCmp {}
@@ -386,10 +361,7 @@ runInEachFileSystem(() => {
           `
               import {Component, Directive} from '@angular/core';
 
-              @Directive({
-                selector: '[dir]',
-                standalone: true,
-              })
+              @Directive({selector: '[dir]'})
               export class TestDir {}
 
               export const DIRECTIVES = [TestDir];
@@ -397,7 +369,6 @@ runInEachFileSystem(() => {
               @Component({
                 selector: 'test-cmp',
                 template: '<div dir></div>',
-                standalone: true,
                 imports: [TestDir, DIRECTIVES],
               })
               export class TestCmp {}
@@ -428,7 +399,6 @@ runInEachFileSystem(() => {
           @Component({
             selector: 'test-cmp',
             template: '<div dir></div>',
-            standalone: true,
             imports: [TestDir],
           })
           export class TestCmp {}
@@ -462,7 +432,6 @@ runInEachFileSystem(() => {
              @Component({
                selector: 'test-cmp',
                template: '<div></div>',
-               standalone: true,
                // @ts-ignore
                imports: [moduleWithProviders()],
              })
@@ -473,7 +442,6 @@ runInEachFileSystem(() => {
              @Component({
                selector: 'test-cmp',
                template: '<div></div>',
-               standalone: true,
                // @ts-ignore
                imports: IMPORTS,
              })
@@ -509,7 +477,6 @@ runInEachFileSystem(() => {
           @Component({
             selector: 'test-cmp',
             template: '<div></div>',
-            standalone: true,
             // @ts-ignore
             imports: [TestModule.forRoot()],
           })
@@ -544,7 +511,6 @@ runInEachFileSystem(() => {
             @Component({
               selector: 'test-cmp',
               template: '<div dir></div>',
-              standalone: true,
               imports: [TestDir],
             })
             export class TestCmp {}
@@ -584,7 +550,6 @@ runInEachFileSystem(() => {
           export class NotStandaloneModule {}
 
           @Component({
-            standalone: true,
             selector: 'is-standalone',
             template: '',
           })
@@ -593,7 +558,6 @@ runInEachFileSystem(() => {
           }
 
           @Component({
-            standalone: true,
             selector: 'test-cmp',
             imports: [NotStandaloneModule, IsStandaloneCmp],
             template: '<not-standalone [value]="3"></not-standalone><is-standalone [value]="true"></is-standalone>',
@@ -615,7 +579,6 @@ runInEachFileSystem(() => {
           import {Component, Input} from '@angular/core';
 
           @Component({
-            standalone: true,
             selector: 'dep-cmp',
             template: '',
           })
@@ -646,14 +609,13 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'test',
-            standalone: true,
             imports: [forwardRef(() => StandaloneComponent)],
             template: "<other-standalone></other-standalone>"
           })
           class TestComponent {
           }
 
-          @Component({selector: 'other-standalone', standalone: true, template: ""})
+          @Component({selector: 'other-standalone', template: ""})
           class StandaloneComponent {
           }
         `,
@@ -662,7 +624,6 @@ runInEachFileSystem(() => {
         const jsCode = env.getContents('test.js');
 
         expect(diags.length).toBe(0);
-        expect(jsCode).toContain('standalone: true');
         expect(jsCode).toContain('dependencies: () => [StandaloneComponent]');
       });
     });
@@ -677,7 +638,6 @@ runInEachFileSystem(() => {
               @Component({
                 selector: 'test-cmp',
                 template: 'Test',
-                standalone: true,
               })
               export class TestCmp {}
 
@@ -700,10 +660,7 @@ runInEachFileSystem(() => {
           `
           import {Pipe, NgModule} from '@angular/core';
 
-          @Pipe({
-            name: 'test',
-            standalone: true,
-          })
+          @Pipe({name: 'test'})
           export class TestPipe {}
 
           @NgModule({
@@ -727,7 +684,6 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'st-cmp',
-            standalone: true,
             template: 'Test',
           })
           export class StandaloneCmp {}
@@ -756,10 +712,7 @@ runInEachFileSystem(() => {
           `
           import {Component, Directive, NgModule} from '@angular/core';
 
-          @Directive({
-            selector: '[st-dir]',
-            standalone: true,
-          })
+          @Directive({selector: '[st-dir]'})
           export class StandaloneDir {}
 
           @Component({
@@ -786,10 +739,7 @@ runInEachFileSystem(() => {
           `
           import {Component, Pipe, NgModule} from '@angular/core';
 
-          @Pipe({
-            name: 'stpipe',
-            standalone: true,
-          })
+          @Pipe({name: 'stpipe'})
           export class StandalonePipe {
             transform(value: any): any {
               return value;
@@ -822,10 +772,7 @@ runInEachFileSystem(() => {
           `
           import {Component, Directive, NgModule} from '@angular/core';
 
-          @Directive({
-            selector: '[dir]',
-            standalone: true,
-          })
+          @Directive({selector: '[dir]'})
           export class TestDir {}
 
           @NgModule({
@@ -870,42 +817,6 @@ runInEachFileSystem(() => {
       });
     });
 
-    describe('other types', () => {
-      it('should compile a basic standalone directive', () => {
-        env.write(
-          'test.ts',
-          `
-              import {Directive} from '@angular/core';
-
-              @Directive({
-                selector: '[dir]',
-                standalone: true,
-              })
-              export class TestDir {}
-            `,
-        );
-        env.driveMain();
-        expect(env.getContents('test.js')).toContain('standalone: true');
-      });
-
-      it('should compile a basic standalone pipe', () => {
-        env.write(
-          'test.ts',
-          `
-              import {Pipe} from '@angular/core';
-
-              @Pipe({
-                name: 'testpipe',
-                standalone: true,
-              })
-              export class TestPipe {}
-            `,
-        );
-        env.driveMain();
-        expect(env.getContents('test.js')).toContain('standalone: true');
-      });
-    });
-
     describe('from libraries', () => {
       it('should consume standalone directives from libraries', () => {
         env.write(
@@ -925,7 +836,6 @@ runInEachFileSystem(() => {
           import {StandaloneDir} from './lib';
 
           @Component({
-            standalone: true,
             selector: 'test-cmp',
             template: '<div dir></div>',
             imports: [StandaloneDir],
@@ -957,7 +867,6 @@ runInEachFileSystem(() => {
           import {StandaloneCmp} from './lib';
 
           @Component({
-            standalone: true,
             selector: 'test-cmp',
             template: '<standalone-cmp></standalone-cmp>',
             imports: [StandaloneCmp],
@@ -990,7 +899,6 @@ runInEachFileSystem(() => {
           import {StandalonePipe} from './lib';
 
           @Component({
-            standalone: true,
             selector: 'test-cmp',
             template: '{{value | standalone}}',
             imports: [StandalonePipe],
@@ -1026,7 +934,6 @@ runInEachFileSystem(() => {
           import {DECLARATIONS} from 'external';
 
           @Component({
-            standalone: true,
             selector: 'test-cmp',
             template: '<div dir></div>',
             imports: [DECLARATIONS],
@@ -1058,7 +965,6 @@ runInEachFileSystem(() => {
           export class DepModule {}
 
           @Component({
-            standalone: true,
             selector: 'standalone-cmp',
             imports: [DepModule],
             template: '',
@@ -1097,7 +1003,6 @@ runInEachFileSystem(() => {
             import {DepModule} from './dep';
 
             @Component({
-              standalone: true,
               selector: 'standalone-cmp',
               imports: [DepModule],
               template: '',
@@ -1136,7 +1041,6 @@ runInEachFileSystem(() => {
               import {DepCmp} from './dep';
 
               @Component({
-                standalone: true,
                 selector: 'standalone-cmp',
                 imports: [DepCmp],
                 template: '<dep-cmp/>',
@@ -1162,16 +1066,10 @@ runInEachFileSystem(() => {
           `
           import {Directive, NgModule, Pipe} from '@angular/core';
 
-          @Directive({
-            standalone: true,
-            selector: '[dir]',
-          })
+          @Directive({selector: '[dir]'})
           export class StandaloneDir {}
 
-          @Pipe({
-            standalone: true,
-            name: 'standalone',
-          })
+          @Pipe({name: 'standalone'})
           export class StandalonePipe {
             transform(value: any): any {}
           }
@@ -1199,7 +1097,6 @@ runInEachFileSystem(() => {
             export class DepModule {}
 
             @Component({
-              standalone: true,
               selector: 'test-cmp',
               imports: [DepModule],
               template: '',

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -93,7 +93,6 @@ runInEachFileSystem(() => {
 
         @Component({
           selector: 'sub-cmp',
-          standalone: true,
           template: '',
         })
         class Sub { // intentionally not exported
@@ -102,7 +101,6 @@ runInEachFileSystem(() => {
 
         @Component({
           template: \`<sub-cmp [someInput]="''" />\`,
-          standalone: true,
           imports: [Sub],
         })
         export class MyComponent {}
@@ -550,7 +548,7 @@ runInEachFileSystem(() => {
         `
         import {Component, Directive, Input, Output, EventEmitter} from '@angular/core';
 
-        @Directive({selector: '[dir]', standalone: true})
+        @Directive({selector: '[dir]'})
         export class Dir<T extends {id: string}> {
           @Input() val!: T;
           @Output() valChange = new EventEmitter<T>();
@@ -558,7 +556,6 @@ runInEachFileSystem(() => {
 
         @Component({
           template: '<input dir [(val)]="invalidType">',
-          standalone: true,
           imports: [Dir],
         })
         export class FooCmp {
@@ -588,7 +585,7 @@ runInEachFileSystem(() => {
         `
             import {Component, Directive, Input, Output, EventEmitter} from '@angular/core';
 
-            @Directive({selector: '[dir]', standalone: true})
+            @Directive({selector: '[dir]'})
             export class Dir {
               @Input()
               set val(value: string | null | undefined) {
@@ -604,7 +601,6 @@ runInEachFileSystem(() => {
 
             @Component({
               template: '<input dir [(val)]="nullableType">',
-              standalone: true,
               imports: [Dir],
             })
             export class FooCmp {
@@ -626,7 +622,7 @@ runInEachFileSystem(() => {
 
         type TestFn = (val: number | null | undefined) => string;
 
-        @Directive({selector: '[dir]', standalone: true})
+        @Directive({selector: '[dir]'})
         export class Dir {
           @Input() val!: TestFn;
           @Output() valChange = new EventEmitter<TestFn>();
@@ -634,8 +630,7 @@ runInEachFileSystem(() => {
 
         @Component({
           template: '<input dir [(val)]="invalidType">',
-          standalone: true,
-          imports: [Dir],
+                    imports: [Dir],
         })
         export class FooCmp {
           invalidType = (val: string) => 0;
@@ -664,7 +659,7 @@ runInEachFileSystem(() => {
         `
         import {Component, Directive, Input, Output, EventEmitter} from '@angular/core';
 
-        @Directive({selector: '[dir]', standalone: true})
+        @Directive({selector: '[dir]'})
         export class Dir {
           @Input() val!: number;
           @Output() valChange = new EventEmitter<number>();
@@ -672,7 +667,6 @@ runInEachFileSystem(() => {
 
         @Component({
           template: '<input dir [(val)]="$any(invalidType)">',
-          standalone: true,
           imports: [Dir],
         })
         export class FooCmp {
@@ -720,7 +714,6 @@ runInEachFileSystem(() => {
         import {Component} from '@angular/core';
 
         @Component({
-          standalone: true,
           template: \`
             <ng-content>
               <button (click)="acceptsNumber('hello')"></button>
@@ -747,7 +740,6 @@ runInEachFileSystem(() => {
         import {Component} from '@angular/core';
 
         @Component({
-          standalone: true,
           template: \`
             <ng-content>
               <input #input/>
@@ -773,7 +765,6 @@ runInEachFileSystem(() => {
         import {Component} from '@angular/core';
 
         @Component({
-          standalone: true,
           template: \` {{typeof {} === 'foobar'}} \`,
         })
         class TestCmp {
@@ -793,7 +784,6 @@ runInEachFileSystem(() => {
         import {Component} from '@angular/core';
 
         @Component({
-          standalone: true,
           // should be !(typeof {} === 'object')
           template: \` {{!typeof {} === 'object'}} \`,
         })
@@ -2451,14 +2441,13 @@ runInEachFileSystem(() => {
 
           export function toNumber(val: boolean | string) { return 1; }
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class CoercionDir {
             @Input({transform: toNumber}) val!: number;
           }
 
           @Component({
             template: '<input dir [val]="invalidType">',
-            standalone: true,
             imports: [CoercionDir],
           })
           export class FooCmp {
@@ -2480,14 +2469,13 @@ runInEachFileSystem(() => {
           `
             import {Component, Directive, Input} from '@angular/core';
 
-            @Directive({selector: '[dir]', standalone: true})
+            @Directive({selector: '[dir]'})
             export class CoercionDir {
               @Input({transform: (val: boolean | string) => 1}) val!: number;
             }
 
             @Component({
               template: '<input dir [val]="invalidType">',
-              standalone: true,
               imports: [CoercionDir],
             })
             export class FooCmp {
@@ -2513,7 +2501,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
             inputs: [{
               name: 'val',
               transform: toNumber
@@ -2525,7 +2512,6 @@ runInEachFileSystem(() => {
 
           @Component({
             template: '<input dir [val]="invalidType">',
-            standalone: true,
             imports: [CoercionDir],
           })
           export class FooCmp {
@@ -2547,14 +2533,13 @@ runInEachFileSystem(() => {
           `
           import {Component, Directive, Input} from '@angular/core';
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class CoercionDir {
             @Input({transform: parseInt}) val!: number;
           }
 
           @Component({
             template: '<input dir [val]="invalidType">',
-            standalone: true,
             imports: [CoercionDir],
           })
           export class FooCmp {
@@ -2600,14 +2585,13 @@ runInEachFileSystem(() => {
           import {Component, Directive, Input} from '@angular/core';
           import {toNumber} from './utils';
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class CoercionDir {
             @Input({transform: toNumber}) val!: number;
           }
 
           @Component({
             template: '<input dir [val]="invalidType">',
-            standalone: true,
             imports: [CoercionDir],
           })
           export class FooCmp {
@@ -2656,14 +2640,13 @@ runInEachFileSystem(() => {
               import {Component, Directive, Input} from '@angular/core';
               import {externalToNumber} from 'external';
 
-              @Directive({selector: '[dir]', standalone: true})
+              @Directive({selector: '[dir]'})
               export class CoercionDir {
                 @Input({transform: externalToNumber}) val!: number;
               }
 
               @Component({
                 template: '<input dir [val]="invalidType">',
-                standalone: true,
                 imports: [CoercionDir],
               })
               export class FooCmp {
@@ -2718,7 +2701,7 @@ runInEachFileSystem(() => {
             foo: string;
           }
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class CoercionDir {
             @Input({transform: (val: GenericWrapper<ExportedClass>) => 1}) importedVal!: number;
             @Input({transform: (val: GenericWrapper<LocalInterface>) => 1}) localVal!: number;
@@ -2726,7 +2709,6 @@ runInEachFileSystem(() => {
 
           @Component({
             template: '<input dir [importedVal]="invalidType" [localVal]="invalidType">',
-            standalone: true,
             imports: [CoercionDir],
           })
           export class FooCmp {
@@ -2773,14 +2755,13 @@ runInEachFileSystem(() => {
           import {Component, Directive, Input} from '@angular/core';
           import {CoercionType} from './types';
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class CoercionDir {
             @Input({transform: (val: CoercionType<string>) => 1}) val!: number;
           }
 
           @Component({
             template: '<input dir [val]="invalidType">',
-            standalone: true,
             imports: [CoercionDir],
           })
           export class FooCmp {
@@ -2820,14 +2801,13 @@ runInEachFileSystem(() => {
           import {Component, Directive, Input} from '@angular/core';
           import {ExternalGenericWrapper, ExternalClass} from 'external';
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class CoercionDir {
             @Input({transform: (val: ExternalGenericWrapper<ExternalClass>) => 1}) val!: number;
           }
 
           @Component({
             template: '<input dir [val]="invalidType">',
-            standalone: true,
             imports: [CoercionDir],
           })
           export class FooCmp {
@@ -2855,14 +2835,13 @@ runInEachFileSystem(() => {
           `
               import {Component, Directive, Input} from '@angular/core';
 
-              @Directive({selector: '[dir]', standalone: true})
+              @Directive({selector: '[dir]'})
               export class CoercionDir {
                 @Input({transform: () => 1}) val!: number;
               }
 
               @Component({
                 template: '<input dir [val]="invalidType">',
-                standalone: true,
                 imports: [CoercionDir],
               })
               export class FooCmp {
@@ -2883,14 +2862,13 @@ runInEachFileSystem(() => {
 
           export function toNumber(val: number | boolean) { return 1; }
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class CoercionDir {
             @Input({transform: toNumber}) val!: number;
           }
 
           @Component({
             template: '<input dir val="test">',
-            standalone: true,
             imports: [CoercionDir],
           })
           export class FooCmp {}
@@ -2930,7 +2908,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
             hostDirectives: [{
               directive: HostDir,
               inputs: ['val']
@@ -2940,7 +2917,6 @@ runInEachFileSystem(() => {
 
           @Component({
             template: '<input dir [val]="invalidType">',
-            standalone: true,
             imports: [CoercionDir],
           })
           export class FooCmp {
@@ -2984,15 +2960,11 @@ runInEachFileSystem(() => {
           import {Component, Directive, Input} from '@angular/core';
           import {Parent} from './host-dir';
 
-          @Directive({
-            selector: '[dir]',
-            standalone: true
-          })
+          @Directive({selector: '[dir]'})
           export class CoercionDir extends Parent {}
 
           @Component({
             template: '<input dir [val]="invalidType">',
-            standalone: true,
             imports: [CoercionDir],
           })
           export class FooCmp {
@@ -3025,7 +2997,6 @@ runInEachFileSystem(() => {
 
           @Directive({
             selector: '[dir]',
-            standalone: true,
           })
           export class Dir {
             @Input({transform: (val: HTMLInputElement | ElementRef<HTMLInputElement>) => {
@@ -3035,7 +3006,6 @@ runInEachFileSystem(() => {
           }
 
           @Component({
-            standalone: true,
             imports: [Dir],
             template: '<div dir [expectsInput]="someDiv"></div>',
           })
@@ -3062,7 +3032,7 @@ runInEachFileSystem(() => {
 
           export function toNumber(val: boolean | string) { return 1; }
 
-          @Directive({selector: '[dir]', standalone: true})
+          @Directive({selector: '[dir]'})
           export class CoercionDir {
             @Input({transform: toNumber}) val!: number;
             @Output() valChange = new EventEmitter<number>();
@@ -3070,7 +3040,6 @@ runInEachFileSystem(() => {
 
           @Component({
             template: '<input dir [(val)]="invalidType">',
-            standalone: true,
             imports: [CoercionDir],
           })
           export class FooCmp {
@@ -3380,7 +3349,6 @@ runInEachFileSystem(() => {
 
           @Component({
             template: 'Result: {{getValue(\`foo\`)}}',
-            standalone: true,
           })
           export class Main {
             getValue(value: number) {
@@ -3405,7 +3373,6 @@ runInEachFileSystem(() => {
 
           @Component({
             template: '{{\`Hello \${getName(123)}\`}}',
-            standalone: true,
           })
           export class Main {
             getName(value: string) {
@@ -3437,7 +3404,6 @@ runInEachFileSystem(() => {
 
           @Component({
             template: 'Result: {{ tag\`foo\` }} {{ tag\`foo \${"bar"}\` }}',
-            standalone: true,
           })
           export class Main {
             tag(strings: TemplateStringsArray, ...args: string[]) {
@@ -3459,7 +3425,6 @@ runInEachFileSystem(() => {
 
           @Component({
             template: 'Result: {{ getValue(tag\`foo\`) }}',
-            standalone: true,
           })
           export class Main {
             getValue(value: number) {
@@ -3487,7 +3452,6 @@ runInEachFileSystem(() => {
 
           @Component({
             template: 'Result: {{ null\`foo\` }}',
-            standalone: true,
           })
           export class Main { }
         `,
@@ -3509,7 +3473,6 @@ runInEachFileSystem(() => {
 
           @Component({
             template: 'Result: {{ tag\`foo\${"str"}\` }}',
-            standalone: true,
           })
           export class Main {
             tag(strings: TemplateStringsArray, arg1: number, arg2: string) {
@@ -3562,7 +3525,6 @@ runInEachFileSystem(() => {
         @Component({
           selector: 'blah',
           template: '<foo>test</foo>',
-          standalone: true,
         })
         export class FooCmp {}
         @NgModule({
@@ -3586,7 +3548,6 @@ runInEachFileSystem(() => {
           @Component({
             selector: 'my-comp',
             template: '...',
-            standalone: true,
           })
           export class MyComp {}
 
@@ -3594,7 +3555,6 @@ runInEachFileSystem(() => {
             selector: 'blah',
             imports: [MyComp],
             template: '<my-comp [foo]="true"></my-comp>',
-            standalone: true,
           })
           export class FooCmp {}
         `,
@@ -3640,7 +3600,6 @@ runInEachFileSystem(() => {
         @Component({
           selector: 'blah',
           template: '<my-foo>test</my-foo>',
-          standalone: true,
         })
         export class FooCmp {}
         @NgModule({
@@ -3935,7 +3894,6 @@ runInEachFileSystem(() => {
                   </mfrac>
                 </math>
               \`,
-              standalone: true,
             })
             export class MathCmp {}
           `,
@@ -4257,9 +4215,7 @@ suppress
           `
           import {Component, Directive, NgModule, Input} from '@angular/core';
 
-          @Directive({
-            standalone: true,
-          })
+          @Directive()
           class HostDir {
             @Input() input: number;
             @Input() otherInput: string;
@@ -4305,9 +4261,7 @@ suppress
           `
           import {Component, Directive, NgModule, Output, EventEmitter} from '@angular/core';
 
-          @Directive({
-            standalone: true,
-          })
+          @Directive()
           class HostDir {
             @Output() stringEvent = new EventEmitter<string>();
             @Output() numberEvent = new EventEmitter<number>();
@@ -4358,9 +4312,7 @@ suppress
           `
           import {Component, Directive, NgModule, Input, Output} from '@angular/core';
 
-          @Directive({
-            standalone: true,
-          })
+          @Directive()
           class HostDir {
             @Input() input: number;
             @Output() output: string;
@@ -4409,7 +4361,6 @@ suppress
           import {Component, Directive, NgModule, Output, EventEmitter} from '@angular/core';
 
           @Directive({
-            standalone: true,
             exportAs: 'hostDir',
           })
           class HostDir {}
@@ -4450,17 +4401,13 @@ suppress
           `
           import {Component, Directive, NgModule, Input} from '@angular/core';
 
-          @Directive({
-            standalone: true
-          })
+          @Directive()
           class HostDirParent {
             @Input() input: number;
             @Input() otherInput: string;
           }
 
-          @Directive({
-            standalone: true,
-          })
+          @Directive()
           class HostDir extends HostDirParent {}
 
           @Directive({
@@ -4503,17 +4450,13 @@ suppress
           `
           import {Component, Directive, NgModule, Output, EventEmitter} from '@angular/core';
 
-          @Directive({
-            standalone: true
-          })
+          @Directive()
           class HostDirParent {
             @Output() stringEvent = new EventEmitter<string>();
             @Output() numberEvent = new EventEmitter<number>();
           }
 
-          @Directive({
-            standalone: true,
-          })
+          @Directive()
           class HostDir extends HostDirParent {}
 
           @Directive({
@@ -4561,9 +4504,7 @@ suppress
           `
           import {Component, Directive, NgModule, Input} from '@angular/core';
 
-          @Directive({
-            standalone: true,
-          })
+          @Directive()
           class HostDir {
             @Input('ownInputAlias') input: number;
             @Input('ownOtherInputAlias') otherInput: string;
@@ -4609,9 +4550,7 @@ suppress
           `
           import {Component, Directive, NgModule, Output, EventEmitter} from '@angular/core';
 
-          @Directive({
-            standalone: true,
-          })
+          @Directive()
           class HostDir {
             @Output('ownStringAlias') stringEvent = new EventEmitter<string>();
             @Output('ownNumberAlias') numberEvent = new EventEmitter<number>();
@@ -4697,7 +4636,6 @@ suppress
       @Component({
         template: '<lib-post />',
         imports: [PostModule],
-        standalone: true,
       })
       export class Main { }
        `,
@@ -4715,9 +4653,7 @@ suppress
           `
           import {Component, Directive, NgModule, Input} from '@angular/core';
 
-          @Directive({
-            standalone: true,
-          })
+          @Directive()
           class HostDir {
             @Input() input: number;
             @Input() otherInput: string;
@@ -4768,9 +4704,7 @@ suppress
           `
           import {Component, Directive, NgModule, Output, EventEmitter} from '@angular/core';
 
-          @Directive({
-            standalone: true,
-          })
+          @Directive()
           class HostDir {
             @Output() stringEvent = new EventEmitter<string>();
             @Output() numberEvent = new EventEmitter<number>();
@@ -4840,7 +4774,6 @@ suppress
                 {{does_not_exist_error}}
               }
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -4865,7 +4798,6 @@ suppress
             template: \`
               @defer (when isVisible() || does_not_exist) {Hello}
             \`,
-            standalone: true,
           })
           export class Main {
             isVisible() {
@@ -4891,7 +4823,6 @@ suppress
             template: \`
               @defer (prefetch when isVisible() || does_not_exist) {Hello}
             \`,
-            standalone: true,
           })
           export class Main {
             isVisible() {
@@ -4917,7 +4848,6 @@ suppress
             template: \`
               @defer (hydrate when isVisible() || does_not_exist) {Hello}
             \`,
-            standalone: true,
           })
           export class Main {
             isVisible() {
@@ -4943,7 +4873,6 @@ suppress
             template: \`
               @defer (on viewport(does_not_exist)) {Hello}
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -4970,7 +4899,6 @@ suppress
                 <button #trigger></button>
               </ng-template>
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -5003,7 +4931,6 @@ suppress
                 {{does_not_exist_else}}
               }
             \`,
-            standalone: true,
           })
           export class Main {
             expr = false;
@@ -5038,7 +4965,6 @@ suppress
                 two
               }
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -5062,7 +4988,6 @@ suppress
             template: \`@if (value === 1; as alias) {
               {{acceptsNumber(alias)}}
             }\`,
-            standalone: true,
           })
           export class Main {
             value = 1;
@@ -5090,7 +5015,6 @@ suppress
             template: \`@if (value; as alias) {
               {{acceptsNumber(alias)}}
             }\`,
-            standalone: true,
           })
           export class Main {
             value: 'one' | 0 = 0;
@@ -5118,7 +5042,6 @@ suppress
             template: \`@if (value; as alias) {
               <button (click)="acceptsNumber(alias)"></button>
             }\`,
-            standalone: true,
           })
           export class Main {
             value: 'one' | 0 = 0;
@@ -5145,7 +5068,6 @@ suppress
             template: \`@if (value; as alias) {
               {{ value.length }}
             }\`,
-            standalone: true,
           })
           export class Main {
             value!: string|undefined;
@@ -5166,7 +5088,6 @@ suppress
             template: \`@if (value(); as alias) {
               {{ alias.length }}
             }\`,
-            standalone: true,
           })
           export class Main {
             value!: () => string|undefined;
@@ -5192,7 +5113,6 @@ suppress
                 {{alias}}
               }
             \`,
-            standalone: true,
           })
           export class Main {
             value = 1;
@@ -5220,7 +5140,6 @@ suppress
                 }
               }
             \`,
-            standalone: true,
           })
           export class Main {
             value = 1;
@@ -5252,7 +5171,6 @@ suppress
                 {{acceptsNumber(expr)}}
               }
             \`,
-            standalone: true,
           })
           export class Main {
             expr: 'hello' | 1 = 'hello';
@@ -5282,7 +5200,6 @@ suppress
                 <button (click)="acceptsNumber(expr)"></button>
               }
             \`,
-            standalone: true,
           })
           export class Main {
             expr: 'hello' | 1 = 'hello';
@@ -5314,7 +5231,6 @@ suppress
                 <button (click)="acceptsNumber(expr)"></button>
               }
             \`,
-            standalone: true,
           })
           export class Main {
             expr: 'hello' | 1 | 2 = 'hello';
@@ -5348,7 +5264,6 @@ suppress
                 <button (click)="acceptsNumber(expr)"></button>
               }
             \`,
-            standalone: true,
           })
           export class Main {
             expr: 'hello' | 1 | 2 = 'hello';
@@ -5378,8 +5293,7 @@ suppress
                  <button (click)="test()"></button>
                }
              \`,
-             standalone: true,
-           })
+            })
            export class Main {
              test() {}
            }
@@ -5412,7 +5326,6 @@ suppress
                 }
               }
             \`,
-            standalone: true,
           })
           export class Main {
             expr: any;
@@ -5442,7 +5355,6 @@ suppress
                 }
               }
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -5473,7 +5385,6 @@ suppress
                 }
               }
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -5503,7 +5414,6 @@ suppress
                     }
                   }
                 \`,
-                standalone: true,
               })
               export class Main {
                 value = 'zero';
@@ -5532,7 +5442,6 @@ suppress
                 }
               }
             \`,
-            standalone: true,
           })
           export class Main {
             expr: 'hello' | 1 = 'hello';
@@ -5567,7 +5476,6 @@ suppress
                 }
               }
             \`,
-            standalone: true,
           })
           export class Main {
             expr: 'hello' | 1 = 'hello';
@@ -5613,7 +5521,6 @@ suppress
                 }
               }
             \`,
-            standalone: true,
           })
           export class Main {
             value: Foo | Bar = { type: 'foo', foo: 'foo' };
@@ -5645,7 +5552,6 @@ suppress
                 }
               }
             \`,
-            standalone: true,
           })
           export class Main {
             expr = true;
@@ -5672,7 +5578,6 @@ suppress
                 }
               }
             \`,
-            standalone: true,
           })
           export class Main {
             expr: 'hello' | 1 = 'hello';
@@ -5708,7 +5613,6 @@ suppress
                 }
               }
             \`,
-            standalone: true,
           })
           export class Main {
             expr: 1 | 2 | 'hello' = 'hello';
@@ -6031,10 +5935,7 @@ suppress
           `
           import {Component, Directive, Input, Output, EventEmitter} from '@angular/core';
 
-          @Directive({
-            selector: '[twoWayDir]',
-            standalone: true
-          })
+          @Directive({selector: '[twoWayDir]'})
           export class TwoWayDir {
             @Input() value: number = 0;
             @Output() valueChange: EventEmitter<number> = new EventEmitter();
@@ -6046,7 +5947,6 @@ suppress
                 <button twoWayDir [(value)]="$index"></button>
               }
             \`,
-            standalone: true,
             imports: [TwoWayDir]
           })
           export class Main {
@@ -6067,10 +5967,7 @@ suppress
           `
           import {Component, Directive, Input, Output, EventEmitter, signal} from '@angular/core';
 
-          @Directive({
-            selector: '[twoWayDir]',
-            standalone: true
-          })
+          @Directive({selector: '[twoWayDir]'})
           export class TwoWayDir {
             @Input() value: number = 0;
             @Output() valueChange: EventEmitter<number> = new EventEmitter();
@@ -6082,7 +5979,6 @@ suppress
                 <button twoWayDir [(value)]="current"></button>
               }
             \`,
-            standalone: true,
             imports: [TwoWayDir]
           })
           export class Main {
@@ -6199,7 +6095,6 @@ suppress
 
           @Component({
             selector: 'test-cmp',
-            standalone: true,
             template: '@for (item of items; track $index + $count) {}',
           })
           export class TestCmp {
@@ -6223,7 +6118,6 @@ suppress
 
               @Component({
                 selector: 'test-cmp',
-                standalone: true,
                 template: '@for (item of items; let c = $count; track $index + c) {}',
               })
               export class TestCmp {
@@ -6247,7 +6141,6 @@ suppress
 
             @Component({
               selector: 'test-cmp',
-              standalone: true,
               template: \`
                 <input #ref/>
                 @for (item of items; track $index + ref.value) {}
@@ -6274,7 +6167,6 @@ suppress
 
             @Component({
               selector: 'test-cmp',
-              standalone: true,
               template: \`
                 <input #ref/>
 
@@ -6304,7 +6196,6 @@ suppress
 
             @Component({
               selector: 'test-cmp',
-              standalone: true,
               template: \`
                 <ng-template let-foo>
                   @for (item of items; track $index + foo.value) {}
@@ -6332,7 +6223,6 @@ suppress
 
           @Component({
             selector: 'test-cmp',
-            standalone: true,
             template: \`
               @for (parent of items; track $index) {
                 @for (item of parent.items; track parent) {}
@@ -6360,7 +6250,6 @@ suppress
 
             @Component({
               selector: 'test-cmp',
-              standalone: true,
               template: \`
                 @if (expr; as alias) {
                   @for (item of items; track $index + alias) {}
@@ -6387,7 +6276,7 @@ suppress
           `
           import { Component, Pipe } from '@angular/core';
 
-          @Pipe({name: 'test', standalone: true})
+          @Pipe({name: 'test'})
           export class TestPipe {
             transform(value: any) {
               return value;
@@ -6396,7 +6285,6 @@ suppress
 
           @Component({
             selector: 'test-cmp',
-            standalone: true,
             imports: [TestPipe],
             template: '@for (item of items; track item | test) {}',
           })
@@ -6419,7 +6307,7 @@ suppress
           `
           import {Component, Pipe} from '@angular/core';
 
-          @Pipe({name: 'fakeAsync', standalone: true})
+          @Pipe({name: 'fakeAsync'})
           export class FakeAsyncPipe {
             transform<T>(value: Iterable<T>): Iterable<T> | null | undefined {
               return null;
@@ -6432,7 +6320,6 @@ suppress
                 {{item}}
               }
             \`,
-            standalone: true,
             imports: [FakeAsyncPipe]
           })
           export class Main {
@@ -6479,7 +6366,6 @@ suppress
           import {Component, Directive, Input} from '@angular/core';
 
           @Directive({
-            standalone: true,
             selector: '[dir]'
           })
           export class Dir {
@@ -6487,7 +6373,6 @@ suppress
           }
 
           @Component({
-            standalone: true,
             imports: [Dir],
             template: \`
               @for (document of documents; track document) {
@@ -6518,12 +6403,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content/> <ng-content select="bar, [foo]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6557,12 +6440,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content/> <ng-content select="bar, [foo]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6596,12 +6477,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content select="[foo]"/> <ng-content select="[bar]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6639,12 +6518,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content select="[foo]"/> <ng-content select="[bar]"/> <ng-content select="[baz]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6684,12 +6561,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content/> <ng-content select="bar, [foo]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6723,12 +6598,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content/> <ng-content select="bar, [foo]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6764,12 +6637,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content select="[foo]"/> <ng-content select="[bar]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6805,12 +6676,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content select="[foo]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6846,12 +6715,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content select="[foo]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             preserveWhitespaces: true,
             template: \`
@@ -6886,12 +6753,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content select="[foo]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6918,12 +6783,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content select="[foo]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6952,12 +6815,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -6992,12 +6853,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content/> <ng-content select="bar, [foo]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -7030,12 +6889,10 @@ suppress
               @Component({
                 selector: 'comp',
                 template: '<ng-content/> <ng-content select="bar, [foo]"/>',
-                standalone: true,
               })
               class Comp {}
 
               @Component({
-                standalone: true,
                 imports: [Comp],
                 template: \`
                   <comp>
@@ -7063,12 +6920,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content/> <ng-content select="bar, [foo]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -7106,12 +6961,10 @@ suppress
           @Component({
             selector: 'comp',
             template: '<ng-content select="[foo]"/> <ng-content select="[bar]"/>',
-            standalone: true,
           })
           class Comp {}
 
           @Component({
-            standalone: true,
             imports: [Comp],
             template: \`
               <comp>
@@ -7169,7 +7022,6 @@ suppress
               @let one = 1;
               {{acceptsString(one)}}
             \`,
-            standalone: true,
           })
           export class Main {
             acceptsString(value: string) {}
@@ -7198,7 +7050,6 @@ suppress
                 <span>{{acceptsString(one)}}</span>
               </div>
             \`,
-            standalone: true,
           })
           export class Main {
             acceptsString(value: string) {}
@@ -7224,7 +7075,6 @@ suppress
             template: \`
               @let value = {} + 1;
             \`,
-            standalone: true,
           })
           export class Main {
           }
@@ -7253,7 +7103,6 @@ suppress
                 {{expectsString(value)}}
               }
             \`,
-            standalone: true,
           })
           export class Main {
             cond: boolean = true;
@@ -7284,7 +7133,6 @@ suppress
                 <button (click)="expectsString(value)">Click me</button>
               }
             \`,
-            standalone: true,
           })
           export class Main {
             cond: boolean = true;
@@ -7324,7 +7172,6 @@ suppress
               </ng-template>
 
             \`,
-            standalone: true,
           })
           export class Main {
             expectsString(value: string) {}
@@ -7353,7 +7200,6 @@ suppress
 
               {{value}}
             \`,
-            standalone: true,
           })
           export class Main {
           }
@@ -7381,7 +7227,6 @@ suppress
                 {{value}}
               }
             \`,
-            standalone: true,
           })
           export class Main {
           }
@@ -7404,7 +7249,6 @@ suppress
               @let value = 1;
               {{expectsString(value)}}
             \`,
-            standalone: true,
           })
           export class Main {
             value = 'one';
@@ -7435,7 +7279,6 @@ suppress
                 {{expectsString(value)}}
               }
             \`,
-            standalone: true,
           })
           export class Main {
             expectsString(value: string) {}
@@ -7464,7 +7307,6 @@ suppress
                 {{value}}
               }
             \`,
-            standalone: true,
           })
           export class Main {
           }
@@ -7490,7 +7332,6 @@ suppress
               @let value = 1;
               {{value}}
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -7515,7 +7356,6 @@ suppress
               <input #value>
               {{value}}
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -7542,8 +7382,7 @@ suppress
                   {{value}}
                 </div>
               \`,
-              standalone: true,
-              imports: [CommonModule],
+                imports: [CommonModule],
             })
             export class Main {
               x!: unknown;
@@ -7573,7 +7412,6 @@ suppress
                 {{value}}
               }
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -7594,7 +7432,6 @@ suppress
               {{value}}
               @let value = 1;
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -7620,7 +7457,6 @@ suppress
                 @let value = 1;
               </ng-template>
             \`,
-            standalone: true,
           })
           export class Main {
           }
@@ -7645,7 +7481,6 @@ suppress
               @let value = 1;
               {{this.value}}
             \`,
-            standalone: true,
           })
           export class Main {
           }
@@ -7667,7 +7502,6 @@ suppress
             template: \`
               @let value = value;
             \`,
-            standalone: true,
           })
           export class Main {
           }
@@ -7691,7 +7525,6 @@ suppress
             template: \`
               @let value = value.a.b.c;
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -7714,7 +7547,6 @@ suppress
             template: \`
               @let value = value();
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -7738,7 +7570,6 @@ suppress
               <button (click)="expectsString(value)">Click me</button>
               @let value = 1;
             \`,
-            standalone: true,
           })
           export class Main {
             expectsString(value: string) {}
@@ -7767,7 +7598,6 @@ suppress
 
               @let value = 1;
             \`,
-            standalone: true,
           })
           export class Main {
             expectsString(value: string) {}
@@ -7790,7 +7620,6 @@ suppress
               @let value = 1;
               <button (click)="value = 2">Click me</button>
             \`,
-            standalone: true,
           })
           export class Main {
           }
@@ -7813,7 +7642,6 @@ suppress
               @let value = 1;
               <button (click)="this.value = 2">Click me</button>
             \`,
-            standalone: true,
           })
           export class Main {
           }
@@ -7830,10 +7658,8 @@ suppress
           'test.ts',
           `
           import {Component, Directive, Input, Output, EventEmitter} from '@angular/core';
-          @Directive({
-            selector: '[twoWayDir]',
-            standalone: true
-          })
+
+          @Directive({selector: '[twoWayDir]'})
           export class TwoWayDir {
             @Input() value: number = 0;
             @Output() valueChange: EventEmitter<number> = new EventEmitter();
@@ -7843,7 +7669,6 @@ suppress
               @let nonWritable = 1;
               <button twoWayDir [(value)]="nonWritable"></button>
             \`,
-            standalone: true,
             imports: [TwoWayDir]
           })
           export class Main {
@@ -7862,20 +7687,18 @@ suppress
           'test.ts',
           `
           import {Component, Directive, Input, Output, EventEmitter, signal} from '@angular/core';
-          @Directive({
-            selector: '[twoWayDir]',
-            standalone: true
-          })
+
+          @Directive({selector: '[twoWayDir]'})
           export class TwoWayDir {
             @Input() value: number = 0;
             @Output() valueChange: EventEmitter<number> = new EventEmitter();
           }
+
           @Component({
             template: \`
               @let writable = signalValue;
               <button twoWayDir [(value)]="writable"></button>
             \`,
-            standalone: true,
             imports: [TwoWayDir]
           })
           export class Main {
@@ -7901,7 +7724,6 @@ suppress
               }
               @let value = 123;
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -7928,7 +7750,6 @@ suppress
 
               @let value = [1, 2, 3];
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -7957,7 +7778,6 @@ suppress
 
               @let value = [1, 2, 3];
             \`,
-            standalone: true,
           })
           export class Main {}
         `,
@@ -7978,7 +7798,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[used]', standalone: true})
+            @Directive({selector: '[used]'})
             export class UsedDir {}
           `,
         );
@@ -7988,7 +7808,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[unused]', standalone: true})
+            @Directive({selector: '[unused]'})
             export class UnusedDir {}
           `,
         );
@@ -8007,7 +7827,6 @@ suppress
                 <span used></span>
               </section>
             \`,
-            standalone: true,
             imports: [UsedDir, UnusedDir]
           })
           export class MyComp {}
@@ -8025,7 +7844,7 @@ suppress
           `
             import {Pipe} from '@angular/core';
 
-            @Pipe({name: 'used', standalone: true})
+            @Pipe({name: 'used'})
             export class UsedPipe {
               transform(value: number) {
                 return value * 2;
@@ -8039,7 +7858,7 @@ suppress
           `
             import {Pipe} from '@angular/core';
 
-            @Pipe({name: 'unused', standalone: true})
+            @Pipe({name: 'unused'})
             export class UnusedPipe {
               transform(value: number) {
                 return value * 2;
@@ -8062,7 +7881,6 @@ suppress
                 <span [attr.id]="1 | used"></span>
               </section>
             \`,
-            standalone: true,
             imports: [UsedPipe, UnusedPipe]
           })
           export class MyComp {}
@@ -8080,10 +7898,10 @@ suppress
           `
           import {Component, Directive, Pipe} from '@angular/core';
 
-          @Directive({selector: '[used]', standalone: true})
+          @Directive({selector: '[used]'})
           export class UsedDir {}
 
-          @Pipe({name: 'used', standalone: true})
+          @Pipe({name: 'used'})
           export class UsedPipe {
             transform(value: number) {
               return value * 2;
@@ -8099,7 +7917,6 @@ suppress
                 }
               </section>
             \`,
-            standalone: true,
             imports: [UsedDir, UsedPipe]
           })
           export class MyComp {}
@@ -8116,10 +7933,10 @@ suppress
           `
           import {Component, Directive, Pipe} from '@angular/core';
 
-          @Directive({selector: '[unused]', standalone: true})
+          @Directive({selector: '[unused]'})
           export class UnusedDir {}
 
-          @Pipe({name: 'unused', standalone: true})
+          @Pipe({name: 'unused'})
           export class UnusedPipe {
             transform(value: number) {
               return value * 2;
@@ -8128,7 +7945,6 @@ suppress
 
           @Component({
             template: '',
-            standalone: true,
             imports: [UnusedDir, UnusedPipe]
           })
           export class MyComp {}
@@ -8168,7 +7984,6 @@ suppress
 
           @Component({
             template: '',
-            standalone: true,
             imports: [UnusedModule]
           })
           export class MyComp {}
@@ -8193,12 +8008,11 @@ suppress
           `
           import {Component, Directive} from '@angular/core';
 
-          @Directive({selector: '[unused]', standalone: true})
+          @Directive({selector: '[unused]'})
           export class UnusedDir {}
 
           @Component({
             template: '',
-            standalone: true,
             imports: [UnusedDir]
           })
           export class MyComp {}
@@ -8247,7 +8061,6 @@ suppress
                 <span *ngIf="true"></span>
               </section>
             \`,
-            standalone: true,
             imports: [NgFor, NgIf, PercentPipe]
           })
           export class MyComp {}
@@ -8266,7 +8079,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[used]', standalone: true})
+            @Directive({selector: '[used]'})
             export class UsedDir {}
           `,
         );
@@ -8276,7 +8089,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[other-used]', standalone: true})
+            @Directive({selector: '[other-used]'})
             export class OtherUsedDir {}
           `,
         );
@@ -8286,7 +8099,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[unused]', standalone: true})
+            @Directive({selector: '[unused]'})
             export class UnusedDir {}
           `,
         );
@@ -8308,7 +8121,6 @@ suppress
                 <span used></span>
               </section>
             \`,
-            standalone: true,
             imports: [UsedDir, COMMON]
           })
           export class MyComp {}
@@ -8326,7 +8138,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[used]', standalone: true})
+            @Directive({selector: '[used]'})
             export class UsedDir {}
           `,
         );
@@ -8336,7 +8148,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[unused]', standalone: true})
+            @Directive({selector: '[unused]'})
             export class UnusedDir {}
           `,
         );
@@ -8357,7 +8169,6 @@ suppress
                 <span used></span>
               </section>
             \`,
-            standalone: true,
             imports: IMPORTS
           })
           export class MyComp {}
@@ -8375,7 +8186,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[used]', standalone: true})
+            @Directive({selector: '[used]'})
             export class UsedDir {}
           `,
         );
@@ -8385,7 +8196,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[other-used]', standalone: true})
+            @Directive({selector: '[other-used]'})
             export class OtherUsedDir {}
           `,
         );
@@ -8395,7 +8206,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[unused]', standalone: true})
+            @Directive({selector: '[unused]'})
             export class UnusedDir {}
           `,
         );
@@ -8424,7 +8235,6 @@ suppress
                 <span used></span>
               </section>
             \`,
-            standalone: true,
             imports: [UsedDir, ...COMMON]
           })
           export class MyComp {}
@@ -8441,7 +8251,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[used]', standalone: true})
+            @Directive({selector: '[used]'})
             export class UsedDir {}
           `,
         );
@@ -8451,7 +8261,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[other-used]', standalone: true})
+            @Directive({selector: '[other-used]'})
             export class OtherUsedDir {}
           `,
         );
@@ -8461,7 +8271,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[unused]', standalone: true})
+            @Directive({selector: '[unused]'})
             export class UnusedDir {}
           `,
         );
@@ -8490,7 +8300,6 @@ suppress
                 <span used></span>
               </section>
             \`,
-            standalone: true,
             imports: [UsedDir, COMMON]
           })
           export class MyComp {}
@@ -8507,7 +8316,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[used]', standalone: true})
+            @Directive({selector: '[used]'})
             export class UsedDir {}
           `,
         );
@@ -8517,7 +8326,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[other-used]', standalone: true})
+            @Directive({selector: '[other-used]'})
             export class OtherUsedDir {}
           `,
         );
@@ -8527,7 +8336,7 @@ suppress
           `
             import {Directive} from '@angular/core';
 
-            @Directive({selector: '[unused]', standalone: true})
+            @Directive({selector: '[unused]'})
             export class UnusedDir {}
           `,
         );
@@ -8549,7 +8358,6 @@ suppress
                 <span used></span>
               </section>
             \`,
-            standalone: true,
             imports: [UsedDir, COMMON]
           })
           export class MyComp {}

--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -100,7 +100,6 @@ import {Binding, DirectiveWithBindings} from '../render3/dynamic_bindings';
  *
  * ```angular-ts
  * @Component({
- *   standalone: true,
  *   selector: 'dynamic',
  *   template: `<span>This is a content of a dynamic component.</span>`,
  * })
@@ -109,7 +108,6 @@ import {Binding, DirectiveWithBindings} from '../render3/dynamic_bindings';
  * }
  *
  * @Component({
- *   standalone: true,
  *   selector: 'app',
  *   template: `<main>Hi! This is the main content.</main>`,
  * })

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -30,7 +30,6 @@ import {assertComponentDef} from './errors';
  *
  * ```angular-ts
  * @Component({
- *   standalone: true,
  *   template: `Hello {{ name }}!`
  * })
  * class HelloComponent {
@@ -38,7 +37,6 @@ import {assertComponentDef} from './errors';
  * }
  *
  * @Component({
- *   standalone: true,
  *   template: `<div id="hello-component-host"></div>`
  * })
  * class RootComponent {}
@@ -60,7 +58,7 @@ import {assertComponentDef} from './errors';
  * applicationRef.attachView(componentRef.hostView);
  * componentRef.changeDetectorRef.detectChanges();
  * ```
- * 
+ *
  * @param component Component class reference.
  * @param options Set of options to use:
  *  * `environmentInjector`: An `EnvironmentInjector` instance to be used for the component.
@@ -159,7 +157,6 @@ export interface ComponentMirror<C> {
  *
  * ```angular-ts
  * @Component({
- *   standalone: true,
  *   selector: 'foo-component',
  *   template: `
  *     <ng-content></ng-content>

--- a/packages/core/src/render3/errors.ts
+++ b/packages/core/src/render3/errors.ts
@@ -30,8 +30,8 @@ export function assertStandaloneComponentType(type: Type<unknown>) {
       RuntimeErrorCode.TYPE_IS_NOT_STANDALONE,
       `The ${stringifyForError(type)} component is not marked as standalone, ` +
         `but Angular expects to have a standalone component here. ` +
-        `Please make sure the ${stringifyForError(type)} component has ` +
-        `the \`standalone: true\` flag in the decorator.`,
+        `Please make sure the ${stringifyForError(type)} component does not have ` +
+        `the \`standalone: false\` flag in the decorator.`,
     );
   }
 }

--- a/packages/core/src/render3/jit/util.ts
+++ b/packages/core/src/render3/jit/util.ts
@@ -60,12 +60,11 @@ export function verifyStandaloneImport(depType: Type<unknown>, importingType: Ty
     if (def != null) {
       // if a component, directive or pipe is imported make sure that it is standalone
       if (!def.standalone) {
+        const type = getDependencyTypeForError(depType);
         throw new Error(
-          `The "${stringifyForError(depType)}" ${getDependencyTypeForError(
-            depType,
-          )}, imported from "${stringifyForError(
+          `The "${stringifyForError(depType)}" ${type}, imported from "${stringifyForError(
             importingType,
-          )}", is not standalone. Did you forget to add the standalone: true flag?`,
+          )}", is not standalone. Does the ${type} have the standalone: false flag?`,
         );
       }
     } else {

--- a/packages/core/test/acceptance/control_flow_if_spec.ts
+++ b/packages/core/test/acceptance/control_flow_if_spec.ts
@@ -300,14 +300,13 @@ describe('control flow - if', () => {
 
   it('should support a condition with the a binary expression with the in keyword', () => {
     @Component({
-      standalone: true,
       template: `
-          @if (key in {foo: 'bar'}) {
-            has {{key}}
-          } @else {
-            no {{key}}
-          }
-        `,
+        @if (key in {foo: 'bar'}) {
+          has {{key}}
+        } @else {
+          no {{key}}
+        }
+      `,
     })
     class TestComponent {
       key: string | number = 'foo';

--- a/packages/core/test/acceptance/create_component_spec.ts
+++ b/packages/core/test/acceptance/create_component_spec.ts
@@ -598,7 +598,7 @@ describe('createComponent', () => {
     });
 
     it('should throw if a component class is attached', () => {
-      @Component({template: '', standalone: true})
+      @Component({template: ''})
       class NotADir {}
 
       @Component({template: ''})
@@ -1115,7 +1115,6 @@ describe('createComponent', () => {
 
     it('should update view of component set with the onPush strategy after input change', () => {
       @Component({
-        standalone: true,
         changeDetection: ChangeDetectionStrategy.OnPush,
         template: 'Value: {{ value }}',
       })

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -2981,7 +2981,6 @@ describe('acceptance integration tests', () => {
 
   it('should support tagged template literals with no interpolations in expressions', () => {
     @Component({
-      standalone: true,
       template: `
         <p>:{{ caps\`Hello, World!\` }}:{{ excited?.caps(3)\`Uncomfortably excited\` }}:</p>
         <p>{{ greet\`Hi, I'm \${name}, and I'm \${age}\` }}</p>
@@ -3015,7 +3014,6 @@ describe('acceptance integration tests', () => {
 
   it('should not confuse operators for template literal tags', () => {
     @Component({
-      standalone: true,
       template: '{{ typeof`test` }}',
     })
     class TestComponent {
@@ -3029,7 +3027,6 @@ describe('acceptance integration tests', () => {
 
   it('should support "in" expressions', () => {
     @Component({
-      standalone: true,
       template: `{{'foo' in obj ? 'OK' : 'KO'}}`,
     })
     class TestComponent {

--- a/packages/core/test/acceptance/standalone_spec.ts
+++ b/packages/core/test/acceptance/standalone_spec.ts
@@ -599,7 +599,7 @@ describe('standalone components, directives, and pipes', () => {
     expect(() => {
       TestBed.createComponent(StandaloneCmp);
     }).toThrowError(
-      'The "NonStandaloneCmp" component, imported from "StandaloneCmp", is not standalone. Did you forget to add the standalone: true flag?',
+      'The "NonStandaloneCmp" component, imported from "StandaloneCmp", is not standalone. Does the component have the standalone: false flag?',
     );
   });
 
@@ -620,7 +620,7 @@ describe('standalone components, directives, and pipes', () => {
     expect(() => {
       TestBed.createComponent(StandaloneCmp);
     }).toThrowError(
-      'The "NonStandaloneDirective" directive, imported from "StandaloneCmp", is not standalone. Did you forget to add the standalone: true flag?',
+      'The "NonStandaloneDirective" directive, imported from "StandaloneCmp", is not standalone. Does the directive have the standalone: false flag?',
     );
   });
 
@@ -641,7 +641,7 @@ describe('standalone components, directives, and pipes', () => {
     expect(() => {
       TestBed.createComponent(StandaloneCmp);
     }).toThrowError(
-      'The "NonStandalonePipe" pipe, imported from "StandaloneCmp", is not standalone. Did you forget to add the standalone: true flag?',
+      'The "NonStandalonePipe" pipe, imported from "StandaloneCmp", is not standalone. Does the pipe have the standalone: false flag?',
     );
   });
 

--- a/packages/core/test/bundling/animations-standalone/main.ts
+++ b/packages/core/test/bundling/animations-standalone/main.ts
@@ -18,7 +18,6 @@ import {provideAnimations} from '@angular/platform-browser/animations';
   animations: [
     trigger('myAnimation', [transition('* => on', [animate(1000, style({opacity: 1}))])]),
   ],
-  standalone: true,
 })
 class AnimationsComponent {
   exp: any = false;
@@ -29,7 +28,6 @@ class AnimationsComponent {
   template: `
      <app-animations></app-animations>
    `,
-  standalone: true,
   imports: [AnimationsComponent],
 })
 class RootComponent {}

--- a/packages/core/test/bundling/defer/defer.component.ts
+++ b/packages/core/test/bundling/defer/defer.component.ts
@@ -9,7 +9,6 @@
 import {Component} from '@angular/core';
 
 @Component({
-  standalone: true,
   selector: 'defer-cmp',
   template: `
     <h2>Defer-loaded component</h2>

--- a/packages/core/test/bundling/defer/main.ts
+++ b/packages/core/test/bundling/defer/main.ts
@@ -12,7 +12,6 @@ import {bootstrapApplication} from '@angular/platform-browser';
 import {DeferComponent} from './defer.component';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   imports: [DeferComponent],
   template: `

--- a/packages/core/test/bundling/hydration/main.ts
+++ b/packages/core/test/bundling/hydration/main.ts
@@ -10,7 +10,6 @@ import {Component} from '@angular/core';
 import {bootstrapApplication, provideClientHydration} from '@angular/platform-browser';
 
 @Component({
-  standalone: true,
   selector: 'hello-world',
   template: 'Hello World!',
 })

--- a/packages/core/test/bundling/image-directive/e2e/basic/basic.ts
+++ b/packages/core/test/bundling/image-directive/e2e/basic/basic.ts
@@ -11,7 +11,6 @@ import {Component} from '../../../../../src/core';
 
 @Component({
   selector: 'basic',
-  standalone: true,
   imports: [NgOptimizedImage],
   template: `<img ngSrc="/e2e/a.png" width="150" height="150" priority>`,
   providers: [

--- a/packages/core/test/bundling/image-directive/e2e/fill-mode/fill-mode.ts
+++ b/packages/core/test/bundling/image-directive/e2e/fill-mode/fill-mode.ts
@@ -11,7 +11,6 @@ import {Component} from '../../../../../src/core';
 
 @Component({
   selector: 'fill-mode-passing',
-  standalone: true,
   imports: [NgOptimizedImage],
   template: `
     <!-- Make sure an image in the fill mode has the size of a container -->
@@ -23,7 +22,6 @@ import {Component} from '../../../../../src/core';
 export class FillModePassingComponent {}
 @Component({
   selector: 'fill-mode-failing',
-  standalone: true,
   imports: [NgOptimizedImage],
   template: `
     <div style="position: relative; width: 100%;">

--- a/packages/core/test/bundling/image-directive/e2e/image-distortion/image-distortion.ts
+++ b/packages/core/test/bundling/image-directive/e2e/image-distortion/image-distortion.ts
@@ -11,7 +11,6 @@ import {Component} from '../../../../../src/core';
 
 @Component({
   selector: 'image-distortion-passing',
-  standalone: true,
   imports: [NgOptimizedImage],
   template: `
      <!-- All the images in this template should not throw -->
@@ -66,7 +65,6 @@ import {Component} from '../../../../../src/core';
 export class ImageDistortionPassingComponent {}
 @Component({
   selector: 'image-distortion-failing',
-  standalone: true,
   imports: [NgOptimizedImage],
   template: `
      <!-- With the exception of the priority image, all the images in this template should throw -->

--- a/packages/core/test/bundling/image-directive/e2e/image-perf-warnings-lazy/image-perf-warnings-lazy.ts
+++ b/packages/core/test/bundling/image-directive/e2e/image-perf-warnings-lazy/image-perf-warnings-lazy.ts
@@ -10,7 +10,6 @@ import {Component} from '../../../../../src/core';
 
 @Component({
   selector: 'image-perf-warnings-lazy',
-  standalone: true,
   template: `
     <!-- 'a.png' should be treated as an LCP element -->
     <img src="/e2e/a.png" width="2500" height="2500" loading="lazy">

--- a/packages/core/test/bundling/image-directive/e2e/image-perf-warnings-oversized/image-perf-warnings-oversized.ts
+++ b/packages/core/test/bundling/image-directive/e2e/image-perf-warnings-oversized/image-perf-warnings-oversized.ts
@@ -10,7 +10,6 @@ import {Component} from '../../../../../src/core';
 
 @Component({
   selector: 'image-perf-warnings-oversized',
-  standalone: true,
   template: `
       <!-- Image is rendered too small  -->
       <div style="width: 200px; height: 200px">

--- a/packages/core/test/bundling/image-directive/e2e/image-perf-warnings-oversized/svg-no-perf-oversized-warnings.ts
+++ b/packages/core/test/bundling/image-directive/e2e/image-perf-warnings-oversized/svg-no-perf-oversized-warnings.ts
@@ -10,7 +10,6 @@ import {Component} from '../../../../../src/core';
 
 @Component({
   selector: 'svg-no-perf-oversized-warnings',
-  standalone: true,
   template: `
       <!-- Image is rendered too small  -->
       <div style="width: 200px; height: 200px">

--- a/packages/core/test/bundling/image-directive/e2e/lcp-check/lcp-check.ts
+++ b/packages/core/test/bundling/image-directive/e2e/lcp-check/lcp-check.ts
@@ -11,7 +11,6 @@ import {Component} from '../../../../../src/core';
 
 @Component({
   selector: 'lcp-check',
-  standalone: true,
   imports: [NgOptimizedImage],
   template: `
     <!--

--- a/packages/core/test/bundling/image-directive/e2e/oversized-image/oversized-image.ts
+++ b/packages/core/test/bundling/image-directive/e2e/oversized-image/oversized-image.ts
@@ -16,7 +16,6 @@ const imageLoader = {
 
 @Component({
   selector: 'oversized-image-passing',
-  standalone: true,
   imports: [NgOptimizedImage],
   providers: [imageLoader],
   template: `
@@ -35,7 +34,6 @@ export class OversizedImageComponentPassing {}
 
 @Component({
   selector: 'oversized-image-failing',
-  standalone: true,
   imports: [NgOptimizedImage],
   providers: [imageLoader],
   template: `

--- a/packages/core/test/bundling/image-directive/e2e/preconnect-check/preconnect-check.ts
+++ b/packages/core/test/bundling/image-directive/e2e/preconnect-check/preconnect-check.ts
@@ -11,7 +11,6 @@ import {Component, Inject} from '../../../../../src/core';
 
 @Component({
   selector: 'preconnect-check',
-  standalone: true,
   imports: [NgOptimizedImage],
   template: `
     <img ngSrc="/e2e/a.png" width="50" height="50" priority>

--- a/packages/core/test/bundling/image-directive/index.ts
+++ b/packages/core/test/bundling/image-directive/index.ts
@@ -30,7 +30,6 @@ import {PlaygroundComponent} from './playground';
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [RouterModule],
   template: '<router-outlet></router-outlet>',
 })

--- a/packages/core/test/bundling/image-directive/playground.ts
+++ b/packages/core/test/bundling/image-directive/playground.ts
@@ -35,7 +35,7 @@ import {Component} from '../../../src/core';
   `,
   ],
   template: `
-    <h1> 
+    <h1>
       <img ngSrc="a.png" width="50" height="50" priority ngSrcset="1x, 2x">
       <span>Angular image app</span>
     </h1>
@@ -44,7 +44,6 @@ import {Component} from '../../../src/core';
       <img ngSrc="hermes2.jpeg" ngSrcset="100w, 200w, 1000w, 2000w" width="1791" height="1008">
     </main>
   `,
-  standalone: true,
   imports: [NgOptimizedImage],
   providers: [provideImgixLoader('https://aurora-project.imgix.net')],
 })

--- a/packages/core/test/bundling/router/main.ts
+++ b/packages/core/test/bundling/router/main.ts
@@ -29,7 +29,6 @@ import {
     <li><a routerLink="/item/3" routerLinkActive="active">List Item 3</a></li>
   </ul>
   `,
-  standalone: true,
   imports: [RouterLink, RouterLinkActive],
 })
 class ListComponent {}
@@ -39,7 +38,6 @@ class ListComponent {}
   template: `
   Item {{id}}
   <p><button (click)="viewList()">Back to List</button></p>`,
-  standalone: true,
 })
 class ItemComponent implements OnInit {
   id = -1;
@@ -62,7 +60,6 @@ class ItemComponent implements OnInit {
 @Component({
   selector: 'app-root',
   template: `<router-outlet></router-outlet>`,
-  standalone: true,
   imports: [RouterOutlet],
 })
 class RootComponent {}

--- a/packages/core/test/bundling/standalone_bootstrap/main.ts
+++ b/packages/core/test/bundling/standalone_bootstrap/main.ts
@@ -10,7 +10,6 @@ import {Component, provideZonelessChangeDetection} from '@angular/core';
 import {bootstrapApplication} from '@angular/platform-browser';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   template: 'Hello World!',
 })

--- a/packages/core/test/change_detection_scheduler_spec.ts
+++ b/packages/core/test/change_detection_scheduler_spec.ts
@@ -382,7 +382,6 @@ describe('Angular with zoneless enabled', () => {
         destroyPlatform();
 
         @Component({
-          standalone: true,
           template: `<p>Component created</p>`,
         })
         class DynamicComponent {
@@ -391,7 +390,6 @@ describe('Angular with zoneless enabled', () => {
 
         @Component({
           selector: 'app',
-          standalone: true,
           template: `<main #outlet></main>`,
         })
         class App {

--- a/packages/core/test/render3/component_ref_spec.ts
+++ b/packages/core/test/render3/component_ref_spec.ts
@@ -403,10 +403,7 @@ describe('ComponentFactory', () => {
 
     it('should not set input if value is the same as the previous', () => {
       let log: string[] = [];
-      @Component({
-        template: `{{input}}`,
-        standalone: true,
-      })
+      @Component({template: `{{input}}`})
       class DynamicCmp {
         @Input()
         set input(v: string) {

--- a/packages/core/test/render3/providers_helper.ts
+++ b/packages/core/test/render3/providers_helper.ts
@@ -26,7 +26,6 @@ export function expectProvidersScenario(defs: {
   ngModule?: Type<any>;
 }): void {
   @Component({
-    standalone: true,
     selector: 'view-child',
     template: 'view-child',
     encapsulation: ViewEncapsulation.None,
@@ -40,7 +39,6 @@ export function expectProvidersScenario(defs: {
   }
 
   @Directive({
-    standalone: true,
     selector: 'view-child',
     providers: defs.viewChild?.directiveProviders ?? [],
   })
@@ -51,7 +49,6 @@ export function expectProvidersScenario(defs: {
   }
 
   @Component({
-    standalone: true,
     selector: 'content-child',
     template: 'content-child',
     encapsulation: ViewEncapsulation.None,
@@ -65,7 +62,6 @@ export function expectProvidersScenario(defs: {
   }
 
   @Directive({
-    standalone: true,
     selector: 'content-child',
     providers: defs.contentChild?.directiveProviders ?? [],
   })
@@ -76,7 +72,6 @@ export function expectProvidersScenario(defs: {
   }
 
   @Component({
-    standalone: true,
     imports: [ViewChildComponent, ViewChildDirective],
     selector: 'parent',
     template: '<view-child></view-child>',
@@ -91,7 +86,6 @@ export function expectProvidersScenario(defs: {
   }
 
   @Directive({
-    standalone: true,
     selector: 'parent',
     providers: defs.parent?.directiveProviders ?? [],
   })
@@ -101,7 +95,6 @@ export function expectProvidersScenario(defs: {
     }
   }
   @Directive({
-    standalone: true,
     selector: 'parent',
     providers: defs.parent?.directive2Providers ?? [],
   })
@@ -112,7 +105,6 @@ export function expectProvidersScenario(defs: {
   }
 
   @Component({
-    standalone: true,
     imports: [
       ParentComponent,
       // Note: tests are sensitive to the ordering here - the providers from `ParentDirective`

--- a/packages/elements/test/component-factory-strategy_spec.ts
+++ b/packages/elements/test/component-factory-strategy_spec.ts
@@ -218,7 +218,6 @@ describe('ComponentFactoryNgElementStrategy', () => {
 
     it('should detect changes even when updated during CD', async () => {
       @Component({
-        standalone: true,
         template: ``,
       })
       class DriverCmp {
@@ -361,7 +360,6 @@ describe('ComponentFactoryNgElementStrategy', () => {
 });
 
 @Directive({
-  standalone: true,
   selector: '[cdTracker]',
 })
 export class CdTrackerDir {
@@ -374,7 +372,6 @@ export class CdTrackerDir {
 
 @Component({
   selector: 'fake-component',
-  standalone: true,
   imports: [CdTrackerDir],
   template: `
     <ng-container cdTracker></ng-container>

--- a/packages/elements/test/create-custom-element-env_spec.ts
+++ b/packages/elements/test/create-custom-element-env_spec.ts
@@ -26,7 +26,6 @@ describe('createCustomElement with env injector', () => {
 
   it('should use provided EnvironmentInjector to create a custom element', async () => {
     @Component({
-      standalone: true,
       template: `Hello, standalone element!`,
     })
     class TestStandaloneCmp {}

--- a/packages/examples/router/testing/test/router_testing_harness_examples.spec.ts
+++ b/packages/examples/router/testing/test/router_testing_harness_examples.spec.ts
@@ -63,7 +63,6 @@ describe('navigate for test examples', () => {
   it('test a ActivatedRoute', async () => {
     // #docregion ActivatedRoute
     @Component({
-      standalone: true,
       imports: [AsyncPipe],
       template: `search: {{ (route.queryParams | async)?.query }}`,
     })

--- a/packages/forms/test/form_builder_spec.ts
+++ b/packages/forms/test/form_builder_spec.ts
@@ -264,7 +264,6 @@ import {of} from 'rxjs';
 
     it('should be injectable', () => {
       @Component({
-        standalone: true,
         template: '...',
       })
       class MyComp {
@@ -291,7 +290,6 @@ import {of} from 'rxjs';
 
     it('should be injectable as NonNullableFormBuilder', () => {
       @Component({
-        standalone: true,
         template: '...',
       })
       class MyComp {

--- a/packages/forms/test/ng_control_status_spec.ts
+++ b/packages/forms/test/ng_control_status_spec.ts
@@ -19,7 +19,6 @@ describe('status host binding classes', () => {
     @Component({
       selector: 'test-cmp',
       template: `<input type="text" [formControl]="control">`,
-      standalone: true,
       imports: [FormsModule, ReactiveFormsModule],
       changeDetection: ChangeDetectionStrategy.OnPush,
     })

--- a/packages/language-service/test/code_fixes_spec.ts
+++ b/packages/language-service/test/code_fixes_spec.ts
@@ -576,8 +576,7 @@ describe('code fixes', () => {
          import {Component} from '@angular/core';
          @Component({
            selector: 'foo',
-           template: '<bar></bar>',
-           standalone: true
+           template: '<bar></bar>'
          })
          export class FooComponent {}
          `,
@@ -585,8 +584,7 @@ describe('code fixes', () => {
          import {Component} from '@angular/core';
          @Component({
            selector: 'bar',
-           template: '<div>bar</div>',
-           standalone: true
+           template: '<div>bar</div>'
          })
          export class BarComponent {}
          `,
@@ -613,8 +611,7 @@ describe('code fixes', () => {
          import {Component} from '@angular/core';
          @Component({
            selector: 'foo',
-           template: '<bar></bar>',
-           standalone: true
+           template: '<bar></bar>'
          })
          export class FooComponent {}
          `,
@@ -672,8 +669,7 @@ describe('code fixes', () => {
          @Component({
            selector: 'bar',
            template: '<div>bar</div>',
-           standalone: true,
-         })
+          })
          export class BarComponent {}
          `,
       };
@@ -699,16 +695,14 @@ describe('code fixes', () => {
         import {Component} from '@angular/core';
         @Component({
           selector: 'foo',
-          template: '{{"hello"|bar}}',
-          standalone: true
+          template: '{{"hello"|bar}}'
         })
         export class FooComponent {}
         `,
         'bar.ts': `
         import {Pipe} from '@angular/core';
         @Pipe({
-          name: 'bar',
-          standalone: true
+          name: 'bar'
         })
         export class BarPipe implements PipeTransform {
           transform(value: unknown, ...args: unknown[]): unknown {
@@ -740,8 +734,7 @@ describe('code fixes', () => {
          import {Component} from '@angular/core';
          @Component({
            selector: 'foo',
-           template: '<bar></bar>',
-           standalone: true
+           template: '<bar></bar>'
          })
          export class FooComponent {}
          `,
@@ -792,8 +785,7 @@ describe('code fixes', () => {
          import {Component} from '@angular/core';
          @Component({
            selector: 'foo',
-           template: '<bar></bar>',
-           standalone: true
+           template: '<bar></bar>'
          })
          export class FooComponent {}
          `,
@@ -801,8 +793,7 @@ describe('code fixes', () => {
          import {Component} from '@angular/core';
          @Component({
            selector: 'bar',
-           template: '<div>bar</div>',
-           standalone: true
+           template: '<div>bar</div>'
          })
          class BarComponent {}
          export default BarComponent;
@@ -831,8 +822,7 @@ describe('code fixes', () => {
          import {test} from './bar';
          @Component({
            selector: 'foo',
-           template: '<bar></bar>',
-           standalone: true
+           template: '<bar></bar>'
          })
          export class FooComponent {}
          `,
@@ -840,8 +830,7 @@ describe('code fixes', () => {
          import {Component} from '@angular/core';
          @Component({
            selector: 'bar',
-           template: '<div>bar</div>',
-           standalone: true
+           template: '<div>bar</div>'
          })
          class BarComponent {}
          export default BarComponent;
@@ -871,8 +860,7 @@ describe('code fixes', () => {
          import NewBarComponent, {test} from './bar';
          @Component({
            selector: 'foo',
-           template: '<bar></bar>',
-           standalone: true
+           template: '<bar></bar>'
          })
          export class FooComponent {}
          `,
@@ -880,8 +868,7 @@ describe('code fixes', () => {
          import {Component} from '@angular/core';
          @Component({
            selector: 'bar',
-           template: '<div>bar</div>',
-           standalone: true
+           template: '<div>bar</div>'
          })
          class BarComponent {}
          export default BarComponent;
@@ -909,15 +896,13 @@ describe('code fixes', () => {
           import {Component} from '@angular/core';
 
           @Component({
-            standalone: true,
-            selector: 'one-cmp',
+                        selector: 'one-cmp',
             template: '<two-cmp></two-cmp>',
           })
           export class OneCmp {}
 
           @Component({
-            standalone: true,
-            selector: 'two-cmp',
+                        selector: 'two-cmp',
             template: '<div></div>',
           })
           export class TwoCmp {}
@@ -945,8 +930,7 @@ describe('code fixes', () => {
          import {Component} from '@angular/core';
          @Component({
            selector: 'foo',
-           template: '<mat-card></mat-card>',
-           standalone: true
+           template: '<mat-card></mat-card>'
          })
          export class FooComponent {}
          `,
@@ -977,8 +961,7 @@ describe('code fixes', () => {
            import {Component} from '@angular/core';
            @Component({
              selector: 'foo',
-             template: '<bar></bar>',
-             standalone: true
+             template: '<bar></bar>'
            })
            export class FooComponent {}
            `,
@@ -986,8 +969,7 @@ describe('code fixes', () => {
            import {Component} from '@angular/core';
            @Component({
              selector: 'bar',
-             template: '<div>bar</div>',
-             standalone: true
+             template: '<div>bar</div>'
            })
            export class BarComponent {}
            `,
@@ -1019,8 +1001,7 @@ describe('code fixes', () => {
            import {Component} from '@angular/core';
            @Component({
              selector: 'foo',
-             template: '<bar></bar>',
-             standalone: true
+             template: '<bar></bar>'
            })
            export class FooComponent {}
            `,
@@ -1028,8 +1009,7 @@ describe('code fixes', () => {
            import {Component} from '@angular/core';
            @Component({
              selector: 'bar',
-             template: '<div>bar</div>',
-             standalone: true
+             template: '<div>bar</div>'
            })
            export class BarComponent {}
            `,
@@ -1175,8 +1155,7 @@ describe('code fixes', () => {
 
            @Component({
              selector: 'foo',
-             template: '<bar></bar>',
-             standalone: true
+             template: '<bar></bar>'
            })
            export class FooComponent {}
            `,
@@ -1290,16 +1269,15 @@ describe('code fixes', () => {
         'app.ts': `
          import {Component, Directive} from '@angular/core';
 
-         @Directive({selector: '[used]', standalone: true})
+         @Directive({selector: '[used]'})
          export class UsedDirective {}
 
-         @Directive({selector: '[unused]', standalone: true})
+         @Directive({selector: '[unused]'})
          export class UnusedDirective {}
 
          @Component({
            template: '<span used></span>',
-           standalone: true,
-           imports: [UnusedDirective, UsedDirective],
+                      imports: [UnusedDirective, UsedDirective],
          })
          export class AppComponent {}
        `,
@@ -1325,16 +1303,15 @@ describe('code fixes', () => {
         'app.ts': `
          import {Component, Directive, Pipe} from '@angular/core';
 
-         @Directive({selector: '[unused]', standalone: true})
+         @Directive({selector: '[unused]'})
          export class UnusedDirective {}
 
-         @Pipe({name: 'unused', standalone: true})
+         @Pipe({name: 'unused'})
          export class UnusedPipe {}
 
          @Component({
            template: '',
-           standalone: true,
-           imports: [UnusedDirective, UnusedPipe],
+                      imports: [UnusedDirective, UnusedPipe],
          })
          export class AppComponent {}
        `,
@@ -1360,19 +1337,18 @@ describe('code fixes', () => {
         'app.ts': `
          import {Component, Directive, Pipe} from '@angular/core';
 
-         @Directive({selector: '[used]', standalone: true})
+         @Directive({selector: '[used]'})
          export class UsedDirective {}
 
-         @Directive({selector: '[unused]', standalone: true})
+         @Directive({selector: '[unused]'})
          export class UnusedDirective {}
 
-         @Pipe({name: 'unused', standalone: true})
+         @Pipe({name: 'unused'})
          export class UnusedPipe {}
 
          @Component({
           selector: 'used-cmp',
-          standalone: true,
-          template: '',
+                    template: '',
          })
          export class UsedComponent {}
 
@@ -1386,8 +1362,7 @@ describe('code fixes', () => {
               </div>
             </section>
            \`,
-           standalone: true,
-           imports: [UnusedDirective, UsedDirective, UnusedPipe, UsedComponent],
+                      imports: [UnusedDirective, UsedDirective, UnusedPipe, UsedComponent],
          })
          export class AppComponent {}
        `,
@@ -1414,16 +1389,15 @@ describe('code fixes', () => {
         'app.ts': `
          import {Component, Directive, Pipe} from '@angular/core';
 
-         @Directive({selector: '[unused]', standalone: true})
+         @Directive({selector: '[unused]'})
          export class UnusedDirective {}
 
-         @Pipe({name: 'unused', standalone: true})
+         @Pipe({name: 'unused'})
          export class UnusedPipe {}
 
          @Component({
            template: '',
-           standalone: true,
-           imports: [UnusedDirective, UnusedPipe],
+                      imports: [UnusedDirective, UnusedPipe],
          })
          export class AppComponent {}
        `,

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -837,7 +837,7 @@ describe('completions', () => {
         '',
         {},
         `
-        @Component({selector: 'other-cmp', template: 'unimportant', standalone: true})
+        @Component({selector: 'other-cmp', template: 'unimportant'})
         export class OtherCmp {}
       `,
       );
@@ -1097,7 +1097,6 @@ describe('completions', () => {
           const {templateFile} = setup(`<input dir my>`, '', {
             'Dir': `
               @Directive({
-                standalone: true,
                 inputs: ['myInput']
               })
               export class HostDir {
@@ -1131,8 +1130,7 @@ describe('completions', () => {
           const {templateFile} = setup(`<input dir my>`, '', {
             'Dir': `
               @Directive({
-                standalone: true,
-                inputs: ['myInput']
+                                inputs: ['myInput']
               })
               export class HostDir {
                 myInput = 'foo';
@@ -1161,8 +1159,7 @@ describe('completions', () => {
           const {templateFile} = setup(`<input dir ali>`, '', {
             'Dir': `
               @Directive({
-                standalone: true,
-                inputs: ['myInput']
+                                inputs: ['myInput']
               })
               export class HostDir {
                 myInput = 'foo';
@@ -1195,8 +1192,7 @@ describe('completions', () => {
           const {templateFile} = setup(`<input dir ali>`, '', {
             'Dir': `
                   @Directive({
-                    standalone: true,
-                    inputs: ['myInput: myPublicInput']
+                                        inputs: ['myInput: myPublicInput']
                   })
                   export class HostDir {
                     myInput = 'foo';
@@ -1565,8 +1561,7 @@ describe('completions', () => {
         const {templateFile} = setup(`<input dir (my)>`, '', {
           'Dir': `
             @Directive({
-              standalone: true,
-              outputs: ['myOutput']
+                            outputs: ['myOutput']
             })
             export class HostDir {
               myOutput: any;
@@ -1599,8 +1594,7 @@ describe('completions', () => {
         const {templateFile} = setup(`<input dir (my)>`, '', {
           'Dir': `
             @Directive({
-              standalone: true,
-              outputs: ['myOutput']
+                            outputs: ['myOutput']
             })
             export class HostDir {
               myOutput: any;
@@ -1628,8 +1622,7 @@ describe('completions', () => {
         const {templateFile} = setup(`<input dir (ali)>`, '', {
           'Dir': `
             @Directive({
-              standalone: true,
-              outputs: ['myOutput: myPublicOutput']
+                            outputs: ['myOutput: myPublicOutput']
             })
             export class HostDir {
               myOutput: any;

--- a/packages/language-service/test/diagnostic_spec.ts
+++ b/packages/language-service/test/diagnostic_spec.ts
@@ -574,7 +574,6 @@ describe('getSemanticDiagnostics', () => {
       @Component({
         templateUrl: './test.ng.html',
         imports: [PostModule],
-        standalone: true,
       })
       export class Main { }
        `,
@@ -611,7 +610,7 @@ describe('getSuggestedDiagnostics', () => {
       export class AppComponent {
         /**
          * @deprecated
-         * 
+         *
          * Used to test to get the symbol of the type "string", using the
          * "type.getSymbol()" to check if the symbol is "undefined".
          */

--- a/packages/language-service/test/references_and_rename_spec.ts
+++ b/packages/language-service/test/references_and_rename_spec.ts
@@ -1958,8 +1958,7 @@ describe('find references and rename locations', () => {
         import {Component} from '@angular/core';
 
         @Component({
-          template: '@if (x; as aliasX) { {{aliasX}} {{aliasX + "second"}} }',
-          standalone: true
+          template: '@if (x; as aliasX) { {{aliasX}} {{aliasX + "second"}} }'
         })
         export class AppCmp {
           x?: string;

--- a/packages/language-service/test/type_definitions_spec.ts
+++ b/packages/language-service/test/type_definitions_spec.ts
@@ -58,8 +58,7 @@ describe('type definitions', () => {
           import {Component, Directive, input} from '@angular/core';
 
           @Directive({
-            selector: 'my-dir',
-            standalone: true
+            selector: 'my-dir'
           })
           export class MyDir {
             firstName = input<string>();
@@ -67,7 +66,6 @@ describe('type definitions', () => {
 
           @Component({
             templateUrl: 'app.html',
-            standalone: true,
             imports: [MyDir],
           })
           export class AppCmp {}
@@ -94,8 +92,7 @@ describe('type definitions', () => {
           import {Component, Directive, output} from '@angular/core';
 
           @Directive({
-            selector: 'my-dir',
-            standalone: true
+            selector: 'my-dir'
           })
           export class MyDir {
             nameChanges = output<string>();
@@ -103,8 +100,7 @@ describe('type definitions', () => {
 
           @Component({
             templateUrl: 'app.html',
-            standalone: true,
-            imports: [MyDir],
+                        imports: [MyDir],
           })
           export class AppCmp {
             doSmth() {}
@@ -133,8 +129,7 @@ describe('type definitions', () => {
           import {outputFromObservable} from '@angular/core/rxjs-interop';
 
           @Directive({
-            selector: 'my-dir',
-            standalone: true
+            selector: 'my-dir'
           })
           export class MyDir {
             nameChanges = outputFromObservable(new EventEmitter<number>());
@@ -142,8 +137,7 @@ describe('type definitions', () => {
 
           @Component({
             templateUrl: 'app.html',
-            standalone: true,
-            imports: [MyDir],
+                        imports: [MyDir],
           })
           export class AppCmp {
             doSmth() {}
@@ -168,17 +162,13 @@ describe('type definitions', () => {
       'app.ts': `
         import {Component, Directive, model} from '@angular/core';
 
-        @Directive({
-          selector: 'my-dir',
-          standalone: true
-        })
+        @Directive({selector: 'my-dir'})
         export class MyDir {
           twoWayValue = model<string>();
         }
 
         @Component({
           templateUrl: 'app.html',
-          standalone: true,
           imports: [MyDir],
         })
         export class AppCmp {

--- a/packages/platform-browser/animations/test/animation_renderer_spec.ts
+++ b/packages/platform-browser/animations/test/animation_renderer_spec.ts
@@ -472,7 +472,7 @@ import {withBody, isNode, el} from '@angular/private/testing';
           constructor(rendererFactory: RendererFactory2) {}
         }
 
-        @Component({selector: 'app-root', template: 'app-root content', standalone: true})
+        @Component({selector: 'app-root', template: 'app-root content'})
         class AppComponent {}
 
         const appRef = await bootstrapApplication(AppComponent, {
@@ -504,7 +504,7 @@ import {withBody, isNode, el} from '@angular/private/testing';
     it(
       'should clear bootstrapped component contents when async animations are used',
       withBody('<div>before</div><app-root></app-root><div>after</div>', async () => {
-        @Component({selector: 'app-root', template: 'app-root content', standalone: true})
+        @Component({selector: 'app-root', template: 'app-root content'})
         class AppComponent {}
 
         const appRef = await bootstrapApplication(AppComponent, {

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -222,7 +222,6 @@ describe('bootstrap factory method', () => {
     const NAME = new InjectionToken<string>('name');
 
     @Component({
-      standalone: true,
       selector: 'hello-app',
       template: 'Hello from {{ name }}!',
     })
@@ -231,7 +230,6 @@ describe('bootstrap factory method', () => {
     }
 
     @Component({
-      standalone: true,
       selector: 'hello-app-2',
       template: 'Hello from {{ name }}!',
     })
@@ -240,7 +238,6 @@ describe('bootstrap factory method', () => {
     }
 
     @Component({
-      standalone: true,
       selector: 'hello-app',
       template: 'Hello from {{ name }}!',
     })
@@ -368,7 +365,7 @@ describe('bootstrap factory method', () => {
       const msg =
         'NG0907: The NonStandaloneComp component is not marked as standalone, ' +
         'but Angular expects to have a standalone component here. Please make sure the ' +
-        'NonStandaloneComp component has the `standalone: true` flag in the decorator.';
+        'NonStandaloneComp component does not have the `standalone: false` flag in the decorator.';
       let bootstrapError: string | null = null;
 
       try {
@@ -382,7 +379,6 @@ describe('bootstrap factory method', () => {
 
     it('should throw when trying to bootstrap a standalone directive', async () => {
       @Directive({
-        standalone: true,
         selector: '[dir]',
       })
       class StandaloneDirective {}
@@ -421,7 +417,6 @@ describe('bootstrap factory method', () => {
       let state: TransferState | undefined;
       @Component({
         selector: 'hello-app',
-        standalone: true,
         template: '...',
       })
       class StandaloneComponent {
@@ -452,7 +447,6 @@ describe('bootstrap factory method', () => {
 
     describe('with animations', () => {
       @Component({
-        standalone: true,
         selector: 'hello-app',
         template:
           '<div @myAnimation (@myAnimation.start)="onStart($event)">Hello from AnimationCmp!</div>',
@@ -515,7 +509,6 @@ describe('bootstrap factory method', () => {
         template: '',
         selector: 'hello-app',
         imports: [SomeModule],
-        standalone: true,
       })
       class AnimationCmp {}
 

--- a/packages/platform-browser/test/browser/bootstrap_standalone_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_standalone_spec.ts
@@ -47,7 +47,6 @@ describe('bootstrapApplication for standalone components', () => {
 
       @Component({
         selector: 'test-app',
-        standalone: true,
         template: `({{testToken}})`,
         imports: [AmbientModule],
       })
@@ -71,7 +70,6 @@ describe('bootstrapApplication for standalone components', () => {
     withBody('<test-app></test-app>', async () => {
       @Component({
         selector: 'test-app',
-        standalone: true,
         template: ``,
       })
       class StandaloneCmp {}
@@ -115,7 +113,6 @@ describe('bootstrapApplication for standalone components', () => {
       @Component({
         selector: 'test-app',
         template: `({{service.ambientToken}})`,
-        standalone: true,
         imports: [AmbientModule],
       })
       class StandaloneCmp {
@@ -149,7 +146,6 @@ describe('bootstrapApplication for standalone components', () => {
       @Component({
         selector: 'test-app',
         template: '...',
-        standalone: true,
         imports: [BrowserModule],
       })
       class StandaloneCmp {}
@@ -183,7 +179,6 @@ describe('bootstrapApplication for standalone components', () => {
       @Component({
         selector: 'test-app',
         template: '...',
-        standalone: true,
         imports: [SomeDependencyModule],
       })
       class StandaloneCmp {}
@@ -222,7 +217,6 @@ describe('bootstrapApplication for standalone components', () => {
 
       @Component({
         selector: 'test-app',
-        standalone: true,
         template: 'Hello',
       })
       class ComponentWithOnDestroy {

--- a/packages/platform-server/test/event_replay_spec.ts
+++ b/packages/platform-server/test/event_replay_spec.ts
@@ -93,7 +93,6 @@ describe('event replay', () => {
 
     @Component({
       selector: 'app',
-      standalone: true,
       template: `
         <button id="btn" (click)="onClick()" #localRef></button>
       `,
@@ -120,7 +119,6 @@ describe('event replay', () => {
 
     @Component({
       selector: 'app',
-      standalone: true,
       template: `
         <button id="btn-1" (click)="onClick()"></button>
       `,
@@ -131,7 +129,6 @@ describe('event replay', () => {
 
     @Component({
       selector: 'app-2',
-      standalone: true,
       template: `
         <button id="btn-2" (click)="onClick()"></button>
       `,
@@ -183,7 +180,6 @@ describe('event replay', () => {
   it('should cleanup `window._ejsas[appId]` once app is destroyed', async () => {
     @Component({
       selector: 'app',
-      standalone: true,
       template: `
         <button id="btn" (click)="onClick()"></button>
       `,
@@ -227,7 +223,6 @@ describe('event replay', () => {
     const innerOnClickSpy = jasmine.createSpy();
     @Component({
       selector: 'app-card',
-      standalone: true,
       template: `
         <div class="card">
           <button id="inner-button" (click)="onClick()"></button>
@@ -242,7 +237,6 @@ describe('event replay', () => {
     @Component({
       selector: 'app',
       imports: [CardComponent],
-      standalone: true,
       template: `
         <app-card>
           <h2>Card Title</h2>
@@ -396,7 +390,6 @@ describe('event replay', () => {
 
   it('should remove jsaction attributes, but continue listening to events.', async () => {
     @Component({
-      standalone: true,
       selector: 'app',
       template: `
             <div (click)="onClick()" id="1">
@@ -424,7 +417,6 @@ describe('event replay', () => {
 
   it(`should add 'nonce' attribute to event record script when 'ngCspNonce' is provided`, async () => {
     @Component({
-      standalone: true,
       selector: 'app',
       template: `
             <div (click)="onClick()">
@@ -453,7 +445,6 @@ describe('event replay', () => {
 
     @Component({
       selector: 'app',
-      standalone: true,
       template: `
         <button id="btn" (click)="onClick()"></button>
       `,
@@ -511,7 +502,6 @@ describe('event replay', () => {
     it('should propagate events', async () => {
       const onClickSpy = jasmine.createSpy();
       @Component({
-        standalone: true,
         selector: 'app',
         template: `
             <div id="top" (click)="onClick()">
@@ -543,7 +533,6 @@ describe('event replay', () => {
 
     it('should not propagate events if stopPropagation is called', async () => {
       @Component({
-        standalone: true,
         selector: 'app',
         template: `
             <div id="top" (click)="onClick($event)">
@@ -577,7 +566,6 @@ describe('event replay', () => {
       let latestTarget: EventTarget | null = null;
       let latestCurrentTarget: EventTarget | null = null;
       @Component({
-        standalone: true,
         selector: 'app',
         template: `
             <div id="top" (click)="onClick($event)">
@@ -619,7 +607,6 @@ describe('event replay', () => {
   describe('event dispatch script', () => {
     it('should not be present on a page when hydration is disabled', async () => {
       @Component({
-        standalone: true,
         selector: 'app',
         template: '<input (click)="onClick()" />',
       })
@@ -636,7 +623,6 @@ describe('event replay', () => {
 
     it('should not be present on a page if there are no events to replay', async () => {
       @Component({
-        standalone: true,
         selector: 'app',
         template: 'Some text',
       })
@@ -664,7 +650,6 @@ describe('event replay', () => {
 
     it('should not replay mouse events', async () => {
       @Component({
-        standalone: true,
         selector: 'app',
         template: '<div (mouseenter)="doThing()"><div>',
       })
@@ -682,7 +667,6 @@ describe('event replay', () => {
 
     it('should not be present on a page where event replay is not enabled', async () => {
       @Component({
-        standalone: true,
         selector: 'app',
         template: '<input (click)="onClick()" />',
       })
@@ -702,7 +686,6 @@ describe('event replay', () => {
 
     it('should be retained if there are events to replay', async () => {
       @Component({
-        standalone: true,
         selector: 'app',
         template: '<input (click)="onClick()" />',
       })

--- a/packages/platform-server/test/full_app_hydration_spec.ts
+++ b/packages/platform-server/test/full_app_hydration_spec.ts
@@ -117,14 +117,12 @@ describe('platform-server full application hydration integration', () => {
     describe('annotations', () => {
       it('should add hydration annotations to component host nodes during ssr', async () => {
         @Component({
-          standalone: true,
           selector: 'nested',
           template: 'This is a nested component.',
         })
         class NestedComponent {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NestedComponent],
           template: `
@@ -142,14 +140,12 @@ describe('platform-server full application hydration integration', () => {
 
       it('should skip local ref slots while producing hydration annotations', async () => {
         @Component({
-          standalone: true,
           selector: 'nested',
           template: 'This is a nested component.',
         })
         class NestedComponent {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NestedComponent],
           template: `
@@ -168,7 +164,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should skip embedded views from an ApplicationRef during annotation', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             <ng-template #tmpl>Hi!</ng-template>
@@ -194,7 +189,6 @@ describe('platform-server full application hydration integration', () => {
     describe('server rendering', () => {
       it('should wipe out existing host element content when server side rendering', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             <div>Some content</div>
@@ -216,7 +210,6 @@ describe('platform-server full application hydration integration', () => {
     describe('hydration', () => {
       it('should remove ngh attributes after hydration on the client', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: 'Hi!',
         })
@@ -240,7 +233,6 @@ describe('platform-server full application hydration integration', () => {
       describe('basic scenarios', () => {
         it('should support text-only contents', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               This is hydrated content.
@@ -266,7 +258,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should hydrate root components with empty templates', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: '',
           })
@@ -290,14 +281,12 @@ describe('platform-server full application hydration integration', () => {
 
         it('should hydrate child components with empty templates', async () => {
           @Component({
-            standalone: true,
             selector: 'child',
             template: '',
           })
           class ChildComponent {}
 
           @Component({
-            standalone: true,
             imports: [ChildComponent],
             selector: 'app',
             template: '<child />',
@@ -322,7 +311,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support a single text interpolation', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               {{ text }}
@@ -350,7 +338,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support text and HTML elements', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               <header>Header</header>
@@ -378,7 +365,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support text and HTML elements in nested components', async () => {
           @Component({
-            standalone: true,
             selector: 'nested-cmp',
             template: `
               <h1>Hello World!</h1>
@@ -388,7 +374,6 @@ describe('platform-server full application hydration integration', () => {
           class NestedComponent {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             imports: [NestedComponent],
             template: `
@@ -427,7 +412,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support elements with local refs', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               <header #headerRef>Header</header>
@@ -455,7 +439,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should handle extra child nodes within a root app component', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               <div>Some content</div>
@@ -485,7 +468,6 @@ describe('platform-server full application hydration integration', () => {
       describe('ng-container', () => {
         it('should support empty containers', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               This is an empty container: <ng-container></ng-container>
@@ -511,7 +493,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support non-empty containers', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               This is a non-empty container:
@@ -541,7 +522,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support nested containers', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               This is a non-empty container:
@@ -585,13 +565,11 @@ describe('platform-server full application hydration integration', () => {
         it('should support element containers with *ngIf', async () => {
           @Component({
             selector: 'cmp',
-            standalone: true,
             template: 'Hi!',
           })
           class Cmp {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             imports: [NgIf],
             template: `
@@ -632,7 +610,6 @@ describe('platform-server full application hydration integration', () => {
         describe('*ngIf', () => {
           it('should work with *ngIf on ng-container nodes', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgIf],
               template: `
@@ -663,7 +640,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should work with empty containers on ng-container nodes', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgIf],
               template: `
@@ -692,7 +668,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should work with *ngIf on element nodes', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgIf],
               template: `
@@ -719,7 +694,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should work with empty containers on element nodes', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgIf],
               template: `
@@ -741,7 +715,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should work with *ngIf on component host nodes', async () => {
             @Component({
-              standalone: true,
               selector: 'nested-cmp',
               imports: [NgIf],
               template: `
@@ -751,7 +724,6 @@ describe('platform-server full application hydration integration', () => {
             class NestedComponent {}
 
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgIf, NestedComponent],
               template: `
@@ -780,7 +752,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should support nested *ngIfs', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgIf],
               template: `
@@ -815,7 +786,6 @@ describe('platform-server full application hydration integration', () => {
         describe('*ngFor', () => {
           it('should support *ngFor on <ng-container> nodes', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgIf, NgFor],
               template: `
@@ -852,7 +822,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should support *ngFor on element nodes', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgIf, NgFor],
               template: `
@@ -889,7 +858,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should support *ngFor on host component nodes', async () => {
             @Component({
-              standalone: true,
               selector: 'nested-cmp',
               imports: [NgIf],
               template: `
@@ -899,7 +867,6 @@ describe('platform-server full application hydration integration', () => {
             class NestedComponent {}
 
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgIf, NgFor, NestedComponent],
               template: `
@@ -934,7 +901,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should support compact serialization for *ngFor', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgIf, NgFor],
               template: `
@@ -977,7 +943,6 @@ describe('platform-server full application hydration integration', () => {
         describe('*ngComponentOutlet', () => {
           it('should support hydration on <ng-container> nodes', async () => {
             @Component({
-              standalone: true,
               selector: 'nested-cmp',
               imports: [NgIf],
               template: `
@@ -987,7 +952,6 @@ describe('platform-server full application hydration integration', () => {
             class NestedComponent {}
 
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgComponentOutlet],
               template: `
@@ -1017,7 +981,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should support hydration on element nodes', async () => {
             @Component({
-              standalone: true,
               selector: 'nested-cmp',
               imports: [NgIf],
               template: `
@@ -1027,7 +990,6 @@ describe('platform-server full application hydration integration', () => {
             class NestedComponent {}
 
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgComponentOutlet],
               template: `
@@ -1058,7 +1020,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should support hydration for nested components', async () => {
             @Component({
-              standalone: true,
               selector: 'nested-cmp',
               imports: [NgIf],
               template: `
@@ -1068,7 +1029,6 @@ describe('platform-server full application hydration integration', () => {
             class NestedComponent {}
 
             @Component({
-              standalone: true,
               selector: 'other-nested-cmp',
               imports: [NgComponentOutlet],
               template: `
@@ -1081,7 +1041,6 @@ describe('platform-server full application hydration integration', () => {
             }
 
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgComponentOutlet],
               template: `
@@ -1113,7 +1072,6 @@ describe('platform-server full application hydration integration', () => {
         describe('*ngTemplateOutlet', () => {
           it('should work with <ng-container>', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgTemplateOutlet],
               template: `
@@ -1143,7 +1101,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should work with element nodes', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgTemplateOutlet],
               template: `
@@ -1176,7 +1133,6 @@ describe('platform-server full application hydration integration', () => {
         describe('ViewContainerRef', () => {
           it('should work with ViewContainerRef.createComponent', async () => {
             @Component({
-              standalone: true,
               selector: 'dynamic',
               template: `
                 <span>This is a content of a dynamic component.</span>
@@ -1185,7 +1141,6 @@ describe('platform-server full application hydration integration', () => {
             class DynamicComponent {}
 
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgIf, NgFor],
               template: `
@@ -1220,7 +1175,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should work with ViewContainerRef.createEmbeddedView', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [NgIf, NgFor],
               template: `
@@ -1258,7 +1212,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should hydrate dynamically created components using root component as an anchor', async () => {
             @Component({
-              standalone: true,
               imports: [CommonModule],
               selector: 'dynamic',
               template: `
@@ -1268,7 +1221,6 @@ describe('platform-server full application hydration integration', () => {
             class DynamicComponent {}
 
             @Component({
-              standalone: true,
               selector: 'app',
               template: `
                     <main>Hi! This is the main content.</main>
@@ -1306,7 +1258,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should hydrate embedded views when using root component as an anchor', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               template: `
                 <ng-template #tmpl>
@@ -1349,7 +1300,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should hydrate dynamically created components using root component as an anchor', async () => {
             @Component({
-              standalone: true,
               imports: [CommonModule],
               selector: 'nested-dynamic-a',
               template: `
@@ -1359,7 +1309,6 @@ describe('platform-server full application hydration integration', () => {
             class NestedDynamicComponentA {}
 
             @Component({
-              standalone: true,
               imports: [CommonModule],
               selector: 'nested-dynamic-b',
               template: `
@@ -1369,7 +1318,6 @@ describe('platform-server full application hydration integration', () => {
             class NestedDynamicComponentB {}
 
             @Component({
-              standalone: true,
               imports: [CommonModule],
               selector: 'dynamic',
               template: `
@@ -1386,7 +1334,6 @@ describe('platform-server full application hydration integration', () => {
             }
 
             @Component({
-              standalone: true,
               selector: 'app',
               template: `
                     <main>Hi! This is the main content.</main>
@@ -1465,7 +1412,6 @@ describe('platform-server full application hydration integration', () => {
               "another component's host node as an anchor",
             async () => {
               @Component({
-                standalone: true,
                 selector: 'another-dynamic',
                 template: `<span>This is a content of another dynamic component.</span>`,
               })
@@ -1474,7 +1420,6 @@ describe('platform-server full application hydration integration', () => {
               }
 
               @Component({
-                standalone: true,
                 selector: 'dynamic',
                 template: `<span>This is a content of a dynamic component.</span>`,
               })
@@ -1488,7 +1433,6 @@ describe('platform-server full application hydration integration', () => {
               }
 
               @Component({
-                standalone: true,
                 selector: 'app',
                 template: `<main>Hi! This is the main content.</main>`,
               })
@@ -1528,7 +1472,6 @@ describe('platform-server full application hydration integration', () => {
               "another component's host node as an anchor",
             async () => {
               @Component({
-                standalone: true,
                 selector: 'dynamic',
                 template: `
                       <ng-template #tmpl>
@@ -1549,7 +1492,6 @@ describe('platform-server full application hydration integration', () => {
               }
 
               @Component({
-                standalone: true,
                 selector: 'app',
                 template: `<main>Hi! This is the main content.</main>`,
               })
@@ -1590,7 +1532,6 @@ describe('platform-server full application hydration integration', () => {
               '(that is being created) and the first dehydrated view in the list',
             async () => {
               @Component({
-                standalone: true,
                 selector: 'app',
                 template: `
                     <ng-template #tmplH1>
@@ -1657,7 +1598,6 @@ describe('platform-server full application hydration integration', () => {
 
           it('should allow injecting ViewContainerRef in the root component', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               template: `Hello World!`,
             })
@@ -1689,7 +1629,6 @@ describe('platform-server full application hydration integration', () => {
         describe('<ng-template>', () => {
           it('should support unused <ng-template>s', async () => {
             @Component({
-              standalone: true,
               selector: 'app',
               template: `
                 <ng-template #a>Some content</ng-template>
@@ -1726,7 +1665,6 @@ describe('platform-server full application hydration integration', () => {
         describe('transplanted views', () => {
           it('should work when passing TemplateRef to a different component', async () => {
             @Component({
-              standalone: true,
               imports: [CommonModule],
               selector: 'insertion-component',
               template: `
@@ -1738,7 +1676,6 @@ describe('platform-server full application hydration integration', () => {
             }
 
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [InsertionComponent, CommonModule],
               template: `
@@ -1778,7 +1715,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should append skip hydration flag if component uses i18n blocks and no `withI18nSupport()` call present', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: '<div i18n>Hi!</div>',
           })
@@ -1801,7 +1737,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should not append skip hydration flag if component uses i18n blocks', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
             <div i18n>Hi!</div>
@@ -1817,7 +1752,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should not append skip hydration flag if component uses i18n blocks inside embedded views', async () => {
           @Component({
-            standalone: true,
             imports: [NgIf],
             selector: 'app',
             template: `
@@ -1836,7 +1770,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should not append skip hydration flag if component uses i18n blocks on <ng-container>s', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               <ng-container i18n>Hi!</ng-container>
@@ -1852,7 +1785,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should not append skip hydration flag if component uses i18n blocks (with *ngIfs on <ng-container>s)', async () => {
           @Component({
-            standalone: true,
             imports: [CommonModule],
             selector: 'app',
             template: `
@@ -1874,7 +1806,6 @@ describe('platform-server full application hydration integration', () => {
           });
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `<div i18n>Some <strong>strong</strong> content</div>`,
           })
@@ -1903,14 +1834,12 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support projecting translated content', async () => {
           @Component({
-            standalone: true,
             selector: 'app-content',
             template: `<ng-content select="span"></ng-content><ng-content select="div"></ng-content>`,
           })
           class ContentComponent {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `<div i18n><app-content><div>one</div><span>two</span></app-content></div>`,
             imports: [ContentComponent],
@@ -1940,7 +1869,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should work when i18n content is not projected', async () => {
           @Component({
-            standalone: true,
             selector: 'app-content',
             template: `
               @if (false) {
@@ -1952,7 +1880,6 @@ describe('platform-server full application hydration integration', () => {
           class ContentComponent {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               <app-content>
@@ -1990,14 +1917,12 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support interleaving projected content', async () => {
           @Component({
-            standalone: true,
             selector: 'app-content',
             template: `Start <ng-content select="div" /> Middle <ng-content select="span" /> End`,
           })
           class ContentComponent {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               <app-content i18n>
@@ -2034,14 +1959,12 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support disjoint nodes', async () => {
           @Component({
-            standalone: true,
             selector: 'app-content',
             template: `Start <ng-content select=":not(span)" /> Middle <ng-content select="span" /> End`,
           })
           class ContentComponent {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               <app-content i18n>
@@ -2082,14 +2005,12 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support nested content projection', async () => {
           @Component({
-            standalone: true,
             selector: 'app-content-inner',
             template: `Start <ng-content select=":not(span)" /> Middle <ng-content select="span" /> End`,
           })
           class InnerContentComponent {}
 
           @Component({
-            standalone: true,
             selector: 'app-content-outer',
             template: `<app-content-inner><ng-content /></app-content-inner>`,
             imports: [InnerContentComponent],
@@ -2097,7 +2018,6 @@ describe('platform-server full application hydration integration', () => {
           class OuterContentComponent {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               <app-content-outer i18n>
@@ -2136,14 +2056,12 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support hosting projected content', async () => {
           @Component({
-            standalone: true,
             selector: 'app-content',
             template: `<span i18n>Start <ng-content /> End</span>`,
           })
           class ContentComponent {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `<div><app-content>Middle</app-content></div>`,
             imports: [ContentComponent],
@@ -2173,14 +2091,12 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support projecting multiple elements', async () => {
           @Component({
-            standalone: true,
             selector: 'app-content',
             template: `<ng-content />`,
           })
           class ContentComponent {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               <app-content i18n>
@@ -2216,14 +2132,12 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support disconnecting i18n nodes during projection', async () => {
           @Component({
-            standalone: true,
             selector: 'app-content',
             template: `Start <ng-content select="span" /> End`,
           })
           class ContentComponent {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               <app-content i18n>
@@ -2259,14 +2173,12 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support using translated views as view container anchors', async () => {
           @Component({
-            standalone: true,
             selector: 'dynamic-cmp',
             template: `DynamicComponent content`,
           })
           class DynamicComponent {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `<div i18n><div #target>one</div><span>two</span></div>`,
           })
@@ -2311,7 +2223,6 @@ describe('platform-server full application hydration integration', () => {
           });
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `<div i18n><div>one</div><span>two</span></div>`,
           })
@@ -2345,7 +2256,6 @@ describe('platform-server full application hydration integration', () => {
           });
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `<div i18n>Some {case, plural, other {normal}} content</div>`,
           })
@@ -2380,7 +2290,6 @@ describe('platform-server full application hydration integration', () => {
           });
 
           @Component({
-            standalone: true,
             selector: 'app',
             template: `<div i18n>Hello <strong>World</strong>!</div>`,
           })
@@ -2409,7 +2318,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should cleanup dehydrated ICU cases', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `<div i18n>{isServer, select, true { This is a SERVER-ONLY content } false { This is a CLIENT-ONLY content }}</div>`,
           })
@@ -2451,7 +2359,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should hydrate ICUs (simple)', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `<div i18n>{{firstCase}} {firstCase, plural, =1 {item} other {items}}, {{secondCase}} {secondCase, plural, =1 {item} other {items}}</div>`,
           })
@@ -2483,7 +2390,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should hydrate ICUs (nested)', async () => {
           @Component({
-            standalone: true,
             selector: 'simple-component',
             template: `<div i18n>{firstCase, select, 1 {one-{secondCase, select, 1 {one} 2 {two}}} 2 {two-{secondCase, select, 1 {one} 2 {two}}}}</div>`,
           })
@@ -2493,7 +2399,6 @@ describe('platform-server full application hydration integration', () => {
           }
 
           @Component({
-            standalone: true,
             imports: [SimpleComponent],
             selector: 'app',
             template: `
@@ -2530,7 +2435,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should hydrate containers', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
                 <ng-container i18n>
@@ -2568,7 +2472,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should hydrate when using the *ngFor directive', async () => {
           @Component({
-            standalone: true,
             imports: [NgFor],
             selector: 'app',
             template: `
@@ -2604,7 +2507,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should hydrate when using @for control flow', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
                 <ol i18n>
@@ -2647,14 +2549,12 @@ describe('platform-server full application hydration integration', () => {
             });
 
             @Component({
-              standalone: true,
               selector: 'cmp-a',
               template: `<ng-content />`,
             })
             class CmpA {}
 
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [CmpA],
               template: `
@@ -2693,14 +2593,12 @@ describe('platform-server full application hydration integration', () => {
             });
 
             @Component({
-              standalone: true,
               selector: 'cmp-a',
               template: `<ng-content />`,
             })
             class CmpA {}
 
             @Component({
-              standalone: true,
               selector: 'app',
               imports: [CmpA],
               template: `
@@ -2741,7 +2639,6 @@ describe('platform-server full application hydration integration', () => {
       describe('support is disabled', () => {
         it('should append skip hydration flag if component uses i18n blocks', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
             <div i18n>Hi!</div>
@@ -2766,7 +2663,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should keep the skip hydration flag if component uses i18n blocks', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             host: {ngSkipHydration: 'true'},
             template: `
@@ -2792,7 +2688,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should append skip hydration flag if component uses i18n blocks inside embedded views', async () => {
           @Component({
-            standalone: true,
             imports: [NgIf],
             selector: 'app',
             template: `
@@ -2820,7 +2715,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should append skip hydration flag if component uses i18n blocks on <ng-container>s', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               <ng-container i18n>Hi!</ng-container>
@@ -2845,7 +2739,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should append skip hydration flag if component uses i18n blocks (with *ngIfs on <ng-container>s)', async () => {
           @Component({
-            standalone: true,
             imports: [CommonModule],
             selector: 'app',
             template: `
@@ -2871,7 +2764,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should *not* throw when i18n attributes are used', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               <div i18n-title title="Hello world">Hi!</div>
@@ -2900,7 +2792,6 @@ describe('platform-server full application hydration integration', () => {
             'excluded using `ngSkipHydration`',
           async () => {
             @Component({
-              standalone: true,
               selector: 'nested',
               template: `
                 <div i18n>Hi!</div>
@@ -2909,7 +2800,6 @@ describe('platform-server full application hydration integration', () => {
             class NestedComponent {}
 
             @Component({
-              standalone: true,
               imports: [NestedComponent],
               selector: 'app',
               template: `
@@ -2938,7 +2828,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should exclude components with i18n from hydration automatically', async () => {
           @Component({
-            standalone: true,
             selector: 'nested',
             template: `
             <div i18n>Hi!</div>
@@ -2947,7 +2836,6 @@ describe('platform-server full application hydration integration', () => {
           class NestedComponent {}
 
           @Component({
-            standalone: true,
             imports: [NestedComponent],
             selector: 'app',
             template: `
@@ -2980,13 +2868,12 @@ describe('platform-server full application hydration integration', () => {
       it('should not trigger defer blocks on the server', async () => {
         @Component({
           selector: 'my-lazy-cmp',
-          standalone: true,
+
           template: 'Hi!',
         })
         class MyLazyCmp {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [MyLazyCmp],
           template: `
@@ -3055,13 +2942,12 @@ describe('platform-server full application hydration integration', () => {
 
         @Component({
           selector: 'my-lazy-cmp',
-          standalone: true,
+
           template: 'Hi!',
         })
         class MyLazyCmp {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [MyLazyCmp],
           template: `
@@ -3088,21 +2974,20 @@ describe('platform-server full application hydration integration', () => {
       it('should hydrate a placeholder block', async () => {
         @Component({
           selector: 'my-lazy-cmp',
-          standalone: true,
+
           template: 'Hi!',
         })
         class MyLazyCmp {}
 
         @Component({
           selector: 'my-placeholder-cmp',
-          standalone: true,
+
           imports: [NgIf],
           template: '<div *ngIf="true">Hi!</div>',
         })
         class MyPlaceholderCmp {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [MyLazyCmp, MyPlaceholderCmp],
           template: `
@@ -3148,21 +3033,20 @@ describe('platform-server full application hydration integration', () => {
       it('should render nothing on the server if no placeholder block is provided', async () => {
         @Component({
           selector: 'my-lazy-cmp',
-          standalone: true,
+
           template: 'Hi!',
         })
         class MyLazyCmp {}
 
         @Component({
           selector: 'my-placeholder-cmp',
-          standalone: true,
+
           imports: [NgIf],
           template: '<div *ngIf="true">Hi!</div>',
         })
         class MyPlaceholderCmp {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [MyLazyCmp, MyPlaceholderCmp],
           template: `
@@ -3201,13 +3085,12 @@ describe('platform-server full application hydration integration', () => {
         // when `on viewport` trigger is used for a defer block.
         @Component({
           selector: 'my-lazy-cmp',
-          standalone: true,
+
           template: 'Hi!',
         })
         class MyLazyCmp {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [MyLazyCmp],
           template: `
@@ -3247,13 +3130,12 @@ describe('platform-server full application hydration integration', () => {
       it('should not hydrate when an entire block in skip hydration section', async () => {
         @Component({
           selector: 'my-lazy-cmp',
-          standalone: true,
+
           template: 'Hi!',
         })
         class MyLazyCmp {}
 
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: `
              <main>
@@ -3265,14 +3147,13 @@ describe('platform-server full application hydration integration', () => {
 
         @Component({
           selector: 'my-placeholder-cmp',
-          standalone: true,
+
           imports: [NgIf],
           template: '<div *ngIf="true">Hi!</div>',
         })
         class MyPlaceholderCmp {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [MyLazyCmp, MyPlaceholderCmp, ProjectorCmp],
           template: `
@@ -3325,13 +3206,12 @@ describe('platform-server full application hydration integration', () => {
       it('should not hydrate when a placeholder block in skip hydration section', async () => {
         @Component({
           selector: 'my-lazy-cmp',
-          standalone: true,
+
           template: 'Hi!',
         })
         class MyLazyCmp {}
 
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: `
              <main>
@@ -3343,14 +3223,13 @@ describe('platform-server full application hydration integration', () => {
 
         @Component({
           selector: 'my-placeholder-cmp',
-          standalone: true,
+
           imports: [NgIf],
           template: '<div *ngIf="true">Hi!</div>',
         })
         class MyPlaceholderCmp {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [MyLazyCmp, MyPlaceholderCmp, ProjectorCmp],
           template: `
@@ -3404,7 +3283,6 @@ describe('platform-server full application hydration integration', () => {
     describe('ShadowDom encapsulation', () => {
       it('should append skip hydration flag if component uses ShadowDom encapsulation', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           encapsulation: ViewEncapsulation.ShadowDom,
           template: `Hi!`,
@@ -3422,7 +3300,6 @@ describe('platform-server full application hydration integration', () => {
           '(but keep parent and sibling elements hydratable)',
         async () => {
           @Component({
-            standalone: true,
             selector: 'shadow-dom',
             encapsulation: ViewEncapsulation.ShadowDom,
             template: `ShadowDom component`,
@@ -3431,7 +3308,6 @@ describe('platform-server full application hydration integration', () => {
           class ShadowDomComponent {}
 
           @Component({
-            standalone: true,
             selector: 'regular',
             template: `<p>Regular component</p>`,
           })
@@ -3440,7 +3316,6 @@ describe('platform-server full application hydration integration', () => {
           }
 
           @Component({
-            standalone: true,
             selector: 'app',
             imports: [RegularComponent, ShadowDomComponent],
             template: `
@@ -3466,7 +3341,6 @@ describe('platform-server full application hydration integration', () => {
     describe('ngSkipHydration', () => {
       it('should skip hydrating elements with ngSkipHydration attribute', async () => {
         @Component({
-          standalone: true,
           selector: 'nested-cmp',
           template: `
             <h1>Hello World!</h1>
@@ -3478,7 +3352,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NestedComponent],
           template: `
@@ -3509,7 +3382,6 @@ describe('platform-server full application hydration integration', () => {
         'should skip hydrating elements when host element ' + 'has the ngSkipHydration attribute',
         async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
             <main>Main content</main>
@@ -3548,7 +3420,6 @@ describe('platform-server full application hydration integration', () => {
           '(when component with `ngSkipHydration` goes first)',
         async () => {
           @Component({
-            standalone: true,
             selector: 'nested',
             imports: [NgIf],
             template: `
@@ -3558,7 +3429,6 @@ describe('platform-server full application hydration integration', () => {
           class Nested {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             imports: [NgIf, Nested],
             template: `
@@ -3592,7 +3462,6 @@ describe('platform-server full application hydration integration', () => {
           '(view containers with embedded views as projection root nodes)',
         async () => {
           @Component({
-            standalone: true,
             selector: 'regular-cmp',
             template: `
                 <ng-content />
@@ -3601,7 +3470,6 @@ describe('platform-server full application hydration integration', () => {
           class RegularCmp {}
 
           @Component({
-            standalone: true,
             selector: 'deeply-nested',
             host: {ngSkipHydration: 'true'},
             template: `
@@ -3611,7 +3479,6 @@ describe('platform-server full application hydration integration', () => {
           class DeeplyNested {}
 
           @Component({
-            standalone: true,
             selector: 'deeply-nested-wrapper',
             host: {ngSkipHydration: 'true'},
             imports: [RegularCmp],
@@ -3624,7 +3491,6 @@ describe('platform-server full application hydration integration', () => {
           class DeeplyNestedWrapper {}
 
           @Component({
-            standalone: true,
             selector: 'layout',
             imports: [DeeplyNested, DeeplyNestedWrapper],
             template: `
@@ -3638,7 +3504,6 @@ describe('platform-server full application hydration integration', () => {
           class Layout {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             imports: [NgIf, Layout],
             template: `
@@ -3671,14 +3536,12 @@ describe('platform-server full application hydration integration', () => {
           '(view containers with components as projection root nodes)',
         async () => {
           @Component({
-            standalone: true,
             selector: 'dynamic-cmp',
             template: `DynamicComponent content`,
           })
           class DynamicComponent {}
 
           @Component({
-            standalone: true,
             selector: 'regular-cmp',
             template: `
             <ng-content />
@@ -3687,7 +3550,6 @@ describe('platform-server full application hydration integration', () => {
           class RegularCmp {}
 
           @Component({
-            standalone: true,
             selector: 'deeply-nested',
             host: {ngSkipHydration: 'true'},
             template: `
@@ -3697,7 +3559,6 @@ describe('platform-server full application hydration integration', () => {
           class DeeplyNested {}
 
           @Component({
-            standalone: true,
             selector: 'deeply-nested-wrapper',
             host: {ngSkipHydration: 'true'},
             imports: [RegularCmp],
@@ -3710,7 +3571,6 @@ describe('platform-server full application hydration integration', () => {
           class DeeplyNestedWrapper {}
 
           @Component({
-            standalone: true,
             selector: 'layout',
             imports: [DeeplyNested, DeeplyNestedWrapper],
             template: `
@@ -3724,7 +3584,6 @@ describe('platform-server full application hydration integration', () => {
           class Layout {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             imports: [NgIf, Layout],
             template: `
@@ -3771,7 +3630,6 @@ describe('platform-server full application hydration integration', () => {
           '(with ng-containers as projection root nodes)',
         async () => {
           @Component({
-            standalone: true,
             selector: 'regular-cmp',
             template: `
                 <ng-content />
@@ -3780,7 +3638,6 @@ describe('platform-server full application hydration integration', () => {
           class RegularCmp {}
 
           @Component({
-            standalone: true,
             selector: 'deeply-nested',
             host: {ngSkipHydration: 'true'},
             template: `
@@ -3790,7 +3647,6 @@ describe('platform-server full application hydration integration', () => {
           class DeeplyNested {}
 
           @Component({
-            standalone: true,
             selector: 'deeply-nested-wrapper',
             host: {ngSkipHydration: 'true'},
             imports: [RegularCmp],
@@ -3803,7 +3659,6 @@ describe('platform-server full application hydration integration', () => {
           class DeeplyNestedWrapper {}
 
           @Component({
-            standalone: true,
             selector: 'layout',
             imports: [DeeplyNested, DeeplyNestedWrapper],
             template: `
@@ -3817,7 +3672,6 @@ describe('platform-server full application hydration integration', () => {
           class Layout {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             imports: [NgIf, Layout],
             template: `
@@ -3850,7 +3704,6 @@ describe('platform-server full application hydration integration', () => {
           '(when component without `ngSkipHydration` goes first)',
         async () => {
           @Component({
-            standalone: true,
             selector: 'nested',
             imports: [NgIf],
             template: `
@@ -3860,7 +3713,6 @@ describe('platform-server full application hydration integration', () => {
           class Nested {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             imports: [NgIf, Nested],
             template: `
@@ -3891,7 +3743,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should hydrate when the value of an attribute is "ngskiphydration"', async () => {
         @Component({
-          standalone: true,
           selector: 'nested-cmp',
           template: `
             <h1>Hello World!</h1>
@@ -3903,7 +3754,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NestedComponent],
           template: `
@@ -3932,14 +3782,12 @@ describe('platform-server full application hydration integration', () => {
 
       it('should skip hydrating elements with ngSkipHydration host binding', async () => {
         @Component({
-          standalone: true,
           selector: 'second-cmp',
           template: `<div>Not hydrated</div>`,
         })
         class SecondCmd {}
 
         @Component({
-          standalone: true,
           imports: [SecondCmd],
           selector: 'nested-cmp',
           template: `<second-cmp />`,
@@ -3948,7 +3796,6 @@ describe('platform-server full application hydration integration', () => {
         class NestedCmp {}
 
         @Component({
-          standalone: true,
           imports: [NestedCmp],
           selector: 'app',
           template: `
@@ -3975,7 +3822,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should skip hydrating all child content of an element with ngSkipHydration attribute', async () => {
         @Component({
-          standalone: true,
           selector: 'nested-cmp',
           template: `
               <h1>Hello World!</h1>
@@ -3987,7 +3833,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NestedComponent],
           template: `
@@ -4019,7 +3864,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should skip hydrating when ng-containers exist and ngSkipHydration attribute is present', async () => {
         @Component({
-          standalone: true,
           selector: 'nested-cmp',
           template: `
               <h1>Hello World!</h1>
@@ -4029,7 +3873,6 @@ describe('platform-server full application hydration integration', () => {
         class NestedComponent {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NestedComponent],
           template: `
@@ -4069,7 +3912,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should skip hydrating and safely allow DOM manipulation inside block that was skipped', async () => {
         @Component({
-          standalone: true,
           selector: 'nested-cmp',
           template: `
               <h1>Hello World!</h1>
@@ -4087,7 +3929,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NestedComponent],
           template: `
@@ -4117,7 +3958,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should skip hydrating and safely allow adding and removing DOM nodes inside block that was skipped', async () => {
         @Component({
-          standalone: true,
           selector: 'nested-cmp',
           template: `
               <h1>Hello World!</h1>
@@ -4138,7 +3978,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NestedComponent],
           template: `
@@ -4168,7 +4007,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should skip hydrating elements with ngSkipHydration attribute on ViewContainerRef host', async () => {
         @Component({
-          standalone: true,
           selector: 'nested-cmp',
           template: `<p>Just some text</p>`,
         })
@@ -4186,7 +4024,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           imports: [NestedComponent],
           template: `
@@ -4200,7 +4037,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp],
           selector: 'app',
           template: `
@@ -4231,7 +4067,6 @@ describe('platform-server full application hydration integration', () => {
           'which is not a component host',
         async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
                 <header ngSkipHydration>Header</header>
@@ -4265,14 +4100,12 @@ describe('platform-server full application hydration integration', () => {
           'which is not a component host (when using host bindings)',
         async () => {
           @Directive({
-            standalone: true,
             selector: '[dir]',
             host: {ngSkipHydration: 'true'},
           })
           class Dir {}
 
           @Component({
-            standalone: true,
             selector: 'app',
             imports: [Dir],
             template: `
@@ -4309,7 +4142,6 @@ describe('platform-server full application hydration integration', () => {
     describe('corrupted text nodes restoration', () => {
       it('should support empty text nodes', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             This is hydrated content.
@@ -4345,7 +4177,6 @@ describe('platform-server full application hydration integration', () => {
           '(when interpolation is on a new line)',
         async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
                 <div>
@@ -4386,7 +4217,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should not treat text nodes with `&nbsp`s as empty', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             <div>&nbsp;{{ text }}&nbsp;</div>
@@ -4423,7 +4253,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should support restoration of multiple text nodes in a row', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             This is hydrated content.<span>{{emptyText}}{{moreText}}{{andMoreText}}</span>.
@@ -4456,7 +4285,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should support projected text node content with plain text nodes', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NgIf],
           template: `
@@ -4489,7 +4317,6 @@ describe('platform-server full application hydration integration', () => {
     describe('post-hydration cleanup', () => {
       it('should cleanup unclaimed views in a component (when using elements)', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NgIf],
           template: `
@@ -4536,7 +4363,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should cleanup unclaimed views in a component (when using <ng-container>s)', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NgIf],
           template: `
@@ -4586,7 +4412,6 @@ describe('platform-server full application hydration integration', () => {
           'root component is used as an anchor for ViewContainerRef',
         async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             imports: [NgIf],
             template: `
@@ -4665,7 +4490,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should cleanup within inner containers', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NgIf],
           template: `
@@ -4719,7 +4543,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should reconcile *ngFor-generated views', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NgIf, NgFor],
           template: `
@@ -4769,7 +4592,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should cleanup dehydrated views within dynamically created components', async () => {
         @Component({
-          standalone: true,
           imports: [CommonModule],
           selector: 'dynamic',
           template: `
@@ -4787,7 +4609,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NgIf, NgFor],
           template: `
@@ -4838,7 +4659,6 @@ describe('platform-server full application hydration integration', () => {
         const observedChildCountLog: number[] = [];
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NgIf],
           template: `
@@ -4883,7 +4703,6 @@ describe('platform-server full application hydration integration', () => {
         const observedChildCountLog: number[] = [];
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NgIf],
           template: `
@@ -4939,7 +4758,6 @@ describe('platform-server full application hydration integration', () => {
     describe('content projection', () => {
       it('should project plain text', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: `
             <main>
@@ -4950,7 +4768,6 @@ describe('platform-server full application hydration integration', () => {
         class ProjectorCmp {}
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp],
           selector: 'app',
           template: `
@@ -4986,7 +4803,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should allow re-projection of child content', async () => {
         @Component({
-          standalone: true,
           selector: 'mat-step',
           template: `<ng-template><ng-content /></ng-template>`,
         })
@@ -4995,7 +4811,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'mat-stepper',
           imports: [NgTemplateOutlet],
           template: `
@@ -5009,14 +4824,12 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'nested-cmp',
           template: 'Nested cmp content',
         })
         class NestedCmp {}
 
         @Component({
-          standalone: true,
           imports: [MatStepper, MatStep, NgIf, NestedCmp],
           selector: 'app',
           template: `
@@ -5073,7 +4886,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should project plain text and HTML elements', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: `
             <main>
@@ -5084,7 +4896,6 @@ describe('platform-server full application hydration integration', () => {
         class ProjectorCmp {}
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp],
           selector: 'app',
           template: `
@@ -5114,7 +4925,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should support re-projection of contents', async () => {
         @Component({
-          standalone: true,
           selector: 'reprojector-cmp',
           template: `
             <main>
@@ -5125,7 +4935,6 @@ describe('platform-server full application hydration integration', () => {
         class ReprojectorCmp {}
 
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           imports: [ReprojectorCmp],
           template: `
@@ -5139,7 +4948,6 @@ describe('platform-server full application hydration integration', () => {
         class ProjectorCmp {}
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp],
           selector: 'app',
           template: `
@@ -5168,7 +4976,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle multiple nodes projected in a single slot', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: `
             <ng-content select="foo" />
@@ -5177,14 +4984,13 @@ describe('platform-server full application hydration integration', () => {
         })
         class ProjectorCmp {}
 
-        @Component({selector: 'foo', standalone: true, template: ''})
+        @Component({selector: 'foo', template: ''})
         class FooCmp {}
 
-        @Component({selector: 'bar', standalone: true, template: ''})
+        @Component({selector: 'bar', template: ''})
         class BarCmp {}
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp, FooCmp, BarCmp],
           selector: 'app',
           template: `
@@ -5215,7 +5021,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle multiple nodes projected in a single slot (different order)', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: `
             <ng-content select="foo" />
@@ -5224,14 +5029,13 @@ describe('platform-server full application hydration integration', () => {
         })
         class ProjectorCmp {}
 
-        @Component({selector: 'foo', standalone: true, template: ''})
+        @Component({selector: 'foo', template: ''})
         class FooCmp {}
 
-        @Component({selector: 'bar', standalone: true, template: ''})
+        @Component({selector: 'bar', template: ''})
         class BarCmp {}
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp, FooCmp, BarCmp],
           selector: 'app',
           template: `
@@ -5262,7 +5066,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle empty projection slots within <ng-container>', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           imports: [CommonModule],
           template: `
@@ -5278,7 +5081,6 @@ describe('platform-server full application hydration integration', () => {
         class ProjectorCmp {}
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp],
           selector: 'app',
           template: `
@@ -5308,7 +5110,6 @@ describe('platform-server full application hydration integration', () => {
           '(when no other elements are present)',
         async () => {
           @Component({
-            standalone: true,
             selector: 'projector-cmp',
             imports: [CommonModule],
             template: `
@@ -5321,7 +5122,6 @@ describe('platform-server full application hydration integration', () => {
           class ProjectorCmp {}
 
           @Component({
-            standalone: true,
             imports: [ProjectorCmp],
             selector: 'app',
             template: `
@@ -5352,7 +5152,6 @@ describe('platform-server full application hydration integration', () => {
           '(when no other elements are present)',
         async () => {
           @Component({
-            standalone: true,
             selector: 'projector-cmp',
             template: `
               <ng-content select="[left]"></ng-content>
@@ -5362,7 +5161,6 @@ describe('platform-server full application hydration integration', () => {
           class ProjectorCmp {}
 
           @Component({
-            standalone: true,
             imports: [ProjectorCmp],
             selector: 'app',
             template: `
@@ -5390,7 +5188,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should project contents into different slots', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: `
             <div>
@@ -5404,7 +5201,6 @@ describe('platform-server full application hydration integration', () => {
         class ProjectorCmp {}
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp],
           selector: 'app',
           template: `
@@ -5438,7 +5234,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle view container nodes that go after projection slots', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           imports: [CommonModule],
           template: `
@@ -5453,7 +5248,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp],
           selector: 'app',
           template: `
@@ -5483,7 +5277,6 @@ describe('platform-server full application hydration integration', () => {
           '(when view container host node is <ng-container>)',
         async () => {
           @Component({
-            standalone: true,
             selector: 'projector-cmp',
             imports: [CommonModule],
             template: `
@@ -5498,7 +5291,6 @@ describe('platform-server full application hydration integration', () => {
           }
 
           @Component({
-            standalone: true,
             imports: [ProjectorCmp],
             selector: 'app',
             template: `
@@ -5527,7 +5319,6 @@ describe('platform-server full application hydration integration', () => {
       describe('partial projection', () => {
         it('should support cases when some element nodes are not projected', async () => {
           @Component({
-            standalone: true,
             selector: 'projector-cmp',
             template: `
               <div>
@@ -5541,7 +5332,6 @@ describe('platform-server full application hydration integration', () => {
           class ProjectorCmp {}
 
           @Component({
-            standalone: true,
             imports: [ProjectorCmp],
             selector: 'app',
             template: `
@@ -5575,14 +5365,12 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support cases when some element nodes are not projected', async () => {
           @Component({
-            standalone: true,
             selector: 'app-dropdown-content',
             template: `<ng-content />`,
           })
           class DropdownContentComponent {}
 
           @Component({
-            standalone: true,
             selector: 'app-dropdown',
             template: `
               @if (false) {
@@ -5593,7 +5381,6 @@ describe('platform-server full application hydration integration', () => {
           class DropdownComponent {}
 
           @Component({
-            standalone: true,
             imports: [DropdownComponent, DropdownContentComponent],
             selector: 'app-menu',
             template: `
@@ -5608,7 +5395,7 @@ describe('platform-server full application hydration integration', () => {
 
           @Component({
             selector: 'app',
-            standalone: true,
+
             imports: [MenuComponent],
             template: `
               <app-menu>
@@ -5641,14 +5428,12 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support cases when view containers are not projected', async () => {
           @Component({
-            standalone: true,
             selector: 'projector-cmp',
             template: `No content projection slots.`,
           })
           class ProjectorCmp {}
 
           @Component({
-            standalone: true,
             imports: [ProjectorCmp],
             selector: 'app',
             template: `
@@ -5680,21 +5465,18 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support cases when component nodes are not projected', async () => {
           @Component({
-            standalone: true,
             selector: 'projector-cmp',
             template: `No content projection slots.`,
           })
           class ProjectorCmp {}
 
           @Component({
-            standalone: true,
             selector: 'nested',
             template: 'This is a nested component.',
           })
           class NestedComponent {}
 
           @Component({
-            standalone: true,
             imports: [ProjectorCmp, NestedComponent],
             selector: 'app',
             template: `
@@ -5726,7 +5508,6 @@ describe('platform-server full application hydration integration', () => {
 
         it('should support cases when component nodes are not projected in nested components', async () => {
           @Component({
-            standalone: true,
             selector: 'projector-cmp',
             template: `
                 <main>
@@ -5737,14 +5518,12 @@ describe('platform-server full application hydration integration', () => {
           class ProjectorCmp {}
 
           @Component({
-            standalone: true,
             selector: 'nested',
             template: 'No content projection slots.',
           })
           class NestedComponent {}
 
           @Component({
-            standalone: true,
             imports: [ProjectorCmp, NestedComponent],
             selector: 'app',
             template: `
@@ -5777,7 +5556,6 @@ describe('platform-server full application hydration integration', () => {
 
       it("should project contents with *ngIf's", async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: `
             <main>
@@ -5788,7 +5566,6 @@ describe('platform-server full application hydration integration', () => {
         class ProjectorCmp {}
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp, CommonModule],
           selector: 'app',
           template: `
@@ -5819,7 +5596,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should project contents with *ngFor', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: `
             <main>
@@ -5830,7 +5606,6 @@ describe('platform-server full application hydration integration', () => {
         class ProjectorCmp {}
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp, CommonModule],
           selector: 'app',
           template: `
@@ -5861,7 +5636,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should support projecting contents outside of a current host element', async () => {
         @Component({
-          standalone: true,
           selector: 'dynamic-cmp',
           template: `<div #target></div>`,
         })
@@ -5874,7 +5648,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: `
             <ng-template #ref>
@@ -5913,7 +5686,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp, CommonModule],
           selector: 'app',
           template: `
@@ -5994,21 +5766,18 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle projected containers inside other containers', async () => {
         @Component({
-          standalone: true,
           selector: 'child-comp',
           template: '<ng-content />',
         })
         class ChildComp {}
 
         @Component({
-          standalone: true,
           selector: 'root-comp',
           template: '<ng-content />',
         })
         class RootComp {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [CommonModule, RootComp, ChildComp],
           template: `
@@ -6041,7 +5810,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should throw an error when projecting DOM nodes via ViewContainerRef.createComponent API', async () => {
         @Component({
-          standalone: true,
           selector: 'dynamic',
           template: `
               <ng-content />
@@ -6051,7 +5819,6 @@ describe('platform-server full application hydration integration', () => {
         class DynamicComponent {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NgIf, NgFor],
           template: `
@@ -6094,7 +5861,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should throw an error when projecting DOM nodes via createComponent function call', async () => {
         @Component({
-          standalone: true,
           selector: 'dynamic',
           template: `
               <ng-content />
@@ -6104,7 +5870,6 @@ describe('platform-server full application hydration integration', () => {
         class DynamicComponent {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NgIf, NgFor],
           template: `
@@ -6149,7 +5914,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should support cases when <ng-content> is used with *ngIf="false"', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           imports: [NgIf],
           template: `
@@ -6162,7 +5926,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp],
           selector: 'app',
           template: `
@@ -6214,7 +5977,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should support cases when <ng-content> is used with *ngIf="true"', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           imports: [NgIf],
           template: `
@@ -6227,7 +5989,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp],
           selector: 'app',
           template: `
@@ -6279,7 +6040,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should support slots with fallback content', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: `
             <div>
@@ -6295,7 +6055,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp],
           selector: 'app',
           template: `<projector-cmp></projector-cmp>`,
@@ -6325,7 +6084,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should support mixed slots with and without fallback content', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: `
             <div>
@@ -6341,7 +6099,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           imports: [ProjectorCmp],
           selector: 'app',
           template: `
@@ -6384,7 +6141,6 @@ describe('platform-server full application hydration integration', () => {
     describe('error handling', () => {
       it('should handle text node mismatch', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
         <div id="abc">This is an original content</div>
@@ -6421,7 +6177,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should not crash when a node can not be found during hydration', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
         Some text.
@@ -6460,7 +6215,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle element node mismatch', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
         <div id="abc">
@@ -6500,7 +6254,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle <ng-container> node mismatch', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
         <b>Bold text</b>
@@ -6543,7 +6296,6 @@ describe('platform-server full application hydration integration', () => {
           '(when it is wrapped into a non-container node)',
         async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
           <div id="abc" class="wrapper">
@@ -6585,7 +6337,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle <ng-template> node mismatch', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [CommonModule],
           template: `
@@ -6626,7 +6377,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle node mismatches in nested components', async () => {
         @Component({
-          standalone: true,
           selector: 'nested-cmp',
           imports: [CommonModule],
           template: `
@@ -6646,7 +6396,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NestedComponent],
           template: `<nested-cmp />`,
@@ -6676,7 +6425,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle sibling count mismatch', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [CommonModule],
           template: `
@@ -6716,7 +6464,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle ViewContainerRef node mismatch', async () => {
         @Directive({
-          standalone: true,
           selector: 'b',
         })
         class SimpleDir {
@@ -6724,7 +6471,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [CommonModule, SimpleDir],
           template: `
@@ -6764,7 +6510,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle a mismatch for a node that goes after a ViewContainerRef node', async () => {
         @Directive({
-          standalone: true,
           selector: 'b',
         })
         class SimpleDir {
@@ -6772,7 +6517,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [CommonModule, SimpleDir],
           template: `
@@ -6812,14 +6556,12 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle a case when a node is not found (removed)', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: '<ng-content />',
         })
         class ProjectorComponent {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [CommonModule, ProjectorComponent],
           template: `
@@ -6851,14 +6593,12 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle a case when a node is not found (detached)', async () => {
         @Component({
-          standalone: true,
           selector: 'projector-cmp',
           template: '<ng-content />',
         })
         class ProjectorComponent {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [CommonModule, ProjectorComponent],
           template: `
@@ -6899,7 +6639,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle a case when a node is not found (invalid DOM)', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [CommonModule],
           template: `
@@ -6940,7 +6679,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should log a warning when there was no hydration info in the TransferState', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `Hi!`,
         })
@@ -6982,7 +6720,6 @@ describe('platform-server full application hydration integration', () => {
           'but a client mode marker is present',
         async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `Hi!`,
           })
@@ -7013,7 +6750,6 @@ describe('platform-server full application hydration integration', () => {
         const logs: string[] = [];
 
         @Component({
-          standalone: true,
           selector: 'app',
           template: `Hi!`,
         })
@@ -7064,7 +6800,6 @@ describe('platform-server full application hydration integration', () => {
     describe('@if', () => {
       it('should work with `if`s that have different value on the client and on the server', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NgIf],
           template: `
@@ -7145,7 +6880,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should support nested `if`s', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             This is a non-empty block:
@@ -7181,7 +6915,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should hydrate `else` blocks', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             @if (conditionA) {
@@ -7231,7 +6964,6 @@ describe('platform-server full application hydration integration', () => {
     describe('@switch', () => {
       it('should work with `switch`es that have different value on the client and on the server', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [NgSwitch, NgSwitchCase],
           template: `
@@ -7307,7 +7039,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should cleanup rendered case if none of the cases match on the client', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
               @switch (label) {
@@ -7358,7 +7089,6 @@ describe('platform-server full application hydration integration', () => {
     describe('@for', () => {
       it('should hydrate for loop content', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             @for (item of items; track item) {
@@ -7395,7 +7125,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should hydrate @empty block content', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             @for (item of items; track item) {
@@ -7430,7 +7159,6 @@ describe('platform-server full application hydration integration', () => {
           'on the server and main content on the client',
         async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
                 @for (item of items; track item) {
@@ -7489,7 +7217,6 @@ describe('platform-server full application hydration integration', () => {
           'on the client and main content on the server',
         async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: `
               @for (item of items; track item) {
@@ -7546,7 +7273,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle different number of items rendered on the client and on the server', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
                 @for (item of items; track item) {
@@ -7599,7 +7325,7 @@ describe('platform-server full application hydration integration', () => {
       it('should handle a reconciliation with swaps', async () => {
         @Component({
           selector: 'app',
-          standalone: true,
+
           template: `
                 @for(item of items; track item) {
                   <div>{{ item }}</div>
@@ -7648,7 +7374,6 @@ describe('platform-server full application hydration integration', () => {
     describe('@let', () => {
       it('should handle a let declaration', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             @let greeting = name + '!!!';
@@ -7683,7 +7408,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle multiple let declarations that depend on each other', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             @let plusOne = value + 1;
@@ -7722,7 +7446,6 @@ describe('platform-server full application hydration integration', () => {
       it('should handle a let declaration using a pipe that injects ChangeDetectorRef', async () => {
         @Pipe({
           name: 'double',
-          standalone: true,
         })
         class DoublePipe implements PipeTransform {
           changeDetectorRef = inject(ChangeDetectorRef);
@@ -7733,7 +7456,6 @@ describe('platform-server full application hydration integration', () => {
         }
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [DoublePipe],
           template: `
@@ -7769,7 +7491,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle let declarations referenced through multiple levels of views', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             @if (true) {
@@ -7817,12 +7538,10 @@ describe('platform-server full application hydration integration', () => {
             <ng-content>Fallback content</ng-content>
             <ng-content select="footer">Fallback footer</ng-content>
           `,
-          standalone: true,
         })
         class InnerComponent {}
 
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             <inner>
@@ -7860,7 +7579,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle let declaration before and directly inside of an embedded view', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             @let before = 'before';
@@ -7892,7 +7610,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle let declaration before, directly inside of and after an embedded view', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             @let before = 'before';
@@ -7926,7 +7643,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should handle let declaration with array inside of an embedded view', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             @let foo = ['foo'];
@@ -7999,7 +7715,6 @@ describe('platform-server full application hydration integration', () => {
     describe('zoneless', () => {
       it('should not produce "unsupported configuration" warnings for zoneless mode', async () => {
         @Component({
-          standalone: true,
           selector: 'app',
           template: `
             <header>Header</header>
@@ -8042,7 +7757,6 @@ describe('platform-server full application hydration integration', () => {
         const ngZone = TestBed.inject(NgZone);
 
         @Component({
-          standalone: true,
           selector: 'lazy',
           template: `LazyCmp content`,
         })
@@ -8062,7 +7776,6 @@ describe('platform-server full application hydration integration', () => {
         ];
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [RouterOutlet],
           template: `
@@ -8105,7 +7818,6 @@ describe('platform-server full application hydration integration', () => {
         const ngZone = TestBed.inject(NgZone);
 
         @Component({
-          standalone: true,
           selector: 'lazy',
           template: `LazyCmp content`,
         })
@@ -8125,7 +7837,6 @@ describe('platform-server full application hydration integration', () => {
         ];
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [RouterOutlet],
           template: `
@@ -8166,7 +7877,6 @@ describe('platform-server full application hydration integration', () => {
 
       it('should cleanup dehydrated views in routed components that use ViewContainerRef', async () => {
         @Component({
-          standalone: true,
           selector: 'cmp-a',
           template: `
             @if (isServer) {
@@ -8189,7 +7899,6 @@ describe('platform-server full application hydration integration', () => {
         ];
 
         @Component({
-          standalone: true,
           selector: 'app',
           imports: [RouterOutlet],
           template: `

--- a/packages/platform-server/test/incremental_hydration_spec.ts
+++ b/packages/platform-server/test/incremental_hydration_spec.ts
@@ -2149,7 +2149,6 @@ describe('platform-server partial hydration integration', () => {
     it('should render an error block when loading fails and cleanup the original content', async () => {
       @Component({
         selector: 'nested-cmp',
-        standalone: true,
         template: 'Rendering {{ block }} block.',
       })
       class NestedCmp {
@@ -2157,7 +2156,6 @@ describe('platform-server partial hydration integration', () => {
       }
 
       @Component({
-        standalone: true,
         selector: 'app',
         imports: [NestedCmp],
         template: `

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -1060,7 +1060,6 @@ class HiddenModule {}
 
         it('appends SSR integrity marker comment when hydration is enabled', async () => {
           @Component({
-            standalone: true,
             selector: 'app',
             template: ``,
           })
@@ -1372,7 +1371,6 @@ class HiddenModule {}
         const ngZone = TestBed.inject(NgZone);
 
         @Component({
-          standalone: true,
           selector: 'lazy',
           template: `LazyCmp content`,
         })

--- a/packages/platform-server/test/render_spec.ts
+++ b/packages/platform-server/test/render_spec.ts
@@ -13,7 +13,6 @@ describe('renderApplication', () => {
   it('should render ARIA attributes from attribute bindings', async () => {
     @Component({
       selector: 'app',
-      standalone: true,
       template: '<div [attr.aria-label]="label"></div>',
     })
     class SomeComponent {
@@ -27,7 +26,6 @@ describe('renderApplication', () => {
   it('should render ARIA attributes using property binding syntax', async () => {
     @Component({
       selector: 'app',
-      standalone: true,
       template: '<div [aria-label]="label"></div>',
     })
     class SomeComponent {

--- a/packages/router/test/standalone.spec.ts
+++ b/packages/router/test/standalone.spec.ts
@@ -486,7 +486,6 @@ describe('standalone in Router API', () => {
       const TOKEN = new InjectionToken<string>('token');
       @Component({
         template: ``,
-        standalone: true,
       })
       class Cmp {
         constructor(public service: any) {}

--- a/packages/upgrade/static/test/integration/downgrade_component_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_component_spec.ts
@@ -1069,7 +1069,7 @@ withEachNg1Version(() => {
     afterEach(() => destroyPlatform());
 
     it('should downgrade a standalone component using NgModule APIs', waitForAsync(() => {
-      @Component({selector: 'ng2', standalone: true, template: 'Hi from Angular!'})
+      @Component({selector: 'ng2', template: 'Hi from Angular!'})
       class Ng2Component {}
 
       const ng1Module = angular

--- a/packages/upgrade/static/test/integration/upgrade_component_spec.ts
+++ b/packages/upgrade/static/test/integration/upgrade_component_spec.ts
@@ -4780,7 +4780,7 @@ withEachNg1Version(() => {
         const ng1Component: angular.IComponent = {template: `I'm from AngularJS!`};
 
         // Define `Ng1ComponentFacade` (standalone)
-        @Directive({selector: 'ng1', standalone: true})
+        @Directive({selector: 'ng1'})
         class Ng1ComponentStandaloneFacade extends UpgradeComponent {
           constructor(elementRef: ElementRef, injector: Injector) {
             super('ng1', elementRef, injector);


### PR DESCRIPTION
Since standalone is the default, we can dropn the `standalone: true` flags from our tests.
