### PR TITLE
docs(docs-infra): align docs-step number to the heading

### DIFF
--- a/adev/shared-docs/styles/docs/_steps.scss
+++ b/adev/shared-docs/styles/docs/_steps.scss
@@ -27,7 +27,7 @@
     pointer-events: none;
     position: absolute;
     left: calc(var(--gutter) * -1);
-    top: 2.7rem;
+    top: 1rem;
     bottom: 0;
 
     &::before {
@@ -39,7 +39,8 @@
       border-radius: 50%;
       aspect-ratio: 1 / 1;
       border: 1px solid transparent;
-      background-image: linear-gradient(var(--page-background), var(--page-background)),
+      background-image:
+        linear-gradient(var(--page-background), var(--page-background)),
         var(--pink-to-purple-horizontal-gradient);
       background-origin: border-box;
       background-clip: content-box, border-box;


### PR DESCRIPTION
Noticed that the `docs-step` numbers are misaligned while browsing the docs.

Example: https://angular.dev/guide/forms/reactive-forms#import-the-formarray-class