### PR TITLE
fix(schematics): skip migration for inputs with 'this' references

### DIFF
--- a/packages/core/schematics/test/signal_input_migration_spec.ts
+++ b/packages/core/schematics/test/signal_input_migration_spec.ts
@@ -128,6 +128,30 @@ describe('signal input migration', () => {
     expect(messages).toContain(`  -> Migrated 1/2 inputs.`);
   });
 
+  it('should not migrate input functions that reference this', async () => {
+    const source = `
+      import {Component, Input} from '@angular/core';
+
+      @Component({})
+      export class TestComponent {
+
+        @Input() fnDisplay = (item: any) => item;
+        @Input() fnEquals = (a: any, b: any) => this.fnDisplay(a) === this.fnDisplay(b);
+
+      }
+    `;
+
+    writeFile('/index.ts', source);
+    await runMigration();
+    const content = tree.readContent('/index.ts');
+
+    // Verify the simple function was migrated
+    expect(content).toContain('readonly fnDisplay = input((item: any) => item);');
+    expect(content).toContain(
+      '@Input() fnEquals = (a: any, b: any) => this.fnDisplay()(a) === this.fnDisplay()(b);',
+    );
+  });
+
   it('should report correct statistics with best effort mode', async () => {
     writeFile(`node_modules/@tsconfig/strictest/tsconfig.json`, `{}`);
     writeFile(


### PR DESCRIPTION
Prevents migration of @Input() properties that contain references to 'this' in their initializer functions. This ensures that functions accessing class members via 'this' remain unchanged, preventing potential build errors.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Migration attempts to migrate @Input properties with 'this' references, resulting in a build error.

Issue Number: #64112 

## What is the new behavior?
Migration avoids migrating @Input with 'this' references thus avoiding generating errors after migration

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
