### PR TITLE
fix(migrations): handle reused templates in control flow migration

### DIFF
--- a/packages/core/schematics/test/control_flow_migration_spec.ts
+++ b/packages/core/schematics/test/control_flow_migration_spec.ts
@@ -5074,6 +5074,44 @@ describe('control flow migration (ng update)', () => {
         '@if (show) {<div>Some greek characters: θδ!</div>}',
       );
     });
+
+    it('should migrate multiple ngIf directives with same else template and preserve template outlet', async () => {
+      writeFile(
+        '/comp.ts',
+        `
+        import {Component} from '@angular/core';
+        import {NgIf} from '@angular/common';
+
+        @Component({
+          imports: [NgIf],
+          template: \`
+            <div *ngIf="1 == 1; else elseTemplate">
+              <h1>TEST</h1>
+            </div>
+            <div *ngIf="1 == 1; else elseTemplate">
+              <h1>TEST</h1>
+            </div>
+
+            <ng-container [ngTemplateOutlet]="elseTemplate"></ng-container>
+            <ng-template #elseTemplate>
+              <h1>Test</h1>
+              <div>Test</div>
+            </ng-template>
+          \`
+        })
+        class Comp {
+        }
+      `,
+      );
+
+      await runMigration();
+      const content = tree.readContent('/comp.ts');
+
+      expect(content.replace(/\s+/g, ' ')).toContain(
+        `<ng-container [ngTemplateOutlet]="elseTemplate"></ng-container>`,
+      );
+      expect(content.replace(/\s+/g, ' ')).toContain(`<ng-template #elseTemplate>`);
+    });
   });
 
   describe('formatting', () => {


### PR DESCRIPTION
The control flow migration was incorrectly removing `ng-template` elements in scenarios where they were referenced by multiple `*ngIf` directives' `else` clauses and also used independently via `ngTemplateOutlet`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Template:
```
<div *ngIf="1 == 1; else elseTemplate">
  <h1>TEST</h1>
</div>
<div *ngIf="1 == 1; else elseTemplate">
  <h1>TEST</h1>
</div>

<ng-container [ngTemplateOutlet]="elseTemplate"></ng-container>
<ng-template #elseTemplate>
  <h1>Test</h1>
  <div>Test</div>
</ng-template>
```

After:

```
@if (1==1) {
  <div>
    <h1>TEST</h1>
  </div>
} @else {
  <h1>Test</h1>
  <div>Test</div>
}

@if (1==1) {
  <div>
    <h1>TEST</h1>
  </div>
} @else {
  <h1>Test</h1>
  <div>Test</div>
}
<ng-container [ngTemplateOutlet]="elseTemplate"></ng-container>
```


## What is the new behavior?
This change updates the template processing logic to correctly detect all usages of a template, including property-bound `[ngTemplateOutlet]`. The migration will now preserve the `ng-template` if it's still referenced after the `*ngIf` directives have been migrated.

Now:

```
@if (1 == 1) {
<div><h1>TEST</h1></div>
} @else {
<h1>Test</h1>
<div>Test</div>
} @if (1 == 1) {
<div><h1>TEST</h1></div>
} @else {
<h1>Test</h1>
<div>Test</div>
} <ng-container [ngTemplateOutlet]="elseTemplate"></ng-container>
<ng-template #elseTemplate>
  <h1>Test</h1>
  <div>Test</div>
</ng-template>

```


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
