### PR TITLE
feat(devtools): Use "App Root" as name for root of router tree.

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/router-tree.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/router-tree.spec.ts
@@ -13,42 +13,36 @@ describe('parseRoutes', () => {
     const routes: any[] = [];
     const parsedRoutes = parseRoutes(routes as any);
     expect(parsedRoutes).toEqual({
-      component: 'no-name',
-      path: '/',
+      component: 'App Root',
+      path: 'App Root',
       children: [],
       data: [],
       isAux: false,
       isLazy: false,
-      isActive: false,
+      isActive: true,
       isRedirect: false,
     });
   });
 
   it('should work with single route', () => {
     const nestedRouter = {
-      rootComponentType: {
-        name: 'homeComponent',
-      },
       config: [],
     };
     const parsedRoutes = parseRoutes(nestedRouter as any);
     expect(parsedRoutes).toEqual({
-      'component': 'homeComponent',
-      'path': '/',
+      'component': 'App Root',
+      'path': 'App Root',
       'data': [],
       'children': [],
       'isAux': false,
       'isLazy': false,
-      'isActive': false,
+      'isActive': true,
       isRedirect: false,
     });
   });
 
   it('should work with nested routes', () => {
     const nestedRouter = {
-      rootComponentType: {
-        name: 'homeComponent',
-      },
       config: [
         {
           outlet: 'outlet',
@@ -96,8 +90,8 @@ describe('parseRoutes', () => {
     };
     const parsedRoutes = parseRoutes(nestedRouter as any);
     expect(parsedRoutes).toEqual({
-      'component': 'homeComponent',
-      'path': '/',
+      'component': 'App Root',
+      'path': 'App Root',
       'children': [
         {
           'component': 'component-one',
@@ -186,7 +180,7 @@ describe('parseRoutes', () => {
       'isLazy': false,
       'isRedirect': false,
       'data': [],
-      'isActive': false,
+      'isActive': true,
     } as any);
   });
 });

--- a/devtools/projects/ng-devtools-backend/src/lib/router-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/router-tree.ts
@@ -18,18 +18,18 @@ type Router = any;
 
 export function parseRoutes(router: Router): Route {
   const currentUrl = router.stateManager?.routerState?.snapshot?.url;
-  const rootName = (router as any).rootComponentType?.name || 'no-name';
+  const rootName = 'App Root';
   const rootChildren = router.config;
 
   const root: Route = {
     component: rootName,
-    path: '/',
+    path: rootName,
     children: rootChildren ? assignChildrenToParent(null, rootChildren, currentUrl) : [],
     isAux: false,
     isLazy: false,
     isRedirect: false,
+    isActive: true, // Root is always active.
     data: [],
-    isActive: currentUrl === '/',
   };
 
   return root;


### PR DESCRIPTION
Previously '/' could cause confusion with other routes that use a path here. Since this node is unique in that it is not actually a "Route" that the user configures, we should make it clear with the label that is simply the App Root.

<img width="165" height="57" alt="Screenshot 2025-09-21 at 4 53 08 PM" src="https://github.com/user-attachments/assets/6e609673-f1d9-494c-8df8-dbc001b18686" />
