### PR TITLE
refactor(core): run control-flow migration by default

### DIFF
--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -3,8 +3,7 @@
     "control-flow-migration": {
       "version": "21.0.0",
       "description": "Converts the entire application to block control flow syntax",
-      "factory": "./bundles/control-flow-migration.cjs#migrate",
-      "optional": true
+      "factory": "./bundles/control-flow-migration.cjs#migrate"
     },
     "router-current-navigation": {
       "version": "21.0.0",


### PR DESCRIPTION
After adding the control flow migration as optional in v20, we enable it by default in v21.
