### PR TITLE
refactor(devtools): guard value reads in the serializer

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
@@ -71,6 +71,7 @@ const typeToDescriptorPreview: Formatter<string> = {
     return `${prop}`;
   },
   [PropType.Unknown]: (_: any) => 'unknown',
+  [PropType.Error]: (_: any) => '[⚠️ Error when retrieving the value]',
 };
 
 type Key = string | number;
@@ -138,6 +139,10 @@ const shallowPropTypeToTreeMetaData: Record<
     expandable: false,
   },
   [PropType.Map]: {
+    editable: false,
+    expandable: false,
+  },
+  [PropType.Error]: {
     editable: false,
     expandable: false,
   },

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.ts
@@ -81,7 +81,20 @@ function levelSerializer(
   level = MAX_LEVEL,
   continuation = levelSerializer,
 ): Descriptor {
-  const serializableInstance = instance[propName];
+  let serializableInstance: any;
+  try {
+    serializableInstance = instance[propName];
+  } catch {
+    return {
+      type: PropType.Error,
+      value: '',
+      containerType: null,
+      editable: false,
+      expandable: false,
+      preview: '',
+    };
+  }
+
   const propData: PropertyData = {
     prop: serializableInstance,
     type: getPropType(serializableInstance),

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -150,6 +150,9 @@ export enum PropType {
   Set,
   Map,
   Unknown,
+
+  // Special Type when an error occurs during property access
+  Error,
 }
 
 export interface Descriptor {


### PR DESCRIPTION
Some properties (like gets) might throw when we try to read them. With this commit we fail gracefuly and show a warning message for the property that can't be read.

<img width="344" height="187" alt="Screenshot 2025-09-26 at 02 08 46" src="https://github.com/user-attachments/assets/792e6de3-c4a7-4a76-9700-463c57a541de" />

fixes #56755
