### PR TITLE
refactor(compiler): throw on attribute bindings for `ng-container`

### DIFF
--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -234,6 +234,18 @@ class HtmlAstToIvyAst implements html.Visitor {
         parsedProperties,
         i18nAttrsMeta,
       );
+
+      if (element.name === 'ng-container') {
+        for (const bound of attrs.bound) {
+          if (bound.type === BindingType.Attribute) {
+            this.reportError(
+              `Attribute bindings are not supported on ng-container. Use property bindings instead.`,
+              bound.sourceSpan,
+            );
+          }
+        }
+      }
+
       parsedElement = new t.Element(
         element.name,
         attributes,

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -2664,7 +2664,7 @@ describe('R3 template transform', () => {
         ['Directive', 'Dir'],
         ['TextAttribute', 'a', '1'],
         ['BoundAttribute', 0, 'b', 'two'],
-        ['BoundAttribute', 5, 'd', 'd'],
+        ['BoundAttribute', BindingType.TwoWay, 'd', 'd'],
         ['BoundEvent', 0, 'c', null, 'c()'],
         ['BoundEvent', 2, 'dChange', null, 'd'],
       ]);
@@ -2770,5 +2770,20 @@ describe('R3 template transform', () => {
         expect(() => parseSelectorless('<div @Dir(#foo #foo)></div>')).toThrowError(pattern);
       });
     });
+  });
+
+  it('should report an error for attribute bindings on ng-container', () => {
+    const template = `<ng-container [attr.title]="'test'"></ng-container>`;
+    const errors = parse(template, {ignoreError: true}).errors;
+    expect(errors.length).toBe(1);
+    expect(errors[0].msg).toBe(
+      'Attribute bindings are not supported on ng-container. Use property bindings instead.',
+    );
+  });
+
+  it('should not report an error on non-attr bindings on ng-container', () => {
+    const template = `<ng-container *ngIf"test" [ngTemplateOutlet]="foo"></ng-container>`;
+    const errors = parse(template, {ignoreError: true}).errors;
+    expect(errors.length).toBe(0);
   });
 });


### PR DESCRIPTION
They are never valid on ng-container.
fixes #53760
