### PR TITLE
fix(devtools): signal graph linkedSignal node UI

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-details.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-details.component.scss
@@ -68,7 +68,7 @@
         }
 
         &.type-computed {
-          background-color: var(--green-02);
+          background-color: var(--green-01);
         }
 
         &.type-effect {
@@ -77,6 +77,10 @@
 
         &.type-template {
           background-color: var(--gray-500);
+        }
+
+        &.type-linked-signal {
+          background-color: var(--red-03);
         }
       }
     }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-details.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-details.component.ts
@@ -24,6 +24,7 @@ const TYPE_CLASS_MAP: {[key: string]: string} = {
   'computed': 'type-computed',
   'effect': 'type-effect',
   'template': 'type-template',
+  'linkedSignal': 'type-linked-signal',
 };
 
 @Component({

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-tab.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-tab.component.scss
@@ -21,31 +21,36 @@
         text-align: center;
         word-wrap: break-word;
         border-radius: 8px;
-        background-color: var(--red-03);
+        background-color: var(--gray-400);
         cursor: pointer;
         transition: border-width 0.25s ease-in-out;
         border: 0px solid black;
+
         &.animating {
           border-width: 5px;
         }
+
         .header {
           overflow: hidden;
           text-overflow: ellipsis;
           white-space: nowrap;
-          padding: 3px;
-          background-color: var(--red-06);
+          padding: 3px 5px;
+          background-color: var(--gray-500);
 
           &.special {
             font-style: italic;
           }
         }
+
         .body {
           font-family: tg.$font-family-mono;
           font-size: 11px;
           padding: 5px;
-          flex: 1;
+          overflow: hidden;
+          text-overflow: ellipsis;
         }
       }
+
       .selected rect {
         stroke: var(--dynamic-blue-02);
         stroke-width: 3px;
@@ -55,26 +60,41 @@
 
       .kind-signal {
         background-color: var(--blue-02);
+
         .header {
           background-color: var(--blue-01);
         }
       }
+
       .kind-computed {
         background-color: var(--green-02);
+
         .header {
           background-color: var(--green-01);
         }
       }
+
       .kind-effect {
         background-color: var(--purple-02);
+
         .header {
           background-color: var(--purple-01);
         }
       }
+
       .kind-template {
         background-color: var(--gray-400);
+
         .header {
           background-color: var(--gray-700);
+        }
+      }
+
+      .kind-linked-signal {
+        background-color: var(--red-04);
+
+        .header {
+          background-color: var(--red-03);
         }
       }
     }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-visualizer.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-visualizer.ts
@@ -10,6 +10,14 @@ import {DebugSignalGraph, DebugSignalGraphNode} from '../../../../../../protocol
 import * as d3 from 'd3';
 import {graphlib, render as dagreRender} from 'dagre-d3-es';
 
+const KIND_CLASS_MAP: {[key: string]: string} = {
+  'signal': 'kind-signal',
+  'computed': 'kind-computed',
+  'effect': 'kind-effect',
+  'template': 'kind-template',
+  'linkedSignal': 'kind-linked-signal',
+};
+
 export class SignalsGraphVisualizer {
   private graph: graphlib.Graph;
   private drender: ReturnType<typeof dagreRender>;
@@ -111,7 +119,7 @@ export class SignalsGraphVisualizer {
           cb(node);
         }
       };
-      outer.className = `node-label kind-${node.kind}`;
+      outer.className = `node-label ${KIND_CLASS_MAP[node.kind]}`;
       const header = document.createElement('div');
       let label = node.label;
       if (node.kind === 'effect') {


### PR DESCRIPTION
Fix the colors of `linkedSignal`s. Use grayish colors for unknown/unhandled signals.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## What is the new behavior?

The header used to be lighter than the body of the node. Also, the red colors apparently were assigned to unknown nodes since we didn't handle the linked signals.
<img width="364" height="234" alt="Screenshot 2025-09-26 at 17 51 41" src="https://github.com/user-attachments/assets/3b4f2f7b-0e6d-4fd2-a15b-955127f69024" />


