### PR TITLE
refactor(compiler-cli): relax optional chain non nullable diagnostics on indexed access.

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/optional_chain_not_nullable/optional_chain_not_nullable_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/optional_chain_not_nullable/optional_chain_not_nullable_spec.ts
@@ -226,6 +226,66 @@ runInEachFileSystem(() => {
       expect(diags.length).toBe(0);
     });
 
+    it('should not produce optional chain warning for an indexed access if noUncheckedIndexedAccess is false', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup(
+        [
+          {
+            fileName,
+            templates: {
+              'TestCmp': `{{ arr[0]?.bar }}`,
+            },
+            source: `
+               export class TestCmp {
+                  arr: Array<{ bar: string }> = [];
+               }
+             `,
+          },
+        ],
+        {options: {noUncheckedIndexedAccess: false}},
+      );
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [optionalChainNotNullableFactory],
+        {strictNullChecks: true} /* options */,
+      );
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(0);
+    });
+
+    it('should produce optional chain warning for an indexed access if noUncheckedIndexedAccess is true', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup(
+        [
+          {
+            fileName,
+            templates: {
+              'TestCmp': `{{ arr[0]?.bar }}`,
+            },
+            source: `
+               export class TestCmp {
+                  arr: Array<{ bar: string }> = [];
+               }
+             `,
+          },
+        ],
+        {options: {noUncheckedIndexedAccess: true}},
+      );
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [optionalChainNotNullableFactory],
+        {strictNullChecks: true} /* options */,
+      );
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(0);
+    });
+
     it('should not produce optional chain warning for a type that includes undefined', () => {
       const fileName = absoluteFrom('/main.ts');
       const {program, templateTypeChecker} = setup([


### PR DESCRIPTION
…stics on indexed access.

When `noUncheckedIndexedAccess` is not enabled, indexed accesses do not include `undefined` in the type. This makes the OptionalChainNotNullableCheck inconvenient when wanting to safe guard an indexed access (and when the typings isn't helping you).

eg
```
myArra[0]?.foobar; // should not warn/error if noUncheckedIndexedAccess != true 
```

Ideally projectw should enable `noUncheckedIndexedAccess` for better typesafety, but this is often inconveninent (we do not enable it by default) and often not the resort of the developer.

So more better coding convinience,  `OptionalChainNotNullableCheck` will not raise an error/warning on indexed Acessed followed by an optional chaining when `noUncheckedIndexedAccess` is not enabled.

See also #63809 which will detect more cases
