### PR TITLE
fix(core): fix narrowing of `Resource.hasValue()`

### DIFF
--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -2903,7 +2903,9 @@ export interface HttpResourceRef<T> extends WritableResource<T>, ResourceRef<T> 
     // (undocumented)
     destroy(): void;
     // (undocumented)
-    hasValue(): this is HttpResourceRef<Exclude<T, undefined>>;
+    hasValue(this: T extends undefined ? this : never): this is HttpResourceRef<Exclude<T, undefined>>;
+    // (undocumented)
+    hasValue(): boolean;
     readonly headers: Signal<HttpHeaders | undefined>;
     readonly progress: Signal<HttpProgressEvent | undefined>;
     readonly statusCode: Signal<number | undefined>;

--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1600,7 +1600,9 @@ export function resolveForwardRef<T>(type: T): T;
 // @public
 export interface Resource<T> {
     readonly error: Signal<Error | undefined>;
-    hasValue(): this is Resource<Exclude<T, undefined>>;
+    hasValue(this: T extends undefined ? this : never): this is Resource<Exclude<T, undefined>>;
+    // (undocumented)
+    hasValue(): boolean;
     readonly isLoading: Signal<boolean>;
     readonly status: Signal<ResourceStatus>;
     readonly value: Signal<T>;
@@ -1636,7 +1638,9 @@ export type ResourceOptions<T, R> = PromiseResourceOptions<T, R> | StreamingReso
 export interface ResourceRef<T> extends WritableResource<T> {
     destroy(): void;
     // (undocumented)
-    hasValue(): this is ResourceRef<Exclude<T, undefined>>;
+    hasValue(this: T extends undefined ? this : never): this is ResourceRef<Exclude<T, undefined>>;
+    // (undocumented)
+    hasValue(): boolean;
 }
 
 // @public
@@ -2013,7 +2017,9 @@ export interface WritableResource<T> extends Resource<T> {
     // (undocumented)
     asReadonly(): Resource<T>;
     // (undocumented)
-    hasValue(): this is WritableResource<Exclude<T, undefined>>;
+    hasValue(this: T extends undefined ? this : never): this is WritableResource<Exclude<T, undefined>>;
+    // (undocumented)
+    hasValue(): boolean;
     reload(): boolean;
     set(value: T): void;
     update(updater: (value: T) => T): void;

--- a/packages/common/http/src/resource_api.ts
+++ b/packages/common/http/src/resource_api.ts
@@ -191,6 +191,11 @@ export interface HttpResourceRef<T> extends WritableResource<T>, ResourceRef<T> 
    */
   readonly progress: Signal<HttpProgressEvent | undefined>;
 
-  hasValue(): this is HttpResourceRef<Exclude<T, undefined>>;
+  hasValue(
+    this: T extends undefined ? this : never,
+  ): this is HttpResourceRef<Exclude<T, undefined>>;
+
+  hasValue(): boolean;
+
   destroy(): void;
 }

--- a/packages/common/http/test/resource_spec.ts
+++ b/packages/common/http/test/resource_spec.ts
@@ -15,6 +15,7 @@ import {
   httpResource,
   HttpContext,
   HttpContextToken,
+  HttpResourceRef,
 } from '../index';
 import {HttpTestingController, provideHttpClientTesting} from '../testing';
 
@@ -337,5 +338,50 @@ describe('httpResource', () => {
     expect(res.headers()).toBe(undefined);
     expect(res.progress()).toBe(undefined);
     expect(res.statusCode()).toBe(undefined);
+  });
+
+  describe('types', () => {
+    it('should narrow hasValue() when the value can be undefined', () => {
+      const result: HttpResourceRef<number | undefined> = httpResource(() => '/data', {
+        injector: TestBed.inject(Injector),
+        parse: () => 0,
+      });
+
+      if (result.hasValue()) {
+        const _value: number = result.value();
+      } else if (result.isLoading()) {
+        // @ts-expect-error
+        const _value: number = result.value();
+      } else if (result.error()) {
+      }
+    });
+
+    it('should not narrow hasValue() when a default value is provided', () => {
+      const result: HttpResourceRef<number> = httpResource(() => '/data', {
+        injector: TestBed.inject(Injector),
+        parse: () => 0,
+        defaultValue: 0,
+      });
+
+      if (result.hasValue()) {
+        const _value: number = result.value();
+      } else if (result.isLoading()) {
+        const _value: number = result.value();
+      } else if (result.error()) {
+      }
+    });
+
+    it('should not narrow hasValue() when the resource type is unknown', () => {
+      const result: HttpResourceRef<unknown> = httpResource(() => '/data', {
+        injector: TestBed.inject(Injector),
+      });
+
+      if (result.hasValue()) {
+        const _value: unknown = result.value();
+      } else if (result.isLoading()) {
+        const _value: unknown = result.value();
+      } else if (result.error()) {
+      }
+    });
   });
 });

