### PR TITLE
docs: angular does not support BigInt literal values

### DIFF
--- a/adev/src/content/guide/templates/expression-syntax.md
+++ b/adev/src/content/guide/templates/expression-syntax.md
@@ -19,6 +19,12 @@ Angular supports a subset of [literal values](https://developer.mozilla.org/en-U
 | Template string | `` `Hello ${name}` ``           |
 | RegExp          | `/\d+/`                         |
 
+### Unsupported value literals
+
+| Literal type | Example values |
+|--------------|----------------|
+| BigInt       | `1n`           |
+
 ## Globals
 
 Angular expressions support the following [globals](https://developer.mozilla.org/en-US/docs/Glossary/Global_object):


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

Now that RegExp are supported, there is no longer the "unsupported literal values" table in the docs.
This updates the section to mention that BigInt aren't supported, hence the "a subset of literal values".

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
