### PR TITLE
fix(forms): Emit `FormResetEvent` when resetting control

### DIFF
--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -366,7 +366,6 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
   resetForm(value: any = undefined): void {
     this.form.reset(value);
     this.submittedReactive.set(false);
-    this.form._events.next(new FormResetEvent(this.form));
   }
 
   private _setUpdateStrategy() {

--- a/packages/forms/src/directives/reactive_directives/abstract_form.directive.ts
+++ b/packages/forms/src/directives/reactive_directives/abstract_form.directive.ts
@@ -301,9 +301,6 @@ export abstract class AbstractFormDirective
   resetForm(value: any = undefined, options: {onlySelf?: boolean; emitEvent?: boolean} = {}): void {
     this.form.reset(value, options);
     this._submittedReactive.set(false);
-    if (options?.emitEvent !== false) {
-      this.form._events.next(new FormResetEvent(this.form));
-    }
   }
 
   /**

--- a/packages/forms/src/model/form_array.ts
+++ b/packages/forms/src/model/form_array.ts
@@ -15,6 +15,7 @@ import {
   AbstractControlOptions,
   assertAllValuesPresent,
   assertControlPresent,
+  FormResetEvent,
   pickAsyncValidators,
   pickValidators,
   ɵRawValue,
@@ -431,6 +432,9 @@ export class FormArray<TControl extends AbstractControl<any> = any> extends Abst
     this._updatePristine(options, this);
     this._updateTouched(options, this);
     this.updateValueAndValidity(options);
+    if (options?.emitEvent !== false) {
+      this._events.next(new FormResetEvent(this));
+    }
   }
 
   /**

--- a/packages/forms/src/model/form_control.ts
+++ b/packages/forms/src/model/form_control.ts
@@ -14,6 +14,7 @@ import {removeListItem} from '../util';
 import {
   AbstractControl,
   AbstractControlOptions,
+  FormResetEvent,
   isOptionsObj,
   pickAsyncValidators,
   pickValidators,
@@ -529,6 +530,9 @@ export const FormControl: ɵFormControlCtor = class FormControl<TValue = any>
     this.markAsUntouched(options);
     this.setValue(this.value, options);
     this._pendingChange = false;
+    if (options?.emitEvent !== false) {
+      this._events.next(new FormResetEvent(this));
+    }
   }
 
   /**  @internal */

--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -15,6 +15,7 @@ import {
   AbstractControlOptions,
   assertAllValuesPresent,
   assertControlPresent,
+  FormResetEvent,
   pickAsyncValidators,
   pickValidators,
   ɵRawValue,
@@ -566,6 +567,9 @@ export class FormGroup<
     this._updatePristine(options, this);
     this._updateTouched(options, this);
     this.updateValueAndValidity(options);
+    if (options?.emitEvent !== false) {
+      this._events.next(new FormResetEvent(this));
+    }
   }
 
   /**


### PR DESCRIPTION
Prior to this change, the event was emitted by the Form Directive. With the change, it is now emitted at the control level.

fixes #58894
