### PR TITLE
docs(docs-infra): home page UI fixes for smaller viewports

### DIFF
--- a/adev/src/app/app.component.scss
+++ b/adev/src/app/app.component.scss
@@ -62,6 +62,10 @@
     .adev-nav {
       width: 0;
       height: 0;
+
+      @include mq.for-tablet-landscape-down {
+        width: 100%;
+      }
     }
 
     @include mq.for-tablet-landscape-up {

--- a/adev/src/app/features/home/home.component.scss
+++ b/adev/src/app/features/home/home.component.scss
@@ -102,6 +102,11 @@
   background-repeat: repeat;
   background-color: transparent;
   padding-bottom: 36px;
+  padding-top: 7rem;
+
+  @include mq.for-tablet-landscape-down {
+    padding-top: 9rem;
+  }
 
   button {
     font-size: 1.2rem;
@@ -114,8 +119,6 @@
       font-size: 0.8rem;
     }
   }
-
-  margin-top: 5rem;
 
   .svg {
     fill-rule: evenodd;
@@ -140,7 +143,7 @@
 }
 
 section {
-  padding-left: 2rem;
+  padding-left: 9rem;
   padding-right: 2rem;
 
   h2 {
@@ -157,10 +160,14 @@ section {
     max-width: 1200px;
     margin: 0 auto;
   }
+
+  @include mq.for-tablet-landscape-down {
+    padding-left: 2rem;
+  }
 }
 
 .features {
-  padding: 2rem;
+  padding-block: 2rem;
   text-align: center;
 
   h2 {
@@ -304,7 +311,7 @@ section {
   background-repeat: repeat;
   background-color: transparent;
 
-  padding: 5rem 2rem;
+  padding-block: 5rem;
   text-align: left;
 
   h2 {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] angular.dev application / infrastructure changes


## What is the current behavior?

Padding issues:
<img width="907" height="1203" alt="Screenshot 2025-09-22 at 12 38 05" src="https://github.com/user-attachments/assets/fac58ae9-1feb-401e-81c7-22ab2ae2b0ca" />

Missing nav menu:
<img width="760" height="396" alt="Screenshot 2025-09-22 at 12 37 52" src="https://github.com/user-attachments/assets/b57eb507-799a-402c-8c0a-a44cd8cd5c69" />


## What is the new behavior?

Fixes the displayed issues above that are reproducible when the viewport is smaller than ~1100px.