### PR TITLE
ci: use release config when deploying adev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
       - name: Install node modules
         run: pnpm install --frozen-lockfile
       - name: Build adev
-        run: pnpm bazel build //adev:build.production
+        run: pnpm bazel build //adev:build.production --config=release
       - name: Deploy to firebase
         uses: ./.github/actions/deploy-docs-site
         with:


### PR DESCRIPTION
Use the release config when deploying to adev to ensure that the version stamping is in place and correct