### PR TITLE
feat(forms): allow to update the a `FormControl.defaultValue`

### DIFF
--- a/goldens/public-api/forms/index.api.md
+++ b/goldens/public-api/forms/index.api.md
@@ -308,6 +308,7 @@ export class FormArray<TControl extends AbstractControl<any> = any> extends Abst
     reset(value?: ɵTypedOrUntyped<TControl, ɵFormArrayValue<TControl>, any>, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
+        overwriteDefaultValue?: boolean;
     }): void;
     setControl(index: number, control: TControl, options?: {
         emitEvent?: boolean;
@@ -378,7 +379,7 @@ export class FormBuilder {
 
 // @public
 export interface FormControl<TValue = any> extends AbstractControl<TValue> {
-    readonly defaultValue: TValue;
+    defaultValue: TValue;
     getRawValue(): TValue;
     patchValue(value: TValue, options?: {
         onlySelf?: boolean;
@@ -391,6 +392,7 @@ export interface FormControl<TValue = any> extends AbstractControl<TValue> {
     reset(formState?: TValue | FormControlState<TValue>, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
+        overwriteDefaultValue?: boolean;
     }): void;
     setValue(value: TValue, options?: {
         onlySelf?: boolean;
@@ -509,6 +511,7 @@ export class FormGroup<TControl extends {
     reset(value?: ɵTypedOrUntyped<TControl, ɵFormGroupArgumentValue<TControl>, any>, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
+        overwriteDefaultValue?: boolean;
     }): void;
     setControl<K extends string & keyof TControl>(name: K, control: TControl[K], options?: {
         emitEvent?: boolean;

--- a/packages/forms/src/model/form_array.ts
+++ b/packages/forms/src/model/form_array.ts
@@ -424,10 +424,11 @@ export class FormArray<TControl extends AbstractControl<any> = any> extends Abst
     options: {
       onlySelf?: boolean;
       emitEvent?: boolean;
+      overwriteDefaultValue?: boolean;
     } = {},
   ): void {
     this._forEachChild((control: AbstractControl, index: number) => {
-      control.reset(value[index], {onlySelf: true, emitEvent: options.emitEvent});
+      control.reset(value[index], {...options, onlySelf: true});
     });
     this._updatePristine(options, this);
     this._updateTouched(options, this);

--- a/packages/forms/src/model/form_control.ts
+++ b/packages/forms/src/model/form_control.ts
@@ -197,7 +197,7 @@ export interface FormControl<TValue = any> extends AbstractControl<TValue> {
    * value. See {@link FormControlOptions#nonNullable} for more information on configuring
    * a default value.
    */
-  readonly defaultValue: TValue;
+  defaultValue: TValue;
 
   /** @internal */
   _onChange: Function[];
@@ -294,6 +294,7 @@ export interface FormControl<TValue = any> extends AbstractControl<TValue> {
    * `valueChanges`
    * observables emit events with the latest status and value when the control is reset.
    * When false, no events are emitted.
+   * * `overwriteDefaultValue`: When true, the value used to reset the control becomes the new default value of the control.
    *
    */
   reset(
@@ -301,6 +302,7 @@ export interface FormControl<TValue = any> extends AbstractControl<TValue> {
     options?: {
       onlySelf?: boolean;
       emitEvent?: boolean;
+      overwriteDefaultValue?: boolean;
     },
   ): void;
 
@@ -450,7 +452,7 @@ export const FormControl: ɵFormControlCtor = class FormControl<TValue = any>
   implements FormControlInterface<TValue>
 {
   /** @publicApi */
-  public readonly defaultValue: TValue = null as unknown as TValue;
+  public defaultValue: TValue = null as unknown as TValue;
 
   /** @internal */
   _onChange: Array<Function> = [];
@@ -523,12 +525,15 @@ export const FormControl: ɵFormControlCtor = class FormControl<TValue = any>
 
   override reset(
     formState: TValue | FormControlState<TValue> = this.defaultValue,
-    options: {onlySelf?: boolean; emitEvent?: boolean} = {},
+    options: {onlySelf?: boolean; emitEvent?: boolean; overwriteDefaultValue?: boolean} = {},
   ): void {
     this._applyFormState(formState);
     this.markAsPristine(options);
     this.markAsUntouched(options);
     this.setValue(this.value, options);
+    if (options.overwriteDefaultValue) {
+      this.defaultValue = this.value;
+    }
     this._pendingChange = false;
     if (options?.emitEvent !== false) {
       this._events.next(new FormResetEvent(this));

--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -556,13 +556,10 @@ export class FormGroup<
    */
   override reset(
     value: ɵTypedOrUntyped<TControl, ɵFormGroupArgumentValue<TControl>, any> = {},
-    options: {onlySelf?: boolean; emitEvent?: boolean} = {},
+    options: {onlySelf?: boolean; emitEvent?: boolean; overwriteDefaultValue?: boolean} = {},
   ): void {
     this._forEachChild((control: AbstractControl, name) => {
-      control.reset(value ? (value as any)[name] : null, {
-        onlySelf: true,
-        emitEvent: options.emitEvent,
-      });
+      control.reset(value ? (value as any)[name] : null, {...options, onlySelf: true});
     });
     this._updatePristine(options, this);
     this._updateTouched(options, this);

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -894,6 +894,10 @@ import {asyncValidator, asyncValidatorReturningObservable} from './util';
         expect(c2.value).toBe('foo');
         expect(c2.defaultValue).toBe('foo');
 
+        c2.reset('baz', {overwriteDefaultValue: true});
+        expect(c2.value).toBe('baz');
+        expect(c2.defaultValue).toBe('baz');
+
         const c3 = new FormControl('foo', {nonNullable: false});
         expect(c3.value).toBe('foo');
         expect(c3.defaultValue).toBe(null);
@@ -905,6 +909,10 @@ import {asyncValidator, asyncValidatorReturningObservable} from './util';
         c3.reset();
         expect(c3.value).toBe(null);
         expect(c3.defaultValue).toBe(null);
+
+        c3.reset('baz', {overwriteDefaultValue: true});
+        expect(c3.value).toBe('baz');
+        expect(c3.defaultValue).toBe('baz');
       });
 
       it('should look inside FormState objects for a default value', () => {

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -11,14 +11,13 @@ import {
   AbstractControl,
   ControlEvent,
   FormArray,
-  FormBuilder,
   FormControl,
   FormGroup,
   ValidationErrors,
   Validators,
   ValueChangeEvent,
 } from '../index';
-import {delay, filter, map, of, startWith, timer} from 'rxjs';
+import {filter, map, of} from 'rxjs';
 
 import {
   asyncValidator,
@@ -877,6 +876,21 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           form.statusChanges.subscribe(pristineAndNotDirty);
 
           form.reset();
+        });
+
+        it('should reset default value when resetting', () => {
+          const c = new FormControl('default', {nonNullable: true});
+          const g = new FormGroup({'one': c});
+
+          expect(g.value).toEqual({one: 'default'});
+
+          g.reset();
+          expect(g.value).toEqual({one: 'default'});
+          expect(c.defaultValue).toEqual('default');
+
+          g.reset({one: 'newDefault'}, {overwriteDefaultValue: true});
+          expect(c.value).toEqual('newDefault');
+          expect(c.defaultValue).toEqual('newDefault');
         });
       });
     });

--- a/packages/forms/test/typed_integration_spec.ts
+++ b/packages/forms/test/typed_integration_spec.ts
@@ -169,6 +169,17 @@ describe('Typed Class', () => {
       val = valueFn(c);
       val = valueFn(c)!;
     });
+
+    it('should only allow to set valid values as defaultValue', () => {
+      const c1 = new FormControl('valid', {nonNullable: true});
+      c1.defaultValue = 'also valid';
+      // @ts-expect-error this should not be allowed
+      c1.defaultValue = null;
+
+      const c2 = new FormControl<string | null>('valid');
+      c2.defaultValue = 'also valid';
+      c2.defaultValue = null;
+    });
   });
 
   describe('FormGroup', () => {


### PR DESCRIPTION
Prior to this commit the `defaultValue` of a `FormControl` was readonly. This didn't allow to change the default value after initialization. Now it is possible to update it via
- setting the `defaultValue` directly on the control
- overwritting the defaultValue while resetting a form.

fixes #54022
