### PR TITLE
feat(core): support IntersectionObserver options in viewport triggers

### DIFF
--- a/adev/src/content/guide/templates/defer.md
+++ b/adev/src/content/guide/templates/defer.md
@@ -177,6 +177,24 @@ Alternatively, you can specify a [template reference variable](/guide/templates/
 }
 ```
 
+If you want to customize the options of the `IntersectionObserver`, the `viewport` trigger supports passing in an object literal. The literal supports all properties from the second parameter of `IntersectionObserver`, except for `root`. When using the object literal notation, you have to pass your trigger using the `trigger` property.
+
+```angular-html
+<div #greeting>Hello!</div>
+
+<!-- With options and a trigger -->
+@defer (on viewport({trigger: greeting, rootMargin: '100px', threshold: 0.5})) {
+  <greetings-cmp />
+}
+
+<!-- With options and an implied trigger -->
+@defer (on viewport({rootMargin: '100px', threshold: 0.5})) {
+  <greetings-cmp />
+} @placeholder {
+  <div>Implied trigger</div>
+}
+```
+
 #### `interaction`
 
 The `interaction` trigger loads the deferred content when the user interacts with the specified element through `click` or `keydown` events.

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/oob.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/oob.ts
@@ -804,7 +804,7 @@ export class OutOfBandDiagnosticRecorderImpl implements OutOfBandDiagnosticRecor
         trigger.sourceSpan,
         ts.DiagnosticCategory.Error,
         ngErrorCode(ErrorCode.DEFER_IMPLICIT_TRIGGER_MISSING_PLACEHOLDER),
-        'Trigger with no parameters can only be placed on an @defer that has a @placeholder block',
+        'Trigger with no target can only be placed on an @defer that has a @placeholder block',
       ),
     );
   }
@@ -823,7 +823,7 @@ export class OutOfBandDiagnosticRecorderImpl implements OutOfBandDiagnosticRecor
         trigger.sourceSpan,
         ts.DiagnosticCategory.Error,
         ngErrorCode(ErrorCode.DEFER_IMPLICIT_TRIGGER_INVALID_PLACEHOLDER),
-        'Trigger with no parameters can only be placed on an @defer that has a ' +
+        'Trigger with no target can only be placed on an @defer that has a ' +
           '@placeholder block with exactly one root element node',
       ),
     );

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -2122,6 +2122,34 @@ class TcbForOfOp extends TcbOp {
 }
 
 /**
+ * A `TcbOp` which can be used to type check the options of an `IntersectionObserver`.
+ */
+class TcbIntersectionObserverOp extends TcbOp {
+  constructor(
+    private tcb: Context,
+    private scope: Scope,
+    private options: AST,
+  ) {
+    super();
+  }
+
+  override readonly optional = false;
+
+  override execute(): null {
+    const options = tcbExpression(this.options, this.tcb, this.scope);
+    const callback = ts.factory.createNonNullExpression(ts.factory.createNull());
+    const expression = ts.factory.createNewExpression(
+      ts.factory.createIdentifier('IntersectionObserver'),
+      undefined,
+      [callback, options],
+    );
+
+    this.scope.addStatement(ts.factory.createExpressionStatement(expression));
+    return null;
+  }
+}
+
+/**
  * Overall generation context for the type check block.
  *
  * `Context` handles operations during code generation which are global with respect to the whole
@@ -3010,6 +3038,10 @@ class Scope {
   ): void {
     if (triggers.when !== undefined) {
       this.opQueue.push(new TcbExpressionOp(this.tcb, this, triggers.when.value));
+    }
+
+    if (triggers.viewport !== undefined && triggers.viewport.options !== null) {
+      this.opQueue.push(new TcbIntersectionObserverOp(this.tcb, this, triggers.viewport.options));
     }
 
     if (triggers.hover !== undefined) {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1856,6 +1856,20 @@ describe('type check blocks', () => {
 
       expect(tcb(TEMPLATE)).toContain('((this).shouldShow()) && (((this).isVisible));');
     });
+
+    it('should generate options for `viewport` trigger', () => {
+      const TEMPLATE = `
+        @defer (on viewport({rootMargin: '123px'})) {
+          {{main()}}
+        } @placeholder {
+          <div>{{placeholder()}}</div>
+        }
+      `;
+
+      expect(tcb(TEMPLATE)).toContain(
+        'new IntersectionObserver(null!, { "rootMargin": "123px" }); "" + ((this).main()); "" + ((this).placeholder());',
+      );
+    });
   });
 
   describe('conditional blocks', () => {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/GOLDEN_PARTIAL.js
@@ -1291,3 +1291,128 @@ export declare class TestCmp {
     static ɵcmp: i0.ɵɵComponentDeclaration<TestCmp, "test-cmp", never, {}, {}, never, never, true, never>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: deferred_on_viewport_with_options.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
+    {{message}}
+    @defer (on viewport({trigger: button, rootMargin: '123px', threshold: 59})) {
+      {{message}}
+    } @placeholder {
+      <button #button>Click me</button>
+    }
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    {{message}}
+    @defer (on viewport({trigger: button, rootMargin: '123px', threshold: 59})) {
+      {{message}}
+    } @placeholder {
+      <button #button>Click me</button>
+    }
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: deferred_on_viewport_with_options.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    message: string;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: deferred_prefetch_on_viewport_with_options.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
+    {{message}}
+    @defer (prefetch on viewport({trigger: button, rootMargin: '123px', threshold: 59})) {
+      {{message}}
+    } @placeholder {
+      <button #button>Click me</button>
+    }
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    {{message}}
+    @defer (prefetch on viewport({trigger: button, rootMargin: '123px', threshold: 59})) {
+      {{message}}
+    } @placeholder {
+      <button #button>Click me</button>
+    }
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: deferred_prefetch_on_viewport_with_options.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    message: string;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: deferred_hydrate_on_viewport_with_options.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
+    {{message}}
+    @defer (hydrate on viewport({rootMargin: '123px', threshold: 59})) {
+      {{message}}
+    }
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    {{message}}
+    @defer (hydrate on viewport({rootMargin: '123px', threshold: 59})) {
+      {{message}}
+    }
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: deferred_hydrate_on_viewport_with_options.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    message: string;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/TEST_CASES.json
@@ -329,6 +329,51 @@
           "failureMessage": "Defer block output with import alias does not match deferred_import_alias.js (possible alias resolution regression)"
         }
       ]
+    },
+    {
+      "description": "should generate a defer block with a `on viewport` trigger that has options",
+      "inputFiles": ["deferred_on_viewport_with_options.ts"],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "deferred_on_viewport_with_options_template.js",
+              "generated": "deferred_on_viewport_with_options.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ]
+    },
+    {
+      "description": "should generate a defer block with a `prefetch on viewport` trigger that has options",
+      "inputFiles": ["deferred_prefetch_on_viewport_with_options.ts"],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "deferred_prefetch_on_viewport_with_options_template.js",
+              "generated": "deferred_prefetch_on_viewport_with_options.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ]
+    },
+    {
+      "description": "should generate a defer block with a `hydrate on viewport` trigger that has options",
+      "inputFiles": ["deferred_hydrate_on_viewport_with_options.ts"],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "deferred_hydrate_on_viewport_with_options_template.js",
+              "generated": "deferred_hydrate_on_viewport_with_options.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_hydrate_on_viewport_with_options.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_hydrate_on_viewport_with_options.ts
@@ -1,0 +1,13 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    {{message}}
+    @defer (hydrate on viewport({rootMargin: '123px', threshold: 59})) {
+      {{message}}
+    }
+  `,
+})
+export class MyApp {
+  message = 'hello';
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_hydrate_on_viewport_with_options_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_hydrate_on_viewport_with_options_template.js
@@ -1,0 +1,12 @@
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+    $r3$.ɵɵdomTemplate(1, MyApp_Defer_1_Template, 1, 1);
+    $r3$.ɵɵdefer(2, 1, null, null, null, null, null, null, null, 1);
+    $r3$.ɵɵdeferHydrateOnViewport({rootMargin: "123px", threshold: 59});
+    $r3$.ɵɵdeferOnIdle();
+  }
+  if (rf & 2) {
+    $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_on_viewport_with_options.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_on_viewport_with_options.ts
@@ -1,0 +1,15 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    {{message}}
+    @defer (on viewport({trigger: button, rootMargin: '123px', threshold: 59})) {
+      {{message}}
+    } @placeholder {
+      <button #button>Click me</button>
+    }
+  `,
+})
+export class MyApp {
+  message = 'hello';
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_on_viewport_with_options_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_on_viewport_with_options_template.js
@@ -1,0 +1,11 @@
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+    $r3$.ɵɵdomTemplate(1, MyApp_Defer_1_Template, 1, 1)(2, MyApp_DeferPlaceholder_2_Template, 3, 0);
+    $r3$.ɵɵdefer(3, 1, null, null, 2);
+    $r3$.ɵɵdeferOnViewport(0, -1, {rootMargin: "123px", threshold: 59});
+  }
+  if (rf & 2) {
+    $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_prefetch_on_viewport_with_options.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_prefetch_on_viewport_with_options.ts
@@ -1,0 +1,15 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    {{message}}
+    @defer (prefetch on viewport({trigger: button, rootMargin: '123px', threshold: 59})) {
+      {{message}}
+    } @placeholder {
+      <button #button>Click me</button>
+    }
+  `,
+})
+export class MyApp {
+  message = 'hello';
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_prefetch_on_viewport_with_options_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_prefetch_on_viewport_with_options_template.js
@@ -1,0 +1,12 @@
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+    $r3$.ɵɵdomTemplate(1, MyApp_Defer_1_Template, 1, 1)(2, MyApp_DeferPlaceholder_2_Template, 3, 0);
+    $r3$.ɵɵdefer(3, 1, null, null, 2);
+    $r3$.ɵɵdeferPrefetchOnViewport(0, -1, {rootMargin: "123px", threshold: 59});
+    $r3$.ɵɵdeferOnIdle();
+  }
+  if (rf & 2) {
+    $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
+  }
+}