--- a/packages/core/src/resource/api.ts
+++ b/packages/core/src/resource/api.ts
@@ -71,7 +71,9 @@ export interface Resource<T> {
    *
    * This function is reactive.
    */
-  hasValue(): this is Resource<Exclude<T, undefined>>;
+  hasValue(this: T extends undefined ? this : never): this is Resource<Exclude<T, undefined>>;
+
+  hasValue(): boolean;
 }
 
 /**
@@ -83,7 +85,11 @@ export interface Resource<T> {
  */
 export interface WritableResource<T> extends Resource<T> {
   readonly value: WritableSignal<T>;
-  hasValue(): this is WritableResource<Exclude<T, undefined>>;
+  hasValue(
+    this: T extends undefined ? this : never,
+  ): this is WritableResource<Exclude<T, undefined>>;
+
+  hasValue(): boolean;
 
   /**
    * Convenience wrapper for `value.set`.
@@ -113,8 +119,9 @@ export interface WritableResource<T> extends Resource<T> {
  * @experimental
  */
 export interface ResourceRef<T> extends WritableResource<T> {
-  hasValue(): this is ResourceRef<Exclude<T, undefined>>;
+  hasValue(this: T extends undefined ? this : never): this is ResourceRef<Exclude<T, undefined>>;
 
+  hasValue(): boolean;
   /**
    * Manually destroy the resource, which cancels pending requests and returns it to `idle` state.
    */

--- a/packages/core/test/resource/resource_spec.ts
+++ b/packages/core/test/resource/resource_spec.ts
@@ -14,6 +14,7 @@ import {
   EnvironmentInjector,
   Injector,
   resource,
+  ResourceRef,
   ResourceStatus,
   signal,
 } from '../../src/core';
@@ -940,6 +941,81 @@ describe('resource', () => {
     expect(echoResource.hasValue()).toBeTrue();
     expect(echoResource.value()).toEqual({});
     expect(echoResource.error()).toEqual(undefined);
+  });
+
+  describe('types', () => {
+    it('should narrow hasValue() when the value can be undefined', () => {
+      const result: ResourceRef<number | undefined> = resource({
+        params: () => 1,
+        loader: async ({params}) => params,
+        injector: TestBed.inject(Injector),
+      });
+
+      if (result.hasValue()) {
+        const _value: number = result.value();
+      } else if (result.isLoading()) {
+        // @ts-expect-error
+        const _value: number = result.value();
+      } else if (result.error()) {
+      }
+
+      const readonly = result.asReadonly();
+      if (readonly.hasValue()) {
+        const _value: number = readonly.value();
+      } else if (readonly.isLoading()) {
+        // @ts-expect-error
+        const _value: number = readonly.value();
+      } else if (readonly.error()) {
+      }
+    });
+
+    it('should not narrow hasValue() when a default value is provided', () => {
+      const result: ResourceRef<number> = resource({
+        params: () => 1,
+        loader: async ({params}) => params,
+        injector: TestBed.inject(Injector),
+        defaultValue: 0,
+      });
+
+      if (result.hasValue()) {
+        const _value: number = result.value();
+      } else if (result.isLoading()) {
+        const _value: number = result.value();
+      } else if (result.error()) {
+      }
+
+      const readonly = result.asReadonly();
+      if (readonly.hasValue()) {
+        const _value: number = readonly.value();
+      } else if (readonly.isLoading()) {
+        const _value: number = readonly.value();
+      } else if (readonly.error()) {
+      }
+    });
+
+    it('should not narrow hasValue() when the resource type is unknown', () => {
+      const result: ResourceRef<unknown> = resource({
+        params: () => 1 as unknown,
+        loader: async ({params}) => params,
+        injector: TestBed.inject(Injector),
+        defaultValue: 0,
+      });
+
+      if (result.hasValue()) {
+        const _value: unknown = result.value();
+      } else if (result.isLoading()) {
+        const _value: unknown = result.value();
+      } else if (result.error()) {
+      }
+
+      const readonly = result.asReadonly();
+      if (readonly.hasValue()) {
+        const _value: unknown = readonly.value();
+      } else if (readonly.isLoading()) {
+        const _value: unknown = readonly.value();
+      } else if (readonly.error()) {
+      }
+    });
   });
 });
 


### PR DESCRIPTION
This commit changes `Resource.hasValue()` and its derived types to improve narrowing of resources whose generic type either does not include `undefined` (i.e. when a default value has been provided) or when the generic type is `unknown`. This fixes the undesirable behavior where `hasValue()` would cause the `else` branch of an `hasValue()` conditional to have a narrowed type of `never`, given that the `hasValue()`'s type guard covers the entire type range already (meaning that the type in the else-branch cannot be inhabited in the type system, yielding the `never` type).

By making the `hasValue()` method only a type guard when the generic type includes `undefined` these problems are avoided.

Fixes #60766
Fixes #63545
Fixes #63982