### PR TITLE
fix(forms): Emit `FormResetEvent` when resetting control

### DIFF
--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -366,7 +366,6 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
   resetForm(value: any = undefined): void {
     this.form.reset(value);
     this.submittedReactive.set(false);
-    this.form._events.next(new FormResetEvent(this.form));
   }
 
   private _setUpdateStrategy() {

--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -344,9 +344,6 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
   resetForm(value: any = undefined, options: {onlySelf?: boolean; emitEvent?: boolean} = {}): void {
     this.form.reset(value, options);
     this._submittedReactive.set(false);
-    if (options?.emitEvent !== false) {
-      this.form._events.next(new FormResetEvent(this.form));
-    }
   }
 
   /** @internal */

--- a/packages/forms/src/model/form_array.ts
+++ b/packages/forms/src/model/form_array.ts
@@ -15,6 +15,7 @@ import {
   AbstractControlOptions,
   assertAllValuesPresent,
   assertControlPresent,
+  FormResetEvent,
   pickAsyncValidators,
   pickValidators,
   ɵRawValue,
@@ -431,6 +432,9 @@ export class FormArray<TControl extends AbstractControl<any> = any> extends Abst
     this._updatePristine(options, this);
     this._updateTouched(options, this);
     this.updateValueAndValidity(options);
+    if (options?.emitEvent !== false) {
+      this._events.next(new FormResetEvent(this));
+    }
   }
 
   /**

--- a/packages/forms/src/model/form_control.ts
+++ b/packages/forms/src/model/form_control.ts
@@ -14,6 +14,7 @@ import {removeListItem} from '../util';
 import {
   AbstractControl,
   AbstractControlOptions,
+  FormResetEvent,
   isOptionsObj,
   pickAsyncValidators,
   pickValidators,
@@ -529,6 +530,9 @@ export const FormControl: ɵFormControlCtor = class FormControl<TValue = any>
     this.markAsUntouched(options);
     this.setValue(this.value, options);
     this._pendingChange = false;
+    if (options?.emitEvent !== false) {
+      this._events.next(new FormResetEvent(this));
+    }
   }
 
   /**  @internal */

--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -15,6 +15,7 @@ import {
   AbstractControlOptions,
   assertAllValuesPresent,
   assertControlPresent,
+  FormResetEvent,
   pickAsyncValidators,
   pickValidators,
   ɵRawValue,
@@ -566,6 +567,9 @@ export class FormGroup<
     this._updatePristine(options, this);
     this._updateTouched(options, this);
     this.updateValueAndValidity(options);
+    if (options?.emitEvent !== false) {
+      this._events.next(new FormResetEvent(this));
+    }
   }
 
   /**

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -1495,6 +1495,94 @@ describe('reactive forms integration tests', () => {
       expect(events[0]).toBeInstanceOf(FormSubmittedEvent);
       expect(events[0].source).toBe(form);
     });
+
+    it('formControl should emit an event when resetting it', () => {
+      const fc = new FormControl<string | null>('foo', Validators.required);
+      const fcEvents: ControlEvent[] = [];
+      fc.events.subscribe((event) => fcEvents.push(event));
+      expect(fcEvents.length).toBe(0);
+
+      fc.reset('bar');
+      expect(fcEvents.length).toBe(3);
+      expect(fcEvents[0]).toBeInstanceOf(ValueChangeEvent);
+      expect(fcEvents[1]).toBeInstanceOf(StatusChangeEvent);
+      expect(fcEvents[2]).toBeInstanceOf(FormResetEvent);
+      expect(fcEvents[2].source).toBe(fc);
+    });
+
+    it('formControl should not emit an event when resetting it with emit:false', () => {
+      const fc = new FormControl<string | null>('foo', Validators.required);
+      const fcEvents: ControlEvent[] = [];
+      fc.events.subscribe((event) => fcEvents.push(event));
+      expect(fcEvents.length).toBe(0);
+
+      fc.reset('bar', {emitEvent: false});
+      expect(fcEvents.length).toBe(0);
+    });
+
+    it('formGroup should emit a reset event when resetting it', () => {
+      const fc1 = new FormControl<string | null>('foo', Validators.required);
+      const fc2 = new FormControl<string | null>('bar', Validators.required);
+      const fg = new FormGroup({fc1, fc2});
+
+      const fgEvents: ControlEvent[] = [];
+      fg.events.subscribe((event) => fgEvents.push(event));
+      expect(fgEvents.length).toBe(0);
+
+      fg.reset({fc1: 'newFoo', fc2: 'newBar'});
+      expect(fgEvents.length).toBe(4);
+      expect(fgEvents[0]).toBeInstanceOf(TouchedChangeEvent);
+      expect(fgEvents[1]).toBeInstanceOf(ValueChangeEvent);
+      expect(fgEvents[2]).toBeInstanceOf(StatusChangeEvent);
+      expect(fgEvents[3]).toBeInstanceOf(FormResetEvent);
+      expect(fgEvents[3].source).toBe(fg);
+    });
+
+    it('formGroup should not emit a reset event when resetting it with emit:false', () => {
+      const fc1 = new FormControl<string | null>('foo', Validators.required);
+      const fc2 = new FormControl<string | null>('bar', Validators.required);
+      const fg = new FormGroup({fc1, fc2});
+
+      const fgEvents: ControlEvent[] = [];
+      fg.events.subscribe((event) => fgEvents.push(event));
+      expect(fgEvents.length).toBe(0);
+
+      fg.reset({fc1: 'newFoo', fc2: 'newBar'}, {emitEvent: false});
+      expect(fgEvents.length).toBe(1);
+      expect(fgEvents[0]).toBeInstanceOf(TouchedChangeEvent);
+    });
+
+    it('formArray should emit a reset event when resetting it', () => {
+      const fc1 = new FormControl<string | null>('foo', Validators.required);
+      const fc2 = new FormControl<string | null>('bar', Validators.required);
+      const fa = new FormArray([fc1, fc2]);
+
+      const faEvents: ControlEvent[] = [];
+      fa.events.subscribe((event) => faEvents.push(event));
+      expect(faEvents.length).toBe(0);
+
+      fa.reset(['newFoo', 'newBar']);
+      expect(faEvents.length).toBe(4);
+      expect(faEvents[0]).toBeInstanceOf(TouchedChangeEvent);
+      expect(faEvents[1]).toBeInstanceOf(ValueChangeEvent);
+      expect(faEvents[2]).toBeInstanceOf(StatusChangeEvent);
+      expect(faEvents[3]).toBeInstanceOf(FormResetEvent);
+      expect(faEvents[3].source).toBe(fa);
+    });
+
+    it('formArray should not emit a reset event when resetting it with emit:false', () => {
+      const fc1 = new FormControl<string | null>('foo', Validators.required);
+      const fc2 = new FormControl<string | null>('bar', Validators.required);
+      const fa = new FormArray([fc1, fc2]);
+
+      const faEvents: ControlEvent[] = [];
+      fa.events.subscribe((event) => faEvents.push(event));
+      expect(faEvents.length).toBe(0);
+
+      fa.reset(['newFoo', 'newBar'], {emitEvent: false});
+      expect(faEvents.length).toBe(1);
+      expect(faEvents[0]).toBeInstanceOf(TouchedChangeEvent);
+    });
   });
 
   describe('setting status classes', () => {


### PR DESCRIPTION
Patch-port of #64024

----

Prior to this change, the event was emitted by the Form Directive. With the change, it is now emitted at the control level.

fixes #58894

