### PR TITLE
Fix a @keyframes style encapsulation test

### DIFF
--- a/packages/compiler/test/shadow_css/keyframes_spec.ts
+++ b/packages/compiler/test/shadow_css/keyframes_spec.ts
@@ -467,7 +467,7 @@ describe('ShadowCss, keyframes and animations', () => {
 
         @keyframes foo {}
         @keyframes 'fo\\'o' {}
-        @keyframes 'foo'' {}
+        @keyframes 'foo\\'' {}
         @keyframes 'foo\\\\' {}
         @keyframes "bar" {}
         @keyframes 'ba\\'r' {}
@@ -476,7 +476,7 @@ describe('ShadowCss, keyframes and animations', () => {
     const result = shim(css, 'host-a');
     expect(result).toContain('@keyframes host-a_foo {}');
     expect(result).toContain("@keyframes 'host-a_fo\\'o' {}");
-    expect(result).toContain("@keyframes 'host-a_foo'' {}");
+    expect(result).toContain("@keyframes 'host-a_foo\\'' {}");
     expect(result).toContain("@keyframes 'host-a_foo\\\\' {}");
     expect(result).toContain('@keyframes "host-a_bar" {}');
     expect(result).toContain("@keyframes 'host-a_ba\\'r' {}");


### PR DESCRIPTION
I've updated the test to assert what I believe it was trying to assert before. Without this change, the CSS is invalid so it's unclear what behavior we're demonstrating.