### PR TITLE
refactor(compiler-cli): include linkedSignal in the signal debugName transformer

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1134,6 +1134,7 @@ export class KeyValueDiffers {
 // @public
 export function linkedSignal<D>(computation: () => D, options?: {
     equal?: ValueEqualityFn<NoInfer<D>>;
+    debugName?: string;
 }): WritableSignal<D>;
 
 // @public

--- a/packages/core/src/render3/reactivity/linked_signal.ts
+++ b/packages/core/src/render3/reactivity/linked_signal.ts
@@ -27,7 +27,7 @@ const identityFn = <T>(v: T) => v;
  */
 export function linkedSignal<D>(
   computation: () => D,
-  options?: {equal?: ValueEqualityFn<NoInfer<D>>},
+  options?: {equal?: ValueEqualityFn<NoInfer<D>>; debugName?: string},
 ): WritableSignal<D>;
 
 /**


### PR DESCRIPTION
While #63346 addresses the lack of `debugName` in `linkedSignal`'s options, it seems that we are missing a transformer that adds that `debugName` to the source files.

The change introduces a special case to the general-purpose signal transformer. This is not ideal (rather the quickest solution) and I've been thinking that maybe we should consider updating the design of that transformer to something more strategy-oriented since the reactivity API is evolving.

On another note, it might be good to add some tests.
