### PR TITLE
refactor(core): narrow down ReactiveNode.kind type

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-details.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-details.component.ts
@@ -19,13 +19,14 @@ import {
 } from './signals-value-tree/signals-value-tree.component';
 import {ButtonComponent} from '../../../../shared/button/button.component';
 
-const TYPE_CLASS_MAP: {[key: string]: string} = {
+const TYPE_CLASS_MAP: {[key in DebugSignalGraphNode['kind']]: string} = {
   'signal': 'type-signal',
   'computed': 'type-computed',
   'effect': 'type-effect',
   'afterRenderEffectPhase': 'type-effect',
   'template': 'type-template',
   'linkedSignal': 'type-linked-signal',
+  'unknown': 'type-unknown',
 };
 
 @Component({

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-visualizer.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-visualizer.ts
@@ -10,13 +10,14 @@ import {DebugSignalGraph, DebugSignalGraphNode} from '../../../../../../protocol
 import * as d3 from 'd3';
 import {graphlib, render as dagreRender} from 'dagre-d3-es';
 
-const KIND_CLASS_MAP: {[key: string]: string} = {
+const KIND_CLASS_MAP: {[key in DebugSignalGraphNode['kind']]: string} = {
   'signal': 'kind-signal',
   'computed': 'kind-computed',
   'effect': 'kind-effect',
   'afterRenderEffectPhase': 'kind-effect',
   'template': 'kind-template',
   'linkedSignal': 'kind-linked-signal',
+  'unknown': 'kind-unknown',
 };
 
 export class SignalsGraphVisualizer {

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -18,7 +18,14 @@ import {
 
 export interface DebugSignalGraphNode {
   id: string;
-  kind: 'signal' | 'computed' | 'effect' | 'template' | 'linkedSignal' | 'unknown';
+  kind:
+    | 'signal'
+    | 'computed'
+    | 'effect'
+    | 'template'
+    | 'linkedSignal'
+    | 'afterRenderEffectPhase'
+    | 'unknown';
   epoch: number;
   label?: string;
   preview: Descriptor;

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -18,7 +18,7 @@ import {
 
 export interface DebugSignalGraphNode {
   id: string;
-  kind: string;
+  kind: 'signal' | 'computed' | 'effect' | 'template' | 'linkedSignal' | 'unknown';
   epoch: number;
   label?: string;
   preview: Descriptor;

--- a/goldens/public-api/core/primitives/signals/index.api.md
+++ b/goldens/public-api/core/primitives/signals/index.api.md
@@ -144,7 +144,7 @@ export interface ReactiveNode {
     consumersTail: ReactiveLink | undefined;
     debugName?: string;
     dirty: boolean;
-    kind: string;
+    kind: ReactiveNodeKind;
     lastCleanEpoch: Version;
     producerMustRecompute(node: unknown): boolean;
     // (undocumented)
@@ -154,6 +154,9 @@ export interface ReactiveNode {
     recomputing: boolean;
     version: Version;
 }
+
+// @public (undocumented)
+export type ReactiveNodeKind = 'signal' | 'computed' | 'effect' | 'template' | 'linkedSignal' | 'unknown';
 
 // @public
 export function resetConsumerBeforeComputation(node: ReactiveNode): void;

--- a/goldens/public-api/core/primitives/signals/index.api.md
+++ b/goldens/public-api/core/primitives/signals/index.api.md
@@ -156,7 +156,7 @@ export interface ReactiveNode {
 }
 
 // @public (undocumented)
-export type ReactiveNodeKind = 'signal' | 'computed' | 'effect' | 'template' | 'linkedSignal' | 'unknown';
+export type ReactiveNodeKind = 'signal' | 'computed' | 'effect' | 'template' | 'linkedSignal' | 'afterRenderEffectPhase' | 'unknown';
 
 // @public
 export function resetConsumerBeforeComputation(node: ReactiveNode): void;

--- a/packages/core/primitives/signals/index.ts
+++ b/packages/core/primitives/signals/index.ts
@@ -24,6 +24,7 @@ export {
   Reactive,
   ReactiveHookFn,
   ReactiveNode,
+  ReactiveNodeKind,
   SIGNAL,
   consumerAfterComputation,
   consumerBeforeComputation,

--- a/packages/core/primitives/signals/src/graph.ts
+++ b/packages/core/primitives/signals/src/graph.ts
@@ -88,6 +88,14 @@ interface ReactiveLink {
   nextProducer: ReactiveLink | undefined;
 }
 
+export type ReactiveNodeKind =
+  | 'signal'
+  | 'computed'
+  | 'effect'
+  | 'template'
+  | 'linkedSignal'
+  | 'unknown';
+
 /**
  * A producer and/or consumer which participates in the reactive graph.
  *
@@ -186,7 +194,7 @@ export interface ReactiveNode {
    *
    * Used in Angular DevTools to identify the kind of signal.
    */
-  kind: string;
+  kind: ReactiveNodeKind;
 }
 
 /**

--- a/packages/core/primitives/signals/src/graph.ts
+++ b/packages/core/primitives/signals/src/graph.ts
@@ -94,6 +94,7 @@ export type ReactiveNodeKind =
   | 'effect'
   | 'template'
   | 'linkedSignal'
+  | 'afterRenderEffectPhase'
   | 'unknown';
 
 /**

--- a/packages/core/src/render3/util/signal_debug.ts
+++ b/packages/core/src/render3/util/signal_debug.ts
@@ -14,11 +14,17 @@ import {EffectNode, EffectRefImpl} from '../reactivity/effect';
 import {Injector} from '../../di/injector';
 import {R3Injector} from '../../di/r3_injector';
 import {throwError} from '../../util/assert';
-import {ComputedNode, ReactiveNode, SIGNAL, SignalNode} from '../../../primitives/signals';
+import {
+  ComputedNode,
+  ReactiveNode,
+  ReactiveNodeKind,
+  SIGNAL,
+  SignalNode,
+} from '../../../primitives/signals';
 import {isLView} from '../interfaces/type_checks';
 
 export interface DebugSignalGraphNode {
-  kind: string;
+  kind: ReactiveNodeKind;
   id: string;
   epoch: number;
   label?: string;


### PR DESCRIPTION
This narrows down the type to a string literal union, which should prevent any type-related bugs that we are currently susceptible to on the Devtools side.