### PR TITLE
docs(docs-infra): fix home page UI issues on Firefox and Safari

### DIFF
--- a/adev/src/app/features/home/home.component.scss
+++ b/adev/src/app/features/home/home.component.scss
@@ -3,6 +3,7 @@
 :host {
   width: 100%;
   position: relative;
+  display: block;
 }
 
 .banners-layer {
@@ -324,7 +325,8 @@ section {
   }
 
   svg {
-    max-width: 64px;
+    width: 64px;
+    flex: 0 0 64px;
     margin: 0 1rem;
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] angular.dev application / infrastructure changes


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Banner (FF & Safari):
<img width="227" height="247" alt="Screenshot 2025-09-23 at 15 59 36" src="https://github.com/user-attachments/assets/35add2be-f47b-41aa-b6d7-ac32aaf46f8b" />

"Learn More" icons (Safari only):
<img width="640" height="437" alt="Screenshot 2025-09-23 at 15 59 48" src="https://github.com/user-attachments/assets/91b98084-81a4-4e92-8e00-0e063a874134" />

## What is the new behavior?

Fix broken banners and "Learn More" icons.
