### PR TITLE
build: mark lsp integration test as flaky

### DIFF
--- a/vscode-ng-language-service/integration/lsp/BUILD.bazel
+++ b/vscode-ng-language-service/integration/lsp/BUILD.bazel
@@ -15,11 +15,12 @@ jasmine_test(
         "//vscode-ng-language-service/integration/project:node_modules/@angular/core",
         "//vscode-ng-language-service/server:index",
     ],
+    flaky = True,
     node_modules = "//vscode-ng-language-service:node_modules",
     shard_count = 2,
     tags = [
         "e2e",
-        "no-remote",
+        "no-remote-exec",
         "no-sandbox",
     ],
 )


### PR DESCRIPTION
The lsp integration test is flaky and can fail intermittently. This change marks the test as `flaky = True` to prevent it from failing the build.

Additionally, the `no-remote` tag is updated to `no-remote-exec`. The former disables remote caching, while the test can still benefit from it.