--- a/packages/compiler-cli/test/ngtsc/defer_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/defer_spec.ts
@@ -1521,7 +1521,7 @@ runInEachFileSystem(() => {
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
         expect(diags[0].messageText).toBe(
-          'Trigger with no parameters can only be placed on an @defer that has a @placeholder block',
+          'Trigger with no target can only be placed on an @defer that has a @placeholder block',
         );
       });
 
@@ -1539,7 +1539,7 @@ runInEachFileSystem(() => {
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
         expect(diags[0].messageText).toBe(
-          'Trigger with no parameters can only be placed on an @defer that has a @placeholder block',
+          'Trigger with no target can only be placed on an @defer that has a @placeholder block',
         );
       });
 
@@ -1557,7 +1557,7 @@ runInEachFileSystem(() => {
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
         expect(diags[0].messageText).toBe(
-          'Trigger with no parameters can only be placed on an @defer that has a @placeholder block with exactly one root element node',
+          'Trigger with no target can only be placed on an @defer that has a @placeholder block with exactly one root element node',
         );
       });
 
@@ -1575,7 +1575,7 @@ runInEachFileSystem(() => {
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
         expect(diags[0].messageText).toBe(
-          'Trigger with no parameters can only be placed on an @defer that has a @placeholder block with exactly one root element node',
+          'Trigger with no target can only be placed on an @defer that has a @placeholder block with exactly one root element node',
         );
       });
 
