### PR TITLE
fix(router): Ensures guard references are cleared after navigation

### DIFF
--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -852,6 +852,8 @@ export class NavigationTransitions {
               this.currentNavigation.set(null);
               this.currentTransition = null;
             }
+            // Clear out to avoid holding on to resources.
+            (overallTransitionState as any) = null;
           }),
           catchError((e) => {
             // If the application is already destroyed, the catch block should not


### PR DESCRIPTION
Allows component instances to be garbage collected, improving resource use in long-running apps

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  https://github.com/angular/angular/issues/63983


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Previous behavior
Old references were retained after navigation.
<img width="1429" height="271" alt="image" src="https://github.com/user-attachments/assets/fcd31e56-7a8d-41cf-8982-1dbc06cfac9e" />




Old references are now properly cleaned up when navigating, 
<img width="1427" height="358" alt="image" src="https://github.com/user-attachments/assets/4330f282-540c-4a64-ace5-f95ece0f52fa" />

