### PR TITLE
refactor(devtools): themed devtool tab icons for firefox

### DIFF
--- a/devtools/projects/shell-browser/src/devtools.ts
+++ b/devtools/projects/shell-browser/src/devtools.ts
@@ -7,4 +7,11 @@
  */
 
 /// <reference types="chrome"/>
-chrome.devtools.panels.create('Angular', 'assets/icon-bw16.png', 'index.html');
+const theme = chrome.devtools.panels.themeName;
+chrome.devtools.panels.create(
+  'Angular',
+  // Firefox specifically displays the icon in the tab.
+  // the bw icon wasn't visible in dark mode
+  theme === 'dark' ? 'assets/icon16.png' : 'assets/icon-bw16.png',
+  'index.html',
+);


### PR DESCRIPTION
With this change, Firefox get a different tab icon when the dark theme is enabled

fixes #52980
