### PR TITLE
feat(core): add no-argument overload to signal function  

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1717,7 +1717,17 @@ export type Signal<T> = (() => T) & {
 };
 
 // @public
-export function signal<T>(initialValue: T, options?: CreateSignalOptions<T>): WritableSignal<T>;
+export const signal: SignalFunction;
+
+// @public
+export interface SignalFunction {
+  <T>(): WritableSignal<T | undefined>;
+  <T>(initialValue: T, options?: CreateSignalOptions<T>): WritableSignal<T>;
+  <T>(
+    initialValue: undefined,
+    options?: CreateSignalOptions<T | undefined>,
+  ): WritableSignal<T | undefined>;
+}
 
 // @public
 export class SimpleChange {

--- a/packages/core/test/signals/signal_spec.ts
+++ b/packages/core/test/signals/signal_spec.ts
@@ -224,4 +224,41 @@ describe('signals', () => {
     expect(producerKindsCreated).toEqual(['signal']);
     setPostProducerCreatedFn(prev);
   });
+
+  describe('signal() with optional initial value', () => {
+    it('should create signal with undefined initial value', () => {
+      const s = signal<string>();
+      expect(s()).toBe(undefined);
+
+      s.set('hello');
+      expect(s()).toBe('hello');
+
+      s.update((val) => val + ' world');
+      expect(s()).toBe('hello world');
+    });
+
+    it('should create signal with explicit initial value', () => {
+      const s = signal('initial');
+      expect(s()).toBe('initial');
+    });
+
+    it('should create signal with explicit undefined and options', () => {
+      const s = signal<string>(undefined, {debugName: 'test-signal'});
+      expect(s()).toBe(undefined);
+
+      if (ngDevMode) {
+        expect(s.toString()).toContain('test-signal');
+      }
+    });
+
+    it('should work with asReadonly()', () => {
+      const s = signal<number>();
+      const readonly = s.asReadonly();
+
+      expect(readonly()).toBe(undefined);
+
+      s.set(42);
+      expect(readonly()).toBe(42);
+    });
+  });
 });


### PR DESCRIPTION
 
Allow signal() to be called without arguments, defaulting to undefined.
This aligns with the input() function pattern for consistency across  
Angular's reactive primitives. When no initial value is provided,  
the signal will have type WritableSignal<T | undefined>.
  
Before: signal<string | undefined>(undefined)  
After:  signal<string | undefined>()  

closes #64118

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Creating Signal required initial value

Issue Number: https://github.com/angular/angular/issues/64118


## What is the new behavior?
Initial value not required on crating signal, default is undefined

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