@@ -1593,7 +1593,7 @@ runInEachFileSystem(() => {
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
         expect(diags[0].messageText).toBe(
-          'Trigger with no parameters can only be placed on an @defer that has a @placeholder block',
+          'Trigger with no target can only be placed on an @defer that has a @placeholder block',
         );
       });
 
@@ -1611,7 +1611,7 @@ runInEachFileSystem(() => {
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
         expect(diags[0].messageText).toBe(
-          'Trigger with no parameters can only be placed on an @defer that has a @placeholder block with exactly one root element node',
+          'Trigger with no target can only be placed on an @defer that has a @placeholder block with exactly one root element node',
         );
       });
 
@@ -1629,7 +1629,7 @@ runInEachFileSystem(() => {
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
         expect(diags[0].messageText).toBe(
-          'Trigger with no parameters can only be placed on an @defer that has a @placeholder block with exactly one root element node',
+          'Trigger with no target can only be placed on an @defer that has a @placeholder block with exactly one root element node',
         );
       });
 
@@ -1650,7 +1650,7 @@ runInEachFileSystem(() => {
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
         expect(diags[0].messageText).toBe(
-          'Trigger with no parameters can only be placed on an @defer that has a @placeholder block with exactly one root element node',
+          'Trigger with no target can only be placed on an @defer that has a @placeholder block with exactly one root element node',
         );
       });
     });

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -4910,6 +4910,32 @@ suppress
           'Trigger cannot find reference "trigger".',
         );
       });
