### PR TITLE
refactor(language-service): move typescript to `dependencies`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1447,13 +1447,13 @@ importers:
       '@angular/language-service':
         specifier: 21.0.0-next.5
         version: 21.0.0-next.5
+      typescript:
+        specifier: 5.9.2
+        version: 5.9.2
     devDependencies:
       '@types/node':
         specifier: ^24.5.2
         version: 24.5.2
-      typescript:
-        specifier: 5.9.2
-        version: 5.9.2
       vscode-html-languageservice:
         specifier: 5.5.1
         version: 5.5.1

--- a/vscode-ng-language-service/server/package.json
+++ b/vscode-ng-language-service/server/package.json
@@ -15,11 +15,11 @@
     "ngserver": "./bin/ngserver"
   },
   "dependencies": {
-    "@angular/language-service": "21.0.0-next.5"
+    "@angular/language-service": "21.0.0-next.5",
+    "typescript": "5.9.2"
   },
   "devDependencies": {
     "@types/node": "^24.5.2",
-    "typescript": "5.9.2",
     "vscode-html-languageservice": "5.5.1",
     "vscode-languageserver": "7.0.0",
     "vscode-languageserver-textdocument": "^1.0.12",


### PR DESCRIPTION
This is actually a runtime dependency and is marked as external in esbuild
