### PR TITLE
ci: authenticate to Bazel RBE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,8 @@ jobs:
         uses: angular/dev-infra/github-actions/bazel/setup@08d451f9b4e900928b65cd31234693ef9a994492
       - name: Setup Bazel RBE
         uses: angular/dev-infra/github-actions/bazel/configure-remote@08d451f9b4e900928b65cd31234693ef9a994492
+        with:
+          google_credential: ${{ secrets.RBE_TRUSTED_BUILDS_USER }}
       - name: Install node modules
         run: pnpm install --frozen-lockfile
       - name: Run tests


### PR DESCRIPTION
This commit configures the Bazel RBE setup action to use the 'RBE_TRUSTED_BUILDS_USER' secret for authentication. This is necessary to ensure that the CI can properly connect to the remote build execution environment.
