### PR TITLE
build: update dependencies and build config

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1310,18 +1310,6 @@ importers:
       '@angular/language-service':
         specifier: 21.0.0-next.5
         version: 21.0.0-next.5
-      vscode-html-languageservice:
-        specifier: ^5.5.1
-        version: 5.5.1
-      vscode-jsonrpc:
-        specifier: 6.0.0
-        version: 6.0.0
-      vscode-languageclient:
-        specifier: 7.0.0
-        version: 7.0.0
-      vscode-languageserver-protocol:
-        specifier: 3.16.0
-        version: 3.16.0
     devDependencies:
       '@angular/core':
         specifier: 21.0.0-next.5
@@ -1353,15 +1341,21 @@ importers:
       typescript:
         specifier: 5.9.2
         version: 5.9.2
+      vscode-jsonrpc:
+        specifier: 6.0.0
+        version: 6.0.0
+      vscode-languageclient:
+        specifier: 7.0.0
+        version: 7.0.0
       vscode-languageserver:
         specifier: 7.0.0
         version: 7.0.0
-      vscode-languageserver-textdocument:
-        specifier: ^1.0.12
-        version: 1.0.12
-      vscode-languageserver-types:
+      vscode-languageserver-protocol:
         specifier: 3.16.0
         version: 3.16.0
+      vscode-languageserver-textdocument:
+        specifier: 1.0.12
+        version: 1.0.12
       vscode-test:
         specifier: 1.6.1
         version: 1.6.1
@@ -1422,7 +1416,7 @@ importers:
     devDependencies:
       ng-packagr:
         specifier: 21.0.0-next.3
-        version: 21.0.0-next.3(@angular/compiler-cli@21.0.0-next.5(@angular/compiler@21.0.0-next.5)(typescript@5.9.2))(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2)))(tslib@2.8.1)(typescript@5.9.2)
+        version: 21.0.0-next.3(@angular/compiler-cli@21.0.0-next.5(@angular/compiler@21.0.0-next.5)(typescript@5.9.2))(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@24.5.2)(typescript@5.9.2)))(tslib@2.8.1)(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
@@ -1453,15 +1447,16 @@ importers:
       '@angular/language-service':
         specifier: 21.0.0-next.5
         version: 21.0.0-next.5
+    devDependencies:
+      '@types/node':
+        specifier: ^24.5.2
+        version: 24.5.2
       typescript:
         specifier: 5.9.2
         version: 5.9.2
       vscode-html-languageservice:
-        specifier: ^5.5.1
+        specifier: 5.5.1
         version: 5.5.1
-      vscode-jsonrpc:
-        specifier: 6.0.0
-        version: 6.0.0
       vscode-languageserver:
         specifier: 7.0.0
         version: 7.0.0
@@ -23228,7 +23223,7 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  ng-packagr@21.0.0-next.3(@angular/compiler-cli@21.0.0-next.5(@angular/compiler@21.0.0-next.5)(typescript@5.9.2))(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2)))(tslib@2.8.1)(typescript@5.9.2):
+  ng-packagr@21.0.0-next.3(@angular/compiler-cli@21.0.0-next.5(@angular/compiler@21.0.0-next.5)(typescript@5.9.2))(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@24.5.2)(typescript@5.9.2)))(tslib@2.8.1)(typescript@5.9.2):
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular/compiler-cli': 21.0.0-next.5(@angular/compiler@21.0.0-next.5)(typescript@5.9.2)
@@ -23256,7 +23251,7 @@ snapshots:
       typescript: 5.9.2
     optionalDependencies:
       rollup: 4.52.3
-      tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2))
+      tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@24.5.2)(typescript@5.9.2))
 
   ng-packagr@21.0.0-next.3(@angular/compiler-cli@packages+compiler-cli)(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2)))(tslib@2.8.1)(typescript@5.9.2):
     dependencies:
@@ -25960,7 +25955,7 @@ snapshots:
 
   tsutils@3.21.0(typescript@5.9.2):
     dependencies:
-      tslib: 1.9.0
+      tslib: 1.14.1
       typescript: 5.9.2
 
   tsx@4.20.6:

--- a/renovate.json
+++ b/renovate.json
@@ -18,8 +18,7 @@
     "vscode-jsonrpc",
     "vscode-languageclient",
     "vscode-languageserver",
