### PR TITLE
fix(router): Fix memory leak through Navigation.abort and canDeactiva…

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -927,6 +927,7 @@
       "nodeChildrenAsMap",
       "noop",
       "noop2",
+      "noop3",
       "normalizeQueryParams",
       "notFoundValueOrThrow",
       "observable",


### PR DESCRIPTION
…te guards

This commit updates the internal transition to handle context retention through the abort function. This retention chain included the previousNavigation and setting this to a noop function resolves the issue.

fixes #63983
