### PR TITLE
feat(devtools): Change lazy/eager visualization by using dashed lines and correctly positioned edge arrows

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
@@ -118,12 +118,14 @@ export class InjectorTreeComponent {
   environmentTreeConfig: Partial<TreeVisualizerConfig<InjectorTreeNode>> = {
     d3NodeModifier: d3InjectorTreeNodeModifier,
     d3LinkModifier: d3InjectorTreeLinkModifier,
+    arrowDirection: 'child-to-parent',
   };
 
   elementTreeConfig: Partial<TreeVisualizerConfig<InjectorTreeNode>> = {
     nodeSeparation: () => 1,
     d3NodeModifier: d3InjectorTreeNodeModifier,
     d3LinkModifier: d3InjectorTreeLinkModifier,
+    arrowDirection: 'child-to-parent',
   };
 
   constructor() {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.html
@@ -15,9 +15,8 @@
   <as-split unit="percent" direction="horizontal" [gutterSize]="9" class="visualization">
     <aside class="legend" aria-hidden="true">
       <ul>
-        <li class="eager">Eager-loaded route</li>
-        <li class="lazy">Lazy-loaded route</li>
         <li class="active">Active route</li>
+        <li class="dashed-line">Lazy-loading</li>
       </ul>
     </aside>
     <as-split-area size="70">

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.scss
@@ -101,6 +101,15 @@
             border-color: var(--green-02);
             background-color: var(--green-03);
           }
+
+          &.dashed-line::before {
+            border-color: var(--quaternary-contrast);
+            background-color: transparent;
+            border-style: dashed;
+            border-width: 1px;
+            width: 16px;
+            height: 0;
+          }
         }
       }
     }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.ts
@@ -24,7 +24,11 @@ import {ApplicationOperations} from '../../application-operations/index';
 import {RouteDetailsRowComponent} from './route-details-row.component';
 import {FrameManager} from '../../application-services/frame_manager';
 import {Events, MessageBus, Route} from '../../../../../protocol';
-import {SvgD3Node, TreeVisualizerConfig} from '../../shared/tree-visualizer/tree-visualizer';
+import {
+  SvgD3Node,
+  SvgD3Link,
+  TreeVisualizerConfig,
+} from '../../shared/tree-visualizer/tree-visualizer';
 import {
   RouterTreeD3Node,
   transformRoutesIntoVisTree,
@@ -97,6 +101,7 @@ export class RouterTreeComponent {
   protected readonly routerTreeConfig: Partial<TreeVisualizerConfig<RouterTreeNode>> = {
     nodeSeparation: () => 1,
     d3NodeModifier: (n) => this.d3NodeModifier(n),
+    d3LinkModifier: (l) => this.d3LinkModifier(l),
   };
 
   constructor() {
@@ -164,10 +169,6 @@ export class RouterTreeComponent {
 
       if (node.data.isActive) {
         nodeClasses.push('node-element');
-      } else if (node.data.isLazy) {
-        nodeClasses.push('node-lazy');
-      } else {
-        nodeClasses.push('node-environment');
       }
 
       if (this.searchMatches.has(node.data)) {
@@ -177,6 +178,13 @@ export class RouterTreeComponent {
       }
 
       return nodeClasses.join(' ');
+    });
+  }
+
+  private d3LinkModifier(d3Link: SvgD3Link<RouterTreeNode>) {
+    d3Link.attr('stroke-dasharray', (node: RouterTreeD3Node) => {
+      // Make edges to lazy loaded routes dashed
+      return node.data.isLazy ? '5,5' : 'none';
     });
   }
 }

--- a/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer/tree-visualizer.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer/tree-visualizer.ts
@@ -44,6 +44,7 @@ export interface TreeVisualizerConfig<T extends TreeNode> {
   nodeSize: [width: number, height: number];
   nodeSeparation: (nodeA: TreeD3Node<T>, nodeB: TreeD3Node<T>) => number;
   nodeLabelSize: [width: number, height: number];
+  arrowDirection: 'parent-to-child' | 'child-to-parent';
   /** Perform custom changes on the SVG node (e.g. set classes, colors, attributes, etc.) */
   d3NodeModifier: (node: SvgD3Node<T>) => void;
   /** Perform custom changes on the SVG link (e.g. set classes, colors, attributes, etc.) */
@@ -68,6 +69,7 @@ export class TreeVisualizer<T extends TreeNode = TreeNode> extends GraphRenderer
     nodeSize: [200, 500],
     nodeSeparation: () => 2,
     nodeLabelSize: [250, 60],
+    arrowDirection: 'parent-to-child',
     d3NodeModifier: () => {},
     d3LinkModifier: () => {},
   };
@@ -175,6 +177,23 @@ export class TreeVisualizer<T extends TreeNode = TreeNode> extends GraphRenderer
       .append('svg:path')
       .attr('d', 'M0,-5L10,0L0,5');
 
+    svg
+      .append('svg:defs')
+      .selectAll('marker')
+      .data([`start${arrowDefId}`]) // Different link/path types can be defined here
+      .enter()
+      .append('svg:marker') // This section adds in the arrows
+      .attr('id', String)
+      .attr('viewBox', '0 -5 10 10')
+      .attr('refX', 0)
+      .attr('refY', 0)
+      .attr('class', 'arrow')
+      .attr('markerWidth', 6)
+      .attr('markerHeight', 6)
+      .attr('orient', 'auto')
+      .append('svg:path')
+      .attr('d', 'M10,-5L0,0L10,5');
+
     const [labelWidth, labelHeight] = this.config.nodeLabelSize;
     const halfLabelWidth = labelWidth / 2;
     const halfLabelHeight = labelHeight / 2;
@@ -186,7 +205,12 @@ export class TreeVisualizer<T extends TreeNode = TreeNode> extends GraphRenderer
       .append('path')
       .attr('aria-labelledby', (_, idx) => `tree-link-${instanceIdx}-${idx}`)
       .attr('class', 'link')
-      .attr('marker-end', `url(#end${arrowDefId})`)
+      .attr(
+        this.config.arrowDirection === 'parent-to-child' ? 'marker-start' : 'marker-end',
+        this.config.arrowDirection === 'parent-to-child'
+          ? `url(#start${arrowDefId})`
+          : `url(#end${arrowDefId})`,
+      )
       .attr('d', (node: TreeD3Node<T>) => {
         const {x, y} = this.getNodeCoor(node);
         const {x: parentX, y: parentY} = this.getNodeCoor(node.parent!);


### PR DESCRIPTION
Previously we would visualize route config "types" by colouring different nodes.

Now we only colour nodes to represent the active route path. Lazy loaded routes are represented with dashed line edges that point in the direction of loading.

Example
<img width="342" height="312" alt="Screenshot 2025-09-21 at 4 55 35 PM" src="https://github.com/user-attachments/assets/4218d0c1-c335-4f02-9947-79a7b5339741" />


