### PR TITLE
docs: remove note about node.js 17+

### DIFF
--- a/adev/src/content/tools/cli/serve.md
+++ b/adev/src/content/tools/cli/serve.md
@@ -77,14 +77,3 @@ Edit the proxy configuration file to add configuration options; following are so
 For a detailed description of all options, refer to the [webpack DevServer documentation](https://webpack.js.org/configuration/dev-server/#devserverproxy) when using `@angular-devkit/build-angular:browser`, or the [Vite DevServer documentation](https://vite.dev/config/server-options#server-proxy) when using `@angular-devkit/build-angular:browser-esbuild` or `@angular-devkit/build-angular:application`.
 
 NOTE: If you edit the proxy configuration file, you must relaunch the `ng serve` process to make your changes effective.
-
-## `localhost` resolution
-
-As of Node version 17, Node will _not_ always resolve `http://localhost:<port>` to `http://127.0.0.1:<port>`
-depending on each machine's configuration.
-
-If you get an `ECONNREFUSED` error using a proxy targeting a `localhost` URL,
-you can fix this issue by updating the target from `http://localhost:<port>` to `http://127.0.0.1:<port>`.
-
-See [the `http-proxy-middleware` documentation](https://github.com/chimurai/http-proxy-middleware#nodejs-17-econnrefused-issue-with-ipv6-and-localhost-705)
-for more information.


### PR DESCRIPTION
This note is pretty old and the mentioned behaviour has been the default for a number of major version.
