### PR TITLE
ci: correct paths for disabled projects

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,8 +25,8 @@
     {
       "matchFileNames": [
         "modules/ssr-benchmarks/package.json",
-        "vscode-ng-language-service/integration/pre_apf_project",
-        "vscode-ng-language-service/integration/pre_standalone_project"
+        "vscode-ng-language-service/integration/pre_apf_project/package.json",
+        "vscode-ng-language-service/integration/pre_standalone_project/package.json"
       ],
       "enabled": false
     },


### PR DESCRIPTION
The paths for `pre_apf_project` and `pre_standalone_project` in the renovate configuration were missing the `package.json` suffix. This resulted in renovate not being able to find and disable updates for these projects as intended.

This commit corrects the paths to include `package.json`.