+
+      it('should check the options of the `viewport` trigger', () => {
+        env.write(
+          'test.ts',
+          `
+          import {Component} from '@angular/core';
+
+          @Component({
+            template: \`
+              @defer (on viewport({trigger: target, rootMargin: '10px', doesNotExist: true})) {
+                Content
+              }
+
+              <div #target></div>
+            \`,
+          })
+          export class Main {}
+        `,
+        );
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText).toBe(
+          `Object literal may only specify known properties, and '"doesNotExist"' does not exist in type 'IntersectionObserverInit'.`,
+        );
+      });
     });
 
     describe('conditional blocks', () => {

--- a/packages/compiler/src/combined_visitor.ts
+++ b/packages/compiler/src/combined_visitor.ts
@@ -70,6 +70,8 @@ export class CombinedRecursiveAstVisitor extends RecursiveAstVisitor implements 
   visitDeferredTrigger(trigger: t.DeferredTrigger): void {
     if (trigger instanceof t.BoundDeferredTrigger) {
       this.visit(trigger.value);
+    } else if (trigger instanceof t.ViewportDeferredTrigger && trigger.options !== null) {
+      this.visit(trigger.options);
     }
   }
 

--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -12,6 +12,7 @@ import {
   ASTWithSource,
   BindingType,
   BoundElementProperty,
+  LiteralMap,
   ParsedEvent,
   ParsedEventType,
 } from '../expression_parser/ast';
@@ -252,7 +253,8 @@ export class InteractionDeferredTrigger extends DeferredTrigger {
 
 export class ViewportDeferredTrigger extends DeferredTrigger {
   constructor(
-    public reference: string | null,
+    readonly reference: string | null,
+    readonly options: LiteralMap | null,
     nameSpan: ParseSourceSpan,
     sourceSpan: ParseSourceSpan,
     prefetchSpan: ParseSourceSpan | null,

--- a/packages/compiler/src/render3/r3_deferred_blocks.ts
+++ b/packages/compiler/src/render3/r3_deferred_blocks.ts
@@ -279,15 +279,15 @@ function parsePrimaryTriggers(
     if (WHEN_PARAMETER_PATTERN.test(param.expression)) {
       parseWhenTrigger(param, bindingParser, triggers, errors);
     } else if (ON_PARAMETER_PATTERN.test(param.expression)) {
-      parseOnTrigger(param, triggers, errors, placeholder);
+      parseOnTrigger(param, bindingParser, triggers, errors, placeholder);
     } else if (PREFETCH_WHEN_PATTERN.test(param.expression)) {
       parseWhenTrigger(param, bindingParser, prefetchTriggers, errors);
     } else if (PREFETCH_ON_PATTERN.test(param.expression)) {
-      parseOnTrigger(param, prefetchTriggers, errors, placeholder);
+      parseOnTrigger(param, bindingParser, prefetchTriggers, errors, placeholder);
     } else if (HYDRATE_WHEN_PATTERN.test(param.expression)) {
       parseWhenTrigger(param, bindingParser, hydrateTriggers, errors);
     } else if (HYDRATE_ON_PATTERN.test(param.expression)) {
-      parseOnTrigger(param, hydrateTriggers, errors, placeholder);
+      parseOnTrigger(param, bindingParser, hydrateTriggers, errors, placeholder);
     } else if (HYDRATE_NEVER_PATTERN.test(param.expression)) {
       parseNeverTrigger(param, hydrateTriggers, errors);
     } else {

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -1407,6 +1407,7 @@ interface DeferInteractionTrigger extends DeferTriggerWithTargetBase {
 
 interface DeferViewportTrigger extends DeferTriggerWithTargetBase {
   kind: DeferTriggerKind.Viewport;
+  options: o.Expression | null;
 }
 
 /**

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -849,6 +849,9 @@ function ingestDeferTriggers(
         targetSlot: null,
         targetView: null,
         targetSlotViewSteps: null,
+        options: triggers.viewport.options
+          ? convertAst(triggers.viewport.options, unit.job, triggers.viewport.sourceSpan)
+          : null,
       },
       modifier,
       triggers.viewport.sourceSpan,

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -375,7 +375,7 @@ const deferTriggerToR3TriggerInstructionsMap = new Map([
 
 export function deferOn(
   trigger: ir.DeferTriggerKind,
-  args: (number | null)[],
+  args: o.Expression[],
   modifier: ir.DeferOpModifierKind,
   sourceSpan: ParseSourceSpan | null,
 ): ir.CreateOp {
@@ -383,11 +383,7 @@ export function deferOn(
   if (instructionToCall === undefined) {
     throw new Error(`Unable to determine instruction for trigger ${trigger}`);
   }
-  return call(
-    instructionToCall,
-    args.map((a) => o.literal(a)),
-    sourceSpan,
-  );
+  return call(instructionToCall, args, sourceSpan);
 }
 
 export function projectionDef(def: o.Expression | null): ir.CreateOp {

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -179,6 +179,8 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
   visitDeferredTrigger(trigger: t.DeferredTrigger): void {
     if (trigger instanceof t.BoundDeferredTrigger) {
       this.recordAst(trigger.value);
+    } else if (trigger instanceof t.ViewportDeferredTrigger && trigger.options !== null) {
+      this.recordAst(trigger.options);
     }
   }
 

--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -541,7 +541,7 @@ export function ɵɵdeferHydrateOnTimer(delay: number) {
   if (!shouldAttachTrigger(TriggerType.Hydrate, lView, tNode)) return;
 
   const hydrateTriggers = getHydrateTriggers(getTView(), tNode);
-  hydrateTriggers.set(DeferBlockTrigger.Timer, {delay});
+  hydrateTriggers.set(DeferBlockTrigger.Timer, {type: DeferBlockTrigger.Timer, delay});
 
   if (typeof ngServerMode !== 'undefined' && ngServerMode) {
     // We are on the server and SSR for defer blocks is enabled.
@@ -751,15 +751,26 @@ export function ɵɵdeferHydrateOnInteraction() {
  * @param walkUpTimes Number of times to walk up/down the tree hierarchy to find the trigger.
  * @codeGenApi
  */
-export function ɵɵdeferOnViewport(triggerIndex: number, walkUpTimes?: number) {
+export function ɵɵdeferOnViewport(
+  triggerIndex: number,
+  walkUpTimes?: number | null,
+  options?: IntersectionObserverInit,
+) {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
 
   if (ngDevMode) {
+    const args: string[] = [];
+    if (walkUpTimes !== undefined && walkUpTimes !== -1) {
+      args.push('<target>');
+    }
+    if (options) {
+      args.push(JSON.stringify(options));
+    }
     trackTriggerForDebugging(
       lView[TVIEW],
       tNode,
-      `on viewport${walkUpTimes === -1 ? '' : '(<target>)'}`,
+      `on viewport${args.length === 0 ? '' : `(${args.join(', ')})`}`,
     );
   }
 
@@ -777,6 +788,7 @@ export function ɵɵdeferOnViewport(triggerIndex: number, walkUpTimes?: number) 
       onViewportWrapper,
       () => triggerDeferBlock(TriggerType.Regular, lView, tNode),
       TriggerType.Regular,
+      options,
     );
   }
 }
@@ -787,15 +799,26 @@ export function ɵɵdeferOnViewport(triggerIndex: number, walkUpTimes?: number) 
  * @param walkUpTimes Number of times to walk up/down the tree hierarchy to find the trigger.
  * @codeGenApi
  */
-export function ɵɵdeferPrefetchOnViewport(triggerIndex: number, walkUpTimes?: number) {
+export function ɵɵdeferPrefetchOnViewport(
+  triggerIndex: number,
+  walkUpTimes?: number | null,
+  options?: IntersectionObserverInit,
+) {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
 
   if (ngDevMode) {
+    const args: string[] = [];
+    if (walkUpTimes !== undefined && walkUpTimes !== -1) {
+      args.push('<target>');
+    }
+    if (options) {
+      args.push(JSON.stringify(options));
+    }
     trackTriggerForDebugging(
       lView[TVIEW],
       tNode,
-      `prefetch on viewport${walkUpTimes === -1 ? '' : '(<target>)'}`,
+      `prefetch on viewport${args.length === 0 ? '' : `(${args.join(', ')})`}`,
     );
   }
 
@@ -813,6 +836,7 @@ export function ɵɵdeferPrefetchOnViewport(triggerIndex: number, walkUpTimes?: 
       onViewportWrapper,
       () => triggerPrefetching(tDetails, lView, tNode),
       TriggerType.Prefetch,
+      options,
     );
   }
 }
@@ -821,18 +845,30 @@ export function ɵɵdeferPrefetchOnViewport(triggerIndex: number, walkUpTimes?: 
  * Creates runtime data structures for the `on viewport` hydrate trigger.
  * @codeGenApi
  */
-export function ɵɵdeferHydrateOnViewport() {
+export function ɵɵdeferHydrateOnViewport(options?: IntersectionObserverInit) {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
 
   if (ngDevMode) {
-    trackTriggerForDebugging(lView[TVIEW], tNode, 'hydrate on viewport');
+    trackTriggerForDebugging(
+      lView[TVIEW],
+      tNode,
+      `hydrate on viewport${options ? `(${JSON.stringify(options)})` : ''}`,
+    );
   }
 
   if (!shouldAttachTrigger(TriggerType.Hydrate, lView, tNode)) return;
 
   const hydrateTriggers = getHydrateTriggers(getTView(), tNode);
-  hydrateTriggers.set(DeferBlockTrigger.Viewport, null);
+  hydrateTriggers.set(
+    DeferBlockTrigger.Viewport,
+    options
+      ? {
+          type: DeferBlockTrigger.Viewport,
+          intersectionObserverOptions: options,
+        }
+      : null,
+  );
 
   if (typeof ngServerMode !== 'undefined' && ngServerMode) {
     // We are on the server and SSR for defer blocks is enabled.

--- a/packages/core/src/defer/interfaces.ts
+++ b/packages/core/src/defer/interfaces.ts
@@ -203,13 +203,20 @@ export const enum DeferBlockTrigger {
   Never,
 }
 
-/** * Describes specified delay (in ms) in the `hydrate on timer()` trigger. */
+/** Describes specified delay (in ms) in the `hydrate on timer()` trigger. */
 export interface HydrateTimerTriggerDetails {
-  delay: number;
+  type: DeferBlockTrigger.Timer;
+  delay?: number;
+}
+
+/** Describes the config for a `hydrate on viewport` trigger. */
+export interface HydrateViewportTriggerDetails {
+  type: DeferBlockTrigger.Viewport;
+  intersectionObserverOptions?: IntersectionObserverInit;
 }
 
 /** * Describes all possible hydration trigger details specified in a template. */
-export type HydrateTriggerDetails = HydrateTimerTriggerDetails;
+export type HydrateTriggerDetails = HydrateTimerTriggerDetails | HydrateViewportTriggerDetails;
 
 /**
  * Describes the initial state of this defer block instance.

--- a/packages/core/src/defer/triggering.ts
+++ b/packages/core/src/defer/triggering.ts
@@ -682,6 +682,9 @@ export function processAndInitTriggers(
           timerElements.push(elementTrigger);
         }
         if (blockSummary.hydrate.viewport) {
+          if (typeof blockSummary.hydrate.viewport !== 'boolean') {
+            elementTrigger.intersectionObserverOptions = blockSummary.hydrate.viewport;
+          }
           viewportElements.push(elementTrigger);
         }
       }
@@ -711,6 +714,7 @@ function setViewportTriggers(injector: Injector, elementTriggers: ElementTrigger
         elementTrigger.el,
         () => triggerHydrationFromBlockName(injector, elementTrigger.blockName),
         injector,
+        elementTrigger.intersectionObserverOptions,
       );
       registry.addCleanupFn(elementTrigger.blockName, cleanupFn);
     }

--- a/packages/core/src/hydration/annotate.ts
+++ b/packages/core/src/hydration/annotate.ts
@@ -492,8 +492,10 @@ function serializeHydrateTriggers(
     if (serializableDeferBlockTrigger.has(trigger)) {
       if (details === null) {
         triggers.push(trigger);
-      } else {
+      } else if (details.type === DeferBlockTrigger.Timer) {
         triggers.push({trigger, delay: details.delay});
+      } else {
+        triggers.push({trigger, intersectionObserverOptions: details.intersectionObserverOptions});
       }
     }
   }

--- a/packages/core/src/hydration/interfaces.ts
+++ b/packages/core/src/hydration/interfaces.ts
@@ -187,6 +187,7 @@ export interface SerializedDeferBlock {
 export interface SerializedTriggerDetails {
   trigger: DeferBlockTrigger;
   delay?: number;
+  intersectionObserverOptions?: IntersectionObserverInit;
 }
 
 /**
@@ -285,7 +286,12 @@ export interface DehydratedIcuData {
  */
 export interface BlockSummary {
   data: SerializedDeferBlock;
-  hydrate: {idle: boolean; immediate: boolean; viewport: boolean; timer: number | null};
+  hydrate: {
+    idle: boolean;
+    immediate: boolean;
+    viewport: true | IntersectionObserverInit | null;
+    timer: number | null;
+  };
 }
 
 /**
@@ -295,4 +301,5 @@ export interface ElementTrigger {
   el: HTMLElement;
   blockName: string;
   delay?: number;
+  intersectionObserverOptions?: IntersectionObserverInit;
 }

--- a/packages/core/src/hydration/utils.ts
+++ b/packages/core/src/hydration/utils.ts
@@ -691,6 +691,22 @@ function getHydrateTimerTrigger(blockData: SerializedDeferBlock): number | null 
   return (trigger as SerializedTriggerDetails)?.delay ?? null;
 }
 
+function getHydrateViewportTrigger(
+  blockData: SerializedDeferBlock,
+): true | IntersectionObserverInit | null {
+  const details = blockData[DEFER_HYDRATE_TRIGGERS];
+  if (details) {
+    for (const current of details) {
+      if (current === DeferBlockTrigger.Viewport) {
+        return true;
+      } else if (typeof current === 'object' && current.trigger === DeferBlockTrigger.Viewport) {
+        return current.intersectionObserverOptions || true;
+      }
+    }
+  }
+  return null;
+}
+
 function hasHydrateTrigger(blockData: SerializedDeferBlock, trigger: DeferBlockTrigger): boolean {
   return blockData[DEFER_HYDRATE_TRIGGERS]?.includes(trigger) ?? false;
 }
@@ -706,7 +722,7 @@ function createBlockSummary(blockInfo: SerializedDeferBlock): BlockSummary {
       idle: hasHydrateTrigger(blockInfo, DeferBlockTrigger.Idle),
       immediate: hasHydrateTrigger(blockInfo, DeferBlockTrigger.Immediate),
       timer: getHydrateTimerTrigger(blockInfo),
-      viewport: hasHydrateTrigger(blockInfo, DeferBlockTrigger.Viewport),
+      viewport: getHydrateViewportTrigger(blockInfo),
     },
   };
 }

--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -3504,7 +3504,10 @@ describe('@defer', () => {
       observedElements = new Set<Element>();
       private elementsInView = new Set<Element>();
 
-      constructor(private callback: IntersectionObserverCallback) {
+      constructor(
+        private callback: IntersectionObserverCallback,
+        readonly options: IntersectionObserverInit | null = null,
+      ) {
         activeObservers.push(this);
       }
 
@@ -3781,16 +3784,16 @@ describe('@defer', () => {
     it('should disconnect the intersection observer once all deferred blocks have been loaded', fakeAsync(() => {
       @Component({
         template: `
-            <button #triggerOne></button>
-            @defer (on viewport(triggerOne)) {
-              One
-            }
+          <button #triggerOne></button>
+          @defer (on viewport(triggerOne)) {
+            One
+          }
 
-            <button #triggerTwo></button>
-            @defer (on viewport(triggerTwo)) {
-              Two
-            }
-          `,
+          <button #triggerTwo></button>
+          @defer (on viewport(triggerTwo)) {
+            Two
+          }
+        `,
       })
       class MyCmp {}
 
@@ -3946,6 +3949,76 @@ describe('@defer', () => {
         flush();
       }
       expect(fixture.nativeElement.textContent.trim()).toBe('d1 d2 d3 d4 d5 d6');
+    }));
+
+    it('should take the `on viewport` options into account when creating IntersectionObserver', fakeAsync(() => {
+      @Component({
+        template: `
+          @defer (on viewport({trigger, rootMargin: '123px', threshold: 0.5})) {Hello}
+          <button #trigger></button>
+        `,
+      })
+      class MyCmp {}
+
+      const fixture = TestBed.createComponent(MyCmp);
+      fixture.detectChanges();
+
+      const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+      expect(activeObservers.length).toBe(1);
+      expect(activeObservers[0].observedElements.size).toBe(1);
+      expect(activeObservers[0].observedElements.has(button)).toBe(true);
+      expect(activeObservers[0].options).toEqual({rootMargin: '123px', threshold: 0.5});
+    }));
+
+    it('should take the `prefetch on viewport` options into account when creating IntersectionObserver', fakeAsync(() => {
+      @Component({
+        template: `
+          @defer (prefetch on viewport({trigger, rootMargin: '123px', threshold: 0.5})) {Hello}
+          <button #trigger></button>
+        `,
+      })
+      class MyCmp {}
+
+      const fixture = TestBed.createComponent(MyCmp);
+      fixture.detectChanges();
+
+      const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+      expect(activeObservers.length).toBe(1);
+      expect(activeObservers[0].observedElements.size).toBe(1);
+      expect(activeObservers[0].observedElements.has(button)).toBe(true);
+      expect(activeObservers[0].options).toEqual({rootMargin: '123px', threshold: 0.5});
+    }));
+
+    it('should create different intersection observers depending on their options', fakeAsync(() => {
+      @Component({
+        template: `
+          @defer (on viewport(trigger)) {One}
+          @defer (on viewport({trigger, rootMargin: '123px'})) {Two}
+          @defer (on viewport({trigger, rootMargin: '1vh'})) {Three}
+          @defer (on viewport(trigger)) {One Duplicate}
+          @defer (on viewport({trigger, rootMargin: '123px'})) {Two Duplicate}
+
+          <button #trigger></button>
+        `,
+      })
+      class MyCmp {}
+
+      const fixture = TestBed.createComponent(MyCmp);
+      fixture.detectChanges();
+
+      const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+      expect(activeObservers.length).toBe(3);
+      expect(activeObservers[0].observedElements.size).toBe(1);
+      expect(activeObservers[0].observedElements.has(button)).toBe(true);
+      expect(activeObservers[0].options).toBe(null);
+
+      expect(activeObservers[1].observedElements.size).toBe(1);
+      expect(activeObservers[1].observedElements.has(button)).toBe(true);
+      expect(activeObservers[1].options).toEqual({rootMargin: '123px'});
+
+      expect(activeObservers[2].observedElements.size).toBe(1);
+      expect(activeObservers[2].observedElements.has(button)).toBe(true);
+      expect(activeObservers[2].options).toEqual({rootMargin: '1vh'});
     }));
   });
 

--- a/packages/language-service/src/template_target.ts
+++ b/packages/language-service/src/template_target.ts
@@ -46,6 +46,7 @@ import {
   TmplAstTextAttribute,
   TmplAstUnknownBlock,
   TmplAstVariable,
+  TmplAstViewportDeferredTrigger,
   tmplAstVisitAll,
   TmplAstVisitor,
 } from '@angular/compiler';
@@ -650,6 +651,8 @@ class TemplateTargetVisitor implements TmplAstVisitor {
   visitDeferredTrigger(trigger: TmplAstDeferredTrigger) {
     if (trigger instanceof TmplAstBoundDeferredTrigger) {
       this.visitBinding(trigger.value);
+    } else if (trigger instanceof TmplAstViewportDeferredTrigger && trigger.options !== null) {
+      this.visitBinding(trigger.options);
     }
   }
 


### PR DESCRIPTION
Adds support for customizing the `IntersectionObserver` options for the `on viewport`, `prefetch on viewport` and `hydrate on viewport` triggers.

Note that the options need to be a static object literal, e.g. `@defer (on viewport({trigger, rootMargin: '123px'})`.

Fixes #52799.