### PR TITLE
fix(compiler-cli): resolve import alias in defer blocks

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -2158,11 +2158,12 @@ export class ComponentDecoratorHandler
     for (const [_, deps] of resolution.deferPerBlockDependencies) {
       for (const deferBlockDep of deps) {
         const node = deferBlockDep.declaration.node;
-        const importDecl = resolution.deferrableDeclToImportDecl.get(node) ?? null;
-        if (importDecl !== null && this.deferredSymbolTracker.canDefer(importDecl)) {
+        const importInfo = resolution.deferrableDeclToImportDecl.get(node) ?? null;
+        if (importInfo !== null && this.deferredSymbolTracker.canDefer(importInfo.node)) {
           deferBlockDep.isDeferrable = true;
-          deferBlockDep.importPath = (importDecl.moduleSpecifier as ts.StringLiteral).text;
-          deferBlockDep.isDefaultImport = isDefaultImport(importDecl);
+          deferBlockDep.symbolName = importInfo.name;
+          deferBlockDep.importPath = importInfo.from;
+          deferBlockDep.isDefaultImport = isDefaultImport(importInfo.node);
 
           // The same dependency may be used across multiple deferred blocks. De-duplicate it
           // because it can throw off other logic further down the compilation pipeline.
@@ -2412,9 +2413,10 @@ export class ComponentDecoratorHandler
       return;
     }
 
-    // Keep track of how this class made it into the current source file
-    // (which ts.ImportDeclaration was used for this symbol).
-    resolutionData.deferrableDeclToImportDecl.set(decl.node, imp.node);
+    // Keep track of how this class made it into the current source file.
+    // Store the full `Import` info so that callers can correctly determine the
+    // exported name (handling aliasing) and the module specifier.
+    resolutionData.deferrableDeclToImportDecl.set(decl.node, imp);
 
     this.deferredSymbolTracker.markAsDeferrableCandidate(
       node,

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/metadata.ts
@@ -29,7 +29,7 @@ import {
   HostDirectiveMeta,
   InputMapping,
 } from '../../../metadata';
-import {ClassDeclaration} from '../../../reflection';
+import {ClassDeclaration, Import} from '../../../reflection';
 import {SubsetOfKeys} from '../../../util/src/typescript';
 
 import {ParsedTemplateWithSource, StyleUrlMeta} from './resources';
@@ -129,10 +129,11 @@ export interface ComponentResolutionData {
 
   /**
    * Map of all types that can be defer loaded (ts.ClassDeclaration) ->
-   * corresponding import declaration (ts.ImportDeclaration) within
-   * the current source file.
+   * corresponding import information (reflection `Import`) within
+   * the current source file. The `Import` preserves the exported name
+   * as seen by the importing module so aliasing is handled correctly.
    */
-  deferrableDeclToImportDecl: Map<ClassDeclaration, ts.ImportDeclaration>;
+  deferrableDeclToImportDecl: Map<ClassDeclaration, Import>;
 
   /**
    * Map of `@defer` blocks -> their corresponding dependencies.

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/GOLDEN_PARTIAL.js
@@ -1218,3 +1218,76 @@ export declare class MyApp {
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: counter.component.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class CounterComponent {
+}
+CounterComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: CounterComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
+CounterComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: CounterComponent, isStandalone: true, selector: "my-counter-cmp", ngImport: i0, template: 'Counter!', isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: CounterComponent, decorators: [{
+            type: Component,
+            args: [{
+                    standalone: true,
+                    selector: 'my-counter-cmp',
+                    template: 'Counter!',
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: counter.component.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class CounterComponent {
+    static ɵfac: i0.ɵɵFactoryDeclaration<CounterComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<CounterComponent, "my-counter-cmp", never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: deferred_import_alias_index.js
+ ****************************************************************************************************/
+export { CounterComponent as MyCounterCmp } from './counter.component';
+
+/****************************************************************************************************
+ * PARTIAL FILE: deferred_import_alias_index.d.ts
+ ****************************************************************************************************/
+export { CounterComponent as MyCounterCmp } from './counter.component';
+
+/****************************************************************************************************
+ * PARTIAL FILE: deferred_import_alias.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class TestCmp {
+}
+TestCmp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestCmp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+TestCmp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: TestCmp, isStandalone: true, selector: "test-cmp", ngImport: i0, template: `
+    @defer {
+      <my-counter-cmp />
+    }
+  `, isInline: true, deferBlockDependencies: [() => [import("./deferred_import_alias_index").then(m => m.MyCounterCmp)]] });
+i0.ɵɵngDeclareClassMetadataAsync({ minVersion: "18.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestCmp, resolveDeferredDeps: () => [import("./deferred_import_alias_index").then(m => m.MyCounterCmp)], resolveMetadata: MyCounterCmp => ({ decorators: [{
+                type: Component,
+                args: [{
+                        selector: 'test-cmp',
+                        standalone: true,
+                        imports: [MyCounterCmp],
+                        template: `
+    @defer {
+      <my-counter-cmp />
+    }
+  `,
+                    }]
+            }], ctorParameters: null, propDecorators: null }) });
+
+/****************************************************************************************************
+ * PARTIAL FILE: deferred_import_alias.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class TestCmp {
+    static ɵfac: i0.ɵɵFactoryDeclaration<TestCmp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<TestCmp, "test-cmp", never, {}, {}, never, never, true, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/TEST_CASES.json
@@ -309,6 +309,26 @@
           "failureMessage": "Incorrect template"
         }
       ]
+    },
+    {
+      "description": "Defer alias re-export/import",
+      "inputFiles": [
+        "deferred_import_alias.ts",
+        "deferred_import_alias_index.ts",
+        "counter.component.ts"
+      ],
+      "compilationModeFilter": ["declaration-only emit"],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "deferred_import_alias.js",
+              "generated": "deferred_import_alias_generated.js"
+            }
+          ],
+          "failureMessage": "Defer block output with import alias does not match deferred_import_alias.js (possible alias resolution regression)"
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/counter.component.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/counter.component.ts
@@ -1,0 +1,8 @@
+import {Component} from '@angular/core';
+
+@Component({
+  standalone: true,
+  selector: 'my-counter-cmp',
+  template: 'Counter!',
+})
+export class CounterComponent {}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_import_alias.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_import_alias.js
@@ -1,0 +1,73 @@
+/****************************************************************************************************
+ * PARTIAL FILE: counter.component.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class CounterComponent {
+}
+CounterComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: CounterComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
+CounterComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: CounterComponent, isStandalone: true, selector: "my-counter-cmp", ngImport: i0, template: 'Counter!', isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: CounterComponent, decorators: [{
+            type: Component,
+            args: [{
+                    standalone: true,
+                    selector: 'my-counter-cmp',
+                    template: 'Counter!',
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: counter.component.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class CounterComponent {
+    static ɵfac: i0.ɵɵFactoryDeclaration<CounterComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<CounterComponent, "my-counter-cmp", never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: index.js
+ ****************************************************************************************************/
+export { CounterComponent as MyCounterCmp } from './counter.component';
+
+/****************************************************************************************************
+ * PARTIAL FILE: index.d.ts
+ ****************************************************************************************************/
+export { CounterComponent as MyCounterCmp } from './counter.component';
+
+/****************************************************************************************************
+ * PARTIAL FILE: test.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class TestCmp {
+}
+TestCmp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestCmp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+TestCmp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: TestCmp, isStandalone: true, selector: "test-cmp", ngImport: i0, template: `
+    @defer {
+      <my-counter-cmp />
+    }
+  `, isInline: true, deferBlockDependencies: [() => [import("./index").then(m => m.MyCounterCmp)]] });
+i0.ɵɵngDeclareClassMetadataAsync({ minVersion: "18.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestCmp, resolveDeferredDeps: () => [import("./index").then(m => m.MyCounterCmp)], resolveMetadata: MyCounterCmp => ({ decorators: [{
+                type: Component,
+                args: [{
+                        selector: 'test-cmp',
+                        standalone: true,
+                        imports: [MyCounterCmp],
+                        template: `
+    @defer {
+      <my-counter-cmp />
+    }
+  `,
+                    }]
+            }], ctorParameters: null, propDecorators: null }) });
+
+/****************************************************************************************************
+ * PARTIAL FILE: test.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class TestCmp {
+    static ɵfac: i0.ɵɵFactoryDeclaration<TestCmp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<TestCmp, "test-cmp", never, {}, {}, never, never, true, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_import_alias.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_import_alias.ts
@@ -1,0 +1,14 @@
+import {Component} from '@angular/core';
+import {MyCounterCmp} from './deferred_import_alias_index';
+
+@Component({
+  selector: 'test-cmp',
+  standalone: true,
+  imports: [MyCounterCmp],
+  template: `
+    @defer {
+      <my-counter-cmp />
+    }
+  `,
+})
+export class TestCmp {}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_import_alias_index.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_import_alias_index.ts
@@ -1,0 +1,1 @@
+export {CounterComponent as MyCounterCmp} from './counter.component';


### PR DESCRIPTION
Fixes an error where using an alias in a defer block caused the compiler CLI  when parsing. The resolution logic in ComponentDecoratorHandler was updated to correctly handle deferred dependencies with aliased imports.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  https://github.com/angular/angular/issues/63965


## What is the new behavior?
`@defer` block now works correctly with import aliases.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
