### PR TITLE
docs(docs-infra): fix docs-card padding

### DIFF
--- a/adev/shared-docs/styles/docs/_card.scss
+++ b/adev/shared-docs/styles/docs/_card.scss
@@ -52,6 +52,7 @@
         flex-grow: 1;
         margin-block-start: 0;
         padding-inline: 1.5rem;
+        padding-block: 1rem;
         display: flex;
         flex-direction: column;
         justify-content: space-between;
@@ -59,7 +60,6 @@
 
         h3 {
           margin-bottom: 0;
-          margin-block-start: 1rem;
           font-size: 1rem;
         }
         p {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Look at the bottom padding
<img width="484" height="382" alt="6fGuFqLucdKMZfh" src="https://github.com/user-attachments/assets/a33fb79d-2784-471a-9bb8-99f4db6310f2" />


Issue Number: N/A


## What is the new behavior?
<img width="483" height="394" alt="BkRjRUbcrFSHNPN" src="https://github.com/user-attachments/assets/d9a53fd6-1b26-4d67-8509-d66f4090c5ad" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
