### PR TITLE
docs: add missing `signal` function

### DIFF
--- a/adev/src/content/guide/templates/binding.md
+++ b/adev/src/content/guide/templates/binding.md
@@ -151,7 +151,7 @@ You can also bind directly to the `class` property. Angular accepts three types 
 export class UserProfile {
   listClasses = 'full-width outlined';
   sectionClasses = signal(['expandable', 'elevated']);
-  buttonClasses = ({
+  buttonClasses = signal({
     highlighted: true,
     embiggened: false,
   });


### PR DESCRIPTION
The `buttonClasses` variable should be a signal according to the example, so we added the call.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The `signal` function is missing.

Issue Number: N/A


## What is the new behavior?
The `signal` function is correctly used.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