-    "vscode-languageserver-protocol",
-    "vscode-languageserver-types"
+    "vscode-languageserver-protocol"
   ],
   "packageRules": [
     {

--- a/vscode-ng-language-service/BUILD.bazel
+++ b/vscode-ng-language-service/BUILD.bazel
@@ -34,13 +34,18 @@ expand_template_rule(
 npm_package(
     name = "vsix_sandbox",
     srcs = [
+        "package_expanded.json",
+        "angular.png",
         "CHANGELOG.md",
         "README.md",
-        "angular.png",
-        "package_expanded.json",
         "//vscode-ng-language-service/client:index.js",
         "//vscode-ng-language-service/server:npm_files",
         "//vscode-ng-language-service/syntaxes:npm_files",
+        # Transitive closure of npm deps that are marked as "external" in esbuild needed for vsce;
+        # this set was determined manually by running `bazel build //:vsix` and burning down missing packages.
+        # We do this so that we don't have to run an additional `npm install` action to create a node_modules within the
+        # //:npm npm_package where the vsce build takes place.
+        "//vscode-ng-language-service:node_modules/@angular/language-service",
     ],
     exclude_srcs_patterns = [
         "*.map",
@@ -67,11 +72,13 @@ vsce_bin.vsce(
         "package",
         "-o",
         "../ng-template.vsix",
-        "--no-dependencies",
         "--allow-package-env-file",
         "--allow-package-all-secrets",
     ],
     chdir = "vscode-ng-language-service/vsix_sandbox",
+    # vsce requires npm on the PATH; we can get this from the Bazel rules_nodejs but it is not
+    # included by default in rules_js binary rules so we include it here explicitly
+    include_npm = True,
 )
 
 npm_package(

--- a/vscode-ng-language-service/client/BUILD.bazel
+++ b/vscode-ng-language-service/client/BUILD.bazel
@@ -16,6 +16,10 @@ esbuild(
     config = {
         # Workaround for https://github.com/aspect-build/rules_esbuild/issues/58
         "resolveExtensions": [".js"],
+        "mainFields": [
+            "module",
+            "main",
+        ],
     },
     entry_point = "//vscode-ng-language-service/client/src:extension.js",
     external = [

--- a/vscode-ng-language-service/client/BUILD.bazel
+++ b/vscode-ng-language-service/client/BUILD.bazel
@@ -19,12 +19,7 @@ esbuild(
     },
     entry_point = "//vscode-ng-language-service/client/src:extension.js",
     external = [
-        "fs",
-        "path",
         "vscode",
-        "vscode-languageclient/node",
-        "vscode-languageserver-protocol",
-        "vscode-jsonrpc",
     ],
     format = "cjs",
     # Do not enable minification. It seems to break the extension on Windows (with WSL). See #1198.

--- a/vscode-ng-language-service/package.json
+++ b/vscode-ng-language-service/package.json
@@ -245,7 +245,6 @@
   "main": "./bazel-bin/client/src/extension",
   "scripts": {
     "build:syntaxes": "bazel run //vscode-ng-language-service/syntaxes:syntaxes",
-    "format": "pnpm ng-dev format all",
     "watch": "ibazel build //vscode-ng-language-service:index.js //vscode-ng-language-service/server:index.js",
     "package": "pnpm bazel build //vscode-ng-language-service:npm --config=release",
     "test": "bazel test --test_tag_filters=unit_test //vscode-ng-language-service/...",
@@ -258,11 +257,7 @@
     "test:inspect-syntaxes": "bazel run --config=debug //vscode-ng-language-service/syntaxes/test:test"
   },
   "dependencies": {
-    "@angular/language-service": "21.0.0-next.5",
-    "vscode-html-languageservice": "^5.5.1",
-    "vscode-jsonrpc": "6.0.0",
-    "vscode-languageclient": "7.0.0",
-    "vscode-languageserver-protocol": "3.16.0"
+    "@angular/language-service": "21.0.0-next.5"
   },
   "devDependencies": {
     "@angular/core": "21.0.0-next.5",
@@ -270,15 +265,16 @@
     "@types/node": "^24.5.2",
     "@types/vscode": "^1.74.3",
     "@vscode/vsce": "~3.6.1",
+    "jasmine": "~5.11.0",
     "jasmine-core": "~5.11.0",
     "jasmine-reporters": "~2.5.2",
-    "jasmine": "~5.11.0",
     "source-map-support": "^0.5.21",
     "typescript": "5.9.2",
-    "vscode-html-languageservice": "^5.5.1",
-    "vscode-languageserver-textdocument": "^1.0.12",
-    "vscode-languageserver-types": "3.16.0",
+    "vscode-jsonrpc": "6.0.0",
+    "vscode-languageclient": "7.0.0",
     "vscode-languageserver": "7.0.0",
+    "vscode-languageserver-protocol": "3.16.0",
+    "vscode-languageserver-textdocument": "1.0.12",
     "vscode-test": "1.6.1",
     "vscode-tmgrammar-test": "0.1.3",
     "vscode-uri": "3.1.0"

--- a/vscode-ng-language-service/server/BUILD.bazel
+++ b/vscode-ng-language-service/server/BUILD.bazel
@@ -50,14 +50,7 @@ esbuild(
     config = "esbuild.mjs",
     entry_point = "//vscode-ng-language-service/server/src:server.js",
     external = [
-        "fs",
-        "path",
         "typescript/lib/tsserverlibrary",
-        "vscode-languageserver",
-        "vscode-uri",
-        "vscode-jsonrpc",
-        "vscode-languageserver-textdocument",
-        "vscode-html-languageservice",
     ],
     format = "cjs",
     # Do not enable minification. It seems to break the extension on Windows (with WSL). See #1198.

--- a/vscode-ng-language-service/server/esbuild.mjs
+++ b/vscode-ng-language-service/server/esbuild.mjs
@@ -1,5 +1,6 @@
 import {readFileSync} from 'fs';
 const banner = readFileSync('vscode-ng-language-service/server/banner.js', 'utf8');
+
 export default {
   banner: {js: banner},
   mainFields: ['module', 'main'],

--- a/vscode-ng-language-service/server/esbuild.mjs
+++ b/vscode-ng-language-service/server/esbuild.mjs
@@ -2,6 +2,7 @@ import {readFileSync} from 'fs';
 const banner = readFileSync('vscode-ng-language-service/server/banner.js', 'utf8');
 export default {
   banner: {js: banner},
+  mainFields: ['module', 'main'],
   // Workaround for https://github.com/aspect-build/rules_esbuild/issues/58
   resolveExtensions: ['.js'],
 };

--- a/vscode-ng-language-service/server/package.json
+++ b/vscode-ng-language-service/server/package.json
@@ -15,10 +15,12 @@
     "ngserver": "./bin/ngserver"
   },
   "dependencies": {
-    "@angular/language-service": "21.0.0-next.5",
+    "@angular/language-service": "21.0.0-next.5"
+  },
+  "devDependencies": {
+    "@types/node": "^24.5.2",
     "typescript": "5.9.2",
-    "vscode-html-languageservice": "^5.5.1",
-    "vscode-jsonrpc": "6.0.0",
+    "vscode-html-languageservice": "5.5.1",
     "vscode-languageserver": "7.0.0",
     "vscode-languageserver-textdocument": "^1.0.12",
     "vscode-uri": "3.1.0"

--- a/vscode-ng-language-service/server/src/BUILD.bazel
+++ b/vscode-ng-language-service/server/src/BUILD.bazel
@@ -18,11 +18,11 @@ ts_project(
     deps = [
         "//:node_modules/@angular/language-service",
         "//:node_modules/typescript",
-        "//vscode-ng-language-service:node_modules/@types/node",
-        "//vscode-ng-language-service:node_modules/vscode-html-languageservice",
-        "//vscode-ng-language-service:node_modules/vscode-languageserver",
-        "//vscode-ng-language-service:node_modules/vscode-languageserver-textdocument",
-        "//vscode-ng-language-service:node_modules/vscode-uri",
         "//vscode-ng-language-service/common",
+        "//vscode-ng-language-service/server:node_modules/@types/node",
+        "//vscode-ng-language-service/server:node_modules/vscode-html-languageservice",
+        "//vscode-ng-language-service/server:node_modules/vscode-languageserver",
+        "//vscode-ng-language-service/server:node_modules/vscode-languageserver-textdocument",
+        "//vscode-ng-language-service/server:node_modules/vscode-uri",
     ],
 )


### PR DESCRIPTION


The VS Code extension build is failing due to some dependency issues. This commit updates the dependencies and build configuration to fix the build.

- Update `pnpm-lock.yaml` to reflect the dependency changes.
- Update `BUILD.bazel` files to adjust the external dependencies for `esbuild` and to correctly package the VSIX file.