### PR TITLE
fix(core): do not rename ARIA property bindings to attributes

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/GOLDEN_PARTIAL.js
@@ -1,4 +1,42 @@
 /****************************************************************************************************
+ * PARTIAL FILE: aria_bindings.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyComponent {
+    constructor() {
+        this.disabled = '';
+        this.readonly = '';
+        this.label = '';
+    }
+}
+MyComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent, isStandalone: true, selector: "ng-component", host: { properties: { "attr.aria-disabled": "disabled", "aria-readonly": "readonly", "ariaLabel": "label" } }, ngImport: i0, template: ``, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, decorators: [{
+            type: Component,
+            args: [{
+                    template: ``,
+                    host: {
+                        '[attr.aria-disabled]': 'disabled',
+                        '[aria-readonly]': 'readonly',
+                        '[ariaLabel]': 'label',
+                    },
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: aria_bindings.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyComponent {
+    disabled: string;
+    readonly: string;
+    label: string;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyComponent, "ng-component", never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
  * PARTIAL FILE: host_bindings.js
  ****************************************************************************************************/
 import { Directive, HostBinding, NgModule } from '@angular/core';

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/TEST_CASES.json
@@ -2,6 +2,16 @@
   "$schema": "../../test_case_schema.json",
   "cases": [
     {
+      "description": "should support host bindings to ARIA attributes",
+      "inputFiles": ["aria_bindings.ts"],
+      "expectations": [
+        {
+          "failureMessage": "Invalid host binding code",
+          "files": ["aria_bindings.js"]
+        }
+      ]
+    },
+    {
       "description": "should support host bindings",
       "inputFiles": ["host_bindings.ts"],
       "expectations": [

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/aria_bindings.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/aria_bindings.js
@@ -1,0 +1,6 @@
+hostBindings: function MyComponent_HostBindings(rf, ctx) {
+  if (rf & 2) {
+    $r3$.ɵɵdomProperty("ariaLabel", ctx.label);
+    $r3$.ɵɵattribute("aria-disabled", ctx.disabled)("aria-readonly", ctx.readonly);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/aria_bindings.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/aria_bindings.ts
@@ -1,0 +1,15 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: ``,
+  host: {
+    '[attr.aria-disabled]': 'disabled',
+    '[aria-readonly]': 'readonly',
+    '[ariaLabel]': 'label',
+  },
+})
+export class MyComponent {
+  disabled = '';
+  readonly = '';
+  label = '';
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/aria_dom_properties.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/aria_dom_properties.js
@@ -1,3 +1,4 @@
 if (rf & 2) {
-  $r3$.ɵɵattribute("aria-readonly", ctx.readonly)("aria-label", ctx.label)("aria-disabled", ctx.disabled);
+  $r3$.ɵɵdomProperty("ariaLabel", ctx.label);
+  $r3$.ɵɵattribute("aria-disabled", ctx.disabled)("aria-readonly", ctx.readonly);
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/aria_properties.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/aria_properties.js
@@ -1,4 +1,5 @@
 if (rf & 2) {
-  $r3$.ɵɵariaProperty("aria-readonly", ctx.readonly)("ariaLabel", ctx.label);
+  $r3$.ɵɵariaProperty("aria-readonly", ctx.readonly);
+  $r3$.ɵɵproperty("ariaLabel", ctx.label);
   $r3$.ɵɵattribute("aria-disabled", ctx.disabled);
 }

--- a/packages/compiler/src/template/pipeline/src/util/attributes.ts
+++ b/packages/compiler/src/template/pipeline/src/util/attributes.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+const ARIA_PREFIX = 'aria-';
+
+/**
+ * Returns whether `name` is an ARIA attribute name.
+ *
+ * This is a heuristic based on whether name begins with and is longer than `aria-`.
+ */
+export function isAriaAttribute(name: string): boolean {
+  return name.startsWith(ARIA_PREFIX) && name.length > ARIA_PREFIX.length;
+}

--- a/packages/core/src/render3/instructions/aria_property.ts
+++ b/packages/core/src/render3/instructions/aria_property.ts
@@ -21,15 +21,13 @@ import {
   storePropertyBindingMetadata,
 } from './shared';
 
-const ARIA_PREFIX = 'aria';
-
 /**
- * Update an ARIA attribute by either its attribute or property name on a selected element.
+ * Update an ARIA attribute on a selected element.
  *
- * If the property name also exists as an input property on any of the element's directives, those
- * inputs will be set instead of the element property.
+ * If the attribute name also exists as an input property on any of the element's directives, those
+ * inputs will be set instead of the element attribute.
  *
- * @param name Name of the ARIA attribute or property (beginning with `aria`).
+ * @param name Name of the ARIA attribute (beginning with `aria-`).
  * @param value New value to write.
  * @returns This function returns itself so that it may be chained.
  *
@@ -49,30 +47,10 @@ export function ɵɵariaProperty<T>(name: string, value: T): typeof ɵɵariaProp
     } else {
       ngDevMode && assertTNodeType(tNode, TNodeType.Element);
       const element = getNativeByTNode(tNode, lView) as RElement;
-      const attributeName = ariaAttrName(name);
-      setElementAttribute(lView[RENDERER], element, null, tNode.value, attributeName, value, null);
+      setElementAttribute(lView[RENDERER], element, null, tNode.value, name, value, null);
     }
 
     ngDevMode && storePropertyBindingMetadata(tView.data, tNode, name, bindingIndex);
   }
   return ɵɵariaProperty;
-}
-
-/**
- * Converts an ARIA property name to its corresponding attribute name, if necessary.
- *
- * For example, converts `ariaLabel` to `aria-label`.
- *
- * https://www.w3.org/TR/wai-aria-1.2/#accessibilityroleandproperties-correspondence
- *
- * This must be kept in sync with the the function of the same name in
- * packages/compiler/src/template/pipeline/src/phases/reify.ts
- *
- * @param name A property name that starts with `aria`.
- * @returns The corresponding attribute name.
- */
-function ariaAttrName(name: string): string {
-  return name.charAt(ARIA_PREFIX.length) !== '-'
-    ? ARIA_PREFIX + '-' + name.slice(ARIA_PREFIX.length).toLowerCase()
-    : name; // Property already has attribute name.
 }

--- a/packages/core/test/acceptance/property_binding_spec.ts
+++ b/packages/core/test/acceptance/property_binding_spec.ts
@@ -142,7 +142,7 @@ describe('property bindings', () => {
     },
   );
 
-  it('should bind ARIA properties to their corresponding attributes', () => {
+  it('should bind ARIA properties', () => {
     @Component({
       template: '<button [ariaLabel]="label" [ariaHasPopup]="hasPopup"></button>',
     })
@@ -152,19 +152,19 @@ describe('property bindings', () => {
     }
 
     const fixture = TestBed.createComponent(MyComp);
-    const button = fixture.debugElement.query(By.css('button')).nativeElement;
+    const button = fixture.debugElement.query(By.css('button')).nativeElement as HTMLButtonElement;
 
     fixture.componentInstance.label = 'Open';
     fixture.componentInstance.hasPopup = 'menu';
     fixture.detectChanges();
 
-    expect(button.getAttribute('aria-label')).toBe('Open');
-    expect(button.getAttribute('aria-haspopup')).toBe('menu');
+    expect(button.ariaLabel).toBe('Open');
+    expect(button.ariaHasPopup).toBe('menu');
 
     fixture.componentInstance.label = 'Close';
     fixture.detectChanges();
 
-    expect(button.getAttribute('aria-label')).toBe('Close');
+    expect(button.ariaLabel).toBe('Close');
   });
 
   it('should bind interpolated ARIA attributes', () => {

--- a/packages/platform-server/test/render_spec.ts
+++ b/packages/platform-server/test/render_spec.ts
@@ -24,20 +24,6 @@ describe('renderApplication', () => {
     expect(html).toContain('aria-label="some label"');
   });
 
-  it('should render ARIA attributes from their corresponding property bindings', async () => {
-    @Component({
-      selector: 'app',
-      standalone: true,
-      template: '<div [ariaLabel]="label"></div>',
-    })
-    class SomeComponent {
-      label = 'some other label';
-    }
-
-    const html = await ssr(SomeComponent);
-    expect(html).toContain('aria-label="some other label"');
-  });
-
   it('should render ARIA attributes using property binding syntax', async () => {
     @Component({
       selector: 'app',


### PR DESCRIPTION
Patch port of #63925
----
angular#62630 made it so that all ARIA
property bindings would write to their corresponding attribute instead. The primary motivation for this change was to ensure that ARIA attributes were always rendered correctly on the server, where the emulated DOM may not correctly reflect ARIA properties as attributes. Furthermore, this change added support for binding to ARIA attributes using the property binding syntax (e.g. `[aria-label]`).

Unfortunately, angular#62630 relied on
the incorrect assumptions that an ARIA property name could be converted to its attribute name (without hardcoding the conversion), and that the value of an ARIA property matched its corresponding attribute. For example, the `ariaLabelledByElements` property's value is an array of DOM elements, while the corresponding `aria-labelledby` attribute's value is a string containing the IDs of the DOM elements.

This partially reverts angular#62630 so
that only property bindings with ARIA attribute names (begin with `aria-`) are converted to attribute bindings.

* `[ariaLabel]` will revert to binding to the `ariaLabel` property.
* `[aria-label]` will continue binding to the `aria-label` attribute.
