### PR TITLE
feat(core): enhance Idle Defer to support optional delay parameter

### DIFF
--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -207,7 +207,18 @@ export class BoundDeferredTrigger extends DeferredTrigger {
 
 export class NeverDeferredTrigger extends DeferredTrigger {}
 
-export class IdleDeferredTrigger extends DeferredTrigger {}
+export class IdleDeferredTrigger extends DeferredTrigger {
+  constructor(
+    nameSpan: ParseSourceSpan,
+    sourceSpan: ParseSourceSpan,
+    prefetchSpan: ParseSourceSpan | null,
+    onSourceSpan: ParseSourceSpan | null,
+    hydrateSpan: ParseSourceSpan | null,
+    public delay: number | null,
+  ) {
+    super(nameSpan, sourceSpan, prefetchSpan, onSourceSpan, hydrateSpan);
+  }
+}
 
 export class ImmediateDeferredTrigger extends DeferredTrigger {}
 

--- a/packages/compiler/src/render3/r3_deferred_triggers.ts
+++ b/packages/compiler/src/render3/r3_deferred_triggers.ts
@@ -458,11 +458,26 @@ function createIdleTrigger(
   onSourceSpan: ParseSourceSpan | null,
   hydrateSpan: ParseSourceSpan | null,
 ): t.IdleDeferredTrigger {
-  if (parameters.length > 0) {
-    throw new Error(`"${OnTriggerType.IDLE}" trigger cannot have parameters`);
+  if (parameters.length > 1) {
+    throw new Error(`"${OnTriggerType.IDLE}" trigger can only have zero or one parameters`);
   }
 
-  return new t.IdleDeferredTrigger(nameSpan, sourceSpan, prefetchSpan, onSourceSpan, hydrateSpan);
+  let delay: number | null = null;
+  if (parameters[0]) {
+    delay = parseDeferredTime(parameters[0]);
+    if (delay === null) {
+      throw new Error(`Could not parse time value of trigger "${OnTriggerType.IDLE}"`);
+    }
+  }
+
+  return new t.IdleDeferredTrigger(
+    nameSpan,
+    sourceSpan,
+    prefetchSpan,
+    onSourceSpan,
+    hydrateSpan,
+    delay,
+  );
 }
 
 function createTimerTrigger(

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -1381,6 +1381,8 @@ interface DeferTriggerWithTargetBase extends DeferTriggerBase {
 
 interface DeferIdleTrigger extends DeferTriggerBase {
   kind: DeferTriggerKind.Idle;
+
+  delay: number | null;
 }
 
 interface DeferImmediateTrigger extends DeferTriggerBase {

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -754,7 +754,7 @@ function ingestDeferBlock(unit: ViewCompilationUnit, deferBlock: t.DeferredBlock
     deferOnOps.push(
       ir.createDeferOnOp(
         deferXref,
-        {kind: ir.DeferTriggerKind.Idle},
+        {kind: ir.DeferTriggerKind.Idle, delay: null},
         ir.DeferOpModifierKind.NONE,
         null!,
       ),
@@ -783,7 +783,7 @@ function ingestDeferTriggers(
   if (triggers.idle !== undefined) {
     const deferOnOp = ir.createDeferOnOp(
       deferXref,
-      {kind: ir.DeferTriggerKind.Idle},
+      {kind: ir.DeferTriggerKind.Idle, delay: triggers.idle.delay ?? null},
       modifier,
       triggers.idle.sourceSpan,
     );

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -378,11 +378,12 @@ function reifyCreateOperations(unit: CompilationUnit, ops: ir.OpList<ir.CreateOp
         let args: (number | null)[] = [];
         switch (op.trigger.kind) {
           case ir.DeferTriggerKind.Never:
-          case ir.DeferTriggerKind.Idle:
           case ir.DeferTriggerKind.Immediate:
             break;
           case ir.DeferTriggerKind.Timer:
-            args = [op.trigger.delay];
+          case ir.DeferTriggerKind.Idle:
+            // Use delay if specified, otherwise default to null to preserve normal behavior on IDLE
+            args = [op.trigger.delay ?? null];
             break;
           case ir.DeferTriggerKind.Interaction:
           case ir.DeferTriggerKind.Hover:

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -144,7 +144,13 @@ class R3AstHumanizer implements t.Visitor<void> {
     } else if (trigger instanceof t.HoverDeferredTrigger) {
       this.result.push(['HoverDeferredTrigger', trigger.reference]);
     } else if (trigger instanceof t.IdleDeferredTrigger) {
-      this.result.push(['IdleDeferredTrigger']);
+      // Idle triggers may optionally include a delay. Preserve previous
+      // behavior of only reporting the trigger name when no delay is set.
+      if ((trigger as t.IdleDeferredTrigger).delay != null) {
+        this.result.push(['IdleDeferredTrigger', (trigger as t.IdleDeferredTrigger).delay]);
+      } else {
+        this.result.push(['IdleDeferredTrigger']);
+      }
     } else if (trigger instanceof t.TimerDeferredTrigger) {
       this.result.push(['TimerDeferredTrigger', trigger.delay]);
     } else if (trigger instanceof t.InteractionDeferredTrigger) {
@@ -1187,6 +1193,28 @@ describe('R3 template transform', () => {
       ]);
     });
 
+    it('should parse prefetch `on idle(100)` trigger and preserve delay', () => {
+      const html = '@defer (on idle; prefetch on idle(100)){hello}';
+
+      expectFromHtml(html).toEqual([
+        ['DeferredBlock'],
+        ['IdleDeferredTrigger'],
+        ['IdleDeferredTrigger', 100],
+        ['Text', 'hello'],
+      ]);
+    });
+
+    it('should parse hydrate `on idle(100)` trigger and preserve delay', () => {
+      const html = '@defer (on idle; hydrate on idle(100)){hello}';
+
+      expectFromHtml(html).toEqual([
+        ['DeferredBlock'],
+        ['IdleDeferredTrigger', 100],
+        ['IdleDeferredTrigger'],
+        ['Text', 'hello'],
+      ]);
+    });
+
     it('should allow arbitrary number of spaces after the `prefetch` keyword', () => {
       const html =
         '@defer (on idle; prefetch         on viewport(button), hover(button); prefetch    when shouldPrefetch()){hello}';
@@ -1456,9 +1484,23 @@ describe('R3 template transform', () => {
         expect(() => parse('@defer (on viewport[]) {hello}')).toThrowError(/Unexpected token/);
       });
 
-      it('should report if parameters are passed to `idle` trigger', () => {
-        expect(() => parse('@defer (on idle(1)) {hello}')).toThrowError(
-          /"idle" trigger cannot have parameters/,
+      it('should allow optional parameter on `idle` trigger and parse delay', () => {
+        expectFromHtml('@defer (on idle(1)) {hello}').toEqual([
+          ['DeferredBlock'],
+          ['IdleDeferredTrigger', 1],
+          ['Text', 'hello'],
+        ]);
+      });
+
+      it('should report if `idle` trigger value cannot be parsed', () => {
+        expect(() => parse('@defer (on idle(123abc)) {hello}')).toThrowError(
+          /Could not parse time value of trigger "idle"/,
+        );
+      });
+
+      it('should report if `idle` trigger has more than one parameter', () => {
+        expect(() => parse('@defer (on idle(a, b)) {hello}')).toThrowError(
+          /"idle" trigger can only have zero or one parameters/,
         );
       });
 

--- a/packages/core/src/defer/composition_scheduler.ts
+++ b/packages/core/src/defer/composition_scheduler.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { Injector } from '../di';
+import { onIdle } from './idle_scheduler';
+import { onTimer } from './timer_scheduler';
+
+/**
+ * Creates a composed scheduler that combines timer and idle callbacks.
+ * The resulting scheduler will wait for the timer to complete before scheduling
+ * the idle callback.
+ * 
+ * The composed scheduler maintains the following properties:
+ * 1. The original callback is not executed until both the timer expires AND the browser is idle
+ * 2. Both timer and idle callbacks are properly cleaned up when the cleanup function is called
+ * 3. The cleanup function is safe to call at any time, whether the timer has fired or not
+ *
+ * @param delay The delay in milliseconds before scheduling the idle callback
+ * @returns A scheduler function that can be used with defer triggers
+ */
+export function composeTimerAndIdle(delay: number) {
+    return (callback: VoidFunction, injector: Injector) => {
+        let idleCleanup: VoidFunction | null = null;
+        let isDestroyed = false;
+
+        // Schedule the timer first
+        const timerCleanup = onTimer(delay)(() => {
+            // When timer completes, schedule the idle callback if not destroyed
+            if (!isDestroyed) {
+                idleCleanup = onIdle(callback, injector);
+            }
+        }, injector);
+
+        // Return a cleanup function that handles both timer and idle
+        return () => {
+            isDestroyed = true;
+            timerCleanup();
+            idleCleanup?.();
+        };
+    };
+}

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -58,6 +58,7 @@
       "shimStylesContent"
     ],
     "lazy": [
+      "DeferComponent",
       "AFTER_RENDER_SEQUENCES_TO_ADD",
       "ANIMATIONS",
       "APP_BOOTSTRAP_LISTENER",
@@ -744,8 +745,7 @@
       "wasLastNodeCreated",
       "writeDirectClass",
       "writeDirectStyle",
-      "writeToDirectiveInput",
-      "DeferComponent"
+      "writeToDirectiveInput"
     ]
   }
 }


### PR DESCRIPTION
WIP
feat(core): enhance Idle Defer to support optional delay parameter

This PR introduces an optional `delay` parameter to the `idle` trigger in `@defer`.  
It provides a safer alternative to nested `@defer` blocks, which are considered a bad practice due to cascading loads ([Angular docs](https://angular.dev/guide/templates/defer#avoid-cascading-loads-with-nested-defer-blocks)).

Bad practice (nested `@defer`) 

```html
@defer (on timer(2000)) {
  @defer (on idle) {
    <heavy-component/>
  }
}
```

Proposed 

```html
@defer (on idle(2000)) {
    <heavy-component/>
 }
```


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  https://github.com/angular/angular/issues/57814


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
